### PR TITLE
refactor(rpc): establish a first-class services foundation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -291,6 +291,13 @@ Key abstractions for UI adaptation:
 
 **`TreeNav`**: Reusable tree navigation component (plain struct, not a GPUI Entity). Supports cursor movement, expand/collapse, select-by-id. Used by Settings sidebar and connections sidebar.
 
+### RPC Services Foundation
+
+- RPC services are first-class persisted descriptors with `RpcServiceKind` (`Driver`, `AuthProvider`).
+- Only `Driver` services are active today; `AuthProvider` services may be stored and discovered but must remain inert until a real auth-provider adapter exists.
+- The runtime seam for service discovery/classification lives in `dbflux_app::rpc_services`; extend that boundary for future RPC capabilities instead of hardcoding new driver-only bootstrap logic in `app_state.rs`.
+- Preserve compatibility for external driver registration IDs as `rpc:<socket_id>`.
+
 ### Connection Hooks
 
 - Hooks are reusable command definitions (name, command, args, cwd, env, timeout, failure policy)
@@ -314,6 +321,8 @@ Key abstractions for UI adaptation:
 5. Implement `QueryGenerator` when the driver can generate native mutation/read templates for UI previews, copy-as-query, or MCP previews
 6. Add feature flag in `crates/dbflux/Cargo.toml`
 7. Register in `AppState::new()` under `#[cfg(feature = "name")]`
+
+For external RPC-backed drivers, keep discovery/adaptation in `dbflux_app::rpc_services` rather than adding a parallel bootstrap path.
 
 ### Driver Capabilities
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -161,7 +161,7 @@ crates/
             ssh_tunnels.rs   # SSH tunnel CRUD form with FormGridNav
             hooks.rs         # Hook definitions CRUD
             drivers.rs       # Per-driver settings overrides
-            rpc_services.rs  # External RPC service management
+            rpc_services.rs  # RPC services settings UI (Driver/Auth Provider descriptors)
             mcp_section.rs   # MCP settings (trusted clients, roles, policies, audit)
           connection_manager/ # Connection manager window
             mod.rs
@@ -187,6 +187,7 @@ crates/
       hook_executor.rs       # Composite hook executor routing
       proxy.rs               # create_proxy_tunnel callback for CreateTunnelFn
       config_loader.rs       # SQLite-backed configuration persistence
+      rpc_services.rs        # RPC service discovery/adaptation seam for runtime bootstrap
       history_manager_sqlite.rs # SQLite-backed query history
       mcp_command.rs         # MCP subcommand integration and arg parsing
       keymap/                # Keyboard system (pure domain types)
@@ -635,7 +636,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 - Redis: `redis` driver with key-value API for all Redis types, variadic commands, keyspace support, key scanning, and command generation (crates/dbflux_driver_redis/src/driver.rs).
 - DynamoDB: `aws-sdk-dynamodb` driver with AWS profile/region support for remote DynamoDB, plus optional endpoint override for local emulators and tests (crates/dbflux_driver_dynamodb/src/driver.rs).
 - AWS auth stack: `dbflux_aws` provides AWS SSO/shared/static auth providers, SSO login orchestration, account/role discovery, and `~/.aws/config` profile write-back for newly saved auth profiles.
-- Local IPC/RPC: `interprocess` sockets + versioned envelopes for app control and external driver communication (`crates/dbflux_ipc/`, `crates/dbflux_driver_ipc/`, `crates/dbflux_driver_host/`). Auth tokens are managed by `dbflux_ipc/src/auth.rs`.
+- Local IPC/RPC: `interprocess` sockets + versioned envelopes for app control and RPC service communication (`crates/dbflux_ipc/`, `crates/dbflux_driver_ipc/`, `crates/dbflux_driver_host/`). `dbflux_app::rpc_services` discovers persisted service descriptors, adapts only `RpcServiceKind::Driver` into runtime `DbDriver`s today, and preserves `rpc:<socket_id>` compatibility. `RpcServiceKind::AuthProvider` is stored/discoverable but not yet wired into runtime auth flows. Auth tokens are managed by `dbflux_ipc/src/auth.rs`.
 - Proxy: SOCKS5/HTTP CONNECT tunnels via `dbflux_tunnel_core::Tunnel` (crates/dbflux_proxy/src/lib.rs).
 - SSH: `ssh2` sessions with local TCP forwarding via `dbflux_tunnel_core::Tunnel` (crates/dbflux_ssh/src/lib.rs).
 - OS keyring: optional secret storage for passwords, SSH passphrases, and proxy credentials (crates/dbflux_core/src/storage/secrets.rs).
@@ -650,7 +651,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
   - `cfg_auth_profiles` (provider-agnostic auth profile storage)
   - `cfg_ssh_tunnel_profiles`, `cfg_proxy_profiles`
   - `cfg_hooks`, `cfg_hook_bindings`
-  - `cfg_services`, `cfg_service_args`, `cfg_service_env` (external RPC services)
+  - `cfg_services`, `cfg_service_args`, `cfg_service_env` (RPC service descriptors; `cfg_services.service_kind` records `driver` vs `auth_provider`)
   - `cfg_governance_*` tables (roles, policies, trusted clients)
   - `cfg_drivers` (per-driver settings overrides)
   - `cfg_folders` (connection tree organization)
@@ -661,7 +662,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
   - `~/.config/dbflux/profiles.json` → `cfg_connection_profiles`
   - `~/.config/dbflux/auth_profiles.json` → `cfg_auth_profiles`
   - `~/.config/dbflux/ssh_tunnels.json` → `cfg_ssh_tunnel_profiles`
-  - `~/.config/dbflux/config.json` (rpc_services only) → `cfg_services`
+  - `~/.config/dbflux/config.json` (legacy rpc_services only) → `cfg_services` with legacy rows defaulted to `service_kind='driver'`
   - Import is idempotent (tracked in `sys_legacy_imports`)
 - Session data (data dir):
   - `sessions/` scratch and shadow files for auto-save (crates/dbflux_core/src/storage/session.rs).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,6 +291,13 @@ Key abstractions for UI adaptation:
 
 **`TreeNav`**: Reusable tree navigation component (plain struct, not a GPUI Entity). Supports cursor movement, expand/collapse, select-by-id. Used by Settings sidebar and connections sidebar.
 
+### RPC Services Foundation
+
+- RPC services are first-class persisted descriptors with `RpcServiceKind` (`Driver`, `AuthProvider`).
+- Only `Driver` services are active today; `AuthProvider` services may be stored and discovered but must remain inert until a real auth-provider adapter exists.
+- The runtime seam for service discovery/classification lives in `dbflux_app::rpc_services`; extend that boundary for future RPC capabilities instead of hardcoding new driver-only bootstrap logic in `app_state.rs`.
+- Preserve compatibility for external driver registration IDs as `rpc:<socket_id>`.
+
 ### Connection Hooks
 
 - Hooks are reusable command definitions (name, command, args, cwd, env, timeout, failure policy)
@@ -314,6 +321,8 @@ Key abstractions for UI adaptation:
 5. Implement `QueryGenerator` when the driver can generate native mutation/read templates for UI previews, copy-as-query, or MCP previews
 6. Add feature flag in `crates/dbflux/Cargo.toml`
 7. Register in `AppState::new()` under `#[cfg(feature = "name")]`
+
+For external RPC-backed drivers, keep discovery/adaptation in `dbflux_app::rpc_services` rather than adding a parallel bootstrap path.
 
 ### Driver Capabilities
 

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -18,7 +18,6 @@ use dbflux_core::{
     SchemaIndexInfo, SchemaSnapshot, ScriptsDirectory, SecretStore, ServiceConfig, SessionFacade,
     ShutdownPhase, SshTunnelProfile, TaskId, TaskKind, TaskSnapshot,
 };
-use dbflux_driver_ipc::{IpcDriver, driver::IpcDriverLaunchConfig};
 use dbflux_storage::bootstrap::StorageRuntime;
 
 #[cfg(feature = "mcp")]
@@ -56,16 +55,19 @@ use std::sync::RwLock;
 use uuid::Uuid;
 
 use crate::auth_provider_registry::{AuthProviderRegistry, RegistryAuthProviderWrapper};
+use crate::rpc_services::{DriverServiceAdaptation, adapt_driver_service, discover_services};
+
+#[cfg(test)]
+use crate::rpc_services::{DriverProbe, adapt_driver_service_with};
+
+#[cfg(test)]
+use dbflux_driver_ipc::driver::IpcDriverLaunchConfig;
 
 pub use dbflux_core::{
     ConnectProfileParams, ConnectedProfile, DangerousQuerySuppressions, FetchDatabaseSchemaParams,
     FetchSchemaForeignKeysParams, FetchSchemaIndexesParams, FetchSchemaTypesParams,
     FetchTableDetailsParams, SwitchDatabaseParams,
 };
-
-fn rpc_registry_id(socket_id: &str) -> String {
-    format!("rpc:{}", socket_id)
-}
 
 struct BuiltDrivers {
     drivers: HashMap<String, Arc<dyn DbDriver>>,
@@ -436,7 +438,7 @@ impl AppState {
         Vec<ProxyProfile>,
         Vec<SshTunnelProfile>,
     ) {
-        let drivers = Self::build_builtin_drivers();
+        let mut drivers = Self::build_builtin_drivers();
 
         let (
             general_settings,
@@ -448,7 +450,7 @@ impl AppState {
         ) = Self::load_app_config_from_storage();
 
         if !services.is_empty() {
-            Self::launch_rpc_services(&mut drivers.clone(), services);
+            Self::launch_rpc_services(&mut drivers, services);
         }
 
         let loaded = crate::config_loader::load_config(&runtime);
@@ -497,57 +499,85 @@ impl AppState {
         drivers: &mut HashMap<String, Arc<dyn DbDriver>>,
         services: Vec<ServiceConfig>,
     ) {
-        for service in services {
-            if !service.enabled {
-                log::info!("Skipping disabled service '{}'", service.socket_id);
-                continue;
+        for descriptor in discover_services(services) {
+            match adapt_driver_service(descriptor, |driver_id| drivers.contains_key(driver_id)) {
+                DriverServiceAdaptation::Registered { driver_id, service } => {
+                    drivers.insert(driver_id, service);
+                }
+                DriverServiceAdaptation::SkippedDisabled { socket_id } => {
+                    log::info!("Skipping disabled service '{}'", socket_id);
+                }
+                DriverServiceAdaptation::SkippedNonDriver { socket_id, kind } => {
+                    log::info!(
+                        "Deferring non-driver RPC service '{}' of kind {:?}",
+                        socket_id,
+                        kind
+                    );
+                }
+                DriverServiceAdaptation::SkippedDuplicate { socket_id } => {
+                    log::warn!(
+                        "Skipping external RPC service '{}': driver id already exists",
+                        socket_id
+                    );
+                }
+                DriverServiceAdaptation::ProbeFailed { socket_id, error } => {
+                    log::warn!(
+                        "Skipping RPC service '{}': failed to probe driver metadata: {}",
+                        socket_id,
+                        error
+                    );
+                }
             }
+        }
+    }
 
-            let driver_id = rpc_registry_id(&service.socket_id);
-
-            if drivers.contains_key(&driver_id) {
-                log::warn!(
-                    "Skipping external RPC service '{}': driver id already exists",
-                    service.socket_id
-                );
-                continue;
+    #[cfg(test)]
+    fn launch_rpc_services_with<Probe, Build>(
+        drivers: &mut HashMap<String, Arc<dyn DbDriver>>,
+        services: Vec<ServiceConfig>,
+        mut probe: Probe,
+        mut build: Build,
+    ) where
+        Probe:
+            FnMut(&str, &IpcDriverLaunchConfig) -> Result<DriverProbe, Box<dbflux_core::DbError>>,
+        Build: FnMut(String, String, DriverProbe, IpcDriverLaunchConfig) -> Arc<dyn DbDriver>,
+    {
+        for descriptor in discover_services(services) {
+            match adapt_driver_service_with(
+                descriptor,
+                |driver_id| drivers.contains_key(driver_id),
+                |socket_id, launch| probe(socket_id, launch),
+                |driver_id, socket_id, probe_result, launch| {
+                    build(driver_id, socket_id, probe_result, launch)
+                },
+            ) {
+                DriverServiceAdaptation::Registered { driver_id, service } => {
+                    drivers.insert(driver_id, service);
+                }
+                DriverServiceAdaptation::SkippedDisabled { socket_id } => {
+                    log::info!("Skipping disabled service '{}'", socket_id);
+                }
+                DriverServiceAdaptation::SkippedNonDriver { socket_id, kind } => {
+                    log::info!(
+                        "Deferring non-driver RPC service '{}' of kind {:?}",
+                        socket_id,
+                        kind
+                    );
+                }
+                DriverServiceAdaptation::SkippedDuplicate { socket_id } => {
+                    log::warn!(
+                        "Skipping external RPC service '{}': driver id already exists",
+                        socket_id
+                    );
+                }
+                DriverServiceAdaptation::ProbeFailed { socket_id, error } => {
+                    log::warn!(
+                        "Skipping RPC service '{}': failed to probe driver metadata: {}",
+                        socket_id,
+                        error
+                    );
+                }
             }
-
-            let launch = IpcDriverLaunchConfig {
-                program: service
-                    .command
-                    .clone()
-                    .unwrap_or_else(|| "dbflux-driver-host".to_string()),
-                args: service.args.clone(),
-                env: service.env.into_iter().collect(),
-                startup_timeout: std::time::Duration::from_millis(
-                    service.startup_timeout_ms.unwrap_or(5_000),
-                ),
-            };
-
-            let (kind, metadata, form_definition, settings_schema) =
-                match IpcDriver::probe_driver(&service.socket_id, Some(&launch)) {
-                    Ok(info) => info,
-                    Err(error) => {
-                        log::warn!(
-                            "Skipping RPC service '{}': failed to probe driver metadata: {}",
-                            service.socket_id,
-                            error
-                        );
-                        continue;
-                    }
-                };
-
-            let ipc_driver = IpcDriver::new(
-                service.socket_id.clone(),
-                kind,
-                metadata,
-                form_definition,
-                settings_schema,
-            )
-            .with_launch_config(launch);
-
-            drivers.insert(driver_id, Arc::new(ipc_driver));
         }
     }
 
@@ -2479,5 +2509,94 @@ impl AppState {
 impl Default for AppState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dbflux_core::{
+        DatabaseCategory, DbError, DbKind, DriverFormDef, DriverMetadataBuilder, QueryLanguage,
+        RpcServiceKind,
+    };
+    use dbflux_driver_ipc::IpcDriver;
+
+    fn fake_probe() -> crate::rpc_services::DriverProbe {
+        let metadata = DriverMetadataBuilder::new(
+            "sqlite",
+            "SQLite",
+            DatabaseCategory::Relational,
+            QueryLanguage::Sql,
+        )
+        .build();
+
+        (
+            DbKind::SQLite,
+            metadata,
+            DriverFormDef { tabs: vec![] },
+            None,
+        )
+    }
+
+    fn test_service(kind: RpcServiceKind) -> ServiceConfig {
+        ServiceConfig {
+            socket_id: "svc-socket".to_string(),
+            enabled: true,
+            command: Some("dbflux-driver-host".to_string()),
+            args: vec!["--stdio".to_string()],
+            env: HashMap::new(),
+            startup_timeout_ms: Some(1_000),
+            kind,
+        }
+    }
+
+    #[test]
+    fn launch_rpc_services_registers_driver_services_into_runtime_map() {
+        let mut drivers = HashMap::new();
+
+        AppState::launch_rpc_services_with(
+            &mut drivers,
+            vec![test_service(RpcServiceKind::Driver)],
+            |socket_id, _launch| {
+                assert_eq!(socket_id, "svc-socket");
+                Ok(fake_probe())
+            },
+            |_, socket_id, (kind, metadata, form_definition, settings_schema), launch| {
+                Arc::new(
+                    IpcDriver::new(socket_id, kind, metadata, form_definition, settings_schema)
+                        .with_launch_config(launch),
+                ) as Arc<dyn DbDriver>
+            },
+        );
+
+        assert!(drivers.contains_key("rpc:svc-socket"));
+    }
+
+    #[test]
+    fn launch_rpc_services_defers_non_driver_services_without_registration() {
+        let mut drivers = HashMap::new();
+
+        AppState::launch_rpc_services_with(
+            &mut drivers,
+            vec![test_service(RpcServiceKind::AuthProvider)],
+            |_, _| panic!("non-driver services must not be probed"),
+            |_, _, _, _| panic!("non-driver services must not be registered"),
+        );
+
+        assert!(drivers.is_empty());
+    }
+
+    #[test]
+    fn launch_rpc_services_skips_failed_driver_probes_without_registration() {
+        let mut drivers = HashMap::new();
+
+        AppState::launch_rpc_services_with(
+            &mut drivers,
+            vec![test_service(RpcServiceKind::Driver)],
+            |_, _| Err(Box::new(DbError::connection_failed("probe failed"))),
+            |_, _, _, _| panic!("failed probes must not build a driver"),
+        );
+
+        assert!(drivers.is_empty());
     }
 }

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -8,7 +8,7 @@ use dbflux_core::{
     AccessKind, ConnectionHook, ConnectionHookBindings, ConnectionHooks, ConnectionMcpGovernance,
     ConnectionMcpPolicyBinding, ConnectionProfile, DbKind, DriverKey, FormValues, GeneralSettings,
     GlobalOverrides, HookExecutionMode, HookFailureMode, HookKind, HookPhase, ProxyProfile,
-    ScriptLanguage, ScriptSource, ServiceConfig, SshTunnelProfile, ValueRef,
+    RpcServiceKind, ScriptLanguage, ScriptSource, ServiceConfig, SshTunnelProfile, ValueRef,
 };
 use dbflux_storage::bootstrap::StorageRuntime;
 use dbflux_storage::repositories::connection_driver_configs::ConnectionDriverConfigDto;
@@ -246,6 +246,7 @@ pub fn save_services(
             enabled: svc.enabled,
             command: svc.command.clone(),
             startup_timeout_ms: svc.startup_timeout_ms.map(|v| v as i64),
+            service_kind: rpc_service_kind_to_storage(svc.kind).to_string(),
             created_at: String::new(),
             updated_at: String::new(),
         };
@@ -1102,11 +1103,33 @@ fn load_services(
                     args,
                     env,
                     startup_timeout_ms: dto.startup_timeout_ms.map(|v| v as u64),
+                    kind: rpc_service_kind_from_storage(&dto.service_kind),
                 }
             })
             .collect()
     } else {
         Vec::new()
+    }
+}
+
+fn rpc_service_kind_to_storage(kind: RpcServiceKind) -> &'static str {
+    match kind {
+        RpcServiceKind::Driver => "driver",
+        RpcServiceKind::AuthProvider => "auth_provider",
+    }
+}
+
+fn rpc_service_kind_from_storage(kind: &str) -> RpcServiceKind {
+    match kind {
+        "driver" => RpcServiceKind::Driver,
+        "auth_provider" => RpcServiceKind::AuthProvider,
+        other => {
+            log::warn!(
+                "Unknown RPC service kind '{}'; defaulting to driver for compatibility",
+                other
+            );
+            RpcServiceKind::Driver
+        }
     }
 }
 
@@ -1607,12 +1630,12 @@ fn load_ssh_tunnels(
 #[cfg(test)]
 mod tests {
     use super::{
-        general_settings_theme_to_storage, load_config, save_profiles, save_ssh_tunnels,
-        theme_setting_from_storage,
+        general_settings_theme_to_storage, load_config, save_profiles, save_services,
+        save_ssh_tunnels, theme_setting_from_storage,
     };
     use dbflux_core::{
-        AccessKind, ConnectionProfile, DbConfig, GeneralSettings, SshAuthMethod, SshTunnelConfig,
-        SshTunnelProfile, ThemeSetting,
+        AccessKind, ConnectionProfile, DbConfig, GeneralSettings, RpcServiceKind, ServiceConfig,
+        SshAuthMethod, SshTunnelConfig, SshTunnelProfile, ThemeSetting,
     };
     use dbflux_storage::bootstrap::StorageRuntime;
     use dbflux_storage::repositories::general_settings::GeneralSettingsDto;
@@ -1779,5 +1802,79 @@ mod tests {
             }
             other => panic!("expected postgres config, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn load_config_defaults_legacy_service_rows_to_driver_kind() {
+        let runtime = StorageRuntime::in_memory().expect("in-memory storage runtime");
+        let conn = runtime.open_dbflux_db().expect("open runtime database");
+
+        conn.execute(
+            "INSERT INTO cfg_services (socket_id, enabled, command, startup_timeout_ms) VALUES (?1, ?2, ?3, ?4)",
+            [
+                "legacy-socket",
+                "1",
+                "dbflux-driver-host",
+                "5000",
+            ],
+        )
+            .expect("insert legacy service row");
+
+        let loaded = load_config(&runtime);
+
+        assert_eq!(loaded.services.len(), 1);
+        assert_eq!(loaded.services[0].socket_id, "legacy-socket");
+        assert_eq!(loaded.services[0].kind, RpcServiceKind::Driver);
+    }
+
+    #[test]
+    fn save_services_persists_service_kind_for_roundtrip() {
+        let runtime = StorageRuntime::in_memory().expect("in-memory storage runtime");
+        let services = vec![ServiceConfig {
+            socket_id: "auth-socket".to_string(),
+            enabled: true,
+            command: Some("dbflux-driver-host".to_string()),
+            args: vec!["--stdio".to_string()],
+            env: std::collections::HashMap::new(),
+            startup_timeout_ms: Some(5_000),
+            kind: RpcServiceKind::AuthProvider,
+        }];
+
+        save_services(&runtime, &services).expect("save services");
+
+        let dto = runtime
+            .services()
+            .get("auth-socket")
+            .expect("load service dto")
+            .expect("service row");
+
+        assert_eq!(dto.service_kind, "auth_provider");
+
+        let loaded = load_config(&runtime);
+        assert_eq!(loaded.services.len(), 1);
+        assert_eq!(loaded.services[0].kind, RpcServiceKind::AuthProvider);
+    }
+
+    #[test]
+    fn load_config_defaults_unknown_service_kind_to_driver() {
+        let runtime = StorageRuntime::in_memory().expect("in-memory storage runtime");
+        let conn = runtime.open_dbflux_db().expect("open runtime database");
+
+        conn.execute(
+            "INSERT INTO cfg_services (socket_id, enabled, command, startup_timeout_ms, service_kind) VALUES (?1, ?2, ?3, ?4, ?5)",
+            [
+                "unknown-socket",
+                "1",
+                "dbflux-driver-host",
+                "5000",
+                "mystery_kind",
+            ],
+        )
+        .expect("insert unknown-kind service row");
+
+        let loaded = load_config(&runtime);
+
+        assert_eq!(loaded.services.len(), 1);
+        assert_eq!(loaded.services[0].kind, RpcServiceKind::Driver);
     }
 }

--- a/crates/dbflux_app/src/lib.rs
+++ b/crates/dbflux_app/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hook_executor;
 pub mod keymap;
 pub mod mcp_command;
 pub mod proxy;
+pub mod rpc_services;
 
 pub use access_manager::AppAccessManager;
 pub use app_state::AppState;

--- a/crates/dbflux_app/src/rpc_services.rs
+++ b/crates/dbflux_app/src/rpc_services.rs
@@ -1,0 +1,264 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use dbflux_core::{
+    DbDriver, DbError, DbKind, DriverFormDef, DriverMetadata, RpcServiceKind, ServiceConfig,
+};
+use dbflux_driver_ipc::{IpcDriver, driver::IpcDriverLaunchConfig};
+
+pub(crate) type DriverProbe = (DbKind, DriverMetadata, DriverFormDef, Option<DriverFormDef>);
+
+#[derive(Clone, Debug)]
+pub(crate) struct RpcServiceDescriptor {
+    pub(crate) config: ServiceConfig,
+    pub(crate) launch: IpcDriverLaunchConfig,
+}
+
+pub(crate) enum DriverServiceAdaptation<T> {
+    Registered {
+        driver_id: String,
+        service: T,
+    },
+    SkippedDisabled {
+        socket_id: String,
+    },
+    SkippedNonDriver {
+        socket_id: String,
+        kind: RpcServiceKind,
+    },
+    SkippedDuplicate {
+        socket_id: String,
+    },
+    ProbeFailed {
+        socket_id: String,
+        error: Box<DbError>,
+    },
+}
+
+pub(crate) fn rpc_registry_id(socket_id: &str) -> String {
+    format!("rpc:{}", socket_id)
+}
+
+pub(crate) fn discover_services(services: Vec<ServiceConfig>) -> Vec<RpcServiceDescriptor> {
+    services
+        .into_iter()
+        .map(|config| RpcServiceDescriptor {
+            launch: IpcDriverLaunchConfig {
+                program: config
+                    .command
+                    .clone()
+                    .unwrap_or_else(|| "dbflux-driver-host".to_string()),
+                args: config.args.clone(),
+                env: config
+                    .env
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone()))
+                    .collect(),
+                startup_timeout: Duration::from_millis(config.startup_timeout_ms.unwrap_or(5_000)),
+            },
+            config,
+        })
+        .collect()
+}
+
+pub(crate) fn adapt_driver_service(
+    descriptor: RpcServiceDescriptor,
+    driver_exists: impl FnOnce(&str) -> bool,
+) -> DriverServiceAdaptation<Arc<dyn DbDriver>> {
+    adapt_driver_service_with(
+        descriptor,
+        driver_exists,
+        |socket_id, launch| IpcDriver::probe_driver(socket_id, Some(launch)).map_err(Box::new),
+        |_, socket_id, (kind, metadata, form_definition, settings_schema), launch| {
+            Arc::new(
+                IpcDriver::new(socket_id, kind, metadata, form_definition, settings_schema)
+                    .with_launch_config(launch),
+            ) as Arc<dyn DbDriver>
+        },
+    )
+}
+
+pub(crate) fn adapt_driver_service_with<T, Probe, Build>(
+    descriptor: RpcServiceDescriptor,
+    driver_exists: impl FnOnce(&str) -> bool,
+    probe: Probe,
+    build: Build,
+) -> DriverServiceAdaptation<T>
+where
+    Probe: FnOnce(&str, &IpcDriverLaunchConfig) -> Result<DriverProbe, Box<DbError>>,
+    Build: FnOnce(String, String, DriverProbe, IpcDriverLaunchConfig) -> T,
+{
+    if !descriptor.config.enabled {
+        return DriverServiceAdaptation::SkippedDisabled {
+            socket_id: descriptor.config.socket_id,
+        };
+    }
+
+    if descriptor.config.kind != RpcServiceKind::Driver {
+        return DriverServiceAdaptation::SkippedNonDriver {
+            socket_id: descriptor.config.socket_id,
+            kind: descriptor.config.kind,
+        };
+    }
+
+    let driver_id = rpc_registry_id(&descriptor.config.socket_id);
+    if driver_exists(&driver_id) {
+        return DriverServiceAdaptation::SkippedDuplicate {
+            socket_id: descriptor.config.socket_id,
+        };
+    }
+
+    let probe_result = match probe(&descriptor.config.socket_id, &descriptor.launch) {
+        Ok(probe_result) => probe_result,
+        Err(error) => {
+            return DriverServiceAdaptation::ProbeFailed {
+                socket_id: descriptor.config.socket_id,
+                error,
+            };
+        }
+    };
+
+    let socket_id = descriptor.config.socket_id;
+    let service = build(
+        driver_id.clone(),
+        socket_id,
+        probe_result,
+        descriptor.launch,
+    );
+
+    DriverServiceAdaptation::Registered { driver_id, service }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dbflux_core::{DatabaseCategory, DriverMetadataBuilder, QueryLanguage};
+
+    fn fake_probe() -> DriverProbe {
+        let metadata = DriverMetadataBuilder::new(
+            "sqlite",
+            "SQLite",
+            DatabaseCategory::Relational,
+            QueryLanguage::Sql,
+        )
+        .build();
+
+        (
+            DbKind::SQLite,
+            metadata,
+            DriverFormDef { tabs: vec![] },
+            None,
+        )
+    }
+
+    fn test_service(kind: RpcServiceKind, enabled: bool) -> ServiceConfig {
+        ServiceConfig {
+            socket_id: "svc-socket".to_string(),
+            enabled,
+            command: None,
+            args: vec!["--stdio".to_string()],
+            env: std::collections::HashMap::from([("RUST_LOG".to_string(), "info".to_string())]),
+            startup_timeout_ms: Some(7_500),
+            kind,
+        }
+    }
+
+    #[test]
+    fn discover_and_adapt_driver_service_preserves_rpc_registry_id() {
+        let descriptor = discover_services(vec![test_service(RpcServiceKind::Driver, true)])
+            .into_iter()
+            .next()
+            .expect("descriptor");
+
+        let adaptation = adapt_driver_service_with(
+            descriptor,
+            |_| false,
+            |socket_id, launch| {
+                assert_eq!(socket_id, "svc-socket");
+                assert_eq!(launch.program, "dbflux-driver-host");
+                assert_eq!(launch.args, vec!["--stdio".to_string()]);
+                assert_eq!(launch.startup_timeout, Duration::from_millis(7_500));
+                Ok(fake_probe())
+            },
+            |driver_id, socket_id, _, launch| (driver_id, socket_id, launch.program),
+        );
+
+        match adaptation {
+            DriverServiceAdaptation::Registered { driver_id, service } => {
+                assert_eq!(driver_id, "rpc:svc-socket");
+                assert_eq!(service.0, "rpc:svc-socket");
+                assert_eq!(service.1, "svc-socket");
+                assert_eq!(service.2, "dbflux-driver-host");
+            }
+            _ => panic!("expected driver registration"),
+        }
+    }
+
+    #[test]
+    fn adapt_driver_service_skips_non_driver_descriptors() {
+        let descriptor = discover_services(vec![test_service(RpcServiceKind::AuthProvider, true)])
+            .into_iter()
+            .next()
+            .expect("descriptor");
+
+        let adaptation = adapt_driver_service_with(
+            descriptor,
+            |_| false,
+            |_, _| Ok(fake_probe()),
+            |driver_id, _, _, _| driver_id,
+        );
+
+        match adaptation {
+            DriverServiceAdaptation::SkippedNonDriver { socket_id, kind } => {
+                assert_eq!(socket_id, "svc-socket");
+                assert_eq!(kind, RpcServiceKind::AuthProvider);
+            }
+            _ => panic!("expected non-driver service to stay inert"),
+        }
+    }
+
+    #[test]
+    fn adapt_driver_service_skips_disabled_descriptors_before_probe() {
+        let descriptor = discover_services(vec![test_service(RpcServiceKind::Driver, false)])
+            .into_iter()
+            .next()
+            .expect("descriptor");
+
+        let adaptation = adapt_driver_service_with(
+            descriptor,
+            |_| false,
+            |_, _| panic!("disabled services must not be probed"),
+            |driver_id, _, _, _| driver_id,
+        );
+
+        match adaptation {
+            DriverServiceAdaptation::SkippedDisabled { socket_id } => {
+                assert_eq!(socket_id, "svc-socket");
+            }
+            _ => panic!("expected disabled service to be skipped"),
+        }
+    }
+
+    #[test]
+    fn adapt_driver_service_returns_probe_failure_without_registration() {
+        let descriptor = discover_services(vec![test_service(RpcServiceKind::Driver, true)])
+            .into_iter()
+            .next()
+            .expect("descriptor");
+
+        let adaptation = adapt_driver_service_with(
+            descriptor,
+            |_| false,
+            |_, _| Err(Box::new(DbError::connection_failed("probe failed"))),
+            |driver_id, _, _, _| driver_id,
+        );
+
+        match adaptation {
+            DriverServiceAdaptation::ProbeFailed { socket_id, error } => {
+                assert_eq!(socket_id, "svc-socket");
+                assert_eq!(error.to_string(), "Connection failed: probe failed");
+            }
+            _ => panic!("expected probe failure"),
+        }
+    }
+}

