### PR TITLE
feat(aws): register value providers for static credentials auth

### DIFF
--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -585,15 +585,25 @@ fn build_aws_value_providers_blocking(
 /// Reads `access_key_id`, `secret_access_key`, `session_token`, and `region`
 /// from `profile.fields`. Returns an error if `access_key_id` or
 /// `secret_access_key` is absent or empty.
-fn build_static_sdk_config_blocking(profile: &AuthProfile) -> Result<aws_config::SdkConfig, DbError> {
-    let access_key_id = profile.fields.get("access_key_id").map(String::as_str).unwrap_or("");
+fn build_static_sdk_config_blocking(
+    profile: &AuthProfile,
+) -> Result<aws_config::SdkConfig, DbError> {
+    let access_key_id = profile
+        .fields
+        .get("access_key_id")
+        .map(String::as_str)
+        .unwrap_or("");
     if access_key_id.is_empty() {
         return Err(DbError::ValueResolutionFailed(
             "Missing required field 'access_key_id' for static AWS credentials".to_string(),
         ));
     }
 
-    let secret_access_key = profile.fields.get("secret_access_key").map(String::as_str).unwrap_or("");
+    let secret_access_key = profile
+        .fields
+        .get("secret_access_key")
+        .map(String::as_str)
+        .unwrap_or("");
     if secret_access_key.is_empty() {
         return Err(DbError::ValueResolutionFailed(
             "Missing required field 'secret_access_key' for static AWS credentials".to_string(),
@@ -932,7 +942,8 @@ impl dbflux_core::auth::DynAuthProvider for AwsStaticCredentialsAuthProvider {
     ) -> Result<(), DbError> {
         let sdk_config = build_static_sdk_config_blocking(profile)?;
 
-        resolver.register_secret_provider(Arc::new(AwsSecretsManagerProvider::new(sdk_config.clone())));
+        resolver
+            .register_secret_provider(Arc::new(AwsSecretsManagerProvider::new(sdk_config.clone())));
         resolver.register_parameter_provider(Arc::new(AwsSsmParameterProvider::new(sdk_config)));
 
         Ok(())
@@ -1538,15 +1549,18 @@ mod tests {
 
         let fields = &form.tabs[0].sections[0].fields;
 
-        let access_key = field_def_by_id(fields, "access_key_id").expect("access_key_id field missing");
+        let access_key =
+            field_def_by_id(fields, "access_key_id").expect("access_key_id field missing");
         assert_eq!(access_key.kind, FormFieldKind::Text);
         assert!(access_key.required);
 
-        let secret_key = field_def_by_id(fields, "secret_access_key").expect("secret_access_key field missing");
+        let secret_key =
+            field_def_by_id(fields, "secret_access_key").expect("secret_access_key field missing");
         assert_eq!(secret_key.kind, FormFieldKind::Password);
         assert!(secret_key.required);
 
-        let session_token = field_def_by_id(fields, "session_token").expect("session_token field missing");
+        let session_token =
+            field_def_by_id(fields, "session_token").expect("session_token field missing");
         assert_eq!(session_token.kind, FormFieldKind::Password);
         assert!(!session_token.required);
 
@@ -1558,7 +1572,10 @@ mod tests {
     #[test]
     fn static_credentials_missing_access_key_returns_error() {
         let mut fields = std::collections::HashMap::new();
-        fields.insert("secret_access_key".to_string(), "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string());
+        fields.insert(
+            "secret_access_key".to_string(),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
+        );
         fields.insert("region".to_string(), "us-east-1".to_string());
 
         let profile = AuthProfile::new("test-static", "aws-static-credentials", fields);
@@ -1577,7 +1594,10 @@ mod tests {
     #[test]
     fn static_credentials_missing_secret_key_returns_error() {
         let mut fields = std::collections::HashMap::new();
-        fields.insert("access_key_id".to_string(), "AKIAIOSFODNN7EXAMPLE".to_string());
+        fields.insert(
+            "access_key_id".to_string(),
+            "AKIAIOSFODNN7EXAMPLE".to_string(),
+        );
         fields.insert("region".to_string(), "us-east-1".to_string());
 
         let profile = AuthProfile::new("test-static", "aws-static-credentials", fields);
@@ -1596,8 +1616,14 @@ mod tests {
     #[test]
     fn static_credentials_empty_session_token_succeeds() {
         let mut fields = std::collections::HashMap::new();
-        fields.insert("access_key_id".to_string(), "AKIAIOSFODNN7EXAMPLE".to_string());
-        fields.insert("secret_access_key".to_string(), "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string());
+        fields.insert(
+            "access_key_id".to_string(),
+            "AKIAIOSFODNN7EXAMPLE".to_string(),
+        );
+        fields.insert(
+            "secret_access_key".to_string(),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
+        );
         fields.insert("session_token".to_string(), String::new());
         fields.insert("region".to_string(), "us-east-1".to_string());
 
@@ -1630,8 +1656,14 @@ mod tests {
     #[test]
     fn static_credentials_missing_session_token_succeeds() {
         let mut fields = std::collections::HashMap::new();
-        fields.insert("access_key_id".to_string(), "AKIAIOSFODNN7EXAMPLE".to_string());
-        fields.insert("secret_access_key".to_string(), "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string());
+        fields.insert(
+            "access_key_id".to_string(),
+            "AKIAIOSFODNN7EXAMPLE".to_string(),
+        );
+        fields.insert(
+            "secret_access_key".to_string(),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
+        );
         fields.insert("region".to_string(), "us-east-1".to_string());
         // Deliberately NOT inserting "session_token" at all.
 
@@ -1677,8 +1709,14 @@ mod tests {
     #[test]
     fn static_credentials_register_value_providers_with_fake_credentials() {
         let mut fields = std::collections::HashMap::new();
-        fields.insert("access_key_id".to_string(), "AKIAIOSFODNN7EXAMPLE".to_string());
-        fields.insert("secret_access_key".to_string(), "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string());
+        fields.insert(
+            "access_key_id".to_string(),
+            "AKIAIOSFODNN7EXAMPLE".to_string(),
+        );
+        fields.insert(
+            "secret_access_key".to_string(),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
+        );
         fields.insert("region".to_string(), "us-east-1".to_string());
 
         let profile = AuthProfile::new("test-register", "aws-static-credentials", fields);
@@ -1707,7 +1745,9 @@ mod tests {
                 let param_providers = resolver.available_parameter_providers();
 
                 assert!(
-                    secret_providers.iter().any(|(id, _)| *id == "aws-secrets-manager"),
+                    secret_providers
+                        .iter()
+                        .any(|(id, _)| *id == "aws-secrets-manager"),
                     "Expected aws-secrets-manager provider to be registered, found: {:?}",
                     secret_providers
                 );

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -448,6 +448,19 @@ fn required_text_field(id: &str, label: &str, placeholder: &str) -> FormFieldDef
     }
 }
 
+fn password_field(id: &str, label: &str, placeholder: &str, required: bool) -> FormFieldDef {
+    FormFieldDef {
+        id: id.to_string(),
+        label: label.to_string(),
+        kind: FormFieldKind::Password,
+        placeholder: placeholder.to_string(),
+        required,
+        default_value: String::new(),
+        enabled_when_checked: None,
+        enabled_when_unchecked: None,
+    }
+}
+
 fn build_aws_sso_form() -> AuthFormDef {
     AuthFormDef {
         tabs: vec![FormTab {
@@ -494,7 +507,12 @@ fn build_aws_static_credentials_form() -> AuthFormDef {
             label: "Main".to_string(),
             sections: vec![FormSection {
                 title: "AWS Static Credentials".to_string(),
-                fields: vec![required_text_field("region", "Region", "us-east-1")],
+                fields: vec![
+                    required_text_field("access_key_id", "Access Key ID", "AKIAIOSFODNN7EXAMPLE"),
+                    password_field("secret_access_key", "Secret Access Key", "", true),
+                    password_field("session_token", "Session Token", "", false),
+                    required_text_field("region", "Region", "us-east-1"),
+                ],
             }],
         }],
     }
@@ -558,6 +576,73 @@ fn build_aws_value_providers_blocking(
             AwsSecretsManagerProvider::new(sdk_config.clone()),
             AwsSsmParameterProvider::new(sdk_config),
         ))
+    })
+}
+
+/// Builds an `SdkConfig` from explicit static credentials stored in the
+/// auth profile's `fields` map, bypassing the default credential chain.
+///
+/// Reads `access_key_id`, `secret_access_key`, `session_token`, and `region`
+/// from `profile.fields`. Returns an error if `access_key_id` or
+/// `secret_access_key` is absent or empty.
+fn build_static_sdk_config_blocking(profile: &AuthProfile) -> Result<aws_config::SdkConfig, DbError> {
+    let access_key_id = profile.fields.get("access_key_id").map(String::as_str).unwrap_or("");
+    if access_key_id.is_empty() {
+        return Err(DbError::ValueResolutionFailed(
+            "Missing required field 'access_key_id' for static AWS credentials".to_string(),
+        ));
+    }
+
+    let secret_access_key = profile.fields.get("secret_access_key").map(String::as_str).unwrap_or("");
+    if secret_access_key.is_empty() {
+        return Err(DbError::ValueResolutionFailed(
+            "Missing required field 'secret_access_key' for static AWS credentials".to_string(),
+        ));
+    }
+
+    let session_token = profile
+        .fields
+        .get("session_token")
+        .map(String::as_str)
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+
+    let region = profile
+        .fields
+        .get("region")
+        .cloned()
+        .unwrap_or_else(|| "us-east-1".to_string());
+
+    let access_key_id = access_key_id.to_string();
+    let secret_access_key = secret_access_key.to_string();
+
+    let creds = aws_sdk_sts::config::Credentials::new(
+        access_key_id,
+        secret_access_key,
+        session_token,
+        None,
+        "dbflux-static",
+    );
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .map_err(|err| {
+            DbError::ValueResolutionFailed(format!(
+                "Failed to create Tokio runtime for static AWS provider init: {}",
+                err
+            ))
+        })?;
+
+    runtime.block_on(async move {
+        let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .credentials_provider(creds)
+            .region(aws_config::Region::new(region))
+            .load()
+            .await;
+
+        Ok(sdk_config)
     })
 }
 
@@ -837,6 +922,20 @@ impl dbflux_core::auth::DynAuthProvider for AwsStaticCredentialsAuthProvider {
         profile: &AuthProfile,
     ) -> Result<ResolvedCredentials, DbError> {
         resolve_aws_credentials(profile).await
+    }
+
+    fn register_value_providers(
+        &self,
+        profile: &AuthProfile,
+        _session: Option<&AuthSession>,
+        resolver: &mut dbflux_core::values::CompositeValueResolver,
+    ) -> Result<(), DbError> {
+        let sdk_config = build_static_sdk_config_blocking(profile)?;
+
+        resolver.register_secret_provider(Arc::new(AwsSecretsManagerProvider::new(sdk_config.clone())));
+        resolver.register_parameter_provider(Arc::new(AwsSsmParameterProvider::new(sdk_config)));
+
+        Ok(())
     }
 }
 
@@ -1425,6 +1524,216 @@ mod tests {
         } else {
             AuthSessionState::Valid {
                 expires_at: Some(expires_at),
+            }
+        }
+    }
+
+    fn field_def_by_id<'a>(fields: &'a [FormFieldDef], id: &str) -> Option<&'a FormFieldDef> {
+        fields.iter().find(|f| f.id == id)
+    }
+
+    #[test]
+    fn static_credentials_form_has_all_fields() {
+        let form = build_aws_static_credentials_form();
+
+        let fields = &form.tabs[0].sections[0].fields;
+
+        let access_key = field_def_by_id(fields, "access_key_id").expect("access_key_id field missing");
+        assert_eq!(access_key.kind, FormFieldKind::Text);
+        assert!(access_key.required);
+
+        let secret_key = field_def_by_id(fields, "secret_access_key").expect("secret_access_key field missing");
+        assert_eq!(secret_key.kind, FormFieldKind::Password);
+        assert!(secret_key.required);
+
+        let session_token = field_def_by_id(fields, "session_token").expect("session_token field missing");
+        assert_eq!(session_token.kind, FormFieldKind::Password);
+        assert!(!session_token.required);
+
+        let region = field_def_by_id(fields, "region").expect("region field missing");
+        assert_eq!(region.kind, FormFieldKind::Text);
+        assert!(region.required);
+    }
+
+    #[test]
+    fn static_credentials_missing_access_key_returns_error() {
+        let mut fields = std::collections::HashMap::new();
+        fields.insert("secret_access_key".to_string(), "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string());
+        fields.insert("region".to_string(), "us-east-1".to_string());
+
+        let profile = AuthProfile::new("test-static", "aws-static-credentials", fields);
+
+        let result = build_static_sdk_config_blocking(&profile);
+        assert!(result.is_err());
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("access_key_id"),
+            "Error should mention access_key_id, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn static_credentials_missing_secret_key_returns_error() {
+        let mut fields = std::collections::HashMap::new();
+        fields.insert("access_key_id".to_string(), "AKIAIOSFODNN7EXAMPLE".to_string());
+        fields.insert("region".to_string(), "us-east-1".to_string());
+
+        let profile = AuthProfile::new("test-static", "aws-static-credentials", fields);
+
+        let result = build_static_sdk_config_blocking(&profile);
+        assert!(result.is_err());
+
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("secret_access_key"),
+            "Error should mention secret_access_key, got: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn static_credentials_empty_session_token_succeeds() {
+        let mut fields = std::collections::HashMap::new();
+        fields.insert("access_key_id".to_string(), "AKIAIOSFODNN7EXAMPLE".to_string());
+        fields.insert("secret_access_key".to_string(), "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string());
+        fields.insert("session_token".to_string(), String::new());
+        fields.insert("region".to_string(), "us-east-1".to_string());
+
+        let profile = AuthProfile::new("test-static", "aws-static-credentials", fields);
+
+        let result = build_static_sdk_config_blocking(&profile);
+
+        // The SdkConfig load attempts a network call to STS regional endpoints,
+        // which may fail in CI without real AWS credentials. The important
+        // assertion is that the function passes validation — it must NOT return
+        // a "missing required field" error for access_key_id, secret_access_key,
+        // or session_token (since the latter is optional and was provided as empty).
+        match result {
+            Ok(_) => {}
+            Err(err) => {
+                let msg = err.to_string();
+                let forbidden_fields = ["access_key_id", "secret_access_key", "session_token"];
+                for field in &forbidden_fields {
+                    assert!(
+                        !msg.contains(field),
+                        "Should not fail on field '{}', got error: {}",
+                        field,
+                        msg
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn static_credentials_missing_session_token_succeeds() {
+        let mut fields = std::collections::HashMap::new();
+        fields.insert("access_key_id".to_string(), "AKIAIOSFODNN7EXAMPLE".to_string());
+        fields.insert("secret_access_key".to_string(), "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string());
+        fields.insert("region".to_string(), "us-east-1".to_string());
+        // Deliberately NOT inserting "session_token" at all.
+
+        let profile = AuthProfile::new("test-static-no-token", "aws-static-credentials", fields);
+
+        let result = build_static_sdk_config_blocking(&profile);
+
+        // Same as the empty-session-token test — we just need to verify the
+        // function does not error on missing session_token (it's optional).
+        // Network failures from fake credentials are acceptable.
+        match result {
+            Ok(_) => {}
+            Err(err) => {
+                let msg = err.to_string();
+                assert!(
+                    !msg.contains("access_key_id"),
+                    "Should not fail on access_key_id, got: {}",
+                    msg
+                );
+                assert!(
+                    !msg.contains("secret_access_key"),
+                    "Should not fail on secret_access_key, got: {}",
+                    msg
+                );
+                assert!(
+                    !msg.contains("session_token"),
+                    "session_token is optional, got error mentioning it: {}",
+                    msg
+                );
+            }
+        }
+    }
+
+    /// Verifies that `register_value_providers()` exercises the full code path
+    /// through `build_static_sdk_config_blocking` with present-but-fake
+    /// credentials. The AWS SDK will reject the fake credentials at runtime,
+    /// but the test proves the function does not fail on missing-field
+    /// validation and that the error (if any) propagates correctly.
+    ///
+    /// The happy path (real AWS credentials resolving to a working SdkConfig
+    /// and providers being registered) requires integration testing with live
+    /// AWS credentials and is not covered here.
+    #[test]
+    fn static_credentials_register_value_providers_with_fake_credentials() {
+        let mut fields = std::collections::HashMap::new();
+        fields.insert("access_key_id".to_string(), "AKIAIOSFODNN7EXAMPLE".to_string());
+        fields.insert("secret_access_key".to_string(), "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string());
+        fields.insert("region".to_string(), "us-east-1".to_string());
+
+        let profile = AuthProfile::new("test-register", "aws-static-credentials", fields);
+
+        let provider = AwsStaticCredentialsAuthProvider::new();
+        let cache = Arc::new(dbflux_core::values::ValueCache::new(
+            std::time::Duration::from_secs(60),
+        ));
+        let mut resolver = dbflux_core::values::CompositeValueResolver::new(cache);
+
+        let result = dbflux_core::auth::DynAuthProvider::register_value_providers(
+            &provider,
+            &profile,
+            None,
+            &mut resolver,
+        );
+
+        // With fake credentials, the SdkConfig load may or may not succeed
+        // depending on the environment. The critical assertion is that if it
+        // fails, the error is NOT about missing required fields — proving the
+        // validation passed and the error came from the AWS SDK layer.
+        match result {
+            Ok(()) => {
+                // SdkConfig loaded successfully — verify providers were registered.
+                let secret_providers = resolver.available_secret_providers();
+                let param_providers = resolver.available_parameter_providers();
+
+                assert!(
+                    secret_providers.iter().any(|(id, _)| *id == "aws-secrets-manager"),
+                    "Expected aws-secrets-manager provider to be registered, found: {:?}",
+                    secret_providers
+                );
+                assert!(
+                    param_providers.iter().any(|(id, _)| *id == "aws-ssm"),
+                    "Expected aws-ssm provider to be registered, found: {:?}",
+                    param_providers
+                );
+            }
+            Err(err) => {
+                let msg = err.to_string();
+                assert!(
+                    !msg.contains("access_key_id"),
+                    "Should not fail on access_key_id validation, got: {}",
+                    msg
+                );
+                assert!(
+                    !msg.contains("secret_access_key"),
+                    "Should not fail on secret_access_key validation, got: {}",
+                    msg
+                );
+                assert!(
+                    !msg.contains("session_token"),
+                    "session_token is optional, got: {}",
+                    msg
+                );
             }
         }
     }


### PR DESCRIPTION
## Linked Issue

Closes #3

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Enable AWS Secrets Manager and SSM Parameter Store value providers when using static credentials authentication
- Extend the static credentials form with `access_key_id`, `secret_access_key`, and optional `session_token` fields
- Implement `register_value_providers()` on `AwsStaticCredentialsAuthProvider` using explicit `Credentials::new()` instead of the default credential chain

## Changes

| File | Change |
|------|--------|
| `crates/dbflux_aws/src/auth.rs` | Added `password_field()` helper, extended static credentials form with 3 new fields, added `build_static_sdk_config_blocking()` to construct SdkConfig from explicit credentials, implemented `register_value_providers()` on `AwsStaticCredentialsAuthProvider`, added 6 unit tests |

## Validation

- [x] `cargo check -p dbflux_aws` passes
- [x] `cargo test -p dbflux_aws` — 37 passed, 0 failed
- [x] `cargo clippy -p dbflux_aws -- -D warnings` clean
- [x] No changes required in core pipeline, UI, or other crates

## Testing Coverage

6 unit tests added:
- `static_credentials_form_has_all_fields` — verifies form has access_key_id (Text), secret_access_key (Password), session_token (Password), region (Text)
- `static_credentials_missing_access_key_returns_error` — missing required field returns named error
- `static_credentials_missing_secret_key_returns_error` — missing required field returns named error
- `static_credentials_empty_session_token_succeeds` — empty optional token does not fail validation
- `static_credentials_missing_session_token_succeeds` — absent optional token does not fail validation
- `static_credentials_register_value_providers_with_fake_credentials` — exercises full registration code path

Integration testing with real AWS credentials (happy path for secret/parameter resolution) requires live AWS access and follows the existing `--ignored` test pattern.