### PR TITLE
refactor(rpc): formalize external driver services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ scripts/src
 scripts/pkg
 scripts/dbflux*
 .logs
+.atl

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -258,7 +258,7 @@ crates/
 
 - `crates/dbflux_ipc/` defines versioned app-control and driver RPC contracts, transport framing, and cross-platform socket naming.
 - `crates/dbflux/src/main.rs` uses app-control IPC for single-instance behavior (`Focus`, `OpenScript`) with protocol-version compatibility checks.
-- `crates/dbflux_core/src/config/app.rs` loads `~/.config/dbflux/config.json` and exposes `rpc_services` runtime configuration.
+- `crates/dbflux_core/src/config/app.rs` loads `~/.config/dbflux/config.json` and only accepts the canonical `services` runtime configuration.
 - `crates/dbflux/src/app.rs` probes each configured RPC service at startup (`Hello`) and registers it as an in-memory driver key `rpc:<socket_id>`.
 - `crates/dbflux_driver_ipc/src/driver.rs` implements `DbDriver` as an RPC proxy and only shuts down managed hosts that DBFlux spawned itself.
 - External connection profiles use `DbConfig::External { kind, values }`, where form values come from the remote `form_definition` returned during `Hello`.
@@ -322,7 +322,7 @@ crates/
 ## Data Flow
 
 - Startup: `main` creates `AppState` and `Workspace`, restores the previous session (tabs from `session.json`), and opens the main window. If no tabs are restored, focus defaults to the sidebar (crates/dbflux/src/main.rs, crates/dbflux/src/ui/workspace.rs).
-- External driver bootstrap: at startup, DBFlux reads `~/.config/dbflux/config.json`, probes each `rpc_service`, and only registers services that complete the RPC handshake (`Hello`) successfully.
+- External driver bootstrap: at startup, DBFlux reads `~/.config/dbflux/config.json`, validates each configured service launch contract, probes each service, and only registers services that complete the RPC handshake (`Hello`) successfully.
 - Connect flow: `AppState::prepare_connect_profile` selects a driver and builds `ConnectProfileParams`, which optionally creates a proxy tunnel, then connects and fetches schema (crates/dbflux/src/app.rs). Supports form-based configuration, direct URI input, optional proxy tunneling, and SSH tunneling (mutually exclusive). Connection hooks run at each phase (PreConnect, PostConnect, PreDisconnect, PostDisconnect).
 - Query flow: SqlQueryDocument submits queries to a `Connection` implementation; the query language (SQL/MongoDB/etc) is determined by driver metadata. Results are rendered in result tabs within the document. Dangerous queries (DELETE without WHERE, DROP, TRUNCATE) trigger confirmation dialogs.
 - View mode selection: `DataGridPanel` automatically selects appropriate view mode based on database category—Table view for relational databases, Document tree view for document databases like MongoDB. Context menus include "Copy as Query" for generating INSERT/UPDATE/DELETE via the connection's `QueryGenerator`.
@@ -359,7 +359,7 @@ crates/
 - Workspace settings: `Cargo.toml` defines workspace members and shared dependencies.
 - App features: `crates/dbflux/Cargo.toml` gates `sqlite`, `postgres`, `mysql`, `mongodb`, and `redis` drivers (all enabled by default).
 - Runtime data (config dir via `dirs::config_dir`):
-  - `config.json` for external RPC services (`rpc_services` with socket id, command, args, env, startup timeout) (crates/dbflux_core/src/config/app.rs).
+  - `config.json` for external RPC services (`services` with socket id, command, args, env, startup timeout) (crates/dbflux_core/src/config/app.rs).
   - `profiles.json`, `ssh_tunnels.json`, and `proxies.json` (crates/dbflux_core/src/storage/json_store.rs).
   - `history.json` for query history (crates/dbflux_core/src/storage/history.rs).
   - `saved_queries.json` for user-saved queries (crates/dbflux_core/src/storage/saved_query.rs).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,26 @@ All notable changes to DBFlux will be documented in this file.
 
 ---
 
+## [0.3.7] – 2026-03-06
+
+### Added
+
+* Dedicated style CI workflow that runs `cargo fmt --check` and `cargo clippy --workspace -- -D warnings`
+
+### Changed
+
+* New connections and SSH tunnels now save credentials to the system keyring by default unless the checkbox is explicitly disabled
+* Release workflow now blocks artifact builds until both tests and style checks pass
+
+### Fixed
+
+* SQL query context selectors now refresh when connections and databases change, so tabs opened before connecting can pick their execution target correctly
+* Per-database query task cancellation now cleans up the exact connection target, allowing the sidebar to reopen those databases after cancellation
+* PostgreSQL connection retry setup and live integration tests now compile cleanly under current type inference requirements
+* Restored the full `LICENSE-MIT` text in release artifacts
+
+---
+
 ## [0.3.6] – 2026-02-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_mongodb"
