### PR TITLE
refactor(rpc): enforce negotiated API version contracts

### DIFF
--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -2517,7 +2517,7 @@ mod tests {
     use super::*;
     use dbflux_core::{
         DatabaseCategory, DbError, DbKind, DriverFormDef, DriverMetadataBuilder, QueryLanguage,
-        RpcServiceKind,
+        RpcServiceKind, ServiceRpcApiContract,
     };
     use dbflux_driver_ipc::IpcDriver;
 
@@ -2547,6 +2547,7 @@ mod tests {
             env: HashMap::new(),
             startup_timeout_ms: Some(1_000),
             kind,
+            api_contract: None,
         }
     }
 
@@ -2557,6 +2558,35 @@ mod tests {
         AppState::launch_rpc_services_with(
             &mut drivers,
             vec![test_service(RpcServiceKind::Driver)],
+            |socket_id, _launch| {
+                assert_eq!(socket_id, "svc-socket");
+                Ok(fake_probe())
+            },
+            |_, socket_id, (kind, metadata, form_definition, settings_schema), launch| {
+                Arc::new(
+                    IpcDriver::new(socket_id, kind, metadata, form_definition, settings_schema)
+                        .with_launch_config(launch),
+                ) as Arc<dyn DbDriver>
+            },
+        );
+
+        assert!(drivers.contains_key("rpc:svc-socket"));
+    }
+
+    #[test]
+    fn launch_rpc_services_registers_legacy_driver_services_without_api_metadata() {
+        let mut drivers = HashMap::new();
+        let service = test_service(RpcServiceKind::Driver);
+
+        assert_eq!(service.api_contract, None);
+        assert_eq!(
+            service.resolved_api_contract(),
+            ServiceRpcApiContract::new("driver_rpc", 1, 1)
+        );
+
+        AppState::launch_rpc_services_with(
+            &mut drivers,
+            vec![service],
             |socket_id, _launch| {
                 assert_eq!(socket_id, "svc-socket");
                 Ok(fake_probe())

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -241,12 +241,18 @@ pub fn save_services(
 
     // Upsert all services that are in the desired state.
     for svc in services {
+        let api_contract = svc.api_contract.clone();
         let dto = dbflux_storage::repositories::services::ServiceDto {
             socket_id: svc.socket_id.clone(),
             enabled: svc.enabled,
             command: svc.command.clone(),
             startup_timeout_ms: svc.startup_timeout_ms.map(|v| v as i64),
             service_kind: rpc_service_kind_to_storage(svc.kind).to_string(),
+            api_family: api_contract
+                .as_ref()
+                .map(|contract| contract.family.clone()),
+            api_major: api_contract.as_ref().map(|contract| contract.major as i64),
+            api_minor: api_contract.as_ref().map(|contract| contract.minor as i64),
             created_at: String::new(),
             updated_at: String::new(),
         };
@@ -1095,6 +1101,7 @@ fn load_services(
             .map(|dto| {
                 let args = repo.get_args(&dto.socket_id).unwrap_or_default();
                 let env = repo.get_env(&dto.socket_id).unwrap_or_default();
+                let api_contract = service_api_contract_from_dto(&dto);
 
                 ServiceConfig {
                     socket_id: dto.socket_id,
@@ -1104,6 +1111,7 @@ fn load_services(
                     env,
                     startup_timeout_ms: dto.startup_timeout_ms.map(|v| v as u64),
                     kind: rpc_service_kind_from_storage(&dto.service_kind),
+                    api_contract,
                 }
             })
             .collect()
@@ -1130,6 +1138,45 @@ fn rpc_service_kind_from_storage(kind: &str) -> RpcServiceKind {
             );
             RpcServiceKind::Driver
         }
+    }
+}
+
+fn service_api_contract_from_dto(
+    dto: &dbflux_storage::repositories::services::ServiceDto,
+) -> Option<dbflux_core::ServiceRpcApiContract> {
+    match (&dto.api_family, dto.api_major, dto.api_minor) {
+        (Some(family), Some(major), Some(minor)) => {
+            let major = match u16::try_from(major) {
+                Ok(major) => major,
+                Err(_) => {
+                    log::warn!(
+                        "Ignoring persisted RPC API contract for service '{}' because api_major={} is out of range for u16",
+                        dto.socket_id,
+                        major,
+                    );
+                    return None;
+                }
+            };
+
+            let minor = match u16::try_from(minor) {
+                Ok(minor) => minor,
+                Err(_) => {
+                    log::warn!(
+                        "Ignoring persisted RPC API contract for service '{}' because api_minor={} is out of range for u16",
+                        dto.socket_id,
+                        minor,
+                    );
+                    return None;
+                }
+            };
+
+            Some(dbflux_core::ServiceRpcApiContract::new(
+                family.clone(),
+                major,
+                minor,
+            ))
+        }
+        _ => None,
     }
 }
 
@@ -1838,6 +1885,11 @@ mod tests {
             env: std::collections::HashMap::new(),
             startup_timeout_ms: Some(5_000),
             kind: RpcServiceKind::AuthProvider,
+            api_contract: Some(dbflux_core::ServiceRpcApiContract::new(
+                "auth_provider_rpc",
+                1,
+                0,
+            )),
         }];
 
         save_services(&runtime, &services).expect("save services");
@@ -1849,10 +1901,17 @@ mod tests {
             .expect("service row");
 
         assert_eq!(dto.service_kind, "auth_provider");
+        assert_eq!(dto.api_family.as_deref(), Some("auth_provider_rpc"));
+        assert_eq!(dto.api_major, Some(1));
+        assert_eq!(dto.api_minor, Some(0));
 
         let loaded = load_config(&runtime);
         assert_eq!(loaded.services.len(), 1);
         assert_eq!(loaded.services[0].kind, RpcServiceKind::AuthProvider);
+        assert_eq!(
+            loaded.services[0].resolved_api_contract(),
+            dbflux_core::ServiceRpcApiContract::new("auth_provider_rpc", 1, 0)
+        );
     }
 
     #[test]
@@ -1876,5 +1935,55 @@ mod tests {
 
         assert_eq!(loaded.services.len(), 1);
         assert_eq!(loaded.services[0].kind, RpcServiceKind::Driver);
+    }
+
+    #[test]
+    fn load_config_defaults_missing_api_contract_to_driver_rpc_baseline() {
+        let runtime = StorageRuntime::in_memory().expect("in-memory storage runtime");
+        let conn = runtime.open_dbflux_db().expect("open runtime database");
+
+        conn.execute(
+            "INSERT INTO cfg_services (socket_id, enabled, command, startup_timeout_ms, service_kind) VALUES (?1, ?2, ?3, ?4, ?5)",
+            [
+                "driver-socket",
+                "1",
+                "dbflux-driver-host",
+                "5000",
+                "driver",
+            ],
+        )
+        .expect("insert driver service row");
+
+        let loaded = load_config(&runtime);
+
+        assert_eq!(loaded.services.len(), 1);
+        assert_eq!(
+            loaded.services[0].resolved_api_contract(),
+            dbflux_core::ServiceRpcApiContract::new("driver_rpc", 1, 1)
+        );
+    }
+
+    #[test]
+    fn load_config_ignores_out_of_range_api_contract_versions() {
+        let runtime = StorageRuntime::in_memory().expect("in-memory storage runtime");
+        let conn = runtime.open_dbflux_db().expect("open runtime database");
+
+        conn.execute(
+            &format!(
+                "INSERT INTO cfg_services (socket_id, enabled, command, startup_timeout_ms, service_kind, api_family, api_major, api_minor) VALUES ('driver-socket', 1, 'dbflux-driver-host', 5000, 'driver', 'driver_rpc', {}, -1)",
+                i64::from(u16::MAX) + 1,
+            ),
+            [],
+        )
+        .expect("insert malformed api contract row");
+
+        let loaded = load_config(&runtime);
+
+        assert_eq!(loaded.services.len(), 1);
+        assert_eq!(loaded.services[0].api_contract, None);
+        assert_eq!(
+            loaded.services[0].resolved_api_contract(),
+            dbflux_core::ServiceRpcApiContract::new("driver_rpc", 1, 1)
+        );
     }
 }

--- a/crates/dbflux_app/src/rpc_services.rs
+++ b/crates/dbflux_app/src/rpc_services.rs
@@ -160,6 +160,7 @@ mod tests {
             env: std::collections::HashMap::from([("RUST_LOG".to_string(), "info".to_string())]),
             startup_timeout_ms: Some(7_500),
             kind,
+            api_contract: None,
         }
     }
 

--- a/crates/dbflux_core/src/config/app.rs
+++ b/crates/dbflux_core/src/config/app.rs
@@ -466,6 +466,34 @@ pub struct ServiceConfig {
 
     #[serde(default)]
     pub kind: RpcServiceKind,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_contract: Option<ServiceRpcApiContract>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ServiceRpcApiContract {
+    pub family: String,
+    pub major: u16,
+    pub minor: u16,
+}
+
+impl ServiceRpcApiContract {
+    pub fn new(family: impl Into<String>, major: u16, minor: u16) -> Self {
+        Self {
+            family: family.into(),
+            major,
+            minor,
+        }
+    }
+}
+
+impl ServiceConfig {
+    pub fn resolved_api_contract(&self) -> ServiceRpcApiContract {
+        self.api_contract
+            .clone()
+            .unwrap_or_else(|| self.kind.default_api_contract())
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -474,6 +502,15 @@ pub enum RpcServiceKind {
     #[default]
     Driver,
     AuthProvider,
+}
+
+impl RpcServiceKind {
+    pub fn default_api_contract(self) -> ServiceRpcApiContract {
+        match self {
+            RpcServiceKind::Driver => ServiceRpcApiContract::new("driver_rpc", 1, 1),
+            RpcServiceKind::AuthProvider => ServiceRpcApiContract::new("auth_provider_rpc", 1, 0),
+        }
+    }
 }
 
 fn default_enabled() -> bool {
@@ -1045,6 +1082,7 @@ mod tests {
             env: HashMap::new(),
             startup_timeout_ms: Some(5_000),
             kind: RpcServiceKind::AuthProvider,
+            api_contract: Some(ServiceRpcApiContract::new("auth_provider_rpc", 1, 0)),
         };
 
         let json = serde_json::to_value(&service).unwrap();
@@ -1053,6 +1091,29 @@ mod tests {
 
         let restored: ServiceConfig = serde_json::from_value(json).unwrap();
         assert_eq!(restored.kind, RpcServiceKind::AuthProvider);
+        assert_eq!(
+            restored.api_contract,
+            Some(ServiceRpcApiContract::new("auth_provider_rpc", 1, 0))
+        );
+    }
+
+    #[test]
+    fn service_config_defaults_missing_api_contract_from_kind() {
+        let service = ServiceConfig {
+            socket_id: "legacy-socket".to_string(),
+            enabled: true,
+            command: None,
+            args: Vec::new(),
+            env: HashMap::new(),
+            startup_timeout_ms: None,
+            kind: RpcServiceKind::Driver,
+            api_contract: None,
+        };
+
+        assert_eq!(
+            service.resolved_api_contract(),
+            ServiceRpcApiContract::new("driver_rpc", 1, 1)
+        );
     }
 
     #[test]

--- a/crates/dbflux_core/src/config/mod.rs
+++ b/crates/dbflux_core/src/config/mod.rs
@@ -5,8 +5,8 @@ pub(crate) mod scripts_directory;
 pub use app::{
     AppConfig, AppConfigStore, DangerousAction, DriverKey, EffectiveSettings, GeneralSettings,
     GlobalOverrides, GovernanceSettings, PolicyRoleConfig, RefreshPolicySetting, RpcServiceKind,
-    ServiceConfig, StartupFocus, ThemeSetting, ToolPolicyConfig, TrustedClientConfig,
-    driver_maps_differ, migrate_app_config,
+    ServiceConfig, ServiceRpcApiContract, StartupFocus, ThemeSetting, ToolPolicyConfig,
+    TrustedClientConfig, driver_maps_differ, migrate_app_config,
 };
 pub use refresh_policy::RefreshPolicy;
 pub use scripts_directory::{

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -26,9 +26,9 @@ pub use auth::{
 pub use config::{
     AppConfig, AppConfigStore, DangerousAction, DriverKey, EffectiveSettings, GeneralSettings,
     GlobalOverrides, GovernanceSettings, PolicyRoleConfig, RefreshPolicy, RefreshPolicySetting,
-    RpcServiceKind, ScriptEntry, ScriptsDirectory, ServiceConfig, StartupFocus, ThemeSetting,
-    ToolPolicyConfig, TrustedClientConfig, all_script_extensions, driver_maps_differ,
-    filter_entries, hook_script_path, is_openable_script, migrate_app_config,
+    RpcServiceKind, ScriptEntry, ScriptsDirectory, ServiceConfig, ServiceRpcApiContract,
+    StartupFocus, ThemeSetting, ToolPolicyConfig, TrustedClientConfig, all_script_extensions,
+    driver_maps_differ, filter_entries, hook_script_path, is_openable_script, migrate_app_config,
 };
 
 pub use connection::{

--- a/crates/dbflux_driver_host/src/main.rs
+++ b/crates/dbflux_driver_host/src/main.rs
@@ -10,9 +10,12 @@ use dbflux_core::secrecy::SecretString;
 use dbflux_core::{ConnectionProfile, DbDriver};
 use dbflux_ipc::driver_protocol::{
     DriverHelloResponse, DriverRequestBody, DriverRequestEnvelope, DriverResponseBody,
-    DriverResponseEnvelope, DriverRpcErrorCode,
+    DriverResponseEnvelope, DriverRpcError, DriverRpcErrorCode,
 };
-use dbflux_ipc::{DRIVER_RPC_AUTH_TOKEN_ENV, DRIVER_RPC_VERSION, framing};
+use dbflux_ipc::{
+    DRIVER_RPC_AUTH_TOKEN_ENV, DRIVER_RPC_VERSION, ProtocolVersion, driver_rpc_supported_versions,
+    framing, negotiate_highest_mutual_version,
+};
 use interprocess::local_socket::{
     GenericNamespaced, ListenerNonblockingMode::Neither, ListenerOptions, prelude::*,
 };
@@ -74,7 +77,7 @@ fn handle_connection(
     expected_auth_token: Option<&str>,
 ) {
     let mut sessions = SessionManager::new();
-    let mut hello_done = false;
+    let mut negotiated_version = None;
 
     loop {
         let envelope: DriverRequestEnvelope = match framing::recv_msg(&mut stream) {
@@ -91,6 +94,47 @@ fn handle_connection(
 
         let request_id = envelope.request_id;
         let session_id = envelope.session_id;
+        let request_version = envelope.protocol_version;
+
+        if !matches!(envelope.body, DriverRequestBody::Hello(_)) {
+            let Some(selected_version) = negotiated_version else {
+                let response = DriverResponseEnvelope::error(
+                    request_version,
+                    request_id,
+                    session_id,
+                    DriverRpcErrorCode::InvalidRequest,
+                    "Hello handshake required before OpenSession",
+                    false,
+                );
+
+                if let Err(e) = framing::send_msg(&mut stream, &response) {
+                    log::warn!("Failed to send response: {e}");
+                    break;
+                }
+
+                continue;
+            };
+
+            if let Err(error) =
+                validate_negotiated_request_version(selected_version, request_version)
+            {
+                let response = DriverResponseEnvelope::error(
+                    request_version,
+                    request_id,
+                    session_id,
+                    error.code,
+                    error.message,
+                    error.retriable,
+                );
+
+                if let Err(e) = framing::send_msg(&mut stream, &response) {
+                    log::warn!("Failed to send response: {e}");
+                    break;
+                }
+
+                continue;
+            }
+        }
 
         let response = match envelope.body {
             DriverRequestBody::Hello(hello_req) => {
@@ -98,6 +142,7 @@ fn handle_connection(
                     && hello_req.auth_token.as_deref() != Some(expected_token)
                 {
                     DriverResponseEnvelope::error(
+                        request_version,
                         request_id,
                         None,
                         DriverRpcErrorCode::InvalidRequest,
@@ -105,41 +150,31 @@ fn handle_connection(
                         false,
                     )
                 } else {
-                    hello_done = true;
+                    match negotiate_hello_version(&hello_req.supported_versions) {
+                        Ok(selected_version) => {
+                            negotiated_version = Some(selected_version);
 
-                    let compatible = hello_req
-                        .supported_versions
-                        .iter()
-                        .any(|v| v.is_compatible_with(DRIVER_RPC_VERSION));
-
-                    if !compatible {
-                        DriverResponseEnvelope::error(
-                            request_id,
-                            None,
-                            DriverRpcErrorCode::VersionMismatch,
-                            format!(
-                                "No compatible protocol version. Server: {}.{}",
-                                DRIVER_RPC_VERSION.major, DRIVER_RPC_VERSION.minor
-                            ),
-                            false,
-                        )
-                    } else {
-                        DriverResponseEnvelope::ok(
-                            request_id,
-                            None,
-                            DriverResponseBody::Hello(DriverHelloResponse {
-                                server_name: "dbflux-driver-host".to_string(),
-                                server_version: env!("CARGO_PKG_VERSION").to_string(),
-                                selected_version: DRIVER_RPC_VERSION,
-                                capabilities: hello_req.requested_capabilities,
-                                driver_kind: driver.kind(),
-                                driver_metadata: driver.metadata().clone(),
-                                form_definition: driver.form_definition().clone(),
-                                settings_schema: driver
-                                    .settings_schema()
-                                    .map(|schema| schema.as_ref().clone()),
-                            }),
-                        )
+                            DriverResponseEnvelope::ok(
+                                selected_version,
+                                request_id,
+                                None,
+                                DriverResponseBody::Hello(DriverHelloResponse {
+                                    server_name: "dbflux-driver-host".to_string(),
+                                    server_version: env!("CARGO_PKG_VERSION").to_string(),
+                                    selected_version,
+                                    capabilities: hello_req.requested_capabilities,
+                                    driver_kind: driver.kind(),
+                                    driver_metadata: driver.metadata().clone(),
+                                    form_definition: driver.form_definition().clone(),
+                                    settings_schema: driver
+                                        .settings_schema()
+                                        .map(|schema| schema.as_ref().clone()),
+                                }),
+                            )
+                        }
+                        Err(error) => {
+                            hello_version_error_response(request_version, request_id, error)
+                        }
                     }
                 }
             }
@@ -148,32 +183,22 @@ fn handle_connection(
                 profile_json,
                 password,
                 ssh_secret,
-            } => {
-                if !hello_done {
-                    DriverResponseEnvelope::error(
-                        request_id,
-                        None,
-                        DriverRpcErrorCode::InvalidRequest,
-                        "Hello handshake required before OpenSession",
-                        false,
-                    )
-                } else {
-                    handle_open_session(
-                        request_id,
-                        driver,
-                        &mut sessions,
-                        &profile_json,
-                        password.as_deref(),
-                        ssh_secret.as_deref(),
-                    )
-                }
-            }
+            } => handle_open_session(
+                negotiated_version.expect("validated before dispatch"),
+                request_id,
+                driver,
+                &mut sessions,
+                &profile_json,
+                password.as_deref(),
+                ssh_secret.as_deref(),
+            ),
 
             DriverRequestBody::CloseSession => {
                 if let Some(sid) = session_id {
                     match sessions.remove(&sid) {
                         Some(mut conn) => match conn.close() {
                             Ok(()) => DriverResponseEnvelope::ok(
+                                negotiated_version.expect("validated before dispatch"),
                                 request_id,
                                 Some(sid),
                                 DriverResponseBody::SessionClosed,
@@ -181,6 +206,7 @@ fn handle_connection(
                             Err(e) => {
                                 log::warn!("Error closing session {sid}: {e}");
                                 DriverResponseEnvelope::error(
+                                    negotiated_version.expect("validated before dispatch"),
                                     request_id,
                                     Some(sid),
                                     DriverRpcErrorCode::Driver,
@@ -190,6 +216,7 @@ fn handle_connection(
                             }
                         },
                         None => DriverResponseEnvelope::error(
+                            negotiated_version.expect("validated before dispatch"),
                             request_id,
                             Some(sid),
                             DriverRpcErrorCode::SessionNotFound,
@@ -199,6 +226,7 @@ fn handle_connection(
                     }
                 } else {
                     DriverResponseEnvelope::error(
+                        negotiated_version.expect("validated before dispatch"),
                         request_id,
                         None,
                         DriverRpcErrorCode::SessionNotFound,
@@ -212,9 +240,15 @@ fn handle_connection(
                 if let Some(sid) = session_id {
                     if let Some(conn) = sessions.get(&sid) {
                         let body = session::dispatch(conn, other);
-                        DriverResponseEnvelope::ok(request_id, Some(sid), body)
+                        DriverResponseEnvelope::ok(
+                            negotiated_version.expect("validated before dispatch"),
+                            request_id,
+                            Some(sid),
+                            body,
+                        )
                     } else {
                         DriverResponseEnvelope::error(
+                            negotiated_version.expect("validated before dispatch"),
                             request_id,
                             Some(sid),
                             DriverRpcErrorCode::SessionNotFound,
@@ -224,6 +258,7 @@ fn handle_connection(
                     }
                 } else {
                     DriverResponseEnvelope::error(
+                        negotiated_version.expect("validated before dispatch"),
                         request_id,
                         None,
                         DriverRpcErrorCode::SessionNotFound,
@@ -244,6 +279,7 @@ fn handle_connection(
 }
 
 fn handle_open_session(
+    protocol_version: ProtocolVersion,
     request_id: u64,
     driver: &dyn DbDriver,
     sessions: &mut SessionManager,
@@ -255,6 +291,7 @@ fn handle_open_session(
         Ok(p) => p,
         Err(e) => {
             return DriverResponseEnvelope::error(
+                protocol_version,
                 request_id,
                 None,
                 DriverRpcErrorCode::InvalidRequest,
@@ -283,6 +320,7 @@ fn handle_open_session(
             sessions.insert(session_id, conn);
 
             DriverResponseEnvelope::ok(
+                protocol_version,
                 request_id,
                 Some(session_id),
                 DriverResponseBody::SessionOpened {
@@ -296,6 +334,7 @@ fn handle_open_session(
             )
         }
         Err(e) => DriverResponseEnvelope::error(
+            protocol_version,
             request_id,
             None,
             DriverRpcErrorCode::Driver,
@@ -303,6 +342,65 @@ fn handle_open_session(
             false,
         ),
     }
+}
+
+fn choose_negotiated_driver_version(
+    client_supported_versions: &[ProtocolVersion],
+) -> Option<ProtocolVersion> {
+    negotiate_highest_mutual_version(
+        dbflux_ipc::RpcApiFamily::DriverRpc,
+        driver_rpc_supported_versions(),
+        client_supported_versions,
+    )
+}
+
+fn hello_version_error_response(
+    request_version: ProtocolVersion,
+    request_id: u64,
+    error: DriverRpcError,
+) -> DriverResponseEnvelope {
+    DriverResponseEnvelope::error(
+        request_version,
+        request_id,
+        None,
+        error.code,
+        error.message,
+        error.retriable,
+    )
+}
+
+fn negotiate_hello_version(
+    client_supported_versions: &[ProtocolVersion],
+) -> Result<ProtocolVersion, DriverRpcError> {
+    choose_negotiated_driver_version(client_supported_versions).ok_or_else(|| DriverRpcError {
+        code: DriverRpcErrorCode::VersionMismatch,
+        message: format!(
+            "No compatible protocol version. Server: {}.{}",
+            DRIVER_RPC_VERSION.major, DRIVER_RPC_VERSION.minor
+        ),
+        retriable: false,
+    })
+}
+
+fn validate_negotiated_request_version(
+    negotiated_version: ProtocolVersion,
+    request_version: ProtocolVersion,
+) -> Result<(), DriverRpcError> {
+    if negotiated_version != request_version {
+        return Err(DriverRpcError {
+            code: DriverRpcErrorCode::VersionMismatch,
+            message: format!(
+                "Protocol version drift detected: negotiated {}.{}, received {}.{}",
+                negotiated_version.major,
+                negotiated_version.minor,
+                request_version.major,
+                request_version.minor
+            ),
+            retriable: false,
+        });
+    }
+
+    Ok(())
 }
 
 struct Args {
@@ -404,7 +502,14 @@ fn fatal(message: &str) -> ! {
 
 #[cfg(test)]
 mod tests {
-    use super::create_driver;
+    use super::{
+        choose_negotiated_driver_version, create_driver, hello_version_error_response,
+        negotiate_hello_version, validate_negotiated_request_version,
+    };
+    use dbflux_ipc::{
+        ProtocolVersion,
+        driver_protocol::{DriverResponseBody, DriverRpcErrorCode},
+    };
 
     #[cfg(feature = "dynamodb")]
     #[test]
@@ -428,6 +533,72 @@ mod tests {
                 error.contains("No drivers compiled into this binary"),
                 "unexpected error when dynamodb feature is disabled: {error}"
             );
+        }
+    }
+
+    #[test]
+    fn choose_negotiated_driver_version_prefers_highest_mutual_minor() {
+        let selected = choose_negotiated_driver_version(&[
+            ProtocolVersion::new(1, 0),
+            ProtocolVersion::new(1, 1),
+        ]);
+
+        assert_eq!(selected, Some(ProtocolVersion::new(1, 1)));
+    }
+
+    #[test]
+    fn choose_negotiated_driver_version_returns_none_without_overlap() {
+        let selected = choose_negotiated_driver_version(&[ProtocolVersion::new(2, 0)]);
+
+        assert_eq!(selected, None);
+    }
+
+    #[test]
+    fn validate_negotiated_request_version_rejects_post_hello_drift() {
+        let error = validate_negotiated_request_version(
+            ProtocolVersion::new(1, 0),
+            ProtocolVersion::new(1, 1),
+        )
+        .expect_err("drifted protocol version should be rejected");
+
+        assert_eq!(
+            error.code,
+            dbflux_ipc::driver_protocol::DriverRpcErrorCode::VersionMismatch
+        );
+        assert!(error.message.contains("1.0"));
+        assert!(error.message.contains("1.1"));
+    }
+
+    #[test]
+    fn negotiate_hello_version_returns_version_mismatch_response_without_overlap() {
+        let error = negotiate_hello_version(&[ProtocolVersion::new(2, 0)])
+            .expect_err("missing overlap should reject hello before opening a session");
+
+        assert_eq!(error.code, DriverRpcErrorCode::VersionMismatch);
+        assert!(error.message.contains("No compatible protocol version"));
+    }
+
+    #[test]
+    fn hello_version_error_response_preserves_request_metadata() {
+        let response = hello_version_error_response(
+            ProtocolVersion::new(1, 0),
+            17,
+            dbflux_ipc::driver_protocol::DriverRpcError {
+                code: DriverRpcErrorCode::VersionMismatch,
+                message: "No compatible protocol version. Server: 1.1".to_string(),
+                retriable: false,
+            },
+        );
+
+        assert_eq!(response.protocol_version, ProtocolVersion::new(1, 0));
+        assert_eq!(response.request_id, 17);
+
+        match response.body {
+            DriverResponseBody::Error(error) => {
+                assert_eq!(error.code, DriverRpcErrorCode::VersionMismatch);
+                assert!(error.message.contains("No compatible protocol version"));
+            }
+            other => panic!("expected version mismatch error, got {other:?}"),
         }
     }
 }

--- a/crates/dbflux_driver_ipc/src/transport.rs
+++ b/crates/dbflux_driver_ipc/src/transport.rs
@@ -2,12 +2,12 @@ use std::sync::{Arc, Mutex};
 
 use dbflux_core::DbError;
 use dbflux_ipc::{
-    DRIVER_RPC_AUTH_TOKEN_ENV, DRIVER_RPC_VERSION, ProtocolVersion,
+    DRIVER_RPC_AUTH_TOKEN_ENV, DRIVER_RPC_VERSION, ProtocolVersion, RpcApiFamily,
     driver_protocol::{
         DriverCapability, DriverHelloRequest, DriverHelloResponse, DriverRequestBody,
         DriverRequestEnvelope, DriverResponseBody, DriverResponseEnvelope,
     },
-    framing,
+    driver_rpc_supported_versions, framing,
 };
 use interprocess::local_socket::{Name, Stream as IpcStream, prelude::*};
 use uuid::Uuid;
@@ -117,11 +117,12 @@ impl RpcClient {
             .filter(|token| !token.is_empty());
 
         let request = DriverRequestEnvelope::new(
+            DRIVER_RPC_VERSION,
             0,
             DriverRequestBody::Hello(DriverHelloRequest {
                 client_name: "dbflux_driver_ipc".to_string(),
                 client_version: env!("CARGO_PKG_VERSION").to_string(),
-                supported_versions: vec![DRIVER_RPC_VERSION],
+                supported_versions: driver_rpc_supported_versions().to_vec(),
                 requested_capabilities: vec![
                     DriverCapability::Cancellation,
                     DriverCapability::ChunkedResults,
@@ -136,6 +137,11 @@ impl RpcClient {
 
         match response.body {
             DriverResponseBody::Hello(hello) => {
+                validate_hello_selected_version(
+                    hello.selected_version,
+                    driver_rpc_supported_versions(),
+                )?;
+
                 log::info!(
                     "Connected to driver host: {} v{}",
                     hello.server_name,
@@ -744,11 +750,8 @@ impl RpcClient {
         body: DriverRequestBody,
     ) -> Result<DriverResponseBody, RpcError> {
         let request_id = self.next_request_id()?;
-        let mut envelope = DriverRequestEnvelope::new(request_id, body);
-
-        if let Some(sid) = session_id {
-            envelope = envelope.with_session(sid);
-        }
+        let envelope =
+            build_call_request_envelope(self.selected_version(), request_id, body, session_id);
 
         let response = self.send_raw(envelope)?;
         Ok(response.body)
@@ -795,6 +798,8 @@ impl RpcClient {
             return Err(RpcError::Protocol("Request ID mismatch".into()));
         }
 
+        validate_response_protocol_version(request.protocol_version, response.protocol_version)?;
+
         Ok(response)
     }
 
@@ -813,10 +818,68 @@ fn protocol_supports_semantic_planning(version: ProtocolVersion) -> bool {
         || (version.major == DRIVER_RPC_VERSION.major && version.minor >= 1)
 }
 
+fn build_call_request_envelope(
+    selected_version: ProtocolVersion,
+    request_id: u64,
+    body: DriverRequestBody,
+    session_id: Option<Uuid>,
+) -> DriverRequestEnvelope {
+    let mut envelope = DriverRequestEnvelope::new(selected_version, request_id, body);
+
+    if let Some(session_id) = session_id {
+        envelope = envelope.with_session(session_id);
+    }
+
+    envelope
+}
+
+fn validate_hello_selected_version(
+    selected_version: ProtocolVersion,
+    client_supported_versions: &[ProtocolVersion],
+) -> Result<(), RpcError> {
+    let selected_contract =
+        dbflux_ipc::RpcApiContract::new(RpcApiFamily::DriverRpc, selected_version);
+    let client_contract =
+        dbflux_ipc::RpcApiContract::new(RpcApiFamily::DriverRpc, DRIVER_RPC_VERSION);
+
+    if !client_contract.is_compatible_with(selected_contract)
+        || !client_supported_versions.contains(&selected_version)
+    {
+        return Err(RpcError::Protocol(format!(
+            "Driver host returned unsupported selected_version {}.{}",
+            selected_version.major, selected_version.minor
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_response_protocol_version(
+    negotiated_version: ProtocolVersion,
+    response_version: ProtocolVersion,
+) -> Result<(), RpcError> {
+    if negotiated_version != response_version {
+        return Err(RpcError::Protocol(format!(
+            "Driver host responded with protocol {}.{} but negotiated version is {}.{}",
+            response_version.major,
+            response_version.minor,
+            negotiated_version.major,
+            negotiated_version.minor
+        )));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use super::protocol_supports_semantic_planning;
-    use dbflux_ipc::ProtocolVersion;
+    use super::{
+        build_call_request_envelope, protocol_supports_semantic_planning,
+        validate_hello_selected_version, validate_response_protocol_version,
+    };
+    use dbflux_ipc::driver_protocol::DriverRequestBody;
+    use dbflux_ipc::{ProtocolVersion, driver_rpc_supported_versions};
+    use uuid::Uuid;
 
     #[test]
     fn semantic_planning_requires_driver_rpc_v1_1_or_newer() {
@@ -829,5 +892,77 @@ mod tests {
         assert!(protocol_supports_semantic_planning(ProtocolVersion::new(
             2, 0
         )));
+    }
+
+    #[test]
+    fn hello_selected_version_must_be_supported_by_both_peers() {
+        let error = validate_hello_selected_version(
+            ProtocolVersion::new(1, 2),
+            driver_rpc_supported_versions(),
+        )
+        .expect_err("unsupported selection should be rejected");
+
+        assert!(error.to_string().contains("unsupported selected_version"));
+    }
+
+    #[test]
+    fn hello_selected_version_accepts_supported_downgrade() {
+        validate_hello_selected_version(
+            ProtocolVersion::new(1, 0),
+            driver_rpc_supported_versions(),
+        )
+        .expect("selected downgrade within client support should be accepted");
+    }
+
+    #[test]
+    fn hello_selected_version_rejects_major_mismatch_even_if_listed() {
+        let error = validate_hello_selected_version(
+            ProtocolVersion::new(2, 0),
+            &[ProtocolVersion::new(2, 0)],
+        )
+        .expect_err("major mismatch should be rejected");
+
+        assert!(error.to_string().contains("unsupported selected_version"));
+    }
+
+    #[test]
+    fn response_protocol_version_must_match_negotiated_version() {
+        let error = validate_response_protocol_version(
+            ProtocolVersion::new(1, 0),
+            ProtocolVersion::new(1, 1),
+        )
+        .expect_err("response drift should be rejected");
+
+        assert!(error.to_string().contains("negotiated version"));
+    }
+
+    #[test]
+    fn call_request_envelope_uses_negotiated_version_and_session_id() {
+        let session_id = Uuid::nil();
+
+        let envelope = build_call_request_envelope(
+            ProtocolVersion::new(1, 0),
+            7,
+            DriverRequestBody::Ping,
+            Some(session_id),
+        );
+
+        assert_eq!(envelope.protocol_version, ProtocolVersion::new(1, 0));
+        assert_eq!(envelope.request_id, 7);
+        assert_eq!(envelope.session_id, Some(session_id));
+    }
+
+    #[test]
+    fn call_request_envelope_omits_session_id_when_absent() {
+        let envelope = build_call_request_envelope(
+            ProtocolVersion::new(1, 0),
+            8,
+            DriverRequestBody::Ping,
+            None,
+        );
+
+        assert_eq!(envelope.protocol_version, ProtocolVersion::new(1, 0));
+        assert_eq!(envelope.request_id, 8);
+        assert_eq!(envelope.session_id, None);
     }
 }

--- a/crates/dbflux_ipc/src/driver_protocol.rs
+++ b/crates/dbflux_ipc/src/driver_protocol.rs
@@ -1,4 +1,4 @@
-use crate::envelope::{DRIVER_RPC_VERSION, ProtocolVersion};
+use crate::envelope::ProtocolVersion;
 use dbflux_core::{
     CodeGenCapabilities, CodeGeneratorInfo, CollectionBrowseRequest, CollectionCountRequest,
     ColumnMeta, CrudResult, CustomTypeInfo, DatabaseInfo, DbSchemaInfo, DescribeRequest,
@@ -377,9 +377,13 @@ pub struct DriverRequestEnvelope {
 }
 
 impl DriverRequestEnvelope {
-    pub fn new(request_id: u64, body: DriverRequestBody) -> Self {
+    pub fn new(
+        protocol_version: ProtocolVersion,
+        request_id: u64,
+        body: DriverRequestBody,
+    ) -> Self {
         Self {
-            protocol_version: DRIVER_RPC_VERSION,
+            protocol_version,
             request_id,
             session_id: None,
             timeout_ms: None,
@@ -508,9 +512,14 @@ pub struct DriverResponseEnvelope {
 }
 
 impl DriverResponseEnvelope {
-    pub fn ok(request_id: u64, session_id: Option<Uuid>, body: DriverResponseBody) -> Self {
+    pub fn ok(
+        protocol_version: ProtocolVersion,
+        request_id: u64,
+        session_id: Option<Uuid>,
+        body: DriverResponseBody,
+    ) -> Self {
         Self {
-            protocol_version: DRIVER_RPC_VERSION,
+            protocol_version,
             request_id,
             session_id,
             done: true,
@@ -519,12 +528,13 @@ impl DriverResponseEnvelope {
     }
 
     pub fn stream_chunk(
+        protocol_version: ProtocolVersion,
         request_id: u64,
         session_id: Option<Uuid>,
         chunk: QueryResultChunk,
     ) -> Self {
         Self {
-            protocol_version: DRIVER_RPC_VERSION,
+            protocol_version,
             request_id,
             session_id,
             done: chunk.done,
@@ -533,6 +543,7 @@ impl DriverResponseEnvelope {
     }
 
     pub fn error(
+        protocol_version: ProtocolVersion,
         request_id: u64,
         session_id: Option<Uuid>,
         code: DriverRpcErrorCode,
@@ -540,7 +551,7 @@ impl DriverResponseEnvelope {
         retriable: bool,
     ) -> Self {
         Self {
-            protocol_version: DRIVER_RPC_VERSION,
+            protocol_version,
             request_id,
             session_id,
             done: true,
@@ -550,5 +561,35 @@ impl DriverResponseEnvelope {
                 retriable,
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DriverRequestBody, DriverRequestEnvelope, DriverResponseBody, DriverResponseEnvelope,
+    };
+    use crate::ProtocolVersion;
+
+    #[test]
+    fn request_envelope_uses_explicit_protocol_version() {
+        let envelope =
+            DriverRequestEnvelope::new(ProtocolVersion::new(1, 0), 41, DriverRequestBody::Ping);
+
+        assert_eq!(envelope.protocol_version, ProtocolVersion::new(1, 0));
+        assert_eq!(envelope.request_id, 41);
+    }
+
+    #[test]
+    fn response_envelope_uses_explicit_protocol_version() {
+        let response = DriverResponseEnvelope::ok(
+            ProtocolVersion::new(1, 0),
+            41,
+            None,
+            DriverResponseBody::Pong,
+        );
+
+        assert_eq!(response.protocol_version, ProtocolVersion::new(1, 0));
+        assert_eq!(response.request_id, 41);
     }
 }

--- a/crates/dbflux_ipc/src/envelope.rs
+++ b/crates/dbflux_ipc/src/envelope.rs
@@ -18,4 +18,104 @@ impl ProtocolVersion {
 }
 
 pub const APP_CONTROL_VERSION: ProtocolVersion = ProtocolVersion::new(1, 0);
+pub const DRIVER_RPC_V1_0: ProtocolVersion = ProtocolVersion::new(1, 0);
 pub const DRIVER_RPC_VERSION: ProtocolVersion = ProtocolVersion::new(1, 1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RpcApiFamily {
+    DriverRpc,
+    AuthProviderRpc,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RpcApiContract {
+    pub family: RpcApiFamily,
+    pub version: ProtocolVersion,
+}
+
+impl RpcApiContract {
+    pub const fn new(family: RpcApiFamily, version: ProtocolVersion) -> Self {
+        Self { family, version }
+    }
+
+    pub fn is_compatible_with(self, other: Self) -> bool {
+        self.family == other.family && self.version.is_compatible_with(other.version)
+    }
+}
+
+pub const DRIVER_RPC_API_CONTRACT: RpcApiContract =
+    RpcApiContract::new(RpcApiFamily::DriverRpc, DRIVER_RPC_VERSION);
+
+pub const AUTH_PROVIDER_RPC_API_CONTRACT: RpcApiContract =
+    RpcApiContract::new(RpcApiFamily::AuthProviderRpc, ProtocolVersion::new(1, 0));
+
+pub const DRIVER_RPC_SUPPORTED_VERSIONS: [ProtocolVersion; 2] =
+    [DRIVER_RPC_V1_0, DRIVER_RPC_VERSION];
+
+pub const fn driver_rpc_supported_versions() -> &'static [ProtocolVersion] {
+    &DRIVER_RPC_SUPPORTED_VERSIONS
+}
+
+pub fn negotiate_highest_mutual_version(
+    family: RpcApiFamily,
+    local_versions: &[ProtocolVersion],
+    remote_versions: &[ProtocolVersion],
+) -> Option<ProtocolVersion> {
+    let _family = family;
+
+    local_versions
+        .iter()
+        .copied()
+        .filter(|local| remote_versions.contains(local))
+        .max_by_key(|version| (version.major, version.minor))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        DRIVER_RPC_VERSION, ProtocolVersion, RpcApiContract, RpcApiFamily,
+        negotiate_highest_mutual_version,
+    };
+
+    #[test]
+    fn rpc_api_contract_requires_matching_family_and_major() {
+        let driver_v1 = RpcApiContract::new(RpcApiFamily::DriverRpc, ProtocolVersion::new(1, 1));
+        let same_family_same_major =
+            RpcApiContract::new(RpcApiFamily::DriverRpc, ProtocolVersion::new(1, 0));
+        let different_family =
+            RpcApiContract::new(RpcApiFamily::AuthProviderRpc, ProtocolVersion::new(1, 1));
+        let different_major =
+            RpcApiContract::new(RpcApiFamily::DriverRpc, ProtocolVersion::new(2, 0));
+
+        assert!(driver_v1.is_compatible_with(same_family_same_major));
+        assert!(!driver_v1.is_compatible_with(different_family));
+        assert!(!driver_v1.is_compatible_with(different_major));
+    }
+
+    #[test]
+    fn negotiate_highest_mutual_minor_is_deterministic() {
+        let selected = negotiate_highest_mutual_version(
+            RpcApiFamily::DriverRpc,
+            &[ProtocolVersion::new(1, 1), ProtocolVersion::new(1, 0)],
+            &[
+                ProtocolVersion::new(1, 0),
+                ProtocolVersion::new(1, 1),
+                ProtocolVersion::new(1, 3),
+            ],
+        );
+
+        assert_eq!(selected, Some(DRIVER_RPC_VERSION));
+    }
+
+    #[test]
+    fn negotiate_highest_mutual_minor_returns_none_without_overlap() {
+        let selected = negotiate_highest_mutual_version(
+            RpcApiFamily::DriverRpc,
+            &[ProtocolVersion::new(1, 1)],
+            &[ProtocolVersion::new(2, 0)],
+        );
+
+        assert_eq!(selected, None);
+    }
+}

--- a/crates/dbflux_ipc/src/lib.rs
+++ b/crates/dbflux_ipc/src/lib.rs
@@ -14,7 +14,11 @@ pub use driver_protocol::{
     DriverRequestEnvelope, DriverResponseBody, DriverResponseEnvelope, DriverRpcError,
     DriverRpcErrorCode, QueryRequestDto, QueryResultChunk, QueryResultDto, QueryResultShapeDto,
 };
-pub use envelope::{APP_CONTROL_VERSION, DRIVER_RPC_VERSION, ProtocolVersion};
+pub use envelope::{
+    APP_CONTROL_VERSION, AUTH_PROVIDER_RPC_API_CONTRACT, DRIVER_RPC_API_CONTRACT,
+    DRIVER_RPC_SUPPORTED_VERSIONS, DRIVER_RPC_V1_0, DRIVER_RPC_VERSION, ProtocolVersion,
+    RpcApiContract, RpcApiFamily, driver_rpc_supported_versions, negotiate_highest_mutual_version,
+};
 pub use framing::{recv_msg, send_msg};
 pub use protocol::{AppControlRequest, AppControlResponse, IpcMessage, IpcResponse};
 pub use socket::{driver_socket_name, socket_name};

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -136,6 +136,7 @@ impl MigrationRegistry {
         registry.register(mod_003_audit_settings::MigrationImpl);
         registry.register(mod_004_audit_saved_filters::MigrationImpl);
         registry.register(mod_005_rpc_service_kind::MigrationImpl);
+        registry.register(mod_006_rpc_service_api_contract::MigrationImpl);
         registry
     }
 
@@ -279,12 +280,14 @@ mod mod_002_audit_extended;
 mod mod_003_audit_settings;
 mod mod_004_audit_saved_filters;
 mod mod_005_rpc_service_kind;
+mod mod_006_rpc_service_api_contract;
 
 pub use mod_001_initial::MigrationImpl;
 pub use mod_002_audit_extended::MigrationImpl as MigrationImplAuditExtended;
 pub use mod_003_audit_settings::MigrationImpl as MigrationImplAuditSettings;
 pub use mod_004_audit_saved_filters::MigrationImpl as MigrationImplAuditSavedFilters;
 pub use mod_005_rpc_service_kind::MigrationImpl as MigrationImplRpcServiceKind;
+pub use mod_006_rpc_service_api_contract::MigrationImpl as MigrationImplRpcServiceApiContract;
 
 // ---------------------------------------------------------------------------
 // Database verification utilities
@@ -365,7 +368,7 @@ mod tests {
         let count_first: i64 = conn
             .query_row("SELECT COUNT(*) FROM sys_migrations", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(count_first, 5, "expected 5 migrations after first run");
+        assert_eq!(count_first, 6, "expected 6 migrations after first run");
 
         registry.run_all(&conn).unwrap();
 
@@ -373,8 +376,8 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM sys_migrations", [], |row| row.get(0))
             .unwrap();
         assert_eq!(
-            count_second, 5,
-            "expected still 5 migrations after second run (idempotent)"
+            count_second, 6,
+            "expected still 6 migrations after second run (idempotent)"
         );
 
         drop(conn);
@@ -500,14 +503,15 @@ mod tests {
         let pending_before = registry.get_pending(&conn).unwrap();
         assert_eq!(
             pending_before.len(),
-            5,
-            "expected 5 pending migrations before running"
+            6,
+            "expected 6 pending migrations before running"
         );
         assert_eq!(pending_before[0].name(), "001_initial");
         assert_eq!(pending_before[1].name(), "002_audit_extended");
         assert_eq!(pending_before[2].name(), "003_audit_settings");
         assert_eq!(pending_before[3].name(), "004_audit_saved_filters");
         assert_eq!(pending_before[4].name(), "005_rpc_service_kind");
+        assert_eq!(pending_before[5].name(), "006_rpc_service_api_contract");
 
         registry.run_all(&conn).unwrap();
 

--- a/crates/dbflux_storage/src/migrations/mod_006_rpc_service_api_contract.rs
+++ b/crates/dbflux_storage/src/migrations/mod_006_rpc_service_api_contract.rs
@@ -1,0 +1,71 @@
+//! Migration 006: Add RPC API contract metadata to services.
+
+use rusqlite::Transaction;
+
+use crate::migrations::{Migration, MigrationError};
+
+pub struct MigrationImpl;
+
+impl Migration for MigrationImpl {
+    fn name(&self) -> &str {
+        "006_rpc_service_api_contract"
+    }
+
+    fn run(&self, tx: &Transaction) -> Result<(), MigrationError> {
+        add_column_if_missing(tx, "api_family", "TEXT")?;
+        add_column_if_missing(tx, "api_major", "INTEGER")?;
+        add_column_if_missing(tx, "api_minor", "INTEGER")?;
+
+        Ok(())
+    }
+}
+
+fn add_column_if_missing(
+    tx: &Transaction,
+    column_name: &str,
+    column_definition: &str,
+) -> Result<(), MigrationError> {
+    if has_column(tx, column_name)? {
+        return Ok(());
+    }
+
+    tx.execute(
+        &format!("ALTER TABLE cfg_services ADD COLUMN {column_name} {column_definition}"),
+        [],
+    )
+    .map_err(|source| MigrationError::Sqlite {
+        path: std::path::PathBuf::from("<unknown>"),
+        source,
+    })?;
+
+    Ok(())
+}
+
+fn has_column(tx: &Transaction, column_name: &str) -> Result<bool, MigrationError> {
+    let mut stmt = tx
+        .prepare("PRAGMA table_info(cfg_services)")
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    for column in columns {
+        let column = column.map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+        if column == column_name {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}

--- a/crates/dbflux_storage/src/repositories/services.rs
+++ b/crates/dbflux_storage/src/repositories/services.rs
@@ -83,7 +83,7 @@ impl ServiceRepository {
             .conn()
             .prepare(
                 r#"
-                SELECT socket_id, enabled, command, startup_timeout_ms, service_kind, created_at, updated_at
+                SELECT socket_id, enabled, command, startup_timeout_ms, service_kind, api_family, api_major, api_minor, created_at, updated_at
                 FROM cfg_services
                 ORDER BY socket_id ASC
                 "#,
@@ -101,8 +101,11 @@ impl ServiceRepository {
                     command: row.get(2)?,
                     startup_timeout_ms: row.get(3)?,
                     service_kind: row.get(4)?,
-                    created_at: row.get(5)?,
-                    updated_at: row.get(6)?,
+                    api_family: row.get(5)?,
+                    api_major: row.get(6)?,
+                    api_minor: row.get(7)?,
+                    created_at: row.get(8)?,
+                    updated_at: row.get(9)?,
                 })
             })
             .map_err(|source| StorageError::Sqlite {
@@ -135,7 +138,7 @@ impl ServiceRepository {
             .conn()
             .prepare(
                 r#"
-                SELECT socket_id, enabled, command, startup_timeout_ms, service_kind, created_at, updated_at
+                SELECT socket_id, enabled, command, startup_timeout_ms, service_kind, api_family, api_major, api_minor, created_at, updated_at
                 FROM cfg_services
                 WHERE socket_id = ?1
                 "#,
@@ -152,8 +155,11 @@ impl ServiceRepository {
                 command: row.get(2)?,
                 startup_timeout_ms: row.get(3)?,
                 service_kind: row.get(4)?,
-                created_at: row.get(5)?,
-                updated_at: row.get(6)?,
+                api_family: row.get(5)?,
+                api_major: row.get(6)?,
+                api_minor: row.get(7)?,
+                created_at: row.get(8)?,
+                updated_at: row.get(9)?,
             })
         });
 
@@ -181,9 +187,9 @@ impl ServiceRepository {
         tx.execute(
             r#"
                 INSERT INTO cfg_services (
-                    socket_id, enabled, command, startup_timeout_ms, service_kind, created_at, updated_at
+                    socket_id, enabled, command, startup_timeout_ms, service_kind, api_family, api_major, api_minor, created_at, updated_at
                 ) VALUES (
-                    ?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now')
+                    ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'), datetime('now')
                 )
                 "#,
             params![
@@ -192,6 +198,9 @@ impl ServiceRepository {
                 service.command,
                 service.startup_timeout_ms,
                 service.service_kind,
+                service.api_family,
+                service.api_major,
+                service.api_minor,
             ],
         )
         .map_err(|source| StorageError::Sqlite {
@@ -227,6 +236,9 @@ impl ServiceRepository {
                     command = ?3,
                     startup_timeout_ms = ?4,
                     service_kind = ?5,
+                    api_family = ?6,
+                    api_major = ?7,
+                    api_minor = ?8,
                     updated_at = datetime('now')
                 WHERE socket_id = ?1
                 "#,
@@ -236,6 +248,9 @@ impl ServiceRepository {
                     service.command,
                     service.startup_timeout_ms,
                     service.service_kind,
+                    service.api_family,
+                    service.api_major,
+                    service.api_minor,
                 ],
             )
             .map_err(|source| StorageError::Sqlite {
@@ -272,13 +287,16 @@ impl ServiceRepository {
         tx.execute(
             r#"
                 INSERT INTO cfg_services (
-                    socket_id, enabled, command, startup_timeout_ms, service_kind, created_at, updated_at
-                ) VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'), datetime('now'))
+                    socket_id, enabled, command, startup_timeout_ms, service_kind, api_family, api_major, api_minor, created_at, updated_at
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, datetime('now'), datetime('now'))
                 ON CONFLICT(socket_id) DO UPDATE SET
                     enabled = excluded.enabled,
                     command = excluded.command,
                     startup_timeout_ms = excluded.startup_timeout_ms,
                     service_kind = excluded.service_kind,
+                    api_family = excluded.api_family,
+                    api_major = excluded.api_major,
+                    api_minor = excluded.api_minor,
                     updated_at = datetime('now')
                 "#,
             params![
@@ -287,6 +305,9 @@ impl ServiceRepository {
                 service.command,
                 service.startup_timeout_ms,
                 service.service_kind,
+                service.api_family,
+                service.api_major,
+                service.api_minor,
             ],
         )
         .map_err(|source| StorageError::Sqlite {
@@ -340,6 +361,9 @@ pub struct ServiceDto {
     pub command: Option<String>,
     pub startup_timeout_ms: Option<i64>,
     pub service_kind: String,
+    pub api_family: Option<String>,
+    pub api_major: Option<i64>,
+    pub api_minor: Option<i64>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -353,6 +377,9 @@ impl ServiceDto {
             command: None,
             startup_timeout_ms: None,
             service_kind: "driver".to_string(),
+            api_family: None,
+            api_major: None,
+            api_minor: None,
             created_at: String::new(),
             updated_at: String::new(),
         }
@@ -416,6 +443,9 @@ mod tests {
             command: Some("dbflux-driver-host".to_string()),
             startup_timeout_ms: Some(5_000),
             service_kind: "auth_provider".to_string(),
+            api_family: Some("auth_provider_rpc".to_string()),
+            api_major: Some(1),
+            api_minor: Some(0),
             created_at: String::new(),
             updated_at: String::new(),
         };
@@ -428,6 +458,38 @@ mod tests {
             .expect("service row");
 
         assert_eq!(fetched.service_kind, "auth_provider");
+        assert_eq!(fetched.api_family.as_deref(), Some("auth_provider_rpc"));
+        assert_eq!(fetched.api_major, Some(1));
+        assert_eq!(fetched.api_minor, Some(0));
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+        let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    }
+
+    #[test]
+    fn service_insert_defaults_missing_api_contract_columns_to_null() {
+        let path = temp_db("service_api_contract_defaults");
+        let _ = std::fs::remove_file(&path);
+
+        let conn = open_database(&path).expect("should open");
+        MigrationRegistry::new()
+            .run_all(&conn)
+            .expect("migration should run");
+
+        let repo = ServiceRepository::new(Arc::new(conn));
+        let dto = ServiceDto::new("driver-socket".to_string());
+
+        repo.insert(&dto).expect("should insert");
+
+        let fetched = repo
+            .get("driver-socket")
+            .expect("should load")
+            .expect("service row");
+
+        assert_eq!(fetched.api_family, None);
+        assert_eq!(fetched.api_major, None);
+        assert_eq!(fetched.api_minor, None);
 
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));

--- a/crates/dbflux_ui/src/ui/windows/settings/rpc_services.rs
+++ b/crates/dbflux_ui/src/ui/windows/settings/rpc_services.rs
@@ -63,7 +63,17 @@ fn build_service_config(
         env,
         startup_timeout_ms,
         kind,
+        api_contract: None,
     }
+}
+
+fn preserved_api_contract_for_edit(
+    services: &[ServiceConfig],
+    editing_svc_idx: Option<usize>,
+) -> Option<dbflux_core::ServiceRpcApiContract> {
+    editing_svc_idx
+        .and_then(|idx| services.get(idx))
+        .and_then(|service| service.api_contract.clone())
 }
 
 fn service_form_rows(
@@ -108,10 +118,10 @@ fn service_row_max_col(row: ServiceFormRow) -> usize {
 #[cfg(test)]
 mod tests {
     use super::{
-        ServiceFormRow, build_service_config, editable_service_kind, service_form_rows,
-        service_row_max_col,
+        ServiceFormRow, build_service_config, editable_service_kind,
+        preserved_api_contract_for_edit, service_form_rows, service_row_max_col,
     };
-    use dbflux_core::{RpcServiceKind, ServiceConfig};
+    use dbflux_core::{RpcServiceKind, ServiceConfig, ServiceRpcApiContract};
     use std::collections::HashMap;
 
     #[test]
@@ -149,6 +159,7 @@ mod tests {
             env: HashMap::new(),
             startup_timeout_ms: Some(5000),
             kind: RpcServiceKind::AuthProvider,
+            api_contract: None,
         };
 
         assert_eq!(
@@ -171,6 +182,26 @@ mod tests {
 
         assert_eq!(service.kind, RpcServiceKind::AuthProvider);
         assert_eq!(service.socket_id, "auth.sock");
+    }
+
+    #[test]
+    fn preserved_api_contract_for_edit_returns_saved_metadata() {
+        let api_contract = ServiceRpcApiContract::new("auth_provider_rpc", 1, 0);
+        let services = vec![ServiceConfig {
+            socket_id: "auth.sock".into(),
+            enabled: true,
+            command: Some("dbflux-auth".into()),
+            args: vec!["--serve".into()],
+            env: HashMap::from([("MODE".into(), "auth".into())]),
+            startup_timeout_ms: Some(5000),
+            kind: RpcServiceKind::AuthProvider,
+            api_contract: Some(api_contract.clone()),
+        }];
+
+        assert_eq!(
+            preserved_api_contract_for_edit(&services, Some(0)),
+            Some(api_contract)
+        );
     }
 }
 
@@ -396,7 +427,7 @@ impl ServicesSection {
             })
             .collect();
 
-        let service = build_service_config(
+        let mut service = build_service_config(
             socket_id,
             self.svc_enabled,
             command,
@@ -405,6 +436,9 @@ impl ServicesSection {
             startup_timeout_ms,
             self.svc_kind,
         );
+
+        service.api_contract =
+            preserved_api_contract_for_edit(&self.svc_services, self.editing_svc_idx);
 
         let saved_idx = if let Some(idx) = self.editing_svc_idx {
             if idx < self.svc_services.len() {

--- a/docs/DRIVER_RPC_PROTOCOL.md
+++ b/docs/DRIVER_RPC_PROTOCOL.md
@@ -89,13 +89,15 @@ Notes:
 
 DBFlux connects and sends `Hello` first.
 
+The active driver RPC API family is `driver_rpc`. In the current dedicated driver RPC transport, that family is implicit in the protocol itself rather than transmitted on the wire during `Hello`. Compatibility is enforced by the driver RPC endpoint plus the selected protocol major version; minor versions are additive and are negotiated deterministically within that major line.
+
 Client request:
 
 ```rust
 DriverRequestBody::Hello(DriverHelloRequest {
     client_name: "dbflux_driver_ipc".to_string(),
     client_version: "<version>".to_string(),
-    supported_versions: vec![DRIVER_RPC_VERSION],
+    supported_versions: vec![ProtocolVersion::new(1, 0), ProtocolVersion::new(1, 1)],
     requested_capabilities: vec![
         DriverCapability::Cancellation,
         DriverCapability::ChunkedResults,
@@ -141,7 +143,16 @@ DriverResponseBody::Hello(DriverHelloResponse {
 })
 ```
 
+If multiple compatible minors overlap, the host must select the highest mutual minor version.
+
 If no compatible version exists, return `DriverRpcErrorCode::VersionMismatch`.
+
+After `Hello`, every request and response envelope must use the negotiated `selected_version`. A peer that receives a different post-handshake envelope version must reject it as a version mismatch.
+
+Current validation boundary:
+
+- DBFlux persists per-service API family/version metadata for discovery and future runtime seams.
+- The live driver handshake currently validates negotiated protocol versions, but it does not transmit or separately re-validate the API family string on the wire because the driver RPC transport is already family-specific.
 
 ## Form contract
 
@@ -234,6 +245,7 @@ Recommended:
 7. validate `DbConfig::External.values` in `OpenSession`
 8. return clear `InvalidRequest` errors for missing/invalid form values
 9. keep `Hello` metadata and `SessionOpened` metadata consistent
+10. stamp every post-`Hello` envelope with the negotiated version instead of assuming the latest constant
 
 ## Working example in this repository
 

--- a/docs/RPC_SERVICES_CONFIG.md
+++ b/docs/RPC_SERVICES_CONFIG.md
@@ -14,6 +14,7 @@ RPC services are stored in SQLite at `~/.local/share/dbflux/dbflux.db`, not in a
 **Tables:**
 
 - `cfg_services` — main service record (socket_id, service_kind, command, startup_timeout_ms, enabled)
+- `cfg_services.api_family`, `cfg_services.api_major`, `cfg_services.api_minor` — optional RPC API contract metadata
 - `cfg_service_args` — ordered process arguments
 - `cfg_service_env` — environment variables
 
@@ -21,24 +22,26 @@ RPC services are stored in SQLite at `~/.local/share/dbflux/dbflux.db`, not in a
 
 ```sql
 CREATE TABLE cfg_services (
-    id TEXT PRIMARY KEY,
     socket_id TEXT NOT NULL UNIQUE,
     service_kind TEXT NOT NULL DEFAULT 'driver',
     command TEXT,
     startup_timeout_ms INTEGER DEFAULT 5000,
-    enabled INTEGER DEFAULT 1
+    enabled INTEGER DEFAULT 1,
+    api_family TEXT,
+    api_major INTEGER,
+    api_minor INTEGER
 );
 
 CREATE TABLE cfg_service_args (
     id INTEGER PRIMARY KEY,
-    service_id TEXT NOT NULL REFERENCES cfg_services(id),
+    service_id TEXT NOT NULL REFERENCES cfg_services(socket_id),
     position INTEGER NOT NULL,
     value TEXT NOT NULL
 );
 
 CREATE TABLE cfg_service_env (
     id INTEGER PRIMARY KEY,
-    service_id TEXT NOT NULL REFERENCES cfg_services(id),
+    service_id TEXT NOT NULL REFERENCES cfg_services(socket_id),
     key TEXT NOT NULL,
     value TEXT NOT NULL
 );
@@ -60,6 +63,9 @@ Notes:
 - Only `Driver` services are active in the runtime today.
 - `Auth Provider` services are preserved in storage and pass through discovery/classification, but they are not registered into any runtime auth-provider registry yet.
 - DBFlux preserves compatibility for driver registration IDs as `rpc:<socket_id>`.
+- If API metadata is missing on an existing driver row, DBFlux defaults it to the current `driver_rpc` contract at version `1.1`.
+- Auth-provider rows may persist API metadata, but they remain inert until runtime auth-provider support exists.
+- The stored `api_family` metadata is descriptive for discovery/config today; the current driver handshake still enforces compatibility through the dedicated driver RPC transport and negotiated protocol version rather than an on-wire family field.
 
 ## Legacy Migration
 
@@ -93,6 +99,7 @@ This is converted to the SQLite schema automatically. Legacy rows are treated as
 - Driver name/icon/category/form come from the service's `Hello` response (`driver_metadata`, `form_definition`), not from configuration
 - Services with `service_kind='driver'` that fail to complete the RPC handshake (`Hello`) during startup are not registered
 - Services with `service_kind='auth_provider'` are currently stored and discovered only; they do not participate in runtime features yet
+- Driver-path negotiation selects the highest mutually supported compatible minor version during `Hello`, then requires every later envelope to use that exact negotiated version
 
 ## Common Mistakes
 

--- a/examples/custom_driver/src/main.rs
+++ b/examples/custom_driver/src/main.rs
@@ -24,7 +24,8 @@ use dbflux_ipc::{
         DriverHelloResponse, DriverRequestBody, DriverRequestEnvelope, DriverResponseBody,
         DriverResponseEnvelope, DriverRpcErrorCode, QueryResultDto,
     },
-    framing, DRIVER_RPC_VERSION,
+    driver_rpc_supported_versions, framing, negotiate_highest_mutual_version, ProtocolVersion,
+    RpcApiFamily, DRIVER_RPC_VERSION,
 };
 use interprocess::local_socket::{
     prelude::*, GenericNamespaced, ListenerOptions, Stream as IpcStream,
@@ -136,7 +137,7 @@ fn handle_connection(
     mut stream: IpcStream,
     sessions: Arc<Mutex<SessionManager>>,
 ) -> io::Result<()> {
-    let mut hello_done = false;
+    let mut negotiated_version = None;
     let mut current_session: Option<Uuid> = None;
 
     loop {
@@ -155,21 +156,66 @@ fn handle_connection(
 
         let request_id = envelope.request_id;
         let session_id = envelope.session_id;
+        let request_version = envelope.protocol_version;
+
+        if !matches!(envelope.body, DriverRequestBody::Hello(_)) {
+            let Some(selected_version) = negotiated_version else {
+                let response = return_error(
+                    request_version,
+                    request_id,
+                    "Hello required before OpenSession",
+                );
+                framing::send_msg(&mut stream, &response)?;
+                continue;
+            };
+
+            if request_version != selected_version {
+                let response = DriverResponseEnvelope::error(
+                    request_version,
+                    request_id,
+                    session_id,
+                    DriverRpcErrorCode::VersionMismatch,
+                    format!(
+                        "Protocol version drift detected: negotiated {}.{}, received {}.{}",
+                        selected_version.major,
+                        selected_version.minor,
+                        request_version.major,
+                        request_version.minor
+                    ),
+                    false,
+                );
+                framing::send_msg(&mut stream, &response)?;
+                continue;
+            }
+        }
 
         // Dispatch request
         let response = match envelope.body {
             // Step 1: Hello handshake (required first)
             DriverRequestBody::Hello(hello_req) => {
-                hello_done = true;
+                if let Some(selected_version) =
+                    choose_negotiated_version(&hello_req.supported_versions)
+                {
+                    negotiated_version = Some(selected_version);
 
-                // Check if we support any of the client's versions
-                let compatible = hello_req
-                    .supported_versions
-                    .iter()
-                    .any(|v| v.major == DRIVER_RPC_VERSION.major);
-
-                if !compatible {
+                    DriverResponseEnvelope::ok(
+                        selected_version,
+                        request_id,
+                        None,
+                        DriverResponseBody::Hello(DriverHelloResponse {
+                            server_name: "custom-mock-driver".to_string(),
+                            server_version: env!("CARGO_PKG_VERSION").to_string(),
+                            selected_version,
+                            capabilities: hello_req.requested_capabilities,
+                            driver_kind: DbKind::SQLite,
+                            driver_metadata: create_metadata(),
+                            form_definition: mock_form(),
+                            settings_schema: None,
+                        }),
+                    )
+                } else {
                     DriverResponseEnvelope::error(
+                        request_version,
                         request_id,
                         None,
                         DriverRpcErrorCode::VersionMismatch,
@@ -179,21 +225,6 @@ fn handle_connection(
                         ),
                         false,
                     )
-                } else {
-                    DriverResponseEnvelope::ok(
-                        request_id,
-                        None,
-                        DriverResponseBody::Hello(DriverHelloResponse {
-                            server_name: "custom-mock-driver".to_string(),
-                            server_version: env!("CARGO_PKG_VERSION").to_string(),
-                            selected_version: DRIVER_RPC_VERSION,
-                            capabilities: hello_req.requested_capabilities,
-                            driver_kind: DbKind::SQLite,
-                            driver_metadata: create_metadata(),
-                            form_definition: mock_form(),
-                            settings_schema: None,
-                        }),
-                    )
                 }
             }
 
@@ -202,101 +233,106 @@ fn handle_connection(
                 profile_json,
                 password,
                 ssh_secret,
-            } => {
-                if !hello_done {
-                    return_error(request_id, "Hello required before OpenSession")
-                } else {
-                    match serde_json::from_str::<ConnectionProfile>(&profile_json) {
-                        Ok(profile) => {
-                            if let DbConfig::External { values, .. } = &profile.config {
-                                let endpoint = values.get("endpoint").cloned().unwrap_or_default();
-                                if endpoint.trim().is_empty() {
-                                    DriverResponseEnvelope::error(
-                                        request_id,
-                                        None,
-                                        DriverRpcErrorCode::InvalidRequest,
-                                        "endpoint is required".to_string(),
-                                        false,
-                                    )
-                                } else {
-                                    let api_key_present = values
-                                        .get("api_key")
-                                        .map(|value| !value.is_empty())
-                                        .unwrap_or(false);
+            } => match serde_json::from_str::<ConnectionProfile>(&profile_json) {
+                Ok(profile) => {
+                    if let DbConfig::External { values, .. } = &profile.config {
+                        let endpoint = values.get("endpoint").cloned().unwrap_or_default();
+                        if endpoint.trim().is_empty() {
+                            DriverResponseEnvelope::error(
+                                negotiated_version.expect("validated before dispatch"),
+                                request_id,
+                                None,
+                                DriverRpcErrorCode::InvalidRequest,
+                                "endpoint is required".to_string(),
+                                false,
+                            )
+                        } else {
+                            let api_key_present = values
+                                .get("api_key")
+                                .map(|value| !value.is_empty())
+                                .unwrap_or(false);
 
-                                    log::info!(
-                                        "Opening session to endpoint='{}' api_key_present={}",
-                                        endpoint,
-                                        api_key_present
-                                    );
+                            log::info!(
+                                "Opening session to endpoint='{}' api_key_present={}",
+                                endpoint,
+                                api_key_present
+                            );
 
-                                    if password.is_some() {
-                                        log::info!(
-                                            "Password provided (length: {})",
-                                            password.as_ref().unwrap().len()
-                                        );
-                                    }
-                                    if ssh_secret.is_some() {
-                                        log::info!("SSH secret provided");
-                                    }
-
-                                    let session_id = sessions.lock().unwrap().create_session();
-                                    current_session = Some(session_id);
-
-                                    DriverResponseEnvelope::ok(
-                                        request_id,
-                                        Some(session_id),
-                                        DriverResponseBody::SessionOpened {
-                                            session_id,
-                                            kind: DbKind::SQLite,
-                                            metadata: create_metadata(),
-                                            schema_loading_strategy:
-                                                SchemaLoadingStrategy::LazyPerDatabase,
-                                            schema_features: dbflux_core::SchemaFeatures::empty(),
-                                            code_gen_capabilities:
-                                                dbflux_core::CodeGenCapabilities::empty(),
-                                        },
-                                    )
-                                }
-                            } else {
-                                DriverResponseEnvelope::error(
-                                    request_id,
-                                    None,
-                                    DriverRpcErrorCode::InvalidRequest,
-                                    "Expected DbConfig::External for custom driver".to_string(),
-                                    false,
-                                )
+                            if password.is_some() {
+                                log::info!(
+                                    "Password provided (length: {})",
+                                    password.as_ref().unwrap().len()
+                                );
                             }
+                            if ssh_secret.is_some() {
+                                log::info!("SSH secret provided");
+                            }
+
+                            let session_id = sessions.lock().unwrap().create_session();
+                            current_session = Some(session_id);
+
+                            DriverResponseEnvelope::ok(
+                                negotiated_version.expect("validated before dispatch"),
+                                request_id,
+                                Some(session_id),
+                                DriverResponseBody::SessionOpened {
+                                    session_id,
+                                    kind: DbKind::SQLite,
+                                    metadata: create_metadata(),
+                                    schema_loading_strategy: SchemaLoadingStrategy::LazyPerDatabase,
+                                    schema_features: dbflux_core::SchemaFeatures::empty(),
+                                    code_gen_capabilities: dbflux_core::CodeGenCapabilities::empty(
+                                    ),
+                                },
+                            )
                         }
-                        Err(error) => DriverResponseEnvelope::error(
+                    } else {
+                        DriverResponseEnvelope::error(
+                            negotiated_version.expect("validated before dispatch"),
                             request_id,
                             None,
                             DriverRpcErrorCode::InvalidRequest,
-                            format!("Invalid profile JSON: {error}"),
+                            "Expected DbConfig::External for custom driver".to_string(),
                             false,
-                        ),
+                        )
                     }
                 }
-            }
+                Err(error) => DriverResponseEnvelope::error(
+                    negotiated_version.expect("validated before dispatch"),
+                    request_id,
+                    None,
+                    DriverRpcErrorCode::InvalidRequest,
+                    format!("Invalid profile JSON: {error}"),
+                    false,
+                ),
+            },
 
             // Close session
             DriverRequestBody::CloseSession => {
                 if let Some(sid) = session_id {
                     sessions.lock().unwrap().close_session(&sid);
                     DriverResponseEnvelope::ok(
+                        negotiated_version.expect("validated before dispatch"),
                         request_id,
                         Some(sid),
                         DriverResponseBody::SessionClosed,
                     )
                 } else {
-                    return_error(request_id, "No session_id provided")
+                    return_error(
+                        negotiated_version.expect("validated before dispatch"),
+                        request_id,
+                        "No session_id provided",
+                    )
                 }
             }
 
             // Ping - health check
-            DriverRequestBody::Ping => {
-                DriverResponseEnvelope::ok(request_id, session_id, DriverResponseBody::Pong)
-            }
+            DriverRequestBody::Ping => DriverResponseEnvelope::ok(
+                negotiated_version.expect("validated before dispatch"),
+                request_id,
+                session_id,
+                DriverResponseBody::Pong,
+            ),
 
             // Execute a query
             DriverRequestBody::Execute { request } => match session_id {
@@ -304,6 +340,7 @@ fn handle_connection(
                     let result = execute_query(&request.sql, &mut sessions.lock().unwrap(), &sid);
                     match result {
                         Ok(query_result) => DriverResponseEnvelope::ok(
+                            negotiated_version.expect("validated before dispatch"),
                             request_id,
                             Some(sid),
                             DriverResponseBody::ExecuteResult {
@@ -311,6 +348,7 @@ fn handle_connection(
                             },
                         ),
                         Err(e) => DriverResponseEnvelope::error(
+                            negotiated_version.expect("validated before dispatch"),
                             request_id,
                             Some(sid),
                             DriverRpcErrorCode::Driver,
@@ -319,11 +357,16 @@ fn handle_connection(
                         ),
                     }
                 }
-                None => return_error(request_id, "No session_id provided"),
+                None => return_error(
+                    negotiated_version.expect("validated before dispatch"),
+                    request_id,
+                    "No session_id provided",
+                ),
             },
 
             // List databases
             DriverRequestBody::ListDatabases => DriverResponseEnvelope::ok(
+                negotiated_version.expect("validated before dispatch"),
                 request_id,
                 session_id,
                 DriverResponseBody::Databases {
@@ -336,6 +379,7 @@ fn handle_connection(
 
             // Get schema
             DriverRequestBody::Schema => DriverResponseEnvelope::ok(
+                negotiated_version.expect("validated before dispatch"),
                 request_id,
                 session_id,
                 DriverResponseBody::Schema {
@@ -345,6 +389,7 @@ fn handle_connection(
 
             // All other requests - not implemented in this example
             _ => DriverResponseEnvelope::error(
+                negotiated_version.expect("validated before dispatch"),
                 request_id,
                 session_id,
                 DriverRpcErrorCode::UnsupportedMethod,
@@ -511,8 +556,23 @@ fn mock_form() -> DriverFormDef {
     }
 }
 
-fn return_error(request_id: u64, message: &str) -> DriverResponseEnvelope {
+fn choose_negotiated_version(
+    client_supported_versions: &[ProtocolVersion],
+) -> Option<ProtocolVersion> {
+    negotiate_highest_mutual_version(
+        RpcApiFamily::DriverRpc,
+        driver_rpc_supported_versions(),
+        client_supported_versions,
+    )
+}
+
+fn return_error(
+    protocol_version: ProtocolVersion,
+    request_id: u64,
+    message: &str,
+) -> DriverResponseEnvelope {
     DriverResponseEnvelope::error(
+        protocol_version,
         request_id,
         None,
         DriverRpcErrorCode::InvalidRequest,


### PR DESCRIPTION
## Summary

- make driver RPC version negotiation deterministic and enforce the negotiated version on post-`Hello` traffic
- persist RPC service API contract metadata with backward-compatible defaults and reject inconsistent stored service contracts
- align Settings, docs, and the custom driver example with the enforced versioning contract

## What does this resolve?

- Resolves #32

## How was this solved?

- added shared RPC API contract/version helpers and tightened host/client negotiation plus envelope validation
- extended service config/storage with canonical API contract metadata while preserving `rpc:<socket_id>` compatibility and legacy defaults
- fixed judgment-day findings around downgrade handling, handshake error surfacing, stale Settings metadata, and outdated docs/example guidance

## Validation

- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- judgment-day adversarial review with follow-up fixes

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [x] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable