### PR TITLE
fix(ui): add linux client-side window decorations

### DIFF
--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -251,12 +251,9 @@ fn run_gui() {
                 title: Some("DBFlux".into()),
                 ..Default::default()
             }),
-            // Request server-side decorations explicitly so GNOME (and other
-            // compositors on Wayland and X11) render the native title bar with
-            // window controls. Without this, many Linux compositors do not paint
-            // a title bar, leaving the window impossible to move or close with
-            // the mouse. This field is ignored on macOS and Windows.
-            window_decorations: Some(WindowDecorations::Server),
+            // Request client-side decorations on Linux to enable native Wayland support.
+            // On other platforms this returns Server explicitly.
+            window_decorations: platform::main_window_decoration_request(),
             ..Default::default()
         };
         platform::apply_window_options(&mut main_window_options, 800.0, 600.0);

--- a/crates/dbflux_ui/src/platform.rs
+++ b/crates/dbflux_ui/src/platform.rs
@@ -5,8 +5,8 @@
 /// adjust window creation accordingly.
 use crate::ui::icons::AppIcon;
 use gpui::{
-    div, px, svg, App, ClickEvent, Decorations, InteractiveElement, IntoElement, ParentElement,
-    Stateful, Styled, Window, WindowDecorations, WindowKind, WindowOptions,
+    App, ClickEvent, Decorations, InteractiveElement, IntoElement, ParentElement, Stateful, Styled,
+    Window, WindowDecorations, WindowKind, WindowOptions, div, px, svg,
 };
 use gpui_component::ActiveTheme;
 use gpui_component::InteractiveElementExt;

--- a/crates/dbflux_ui/src/platform.rs
+++ b/crates/dbflux_ui/src/platform.rs
@@ -3,32 +3,184 @@
 /// Different window systems have different behaviors and requirements.
 /// This module provides helpers to detect the current platform and
 /// adjust window creation accordingly.
+use crate::ui::icons::AppIcon;
+use gpui::{
+    div, px, svg, App, ClickEvent, Decorations, InteractiveElement, IntoElement, ParentElement,
+    Stateful, Styled, Window, WindowDecorations, WindowKind, WindowOptions,
+};
+use gpui_component::ActiveTheme;
+use gpui_component::InteractiveElementExt;
+
+/// Title bar height for Linux CSD mode. Used for layout and client inset reporting.
+pub const TITLE_BAR_HEIGHT: gpui::Pixels = px(32.0);
+
+/// Returns the `WindowDecorations` value to request when creating a top-level window.
 ///
-/// # Title bar on GNOME Wayland
+/// On Linux, requests `Client` (CSD) so Wayland compositors that honor the request
+/// (e.g. GNOME, Sway) grant CSD mode and the app renders its own title bar.
+/// On X11, requesting `Client` is safe because:
+/// - Most X11 window managers ignore the request and keep server-side decorations.
+/// - GPUI's `window.window_decorations()` returns the *actual negotiated result* at
+///   runtime, so `should_render_csd()` will return `false` when the compositor kept SSD.
+/// - No custom title bar renders unless the compositor actually switched to CSD mode.
 ///
-/// GNOME Wayland (43+) deliberately does not implement the `zxdg-decoration-v1`
-/// protocol for non-GTK apps. When GPUI requests server-side decorations (SSD),
-/// GNOME responds with `ClientSide`, causing GPUI to enter CSD mode. Because
-/// DBFlux does not render its own title bar, the window ends up with no title
-/// bar at all — impossible to move or close with the mouse.
+/// On other platforms, returns `Server` explicitly to preserve the original behavior.
+#[cfg(target_os = "linux")]
+pub fn decoration_request() -> Option<WindowDecorations> {
+    Some(WindowDecorations::Client)
+}
+
+/// Returns the `WindowDecorations` value to request when creating a top-level window.
 ///
-/// Current workaround: the `.desktop` files force XWayland by setting
-/// `WAYLAND_DISPLAY=` (empty), so GPUI falls back to X11 where GNOME honors
-/// `_MOTIF_WM_HINTS` and renders a proper server-side title bar.
+/// On non-Linux platforms, returns `Server` explicitly to preserve original behavior
+/// (not `None`, which leaves the decision to the platform default and could differ).
+#[cfg(not(target_os = "linux"))]
+pub fn decoration_request() -> Option<WindowDecorations> {
+    Some(WindowDecorations::Server)
+}
+
+/// Backward-compatible alias used by main window creation in `main.rs`.
+pub use decoration_request as main_window_decoration_request;
+
+/// Returns `true` if the window is in client-side decoration (CSD) mode.
 ///
-/// TODO(csd): Implement client-side decorations (CSD) for Linux, similar to
-/// how Zed renders its own title bar on GNOME Wayland. Steps:
-/// - Detect CSD mode via `Window::window_decorations()` returning
-///   `Decorations::Client { tiling }` and expose a flag to the root view.
-/// - Render a thin title bar strip at the top of the root view containing the
-///   window title, close/maximize/minimize buttons, and drag-to-move support
-///   (via `window.start_window_move()`).
-/// - Handle the `Tiling` bitflags from `Decorations::Client { tiling }` to
-///   suppress edge shadows/borders on tiled sides.
-/// - Once CSD is in place, remove the `WAYLAND_DISPLAY=` workaround from both
-///   `.desktop` files (`resources/desktop/` and `packaging/`).
-/// - Reference: Zed's `TitleBar` component for layout and button behavior.
-use gpui::{WindowKind, WindowOptions, px};
+/// On Linux, checks if `window.window_decorations()` returns `Decorations::Client`.
+/// On other platforms, always returns `false`.
+#[cfg(target_os = "linux")]
+pub fn should_render_csd(window: &Window) -> bool {
+    matches!(window.window_decorations(), Decorations::Client { .. })
+}
+
+/// Returns `false` on non-Linux platforms (no CSD support needed).
+#[cfg(not(target_os = "linux"))]
+pub fn should_render_csd(_window: &Window) -> bool {
+    false
+}
+
+/// Conditionally renders a CSD title bar for Linux and configures the client inset.
+///
+/// Call this at the start of every top-level window's `Render::render()` and store
+/// the result. Prepend it as the first child of the root flex column.
+///
+/// Returns `Some(element)` when CSD is active (Linux Wayland with compositor granting
+/// CSD), `None` otherwise. When `None` is returned on Linux, the client inset is
+/// explicitly reset to zero to prevent stale insets.
+pub fn render_csd_title_bar(
+    window: &mut Window,
+    cx: &mut App,
+    title: &str,
+) -> Option<Stateful<gpui::Div>> {
+    if !should_render_csd(window) {
+        #[cfg(target_os = "linux")]
+        window.set_client_inset(px(0.0));
+        return None;
+    }
+
+    window.set_client_inset(TITLE_BAR_HEIGHT);
+
+    #[cfg(target_os = "linux")]
+    {
+        let controls = window.window_controls();
+        let theme = cx.theme();
+        let title_text = title.to_string();
+
+        let make_button = |icon: AppIcon, handler: Box<dyn Fn(&mut Window) + 'static>| {
+            div()
+                .flex()
+                .items_center()
+                .justify_center()
+                .w(px(46.0))
+                .h_full()
+                .cursor_pointer()
+                .hover(move |d| d.bg(theme.secondary))
+                .on_mouse_down(gpui::MouseButton::Left, move |_, window, _cx| {
+                    handler(window);
+                })
+                .child(
+                    svg()
+                        .path(icon.path())
+                        .size_4()
+                        .text_color(theme.muted_foreground),
+                )
+        };
+
+        let mut title_bar = div()
+            .id("linux-csd-title-bar")
+            .flex()
+            .flex_row()
+            .items_center()
+            .h(TITLE_BAR_HEIGHT)
+            .bg(theme.tab_bar)
+            .border_b_1()
+            .border_color(theme.border)
+            .on_double_click(|_: &ClickEvent, window: &mut Window, _cx: &mut App| {
+                window.zoom_window();
+            })
+            .on_mouse_down(
+                gpui::MouseButton::Right,
+                |event: &gpui::MouseDownEvent, window: &mut Window, _cx: &mut App| {
+                    window.show_window_menu(event.position);
+                },
+            );
+
+        let drag_area = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .flex_1()
+            .h_full()
+            .pl_3()
+            .gap_2()
+            .cursor_pointer()
+            .on_mouse_down(gpui::MouseButton::Left, |_, window, _cx| {
+                window.start_window_move();
+            })
+            .child(
+                div()
+                    .text_sm()
+                    .text_color(theme.foreground)
+                    .font_weight(gpui::FontWeight::MEDIUM)
+                    .child(title_text),
+            );
+
+        title_bar = title_bar.child(drag_area);
+
+        if controls.minimize {
+            title_bar = title_bar.child(make_button(
+                AppIcon::Minimize2,
+                Box::new(|window| window.minimize_window()),
+            ));
+        }
+
+        if controls.maximize {
+            title_bar = title_bar.child(make_button(
+                AppIcon::Maximize2,
+                Box::new(|window| window.zoom_window()),
+            ));
+        }
+
+        title_bar = title_bar.child(make_button(
+            AppIcon::X,
+            Box::new(|window| window.remove_window()),
+        ));
+
+        Some(title_bar)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// Backward-compatible alias: renders the title bar with a fixed "DBFlux" title.
+/// Prefer `render_csd_title_bar` for new code that needs per-window titles.
+pub fn render_linux_title_bar(window: &mut Window, cx: &mut App) -> impl IntoElement + 'static {
+    match render_csd_title_bar(window, cx, "DBFlux") {
+        Some(el) => el.into_any_element(),
+        None => div().into_any_element(),
+    }
+}
 
 /// Returns true if running on X11 (not Wayland, macOS, or Windows).
 ///