-version = "0.1.0"
+version = "0.4.0-dev.5"
 dependencies = [
  "base64 0.22.1",
  "bson",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_mysql"
-version = "0.1.0"
+version = "0.4.0-dev.5"
 dependencies = [
  "chrono",
  "dbflux_core",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_postgres"
-version = "0.1.0"
+version = "0.4.0-dev.5"
 dependencies = [
  "chrono",
  "dbflux_core",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_redis"
-version = "0.1.0"
+version = "0.4.0-dev.5"
 dependencies = [
  "dbflux_core",
  "dbflux_ssh",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_sqlite"
-version = "0.0.0"
+version = "0.4.0-dev.5"
 dependencies = [
  "dbflux_core",
  "dbflux_test_support",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_export"
-version = "0.1.0"
+version = "0.4.0-dev.5"
 dependencies = [
  "base64 0.22.1",
  "csv",
@@ -1858,7 +1858,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_ssh"
-version = "0.1.0"
+version = "0.4.0-dev.5"
 dependencies = [
  "dbflux_core",
  "dbflux_tunnel_core",
@@ -1869,7 +1869,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_test_support"
-version = "0.1.0"
+version = "0.4.0-dev.5"
 dependencies = [
  "dbflux_core",
  "serde_json",

--- a/crates/dbflux/src/app.rs
+++ b/crates/dbflux/src/app.rs
@@ -5,7 +5,7 @@ use dbflux_core::{
     SchemaForeignKeyInfo, SchemaIndexInfo, SchemaSnapshot, ScriptsDirectory, SecretStore,
     SessionFacade, SessionStore, ShutdownPhase, SshTunnelProfile, TaskId, TaskKind, TaskSnapshot,
 };
-use dbflux_driver_ipc::{driver::IpcDriverLaunchConfig, IpcDriver};
+use dbflux_driver_ipc::{IpcDriver, driver::IpcDriverLaunchConfig};
 use gpui::{EventEmitter, WindowHandle};
 use gpui_component::Root;
 use std::collections::HashMap;
@@ -34,11 +34,33 @@ use dbflux_driver_redis::RedisDriver;
 pub use dbflux_core::{
     ConnectProfileParams, ConnectedProfile, DangerousQuerySuppressions, FetchDatabaseSchemaParams,
     FetchSchemaForeignKeysParams, FetchSchemaIndexesParams, FetchSchemaTypesParams,
-    FetchTableDetailsParams, SwitchDatabaseParams,
+    FetchTableDetailsParams, PrepareConnectError, SwitchDatabaseParams,
 };
 
 fn rpc_registry_id(socket_id: &str) -> String {
     format!("rpc:{}", socket_id)
+}
+
+const EXTERNAL_DRIVER_STARTUP_OUTPUT_SEPARATOR: &str = "\n\nRecent host output:\n";
+const EXTERNAL_DRIVER_LAUNCH_FAILURE_MARKERS: &[&str] = &[
+    "Failed to start driver host '",
+    "exited before socket was ready",
+    "did not become ready within",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalDriverStage {
+    Config,
+    Launch,
+    Probe,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalDriverDiagnostic {
+    pub socket_id: String,
+    pub stage: ExternalDriverStage,
+    pub summary: String,
+    pub details: Option<String>,
 }
 
 struct BuiltDrivers {
@@ -47,6 +69,7 @@ struct BuiltDrivers {
     driver_overrides: HashMap<DriverKey, GlobalOverrides>,
     driver_settings: HashMap<DriverKey, FormValues>,
     hook_definitions: HashMap<String, ConnectionHook>,
+    external_driver_diagnostics: HashMap<String, ExternalDriverDiagnostic>,
 }
 
 pub struct AppState {
@@ -56,6 +79,7 @@ pub struct AppState {
     driver_overrides: HashMap<DriverKey, GlobalOverrides>,
     driver_settings: HashMap<DriverKey, FormValues>,
     hook_definitions: HashMap<String, ConnectionHook>,
+    external_driver_diagnostics: HashMap<String, ExternalDriverDiagnostic>,
     recent_files: Option<RecentFilesStore>,
     scripts_directory: Option<ScriptsDirectory>,
     session_store: Option<SessionStore>,
@@ -71,6 +95,7 @@ impl AppState {
             built.driver_overrides,
             built.driver_settings,
             built.hook_definitions,
+            built.external_driver_diagnostics,
         )
     }
 
@@ -80,6 +105,7 @@ impl AppState {
         driver_overrides: HashMap<DriverKey, GlobalOverrides>,
         driver_settings: HashMap<DriverKey, FormValues>,
         hook_definitions: HashMap<String, ConnectionHook>,
+        external_driver_diagnostics: HashMap<String, ExternalDriverDiagnostic>,
     ) -> Self {
         let recent_files = RecentFilesStore::new()
             .inspect_err(|e| log::warn!("Failed to initialize recent files store: {}", e))
@@ -105,6 +131,7 @@ impl AppState {
             driver_overrides,
             driver_settings,
             hook_definitions,
+            external_driver_diagnostics,
             recent_files,
             scripts_directory,
             session_store,
@@ -148,13 +175,20 @@ impl AppState {
         }
 
         let app_config = AppConfigStore::new()
-            .and_then(|store| store.load())
+            .and_then(|store| store.load_with_warnings())
             .inspect_err(|e| log::warn!("Failed to load app config: {}", e))
             .ok();
 
+        if let Some(loaded) = app_config.as_ref() {
+            for warning in &loaded.warnings {
+                log::warn!("App config warning: {}", warning);
+            }
+        }
+
         let (general_settings, driver_overrides, driver_settings, hook_definitions) = app_config
             .as_ref()
-            .map(|config| {
+            .map(|loaded| {
+                let config = &loaded.config;
                 (
                     config.general.clone(),
                     config.driver_overrides.clone(),
@@ -171,60 +205,16 @@ impl AppState {
                 )
             });
 
-        if let Some(config) = app_config {
-            for service in config.services {
-                if !service.enabled {
-                    log::info!("Skipping disabled service '{}'", service.socket_id);
-                    continue;
-                }
-
-                let driver_id = rpc_registry_id(&service.socket_id);
-
-                if drivers.contains_key(&driver_id) {
-                    log::warn!(
-                        "Skipping external RPC service '{}': driver id already exists",
-                        service.socket_id
-                    );
-                    continue;
-                }
-
-                let launch = IpcDriverLaunchConfig {
-                    program: service
-                        .command
-                        .clone()
-                        .unwrap_or_else(|| "dbflux-driver-host".to_string()),
-                    args: service.args.clone(),
-                    env: service.env.into_iter().collect(),
-                    startup_timeout: std::time::Duration::from_millis(
-                        service.startup_timeout_ms.unwrap_or(5_000),
-                    ),
-                };
-
-                let (kind, metadata, form_definition, settings_schema) =
-                    match IpcDriver::probe_driver(&service.socket_id, Some(&launch)) {
-                        Ok(info) => info,
-                        Err(error) => {
-                            log::warn!(
-                                "Skipping RPC service '{}': failed to probe driver metadata: {}",
-                                service.socket_id,
-                                error
-                            );
-                            continue;
-                        }
-                    };
-
-                let ipc_driver = IpcDriver::new(
-                    service.socket_id.clone(),
-                    kind,
-                    metadata,
-                    form_definition,
-                    settings_schema,
+        let external_driver_diagnostics = app_config
+            .map(|loaded| {
+                let config = loaded.config;
+                Self::register_external_services(
+                    &mut drivers,
+                    config.services,
+                    |service, launch| IpcDriver::probe_driver(&service.socket_id, launch),
                 )
-                .with_launch_config(launch);
-
-                drivers.insert(driver_id, Arc::new(ipc_driver));
-            }
-        }
+            })
+            .unwrap_or_default();
 
         BuiltDrivers {
             drivers,
@@ -232,6 +222,148 @@ impl AppState {
             driver_overrides,
             driver_settings,
             hook_definitions,
+            external_driver_diagnostics,
+        }
+    }
+
+    fn register_external_services<F, E>(
+        drivers: &mut HashMap<String, Arc<dyn DbDriver>>,
+        services: Vec<dbflux_core::ServiceConfig>,
+        mut probe: F,
+    ) -> HashMap<String, ExternalDriverDiagnostic>
+    where
+        F: FnMut(
+            &dbflux_core::ServiceConfig,
+            Option<&IpcDriverLaunchConfig>,
+        ) -> Result<
+            (
+                DbKind,
+                dbflux_core::DriverMetadata,
+                dbflux_core::DriverFormDef,
+                Option<dbflux_core::DriverFormDef>,
+            ),
+            E,
+        >,
+        E: ToString,
+    {
+        let mut diagnostics = HashMap::new();
+
+        for service in services {
+            if !service.enabled {
+                log::info!("Skipping disabled service '{}'", service.socket_id);
+                continue;
+            }
+
+            let driver_id = rpc_registry_id(&service.socket_id);
+
+            if drivers.contains_key(&driver_id) {
+                let summary = format!(
+                    "Skipping external RPC service '{}': driver id already exists",
+                    service.socket_id
+                );
+                log::warn!("{}", summary);
+                diagnostics.insert(
+                    service.socket_id.clone(),
+                    ExternalDriverDiagnostic {
+                        socket_id: service.socket_id.clone(),
+                        stage: ExternalDriverStage::Config,
+                        summary,
+                        details: None,
+                    },
+                );
+                continue;
+            }
+
+            let launch = match IpcDriver::build_launch_config(
+                &service.socket_id,
+                service.command.as_deref(),
+                &service.args,
+                &service.env,
+                service.startup_timeout_ms,
+            ) {
+                Ok(launch) => launch,
+                Err(error) => {
+                    let summary = error.to_string();
+                    log::warn!(
+                        "Skipping RPC service '{}': invalid launch config: {}",
+                        service.socket_id,
+                        summary
+                    );
+                    diagnostics.insert(
+                        service.socket_id.clone(),
+                        ExternalDriverDiagnostic {
+                            socket_id: service.socket_id.clone(),
+                            stage: ExternalDriverStage::Config,
+                            summary,
+                            details: None,
+                        },
+                    );
+                    continue;
+                }
+            };
+
+            let (kind, metadata, form_definition, settings_schema) =
+                match probe(&service, launch.as_ref()) {
+                    Ok(info) => info,
+                    Err(error) => {
+                        let (summary, details) =
+                            Self::split_external_driver_error(error.to_string());
+                        let stage = Self::classify_external_driver_probe_failure_stage(&summary);
+                        log::warn!(
+                            "Skipping RPC service '{}': failed to probe driver metadata: {}",
+                            service.socket_id,
+                            summary
+                        );
+                        diagnostics.insert(
+                            service.socket_id.clone(),
+                            ExternalDriverDiagnostic {
+                                socket_id: service.socket_id.clone(),
+                                stage,
+                                summary,
+                                details,
+                            },
+                        );
+                        continue;
+                    }
+                };
+
+            let ipc_driver = IpcDriver::new(
+                service.socket_id.clone(),
+                kind,
+                metadata,
+                form_definition,
+                settings_schema,
+            );
+
+            let ipc_driver = match launch {
+                Some(launch) => ipc_driver.with_launch_config(launch),
+                None => ipc_driver,
+            };
+
+            drivers.insert(driver_id, Arc::new(ipc_driver));
+        }
+
+        diagnostics
+    }
+
+    fn split_external_driver_error(message: String) -> (String, Option<String>) {
+        match message.split_once(EXTERNAL_DRIVER_STARTUP_OUTPUT_SEPARATOR) {
+            Some((summary, details)) => (
+                summary.to_string(),
+                Some(format!("Recent host output:\n{}", details.trim())),
+            ),
+            None => (message, None),
+        }
+    }
+
+    fn classify_external_driver_probe_failure_stage(message: &str) -> ExternalDriverStage {
+        if EXTERNAL_DRIVER_LAUNCH_FAILURE_MARKERS
+            .iter()
+            .any(|marker| message.contains(marker))
+        {
+            ExternalDriverStage::Launch
+        } else {
+            ExternalDriverStage::Probe
         }
     }
 
@@ -479,7 +611,7 @@ impl AppState {
     pub fn prepare_connect_profile(
         &self,
         profile_id: Uuid,
-    ) -> Result<ConnectProfileParams, String> {
+    ) -> Result<ConnectProfileParams, PrepareConnectError> {
         let secrets = &self.facade.secrets;
 
         let proxy_secret = {
@@ -1010,6 +1142,10 @@ impl AppState {
         &self.facade.connections.drivers
     }
 
+    pub fn external_driver_diagnostic(&self, socket_id: &str) -> Option<&ExternalDriverDiagnostic> {
+        self.external_driver_diagnostics.get(socket_id)
+    }
+
     pub fn driver_for_profile(&self, profile: &ConnectionProfile) -> Option<Arc<dyn DbDriver>> {
         self.facade
             .connections
@@ -1237,11 +1373,17 @@ impl EventEmitter<AppStateChanged> for AppState {}
 
 #[cfg(test)]
 mod tests {
-    use super::AppState;
-    use dbflux_core::{DbDriver, DbKind, FormValues, GeneralSettings, RefreshPolicySetting};
+    use super::{
+        AppState, EXTERNAL_DRIVER_STARTUP_OUTPUT_SEPARATOR, ExternalDriverDiagnostic,
+        ExternalDriverStage,
+    };
+    use dbflux_core::{
+        DbDriver, DbKind, DriverFormDef, FormValues, GeneralSettings, RefreshPolicySetting,
+        ServiceConfig,
+    };
     use dbflux_test_support::FakeDriver;
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, RwLock};
 
     fn test_state(general_settings: GeneralSettings) -> AppState {
         let fake = FakeDriver::new(DbKind::SQLite);
@@ -1251,6 +1393,7 @@ mod tests {
         AppState::new_with_drivers_and_settings(
             drivers,
             general_settings,
+            HashMap::new(),
             HashMap::new(),
             HashMap::new(),
             HashMap::new(),
@@ -1273,6 +1416,7 @@ mod tests {
         let state = AppState::new_with_drivers_and_settings(
             drivers,
             GeneralSettings::default(),
+            HashMap::new(),
             HashMap::new(),
             HashMap::new(),
             HashMap::new(),
@@ -1509,5 +1653,189 @@ mod tests {
 
         assert!(!state.driver_overrides().contains_key("builtin:redis"));
         assert!(!state.driver_settings().contains_key("builtin:redis"));
+    }
+
+    fn service(socket_id: &str, command: Option<&str>, args: &[&str]) -> ServiceConfig {
+        ServiceConfig {
+            socket_id: socket_id.to_string(),
+            enabled: true,
+            command: command.map(str::to_string),
+            args: args.iter().map(|value| value.to_string()).collect(),
+            env: HashMap::new(),
+            startup_timeout_ms: None,
+        }
+    }
+
+    fn probed_driver_parts() -> (
+        DbKind,
+        dbflux_core::DriverMetadata,
+        DriverFormDef,
+        Option<DriverFormDef>,
+    ) {
+        let fake = FakeDriver::new(DbKind::SQLite);
+        (
+            fake.kind(),
+            fake.metadata().clone(),
+            fake.form_definition().clone(),
+            None,
+        )
+    }
+
+    #[test]
+    fn external_services_register_valid_driver_and_record_invalid_diagnostic() {
+        let fake = FakeDriver::new(DbKind::SQLite);
+        let mut drivers: HashMap<String, Arc<dyn DbDriver>> = HashMap::new();
+        drivers.insert(fake.metadata().id.clone(), Arc::new(fake));
+
+        let services = vec![
+            service("valid.sock", Some("custom-host"), &["--serve"]),
+            service("invalid.sock", None, &["--driver", "demo"]),
+        ];
+
+        let diagnostics =
+            AppState::register_external_services(&mut drivers, services, |service, _launch| {
+                if service.socket_id == "valid.sock" {
+                    Ok(probed_driver_parts())
+                } else {
+                    Err("probe should not run for invalid launch config".to_string())
+                }
+            });
+
+        assert!(drivers.contains_key("rpc:valid.sock"));
+        assert!(!drivers.contains_key("rpc:invalid.sock"));
+        assert_eq!(diagnostics.len(), 1);
+        let diagnostic = diagnostics.get("invalid.sock").unwrap();
+        assert_eq!(diagnostic.socket_id, "invalid.sock");
+        assert_eq!(diagnostic.stage, ExternalDriverStage::Config);
+        assert!(diagnostic.summary.contains("--socket"));
+    }
+
+    #[test]
+    fn external_services_probe_manual_live_service_without_launch_config() {
+        let mut drivers: HashMap<String, Arc<dyn DbDriver>> = HashMap::new();
+        let services = vec![service("live.sock", None, &[])];
+        let probe_calls = Arc::new(RwLock::new(Vec::new()));
+        let probe_calls_for_closure = probe_calls.clone();
+
+        let diagnostics =
+            AppState::register_external_services(&mut drivers, services, move |service, launch| {
+                probe_calls_for_closure
+                    .write()
+                    .unwrap()
+                    .push((service.socket_id.clone(), launch.is_some()));
+                Ok::<_, String>(probed_driver_parts())
+            });
+
+        assert!(diagnostics.is_empty());
+        assert!(drivers.contains_key("rpc:live.sock"));
+        assert_eq!(
+            probe_calls.read().unwrap().as_slice(),
+            &[("live.sock".to_string(), false)]
+        );
+    }
+
+    #[test]
+    fn external_services_store_probe_failures_by_socket_id() {
+        let mut diagnostics = HashMap::new();
+        diagnostics.insert(
+            "broken.sock".to_string(),
+            ExternalDriverDiagnostic {
+                socket_id: "broken.sock".to_string(),
+                stage: ExternalDriverStage::Probe,
+                summary: "Probe failed".to_string(),
+                details: Some("socket missing".to_string()),
+            },
+        );
+
+        let state = AppState::new_with_drivers_and_settings(
+            HashMap::new(),
+            GeneralSettings::default(),
+            HashMap::new(),
+            HashMap::new(),
+            HashMap::new(),
+            diagnostics,
+        );
+
+        let diagnostic = state.external_driver_diagnostic("broken.sock").unwrap();
+
+        assert_eq!(diagnostic.stage, ExternalDriverStage::Probe);
+        assert_eq!(diagnostic.details.as_deref(), Some("socket missing"));
+    }
+
+    #[test]
+    fn external_services_split_probe_failure_summary_and_details() {
+        let mut drivers: HashMap<String, Arc<dyn DbDriver>> = HashMap::new();
+        let services = vec![service("broken.sock", Some("custom-host"), &["--serve"])];
+
+        let diagnostics = AppState::register_external_services(&mut drivers, services, |_, _| {
+            Err(format!(
+                "Driver host 'custom-host' exited before socket was ready (exit status: 1){EXTERNAL_DRIVER_STARTUP_OUTPUT_SEPARATOR}stderr line"
+            ))
+        });
+
+        assert!(!drivers.contains_key("rpc:broken.sock"));
+
+        let diagnostic = diagnostics.get("broken.sock").unwrap();
+        assert_eq!(diagnostic.stage, ExternalDriverStage::Launch);
+        assert_eq!(
+            diagnostic.summary,
+            "Driver host 'custom-host' exited before socket was ready (exit status: 1)"
+        );
+        assert_eq!(
+            diagnostic.details.as_deref(),
+            Some("Recent host output:\nstderr line")
+        );
+    }
+
+    #[test]
+    fn external_services_keep_probe_failure_without_startup_tail_in_summary_only() {
+        let mut drivers: HashMap<String, Arc<dyn DbDriver>> = HashMap::new();
+        let services = vec![service("broken.sock", Some("custom-host"), &["--serve"])];
+
+        let diagnostics = AppState::register_external_services(&mut drivers, services, |_, _| {
+            Err("probe failed".to_string())
+        });
+
+        assert!(!drivers.contains_key("rpc:broken.sock"));
+
+        let diagnostic = diagnostics.get("broken.sock").unwrap();
+        assert_eq!(diagnostic.summary, "probe failed");
+        assert_eq!(diagnostic.details, None);
+    }
+
+    #[test]
+    fn external_services_classify_launch_failures_separately_from_probe_failures() {
+        assert_eq!(
+            AppState::classify_external_driver_probe_failure_stage(
+                "Failed to start driver host 'custom-host': No such file or directory"
+            ),
+            ExternalDriverStage::Launch
+        );
+
+        assert_eq!(
+            AppState::classify_external_driver_probe_failure_stage(
+                "Driver host 'custom-host' exited before socket was ready (exit status: 1)"
+            ),
+            ExternalDriverStage::Launch
+        );
+
+        assert_eq!(
+            AppState::classify_external_driver_probe_failure_stage(
+                "Driver host socket 'manual.sock' is not available"
+            ),
+            ExternalDriverStage::Probe
+        );
+
+        assert_eq!(
+            AppState::classify_external_driver_probe_failure_stage(
+                "Managed RPC host for 'managed.sock' is running but socket is unavailable"
+            ),
+            ExternalDriverStage::Probe
+        );
+
+        assert_eq!(
+            AppState::classify_external_driver_probe_failure_stage("Unexpected response to Hello"),
+            ExternalDriverStage::Probe
+        );
     }
 }

--- a/crates/dbflux/src/app.rs
+++ b/crates/dbflux/src/app.rs
@@ -5,7 +5,7 @@ use dbflux_core::{
     SchemaForeignKeyInfo, SchemaIndexInfo, SchemaSnapshot, ScriptsDirectory, SecretStore,
     SessionFacade, SessionStore, ShutdownPhase, SshTunnelProfile, TaskId, TaskKind, TaskSnapshot,
 };
-use dbflux_driver_ipc::{IpcDriver, driver::IpcDriverLaunchConfig};
+use dbflux_driver_ipc::{driver::IpcDriverLaunchConfig, IpcDriver};
 use gpui::{EventEmitter, WindowHandle};
 use gpui_component::Root;
 use std::collections::HashMap;
@@ -893,15 +893,29 @@ impl AppState {
         self.facade.tasks.start(kind, description)
     }
 
+    pub fn start_task_for_target(
+        &mut self,
+        kind: TaskKind,
+        description: impl Into<String>,
+        target: Option<dbflux_core::TaskTarget>,
+    ) -> (TaskId, CancelToken) {
+        self.facade
+            .tasks
+            .start_for_target(kind, description, target)
+    }
+
     pub fn start_task_for_profile(
         &mut self,
         kind: TaskKind,
         description: impl Into<String>,
         profile_id: Option<Uuid>,
     ) -> (TaskId, CancelToken) {
-        self.facade
-            .tasks
-            .start_for_profile(kind, description, profile_id)
+        let target = profile_id.map(|profile_id| dbflux_core::TaskTarget {
+            profile_id,
+            database: None,
+        });
+
+        self.start_task_for_target(kind, description, target)
     }
 
     pub fn start_hook_task_for_profile(
@@ -1022,6 +1036,27 @@ impl AppState {
 
     pub fn connections(&self) -> &HashMap<Uuid, ConnectedProfile> {
         &self.facade.connections.connections
+    }
+
+    pub fn remove_database_connection(&mut self, profile_id: Uuid, database: &str) -> bool {
+        self.facade
+            .connections
+            .remove_database_connection(profile_id, database)
+    }
+
+    pub fn cancel_query_for_target(&self, target: &dbflux_core::TaskTarget) {
+        let Some(connection) = self.facade.connections.connection_for_task_target(target) else {
+            return;
+        };
+
+        let cancel_handle = connection.cancel_handle();
+        if let Err(error) = cancel_handle.cancel() {
+            log::warn!("Failed to send cancel via handle: {}", error);
+        }
+
+        if let Err(error) = connection.cancel_active() {
+            log::warn!("Failed to send cancel to database: {}", error);
+        }
     }
 
     pub fn connections_mut(&mut self) -> &mut HashMap<Uuid, ConnectedProfile> {

--- a/crates/dbflux/src/ui/document/data_grid_panel/query.rs
+++ b/crates/dbflux/src/ui/document/data_grid_panel/query.rs
@@ -3,7 +3,7 @@ use crate::ui::components::data_table::SortState as TableSortState;
 use crate::ui::components::toast::ToastExt;
 use dbflux_core::{
     CollectionBrowseRequest, CollectionCountRequest, CollectionRef, OrderByColumn, Pagination,
-    QueryResult, TableBrowseRequest, TableCountRequest, TableRef, TaskKind,
+    QueryResult, TableBrowseRequest, TableCountRequest, TableRef, TaskKind, TaskTarget,
 };
 use gpui::*;
 use log::info;
@@ -140,9 +140,15 @@ impl DataGridPanel {
             browse_request.table.qualified_name()
         );
 
-        let (task_id, cancel_token) = self.runner.start_primary(
+        let task_target = TaskTarget {
+            profile_id,
+            database: database.clone(),
+        };
+
+        let (task_id, cancel_token) = self.runner.start_primary_for_target(
             TaskKind::Query,
             format!("SELECT * FROM {}", table.qualified_name()),
+            Some(task_target),
             cx,
         );
 
@@ -286,9 +292,15 @@ impl DataGridPanel {
             collection.database, collection.name
         );
 
-        let (task_id, cancel_token) = self.runner.start_primary(
+        let task_target = TaskTarget {
+            profile_id,
+            database: Some(collection.database.clone()),
+        };
+
+        let (task_id, cancel_token) = self.runner.start_primary_for_target(
             TaskKind::Query,
             format!("find {}.{}", collection.database, collection.name),
+            Some(task_target),
             cx,
         );
 

--- a/crates/dbflux/src/ui/document/sql_query/context_bar.rs
+++ b/crates/dbflux/src/ui/document/sql_query/context_bar.rs
@@ -9,15 +9,12 @@ impl SqlQueryDocument {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> (Entity<Dropdown>, Subscription) {
-        let connections = app_state.read(cx).connections();
-        let items: Vec<DropdownItem> = connections
-            .values()
-            .map(|c| DropdownItem::with_value(&c.profile.name, c.profile.id.to_string()))
-            .collect();
+        let items = Self::connection_items(app_state, cx);
 
-        let selected_index = exec_ctx
-            .connection_id
-            .and_then(|id| connections.values().position(|c| c.profile.id == id));
+        let selected_index = exec_ctx.connection_id.and_then(|id| {
+            let id = id.to_string();
+            items.iter().position(|item| item.value.as_ref() == id)
+        });
 
         let dropdown = cx.new(|_cx| {
             Dropdown::new("ctx-connection")
@@ -30,11 +27,184 @@ impl SqlQueryDocument {
             &dropdown,
             window,
             |this, _, event: &DropdownSelectionChanged, window, cx| {
-                this.on_connection_changed(event.index, window, cx);
+                this.on_connection_changed(&event.item, window, cx);
             },
         );
 
         (dropdown, sub)
+    }
+
+    fn connection_items(app_state: &Entity<AppState>, cx: &App) -> Vec<DropdownItem> {
+        let mut items: Vec<_> = app_state
+            .read(cx)
+            .connections()
+            .values()
+            .map(|connected| {
+                DropdownItem::with_value(&connected.profile.name, connected.profile.id.to_string())
+            })
+            .collect();
+
+        items.sort_by(|left, right| left.label.as_ref().cmp(right.label.as_ref()));
+        items
+    }
+
+    fn default_database_for_connection(
+        app_state: &Entity<AppState>,
+        connection_id: Uuid,
+        cx: &App,
+    ) -> Option<String> {
+        let connected = app_state.read(cx).connections().get(&connection_id)?;
+
+        connected.active_database.clone().or_else(|| {
+            connected
+                .schema
+                .as_ref()
+                .and_then(|schema| schema.current_database().map(String::from))
+        })
+    }
+
+    fn update_completion_provider(&mut self, cx: &mut Context<Self>) {
+        let connection_id = self
+            .connection_id
+            .filter(|id| self.app_state.read(cx).connections().contains_key(id));
+
+        let completion_provider: Rc<dyn CompletionProvider> =
+            Rc::new(QueryCompletionProvider::new(
+                self.query_language.clone(),
+                self.app_state.clone(),
+                connection_id,
+            ));
+
+        self.input_state.update(cx, |state, _cx| {
+            state.lsp.completion_provider = Some(completion_provider);
+        });
+    }
+
+    pub(super) fn sync_context_dropdowns(&mut self, cx: &mut Context<Self>) {
+        let mut did_change = false;
+
+        if self.connection_id.is_none()
+            && self.exec_ctx.connection_id.is_none()
+            && let Some(active_connection_id) = self.app_state.read(cx).active_connection_id()
+            && self
+                .app_state
+                .read(cx)
+                .connections()
+                .contains_key(&active_connection_id)
+        {
+            self.connection_id = Some(active_connection_id);
+            self.exec_ctx.connection_id = Some(active_connection_id);
+            did_change = true;
+        }
+
+        let connection_items = Self::connection_items(&self.app_state, cx);
+        let selected_connection_index = self.connection_id.and_then(|id| {
+            let id = id.to_string();
+            connection_items
+                .iter()
+                .position(|item| item.value.as_ref() == id)
+        });
+
+        let has_selected_connection = self
+            .connection_id
+            .is_some_and(|id| self.app_state.read(cx).connections().contains_key(&id));
+
+        self.connection_dropdown.update(cx, |dd, cx| {
+            dd.set_items(connection_items, cx);
+            dd.set_selected_index(selected_connection_index, cx);
+        });
+
+        if has_selected_connection {
+            if let Some(connection_id) = self.connection_id {
+                self.runner.set_profile_id(connection_id);
+
+                let database_items =
+                    Self::database_items_for_connection(&self.app_state, Some(connection_id), cx);
+
+                if self.exec_ctx.database.is_none() {
+                    self.exec_ctx.database =
+                        Self::default_database_for_connection(&self.app_state, connection_id, cx);
+                    did_change = true;
+                }
+
+                if self.exec_ctx.database.as_ref().is_some_and(|database| {
+                    !database_items
+                        .iter()
+                        .any(|item| item.value.as_ref() == database)
+                }) {
+                    self.exec_ctx.database =
+                        Self::default_database_for_connection(&self.app_state, connection_id, cx);
+                    did_change = true;
+                }
+
+                let selected_database_index =
+                    self.exec_ctx.database.as_ref().and_then(|database| {
+                        database_items
+                            .iter()
+                            .position(|item| item.value.as_ref() == database)
+                    });
+
+                self.database_dropdown.update(cx, |dd, cx| {
+                    dd.set_items(database_items, cx);
+                    dd.set_selected_index(selected_database_index, cx);
+                });
+
+                let schema_items =
+                    Self::schema_items_for_connection(&self.app_state, &self.exec_ctx, cx);
+                let selected_schema_index = self.exec_ctx.schema.as_ref().and_then(|schema| {
+                    schema_items
+                        .iter()
+                        .position(|item| item.value.as_ref() == schema)
+                });
+
+                let next_schema = if selected_schema_index.is_some() {
+                    self.exec_ctx.schema.clone()
+                } else if schema_items
+                    .iter()
+                    .any(|item| item.value.as_ref() == "public")
+                {
+                    Some("public".to_string())
+                } else {
+                    None
+                };
+
+                if self.exec_ctx.schema != next_schema {
+                    self.exec_ctx.schema = next_schema.clone();
+                    did_change = true;
+                }
+
+                let selected_schema_index = next_schema.as_ref().and_then(|schema| {
+                    schema_items
+                        .iter()
+                        .position(|item| item.value.as_ref() == schema)
+                });
+
+                self.schema_dropdown.update(cx, |dd, cx| {
+                    dd.set_items(schema_items, cx);
+                    dd.set_selected_index(selected_schema_index, cx);
+                });
+            }
+        } else {
+            self.runner.clear_profile_id();
+
+            self.database_dropdown.update(cx, |dd, cx| {
+                dd.set_items(Vec::new(), cx);
+                dd.set_selected_index(None, cx);
+            });
+
+            self.schema_dropdown.update(cx, |dd, cx| {
+                dd.set_items(Vec::new(), cx);
+                dd.set_selected_index(None, cx);
+            });
+        }
+
+        self.update_completion_provider(cx);
+
+        if did_change {
+            cx.emit(DocumentEvent::MetaChanged);
+        }
+
+        cx.notify();
     }
 
     pub(super) fn create_database_dropdown(
@@ -101,60 +271,30 @@ impl SqlQueryDocument {
 
     // === Event handlers for context changes ===
 
-    fn on_connection_changed(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
-        let connections = self.app_state.read(cx).connections();
-        let conn = connections.values().nth(index);
-
-        let Some(conn) = conn else {
+    fn on_connection_changed(
+        &mut self,
+        item: &DropdownItem,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Ok(new_conn_id) = Uuid::parse_str(item.value.as_ref()) else {
+            log::warn!("Invalid connection id in dropdown: {}", item.value.as_ref());
             return;
         };
 
-        let new_conn_id = conn.profile.id;
         self.exec_ctx.connection_id = Some(new_conn_id);
         self.connection_id = Some(new_conn_id);
-
-        // Reset dependent dropdowns
-        self.exec_ctx.database = conn.active_database.clone();
+        self.exec_ctx.database =
+            Self::default_database_for_connection(&self.app_state, new_conn_id, cx);
         self.exec_ctx.schema = None;
         self.exec_ctx.container = None;
 
-        // Update the task runner
-        self.runner.set_profile_id(new_conn_id);
-
-        // Refresh database dropdown items
-        let db_items = Self::database_items_for_connection(&self.app_state, Some(new_conn_id), cx);
-        let db_selected = self
-            .exec_ctx
-            .database
-            .as_ref()
-            .and_then(|db| db_items.iter().position(|item| item.value.as_ref() == db));
-
-        self.database_dropdown.update(cx, |dd, cx| {
-            dd.set_items(db_items, cx);
-            dd.set_selected_index(db_selected, cx);
-        });
-
-        // Refresh schema dropdown with default pre-selection
-        self.refresh_schema_dropdown_with_default(cx);
-
-        // Update completion provider
-        let completion_provider: Rc<dyn CompletionProvider> =
-            Rc::new(QueryCompletionProvider::new(
-                self.query_language.clone(),
-                self.app_state.clone(),
-                Some(new_conn_id),
-            ));
-        self.input_state.update(cx, |state, _cx| {
-            state.lsp.completion_provider = Some(completion_provider);
-        });
+        self.sync_context_dropdowns(cx);
 
         // Re-validate context bar index since dropdown visibility may have changed
         if self.focus_mode == SqlQueryFocus::ContextBar {
             self.revalidate_context_bar_index(window, cx);
         }
-
-        cx.emit(DocumentEvent::MetaChanged);
-        cx.notify();
     }
 
     fn on_database_changed(&mut self, item: &DropdownItem, cx: &mut Context<Self>) {
@@ -190,11 +330,13 @@ impl SqlQueryDocument {
 
         self.refresh_schema_dropdown_with_default(cx);
 
+        cx.emit(DocumentEvent::MetaChanged);
         cx.notify();
     }
 
     fn on_schema_changed(&mut self, item: &DropdownItem, cx: &mut Context<Self>) {
         self.exec_ctx.schema = Some(item.value.to_string());
+        cx.emit(DocumentEvent::MetaChanged);
         cx.notify();
     }
 
@@ -202,17 +344,34 @@ impl SqlQueryDocument {
     fn refresh_schema_dropdown_with_default(&mut self, cx: &mut Context<Self>) {
         let schema_items = Self::schema_items_for_connection(&self.app_state, &self.exec_ctx, cx);
 
-        let default_index = schema_items
-            .iter()
-            .position(|item| item.value.as_ref() == "public");
+        let selected_index = self.exec_ctx.schema.as_ref().and_then(|schema| {
+            schema_items
+                .iter()
+                .position(|item| item.value.as_ref() == schema)
+        });
 
-        if default_index.is_some() {
-            self.exec_ctx.schema = Some("public".to_string());
-        }
+        let next_schema = if selected_index.is_some() {
+            self.exec_ctx.schema.clone()
+        } else if schema_items
+            .iter()
+            .any(|item| item.value.as_ref() == "public")
+        {
+            Some("public".to_string())
+        } else {
+            None
+        };
+
+        self.exec_ctx.schema = next_schema.clone();
+
+        let selected_index = next_schema.as_ref().and_then(|schema| {
+            schema_items
+                .iter()
+                .position(|item| item.value.as_ref() == schema)
+        });
 
         self.schema_dropdown.update(cx, |dd, cx| {
             dd.set_items(schema_items, cx);
-            dd.set_selected_index(default_index, cx);
+            dd.set_selected_index(selected_index, cx);
         });
     }
 
@@ -416,26 +575,6 @@ impl SqlQueryDocument {
                     .contains(DriverCapabilities::SCHEMAS)
             })
             .unwrap_or(false)
-    }
-
-    /// Refresh context dropdowns when connections change externally.
-    #[allow(dead_code)]
-    pub fn refresh_context_dropdowns(&mut self, cx: &mut Context<Self>) {
-        let connections = self.app_state.read(cx).connections();
-        let items: Vec<DropdownItem> = connections
-            .values()
-            .map(|c| DropdownItem::with_value(&c.profile.name, c.profile.id.to_string()))
-            .collect();
-
-        let selected_index = self
-            .exec_ctx
-            .connection_id
-            .and_then(|id| connections.values().position(|c| c.profile.id == id));
-
-        self.connection_dropdown.update(cx, |dd, cx| {
-            dd.set_items(items, cx);
-            dd.set_selected_index(selected_index, cx);
-        });
     }
 
     // === Context bar keyboard navigation ===

--- a/crates/dbflux/src/ui/document/sql_query/execution.rs
+++ b/crates/dbflux/src/ui/document/sql_query/execution.rs
@@ -33,6 +33,28 @@ fn evaluate_dangerous_with_effective_settings(
     dbflux_core::DangerousAction::Confirm(kind)
 }
 
+fn task_target_for_execution(
+    profile_id: Uuid,
+    connected: &dbflux_core::ConnectedProfile,
+    target_db: Option<&str>,
+) -> TaskTarget {
+    let database = target_db.and_then(|database| {
+        (connected.connection.schema_loading_strategy()
+            == SchemaLoadingStrategy::ConnectionPerDatabase
+            && connected
+                .schema
+                .as_ref()
+                .and_then(|schema| schema.current_database())
+                .is_none_or(|current| current != database))
+        .then(|| database.to_string())
+    });
+
+    TaskTarget {
+        profile_id,
+        database,
+    }
+}
+
 impl SqlQueryDocument {
     /// Returns selected text when a non-empty selection exists.
     fn selected_query(&self, window: &mut Window, cx: &mut Context<Self>) -> Option<String> {
@@ -165,15 +187,25 @@ impl SqlQueryDocument {
             return;
         };
 
-        let connection = {
+        let (connection, active_database, task_target) = {
             let connections = self.app_state.read(cx).connections();
             let Some(connected) = connections.get(&conn_id) else {
                 cx.toast_error("Connection not found", window);
                 return;
             };
 
-            match connected.resolve_connection_for_execution(self.exec_ctx.database.as_deref()) {
-                Ok(connection) => connection,
+            let active_database = self
+                .exec_ctx
+                .database
+                .clone()
+                .or_else(|| connected.active_database.clone());
+
+            match connected.resolve_connection_for_execution(active_database.as_deref()) {
+                Ok(connection) => (
+                    connection,
+                    active_database.clone(),
+                    task_target_for_execution(conn_id, connected, active_database.as_deref()),
+                ),
                 Err(dbflux_core::ConnectionResolutionError::PendingDatabaseConnection {
                     database,
                 }) => {
@@ -189,9 +221,12 @@ impl SqlQueryDocument {
         self.run_in_new_tab = in_new_tab;
 
         let description = dbflux_core::truncate_string_safe(query.trim(), 80);
-        let (task_id, cancel_token) =
-            self.runner
-                .start_primary(dbflux_core::TaskKind::Query, description, cx);
+        let (task_id, cancel_token) = self.runner.start_primary_for_target(
+            dbflux_core::TaskKind::Query,
+            description,
+            Some(task_target.clone()),
+            cx,
+        );
 
         let exec_id = Uuid::new_v4();
         let record = ExecutionRecord {
@@ -204,18 +239,14 @@ impl SqlQueryDocument {
         };
         self.execution_history.push(record);
         self.active_execution_index = Some(self.execution_history.len() - 1);
+        self.active_query_task = Some(ActiveQueryTask {
+            task_id,
+            target: task_target.clone(),
+        });
 
         self.state = DocumentState::Executing;
         cx.emit(DocumentEvent::ExecutionStarted);
         cx.notify();
-
-        let active_database = self.exec_ctx.database.clone().or_else(|| {
-            self.app_state
-                .read(cx)
-                .connections()
-                .get(&conn_id)
-                .and_then(|c| c.active_database.clone())
-        });
 
         let request = QueryRequest::new(query.clone()).with_database(active_database);
 
@@ -229,6 +260,19 @@ impl SqlQueryDocument {
 
             if cancel_token.is_cancelled() {
                 log::info!("Query was cancelled, discarding result");
+
+                if let Err(error) = connection.cleanup_after_cancel() {
+                    log::warn!("Cleanup after cancel failed: {}", error);
+                }
+
+                cx.update(|cx| {
+                    this.update(cx, |doc, cx| {
+                        doc.complete_cancelled_query(task_id, exec_id, &task_target, cx);
+                    })
+                    .ok();
+                })
+                .ok();
+
                 return;
             }
 
@@ -268,6 +312,47 @@ impl SqlQueryDocument {
         }
 
         self.execute_query_internal(pending.query, pending.in_new_tab, window, cx);
+    }
+
+    fn complete_cancelled_query(
+        &mut self,
+        task_id: dbflux_core::TaskId,
+        exec_id: Uuid,
+        target: &TaskTarget,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(record) = self
+            .execution_history
+            .iter_mut()
+            .find(|record| record.id == exec_id)
+        {
+            record.finished_at = Some(Instant::now());
+        }
+
+        let is_active_task = self
+            .active_query_task
+            .as_ref()
+            .is_some_and(|task| task.task_id == task_id);
+
+        if is_active_task {
+            self.runner.clear_primary(task_id);
+            self.active_query_task = None;
+            self.state = DocumentState::Clean;
+        }
+
+        if let Some(database) = target.database.as_deref() {
+            self.app_state.update(cx, |state, cx| {
+                if state.remove_database_connection(target.profile_id, database) {
+                    cx.emit(AppStateChanged);
+                }
+            });
+        }
+
+        if is_active_task {
+            cx.emit(DocumentEvent::ExecutionFinished);
+            cx.emit(DocumentEvent::MetaChanged);
+            cx.notify();
+        }
     }
 
     pub(super) fn cancel_dangerous_query(&mut self, cx: &mut Context<Self>) {
@@ -390,6 +475,14 @@ impl SqlQueryDocument {
             }
         }
 
+        if self
+            .active_query_task
+            .as_ref()
+            .is_some_and(|task| task.task_id == pending.task_id)
+        {
+            self.active_query_task = None;
+        }
+
         cx.emit(DocumentEvent::ExecutionFinished);
         cx.emit(DocumentEvent::MetaChanged);
     }
@@ -481,20 +574,21 @@ impl SqlQueryDocument {
 
     pub fn cancel_query(&mut self, cx: &mut Context<Self>) {
         if self.runner.cancel_primary(cx) {
-            if let Some(conn_id) = self.connection_id
+            if let Some(task) = self.active_query_task.as_ref() {
+                self.app_state
+                    .read(cx)
+                    .cancel_query_for_target(&task.target);
+            } else if let Some(conn_id) = self.connection_id
                 && let Some(connected) = self.app_state.read(cx).connections().get(&conn_id)
             {
-                let conn = connected
-                    .resolve_connection_for_execution(self.exec_ctx.database.as_deref())
-                    .unwrap_or_else(|_| connected.connection.clone());
+                let active_database = self
+                    .exec_ctx
+                    .database
+                    .clone()
+                    .or_else(|| connected.active_database.clone());
+                let target = task_target_for_execution(conn_id, connected, active_database.as_deref());
 
-                let cancel_handle = conn.cancel_handle();
-                if let Err(e) = cancel_handle.cancel() {
-                    log::warn!("Failed to send cancel via handle: {}", e);
-                }
-                if let Err(e) = conn.cancel_active() {
-                    log::warn!("Failed to send cancel to database: {}", e);
-                }
+                self.app_state.read(cx).cancel_query_for_target(&target);
             }
 
             self.state = DocumentState::Clean;

--- a/crates/dbflux/src/ui/document/sql_query/execution.rs
+++ b/crates/dbflux/src/ui/document/sql_query/execution.rs
@@ -586,7 +586,8 @@ impl SqlQueryDocument {
                     .database
                     .clone()
                     .or_else(|| connected.active_database.clone());
-                let target = task_target_for_execution(conn_id, connected, active_database.as_deref());
+                let target =
+                    task_target_for_execution(conn_id, connected, active_database.as_deref());
 
                 self.app_state.read(cx).cancel_query_for_target(&target);
             }

--- a/crates/dbflux/src/ui/document/sql_query/mod.rs
+++ b/crates/dbflux/src/ui/document/sql_query/mod.rs
@@ -12,7 +12,7 @@ use crate::ui::tokens::{FontSizes, Heights, Radii, Spacing};
 use dbflux_core::{
     DangerousAction, DangerousQueryKind, DbError, DiagnosticSeverity as CoreDiagnosticSeverity,
     DriverCapabilities, EditorDiagnostic as CoreEditorDiagnostic, ExecutionContext, HistoryEntry,
-    QueryLanguage, QueryRequest, QueryResult, RefreshPolicy, SchemaLoadingStrategy,
+    QueryLanguage, QueryRequest, QueryResult, RefreshPolicy, SchemaLoadingStrategy, TaskTarget,
     ValidationResult, detect_dangerous_query,
 };
 use gpui::prelude::FluentBuilder;
@@ -106,6 +106,7 @@ pub struct SqlQueryDocument {
     execution_history: Vec<ExecutionRecord>,
     active_execution_index: Option<usize>,
     pending_result: Option<PendingQueryResult>,
+    active_query_task: Option<ActiveQueryTask>,
 
     // Result tabs
     result_tabs: Vec<ResultTab>,
@@ -161,6 +162,11 @@ struct PendingQueryResult {
     exec_id: Uuid,
     query: String,
     result: Result<QueryResult, DbError>,
+}
+
+struct ActiveQueryTask {
+    task_id: dbflux_core::TaskId,
+    target: TaskTarget,
 }
 
 /// Pending dangerous query confirmation.
@@ -334,6 +340,9 @@ impl SqlQueryDocument {
             Self::create_database_dropdown(&app_state, &exec_ctx, window, cx);
         let (schema_dropdown, schema_sub) =
             Self::create_schema_dropdown(&app_state, &exec_ctx, window, cx);
+        let app_state_sub = cx.subscribe(&app_state, |this, _, _: &AppStateChanged, cx| {
+            this.sync_context_dropdowns(cx);
+        });
 
         let refresh_policy = default_refresh;
 
@@ -355,10 +364,11 @@ impl SqlQueryDocument {
             connection_dropdown,
             database_dropdown,
             schema_dropdown,
-            _context_subscriptions: vec![conn_sub, db_sub, schema_sub],
+            _context_subscriptions: vec![conn_sub, db_sub, schema_sub, app_state_sub],
             execution_history: Vec::new(),
             active_execution_index: None,
             pending_result: None,
+            active_query_task: None,
             result_tabs: Vec::new(),
             active_result_index: None,
             result_tab_counter: 0,
@@ -473,11 +483,10 @@ impl SqlQueryDocument {
     }
 
     /// Set the execution context (e.g. parsed from file header).
-    pub fn with_exec_ctx(mut self, ctx: ExecutionContext) -> Self {
-        if let Some(conn_id) = ctx.connection_id {
-            self.connection_id = Some(conn_id);
-            self.exec_ctx = ctx;
-        }
+    pub fn with_exec_ctx(mut self, ctx: ExecutionContext, cx: &mut Context<Self>) -> Self {
+        self.connection_id = ctx.connection_id;
+        self.exec_ctx = ctx;
+        self.sync_context_dropdowns(cx);
         self
     }
 

--- a/crates/dbflux/src/ui/document/task_runner.rs
+++ b/crates/dbflux/src/ui/document/task_runner.rs
@@ -1,5 +1,5 @@
 use crate::app::{AppState, AppStateChanged};
-use dbflux_core::{CancelToken, TaskId, TaskKind, TaskSlot};
+use dbflux_core::{CancelToken, TaskId, TaskKind, TaskSlot, TaskTarget};
 use gpui::*;
 use uuid::Uuid;
 
@@ -22,6 +22,17 @@ impl DocumentTaskRunner {
         self.profile_id = Some(profile_id);
     }
 
+    pub fn clear_profile_id(&mut self) {
+        self.profile_id = None;
+    }
+
+    fn default_target(&self) -> Option<TaskTarget> {
+        self.profile_id.map(|profile_id| TaskTarget {
+            profile_id,
+            database: None,
+        })
+    }
+
     // -- Primary slot (reads — auto-cancel-previous) --
 
     pub fn start_primary(
@@ -30,9 +41,18 @@ impl DocumentTaskRunner {
         description: impl Into<String>,
         cx: &mut App,
     ) -> (TaskId, CancelToken) {
-        let profile_id = self.profile_id;
+        self.start_primary_for_target(kind, description, self.default_target(), cx)
+    }
+
+    pub fn start_primary_for_target(
+        &mut self,
+        kind: TaskKind,
+        description: impl Into<String>,
+        target: Option<TaskTarget>,
+        cx: &mut App,
+    ) -> (TaskId, CancelToken) {
         let (task_id, cancel_token) = self.app_state.update(cx, |state, _cx| {
-            state.start_task_for_profile(kind, description, profile_id)
+            state.start_task_for_target(kind, description, target)
         });
 
         if let Some(old_id) = self.primary.start(task_id, cancel_token.clone()) {
@@ -74,6 +94,10 @@ impl DocumentTaskRunner {
         false
     }
 
+    pub fn clear_primary(&mut self, task_id: TaskId) {
+        let _ = self.primary.take_if(task_id);
+    }
+
     pub fn is_primary_active(&self) -> bool {
         self.primary.is_active()
     }
@@ -91,9 +115,8 @@ impl DocumentTaskRunner {
         description: impl Into<String>,
         cx: &mut App,
     ) -> (TaskId, CancelToken) {
-        let profile_id = self.profile_id;
         self.app_state.update(cx, |state, _cx| {
-            state.start_task_for_profile(kind, description, profile_id)
+            state.start_task_for_target(kind, description, self.default_target())
         })
     }
 

--- a/crates/dbflux/src/ui/views/sidebar/mod.rs
+++ b/crates/dbflux/src/ui/views/sidebar/mod.rs
@@ -890,6 +890,9 @@ impl Sidebar {
 #[cfg(test)]
 mod tests {
     use super::{ItemIdParts, NODE_KIND_NONE, parse_node_kind};
+    use crate::app::{ExternalDriverDiagnostic, ExternalDriverStage};
+    use crate::ui::views::sidebar::operations::format_connect_prepare_error;
+    use dbflux_core::PrepareConnectError;
     use dbflux_core::{SchemaNodeId, SchemaNodeKind};
     use uuid::Uuid;
 
@@ -1079,5 +1082,36 @@ mod tests {
 
         let menu_items = ContextMenuItem::to_menu_items(&[]);
         assert!(menu_items.is_empty());
+    }
+
+    #[test]
+    fn format_connect_prepare_error_uses_external_driver_diagnostic_details() {
+        let error = PrepareConnectError::ExternalDriverUnavailable {
+            driver_id: "rpc:missing.sock".to_string(),
+            socket_id: "missing.sock".to_string(),
+        };
+        let diagnostic = ExternalDriverDiagnostic {
+            socket_id: "missing.sock".to_string(),
+            stage: ExternalDriverStage::Probe,
+            summary: "Probe failed".to_string(),
+            details: Some("host exited before ready".to_string()),
+        };
+
+        let message = format_connect_prepare_error(&error, Some(&diagnostic));
+
+        assert!(message.contains("rpc:missing.sock"));
+        assert!(message.contains("Probe failed"));
+        assert!(message.contains("host exited before ready"));
+    }
+
+    #[test]
+    fn format_connect_prepare_error_falls_back_to_generic_message_without_diagnostic() {
+        let error = PrepareConnectError::DriverNotRegistered {
+            driver_id: "sqlite".to_string(),
+        };
+
+        let message = format_connect_prepare_error(&error, None);
+
+        assert_eq!(message, "No driver registered for 'sqlite'");
     }
 }

--- a/crates/dbflux/src/ui/views/sidebar/operations.rs
+++ b/crates/dbflux/src/ui/views/sidebar/operations.rs
@@ -1,12 +1,70 @@
 use super::*;
+use crate::app::{ExternalDriverDiagnostic, ExternalDriverStage};
 use dbflux_core::{
     CancelToken, ConnectionHook, HookContext, HookPhase, HookPhaseOutcome, HookResult, HookRunner,
+    PrepareConnectError,
 };
 
 enum HookPhaseState {
     Continue { warnings: Vec<String> },
     Aborted { error: String },
     Cancelled,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        format_connect_prepare_error, is_quiet_connect_skip, sanitize_connect_skip_log_message,
+    };
+    use crate::app::{ExternalDriverDiagnostic, ExternalDriverStage};
+    use dbflux_core::PrepareConnectError;
+
+    #[test]
+    fn format_connect_prepare_error_uses_diagnostic_stage_in_message() {
+        let error = PrepareConnectError::ExternalDriverUnavailable {
+            driver_id: "rpc:demo.sock".to_string(),
+            socket_id: "demo.sock".to_string(),
+        };
+
+        let config_message = format_connect_prepare_error(
+            &error,
+            Some(&ExternalDriverDiagnostic {
+                socket_id: "demo.sock".to_string(),
+                stage: ExternalDriverStage::Config,
+                summary: "bad config".to_string(),
+                details: None,
+            }),
+        );
+        let probe_message = format_connect_prepare_error(
+            &error,
+            Some(&ExternalDriverDiagnostic {
+                socket_id: "demo.sock".to_string(),
+                stage: ExternalDriverStage::Probe,
+                summary: "probe failed".to_string(),
+                details: None,
+            }),
+        );
+
+        assert!(config_message.contains("invalid configuration"));
+        assert!(probe_message.contains("failed during driver probe"));
+    }
+
+    #[test]
+    fn connect_skip_classifier_keeps_pending_and_racing_connects_quiet() {
+        assert!(is_quiet_connect_skip("Connection already pending"));
+        assert!(is_quiet_connect_skip("Operation started by another thread"));
+        assert!(!is_quiet_connect_skip("External driver unavailable"));
+    }
+
+    #[test]
+    fn sanitize_connect_skip_log_message_drops_recent_host_output_block() {
+        let message = "External driver unavailable\n\nRecent host output:\nstderr line";
+
+        assert_eq!(
+            sanitize_connect_skip_log_message(message),
+            "External driver unavailable"
+        );
+    }
 }
 
 fn single_hook_result(executions: Vec<dbflux_core::HookExecution>) -> Result<HookResult, String> {
@@ -58,6 +116,71 @@ fn hook_task_details(
                 error
             )
         }
+    }
+}
+
+fn format_external_driver_stage_message(
+    stage: &ExternalDriverStage,
+    driver_id: &str,
+    socket_id: &str,
+    summary: &str,
+) -> String {
+    match stage {
+        ExternalDriverStage::Config => format!(
+            "External driver '{}' is unavailable because service '{}' has an invalid configuration: {}",
+            driver_id, socket_id, summary
+        ),
+        ExternalDriverStage::Launch => format!(
+            "External driver '{}' is unavailable because service '{}' did not start: {}",
+            driver_id, socket_id, summary
+        ),
+        ExternalDriverStage::Probe => format!(
+            "External driver '{}' is unavailable because service '{}' failed during driver probe: {}",
+            driver_id, socket_id, summary
+        ),
+    }
+}
+
+fn is_quiet_connect_skip(message: &str) -> bool {
+    message.contains("already pending") || message.contains("another thread")
+}
+
+fn sanitize_connect_skip_log_message(message: &str) -> &str {
+    message
+        .split_once("\n\nRecent host output:\n")
+        .map(|(summary, _)| summary)
+        .unwrap_or(message)
+}
+
+pub(super) fn format_connect_prepare_error(
+    error: &PrepareConnectError,
+    diagnostic: Option<&ExternalDriverDiagnostic>,
+) -> String {
+    match (error, diagnostic) {
+        (
+            PrepareConnectError::ExternalDriverUnavailable {
+                driver_id,
+                socket_id,
+            },
+            Some(diagnostic),
+        ) => {
+            let mut message = format_external_driver_stage_message(
+                &diagnostic.stage,
+                driver_id,
+                socket_id,
+                &diagnostic.summary,
+            );
+
+            if let Some(details) = diagnostic.details.as_deref()
+                && !details.trim().is_empty()
+            {
+                message.push_str("\n\n");
+                message.push_str(details);
+            }
+
+            message
+        }
+        _ => error.to_string(),
     }
 }
 
@@ -913,22 +1036,44 @@ impl Sidebar {
                     return Err("Operation started by another thread".to_string());
                 }
 
-                result.map(|p| {
-                    let name = p.profile.name.clone();
-                    let hook_execution = p.prepare_hooks(state.resolve_profile_hooks(&p.profile));
+                match result {
+                    Ok(params) => {
+                        let name = params.profile.name.clone();
+                        let hook_execution =
+                            params.prepare_hooks(state.resolve_profile_hooks(&params.profile));
 
-                    (
-                        p,
-                        name,
-                        hook_execution.hooks.pre_connect,
-                        hook_execution.hooks.post_connect,
-                        hook_execution.context,
-                    )
-                })
+                        Ok((
+                            params,
+                            name,
+                            hook_execution.hooks.pre_connect,
+                            hook_execution.hooks.post_connect,
+                            hook_execution.context,
+                        ))
+                    }
+                    Err(error) => Err(format_connect_prepare_error(
+                        &error,
+                        error
+                            .socket_id()
+                            .and_then(|socket_id| state.external_driver_diagnostic(socket_id)),
+                    )),
+                }
             }) {
                 Ok(p) => p,
-                Err(e) => {
-                    log::info!("Connect skipped: {}", e);
+                Err(message) => {
+                    log::info!(
+                        "Connect skipped: {}",
+                        sanitize_connect_skip_log_message(&message)
+                    );
+
+                    if !is_quiet_connect_skip(&message) {
+                        self.pending_toast = Some(PendingToast {
+                            message,
+                            is_error: true,
+                        });
+                    }
+
+                    self.refresh_tree(cx);
+                    cx.notify();
                     return;
                 }
             };

--- a/crates/dbflux/src/ui/views/tasks_panel.rs
+++ b/crates/dbflux/src/ui/views/tasks_panel.rs
@@ -98,23 +98,24 @@ impl TasksPanel {
     ) {
         match task_kind {
             TaskKind::Query => {
-                let conn = profile_id.and_then(|pid| {
+                let task_target = self
+                    .app_state
+                    .read(cx)
+                    .tasks()
+                    .get(task_id)
+                    .and_then(|task| task.target);
+
+                if let Some(target) = task_target {
+                    self.app_state.read(cx).cancel_query_for_target(&target);
+                } else if let Some(profile_id) = profile_id {
+                    let fallback_target = dbflux_core::TaskTarget {
+                        profile_id,
+                        database: None,
+                    };
+
                     self.app_state
                         .read(cx)
-                        .connections()
-                        .get(&pid)
-                        .map(|c| c.connection.clone())
-                });
-
-                if let Some(conn) = conn {
-                    let cancel_handle = conn.cancel_handle();
-                    if let Err(e) = cancel_handle.cancel() {
-                        log::warn!("Failed to send cancel via handle: {}", e);
-                    }
-
-                    if let Err(e) = conn.cancel_active() {
-                        log::warn!("Failed to send cancel to database: {}", e);
-                    }
+                        .cancel_query_for_target(&fallback_target);
                 }
             }
 

--- a/crates/dbflux/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux/src/ui/views/workspace/actions.rs
@@ -621,7 +621,7 @@ impl Workspace {
                 cx,
             )
             .with_path(pending.path)
-            .with_exec_ctx(pending.exec_ctx);
+            .with_exec_ctx(pending.exec_ctx, cx);
 
             doc.set_content(&pending.body, window, cx);
             doc
@@ -906,7 +906,7 @@ impl Workspace {
                     doc = doc.with_path(p);
                 }
 
-                doc = doc.with_title(title).with_exec_ctx(exec_ctx);
+                doc = doc.with_title(title).with_exec_ctx(exec_ctx, cx);
                 doc.set_content(body, window, cx);
 
                 // If there was a shadow, the tab had unsaved changes — mark dirty

--- a/crates/dbflux/src/ui/windows/settings/lifecycle.rs
+++ b/crates/dbflux/src/ui/windows/settings/lifecycle.rs
@@ -373,6 +373,7 @@ impl SettingsWindow {
 
             svc_services: Vec::new(),
             svc_config_store: None,
+            svc_load_error: None,
             svc_focus: ServiceFocus::List,
             svc_selected_idx: None,
             svc_form_cursor: 0,

--- a/crates/dbflux/src/ui/windows/settings/mod.rs
+++ b/crates/dbflux/src/ui/windows/settings/mod.rs
@@ -266,6 +266,7 @@ pub struct SettingsWindow {
     // Services section state
     svc_services: Vec<ServiceConfig>,
     svc_config_store: Option<AppConfigStore>,
+    svc_load_error: Option<String>,
 
     svc_focus: ServiceFocus,
     svc_selected_idx: Option<usize>,

--- a/crates/dbflux/src/ui/windows/settings/render.rs
+++ b/crates/dbflux/src/ui/windows/settings/render.rs
@@ -1,3 +1,4 @@
+use crate::app::{ExternalDriverDiagnostic, ExternalDriverStage};
 use crate::ui::components::tree_nav::{self, FlatRow, TreeNavAction};
 use crate::ui::icons::AppIcon;
 use crate::ui::tokens::{Heights, Radii};
@@ -19,6 +20,45 @@ use super::{
     ProxyAuthSelection, ProxyFocus, ProxyFormField, ServiceFocus, ServiceFormRow, SettingsFocus,
     SettingsSection, SettingsWindow, SshFocus, SshFormField, SshTestStatus,
 };
+
+const SERVICE_COMMAND_HELP_TEXT: &str = "Leave Command and Arguments empty to use an already running service. To launch the default dbflux-driver-host, leave Command empty and include Arguments with both --driver and --socket.";
+
+fn service_command_subtitle(service: &ServiceConfig) -> String {
+    match service
+        .command
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(command) => command.to_string(),
+        None if service.args.is_empty() => "(manual service)".to_string(),
+        None => "dbflux-driver-host".to_string(),
+    }
+}
+
+fn service_diagnostic_lines(diagnostic: Option<&ExternalDriverDiagnostic>) -> Vec<String> {
+    diagnostic.map_or_else(Vec::new, |diagnostic| {
+        let prefix = match diagnostic.stage {
+            ExternalDriverStage::Config => "Config validation",
+            ExternalDriverStage::Launch => "Launch",
+            ExternalDriverStage::Probe => "Probe",
+        };
+
+        let mut lines = vec![format!("{prefix}: {}", diagnostic.summary)];
+
+        if let Some(details) = diagnostic.details.as_deref() {
+            lines.extend(
+                details
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty())
+                    .map(ToString::to_string),
+            );
+        }
+
+        lines
+    })
+}
 
 const INDENT_PX: f32 = 16.0;
 
@@ -1292,6 +1332,7 @@ impl SettingsWindow {
         let theme = cx.theme();
         let services = &self.svc_services;
         let editing_idx = self.editing_svc_idx;
+        let load_error = self.svc_load_error.clone();
 
         div()
             .flex_1()
@@ -1314,7 +1355,16 @@ impl SettingsWindow {
                             .text_sm()
                             .text_color(theme.muted_foreground)
                             .child("Manage external driver services. Changes require restart."),
-                    ),
+                    )
+                    .when_some(load_error, |section, error| {
+                        section.child(
+                            div()
+                                .mt_2()
+                                .text_sm()
+                                .text_color(theme.warning)
+                                .child(error),
+                        )
+                    }),
             )
             .child(
                 div()
@@ -1388,12 +1438,14 @@ impl SettingsWindow {
                         let is_selected = editing_idx == Some(idx);
                         let is_focused = is_list_focused && self.svc_selected_idx == Some(idx);
                         let is_disabled = !service.enabled;
+                        let diagnostic = self
+                            .app_state
+                            .read(cx)
+                            .external_driver_diagnostic(&service.socket_id)
+                            .cloned();
 
-                        let subtitle = service
-                            .command
-                            .as_deref()
-                            .filter(|s| !s.is_empty())
-                            .unwrap_or("(default)");
+                        let subtitle = service_command_subtitle(service);
+                        let diagnostic_lines = service_diagnostic_lines(diagnostic.as_ref());
 
                         div()
                             .id(SharedString::from(format!("svc-item-{}", idx)))
@@ -1460,8 +1512,18 @@ impl SettingsWindow {
                                                 div()
                                                     .text_xs()
                                                     .text_color(theme.muted_foreground)
-                                                    .child(subtitle.to_string()),
-                                            ),
+                                                    .child(subtitle),
+                                            )
+                                            .when(!diagnostic_lines.is_empty(), |d| {
+                                                d.child(div().flex().flex_col().gap_0p5().children(
+                                                    diagnostic_lines.into_iter().map(|message| {
+                                                        div()
+                                                            .text_xs()
+                                                            .text_color(theme.warning)
+                                                            .child(message)
+                                                    }),
+                                                ))
+                                            }),
                                     ),
                             )
                     })),
@@ -1476,6 +1538,7 @@ impl SettingsWindow {
         let theme = cx.theme();
         let primary = theme.primary;
         let border = theme.border;
+        let muted_foreground = theme.muted_foreground;
 
         let is_form_focused =
             self.focus_area == SettingsFocus::Content && self.svc_focus == ServiceFocus::Form;
@@ -1530,6 +1593,12 @@ impl SettingsWindow {
                         ServiceFormRow::Command,
                         cx,
                     ))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(muted_foreground)
+                            .child(SERVICE_COMMAND_HELP_TEXT),
+                    )
                     .child(self.render_svc_input_field(
                         "Startup Timeout (ms)",
                         &self.input_svc_timeout,
@@ -2479,6 +2548,72 @@ impl SettingsWindow {
             .cursor_pointer()
             .hover(move |d| d.bg(secondary))
             .child(svg().path(icon_path).size_4().text_color(muted_foreground))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SERVICE_COMMAND_HELP_TEXT, service_command_subtitle, service_diagnostic_lines};
+    use crate::app::{ExternalDriverDiagnostic, ExternalDriverStage};
+    use dbflux_core::ServiceConfig;
+    use std::collections::HashMap;
+
+    fn service(command: Option<&str>, args: &[&str]) -> ServiceConfig {
+        ServiceConfig {
+            socket_id: "demo.sock".to_string(),
+            enabled: true,
+            command: command.map(ToString::to_string),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+            env: HashMap::new(),
+            startup_timeout_ms: None,
+        }
+    }
+
+    #[test]
+    fn service_command_subtitle_distinguishes_manual_and_default_host_services() {
+        assert_eq!(
+            service_command_subtitle(&service(Some("custom-host"), &[])),
+            "custom-host"
+        );
+        assert_eq!(
+            service_command_subtitle(&service(None, &[])),
+            "(manual service)"
+        );
+        assert_eq!(
+            service_command_subtitle(&service(
+                None,
+                &["--driver", "demo", "--socket", "demo.sock"]
+            )),
+            "dbflux-driver-host"
+        );
+    }
+
+    #[test]
+    fn service_diagnostic_lines_include_details_when_present() {
+        let lines = service_diagnostic_lines(Some(&ExternalDriverDiagnostic {
+            socket_id: "demo.sock".to_string(),
+            stage: ExternalDriverStage::Config,
+            summary: "missing --socket".to_string(),
+            details: Some("Recent host output:\nline one\nline two".to_string()),
+        }));
+
+        assert_eq!(
+            lines,
+            vec![
+                "Config validation: missing --socket".to_string(),
+                "Recent host output:".to_string(),
+                "line one".to_string(),
+                "line two".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn service_command_help_text_describes_manual_and_default_host_modes() {
+        assert!(SERVICE_COMMAND_HELP_TEXT.contains("already running service"));
+        assert!(SERVICE_COMMAND_HELP_TEXT.contains("dbflux-driver-host"));
+        assert!(SERVICE_COMMAND_HELP_TEXT.contains("--driver"));
+        assert!(SERVICE_COMMAND_HELP_TEXT.contains("--socket"));
     }
 }
 

--- a/crates/dbflux/src/ui/windows/settings/rpc_services.rs
+++ b/crates/dbflux/src/ui/windows/settings/rpc_services.rs
@@ -1,10 +1,61 @@
 use crate::ui::components::toast::ToastExt;
-use dbflux_core::{AppConfig, AppConfigStore, ServiceConfig};
+use dbflux_core::{AppConfig, AppConfigStore, AppConfigWarning, LoadedAppConfig, ServiceConfig};
+use dbflux_driver_ipc::IpcDriver;
 use gpui::*;
 use gpui_component::input::InputState;
 use std::collections::HashMap;
 
 use super::{ServiceFocus, ServiceFormRow, SettingsWindow};
+
+fn validate_service_launch_config(
+    socket_id: &str,
+    command: Option<&str>,
+    args: &[String],
+    env: &HashMap<String, String>,
+    startup_timeout_ms: Option<u64>,
+) -> Result<(), String> {
+    IpcDriver::build_launch_config(socket_id, command, args, env, startup_timeout_ms)
+        .map(|_| ())
+        .map_err(|error| error.to_string())
+}
+
+fn validate_service_for_save(service: &ServiceConfig) -> Result<(), String> {
+    IpcDriver::validate_socket_id(&service.socket_id).map_err(|error| error.to_string())?;
+
+    if !service.enabled {
+        return Ok(());
+    }
+
+    validate_service_launch_config(
+        &service.socket_id,
+        service.command.as_deref(),
+        &service.args,
+        &service.env,
+        service.startup_timeout_ms,
+    )
+}
+
+fn summarize_config_warnings(warnings: &[AppConfigWarning]) -> Option<String> {
+    if warnings.is_empty() {
+        None
+    } else {
+        Some(
+            warnings
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" "),
+        )
+    }
+}
+
+fn finalize_service_config_save(
+    mut loaded: LoadedAppConfig,
+    services: &[ServiceConfig],
+) -> Result<AppConfig, String> {
+    loaded.config.services = services.to_vec();
+    Ok(loaded.config)
+}
 
 impl SettingsWindow {
     pub(super) fn load_services(&mut self) {
@@ -14,41 +65,61 @@ impl SettingsWindow {
                 log::error!("Failed to create config store: {}", e);
                 self.svc_services = Vec::new();
                 self.svc_config_store = None;
+                self.svc_load_error = Some(format!("Failed to create config store: {}", e));
                 return;
             }
         };
 
-        self.svc_services = match store.load() {
-            Ok(config) => config.services,
+        match store.load_with_warnings() {
+            Ok(loaded) => {
+                self.svc_load_error = summarize_config_warnings(&loaded.warnings);
+                self.svc_services = loaded.config.services;
+            }
             Err(e) => {
                 log::error!("Failed to load config: {}", e);
-                Vec::new()
+                self.svc_services = Vec::new();
+                self.svc_load_error = Some(format!("Failed to load config: {}", e));
             }
-        };
+        }
 
         self.svc_config_store = Some(store);
     }
 
-    fn persist_services(&self, window: &mut Window, cx: &mut Context<Self>) {
+    fn persist_services(
+        &self,
+        services: &[ServiceConfig],
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
         let Some(ref store) = self.svc_config_store else {
             cx.toast_error("Cannot save: config store unavailable", window);
-            return;
+            return false;
         };
 
-        let mut config = match store.load() {
-            Ok(c) => c,
+        let loaded = match store.load_with_warnings() {
+            Ok(config) => config,
             Err(e) => {
                 log::error!("Failed to load config before save: {}", e);
-                AppConfig::default()
+                cx.toast_error(format!("Cannot save services: {}", e), window);
+                return false;
             }
         };
 
-        config.services = self.svc_services.clone();
+        let config = match finalize_service_config_save(loaded, services) {
+            Ok(config) => config,
+            Err(error) => {
+                cx.toast_error(format!("Cannot save services: {}", error), window);
+                return false;
+            }
+        };
 
-        if let Err(e) = store.save(&config) {
+        if let Err(e) = store.save_without_legacy_service_key(&config) {
             log::error!("Failed to save config: {}", e);
             cx.toast_error(format!("Failed to save config: {}", e), window);
+            return false;
         }
+
+        true
     }
 
     // --- Form lifecycle ---
@@ -204,17 +275,28 @@ impl SettingsWindow {
             startup_timeout_ms,
         };
 
+        if let Err(error) = validate_service_for_save(&service) {
+            cx.toast_error(error, window);
+            return;
+        }
+
+        let mut next_services = self.svc_services.clone();
+
         let saved_idx = if let Some(idx) = self.editing_svc_idx {
-            if idx < self.svc_services.len() {
-                self.svc_services[idx] = service;
+            if idx < next_services.len() {
+                next_services[idx] = service;
             }
             idx
         } else {
-            self.svc_services.push(service);
-            self.svc_services.len() - 1
+            next_services.push(service);
+            next_services.len() - 1
         };
 
-        self.persist_services(window, cx);
+        if !self.persist_services(&next_services, window, cx) {
+            return;
+        }
+
+        self.svc_services = next_services;
         cx.toast_info("Service saved. Restart required to apply changes.", window);
 
         self.svc_selected_idx = Some(saved_idx);
@@ -238,7 +320,15 @@ impl SettingsWindow {
             return;
         }
 
-        self.svc_services.remove(idx);
+        let mut next_services = self.svc_services.clone();
+        next_services.remove(idx);
+
+        if !self.persist_services(&next_services, window, cx) {
+            self.pending_delete_svc_idx = Some(idx);
+            return;
+        }
+
+        self.svc_services = next_services;
 
         if self.editing_svc_idx == Some(idx) {
             self.clear_svc_form(window, cx);
@@ -259,7 +349,6 @@ impl SettingsWindow {
             }
         }
 
-        self.persist_services(window, cx);
         cx.toast_info(
             "Service deleted. Restart required to apply changes.",
             window,
@@ -626,5 +715,127 @@ impl SettingsWindow {
             self.svc_form_cursor = count - 1;
         }
         self.svc_env_col = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        finalize_service_config_save, summarize_config_warnings, validate_service_for_save,
+        validate_service_launch_config,
+    };
+    use dbflux_core::{AppConfig, AppConfigWarning, LoadedAppConfig, ServiceConfig};
+    use std::collections::HashMap;
+
+    fn service(
+        socket_id: &str,
+        enabled: bool,
+        command: Option<&str>,
+        timeout: Option<u64>,
+    ) -> ServiceConfig {
+        ServiceConfig {
+            socket_id: socket_id.to_string(),
+            enabled,
+            command: command.map(str::to_string),
+            args: Vec::new(),
+            env: HashMap::new(),
+            startup_timeout_ms: timeout,
+        }
+    }
+
+    #[test]
+    fn validate_service_launch_config_rejects_zero_timeout() {
+        let error = validate_service_launch_config(
+            "demo.sock",
+            Some("custom-host"),
+            &[],
+            &HashMap::new(),
+            Some(0),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("at least 1 ms"));
+    }
+
+    #[test]
+    fn validate_service_launch_config_rejects_invalid_default_host_args() {
+        let error = validate_service_launch_config(
+            "demo.sock",
+            None,
+            &["--driver".to_string(), "demo".to_string()],
+            &HashMap::new(),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(error.contains("--socket"));
+    }
+
+    #[test]
+    fn validate_service_for_save_allows_disabling_broken_service() {
+        let service = service("demo.sock", false, None, Some(0));
+
+        validate_service_for_save(&service).expect("disabled services should still be savable");
+    }
+
+    #[test]
+    fn validate_service_for_save_rejects_invalid_socket_id() {
+        let error =
+            validate_service_for_save(&service("bad/socket", true, None, None)).unwrap_err();
+
+        assert!(error.contains("bad/socket"));
+    }
+
+    #[test]
+    fn summarize_config_warnings_returns_none_for_empty_warning_list() {
+        assert_eq!(summarize_config_warnings(&[]), None);
+    }
+
+    #[test]
+    fn finalize_service_config_save_allows_legacy_warning_and_updates_services() {
+        let loaded = LoadedAppConfig {
+            config: AppConfig::default(),
+            warnings: vec![AppConfigWarning::LegacyRpcServicesIgnored],
+        };
+
+        let updated =
+            finalize_service_config_save(loaded, &[service("demo.sock", true, None, None)])
+                .unwrap();
+
+        assert_eq!(updated.services.len(), 1);
+        assert_eq!(updated.services[0].socket_id, "demo.sock");
+    }
+
+    #[test]
+    fn finalize_service_config_save_updates_services_without_touching_other_sections() {
+        let mut config = AppConfig::default();
+        config.general.theme = dbflux_core::ThemeSetting::Light;
+        config.hook_definitions.insert(
+            "after_connect".to_string(),
+            dbflux_core::ConnectionHook {
+                enabled: true,
+                command: "echo".to_string(),
+                args: Vec::new(),
+                cwd: None,
+                env: HashMap::new(),
+                inherit_env: true,
+                timeout_ms: None,
+                on_failure: dbflux_core::HookFailureMode::Warn,
+            },
+        );
+
+        let loaded = LoadedAppConfig {
+            config,
+            warnings: Vec::new(),
+        };
+
+        let updated =
+            finalize_service_config_save(loaded, &[service("demo.sock", true, None, None)])
+                .unwrap();
+
+        assert_eq!(updated.services.len(), 1);
+        assert_eq!(updated.services[0].socket_id, "demo.sock");
+        assert_eq!(updated.general.theme, dbflux_core::ThemeSetting::Light);
+        assert!(updated.hook_definitions.contains_key("after_connect"));
     }
 }

--- a/crates/dbflux/tests/architecture.rs
+++ b/crates/dbflux/tests/architecture.rs
@@ -1,3 +1,4 @@
+use dbflux_core::EXTERNAL_SERVICES_CONFIG_KEY;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -26,6 +27,10 @@ fn workspace_root() -> PathBuf {
         .and_then(Path::parent)
         .expect("workspace root")
         .to_path_buf()
+}
+
+fn read_workspace_file(relative_path: &str) -> String {
+    fs::read_to_string(workspace_root().join(relative_path)).expect("workspace file")
 }
 
 #[test]
@@ -119,4 +124,29 @@ fn postgres_config_pattern_is_confined_to_core_and_driver() {
         "Found postgres config variant outside allowed modules: {:?}",
         violations
     );
+}
+
+#[test]
+fn external_driver_docs_use_only_canonical_services_key() {
+    let docs = [
+        read_workspace_file("docs/RPC_SERVICES_CONFIG.md"),
+        read_workspace_file("docs/DRIVER_RPC_PROTOCOL.md"),
+        read_workspace_file("examples/custom_driver/README.md"),
+    ];
+
+    for content in docs {
+        assert!(content.contains(EXTERNAL_SERVICES_CONFIG_KEY));
+        assert!(!content.contains("rpc_services"));
+    }
+}
+
+#[test]
+fn custom_driver_example_json_uses_only_canonical_services_key() {
+    let example = read_workspace_file("examples/custom_driver/config.example.json");
+    let parsed: serde_json::Value = serde_json::from_str(&example).expect("valid example json");
+
+    let object = parsed.as_object().expect("top-level object");
+
+    assert!(object.contains_key(EXTERNAL_SERVICES_CONFIG_KEY));
+    assert!(!object.contains_key("rpc_services"));
 }

--- a/crates/dbflux_core/src/config/app.rs
+++ b/crates/dbflux_core/src/config/app.rs
@@ -15,6 +15,31 @@ pub type DriverKey = String;
 const CONFIG_VERSION_1: u32 = 1;
 const CONFIG_VERSION_2: u32 = 2;
 
+pub const EXTERNAL_SERVICES_CONFIG_KEY: &str = "services";
+const LEGACY_EXTERNAL_SERVICES_CONFIG_KEY: &str = "rpc_services";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AppConfigWarning {
+    LegacyRpcServicesIgnored,
+}
+
+impl std::fmt::Display for AppConfigWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LegacyRpcServicesIgnored => write!(
+                f,
+                "Legacy config key 'rpc_services' is ignored; rename it to 'services'"
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadedAppConfig {
+    pub config: AppConfig,
+    pub warnings: Vec<AppConfigWarning>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
     #[serde(default = "default_config_version")]
@@ -407,13 +432,22 @@ impl AppConfigStore {
     }
 
     pub fn load(&self) -> Result<AppConfig, DbError> {
+        self.load_with_warnings().map(|loaded| loaded.config)
+    }
+
+    pub fn load_with_warnings(&self) -> Result<LoadedAppConfig, DbError> {
         if !self.path.exists() {
-            return Ok(AppConfig::default());
+            return Ok(LoadedAppConfig {
+                config: AppConfig::default(),
+                warnings: Vec::new(),
+            });
         }
 
         let content = fs::read_to_string(&self.path).map_err(DbError::IoError)?;
-        let json: serde_json::Value =
+        let mut json: serde_json::Value =
             serde_json::from_str(&content).map_err(|e| DbError::InvalidProfile(e.to_string()))?;
+
+        let warnings = Self::strip_legacy_service_keys(&mut json);
 
         let legacy_allow_redis_flush = json
             .get("general")
@@ -428,7 +462,28 @@ impl AppConfigStore {
             self.save(&config)?;
         }
 
-        Ok(config)
+        Ok(LoadedAppConfig { config, warnings })
+    }
+
+    fn strip_legacy_service_keys(json: &mut serde_json::Value) -> Vec<AppConfigWarning> {
+        let Some(object) = json.as_object_mut() else {
+            return Vec::new();
+        };
+
+        if object.remove(LEGACY_EXTERNAL_SERVICES_CONFIG_KEY).is_some() {
+            vec![AppConfigWarning::LegacyRpcServicesIgnored]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn existing_legacy_service_entries(&self) -> Option<serde_json::Value> {
+        let content = fs::read_to_string(&self.path).ok()?;
+        let json: serde_json::Value = serde_json::from_str(&content).ok()?;
+
+        json.as_object()?
+            .get(LEGACY_EXTERNAL_SERVICES_CONFIG_KEY)
+            .cloned()
     }
 
     fn migrate_v1_to_v2(&self, config: &mut AppConfig, legacy_allow_redis_flush: bool) -> bool {
@@ -450,11 +505,39 @@ impl AppConfigStore {
     }
 
     pub fn save(&self, config: &AppConfig) -> Result<(), DbError> {
+        self.save_with_legacy_service_key(config, true)
+    }
+
+    pub fn save_without_legacy_service_key(&self, config: &AppConfig) -> Result<(), DbError> {
+        self.save_with_legacy_service_key(config, false)
+    }
+
+    fn save_with_legacy_service_key(
+        &self,
+        config: &AppConfig,
+        preserve_existing_legacy_key: bool,
+    ) -> Result<(), DbError> {
         if let Some(parent) = self.path.parent() {
             fs::create_dir_all(parent).map_err(DbError::IoError)?;
         }
 
-        let content = serde_json::to_string_pretty(config)
+        let mut json =
+            serde_json::to_value(config).map_err(|e| DbError::InvalidProfile(e.to_string()))?;
+
+        if let Some(object) = json.as_object_mut() {
+            if preserve_existing_legacy_key {
+                if let Some(legacy_services) = self.existing_legacy_service_entries() {
+                    object.insert(
+                        LEGACY_EXTERNAL_SERVICES_CONFIG_KEY.to_string(),
+                        legacy_services,
+                    );
+                }
+            } else {
+                object.remove(LEGACY_EXTERNAL_SERVICES_CONFIG_KEY);
+            }
+        }
+
+        let content = serde_json::to_string_pretty(&json)
             .map_err(|e| DbError::InvalidProfile(e.to_string()))?;
         fs::write(&self.path, content).map_err(DbError::IoError)?;
 
@@ -486,6 +569,16 @@ pub fn driver_maps_differ(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    fn temp_config_store() -> (TempDir, AppConfigStore) {
+        let temp_dir = TempDir::new().unwrap();
+        let store = AppConfigStore {
+            path: temp_dir.path().join("config.json"),
+        };
+
+        (temp_dir, store)
+    }
 
     // =========================================================================
     // GlobalOverrides
@@ -1018,6 +1111,189 @@ mod tests {
 
         assert!(!migrated);
         assert!(config.driver_settings.is_empty());
+    }
+
+    #[test]
+    fn load_ignores_legacy_rpc_services_key_and_reports_warning() {
+        let (_temp_dir, store) = temp_config_store();
+
+        fs::write(
+            store.path(),
+            r#"{
+                "version": 2,
+                "general": {
+                    "theme": "light"
+                },
+                "hook_definitions": {
+                    "after_connect": {
+                        "name": "After connect",
+                        "kind": "command",
+                        "command": "echo",
+                        "args": ["ok"],
+                        "cwd": null,
+                        "env": {},
+                        "timeout_ms": null,
+                        "enabled": true,
+                        "failure_mode": "warn"
+                    }
+                },
+                "rpc_services": [
+                    {
+                        "socket_id": "legacy.sock",
+                        "enabled": true,
+                        "command": "legacy-host",
+                        "args": ["--serve"]
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = store.load_with_warnings().unwrap();
+
+        assert!(loaded.config.services.is_empty());
+        assert_eq!(loaded.config.general.theme, ThemeSetting::Light);
+        assert!(loaded.config.hook_definitions.contains_key("after_connect"));
+        assert_eq!(
+            loaded.warnings,
+            vec![AppConfigWarning::LegacyRpcServicesIgnored]
+        );
+    }
+
+    #[test]
+    fn load_prefers_canonical_services_key_when_legacy_key_is_present() {
+        let (_temp_dir, store) = temp_config_store();
+
+        fs::write(
+            store.path(),
+            r#"{
+                "version": 2,
+                "services": [
+                    {
+                        "socket_id": "canonical.sock",
+                        "enabled": true,
+                        "command": "canonical-host"
+                    }
+                ],
+                "rpc_services": [
+                    {
+                        "socket_id": "legacy.sock",
+                        "enabled": true,
+                        "command": "legacy-host"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = store.load_with_warnings().unwrap();
+
+        assert_eq!(loaded.config.services.len(), 1);
+        assert_eq!(loaded.config.services[0].socket_id, "canonical.sock");
+        assert_eq!(
+            loaded.warnings,
+            vec![AppConfigWarning::LegacyRpcServicesIgnored]
+        );
+    }
+
+    #[test]
+    fn load_keeps_canonical_services_key_unchanged() {
+        let (_temp_dir, store) = temp_config_store();
+
+        fs::write(
+            store.path(),
+            r#"{
+                "version": 2,
+                "services": [
+                    {
+                        "socket_id": "canonical.sock",
+                        "enabled": true,
+                        "command": "canonical-host"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let _ = store.load().unwrap();
+        let saved = fs::read_to_string(store.path()).unwrap();
+
+        assert!(saved.contains("\"services\""));
+        assert!(!saved.contains("\"rpc_services\""));
+        assert!(saved.contains("canonical.sock"));
+    }
+
+    #[test]
+    fn save_preserves_existing_legacy_rpc_services_key_for_unrelated_updates() {
+        let (_temp_dir, store) = temp_config_store();
+
+        fs::write(
+            store.path(),
+            r#"{
+                "version": 2,
+                "general": {
+                    "theme": "dark"
+                },
+                "rpc_services": [
+                    {
+                        "socket_id": "legacy.sock",
+                        "enabled": true,
+                        "command": "legacy-host"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let mut config = store.load().unwrap();
+        config.general.theme = ThemeSetting::Light;
+
+        store.save(&config).unwrap();
+
+        let saved = fs::read_to_string(store.path()).unwrap();
+
+        assert!(saved.contains("\"rpc_services\""));
+        assert!(saved.contains("legacy.sock"));
+        assert!(saved.contains("\"theme\": \"light\""));
+    }
+
+    #[test]
+    fn save_without_legacy_service_key_explicitly_removes_legacy_rpc_services() {
+        let (_temp_dir, store) = temp_config_store();
+
+        fs::write(
+            store.path(),
+            r#"{
+                "version": 2,
+                "rpc_services": [
+                    {
+                        "socket_id": "legacy.sock",
+                        "enabled": true,
+                        "command": "legacy-host"
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        let mut config = AppConfig::default();
+        config.services.push(ServiceConfig {
+            socket_id: "canonical.sock".to_string(),
+            enabled: true,
+            command: Some("canonical-host".to_string()),
+            args: Vec::new(),
+            env: HashMap::new(),
+            startup_timeout_ms: None,
+        });
+
+        store.save_without_legacy_service_key(&config).unwrap();
+
+        let saved = fs::read_to_string(store.path()).unwrap();
+
+        assert!(saved.contains("\"services\""));
+        assert!(saved.contains("canonical.sock"));
+        assert!(!saved.contains("\"rpc_services\""));
+        assert!(!saved.contains("legacy.sock"));
     }
 
     // =========================================================================

--- a/crates/dbflux_core/src/config/mod.rs
+++ b/crates/dbflux_core/src/config/mod.rs
@@ -3,8 +3,9 @@ pub(crate) mod refresh_policy;
 pub(crate) mod scripts_directory;
 
 pub use app::{
-    AppConfig, AppConfigStore, DangerousAction, DriverKey, EffectiveSettings, GeneralSettings,
-    GlobalOverrides, RefreshPolicySetting, ServiceConfig, StartupFocus, ThemeSetting,
+    AppConfig, AppConfigStore, AppConfigWarning, DangerousAction, DriverKey,
+    EXTERNAL_SERVICES_CONFIG_KEY, EffectiveSettings, GeneralSettings, GlobalOverrides,
+    LoadedAppConfig, RefreshPolicySetting, ServiceConfig, StartupFocus, ThemeSetting,
     driver_maps_differ,
 };
 pub use refresh_policy::RefreshPolicy;

--- a/crates/dbflux_core/src/connection/manager.rs
+++ b/crates/dbflux_core/src/connection/manager.rs
@@ -2,6 +2,7 @@ use crate::{
     Connection, ConnectionHooks, ConnectionProfile, CustomTypeInfo, DbDriver, DbKind, DbSchemaInfo,
     HookContext, ProxyProfile, SchemaForeignKeyInfo, SchemaIndexInfo, SchemaLoadingStrategy,
     SchemaSnapshot, SecretStore, ShutdownCoordinator, ShutdownPhase, SshTunnelProfile, TableInfo,
+    TaskTarget,
 };
 use log::{error, info};
 use std::any::Any;
@@ -356,6 +357,10 @@ impl ConnectedProfile {
             })
     }
 
+    pub fn remove_database_connection(&mut self, database: &str) -> Option<DatabaseConnection> {
+        self.database_connections.remove(database)
+    }
+
     /// Returns the per-database schema if available, otherwise the primary.
     pub fn schema_for_target_database(&self, database: &str) -> Option<&SchemaSnapshot> {
         self.database_connections
@@ -416,6 +421,32 @@ impl ConnectionManager {
         self.connections
             .get(&profile_id)
             .map(|c| c.connection.clone())
+    }
+
+    pub fn connection_for_task_target(&self, target: &TaskTarget) -> Option<Arc<dyn Connection>> {
+        let connected = self.connections.get(&target.profile_id)?;
+
+        match target.database.as_deref() {
+            Some(database)
+                if connected.connection.schema_loading_strategy()
+                    == SchemaLoadingStrategy::ConnectionPerDatabase =>
+            {
+                let is_primary = connected
+                    .schema
+                    .as_ref()
+                    .and_then(|schema| schema.current_database())
+                    .is_some_and(|current| current == database);
+
+                if is_primary {
+                    Some(connected.connection.clone())
+                } else {
+                    connected
+                        .database_connection(database)
+                        .map(|db_conn| db_conn.connection.clone())
+                }
+            }
+            _ => Some(connected.connection.clone()),
+        }
     }
 
     pub fn set_active_connection(&mut self, profile_id: Uuid) {
@@ -660,6 +691,23 @@ impl ConnectionManager {
         if let Some(connected) = self.connections.get_mut(&profile_id) {
             connected.add_database_connection(database, DatabaseConnection { connection, schema });
         }
+    }
+
+    pub fn remove_database_connection(&mut self, profile_id: Uuid, database: &str) -> bool {
+        let Some(connected) = self.connections.get_mut(&profile_id) else {
+            return false;
+        };
+
+        let removed = connected.remove_database_connection(database).is_some();
+
+        if removed && connected.active_database.as_deref() == Some(database) {
+            connected.active_database = connected
+                .schema
+                .as_ref()
+                .and_then(|schema| schema.current_database().map(String::from));
+        }
+
+        removed
     }
 
     // --- Pending operations ---

--- a/crates/dbflux_core/src/connection/manager.rs
+++ b/crates/dbflux_core/src/connection/manager.rs
@@ -195,6 +195,48 @@ pub enum ConnectionResolutionError {
     PendingDatabaseConnection { database: String },
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PrepareConnectError {
+    ProfileNotFound,
+    AlreadyConnected,
+    DriverNotRegistered {
+        driver_id: String,
+    },
+    ExternalDriverUnavailable {
+        driver_id: String,
+        socket_id: String,
+    },
+}
+
+impl PrepareConnectError {
+    pub fn socket_id(&self) -> Option<&str> {
+        match self {
+            Self::ExternalDriverUnavailable { socket_id, .. } => Some(socket_id),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for PrepareConnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProfileNotFound => write!(f, "Profile not found"),
+            Self::AlreadyConnected => write!(f, "Already connected"),
+            Self::DriverNotRegistered { driver_id } => {
+                write!(f, "No driver registered for '{}'", driver_id)
+            }
+            Self::ExternalDriverUnavailable {
+                driver_id,
+                socket_id,
+            } => write!(
+                f,
+                "External driver '{}' is unavailable because service '{}' was not registered",
+                driver_id, socket_id
+            ),
+        }
+    }
+}
+
 pub struct ConnectedProfile {
     pub profile: ConnectionProfile,
     pub connection: Arc<dyn Connection>,
@@ -747,24 +789,30 @@ impl ConnectionManager {
         secret_store: &Arc<RwLock<Box<dyn SecretStore>>>,
         get_ssh_secret: impl FnOnce(&ConnectionProfile, &[SshTunnelProfile]) -> Option<String>,
         proxy_secret: Option<String>,
-    ) -> Result<ConnectProfileParams, String> {
+    ) -> Result<ConnectProfileParams, PrepareConnectError> {
         let profile = profiles
             .iter()
             .find(|p| p.id == profile_id)
             .cloned()
-            .ok_or_else(|| "Profile not found".to_string())?;
+            .ok_or(PrepareConnectError::ProfileNotFound)?;
 
         if self.connections.contains_key(&profile_id) {
-            return Err("Already connected".to_string());
+            return Err(PrepareConnectError::AlreadyConnected);
         }
 
         let kind = profile.kind();
         let driver_id = profile.driver_id();
-        let driver = self
-            .drivers
-            .get(&driver_id)
-            .cloned()
-            .ok_or_else(|| format!("No driver registered for '{}'", driver_id))?;
+        let driver = self.drivers.get(&driver_id).cloned().ok_or_else(|| {
+            match driver_id.strip_prefix("rpc:") {
+                Some(socket_id) => PrepareConnectError::ExternalDriverUnavailable {
+                    driver_id: driver_id.clone(),
+                    socket_id: socket_id.to_string(),
+                },
+                None => PrepareConnectError::DriverNotRegistered {
+                    driver_id: driver_id.clone(),
+                },
+            }
+        })?;
 
         let secret_store_param = if kind == DbKind::SQLite {
             None
@@ -1506,7 +1554,10 @@ pub struct FetchSchemaForeignKeysResult {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{DbConfig, DbError, DbKind, DriverCapabilities, DriverMetadata, QueryLanguage};
+    use crate::{
+        DbConfig, DbError, DbKind, DriverCapabilities, DriverMetadata, NoopSecretStore,
+        QueryLanguage,
+    };
 
     struct TestConnection {
         kind: DbKind,
@@ -1796,6 +1847,66 @@ mod tests {
         assert_eq!(
             resolved.profile.no_proxy.as_deref(),
             Some("localhost,10.0.0.0/8")
+        );
+    }
+
+    #[test]
+    fn prepare_connect_profile_returns_external_driver_unavailable_error_for_missing_rpc_driver() {
+        let manager = ConnectionManager::new(HashMap::new());
+
+        let mut profile = ConnectionProfile::new("rpc profile", DbConfig::default_postgres());
+        profile.set_driver_id("rpc:missing.sock".to_string());
+
+        let error = match manager.prepare_connect_profile(
+            profile.id,
+            &[profile],
+            &[],
+            &[],
+            &Arc::new(RwLock::new(
+                Box::new(NoopSecretStore) as Box<dyn SecretStore>
+            )),
+            |_profile, _ssh_tunnels| None,
+            None,
+        ) {
+            Ok(_) => panic!("expected missing rpc driver to return an error"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error,
+            PrepareConnectError::ExternalDriverUnavailable {
+                driver_id: "rpc:missing.sock".to_string(),
+                socket_id: "missing.sock".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn prepare_connect_profile_keeps_generic_error_for_non_rpc_missing_driver() {
+        let manager = ConnectionManager::new(HashMap::new());
+
+        let profile = ConnectionProfile::new("sqlite", DbConfig::default_sqlite());
+
+        let error = match manager.prepare_connect_profile(
+            profile.id,
+            &[profile],
+            &[],
+            &[],
+            &Arc::new(RwLock::new(
+                Box::new(NoopSecretStore) as Box<dyn SecretStore>
+            )),
+            |_profile, _ssh_tunnels| None,
+            None,
+        ) {
+            Ok(_) => panic!("expected missing builtin driver to return an error"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error,
+            PrepareConnectError::DriverNotRegistered {
+                driver_id: "sqlite".to_string(),
+            }
         );
     }
 

--- a/crates/dbflux_core/src/connection/mod.rs
+++ b/crates/dbflux_core/src/connection/mod.rs
@@ -23,8 +23,8 @@ pub use manager::{
     FetchDatabaseSchemaResult, FetchSchemaForeignKeysParams, FetchSchemaForeignKeysResult,
     FetchSchemaIndexesParams, FetchSchemaIndexesResult, FetchSchemaTypesParams,
     FetchSchemaTypesResult, FetchTableDetailsParams, FetchTableDetailsResult, HookExecutionContext,
-    OwnedCacheEntry, PendingOperation, RedisKeyCache, RedisKeyCacheEntry, ResolvedProxy,
-    SchemaCacheKey, SwitchDatabaseParams, SwitchDatabaseResult,
+    OwnedCacheEntry, PendingOperation, PrepareConnectError, RedisKeyCache, RedisKeyCacheEntry,
+    ResolvedProxy, SchemaCacheKey, SwitchDatabaseParams, SwitchDatabaseResult,
 };
 pub use profile::{
     ConnectionProfile, DbConfig, DbKind, SshAuthMethod, SshTunnelConfig, SshTunnelProfile, SslMode,

--- a/crates/dbflux_core/src/core/mod.rs
+++ b/crates/dbflux_core/src/core/mod.rs
@@ -11,7 +11,9 @@ pub use error_formatter::{
     QueryErrorFormatter, sanitize_uri,
 };
 pub use shutdown::{ShutdownCoordinator, ShutdownPhase};
-pub use task::{CancelToken, TaskId, TaskKind, TaskManager, TaskSlot, TaskSnapshot, TaskStatus};
+pub use task::{
+    CancelToken, TaskId, TaskKind, TaskManager, TaskSlot, TaskSnapshot, TaskStatus, TaskTarget,
+};
 pub use traits::{
     CodeGenScope, CodeGeneratorInfo, Connection, DbDriver, KeyValueApi, NoopCancelHandle,
     QueryCancelHandle, SchemaFeatures, SchemaLoadingStrategy,

--- a/crates/dbflux_core/src/core/task.rs
+++ b/crates/dbflux_core/src/core/task.rs
@@ -9,6 +9,12 @@ use crate::HookPhase;
 
 pub type TaskId = Uuid;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskTarget {
+    pub profile_id: Uuid,
+    pub database: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskKind {
     Query,
@@ -96,6 +102,7 @@ pub struct Task {
     pub progress: Option<f32>,
     pub details: Option<String>,
     pub profile_id: Option<Uuid>,
+    pub target: Option<TaskTarget>,
     cancel_token: CancelToken,
 }
 
@@ -127,6 +134,7 @@ pub struct TaskSnapshot {
     pub details: Option<String>,
     pub is_cancellable: bool,
     pub profile_id: Option<Uuid>,
+    pub target: Option<TaskTarget>,
 }
 
 impl From<&Task> for TaskSnapshot {
@@ -141,6 +149,7 @@ impl From<&Task> for TaskSnapshot {
             details: task.details.clone(),
             is_cancellable: task.is_cancellable(),
             profile_id: task.profile_id,
+            target: task.target.clone(),
         }
     }
 }
@@ -162,17 +171,18 @@ impl TaskManager {
         kind: TaskKind,
         description: impl Into<String>,
     ) -> (TaskId, CancelToken) {
-        self.start_for_profile(kind, description, None)
+        self.start_for_target(kind, description, None)
     }
 
-    pub fn start_for_profile(
+    pub fn start_for_target(
         &mut self,
         kind: TaskKind,
         description: impl Into<String>,
-        profile_id: Option<Uuid>,
+        target: Option<TaskTarget>,
     ) -> (TaskId, CancelToken) {
         let id = TaskId::new_v4();
         let cancel_token = CancelToken::new();
+        let profile_id = target.as_ref().map(|target| target.profile_id);
 
         let task = Task {
             id,
@@ -184,6 +194,7 @@ impl TaskManager {
             progress: None,
             details: None,
             profile_id,
+            target,
             cancel_token: cancel_token.clone(),
         };
 

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -12,8 +12,9 @@ mod sql;
 mod storage;
 
 pub use config::{
-    AppConfig, AppConfigStore, DangerousAction, DriverKey, EffectiveSettings, GeneralSettings,
-    GlobalOverrides, RefreshPolicy, RefreshPolicySetting, ScriptEntry, ScriptsDirectory,
+    AppConfig, AppConfigStore, AppConfigWarning, DangerousAction, DriverKey,
+    EXTERNAL_SERVICES_CONFIG_KEY, EffectiveSettings, GeneralSettings, GlobalOverrides,
+    LoadedAppConfig, RefreshPolicy, RefreshPolicySetting, ScriptEntry, ScriptsDirectory,
     ServiceConfig, StartupFocus, ThemeSetting, all_script_extensions, driver_maps_differ,
     filter_entries,
 };
@@ -28,18 +29,18 @@ pub use connection::{
     FetchSchemaIndexesResult, FetchSchemaTypesParams, FetchSchemaTypesResult,
     FetchTableDetailsParams, FetchTableDetailsResult, HookContext, HookExecution,
     HookExecutionContext, HookFailureMode, HookPhase, HookPhaseOutcome, HookResult, HookRunner,
-    Identifiable, ItemManager, OwnedCacheEntry, PendingOperation, ProfileManager, ProxyAuth,
-    ProxyKind, ProxyManager, ProxyProfile, RedisKeyCache, RedisKeyCacheEntry, ResolvedProxy,
-    SchemaCacheKey, SshAuthMethod, SshTunnelConfig, SshTunnelManager, SshTunnelProfile, SslMode,
-    SwitchDatabaseParams, SwitchDatabaseResult,
+    Identifiable, ItemManager, OwnedCacheEntry, PendingOperation, PrepareConnectError,
+    ProfileManager, ProxyAuth, ProxyKind, ProxyManager, ProxyProfile, RedisKeyCache,
+    RedisKeyCacheEntry, ResolvedProxy, SchemaCacheKey, SshAuthMethod, SshTunnelConfig,
+    SshTunnelManager, SshTunnelProfile, SslMode, SwitchDatabaseParams, SwitchDatabaseResult,
 };
 
 pub use core::{
     CancelToken, CodeGenScope, CodeGeneratorInfo, Connection, ConnectionErrorFormatter, DbDriver,
     DbError, DefaultErrorFormatter, ErrorLocation, FormattedError, KeyValueApi, NoopCancelHandle,
-    QueryCancelHandle, QueryErrorFormatter, SchemaFeatures, SchemaLoadingStrategy, TaskTarget,
+    QueryCancelHandle, QueryErrorFormatter, SchemaFeatures, SchemaLoadingStrategy,
     ShutdownCoordinator, ShutdownPhase, TaskId, TaskKind, TaskManager, TaskSlot, TaskSnapshot,
-    TaskStatus, Value, sanitize_uri,
+    TaskStatus, TaskTarget, Value, sanitize_uri,
 };
 
 pub use data::{
@@ -98,6 +99,7 @@ pub use sql::{
     generate_truncate, generate_update_template,
 };
 
+pub use chrono;
 pub use storage::{
     HasSecretRef, HistoryEntry, HistoryManager, HistoryStore, JsonStore, KeyringSecretStore,
     NoopSecretStore, ProfileStore, ProxyStore, RecentFile, RecentFilesStore, SavedQuery,
@@ -105,7 +107,6 @@ pub use storage::{
     SessionTab, SessionTabKind, SshTunnelStore, UiState, UiStateStore, connection_secret_ref,
     create_secret_store, proxy_secret_ref, ssh_tunnel_secret_ref,
 };
-pub use chrono;
 
 // Backward-compatible public module paths for external crates that use
 // `dbflux_core::connection_manager::*` etc.

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -37,7 +37,7 @@ pub use connection::{
 pub use core::{
     CancelToken, CodeGenScope, CodeGeneratorInfo, Connection, ConnectionErrorFormatter, DbDriver,
     DbError, DefaultErrorFormatter, ErrorLocation, FormattedError, KeyValueApi, NoopCancelHandle,
-    QueryCancelHandle, QueryErrorFormatter, SchemaFeatures, SchemaLoadingStrategy,
+    QueryCancelHandle, QueryErrorFormatter, SchemaFeatures, SchemaLoadingStrategy, TaskTarget,
     ShutdownCoordinator, ShutdownPhase, TaskId, TaskKind, TaskManager, TaskSlot, TaskSnapshot,
     TaskStatus, Value, sanitize_uri,
 };
@@ -105,7 +105,6 @@ pub use storage::{
     SessionTab, SessionTabKind, SshTunnelStore, UiState, UiStateStore, connection_secret_ref,
     create_secret_store, proxy_secret_ref, ssh_tunnel_secret_ref,
 };
-
 pub use chrono;
 
 // Backward-compatible public module paths for external crates that use

--- a/crates/dbflux_driver_ipc/src/driver.rs
+++ b/crates/dbflux_driver_ipc/src/driver.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader};
 use std::process::Child;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -14,6 +16,12 @@ use crate::connection::IpcConnection;
 use crate::transport::RpcClient;
 
 static MANAGED_HOSTS: OnceLock<Mutex<HashMap<String, Child>>> = OnceLock::new();
+
+const DEFAULT_MANAGED_HOST_PROGRAM: &str = "dbflux-driver-host";
+const DEFAULT_STARTUP_TIMEOUT_MS: u64 = 5_000;
+const MIN_STARTUP_TIMEOUT_MS: u64 = 1;
+const STARTUP_OUTPUT_TAIL_LINES: usize = 6;
+const STARTUP_OUTPUT_TAIL_BYTES: usize = 4_096;
 
 fn managed_hosts() -> &'static Mutex<HashMap<String, Child>> {
     MANAGED_HOSTS.get_or_init(|| Mutex::new(HashMap::new()))
@@ -101,6 +109,13 @@ pub struct IpcDriverLaunchConfig {
     pub startup_timeout: Duration,
 }
 
+#[derive(Clone, Default)]
+struct StartupOutputCollector {
+    stdout: Arc<Mutex<VecDeque<String>>>,
+    stderr: Arc<Mutex<VecDeque<String>>>,
+    readers: Arc<Mutex<Vec<thread::JoinHandle<()>>>>,
+}
+
 impl IpcDriver {
     pub fn new(
         socket_id: String,
@@ -124,8 +139,78 @@ impl IpcDriver {
         self
     }
 
+    #[allow(clippy::result_large_err)]
+    pub fn build_launch_config(
+        socket_id: &str,
+        command: Option<&str>,
+        args: &[String],
+        env: &HashMap<String, String>,
+        startup_timeout_ms: Option<u64>,
+    ) -> Result<Option<IpcDriverLaunchConfig>, DbError> {
+        Self::validate_socket_id(socket_id)?;
+
+        let program = match command.map(str::trim).filter(|value| !value.is_empty()) {
+            Some(program) => Some(program.to_string()),
+            None if args.is_empty() => None,
+            None => {
+                Self::validate_default_host_launch_args(socket_id, args)?;
+                Some(DEFAULT_MANAGED_HOST_PROGRAM.to_string())
+            }
+        };
+
+        let Some(program) = program else {
+            return Ok(None);
+        };
+
+        let startup_timeout_ms = match startup_timeout_ms {
+            Some(0) => {
+                return Err(DbError::ConnectionFailed(
+                    format!(
+                        "Startup timeout for service '{}' must be at least {} ms",
+                        socket_id, MIN_STARTUP_TIMEOUT_MS
+                    )
+                    .into(),
+                ));
+            }
+            Some(timeout) => timeout,
+            None => DEFAULT_STARTUP_TIMEOUT_MS,
+        };
+
+        let mut env_pairs = env
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Vec<_>>();
+        env_pairs.sort_by(|left, right| left.0.cmp(&right.0));
+
+        Ok(Some(IpcDriverLaunchConfig {
+            program,
+            args: args.to_vec(),
+            env: env_pairs,
+            startup_timeout: Duration::from_millis(startup_timeout_ms),
+        }))
+    }
+
     pub fn socket_id(&self) -> &str {
         &self.socket_id
+    }
+
+    #[allow(clippy::result_large_err)]
+    pub fn validate_socket_id(socket_id: &str) -> Result<(), DbError> {
+        if socket_id.is_empty()
+            || !socket_id
+                .chars()
+                .all(|char| char.is_ascii_alphanumeric() || matches!(char, '.' | '_' | '-'))
+        {
+            return Err(DbError::ConnectionFailed(
+                format!(
+                    "Invalid socket ID '{}': use only letters, numbers, '.', '_' or '-'",
+                    socket_id
+                )
+                .into(),
+            ));
+        }
+
+        Self::parse_socket_name(socket_id).map(|_| ())
     }
 
     #[allow(clippy::result_large_err)]
@@ -263,8 +348,8 @@ impl IpcDriver {
         command
             .args(&launch.args)
             .envs(launch.env.iter().map(|(k, v)| (k, v)))
-            .stdout(Stdio::null())
-            .stderr(Stdio::null());
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
 
         let mut child = command.spawn().map_err(|e| {
             DbError::ConnectionFailed(
@@ -279,6 +364,8 @@ impl IpcDriver {
             child.id()
         );
 
+        let output_collector = StartupOutputCollector::capture_from_child(&mut child);
+
         let deadline = Instant::now() + launch.startup_timeout;
         while Instant::now() < deadline {
             if Self::socket_is_live_for(socket_id)? {
@@ -287,10 +374,14 @@ impl IpcDriver {
             }
 
             if let Some(status) = child.try_wait().map_err(DbError::IoError)? {
+                let details = output_collector.failure_details();
                 return Err(DbError::ConnectionFailed(
-                    format!(
-                        "Driver host '{}' exited before socket was ready ({})",
-                        launch.program, status
+                    Self::with_startup_details(
+                        format!(
+                            "Driver host '{}' exited before socket was ready ({})",
+                            launch.program, status
+                        ),
+                        details,
                     )
                     .into(),
                 ));
@@ -302,11 +393,16 @@ impl IpcDriver {
         let _ = child.kill();
         let _ = child.wait();
 
+        let details = output_collector.failure_details();
+
         Err(DbError::ConnectionFailed(
-            format!(
-                "Driver host '{}' did not become ready within {} ms",
-                launch.program,
-                launch.startup_timeout.as_millis()
+            Self::with_startup_details(
+                format!(
+                    "Driver host '{}' did not become ready within {} ms",
+                    launch.program,
+                    launch.startup_timeout.as_millis()
+                ),
+                details,
             )
             .into(),
         ))
@@ -315,6 +411,242 @@ impl IpcDriver {
     #[allow(clippy::result_large_err)]
     fn ensure_host_running(&self) -> Result<(), DbError> {
         Self::ensure_host_running_for(&self.socket_id, self.launch.as_ref())
+    }
+
+    fn missing_default_host_flag_value(flag: &str) -> DbError {
+        DbError::ConnectionFailed(
+            format!(
+                "Managed external drivers using the default 'dbflux-driver-host' command require a value immediately after '{flag}'"
+            )
+            .into(),
+        )
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn parse_default_host_launch_args(args: &[String]) -> Result<(String, String), DbError> {
+        let mut driver = None;
+        let mut configured_socket = None;
+
+        let mut index = 0;
+        while index < args.len() {
+            match args[index].as_str() {
+                "--driver" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or_else(|| Self::missing_default_host_flag_value("--driver"))?
+                        .clone();
+                    driver = Some(value);
+                    index += 2;
+                }
+                "--socket" => {
+                    let value = args
+                        .get(index + 1)
+                        .ok_or_else(|| Self::missing_default_host_flag_value("--socket"))?
+                        .clone();
+                    configured_socket = Some(value);
+                    index += 2;
+                }
+                "--help" | "-h" => {
+                    return Err(DbError::ConnectionFailed(
+                        "Managed external drivers using the default 'dbflux-driver-host' command cannot use '--help' or '-h'"
+                            .into(),
+                    ));
+                }
+                other => {
+                    return Err(DbError::ConnectionFailed(
+                        format!(
+                            "Managed external drivers using the default 'dbflux-driver-host' command does not accept argument '{}'; use '--driver <name>' and '--socket <name>'",
+                            other
+                        )
+                        .into(),
+                    ));
+                }
+            }
+        }
+
+        let Some(driver) = driver else {
+            return Err(DbError::ConnectionFailed(
+                "Managed external drivers using the default 'dbflux-driver-host' command must include both '--driver' and '--socket' arguments"
+                    .into(),
+            ));
+        };
+
+        if driver.trim().is_empty() || driver.starts_with("--") {
+            return Err(DbError::ConnectionFailed(
+                "Managed external drivers using the default 'dbflux-driver-host' command require a non-empty value for '--driver'"
+                    .into(),
+            ));
+        }
+
+        let Some(configured_socket) = configured_socket else {
+            return Err(DbError::ConnectionFailed(
+                "Managed external drivers using the default 'dbflux-driver-host' command must include both '--driver' and '--socket' arguments"
+                    .into(),
+            ));
+        };
+
+        if configured_socket.trim().is_empty() || configured_socket.starts_with("--") {
+            return Err(DbError::ConnectionFailed(
+                "Managed external drivers using the default 'dbflux-driver-host' command require a non-empty value for '--socket'"
+                    .into(),
+            ));
+        }
+
+        Ok((driver, configured_socket))
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn validate_default_host_launch_args(socket_id: &str, args: &[String]) -> Result<(), DbError> {
+        let (_, configured_socket) = Self::parse_default_host_launch_args(args)?;
+
+        if configured_socket != socket_id {
+            return Err(DbError::ConnectionFailed(
+                format!(
+                    "Managed external driver socket mismatch: service '{}' must launch 'dbflux-driver-host' with '--socket {}'",
+                    socket_id, socket_id
+                )
+                .into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn startup_output_tail(stdout: &str, stderr: &str) -> String {
+        let stdout_tail = Self::trim_recent_bytes(
+            &Self::tail_lines(stdout, STARTUP_OUTPUT_TAIL_LINES).join("\n"),
+            STARTUP_OUTPUT_TAIL_BYTES,
+        );
+        let stderr_tail = Self::trim_recent_bytes(
+            &Self::tail_lines(stderr, STARTUP_OUTPUT_TAIL_LINES).join("\n"),
+            STARTUP_OUTPUT_TAIL_BYTES,
+        );
+
+        let mut sections = Vec::new();
+
+        if !stdout_tail.is_empty() {
+            sections.push(format!("stdout:\n{stdout_tail}"));
+        }
+
+        if !stderr_tail.is_empty() {
+            sections.push(format!("stderr:\n{stderr_tail}"));
+        }
+
+        sections.join("\n\n")
+    }
+
+    fn tail_lines(output: &str, limit: usize) -> Vec<&str> {
+        let lines = output
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .collect::<Vec<_>>();
+
+        let start = lines.len().saturating_sub(limit);
+        lines.into_iter().skip(start).collect()
+    }
+
+    fn with_startup_details(summary: String, details: Option<String>) -> String {
+        match details {
+            Some(details) if !details.is_empty() => {
+                format!("{summary}\n\nRecent host output:\n{details}")
+            }
+            _ => summary,
+        }
+    }
+
+    fn trim_recent_bytes(output: &str, limit: usize) -> String {
+        if output.len() <= limit {
+            return output.to_string();
+        }
+
+        let ellipsis = "…";
+        let content_limit = limit.saturating_sub(ellipsis.len());
+        if content_limit == 0 {
+            return ellipsis.to_string();
+        }
+
+        let mut start = output.len().saturating_sub(content_limit);
+        while !output.is_char_boundary(start) {
+            start += 1;
+        }
+
+        format!("{ellipsis}{}", &output[start..])
+    }
+}
+
+impl StartupOutputCollector {
+    fn capture_from_child(child: &mut Child) -> Self {
+        let collector = Self::default();
+
+        if let Some(stdout) = child.stdout.take() {
+            collector.capture_reader(stdout, collector.stdout.clone());
+        }
+
+        if let Some(stderr) = child.stderr.take() {
+            collector.capture_reader(stderr, collector.stderr.clone());
+        }
+
+        collector
+    }
+
+    fn capture_reader<R>(&self, reader: R, target: Arc<Mutex<VecDeque<String>>>)
+    where
+        R: std::io::Read + Send + 'static,
+    {
+        let handle = thread::spawn(move || {
+            for line in BufReader::new(reader).lines().map_while(Result::ok) {
+                let Ok(mut tail) = target.lock() else {
+                    return;
+                };
+
+                tail.push_back(line);
+                if tail.len() > STARTUP_OUTPUT_TAIL_LINES {
+                    tail.pop_front();
+                }
+            }
+        });
+
+        if let Ok(mut readers) = self.readers.lock() {
+            readers.push(handle);
+        }
+    }
+
+    fn wait_for_readers(&self) {
+        let Ok(mut readers) = self.readers.lock() else {
+            return;
+        };
+
+        for handle in readers.drain(..) {
+            let _ = handle.join();
+        }
+    }
+
+    fn failure_details(&self) -> Option<String> {
+        self.wait_for_readers();
+
+        let stdout = self
+            .stdout
+            .lock()
+            .ok()?
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n");
+        let stderr = self
+            .stderr
+            .lock()
+            .ok()?
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+            .join("\n");
+        let details = IpcDriver::startup_output_tail(&stdout, &stderr);
+
+        if details.is_empty() {
+            None
+        } else {
+            Some(details)
+        }
     }
 }
 
@@ -425,5 +757,251 @@ impl dbflux_core::DbDriver for IpcDriver {
         let _ = client.close_session(session_id);
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_launch_config_keeps_explicit_command_and_args() {
+        let config = IpcDriver::build_launch_config(
+            "demo.sock",
+            Some("custom-host"),
+            &["--flag".to_string()],
+            &HashMap::from([("KEY".to_string(), "VALUE".to_string())]),
+            Some(9_000),
+        )
+        .unwrap();
+
+        let config = config.expect("explicit command should build launch config");
+
+        assert_eq!(config.program, "custom-host");
+        assert_eq!(config.args, vec!["--flag"]);
+        assert_eq!(config.env, vec![("KEY".to_string(), "VALUE".to_string())]);
+        assert_eq!(config.startup_timeout, Duration::from_millis(9_000));
+    }
+
+    #[test]
+    fn build_launch_config_defaults_timeout_and_driver_host_when_valid() {
+        let config = IpcDriver::build_launch_config(
+            "demo.sock",
+            None,
+            &[
+                "--driver".to_string(),
+                "demo".to_string(),
+                "--socket".to_string(),
+                "demo.sock".to_string(),
+            ],
+            &HashMap::new(),
+            None,
+        )
+        .unwrap();
+
+        let config = config.expect("default host args should build launch config");
+
+        assert_eq!(config.program, "dbflux-driver-host");
+        assert_eq!(config.startup_timeout, Duration::from_millis(5_000));
+    }
+
+    #[test]
+    fn build_launch_config_rejects_default_driver_host_without_required_args() {
+        let error = IpcDriver::build_launch_config(
+            "demo.sock",
+            None,
+            &["--driver".to_string(), "demo".to_string()],
+            &HashMap::new(),
+            None,
+        )
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("--socket"));
+        assert!(message.contains("dbflux-driver-host"));
+    }
+
+    #[test]
+    fn build_launch_config_rejects_default_driver_host_socket_mismatch() {
+        let error = IpcDriver::build_launch_config(
+            "expected.sock",
+            None,
+            &[
+                "--driver".to_string(),
+                "demo".to_string(),
+                "--socket".to_string(),
+                "other.sock".to_string(),
+            ],
+            &HashMap::new(),
+            None,
+        )
+        .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("socket mismatch"));
+        assert!(message.contains("expected.sock"));
+    }
+
+    #[test]
+    fn build_launch_config_uses_last_duplicate_socket_flag_value() {
+        let config = IpcDriver::build_launch_config(
+            "expected.sock",
+            None,
+            &[
+                "--driver".to_string(),
+                "demo".to_string(),
+                "--socket".to_string(),
+                "wrong.sock".to_string(),
+                "--socket".to_string(),
+                "expected.sock".to_string(),
+            ],
+            &HashMap::new(),
+            None,
+        )
+        .unwrap();
+
+        let config = config.expect("duplicate socket args should still build launch config");
+
+        assert_eq!(config.program, "dbflux-driver-host");
+    }
+
+    #[test]
+    fn build_launch_config_rejects_equals_syntax_for_default_driver_host_flags() {
+        let error = IpcDriver::build_launch_config(
+            "demo.sock",
+            None,
+            &[
+                "--driver=demo".to_string(),
+                "--socket=demo.sock".to_string(),
+            ],
+            &HashMap::new(),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not accept argument '--driver=demo'")
+        );
+    }
+
+    #[test]
+    fn build_launch_config_rejects_unknown_default_driver_host_flags() {
+        let error = IpcDriver::build_launch_config(
+            "demo.sock",
+            None,
+            &[
+                "--driver".to_string(),
+                "demo".to_string(),
+                "--socket".to_string(),
+                "demo.sock".to_string(),
+                "--verbose".to_string(),
+            ],
+            &HashMap::new(),
+            None,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not accept argument '--verbose'")
+        );
+    }
+
+    #[test]
+    fn build_launch_config_allows_manual_service_without_launch_command() {
+        let config =
+            IpcDriver::build_launch_config("live.sock", None, &[], &HashMap::new(), None).unwrap();
+
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn build_launch_config_allows_manual_service_with_unused_zero_timeout() {
+        let config =
+            IpcDriver::build_launch_config("live.sock", None, &[], &HashMap::new(), Some(0))
+                .unwrap();
+
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn build_launch_config_rejects_zero_timeout() {
+        let error = IpcDriver::build_launch_config(
+            "demo.sock",
+            Some("custom-host"),
+            &[],
+            &HashMap::new(),
+            Some(0),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("at least 1 ms"));
+    }
+
+    #[test]
+    fn startup_output_tail_keeps_recent_stdout_and_stderr_lines() {
+        let stdout = (1..=8)
+            .map(|index| format!("stdout-{index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let stderr = (1..=8)
+            .map(|index| format!("stderr-{index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let details = IpcDriver::startup_output_tail(&stdout, &stderr);
+
+        assert!(details.contains("stdout-8"));
+        assert!(details.contains("stderr-8"));
+        assert!(!details.contains("stdout-1"));
+        assert!(!details.contains("stderr-1"));
+    }
+
+    #[test]
+    fn startup_output_tail_truncates_large_output_by_bytes() {
+        let details =
+            IpcDriver::startup_output_tail(&"x".repeat(STARTUP_OUTPUT_TAIL_LINES * 2_000), "");
+
+        assert!(details.len() <= 4_096 + "stdout:\n".len());
+    }
+
+    #[test]
+    fn startup_output_collector_waits_for_readers_before_reporting_failure_details() {
+        struct SlowReader {
+            bytes: std::io::Cursor<Vec<u8>>,
+            delay_applied: bool,
+        }
+
+        impl SlowReader {
+            fn new(contents: &str) -> Self {
+                Self {
+                    bytes: std::io::Cursor::new(contents.as_bytes().to_vec()),
+                    delay_applied: false,
+                }
+            }
+        }
+
+        impl std::io::Read for SlowReader {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                if !self.delay_applied {
+                    self.delay_applied = true;
+                    thread::sleep(Duration::from_millis(25));
+                }
+
+                self.bytes.read(buf)
+            }
+        }
+
+        let collector = StartupOutputCollector::default();
+        collector.capture_reader(SlowReader::new("stderr-line\n"), collector.stderr.clone());
+
+        let details = collector
+            .failure_details()
+            .expect("collector should include stderr");
+
+        assert!(details.contains("stderr-line"));
     }
 }

--- a/crates/dbflux_driver_mongodb/Cargo.toml
+++ b/crates/dbflux_driver_mongodb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbflux_driver_mongodb"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 publish = false
 authors.workspace = true

--- a/crates/dbflux_driver_mysql/Cargo.toml
+++ b/crates/dbflux_driver_mysql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbflux_driver_mysql"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 publish = false
 authors.workspace = true

--- a/crates/dbflux_driver_postgres/Cargo.toml
+++ b/crates/dbflux_driver_postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbflux_driver_postgres"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 publish = false
 authors.workspace = true

--- a/crates/dbflux_driver_redis/Cargo.toml
+++ b/crates/dbflux_driver_redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbflux_driver_redis"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 publish = false
 authors.workspace = true

--- a/crates/dbflux_driver_sqlite/Cargo.toml
+++ b/crates/dbflux_driver_sqlite/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "dbflux_driver_sqlite"
+version.workspace = true
 edition.workspace = true
 publish = false
 authors.workspace = true

--- a/crates/dbflux_export/Cargo.toml
+++ b/crates/dbflux_export/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbflux_export"
-version = "0.1.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 authors.workspace = true

--- a/crates/dbflux_ssh/Cargo.toml
+++ b/crates/dbflux_ssh/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbflux_ssh"
-version = "0.1.0"
+version.workspace = true
 publish = false
 edition.workspace = true
 authors.workspace = true

--- a/crates/dbflux_test_support/Cargo.toml
+++ b/crates/dbflux_test_support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dbflux_test_support"
-version = "0.1.0"
+version.workspace = true
 edition.workspace = true
 publish = false
 authors.workspace = true

--- a/docs/DRIVER_RPC_PROTOCOL.md
+++ b/docs/DRIVER_RPC_PROTOCOL.md
@@ -14,14 +14,14 @@ For external services, **the driver service is the source of truth** for:
 
 ## Integration model
 
-At app startup, DBFlux reads `~/.config/dbflux/config.json`, then for each `rpc_service`:
+At app startup, DBFlux reads `~/.config/dbflux/config.json`, then for each configured `services` entry:
 
 1. ensures the service is running (starts it if needed)
 2. performs a `Hello` handshake
 3. reads `driver_kind`, `driver_metadata`, and `form_definition` from the service
 4. registers the driver in-memory so it appears in the connection manager
 
-If any step fails, that service is skipped and not shown in the UI.
+If any step fails, that service is skipped and not shown as a usable driver. DBFlux also keeps a startup diagnostic so the failure can be surfaced in Settings and connect-time errors.
 
 Important behavior:
 
@@ -54,7 +54,7 @@ Schema used by DBFlux:
 
 ```json
 {
-  "rpc_services": [
+  "services": [
     {
       "socket_id": "my-driver.sock",
       "command": "/absolute/path/to/driver-binary",
@@ -71,7 +71,11 @@ Schema used by DBFlux:
 Notes:
 
 - `socket_id` is required.
-- `command` is optional. If omitted, DBFlux uses `dbflux-driver-host`.
+- `services` is the only supported config key.
+- `command` is optional.
+  - If `command` is omitted and `args` is empty, DBFlux expects the service to already be running.
+  - If `command` is omitted and `args` is non-empty, DBFlux launches `dbflux-driver-host`.
+  - In that default-host mode, `args` must include both `--driver` and `--socket`.
 - `args`, `env`, and `startup_timeout_ms` are optional.
 - DBFlux derives an internal registry key as `rpc:<socket_id>`.
 
@@ -199,7 +203,7 @@ Use `InvalidRequest` for malformed profiles/form values and `UnsupportedMethod` 
 
 ## Process lifecycle and cleanup
 
-When DBFlux starts a service process itself (via `command`), that process is tracked as a managed host.
+When DBFlux starts a service process itself (via `command` or the supported default host command), that process is tracked as a managed host.
 
 On DBFlux shutdown:
 
@@ -207,6 +211,8 @@ On DBFlux shutdown:
 - hosts started manually outside DBFlux are not tracked and are not killed
 
 This guarantees DBFlux cleans up only the processes it owns.
+
+If a managed host exits early or times out before the socket is ready, DBFlux reports the service id together with a bounded tail of recent stdout/stderr to aid troubleshooting.
 
 ## Minimal implementation checklist
 

--- a/docs/RPC_SERVICES_CONFIG.md
+++ b/docs/RPC_SERVICES_CONFIG.md
@@ -12,7 +12,7 @@ DBFlux reads this file at startup.
 
 ```json
 {
-  "rpc_services": [
+  "services": [
     {
       "socket_id": "my-driver.sock",
       "command": "/absolute/path/to/driver",
@@ -29,8 +29,13 @@ DBFlux reads this file at startup.
 ## Fields
 
 - `socket_id` (required): local socket name used by DBFlux and the service.
+  - Allowed characters: ASCII letters, numbers, `.`, `_`, `-`
+  - Path separators, spaces, and other punctuation are rejected.
+  - The value is passed to the platform socket namespace as-is, so keep it short and stable.
 - `command` (optional): executable to run when DBFlux needs to start the service.
-  - Default: `dbflux-driver-host`
+  - If omitted and `args` is also empty, DBFlux treats the service as already running and does not spawn anything.
+  - If omitted and `args` is non-empty, DBFlux launches `dbflux-driver-host`.
+  - In that default-host mode, `args` must include both `--driver` and `--socket` so the host can start correctly.
 - `args` (optional): process arguments.
 - `env` (optional): environment variables for the spawned process.
 - `startup_timeout_ms` (optional): max wait time for socket readiness after spawn.
@@ -42,12 +47,13 @@ DBFlux reads this file at startup.
 - DBFlux internally identifies each service as `rpc:<socket_id>`.
 - Driver name/icon/category/form are **not** configured here.
   - They come from service `Hello` response (`driver_metadata`, `form_definition`).
+- `services` is the canonical key.
 
 ## Minimal example (service provides everything)
 
 ```json
 {
-  "rpc_services": [
+  "services": [
     {
       "socket_id": "my-test-driver.sock",
       "command": "/home/user/dbflux/examples/custom_driver/target/debug/custom-driver",
@@ -60,6 +66,7 @@ DBFlux reads this file at startup.
 ## Common mistakes
 
 - Mismatched socket names between config and service args.
+- Omitting `command` while providing partial `args`; if you want DBFlux to launch the default host, `args` must include both `--driver` and `--socket`.
 - Relative `command` path that does not resolve under DBFlux process environment.
 - Editing config without restarting DBFlux.
 - Service not implementing `Hello` fields required by current protocol.

--- a/examples/custom_driver/README.md
+++ b/examples/custom_driver/README.md
@@ -45,7 +45,7 @@ DBFlux now treats the external service as the source of truth for driver metadat
 
 ```json
 {
-  "rpc_services": [
+  "services": [
     {
       "socket_id": "my-test-driver.sock",
       "command": "/ABSOLUTE/PATH/TO/examples/custom_driver/target/debug/custom-driver",
@@ -74,8 +74,10 @@ DBFlux now treats the external service as the source of truth for driver metadat
 ## Notes
 
 - The service key used internally by DBFlux is `rpc:<socket_id>`.
-- If `command` is omitted, DBFlux defaults to `dbflux-driver-host`.
+- If `command` and `args` are both omitted, DBFlux expects this service to already be running.
+- If `command` is omitted but `args` is present, DBFlux launches `dbflux-driver-host`, and your `args` must include both `--driver` and `--socket`.
 - Use absolute paths for `command` while testing to avoid PATH issues.
+- DBFlux only reads the canonical `services` key.
 
 ## Queries to try
 
@@ -88,7 +90,7 @@ DELETE FROM users WHERE id = 1
 
 ## Troubleshooting
 
-- **Driver does not appear in UI**: check DBFlux logs for probe/launch errors.
+- **Driver does not appear in UI**: check the Services settings panel and DBFlux logs for launch/probe diagnostics.
 - **Connection refused**: ensure `socket_id` matches between config and `--socket` arg.
 - **Permission denied**: ensure the binary in `command` is executable.
 - **Version mismatch**: ensure example and DBFlux are built from compatible code.

--- a/examples/custom_driver/config.example.json
+++ b/examples/custom_driver/config.example.json
@@ -1,5 +1,5 @@
 {
-  "rpc_services": [
+  "services": [
     {
       "socket_id": "my-test-driver.sock",
       "command": "/ABSOLUTE/PATH/TO/examples/custom_driver/target/debug/custom-driver",

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
         # Import default.nix with crane support
         dbflux = import ./default.nix {
           inherit pkgs craneLib;
-          version = "0.2.0";
+          version = "0.3.7";
         };
 
         # Main package built with crane

--- a/resources/windows/installer.iss
+++ b/resources/windows/installer.iss
@@ -1,6 +1,6 @@
 #define MyAppName "DBFlux"
 #ifndef MyAppVersion
-#define MyAppVersion "0.3.0"
+#define MyAppVersion "0.3.7"
 #endif
 #define MyAppPublisher "Ignacio Perez"
 #define MyAppURL "https://github.com/0xErwin1/dbflux"


### PR DESCRIPTION
## Summary

- harden the current external-driver RPC path with stricter launch validation, bounded diagnostics, and clearer startup/connect failure surfacing
- remove `rpc_services` as a supported config path while preserving unrelated config sections and making the Services screen own canonical `services` updates
- align Settings, docs, and the custom-driver example with the supported external-driver workflow

## What does this resolve?

- Resolves #31

## How was this solved?

- tightened managed-host validation and diagnostics in the current driver-only RPC path, including manual-service vs managed-host behavior and actionable user-facing failure stages
- updated config loading/persistence so canonical `services` is the supported path, legacy `rpc_services` is no longer supported, and unrelated config sections are not lost during migration or settings saves
- refreshed Settings, architecture/docs, and the shipped custom-driver example to match the supported workflow and error handling model

## Validation

- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- multiple judgment-day review/fix iterations before commit

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [x] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable

## Known limitations / follow-up

- The change was archived and committed after several judgment-day rounds; a few suspect warnings remained around validation parity and deeper end-to-end behavioral proof, but no critical blockers remained and all workspace gates passed.