### PR TITLE
fix(ui): expand command palette global search

### DIFF
--- a/crates/dbflux_ui/src/keymap/defaults.rs
+++ b/crates/dbflux_ui/src/keymap/defaults.rs
@@ -36,6 +36,10 @@ fn global_layer() -> KeymapLayer {
         KeyChord::new("p", Modifiers::ctrl_shift()),
         Command::ToggleCommandPalette,
     );
+    layer.bind(
+        KeyChord::new(":", Modifiers::none()),
+        Command::ToggleCommandPalette,
+    );
 
     // Tab management
     layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);

--- a/crates/dbflux_ui/src/ui/document/data_document.rs
+++ b/crates/dbflux_ui/src/ui/document/data_document.rs
@@ -214,6 +214,15 @@ impl DataDocument {
         self.data_grid.read(cx).source().table_ref().cloned()
     }
 
+    /// Returns the database name if this is a table document.
+    pub fn database(&self, cx: &App) -> Option<String> {
+        self.data_grid
+            .read(cx)
+            .source()
+            .database()
+            .map(|s| s.to_string())
+    }
+
     pub fn collection_ref(&self, cx: &App) -> Option<CollectionRef> {
         self.data_grid.read(cx).source().collection_ref().cloned()
     }

--- a/crates/dbflux_ui/src/ui/document/handle.rs
+++ b/crates/dbflux_ui/src/ui/document/handle.rs
@@ -97,6 +97,24 @@ impl DocumentHandle {
         }
     }
 
+    /// Checks if this is a table document matching the given table AND database.
+    /// Unlike `is_table`, this also compares the database field, which is necessary
+    /// when the same profile can browse tables across multiple databases.
+    pub fn is_table_with_database(
+        &self,
+        table: &dbflux_core::TableRef,
+        database: Option<&str>,
+        cx: &App,
+    ) -> bool {
+        match self {
+            Self::Data { entity, .. } => {
+                let doc = entity.read(cx);
+                doc.table_ref(cx).as_ref() == Some(table) && doc.database(cx).as_deref() == database
+            }
+            _ => false,
+        }
+    }
+
     pub fn is_collection(&self, collection: &dbflux_core::CollectionRef, cx: &App) -> bool {
         match self {
             Self::Data { entity, .. } => {
@@ -113,6 +131,15 @@ impl DocumentHandle {
                 doc.connection_id() == Some(profile_id) && doc.database_name() == database
             }
             _ => false,
+        }
+    }
+
+    /// Returns the connection (profile) ID for data and key-value documents.
+    pub fn connection_id(&self, cx: &App) -> Option<uuid::Uuid> {
+        match self {
+            Self::Data { entity, .. } => entity.read(cx).connection_id(cx),
+            Self::KeyValue { entity, .. } => entity.read(cx).connection_id(),
+            _ => None,
         }
     }
 

--- a/crates/dbflux_ui/src/ui/overlays/command_palette.rs
+++ b/crates/dbflux_ui/src/ui/overlays/command_palette.rs
@@ -1,11 +1,14 @@
 use crate::keymap::ContextId;
 use crate::ui::tokens::{FontSizes, Radii, Spacing};
+use dbflux_core::{CollectionRef, TableRef};
 use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::input::{Input, InputEvent, InputState};
 use gpui_component::{ActiveTheme, Sizable};
+use std::path::PathBuf;
+use uuid::Uuid;
 
 actions!(command_palette, [SelectNext, SelectPrev, Close, Execute]);
 
@@ -21,6 +24,195 @@ pub fn command_palette_keybindings() -> Vec<KeyBinding> {
     ]
 }
 