@@ -73,9 +225,12 @@ pub fn floating_window_kind() -> Option<WindowKind> {
     }
 }
 
-/// Applies standard DBFlux window options: floating kind (where supported) and
-/// min size so X11 window managers emit `WM_NORMAL_HINTS`, enabling floating
-/// and resizing in tiling WMs like LeftWM, i3, and bspwm.
+/// Applies standard DBFlux window options for secondary windows (Settings, Connection
+/// Manager, SSO Wizard, etc.): floating kind (where supported), min size so X11 window
+/// managers emit `WM_NORMAL_HINTS`, and platform-appropriate decorations.
+///
+/// On Linux, requests CSD so secondary windows match the main window behavior and
+/// render their own title bars. On other platforms, requests server-side decorations.
 pub fn apply_window_options(options: &mut WindowOptions, min_width: f32, min_height: f32) {
     if let Some(kind) = floating_window_kind() {
         options.kind = kind;
@@ -85,4 +240,6 @@ pub fn apply_window_options(options: &mut WindowOptions, min_width: f32, min_hei
         width: px(min_width),
         height: px(min_height),
     });
+
+    options.window_decorations = decoration_request();
 }

--- a/crates/dbflux_ui/src/ui/overlays/sso_wizard.rs
+++ b/crates/dbflux_ui/src/ui/overlays/sso_wizard.rs
@@ -1,4 +1,5 @@
 use crate::app::{AppStateChanged, AppStateEntity, AuthProfileCreated};
+use crate::platform;
 use crate::ui::components::modal_frame::ModalFrame;
 use crate::ui::icons::AppIcon;
 use crate::ui::tokens::{FontSizes, Spacing};