--- a/crates/dbflux_core/src/config/app.rs
+++ b/crates/dbflux_core/src/config/app.rs
@@ -463,6 +463,17 @@ pub struct ServiceConfig {
 
     #[serde(default)]
     pub startup_timeout_ms: Option<u64>,
+
+    #[serde(default)]
+    pub kind: RpcServiceKind,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RpcServiceKind {
+    #[default]
+    Driver,
+    AuthProvider,
 }
 
 fn default_enabled() -> bool {
@@ -1008,6 +1019,40 @@ mod tests {
         );
         assert!(restored.hook_definitions.is_empty());
         assert_eq!(restored.governance, GovernanceSettings::default());
+    }
+
+    #[test]
+    fn service_config_deserializes_missing_kind_as_driver() {
+        let json = r#"{
+            "socket_id": "legacy-socket",
+            "enabled": true,
+            "command": "dbflux-driver-host",
+            "args": ["--stdio"]
+        }"#;
+
+        let service: ServiceConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(service.kind, RpcServiceKind::Driver);
+    }
+
+    #[test]
+    fn service_config_serializes_kind_for_roundtrip() {
+        let service = ServiceConfig {
+            socket_id: "auth-socket".to_string(),
+            enabled: true,
+            command: Some("dbflux-driver-host".to_string()),
+            args: vec!["--stdio".to_string()],
+            env: HashMap::new(),
+            startup_timeout_ms: Some(5_000),
+            kind: RpcServiceKind::AuthProvider,
+        };
+
+        let json = serde_json::to_value(&service).unwrap();
+
+        assert_eq!(json.get("kind"), Some(&serde_json::json!("auth_provider")));
+
+        let restored: ServiceConfig = serde_json::from_value(json).unwrap();
+        assert_eq!(restored.kind, RpcServiceKind::AuthProvider);
     }
 
     #[test]