+/// A searchable item in the command palette.
+#[derive(Clone)]
+pub enum PaletteItem {
+    Action {
+        id: &'static str,
+        name: &'static str,
+        category: &'static str,
+        shortcut: Option<&'static str>,
+    },
+    Connection {
+        profile_id: Uuid,
+        name: String,
+        is_connected: bool,
+    },
+    Resource(ResourceItem),
+    Script {
+        /// Absolute filesystem path (used to open the script).
+        path: PathBuf,
+        /// File name (e.g., "health-check.sql").
+        name: String,
+        /// Path relative to the scripts root directory (for display/search).
+        relative_path: String,
+    },
+}
+
+/// Schema resource variants surfaced by connected profiles.
+#[derive(Clone)]
+pub enum ResourceItem {
+    Table {
+        profile_id: Uuid,
+        profile_name: String,
+        database: Option<String>,
+        schema: Option<String>,
+        name: String,
+    },
+    Collection {
+        profile_id: Uuid,
+        profile_name: String,
+        database: String,
+        name: String,
+    },
+    View {
+        profile_id: Uuid,
+        profile_name: String,
+        database: Option<String>,
+        schema: Option<String>,
+        name: String,
+    },
+    KeyValueDb {
+        profile_id: Uuid,
+        profile_name: String,
+        database: String,
+    },
+}
+
+impl PaletteItem {
+    /// Text searched by `SkimMatcherV2`.
+    pub fn search_text(&self) -> String {
+        match self {
+            Self::Action { category, name, .. } => format!("{} {}", category, name),
+            Self::Connection { name, .. } => format!("Connection {}", name),
+            Self::Resource(r) => match r {
+                ResourceItem::Table {
+                    profile_name,
+                    database,
+                    schema,
+                    name,
+                    ..
+                } => {
+                    let mut parts = format!("Table {} {}", profile_name, name);
+                    if let Some(db) = database {
+                        parts.push_str(&format!(" {}", db));
+                    }
+                    if let Some(s) = schema {
+                        parts.push_str(&format!(" {}", s));
+                    }
+                    parts
+                }
+                ResourceItem::Collection {
+                    profile_name,
+                    database,
+                    name,
+                    ..
+                } => format!("Collection {} {} {}", profile_name, name, database),
+                ResourceItem::View {
+                    profile_name,
+                    database,
+                    schema,
+                    name,
+                    ..
+                } => {
+                    let mut parts = format!("View {} {}", profile_name, name);
+                    if let Some(db) = database {
+                        parts.push_str(&format!(" {}", db));
+                    }
+                    if let Some(s) = schema {
+                        parts.push_str(&format!(" {}", s));
+                    }
+                    parts
+                }
+                ResourceItem::KeyValueDb {
+                    profile_name,
+                    database,
+                    ..
+                } => format!("Keyspace {} {}", profile_name, database),
+            },
+            Self::Script {
+                name,
+                relative_path,
+                ..
+            } => {
+                format!("Script {} {}", name, relative_path)
+            }
+        }
+    }
+
+    /// Returns `(category_label, display_name)`.
+    pub fn display_label(&self) -> (String, String) {
+        match self {
+            Self::Action { category, name, .. } => (category.to_string(), name.to_string()),
+            Self::Connection { name, .. } => ("Connection".to_string(), name.clone()),
+            Self::Resource(r) => match r {
+                ResourceItem::Table { name, .. } => ("Table".to_string(), name.clone()),
+                ResourceItem::Collection { name, .. } => ("Collection".to_string(), name.clone()),
+                ResourceItem::View { name, .. } => ("View".to_string(), name.clone()),
+                ResourceItem::KeyValueDb { database, .. } => {
+                    ("Keyspace".to_string(), database.clone())
+                }
+            },
+            Self::Script { name, .. } => ("Script".to_string(), name.clone()),
+        }
+    }
+
+    /// Type priority for tiebreaking (lower = higher priority).
+    pub fn type_priority(&self) -> u8 {
+        match self {
+            Self::Action { .. } => 0,
+            Self::Connection { .. } => 1,
+            Self::Resource(_) => 2,
+            Self::Script { .. } => 3,
+        }
+    }
+
+    /// Optional qualifier text shown after the item name.
+    pub fn qualifier(&self) -> Option<String> {
+        match self {
+            Self::Action { shortcut, .. } => shortcut.map(|s| s.to_string()),
+            Self::Resource(r) => match r {
+                ResourceItem::Table {
+                    profile_name,
+                    database,
+                    schema,
+                    ..
+                }
+                | ResourceItem::View {
+                    profile_name,
+                    database,
+                    schema,
+                    ..
+                } => {
+                    let mut parts = profile_name.clone();
+                    if let Some(db) = database {
+                        parts.push_str(&format!(" / {}", db));
+                    }
+                    if let Some(s) = schema {
+                        parts.push_str(&format!(" / {}", s));
+                    }
+                    Some(parts)
+                }
+                ResourceItem::Collection {
+                    profile_name,
+                    database,
+                    ..
+                } => Some(format!("{} / {}", profile_name, database)),
+                ResourceItem::KeyValueDb { profile_name, .. } => Some(profile_name.clone()),
+            },
+            Self::Script { relative_path, .. } => {
+                if relative_path.contains('/') {
+                    Some(relative_path.clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Legacy static command descriptor kept for `default_commands()` backwards compat.
 #[derive(Clone)]
 pub struct PaletteCommand {
     pub id: &'static str,
@@ -45,7 +237,18 @@ impl PaletteCommand {
     }
 }
 
-struct FilteredCommand {
+impl From<PaletteCommand> for PaletteItem {
+    fn from(cmd: PaletteCommand) -> Self {
+        PaletteItem::Action {
+            id: cmd.id,
+            name: cmd.name,
+            category: cmd.category,
+            shortcut: cmd.shortcut,
+        }
+    }
+}
+
+struct FilteredItem {
     index: usize,
     score: i64,
 }
@@ -54,23 +257,51 @@ const VISIBLE_ITEMS: usize = 8;
 
 pub struct CommandPalette {
     visible: bool,
-    commands: Vec<PaletteCommand>,
-    filtered: Vec<FilteredCommand>,
+    items: Vec<PaletteItem>,
+    filtered: Vec<FilteredItem>,
     selected_index: usize,
     scroll_offset: usize,
     input_state: Entity<InputState>,
     matcher: SkimMatcherV2,
 }
 
-pub struct CommandExecuted {
-    pub command_id: &'static str,
+/// Event emitted when the user selects a palette item.
+pub enum PaletteSelection {
+    Command {
+        id: &'static str,
+    },
+    Connect {
+        profile_id: Uuid,
+    },
+    OpenTable {
+        profile_id: Uuid,
+        table: TableRef,
+        database: Option<String>,
+    },
+    OpenCollection {
+        profile_id: Uuid,
+        collection: CollectionRef,
+    },
+    OpenKeyValue {
+        profile_id: Uuid,
+        database: String,
+    },
+    FocusConnection {
+        profile_id: Uuid,
+    },
+    OpenScript {
+        path: PathBuf,
+    },
 }
 
 pub struct CommandPaletteClosed;
 
 impl CommandPalette {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let input_state = cx.new(|cx| InputState::new(window, cx).placeholder("Type a command..."));
+        let input_state = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder("Search commands, connections, tables, scripts...")
+        });
 
         cx.subscribe_in(
             &input_state,
@@ -90,7 +321,7 @@ impl CommandPalette {
 
         Self {
             visible: false,
-            commands: Vec::new(),
+            items: Vec::new(),
             filtered: Vec::new(),
             selected_index: 0,
             scroll_offset: 0,
@@ -99,14 +330,36 @@ impl CommandPalette {
         }
     }
 
-    pub fn register_commands(&mut self, commands: Vec<PaletteCommand>) {
-        self.commands = commands;
+    /// Set items and reset filter state. Called by Workspace on each toggle.
+    pub fn open_with_items(
+        &mut self,
+        items: Vec<PaletteItem>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.items = items;
         self.filtered = self
-            .commands
+            .items
             .iter()
             .enumerate()
-            .map(|(index, _)| FilteredCommand { index, score: 0 })
+            .map(|(index, _)| FilteredItem { index, score: 0 })
             .collect();
+
+        self.visible = true;
+        self.selected_index = 0;
+        self.scroll_offset = 0;
+
+        self.input_state.update(cx, |state, cx| {
+            state.set_value("", window, cx);
+            state.focus(window, cx);
+        });
+
+        cx.notify();
+    }
+
+    pub fn register_commands(&mut self, _commands: Vec<PaletteCommand>) {
+        // No-op; items are now set via open_with_items.
+        // Kept to avoid breaking the call site during migration.
     }
 
     pub fn toggle(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -120,10 +373,10 @@ impl CommandPalette {
             self.selected_index = 0;
             self.scroll_offset = 0;
             self.filtered = self
-                .commands
+                .items
                 .iter()
                 .enumerate()
-                .map(|(index, _)| FilteredCommand { index, score: 0 })
+                .map(|(index, _)| FilteredItem { index, score: 0 })
                 .collect();
         }
 
@@ -144,25 +397,32 @@ impl CommandPalette {
     fn update_filter(&mut self, query: &str, cx: &mut Context<Self>) {
         if query.is_empty() {
             self.filtered = self
-                .commands
+                .items
                 .iter()
                 .enumerate()
-                .map(|(index, _)| FilteredCommand { index, score: 0 })
+                .map(|(index, _)| FilteredItem { index, score: 0 })
                 .collect();
         } else {
-            let mut scored: Vec<FilteredCommand> = self
-                .commands
+            let mut scored: Vec<FilteredItem> = self
+                .items
                 .iter()
                 .enumerate()
-                .filter_map(|(index, cmd)| {
-                    let search_text = format!("{} {}", cmd.category, cmd.name);
+                .filter_map(|(index, item)| {
+                    let search_text = item.search_text();
                     self.matcher
                         .fuzzy_match(&search_text, query)
-                        .map(|score| FilteredCommand { index, score })
+                        .map(|score| FilteredItem { index, score })
                 })
                 .collect();
 
-            scored.sort_by_key(|s| std::cmp::Reverse(s.score));
+            scored.sort_by(|a, b| {
+                b.score.cmp(&a.score).then_with(|| {
+                    self.items[a.index]
+                        .type_priority()
+                        .cmp(&self.items[b.index].type_priority())
+                })
+            });
+
             self.filtered = scored;
         }
 
@@ -192,18 +452,15 @@ impl CommandPalette {
     }
 
     fn ensure_selected_visible(&mut self) {
-        // If selected is above visible window, scroll up
         if self.selected_index < self.scroll_offset {
             self.scroll_offset = self.selected_index;
         }
-        // If selected is below visible window, scroll down
         if self.selected_index >= self.scroll_offset + VISIBLE_ITEMS {
             self.scroll_offset = self.selected_index - VISIBLE_ITEMS + 1;
         }
     }
 
     fn scroll_down(&mut self, cx: &mut Context<Self>) {
-        // Move selection down (same as select_next but doesn't wrap)
         if self.selected_index < self.filtered.len().saturating_sub(1) {
             self.selected_index += 1;
             self.ensure_selected_visible();
@@ -212,7 +469,6 @@ impl CommandPalette {
     }
 
     fn scroll_up(&mut self, cx: &mut Context<Self>) {
-        // Move selection up (same as select_prev but doesn't wrap)
         if self.selected_index > 0 {
             self.selected_index -= 1;
             self.ensure_selected_visible();
@@ -222,37 +478,141 @@ impl CommandPalette {
 
     fn execute_selected(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         if let Some(filtered) = self.filtered.get(self.selected_index)
-            && let Some(cmd) = self.commands.get(filtered.index)
+            && let Some(item) = self.items.get(filtered.index)
         {
-            let command_id = cmd.id;
+            let selection = match item {
+                PaletteItem::Action { id, .. } => PaletteSelection::Command { id },
+                PaletteItem::Connection {
+                    profile_id,
+                    is_connected,
+                    ..
+                } => {
+                    if *is_connected {
+                        PaletteSelection::FocusConnection {
+                            profile_id: *profile_id,
+                        }
+                    } else {
+                        PaletteSelection::Connect {
+                            profile_id: *profile_id,
+                        }
+                    }
+                }
+                PaletteItem::Resource(r) => match r {
+                    ResourceItem::Table {
+                        profile_id,
+                        schema,
+                        name,
+                        database,
+                        ..
+                    }
+                    | ResourceItem::View {
+                        profile_id,
+                        schema,
+                        name,
+                        database,
+                        ..
+                    } => PaletteSelection::OpenTable {
+                        profile_id: *profile_id,
+                        table: TableRef {
+                            schema: schema.clone(),
+                            name: name.clone(),
+                        },
+                        database: database.clone(),
+                    },
+                    ResourceItem::Collection {
+                        profile_id,
+                        database,
+                        name,
+                        ..
+                    } => PaletteSelection::OpenCollection {
+                        profile_id: *profile_id,
+                        collection: CollectionRef {
+                            database: database.clone(),
+                            name: name.clone(),
+                        },
+                    },
+                    ResourceItem::KeyValueDb {
+                        profile_id,
+                        database,
+                        ..
+                    } => PaletteSelection::OpenKeyValue {
+                        profile_id: *profile_id,
+                        database: database.clone(),
+                    },
+                },
+                PaletteItem::Script { path, .. } => {
+                    PaletteSelection::OpenScript { path: path.clone() }
+                }
+            };
+
             self.visible = false;
-            cx.emit(CommandExecuted { command_id });
+            cx.emit(selection);
             cx.notify();
         }
     }
 
-    fn render_command_item(
+    fn render_palette_item(
         idx: usize,
-        cmd: PaletteCommand,
+        item: &PaletteItem,
         is_selected: bool,
         theme: &gpui_component::theme::Theme,
     ) -> Stateful<Div> {
-        let shortcut_el = cmd.shortcut.map(|shortcut| {
-            div()
-                .px(Spacing::SM)
-                .py(Spacing::XS)
-                .rounded(Radii::SM)
-                .text_size(FontSizes::XS)
-                .font_family("monospace")
-                .when(is_selected, |d| {
-                    d.bg(theme.primary_foreground.opacity(0.2))
-                        .text_color(theme.primary_foreground)
-                })
-                .when(!is_selected, |d| {
-                    d.bg(theme.secondary).text_color(theme.muted_foreground)
-                })
-                .child(shortcut)
-        });
+        let (category, name) = item.display_label();
+
+        let right_el = match item {
+            PaletteItem::Action { shortcut, .. } => shortcut.map(|s| {
+                div()
+                    .px(Spacing::SM)
+                    .py(Spacing::XS)
+                    .rounded(Radii::SM)
+                    .text_size(FontSizes::XS)
+                    .font_family("monospace")
+                    .when(is_selected, |d| {
+                        d.bg(theme.primary_foreground.opacity(0.2))
+                            .text_color(theme.primary_foreground)
+                    })
+                    .when(!is_selected, |d| {
+                        d.bg(theme.secondary).text_color(theme.muted_foreground)
+                    })
+                    .child(s)
+            }),
+            PaletteItem::Connection { is_connected, .. } => {
+                let indicator = if *is_connected {
+                    div()
+                        .size(px(8.0))
+                        .rounded_full()
+                        .bg(gpui::green())
+                        .when(is_selected, |d| {
+                            d.border_1()
+                                .border_color(theme.primary_foreground.opacity(0.5))
+                        })
+                } else {
+                    div()
+                        .size(px(8.0))
+                        .rounded_full()
+                        .bg(theme.muted_foreground.opacity(0.4))
+                };
+                Some(indicator)
+            }
+            PaletteItem::Resource(_) => item.qualifier().map(|q| {
+                div()
+                    .text_size(FontSizes::XS)
+                    .when(is_selected, |d| {
+                        d.text_color(theme.primary_foreground.opacity(0.6))
+                    })
+                    .when(!is_selected, |d| d.text_color(theme.muted_foreground))
+                    .child(q)
+            }),
+            PaletteItem::Script { .. } => item.qualifier().map(|q| {
+                div()
+                    .text_size(FontSizes::XS)
+                    .when(is_selected, |d| {
+                        d.text_color(theme.primary_foreground.opacity(0.6))
+                    })
+                    .when(!is_selected, |d| d.text_color(theme.muted_foreground))
+                    .child(q)
+            }),
+        };
 
         div()
             .id(("cmd", idx))
@@ -284,20 +644,20 @@ impl CommandPalette {
                                 d.text_color(theme.primary_foreground.opacity(0.7))
                             })
                             .when(!is_selected, |d| d.text_color(theme.muted_foreground))
-                            .child(cmd.category),
+                            .child(category),
                     )
                     .child(
                         div()
                             .text_size(FontSizes::SM)
                             .font_weight(FontWeight::MEDIUM)
-                            .child(cmd.name),
+                            .child(name),
                     ),
             )
-            .when_some(shortcut_el, |d, el| d.child(el))
+            .when_some(right_el, |d, el| d.child(el))
     }
 }
 
-impl EventEmitter<CommandExecuted> for CommandPalette {}
+impl EventEmitter<PaletteSelection> for CommandPalette {}
 impl EventEmitter<CommandPaletteClosed> for CommandPalette {}
 
 impl Render for CommandPalette {
@@ -309,16 +669,16 @@ impl Render for CommandPalette {
         let theme = cx.theme();
         let input_state = self.input_state.clone();
 
-        let commands_to_render: Vec<(usize, PaletteCommand, bool)> = self
+        let items_to_render: Vec<(usize, PaletteItem, bool)> = self
             .filtered
             .iter()
             .enumerate()
             .skip(self.scroll_offset)
             .take(VISIBLE_ITEMS)
             .map(|(idx, filtered)| {
-                let cmd = self.commands[filtered.index].clone();
+                let item = self.items[filtered.index].clone();
                 let is_selected = idx == self.selected_index;
-                (idx, cmd, is_selected)
+                (idx, item, is_selected)
             })
             .collect();
 
@@ -388,9 +748,9 @@ impl Render for CommandPalette {
                                     }
                                 },
                             ))
-                            .children(commands_to_render.into_iter().map(
-                                |(idx, cmd, is_selected)| {
-                                    Self::render_command_item(idx, cmd, is_selected, theme)
+                            .children(items_to_render.into_iter().map(
+                                |(idx, item, is_selected)| {
+                                    Self::render_palette_item(idx, &item, is_selected, theme)
                                         .on_mouse_down(MouseButton::Left, |_, _, cx| {
                                             cx.stop_propagation();
                                         })
@@ -409,7 +769,7 @@ impl Render for CommandPalette {
                                         .justify_center()
                                         .text_size(FontSizes::SM)
                                         .text_color(theme.muted_foreground)
-                                        .child("No matching commands"),
+                                        .child("No matching items"),
                                 )
                             }),
                     )
@@ -433,7 +793,7 @@ impl Render for CommandPalette {
                                     .child("↵ Execute")
                                     .child("Esc Close"),
                             )
-                            .child(format!("{} commands", self.filtered.len())),
+                            .child(format!("{} items", self.filtered.len())),
                     ),
             )
             .into_any_element()

--- a/crates/dbflux_ui/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions.rs
@@ -317,7 +317,10 @@ impl Workspace {
                 .read(cx)
                 .documents()
                 .iter()
-                .find(|doc| doc.is_table(&table, cx))
+                .find(|doc| {
+                    doc.is_table_with_database(&table, database.as_deref(), cx)
+                        && doc.connection_id(cx) == Some(profile_id)
+                })
                 .map(|doc| doc.id())
         } else {
             None
@@ -382,7 +385,9 @@ impl Workspace {
                 .read(cx)
                 .documents()
                 .iter()
-                .find(|doc| doc.is_collection(&collection, cx))
+                .find(|doc| {
+                    doc.is_collection(&collection, cx) && doc.connection_id(cx) == Some(profile_id)
+                })
                 .map(|doc| doc.id())
         } else {
             None
@@ -1272,5 +1277,935 @@ mod tests {
         let result =
             Workspace::strip_annotation_header(content, &dbflux_core::QueryLanguage::RedisCommands);
         assert_eq!(result, "GET key");
+    }
+
+    // --- PaletteItem model tests ---
+
+    use crate::ui::overlays::command_palette::{PaletteItem, PaletteSelection, ResourceItem};
+    use crate::ui::views::workspace::{build_resource_items_from_schema, map_item_to_selection};
+    use dbflux_core::{
+        CollectionInfo, DataStructure, DbSchemaInfo, DocumentSchema, KeySpaceInfo, KeyValueSchema,
+        RelationalSchema, ScriptEntry, TableInfo, ViewInfo,
+    };
+    use fuzzy_matcher::FuzzyMatcher;
+    use fuzzy_matcher::skim::SkimMatcherV2;
+    use std::path::{Path, PathBuf};
+
+    fn sample_action() -> PaletteItem {
+        PaletteItem::Action {
+            id: "new_query_tab",
+            name: "New Query Tab",
+            category: "Editor",
+            shortcut: Some("Ctrl+N"),
+        }
+    }
+
+    fn sample_connection(name: &str, connected: bool) -> PaletteItem {
+        PaletteItem::Connection {
+            profile_id: Uuid::new_v4(),
+            name: name.to_string(),
+            is_connected: connected,
+        }
+    }
+
+    fn sample_table(profile_name: &str, name: &str) -> PaletteItem {
+        PaletteItem::Resource(ResourceItem::Table {
+            profile_id: Uuid::new_v4(),
+            profile_name: profile_name.to_string(),
+            database: Some("main".to_string()),
+            schema: Some("public".to_string()),
+            name: name.to_string(),
+        })
+    }
+
+    fn sample_view(profile_name: &str, name: &str) -> PaletteItem {
+        PaletteItem::Resource(ResourceItem::View {
+            profile_id: Uuid::new_v4(),
+            profile_name: profile_name.to_string(),
+            database: Some("main".to_string()),
+            schema: Some("public".to_string()),
+            name: name.to_string(),
+        })
+    }
+
+    fn sample_script(name: &str) -> PaletteItem {
+        PaletteItem::Script {
+            path: PathBuf::from(format!("{}.sql", name)),
+            name: name.to_string(),
+            relative_path: format!("{}.sql", name),
+        }
+    }
+
+    #[test]
+    fn palette_item_search_text_includes_relevant_fields() {
+        let action = sample_action();
+        assert!(action.search_text().contains("Editor"));
+        assert!(action.search_text().contains("New Query Tab"));
+
+        let conn = sample_connection("prod-pg", true);
+        assert!(conn.search_text().contains("Connection"));
+        assert!(conn.search_text().contains("prod-pg"));
+
+        let table = sample_table("prod-pg", "orders");
+        assert!(table.search_text().contains("Table"));
+        assert!(table.search_text().contains("prod-pg"));
+        assert!(table.search_text().contains("orders"));
+        assert!(
+            table.search_text().contains("main"),
+            "search_text should include database"
+        );
+        assert!(
+            table.search_text().contains("public"),
+            "search_text should include schema"
+        );
+
+        let view = sample_view("prod-pg", "active_users");
+        assert!(view.search_text().contains("View"));
+        assert!(view.search_text().contains("active_users"));
+        assert!(view.search_text().contains("main"));
+
+        let script = sample_script("health-check");
+        assert!(script.search_text().contains("Script"));
+        assert!(script.search_text().contains("health-check"));
+    }
+
+    #[test]
+    fn palette_item_search_text_table_without_schema() {
+        let table = PaletteItem::Resource(ResourceItem::Table {
+            profile_id: Uuid::new_v4(),
+            profile_name: "sqlite-local".to_string(),
+            database: None,
+            schema: None,
+            name: "notes".to_string(),
+        });
+        let text = table.search_text();
+        assert!(text.contains("Table"));
+        assert!(text.contains("sqlite-local"));
+        assert!(text.contains("notes"));
+    }
+
+    #[test]
+    fn palette_item_search_text_collection_includes_database() {
+        let collection = PaletteItem::Resource(ResourceItem::Collection {
+            profile_id: Uuid::new_v4(),
+            profile_name: "mongo-prod".to_string(),
+            database: "analytics".to_string(),
+            name: "events".to_string(),
+        });
+        let text = collection.search_text();
+        assert!(text.contains("Collection"));
+        assert!(text.contains("analytics"));
+        assert!(text.contains("events"));
+    }
+
+    #[test]
+    fn palette_item_type_priority_ordering() {
+        let action = sample_action();
+        let connection = sample_connection("test", false);
+        let resource = sample_table("test", "t");
+        let script = sample_script("test");
+
+        assert_eq!(action.type_priority(), 0);
+        assert_eq!(connection.type_priority(), 1);
+        assert_eq!(resource.type_priority(), 2);
+        assert_eq!(script.type_priority(), 3);
+
+        assert!(action.type_priority() < connection.type_priority());
+        assert!(connection.type_priority() < resource.type_priority());
+        assert!(resource.type_priority() < script.type_priority());
+    }
+
+    #[test]
+    fn palette_item_display_label_returns_category_and_name() {
+        let action = sample_action();
+        let (cat, name) = action.display_label();
+        assert_eq!(cat, "Editor");
+        assert_eq!(name, "New Query Tab");
+
+        let conn = sample_connection("prod-pg", true);
+        let (cat, name) = conn.display_label();
+        assert_eq!(cat, "Connection");
+        assert_eq!(name, "prod-pg");
+
+        let table = sample_table("prod-pg", "orders");
+        let (cat, name) = table.display_label();
+        assert_eq!(cat, "Table");
+        assert_eq!(name, "orders");
+
+        let view = sample_view("prod-pg", "active_users");
+        let (cat, name) = view.display_label();
+        assert_eq!(cat, "View");
+        assert_eq!(name, "active_users");
+
+        let script = sample_script("health-check");
+        let (cat, name) = script.display_label();
+        assert_eq!(cat, "Script");
+        assert_eq!(name, "health-check");
+    }
+
+    #[test]
+    fn palette_item_qualifier_resources_show_profile_name() {
+        let table = sample_table("prod-pg", "orders");
+        assert!(table.qualifier().unwrap().contains("prod-pg"));
+        assert!(table.qualifier().unwrap().contains("main"));
+
+        let view = sample_view("prod-pg", "active_users");
+        assert!(view.qualifier().unwrap().contains("prod-pg"));
+    }
+
+    #[test]
+    fn palette_filtering_sorts_by_score_descending_with_type_tiebreaker() {
+        let matcher = SkimMatcherV2::default();
+
+        let items: Vec<PaletteItem> = vec![
+            sample_script("prod-health"),
+            sample_connection("prod-pg", true),
+            sample_action(), // "New Query Tab" — does not match "prod"
+        ];
+
+        let matched: Vec<(usize, i64)> = items
+            .iter()
+            .enumerate()
+            .filter_map(|(i, item)| {
+                matcher
+                    .fuzzy_match(&item.search_text(), "prod")
+                    .map(|score| (i, score))
+            })
+            .collect();
+
+        // Only script and connection match "prod"
+        assert_eq!(matched.len(), 2);
+
+        // Both match — verify type-priority ordering at equal scores
+        let mut sorted = matched.clone();
+        sorted.sort_by(|a, b| {
+            b.1.cmp(&a.1)
+                .then_with(|| items[a.0].type_priority().cmp(&items[b.0].type_priority()))
+        });
+
+        // Connection (priority 1) should come before Script (priority 3) at equal scores
+        assert!(items[sorted[0].0].type_priority() <= items[sorted[1].0].type_priority());
+    }
+
+    #[test]
+    fn palette_item_view_and_table_have_same_priority() {
+        let table = sample_table("p", "t");
+        let view = sample_view("p", "v");
+        assert_eq!(table.type_priority(), view.type_priority());
+    }
+
+    // --- Resource item building from schema ---
+
+    #[test]
+    fn build_resources_from_relational_schema() {
+        let pid = Uuid::new_v4();
+        let mut items = Vec::new();
+
+        let structure = DataStructure::Relational(RelationalSchema {
+            current_database: Some("mydb".to_string()),
+            tables: vec![
+                TableInfo {
+                    name: "users".to_string(),
+                    schema: Some("public".to_string()),
+                    columns: None,
+                    indexes: None,
+                    foreign_keys: None,
+                    constraints: None,
+                    sample_fields: None,
+                },
+                TableInfo {
+                    name: "orders".to_string(),
+                    schema: Some("public".to_string()),
+                    columns: None,
+                    indexes: None,
+                    foreign_keys: None,
+                    constraints: None,
+                    sample_fields: None,
+                },
+            ],
+            views: vec![ViewInfo {
+                name: "active_users".to_string(),
+                schema: Some("public".to_string()),
+            }],
+            ..Default::default()
+        });
+
+        build_resource_items_from_schema(pid, "prod-pg", &structure, &mut items);
+
+        assert_eq!(items.len(), 3);
+
+        let table_names: Vec<&str> = items
+            .iter()
+            .filter_map(|item| match item {
+                PaletteItem::Resource(ResourceItem::Table { name, .. }) => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(table_names.contains(&"users"));
+        assert!(table_names.contains(&"orders"));
+
+        let view_count = items
+            .iter()
+            .filter(|item| matches!(item, PaletteItem::Resource(ResourceItem::View { .. })))
+            .count();
+        assert_eq!(view_count, 1);
+    }
+
+    #[test]
+    fn build_resources_from_relational_schema_with_nested_schemas() {
+        let pid = Uuid::new_v4();
+        let mut items = Vec::new();
+
+        let structure = DataStructure::Relational(RelationalSchema {
+            current_database: Some("mydb".to_string()),
+            tables: vec![],
+            views: vec![],
+            schemas: vec![DbSchemaInfo {
+                name: "app_schema".to_string(),
+                tables: vec![TableInfo {
+                    name: "products".to_string(),
+                    schema: Some("app_schema".to_string()),
+                    columns: None,
+                    indexes: None,
+                    foreign_keys: None,
+                    constraints: None,
+                    sample_fields: None,
+                }],
+                views: vec![],
+                custom_types: None,
+            }],
+            ..Default::default()
+        });
+
+        build_resource_items_from_schema(pid, "pg-prod", &structure, &mut items);
+
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            PaletteItem::Resource(ResourceItem::Table {
+                database,
+                schema,
+                name,
+                ..
+            }) => {
+                assert_eq!(database.as_deref(), Some("mydb"));
+                assert_eq!(schema.as_deref(), Some("app_schema"));
+                assert_eq!(name, "products");
+            }
+            _ => panic!("Expected Table resource"),
+        }
+    }
+
+    #[test]
+    fn build_resources_from_document_schema() {
+        let pid = Uuid::new_v4();
+        let mut items = Vec::new();
+
+        let structure = DataStructure::Document(DocumentSchema {
+            current_database: Some("shop".to_string()),
+            collections: vec![
+                CollectionInfo {
+                    name: "products".to_string(),
+                    database: Some("shop".to_string()),
+                    document_count: None,
+                    avg_document_size: None,
+                    sample_fields: None,
+                    indexes: None,
+                    validator: None,
+                    is_capped: false,
+                },
+                CollectionInfo {
+                    name: "orders".to_string(),
+                    database: None,
+                    document_count: None,
+                    avg_document_size: None,
+                    sample_fields: None,
+                    indexes: None,
+                    validator: None,
+                    is_capped: false,
+                },
+            ],
+            ..Default::default()
+        });
+
+        build_resource_items_from_schema(pid, "mongo-prod", &structure, &mut items);
+
+        assert_eq!(items.len(), 2);
+
+        match &items[0] {
+            PaletteItem::Resource(ResourceItem::Collection { database, name, .. }) => {
+                assert_eq!(database, "shop");
+                assert_eq!(name, "products");
+            }
+            _ => panic!("Expected Collection resource"),
+        }
+
+        // Second collection falls back to current_database
+        match &items[1] {
+            PaletteItem::Resource(ResourceItem::Collection { database, name, .. }) => {
+                assert_eq!(database, "shop");
+                assert_eq!(name, "orders");
+            }
+            _ => panic!("Expected Collection resource"),
+        }
+    }
+
+    #[test]
+    fn build_resources_from_keyvalue_schema() {
+        let pid = Uuid::new_v4();
+        let mut items = Vec::new();
+
+        let structure = DataStructure::KeyValue(KeyValueSchema {
+            keyspaces: vec![
+                KeySpaceInfo {
+                    db_index: 0,
+                    key_count: Some(100),
+                    memory_bytes: None,
+                    avg_ttl_seconds: None,
+                },
+                KeySpaceInfo {
+                    db_index: 1,
+                    key_count: Some(50),
+                    memory_bytes: None,
+                    avg_ttl_seconds: None,
+                },
+            ],
+            ..Default::default()
+        });
+
+        build_resource_items_from_schema(pid, "redis-prod", &structure, &mut items);
+
+        assert_eq!(items.len(), 2);
+
+        match &items[0] {
+            PaletteItem::Resource(ResourceItem::KeyValueDb { database, .. }) => {
+                assert_eq!(database, "db0");
+            }
+            _ => panic!("Expected KeyValueDb resource"),
+        }
+        match &items[1] {
+            PaletteItem::Resource(ResourceItem::KeyValueDb { database, .. }) => {
+                assert_eq!(database, "db1");
+            }
+            _ => panic!("Expected KeyValueDb resource"),
+        }
+    }
+
+    #[test]
+    fn build_resources_ignores_unsupported_schema_types() {
+        let pid = Uuid::new_v4();
+        let mut items = Vec::new();
+
+        let structure = DataStructure::Graph(Default::default());
+        build_resource_items_from_schema(pid, "neo4j", &structure, &mut items);
+
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn build_resources_empty_schema_produces_no_items() {
+        let pid = Uuid::new_v4();
+        let mut items = Vec::new();
+
+        let structure = DataStructure::Relational(RelationalSchema {
+            current_database: None,
+            tables: vec![],
+            views: vec![],
+            schemas: vec![],
+            ..Default::default()
+        });
+
+        build_resource_items_from_schema(pid, "empty", &structure, &mut items);
+        assert!(items.is_empty());
+    }
+
+    // --- Script flattening tests ---
+
+    #[test]
+    fn flatten_script_entries_includes_openable_files() {
+        let entries = vec![
+            ScriptEntry::File {
+                path: PathBuf::from("/scripts/query.sql"),
+                name: "query.sql".to_string(),
+                extension: "sql".to_string(),
+            },
+            ScriptEntry::File {
+                path: PathBuf::from("/scripts/hook.lua"),
+                name: "hook.lua".to_string(),
+                extension: "lua".to_string(),
+            },
+        ];
+
+        let mut items = Vec::new();
+        Workspace::flatten_script_entries(&entries, Path::new("/scripts"), &mut items);
+
+        assert_eq!(items.len(), 2);
+        match &items[0] {
+            PaletteItem::Script {
+                name,
+                relative_path,
+                ..
+            } => {
+                assert_eq!(name, "query.sql");
+                assert_eq!(relative_path, "query.sql");
+            }
+            _ => panic!("Expected Script item"),
+        }
+    }
+
+    #[test]
+    fn flatten_script_entries_skips_non_openable_files() {
+        let entries = vec![
+            ScriptEntry::File {
+                path: PathBuf::from("/scripts/data.csv"),
+                name: "data.csv".to_string(),
+                extension: "csv".to_string(),
+            },
+            ScriptEntry::File {
+                path: PathBuf::from("/scripts/query.sql"),
+                name: "query.sql".to_string(),
+                extension: "sql".to_string(),
+            },
+        ];
+
+        let mut items = Vec::new();
+        Workspace::flatten_script_entries(&entries, Path::new("/scripts"), &mut items);
+
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            PaletteItem::Script {
+                name,
+                relative_path,
+                ..
+            } => {
+                assert_eq!(name, "query.sql");
+                assert_eq!(relative_path, "query.sql");
+            }
+            _ => panic!("Expected Script item"),
+        }
+    }
+
+    #[test]
+    fn flatten_script_entries_recurses_into_folders() {
+        let entries = vec![ScriptEntry::Folder {
+            path: PathBuf::from("/scripts/migrations"),
+            name: "migrations".to_string(),
+            children: vec![
+                ScriptEntry::File {
+                    path: PathBuf::from("/scripts/migrations/001_init.sql"),
+                    name: "001_init.sql".to_string(),
+                    extension: "sql".to_string(),
+                },
+                ScriptEntry::File {
+                    path: PathBuf::from("/scripts/migrations/002_add_users.sql"),
+                    name: "002_add_users.sql".to_string(),
+                    extension: "sql".to_string(),
+                },
+            ],
+        }];
+
+        let mut items = Vec::new();
+        Workspace::flatten_script_entries(&entries, Path::new("/scripts"), &mut items);
+
+        assert_eq!(items.len(), 2);
+
+        // Verify nested files get relative paths with the folder prefix
+        match &items[0] {
+            PaletteItem::Script { relative_path, .. } => {
+                assert_eq!(relative_path, "migrations/001_init.sql");
+            }
+            _ => panic!("Expected Script item"),
+        }
+        match &items[1] {
+            PaletteItem::Script { relative_path, .. } => {
+                assert_eq!(relative_path, "migrations/002_add_users.sql");
+            }
+            _ => panic!("Expected Script item"),
+        }
+    }
+
+    // --- Selection routing (map_item_to_selection) ---
+
+    #[test]
+    fn selection_routing_action_produces_command() {
+        let item = PaletteItem::Action {
+            id: "new_query_tab",
+            name: "New Query Tab",
+            category: "Editor",
+            shortcut: Some("Ctrl+N"),
+        };
+
+        let sel = map_item_to_selection(&item).unwrap();
+        match sel {
+            PaletteSelection::Command { id } => assert_eq!(id, "new_query_tab"),
+            _ => panic!("Expected Command selection"),
+        }
+    }
+
+    #[test]
+    fn selection_routing_disconnected_profile_produces_connect() {
+        let pid = Uuid::new_v4();
+        let item = PaletteItem::Connection {
+            profile_id: pid,
+            name: "analytics".to_string(),
+            is_connected: false,
+        };
+
+        let sel = map_item_to_selection(&item).unwrap();
+        match sel {
+            PaletteSelection::Connect { profile_id } => assert_eq!(profile_id, pid),
+            _ => panic!("Expected Connect selection"),
+        }
+    }
+
+    #[test]
+    fn selection_routing_connected_profile_produces_focus_connection() {
+        let pid = Uuid::new_v4();
+        let item = PaletteItem::Connection {
+            profile_id: pid,
+            name: "prod-pg".to_string(),
+            is_connected: true,
+        };
+
+        let sel = map_item_to_selection(&item).unwrap();
+        match sel {
+            PaletteSelection::FocusConnection { profile_id } => assert_eq!(profile_id, pid),
+            _ => panic!("Expected FocusConnection selection"),
+        }
+    }
+
+    #[test]
+    fn selection_routing_table_produces_open_table() {
+        let pid = Uuid::new_v4();
+        let item = PaletteItem::Resource(ResourceItem::Table {
+            profile_id: pid,
+            profile_name: "prod".to_string(),
+            database: Some("mydb".to_string()),
+            schema: Some("public".to_string()),
+            name: "orders".to_string(),
+        });
+
+        let sel = map_item_to_selection(&item).unwrap();
+        match sel {
+            PaletteSelection::OpenTable {
+                profile_id,
+                table,
+                database,
+            } => {
+                assert_eq!(profile_id, pid);
+                assert_eq!(table.name, "orders");
+                assert_eq!(table.schema.as_deref(), Some("public"));
+                assert_eq!(database.as_deref(), Some("mydb"));
+            }
+            _ => panic!("Expected OpenTable selection"),
+        }
+    }
+
+    #[test]
+    fn selection_routing_view_produces_open_table_same_as_sidebar() {
+        let pid = Uuid::new_v4();
+        let item = PaletteItem::Resource(ResourceItem::View {
+            profile_id: pid,
+            profile_name: "prod".to_string(),
+            database: Some("mydb".to_string()),
+            schema: Some("public".to_string()),
+            name: "active_users".to_string(),
+        });
+
+        let sel = map_item_to_selection(&item).unwrap();
+        match sel {
+            PaletteSelection::OpenTable { table, .. } => {
+                assert_eq!(table.name, "active_users");
+            }
+            _ => panic!("Expected OpenTable selection (views route like tables)"),
+        }
+    }
+
+    #[test]
+    fn selection_routing_collection_produces_open_collection() {
+        let pid = Uuid::new_v4();
+        let item = PaletteItem::Resource(ResourceItem::Collection {
+            profile_id: pid,
+            profile_name: "mongo-prod".to_string(),
+            database: "shop".to_string(),
+            name: "products".to_string(),
+        });
+
+        let sel = map_item_to_selection(&item).unwrap();
+        match sel {
+            PaletteSelection::OpenCollection {
+                profile_id,
+                collection,
+            } => {
+                assert_eq!(profile_id, pid);
+                assert_eq!(collection.database, "shop");
+                assert_eq!(collection.name, "products");
+            }
+            _ => panic!("Expected OpenCollection selection"),
+        }
+    }
+
+    #[test]
+    fn selection_routing_keyvalue_produces_open_key_value() {
+        let pid = Uuid::new_v4();
+        let item = PaletteItem::Resource(ResourceItem::KeyValueDb {
+            profile_id: pid,
+            profile_name: "redis-prod".to_string(),
+            database: "db0".to_string(),
+        });
+
+        let sel = map_item_to_selection(&item).unwrap();
+        match sel {
+            PaletteSelection::OpenKeyValue {
+                profile_id,
+                database,
+            } => {
+                assert_eq!(profile_id, pid);
+                assert_eq!(database, "db0");
+            }
+            _ => panic!("Expected OpenKeyValue selection"),
+        }
+    }
+
+    #[test]
+    fn selection_routing_script_produces_open_script() {
+        let path = PathBuf::from("/scripts/health-check.sql");
+        let item = PaletteItem::Script {
+            path: path.clone(),
+            name: "health-check".to_string(),
+            relative_path: "health-check.sql".to_string(),
+        };
+
+        let sel = map_item_to_selection(&item).unwrap();
+        match sel {
+            PaletteSelection::OpenScript { path: p } => assert_eq!(p, path),
+            _ => panic!("Expected OpenScript selection"),
+        }
+    }
+
+    // --- Disambiguation scenarios ---
+
+    #[test]
+    fn two_connections_same_table_name_are_distinguished_by_profile() {
+        let pid1 = Uuid::new_v4();
+        let pid2 = Uuid::new_v4();
+
+        let table1 = PaletteItem::Resource(ResourceItem::Table {
+            profile_id: pid1,
+            profile_name: "prod".to_string(),
+            database: Some("mydb".to_string()),
+            schema: Some("public".to_string()),
+            name: "users".to_string(),
+        });
+
+        let table2 = PaletteItem::Resource(ResourceItem::Table {
+            profile_id: pid2,
+            profile_name: "staging".to_string(),
+            database: Some("mydb".to_string()),
+            schema: Some("public".to_string()),
+            name: "users".to_string(),
+        });
+
+        // Both have same table name but different qualifiers (include profile name)
+        assert!(table1.qualifier().unwrap().contains("prod"));
+        assert!(table2.qualifier().unwrap().contains("staging"));
+
+        // Search text includes profile name for disambiguation
+        assert!(table1.search_text().contains("prod"));
+        assert!(table2.search_text().contains("staging"));
+
+        // They route to different profiles
+        let sel1 = map_item_to_selection(&table1).unwrap();
+        let sel2 = map_item_to_selection(&table2).unwrap();
+        match (&sel1, &sel2) {
+            (
+                PaletteSelection::OpenTable {
+                    profile_id: id1, ..
+                },
+                PaletteSelection::OpenTable {
+                    profile_id: id2, ..
+                },
+            ) => {
+                assert_ne!(id1, id2);
+            }
+            _ => panic!("Expected OpenTable selections"),
+        }
+    }
+
+    // --- Same profile, same schema+table, different database dedup regression ---
+
+    #[test]
+    fn same_profile_same_table_different_database_produces_distinct_selections() {
+        let pid = Uuid::new_v4();
+
+        let table_db1 = PaletteItem::Resource(ResourceItem::Table {
+            profile_id: pid,
+            profile_name: "pg-multi-db".to_string(),
+            database: Some("db_alpha".to_string()),
+            schema: Some("public".to_string()),
+            name: "orders".to_string(),
+        });
+
+        let table_db2 = PaletteItem::Resource(ResourceItem::Table {
+            profile_id: pid,
+            profile_name: "pg-multi-db".to_string(),
+            database: Some("db_beta".to_string()),
+            schema: Some("public".to_string()),
+            name: "orders".to_string(),
+        });
+
+        // Both have same profile, schema, and table name but different databases
+        let sel1 = map_item_to_selection(&table_db1).unwrap();
+        let sel2 = map_item_to_selection(&table_db2).unwrap();
+
+        match (&sel1, &sel2) {
+            (
+                PaletteSelection::OpenTable {
+                    profile_id: id1,
+                    table: t1,
+                    database: db1,
+                },
+                PaletteSelection::OpenTable {
+                    profile_id: id2,
+                    table: t2,
+                    database: db2,
+                },
+            ) => {
+                assert_eq!(id1, id2, "Same profile");
+                assert_eq!(t1, t2, "Same table ref (schema+name)");
+                assert_ne!(
+                    db1, db2,
+                    "Different databases must produce distinct selections"
+                );
+                assert_eq!(db1.as_deref(), Some("db_alpha"));
+                assert_eq!(db2.as_deref(), Some("db_beta"));
+            }
+            _ => panic!("Expected OpenTable selections"),
+        }
+
+        // Qualifiers must also differ (they include database)
+        assert!(table_db1.qualifier().unwrap().contains("db_alpha"));
+        assert!(table_db2.qualifier().unwrap().contains("db_beta"));
+    }
+
+    // --- Empty / no-match filtering ---
+
+    #[test]
+    fn fuzzy_filter_no_match_returns_empty() {
+        let matcher = SkimMatcherV2::default();
+        let items: Vec<PaletteItem> = vec![
+            sample_action(),
+            sample_connection("prod-pg", true),
+            sample_table("prod-pg", "orders"),
+        ];
+
+        let matched: Vec<_> = items
+            .iter()
+            .enumerate()
+            .filter_map(|(i, item)| {
+                matcher
+                    .fuzzy_match(&item.search_text(), "zzzzzzz")
+                    .map(|score| (i, score))
+            })
+            .collect();
+
+        assert!(matched.is_empty());
+    }
+
+    #[test]
+    fn fuzzy_filter_empty_query_matches_all() {
+        let items: Vec<PaletteItem> = vec![
+            sample_action(),
+            sample_connection("prod-pg", true),
+            sample_table("prod-pg", "orders"),
+            sample_script("health-check"),
+        ];
+
+        // Empty query should show all items (score 0 for all)
+        let mut filtered: Vec<(usize, i64)> = items
+            .iter()
+            .enumerate()
+            .map(|(index, _)| (index, 0))
+            .collect();
+
+        assert_eq!(filtered.len(), 4);
+        filtered.sort_by_key(|s| std::cmp::Reverse(s.1));
+        assert_eq!(filtered.len(), items.len());
+    }
+
+    // --- Performance: fuzzy filtering on large dataset ---
+
+    #[test]
+    fn palette_filtering_large_dataset_completes_within_budget() {
+        let matcher = SkimMatcherV2::default();
+
+        // Build a representative large dataset: 100 connections, 1000 resources, 200 scripts
+        let mut items: Vec<PaletteItem> = Vec::with_capacity(1325);
+
+        for i in 0..100 {
+            items.push(PaletteItem::Action {
+                id: Box::leak(format!("cmd_{}", i).into_boxed_str()),
+                name: Box::leak(format!("Command {}", i).into_boxed_str()),
+                category: "Editor",
+                shortcut: None,
+            });
+        }
+
+        for i in 0..100 {
+            items.push(PaletteItem::Connection {
+                profile_id: Uuid::new_v4(),
+                name: format!("connection-{}", i),
+                is_connected: i < 50,
+            });
+        }
+
+        for i in 0..1000 {
+            items.push(PaletteItem::Resource(ResourceItem::Table {
+                profile_id: Uuid::new_v4(),
+                profile_name: format!("profile-{}", i % 10),
+                database: Some("mydb".to_string()),
+                schema: Some("public".to_string()),
+                name: format!("table_{}", i),
+            }));
+        }
+
+        for i in 0..200 {
+            items.push(PaletteItem::Script {
+                path: PathBuf::from(format!("/scripts/script_{}.sql", i)),
+                name: format!("script_{}", i),
+                relative_path: format!("script_{}.sql", i),
+            });
+        }
+
+        assert_eq!(items.len(), 1400);
+
+        // Measure item build time (simulated: just the search_text generation)
+        let build_start = std::time::Instant::now();
+        let search_texts: Vec<String> = items.iter().map(|i| i.search_text()).collect();
+        let build_elapsed = build_start.elapsed();
+        assert!(
+            build_elapsed.as_millis() < 50,
+            "Item search_text build took {}ms, exceeds 50ms budget",
+            build_elapsed.as_millis()
+        );
+
+        // Measure per-keystroke filter time
+        let filter_start = std::time::Instant::now();
+        let matched: Vec<_> = items
+            .iter()
+            .enumerate()
+            .filter_map(|(i, _item)| {
+                matcher
+                    .fuzzy_match(&search_texts[i], "table_5")
+                    .map(|score| (i, score))
+            })
+            .collect();
+        let filter_elapsed = filter_start.elapsed();
+
+        assert!(
+            filter_elapsed.as_millis() < 16,
+            "Per-keystroke filter took {}ms, exceeds 16ms budget",
+            filter_elapsed.as_millis()
+        );
+        assert!(!matched.is_empty(), "Should match some items");
     }
 }

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -23,7 +23,8 @@ use crate::ui::document::{
 use crate::ui::document::{McpApprovalsView, McpAuditView};
 use crate::ui::icons::AppIcon;
 use crate::ui::overlays::command_palette::{
-    CommandExecuted, CommandPalette, CommandPaletteClosed, PaletteCommand,
+    CommandPalette, CommandPaletteClosed, PaletteCommand, PaletteItem, PaletteSelection,
+    ResourceItem,
 };
 use crate::ui::overlays::login_modal::{LoginModal, LoginModalEvent};
 use crate::ui::overlays::shutdown_overlay::ShutdownOverlay;
@@ -35,6 +36,8 @@ use crate::ui::views::status_bar::{StatusBar, ToggleTasksPanel};
 use crate::ui::views::tasks_panel::TasksPanel;
 use crate::ui::windows::connection_manager::ConnectionManagerWindow;
 use crate::ui::windows::settings::SettingsWindow;
+#[cfg(test)]
+use dbflux_core::{CollectionRef, TableRef};
 use dbflux_core::{ExecutionContext, QueryLanguage};
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -42,6 +45,160 @@ use gpui_component::ActiveTheme;
 use gpui_component::Root;
 use gpui_component::resizable::{resizable_panel, v_resizable};
 use std::path::PathBuf;
+
+/// Extract resource items from a schema snapshot into a palette item list.
+///
+/// Separated from `Workspace` for testability — this is pure data transformation
+/// with no GPUI dependency.
+pub(super) fn build_resource_items_from_schema(
+    profile_id: uuid::Uuid,
+    profile_name: &str,
+    structure: &dbflux_core::DataStructure,
+    items: &mut Vec<PaletteItem>,
+) {
+    match structure {
+        dbflux_core::DataStructure::Relational(rel) => {
+            let database = rel.current_database.clone();
+            for table in &rel.tables {
+                items.push(PaletteItem::Resource(ResourceItem::Table {
+                    profile_id,
+                    profile_name: profile_name.to_string(),
+                    database: database.clone(),
+                    schema: table.schema.clone(),
+                    name: table.name.clone(),
+                }));
+            }
+            for view in &rel.views {
+                items.push(PaletteItem::Resource(ResourceItem::View {
+                    profile_id,
+                    profile_name: profile_name.to_string(),
+                    database: database.clone(),
+                    schema: view.schema.clone(),
+                    name: view.name.clone(),
+                }));
+            }
+            for db_schema in &rel.schemas {
+                let schema_name = db_schema.name.clone();
+                for table in &db_schema.tables {
+                    items.push(PaletteItem::Resource(ResourceItem::Table {
+                        profile_id,
+                        profile_name: profile_name.to_string(),
+                        database: database.clone(),
+                        schema: Some(schema_name.clone()),
+                        name: table.name.clone(),
+                    }));
+                }
+                for view in &db_schema.views {
+                    items.push(PaletteItem::Resource(ResourceItem::View {
+                        profile_id,
+                        profile_name: profile_name.to_string(),
+                        database: database.clone(),
+                        schema: Some(schema_name.clone()),
+                        name: view.name.clone(),
+                    }));
+                }
+            }
+        }
+        dbflux_core::DataStructure::Document(doc) => {
+            let default_db = doc
+                .current_database
+                .clone()
+                .unwrap_or_else(|| "default".to_string());
+            for collection in &doc.collections {
+                items.push(PaletteItem::Resource(ResourceItem::Collection {
+                    profile_id,
+                    profile_name: profile_name.to_string(),
+                    database: collection
+                        .database
+                        .clone()
+                        .unwrap_or_else(|| default_db.clone()),
+                    name: collection.name.clone(),
+                }));
+            }
+        }
+        dbflux_core::DataStructure::KeyValue(kv) => {
+            for ks in &kv.keyspaces {
+                items.push(PaletteItem::Resource(ResourceItem::KeyValueDb {
+                    profile_id,
+                    profile_name: profile_name.to_string(),
+                    database: format!("db{}", ks.db_index),
+                }));
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Map a `PaletteItem` to its corresponding `PaletteSelection`.
+///
+/// Separated from `CommandPalette` for testability — pure data transformation.
+#[cfg(test)]
+pub(super) fn map_item_to_selection(item: &PaletteItem) -> Option<PaletteSelection> {
+    match item {
+        PaletteItem::Action { id, .. } => Some(PaletteSelection::Command { id }),
+        PaletteItem::Connection {
+            profile_id,
+            is_connected,
+            ..
+        } => {
+            if *is_connected {
+                Some(PaletteSelection::FocusConnection {
+                    profile_id: *profile_id,
+                })
+            } else {
+                Some(PaletteSelection::Connect {
+                    profile_id: *profile_id,
+                })
+            }
+        }
+        PaletteItem::Resource(r) => match r {
+            ResourceItem::Table {
+                profile_id,
+                schema,
+                name,
+                database,
+                ..
+            }
+            | ResourceItem::View {
+                profile_id,
+                schema,
+                name,
+                database,
+                ..
+            } => Some(PaletteSelection::OpenTable {
+                profile_id: *profile_id,
+                table: TableRef {
+                    schema: schema.clone(),
+                    name: name.clone(),
+                },
+                database: database.clone(),
+            }),
+            ResourceItem::Collection {
+                profile_id,
+                database,
+                name,
+                ..
+            } => Some(PaletteSelection::OpenCollection {
+                profile_id: *profile_id,
+                collection: CollectionRef {
+                    database: database.clone(),
+                    name: name.clone(),
+                },
+            }),
+            ResourceItem::KeyValueDb {
+                profile_id,
+                database,
+                ..
+            } => Some(PaletteSelection::OpenKeyValue {
+                profile_id: *profile_id,
+                database: database.clone(),
+            }),
+        },
+        PaletteItem::Script { path, .. } => {
+            Some(PaletteSelection::OpenScript { path: path.clone() })
+        }
+    }
+}
 
 /// State for collapsible panels (tasks panel).
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -148,11 +305,7 @@ impl Workspace {
         #[cfg(feature = "mcp")]
         let mcp_audit_view = cx.new(|cx| McpAuditView::new(app_state.clone(), window, cx));
 
-        let command_palette = cx.new(|cx| {
-            let mut palette = CommandPalette::new(window, cx);
-            palette.register_commands(Self::default_commands());
-            palette
-        });
+        let command_palette = cx.new(|cx| CommandPalette::new(window, cx));
 
         let sql_preview_modal = cx.new(|cx| SqlPreviewModal::new(app_state.clone(), window, cx));
         let login_modal = cx.new(|cx| LoginModal::new(window, cx));
@@ -164,10 +317,62 @@ impl Workspace {
         })
         .detach();
 
-        cx.subscribe(&command_palette, |this, _, event: &CommandExecuted, cx| {
-            this.pending_command = Some(event.command_id);
-            cx.notify();
-        })
+        cx.subscribe_in(
+            &command_palette,
+            window,
+            |this, _, event: &PaletteSelection, window, cx| match event {
+                PaletteSelection::Command { id } => {
+                    this.pending_command = Some(id);
+                    cx.notify();
+                }
+                PaletteSelection::Connect { profile_id } => {
+                    this.sidebar.update(cx, |sidebar, cx| {
+                        sidebar.connect_to_profile(*profile_id, cx);
+                    });
+                }
+                PaletteSelection::FocusConnection { profile_id } => {
+                    // Mirror sidebar's execute_item for connected profiles:
+                    // set the connection as active in AppState, then focus the sidebar.
+                    this.app_state.update(cx, |state, cx| {
+                        state.set_active_connection(*profile_id);
+                        cx.emit(AppStateChanged);
+                    });
+                    if this.is_sidebar_collapsed(cx) {
+                        this.toggle_sidebar(cx);
+                    }
+                    this.pending_focus = Some(FocusTarget::Sidebar);
+                    cx.notify();
+                }
+                PaletteSelection::OpenTable {
+                    profile_id,
+                    table,
+                    database,
+                } => {
+                    this.open_table_document(
+                        *profile_id,
+                        table.clone(),
+                        database.clone(),
+                        window,
+                        cx,
+                    );
+                }
+                PaletteSelection::OpenCollection {
+                    profile_id,
+                    collection,
+                } => {
+                    this.open_collection_document(*profile_id, collection.clone(), window, cx);
+                }
+                PaletteSelection::OpenKeyValue {
+                    profile_id,
+                    database,
+                } => {
+                    this.open_key_value_document(*profile_id, database.clone(), window, cx);
+                }
+                PaletteSelection::OpenScript { path } => {
+                    this.open_script_from_path(path.clone(), cx);
+                }
+            },
+        )
         .detach();
 
         cx.subscribe(&command_palette, |this, _, _: &CommandPaletteClosed, cx| {
@@ -729,12 +934,89 @@ impl Workspace {
 
     pub fn toggle_command_palette(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let was_visible = self.command_palette.read(cx).is_visible();
-        self.command_palette.update(cx, |palette, cx| {
-            palette.toggle(window, cx);
-        });
 
-        if was_visible {
+        if !was_visible {
+            let items = self.build_palette_items(cx);
+            self.command_palette.update(cx, |palette, cx| {
+                palette.open_with_items(items, window, cx);
+            });
+        } else {
+            self.command_palette.update(cx, |palette, cx| {
+                palette.hide(cx);
+            });
             self.focus_handle.focus(window);
+        }
+    }
+
+    /// Build the palette item list from current app state.
+    fn build_palette_items(&self, cx: &Context<Self>) -> Vec<PaletteItem> {
+        let mut items: Vec<PaletteItem> = Self::default_commands()
+            .into_iter()
+            .map(|cmd| cmd.into())
+            .collect();
+
+        let app_state = self.app_state.read(cx);
+        let connections = app_state.connections();
+
+        for profile in app_state.profiles() {
+            let is_connected = connections.contains_key(&profile.id);
+            items.push(PaletteItem::Connection {
+                profile_id: profile.id,
+                name: profile.name.clone(),
+                is_connected,
+            });
+        }
+
+        for (&profile_id, connected) in connections.iter() {
+            let profile_name = connected.profile.name.clone();
+
+            if let Some(schema) = &connected.schema {
+                build_resource_items_from_schema(
+                    profile_id,
+                    &profile_name,
+                    &schema.structure,
+                    &mut items,
+                );
+            }
+        }
+
+        if let Some(dir) = app_state.scripts_directory() {
+            let root = dir.root_path().to_path_buf();
+            Self::flatten_script_entries(dir.entries(), &root, &mut items);
+        }
+
+        items
+    }
+
+    /// Recursively flatten script directory entries into palette items.
+    fn flatten_script_entries(
+        entries: &[dbflux_core::ScriptEntry],
+        scripts_root: &std::path::Path,
+        items: &mut Vec<PaletteItem>,
+    ) {
+        use dbflux_core::ScriptEntry;
+
+        for entry in entries {
+            match entry {
+                ScriptEntry::File { path, name, .. } => {
+                    if !dbflux_core::is_openable_script(path) {
+                        continue;
+                    }
+                    let relative_path = path
+                        .strip_prefix(scripts_root)
+                        .unwrap_or(path)
+                        .to_string_lossy()
+                        .to_string();
+                    items.push(PaletteItem::Script {
+                        path: path.clone(),
+                        name: name.clone(),
+                        relative_path,
+                    });
+                }
+                ScriptEntry::Folder { children, .. } => {
+                    Self::flatten_script_entries(children, scripts_root, items);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #7

## PR Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- expand the command palette to search actions, connections, schema resources, and scripts from one place
- improve palette routing and identity handling for cross-connection and cross-database resources
- add `:` as an additional global shortcut for opening the palette

## Changes
| File | Change |
|------|--------|
| `crates/dbflux_ui/src/keymap/defaults.rs` | Added `:` shortcut for opening the command palette |
| `crates/dbflux_ui/src/ui/document/data_document.rs` | Exposed document database metadata for identity checks |
| `crates/dbflux_ui/src/ui/document/handle.rs` | Added table identity matching that includes database |
| `crates/dbflux_ui/src/ui/overlays/command_palette.rs` | Reworked the palette to support typed mixed results, qualifiers, and relative script paths |
| `crates/dbflux_ui/src/ui/views/workspace/actions.rs` | Added palette-focused tests and tightened resource identity/dedup behavior |
| `crates/dbflux_ui/src/ui/views/workspace/mod.rs` | Built palette items from app state and routed selections through existing workspace/sidebar flows |

## Test Plan
- [x] `cargo check --workspace`
- [x] `cargo clippy -p dbflux_ui -- -D warnings`
- [x] `cargo test -p dbflux_ui`
- [ ] Manual runtime verification of GPUI overlay interactions is still pending

## Notes
- Judgment Day found and fixed the confirmed routing/identity issues before this PR.
- The issue does not currently have a `status:approved` label, so repository PR validation may remain blocked until that label is added.