@@ -274,10 +275,24 @@ impl EventEmitter<SsoWizardEvent> for SsoWizard {}
 
 impl Render for SsoWizard {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        if !self.visible {
-            return div().into_any_element();
-        }
+        let csd_title_bar = platform::render_csd_title_bar(_window, cx, "AWS SSO Wizard");
 
+        let content = if !self.visible {
+            div().into_any_element()
+        } else {
+            self.render_visible(_window, cx)
+        };
+
+        div()
+            .size_full()
+            .when_some(csd_title_bar, |el, title_bar| el.child(title_bar))
+            .child(content)
+            .into_any_element()
+    }
+}
+
+impl SsoWizard {
+    fn render_visible(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         let close_entity = cx.entity().downgrade();
         let close = move |_window: &mut Window, cx: &mut App| {
             let _ = close_entity.update(cx, |this, cx| this.close(cx));

--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::platform;
 
 impl Workspace {
     fn render_panel_header(
@@ -111,6 +112,9 @@ impl Render for Workspace {
         let bg_color = theme.background;
         let muted_fg = theme.muted_foreground;
         let header_size = px(25.0);
+
+        // Linux CSD title bar: render only when the compositor has negotiated CSD mode.
+        let linux_title_bar = platform::render_csd_title_bar(window, cx, "DBFlux");
 
         let right_pane = if has_tabs {
             let tasks_header = self.render_panel_header(
@@ -527,6 +531,7 @@ impl Render for Workspace {
                     .flex()
                     .flex_col()
                     .size_full()
+                    .when_some(linux_title_bar, |el, title_bar| el.child(title_bar))
                     .child(
                         div()
                             .flex()

--- a/crates/dbflux_ui/src/ui/windows/connection_manager/render.rs
+++ b/crates/dbflux_ui/src/ui/windows/connection_manager/render.rs
@@ -1,4 +1,5 @@
 use crate::keymap::ContextId;
+use crate::platform;
 use crate::ui::icons::AppIcon;
 use crate::ui::windows::ssh_shared::SshAuthSelection;
 use dbflux_core::{FormFieldDef, FormFieldKind, FormTab};
@@ -1202,6 +1203,8 @@ impl Render for ConnectionManagerWindow {
             state.set_masked(!show_ssh_password, window, cx);
         });
 
+        let csd_title_bar = platform::render_csd_title_bar(window, cx, "Connection Manager");
+
         let theme = cx.theme();
 
         div()
@@ -1224,6 +1227,7 @@ impl Render for ConnectionManagerWindow {
             }))
             .size_full()
             .bg(theme.background)
+            .when_some(csd_title_bar, |el, title_bar| el.child(title_bar))
             .child(match self.view {
                 View::DriverSelect => self.render_driver_select(window, cx).into_any_element(),
                 View::EditForm => self.render_form(window, cx).into_any_element(),

--- a/crates/dbflux_ui/src/ui/windows/settings/render.rs
+++ b/crates/dbflux_ui/src/ui/windows/settings/render.rs
@@ -1,16 +1,17 @@
+use crate::platform;
 use crate::ui::components::tree_nav::{self, FlatRow};
 use crate::ui::icons::AppIcon;
 use crate::ui::tokens::Heights;
 use gpui::prelude::*;
 use gpui::*;
-use gpui_component::ActiveTheme;
-use gpui_component::Sizable;
 use gpui_component::button::{Button, ButtonVariants};
 use gpui_component::dialog::Dialog;
+use gpui_component::ActiveTheme;
+use gpui_component::Sizable;
 
 use super::{
-    SETTINGS_SIDEBAR_GRIP_WIDTH, SETTINGS_SIDEBAR_MAX_WIDTH, SETTINGS_SIDEBAR_MIN_WIDTH,
-    SettingsCoordinator, SettingsFocus,
+    SettingsCoordinator, SettingsFocus, SETTINGS_SIDEBAR_GRIP_WIDTH, SETTINGS_SIDEBAR_MAX_WIDTH,
+    SETTINGS_SIDEBAR_MIN_WIDTH,
 };
 
 const INDENT_PX: f32 = 16.0;
@@ -258,33 +259,43 @@ impl Render for SettingsCoordinator {
 
         let _ = self.app_state.read(cx);
 
+        let csd_title_bar = platform::render_csd_title_bar(_window, cx, "Settings");
+
         div()
             .size_full()
             .bg(cx.theme().background)
             .flex()
+            .flex_col()
             .track_focus(&self.focus_handle)
             .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
                 this.handle_key_event(event, window, cx);
             }))
-            .child(
-                div()
-                    .h_full()
-                    .w(self.sidebar_width)
-                    .flex()
-                    .flex_row()
-                    .child(div().h_full().flex_1().child(self.render_sidebar(cx)))
-                    .child(self.render_sidebar_grip(cx)),
-            )
+            .when_some(csd_title_bar, |el, title_bar| el.child(title_bar))
             .child(
                 div()
                     .flex_1()
                     .min_h_0()
-                    .h_full()
                     .flex()
-                    .flex_col()
-                    .overflow_hidden()
-                    .bg(cx.theme().background)
-                    .child(self.active_section_view.clone()),
+                    .child(
+                        div()
+                            .h_full()
+                            .w(self.sidebar_width)
+                            .flex()
+                            .flex_row()
+                            .child(div().h_full().flex_1().child(self.render_sidebar(cx)))
+                            .child(self.render_sidebar_grip(cx)),
+                    )
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_h_0()
+                            .h_full()
+                            .flex()
+                            .flex_col()
+                            .overflow_hidden()
+                            .bg(cx.theme().background)
+                            .child(self.active_section_view.clone()),
+                    ),
             )
             .when_some(self.pending_section_confirm, |element, target_section| {
                 let confirm_entity = cx.entity().clone();

--- a/crates/dbflux_ui/src/ui/windows/settings/render.rs
+++ b/crates/dbflux_ui/src/ui/windows/settings/render.rs
@@ -4,14 +4,14 @@ use crate::ui::icons::AppIcon;
 use crate::ui::tokens::Heights;
 use gpui::prelude::*;
 use gpui::*;
-use gpui_component::button::{Button, ButtonVariants};
-use gpui_component::dialog::Dialog;
 use gpui_component::ActiveTheme;
 use gpui_component::Sizable;
+use gpui_component::button::{Button, ButtonVariants};
+use gpui_component::dialog::Dialog;
 
 use super::{
-    SettingsCoordinator, SettingsFocus, SETTINGS_SIDEBAR_GRIP_WIDTH, SETTINGS_SIDEBAR_MAX_WIDTH,
-    SETTINGS_SIDEBAR_MIN_WIDTH,
+    SETTINGS_SIDEBAR_GRIP_WIDTH, SETTINGS_SIDEBAR_MAX_WIDTH, SETTINGS_SIDEBAR_MIN_WIDTH,
+    SettingsCoordinator, SettingsFocus,
 };
 
 const INDENT_PX: f32 = 16.0;

--- a/packaging/dbflux.desktop
+++ b/packaging/dbflux.desktop
@@ -4,7 +4,7 @@ Type=Application
 Name=DBFlux
 GenericName=Database Client
 Comment=A fast, keyboard-first database client for SQL and NoSQL databases
-Exec=env WAYLAND_DISPLAY= dbflux %F
+Exec=dbflux %F
 Icon=dbflux
 Terminal=false
 StartupNotify=true

--- a/resources/desktop/dbflux.desktop
+++ b/resources/desktop/dbflux.desktop
@@ -4,7 +4,7 @@ Type=Application
 Name=DBFlux
 GenericName=Database Client
 Comment=A fast, keyboard-first database client for SQL databases
-Exec=env WAYLAND_DISPLAY= @EXEC_PATH@ %F
+Exec=@EXEC_PATH@ %F
 Icon=dbflux
 Terminal=false
 StartupNotify=true


### PR DESCRIPTION
Closes #13

## Summary
- add Linux client-side decoration rendering for the main workspace and standalone secondary windows
- centralize decoration policy and title bar rendering in `crates/dbflux_ui/src/platform.rs`
- remove the desktop-level `WAYLAND_DISPLAY=` XWayland workaround from packaged launchers

## Changes
| File | Change |
|------|--------|
| `crates/dbflux_ui/src/platform.rs` | Added reusable Linux CSD helpers, title bar rendering, and centralized decoration policy |
| `crates/dbflux/src/main.rs` | Switched main window decoration setup to platform-managed policy |
| `crates/dbflux_ui/src/ui/views/workspace/render.rs` | Integrated custom CSD title bar into the main workspace window |
| `crates/dbflux_ui/src/ui/windows/settings/render.rs` | Integrated custom CSD title bar into Settings |
| `crates/dbflux_ui/src/ui/windows/connection_manager/render.rs` | Integrated custom CSD title bar into Connection Manager |
| `crates/dbflux_ui/src/ui/overlays/sso_wizard.rs` | Integrated custom CSD title bar into AWS SSO Wizard |
| `resources/desktop/dbflux.desktop` | Removed forced XWayland launcher behavior |
| `packaging/dbflux.desktop` | Removed forced XWayland launcher behavior |

## Test Plan
- [x] `cargo check --workspace`
- [ ] Manual GNOME Wayland smoke test
- [ ] Manual Hyprland/Wayland smoke test
- [ ] Manual X11 smoke test

## Notes
- This PR references issue #13 in the body as requested.
- Existing repository labels are used as-is.