--- a/crates/dbflux_core/src/config/mod.rs
+++ b/crates/dbflux_core/src/config/mod.rs
@@ -4,9 +4,9 @@ pub(crate) mod scripts_directory;
 
 pub use app::{
     AppConfig, AppConfigStore, DangerousAction, DriverKey, EffectiveSettings, GeneralSettings,
-    GlobalOverrides, GovernanceSettings, PolicyRoleConfig, RefreshPolicySetting, ServiceConfig,
-    StartupFocus, ThemeSetting, ToolPolicyConfig, TrustedClientConfig, driver_maps_differ,
-    migrate_app_config,
+    GlobalOverrides, GovernanceSettings, PolicyRoleConfig, RefreshPolicySetting, RpcServiceKind,
+    ServiceConfig, StartupFocus, ThemeSetting, ToolPolicyConfig, TrustedClientConfig,
+    driver_maps_differ, migrate_app_config,
 };
 pub use refresh_policy::RefreshPolicy;
 pub use scripts_directory::{

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -26,9 +26,9 @@ pub use auth::{
 pub use config::{
     AppConfig, AppConfigStore, DangerousAction, DriverKey, EffectiveSettings, GeneralSettings,
     GlobalOverrides, GovernanceSettings, PolicyRoleConfig, RefreshPolicy, RefreshPolicySetting,
-    ScriptEntry, ScriptsDirectory, ServiceConfig, StartupFocus, ThemeSetting, ToolPolicyConfig,
-    TrustedClientConfig, all_script_extensions, driver_maps_differ, filter_entries,
-    hook_script_path, is_openable_script, migrate_app_config,
+    RpcServiceKind, ScriptEntry, ScriptsDirectory, ServiceConfig, StartupFocus, ThemeSetting,
+    ToolPolicyConfig, TrustedClientConfig, all_script_extensions, driver_maps_differ,
+    filter_entries, hook_script_path, is_openable_script, migrate_app_config,
 };
 
 pub use connection::{

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -135,6 +135,7 @@ impl MigrationRegistry {
         registry.register(mod_002_audit_extended::MigrationImpl);
         registry.register(mod_003_audit_settings::MigrationImpl);
         registry.register(mod_004_audit_saved_filters::MigrationImpl);
+        registry.register(mod_005_rpc_service_kind::MigrationImpl);
         registry
     }
 
@@ -277,11 +278,13 @@ mod mod_001_initial;
 mod mod_002_audit_extended;
 mod mod_003_audit_settings;
 mod mod_004_audit_saved_filters;
+mod mod_005_rpc_service_kind;
 
 pub use mod_001_initial::MigrationImpl;
 pub use mod_002_audit_extended::MigrationImpl as MigrationImplAuditExtended;
 pub use mod_003_audit_settings::MigrationImpl as MigrationImplAuditSettings;
 pub use mod_004_audit_saved_filters::MigrationImpl as MigrationImplAuditSavedFilters;
+pub use mod_005_rpc_service_kind::MigrationImpl as MigrationImplRpcServiceKind;
 
 // ---------------------------------------------------------------------------
 // Database verification utilities
@@ -313,6 +316,29 @@ mod tests {
     use super::*;
     use rusqlite::Connection;
 
+    fn column_names(conn: &Connection, table: &str) -> std::collections::HashSet<String> {
+        let mut stmt = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .unwrap();
+
+        stmt.query_map([], |row| row.get::<_, String>(1))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect()
+    }
+
+    fn temp_dir(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "dbflux_migration_{}_{}_{}",
+            label,
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
     /// Helper to get all table names from sqlite_master.
     fn table_names(conn: &Connection) -> std::collections::HashSet<String> {
         let mut stmt = conn
@@ -326,7 +352,7 @@ mod tests {
 
     #[test]
     fn test_run_all_idempotent() {
-        let temp_dir = std::env::temp_dir().join("dbflux_migration_idempotent");
+        let temp_dir = temp_dir("idempotent");
         let _ = std::fs::remove_dir_all(&temp_dir);
         std::fs::create_dir_all(&temp_dir).unwrap();
         let db_path = temp_dir.join("test.db");
@@ -339,7 +365,7 @@ mod tests {
         let count_first: i64 = conn
             .query_row("SELECT COUNT(*) FROM sys_migrations", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(count_first, 4, "expected 4 migrations after first run");
+        assert_eq!(count_first, 5, "expected 5 migrations after first run");
 
         registry.run_all(&conn).unwrap();
 
@@ -347,8 +373,8 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM sys_migrations", [], |row| row.get(0))
             .unwrap();
         assert_eq!(
-            count_second, 4,
-            "expected still 4 migrations after second run (idempotent)"
+            count_second, 5,
+            "expected still 5 migrations after second run (idempotent)"
         );
 
         drop(conn);
@@ -357,7 +383,7 @@ mod tests {
 
     #[test]
     fn test_run_all_creates_all_tables() {
-        let temp_dir = std::env::temp_dir().join("dbflux_migration_tables");
+        let temp_dir = temp_dir("tables");
         let _ = std::fs::remove_dir_all(&temp_dir);
         std::fs::create_dir_all(&temp_dir).unwrap();
         let db_path = temp_dir.join("test.db");
@@ -463,7 +489,7 @@ mod tests {
 
     #[test]
     fn test_get_pending_returns_unapplied() {
-        let temp_dir = std::env::temp_dir().join("dbflux_migration_pending");
+        let temp_dir = temp_dir("pending");
         let _ = std::fs::remove_dir_all(&temp_dir);
         std::fs::create_dir_all(&temp_dir).unwrap();
         let db_path = temp_dir.join("test.db");
@@ -474,13 +500,14 @@ mod tests {
         let pending_before = registry.get_pending(&conn).unwrap();
         assert_eq!(
             pending_before.len(),
-            4,
-            "expected 4 pending migrations before running"
+            5,
+            "expected 5 pending migrations before running"
         );
         assert_eq!(pending_before[0].name(), "001_initial");
         assert_eq!(pending_before[1].name(), "002_audit_extended");
         assert_eq!(pending_before[2].name(), "003_audit_settings");
         assert_eq!(pending_before[3].name(), "004_audit_saved_filters");
+        assert_eq!(pending_before[4].name(), "005_rpc_service_kind");
 
         registry.run_all(&conn).unwrap();
 
@@ -532,6 +559,77 @@ mod tests {
                 fk_check_result
             );
         }
+
+        drop(conn);
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_run_all_adds_service_kind_column_to_cfg_services() {
+        let temp_dir = temp_dir("service_kind_column");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.db");
+
+        let conn = Connection::open(&db_path).unwrap();
+        MigrationRegistry::new().run_all(&conn).unwrap();
+
+        let columns = column_names(&conn, "cfg_services");
+        assert!(columns.contains("service_kind"));
+
+        drop(conn);
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_pending_service_kind_migration_upgrades_legacy_rows_to_driver() {
+        let temp_dir = temp_dir("service_kind_legacy");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.db");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE sys_migrations (name TEXT PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')))",
+            [],
+        )
+        .unwrap();
+        for migration in [
+            "001_initial",
+            "002_audit_extended",
+            "003_audit_settings",
+            "004_audit_saved_filters",
+        ] {
+            conn.execute("INSERT INTO sys_migrations (name) VALUES (?1)", [migration])
+                .unwrap();
+        }
+
+        conn.execute_batch(
+            r#"
+            CREATE TABLE cfg_services (
+                socket_id TEXT PRIMARY KEY,
+                enabled INTEGER DEFAULT 1,
+                command TEXT,
+                startup_timeout_ms INTEGER,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            INSERT INTO cfg_services (socket_id, enabled, command, startup_timeout_ms)
+            VALUES ('legacy-socket', 1, 'dbflux-driver-host', 5000);
+            "#,
+        )
+        .unwrap();
+
+        MigrationRegistry::new().run_all(&conn).unwrap();
+
+        let service_kind: String = conn
+            .query_row(
+                "SELECT service_kind FROM cfg_services WHERE socket_id = ?1",
+                ["legacy-socket"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(service_kind, "driver");
 
         drop(conn);
         let _ = std::fs::remove_dir_all(temp_dir);

--- a/crates/dbflux_storage/src/migrations/mod_005_rpc_service_kind.rs
+++ b/crates/dbflux_storage/src/migrations/mod_005_rpc_service_kind.rs
@@ -1,0 +1,60 @@
+//! Migration 005: Add service kind classification to RPC services.
+
+use rusqlite::Transaction;
+
+use crate::migrations::{Migration, MigrationError};
+
+/// Adds the `service_kind` column to `cfg_services` with a backward-compatible default.
+pub struct MigrationImpl;
+
+impl Migration for MigrationImpl {
+    fn name(&self) -> &str {
+        "005_rpc_service_kind"
+    }
+
+    fn run(&self, tx: &Transaction) -> Result<(), MigrationError> {
+        if has_service_kind_column(tx)? {
+            return Ok(());
+        }
+
+        tx.execute(
+            "ALTER TABLE cfg_services ADD COLUMN service_kind TEXT NOT NULL DEFAULT 'driver'",
+            [],
+        )
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+        Ok(())
+    }
+}
+
+fn has_service_kind_column(tx: &Transaction) -> Result<bool, MigrationError> {
+    let mut stmt = tx
+        .prepare("PRAGMA table_info(cfg_services)")
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    for column in columns {
+        let column = column.map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+        if column == "service_kind" {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/crates/dbflux_storage/src/repositories/services.rs
+++ b/crates/dbflux_storage/src/repositories/services.rs
@@ -83,7 +83,7 @@ impl ServiceRepository {
             .conn()
             .prepare(
                 r#"
-                SELECT socket_id, enabled, command, startup_timeout_ms, created_at, updated_at
+                SELECT socket_id, enabled, command, startup_timeout_ms, service_kind, created_at, updated_at
                 FROM cfg_services
                 ORDER BY socket_id ASC
                 "#,
@@ -100,8 +100,9 @@ impl ServiceRepository {
                     enabled: row.get::<_, i32>(1)? != 0,
                     command: row.get(2)?,
                     startup_timeout_ms: row.get(3)?,
-                    created_at: row.get(4)?,
-                    updated_at: row.get(5)?,
+                    service_kind: row.get(4)?,
+                    created_at: row.get(5)?,
+                    updated_at: row.get(6)?,
                 })
             })
             .map_err(|source| StorageError::Sqlite {
@@ -134,7 +135,7 @@ impl ServiceRepository {
             .conn()
             .prepare(
                 r#"
-                SELECT socket_id, enabled, command, startup_timeout_ms, created_at, updated_at
+                SELECT socket_id, enabled, command, startup_timeout_ms, service_kind, created_at, updated_at
                 FROM cfg_services
                 WHERE socket_id = ?1
                 "#,
@@ -150,8 +151,9 @@ impl ServiceRepository {
                 enabled: row.get::<_, i32>(1)? != 0,
                 command: row.get(2)?,
                 startup_timeout_ms: row.get(3)?,
-                created_at: row.get(4)?,
-                updated_at: row.get(5)?,
+                service_kind: row.get(4)?,
+                created_at: row.get(5)?,
+                updated_at: row.get(6)?,
             })
         });
 
@@ -179,9 +181,9 @@ impl ServiceRepository {
         tx.execute(
             r#"
                 INSERT INTO cfg_services (
-                    socket_id, enabled, command, startup_timeout_ms, created_at, updated_at
+                    socket_id, enabled, command, startup_timeout_ms, service_kind, created_at, updated_at
                 ) VALUES (
-                    ?1, ?2, ?3, ?4, datetime('now'), datetime('now')
+                    ?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now')
                 )
                 "#,
             params![
@@ -189,6 +191,7 @@ impl ServiceRepository {
                 service.enabled as i32,
                 service.command,
                 service.startup_timeout_ms,
+                service.service_kind,
             ],
         )
         .map_err(|source| StorageError::Sqlite {
@@ -223,6 +226,7 @@ impl ServiceRepository {
                     enabled = ?2,
                     command = ?3,
                     startup_timeout_ms = ?4,
+                    service_kind = ?5,
                     updated_at = datetime('now')
                 WHERE socket_id = ?1
                 "#,
@@ -231,6 +235,7 @@ impl ServiceRepository {
                     service.enabled as i32,
                     service.command,
                     service.startup_timeout_ms,
+                    service.service_kind,
                 ],
             )
             .map_err(|source| StorageError::Sqlite {
@@ -267,12 +272,13 @@ impl ServiceRepository {
         tx.execute(
             r#"
                 INSERT INTO cfg_services (
-                    socket_id, enabled, command, startup_timeout_ms, created_at, updated_at
-                ) VALUES (?1, ?2, ?3, ?4, datetime('now'), datetime('now'))
+                    socket_id, enabled, command, startup_timeout_ms, service_kind, created_at, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now'))
                 ON CONFLICT(socket_id) DO UPDATE SET
                     enabled = excluded.enabled,
                     command = excluded.command,
                     startup_timeout_ms = excluded.startup_timeout_ms,
+                    service_kind = excluded.service_kind,
                     updated_at = datetime('now')
                 "#,
             params![
@@ -280,6 +286,7 @@ impl ServiceRepository {
                 service.enabled as i32,
                 service.command,
                 service.startup_timeout_ms,
+                service.service_kind,
             ],
         )
         .map_err(|source| StorageError::Sqlite {
@@ -332,6 +339,7 @@ pub struct ServiceDto {
     pub enabled: bool,
     pub command: Option<String>,
     pub startup_timeout_ms: Option<i64>,
+    pub service_kind: String,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -344,6 +352,7 @@ impl ServiceDto {
             enabled: true,
             command: None,
             startup_timeout_ms: None,
+            service_kind: "driver".to_string(),
             created_at: String::new(),
             updated_at: String::new(),
         }
@@ -383,6 +392,42 @@ mod tests {
         let fetched = repo.all().expect("should fetch");
         assert_eq!(fetched.len(), 1);
         assert_eq!(fetched[0].socket_id, "test-socket");
+        assert_eq!(fetched[0].service_kind, "driver");
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+        let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    }
+
+    #[test]
+    fn service_upsert_persists_service_kind() {
+        let path = temp_db("service_kind");
+        let _ = std::fs::remove_file(&path);
+
+        let conn = open_database(&path).expect("should open");
+        MigrationRegistry::new()
+            .run_all(&conn)
+            .expect("migration should run");
+
+        let repo = ServiceRepository::new(Arc::new(conn));
+        let dto = ServiceDto {
+            socket_id: "auth-socket".to_string(),
+            enabled: true,
+            command: Some("dbflux-driver-host".to_string()),
+            startup_timeout_ms: Some(5_000),
+            service_kind: "auth_provider".to_string(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        };
+
+        repo.upsert(&dto).expect("should upsert");
+
+        let fetched = repo
+            .get("auth-socket")
+            .expect("should load")
+            .expect("service row");
+
+        assert_eq!(fetched.service_kind, "auth_provider");
 
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));

--- a/crates/dbflux_ui/src/ui/windows/settings/render.rs
+++ b/crates/dbflux_ui/src/ui/windows/settings/render.rs
@@ -44,7 +44,7 @@ impl SettingsCoordinator {
             super::SettingsSectionId::Proxies => "Proxy",
             super::SettingsSectionId::SshTunnels => "SSH Tunnels",
             super::SettingsSectionId::AuthProfiles => "Auth Profiles",
-            super::SettingsSectionId::Services => "Services",
+            super::SettingsSectionId::Services => "RPC Services",
             super::SettingsSectionId::Hooks => "Hooks",
             super::SettingsSectionId::Drivers => "Drivers",
             super::SettingsSectionId::About => "About",

--- a/crates/dbflux_ui/src/ui/windows/settings/rpc_services.rs
+++ b/crates/dbflux_ui/src/ui/windows/settings/rpc_services.rs
@@ -4,7 +4,7 @@ use crate::ui::tokens::{Heights, Radii};
 use dbflux_components::controls::{GpuiInput as Input, InputState};
 use dbflux_components::primitives::{Icon as PrimitiveIcon, Label};
 use dbflux_components::typography::{Body, MonoCaption, MonoLabel, MonoMeta, PanelTitle};
-use dbflux_core::ServiceConfig;
+use dbflux_core::{RpcServiceKind, ServiceConfig};
 use dbflux_storage::bootstrap::StorageRuntime;
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -17,6 +17,162 @@ use std::collections::HashMap;
 
 use super::layout;
 use super::services_section::{ServiceFocus, ServiceFormRow, ServicesSection};
+
+fn services_section_title() -> &'static str {
+    "RPC Services"
+}
+
+fn services_section_description() -> &'static str {
+    "Manage configured RPC services. Changes require restart."
+}
+
+fn empty_services_message() -> &'static str {
+    "No RPC services configured"
+}
+
+fn service_editor_title(is_editing: bool) -> &'static str {
+    if is_editing {
+        "Edit RPC Service"
+    } else {
+        "New RPC Service"
+    }
+}
+
+fn new_service_button_label() -> &'static str {
+    "New RPC Service"
+}
+
+fn editable_service_kind(service: &ServiceConfig) -> RpcServiceKind {
+    service.kind
+}
+
+fn build_service_config(
+    socket_id: String,
+    enabled: bool,
+    command: Option<String>,
+    args: Vec<String>,
+    env: HashMap<String, String>,
+    startup_timeout_ms: Option<u64>,
+    kind: RpcServiceKind,
+) -> ServiceConfig {
+    ServiceConfig {
+        socket_id,
+        enabled,
+        command,
+        args,
+        env,
+        startup_timeout_ms,
+        kind,
+    }
+}
+
+fn service_form_rows(
+    arg_count: usize,
+    env_count: usize,
+    editing_service: bool,
+) -> Vec<ServiceFormRow> {
+    let mut rows = vec![
+        ServiceFormRow::SocketId,
+        ServiceFormRow::Command,
+        ServiceFormRow::Timeout,
+        ServiceFormRow::Kind,
+        ServiceFormRow::Enabled,
+    ];
+
+    for index in 0..arg_count {
+        rows.push(ServiceFormRow::Arg(index));
+    }
+    rows.push(ServiceFormRow::AddArg);
+
+    for index in 0..env_count {
+        rows.push(ServiceFormRow::EnvKey(index));
+    }
+    rows.push(ServiceFormRow::AddEnv);
+
+    if editing_service {
+        rows.push(ServiceFormRow::DeleteButton);
+    }
+
+    rows.push(ServiceFormRow::SaveButton);
+    rows
+}
+
+fn service_row_max_col(row: ServiceFormRow) -> usize {
+    match row {
+        ServiceFormRow::Kind | ServiceFormRow::Arg(_) => 1,
+        ServiceFormRow::EnvKey(_) => 2,
+        _ => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ServiceFormRow, build_service_config, editable_service_kind, service_form_rows,
+        service_row_max_col,
+    };
+    use dbflux_core::{RpcServiceKind, ServiceConfig};
+    use std::collections::HashMap;
+
+    #[test]
+    fn service_form_rows_include_kind_selector_before_enabled_toggle() {
+        let rows = service_form_rows(0, 0, false);
+
+        assert_eq!(
+            rows,
+            vec![
+                ServiceFormRow::SocketId,
+                ServiceFormRow::Command,
+                ServiceFormRow::Timeout,
+                ServiceFormRow::Kind,
+                ServiceFormRow::Enabled,
+                ServiceFormRow::AddArg,
+                ServiceFormRow::AddEnv,
+                ServiceFormRow::SaveButton,
+            ]
+        );
+    }
+
+    #[test]
+    fn service_row_max_col_allows_driver_and_auth_provider_selection() {
+        assert_eq!(service_row_max_col(ServiceFormRow::Kind), 1);
+        assert_eq!(service_row_max_col(ServiceFormRow::Enabled), 0);
+    }
+
+    #[test]
+    fn editable_service_kind_preserves_saved_auth_provider_kind() {
+        let service = ServiceConfig {
+            socket_id: "auth.sock".into(),
+            enabled: true,
+            command: Some("dbflux-auth".into()),
+            args: vec!["--serve".into()],
+            env: HashMap::new(),
+            startup_timeout_ms: Some(5000),
+            kind: RpcServiceKind::AuthProvider,
+        };
+
+        assert_eq!(
+            editable_service_kind(&service),
+            RpcServiceKind::AuthProvider
+        );
+    }
+
+    #[test]
+    fn build_service_config_preserves_selected_service_kind() {
+        let service = build_service_config(
+            "auth.sock".into(),
+            true,
+            Some("dbflux-auth".into()),
+            vec!["--serve".into()],
+            HashMap::from([("MODE".into(), "auth".into())]),
+            Some(5000),
+            RpcServiceKind::AuthProvider,
+        );
+
+        assert_eq!(service.kind, RpcServiceKind::AuthProvider);
+        assert_eq!(service.socket_id, "auth.sock");
+    }
+}
 
 impl ServicesSection {
     pub(super) fn has_unsaved_svc_changes(&self, cx: &App) -> bool {
@@ -38,6 +194,7 @@ impl ServicesSection {
             if socket_id != saved.socket_id
                 || command != saved_command
                 || timeout != saved_timeout
+                || self.svc_kind != saved.kind
                 || self.svc_enabled != saved.enabled
             {
                 return true;
@@ -84,6 +241,7 @@ impl ServicesSection {
             || !self.svc_arg_inputs.is_empty()
             || !self.svc_env_key_inputs.is_empty()
             || !self.svc_env_value_inputs.is_empty()
+            || self.svc_kind != RpcServiceKind::Driver
             || !self.svc_enabled
     }
 
@@ -96,6 +254,7 @@ impl ServicesSection {
 
     pub(super) fn clear_svc_form(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
         self.editing_svc_idx = None;
+        self.svc_kind = RpcServiceKind::Driver;
         self.svc_enabled = true;
         self.svc_form_cursor = 0;
         self.svc_env_col = 0;
@@ -120,6 +279,7 @@ impl ServicesSection {
         };
 
         self.editing_svc_idx = Some(idx);
+        self.svc_kind = editable_service_kind(&service);
         self.svc_enabled = service.enabled;
         self.svc_form_cursor = 0;
         self.svc_env_col = 0;
@@ -236,14 +396,15 @@ impl ServicesSection {
             })
             .collect();
 
-        let service = ServiceConfig {
+        let service = build_service_config(
             socket_id,
-            enabled: self.svc_enabled,
+            self.svc_enabled,
             command,
             args,
             env,
             startup_timeout_ms,
-        };
+            self.svc_kind,
+        );
 
         let saved_idx = if let Some(idx) = self.editing_svc_idx {
             if idx < self.svc_services.len() {
@@ -261,7 +422,10 @@ impl ServicesSection {
             cx.toast_error(format!("Failed to save config: {}", e), window);
             return;
         }
-        cx.toast_info("Service saved. Restart required to apply changes.", window);
+        cx.toast_info(
+            "RPC service saved. Restart required to apply changes.",
+            window,
+        );
 
         self.svc_selected_idx = Some(saved_idx);
         self.edit_service(saved_idx, window, cx);
@@ -311,7 +475,7 @@ impl ServicesSection {
             return;
         }
         cx.toast_info(
-            "Service deleted. Restart required to apply changes.",
+            "RPC service deleted. Restart required to apply changes.",
             window,
         );
         cx.notify();
@@ -455,29 +619,11 @@ impl ServicesSection {
     // --- Form navigation (linear cursor) ---
 
     pub(super) fn svc_form_rows(&self) -> Vec<ServiceFormRow> {
-        let mut rows = vec![
-            ServiceFormRow::SocketId,
-            ServiceFormRow::Command,
-            ServiceFormRow::Timeout,
-            ServiceFormRow::Enabled,
-        ];
-
-        for i in 0..self.svc_arg_inputs.len() {
-            rows.push(ServiceFormRow::Arg(i));
-        }
-        rows.push(ServiceFormRow::AddArg);
-
-        for i in 0..self.svc_env_key_inputs.len() {
-            rows.push(ServiceFormRow::EnvKey(i));
-        }
-        rows.push(ServiceFormRow::AddEnv);
-
-        if self.editing_svc_idx.is_some() {
-            rows.push(ServiceFormRow::DeleteButton);
-        }
-        rows.push(ServiceFormRow::SaveButton);
-
-        rows
+        service_form_rows(
+            self.svc_arg_inputs.len(),
+            self.svc_env_key_inputs.len(),
+            self.editing_svc_idx.is_some(),
+        )
     }
 
     pub(super) fn current_form_row(&self) -> Option<ServiceFormRow> {
@@ -503,10 +649,7 @@ impl ServicesSection {
     pub(super) fn svc_move_right(&mut self) {
         if let Some(row) = self.current_form_row() {
             match row {
-                ServiceFormRow::EnvKey(_) if self.svc_env_col < 2 => {
-                    self.svc_env_col += 1;
-                }
-                ServiceFormRow::Arg(_) if self.svc_env_col < 1 => {
+                row if self.svc_env_col < service_row_max_col(row) => {
                     self.svc_env_col += 1;
                 }
                 _ => {}
@@ -536,11 +679,7 @@ impl ServicesSection {
     pub(super) fn svc_tab_next(&mut self) {
         let rows = self.svc_form_rows();
         if let Some(row) = rows.get(self.svc_form_cursor) {
-            let max_col = match row {
-                ServiceFormRow::EnvKey(_) => 2,
-                ServiceFormRow::Arg(_) => 1,
-                _ => 0,
-            };
+            let max_col = service_row_max_col(*row);
 
             if self.svc_env_col < max_col {
                 self.svc_env_col += 1;
@@ -564,11 +703,7 @@ impl ServicesSection {
             self.svc_form_cursor -= 1;
             let rows = self.svc_form_rows();
             if let Some(row) = rows.get(self.svc_form_cursor) {
-                self.svc_env_col = match row {
-                    ServiceFormRow::EnvKey(_) => 2,
-                    ServiceFormRow::Arg(_) => 1,
-                    _ => 0,
-                };
+                self.svc_env_col = service_row_max_col(*row);
             }
         }
     }
@@ -587,6 +722,9 @@ impl ServicesSection {
             Some(ServiceFormRow::Timeout) => {
                 self.input_svc_timeout
                     .update(cx, |s, cx| s.focus(window, cx));
+            }
+            Some(ServiceFormRow::Kind) => {
+                self.svc_editing_field = false;
             }
             Some(ServiceFormRow::Arg(i)) if self.svc_env_col == 0 => {
                 if let Some(input) = self.svc_arg_inputs.get(i) {
@@ -626,6 +764,15 @@ impl ServicesSection {
             | Some(ServiceFormRow::Timeout)
             | Some(ServiceFormRow::EnvValue(_)) => {
                 self.svc_focus_current_field(window, cx);
+            }
+
+            Some(ServiceFormRow::Kind) => {
+                self.svc_kind = if self.svc_env_col == 0 {
+                    RpcServiceKind::Driver
+                } else {
+                    RpcServiceKind::AuthProvider
+                };
+                cx.notify();
             }
 
             Some(ServiceFormRow::Arg(i)) => {
@@ -695,8 +842,8 @@ impl ServicesSection {
 
         layout::split_section_shell(
             dbflux_components::composites::section_header(
-                "Services",
-                "Manage external driver services. Changes require restart.",
+                services_section_title(),
+                services_section_description(),
                 cx,
             ),
             self.render_service_list(&services, editing_idx, cx),
@@ -739,7 +886,7 @@ impl ServicesSection {
                         .child(
                             Button::new("new-service")
                                 .icon(Icon::new(IconName::Plus))
-                                .label("New Service")
+                                .label(new_service_button_label())
                                 .small()
                                 .w_full()
                                 .on_click(cx.listener(|this, _, window, cx| {
@@ -762,7 +909,7 @@ impl ServicesSection {
                     .gap_1()
                     .when(services.is_empty(), |container| {
                         container.child(div().p_4().child(
-                            Body::new("No services configured").color(theme.muted_foreground),
+                            Body::new(empty_services_message()).color(theme.muted_foreground),
                         ))
                     })
                     .children(services.iter().enumerate().map(|(idx, service)| {
@@ -851,11 +998,7 @@ impl ServicesSection {
         let cursor = self.svc_form_cursor;
         let rows = self.svc_form_rows();
 
-        let title = if editing_idx.is_some() {
-            "Edit Service"
-        } else {
-            "New Service"
-        };
+        let title = service_editor_title(editing_idx.is_some());
 
         let is_row_focused = |row: ServiceFormRow| -> bool {
             is_form_focused && rows.get(cursor).copied() == Some(row)
@@ -891,6 +1034,7 @@ impl ServicesSection {
                     ServiceFormRow::Timeout,
                     cx,
                 ))
+                .child(self.render_svc_kind_selector(is_form_focused, cursor, &rows, primary, cx))
                 .child(self.render_svc_enabled_checkbox(
                     is_row_focused(ServiceFormRow::Enabled),
                     primary,
@@ -1019,6 +1163,91 @@ impl ServicesSection {
                     })),
             )
             .child(Body::new("Enable this service"))
+    }
+
+    fn render_radio_button(selected: bool, primary: Hsla, border: Hsla) -> Div {
+        div()
+            .size_4()
+            .rounded_full()
+            .border_1()
+            .border_color(if selected { primary } else { border })
+            .flex()
+            .items_center()
+            .justify_center()
+            .child(div().size_2().rounded_full().bg(if selected {
+                primary
+            } else {
+                transparent_black()
+            }))
+    }
+
+    fn render_svc_kind_selector(
+        &self,
+        is_form_focused: bool,
+        cursor: usize,
+        rows: &[ServiceFormRow],
+        primary: Hsla,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let theme = cx.theme();
+        let border = theme.border;
+        let is_row_focused =
+            is_form_focused && rows.get(cursor).copied() == Some(ServiceFormRow::Kind);
+
+        let kinds = [
+            (RpcServiceKind::Driver, 0usize, "Driver"),
+            (RpcServiceKind::AuthProvider, 1usize, "Auth Provider"),
+        ];
+
+        div()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .child(Label::new("Service Type"))
+            .child(
+                div()
+                    .flex()
+                    .gap_4()
+                    .children(kinds.into_iter().map(|(kind, column, label)| {
+                        let is_focused = is_row_focused && self.svc_env_col == column;
+
+                        div()
+                            .id(SharedString::from(format!("service-kind-{}", label)))
+                            .flex()
+                            .items_center()
+                            .gap_2()
+                            .px_2()
+                            .py_1()
+                            .rounded(px(4.0))
+                            .cursor_pointer()
+                            .border_1()
+                            .border_color(if is_focused {
+                                primary
+                            } else {
+                                transparent_black()
+                            })
+                            .on_click(cx.listener(move |this, _, _, cx| {
+                                this.svc_focus = ServiceFocus::Form;
+                                if let Some(position) = this
+                                    .svc_form_rows()
+                                    .iter()
+                                    .position(|candidate| *candidate == ServiceFormRow::Kind)
+                                {
+                                    this.svc_form_cursor = position;
+                                }
+                                this.svc_env_col = column;
+                                this.svc_kind = kind;
+                                this.svc_editing_field = false;
+                                cx.notify();
+                            }))
+                            .child(Self::render_radio_button(
+                                self.svc_kind == kind,
+                                primary,
+                                border,
+                            ))
+                            .child(div().text_sm().child(label))
+                    })),
+            )
     }
 
     fn render_svc_args_section(

--- a/crates/dbflux_ui/src/ui/windows/settings/services_section.rs
+++ b/crates/dbflux_ui/src/ui/windows/settings/services_section.rs
@@ -5,7 +5,7 @@ use super::section_trait::SectionFocusEvent;
 use crate::app::AppStateEntity;
 use crate::keymap::{Modifiers, key_chord_from_gpui};
 use dbflux_components::controls::InputState;
-use dbflux_core::ServiceConfig;
+use dbflux_core::{RpcServiceKind, ServiceConfig};
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::dialog::Dialog;
@@ -21,6 +21,7 @@ pub(super) enum ServiceFormRow {
     SocketId,
     Command,
     Timeout,
+    Kind,
     Enabled,
     Arg(usize),
     #[allow(dead_code)]
@@ -52,6 +53,7 @@ pub(super) struct ServicesSection {
     pub(super) input_socket_id: Entity<InputState>,
     pub(super) input_svc_command: Entity<InputState>,
     pub(super) input_svc_timeout: Entity<InputState>,
+    pub(super) svc_kind: RpcServiceKind,
     pub(super) svc_enabled: bool,
 
     pub(super) svc_arg_inputs: Vec<Entity<InputState>>,
@@ -91,6 +93,7 @@ impl ServicesSection {
             input_socket_id,
             input_svc_command,
             input_svc_timeout,
+            svc_kind: RpcServiceKind::Driver,
             svc_enabled: true,
             svc_arg_inputs: Vec::new(),
             svc_env_key_inputs: Vec::new(),

--- a/crates/dbflux_ui/src/ui/windows/settings/sidebar_nav.rs
+++ b/crates/dbflux_ui/src/ui/windows/settings/sidebar_nav.rs
@@ -41,7 +41,7 @@ impl SettingsCoordinator {
                 vec![
                     TreeNavNode::leaf("hooks", "Hooks", Some(AppIcon::SquareTerminal)),
                     TreeNavNode::leaf("drivers", "Drivers", Some(AppIcon::Database)),
-                    TreeNavNode::leaf("services", "Services (RPC)", Some(AppIcon::Plug)),
+                    TreeNavNode::leaf("services", "RPC Services", Some(AppIcon::Plug)),
                 ],
             ),
             #[cfg(feature = "mcp")]
@@ -186,5 +186,17 @@ mod tests {
             let id = SettingsCoordinator::tree_id_for_section(section);
             assert_eq!(SettingsCoordinator::section_for_tree_id(id), Some(section));
         }
+    }
+
+    #[test]
+    fn services_tree_label_uses_neutral_rpc_wording() {
+        let tree = SettingsCoordinator::build_sidebar_tree();
+        let services_row = tree
+            .rows()
+            .iter()
+            .find(|row| row.id.as_ref() == "services")
+            .expect("services row");
+
+        assert_eq!(services_row.label.as_ref(), "RPC Services");
     }
 }

--- a/docs/DRIVER_RPC_PROTOCOL.md
+++ b/docs/DRIVER_RPC_PROTOCOL.md
@@ -1,31 +1,35 @@
 # Driver RPC Protocol Specification
 
-This document defines how DBFlux discovers, launches, and talks to external driver services over local IPC.
+This document defines how DBFlux discovers, launches, and talks to RPC services over local IPC.
+
+Today, only RPC services with `RpcServiceKind::Driver` are adapted into runtime database drivers. `RpcServiceKind::AuthProvider` is already persisted and discoverable, but it is not wired into runtime auth features yet.
 
 ## Source of truth
 
-For external services, **the driver service is the source of truth** for:
+For active driver services, **the service is the source of truth** for:
 
 - driver kind (`DbKind`)
 - driver metadata (`DriverMetadataDto`: name, icon, category, capabilities, query language, etc.)
 - connection form definition (`DriverFormDefDto`)
 
-`config.json` is only runtime/process configuration (socket and launch command).
+DBFlux stores launch configuration in its SQLite-backed services config. Legacy `config.json` rows are imported for compatibility, but the runtime no longer reads that file on normal startup.
 
 ## Integration model
 
-At app startup, DBFlux reads `~/.config/dbflux/config.json`, then for each `rpc_service`:
+At app startup, DBFlux loads configured RPC services from `~/.local/share/dbflux/dbflux.db`, then for each service:
 
-1. ensures the service is running (starts it if needed)
-2. performs a `Hello` handshake
-3. reads `driver_kind`, `driver_metadata`, and `form_definition` from the service
-4. registers the driver in-memory so it appears in the connection manager
+1. discovers the persisted service descriptor, including `RpcServiceKind`
+2. adapts only `Driver` services into the current driver bootstrap path
+3. ensures the service is running (starts it if needed)
+4. performs a `Hello` handshake
+5. reads `driver_kind`, `driver_metadata`, and `form_definition` from the service
+6. registers the driver in-memory so it appears in the connection manager
 
-If any step fails, that service is skipped and not shown in the UI.
+If driver adaptation or handshake fails, that service is skipped and not shown in the UI as a driver. Non-driver service kinds remain persisted but inert.
 
 Important behavior:
 
-- Config is read at startup. Restart DBFlux after changing `config.json`.
+- Service configuration is read at startup. Restart DBFlux after changing RPC service settings.
 - `socket_id` is used as-is (it is not rewritten by DBFlux).
 - Internal registry key is `rpc:<socket_id>`.
 
@@ -46,9 +50,11 @@ Maximum message size: `16 MiB`.
 
 Socket cleanup is automatic on process exit/drop (provided by `interprocess`).
 
-## Runtime configuration (`config.json`)
+## Runtime configuration
 
-File path: `~/.config/dbflux/config.json`
+Primary storage: `~/.local/share/dbflux/dbflux.db` (`cfg_services`, `cfg_service_args`, `cfg_service_env`)
+
+Settings UI: **Settings → RPC Services**
 
 Schema used by DBFlux:
 
@@ -57,6 +63,7 @@ Schema used by DBFlux:
   "rpc_services": [
     {
       "socket_id": "my-driver.sock",
+      "kind": "driver",
       "command": "/absolute/path/to/driver-binary",
       "args": ["--socket", "my-driver.sock"],
       "env": {
@@ -71,9 +78,12 @@ Schema used by DBFlux:
 Notes:
 
 - `socket_id` is required.
+- `kind` supports `driver` and `auth_provider`.
 - `command` is optional. If omitted, DBFlux uses `dbflux-driver-host`.
 - `args`, `env`, and `startup_timeout_ms` are optional.
-- DBFlux derives an internal registry key as `rpc:<socket_id>`.
+- DBFlux derives an internal driver registry key as `rpc:<socket_id>`.
+- Only `driver` services are registered as database drivers today.
+- `auth_provider` services are stored and discovered but not yet consumed by runtime auth flows.
 
 ## Handshake contract
 
@@ -232,14 +242,15 @@ Use:
 - `examples/custom_driver/src/main.rs`
 - `examples/custom_driver/config.example.json`
 
-That example is compatible with the current DBFlux integration model.
+That example is compatible with the current active driver-service integration model.
 
 Quick test path:
 
-1. copy `examples/custom_driver/config.example.json` to `~/.config/dbflux/config.json`
-2. update `command` to your absolute binary path
-3. restart DBFlux
-4. create a connection using the external driver form fields
+1. add a new **Driver** service in **Settings → RPC Services**
+2. copy the values from `examples/custom_driver/config.example.json`
+3. update `command` to your absolute binary path
+4. restart DBFlux
+5. create a connection using the external driver form fields
 
 ## References
 

--- a/docs/RPC_SERVICES_CONFIG.md
+++ b/docs/RPC_SERVICES_CONFIG.md
@@ -1,6 +1,11 @@
 # RPC Services Config Reference
 
-This file documents the storage and management of external RPC driver services in DBFlux.
+This file documents the storage and management of RPC services in DBFlux.
+
+DBFlux now persists a first-class RPC services foundation through `RpcServiceKind`:
+
+- `Driver` — active today and adapted into runtime database drivers
+- `AuthProvider` — persisted and discoverable today, but not yet wired into runtime auth features
 
 ## Storage
 
@@ -8,7 +13,7 @@ RPC services are stored in SQLite at `~/.local/share/dbflux/dbflux.db`, not in a
 
 **Tables:**
 
-- `cfg_services` — main service record (socket_id, command, startup_timeout_ms, enabled)
+- `cfg_services` — main service record (socket_id, service_kind, command, startup_timeout_ms, enabled)
 - `cfg_service_args` — ordered process arguments
 - `cfg_service_env` — environment variables
 
@@ -18,6 +23,7 @@ RPC services are stored in SQLite at `~/.local/share/dbflux/dbflux.db`, not in a
 CREATE TABLE cfg_services (
     id TEXT PRIMARY KEY,
     socket_id TEXT NOT NULL UNIQUE,
+    service_kind TEXT NOT NULL DEFAULT 'driver',
     command TEXT,
     startup_timeout_ms INTEGER DEFAULT 5000,
     enabled INTEGER DEFAULT 1
@@ -40,13 +46,20 @@ CREATE TABLE cfg_service_env (
 
 ## Managing Services
 
-Services are managed through the Settings UI under the **Services** section, not by editing files directly.
+Services are managed through the Settings UI under the **RPC Services** section, not by editing files directly.
 
 To add or edit a service:
-1. Open Settings → Services
+1. Open Settings → RPC Services
 2. Add a new service or select an existing one
-3. Configure socket ID, command path, arguments, environment variables, and timeout
-4. Save changes
+3. Choose the service kind (`Driver` or `Auth Provider`)
+4. Configure socket ID, command path, arguments, environment variables, and timeout
+5. Save changes
+
+Notes:
+
+- Only `Driver` services are active in the runtime today.
+- `Auth Provider` services are preserved in storage and pass through discovery/classification, but they are not registered into any runtime auth-provider registry yet.
+- DBFlux preserves compatibility for driver registration IDs as `rpc:<socket_id>`.
 
 ## Legacy Migration
 
@@ -70,14 +83,16 @@ The legacy `config.json` format had this structure:
 }
 ```
 
-This is converted to the SQLite schema automatically. The `config.json` file itself is not used after import.
+This is converted to the SQLite schema automatically. Legacy rows are treated as `service_kind='driver'`. The `config.json` file itself is not used after import.
 
 ## Semantics
 
 - `socket_id` is used literally as the socket filename
 - DBFlux internally identifies each service as `rpc:<socket_id>`
+- DBFlux classifies each service by `service_kind` before runtime adaptation
 - Driver name/icon/category/form come from the service's `Hello` response (`driver_metadata`, `form_definition`), not from configuration
-- Services that fail to complete the RPC handshake (`Hello`) during startup are not registered
+- Services with `service_kind='driver'` that fail to complete the RPC handshake (`Hello`) during startup are not registered
+- Services with `service_kind='auth_provider'` are currently stored and discovered only; they do not participate in runtime features yet
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Summary

- introduce a first-class RPC services foundation with `RpcServiceKind` and a `dbflux_app::rpc_services` discovery/adaptation seam
- preserve the existing `rpc:<socket_id>` external driver flow while preparing a clean future insertion point for RPC auth providers
- sync the settings UI and project documentation with the new services model, including service-kind selection

## What does this resolve?

- Resolves #34

## How was this solved?

- added persisted service classification (`Driver` / `AuthProvider`) with backward-compatible defaults for legacy rows
- moved runtime bootstrap toward discover -> classify -> adapt so only driver services register today, while non-driver services remain persisted/discoverable but inert
- updated Settings to expose service kind explicitly and refreshed docs to describe the SQLite-backed services config and runtime seam accurately

## Validation

- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- verified the settings service-kind selector preserves and saves `Driver` vs `AuthProvider`

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [x] X11
- [x] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable