### PR TITLE
feat(cloudwatch): add built-in logs integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -247,6 +247,15 @@ Architecture details live in `ARCHITECTURE.md`. This file only keeps the agent-f
 
 **Never add driver-specific logic in UI code.** The UI must remain agnostic to specific database implementations.
 
+**This rule is strict and applies to both `dbflux_ui` and app-layer orchestration code.** Do not branch on concrete driver IDs or driver names in the app/UI layer, and do not add direct references to specific drivers there unless the code is only registering/building the driver itself.
+
+In practice, this means:
+
+- No `if driver_id == "..."` or `match driver_id` checks in `dbflux_ui` or app-facing workflow code.
+- No CloudWatch/MongoDB/Redis/etc. special cases in document rendering, sidebar routing, workspace tab opening, or query-context controls.
+- The core must expose the seam the UI needs, and the driver must populate or implement that seam.
+- The UI may only respond to generic core abstractions such as metadata, capabilities, collection presentation hints, child-source descriptors, event-stream targets, and source-context specs.
+
 Instead of:
 
 ```rust
@@ -278,6 +287,10 @@ Key abstractions for UI adaptation:
 - `DatabaseCategory`: Determines view mode (table vs document tree), terminology (rows vs documents)
 - `QueryLanguage`: Determines editor syntax highlighting, placeholder text, comment prefix
 - `DriverCapabilities`: Determines which features to enable (pagination, transactions, etc.)
+- `CollectionPresentation`: Determines how a collection/container opens (for example data grid vs event stream)
+- `CollectionChildInfo`: Declares driver-owned child sources that appear in the sidebar without the UI inferring them from driver-specific conventions
+- `EventStreamTarget`: Lets the workspace/audit viewer open driver-backed event streams without embedding driver-specific routing
+- `SourceContextSpec`: Lets drivers declare extra query-context controls while the UI stays generic
 
 ### Generic Deduplication Patterns
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -379,6 +379,7 @@ crates/
 
 - `DocumentHandle` manages document lifecycle as GPUI entities
 - `CodeDocument` provides language-aware editing for queries and scripts (SQL/MongoDB/Redis/Lua/Python/Bash) with multiple result tabs and live output for scripts. Connection/database/schema controls are only shown for languages that support connection context.
+- Driver-owned source-context controls are declared through generic core seams (`SourceContextSpec`, `ExecutionSourceContext`) and rendered generically by `CodeDocument`; no driver-specific query-context widgets should live in the UI layer.
 - Auto-save: tabs auto-save to scratch files (untitled) or shadow files (file-backed) on a 2-second debounce. Explicit Ctrl+S writes to the original file. Tabs close without warnings.
 - Session restore: `SessionStore` persists a manifest of open tabs to `~/.local/share/dbflux/sessions/`. On startup, all tabs are restored with conflict detection for externally modified files.
 - `DataDocument` enables standalone data browsing independent of queries
@@ -398,6 +399,7 @@ crates/
 ### Schema & Navigation
 
 - Sidebar: `crates/dbflux_ui/src/ui/views/sidebar/` displays two tabs — Connections (schema tree with folder organization, drag-drop, multi-selection) and Scripts (file/folder management for saved query files, script hooks, and other user files). Switch tabs with `q` or `e` keys. Shows tables/collections, columns, indexes per database category with lazy loading.
+- Driver-owned child resources under collections/containers are published through generic `CollectionChildInfo` metadata. The sidebar must not infer driver-specific children from names, field types, or driver IDs.
 - Sidebar dock: `crates/dbflux_ui/src/ui/dock/sidebar_dock.rs` provides collapsible, resizable sidebar with ToggleSidebar command (Ctrl+B).
 - Connection tree: `crates/dbflux_core/src/connection/tree.rs` models folders and connections as a tree structure with persistence via `connection_tree_store.rs`.
 
@@ -409,10 +411,16 @@ crates/
   - `DriverCapabilities`: bitflags for features like PAGINATION, TRANSACTIONS, NESTED_DOCUMENTS, etc.
   - `DriverMetadata`: static driver info (id, name, category, query_language, capabilities, icon)
 - **Error formatting**: `crates/dbflux_core/src/core/error_formatter.rs` provides `ErrorFormatter` trait for driver-specific error messages with context (detail, hint, column, table, constraint).
-- Core domain API: `crates/dbflux_core/src/core/traits.rs` defines `DbDriver`, `Connection`, SQL generation, and cancellation contracts.
+- Core domain API: `crates/dbflux_core/src/core/traits.rs` defines `DbDriver`, `Connection`, SQL generation, cancellation contracts, and generic driver-to-UI seams such as `EventStreamTarget` and `SourceContextSpec`.
 - **Query generation**: `crates/dbflux_core/src/query/generator.rs` defines `QueryGenerator` as the driver-owned source of truth for mutation text plus read/query templates. SQL drivers use `SqlMutationGenerator`; MongoDB, Redis, and DynamoDB expose their own native generators. The UI and MCP access generators through `Connection::query_generator()` so previews and copied queries come from the driver rather than a UI-local formatter.
 - Driver forms: `crates/dbflux_core/src/driver/form.rs` defines dynamic form schemas that drivers provide for connection configuration. Supports both form-based and URI connection modes.
-- **Driver/UI decoupling**: The UI never checks driver IDs directly. Instead, it uses `DriverMetadata` abstractions (`DatabaseCategory`, `QueryLanguage`, `DriverCapabilities`) to adapt behavior. This allows new drivers to work automatically without UI changes.
+- **Driver/UI decoupling**: The UI and app orchestration layers must never branch on concrete driver IDs or embed driver-specific routing. The core exposes the seams, and drivers fill them.
+  - `DriverMetadata` covers broad adaptation (`DatabaseCategory`, `QueryLanguage`, `DriverCapabilities`).
+  - `CollectionPresentation` tells the UI how a collection/container opens (for example data grid vs event stream).
+  - `CollectionChildInfo` lets drivers publish child sources under a collection/container without UI heuristics.
+  - `EventStreamTarget` gives workspace/audit a generic identifier for driver-backed event streams.
+  - `SourceContextSpec` lets drivers declare extra query-context controls without hardcoding driver names in `dbflux_ui`.
+  - If the UI needs new behavior, add a generic core abstraction first; do not add `if driver_id == ...` in `dbflux_ui` or app-facing workflow code.
 
 ### Auth & Access Pipeline
 
@@ -505,7 +513,7 @@ crates/
 
 **Session persistence**: Scratch/shadow files and session manifest in `~/.local/share/dbflux/sessions/` for tab restore on startup.
 
-**Execution context**: `crates/dbflux_core/src/connection/context.rs` tracks per-tab connection, database, and schema selection; serialized as annotation comments in saved files.
+**Execution context**: `crates/dbflux_core/src/connection/context.rs` tracks per-tab connection, database, schema, and generic driver-declared source context. The current generic source-window shape is `ExecutionSourceContext::CollectionWindow { targets, start_ms, end_ms }`. Only connection/database/schema annotations are serialized into saved file headers.
 
 **History modal**: `crates/dbflux_ui/src/ui/overlays/history_modal.rs` provides a unified modal for browsing recent queries and saved queries with search, favorites, and rename support.
 
@@ -601,7 +609,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 **UI Integration**:
 - `McpApprovalsView` (`crates/dbflux_ui/src/ui/document/governance.rs`) for reviewing pending executions
 - `mcp_section.rs` in Settings for trusted clients, roles, and policies
-- `AuditDocument` (`crates/dbflux_ui/src/ui/document/audit.rs`) as the unified audit viewer for all event categories (no separate MCP audit surface)
+- `AuditDocument` (`crates/dbflux_ui/src/ui/document/audit/`) as the unified event viewer for both internal audit records and driver-backed external event streams exposed through generic `EventStreamTarget`s (no driver-specific audit document path in the UI)
 - `LoginModal` and `SsoWizard` overlays for AWS SSO authentication flow
 
 ## Data Flow
@@ -611,7 +619,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 - Connect flow: `AppState::prepare_pipeline_input` builds a provider-agnostic pre-connect pipeline input. The pipeline runs auth/session validation, dynamic value resolution, and managed/direct access setup before driver connect + schema fetch. Supports form-based configuration, direct URI input, optional proxy/SSH, and managed access (`aws-ssm`). Connection hooks still run at each phase (PreConnect, PostConnect, PreDisconnect, PostDisconnect).
 - Query flow: `CodeDocument` submits database queries to a `Connection` implementation when the active `QueryLanguage` supports connection context. The query language (SQL/MongoDB/etc) is determined by driver metadata. Results are rendered in result tabs within the document. Dangerous queries (DELETE without WHERE, DROP, TRUNCATE) trigger confirmation dialogs (handled in `code/execution.rs`).
 - Script flow: `CodeDocument` executes Lua, Python, and Bash documents as script hooks rather than database queries. Script runs create a local output channel, stream live text into a document-owned buffer, and keep the final output as a text result when execution completes.
-- View mode selection: `DataGridPanel` (in `document/data_grid_panel/`) automatically selects appropriate view mode based on database category—Table view for relational databases, Document tree view for document databases like MongoDB and DynamoDB, key-value view for Redis. Context menus include "Copy as Query" for generating driver-specific mutation statements/envelopes via `QueryGenerator`.
+- View mode selection: `DataGridPanel` (in `document/data_grid_panel/`) automatically selects appropriate view mode based on database category—Table view for relational databases, Document tree view for document databases like MongoDB and DynamoDB, key-value view for Redis. Event-stream-like document containers are opened through `CollectionPresentation::EventStream` rather than UI-side driver checks. Context menus include "Copy as Query" for generating driver-specific mutation statements/envelopes via `QueryGenerator`.
 - Query preview: `SqlPreviewModal` (in `overlays/sql_preview_modal.rs`) routes relational read/DML previews through `QueryGenerator` for row, table, and view previews, while DDL stays on `CodeGenerator`. Non-SQL languages (MongoDB, Redis) still use generic preview mode with static text and language-specific syntax highlighting.
 - Schema refresh: `Workspace::refresh_schema` runs `Connection::schema` on a background executor and updates `AppState` (crates/dbflux_ui/src/ui/views/workspace/).
 - Lazy loading: Drivers fetch table/collection metadata (columns, indexes) on-demand when items are expanded in sidebar, not during initial connection (performance optimization for large databases).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,6 +247,15 @@ Architecture details live in `ARCHITECTURE.md`. This file only keeps the agent-f
 
 **Never add driver-specific logic in UI code.** The UI must remain agnostic to specific database implementations.
 
+**This rule is strict and applies to both `dbflux_ui` and app-layer orchestration code.** Do not branch on concrete driver IDs or driver names in the app/UI layer, and do not add direct references to specific drivers there unless the code is only registering/building the driver itself.
+
+In practice, this means:
+
+- No `if driver_id == "..."` or `match driver_id` checks in `dbflux_ui` or app-facing workflow code.
+- No CloudWatch/MongoDB/Redis/etc. special cases in document rendering, sidebar routing, workspace tab opening, or query-context controls.
+- The core must expose the seam the UI needs, and the driver must populate or implement that seam.
+- The UI may only respond to generic core abstractions such as metadata, capabilities, collection presentation hints, child-source descriptors, event-stream targets, and source-context specs.
+
 Instead of:
 
 ```rust
@@ -278,6 +287,10 @@ Key abstractions for UI adaptation:
 - `DatabaseCategory`: Determines view mode (table vs document tree), terminology (rows vs documents)
 - `QueryLanguage`: Determines editor syntax highlighting, placeholder text, comment prefix
 - `DriverCapabilities`: Determines which features to enable (pagination, transactions, etc.)
+- `CollectionPresentation`: Determines how a collection/container opens (for example data grid vs event stream)
+- `CollectionChildInfo`: Declares driver-owned child sources that appear in the sidebar without the UI inferring them from driver-specific conventions
+- `EventStreamTarget`: Lets the workspace/audit viewer open driver-backed event streams without embedding driver-specific routing
+- `SourceContextSpec`: Lets drivers declare extra query-context controls while the UI stays generic
 
 ### Generic Deduplication Patterns
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -652,6 +653,31 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-cloudwatchlogs"
+version = "1.119.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9dcb178173d324aabcb02d6856655b13be5ae1aa5f8f2d8ce3522e174b74256"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -806,6 +832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37411f8e0f4bea0c3ca0958ce7f18f6439db24d555dbd809787262cd00926aa9"
 dependencies = [
  "aws-credential-types",
+ "aws-smithy-eventstream",
  "aws-smithy-http",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -833,11 +860,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c0b3e587fbaa5d7f7e870544508af8ce82ea47cd30376e69e1e37c4ac746f79"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
 name = "aws-smithy-http"
 version = "0.63.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d619373d490ad70966994801bc126846afaa0d1ee920697a031f0cf63f2568e7"
 dependencies = [
+ "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -2195,6 +2234,7 @@ dependencies = [
  "dbflux_audit",
  "dbflux_aws",
  "dbflux_core",
+ "dbflux_driver_cloudwatch",
  "dbflux_driver_dynamodb",
  "dbflux_driver_ipc",
  "dbflux_driver_mongodb",
@@ -2238,6 +2278,7 @@ dependencies = [
  "dbflux_audit",
  "dbflux_aws",
  "dbflux_core",
+ "dbflux_driver_cloudwatch",
  "dbflux_driver_dynamodb",
  "dbflux_driver_ipc",
  "dbflux_driver_mongodb",
@@ -2344,6 +2385,18 @@ dependencies = [
  "tree-sitter-sequel",
  "urlencoding",
  "uuid",
+]
+
+[[package]]
+name = "dbflux_driver_cloudwatch"
+version = "0.5.0-dev.1"
+dependencies = [
+ "aws-config",
+ "aws-sdk-cloudwatchlogs",
+ "dbflux_core",
+ "log",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -2655,6 +2708,7 @@ dependencies = [
  "dbflux_aws",
  "dbflux_components",
  "dbflux_core",
+ "dbflux_driver_cloudwatch",
  "dbflux_driver_dynamodb",
  "dbflux_driver_ipc",
  "dbflux_driver_mongodb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/dbflux_driver_mongodb",
     "crates/dbflux_driver_redis",
     "crates/dbflux_driver_dynamodb",
+    "crates/dbflux_driver_cloudwatch",
     "crates/dbflux_ssh",
     "crates/dbflux_proxy",
     "crates/dbflux_tunnel_core",
@@ -52,6 +53,7 @@ dbflux_driver_mysql = { path = "crates/dbflux_driver_mysql" }
 dbflux_driver_mongodb = { path = "crates/dbflux_driver_mongodb" }
 dbflux_driver_redis = { path = "crates/dbflux_driver_redis" }
 dbflux_driver_dynamodb = { path = "crates/dbflux_driver_dynamodb" }
+dbflux_driver_cloudwatch = { path = "crates/dbflux_driver_cloudwatch" }
 dbflux_ssh = { path = "crates/dbflux_ssh" }
 dbflux_proxy = { path = "crates/dbflux_proxy" }
 dbflux_export = { path = "crates/dbflux_export" }

--- a/crates/dbflux/Cargo.toml
+++ b/crates/dbflux/Cargo.toml
@@ -64,6 +64,10 @@ optional = true
 workspace = true
 optional = true
 
+[dependencies.dbflux_driver_cloudwatch]
+workspace = true
+optional = true
+
 [dependencies.dbflux_aws]
 workspace = true
 optional = true
@@ -105,13 +109,14 @@ workspace = true
 optional = true
 
 [features]
-default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "lua", "aws", "mcp"]
+default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "lua", "aws", "mcp"]
 sqlite = ["dbflux_app/sqlite", "dbflux_ui/sqlite"]
 postgres = ["dbflux_app/postgres", "dbflux_ui/postgres"]
 mysql = ["dbflux_app/mysql", "dbflux_ui/mysql"]
 mongodb = ["dbflux_app/mongodb", "dbflux_ui/mongodb"]
 redis = ["dbflux_app/redis", "dbflux_ui/redis"]
 dynamodb = ["dbflux_app/dynamodb", "dbflux_ui/dynamodb"]
+cloudwatch = ["dbflux_driver_cloudwatch", "dbflux_app/cloudwatch", "dbflux_ui/cloudwatch"]
 lua = ["dbflux_lua", "dbflux_app/lua", "dbflux_ui/lua"]
 aws = ["dbflux_aws", "dbflux_ssm", "dbflux_app/aws", "dbflux_ui/aws"]
 mcp = ["dbflux_mcp", "dbflux_mcp_server", "dbflux_policy", "dbflux_approval", "dbflux_app/mcp", "dbflux_ui/mcp"]

--- a/crates/dbflux_app/Cargo.toml
+++ b/crates/dbflux_app/Cargo.toml
@@ -24,6 +24,7 @@ dbflux_driver_mysql = { workspace = true, optional = true }
 dbflux_driver_mongodb = { workspace = true, optional = true }
 dbflux_driver_redis = { workspace = true, optional = true }
 dbflux_driver_dynamodb = { workspace = true, optional = true }
+dbflux_driver_cloudwatch = { workspace = true, optional = true }
 dbflux_lua = { workspace = true, optional = true }
 dbflux_mcp = { workspace = true, optional = true }
 dbflux_mcp_server = { workspace = true, optional = true }
@@ -38,13 +39,14 @@ indexmap.workspace = true
 async-trait = "0.1"
 
 [features]
-default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb"]
+default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch"]
 sqlite = ["dbflux_driver_sqlite"]
 postgres = ["dbflux_driver_postgres"]
 mysql = ["dbflux_driver_mysql"]
 mongodb = ["dbflux_driver_mongodb"]
 redis = ["dbflux_driver_redis"]
 dynamodb = ["dbflux_driver_dynamodb"]
+cloudwatch = ["dbflux_driver_cloudwatch"]
 lua = ["dbflux_lua"]
 aws = ["dbflux_aws", "dbflux_ssm"]
 mcp = ["dbflux_mcp", "dbflux_mcp_server", "dbflux_policy"]

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -12,11 +12,11 @@ use dbflux_core::observability::{
 use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
     AuthProfile, CancelToken, Connection, ConnectionHook, ConnectionHooks, ConnectionProfile,
-    DbDriver, DbSchemaInfo, DriverKey, EffectiveSettings, FormValues, GeneralSettings,
-    GlobalOverrides, HistoryEntry, HistoryManager, HookContext, HookPhase, ProfileManager,
-    ProxyProfile, SavedQuery, SavedQueryManager, SchemaForeignKeyInfo, SchemaIndexInfo,
-    SchemaSnapshot, ScriptsDirectory, SecretStore, ServiceConfig, SessionFacade, ShutdownPhase,
-    SshTunnelProfile, TaskId, TaskKind, TaskSnapshot,
+    DbDriver, DbSchemaInfo, DriverKey, EffectiveSettings, FetchCollectionChildrenParams,
+    FormValues, GeneralSettings, GlobalOverrides, HistoryEntry, HistoryManager, HookContext,
+    HookPhase, ProfileManager, ProxyProfile, SavedQuery, SavedQueryManager, SchemaForeignKeyInfo,
+    SchemaIndexInfo, SchemaSnapshot, ScriptsDirectory, SecretStore, ServiceConfig, SessionFacade,
+    ShutdownPhase, SshTunnelProfile, TaskId, TaskKind, TaskSnapshot,
 };
 use dbflux_storage::bootstrap::StorageRuntime;
 
@@ -1174,6 +1174,30 @@ impl AppState {
         self.facade
             .connections
             .prepare_fetch_table_details(profile_id, database, schema, table)
+    }
+
+    pub fn prepare_fetch_collection_children(
+        &self,
+        profile_id: Uuid,
+        database: &str,
+        collection: &str,
+        limit: u32,
+    ) -> Result<FetchCollectionChildrenParams, String> {
+        self.facade
+            .connections
+            .prepare_fetch_collection_children(profile_id, database, collection, limit)
+    }
+
+    pub fn set_collection_children_page(
+        &mut self,
+        profile_id: Uuid,
+        database: String,
+        collection: String,
+        page: dbflux_core::CollectionChildrenPage,
+    ) {
+        self.facade
+            .connections
+            .set_collection_children_page(profile_id, database, collection, page);
     }
 
     pub fn prepare_fetch_schema_types(

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -48,6 +48,9 @@ use dbflux_driver_redis::RedisDriver;
 #[cfg(feature = "dynamodb")]
 use dbflux_driver_dynamodb::DynamoDriver;
 
+#[cfg(feature = "cloudwatch")]
+use dbflux_driver_cloudwatch::CloudWatchDriver;
+
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -804,6 +807,11 @@ impl AppState {
         #[cfg(feature = "dynamodb")]
         {
             drivers.insert("dynamodb".to_string(), Arc::new(DynamoDriver::new()));
+        }
+
+        #[cfg(feature = "cloudwatch")]
+        {
+            drivers.insert("cloudwatch".to_string(), Arc::new(CloudWatchDriver::new()));
         }
 
         drivers
@@ -2823,6 +2831,17 @@ mod tests {
             Vec::new(),
             Vec::new(),
         )
+    }
+
+    #[test]
+    fn build_builtin_drivers_registers_cloudwatch_driver() {
+        let drivers = AppState::build_builtin_drivers();
+
+        assert!(drivers.contains_key("cloudwatch"));
+
+        let driver = drivers.get("cloudwatch").expect("cloudwatch driver");
+        assert_eq!(driver.metadata().id, "cloudwatch");
+        assert_eq!(driver.display_name(), "CloudWatch Logs");
     }
 
     #[test]

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -2537,6 +2537,10 @@ impl AppState {
         ConnectionHooks::resolve_from_bindings(profile, &self.hook_definitions)
     }
 
+    pub fn profile_uses_connect_pipeline(&self, profile: &ConnectionProfile) -> bool {
+        profile.uses_pipeline() || self.infer_auth_profile_for_connection(profile).is_some()
+    }
+
     pub fn prepare_pipeline_input(
         &self,
         profile_id: Uuid,
@@ -2577,7 +2581,7 @@ impl AppState {
             })
             .or(profile.auth_profile_id);
 
-        let auth_profile = selected_auth_profile_id.and_then(|auth_id| {
+        let selected_auth_profile = selected_auth_profile_id.and_then(|auth_id| {
             self.facade
                 .auth_profiles
                 .items
@@ -2585,6 +2589,9 @@ impl AppState {
                 .find(|p| p.id == auth_id && p.enabled)
                 .cloned()
         });
+
+        let auth_profile =
+            selected_auth_profile.or_else(|| self.infer_auth_profile_for_connection(&profile));
 
         let uses_managed_access = matches!(
             profile.access_kind,
@@ -2700,6 +2707,49 @@ impl AppState {
             cancel,
         })
     }
+
+    fn infer_auth_profile_for_connection(
+        &self,
+        profile: &ConnectionProfile,
+    ) -> Option<AuthProfile> {
+        let aws_profile_name = profile.external_auth_profile_name()?.trim();
+
+        if aws_profile_name.is_empty() {
+            return None;
+        }
+
+        if let Some(profile) = self.facade.auth_profiles.items.iter().find(|auth_profile| {
+            auth_profile.enabled
+                && auth_profile
+                    .fields
+                    .get("profile_name")
+                    .is_some_and(|name| name == aws_profile_name)
+                && self
+                    .auth_provider_registry
+                    .get(&auth_profile.provider_id)
+                    .is_some_and(|provider| provider.capabilities().login.supported)
+        }) {
+            return Some(profile.clone());
+        }
+
+        self.auth_provider_registry
+            .providers()
+            .filter(|provider| provider.capabilities().login.supported)
+            .flat_map(|provider| provider.detect_importable_profiles())
+            .find(|candidate| {
+                candidate
+                    .fields
+                    .get("profile_name")
+                    .is_some_and(|name| name == aws_profile_name)
+            })
+            .map(|candidate| {
+                AuthProfile::new(
+                    candidate.display_name,
+                    candidate.provider_id,
+                    candidate.fields,
+                )
+            })
+    }
 }
 
 impl Default for AppState {
@@ -2714,7 +2764,7 @@ mod tests {
     use dbflux_core::access::AccessKind;
     use dbflux_core::auth::{
         AuthFormDef, AuthProfile, AuthSession, AuthSessionState, DynAuthProvider,
-        ResolvedCredentials, UrlCallback,
+        ImportableProfile, ResolvedCredentials, UrlCallback,
     };
     use dbflux_core::{
         ConnectionProfile, DatabaseCategory, DbConfig, DbError, DbKind, DriverFormDef,
@@ -2755,6 +2805,26 @@ mod tests {
 
     struct TestAuthProvider {
         provider_id: String,
+        importable_profile_name: Option<String>,
+    }
+
+    impl TestAuthProvider {
+        fn new(provider_id: impl Into<String>) -> Self {
+            Self {
+                provider_id: provider_id.into(),
+                importable_profile_name: None,
+            }
+        }
+
+        fn with_importable_profile(
+            provider_id: impl Into<String>,
+            profile_name: impl Into<String>,
+        ) -> Self {
+            Self {
+                provider_id: provider_id.into(),
+                importable_profile_name: Some(profile_name.into()),
+            }
+        }
     }
 
     #[async_trait::async_trait]
@@ -2770,6 +2840,18 @@ mod tests {
         fn form_def(&self) -> &AuthFormDef {
             static FORM: std::sync::OnceLock<AuthFormDef> = std::sync::OnceLock::new();
             FORM.get_or_init(|| AuthFormDef { tabs: vec![] })
+        }
+
+        fn capabilities(&self) -> &dbflux_core::auth::AuthProviderCapabilities {
+            static CAPABILITIES: dbflux_core::auth::AuthProviderCapabilities =
+                dbflux_core::auth::AuthProviderCapabilities {
+                    login: dbflux_core::auth::AuthProviderLoginCapabilities {
+                        supported: true,
+                        verification_url_progress: true,
+                    },
+                };
+
+            &CAPABILITIES
         }
 
         async fn validate_session(
@@ -2799,6 +2881,21 @@ mod tests {
             _profile: &dbflux_core::AuthProfile,
         ) -> Result<ResolvedCredentials, DbError> {
             Ok(ResolvedCredentials::default())
+        }
+
+        fn detect_importable_profiles(&self) -> Vec<ImportableProfile> {
+            let Some(profile_name) = self.importable_profile_name.as_ref() else {
+                return Vec::new();
+            };
+
+            let mut fields = HashMap::new();
+            fields.insert("profile_name".to_string(), profile_name.clone());
+
+            vec![ImportableProfile {
+                display_name: profile_name.clone(),
+                provider_id: self.provider_id.clone(),
+                fields,
+            }]
         }
     }
 
@@ -3001,9 +3098,7 @@ mod tests {
                 assert_eq!(socket_id, "svc-socket");
                 assert_eq!(launch.program, "dbflux-driver-host");
 
-                Ok(Arc::new(TestAuthProvider {
-                    provider_id: "rpc-auth".to_string(),
-                }) as Arc<dyn DynAuthProvider>)
+                Ok(Arc::new(TestAuthProvider::new("rpc-auth")) as Arc<dyn DynAuthProvider>)
             },
         );
 
@@ -3014,18 +3109,12 @@ mod tests {
     #[test]
     fn launch_rpc_auth_providers_preserves_existing_provider_on_duplicate() {
         let mut registry = AuthProviderRegistry::new();
-        registry.register(Arc::new(TestAuthProvider {
-            provider_id: "aws-sso".to_string(),
-        }));
+        registry.register(Arc::new(TestAuthProvider::new("aws-sso")));
 
         AppState::launch_rpc_auth_providers_with(
             &mut registry,
             vec![test_service(RpcServiceKind::AuthProvider)],
-            |_, _| {
-                Ok(Arc::new(TestAuthProvider {
-                    provider_id: "aws-sso".to_string(),
-                }) as Arc<dyn DynAuthProvider>)
-            },
+            |_, _| Ok(Arc::new(TestAuthProvider::new("aws-sso")) as Arc<dyn DynAuthProvider>),
         );
 
         let providers: Vec<String> = registry
@@ -3050,9 +3139,7 @@ mod tests {
         );
         state
             .auth_provider_registry
-            .register(Arc::new(TestAuthProvider {
-                provider_id: "custom-oidc".to_string(),
-            }));
+            .register(Arc::new(TestAuthProvider::new("custom-oidc")));
 
         let input = state
             .build_pipeline_input_for_profile(profile, CancelToken::new())
@@ -3094,9 +3181,7 @@ mod tests {
         );
         state
             .auth_provider_registry
-            .register(Arc::new(TestAuthProvider {
-                provider_id: "custom-oidc".to_string(),
-            }));
+            .register(Arc::new(TestAuthProvider::new("custom-oidc")));
 
         let input = state
             .build_pipeline_input_for_profile(profile, CancelToken::new())
@@ -3108,6 +3193,100 @@ mod tests {
 
         assert_eq!(selected_auth_profile.id, managed_auth_profile.id);
         assert_eq!(selected_auth_profile.provider_id, "custom-oidc");
+    }
+
+    #[test]
+    fn profile_uses_connect_pipeline_for_importable_aws_sso_profile() {
+        let profile = ConnectionProfile::new(
+            "cloudwatch",
+            DbConfig::CloudWatchLogs {
+                region: "us-east-1".to_string(),
+                profile: Some("PREX-DEV-UY".to_string()),
+                endpoint: None,
+            },
+        );
+
+        let mut state = test_state_with_profiles(HashMap::new(), vec![profile.clone()]);
+        state
+            .auth_provider_registry
+            .register(Arc::new(TestAuthProvider::with_importable_profile(
+                "aws-sso",
+                "PREX-DEV-UY",
+            )));
+
+        assert!(state.profile_uses_connect_pipeline(&profile));
+    }
+
+    #[test]
+    fn build_pipeline_input_infers_importable_aws_sso_profile() {
+        let profile = ConnectionProfile::new(
+            "cloudwatch",
+            DbConfig::CloudWatchLogs {
+                region: "us-east-1".to_string(),
+                profile: Some("PREX-DEV-UY".to_string()),
+                endpoint: None,
+            },
+        );
+
+        let mut state = test_state_with_profiles(HashMap::new(), vec![profile.clone()]);
+        state
+            .auth_provider_registry
+            .register(Arc::new(TestAuthProvider::with_importable_profile(
+                "aws-sso",
+                "PREX-DEV-UY",
+            )));
+
+        let input = state
+            .build_pipeline_input_for_profile(profile, CancelToken::new())
+            .expect("importable AWS SSO profile should build pipeline input");
+
+        let auth_profile = input
+            .auth_profile
+            .expect("pipeline input should include inferred auth profile");
+
+        assert_eq!(auth_profile.name, "PREX-DEV-UY");
+        assert_eq!(auth_profile.provider_id, "aws-sso");
+        assert_eq!(
+            auth_profile.fields.get("profile_name").map(String::as_str),
+            Some("PREX-DEV-UY")
+        );
+        assert!(input.auth_provider.is_some());
+    }
+
+    #[test]
+    fn build_pipeline_input_infers_importable_aws_sso_profile_when_selected_id_is_stale() {
+        let mut profile = ConnectionProfile::new(
+            "cloudwatch",
+            DbConfig::CloudWatchLogs {
+                region: "us-east-1".to_string(),
+                profile: Some("PREX-DEV-UY".to_string()),
+                endpoint: None,
+            },
+        );
+        profile.auth_profile_id = Some(Uuid::new_v4());
+
+        let mut state = test_state_with_profiles(HashMap::new(), vec![profile.clone()]);
+        state
+            .auth_provider_registry
+            .register(Arc::new(TestAuthProvider::with_importable_profile(
+                "aws-sso",
+                "PREX-DEV-UY",
+            )));
+
+        let input = state
+            .build_pipeline_input_for_profile(profile, CancelToken::new())
+            .expect("stale auth profile id should fall back to importable AWS SSO profile");
+
+        let auth_profile = input
+            .auth_profile
+            .expect("pipeline input should include inferred auth profile");
+
+        assert_eq!(auth_profile.provider_id, "aws-sso");
+        assert_eq!(
+            auth_profile.fields.get("profile_name").map(String::as_str),
+            Some("PREX-DEV-UY")
+        );
+        assert!(input.auth_provider.is_some());
     }
 
     #[test]

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -420,6 +420,7 @@ fn db_kind_to_str(kind: DbKind) -> String {
         DbKind::MongoDB => "MongoDB",
         DbKind::Redis => "Redis",
         DbKind::DynamoDB => "DynamoDB",
+        DbKind::CloudWatchLogs => "CloudWatchLogs",
     }
     .to_string()
 }
@@ -433,6 +434,7 @@ fn str_to_db_kind(s: &str) -> Option<DbKind> {
         "MongoDB" => Some(DbKind::MongoDB),
         "Redis" => Some(DbKind::Redis),
         "DynamoDB" => Some(DbKind::DynamoDB),
+        "CloudWatchLogs" => Some(DbKind::CloudWatchLogs),
         _ => None,
     }
 }
@@ -445,6 +447,7 @@ fn default_db_config_for_kind(kind: DbKind) -> dbflux_core::DbConfig {
         DbKind::MongoDB => dbflux_core::DbConfig::default_mongodb(),
         DbKind::Redis => dbflux_core::DbConfig::default_redis(),
         DbKind::DynamoDB => dbflux_core::DbConfig::default_dynamodb(),
+        DbKind::CloudWatchLogs => dbflux_core::DbConfig::default_cloudwatch_logs(),
         _ => dbflux_core::DbConfig::default_postgres(),
     }
 }

--- a/crates/dbflux_app/src/keymap/context.rs
+++ b/crates/dbflux_app/src/keymap/context.rs
@@ -54,6 +54,9 @@ pub enum ContextId {
 
     /// Audit event viewer row list.
     Audit,
+
+    /// Event-stream picker modal (collection child picker).
+    EventStreamsPicker,
 }
 
 impl ContextId {
@@ -74,6 +77,7 @@ impl ContextId {
             ContextId::ConfirmModal => None,
             ContextId::FormNavigation => None,
             ContextId::ContextBar => None,
+            ContextId::EventStreamsPicker => None,
             ContextId::Sidebar => Some(ContextId::Global),
             ContextId::Editor => Some(ContextId::Global),
             ContextId::Results => Some(ContextId::Global),
@@ -97,6 +101,7 @@ impl ContextId {
                 | ContextId::ConfirmModal
                 | ContextId::FormNavigation
                 | ContextId::ContextBar
+                | ContextId::EventStreamsPicker
         )
     }
 
@@ -125,6 +130,7 @@ impl ContextId {
             ContextId::FormNavigation => "Form Navigation",
             ContextId::ContextBar => "Context Bar",
             ContextId::Audit => "Audit Viewer",
+            ContextId::EventStreamsPicker => "Event Streams Picker",
         }
     }
 
@@ -147,6 +153,7 @@ impl ContextId {
             ContextId::FormNavigation,
             ContextId::ContextBar,
             ContextId::Audit,
+            ContextId::EventStreamsPicker,
         ]
     }
 
@@ -169,6 +176,7 @@ impl ContextId {
             ContextId::FormNavigation => "FormNavigation",
             ContextId::ContextBar => "ContextBar",
             ContextId::Audit => "Audit",
+            ContextId::EventStreamsPicker => "EventStreamsPicker",
         }
     }
 }

--- a/crates/dbflux_audit/src/redaction.rs
+++ b/crates/dbflux_audit/src/redaction.rs
@@ -308,12 +308,10 @@ mod tests {
 
     #[test]
     fn test_redact_invalid_json_falls_back_to_pattern_matching() {
-        // This will still go through pattern-based redaction since JSON parsing fails
+        // Non-JSON input must still produce a Redacted result without panicking;
+        // whether any patterns match is a property of the regex set, not this fallback.
         let input = "password=secret123";
-        let result = redact_json(input, true);
-        // The regex patterns include hex strings, so "secret123" won't be caught
-        // but "123" might be caught by the hex_secret pattern
-        assert!(result.redaction_count >= 0);
+        let _ = redact_json(input, true);
     }
 
     #[test]

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -533,8 +533,78 @@ fn non_expiring_login(
     }
 }
 
+fn aws_profile_name_fallback_allowed(profile: &AuthProfile) -> bool {
+    matches!(
+        profile.provider_id.as_str(),
+        "aws-sso" | "aws-shared-credentials"
+    )
+}
+
+fn effective_aws_profile_name(profile: &AuthProfile) -> Option<&str> {
+    if let Some(profile_name) = profile
+        .fields
+        .get("profile_name")
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return Some(profile_name);
+    }
+
+    if aws_profile_name_fallback_allowed(profile) {
+        let fallback = profile.name.trim();
+        if !fallback.is_empty() {
+            return Some(fallback);
+        }
+    }
+
+    None
+}
+
+fn sso_profile_config_from_auth_profile(profile: &AuthProfile) -> Option<SsoProfileConfig> {
+    if profile.provider_id != "aws-sso" {
+        return None;
+    }
+
+    let profile_name = effective_aws_profile_name(profile)?.to_string();
+    let region = profile.fields.get("region")?.trim().to_string();
+    let sso_start_url = profile.fields.get("sso_start_url")?.trim().to_string();
+    let sso_account_id = profile.fields.get("sso_account_id")?.trim().to_string();
+    let sso_role_name = profile.fields.get("sso_role_name")?.trim().to_string();
+
+    if region.is_empty()
+        || sso_start_url.is_empty()
+        || sso_account_id.is_empty()
+        || sso_role_name.is_empty()
+    {
+        return None;
+    }
+
+    Some(SsoProfileConfig {
+        profile_name,
+        region,
+        sso_start_url,
+        sso_account_id,
+        sso_role_name,
+    })
+}
+
+fn ensure_sso_profile_configured_from_auth_profile(profile: &AuthProfile) {
+    let Some(config) = sso_profile_config_from_auth_profile(profile) else {
+        return;
+    };
+
+    if let Err(err) = ensure_aws_profile_configured(&config) {
+        log::warn!(
+            "Failed to sync AWS SSO profile '{}' into ~/.aws/config: {}",
+            config.profile_name,
+            err
+        );
+    }
+}
+
 fn profile_name_and_region(profile: &AuthProfile) -> (Option<&str>, &str) {
-    let profile_name = profile.fields.get("profile_name").map(String::as_str);
+    let profile_name = effective_aws_profile_name(profile);
     let region = profile
         .fields
         .get("region")
@@ -683,11 +753,9 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
     }
 
     async fn validate_session(&self, profile: &AuthProfile) -> Result<AuthSessionState, DbError> {
-        let profile_name = profile
-            .fields
-            .get("profile_name")
-            .map(String::as_str)
-            .unwrap_or("");
+        ensure_sso_profile_configured_from_auth_profile(profile);
+
+        let profile_name = effective_aws_profile_name(profile).unwrap_or("");
         let sso_start_url = profile
             .fields
             .get("sso_start_url")
@@ -710,10 +778,8 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
         profile: &AuthProfile,
         url_callback: UrlCallback,
     ) -> Result<AuthSession, DbError> {
-        let profile_name = profile
-            .fields
-            .get("profile_name")
-            .cloned()
+        let profile_name = effective_aws_profile_name(profile)
+            .map(ToOwned::to_owned)
             .unwrap_or_default();
         let region = profile.fields.get("region").cloned().unwrap_or_default();
         let sso_start_url = profile
@@ -1068,12 +1134,22 @@ pub(crate) fn validate_sso_session(sso_start_url: &str) -> Result<AuthSessionSta
 /// is safe to call from async contexts without an active Tokio reactor
 /// (e.g. the GPUI background executor).
 async fn resolve_aws_credentials(profile: &AuthProfile) -> Result<ResolvedCredentials, DbError> {
-    let profile_name = profile.fields.get("profile_name").cloned();
+    ensure_sso_profile_configured_from_auth_profile(profile);
+
+    let profile_name = effective_aws_profile_name(profile).map(ToOwned::to_owned);
     let region = profile
         .fields
         .get("region")
         .cloned()
         .unwrap_or_else(|| "us-east-1".to_string());
+
+    log::debug!(
+        "Resolving AWS credentials for auth profile '{}' (provider={}, aws_profile={}, region={})",
+        profile.name,
+        profile.provider_id,
+        profile_name.as_deref().unwrap_or("<default>"),
+        region
+    );
 
     let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
 
@@ -1104,6 +1180,12 @@ fn resolve_aws_credentials_blocking(
     profile_name: Option<String>,
     region: String,
 ) -> Result<ResolvedCredentials, DbError> {
+    let aws_profile_label = profile_name
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .unwrap_or("<default>")
+        .to_string();
+
     // The AWS SDK internally spawns tasks and uses timers that require a
     // multi-threaded Tokio runtime with a reactor. `new_current_thread` is
     // insufficient here — use `new_multi_thread` with a small thread pool.
@@ -1131,16 +1213,23 @@ fn resolve_aws_credentials_blocking(
         let creds = sdk_config
             .credentials_provider()
             .ok_or_else(|| {
-                DbError::ValueResolutionFailed(
-                    "No credentials provider found in AWS SDK config".to_string(),
-                )
+                DbError::ValueResolutionFailed(format!(
+                    "No credentials provider found in AWS SDK config (aws_profile={}, region={})",
+                    aws_profile_label, region
+                ))
             })?
             .provide_credentials()
             .await
             .map_err(|err| {
-                DbError::ValueResolutionFailed(format!(
-                    "Failed to resolve AWS credentials: {}",
+                log::warn!(
+                    "AWS credential resolution failed (aws_profile={}, region={}): {}",
+                    aws_profile_label,
+                    region,
                     err
+                );
+                DbError::ValueResolutionFailed(format!(
+                    "Failed to resolve AWS credentials (aws_profile={}, region={}): {}",
+                    aws_profile_label, region, err
                 ))
             })?;
 
@@ -1519,6 +1608,70 @@ mod tests {
             state,
             AuthSessionState::Valid { expires_at: None }
         ));
+    }
+
+    #[test]
+    fn shared_credentials_profile_name_falls_back_to_auth_profile_name() {
+        let mut fields = std::collections::HashMap::new();
+        fields.insert("region".to_string(), "us-east-1".to_string());
+
+        let profile = AuthProfile::new("team-sso", "aws-shared-credentials", fields);
+
+        let (profile_name, region) = profile_name_and_region(&profile);
+
+        assert_eq!(profile_name, Some("team-sso"));
+        assert_eq!(region, "us-east-1");
+    }
+
+    #[test]
+    fn sso_profile_config_can_be_derived_from_auth_profile_fields() {
+        let profile = AuthProfile::new(
+            "Aws houlak",
+            "aws-sso",
+            [
+                ("profile_name".to_string(), "houlak".to_string()),
+                ("region".to_string(), "us-east-1".to_string()),
+                (
+                    "sso_start_url".to_string(),
+                    "https://houlak.awsapps.com/start".to_string(),
+                ),
+                ("sso_account_id".to_string(), "868178926296".to_string()),
+                (
+                    "sso_role_name".to_string(),
+                    "AdministratorAccess".to_string(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        );
+
+        let config = sso_profile_config_from_auth_profile(&profile).expect("sso profile config");
+
+        assert_eq!(config.profile_name, "houlak");
+        assert_eq!(config.region, "us-east-1");
+        assert_eq!(config.sso_account_id, "868178926296");
+        assert_eq!(config.sso_role_name, "AdministratorAccess");
+    }
+
+    #[test]
+    fn static_credentials_do_not_fall_back_to_auth_profile_name() {
+        let mut fields = std::collections::HashMap::new();
+        fields.insert(
+            "access_key_id".to_string(),
+            "AKIAIOSFODNN7EXAMPLE".to_string(),
+        );
+        fields.insert(
+            "secret_access_key".to_string(),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
+        );
+        fields.insert("region".to_string(), "us-east-1".to_string());
+
+        let profile = AuthProfile::new("static-creds", "aws-static-credentials", fields);
+
+        let (profile_name, region) = profile_name_and_region(&profile);
+
+        assert_eq!(profile_name, None);
+        assert_eq!(region, "us-east-1");
     }
 
     #[test]

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -1292,14 +1292,36 @@ fn sso_cache_dir() -> PathBuf {
 /// `startUrl` field matches the normalized URL (ignoring trailing slashes).
 /// Returns `None` if no matching file exists or it cannot be read.
 fn find_sso_cache_contents(normalized_url: &str) -> Option<String> {
-    // Fast path: exact hash match (both with and without trailing slash).
+    // Fast path: exact hash match. The AWS CLI may write the cache under either
+    // the trimmed or trailing-slash form of the URL, and stale files from a
+    // previous variant can coexist with a freshly-written one. Pick the most
+    // recently modified file among the candidates so a fresh `aws sso login`
+    // always wins over a stale prior cache entry.
+    let mut newest: Option<(std::time::SystemTime, std::path::PathBuf, String)> = None;
     for candidate in [normalized_url, &format!("{}/", normalized_url)] {
         let hash = Sha1::digest(candidate.as_bytes());
         let path = sso_cache_dir().join(format!("{:x}.json", hash));
-        if let Ok(contents) = std::fs::read_to_string(&path) {
-            log::debug!("SSO cache hit (hash match): {}", path.display());
-            return Some(contents);
+
+        let metadata = match std::fs::metadata(&path) {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let mtime = metadata
+            .modified()
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        match &newest {
+            Some((current_mtime, _, _)) if *current_mtime >= mtime => {}
+            _ => newest = Some((mtime, path, contents)),
         }
+    }
+    if let Some((_, path, contents)) = newest {
+        log::debug!("SSO cache hit (hash match): {}", path.display());
+        return Some(contents);
     }
 
     // Slow path: scan all files and compare by startUrl field value.

--- a/crates/dbflux_components/src/controls/mod.rs
+++ b/crates/dbflux_components/src/controls/mod.rs
@@ -2,7 +2,9 @@ mod button;
 mod checkbox;
 mod dropdown;
 mod input;
+mod readonly_text_view;
 mod select;
+mod selectable_text;
 mod tab_trigger;
 
 pub use button::{Button, ButtonSize, ButtonVariant};
@@ -11,5 +13,7 @@ pub use dropdown::{Dropdown, DropdownDismissed, DropdownItem, DropdownSelectionC
 pub use input::{
     CompletionProvider, GpuiInput, Input, InputEvent, InputPosition, InputState, Rope,
 };
+pub use readonly_text_view::ReadonlyTextView;
 pub use select::Select;
+pub use selectable_text::SelectableText;
 pub use tab_trigger::TabTrigger;

--- a/crates/dbflux_components/src/controls/readonly_text_view.rs
+++ b/crates/dbflux_components/src/controls/readonly_text_view.rs
@@ -1,0 +1,57 @@
+use gpui::prelude::*;
+use gpui::{App, Entity, IntoElement, Window};
+
+use crate::controls::{GpuiInput, InputState};
+
+/// Readonly text/code view backed by the shared GPUI input widget.
+#[derive(IntoElement)]
+pub struct ReadonlyTextView {
+    state: Entity<InputState>,
+    appearance: bool,
+    w_full: bool,
+    h_full: bool,
+}
+
+impl ReadonlyTextView {
+    pub fn new(state: &Entity<InputState>) -> Self {
+        Self {
+            state: state.clone(),
+            appearance: false,
+            w_full: false,
+            h_full: false,
+        }
+    }
+
+    pub fn appearance(mut self, appearance: bool) -> Self {
+        self.appearance = appearance;
+        self
+    }
+
+    pub fn w_full(mut self) -> Self {
+        self.w_full = true;
+        self
+    }
+
+    pub fn h_full(mut self) -> Self {
+        self.h_full = true;
+        self
+    }
+}
+
+impl RenderOnce for ReadonlyTextView {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let mut input = GpuiInput::new(&self.state)
+            .appearance(self.appearance)
+            .disabled(true);
+
+        if self.w_full {
+            input = input.w_full();
+        }
+
+        if self.h_full {
+            input = input.h_full();
+        }
+
+        input
+    }
+}

--- a/crates/dbflux_components/src/controls/readonly_text_view.rs
+++ b/crates/dbflux_components/src/controls/readonly_text_view.rs
@@ -1,5 +1,5 @@
 use gpui::prelude::*;
-use gpui::{App, Entity, IntoElement, Window};
+use gpui::{App, DefiniteLength, Entity, IntoElement, Window};
 
 use crate::controls::{GpuiInput, InputState};
 
@@ -10,6 +10,7 @@ pub struct ReadonlyTextView {
     appearance: bool,
     w_full: bool,
     h_full: bool,
+    height: Option<DefiniteLength>,
 }
 
 impl ReadonlyTextView {
@@ -19,6 +20,7 @@ impl ReadonlyTextView {
             appearance: false,
             w_full: false,
             h_full: false,
+            height: None,
         }
     }
 
@@ -36,6 +38,11 @@ impl ReadonlyTextView {
         self.h_full = true;
         self
     }
+
+    pub fn h(mut self, height: impl Into<DefiniteLength>) -> Self {
+        self.height = Some(height.into());
+        self
+    }
 }
 
 impl RenderOnce for ReadonlyTextView {
@@ -50,6 +57,10 @@ impl RenderOnce for ReadonlyTextView {
 
         if self.h_full {
             input = input.h_full();
+        }
+
+        if let Some(height) = self.height {
+            input = input.h(height);
         }
 
         input

--- a/crates/dbflux_components/src/controls/selectable_text.rs
+++ b/crates/dbflux_components/src/controls/selectable_text.rs
@@ -1,0 +1,57 @@
+use gpui::prelude::*;
+use gpui::{App, Entity, IntoElement, Window};
+
+use crate::controls::{GpuiInput, InputState};
+
+/// Selectable plain-text field backed by the shared GPUI input widget.
+#[derive(IntoElement)]
+pub struct SelectableText {
+    state: Entity<InputState>,
+    appearance: bool,
+    w_full: bool,
+    h_full: bool,
+}
+
+impl SelectableText {
+    pub fn new(state: &Entity<InputState>) -> Self {
+        Self {
+            state: state.clone(),
+            appearance: false,
+            w_full: false,
+            h_full: false,
+        }
+    }
+
+    pub fn appearance(mut self, appearance: bool) -> Self {
+        self.appearance = appearance;
+        self
+    }
+
+    pub fn w_full(mut self) -> Self {
+        self.w_full = true;
+        self
+    }
+
+    pub fn h_full(mut self) -> Self {
+        self.h_full = true;
+        self
+    }
+}
+
+impl RenderOnce for SelectableText {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let mut input = GpuiInput::new(&self.state)
+            .appearance(self.appearance)
+            .disabled(true);
+
+        if self.w_full {
+            input = input.w_full();
+        }
+
+        if self.h_full {
+            input = input.h_full();
+        }
+
+        input
+    }
+}

--- a/crates/dbflux_components/src/controls/selectable_text.rs
+++ b/crates/dbflux_components/src/controls/selectable_text.rs
@@ -1,5 +1,5 @@
 use gpui::prelude::*;
-use gpui::{App, Entity, IntoElement, Window};
+use gpui::{App, DefiniteLength, Entity, IntoElement, Window};
 
 use crate::controls::{GpuiInput, InputState};
 
@@ -10,6 +10,7 @@ pub struct SelectableText {
     appearance: bool,
     w_full: bool,
     h_full: bool,
+    height: Option<DefiniteLength>,
 }
 
 impl SelectableText {
@@ -19,6 +20,7 @@ impl SelectableText {
             appearance: false,
             w_full: false,
             h_full: false,
+            height: None,
         }
     }
 
@@ -36,6 +38,11 @@ impl SelectableText {
         self.h_full = true;
         self
     }
+
+    pub fn h(mut self, height: impl Into<DefiniteLength>) -> Self {
+        self.height = Some(height.into());
+        self
+    }
 }
 
 impl RenderOnce for SelectableText {
@@ -50,6 +57,10 @@ impl RenderOnce for SelectableText {
 
         if self.h_full {
             input = input.h_full();
+        }
+
+        if let Some(height) = self.height {
+            input = input.h(height);
         }
 
         input

--- a/crates/dbflux_core/src/connection/context.rs
+++ b/crates/dbflux_core/src/connection/context.rs
@@ -2,13 +2,24 @@ use crate::QueryLanguage;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExecutionSourceContext {
+    CloudWatchLogs {
+        log_groups: Vec<String>,
+        start_ms: i64,
+        end_ms: i64,
+    },
+}
+
 /// Per-document execution context (connection, database, schema).
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ExecutionContext {
     pub connection_id: Option<Uuid>,
     pub database: Option<String>,
     pub schema: Option<String>,
     pub container: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<ExecutionSourceContext>,
 }
 
 /// Prefix used for metadata annotations in file headers.
@@ -108,12 +119,21 @@ impl ExecutionContext {
             && self.database.is_none()
             && self.schema.is_none()
             && self.container.is_none()
+            && self.source.is_none()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn cloudwatch_source() -> ExecutionSourceContext {
+        ExecutionSourceContext::CloudWatchLogs {
+            log_groups: vec!["/aws/lambda/app".into(), "/aws/ecs/api".into()],
+            start_ms: 1_710_000_000_000,
+            end_ms: 1_710_000_300_000,
+        }
+    }
 
     #[test]
     fn parse_sql_annotations() {
@@ -158,6 +178,7 @@ db.orders.find({})
             database: Some("mydb".into()),
             schema: Some("public".into()),
             container: None,
+            source: Some(cloudwatch_source()),
         };
 
         let header = ctx.to_comment_header(QueryLanguage::Sql);
@@ -166,12 +187,50 @@ db.orders.find({})
         assert_eq!(parsed.connection_id, ctx.connection_id);
         assert_eq!(parsed.database, ctx.database);
         assert_eq!(parsed.schema, ctx.schema);
+        assert!(parsed.source.is_none());
     }
 
     #[test]
     fn empty_context_produces_no_header() {
         let ctx = ExecutionContext::default();
         assert!(ctx.to_comment_header(QueryLanguage::Sql).is_empty());
+    }
+
+    #[test]
+    fn cloudwatch_source_roundtrips_through_serde() {
+        let ctx = ExecutionContext {
+            connection_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
+            database: Some("logs".into()),
+            schema: None,
+            container: None,
+            source: Some(cloudwatch_source()),
+        };
+
+        let json = serde_json::to_string(&ctx).unwrap();
+        let restored: ExecutionContext = serde_json::from_str(&json).unwrap();
+
+        match restored.source {
+            Some(ExecutionSourceContext::CloudWatchLogs {
+                log_groups,
+                start_ms,
+                end_ms,
+            }) => {
+                assert_eq!(log_groups, vec!["/aws/lambda/app", "/aws/ecs/api"]);
+                assert_eq!(start_ms, 1_710_000_000_000);
+                assert_eq!(end_ms, 1_710_000_300_000);
+            }
+            other => panic!("unexpected source context: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn source_only_context_is_not_empty() {
+        let ctx = ExecutionContext {
+            source: Some(cloudwatch_source()),
+            ..ExecutionContext::default()
+        };
+
+        assert!(!ctx.is_empty());
     }
 
     #[test]

--- a/crates/dbflux_core/src/connection/context.rs
+++ b/crates/dbflux_core/src/connection/context.rs
@@ -8,6 +8,8 @@ pub enum ExecutionSourceContext {
         targets: Vec<String>,
         start_ms: i64,
         end_ms: i64,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        query_mode: Option<String>,
     },
 }
 
@@ -132,6 +134,7 @@ mod tests {
             targets: vec!["/aws/lambda/app".into(), "/aws/ecs/api".into()],
             start_ms: 1_710_000_000_000,
             end_ms: 1_710_000_300_000,
+            query_mode: Some("cwli".into()),
         }
     }
 
@@ -214,10 +217,12 @@ db.orders.find({})
                 targets,
                 start_ms,
                 end_ms,
+                query_mode,
             }) => {
                 assert_eq!(targets, vec!["/aws/lambda/app", "/aws/ecs/api"]);
                 assert_eq!(start_ms, 1_710_000_000_000);
                 assert_eq!(end_ms, 1_710_000_300_000);
+                assert_eq!(query_mode.as_deref(), Some("cwli"));
             }
             other => panic!("unexpected source context: {other:?}"),
         }

--- a/crates/dbflux_core/src/connection/context.rs
+++ b/crates/dbflux_core/src/connection/context.rs
@@ -4,8 +4,8 @@ use uuid::Uuid;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ExecutionSourceContext {
-    CloudWatchLogs {
-        log_groups: Vec<String>,
+    CollectionWindow {
+        targets: Vec<String>,
         start_ms: i64,
         end_ms: i64,
     },
@@ -127,9 +127,9 @@ impl ExecutionContext {
 mod tests {
     use super::*;
 
-    fn cloudwatch_source() -> ExecutionSourceContext {
-        ExecutionSourceContext::CloudWatchLogs {
-            log_groups: vec!["/aws/lambda/app".into(), "/aws/ecs/api".into()],
+    fn collection_window_source() -> ExecutionSourceContext {
+        ExecutionSourceContext::CollectionWindow {
+            targets: vec!["/aws/lambda/app".into(), "/aws/ecs/api".into()],
             start_ms: 1_710_000_000_000,
             end_ms: 1_710_000_300_000,
         }
@@ -178,7 +178,7 @@ db.orders.find({})
             database: Some("mydb".into()),
             schema: Some("public".into()),
             container: None,
-            source: Some(cloudwatch_source()),
+            source: Some(collection_window_source()),
         };
 
         let header = ctx.to_comment_header(QueryLanguage::Sql);
@@ -197,25 +197,25 @@ db.orders.find({})
     }
 
     #[test]
-    fn cloudwatch_source_roundtrips_through_serde() {
+    fn collection_window_source_roundtrips_through_serde() {
         let ctx = ExecutionContext {
             connection_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             database: Some("logs".into()),
             schema: None,
             container: None,
-            source: Some(cloudwatch_source()),
+            source: Some(collection_window_source()),
         };
 
         let json = serde_json::to_string(&ctx).unwrap();
         let restored: ExecutionContext = serde_json::from_str(&json).unwrap();
 
         match restored.source {
-            Some(ExecutionSourceContext::CloudWatchLogs {
-                log_groups,
+            Some(ExecutionSourceContext::CollectionWindow {
+                targets,
                 start_ms,
                 end_ms,
             }) => {
-                assert_eq!(log_groups, vec!["/aws/lambda/app", "/aws/ecs/api"]);
+                assert_eq!(targets, vec!["/aws/lambda/app", "/aws/ecs/api"]);
                 assert_eq!(start_ms, 1_710_000_000_000);
                 assert_eq!(end_ms, 1_710_000_300_000);
             }
@@ -226,7 +226,7 @@ db.orders.find({})
     #[test]
     fn source_only_context_is_not_empty() {
         let ctx = ExecutionContext {
-            source: Some(cloudwatch_source()),
+            source: Some(collection_window_source()),
             ..ExecutionContext::default()
         };
 

--- a/crates/dbflux_core/src/connection/hook.rs
+++ b/crates/dbflux_core/src/connection/hook.rs
@@ -487,6 +487,7 @@ fn profile_config_context(config: &DbConfig) -> (Option<String>, Option<u16>, Op
             database.map(|db| db.to_string()),
         ),
         DbConfig::DynamoDB { region, table, .. } => (Some(region.clone()), None, table.clone()),
+        DbConfig::CloudWatchLogs { region, .. } => (Some(region.clone()), None, None),
         DbConfig::External { values, .. } => {
             let host = values.get("host").cloned();
             let port = values

--- a/crates/dbflux_core/src/connection/manager.rs
+++ b/crates/dbflux_core/src/connection/manager.rs
@@ -1,4 +1,5 @@
 use crate::{
+    CollectionChildrenCache, CollectionChildrenPage, CollectionChildrenRequest, CollectionRef,
     Connection, ConnectionHooks, ConnectionProfile, CustomTypeInfo, DbDriver, DbKind, DbSchemaInfo,
     HookContext, ProxyProfile, SchemaForeignKeyInfo, SchemaIndexInfo, SchemaLoadingStrategy,
     SchemaSnapshot, SecretStore, ShutdownCoordinator, ShutdownPhase, SshTunnelProfile, TableInfo,
@@ -26,6 +27,10 @@ pub enum CacheKey {
         database: String,
         table: String,
     },
+    CollectionChildren {
+        database: String,
+        collection: String,
+    },
     SchemaTypes {
         database: String,
         schema: Option<String>,
@@ -51,6 +56,13 @@ impl CacheKey {
         Self::TableDetails {
             database: database.into(),
             table: table.into(),
+        }
+    }
+
+    pub fn collection_children(database: impl Into<String>, collection: impl Into<String>) -> Self {
+        Self::CollectionChildren {
+            database: database.into(),
+            collection: collection.into(),
         }
     }
 
@@ -84,6 +96,7 @@ impl CacheKey {
 pub enum CacheEntry<'a> {
     DatabaseSchema(&'a DbSchemaInfo),
     TableDetails(&'a TableInfo),
+    CollectionChildren(&'a CollectionChildrenCache),
     SchemaTypes(&'a Vec<CustomTypeInfo>),
     SchemaIndexes(&'a Vec<SchemaIndexInfo>),
     SchemaForeignKeys(&'a Vec<SchemaForeignKeyInfo>),
@@ -99,6 +112,11 @@ pub enum OwnedCacheEntry {
         database: String,
         table: String,
         details: TableInfo,
+    },
+    CollectionChildren {
+        database: String,
+        collection: String,
+        page: CollectionChildrenPage,
     },
     SchemaTypes {
         database: String,
@@ -245,6 +263,7 @@ pub struct ConnectedProfile {
     /// Lazy-loaded schemas per database (MySQL/MariaDB).
     pub database_schemas: HashMap<String, DbSchemaInfo>,
     pub table_details: HashMap<(String, String), TableInfo>,
+    pub collection_children: HashMap<(String, String), CollectionChildrenCache>,
     pub schema_types: HashMap<SchemaCacheKey, Vec<CustomTypeInfo>>,
     pub schema_indexes: HashMap<SchemaCacheKey, Vec<SchemaIndexInfo>>,
     pub schema_foreign_keys: HashMap<SchemaCacheKey, Vec<SchemaForeignKeyInfo>>,
@@ -273,6 +292,14 @@ impl ConnectedProfile {
                 .table_details
                 .get(&(database.clone(), table.clone()))
                 .map(CacheEntry::TableDetails),
+
+            CacheKey::CollectionChildren {
+                database,
+                collection,
+            } => self
+                .collection_children
+                .get(&(database.clone(), collection.clone()))
+                .map(CacheEntry::CollectionChildren),
 
             CacheKey::SchemaTypes { database, schema } => {
                 let sk = SchemaCacheKey::new(database.as_str(), schema.as_deref());
@@ -311,6 +338,20 @@ impl ConnectedProfile {
                 details,
             } => {
                 self.table_details.insert((database, table), details);
+            }
+
+            OwnedCacheEntry::CollectionChildren {
+                database,
+                collection,
+                page,
+            } => {
+                let cache = self
+                    .collection_children
+                    .entry((database, collection))
+                    .or_default();
+
+                cache.items.extend(page.items);
+                cache.next_page_token = page.next_page_token;
             }
 
             OwnedCacheEntry::SchemaTypes {
@@ -514,6 +555,7 @@ impl ConnectionManager {
                 schema,
                 database_schemas: HashMap::new(),
                 table_details: HashMap::new(),
+                collection_children: HashMap::new(),
                 schema_types: HashMap::new(),
                 schema_indexes: HashMap::new(),
                 schema_foreign_keys: HashMap::new(),
@@ -611,6 +653,59 @@ impl ConnectionManager {
         self.connections
             .get(&profile_id)
             .is_some_and(|c| !c.cache_contains(&key))
+    }
+
+    pub fn set_collection_children_page(
+        &mut self,
+        profile_id: Uuid,
+        database: String,
+        collection: String,
+        page: CollectionChildrenPage,
+    ) {
+        if let Some(connected) = self.connections.get_mut(&profile_id) {
+            connected.cache_set(OwnedCacheEntry::CollectionChildren {
+                database,
+                collection,
+                page,
+            });
+        }
+    }
+
+    pub fn collection_children_cache(
+        &self,
+        profile_id: Uuid,
+        database: &str,
+        collection: &str,
+    ) -> Option<&CollectionChildrenCache> {
+        self.connections.get(&profile_id).and_then(|connection| {
+            connection
+                .collection_children
+                .get(&(database.to_string(), collection.to_string()))
+        })
+    }
+
+    pub fn needs_initial_collection_children(
+        &self,
+        profile_id: Uuid,
+        database: &str,
+        collection: &str,
+    ) -> bool {
+        let key = CacheKey::collection_children(database, collection);
+
+        self.connections
+            .get(&profile_id)
+            .is_some_and(|connection| !connection.cache_contains(&key))
+    }
+
+    pub fn has_more_collection_children(
+        &self,
+        profile_id: Uuid,
+        database: &str,
+        collection: &str,
+    ) -> bool {
+        self.collection_children_cache(profile_id, database, collection)
+            .and_then(|cache| cache.next_page_token.as_ref())
+            .is_some()
     }
 
     #[allow(dead_code)]
@@ -1009,6 +1104,7 @@ impl ConnectionManager {
                 schema,
                 database_schemas: HashMap::new(),
                 table_details: HashMap::new(),
+                collection_children: HashMap::new(),
                 schema_types: HashMap::new(),
                 schema_indexes: HashMap::new(),
                 schema_foreign_keys: HashMap::new(),
@@ -1075,6 +1171,45 @@ impl ConnectionManager {
             database: database.to_string(),
             schema: schema.map(String::from),
             table: table.to_string(),
+            connection: connected.connection_for_database(database),
+        })
+    }
+
+    pub fn prepare_fetch_collection_children(
+        &self,
+        profile_id: Uuid,
+        database: &str,
+        collection: &str,
+        limit: u32,
+    ) -> Result<FetchCollectionChildrenParams, String> {
+        let connected = self
+            .connections
+            .get(&profile_id)
+            .ok_or_else(|| "Profile not connected".to_string())?;
+
+        let page_token = connected
+            .collection_children
+            .get(&(database.to_string(), collection.to_string()))
+            .map(|cache| cache.next_page_token.clone())
+            .unwrap_or(None);
+
+        if connected
+            .collection_children
+            .contains_key(&(database.to_string(), collection.to_string()))
+            && page_token.is_none()
+        {
+            return Err("Collection children already fully cached".to_string());
+        }
+
+        Ok(FetchCollectionChildrenParams {
+            profile_id,
+            database: database.to_string(),
+            collection: collection.to_string(),
+            request: CollectionChildrenRequest {
+                collection: CollectionRef::new(database, collection),
+                limit,
+                page_token,
+            },
             connection: connected.connection_for_database(database),
         })
     }
@@ -1462,6 +1597,37 @@ pub struct FetchTableDetailsResult {
     pub details: TableInfo,
 }
 
+pub struct FetchCollectionChildrenParams {
+    pub profile_id: Uuid,
+    pub database: String,
+    pub collection: String,
+    pub request: CollectionChildrenRequest,
+    pub connection: Arc<dyn Connection>,
+}
+
+impl FetchCollectionChildrenParams {
+    pub fn execute(self) -> Result<FetchCollectionChildrenResult, String> {
+        let page = self
+            .connection
+            .collection_children(&self.request)
+            .map_err(|e| e.to_string())?;
+
+        Ok(FetchCollectionChildrenResult {
+            profile_id: self.profile_id,
+            database: self.database,
+            collection: self.collection,
+            page,
+        })
+    }
+}
+
+pub struct FetchCollectionChildrenResult {
+    pub profile_id: Uuid,
+    pub database: String,
+    pub collection: String,
+    pub page: CollectionChildrenPage,
+}
+
 pub struct FetchSchemaTypesParams {
     pub profile_id: Uuid,
     pub database: String,
@@ -1655,6 +1821,7 @@ mod tests {
             schema,
             database_schemas: HashMap::new(),
             table_details: HashMap::new(),
+            collection_children: HashMap::new(),
             schema_types: HashMap::new(),
             schema_indexes: HashMap::new(),
             schema_foreign_keys: HashMap::new(),

--- a/crates/dbflux_core/src/connection/mod.rs
+++ b/crates/dbflux_core/src/connection/mod.rs
@@ -27,7 +27,7 @@ pub trait TreeStore {
     fn save(&self, tree: &ConnectionTree) -> Result<(), DbError>;
 }
 
-pub use context::ExecutionContext;
+pub use context::{ExecutionContext, ExecutionSourceContext};
 pub use hook::{
     ConnectionHook, ConnectionHookBindings, ConnectionHooks, DetachedProcessHandle,
     DetachedProcessReceiver, DetachedProcessSender, HookContext, HookExecution, HookExecutionMode,

--- a/crates/dbflux_core/src/connection/mod.rs
+++ b/crates/dbflux_core/src/connection/mod.rs
@@ -39,7 +39,8 @@ pub use hook::{
 pub use item_manager::{AuthProfileManager, Identifiable, ItemManager};
 pub use manager::{
     CacheEntry, CacheKey, ConnectProfileParams, ConnectProfileResult, ConnectedProfile,
-    ConnectionManager, ConnectionResolutionError, DatabaseConnection, FetchDatabaseSchemaParams,
+    ConnectionManager, ConnectionResolutionError, DatabaseConnection,
+    FetchCollectionChildrenParams, FetchCollectionChildrenResult, FetchDatabaseSchemaParams,
     FetchDatabaseSchemaResult, FetchSchemaForeignKeysParams, FetchSchemaForeignKeysResult,
     FetchSchemaIndexesParams, FetchSchemaIndexesResult, FetchSchemaTypesParams,
     FetchSchemaTypesResult, FetchTableDetailsParams, FetchTableDetailsResult, HookExecutionContext,

--- a/crates/dbflux_core/src/connection/profile.rs
+++ b/crates/dbflux_core/src/connection/profile.rs
@@ -20,6 +20,7 @@ pub enum DbKind {
     MongoDB,
     Redis,
     DynamoDB,
+    CloudWatchLogs,
 }
 
 impl DbKind {
@@ -32,6 +33,7 @@ impl DbKind {
             DbKind::MongoDB => "MongoDB",
             DbKind::Redis => "Redis",
             DbKind::DynamoDB => "DynamoDB",
+            DbKind::CloudWatchLogs => "CloudWatch Logs",
         }
     }
 }
@@ -215,6 +217,13 @@ pub enum DbConfig {
         #[serde(default)]
         table: Option<String>,
     },
+    CloudWatchLogs {
+        region: String,
+        #[serde(default)]
+        profile: Option<String>,
+        #[serde(default)]
+        endpoint: Option<String>,
+    },
     /// Generic config for external RPC drivers.
     External {
         kind: DbKind,
@@ -236,6 +245,7 @@ impl DbConfig {
             DbConfig::MongoDB { .. } => DbKind::MongoDB,
             DbConfig::Redis { .. } => DbKind::Redis,
             DbConfig::DynamoDB { .. } => DbKind::DynamoDB,
+            DbConfig::CloudWatchLogs { .. } => DbKind::CloudWatchLogs,
             DbConfig::External { kind, .. } => *kind,
         }
     }
@@ -312,13 +322,24 @@ impl DbConfig {
         }
     }
 
+    pub fn default_cloudwatch_logs() -> Self {
+        DbConfig::CloudWatchLogs {
+            region: "us-east-1".to_string(),
+            profile: None,
+            endpoint: None,
+        }
+    }
+
     pub fn ssh_tunnel(&self) -> Option<&SshTunnelConfig> {
         match self {
             DbConfig::Postgres { ssh_tunnel, .. }
             | DbConfig::MySQL { ssh_tunnel, .. }
             | DbConfig::MongoDB { ssh_tunnel, .. }
             | DbConfig::Redis { ssh_tunnel, .. } => ssh_tunnel.as_ref(),
-            DbConfig::SQLite { .. } | DbConfig::DynamoDB { .. } | DbConfig::External { .. } => None,
+            DbConfig::SQLite { .. }
+            | DbConfig::DynamoDB { .. }
+            | DbConfig::CloudWatchLogs { .. }
+            | DbConfig::External { .. } => None,
         }
     }
 
@@ -345,9 +366,10 @@ impl DbConfig {
                 ssh_tunnel_profile_id,
                 ..
             } => ssh_tunnel.is_some() || ssh_tunnel_profile_id.is_some(),
-            DbConfig::SQLite { .. } | DbConfig::DynamoDB { .. } | DbConfig::External { .. } => {
-                false
-            }
+            DbConfig::SQLite { .. }
+            | DbConfig::DynamoDB { .. }
+            | DbConfig::CloudWatchLogs { .. }
+            | DbConfig::External { .. } => false,
         }
     }
 
@@ -358,7 +380,10 @@ impl DbConfig {
             | DbConfig::MySQL { host, port, .. }
             | DbConfig::MongoDB { host, port, .. }
             | DbConfig::Redis { host, port, .. } => Some((host, *port)),
-            DbConfig::SQLite { .. } | DbConfig::DynamoDB { .. } | DbConfig::External { .. } => None,
+            DbConfig::SQLite { .. }
+            | DbConfig::DynamoDB { .. }
+            | DbConfig::CloudWatchLogs { .. }
+            | DbConfig::External { .. } => None,
         }
     }
 
@@ -393,7 +418,10 @@ impl DbConfig {
                 *port = tunnel_port;
                 *use_uri = false;
             }
-            DbConfig::SQLite { .. } | DbConfig::DynamoDB { .. } | DbConfig::External { .. } => {}
+            DbConfig::SQLite { .. }
+            | DbConfig::DynamoDB { .. }
+            | DbConfig::CloudWatchLogs { .. }
+            | DbConfig::External { .. } => {}
         }
     }
 
@@ -407,7 +435,10 @@ impl DbConfig {
             | DbConfig::MySQL { use_uri, uri, .. }
             | DbConfig::MongoDB { use_uri, uri, .. }
             | DbConfig::Redis { use_uri, uri, .. } => (use_uri, uri),
-            DbConfig::SQLite { .. } | DbConfig::DynamoDB { .. } | DbConfig::External { .. } => {
+            DbConfig::SQLite { .. }
+            | DbConfig::DynamoDB { .. }
+            | DbConfig::CloudWatchLogs { .. }
+            | DbConfig::External { .. } => {
                 return None;
             }
         };
@@ -436,7 +467,7 @@ impl DbConfig {
             DbConfig::MongoDB { database, .. } => database.clone(),
             DbConfig::Redis { database, .. } => database.map(|d| d.to_string()),
             DbConfig::SQLite { .. } => Some("main".to_string()),
-            DbConfig::DynamoDB { .. } => None,
+            DbConfig::DynamoDB { .. } | DbConfig::CloudWatchLogs { .. } => None,
             DbConfig::External { .. } => None,
         }
     }
@@ -818,6 +849,7 @@ impl ConnectionProfile {
             DbKind::MongoDB => "mongodb",
             DbKind::Redis => "redis",
             DbKind::DynamoDB => "dynamodb",
+            DbKind::CloudWatchLogs => "cloudwatch",
         }
     }
 
@@ -1094,6 +1126,54 @@ mod tests {
                 assert_eq!(table.as_deref(), Some("users"));
             }
             _ => panic!("expected DynamoDB config variant"),
+        }
+    }
+
+    #[test]
+    fn cloudwatch_config_kind_and_driver_id_fallback_work() {
+        let json = r#"{
+            "id": "00000000-0000-0000-0000-000000000100",
+            "name": "legacy-cloudwatch",
+            "config": {
+                "CloudWatchLogs": {
+                    "region": "us-east-1"
+                }
+            }
+        }"#;
+
+        let profile: ConnectionProfile =
+            serde_json::from_str(json).expect("cloudwatch profile should deserialize");
+
+        assert_eq!(profile.kind(), DbKind::CloudWatchLogs);
+        assert_eq!(profile.driver_id(), "cloudwatch");
+    }
+
+    #[test]
+    fn cloudwatch_profile_serde_roundtrip_preserves_optional_fields() {
+        let profile = ConnectionProfile::new(
+            "cloudwatch",
+            DbConfig::CloudWatchLogs {
+                region: "us-west-2".to_string(),
+                profile: Some("dev".to_string()),
+                endpoint: Some("http://localhost:4566".to_string()),
+            },
+        );
+
+        let json = serde_json::to_string(&profile).expect("serialize should succeed");
+        let restored: ConnectionProfile =
+            serde_json::from_str(&json).expect("deserialize should succeed");
+
+        match restored.config {
+            DbConfig::CloudWatchLogs {
+                region,
+                profile,
+                endpoint,
+            } => {
+                assert_eq!(region, "us-west-2");
+                assert_eq!(profile.as_deref(), Some("dev"));
+                assert_eq!(endpoint.as_deref(), Some("http://localhost:4566"));
+            }
+            _ => panic!("expected CloudWatch Logs config variant"),
         }
     }
 

--- a/crates/dbflux_core/src/connection/profile.rs
+++ b/crates/dbflux_core/src/connection/profile.rs
@@ -867,6 +867,24 @@ impl ConnectionProfile {
         self.auth_profile_id.is_some() || !self.value_refs.is_empty() || self.access_kind.is_some()
     }
 
+    /// Returns an external auth profile name embedded in the driver config.
+    ///
+    /// This lets app-layer connection orchestration route profiles through the
+    /// generic auth pipeline without matching on concrete driver names.
+    pub fn external_auth_profile_name(&self) -> Option<&str> {
+        match &self.config {
+            DbConfig::CloudWatchLogs {
+                profile: Some(profile),
+                ..
+            }
+            | DbConfig::DynamoDB {
+                profile: Some(profile),
+                ..
+            } => Some(profile.as_str()),
+            _ => None,
+        }
+    }
+
     /// Derives an AccessKind from legacy fields (proxy_profile_id, ssh_tunnel_profile_id)
     /// for backward compatibility.
     pub fn legacy_access_kind(&self) -> AccessKind {

--- a/crates/dbflux_core/src/core/mod.rs
+++ b/crates/dbflux_core/src/core/mod.rs
@@ -18,6 +18,6 @@ pub use traits::{
     CodeGenScope, CodeGeneratorInfo, Connection, ConnectionExt, ConnectionOverrides, DbDriver,
     DocumentConnection, EventStreamTarget, KeyValueApi, KeyValueConnection, NoopCancelHandle,
     QueryCancelHandle, RelationalConnection, SchemaDropTarget, SchemaFeatures,
-    SchemaLoadingStrategy, SchemaObjectKind, SourceContextSpec,
+    SchemaLoadingStrategy, SchemaObjectKind, SourceContextSpec, SourceQueryMode,
 };
 pub use value::Value;

--- a/crates/dbflux_core/src/core/mod.rs
+++ b/crates/dbflux_core/src/core/mod.rs
@@ -16,8 +16,8 @@ pub use task::{
 };
 pub use traits::{
     CodeGenScope, CodeGeneratorInfo, Connection, ConnectionExt, ConnectionOverrides, DbDriver,
-    DocumentConnection, KeyValueApi, KeyValueConnection, NoopCancelHandle, QueryCancelHandle,
-    RelationalConnection, SchemaDropTarget, SchemaFeatures, SchemaLoadingStrategy,
-    SchemaObjectKind,
+    DocumentConnection, EventStreamTarget, KeyValueApi, KeyValueConnection, NoopCancelHandle,
+    QueryCancelHandle, RelationalConnection, SchemaDropTarget, SchemaFeatures,
+    SchemaLoadingStrategy, SchemaObjectKind, SourceContextSpec,
 };
 pub use value::Value;

--- a/crates/dbflux_core/src/core/traits.rs
+++ b/crates/dbflux_core/src/core/traits.rs
@@ -4,13 +4,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     CodeGenCapabilities, CodeGenerator, CollectionBrowseRequest, CollectionCountRequest,
-    ConnectionProfile, CrudResult, CustomTypeInfo, DatabaseInfo, DbConfig, DbError, DbKind,
-    DbSchemaInfo, DescribeRequest, DocumentDelete, DocumentInsert, DocumentUpdate,
-    DriverCapabilities, DriverFormDef, DriverMetadata, ExplainRequest, FormValues, LanguageService,
-    NoOpCodeGenerator, QueryHandle, QueryRequest, QueryResult, RowDelete, RowInsert, RowPatch,
-    SchemaForeignKeyInfo, SchemaIndexInfo, SchemaSnapshot, SemanticPlan, SemanticPlanner,
-    SemanticRequest, SqlDialect, SqlGenerationRequest, SqlLanguageService, TableBrowseRequest,
-    TableCountRequest, TableInfo, Value, ViewInfo,
+    CollectionRef, ConnectionProfile, CrudResult, CustomTypeInfo, DatabaseInfo, DbConfig,
+    DbError, DbKind, DbSchemaInfo, DescribeRequest, DocumentDelete, DocumentInsert,
+    DocumentUpdate, DriverCapabilities, DriverFormDef, DriverMetadata, EventPage, EventQuery,
+    ExplainRequest, FormValues, LanguageService, NoOpCodeGenerator, QueryHandle, QueryRequest,
+    QueryResult, RowDelete, RowInsert, RowPatch, SchemaForeignKeyInfo, SchemaIndexInfo,
+    SchemaSnapshot, SemanticPlan, SemanticPlanner, SemanticRequest, SqlDialect,
+    SqlGenerationRequest, SqlLanguageService, TableBrowseRequest, TableCountRequest, TableInfo,
+    Value, ViewInfo,
     config::DriverKey,
     data::key_value::{
         HashDeleteRequest, HashSetRequest, KeyBulkGetRequest, KeyDeleteRequest, KeyExistsRequest,
@@ -87,6 +88,22 @@ pub enum SchemaObjectKind {
     View,
     Database,
     Collection,
+}
+
+/// Additional source controls requested by a driver for query execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceContextSpec {
+    pub targets_label: String,
+    pub targets_placeholder: String,
+    pub start_label: String,
+    pub end_label: String,
+}
+
+/// A driver-owned event stream target that can be opened in the audit document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EventStreamTarget {
+    pub collection: CollectionRef,
+    pub child_id: Option<String>,
 }
 
 impl SchemaObjectKind {
@@ -815,6 +832,22 @@ pub trait Connection: Send + Sync {
         Err(DbError::NotSupported(
             "Collection counting not supported by this driver".to_string(),
         ))
+    }
+
+    /// Browse a driver-owned event stream source as canonical observability records.
+    fn browse_event_stream(
+        &self,
+        _target: &EventStreamTarget,
+        _query: &EventQuery,
+    ) -> Result<EventPage, DbError> {
+        Err(DbError::NotSupported(
+            "Event stream browsing not supported by this driver".to_string(),
+        ))
+    }
+
+    /// Optional source-context controls exposed by this driver in query documents.
+    fn source_context_spec(&self) -> Option<SourceContextSpec> {
+        None
     }
 
     /// Explain a query execution plan for a table or custom query.

--- a/crates/dbflux_core/src/core/traits.rs
+++ b/crates/dbflux_core/src/core/traits.rs
@@ -3,15 +3,15 @@ use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    CodeGenCapabilities, CodeGenerator, CollectionBrowseRequest, CollectionCountRequest,
-    CollectionRef, ConnectionProfile, CrudResult, CustomTypeInfo, DatabaseInfo, DbConfig, DbError,
-    DbKind, DbSchemaInfo, DescribeRequest, DocumentDelete, DocumentInsert, DocumentUpdate,
-    DriverCapabilities, DriverFormDef, DriverMetadata, EventPage, EventQuery, ExplainRequest,
-    FormValues, LanguageService, NoOpCodeGenerator, QueryHandle, QueryLanguage, QueryRequest,
-    QueryResult, RowDelete, RowInsert, RowPatch, SchemaForeignKeyInfo, SchemaIndexInfo,
-    SchemaSnapshot, SemanticPlan, SemanticPlanner, SemanticRequest, SqlDialect,
-    SqlGenerationRequest, SqlLanguageService, TableBrowseRequest, TableCountRequest, TableInfo,
-    Value, ViewInfo,
+    CodeGenCapabilities, CodeGenerator, CollectionBrowseRequest, CollectionChildrenPage,
+    CollectionChildrenRequest, CollectionCountRequest, CollectionRef, ConnectionProfile,
+    CrudResult, CustomTypeInfo, DatabaseInfo, DbConfig, DbError, DbKind, DbSchemaInfo,
+    DescribeRequest, DocumentDelete, DocumentInsert, DocumentUpdate, DriverCapabilities,
+    DriverFormDef, DriverMetadata, EventPage, EventQuery, ExplainRequest, FormValues,
+    LanguageService, NoOpCodeGenerator, QueryHandle, QueryLanguage, QueryRequest, QueryResult,
+    RowDelete, RowInsert, RowPatch, SchemaForeignKeyInfo, SchemaIndexInfo, SchemaSnapshot,
+    SemanticPlan, SemanticPlanner, SemanticRequest, SqlDialect, SqlGenerationRequest,
+    SqlLanguageService, TableBrowseRequest, TableCountRequest, TableInfo, Value, ViewInfo,
     config::DriverKey,
     data::key_value::{
         HashDeleteRequest, HashSetRequest, KeyBulkGetRequest, KeyDeleteRequest, KeyExistsRequest,
@@ -833,6 +833,16 @@ pub trait Connection: Send + Sync {
     ) -> Result<QueryResult, DbError> {
         Err(DbError::NotSupported(
             "Collection browsing not supported by this driver".to_string(),
+        ))
+    }
+
+    /// List driver-owned child sources under a collection/container.
+    fn collection_children(
+        &self,
+        _request: &CollectionChildrenRequest,
+    ) -> Result<CollectionChildrenPage, DbError> {
+        Err(DbError::NotSupported(
+            "Collection child listing not supported by this driver".to_string(),
         ))
     }
 

--- a/crates/dbflux_core/src/core/traits.rs
+++ b/crates/dbflux_core/src/core/traits.rs
@@ -8,9 +8,10 @@ use crate::{
     DbKind, DbSchemaInfo, DescribeRequest, DocumentDelete, DocumentInsert, DocumentUpdate,
     DriverCapabilities, DriverFormDef, DriverMetadata, EventPage, EventQuery, ExplainRequest,
     FormValues, LanguageService, NoOpCodeGenerator, QueryHandle, QueryLanguage, QueryRequest,
-    QueryResult, RowDelete, RowInsert, RowPatch, SchemaForeignKeyInfo, SchemaIndexInfo, SchemaSnapshot,
-    SemanticPlan, SemanticPlanner, SemanticRequest, SqlDialect, SqlGenerationRequest,
-    SqlLanguageService, TableBrowseRequest, TableCountRequest, TableInfo, Value, ViewInfo,
+    QueryResult, RowDelete, RowInsert, RowPatch, SchemaForeignKeyInfo, SchemaIndexInfo,
+    SchemaSnapshot, SemanticPlan, SemanticPlanner, SemanticRequest, SqlDialect,
+    SqlGenerationRequest, SqlLanguageService, TableBrowseRequest, TableCountRequest, TableInfo,
+    Value, ViewInfo,
     config::DriverKey,
     data::key_value::{
         HashDeleteRequest, HashSetRequest, KeyBulkGetRequest, KeyDeleteRequest, KeyExistsRequest,

--- a/crates/dbflux_core/src/core/traits.rs
+++ b/crates/dbflux_core/src/core/traits.rs
@@ -4,14 +4,13 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     CodeGenCapabilities, CodeGenerator, CollectionBrowseRequest, CollectionCountRequest,
-    CollectionRef, ConnectionProfile, CrudResult, CustomTypeInfo, DatabaseInfo, DbConfig,
-    DbError, DbKind, DbSchemaInfo, DescribeRequest, DocumentDelete, DocumentInsert,
-    DocumentUpdate, DriverCapabilities, DriverFormDef, DriverMetadata, EventPage, EventQuery,
-    ExplainRequest, FormValues, LanguageService, NoOpCodeGenerator, QueryHandle, QueryRequest,
-    QueryResult, RowDelete, RowInsert, RowPatch, SchemaForeignKeyInfo, SchemaIndexInfo,
-    SchemaSnapshot, SemanticPlan, SemanticPlanner, SemanticRequest, SqlDialect,
-    SqlGenerationRequest, SqlLanguageService, TableBrowseRequest, TableCountRequest, TableInfo,
-    Value, ViewInfo,
+    CollectionRef, ConnectionProfile, CrudResult, CustomTypeInfo, DatabaseInfo, DbConfig, DbError,
+    DbKind, DbSchemaInfo, DescribeRequest, DocumentDelete, DocumentInsert, DocumentUpdate,
+    DriverCapabilities, DriverFormDef, DriverMetadata, EventPage, EventQuery, ExplainRequest,
+    FormValues, LanguageService, NoOpCodeGenerator, QueryHandle, QueryRequest, QueryResult,
+    RowDelete, RowInsert, RowPatch, SchemaForeignKeyInfo, SchemaIndexInfo, SchemaSnapshot,
+    SemanticPlan, SemanticPlanner, SemanticRequest, SqlDialect, SqlGenerationRequest,
+    SqlLanguageService, TableBrowseRequest, TableCountRequest, TableInfo, Value, ViewInfo,
     config::DriverKey,
     data::key_value::{
         HashDeleteRequest, HashSetRequest, KeyBulkGetRequest, KeyDeleteRequest, KeyExistsRequest,

--- a/crates/dbflux_core/src/core/traits.rs
+++ b/crates/dbflux_core/src/core/traits.rs
@@ -7,8 +7,8 @@ use crate::{
     CollectionRef, ConnectionProfile, CrudResult, CustomTypeInfo, DatabaseInfo, DbConfig, DbError,
     DbKind, DbSchemaInfo, DescribeRequest, DocumentDelete, DocumentInsert, DocumentUpdate,
     DriverCapabilities, DriverFormDef, DriverMetadata, EventPage, EventQuery, ExplainRequest,
-    FormValues, LanguageService, NoOpCodeGenerator, QueryHandle, QueryRequest, QueryResult,
-    RowDelete, RowInsert, RowPatch, SchemaForeignKeyInfo, SchemaIndexInfo, SchemaSnapshot,
+    FormValues, LanguageService, NoOpCodeGenerator, QueryHandle, QueryLanguage, QueryRequest,
+    QueryResult, RowDelete, RowInsert, RowPatch, SchemaForeignKeyInfo, SchemaIndexInfo, SchemaSnapshot,
     SemanticPlan, SemanticPlanner, SemanticRequest, SqlDialect, SqlGenerationRequest,
     SqlLanguageService, TableBrowseRequest, TableCountRequest, TableInfo, Value, ViewInfo,
     config::DriverKey,
@@ -91,11 +91,22 @@ pub enum SchemaObjectKind {
 
 /// Additional source controls requested by a driver for query execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourceQueryMode {
+    pub value: String,
+    pub label: String,
+    pub query_language: QueryLanguage,
+}
+
+/// Additional source controls requested by a driver for query execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceContextSpec {
     pub targets_label: String,
     pub targets_placeholder: String,
     pub start_label: String,
     pub end_label: String,
+    pub query_mode_label: Option<String>,
+    pub query_modes: Vec<SourceQueryMode>,
+    pub default_query_mode: Option<String>,
 }
 
 /// A driver-owned event stream target that can be opened in the audit document.

--- a/crates/dbflux_core/src/driver/capabilities.rs
+++ b/crates/dbflux_core/src/driver/capabilities.rs
@@ -552,6 +552,15 @@ pub enum QueryLanguage {
     /// Standard SQL (with dialect variations).
     Sql,
 
+    /// CloudWatch Logs Insights query language.
+    CloudWatchLogsInsightsQl,
+
+    /// OpenSearch Piped Processing Language.
+    OpenSearchPpl,
+
+    /// OpenSearch SQL as exposed by CloudWatch Logs.
+    OpenSearchSql,
+
     /// MongoDB Query Language (find, aggregate, etc.).
     MongoQuery,
 
@@ -589,6 +598,8 @@ impl QueryLanguage {
         let ext = path.extension()?.to_str()?.to_lowercase();
         match ext.as_str() {
             "sql" => Some(Self::Sql),
+            "cwli" => Some(Self::CloudWatchLogsInsightsQl),
+            "ppl" => Some(Self::OpenSearchPpl),
             "js" | "mongodb" => Some(Self::MongoQuery),
             "redis" | "red" => Some(Self::RedisCommands),
             "cypher" | "cyp" => Some(Self::Cypher),
@@ -604,7 +615,9 @@ impl QueryLanguage {
     /// Default file extension for "Save As" dialogs.
     pub fn default_extension(&self) -> &'static str {
         match self {
-            Self::Sql | Self::Cql => "sql",
+            Self::Sql | Self::OpenSearchSql | Self::Cql => "sql",
+            Self::CloudWatchLogsInsightsQl => "cwli",
+            Self::OpenSearchPpl => "ppl",
             Self::MongoQuery => "js",
             Self::RedisCommands => "redis",
             Self::Cypher => "cypher",
@@ -620,6 +633,9 @@ impl QueryLanguage {
     pub fn file_dialog_extensions(&self) -> &[&'static str] {
         match self {
             Self::Sql => &["sql"],
+            Self::CloudWatchLogsInsightsQl => &["cwli"],
+            Self::OpenSearchPpl => &["ppl"],
+            Self::OpenSearchSql => &["sql"],
             Self::MongoQuery => &["js", "mongodb"],
             Self::RedisCommands => &["redis", "red"],
             Self::Cypher => &["cypher", "cyp"],
@@ -635,6 +651,9 @@ impl QueryLanguage {
     pub fn display_name(&self) -> &str {
         match self {
             QueryLanguage::Sql => "SQL",
+            QueryLanguage::CloudWatchLogsInsightsQl => "CloudWatch Logs Insights QL",
+            QueryLanguage::OpenSearchPpl => "OpenSearch PPL",
+            QueryLanguage::OpenSearchSql => "OpenSearch SQL",
             QueryLanguage::MongoQuery => "MongoDB Query",
             QueryLanguage::RedisCommands => "Redis Commands",
             QueryLanguage::Cypher => "Cypher",
@@ -651,6 +670,9 @@ impl QueryLanguage {
     pub fn file_extension(&self) -> &'static str {
         match self {
             QueryLanguage::Sql => "sql",
+            QueryLanguage::CloudWatchLogsInsightsQl => "cwli",
+            QueryLanguage::OpenSearchPpl => "ppl",
+            QueryLanguage::OpenSearchSql => "sql",
             QueryLanguage::MongoQuery => "mongodb",
             QueryLanguage::RedisCommands => "redis",
             QueryLanguage::Cypher => "cypher",
@@ -666,7 +688,8 @@ impl QueryLanguage {
     /// Returns the syntax highlighting mode for code editors.
     pub fn editor_mode(&self) -> &'static str {
         match self {
-            QueryLanguage::Sql | QueryLanguage::Cql => "sql",
+            QueryLanguage::Sql | QueryLanguage::OpenSearchSql | QueryLanguage::Cql => "sql",
+            QueryLanguage::CloudWatchLogsInsightsQl | QueryLanguage::OpenSearchPpl => "plaintext",
             QueryLanguage::MongoQuery => "javascript",
             QueryLanguage::RedisCommands => "plaintext",
             QueryLanguage::Cypher => "cypher",
@@ -682,6 +705,11 @@ impl QueryLanguage {
     pub fn placeholder(&self) -> &'static str {
         match self {
             QueryLanguage::Sql => "-- Enter SQL here...",
+            QueryLanguage::CloudWatchLogsInsightsQl => "fields @timestamp, @message | sort @timestamp desc | limit 100",
+            QueryLanguage::OpenSearchPpl => "source = logGroups(logGroupIdentifier: ['LogGroup']) | fields @timestamp, @message | head 100",
+            QueryLanguage::OpenSearchSql => {
+                "SELECT `@timestamp`, `@message` FROM `logGroups(logGroupIdentifier: ['LogGroup'])` LIMIT 100"
+            }
             QueryLanguage::MongoQuery => "// db.collection.find({})",
             QueryLanguage::RedisCommands => "# Enter Redis command...",
             QueryLanguage::Cypher => "// Enter Cypher query...",
@@ -697,7 +725,11 @@ impl QueryLanguage {
     /// Returns the comment prefix for this query language.
     pub fn comment_prefix(&self) -> &'static str {
         match self {
-            QueryLanguage::Sql | QueryLanguage::InfluxQuery | QueryLanguage::Cql => "--",
+            QueryLanguage::Sql
+            | QueryLanguage::OpenSearchSql
+            | QueryLanguage::InfluxQuery
+            | QueryLanguage::Cql => "--",
+            QueryLanguage::CloudWatchLogsInsightsQl | QueryLanguage::OpenSearchPpl => "#",
             QueryLanguage::MongoQuery | QueryLanguage::Cypher => "//",
             QueryLanguage::RedisCommands | QueryLanguage::Python | QueryLanguage::Bash => "#",
             QueryLanguage::Lua => "--",
@@ -709,6 +741,9 @@ impl QueryLanguage {
         matches!(
             self,
             QueryLanguage::Sql
+                | QueryLanguage::CloudWatchLogsInsightsQl
+                | QueryLanguage::OpenSearchPpl
+                | QueryLanguage::OpenSearchSql
                 | QueryLanguage::MongoQuery
                 | QueryLanguage::RedisCommands
                 | QueryLanguage::Cypher

--- a/crates/dbflux_core/src/driver/capabilities.rs
+++ b/crates/dbflux_core/src/driver/capabilities.rs
@@ -705,8 +705,12 @@ impl QueryLanguage {
     pub fn placeholder(&self) -> &'static str {
         match self {
             QueryLanguage::Sql => "-- Enter SQL here...",
-            QueryLanguage::CloudWatchLogsInsightsQl => "fields @timestamp, @message | sort @timestamp desc | limit 100",
-            QueryLanguage::OpenSearchPpl => "source = logGroups(logGroupIdentifier: ['LogGroup']) | fields @timestamp, @message | head 100",
+            QueryLanguage::CloudWatchLogsInsightsQl => {
+                "fields @timestamp, @message | sort @timestamp desc | limit 100"
+            }
+            QueryLanguage::OpenSearchPpl => {
+                "source = logGroups(logGroupIdentifier: ['LogGroup']) | fields @timestamp, @message | head 100"
+            }
             QueryLanguage::OpenSearchSql => {
                 "SELECT `@timestamp`, `@message` FROM `logGroups(logGroupIdentifier: ['LogGroup'])` LIMIT 100"
             }

--- a/crates/dbflux_core/src/driver/form.rs
+++ b/crates/dbflux_core/src/driver/form.rs
@@ -504,6 +504,31 @@ pub static DYNAMODB_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormD
     }],
 });
 
+pub static CLOUDWATCH_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef {
+    tabs: vec![FormTab {
+        id: "main".into(),
+        label: "Main".into(),
+        sections: vec![FormSection {
+            title: "AWS".into(),
+            fields: vec![
+                field_required("region", "Region", FormFieldKind::Text, "us-east-1"),
+                field(
+                    "profile",
+                    "Profile",
+                    FormFieldKind::Text,
+                    "optional AWS profile",
+                ),
+                field(
+                    "endpoint",
+                    "Endpoint Override",
+                    FormFieldKind::Text,
+                    "http://localhost:4566",
+                ),
+            ],
+        }],
+    }],
+});
+
 // ---------------------------------------------------------------------------
 // Impl blocks
 // ---------------------------------------------------------------------------
@@ -535,5 +560,25 @@ impl DriverFormDef {
             .flat_map(|t| t.sections.iter())
             .flat_map(|s| s.fields.iter())
             .find(|f| f.id == id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CLOUDWATCH_FORM;
+
+    #[test]
+    fn cloudwatch_form_exposes_aws_region_profile_and_endpoint_fields() {
+        let main_tab = CLOUDWATCH_FORM.main_tab().expect("main tab");
+
+        assert!(
+            main_tab
+                .sections
+                .iter()
+                .flat_map(|section| section.fields.iter())
+                .any(|field| field.id == "region" && field.required)
+        );
+        assert!(CLOUDWATCH_FORM.field("profile").is_some());
+        assert!(CLOUDWATCH_FORM.field("endpoint").is_some());
     }
 }

--- a/crates/dbflux_core/src/driver/mod.rs
+++ b/crates/dbflux_core/src/driver/mod.rs
@@ -8,7 +8,7 @@ pub use capabilities::{
     TransactionCapabilities, WhereOperator,
 };
 pub use form::{
-    DYNAMODB_FORM, DriverFormDef, FormFieldDef, FormFieldKind, FormSection, FormTab, FormValues,
-    MONGODB_FORM, MYSQL_FORM, POSTGRES_FORM, REDIS_FORM, SQLITE_FORM, SelectOption,
-    field_file_path, field_password, field_use_uri, ssh_tab,
+    CLOUDWATCH_FORM, DYNAMODB_FORM, DriverFormDef, FormFieldDef, FormFieldKind, FormSection,
+    FormTab, FormValues, MONGODB_FORM, MYSQL_FORM, POSTGRES_FORM, REDIS_FORM, SQLITE_FORM,
+    SelectOption, field_file_path, field_password, field_use_uri, ssh_tab,
 };

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -57,11 +57,11 @@ pub use connection::{
 pub use core::{
     CancelToken, CodeGenScope, CodeGeneratorInfo, Connection, ConnectionErrorFormatter,
     ConnectionExt, ConnectionOverrides, DbDriver, DbError, DefaultErrorFormatter,
-    DocumentConnection, ErrorLocation, FormattedError, KeyValueApi, KeyValueConnection,
-    NoopCancelHandle, QueryCancelHandle, QueryErrorFormatter, RelationalConnection,
-    SchemaDropTarget, SchemaFeatures, SchemaLoadingStrategy, SchemaObjectKind, ShutdownCoordinator,
-    ShutdownPhase, TaskId, TaskKind, TaskManager, TaskSlot, TaskSnapshot, TaskStatus, TaskTarget,
-    Value, sanitize_uri,
+    DocumentConnection, ErrorLocation, EventStreamTarget, FormattedError, KeyValueApi,
+    KeyValueConnection, NoopCancelHandle, QueryCancelHandle, QueryErrorFormatter,
+    RelationalConnection, SchemaDropTarget, SchemaFeatures, SchemaLoadingStrategy,
+    SchemaObjectKind, ShutdownCoordinator, ShutdownPhase, SourceContextSpec, TaskId, TaskKind,
+    TaskManager, TaskSlot, TaskSnapshot, TaskStatus, TaskTarget, Value, sanitize_uri,
 };
 
 pub use data::{
@@ -106,17 +106,18 @@ pub use query::{
 
 pub use schema::node_id as schema_node_id;
 pub use schema::{
-    CollectionIndexInfo, CollectionInfo, ColumnFamilyInfo, ColumnInfo, ConstraintInfo,
-    ConstraintKind, ContainerInfo, CustomTypeInfo, CustomTypeKind, DataStructure, DatabaseInfo,
-    DbSchemaInfo, DocumentSchema, FieldInfo, ForeignKeyBuilder, ForeignKeyInfo, GraphInfo,
-    GraphSchema, IndexBuilder, IndexData, IndexDirection, IndexInfo, KeyInfo, KeySpaceInfo,
-    KeyValueSchema, MeasurementInfo, MultiModelCapabilities, MultiModelSchema, NodeLabelInfo,
-    ParseSchemaNodeIdError, PropertyInfo, RelationalSchema, RelationshipTypeInfo,
-    RetentionPolicyInfo, SchemaForeignKeyBuilder, SchemaForeignKeyInfo, SchemaIndexBuilder,
-    SchemaIndexInfo, SchemaNodeId, SchemaNodeKind, SchemaSnapshot, SearchIndexInfo,
-    SearchMappingInfo, SearchSchema, TableInfo, TimeSeriesFieldInfo, TimeSeriesSchema,
-    VectorCollectionInfo, VectorMetadataField, VectorMetric, VectorSchema, ViewInfo,
-    WideColumnInfo, WideColumnKeyspaceInfo, WideColumnSchema,
+    CollectionChildInfo, CollectionIndexInfo, CollectionInfo, CollectionPresentation,
+    ColumnFamilyInfo, ColumnInfo, ConstraintInfo, ConstraintKind, ContainerInfo, CustomTypeInfo,
+    CustomTypeKind, DataStructure, DatabaseInfo, DbSchemaInfo, DocumentSchema, FieldInfo,
+    ForeignKeyBuilder, ForeignKeyInfo, GraphInfo, GraphSchema, IndexBuilder, IndexData,
+    IndexDirection, IndexInfo, KeyInfo, KeySpaceInfo, KeyValueSchema, MeasurementInfo,
+    MultiModelCapabilities, MultiModelSchema, NodeLabelInfo, ParseSchemaNodeIdError,
+    PropertyInfo, RelationalSchema, RelationshipTypeInfo, RetentionPolicyInfo,
+    SchemaForeignKeyBuilder, SchemaForeignKeyInfo, SchemaIndexBuilder, SchemaIndexInfo,
+    SchemaNodeId, SchemaNodeKind, SchemaSnapshot, SearchIndexInfo, SearchMappingInfo,
+    SearchSchema, TableInfo, TimeSeriesFieldInfo, TimeSeriesSchema, VectorCollectionInfo,
+    VectorMetadataField, VectorMetric, VectorSchema, ViewInfo, WideColumnInfo,
+    WideColumnKeyspaceInfo, WideColumnSchema,
 };
 
 pub use sql::{

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -39,19 +39,19 @@ pub use connection::{
     ConnectionResolutionError, ConnectionTree, ConnectionTreeManager, ConnectionTreeNode,
     ConnectionTreeNodeKind, ConnectionTreeStore, DatabaseConnection, DbConfig, DbKind,
     DetachedProcessHandle, DetachedProcessReceiver, DetachedProcessSender, ExecutionContext,
-    ExecutionSourceContext, FetchDatabaseSchemaParams, FetchDatabaseSchemaResult,
-    FetchSchemaForeignKeysParams, FetchSchemaForeignKeysResult, FetchSchemaIndexesParams,
-    FetchSchemaIndexesResult, FetchSchemaTypesParams, FetchSchemaTypesResult,
-    FetchTableDetailsParams, FetchTableDetailsResult, HookContext, HookExecution,
-    HookExecutionContext, HookExecutionMode, HookExecutor, HookFailureMode, HookKind, HookPhase,
-    HookPhaseOutcome, HookResult, HookRunner, Identifiable, ItemManager, LuaCapabilities,
-    OutputEvent, OutputReceiver, OutputSender, OutputStreamKind, OwnedCacheEntry, PendingOperation,
-    PrepareConnectError, ProcessExecutionError, ProcessExecutor, ProfileManager, ProxyAuth,
-    ProxyKind, ProxyManager, ProxyProfile, RedisKeyCache, RedisKeyCacheEntry, ResolvedProxy,
-    SchemaCacheKey, ScriptLanguage, ScriptSource, SshAuthMethod, SshTunnelConfig, SshTunnelManager,
-    SshTunnelProfile, SslMode, SwitchDatabaseParams, SwitchDatabaseResult, TreeLoadResult,
-    TreeStore, detached_process_channel, execute_streaming_process, host_matches_no_proxy,
-    output_channel,
+    ExecutionSourceContext, FetchCollectionChildrenParams, FetchCollectionChildrenResult,
+    FetchDatabaseSchemaParams, FetchDatabaseSchemaResult, FetchSchemaForeignKeysParams,
+    FetchSchemaForeignKeysResult, FetchSchemaIndexesParams, FetchSchemaIndexesResult,
+    FetchSchemaTypesParams, FetchSchemaTypesResult, FetchTableDetailsParams,
+    FetchTableDetailsResult, HookContext, HookExecution, HookExecutionContext, HookExecutionMode,
+    HookExecutor, HookFailureMode, HookKind, HookPhase, HookPhaseOutcome, HookResult, HookRunner,
+    Identifiable, ItemManager, LuaCapabilities, OutputEvent, OutputReceiver, OutputSender,
+    OutputStreamKind, OwnedCacheEntry, PendingOperation, PrepareConnectError,
+    ProcessExecutionError, ProcessExecutor, ProfileManager, ProxyAuth, ProxyKind, ProxyManager,
+    ProxyProfile, RedisKeyCache, RedisKeyCacheEntry, ResolvedProxy, SchemaCacheKey, ScriptLanguage,
+    ScriptSource, SshAuthMethod, SshTunnelConfig, SshTunnelManager, SshTunnelProfile, SslMode,
+    SwitchDatabaseParams, SwitchDatabaseResult, TreeLoadResult, TreeStore,
+    detached_process_channel, execute_streaming_process, host_matches_no_proxy, output_channel,
 };
 
 pub use core::{
@@ -107,7 +107,8 @@ pub use query::{
 
 pub use schema::node_id as schema_node_id;
 pub use schema::{
-    CollectionChildInfo, CollectionIndexInfo, CollectionInfo, CollectionPresentation,
+    CollectionChildInfo, CollectionChildrenCache, CollectionChildrenPage,
+    CollectionChildrenRequest, CollectionIndexInfo, CollectionInfo, CollectionPresentation,
     ColumnFamilyInfo, ColumnInfo, ConstraintInfo, ConstraintKind, ContainerInfo, CustomTypeInfo,
     CustomTypeKind, DataStructure, DatabaseInfo, DbSchemaInfo, DocumentSchema, FieldInfo,
     ForeignKeyBuilder, ForeignKeyInfo, GraphInfo, GraphSchema, IndexBuilder, IndexData,

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -111,13 +111,12 @@ pub use schema::{
     CustomTypeKind, DataStructure, DatabaseInfo, DbSchemaInfo, DocumentSchema, FieldInfo,
     ForeignKeyBuilder, ForeignKeyInfo, GraphInfo, GraphSchema, IndexBuilder, IndexData,
     IndexDirection, IndexInfo, KeyInfo, KeySpaceInfo, KeyValueSchema, MeasurementInfo,
-    MultiModelCapabilities, MultiModelSchema, NodeLabelInfo, ParseSchemaNodeIdError,
-    PropertyInfo, RelationalSchema, RelationshipTypeInfo, RetentionPolicyInfo,
-    SchemaForeignKeyBuilder, SchemaForeignKeyInfo, SchemaIndexBuilder, SchemaIndexInfo,
-    SchemaNodeId, SchemaNodeKind, SchemaSnapshot, SearchIndexInfo, SearchMappingInfo,
-    SearchSchema, TableInfo, TimeSeriesFieldInfo, TimeSeriesSchema, VectorCollectionInfo,
-    VectorMetadataField, VectorMetric, VectorSchema, ViewInfo, WideColumnInfo,
-    WideColumnKeyspaceInfo, WideColumnSchema,
+    MultiModelCapabilities, MultiModelSchema, NodeLabelInfo, ParseSchemaNodeIdError, PropertyInfo,
+    RelationalSchema, RelationshipTypeInfo, RetentionPolicyInfo, SchemaForeignKeyBuilder,
+    SchemaForeignKeyInfo, SchemaIndexBuilder, SchemaIndexInfo, SchemaNodeId, SchemaNodeKind,
+    SchemaSnapshot, SearchIndexInfo, SearchMappingInfo, SearchSchema, TableInfo,
+    TimeSeriesFieldInfo, TimeSeriesSchema, VectorCollectionInfo, VectorMetadataField, VectorMetric,
+    VectorSchema, ViewInfo, WideColumnInfo, WideColumnKeyspaceInfo, WideColumnSchema,
 };
 
 pub use sql::{

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -39,18 +39,19 @@ pub use connection::{
     ConnectionResolutionError, ConnectionTree, ConnectionTreeManager, ConnectionTreeNode,
     ConnectionTreeNodeKind, ConnectionTreeStore, DatabaseConnection, DbConfig, DbKind,
     DetachedProcessHandle, DetachedProcessReceiver, DetachedProcessSender, ExecutionContext,
-    FetchDatabaseSchemaParams, FetchDatabaseSchemaResult, FetchSchemaForeignKeysParams,
-    FetchSchemaForeignKeysResult, FetchSchemaIndexesParams, FetchSchemaIndexesResult,
-    FetchSchemaTypesParams, FetchSchemaTypesResult, FetchTableDetailsParams,
-    FetchTableDetailsResult, HookContext, HookExecution, HookExecutionContext, HookExecutionMode,
-    HookExecutor, HookFailureMode, HookKind, HookPhase, HookPhaseOutcome, HookResult, HookRunner,
-    Identifiable, ItemManager, LuaCapabilities, OutputEvent, OutputReceiver, OutputSender,
-    OutputStreamKind, OwnedCacheEntry, PendingOperation, PrepareConnectError,
-    ProcessExecutionError, ProcessExecutor, ProfileManager, ProxyAuth, ProxyKind, ProxyManager,
-    ProxyProfile, RedisKeyCache, RedisKeyCacheEntry, ResolvedProxy, SchemaCacheKey, ScriptLanguage,
-    ScriptSource, SshAuthMethod, SshTunnelConfig, SshTunnelManager, SshTunnelProfile, SslMode,
-    SwitchDatabaseParams, SwitchDatabaseResult, TreeLoadResult, TreeStore,
-    detached_process_channel, execute_streaming_process, host_matches_no_proxy, output_channel,
+    ExecutionSourceContext, FetchDatabaseSchemaParams, FetchDatabaseSchemaResult,
+    FetchSchemaForeignKeysParams, FetchSchemaForeignKeysResult, FetchSchemaIndexesParams,
+    FetchSchemaIndexesResult, FetchSchemaTypesParams, FetchSchemaTypesResult,
+    FetchTableDetailsParams, FetchTableDetailsResult, HookContext, HookExecution,
+    HookExecutionContext, HookExecutionMode, HookExecutor, HookFailureMode, HookKind, HookPhase,
+    HookPhaseOutcome, HookResult, HookRunner, Identifiable, ItemManager, LuaCapabilities,
+    OutputEvent, OutputReceiver, OutputSender, OutputStreamKind, OwnedCacheEntry, PendingOperation,
+    PrepareConnectError, ProcessExecutionError, ProcessExecutor, ProfileManager, ProxyAuth,
+    ProxyKind, ProxyManager, ProxyProfile, RedisKeyCache, RedisKeyCacheEntry, ResolvedProxy,
+    SchemaCacheKey, ScriptLanguage, ScriptSource, SshAuthMethod, SshTunnelConfig, SshTunnelManager,
+    SshTunnelProfile, SslMode, SwitchDatabaseParams, SwitchDatabaseResult, TreeLoadResult,
+    TreeStore, detached_process_channel, execute_streaming_process, host_matches_no_proxy,
+    output_channel,
 };
 
 pub use core::{
@@ -76,13 +77,13 @@ pub use data::{
 };
 
 pub use driver::{
-    DYNAMODB_FORM, DatabaseCategory, DdlCapabilities, DriverCapabilities, DriverFormDef,
-    DriverLimits, DriverMetadata, DriverMetadataBuilder, ExecutionClassification, FormFieldDef,
-    FormFieldKind, FormSection, FormTab, FormValues, Icon, IsolationLevel, MONGODB_FORM,
-    MYSQL_FORM, MutationCapabilities, OperationClassifier, POSTGRES_FORM, PaginationStyle,
-    QueryCapabilities, QueryLanguage, REDIS_FORM, SQLITE_FORM, SelectOption, SyntaxInfo,
-    TransactionCapabilities, WhereOperator, field_file_path, field_password, field_use_uri,
-    ssh_tab,
+    CLOUDWATCH_FORM, DYNAMODB_FORM, DatabaseCategory, DdlCapabilities, DriverCapabilities,
+    DriverFormDef, DriverLimits, DriverMetadata, DriverMetadataBuilder, ExecutionClassification,
+    FormFieldDef, FormFieldKind, FormSection, FormTab, FormValues, Icon, IsolationLevel,
+    MONGODB_FORM, MYSQL_FORM, MutationCapabilities, OperationClassifier, POSTGRES_FORM,
+    PaginationStyle, QueryCapabilities, QueryLanguage, REDIS_FORM, SQLITE_FORM, SelectOption,
+    SyntaxInfo, TransactionCapabilities, WhereOperator, field_file_path, field_password,
+    field_use_uri, ssh_tab,
 };
 
 pub use facade::{DangerousQuerySuppressions, SessionFacade};

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -60,8 +60,9 @@ pub use core::{
     DocumentConnection, ErrorLocation, EventStreamTarget, FormattedError, KeyValueApi,
     KeyValueConnection, NoopCancelHandle, QueryCancelHandle, QueryErrorFormatter,
     RelationalConnection, SchemaDropTarget, SchemaFeatures, SchemaLoadingStrategy,
-    SchemaObjectKind, ShutdownCoordinator, ShutdownPhase, SourceContextSpec, TaskId, TaskKind,
-    TaskManager, TaskSlot, TaskSnapshot, TaskStatus, TaskTarget, Value, sanitize_uri,
+    SchemaObjectKind, ShutdownCoordinator, ShutdownPhase, SourceContextSpec, SourceQueryMode,
+    TaskId, TaskKind, TaskManager, TaskSlot, TaskSnapshot, TaskStatus, TaskTarget, Value,
+    sanitize_uri,
 };
 
 pub use data::{

--- a/crates/dbflux_core/src/pipeline/mod.rs
+++ b/crates/dbflux_core/src/pipeline/mod.rs
@@ -212,12 +212,14 @@ pub async fn run_pipeline(
     state_tx: &StateSender,
 ) -> Result<PipelineOutput, PipelineError> {
     let cancel = &input.cancel;
+    let needs_auth_credentials = !input.profile.value_refs.is_empty();
 
     // --- Stage 1: Authentication ---
 
     let (auth_session, resolved_credentials) = run_auth_stage(
         input.auth_provider.as_deref(),
         input.auth_profile.as_ref(),
+        needs_auth_credentials,
         cancel,
         state_tx,
     )
@@ -227,6 +229,7 @@ pub async fn run_pipeline(
 
     if let Some(provider) = input.auth_provider.as_deref()
         && let Some(profile) = input.auth_profile.as_ref()
+        && needs_auth_credentials
     {
         provider
             .register_value_providers(profile, auth_session.as_ref(), &mut input.resolver)
@@ -297,6 +300,7 @@ pub async fn run_pipeline(
 async fn run_auth_stage(
     provider: Option<&dyn DynAuthProvider>,
     auth_profile: Option<&AuthProfile>,
+    require_resolved_credentials: bool,
     cancel: &CancelToken,
     state_tx: &StateSender,
 ) -> Result<(Option<AuthSession>, Option<ResolvedCredentials>), PipelineError> {
@@ -368,12 +372,21 @@ async fn run_auth_stage(
         }
     };
 
+    let mut session = session;
+    if !require_resolved_credentials {
+        log::debug!(
+            "[pipeline] skipping credential resolution for provider '{}' because the profile has no value refs",
+            provider_name
+        );
+
+        return Ok((Some(session), None));
+    }
+
     let resolved_credentials = provider
         .resolve_credentials(profile)
         .await
         .map_err(PipelineError::auth)?;
 
-    let mut session = session;
     if session.data.is_none() {
         session.data = resolved_credentials.provider_data.clone();
     }
@@ -412,6 +425,7 @@ mod tests {
     struct MockAuthProvider {
         should_require_login: bool,
         login_delay_ms: u64,
+        resolve_should_fail: bool,
     }
 
     impl crate::auth::AuthProvider for MockAuthProvider {
@@ -451,6 +465,12 @@ mod tests {
             &self,
             _profile: &AuthProfile,
         ) -> Result<ResolvedCredentials, DbError> {
+            if self.resolve_should_fail {
+                return Err(DbError::ValueResolutionFailed(
+                    "mock credential resolution failed".to_string(),
+                ));
+            }
+
             Ok(ResolvedCredentials::default())
         }
     }
@@ -586,6 +606,7 @@ mod tests {
             auth_provider: Some(Box::new(MockAuthProvider {
                 should_require_login: false,
                 login_delay_ms: 0,
+                resolve_should_fail: false,
             })),
             auth_profile: Some(auth_profile),
             resolver: test_resolver(),
@@ -650,6 +671,7 @@ mod tests {
             auth_provider: Some(Box::new(MockAuthProvider {
                 should_require_login: true,
                 login_delay_ms: 0,
+                resolve_should_fail: false,
             })),
             auth_profile: Some(auth_profile),
             resolver: test_resolver(),
@@ -681,6 +703,7 @@ mod tests {
             auth_provider: Some(Box::new(MockAuthProvider {
                 should_require_login: true,
                 login_delay_ms: 100,
+                resolve_should_fail: false,
             })),
             auth_profile: Some(auth_profile),
             resolver: test_resolver(),
@@ -732,5 +755,37 @@ mod tests {
 
         assert_eq!(error.stage, "access");
         assert!(error.source.to_string().contains("access open failed"));
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_auth_and_no_value_refs_skips_credential_resolution() {
+        let profile =
+            ConnectionProfile::new("test-cloudwatch", DbConfig::default_cloudwatch_logs());
+        let auth_profile = test_auth_profile();
+        let (state_tx, _state_rx) = pipeline_state_channel();
+
+        let input = PipelineInput {
+            profile,
+            auth_provider: Some(Box::new(MockAuthProvider {
+                should_require_login: false,
+                login_delay_ms: 0,
+                resolve_should_fail: true,
+            })),
+            auth_profile: Some(auth_profile),
+            resolver: test_resolver(),
+            access_manager: Arc::new(MockAccessManager),
+            cancel: CancelToken::new(),
+        };
+
+        let output = run_pipeline(input, &state_tx)
+            .await
+            .expect("pipeline should succeed without credential resolution");
+
+        assert!(output.auth_session.is_some());
+        assert!(output.resolved_password.is_none());
+        assert!(matches!(
+            output.resolved_profile.config,
+            DbConfig::CloudWatchLogs { .. }
+        ));
     }
 }

--- a/crates/dbflux_core/src/pipeline/resolve.rs
+++ b/crates/dbflux_core/src/pipeline/resolve.rs
@@ -170,6 +170,17 @@ fn patch_config_field(config: &mut DbConfig, field: &str, value: &ResolvedValue)
             _ => {}
         },
 
+        DbConfig::CloudWatchLogs {
+            region,
+            profile,
+            endpoint,
+        } => match field {
+            "region" => *region = val.to_string(),
+            "profile" => *profile = Some(val.to_string()),
+            "endpoint" => *endpoint = Some(val.to_string()),
+            _ => {}
+        },
+
         DbConfig::External { values, .. } => {
             values.insert(field.to_string(), val.to_string());
         }

--- a/crates/dbflux_core/src/query/language_service.rs
+++ b/crates/dbflux_core/src/query/language_service.rs
@@ -169,6 +169,9 @@ pub fn classify_query_for_language(
 ) -> ExecutionClassification {
     match query_language {
         QueryLanguage::Sql => classify_sql_execution(query),
+        QueryLanguage::CloudWatchLogsInsightsQl
+        | QueryLanguage::OpenSearchPpl
+        | QueryLanguage::OpenSearchSql => ExecutionClassification::Read,
         QueryLanguage::MongoQuery => classify_mongo_query(query),
         QueryLanguage::RedisCommands => classify_redis_query(query),
         _ => ExecutionClassification::Write,

--- a/crates/dbflux_core/src/query/types.rs
+++ b/crates/dbflux_core/src/query/types.rs
@@ -1,4 +1,4 @@
-use crate::Value;
+use crate::{ExecutionContext, Value};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use uuid::Uuid;
@@ -67,6 +67,10 @@ pub struct QueryRequest {
     /// if the connection's current database differs. Ignored by PostgreSQL
     /// and SQLite (which use connection-level database selection).
     pub database: Option<String>,
+
+    /// Full per-document execution context for drivers that need more than
+    /// the compatibility `database` field.
+    pub execution_context: Option<ExecutionContext>,
 }
 
 impl QueryRequest {
@@ -89,6 +93,11 @@ impl QueryRequest {
 
     pub fn with_database(mut self, database: Option<String>) -> Self {
         self.database = database;
+        self
+    }
+
+    pub fn with_execution_context(mut self, execution_context: Option<ExecutionContext>) -> Self {
+        self.execution_context = execution_context;
         self
     }
 }

--- a/crates/dbflux_core/src/schema/mod.rs
+++ b/crates/dbflux_core/src/schema/mod.rs
@@ -5,13 +5,14 @@ pub(crate) mod types;
 pub use builder::{ForeignKeyBuilder, IndexBuilder, SchemaForeignKeyBuilder, SchemaIndexBuilder};
 pub use node_id::{ParseSchemaNodeIdError, SchemaNodeId, SchemaNodeKind};
 pub use types::{
-    CollectionIndexInfo, CollectionInfo, ColumnFamilyInfo, ColumnInfo, ConstraintInfo,
-    ConstraintKind, ContainerInfo, CustomTypeInfo, CustomTypeKind, DataStructure, DatabaseInfo,
-    DbSchemaInfo, DocumentSchema, FieldInfo, ForeignKeyInfo, GraphInfo, GraphSchema, IndexData,
-    IndexDirection, IndexInfo, KeyInfo, KeySpaceInfo, KeyValueSchema, MeasurementInfo,
-    MultiModelCapabilities, MultiModelSchema, NodeLabelInfo, PropertyInfo, RelationalSchema,
-    RelationshipTypeInfo, RetentionPolicyInfo, SchemaForeignKeyInfo, SchemaIndexInfo,
-    SchemaSnapshot, SearchIndexInfo, SearchMappingInfo, SearchSchema, TableInfo,
-    TimeSeriesFieldInfo, TimeSeriesSchema, VectorCollectionInfo, VectorMetadataField, VectorMetric,
-    VectorSchema, ViewInfo, WideColumnInfo, WideColumnKeyspaceInfo, WideColumnSchema,
+    CollectionChildInfo, CollectionIndexInfo, CollectionInfo, CollectionPresentation,
+    ColumnFamilyInfo, ColumnInfo, ConstraintInfo, ConstraintKind, ContainerInfo, CustomTypeInfo,
+    CustomTypeKind, DataStructure, DatabaseInfo, DbSchemaInfo, DocumentSchema, FieldInfo,
+    ForeignKeyInfo, GraphInfo, GraphSchema, IndexData, IndexDirection, IndexInfo, KeyInfo,
+    KeySpaceInfo, KeyValueSchema, MeasurementInfo, MultiModelCapabilities, MultiModelSchema,
+    NodeLabelInfo, PropertyInfo, RelationalSchema, RelationshipTypeInfo, RetentionPolicyInfo,
+    SchemaForeignKeyInfo, SchemaIndexInfo, SchemaSnapshot, SearchIndexInfo, SearchMappingInfo,
+    SearchSchema, TableInfo, TimeSeriesFieldInfo, TimeSeriesSchema, VectorCollectionInfo,
+    VectorMetadataField, VectorMetric, VectorSchema, ViewInfo, WideColumnInfo,
+    WideColumnKeyspaceInfo, WideColumnSchema,
 };

--- a/crates/dbflux_core/src/schema/mod.rs
+++ b/crates/dbflux_core/src/schema/mod.rs
@@ -5,7 +5,8 @@ pub(crate) mod types;
 pub use builder::{ForeignKeyBuilder, IndexBuilder, SchemaForeignKeyBuilder, SchemaIndexBuilder};
 pub use node_id::{ParseSchemaNodeIdError, SchemaNodeId, SchemaNodeKind};
 pub use types::{
-    CollectionChildInfo, CollectionIndexInfo, CollectionInfo, CollectionPresentation,
+    CollectionChildInfo, CollectionChildrenCache, CollectionChildrenPage,
+    CollectionChildrenRequest, CollectionIndexInfo, CollectionInfo, CollectionPresentation,
     ColumnFamilyInfo, ColumnInfo, ConstraintInfo, ConstraintKind, ContainerInfo, CustomTypeInfo,
     CustomTypeKind, DataStructure, DatabaseInfo, DbSchemaInfo, DocumentSchema, FieldInfo,
     ForeignKeyInfo, GraphInfo, GraphSchema, IndexData, IndexDirection, IndexInfo, KeyInfo,

--- a/crates/dbflux_core/src/schema/node_id.rs
+++ b/crates/dbflux_core/src/schema/node_id.rs
@@ -94,10 +94,11 @@ pub enum SchemaNodeId {
         database: String,
         name: String,
     },
-    CloudWatchLogStream {
+    CollectionChild {
         profile_id: Uuid,
         database: String,
-        log_group: String,
+        collection: String,
+        child_id: String,
         name: String,
     },
     CustomType {
@@ -235,7 +236,7 @@ pub enum SchemaNodeKind {
     Table,
     View,
     Collection,
-    CloudWatchLogStream,
+    CollectionChild,
     CustomType,
     ColumnsFolder,
     IndexesFolder,
@@ -281,7 +282,7 @@ impl SchemaNodeId {
             Self::Table { .. } => SchemaNodeKind::Table,
             Self::View { .. } => SchemaNodeKind::View,
             Self::Collection { .. } => SchemaNodeKind::Collection,
-            Self::CloudWatchLogStream { .. } => SchemaNodeKind::CloudWatchLogStream,
+            Self::CollectionChild { .. } => SchemaNodeKind::CollectionChild,
             Self::CustomType { .. } => SchemaNodeKind::CustomType,
             Self::ColumnsFolder { .. } => SchemaNodeKind::ColumnsFolder,
             Self::IndexesFolder { .. } => SchemaNodeKind::IndexesFolder,
@@ -327,7 +328,7 @@ impl SchemaNodeId {
             | Self::Table { profile_id, .. }
             | Self::View { profile_id, .. }
             | Self::Collection { profile_id, .. }
-            | Self::CloudWatchLogStream { profile_id, .. }
+            | Self::CollectionChild { profile_id, .. }
             | Self::CustomType { profile_id, .. }
             | Self::ColumnsFolder { profile_id, .. }
             | Self::IndexesFolder { profile_id, .. }
@@ -370,7 +371,7 @@ const P_COLLECTIONS_FOLDER: &str = "CF2";
 const P_TABLE: &str = "T";
 const P_VIEW: &str = "V";
 const P_COLLECTION: &str = "C";
-const P_CLOUDWATCH_LOG_STREAM: &str = "CLS";
+const P_COLLECTION_CHILD: &str = "CCH";
 const P_CUSTOM_TYPE: &str = "Y";
 const P_COLUMNS_FOLDER: &str = "CLF";
 const P_INDEXES_FOLDER: &str = "IXF";
@@ -517,16 +518,17 @@ impl fmt::Display for SchemaNodeId {
             } => {
                 write!(f, "{}|{}|{}|{}", P_COLLECTION, profile_id, database, name)
             }
-            Self::CloudWatchLogStream {
+            Self::CollectionChild {
                 profile_id,
                 database,
-                log_group,
+                collection,
+                child_id,
                 name,
             } => {
                 write!(
                     f,
-                    "{}|{}|{}|{}|{}",
-                    P_CLOUDWATCH_LOG_STREAM, profile_id, database, log_group, name
+                    "{}|{}|{}|{}|{}|{}",
+                    P_COLLECTION_CHILD, profile_id, database, collection, child_id, name
                 )
             }
             Self::CustomType {
@@ -913,16 +915,18 @@ impl FromStr for SchemaNodeId {
                 })
             }
 
-            P_CLOUDWATCH_LOG_STREAM => {
+            P_COLLECTION_CHILD => {
                 let profile_id =
                     Uuid::parse_str(parts.get(1).ok_or_else(err)?).map_err(|_| err())?;
                 let database = parts.get(2).ok_or_else(err)?.to_string();
-                let log_group = parts.get(3).ok_or_else(err)?.to_string();
-                let name = parts.get(4).ok_or_else(err)?.to_string();
-                Ok(Self::CloudWatchLogStream {
+                let collection = parts.get(3).ok_or_else(err)?.to_string();
+                let child_id = parts.get(4).ok_or_else(err)?.to_string();
+                let name = parts.get(5).ok_or_else(err)?.to_string();
+                Ok(Self::CollectionChild {
                     profile_id,
                     database,
-                    log_group,
+                    collection,
+                    child_id,
                     name,
                 })
             }
@@ -1178,7 +1182,7 @@ impl SchemaNodeKind {
                 | Self::Table
                 | Self::View
                 | Self::Collection
-                | Self::CloudWatchLogStream
+                | Self::CollectionChild
                 | Self::ConnectionFolder
                 | Self::Schema
                 | Self::TablesFolder
@@ -1226,7 +1230,7 @@ impl SchemaNodeKind {
             Self::Profile
                 | Self::Database
                 | Self::ConnectionFolder
-                | Self::CloudWatchLogStream
+                | Self::CollectionChild
                 | Self::ScriptFile
         )
     }
@@ -1333,10 +1337,11 @@ mod tests {
             database: "mydb".into(),
             name: "orders".into(),
         });
-        roundtrip(SchemaNodeId::CloudWatchLogStream {
+        roundtrip(SchemaNodeId::CollectionChild {
             profile_id: uuid,
             database: "logs".into(),
-            log_group: "/aws/lambda/app".into(),
+            collection: "/aws/lambda/app".into(),
+            child_id: "stream-2026-04-25".into(),
             name: "2026/04/25/[$LATEST]abc".into(),
         });
         roundtrip(SchemaNodeId::CustomType {

--- a/crates/dbflux_core/src/schema/node_id.rs
+++ b/crates/dbflux_core/src/schema/node_id.rs
@@ -94,6 +94,12 @@ pub enum SchemaNodeId {
         database: String,
         name: String,
     },
+    CloudWatchLogStream {
+        profile_id: Uuid,
+        database: String,
+        log_group: String,
+        name: String,
+    },
     CustomType {
         profile_id: Uuid,
         schema: String,
@@ -229,6 +235,7 @@ pub enum SchemaNodeKind {
     Table,
     View,
     Collection,
+    CloudWatchLogStream,
     CustomType,
     ColumnsFolder,
     IndexesFolder,
@@ -274,6 +281,7 @@ impl SchemaNodeId {
             Self::Table { .. } => SchemaNodeKind::Table,
             Self::View { .. } => SchemaNodeKind::View,
             Self::Collection { .. } => SchemaNodeKind::Collection,
+            Self::CloudWatchLogStream { .. } => SchemaNodeKind::CloudWatchLogStream,
             Self::CustomType { .. } => SchemaNodeKind::CustomType,
             Self::ColumnsFolder { .. } => SchemaNodeKind::ColumnsFolder,
             Self::IndexesFolder { .. } => SchemaNodeKind::IndexesFolder,
@@ -319,6 +327,7 @@ impl SchemaNodeId {
             | Self::Table { profile_id, .. }
             | Self::View { profile_id, .. }
             | Self::Collection { profile_id, .. }
+            | Self::CloudWatchLogStream { profile_id, .. }
             | Self::CustomType { profile_id, .. }
             | Self::ColumnsFolder { profile_id, .. }
             | Self::IndexesFolder { profile_id, .. }
@@ -361,6 +370,7 @@ const P_COLLECTIONS_FOLDER: &str = "CF2";
 const P_TABLE: &str = "T";
 const P_VIEW: &str = "V";
 const P_COLLECTION: &str = "C";
+const P_CLOUDWATCH_LOG_STREAM: &str = "CLS";
 const P_CUSTOM_TYPE: &str = "Y";
 const P_COLUMNS_FOLDER: &str = "CLF";
 const P_INDEXES_FOLDER: &str = "IXF";
@@ -506,6 +516,18 @@ impl fmt::Display for SchemaNodeId {
                 name,
             } => {
                 write!(f, "{}|{}|{}|{}", P_COLLECTION, profile_id, database, name)
+            }
+            Self::CloudWatchLogStream {
+                profile_id,
+                database,
+                log_group,
+                name,
+            } => {
+                write!(
+                    f,
+                    "{}|{}|{}|{}|{}",
+                    P_CLOUDWATCH_LOG_STREAM, profile_id, database, log_group, name
+                )
             }
             Self::CustomType {
                 profile_id,
@@ -891,6 +913,20 @@ impl FromStr for SchemaNodeId {
                 })
             }
 
+            P_CLOUDWATCH_LOG_STREAM => {
+                let profile_id =
+                    Uuid::parse_str(parts.get(1).ok_or_else(err)?).map_err(|_| err())?;
+                let database = parts.get(2).ok_or_else(err)?.to_string();
+                let log_group = parts.get(3).ok_or_else(err)?.to_string();
+                let name = parts.get(4).ok_or_else(err)?.to_string();
+                Ok(Self::CloudWatchLogStream {
+                    profile_id,
+                    database,
+                    log_group,
+                    name,
+                })
+            }
+
             P_CUSTOM_TYPE => {
                 let profile_id =
                     Uuid::parse_str(parts.get(1).ok_or_else(err)?).map_err(|_| err())?;
@@ -1142,6 +1178,7 @@ impl SchemaNodeKind {
                 | Self::Table
                 | Self::View
                 | Self::Collection
+                | Self::CloudWatchLogStream
                 | Self::ConnectionFolder
                 | Self::Schema
                 | Self::TablesFolder
@@ -1186,7 +1223,11 @@ impl SchemaNodeKind {
     pub fn shows_pointer_cursor(&self) -> bool {
         matches!(
             self,
-            Self::Profile | Self::Database | Self::ConnectionFolder | Self::ScriptFile
+            Self::Profile
+                | Self::Database
+                | Self::ConnectionFolder
+                | Self::CloudWatchLogStream
+                | Self::ScriptFile
         )
     }
 }
@@ -1291,6 +1332,12 @@ mod tests {
             profile_id: uuid,
             database: "mydb".into(),
             name: "orders".into(),
+        });
+        roundtrip(SchemaNodeId::CloudWatchLogStream {
+            profile_id: uuid,
+            database: "logs".into(),
+            log_group: "/aws/lambda/app".into(),
+            name: "2026/04/25/[$LATEST]abc".into(),
         });
         roundtrip(SchemaNodeId::CustomType {
             profile_id: uuid,

--- a/crates/dbflux_core/src/schema/node_id.rs
+++ b/crates/dbflux_core/src/schema/node_id.rs
@@ -101,6 +101,11 @@ pub enum SchemaNodeId {
         child_id: String,
         name: String,
     },
+    CollectionChildrenMore {
+        profile_id: Uuid,
+        database: String,
+        collection: String,
+    },
     CustomType {
         profile_id: Uuid,
         schema: String,
@@ -237,6 +242,7 @@ pub enum SchemaNodeKind {
     View,
     Collection,
     CollectionChild,
+    CollectionChildrenMore,
     CustomType,
     ColumnsFolder,
     IndexesFolder,
@@ -283,6 +289,7 @@ impl SchemaNodeId {
             Self::View { .. } => SchemaNodeKind::View,
             Self::Collection { .. } => SchemaNodeKind::Collection,
             Self::CollectionChild { .. } => SchemaNodeKind::CollectionChild,
+            Self::CollectionChildrenMore { .. } => SchemaNodeKind::CollectionChildrenMore,
             Self::CustomType { .. } => SchemaNodeKind::CustomType,
             Self::ColumnsFolder { .. } => SchemaNodeKind::ColumnsFolder,
             Self::IndexesFolder { .. } => SchemaNodeKind::IndexesFolder,
@@ -329,6 +336,7 @@ impl SchemaNodeId {
             | Self::View { profile_id, .. }
             | Self::Collection { profile_id, .. }
             | Self::CollectionChild { profile_id, .. }
+            | Self::CollectionChildrenMore { profile_id, .. }
             | Self::CustomType { profile_id, .. }
             | Self::ColumnsFolder { profile_id, .. }
             | Self::IndexesFolder { profile_id, .. }
@@ -372,6 +380,7 @@ const P_TABLE: &str = "T";
 const P_VIEW: &str = "V";
 const P_COLLECTION: &str = "C";
 const P_COLLECTION_CHILD: &str = "CCH";
+const P_COLLECTION_CHILDREN_MORE: &str = "CCM";
 const P_CUSTOM_TYPE: &str = "Y";
 const P_COLUMNS_FOLDER: &str = "CLF";
 const P_INDEXES_FOLDER: &str = "IXF";
@@ -529,6 +538,17 @@ impl fmt::Display for SchemaNodeId {
                     f,
                     "{}|{}|{}|{}|{}|{}",
                     P_COLLECTION_CHILD, profile_id, database, collection, child_id, name
+                )
+            }
+            Self::CollectionChildrenMore {
+                profile_id,
+                database,
+                collection,
+            } => {
+                write!(
+                    f,
+                    "{}|{}|{}|{}",
+                    P_COLLECTION_CHILDREN_MORE, profile_id, database, collection
                 )
             }
             Self::CustomType {
@@ -931,6 +951,18 @@ impl FromStr for SchemaNodeId {
                 })
             }
 
+            P_COLLECTION_CHILDREN_MORE => {
+                let profile_id =
+                    Uuid::parse_str(parts.get(1).ok_or_else(err)?).map_err(|_| err())?;
+                let database = parts.get(2).ok_or_else(err)?.to_string();
+                let collection = parts.get(3).ok_or_else(err)?.to_string();
+                Ok(Self::CollectionChildrenMore {
+                    profile_id,
+                    database,
+                    collection,
+                })
+            }
+
             P_CUSTOM_TYPE => {
                 let profile_id =
                     Uuid::parse_str(parts.get(1).ok_or_else(err)?).map_err(|_| err())?;
@@ -1183,6 +1215,7 @@ impl SchemaNodeKind {
                 | Self::View
                 | Self::Collection
                 | Self::CollectionChild
+                | Self::CollectionChildrenMore
                 | Self::ConnectionFolder
                 | Self::Schema
                 | Self::TablesFolder
@@ -1231,6 +1264,7 @@ impl SchemaNodeKind {
                 | Self::Database
                 | Self::ConnectionFolder
                 | Self::CollectionChild
+                | Self::CollectionChildrenMore
                 | Self::ScriptFile
         )
     }
@@ -1343,6 +1377,11 @@ mod tests {
             collection: "/aws/lambda/app".into(),
             child_id: "stream-2026-04-25".into(),
             name: "2026/04/25/[$LATEST]abc".into(),
+        });
+        roundtrip(SchemaNodeId::CollectionChildrenMore {
+            profile_id: uuid,
+            database: "logs".into(),
+            collection: "/aws/lambda/app".into(),
         });
         roundtrip(SchemaNodeId::CustomType {
             profile_id: uuid,

--- a/crates/dbflux_core/src/schema/types.rs
+++ b/crates/dbflux_core/src/schema/types.rs
@@ -806,6 +806,10 @@ pub struct CollectionChildInfo {
     pub id: String,
     pub label: String,
 
+    /// Optional driver-provided event timestamp used for generic child pickers.
+    #[serde(default)]
+    pub last_event_ts_ms: Option<i64>,
+
     #[serde(default)]
     pub presentation: CollectionPresentation,
 }

--- a/crates/dbflux_core/src/schema/types.rs
+++ b/crates/dbflux_core/src/schema/types.rs
@@ -814,6 +814,34 @@ pub struct CollectionChildInfo {
     pub presentation: CollectionPresentation,
 }
 
+/// Request for a page of driver-owned child sources under a collection/container.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CollectionChildrenRequest {
+    pub collection: crate::CollectionRef,
+    pub limit: u32,
+
+    #[serde(default)]
+    pub page_token: Option<String>,
+}
+
+/// One page of driver-owned child sources under a collection/container.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CollectionChildrenPage {
+    pub items: Vec<CollectionChildInfo>,
+
+    #[serde(default)]
+    pub next_page_token: Option<String>,
+}
+
+/// Cached collection child list plus continuation token.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CollectionChildrenCache {
+    pub items: Vec<CollectionChildInfo>,
+
+    #[serde(default)]
+    pub next_page_token: Option<String>,
+}
+
 /// Field info discovered from document sampling.
 ///
 /// Unlike SQL columns, document fields are dynamic. This represents

--- a/crates/dbflux_core/src/schema/types.rs
+++ b/crates/dbflux_core/src/schema/types.rs
@@ -595,6 +595,14 @@ pub struct TableInfo {
     /// `None` = not loaded, `Some(vec)` = loaded via document sampling.
     #[serde(default)]
     pub sample_fields: Option<Vec<FieldInfo>>,
+
+    /// Preferred UI presentation for opening this container.
+    #[serde(default)]
+    pub presentation: CollectionPresentation,
+
+    /// Driver-provided child sources that should appear under this container.
+    #[serde(default)]
+    pub child_items: Option<Vec<CollectionChildInfo>>,
 }
 
 /// View metadata.
@@ -774,6 +782,32 @@ pub struct CollectionInfo {
     /// Whether the collection is capped (fixed-size).
     #[serde(default)]
     pub is_capped: bool,
+
+    /// Preferred UI presentation for opening this collection.
+    #[serde(default)]
+    pub presentation: CollectionPresentation,
+
+    /// Driver-provided child sources that should appear under this collection.
+    #[serde(default)]
+    pub child_items: Option<Vec<CollectionChildInfo>>,
+}
+
+/// Preferred UI presentation for document containers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum CollectionPresentation {
+    #[default]
+    DataGrid,
+    EventStream,
+}
+
+/// Driver-provided child source metadata for a collection/container.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CollectionChildInfo {
+    pub id: String,
+    pub label: String,
+
+    #[serde(default)]
+    pub presentation: CollectionPresentation,
 }
 
 /// Field info discovered from document sampling.

--- a/crates/dbflux_core/src/storage/secret_manager.rs
+++ b/crates/dbflux_core/src/storage/secret_manager.rs
@@ -245,7 +245,10 @@ impl SecretManager {
                 ssh_tunnel_profile_id,
                 ..
             } => (ssh_tunnel.as_ref(), *ssh_tunnel_profile_id),
-            DbConfig::SQLite { .. } | DbConfig::DynamoDB { .. } | DbConfig::External { .. } => {
+            DbConfig::SQLite { .. }
+            | DbConfig::DynamoDB { .. }
+            | DbConfig::CloudWatchLogs { .. }
+            | DbConfig::External { .. } => {
                 return None;
             }
         };

--- a/crates/dbflux_core/src/storage/session.rs
+++ b/crates/dbflux_core/src/storage/session.rs
@@ -250,6 +250,7 @@ mod tests {
                         database: Some("mydb".into()),
                         schema: Some("public".into()),
                         container: None,
+                        source: None,
                     },
                 },
             ],

--- a/crates/dbflux_core/src/storage/session.rs
+++ b/crates/dbflux_core/src/storage/session.rs
@@ -36,6 +36,9 @@ impl SessionTab {
     pub fn query_language(&self) -> QueryLanguage {
         match self.language.as_str() {
             "sql" => QueryLanguage::Sql,
+            "cwli" => QueryLanguage::CloudWatchLogsInsightsQl,
+            "ppl" => QueryLanguage::OpenSearchPpl,
+            "opensearch-sql" => QueryLanguage::OpenSearchSql,
             "mongo" => QueryLanguage::MongoQuery,
             "redis" => QueryLanguage::RedisCommands,
             "cypher" => QueryLanguage::Cypher,
@@ -51,6 +54,9 @@ impl SessionTab {
     pub fn language_key(language: QueryLanguage) -> String {
         match language {
             QueryLanguage::Sql => "sql".into(),
+            QueryLanguage::CloudWatchLogsInsightsQl => "cwli".into(),
+            QueryLanguage::OpenSearchPpl => "ppl".into(),
+            QueryLanguage::OpenSearchSql => "opensearch-sql".into(),
             QueryLanguage::MongoQuery => "mongo".into(),
             QueryLanguage::RedisCommands => "redis".into(),
             QueryLanguage::Cypher => "cypher".into(),

--- a/crates/dbflux_driver_cloudwatch/Cargo.toml
+++ b/crates/dbflux_driver_cloudwatch/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dbflux_driver_cloudwatch"
+version.workspace = true
+edition.workspace = true
+publish = false
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+dbflux_core.workspace = true
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-cloudwatchlogs = "1"
+tokio = { version = "1", features = ["rt-multi-thread", "time"] }
+serde_json = "1"
+log = "0.4"

--- a/crates/dbflux_driver_cloudwatch/README.md
+++ b/crates/dbflux_driver_cloudwatch/README.md
@@ -1,0 +1,13 @@
+# dbflux_driver_cloudwatch
+
+## Features
+
+- Built-in CloudWatch Logs driver registration for DBFlux connection profiles.
+- AWS region/profile/endpoint form handling aligned with the existing DynamoDB AWS connection flow.
+- SQL-mode editor metadata so CloudWatch query documents can reuse the existing code document pipeline.
+
+## Limitations
+
+- Connection establishment and query execution are not implemented in this batch.
+- Schema discovery does not yet enumerate CloudWatch log groups.
+- Session-aware source selection and execution-context consumption are implemented in later tasks, not this foundation batch.

--- a/crates/dbflux_driver_cloudwatch/README.md
+++ b/crates/dbflux_driver_cloudwatch/README.md
@@ -4,10 +4,12 @@
 
 - Built-in CloudWatch Logs driver registration for DBFlux connection profiles.
 - AWS region/profile/endpoint form handling aligned with the existing DynamoDB AWS connection flow.
-- SQL-mode editor metadata so CloudWatch query documents can reuse the existing code document pipeline.
+- CloudWatch query execution through `StartQuery` with editor-managed time range and log-group source context.
+- CloudWatch query documents can run Logs Insights QL, OpenSearch PPL, and OpenSearch SQL.
+- Schema discovery enumerates log groups and exposes log streams as event-stream children.
 
 ## Limitations
 
-- Connection establishment and query execution are not implemented in this batch.
-- Schema discovery does not yet enumerate CloudWatch log groups.
-- Session-aware source selection and execution-context consumption are implemented in later tasks, not this foundation batch.
+- Query cancellation is not implemented yet.
+- OpenSearch SQL queries must declare their queried log groups in the SQL text because the CloudWatch API does not accept external log-group parameters for SQL mode.
+- Editor syntax highlighting remains generic; mode selection currently focuses on execution semantics and completion keywords.

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -13,7 +13,8 @@ use dbflux_core::{
     DriverCapabilities, DriverFormDef, DriverMetadata, EventActorType, EventCategory, EventPage,
     EventQuery, EventRecord, EventSeverity, EventSourceId, EventStreamTarget,
     ExecutionSourceContext, FieldInfo, FormValues, Icon, QueryLanguage, QueryRequest, QueryResult,
-    SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot, SourceContextSpec, TableInfo, Value,
+    SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot, SourceContextSpec, SourceQueryMode,
+    TableInfo, ValidationResult, Value,
 };
 
 pub static CLOUDWATCH_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -39,6 +40,11 @@ const CLOUDWATCH_DEFAULT_DATABASE: &str = "logs";
 const DEFAULT_BROWSE_WINDOW_MS: i64 = 24 * 60 * 60 * 1000;
 const MAX_QUERY_WAIT_ATTEMPTS: usize = 120;
 const QUERY_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const CLOUDWATCH_QUERY_MODE_CWLI: &str = "cwli";
+const CLOUDWATCH_QUERY_MODE_PPL: &str = "ppl";
+const CLOUDWATCH_QUERY_MODE_SQL: &str = "sql";
+
+static CLOUDWATCH_LANGUAGE_SERVICE: CloudWatchLanguageService = CloudWatchLanguageService;
 
 pub struct CloudWatchDriver;
 
@@ -63,6 +69,8 @@ struct CloudWatchConnection {
     client: Client,
     config: CloudWatchProfileConfig,
 }
+
+struct CloudWatchLanguageService;
 
 impl CloudWatchDriver {
     pub fn new() -> Self {
@@ -191,9 +199,14 @@ impl Connection for CloudWatchConnection {
             targets: log_groups,
             start_ms,
             end_ms,
+            query_mode,
         } = source;
 
-        if log_groups.is_empty() {
+        let query_mode = query_mode
+            .as_deref()
+            .unwrap_or(CLOUDWATCH_QUERY_MODE_CWLI);
+
+        if query_mode != CLOUDWATCH_QUERY_MODE_SQL && log_groups.is_empty() {
             return Err(DbError::query_failed(
                 "Select at least one CloudWatch log group before running a query".to_string(),
             ));
@@ -203,14 +216,18 @@ impl Connection for CloudWatchConnection {
         let start_seconds = start_ms.div_euclid(1000);
         let end_seconds = end_ms.div_euclid(1000);
 
-        let start_request = self
+        let mut start_request = self
             .client
             .start_query()
             .query_string(req.sql.clone())
             .start_time(start_seconds)
             .end_time(end_seconds)
             .limit(query_limit as i32)
-            .set_log_group_names(Some(log_groups.clone()));
+            .query_language(cloudwatch_sdk_query_language(query_mode));
+
+        if query_mode != CLOUDWATCH_QUERY_MODE_SQL {
+            start_request = start_request.set_log_group_names(Some(log_groups.clone()));
+        }
 
         let start_output = runtime()?.block_on(start_request.send()).map_err(|error| {
             DbError::query_failed(format!("CloudWatch StartQuery failed: {error}"))
@@ -499,7 +516,14 @@ impl Connection for CloudWatchConnection {
             targets_placeholder: "Log groups".to_string(),
             start_label: "Start".to_string(),
             end_label: "End".to_string(),
+            query_mode_label: Some("Syntax".to_string()),
+            query_modes: cloudwatch_query_modes(),
+            default_query_mode: Some(CLOUDWATCH_QUERY_MODE_CWLI.to_string()),
         })
+    }
+
+    fn language_service(&self) -> &dyn dbflux_core::LanguageService {
+        &CLOUDWATCH_LANGUAGE_SERVICE
     }
 
     fn table_details(
@@ -832,6 +856,46 @@ impl CloudWatchConnection {
         ];
 
         Ok(QueryResult::table(columns, rows, None, started.elapsed()))
+    }
+}
+
+impl dbflux_core::LanguageService for CloudWatchLanguageService {
+    fn validate(&self, _query: &str) -> ValidationResult {
+        ValidationResult::Valid
+    }
+
+    fn detect_dangerous(&self, _query: &str) -> Option<dbflux_core::DangerousQueryKind> {
+        None
+    }
+}
+
+fn cloudwatch_query_modes() -> Vec<SourceQueryMode> {
+    vec![
+        SourceQueryMode {
+            value: CLOUDWATCH_QUERY_MODE_CWLI.to_string(),
+            label: "Logs Insights QL".to_string(),
+            query_language: QueryLanguage::CloudWatchLogsInsightsQl,
+        },
+        SourceQueryMode {
+            value: CLOUDWATCH_QUERY_MODE_PPL.to_string(),
+            label: "OpenSearch PPL".to_string(),
+            query_language: QueryLanguage::OpenSearchPpl,
+        },
+        SourceQueryMode {
+            value: CLOUDWATCH_QUERY_MODE_SQL.to_string(),
+            label: "OpenSearch SQL".to_string(),
+            query_language: QueryLanguage::OpenSearchSql,
+        },
+    ]
+}
+
+fn cloudwatch_sdk_query_language(
+    query_mode: &str,
+) -> aws_sdk_cloudwatchlogs::types::QueryLanguage {
+    match query_mode {
+        CLOUDWATCH_QUERY_MODE_PPL => aws_sdk_cloudwatchlogs::types::QueryLanguage::Ppl,
+        CLOUDWATCH_QUERY_MODE_SQL => aws_sdk_cloudwatchlogs::types::QueryLanguage::Sql,
+        _ => aws_sdk_cloudwatchlogs::types::QueryLanguage::Cwli,
     }
 }
 

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -202,9 +202,7 @@ impl Connection for CloudWatchConnection {
             query_mode,
         } = source;
 
-        let query_mode = query_mode
-            .as_deref()
-            .unwrap_or(CLOUDWATCH_QUERY_MODE_CWLI);
+        let query_mode = query_mode.as_deref().unwrap_or(CLOUDWATCH_QUERY_MODE_CWLI);
 
         if query_mode != CLOUDWATCH_QUERY_MODE_SQL && log_groups.is_empty() {
             return Err(DbError::query_failed(
@@ -889,9 +887,7 @@ fn cloudwatch_query_modes() -> Vec<SourceQueryMode> {
     ]
 }
 
-fn cloudwatch_sdk_query_language(
-    query_mode: &str,
-) -> aws_sdk_cloudwatchlogs::types::QueryLanguage {
+fn cloudwatch_sdk_query_language(query_mode: &str) -> aws_sdk_cloudwatchlogs::types::QueryLanguage {
     match query_mode {
         CLOUDWATCH_QUERY_MODE_PPL => aws_sdk_cloudwatchlogs::types::QueryLanguage::Ppl,
         CLOUDWATCH_QUERY_MODE_SQL => aws_sdk_cloudwatchlogs::types::QueryLanguage::Sql,

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -508,24 +508,14 @@ impl Connection for CloudWatchConnection {
         _schema: Option<&str>,
         table: &str,
     ) -> Result<TableInfo, DbError> {
-        let stream_names = fetch_log_streams(&self.client, table)?;
-        let stream_fields = stream_names
+        let stream_items = fetch_log_streams(&self.client, table)?;
+        let stream_fields = stream_items
             .iter()
-            .cloned()
-            .map(|stream_name| FieldInfo {
-                name: stream_name,
+            .map(|stream| FieldInfo {
+                name: stream.label.clone(),
                 common_type: "text".to_string(),
                 occurrence_rate: None,
                 nested_fields: None,
-            })
-            .collect();
-
-        let child_items = stream_names
-            .into_iter()
-            .map(|stream_name| CollectionChildInfo {
-                id: stream_name.clone(),
-                label: stream_name,
-                presentation: CollectionPresentation::EventStream,
             })
             .collect();
 
@@ -538,7 +528,7 @@ impl Connection for CloudWatchConnection {
             constraints: None,
             sample_fields: Some(stream_fields),
             presentation: CollectionPresentation::EventStream,
-            child_items: Some(child_items),
+            child_items: Some(stream_items),
         })
     }
 
@@ -569,16 +559,30 @@ impl CloudWatchConnection {
         query: &EventQuery,
     ) -> CollectionBrowseRequest {
         let mut filter = serde_json::Map::new();
+        let mut from_ts_ms = query.from_ts_ms;
+        let mut to_ts_ms = query.to_ts_ms;
 
-        if let Some(pattern) = query.free_text.as_ref().filter(|value| !value.is_empty()) {
-            filter.insert("filter_pattern".to_string(), serde_json::Value::String(pattern.clone()));
+        if target.child_id.is_some()
+            && from_ts_ms.is_none()
+            && to_ts_ms.is_none()
+            && let Ok(default_end) = current_time_ms()
+        {
+            to_ts_ms = Some(default_end);
+            from_ts_ms = Some(default_end.saturating_sub(DEFAULT_BROWSE_WINDOW_MS));
         }
 
-        if let Some(start_ms) = query.from_ts_ms {
+        if let Some(pattern) = query.free_text.as_ref().filter(|value| !value.is_empty()) {
+            filter.insert(
+                "filter_pattern".to_string(),
+                serde_json::Value::String(pattern.clone()),
+            );
+        }
+
+        if let Some(start_ms) = from_ts_ms {
             filter.insert("start_ms".to_string(), serde_json::Value::from(start_ms));
         }
 
-        if let Some(end_ms) = query.to_ts_ms {
+        if let Some(end_ms) = to_ts_ms {
             filter.insert("end_ms".to_string(), serde_json::Value::from(end_ms));
         }
 
@@ -616,7 +620,13 @@ impl CloudWatchConnection {
             .map(|(index, row)| Self::row_to_event_record(row, collection, child_id, offset, index))
             .collect();
 
-        EventPage::new(records, None, result.next_page_token.is_some(), offset, limit)
+        EventPage::new(
+            records,
+            None,
+            result.next_page_token.is_some(),
+            offset,
+            limit,
+        )
     }
 
     fn row_to_event_record(
@@ -652,20 +662,20 @@ impl CloudWatchConnection {
                 _ => None,
             })
             .unwrap_or_default();
-        let event_id = row
-            .get(4)
-            .and_then(|value| match value {
-                Value::Text(text) if !text.is_empty() => Some(text.clone()),
-                Value::Int(value) => Some(value.to_string()),
-                _ => None,
-            });
+        let event_id = row.get(4).and_then(|value| match value {
+            Value::Text(text) if !text.is_empty() => Some(text.clone()),
+            Value::Int(value) => Some(value.to_string()),
+            _ => None,
+        });
 
         EventRecord {
             id: Some((pagination_offset + index + 1) as i64),
             ts_ms: timestamp_ms,
             level: EventSeverity::Info,
             category: EventCategory::System,
-            action: stream_name.clone().unwrap_or_else(|| collection.name.clone()),
+            action: stream_name
+                .clone()
+                .unwrap_or_else(|| collection.name.clone()),
             outcome: dbflux_core::EventOutcome::Success,
             actor_type: EventActorType::System,
             actor_id: None,
@@ -1064,14 +1074,19 @@ fn bool_field(
     })
 }
 
-fn fetch_log_streams(client: &Client, log_group_name: &str) -> Result<Vec<String>, DbError> {
+fn fetch_log_streams(
+    client: &Client,
+    log_group_name: &str,
+) -> Result<Vec<CollectionChildInfo>, DbError> {
     let mut next_token: Option<String> = None;
-    let mut stream_names = Vec::new();
+    let mut streams = Vec::new();
 
     loop {
         let mut operation = client
             .describe_log_streams()
             .log_group_name(log_group_name)
+            .order_by(aws_sdk_cloudwatchlogs::types::OrderBy::LastEventTime)
+            .descending(true)
             .limit(50);
 
         if let Some(token) = next_token.clone() {
@@ -1084,7 +1099,12 @@ fn fetch_log_streams(client: &Client, log_group_name: &str) -> Result<Vec<String
 
         for stream in output.log_streams() {
             if let Some(stream_name) = stream.log_stream_name() {
-                stream_names.push(stream_name.to_string());
+                streams.push(CollectionChildInfo {
+                    id: stream_name.to_string(),
+                    label: stream_name.to_string(),
+                    last_event_ts_ms: stream.last_event_timestamp(),
+                    presentation: CollectionPresentation::EventStream,
+                });
             }
         }
 
@@ -1094,8 +1114,14 @@ fn fetch_log_streams(client: &Client, log_group_name: &str) -> Result<Vec<String
         }
     }
 
-    stream_names.sort();
-    Ok(stream_names)
+    streams.sort_by(|left, right| {
+        right
+            .last_event_ts_ms
+            .cmp(&left.last_event_ts_ms)
+            .then_with(|| left.label.cmp(&right.label))
+    });
+
+    Ok(streams)
 }
 
 #[cfg(test)]

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -7,14 +7,14 @@ use aws_sdk_cloudwatchlogs::Client;
 use aws_sdk_cloudwatchlogs::config::Builder as CloudWatchConfigBuilder;
 use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
-    CLOUDWATCH_FORM, CollectionBrowseRequest, CollectionChildInfo, CollectionCountRequest,
-    CollectionInfo, CollectionPresentation, ColumnMeta, Connection, ConnectionProfile,
-    DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DocumentSchema,
-    DriverCapabilities, DriverFormDef, DriverMetadata, EventActorType, EventCategory, EventPage,
-    EventQuery, EventRecord, EventSeverity, EventSourceId, EventStreamTarget,
-    ExecutionSourceContext, FieldInfo, FormValues, Icon, QueryLanguage, QueryRequest, QueryResult,
-    SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot, SourceContextSpec, SourceQueryMode,
-    TableInfo, ValidationResult, Value,
+    CLOUDWATCH_FORM, CollectionBrowseRequest, CollectionChildInfo, CollectionChildrenPage,
+    CollectionChildrenRequest, CollectionCountRequest, CollectionInfo, CollectionPresentation,
+    ColumnMeta, Connection, ConnectionProfile, DatabaseCategory, DatabaseInfo, DbConfig, DbDriver,
+    DbError, DbKind, DocumentSchema, DriverCapabilities, DriverFormDef, DriverMetadata,
+    EventActorType, EventCategory, EventPage, EventQuery, EventRecord, EventSeverity,
+    EventSourceId, EventStreamTarget, ExecutionSourceContext, FormValues, Icon, QueryLanguage,
+    QueryRequest, QueryResult, SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot,
+    SourceContextSpec, SourceQueryMode, TableInfo, ValidationResult, Value,
 };
 
 pub static CLOUDWATCH_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -530,17 +530,6 @@ impl Connection for CloudWatchConnection {
         _schema: Option<&str>,
         table: &str,
     ) -> Result<TableInfo, DbError> {
-        let stream_items = fetch_log_streams(&self.client, table)?;
-        let stream_fields = stream_items
-            .iter()
-            .map(|stream| FieldInfo {
-                name: stream.label.clone(),
-                common_type: "text".to_string(),
-                occurrence_rate: None,
-                nested_fields: None,
-            })
-            .collect();
-
         Ok(TableInfo {
             name: table.to_string(),
             schema: Some(CLOUDWATCH_DEFAULT_DATABASE.to_string()),
@@ -548,10 +537,22 @@ impl Connection for CloudWatchConnection {
             indexes: None,
             foreign_keys: None,
             constraints: None,
-            sample_fields: Some(stream_fields),
+            sample_fields: None,
             presentation: CollectionPresentation::EventStream,
-            child_items: Some(stream_items),
+            child_items: None,
         })
+    }
+
+    fn collection_children(
+        &self,
+        request: &CollectionChildrenRequest,
+    ) -> Result<CollectionChildrenPage, DbError> {
+        fetch_log_stream_page(
+            &self.client,
+            &request.collection.name,
+            request.limit,
+            request.page_token.as_deref(),
+        )
     }
 
     fn kind(&self) -> DbKind {
@@ -1134,54 +1135,45 @@ fn bool_field(
     })
 }
 
-fn fetch_log_streams(
+fn fetch_log_stream_page(
     client: &Client,
     log_group_name: &str,
-) -> Result<Vec<CollectionChildInfo>, DbError> {
-    let mut next_token: Option<String> = None;
+    limit: u32,
+    page_token: Option<&str>,
+) -> Result<CollectionChildrenPage, DbError> {
     let mut streams = Vec::new();
+    let limit = limit.clamp(1, 50) as i32;
 
-    loop {
-        let mut operation = client
-            .describe_log_streams()
-            .log_group_name(log_group_name)
-            .order_by(aws_sdk_cloudwatchlogs::types::OrderBy::LastEventTime)
-            .descending(true)
-            .limit(50);
+    let mut operation = client
+        .describe_log_streams()
+        .log_group_name(log_group_name)
+        .order_by(aws_sdk_cloudwatchlogs::types::OrderBy::LastEventTime)
+        .descending(true)
+        .limit(limit);
 
-        if let Some(token) = next_token.clone() {
-            operation = operation.next_token(token);
-        }
+    if let Some(token) = page_token {
+        operation = operation.next_token(token.to_string());
+    }
 
-        let output = runtime()?.block_on(operation.send()).map_err(|error| {
-            DbError::query_failed(format!("CloudWatch DescribeLogStreams failed: {error}"))
-        })?;
+    let output = runtime()?.block_on(operation.send()).map_err(|error| {
+        DbError::query_failed(format!("CloudWatch DescribeLogStreams failed: {error}"))
+    })?;
 
-        for stream in output.log_streams() {
-            if let Some(stream_name) = stream.log_stream_name() {
-                streams.push(CollectionChildInfo {
-                    id: stream_name.to_string(),
-                    label: stream_name.to_string(),
-                    last_event_ts_ms: stream.last_event_timestamp(),
-                    presentation: CollectionPresentation::EventStream,
-                });
-            }
-        }
-
-        next_token = output.next_token().map(ToOwned::to_owned);
-        if next_token.is_none() {
-            break;
+    for stream in output.log_streams() {
+        if let Some(stream_name) = stream.log_stream_name() {
+            streams.push(CollectionChildInfo {
+                id: stream_name.to_string(),
+                label: stream_name.to_string(),
+                last_event_ts_ms: stream.last_event_timestamp(),
+                presentation: CollectionPresentation::EventStream,
+            });
         }
     }
 
-    streams.sort_by(|left, right| {
-        right
-            .last_event_ts_ms
-            .cmp(&left.last_event_ts_ms)
-            .then_with(|| left.label.cmp(&right.label))
-    });
-
-    Ok(streams)
+    Ok(CollectionChildrenPage {
+        items: streams,
+        next_page_token: output.next_token().map(ToOwned::to_owned),
+    })
 }
 
 #[cfg(test)]

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -7,11 +7,13 @@ use aws_sdk_cloudwatchlogs::Client;
 use aws_sdk_cloudwatchlogs::config::Builder as CloudWatchConfigBuilder;
 use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
-    CLOUDWATCH_FORM, CollectionBrowseRequest, CollectionCountRequest, CollectionInfo, ColumnMeta,
-    Connection, ConnectionProfile, DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError,
-    DbKind, DocumentSchema, DriverCapabilities, DriverFormDef, DriverMetadata,
+    CLOUDWATCH_FORM, CollectionBrowseRequest, CollectionChildInfo, CollectionCountRequest,
+    CollectionInfo, CollectionPresentation, ColumnMeta, Connection, ConnectionProfile,
+    DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DocumentSchema,
+    DriverCapabilities, DriverFormDef, DriverMetadata, EventActorType, EventCategory, EventPage,
+    EventQuery, EventRecord, EventSeverity, EventSourceId, EventStreamTarget,
     ExecutionSourceContext, FieldInfo, FormValues, Icon, QueryLanguage, QueryRequest, QueryResult,
-    SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot, TableInfo, Value,
+    SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot, SourceContextSpec, TableInfo, Value,
 };
 
 pub static CLOUDWATCH_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -185,8 +187,8 @@ impl Connection for CloudWatchConnection {
                 DbError::query_failed("CloudWatch execution requires structured source context")
             })?;
 
-        let ExecutionSourceContext::CloudWatchLogs {
-            log_groups,
+        let ExecutionSourceContext::CollectionWindow {
+            targets: log_groups,
             start_ms,
             end_ms,
         } = source;
@@ -475,19 +477,55 @@ impl Connection for CloudWatchConnection {
         ))
     }
 
+    fn browse_event_stream(
+        &self,
+        target: &EventStreamTarget,
+        query: &EventQuery,
+    ) -> Result<EventPage, DbError> {
+        let request = Self::event_stream_request(target, query);
+        let result = self.browse_collection(&request)?;
+
+        Ok(Self::event_query_result_to_page(
+            &target.collection,
+            target.child_id.as_deref(),
+            query,
+            result,
+        ))
+    }
+
+    fn source_context_spec(&self) -> Option<SourceContextSpec> {
+        Some(SourceContextSpec {
+            targets_label: "Log groups".to_string(),
+            targets_placeholder: "Log groups".to_string(),
+            start_label: "Start".to_string(),
+            end_label: "End".to_string(),
+        })
+    }
+
     fn table_details(
         &self,
         _database: &str,
         _schema: Option<&str>,
         table: &str,
     ) -> Result<TableInfo, DbError> {
-        let stream_fields = fetch_log_streams(&self.client, table)?
-            .into_iter()
+        let stream_names = fetch_log_streams(&self.client, table)?;
+        let stream_fields = stream_names
+            .iter()
+            .cloned()
             .map(|stream_name| FieldInfo {
                 name: stream_name,
-                common_type: "cloudwatch_log_stream".to_string(),
+                common_type: "text".to_string(),
                 occurrence_rate: None,
                 nested_fields: None,
+            })
+            .collect();
+
+        let child_items = stream_names
+            .into_iter()
+            .map(|stream_name| CollectionChildInfo {
+                id: stream_name.clone(),
+                label: stream_name,
+                presentation: CollectionPresentation::EventStream,
             })
             .collect();
 
@@ -499,6 +537,8 @@ impl Connection for CloudWatchConnection {
             foreign_keys: None,
             constraints: None,
             sample_fields: Some(stream_fields),
+            presentation: CollectionPresentation::EventStream,
+            child_items: Some(child_items),
         })
     }
 
@@ -524,6 +564,127 @@ impl Connection for CloudWatchConnection {
 }
 
 impl CloudWatchConnection {
+    fn event_stream_request(
+        target: &EventStreamTarget,
+        query: &EventQuery,
+    ) -> CollectionBrowseRequest {
+        let mut filter = serde_json::Map::new();
+
+        if let Some(pattern) = query.free_text.as_ref().filter(|value| !value.is_empty()) {
+            filter.insert("filter_pattern".to_string(), serde_json::Value::String(pattern.clone()));
+        }
+
+        if let Some(start_ms) = query.from_ts_ms {
+            filter.insert("start_ms".to_string(), serde_json::Value::from(start_ms));
+        }
+
+        if let Some(end_ms) = query.to_ts_ms {
+            filter.insert("end_ms".to_string(), serde_json::Value::from(end_ms));
+        }
+
+        if let Some(child_id) = target.child_id.as_ref() {
+            filter.insert(
+                "log_stream_names".to_string(),
+                serde_json::Value::Array(vec![serde_json::Value::String(child_id.clone())]),
+            );
+            filter.insert("most_recent".to_string(), serde_json::Value::Bool(true));
+        }
+
+        CollectionBrowseRequest {
+            collection: target.collection.clone(),
+            filter: (!filter.is_empty()).then_some(serde_json::Value::Object(filter)),
+            semantic_filter: None,
+            pagination: dbflux_core::Pagination::Offset {
+                limit: query.limit.unwrap_or(100) as u32,
+                offset: query.offset.unwrap_or(0) as u64,
+            },
+        }
+    }
+
+    fn event_query_result_to_page(
+        collection: &dbflux_core::CollectionRef,
+        child_id: Option<&str>,
+        query: &EventQuery,
+        result: QueryResult,
+    ) -> EventPage {
+        let offset = query.offset.unwrap_or(0);
+        let limit = query.limit.unwrap_or(100);
+        let records = result
+            .rows
+            .iter()
+            .enumerate()
+            .map(|(index, row)| Self::row_to_event_record(row, collection, child_id, offset, index))
+            .collect();
+
+        EventPage::new(records, None, result.next_page_token.is_some(), offset, limit)
+    }
+
+    fn row_to_event_record(
+        row: &[Value],
+        collection: &dbflux_core::CollectionRef,
+        child_id: Option<&str>,
+        pagination_offset: usize,
+        index: usize,
+    ) -> EventRecord {
+        let timestamp_ms = match row.first() {
+            Some(Value::Int(value)) => *value,
+            Some(Value::Text(value)) => value.parse().unwrap_or_default(),
+            _ => 0,
+        };
+        let ingestion_time_ms = match row.get(1) {
+            Some(Value::Int(value)) => Some(*value),
+            Some(Value::Text(value)) => value.parse().ok(),
+            _ => None,
+        };
+        let stream_name = row
+            .get(2)
+            .and_then(|value| match value {
+                Value::Text(text) if !text.is_empty() => Some(text.clone()),
+                Value::Int(value) => Some(value.to_string()),
+                _ => None,
+            })
+            .or_else(|| child_id.map(ToOwned::to_owned));
+        let message = row
+            .get(3)
+            .and_then(|value| match value {
+                Value::Text(text) => Some(text.clone()),
+                Value::Int(value) => Some(value.to_string()),
+                _ => None,
+            })
+            .unwrap_or_default();
+        let event_id = row
+            .get(4)
+            .and_then(|value| match value {
+                Value::Text(text) if !text.is_empty() => Some(text.clone()),
+                Value::Int(value) => Some(value.to_string()),
+                _ => None,
+            });
+
+        EventRecord {
+            id: Some((pagination_offset + index + 1) as i64),
+            ts_ms: timestamp_ms,
+            level: EventSeverity::Info,
+            category: EventCategory::System,
+            action: stream_name.clone().unwrap_or_else(|| collection.name.clone()),
+            outcome: dbflux_core::EventOutcome::Success,
+            actor_type: EventActorType::System,
+            actor_id: None,
+            source_id: EventSourceId::System,
+            connection_id: Some(collection.name.clone()),
+            database_name: Some(collection.database.clone()),
+            driver_id: Some(CLOUDWATCH_METADATA.id.clone()),
+            object_type: Some("event_stream".to_string()),
+            object_id: event_id,
+            summary: message.clone(),
+            details_json: Some(build_message_details(Some(message.as_str())).to_string()),
+            error_code: None,
+            error_message: ingestion_time_ms.map(|value| value.to_string()),
+            duration_ms: None,
+            session_id: None,
+            correlation_id: None,
+        }
+    }
+
     fn fetch_recent_stream_events(
         &self,
         log_group_name: &str,
@@ -790,6 +951,8 @@ fn fetch_log_groups(client: &Client) -> Result<Vec<CollectionInfo>, DbError> {
                     indexes: None,
                     validator: None,
                     is_capped: false,
+                    presentation: CollectionPresentation::EventStream,
+                    child_items: None,
                 });
             }
         }
@@ -816,6 +979,12 @@ fn current_time_ms() -> Result<i64, DbError> {
 fn runtime() -> Result<tokio::runtime::Runtime, DbError> {
     tokio::runtime::Runtime::new()
         .map_err(|error| DbError::connection_failed(format!("Tokio runtime setup failed: {error}")))
+}
+
+fn build_message_details(message: Option<&str>) -> serde_json::Value {
+    message
+        .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
+        .unwrap_or_else(|| serde_json::json!(message))
 }
 
 fn string_field(

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -1,0 +1,975 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use aws_config::{BehaviorVersion, Region};
+use aws_sdk_cloudwatchlogs::Client;
+use aws_sdk_cloudwatchlogs::config::Builder as CloudWatchConfigBuilder;
+use dbflux_core::secrecy::SecretString;
+use dbflux_core::{
+    CLOUDWATCH_FORM, CollectionBrowseRequest, CollectionCountRequest, CollectionInfo, ColumnMeta,
+    Connection, ConnectionProfile, DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError,
+    DbKind, DocumentSchema, DriverCapabilities, DriverFormDef, DriverMetadata,
+    ExecutionSourceContext, FieldInfo, FormValues, Icon, QueryLanguage, QueryRequest, QueryResult,
+    SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot, TableInfo, Value,
+};
+
+pub static CLOUDWATCH_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
+    id: "cloudwatch".into(),
+    display_name: "CloudWatch Logs".into(),
+    description: "AWS CloudWatch Logs Insights queries with editor-managed source context".into(),
+    category: DatabaseCategory::Document,
+    query_language: QueryLanguage::Sql,
+    capabilities: DriverCapabilities::AUTHENTICATION,
+    default_port: None,
+    uri_scheme: "cloudwatch".into(),
+    icon: Icon::Dynamodb,
+    syntax: None,
+    query: None,
+    mutation: None,
+    ddl: None,
+    transactions: None,
+    limits: None,
+    classification_override: None,
+});
+
+const CLOUDWATCH_DEFAULT_DATABASE: &str = "logs";
+const DEFAULT_BROWSE_WINDOW_MS: i64 = 24 * 60 * 60 * 1000;
+const MAX_QUERY_WAIT_ATTEMPTS: usize = 120;
+const QUERY_POLL_INTERVAL: Duration = Duration::from_millis(500);
+
+pub struct CloudWatchDriver;
+
+#[derive(Clone, Debug)]
+struct CloudWatchProfileConfig {
+    region: String,
+    profile: Option<String>,
+    endpoint: Option<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct CloudWatchCollectionFilter {
+    filter_pattern: Option<String>,
+    start_ms: Option<i64>,
+    end_ms: Option<i64>,
+    log_stream_name_prefix: Option<String>,
+    log_stream_names: Option<Vec<String>>,
+    most_recent: bool,
+}
+
+struct CloudWatchConnection {
+    client: Client,
+    config: CloudWatchProfileConfig,
+}
+
+impl CloudWatchDriver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for CloudWatchDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DbDriver for CloudWatchDriver {
+    fn kind(&self) -> DbKind {
+        DbKind::CloudWatchLogs
+    }
+
+    fn metadata(&self) -> &DriverMetadata {
+        &CLOUDWATCH_METADATA
+    }
+
+    fn form_definition(&self) -> &DriverFormDef {
+        &CLOUDWATCH_FORM
+    }
+
+    fn driver_key(&self) -> dbflux_core::DriverKey {
+        "builtin:cloudwatch".into()
+    }
+
+    fn requires_password(&self) -> bool {
+        false
+    }
+
+    fn build_config(&self, values: &FormValues) -> Result<DbConfig, DbError> {
+        let region = values
+            .get("region")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| DbError::InvalidProfile("AWS Region is required".to_string()))?
+            .to_string();
+
+        let profile = values
+            .get("profile")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string());
+
+        let endpoint = values
+            .get("endpoint")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(|value| value.to_string());
+
+        Ok(DbConfig::CloudWatchLogs {
+            region,
+            profile,
+            endpoint,
+        })
+    }
+
+    fn extract_values(&self, config: &DbConfig) -> FormValues {
+        let DbConfig::CloudWatchLogs {
+            region,
+            profile,
+            endpoint,
+        } = config
+        else {
+            return HashMap::new();
+        };
+
+        let mut values = HashMap::new();
+        values.insert("region".to_string(), region.clone());
+        values.insert("profile".to_string(), profile.clone().unwrap_or_default());
+        values.insert("endpoint".to_string(), endpoint.clone().unwrap_or_default());
+        values
+    }
+
+    fn connect_with_secrets(
+        &self,
+        profile: &ConnectionProfile,
+        _password: Option<&SecretString>,
+        _ssh_secret: Option<&SecretString>,
+    ) -> Result<Box<dyn Connection>, DbError> {
+        let config = profile_config(&profile.config)?;
+        let client = build_client(&config)?;
+
+        probe_connection(&client, &config)?;
+
+        Ok(Box::new(CloudWatchConnection { client, config }))
+    }
+
+    fn test_connection(&self, profile: &ConnectionProfile) -> Result<(), DbError> {
+        let config = profile_config(&profile.config)?;
+        let client = build_client(&config)?;
+
+        probe_connection(&client, &config)
+    }
+}
+
+impl Connection for CloudWatchConnection {
+    fn metadata(&self) -> &DriverMetadata {
+        &CLOUDWATCH_METADATA
+    }
+
+    fn ping(&self) -> Result<(), DbError> {
+        probe_connection(&self.client, &self.config)
+    }
+
+    fn close(&mut self) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    fn execute(&self, req: &QueryRequest) -> Result<QueryResult, DbError> {
+        let started = Instant::now();
+
+        let source = req
+            .execution_context
+            .as_ref()
+            .and_then(|context| context.source.as_ref())
+            .ok_or_else(|| {
+                DbError::query_failed("CloudWatch execution requires structured source context")
+            })?;
+
+        let ExecutionSourceContext::CloudWatchLogs {
+            log_groups,
+            start_ms,
+            end_ms,
+        } = source;
+
+        if log_groups.is_empty() {
+            return Err(DbError::query_failed(
+                "Select at least one CloudWatch log group before running a query".to_string(),
+            ));
+        }
+
+        let query_limit = req.limit.unwrap_or(1000).clamp(1, 10_000);
+        let start_seconds = start_ms.div_euclid(1000);
+        let end_seconds = end_ms.div_euclid(1000);
+
+        let start_request = self
+            .client
+            .start_query()
+            .query_string(req.sql.clone())
+            .start_time(start_seconds)
+            .end_time(end_seconds)
+            .limit(query_limit as i32)
+            .set_log_group_names(Some(log_groups.clone()));
+
+        let start_output = runtime()?.block_on(start_request.send()).map_err(|error| {
+            DbError::query_failed(format!("CloudWatch StartQuery failed: {error}"))
+        })?;
+
+        let query_id = start_output
+            .query_id()
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| DbError::query_failed("CloudWatch StartQuery returned no query id"))?;
+
+        let mut attempts = 0;
+        loop {
+            attempts += 1;
+
+            let output = runtime()?
+                .block_on(
+                    self.client
+                        .get_query_results()
+                        .query_id(query_id.clone())
+                        .send(),
+                )
+                .map_err(|error| {
+                    DbError::query_failed(format!("CloudWatch GetQueryResults failed: {error}"))
+                })?;
+
+            let status = output
+                .status()
+                .map(|value| value.as_str())
+                .unwrap_or("Unknown");
+
+            match status {
+                "Complete" => {
+                    let mut column_order = Vec::new();
+                    let mut seen = HashSet::new();
+                    let mut row_maps = Vec::new();
+
+                    for result_row in output.results() {
+                        let mut row_map = HashMap::new();
+
+                        for field in result_row {
+                            let field_name = field.field().unwrap_or("").to_string();
+                            if field_name.is_empty() {
+                                continue;
+                            }
+
+                            if seen.insert(field_name.clone()) {
+                                column_order.push(field_name.clone());
+                            }
+
+                            let value = field
+                                .value()
+                                .map(|value| Value::Text(value.to_string()))
+                                .unwrap_or(Value::Null);
+                            row_map.insert(field_name, value);
+                        }
+
+                        row_maps.push(row_map);
+                    }
+
+                    let columns = column_order
+                        .iter()
+                        .map(|name| ColumnMeta {
+                            name: name.clone(),
+                            type_name: "text".to_string(),
+                            nullable: true,
+                            is_primary_key: false,
+                        })
+                        .collect::<Vec<_>>();
+
+                    let rows = row_maps
+                        .into_iter()
+                        .map(|mut row_map| {
+                            column_order
+                                .iter()
+                                .map(|name| row_map.remove(name).unwrap_or(Value::Null))
+                                .collect::<Vec<_>>()
+                        })
+                        .collect::<Vec<_>>();
+
+                    return Ok(QueryResult::table(columns, rows, None, started.elapsed()));
+                }
+                "Scheduled" | "Running" => {
+                    if attempts >= MAX_QUERY_WAIT_ATTEMPTS {
+                        return Err(DbError::query_failed(format!(
+                            "CloudWatch query did not finish within {} polling attempts",
+                            MAX_QUERY_WAIT_ATTEMPTS
+                        )));
+                    }
+
+                    std::thread::sleep(QUERY_POLL_INTERVAL);
+                }
+                other => {
+                    return Err(DbError::query_failed(format!(
+                        "CloudWatch query ended with status {other}"
+                    )));
+                }
+            }
+        }
+    }
+
+    fn cancel(&self, _handle: &dbflux_core::QueryHandle) -> Result<(), DbError> {
+        Err(DbError::NotSupported(
+            "Query cancellation not supported for CloudWatch Logs yet".to_string(),
+        ))
+    }
+
+    fn schema(&self) -> Result<SchemaSnapshot, DbError> {
+        let collections = fetch_log_groups(&self.client)?;
+
+        Ok(SchemaSnapshot::document(DocumentSchema {
+            databases: vec![DatabaseInfo {
+                name: CLOUDWATCH_DEFAULT_DATABASE.to_string(),
+                is_current: true,
+            }],
+            current_database: Some(CLOUDWATCH_DEFAULT_DATABASE.to_string()),
+            collections,
+        }))
+    }
+
+    fn list_databases(&self) -> Result<Vec<DatabaseInfo>, DbError> {
+        Ok(vec![DatabaseInfo {
+            name: CLOUDWATCH_DEFAULT_DATABASE.to_string(),
+            is_current: true,
+        }])
+    }
+
+    fn browse_collection(&self, request: &CollectionBrowseRequest) -> Result<QueryResult, DbError> {
+        let started = Instant::now();
+        let filter = CloudWatchCollectionFilter::from_json(request.filter.as_ref())?;
+
+        let limit = request.pagination.limit().clamp(1, 10_000) as usize;
+        let offset = request.pagination.offset() as usize;
+
+        if filter.most_recent
+            && filter.filter_pattern.is_none()
+            && let Some(stream_names) = filter.log_stream_names.as_ref()
+            && stream_names.len() == 1
+        {
+            return self.fetch_recent_stream_events(
+                request.collection.name.as_str(),
+                stream_names[0].as_str(),
+                &filter,
+                limit,
+                offset,
+                started,
+            );
+        }
+
+        let default_end = current_time_ms()?;
+        let default_start = default_end.saturating_sub(DEFAULT_BROWSE_WINDOW_MS);
+
+        let mut next_token: Option<String> = None;
+        let mut skipped = 0usize;
+        let mut rows = Vec::new();
+
+        loop {
+            let mut operation = self
+                .client
+                .filter_log_events()
+                .log_group_name(request.collection.name.clone())
+                .limit(limit as i32)
+                .start_time(filter.start_ms.unwrap_or(default_start))
+                .end_time(filter.end_ms.unwrap_or(default_end));
+
+            if let Some(pattern) = filter.filter_pattern.clone() {
+                operation = operation.filter_pattern(pattern);
+            }
+
+            if let Some(prefix) = filter.log_stream_name_prefix.clone() {
+                operation = operation.log_stream_name_prefix(prefix);
+            }
+
+            if let Some(stream_names) = filter.log_stream_names.clone() {
+                operation = operation.set_log_stream_names(Some(stream_names));
+            }
+
+            if let Some(token) = next_token.clone() {
+                operation = operation.next_token(token);
+            }
+
+            let output = runtime()?.block_on(operation.send()).map_err(|error| {
+                DbError::query_failed(format!("CloudWatch FilterLogEvents failed: {error}"))
+            })?;
+
+            for event in output.events() {
+                if skipped < offset {
+                    skipped += 1;
+                    continue;
+                }
+
+                if rows.len() >= limit {
+                    break;
+                }
+
+                rows.push(vec![
+                    event.timestamp().map(Value::Int).unwrap_or(Value::Null),
+                    event
+                        .ingestion_time()
+                        .map(Value::Int)
+                        .unwrap_or(Value::Null),
+                    event
+                        .log_stream_name()
+                        .map(|value| Value::Text(value.to_string()))
+                        .unwrap_or(Value::Null),
+                    event
+                        .message()
+                        .map(|value| Value::Text(value.to_string()))
+                        .unwrap_or(Value::Null),
+                    event
+                        .event_id()
+                        .map(|value| Value::Text(value.to_string()))
+                        .unwrap_or(Value::Null),
+                ]);
+            }
+
+            next_token = output.next_token().map(ToOwned::to_owned);
+
+            if rows.len() >= limit || next_token.is_none() {
+                break;
+            }
+        }
+
+        let columns = vec![
+            ColumnMeta {
+                name: "timestamp_ms".to_string(),
+                type_name: "bigint".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+            ColumnMeta {
+                name: "ingestion_time_ms".to_string(),
+                type_name: "bigint".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+            ColumnMeta {
+                name: "log_stream_name".to_string(),
+                type_name: "text".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+            ColumnMeta {
+                name: "message".to_string(),
+                type_name: "text".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+            ColumnMeta {
+                name: "event_id".to_string(),
+                type_name: "text".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+        ];
+
+        let mut result = QueryResult::table(columns, rows, None, started.elapsed());
+        result.next_page_token = next_token;
+        Ok(result)
+    }
+
+    fn count_collection(&self, _request: &CollectionCountRequest) -> Result<u64, DbError> {
+        Err(DbError::NotSupported(
+            "CloudWatch event counts are not available as a cheap collection count".to_string(),
+        ))
+    }
+
+    fn table_details(
+        &self,
+        _database: &str,
+        _schema: Option<&str>,
+        table: &str,
+    ) -> Result<TableInfo, DbError> {
+        let stream_fields = fetch_log_streams(&self.client, table)?
+            .into_iter()
+            .map(|stream_name| FieldInfo {
+                name: stream_name,
+                common_type: "cloudwatch_log_stream".to_string(),
+                occurrence_rate: None,
+                nested_fields: None,
+            })
+            .collect();
+
+        Ok(TableInfo {
+            name: table.to_string(),
+            schema: Some(CLOUDWATCH_DEFAULT_DATABASE.to_string()),
+            columns: None,
+            indexes: None,
+            foreign_keys: None,
+            constraints: None,
+            sample_fields: Some(stream_fields),
+        })
+    }
+
+    fn kind(&self) -> DbKind {
+        DbKind::CloudWatchLogs
+    }
+
+    fn schema_loading_strategy(&self) -> SchemaLoadingStrategy {
+        SchemaLoadingStrategy::SingleDatabase
+    }
+
+    fn schema_features(&self) -> SchemaFeatures {
+        SchemaFeatures::empty()
+    }
+
+    fn dialect(&self) -> &dyn dbflux_core::SqlDialect {
+        &dbflux_core::DefaultSqlDialect
+    }
+
+    fn version_query(&self) -> &'static str {
+        "SELECT 'cloudwatch'"
+    }
+}
+
+impl CloudWatchConnection {
+    fn fetch_recent_stream_events(
+        &self,
+        log_group_name: &str,
+        log_stream_name: &str,
+        filter: &CloudWatchCollectionFilter,
+        limit: usize,
+        offset: usize,
+        started: Instant,
+    ) -> Result<QueryResult, DbError> {
+        let mut next_token: Option<String> = None;
+        let mut rows = Vec::new();
+        let mut skipped = 0usize;
+
+        loop {
+            let mut operation = self
+                .client
+                .get_log_events()
+                .log_group_name(log_group_name)
+                .log_stream_name(log_stream_name)
+                .start_from_head(false)
+                .limit(limit as i32);
+
+            if let Some(start_ms) = filter.start_ms {
+                operation = operation.start_time(start_ms);
+            }
+
+            if let Some(end_ms) = filter.end_ms {
+                operation = operation.end_time(end_ms);
+            }
+
+            if let Some(token) = next_token.clone() {
+                operation = operation.next_token(token);
+            }
+
+            let output = runtime()?.block_on(operation.send()).map_err(|error| {
+                DbError::query_failed(format!("CloudWatch GetLogEvents failed: {error}"))
+            })?;
+
+            let mut page_rows = output
+                .events()
+                .iter()
+                .enumerate()
+                .map(|(index, event)| {
+                    let message = event.message().unwrap_or_default().to_string();
+
+                    let timestamp_ms = event.timestamp().unwrap_or_default();
+                    let ingestion_time_ms = event.ingestion_time();
+                    let synthetic_event_id = format!(
+                        "{}:{}:{}:{}",
+                        log_stream_name,
+                        timestamp_ms,
+                        ingestion_time_ms.unwrap_or_default(),
+                        index
+                    );
+
+                    vec![
+                        Value::Int(timestamp_ms),
+                        ingestion_time_ms.map(Value::Int).unwrap_or(Value::Null),
+                        Value::Text(log_stream_name.to_string()),
+                        Value::Text(message),
+                        Value::Text(synthetic_event_id),
+                    ]
+                })
+                .collect::<Vec<_>>();
+
+            page_rows.sort_by(|left, right| {
+                let left_ts = match left.first() {
+                    Some(Value::Int(value)) => *value,
+                    _ => 0,
+                };
+                let right_ts = match right.first() {
+                    Some(Value::Int(value)) => *value,
+                    _ => 0,
+                };
+
+                right_ts.cmp(&left_ts)
+            });
+
+            for row in page_rows {
+                if skipped < offset {
+                    skipped += 1;
+                    continue;
+                }
+
+                if rows.len() >= limit {
+                    break;
+                }
+
+                rows.push(row);
+            }
+
+            if rows.len() >= limit {
+                break;
+            }
+
+            let new_token = output.next_backward_token().map(ToOwned::to_owned);
+            if new_token.is_none() || new_token == next_token {
+                break;
+            }
+
+            next_token = new_token;
+        }
+
+        let columns = vec![
+            ColumnMeta {
+                name: "timestamp_ms".to_string(),
+                type_name: "bigint".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+            ColumnMeta {
+                name: "ingestion_time_ms".to_string(),
+                type_name: "bigint".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+            ColumnMeta {
+                name: "log_stream_name".to_string(),
+                type_name: "text".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+            ColumnMeta {
+                name: "message".to_string(),
+                type_name: "text".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+            ColumnMeta {
+                name: "event_id".to_string(),
+                type_name: "text".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            },
+        ];
+
+        Ok(QueryResult::table(columns, rows, None, started.elapsed()))
+    }
+}
+
+impl CloudWatchCollectionFilter {
+    fn from_json(filter: Option<&serde_json::Value>) -> Result<Self, DbError> {
+        let Some(filter) = filter else {
+            return Ok(Self::default());
+        };
+
+        let object = filter.as_object().ok_or_else(|| {
+            DbError::query_failed("CloudWatch collection filter must be a JSON object")
+        })?;
+
+        let filter_pattern = string_field(object, &["filter_pattern", "filterPattern"]);
+        let start_ms = i64_field(object, &["start_ms", "startTime", "start_time"])?;
+        let end_ms = i64_field(object, &["end_ms", "endTime", "end_time"])?;
+        let log_stream_name_prefix =
+            string_field(object, &["log_stream_name_prefix", "logStreamNamePrefix"]);
+        let log_stream_names = string_array_field(object, &["log_stream_names", "logStreamNames"])?;
+        let most_recent = bool_field(object, &["most_recent", "mostRecent"])?;
+
+        Ok(Self {
+            filter_pattern,
+            start_ms,
+            end_ms,
+            log_stream_name_prefix,
+            log_stream_names,
+            most_recent,
+        })
+    }
+}
+
+fn profile_config(config: &DbConfig) -> Result<CloudWatchProfileConfig, DbError> {
+    let DbConfig::CloudWatchLogs {
+        region,
+        profile,
+        endpoint,
+    } = config
+    else {
+        return Err(DbError::InvalidProfile(
+            "Expected CloudWatch Logs configuration".to_string(),
+        ));
+    };
+
+    let region = region.trim();
+    if region.is_empty() {
+        return Err(DbError::InvalidProfile(
+            "AWS Region is required".to_string(),
+        ));
+    }
+
+    Ok(CloudWatchProfileConfig {
+        region: region.to_string(),
+        profile: profile
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned),
+        endpoint: endpoint
+            .as_ref()
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned),
+    })
+}
+
+fn build_client(config: &CloudWatchProfileConfig) -> Result<Client, DbError> {
+    let mut loader =
+        aws_config::defaults(BehaviorVersion::latest()).region(Region::new(config.region.clone()));
+
+    if let Some(profile) = &config.profile {
+        loader = loader.profile_name(profile);
+    }
+
+    let sdk_config = runtime()?.block_on(loader.load());
+
+    if config.endpoint.is_none() {
+        return Ok(Client::new(&sdk_config));
+    }
+
+    let mut builder = CloudWatchConfigBuilder::from(&sdk_config);
+    if let Some(endpoint) = &config.endpoint {
+        builder = builder.endpoint_url(endpoint);
+    }
+
+    Ok(Client::from_conf(builder.build()))
+}
+
+fn probe_connection(client: &Client, config: &CloudWatchProfileConfig) -> Result<(), DbError> {
+    runtime()?
+        .block_on(client.describe_log_groups().limit(1).send())
+        .map_err(|error| {
+            DbError::connection_failed(format!(
+                "CloudWatch probe failed (region={}, profile={}): {} | debug={:?}",
+                config.region,
+                config.profile.as_deref().unwrap_or("<default>"),
+                error,
+                error
+            ))
+        })?;
+
+    Ok(())
+}
+
+fn fetch_log_groups(client: &Client) -> Result<Vec<CollectionInfo>, DbError> {
+    let mut collections = Vec::new();
+    let mut next_token: Option<String> = None;
+
+    loop {
+        let mut operation = client.describe_log_groups().limit(50);
+        if let Some(token) = next_token.clone() {
+            operation = operation.next_token(token);
+        }
+
+        let output = runtime()?.block_on(operation.send()).map_err(|error| {
+            DbError::query_failed(format!("CloudWatch DescribeLogGroups failed: {error}"))
+        })?;
+
+        for group in output.log_groups() {
+            if let Some(name) = group.log_group_name() {
+                collections.push(CollectionInfo {
+                    name: name.to_string(),
+                    database: Some(CLOUDWATCH_DEFAULT_DATABASE.to_string()),
+                    document_count: None,
+                    avg_document_size: None,
+                    sample_fields: None,
+                    indexes: None,
+                    validator: None,
+                    is_capped: false,
+                });
+            }
+        }
+
+        next_token = output.next_token().map(ToOwned::to_owned);
+        if next_token.is_none() {
+            break;
+        }
+    }
+
+    collections.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(collections)
+}
+
+fn current_time_ms() -> Result<i64, DbError> {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| DbError::query_failed(format!("System clock error: {error}")))?;
+
+    i64::try_from(duration.as_millis())
+        .map_err(|_| DbError::query_failed("Current time does not fit in i64".to_string()))
+}
+
+fn runtime() -> Result<tokio::runtime::Runtime, DbError> {
+    tokio::runtime::Runtime::new()
+        .map_err(|error| DbError::connection_failed(format!("Tokio runtime setup failed: {error}")))
+}
+
+fn string_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Option<String> {
+    keys.iter()
+        .find_map(|key| object.get(*key))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn i64_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Result<Option<i64>, DbError> {
+    let Some(value) = keys.iter().find_map(|key| object.get(*key)) else {
+        return Ok(None);
+    };
+
+    value.as_i64().map(Some).ok_or_else(|| {
+        DbError::query_failed(format!(
+            "CloudWatch collection filter field '{}' must be an integer",
+            keys[0]
+        ))
+    })
+}
+
+fn string_array_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Result<Option<Vec<String>>, DbError> {
+    let Some(value) = keys.iter().find_map(|key| object.get(*key)) else {
+        return Ok(None);
+    };
+
+    let array = value.as_array().ok_or_else(|| {
+        DbError::query_failed(format!(
+            "CloudWatch collection filter field '{}' must be an array of strings",
+            keys[0]
+        ))
+    })?;
+
+    let mut values = Vec::with_capacity(array.len());
+    for item in array {
+        let item = item.as_str().ok_or_else(|| {
+            DbError::query_failed(format!(
+                "CloudWatch collection filter field '{}' must contain only strings",
+                keys[0]
+            ))
+        })?;
+
+        let trimmed = item.trim();
+        if !trimmed.is_empty() {
+            values.push(trimmed.to_string());
+        }
+    }
+
+    Ok((!values.is_empty()).then_some(values))
+}
+
+fn bool_field(
+    object: &serde_json::Map<String, serde_json::Value>,
+    keys: &[&str],
+) -> Result<bool, DbError> {
+    let Some(value) = keys.iter().find_map(|key| object.get(*key)) else {
+        return Ok(false);
+    };
+
+    value.as_bool().ok_or_else(|| {
+        DbError::query_failed(format!(
+            "CloudWatch collection filter field '{}' must be a boolean",
+            keys[0]
+        ))
+    })
+}
+
+fn fetch_log_streams(client: &Client, log_group_name: &str) -> Result<Vec<String>, DbError> {
+    let mut next_token: Option<String> = None;
+    let mut stream_names = Vec::new();
+
+    loop {
+        let mut operation = client
+            .describe_log_streams()
+            .log_group_name(log_group_name)
+            .limit(50);
+
+        if let Some(token) = next_token.clone() {
+            operation = operation.next_token(token);
+        }
+
+        let output = runtime()?.block_on(operation.send()).map_err(|error| {
+            DbError::query_failed(format!("CloudWatch DescribeLogStreams failed: {error}"))
+        })?;
+
+        for stream in output.log_streams() {
+            if let Some(stream_name) = stream.log_stream_name() {
+                stream_names.push(stream_name.to_string());
+            }
+        }
+
+        next_token = output.next_token().map(ToOwned::to_owned);
+        if next_token.is_none() {
+            break;
+        }
+    }
+
+    stream_names.sort();
+    Ok(stream_names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CloudWatchCollectionFilter, CloudWatchDriver};
+    use dbflux_core::{DbConfig, DbDriver};
+
+    #[test]
+    fn cloudwatch_driver_uses_builtin_form_and_key() {
+        let driver = CloudWatchDriver::new();
+
+        assert_eq!(driver.driver_key(), "builtin:cloudwatch");
+        assert!(!driver.requires_password());
+        assert_eq!(driver.form_definition().main_tab().unwrap().label, "Main");
+    }
+
+    #[test]
+    fn cloudwatch_collection_filter_accepts_supported_fields() {
+        let filter = serde_json::json!({
+            "filter_pattern": "ERROR",
+            "start_ms": 10,
+            "end_ms": 20,
+            "log_stream_names": ["stream-a", "stream-b"],
+            "most_recent": true
+        });
+
+        let parsed = CloudWatchCollectionFilter::from_json(Some(&filter)).expect("parse filter");
+
+        assert_eq!(parsed.filter_pattern.as_deref(), Some("ERROR"));
+        assert_eq!(parsed.start_ms, Some(10));
+        assert_eq!(parsed.end_ms, Some(20));
+        assert_eq!(
+            parsed.log_stream_names,
+            Some(vec!["stream-a".to_string(), "stream-b".to_string()])
+        );
+        assert!(parsed.most_recent);
+    }
+
+    #[test]
+    fn cloudwatch_default_config_has_logs_database_kind() {
+        assert!(matches!(
+            DbConfig::default_cloudwatch_logs(),
+            DbConfig::CloudWatchLogs { .. }
+        ));
+    }
+}

--- a/crates/dbflux_driver_cloudwatch/src/lib.rs
+++ b/crates/dbflux_driver_cloudwatch/src/lib.rs
@@ -1,0 +1,5 @@
+#![allow(clippy::result_large_err)]
+
+pub mod driver;
+
+pub use driver::{CLOUDWATCH_METADATA, CloudWatchDriver};

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -637,6 +637,8 @@ impl Connection for DynamoConnection {
                 indexes: None,
                 validator: None,
                 is_capped: false,
+                presentation: dbflux_core::CollectionPresentation::DataGrid,
+                child_items: None,
             })
             .collect();
 
@@ -676,6 +678,8 @@ impl Connection for DynamoConnection {
                 foreign_keys: None,
                 constraints: None,
                 sample_fields: None,
+                presentation: dbflux_core::CollectionPresentation::DataGrid,
+                child_items: None,
             })
             .collect();
 
@@ -3554,6 +3558,8 @@ fn build_table_info_from_description(
         foreign_keys: None,
         constraints: None,
         sample_fields,
+        presentation: dbflux_core::CollectionPresentation::DataGrid,
+        child_items: None,
     }
 }
 

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -1550,6 +1550,8 @@ impl Connection for MongoConnection {
                     foreign_keys: None,
                     constraints: None,
                     sample_fields: None,
+                    presentation: dbflux_core::CollectionPresentation::DataGrid,
+                    child_items: None,
                 }
             })
             .collect();
@@ -1677,6 +1679,8 @@ impl Connection for MongoConnection {
             foreign_keys: None,
             constraints: None,
             sample_fields: Some(sample_fields),
+            presentation: dbflux_core::CollectionPresentation::DataGrid,
+            child_items: None,
         })
     }
 

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -1657,6 +1657,8 @@ impl Connection for MysqlConnection {
             foreign_keys: Some(foreign_keys),
             constraints: Some(constraints),
             sample_fields: None,
+            presentation: dbflux_core::CollectionPresentation::DataGrid,
+            child_items: None,
         })
     }
 
@@ -2559,6 +2561,8 @@ fn fetch_tables_shallow(conn: &mut Conn, database: &str) -> Result<Vec<TableInfo
             foreign_keys: None,
             constraints: None,
             sample_fields: None,
+            presentation: dbflux_core::CollectionPresentation::DataGrid,
+            child_items: None,
         })
         .collect())
 }

--- a/crates/dbflux_driver_postgres/src/driver.rs
+++ b/crates/dbflux_driver_postgres/src/driver.rs
@@ -1532,6 +1532,8 @@ impl Connection for PostgresConnection {
             foreign_keys: Some(foreign_keys),
             constraints: Some(constraints),
             sample_fields: None,
+            presentation: dbflux_core::CollectionPresentation::DataGrid,
+            child_items: None,
         })
     }
 
@@ -2126,6 +2128,8 @@ fn get_tables_for_schema(client: &mut Client, schema: &str) -> Result<Vec<TableI
                 foreign_keys: None,
                 constraints: None,
                 sample_fields: None,
+                presentation: dbflux_core::CollectionPresentation::DataGrid,
+                child_items: None,
             }
         })
         .collect();

--- a/crates/dbflux_driver_sqlite/src/driver.rs
+++ b/crates/dbflux_driver_sqlite/src/driver.rs
@@ -834,6 +834,8 @@ impl Connection for SqliteConnection {
             foreign_keys: Some(foreign_keys),
             constraints: Some(constraints),
             sample_fields: None,
+            presentation: dbflux_core::CollectionPresentation::DataGrid,
+            child_items: None,
         })
     }
 
@@ -1335,6 +1337,8 @@ impl SqliteConnection {
                 foreign_keys: None,
                 constraints: None,
                 sample_fields: None,
+                presentation: dbflux_core::CollectionPresentation::DataGrid,
+                child_items: None,
             })
             .collect();
 
@@ -1958,6 +1962,8 @@ mod tests {
             foreign_keys: None,
             constraints: None,
             sample_fields: None,
+            presentation: dbflux_core::CollectionPresentation::DataGrid,
+            child_items: None,
         };
 
         let composite_pk = TableInfo {
@@ -1985,6 +1991,8 @@ mod tests {
             foreign_keys: None,
             constraints: None,
             sample_fields: None,
+            presentation: dbflux_core::CollectionPresentation::DataGrid,
+            child_items: None,
         };
 
         let single_sql = sqlite_generate_create_table(&single_pk);

--- a/crates/dbflux_ipc/src/driver_protocol.rs
+++ b/crates/dbflux_ipc/src/driver_protocol.rs
@@ -617,10 +617,11 @@ mod tests {
                 database: Some("analytics".into()),
                 schema: Some("public".into()),
                 container: None,
-                source: Some(ExecutionSourceContext::CloudWatchLogs {
-                    log_groups: vec!["/aws/lambda/app".into(), "/aws/ecs/api".into()],
+                source: Some(ExecutionSourceContext::CollectionWindow {
+                    targets: vec!["/aws/lambda/app".into(), "/aws/ecs/api".into()],
                     start_ms: 1_710_000_000_000,
                     end_ms: 1_710_000_300_000,
+                    query_mode: Some("cwli".into()),
                 }),
             }),
         };
@@ -634,16 +635,18 @@ mod tests {
         match restored.execution_context {
             Some(ExecutionContext {
                 source:
-                    Some(ExecutionSourceContext::CloudWatchLogs {
-                        log_groups,
+                    Some(ExecutionSourceContext::CollectionWindow {
+                        targets,
                         start_ms,
                         end_ms,
+                        query_mode,
                     }),
                 ..
             }) => {
-                assert_eq!(log_groups, vec!["/aws/lambda/app", "/aws/ecs/api"]);
+                assert_eq!(targets, vec!["/aws/lambda/app", "/aws/ecs/api"]);
                 assert_eq!(start_ms, 1_710_000_000_000);
                 assert_eq!(end_ms, 1_710_000_300_000);
+                assert_eq!(query_mode.as_deref(), Some("cwli"));
             }
             other => panic!("unexpected execution context: {other:?}"),
         }

--- a/crates/dbflux_ipc/src/driver_protocol.rs
+++ b/crates/dbflux_ipc/src/driver_protocol.rs
@@ -2,10 +2,11 @@ use crate::envelope::ProtocolVersion;
 use dbflux_core::{
     CodeGenCapabilities, CodeGeneratorInfo, CollectionBrowseRequest, CollectionCountRequest,
     ColumnMeta, CrudResult, CustomTypeInfo, DatabaseInfo, DbSchemaInfo, DescribeRequest,
-    DocumentDelete, DocumentInsert, DocumentUpdate, DriverFormDef, DriverMetadata, ExplainRequest,
-    QueryRequest, QueryResult, QueryResultShape, RowDelete, RowInsert, RowPatch, SchemaFeatures,
-    SchemaForeignKeyInfo, SchemaIndexInfo, SchemaLoadingStrategy, SchemaSnapshot, SemanticPlan,
-    SemanticRequest, TableBrowseRequest, TableCountRequest, TableInfo, Value, ViewInfo,
+    DocumentDelete, DocumentInsert, DocumentUpdate, DriverFormDef, DriverMetadata,
+    ExecutionContext, ExplainRequest, QueryRequest, QueryResult, QueryResultShape, RowDelete,
+    RowInsert, RowPatch, SchemaFeatures, SchemaForeignKeyInfo, SchemaIndexInfo,
+    SchemaLoadingStrategy, SchemaSnapshot, SemanticPlan, SemanticRequest, TableBrowseRequest,
+    TableCountRequest, TableInfo, Value, ViewInfo,
 };
 use dbflux_core::{
     HashDeleteRequest, HashSetRequest, KeyBulkGetRequest, KeyDeleteRequest, KeyExistsRequest,
@@ -58,6 +59,7 @@ pub struct QueryRequestDto {
     pub offset: Option<u32>,
     pub statement_timeout_ms: Option<u64>,
     pub database: Option<String>,
+    pub execution_context: Option<ExecutionContext>,
 }
 
 impl From<&QueryRequest> for QueryRequestDto {
@@ -71,6 +73,7 @@ impl From<&QueryRequest> for QueryRequestDto {
                 .statement_timeout
                 .map(|timeout| timeout.as_millis() as u64),
             database: value.database.clone(),
+            execution_context: value.execution_context.clone(),
         }
     }
 }
@@ -84,6 +87,7 @@ impl From<QueryRequestDto> for QueryRequest {
             offset: value.offset,
             statement_timeout: value.statement_timeout_ms.map(Duration::from_millis),
             database: value.database,
+            execution_context: value.execution_context,
         }
     }
 }
@@ -568,8 +572,12 @@ impl DriverResponseEnvelope {
 mod tests {
     use super::{
         DriverRequestBody, DriverRequestEnvelope, DriverResponseBody, DriverResponseEnvelope,
+        QueryRequestDto,
     };
     use crate::ProtocolVersion;
+    use dbflux_core::{ExecutionContext, ExecutionSourceContext, QueryRequest};
+    use std::time::Duration;
+    use uuid::Uuid;
 
     #[test]
     fn request_envelope_uses_explicit_protocol_version() {
@@ -591,5 +599,53 @@ mod tests {
 
         assert_eq!(response.protocol_version, ProtocolVersion::new(1, 0));
         assert_eq!(response.request_id, 41);
+    }
+
+    #[test]
+    fn query_request_dto_roundtrips_execution_context() {
+        let request = QueryRequest {
+            sql: "SELECT * FROM logs".into(),
+            params: Vec::new(),
+            limit: Some(250),
+            offset: Some(5),
+            statement_timeout: Some(Duration::from_secs(30)),
+            database: Some("analytics".into()),
+            execution_context: Some(ExecutionContext {
+                connection_id: Some(
+                    Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+                ),
+                database: Some("analytics".into()),
+                schema: Some("public".into()),
+                container: None,
+                source: Some(ExecutionSourceContext::CloudWatchLogs {
+                    log_groups: vec!["/aws/lambda/app".into(), "/aws/ecs/api".into()],
+                    start_ms: 1_710_000_000_000,
+                    end_ms: 1_710_000_300_000,
+                }),
+            }),
+        };
+
+        let dto = QueryRequestDto::from(&request);
+        let restored = QueryRequest::from(dto.clone());
+
+        assert_eq!(dto.database.as_deref(), Some("analytics"));
+        assert_eq!(restored.database.as_deref(), Some("analytics"));
+
+        match restored.execution_context {
+            Some(ExecutionContext {
+                source:
+                    Some(ExecutionSourceContext::CloudWatchLogs {
+                        log_groups,
+                        start_ms,
+                        end_ms,
+                    }),
+                ..
+            }) => {
+                assert_eq!(log_groups, vec!["/aws/lambda/app", "/aws/ecs/api"]);
+                assert_eq!(start_ms, 1_710_000_000_000);
+                assert_eq!(end_ms, 1_710_000_300_000);
+            }
+            other => panic!("unexpected execution context: {other:?}"),
+        }
     }
 }

--- a/crates/dbflux_mcp_server/src/state.rs
+++ b/crates/dbflux_mcp_server/src/state.rs
@@ -558,6 +558,7 @@ fn str_to_db_kind(value: &str) -> Option<dbflux_core::DbKind> {
         "MongoDB" => Some(dbflux_core::DbKind::MongoDB),
         "Redis" => Some(dbflux_core::DbKind::Redis),
         "DynamoDB" => Some(dbflux_core::DbKind::DynamoDB),
+        "CloudWatchLogs" => Some(dbflux_core::DbKind::CloudWatchLogs),
         _ => None,
     }
 }
@@ -571,6 +572,7 @@ fn default_db_config_for_kind(kind: dbflux_core::DbKind) -> dbflux_core::DbConfi
         dbflux_core::DbKind::MongoDB => dbflux_core::DbConfig::default_mongodb(),
         dbflux_core::DbKind::Redis => dbflux_core::DbConfig::default_redis(),
         dbflux_core::DbKind::DynamoDB => dbflux_core::DbConfig::default_dynamodb(),
+        dbflux_core::DbKind::CloudWatchLogs => dbflux_core::DbConfig::default_cloudwatch_logs(),
     }
 }
 

--- a/crates/dbflux_mcp_server/src/tools/connection.rs
+++ b/crates/dbflux_mcp_server/src/tools/connection.rs
@@ -197,6 +197,7 @@ impl DbFluxServer {
                                 offset: None,
                                 statement_timeout: None,
                                 database: None,
+                                execution_context: None,
                             });
 
                             result.ok().and_then(|r| {

--- a/crates/dbflux_mcp_server/src/tools/ddl_preview/dry_run.rs
+++ b/crates/dbflux_mcp_server/src/tools/ddl_preview/dry_run.rs
@@ -28,6 +28,7 @@ pub fn dry_run_ddl(
         offset: None,
         statement_timeout: None,
         database: database.map(|s| s.to_string()),
+        execution_context: None,
     };
     connection.execute(&begin_req)?;
 
@@ -39,6 +40,7 @@ pub fn dry_run_ddl(
         offset: None,
         statement_timeout: None,
         database: database.map(|s| s.to_string()),
+        execution_context: None,
     };
     let ddl_result = connection.execute(&ddl_req);
 
@@ -58,6 +60,7 @@ pub fn dry_run_ddl(
         offset: None,
         statement_timeout: None,
         database: database.map(|s| s.to_string()),
+        execution_context: None,
     };
     connection.execute(&rollback_req)?;
 

--- a/crates/dbflux_mcp_server/src/tools/scripts.rs
+++ b/crates/dbflux_mcp_server/src/tools/scripts.rs
@@ -593,6 +593,9 @@ impl DbFluxServer {
         // Only SQL/MongoDB/Redis queries are supported for execution
         match language {
             QueryLanguage::Sql
+            | QueryLanguage::CloudWatchLogsInsightsQl
+            | QueryLanguage::OpenSearchPpl
+            | QueryLanguage::OpenSearchSql
             | QueryLanguage::MongoQuery
             | QueryLanguage::RedisCommands
             | QueryLanguage::Cql

--- a/crates/dbflux_mcp_server/src/tools/scripts.rs
+++ b/crates/dbflux_mcp_server/src/tools/scripts.rs
@@ -627,6 +627,7 @@ impl DbFluxServer {
             offset: None,
             statement_timeout: None,
             database: None,
+            execution_context: None,
         };
 
         let result = Self::execute_connection_blocking(conn.clone(), move |connection| {

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -137,6 +137,7 @@ impl MigrationRegistry {
         registry.register(mod_004_audit_saved_filters::MigrationImpl);
         registry.register(mod_005_rpc_service_kind::MigrationImpl);
         registry.register(mod_006_rpc_service_api_contract::MigrationImpl);
+        registry.register(mod_007_session_exec_ctx_json::MigrationImpl);
         registry
     }
 
@@ -281,6 +282,7 @@ mod mod_003_audit_settings;
 mod mod_004_audit_saved_filters;
 mod mod_005_rpc_service_kind;
 mod mod_006_rpc_service_api_contract;
+mod mod_007_session_exec_ctx_json;
 
 pub use mod_001_initial::MigrationImpl;
 pub use mod_002_audit_extended::MigrationImpl as MigrationImplAuditExtended;
@@ -288,6 +290,7 @@ pub use mod_003_audit_settings::MigrationImpl as MigrationImplAuditSettings;
 pub use mod_004_audit_saved_filters::MigrationImpl as MigrationImplAuditSavedFilters;
 pub use mod_005_rpc_service_kind::MigrationImpl as MigrationImplRpcServiceKind;
 pub use mod_006_rpc_service_api_contract::MigrationImpl as MigrationImplRpcServiceApiContract;
+pub use mod_007_session_exec_ctx_json::MigrationImpl as MigrationImplSessionExecCtxJson;
 
 // ---------------------------------------------------------------------------
 // Database verification utilities
@@ -368,7 +371,11 @@ mod tests {
         let count_first: i64 = conn
             .query_row("SELECT COUNT(*) FROM sys_migrations", [], |row| row.get(0))
             .unwrap();
-        assert_eq!(count_first, 6, "expected 6 migrations after first run");
+        assert_eq!(
+            count_first,
+            registry.migrations.len() as i64,
+            "expected all registered migrations after first run"
+        );
 
         registry.run_all(&conn).unwrap();
 
@@ -376,8 +383,9 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM sys_migrations", [], |row| row.get(0))
             .unwrap();
         assert_eq!(
-            count_second, 6,
-            "expected still 6 migrations after second run (idempotent)"
+            count_second,
+            registry.migrations.len() as i64,
+            "expected same migration count after second run (idempotent)"
         );
 
         drop(conn);
@@ -503,8 +511,8 @@ mod tests {
         let pending_before = registry.get_pending(&conn).unwrap();
         assert_eq!(
             pending_before.len(),
-            6,
-            "expected 6 pending migrations before running"
+            registry.migrations.len(),
+            "expected all registered migrations pending before running"
         );
         assert_eq!(pending_before[0].name(), "001_initial");
         assert_eq!(pending_before[1].name(), "002_audit_extended");
@@ -512,6 +520,7 @@ mod tests {
         assert_eq!(pending_before[3].name(), "004_audit_saved_filters");
         assert_eq!(pending_before[4].name(), "005_rpc_service_kind");
         assert_eq!(pending_before[5].name(), "006_rpc_service_api_contract");
+        assert_eq!(pending_before[6].name(), "007_session_exec_ctx_json");
 
         registry.run_all(&conn).unwrap();
 
@@ -634,6 +643,36 @@ mod tests {
             )
             .unwrap();
         assert_eq!(service_kind, "driver");
+
+        drop(conn);
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_session_exec_ctx_json_migration_skips_when_session_tabs_table_is_absent() {
+        let temp_dir = temp_dir("exec_ctx_json_missing_table");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.db");
+
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute(
+            "CREATE TABLE sys_migrations (name TEXT PRIMARY KEY, applied_at TEXT NOT NULL DEFAULT (datetime('now')))",
+            [],
+        )
+        .unwrap();
+
+        let registry = MigrationRegistry::new();
+        registry.run_all(&conn).unwrap();
+
+        let applied: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sys_migrations WHERE name = '007_session_exec_ctx_json'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(applied, 1);
 
         drop(conn);
         let _ = std::fs::remove_dir_all(temp_dir);

--- a/crates/dbflux_storage/src/migrations/mod_007_session_exec_ctx_json.rs
+++ b/crates/dbflux_storage/src/migrations/mod_007_session_exec_ctx_json.rs
@@ -1,0 +1,155 @@
+//! Migration 007: add JSON execution context to session tabs.
+
+use rusqlite::Transaction;
+
+use crate::migrations::{Migration, MigrationError};
+
+pub struct MigrationImpl;
+
+impl Migration for MigrationImpl {
+    fn name(&self) -> &str {
+        "007_session_exec_ctx_json"
+    }
+
+    fn run(&self, tx: &Transaction) -> Result<(), MigrationError> {
+        if !has_table(tx, "st_session_tabs")? {
+            return Ok(());
+        }
+
+        if !has_column(tx, "exec_ctx_json")? {
+            tx.execute(
+                "ALTER TABLE st_session_tabs ADD COLUMN exec_ctx_json TEXT",
+                [],
+            )
+            .map_err(|source| MigrationError::Sqlite {
+                path: std::path::PathBuf::from("<unknown>"),
+                source,
+            })?;
+        }
+
+        backfill_exec_ctx_json(tx)?;
+
+        Ok(())
+    }
+}
+
+fn has_table(tx: &Transaction, table_name: &str) -> Result<bool, MigrationError> {
+    let mut stmt = tx
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?1")
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    let mut rows = stmt
+        .query([table_name])
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    Ok(rows
+        .next()
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?
+        .is_some())
+}
+
+fn has_column(tx: &Transaction, column_name: &str) -> Result<bool, MigrationError> {
+    let mut stmt = tx
+        .prepare("PRAGMA table_info(st_session_tabs)")
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    for column in columns {
+        let column = column.map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+        if column == column_name {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn backfill_exec_ctx_json(tx: &Transaction) -> Result<(), MigrationError> {
+    let mut stmt = tx
+        .prepare(
+            "SELECT id, exec_ctx_connection_id, exec_ctx_database, exec_ctx_schema, exec_ctx_container, exec_ctx_json
+             FROM st_session_tabs",
+        )
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<String>>(2)?,
+                row.get::<_, Option<String>>(3)?,
+                row.get::<_, Option<String>>(4)?,
+                row.get::<_, Option<String>>(5)?,
+            ))
+        })
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+
+    for row in rows {
+        let (tab_id, connection_id, database, schema, container, existing_json) =
+            row.map_err(|source| MigrationError::Sqlite {
+                path: std::path::PathBuf::from("<unknown>"),
+                source,
+            })?;
+
+        if existing_json
+            .as_deref()
+            .is_some_and(|json| serde_json::from_str::<dbflux_core::ExecutionContext>(json).is_ok())
+        {
+            continue;
+        }
+
+        let exec_ctx = dbflux_core::ExecutionContext {
+            connection_id: connection_id.and_then(|value| uuid::Uuid::parse_str(&value).ok()),
+            database,
+            schema,
+            container,
+            source: None,
+        };
+
+        let exec_ctx_json =
+            serde_json::to_string(&exec_ctx).map_err(|error| MigrationError::Failed {
+                name: "007_session_exec_ctx_json".to_string(),
+                details: format!("failed to serialize execution context for tab {tab_id}: {error}"),
+            })?;
+
+        tx.execute(
+            "UPDATE st_session_tabs SET exec_ctx_json = ?2 WHERE id = ?1",
+            rusqlite::params![tab_id, exec_ctx_json],
+        )
+        .map_err(|source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        })?;
+    }
+
+    Ok(())
+}

--- a/crates/dbflux_storage/src/repositories/connection_driver_configs.rs
+++ b/crates/dbflux_storage/src/repositories/connection_driver_configs.rs
@@ -209,6 +209,15 @@ impl ConnectionDriverConfigDto {
                 dto.dynamo_endpoint = endpoint.clone();
                 dto.dynamo_table = table.clone();
             }
+            DbConfig::CloudWatchLogs {
+                region,
+                profile,
+                endpoint,
+            } => {
+                dto.dynamo_region = Some(region.clone());
+                dto.dynamo_profile = profile.clone();
+                dto.dynamo_endpoint = endpoint.clone();
+            }
             DbConfig::External { kind, values } => {
                 dto.external_kind = Some(db_kind_to_str(*kind));
                 dto.external_values_json = Some(serde_json::to_string(values).unwrap_or_default());
@@ -296,6 +305,12 @@ impl ConnectionDriverConfigDto {
                 endpoint: self.dynamo_endpoint.clone(),
                 table: self.dynamo_table.clone(),
             }),
+            DbKind::CloudWatchLogs => Some(DbConfig::CloudWatchLogs {
+                region: self.dynamo_region.clone().unwrap_or_default(),
+                profile: self.dynamo_profile.clone(),
+                endpoint: self.dynamo_endpoint.clone(),
+            }),
+            _ => None,
         }
     }
 }
@@ -313,6 +328,7 @@ fn db_kind_to_str(kind: DbKind) -> String {
         DbKind::MongoDB => "MongoDB",
         DbKind::Redis => "Redis",
         DbKind::DynamoDB => "DynamoDB",
+        DbKind::CloudWatchLogs => "CloudWatchLogs",
     }
     .to_string()
 }
@@ -326,6 +342,7 @@ fn str_to_db_kind(s: &str) -> Option<DbKind> {
         "MongoDB" => Some(DbKind::MongoDB),
         "Redis" => Some(DbKind::Redis),
         "DynamoDB" => Some(DbKind::DynamoDB),
+        "CloudWatchLogs" => Some(DbKind::CloudWatchLogs),
         _ => None,
     }
 }
@@ -678,53 +695,55 @@ impl ConnectionDriverConfigsRepository {
 mod tests {
     use super::*;
 
-    fn mysql_config() -> DbConfig {
-        DbConfig::MySQL {
-            use_uri: false,
-            uri: None,
-            host: "db.example.internal".to_string(),
-            port: 3307,
-            user: "app_user".to_string(),
-            database: Some("app_db".to_string()),
-            ssl_mode: SslMode::Require,
-            ssh_tunnel: None,
-            ssh_tunnel_profile_id: None,
-        }
+    fn temp_repo() -> (tempfile::TempDir, ConnectionDriverConfigsRepository) {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let runtime = StorageRuntime::for_path(temp_dir.path().join("dbflux.db")).expect("runtime");
+        let repo = ConnectionDriverConfigsRepository::new(runtime.dbflux_db());
+
+        (temp_dir, repo)
     }
 
     #[test]
-    fn mysql_driver_config_round_trips_as_mysql() {
-        let dto =
-            ConnectionDriverConfigDto::from_db_config("profile-id".to_string(), &mysql_config());
-        let config = dto.to_db_config().expect("config should round-trip");
+    fn cloudwatch_driver_config_roundtrips_through_repository() {
+        let (_temp_dir, repo) = temp_repo();
+        let profile_id = uuid::Uuid::new_v4().to_string();
 
-        match config {
-            DbConfig::MySQL {
-                host,
-                port,
-                user,
-                database,
-                ssl_mode,
-                ..
+        repo.conn()
+            .execute(
+                r#"
+                INSERT INTO cfg_connection_profiles (
+                    id, name, driver_id, kind, created_at, updated_at
+                ) VALUES (?1, 'CloudWatch', 'cloudwatch', 'cloudwatchlogs', datetime('now'), datetime('now'))
+                "#,
+                params![profile_id],
+            )
+            .expect("insert profile");
+
+        let config = DbConfig::CloudWatchLogs {
+            region: "us-east-1".to_string(),
+            profile: Some("dev".to_string()),
+            endpoint: Some("http://localhost:4566".to_string()),
+        };
+
+        let dto = ConnectionDriverConfigDto::from_db_config(profile_id.clone(), &config);
+        repo.insert(&dto).expect("insert config");
+
+        let restored = repo
+            .get_for_profile(&profile_id)
+            .expect("load config")
+            .expect("stored config");
+
+        match restored.to_db_config().expect("db config") {
+            DbConfig::CloudWatchLogs {
+                region,
+                profile,
+                endpoint,
             } => {
-                assert_eq!(host, "db.example.internal");
-                assert_eq!(port, 3307);
-                assert_eq!(user, "app_user");
-                assert_eq!(database.as_deref(), Some("app_db"));
-                assert_eq!(ssl_mode, SslMode::Require);
+                assert_eq!(region, "us-east-1");
+                assert_eq!(profile.as_deref(), Some("dev"));
+                assert_eq!(endpoint.as_deref(), Some("http://localhost:4566"));
             }
-            other => panic!("expected MySQL config, got {other:?}"),
+            other => panic!("unexpected config: {other:?}"),
         }
-    }
-
-    #[test]
-    fn mariadb_driver_config_key_round_trips_as_mysql_config() {
-        let mut dto =
-            ConnectionDriverConfigDto::from_db_config("profile-id".to_string(), &mysql_config());
-        dto.config_key = "MariaDB".to_string();
-
-        let config = dto.to_db_config().expect("config should round-trip");
-
-        assert!(matches!(config, DbConfig::MySQL { .. }));
     }
 }

--- a/crates/dbflux_storage/src/repositories/connection_driver_configs.rs
+++ b/crates/dbflux_storage/src/repositories/connection_driver_configs.rs
@@ -310,7 +310,6 @@ impl ConnectionDriverConfigDto {
                 profile: self.dynamo_profile.clone(),
                 endpoint: self.dynamo_endpoint.clone(),
             }),
-            _ => None,
         }
     }
 }
@@ -694,6 +693,7 @@ impl ConnectionDriverConfigsRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::StorageRuntime;
 
     fn temp_repo() -> (tempfile::TempDir, ConnectionDriverConfigsRepository) {
         let temp_dir = tempfile::tempdir().expect("tempdir");

--- a/crates/dbflux_storage/src/repositories/state/sessions.rs
+++ b/crates/dbflux_storage/src/repositories/state/sessions.rs
@@ -1318,10 +1318,11 @@ mod tests {
                         database: Some("logs".into()),
                         schema: None,
                         container: None,
-                        source: Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
-                            log_groups: vec!["/aws/lambda/app".into()],
+                        source: Some(dbflux_core::ExecutionSourceContext::CollectionWindow {
+                            targets: vec!["/aws/lambda/app".into()],
                             start_ms: 10,
                             end_ms: 20,
+                            query_mode: Some("cwli".into()),
                         }),
                     },
                     scratch_path: Some(PathBuf::from("/tmp/cloudwatch-1.sql")),
@@ -1340,10 +1341,11 @@ mod tests {
                         database: Some("logs".into()),
                         schema: None,
                         container: None,
-                        source: Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
-                            log_groups: vec!["/aws/ecs/api".into(), "/aws/batch/job".into()],
+                        source: Some(dbflux_core::ExecutionSourceContext::CollectionWindow {
+                            targets: vec!["/aws/ecs/api".into(), "/aws/batch/job".into()],
                             start_ms: 30,
                             end_ms: 40,
+                            query_mode: Some("cwli".into()),
                         }),
                     },
                     scratch_path: Some(PathBuf::from("/tmp/cloudwatch-2.sql")),
@@ -1381,28 +1383,32 @@ mod tests {
             .collect::<Vec<_>>();
 
         match &restored_contexts[0].source {
-            Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
-                log_groups,
+            Some(dbflux_core::ExecutionSourceContext::CollectionWindow {
+                targets,
                 start_ms,
                 end_ms,
+                query_mode,
             }) => {
-                assert_eq!(log_groups, &vec!["/aws/lambda/app".to_string()]);
+                assert_eq!(targets, &vec!["/aws/lambda/app".to_string()]);
                 assert_eq!((*start_ms, *end_ms), (10, 20));
+                assert_eq!(query_mode.as_deref(), Some("cwli"));
             }
             other => panic!("unexpected first source: {other:?}"),
         }
 
         match &restored_contexts[1].source {
-            Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
-                log_groups,
+            Some(dbflux_core::ExecutionSourceContext::CollectionWindow {
+                targets,
                 start_ms,
                 end_ms,
+                query_mode,
             }) => {
                 assert_eq!(
-                    log_groups,
+                    targets,
                     &vec!["/aws/ecs/api".to_string(), "/aws/batch/job".to_string()]
                 );
                 assert_eq!((*start_ms, *end_ms), (30, 40));
+                assert_eq!(query_mode.as_deref(), Some("cwli"));
             }
             other => panic!("unexpected second source: {other:?}"),
         }
@@ -1441,10 +1447,11 @@ mod tests {
             database: Some("logs".into()),
             schema: None,
             container: None,
-            source: Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
-                log_groups: vec!["/aws/json/preferred".into()],
+            source: Some(dbflux_core::ExecutionSourceContext::CollectionWindow {
+                targets: vec!["/aws/json/preferred".into()],
                 start_ms: 111,
                 end_ms: 222,
+                query_mode: Some("cwli".into()),
             }),
         })
         .expect("serialize exec ctx");
@@ -1493,13 +1500,15 @@ mod tests {
         assert!(restored_ctx.container.is_none());
 
         match restored_ctx.source {
-            Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
-                log_groups,
+            Some(dbflux_core::ExecutionSourceContext::CollectionWindow {
+                targets,
                 start_ms,
                 end_ms,
+                query_mode,
             }) => {
-                assert_eq!(log_groups, vec!["/aws/json/preferred".to_string()]);
+                assert_eq!(targets, vec!["/aws/json/preferred".to_string()]);
                 assert_eq!((start_ms, end_ms), (111, 222));
+                assert_eq!(query_mode.as_deref(), Some("cwli"));
             }
             other => panic!("unexpected restored source: {other:?}"),
         }

--- a/crates/dbflux_storage/src/repositories/state/sessions.rs
+++ b/crates/dbflux_storage/src/repositories/state/sessions.rs
@@ -57,6 +57,7 @@ pub(crate) struct FullTab {
     pub scratch_file_path: Option<String>,
     pub shadow_file_path: Option<String>,
     pub file_path: Option<String>,
+    pub exec_ctx_json: Option<String>,
     /// Execution context fields (extracted from exec_ctx_json, stored as native columns)
     pub exec_ctx_connection_id: Option<String>,
     pub exec_ctx_database: Option<String>,
@@ -198,7 +199,7 @@ impl SessionRepository {
             .prepare(
                 "SELECT id, tab_kind, title, position, is_pinned,
                         scratch_file_path, shadow_file_path, language, file_path,
-                        exec_ctx_connection_id, exec_ctx_database, exec_ctx_schema,
+                        exec_ctx_json, exec_ctx_connection_id, exec_ctx_database, exec_ctx_schema,
                         exec_ctx_container, created_at, updated_at
                  FROM st_session_tabs WHERE session_id = ?1 ORDER BY position ASC",
             )
@@ -223,8 +224,9 @@ impl SessionRepository {
                     row.get::<_, Option<String>>(10)?,
                     row.get::<_, Option<String>>(11)?,
                     row.get::<_, Option<String>>(12)?,
-                    row.get::<_, String>(13)?,
+                    row.get::<_, Option<String>>(13)?,
                     row.get::<_, String>(14)?,
+                    row.get::<_, String>(15)?,
                 ))
             })
             .map_err(|source| StorageError::Sqlite {
@@ -247,6 +249,7 @@ impl SessionRepository {
                     shadow_file_path,
                     language,
                     file_path,
+                    exec_ctx_json,
                     exec_ctx_connection_id,
                     exec_ctx_database,
                     exec_ctx_schema,
@@ -265,6 +268,7 @@ impl SessionRepository {
                         scratch_file_path,
                         shadow_file_path,
                         file_path,
+                        exec_ctx_json,
                         exec_ctx_connection_id,
                         exec_ctx_database,
                         exec_ctx_schema,
@@ -344,10 +348,10 @@ impl SessionRepository {
                 r#"
                 INSERT INTO st_session_tabs (id, session_id, tab_kind, title, position, is_pinned,
                                          scratch_file_path, shadow_file_path,
-                                         language, file_path, exec_ctx_connection_id,
+                                         language, file_path, exec_ctx_json, exec_ctx_connection_id,
                                          exec_ctx_database, exec_ctx_schema, exec_ctx_container,
                                          created_at, updated_at)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
                         datetime('now'), datetime('now'))
                 ON CONFLICT(id) DO UPDATE SET
                     tab_kind = excluded.tab_kind,
@@ -358,6 +362,7 @@ impl SessionRepository {
                     shadow_file_path = excluded.shadow_file_path,
                     language = excluded.language,
                     file_path = excluded.file_path,
+                    exec_ctx_json = excluded.exec_ctx_json,
                     exec_ctx_connection_id = excluded.exec_ctx_connection_id,
                     exec_ctx_database = excluded.exec_ctx_database,
                     exec_ctx_schema = excluded.exec_ctx_schema,
@@ -375,6 +380,7 @@ impl SessionRepository {
                     dto.shadow_file_path,
                     dto.language,
                     dto.file_path,
+                    dto.exec_ctx_json,
                     dto.exec_ctx_connection_id,
                     dto.exec_ctx_database,
                     dto.exec_ctx_schema,
@@ -487,18 +493,26 @@ impl SessionRepository {
                 .tabs
                 .into_iter()
                 .map(|tab| {
-                    // Reconstruct exec_ctx_json from native columns.
-                    let exec_ctx = dbflux_core::ExecutionContext {
-                        connection_id: tab
-                            .exec_ctx_connection_id
-                            .as_ref()
-                            .and_then(|s| uuid::Uuid::parse_str(s).ok()),
-                        database: tab.exec_ctx_database.clone(),
-                        schema: tab.exec_ctx_schema.clone(),
-                        container: tab.exec_ctx_container.clone(),
-                    };
-                    let exec_ctx_json =
-                        serde_json::to_string(&exec_ctx).unwrap_or_else(|_| "{}".to_string());
+                    let exec_ctx_json = tab
+                        .exec_ctx_json
+                        .clone()
+                        .filter(|json| {
+                            serde_json::from_str::<dbflux_core::ExecutionContext>(json).is_ok()
+                        })
+                        .unwrap_or_else(|| {
+                            let exec_ctx = dbflux_core::ExecutionContext {
+                                connection_id: tab
+                                    .exec_ctx_connection_id
+                                    .as_ref()
+                                    .and_then(|s| uuid::Uuid::parse_str(s).ok()),
+                                database: tab.exec_ctx_database.clone(),
+                                schema: tab.exec_ctx_schema.clone(),
+                                container: tab.exec_ctx_container.clone(),
+                                source: None,
+                            };
+
+                            serde_json::to_string(&exec_ctx).unwrap_or_else(|_| "{}".to_string())
+                        });
 
                     RestoredTab {
                         id: tab.id,
@@ -634,6 +648,8 @@ impl SessionRepository {
             let exec_ctx_database = tab.exec_ctx.database.clone();
             let exec_ctx_schema = tab.exec_ctx.schema.clone();
             let exec_ctx_container = tab.exec_ctx.container.clone();
+            let exec_ctx_json = serde_json::to_string(&tab.exec_ctx)
+                .map_err(|error| StorageError::Data(error.to_string()))?;
 
             // Validate exec_ctx_connection_id FK — if the referenced profile doesn't exist,
             // null it to avoid FK constraint failures (mirrors legacy import behavior).
@@ -665,10 +681,10 @@ impl SessionRepository {
                 r#"
                 INSERT INTO st_session_tabs (id, session_id, tab_kind, title, position, is_pinned,
                                          scratch_file_path, shadow_file_path,
-                                         language, file_path, exec_ctx_connection_id,
+                                         language, file_path, exec_ctx_json, exec_ctx_connection_id,
                                          exec_ctx_database, exec_ctx_schema, exec_ctx_container,
                                          created_at, updated_at)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
                         datetime('now'), datetime('now'))
                 "#,
                 params![
@@ -682,6 +698,7 @@ impl SessionRepository {
                     shadow_path_str,
                     tab.language,
                     file_path_str,
+                    exec_ctx_json,
                     exec_ctx_connection_id,
                     exec_ctx_database,
                     exec_ctx_schema,
@@ -747,6 +764,7 @@ pub struct SessionTabDto {
     pub scratch_file_path: Option<String>,
     pub shadow_file_path: Option<String>,
     pub language: Option<String>,
+    pub exec_ctx_json: Option<String>,
     pub exec_ctx_connection_id: Option<String>,
     pub exec_ctx_database: Option<String>,
     pub exec_ctx_schema: Option<String>,
@@ -945,6 +963,7 @@ mod tests {
             scratch_file_path: Some(scratch_path.to_string()),
             shadow_file_path: None,
             language: Some("sql".to_string()),
+            exec_ctx_json: None,
             exec_ctx_connection_id: None,
             exec_ctx_database: None,
             exec_ctx_schema: None,
@@ -1079,6 +1098,7 @@ mod tests {
             scratch_file_path: Some(scratch_file.to_string_lossy().to_string()),
             shadow_file_path: None,
             language: Some("sql".to_string()),
+            exec_ctx_json: None,
             exec_ctx_connection_id: None,
             exec_ctx_database: None,
             exec_ctx_schema: None,
@@ -1155,6 +1175,7 @@ mod tests {
             database: Some("testdb".into()),
             schema: Some("public".into()),
             container: None,
+            source: None,
         };
 
         let manifest = WorkspaceSessionManifest {
@@ -1220,6 +1241,7 @@ mod tests {
             database: Some("analytics".into()),
             schema: Some("metrics".into()),
             container: Some("events".into()),
+            source: None,
         };
 
         let manifest = WorkspaceSessionManifest {
@@ -1264,6 +1286,223 @@ mod tests {
         assert_eq!(restored_ctx.database.as_deref(), Some("analytics"));
         assert_eq!(restored_ctx.schema.as_deref(), Some("metrics"));
         assert_eq!(restored_ctx.container.as_deref(), Some("events"));
+
+        let _ = std::fs::remove_dir_all(&artifact_root);
+    }
+
+    #[test]
+    fn cloudwatch_exec_context_roundtrips_per_document() {
+        let path = temp_db("cloudwatch_exec_ctx");
+        let conn = open_database(&path).expect("should open");
+        MigrationRegistry::new()
+            .run_all(&conn)
+            .expect("migration should run");
+        let arc_conn = Arc::new(conn);
+        let repo = SessionRepository::new(arc_conn.clone());
+
+        let profile_id = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+        let profile = ConnectionProfileDto::new(profile_id, "CloudWatch Profile".to_string());
+        let profile_repo = ConnectionProfileRepository::new(arc_conn.clone());
+        profile_repo.insert(&profile).expect("insert profile");
+
+        let manifest = WorkspaceSessionManifest {
+            version: 1,
+            active_index: Some(1),
+            tabs: vec![
+                WorkspaceTab {
+                    id: "cw-1".to_string(),
+                    tab_kind: "Scratch".to_string(),
+                    language: "sql".to_string(),
+                    exec_ctx: dbflux_core::ExecutionContext {
+                        connection_id: Some(profile_id),
+                        database: Some("logs".into()),
+                        schema: None,
+                        container: None,
+                        source: Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
+                            log_groups: vec!["/aws/lambda/app".into()],
+                            start_ms: 10,
+                            end_ms: 20,
+                        }),
+                    },
+                    scratch_path: Some(PathBuf::from("/tmp/cloudwatch-1.sql")),
+                    shadow_path: None,
+                    file_path: None,
+                    title: "CloudWatch One".to_string(),
+                    position: 0,
+                    is_pinned: false,
+                },
+                WorkspaceTab {
+                    id: "cw-2".to_string(),
+                    tab_kind: "Scratch".to_string(),
+                    language: "sql".to_string(),
+                    exec_ctx: dbflux_core::ExecutionContext {
+                        connection_id: Some(profile_id),
+                        database: Some("logs".into()),
+                        schema: None,
+                        container: None,
+                        source: Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
+                            log_groups: vec!["/aws/ecs/api".into(), "/aws/batch/job".into()],
+                            start_ms: 30,
+                            end_ms: 40,
+                        }),
+                    },
+                    scratch_path: Some(PathBuf::from("/tmp/cloudwatch-2.sql")),
+                    shadow_path: None,
+                    file_path: None,
+                    title: "CloudWatch Two".to_string(),
+                    position: 1,
+                    is_pinned: false,
+                },
+            ],
+        };
+
+        repo.save_workspace_session(&manifest).expect("save");
+
+        let artifact_root = std::env::temp_dir().join(format!(
+            "dbflux_test_cloudwatch_exec_ctx_{}_{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let store = ArtifactStore::for_root(artifact_root.clone()).expect("store");
+
+        let restored = repo
+            .restore_session(&store)
+            .expect("restore")
+            .expect("session");
+        assert_eq!(restored.tabs.len(), 2);
+
+        let restored_contexts = restored
+            .tabs
+            .iter()
+            .map(|tab| {
+                serde_json::from_str::<dbflux_core::ExecutionContext>(&tab.exec_ctx_json)
+                    .expect("exec ctx json")
+            })
+            .collect::<Vec<_>>();
+
+        match &restored_contexts[0].source {
+            Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
+                log_groups,
+                start_ms,
+                end_ms,
+            }) => {
+                assert_eq!(log_groups, &vec!["/aws/lambda/app".to_string()]);
+                assert_eq!((*start_ms, *end_ms), (10, 20));
+            }
+            other => panic!("unexpected first source: {other:?}"),
+        }
+
+        match &restored_contexts[1].source {
+            Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
+                log_groups,
+                start_ms,
+                end_ms,
+            }) => {
+                assert_eq!(
+                    log_groups,
+                    &vec!["/aws/ecs/api".to_string(), "/aws/batch/job".to_string()]
+                );
+                assert_eq!((*start_ms, *end_ms), (30, 40));
+            }
+            other => panic!("unexpected second source: {other:?}"),
+        }
+
+        let _ = std::fs::remove_dir_all(&artifact_root);
+    }
+
+    #[test]
+    fn restore_prefers_exec_ctx_json_over_legacy_columns() {
+        let path = temp_db("cloudwatch_exec_ctx_json_backfill");
+        let conn = open_database(&path).expect("should open");
+        MigrationRegistry::new()
+            .run_all(&conn)
+            .expect("migration should run");
+        let arc_conn = Arc::new(conn);
+        let repo = SessionRepository::new(arc_conn.clone());
+
+        let profile_id = Uuid::parse_str("33333333-3333-3333-3333-333333333333").unwrap();
+        let profile = ConnectionProfileDto::new(profile_id, "CloudWatch Profile".to_string());
+        let profile_repo = ConnectionProfileRepository::new(arc_conn.clone());
+        profile_repo.insert(&profile).expect("insert profile");
+
+        repo.upsert(&SessionDto {
+            id: "workspace-json".to_string(),
+            name: "workspace".to_string(),
+            kind: "workspace".to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            updated_at: chrono::Utc::now().to_rfc3339(),
+            last_opened_at: chrono::Utc::now().to_rfc3339(),
+            is_last_active: true,
+        })
+        .expect("upsert session");
+
+        let exec_ctx_json = serde_json::to_string(&dbflux_core::ExecutionContext {
+            connection_id: Some(profile_id),
+            database: Some("logs".into()),
+            schema: None,
+            container: None,
+            source: Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
+                log_groups: vec!["/aws/json/preferred".into()],
+                start_ms: 111,
+                end_ms: 222,
+            }),
+        })
+        .expect("serialize exec ctx");
+
+        arc_conn
+            .execute(
+                r#"
+                INSERT INTO st_session_tabs (
+                    id, session_id, tab_kind, title, position, is_pinned,
+                    scratch_file_path, shadow_file_path, language, file_path,
+                    exec_ctx_connection_id, exec_ctx_database, exec_ctx_schema, exec_ctx_container,
+                    exec_ctx_json, created_at, updated_at
+                ) VALUES (
+                    ?1, ?2, 'Scratch', 'CloudWatch', 0, 0,
+                    ?3, NULL, 'sql', NULL,
+                    ?4, 'legacy-db', 'legacy-schema', 'legacy-container',
+                    ?5, datetime('now'), datetime('now')
+                )
+                "#,
+                params![
+                    "tab-json",
+                    "workspace-json",
+                    "/tmp/cloudwatch-json.sql",
+                    profile_id.to_string(),
+                    exec_ctx_json,
+                ],
+            )
+            .expect("insert tab");
+
+        let artifact_root = std::env::temp_dir().join(format!(
+            "dbflux_test_cloudwatch_json_restore_{}_{}",
+            std::process::id(),
+            Uuid::new_v4()
+        ));
+        let store = ArtifactStore::for_root(artifact_root.clone()).expect("store");
+
+        let restored = repo
+            .restore_session(&store)
+            .expect("restore")
+            .expect("session");
+        let restored_ctx: dbflux_core::ExecutionContext =
+            serde_json::from_str(&restored.tabs[0].exec_ctx_json).expect("deserialize exec ctx");
+
+        assert_eq!(restored_ctx.database.as_deref(), Some("logs"));
+        assert!(restored_ctx.schema.is_none());
+        assert!(restored_ctx.container.is_none());
+
+        match restored_ctx.source {
+            Some(dbflux_core::ExecutionSourceContext::CloudWatchLogs {
+                log_groups,
+                start_ms,
+                end_ms,
+            }) => {
+                assert_eq!(log_groups, vec!["/aws/json/preferred".to_string()]);
+                assert_eq!((start_ms, end_ms), (111, 222));
+            }
+            other => panic!("unexpected restored source: {other:?}"),
+        }
 
         let _ = std::fs::remove_dir_all(&artifact_root);
     }

--- a/crates/dbflux_test_support/src/fake_driver.rs
+++ b/crates/dbflux_test_support/src/fake_driver.rs
@@ -1,11 +1,11 @@
 use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
-    Connection, ConnectionProfile, DYNAMODB_FORM, DatabaseCategory, DbConfig, DbDriver, DbError,
-    DbKind, DdlCapabilities, DriverCapabilities, DriverFormDef, DriverLimits, DriverMetadata,
-    FormValues, Icon, MONGODB_FORM, MYSQL_FORM, MutationCapabilities, POSTGRES_FORM,
-    QueryCapabilities, QueryHandle, QueryLanguage, QueryRequest, QueryResult, REDIS_FORM,
-    SQLITE_FORM, SchemaLoadingStrategy, SchemaSnapshot, SqlDialect, SqlLanguageService, SyntaxInfo,
-    TransactionCapabilities,
+    CLOUDWATCH_FORM, Connection, ConnectionProfile, DYNAMODB_FORM, DatabaseCategory, DbConfig,
+    DbDriver, DbError, DbKind, DdlCapabilities, DriverCapabilities, DriverFormDef, DriverLimits,
+    DriverMetadata, FormValues, Icon, MONGODB_FORM, MYSQL_FORM, MutationCapabilities,
+    POSTGRES_FORM, QueryCapabilities, QueryHandle, QueryLanguage, QueryRequest, QueryResult,
+    REDIS_FORM, SQLITE_FORM, SchemaLoadingStrategy, SchemaSnapshot, SqlDialect, SqlLanguageService,
+    SyntaxInfo, TransactionCapabilities,
 };
 use dbflux_core::{DatabaseInfo, DefaultSqlDialect};
 use dbflux_driver_redis::RedisLanguageService;
@@ -209,6 +209,11 @@ impl DbDriver for FakeDriver {
                 endpoint: get_optional_string(values, "endpoint"),
                 table: get_optional_string(values, "table"),
             },
+            DbKind::CloudWatchLogs => DbConfig::CloudWatchLogs {
+                region: get_string(values, "region", "us-east-1"),
+                profile: get_optional_string(values, "profile"),
+                endpoint: get_optional_string(values, "endpoint"),
+            },
         };
 
         Ok(config)
@@ -287,6 +292,15 @@ impl DbDriver for FakeDriver {
                 values.insert("profile".to_string(), profile.clone().unwrap_or_default());
                 values.insert("endpoint".to_string(), endpoint.clone().unwrap_or_default());
                 values.insert("table".to_string(), table.clone().unwrap_or_default());
+            }
+            DbConfig::CloudWatchLogs {
+                region,
+                profile,
+                endpoint,
+            } => {
+                values.insert("region".to_string(), region.clone());
+                values.insert("profile".to_string(), profile.clone().unwrap_or_default());
+                values.insert("endpoint".to_string(), endpoint.clone().unwrap_or_default());
             }
             DbConfig::External { values: vals, .. } => {
                 values.extend(vals.clone());
@@ -430,7 +444,7 @@ impl Connection for FakeConnection {
             DbKind::SQLite | DbKind::MongoDB | DbKind::Redis => {
                 SchemaLoadingStrategy::SingleDatabase
             }
-            DbKind::DynamoDB => SchemaLoadingStrategy::SingleDatabase,
+            DbKind::DynamoDB | DbKind::CloudWatchLogs => SchemaLoadingStrategy::SingleDatabase,
         }
     }
 
@@ -454,6 +468,7 @@ fn active_database_from_profile(profile: &ConnectionProfile) -> Option<String> {
         DbConfig::MongoDB { database, .. } => database.clone(),
         DbConfig::Redis { database, .. } => database.map(|value| value.to_string()),
         DbConfig::DynamoDB { table, .. } => table.clone(),
+        DbConfig::CloudWatchLogs { .. } => None,
         DbConfig::External { values, .. } => values.get("database").cloned(),
     }
 }
@@ -467,6 +482,7 @@ fn metadata_for_kind(kind: DbKind) -> &'static DriverMetadata {
         DbKind::MongoDB => &FAKE_MONGODB_METADATA,
         DbKind::Redis => &FAKE_REDIS_METADATA,
         DbKind::DynamoDB => &FAKE_DYNAMODB_METADATA,
+        DbKind::CloudWatchLogs => &FAKE_CLOUDWATCH_METADATA,
     }
 }
 
@@ -478,6 +494,7 @@ fn form_for_kind(kind: DbKind) -> &'static DriverFormDef {
         DbKind::MongoDB => &MONGODB_FORM,
         DbKind::Redis => &REDIS_FORM,
         DbKind::DynamoDB => &DYNAMODB_FORM,
+        DbKind::CloudWatchLogs => &CLOUDWATCH_FORM,
     }
 }
 
@@ -825,6 +842,33 @@ static FAKE_DYNAMODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Drive
     classification_override: None,
 });
 
+static FAKE_CLOUDWATCH_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
+    id: "fake-cloudwatch".into(),
+    display_name: "Fake CloudWatch Logs".into(),
+    description: "Deterministic fake driver for tests".into(),
+    category: DatabaseCategory::Document,
+    query_language: QueryLanguage::Sql,
+    capabilities: DriverCapabilities::AUTHENTICATION,
+    default_port: None,
+    uri_scheme: "cloudwatch".into(),
+    icon: Icon::Dynamodb,
+    syntax: None,
+    query: None,
+    mutation: None,
+    ddl: None,
+    transactions: Some(TransactionCapabilities {
+        supports_transactions: false,
+        supported_isolation_levels: vec![],
+        default_isolation_level: None,
+        supports_savepoints: false,
+        supports_nested_transactions: false,
+        supports_read_only: false,
+        supports_deferrable: false,
+    }),
+    limits: None,
+    classification_override: None,
+});
+
 #[cfg(test)]
 mod tests {
     use super::{FakeDriver, FakeQueryOutcome};
@@ -961,6 +1005,10 @@ mod tests {
             (DbKind::MongoDB, SchemaLoadingStrategy::SingleDatabase),
             (DbKind::Redis, SchemaLoadingStrategy::SingleDatabase),
             (DbKind::DynamoDB, SchemaLoadingStrategy::SingleDatabase),
+            (
+                DbKind::CloudWatchLogs,
+                SchemaLoadingStrategy::SingleDatabase,
+            ),
         ];
 
         for (kind, expected_strategy) in cases {
@@ -986,6 +1034,7 @@ mod tests {
                 DbKind::MongoDB => DbConfig::default_mongodb(),
                 DbKind::Redis => DbConfig::default_redis(),
                 DbKind::DynamoDB => DbConfig::default_dynamodb(),
+                DbKind::CloudWatchLogs => DbConfig::default_cloudwatch_logs(),
             };
 
             let profile = ConnectionProfile::new("fake", config);

--- a/crates/dbflux_test_support/src/fixtures.rs
+++ b/crates/dbflux_test_support/src/fixtures.rs
@@ -65,6 +65,8 @@ pub fn relational_schema_with_table(
         foreign_keys: None,
         constraints: None,
         sample_fields: None,
+        presentation: dbflux_core::CollectionPresentation::DataGrid,
+        child_items: None,
     };
 
     let schema = DbSchemaInfo {

--- a/crates/dbflux_ui/Cargo.toml
+++ b/crates/dbflux_ui/Cargo.toml
@@ -71,6 +71,10 @@ optional = true
 workspace = true
 optional = true
 
+[dependencies.dbflux_driver_cloudwatch]
+workspace = true
+optional = true
+
 [dependencies.dbflux_aws]
 workspace = true
 optional = true
@@ -80,13 +84,14 @@ workspace = true
 optional = true
 
 [features]
-default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "lua", "aws", "mcp"]
+default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "lua", "aws", "mcp"]
 sqlite = ["dbflux_driver_sqlite", "dbflux_mcp_server?/sqlite"]
 postgres = ["dbflux_driver_postgres", "dbflux_mcp_server?/postgres"]
 mysql = ["dbflux_driver_mysql", "dbflux_mcp_server?/mysql"]
 mongodb = ["dbflux_driver_mongodb", "dbflux_mcp_server?/mongodb"]
 redis = ["dbflux_driver_redis", "dbflux_mcp_server?/redis"]
 dynamodb = ["dbflux_driver_dynamodb", "dbflux_mcp_server?/dynamodb"]
+cloudwatch = ["dbflux_driver_cloudwatch"]
 lua = ["dbflux_lua", "dbflux_app/lua"]
 aws = ["dbflux_aws", "dbflux_ssm", "dbflux_mcp_server?/aws", "dbflux_app/aws"]
 mcp = ["dbflux_mcp", "dbflux_mcp_server", "dbflux_policy", "dbflux_approval", "dbflux_app/mcp"]

--- a/crates/dbflux_ui/src/keymap/defaults.rs
+++ b/crates/dbflux_ui/src/keymap/defaults.rs
@@ -125,6 +125,7 @@ fn sidebar_layer() -> KeymapLayer {
     let mut layer = KeymapLayer::new(ContextId::Sidebar);
 
     layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);
+    layer.bind(KeyChord::new("/", Modifiers::none()), Command::FocusSearch);
     layer.bind(
         KeyChord::new("q", Modifiers::none()),
         Command::SidebarNextTab,

--- a/crates/dbflux_ui/src/keymap/defaults.rs
+++ b/crates/dbflux_ui/src/keymap/defaults.rs
@@ -19,6 +19,7 @@ static DEFAULT_KEYMAP: LazyLock<KeymapStack> = LazyLock::new(|| {
     stack.add_layer(form_navigation_layer());
     stack.add_layer(context_bar_layer());
     stack.add_layer(audit_layer());
+    stack.add_layer(event_streams_picker_layer());
 
     stack
 });
@@ -254,6 +255,32 @@ fn editor_layer() -> KeymapLayer {
         KeyChord::new("s", Modifiers::ctrl_shift()),
         Command::SaveFileAs,
     );
+
+    layer
+}
+
+fn event_streams_picker_layer() -> KeymapLayer {
+    let mut layer = KeymapLayer::new(ContextId::EventStreamsPicker);
+
+    layer.bind(KeyChord::new("j", Modifiers::none()), Command::SelectNext);
+    layer.bind(
+        KeyChord::new("down", Modifiers::none()),
+        Command::SelectNext,
+    );
+    layer.bind(KeyChord::new("k", Modifiers::none()), Command::SelectPrev);
+    layer.bind(KeyChord::new("up", Modifiers::none()), Command::SelectPrev);
+
+    layer.bind(KeyChord::new("g", Modifiers::none()), Command::SelectFirst);
+    layer.bind(
+        KeyChord::new("home", Modifiers::none()),
+        Command::SelectFirst,
+    );
+    layer.bind(KeyChord::new("g", Modifiers::shift()), Command::SelectLast);
+    layer.bind(KeyChord::new("end", Modifiers::none()), Command::SelectLast);
+
+    layer.bind(KeyChord::new("enter", Modifiers::none()), Command::Execute);
+    layer.bind(KeyChord::new("escape", Modifiers::none()), Command::Cancel);
+    layer.bind(KeyChord::new("/", Modifiers::none()), Command::FocusSearch);
 
     layer
 }

--- a/crates/dbflux_ui/src/ui/components/filter_bar.rs
+++ b/crates/dbflux_ui/src/ui/components/filter_bar.rs
@@ -33,6 +33,8 @@ use dbflux_components::controls::InputState;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::ActiveTheme;
+use gpui_component::Sizable;
+use gpui_component::date_picker::DatePickerState;
 
 // ── Item kinds ────────────────────────────────────────────────────────────────
 
@@ -47,6 +49,10 @@ pub enum FilterBarItem {
     Dropdown {
         label: SharedString,
         dropdown: Entity<Dropdown>,
+    },
+    DatePicker {
+        label: SharedString,
+        date_picker: Entity<DatePickerState>,
     },
     /// An action button. Activated with Enter → the document handles it externally.
     /// `activate_input` returns `false` for buttons so the caller can dispatch the action.
@@ -68,6 +74,16 @@ impl FilterBarItem {
         Self::Dropdown {
             label: label.into(),
             dropdown,
+        }
+    }
+
+    pub fn date_picker(
+        label: impl Into<SharedString>,
+        date_picker: Entity<DatePickerState>,
+    ) -> Self {
+        Self::DatePicker {
+            label: label.into(),
+            date_picker,
         }
     }
 
@@ -156,6 +172,18 @@ impl FilterBarState {
         self.items.len()
     }
 
+    pub fn set_items(&mut self, items: Vec<FilterBarItem>) {
+        self.items = items;
+
+        if self.items.is_empty() {
+            self.focused_index = 0;
+            self.mode = FilterBarMode::Inactive;
+            return;
+        }
+
+        self.focused_index = self.focused_index.min(self.items.len().saturating_sub(1));
+    }
+
     // ── Activation ────────────────────────────────────────────────────────
 
     /// Enter toolbar navigation mode with the ring on `index` (clamped).
@@ -234,6 +262,14 @@ impl FilterBarState {
                 let dropdown = dropdown.clone();
                 dropdown.update(cx, |d, cx| {
                     d.open(cx);
+                });
+                true
+            }
+            FilterBarItem::DatePicker { date_picker, .. } => {
+                self.mode = FilterBarMode::Editing;
+                let date_picker = date_picker.clone();
+                date_picker.update(cx, |state, cx| {
+                    state.focus_handle(cx).focus(window);
                 });
                 true
             }
@@ -371,6 +407,20 @@ fn render_item(
                     .rounded(Radii::SM)
                     .when(ring_active, |d| d.border_1().border_color(theme.ring))
                     .child(dropdown.clone()),
+            )
+            .into_any_element(),
+
+        FilterBarItem::DatePicker { label, date_picker } => div()
+            .flex()
+            .items_center()
+            .gap(Spacing::XS)
+            .child(Text::caption(label.clone()))
+            .child(
+                div()
+                    .min_w(px(220.0))
+                    .rounded(Radii::SM)
+                    .when(ring_active, |d| d.border_1().border_color(theme.ring))
+                    .child(gpui_component::date_picker::DatePicker::new(date_picker).small()),
             )
             .into_any_element(),
 

--- a/crates/dbflux_ui/src/ui/components/modal_frame.rs
+++ b/crates/dbflux_ui/src/ui/components/modal_frame.rs
@@ -41,7 +41,6 @@ impl ModalFrame {
         self
     }
 
-    #[allow(dead_code)]
     pub fn context_id(mut self, context_id: ContextId) -> Self {
         self.inner = self.inner.key_context(context_id.as_gpui_context());
         self

--- a/crates/dbflux_ui/src/ui/document/audit/filters.rs
+++ b/crates/dbflux_ui/src/ui/document/audit/filters.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides filter state management for the audit event viewer.
 
+use dbflux_core::chrono::{DateTime, Local, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use dbflux_core::observability::{
     AuditQuerySource, EventActorType, EventCategory, EventOutcome, EventSeverity, EventSourceId,
 };
@@ -49,12 +50,21 @@ pub struct AuditFilters {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[allow(dead_code)]
 pub enum TimeRange {
-    Last15min,
+    Last5min,
+    Last30min,
     LastHour,
+    Last3Hours,
     #[default]
-    Last24h,
-    Last7Days,
+    Last12Hours,
     Custom,
+}
+
+/// Timestamp display and custom date parsing mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TimestampDisplayMode {
+    #[default]
+    Local,
+    Utc,
 }
 
 impl TimeRange {
@@ -66,11 +76,124 @@ impl TimeRange {
             .unwrap_or(0);
 
         match self {
-            TimeRange::Last15min => (Some(now - 15 * 60 * 1000), None),
+            TimeRange::Last5min => (Some(now - 5 * 60 * 1000), None),
+            TimeRange::Last30min => (Some(now - 30 * 60 * 1000), None),
             TimeRange::LastHour => (Some(now - 60 * 60 * 1000), None),
-            TimeRange::Last24h => (Some(now - 24 * 60 * 60 * 1000), None),
-            TimeRange::Last7Days => (Some(now - 7 * 24 * 60 * 60 * 1000), None),
+            TimeRange::Last3Hours => (Some(now - 3 * 60 * 60 * 1000), None),
+            TimeRange::Last12Hours => (Some(now - 12 * 60 * 60 * 1000), None),
             TimeRange::Custom => (None, None),
         }
+    }
+}
+
+pub fn format_timestamp_ms(ms: i64, mode: TimestampDisplayMode) -> String {
+    let Some(utc) = DateTime::<Utc>::from_timestamp_millis(ms) else {
+        return ms.to_string();
+    };
+
+    match mode {
+        TimestampDisplayMode::Local => utc
+            .with_timezone(&Local)
+            .format("%Y-%m-%d %H:%M:%S%.3f")
+            .to_string(),
+        TimestampDisplayMode::Utc => utc.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
+    }
+}
+
+pub fn timestamp_from_date_time(
+    date: NaiveDate,
+    hour: u32,
+    minute: u32,
+    mode: TimestampDisplayMode,
+) -> Result<i64, String> {
+    let time = NaiveTime::from_hms_opt(hour, minute, 0)
+        .ok_or_else(|| "Time selection is invalid".to_string())?;
+    let naive = NaiveDateTime::new(date, time);
+
+    let timestamp = match mode {
+        TimestampDisplayMode::Utc => Utc.from_utc_datetime(&naive).timestamp_millis(),
+        TimestampDisplayMode::Local => Local
+            .from_local_datetime(&naive)
+            .single()
+            .ok_or_else(|| "Local time is ambiguous or invalid".to_string())?
+            .timestamp_millis(),
+    };
+
+    Ok(timestamp)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn validate_custom_range_parts(
+    start_date: NaiveDate,
+    start_hour: u32,
+    start_minute: u32,
+    end_date: NaiveDate,
+    end_hour: u32,
+    end_minute: u32,
+    mode: TimestampDisplayMode,
+) -> Result<(i64, i64), String> {
+    let start_ms = timestamp_from_date_time(start_date, start_hour, start_minute, mode)
+        .map_err(|error| format!("Invalid start time: {error}"))?;
+    let end_ms = timestamp_from_date_time(end_date, end_hour, end_minute, mode)
+        .map_err(|error| format!("Invalid end time: {error}"))?;
+
+    if start_ms > end_ms {
+        return Err("Start time must be before end time".to_string());
+    }
+
+    Ok((start_ms, end_ms))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        TimeRange, TimestampDisplayMode, format_timestamp_ms, validate_custom_range_parts,
+    };
+    use dbflux_core::chrono::NaiveDate;
+
+    #[test]
+    fn time_range_presets_map_to_expected_windows() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as i64)
+            .unwrap_or(0);
+
+        let cases = [
+            (TimeRange::Last5min, 5 * 60 * 1000),
+            (TimeRange::Last30min, 30 * 60 * 1000),
+            (TimeRange::LastHour, 60 * 60 * 1000),
+            (TimeRange::Last3Hours, 3 * 60 * 60 * 1000),
+            (TimeRange::Last12Hours, 12 * 60 * 60 * 1000),
+        ];
+
+        for (range, expected_ms) in cases {
+            let (start_ms, end_ms) = range.to_filter_values();
+            let actual_ms = now - start_ms.expect("preset should set start");
+
+            assert!(end_ms.is_none());
+            assert!((expected_ms - actual_ms).abs() < 1000);
+        }
+    }
+
+    #[test]
+    fn utc_timestamp_format_includes_date_and_time() {
+        let ms = 1_777_034_096_000;
+        let formatted = format_timestamp_ms(ms, TimestampDisplayMode::Utc);
+
+        assert_eq!(formatted, "2026-04-24 12:34:56.000");
+    }
+
+    #[test]
+    fn custom_range_parts_require_ordered_date_time_values() {
+        let start = NaiveDate::from_ymd_opt(2026, 4, 24).unwrap();
+        let end = NaiveDate::from_ymd_opt(2026, 4, 24).unwrap();
+
+        let result =
+            validate_custom_range_parts(start, 12, 35, end, 12, 34, TimestampDisplayMode::Utc);
+
+        assert_eq!(
+            result,
+            Err("Start time must be before end time".to_string())
+        );
     }
 }

--- a/crates/dbflux_ui/src/ui/document/audit/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/audit/mod.rs
@@ -1008,9 +1008,9 @@ impl AuditDocument {
     ) -> Entity<InputState> {
         let value = value.to_string();
         let rows = if editor_mode.is_some() {
-            Self::event_text_rows(&value, 4)
+            Self::event_code_rows(&value, 4)
         } else {
-            Self::event_text_rows(&value, 2)
+            Self::event_message_rows(&value, 2)
         };
 
         let input = cache
@@ -1028,8 +1028,7 @@ impl AuditDocument {
                             .soft_wrap(true)
                     } else {
                         InputState::new(window, cx)
-                            .multi_line(true)
-                            .rows(initial_rows)
+                            .auto_grow(initial_rows, usize::MAX)
                             .soft_wrap(true)
                     };
 
@@ -1062,6 +1061,14 @@ impl AuditDocument {
             .max(1);
 
         line_rows.max(wrap_rows).max(min_rows)
+    }
+
+    fn event_message_rows(value: &str, min_rows: usize) -> usize {
+        Self::event_text_rows(value, min_rows)
+    }
+
+    fn event_code_rows(value: &str, min_rows: usize) -> usize {
+        value.lines().count().max(min_rows).max(1)
     }
 
     fn event_text_height(rows: usize) -> Pixels {
@@ -2670,25 +2677,20 @@ impl AuditDocument {
             )
             .when_some(message, |root, value| {
                 let message_input = self.ensure_external_message_input(row_event_id, &value, window, cx);
-                let message_rows = Self::event_text_rows(&value, 2);
 
                 root.child(
                     div()
                         .flex_col()
                         .gap_1p5()
                         .child(Label::new("Message"))
-                        .child(
-                            div()
-                                .h(Self::event_text_height(message_rows))
-                                .child(SelectableText::new(&message_input).w_full().h_full()),
-                        ),
+                        .child(SelectableText::new(&message_input).w_full()),
                 )
             })
             .when_some(details_json, |root, value| {
                 let pretty_details = Self::pretty_json(&value);
                 let details_input =
                     self.ensure_external_details_input(row_event_id, &pretty_details, window, cx);
-                let details_rows = Self::event_text_rows(&pretty_details, 4);
+                let details_rows = Self::event_code_rows(&pretty_details, 4);
 
                 root.child(
                     div()
@@ -2700,8 +2702,11 @@ impl AuditDocument {
                                 .bg(theme.secondary)
                                 .p_2()
                                 .rounded(px(4.0))
-                                .h(Self::event_text_height(details_rows))
-                                .child(ReadonlyTextView::new(&details_input).w_full().h_full()),
+                                .child(
+                                    ReadonlyTextView::new(&details_input)
+                                        .w_full()
+                                        .h(Self::event_text_height(details_rows)),
+                                ),
                         ),
                 )
             })
@@ -3047,5 +3052,12 @@ mod tests {
         let long_line = "x".repeat(161);
 
         assert_eq!(AuditDocument::event_text_rows(&long_line, 2), 3);
+    }
+
+    #[test]
+    fn event_code_rows_is_more_conservative_for_pretty_json_blocks() {
+        let line = "a\nb\nc";
+
+        assert_eq!(AuditDocument::event_code_rows(line, 2), 3);
     }
 }

--- a/crates/dbflux_ui/src/ui/document/audit/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/audit/mod.rs
@@ -1347,7 +1347,7 @@ impl AuditDocument {
             })
             .clone();
 
-        if input.read(cx).value().to_string() != value {
+        if input.read(cx).value() != value {
             input.update(cx, |state, cx| state.set_value(value, window, cx));
         }
 

--- a/crates/dbflux_ui/src/ui/document/audit/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/audit/mod.rs
@@ -3,7 +3,7 @@
 mod filters;
 mod source_adapter;
 
-pub use filters::{AuditFilters, TimeRange};
+pub use filters::{AuditFilters, TimeRange, TimestampDisplayMode};
 pub use source_adapter::AuditSourceAdapter;
 
 use std::collections::{HashMap, HashSet};
@@ -14,6 +14,7 @@ use crate::ui::components::dropdown::{Dropdown, DropdownItem, DropdownSelectionC
 use crate::ui::components::filter_bar::{FilterBarItem, FilterBarMode, FilterBarState};
 use crate::ui::components::multi_select::{MultiSelect, MultiSelectChanged};
 use crate::ui::components::toast::{PendingToast, flush_pending_toast};
+use crate::ui::document::audit::filters::{format_timestamp_ms, validate_custom_range_parts};
 use crate::ui::icons::AppIcon;
 use crate::ui::tokens::{FontSizes, Heights, Radii, Spacing};
 use dbflux_components::controls::{
@@ -30,6 +31,8 @@ use gpui::*;
 use gpui_component::ActiveTheme;
 use gpui_component::Sizable;
 use gpui_component::button::{Button, ButtonVariants};
+use gpui_component::calendar::Date;
+use gpui_component::date_picker::{DatePicker, DatePickerEvent, DatePickerState};
 use gpui_component::scroll::ScrollableElement;
 use serde_json::{Value as JsonValue, json};
 use uuid::Uuid;
@@ -114,6 +117,10 @@ enum AuditDocumentSource {
 enum ToolbarSlot {
     Search,
     Time,
+    CustomStart,
+    CustomEnd,
+    CustomApply,
+    Timezone,
     Level,
     Category,
     Outcome,
@@ -146,7 +153,15 @@ pub struct AuditDocument {
     pending_toast: Option<PendingToast>,
     export_menu_open: bool,
     search_input: Entity<InputState>,
+    custom_date_range_picker: Entity<DatePickerState>,
+    custom_start_hour_dropdown: Entity<Dropdown>,
+    custom_start_minute_dropdown: Entity<Dropdown>,
+    custom_end_hour_dropdown: Entity<Dropdown>,
+    custom_end_minute_dropdown: Entity<Dropdown>,
     dropdown_time_range: Entity<Dropdown>,
+    dropdown_timestamp_mode: Entity<Dropdown>,
+    selected_time_range: Option<TimeRange>,
+    timestamp_mode: TimestampDisplayMode,
     multi_select_level: Entity<MultiSelect>,
     multi_select_category: Entity<MultiSelect>,
     multi_select_outcome: Entity<MultiSelect>,
@@ -208,10 +223,7 @@ impl AuditDocument {
     ) -> Self {
         Self::new_with_source(
             app_state,
-            AuditDocumentSource::ExternalEventStream {
-                profile_id,
-                target,
-            },
+            AuditDocumentSource::ExternalEventStream { profile_id, target },
             title,
             "Filter events...",
             window,
@@ -230,13 +242,39 @@ impl AuditDocument {
         let focus_handle = cx.focus_handle();
 
         let search_input = cx.new(|cx| InputState::new(window, cx).placeholder(search_placeholder));
+        let custom_date_range_picker =
+            cx.new(|cx| DatePickerState::range(window, cx).date_format("%Y-%m-%d"));
+        let custom_start_hour_dropdown = cx.new(|_cx| {
+            Dropdown::new("audit-custom-start-hour")
+                .placeholder("HH")
+                .items(Self::hour_items())
+                .selected_index(Some(0))
+        });
+        let custom_start_minute_dropdown = cx.new(|_cx| {
+            Dropdown::new("audit-custom-start-minute")
+                .placeholder("MM")
+                .items(Self::minute_items())
+                .selected_index(Some(0))
+        });
+        let custom_end_hour_dropdown = cx.new(|_cx| {
+            Dropdown::new("audit-custom-end-hour")
+                .placeholder("HH")
+                .items(Self::hour_items())
+                .selected_index(Some(23))
+        });
+        let custom_end_minute_dropdown = cx.new(|_cx| {
+            Dropdown::new("audit-custom-end-minute")
+                .placeholder("MM")
+                .items(Self::minute_items())
+                .selected_index(Some(59))
+        });
 
         let initial_time_range = Self::initial_time_range(&source);
         let time_range_placeholder =
             if matches!(source, AuditDocumentSource::ExternalEventStream { .. }) {
                 "All time"
             } else {
-                "Last 24 h"
+                "Last 12 h"
             };
 
         let dropdown_time_range = cx.new(|_cx| {
@@ -244,6 +282,13 @@ impl AuditDocument {
                 .placeholder(time_range_placeholder)
                 .items(Self::time_range_items())
                 .selected_index(initial_time_range)
+        });
+
+        let dropdown_timestamp_mode = cx.new(|_cx| {
+            Dropdown::new("audit-timestamp-mode")
+                .placeholder("Local")
+                .items(Self::timestamp_mode_items())
+                .selected_index(Some(0))
         });
 
         let multi_select_level = cx.new(|cx| {
@@ -283,15 +328,70 @@ impl AuditDocument {
             }
         });
 
+        let custom_date_range_sub = cx.subscribe(
+            &custom_date_range_picker,
+            |this, _, _event: &DatePickerEvent, cx| {
+                this.status_message = None;
+                cx.notify();
+            },
+        );
+
+        let custom_start_hour_sub = cx.subscribe(
+            &custom_start_hour_dropdown,
+            |this, _, _event: &DropdownSelectionChanged, cx| {
+                this.status_message = None;
+                cx.notify();
+            },
+        );
+        let custom_start_minute_sub = cx.subscribe(
+            &custom_start_minute_dropdown,
+            |this, _, _event: &DropdownSelectionChanged, cx| {
+                this.status_message = None;
+                cx.notify();
+            },
+        );
+        let custom_end_hour_sub = cx.subscribe(
+            &custom_end_hour_dropdown,
+            |this, _, _event: &DropdownSelectionChanged, cx| {
+                this.status_message = None;
+                cx.notify();
+            },
+        );
+        let custom_end_minute_sub = cx.subscribe(
+            &custom_end_minute_dropdown,
+            |this, _, _event: &DropdownSelectionChanged, cx| {
+                this.status_message = None;
+                cx.notify();
+            },
+        );
+
         let time_range_sub = cx.subscribe(
             &dropdown_time_range,
             |this, _, event: &DropdownSelectionChanged, cx| {
                 if let Some(range) = Self::time_range_for_index(event.index) {
+                    this.selected_time_range = Some(range);
+                    this.refresh_filter_bar_items();
+
+                    if range == TimeRange::Custom {
+                        cx.notify();
+                        return;
+                    }
+
                     let (start_ms, end_ms) = range.to_filter_values();
                     this.filters.start_ms = start_ms;
                     this.filters.end_ms = end_ms;
                     this.reset_pagination();
                     this.load_events(cx);
+                }
+            },
+        );
+
+        let timestamp_mode_sub = cx.subscribe(
+            &dropdown_timestamp_mode,
+            |this, _, event: &DropdownSelectionChanged, cx| {
+                if let Some(mode) = Self::timestamp_mode_for_index(event.index) {
+                    this.timestamp_mode = mode;
+                    cx.notify();
                 }
             },
         );
@@ -397,26 +497,20 @@ impl AuditDocument {
             },
         );
 
-        let mut toolbar_items = vec![
-            FilterBarItem::input("Search:", search_input.clone()),
-            FilterBarItem::dropdown("Time:", dropdown_time_range.clone()),
-        ];
-
-        if matches!(source, AuditDocumentSource::Internal { .. }) {
-            toolbar_items.extend([
-                FilterBarItem::button("Level"),
-                FilterBarItem::button("Category"),
-                FilterBarItem::button("Outcome"),
-            ]);
-        }
-
-        toolbar_items.extend([
-            FilterBarItem::button_with_icon("Refresh", AppIcon::RefreshCcw),
-            FilterBarItem::dropdown("Auto-refresh:", refresh_dropdown.clone()),
-            FilterBarItem::button("Clear"),
-        ]);
-
-        let filter_bar = FilterBarState::new(toolbar_items);
+        let selected_time_range = initial_time_range.and_then(Self::time_range_for_index);
+        let filter_bar = FilterBarState::new(Self::toolbar_items_for_state(
+            &source,
+            selected_time_range,
+            &search_input,
+            &dropdown_time_range,
+            &dropdown_timestamp_mode,
+            &custom_date_range_picker,
+            &custom_start_hour_dropdown,
+            &custom_start_minute_dropdown,
+            &custom_end_hour_dropdown,
+            &custom_end_minute_dropdown,
+            &refresh_dropdown,
+        ));
 
         let filters = Self::default_filters_for_source(&source);
 
@@ -441,7 +535,15 @@ impl AuditDocument {
             pending_toast: None,
             export_menu_open: false,
             search_input,
+            custom_date_range_picker,
+            custom_start_hour_dropdown,
+            custom_start_minute_dropdown,
+            custom_end_hour_dropdown,
+            custom_end_minute_dropdown,
             dropdown_time_range,
+            dropdown_timestamp_mode,
+            selected_time_range,
+            timestamp_mode: TimestampDisplayMode::Local,
             multi_select_level,
             multi_select_category,
             multi_select_outcome,
@@ -451,7 +553,13 @@ impl AuditDocument {
             _refresh_timer: None,
             _subscriptions: vec![
                 search_sub,
+                custom_date_range_sub,
+                custom_start_hour_sub,
+                custom_start_minute_sub,
+                custom_end_hour_sub,
+                custom_end_minute_sub,
                 time_range_sub,
+                timestamp_mode_sub,
                 level_sub,
                 category_sub,
                 outcome_sub,
@@ -486,11 +594,7 @@ impl AuditDocument {
         doc
     }
 
-    pub fn matches_event_stream(
-        &self,
-        profile_id: Uuid,
-        target: &EventStreamTarget,
-    ) -> bool {
+    pub fn matches_event_stream(&self, profile_id: Uuid, target: &EventStreamTarget) -> bool {
         match &self.source {
             AuditDocumentSource::ExternalEventStream {
                 profile_id: doc_profile_id,
@@ -504,28 +608,124 @@ impl AuditDocument {
         matches!(self.source, AuditDocumentSource::ExternalEventStream { .. })
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn toolbar_items_for_state(
+        source: &AuditDocumentSource,
+        selected_time_range: Option<TimeRange>,
+        search_input: &Entity<InputState>,
+        dropdown_time_range: &Entity<Dropdown>,
+        dropdown_timestamp_mode: &Entity<Dropdown>,
+        custom_date_range_picker: &Entity<DatePickerState>,
+        custom_start_hour_dropdown: &Entity<Dropdown>,
+        custom_start_minute_dropdown: &Entity<Dropdown>,
+        custom_end_hour_dropdown: &Entity<Dropdown>,
+        custom_end_minute_dropdown: &Entity<Dropdown>,
+        refresh_dropdown: &Entity<Dropdown>,
+    ) -> Vec<FilterBarItem> {
+        let mut toolbar_items = vec![
+            FilterBarItem::input("Search:", search_input.clone()),
+            FilterBarItem::dropdown("Time:", dropdown_time_range.clone()),
+            FilterBarItem::dropdown("Time zone:", dropdown_timestamp_mode.clone()),
+        ];
+
+        if selected_time_range == Some(TimeRange::Custom) {
+            toolbar_items.extend([
+                FilterBarItem::date_picker("Range:", custom_date_range_picker.clone()),
+                FilterBarItem::dropdown("Start hour:", custom_start_hour_dropdown.clone()),
+                FilterBarItem::dropdown("Start minute:", custom_start_minute_dropdown.clone()),
+                FilterBarItem::dropdown("End hour:", custom_end_hour_dropdown.clone()),
+                FilterBarItem::dropdown("End minute:", custom_end_minute_dropdown.clone()),
+                FilterBarItem::button("Apply"),
+            ]);
+        }
+
+        if matches!(source, AuditDocumentSource::Internal { .. }) {
+            toolbar_items.extend([
+                FilterBarItem::button("Level"),
+                FilterBarItem::button("Category"),
+                FilterBarItem::button("Outcome"),
+            ]);
+        }
+
+        toolbar_items.extend([
+            FilterBarItem::button_with_icon("Refresh", AppIcon::RefreshCcw),
+            FilterBarItem::dropdown("Auto-refresh:", refresh_dropdown.clone()),
+            FilterBarItem::button("Clear"),
+        ]);
+
+        toolbar_items
+    }
+
+    fn refresh_filter_bar_items(&mut self) {
+        self.filter_bar.set_items(Self::toolbar_items_for_state(
+            &self.source,
+            self.selected_time_range,
+            &self.search_input,
+            &self.dropdown_time_range,
+            &self.dropdown_timestamp_mode,
+            &self.custom_date_range_picker,
+            &self.custom_start_hour_dropdown,
+            &self.custom_start_minute_dropdown,
+            &self.custom_end_hour_dropdown,
+            &self.custom_end_minute_dropdown,
+            &self.refresh_dropdown,
+        ));
+    }
+
     fn toolbar_index(&self, slot: ToolbarSlot) -> Option<usize> {
+        let custom_offset = if self.selected_time_range == Some(TimeRange::Custom) {
+            6
+        } else {
+            0
+        };
+
         match (&self.source, slot) {
             (_, ToolbarSlot::Search) => Some(0),
             (_, ToolbarSlot::Time) => Some(1),
-            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Level) => Some(2),
-            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Category) => Some(3),
-            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Outcome) => Some(4),
-            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Refresh) => Some(5),
-            (AuditDocumentSource::Internal { .. }, ToolbarSlot::RefreshPolicy) => Some(6),
-            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Clear) => Some(7),
-            (AuditDocumentSource::ExternalEventStream { .. }, ToolbarSlot::Refresh) => Some(2),
-            (AuditDocumentSource::ExternalEventStream { .. }, ToolbarSlot::RefreshPolicy) => {
-                Some(3)
+            (_, ToolbarSlot::Timezone) => Some(2),
+            (_, ToolbarSlot::CustomStart) if custom_offset > 0 => Some(3),
+            (_, ToolbarSlot::CustomEnd) if custom_offset > 0 => Some(6),
+            (_, ToolbarSlot::CustomApply) if custom_offset > 0 => Some(8),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Level) => Some(3 + custom_offset),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Category) => {
+                Some(4 + custom_offset)
             }
-            (AuditDocumentSource::ExternalEventStream { .. }, ToolbarSlot::Clear) => Some(4),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Outcome) => Some(5 + custom_offset),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Refresh) => Some(6 + custom_offset),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::RefreshPolicy) => {
+                Some(7 + custom_offset)
+            }
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Clear) => Some(8 + custom_offset),
+            (AuditDocumentSource::ExternalEventStream { .. }, ToolbarSlot::Refresh) => {
+                Some(3 + custom_offset)
+            }
+            (AuditDocumentSource::ExternalEventStream { .. }, ToolbarSlot::RefreshPolicy) => {
+                Some(4 + custom_offset)
+            }
+            (AuditDocumentSource::ExternalEventStream { .. }, ToolbarSlot::Clear) => {
+                Some(5 + custom_offset)
+            }
             _ => None,
         }
     }
 
     fn slot_has_ring(&self, slot: ToolbarSlot) -> bool {
+        if self.filter_bar.mode() != FilterBarMode::Navigating {
+            return false;
+        }
+
+        let focused_index = self.filter_bar.focused_index();
+
+        if self.selected_time_range == Some(TimeRange::Custom) {
+            match slot {
+                ToolbarSlot::CustomStart => return (3..=5).contains(&focused_index),
+                ToolbarSlot::CustomEnd => return (6..=7).contains(&focused_index),
+                _ => {}
+            }
+        }
+
         self.filter_bar.mode() == FilterBarMode::Navigating
-            && self.toolbar_index(slot) == Some(self.filter_bar.focused_index())
+            && self.toolbar_index(slot) == Some(focused_index)
     }
 
     pub fn set_category_filter(&mut self, category: Option<EventCategory>, cx: &mut Context<Self>) {
@@ -598,7 +798,7 @@ impl AuditDocument {
     fn initial_time_range(source: &AuditDocumentSource) -> Option<usize> {
         match source {
             AuditDocumentSource::ExternalEventStream { .. } => None,
-            AuditDocumentSource::Internal { .. } => Some(2),
+            AuditDocumentSource::Internal { .. } => Some(4),
         }
     }
 
@@ -606,7 +806,7 @@ impl AuditDocument {
         let mut filters = AuditFilters::default();
 
         if !matches!(source, AuditDocumentSource::ExternalEventStream { .. }) {
-            let (start_ms, end_ms) = TimeRange::Last24h.to_filter_values();
+            let (start_ms, end_ms) = TimeRange::Last12Hours.to_filter_values();
             filters.start_ms = start_ms;
             filters.end_ms = end_ms;
         }
@@ -817,6 +1017,19 @@ impl AuditDocument {
             Some(self.pagination_offset()),
         );
         let count_filter = self.active_filter(None, None);
+        let task_id = match &self.source {
+            AuditDocumentSource::ExternalEventStream { profile_id, .. } => {
+                Some(self.app_state.update(cx, |state, _| {
+                    let (task_id, _) = state.start_task_for_profile(
+                        dbflux_core::TaskKind::Query,
+                        format!("Loading event stream: {}", self.title),
+                        Some(*profile_id),
+                    );
+                    task_id
+                }))
+            }
+            AuditDocumentSource::Internal { .. } => None,
+        };
 
         let task = match &self.source {
             AuditDocumentSource::Internal { adapter } => {
@@ -844,7 +1057,8 @@ impl AuditDocument {
                     self.total_events = 0;
                     self.expanded_event_ids.clear();
                     self.is_loading = false;
-                    self.status_message = Some("Connection not found for this event source".to_string());
+                    self.status_message =
+                        Some("Connection not found for this event source".to_string());
                     cx.notify();
                     return;
                 };
@@ -888,6 +1102,12 @@ impl AuditDocument {
                             .retain(|event_id| visible_ids.contains(event_id));
                         doc.retain_external_inline_inputs(&visible_ids);
 
+                        if let Some(task_id) = task_id {
+                            doc.app_state.update(cx, |state, _| {
+                                state.complete_task(task_id);
+                            });
+                        }
+
                         cx.notify();
                     })
                 });
@@ -906,6 +1126,13 @@ impl AuditDocument {
                         doc.is_loading = false;
                         doc.status_message = Some(format!("Error loading events: {}", error));
 
+                        if let Some(task_id) = task_id {
+                            let details = format!("Error loading events: {}", error);
+                            doc.app_state.update(cx, |state, _| {
+                                state.fail_task_with_details(task_id, error.clone(), details);
+                            });
+                        }
+
                         cx.notify();
                     })
                 });
@@ -921,14 +1148,85 @@ impl AuditDocument {
         self.load_events(cx);
     }
 
+    fn custom_date_range(
+        &self,
+        cx: &App,
+    ) -> Option<(
+        dbflux_core::chrono::NaiveDate,
+        dbflux_core::chrono::NaiveDate,
+    )> {
+        match self.custom_date_range_picker.read(cx).date() {
+            Date::Range(Some(start), Some(end)) => Some((start, end)),
+            _ => None,
+        }
+    }
+
+    fn selected_dropdown_number(dropdown: &Entity<Dropdown>, cx: &App) -> Option<u32> {
+        dropdown.read(cx).selected_value()?.parse::<u32>().ok()
+    }
+
+    fn custom_time_parts(&self, cx: &App) -> Option<(u32, u32, u32, u32)> {
+        Some((
+            Self::selected_dropdown_number(&self.custom_start_hour_dropdown, cx)?,
+            Self::selected_dropdown_number(&self.custom_start_minute_dropdown, cx)?,
+            Self::selected_dropdown_number(&self.custom_end_hour_dropdown, cx)?,
+            Self::selected_dropdown_number(&self.custom_end_minute_dropdown, cx)?,
+        ))
+    }
+
+    fn can_apply_custom_time_range(&self, cx: &App) -> bool {
+        self.custom_date_range(cx).is_some() && self.custom_time_parts(cx).is_some()
+    }
+
+    fn apply_custom_time_range(&mut self, cx: &mut Context<Self>) {
+        let Some((start_date, end_date)) = self.custom_date_range(cx) else {
+            return;
+        };
+        let Some((start_hour, start_minute, end_hour, end_minute)) = self.custom_time_parts(cx)
+        else {
+            return;
+        };
+
+        match validate_custom_range_parts(
+            start_date,
+            start_hour,
+            start_minute,
+            end_date,
+            end_hour,
+            end_minute,
+            self.timestamp_mode,
+        ) {
+            Ok((start_ms, end_ms)) => {
+                self.filters.start_ms = Some(start_ms);
+                self.filters.end_ms = Some(end_ms);
+                self.selected_time_range = Some(TimeRange::Custom);
+                self.status_message = None;
+                self.reset_pagination();
+                self.load_events(cx);
+            }
+            Err(error) => {
+                self.status_message = Some(error.clone());
+                self.pending_toast = Some(PendingToast {
+                    message: error,
+                    is_error: true,
+                });
+                cx.notify();
+            }
+        }
+    }
+
     pub fn clear_filters(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.filters = Self::default_filters_for_source(&self.source);
         self.reset_pagination();
         self.export_menu_open = false;
 
         self.suppress_load = true;
-        self.dropdown_time_range
-            .update(cx, |dropdown, cx| dropdown.set_selected_index(Some(2), cx));
+        let selected_time_range = Self::initial_time_range(&self.source);
+        self.selected_time_range = selected_time_range.and_then(Self::time_range_for_index);
+        self.dropdown_time_range.update(cx, |dropdown, cx| {
+            dropdown.set_selected_index(selected_time_range, cx)
+        });
+        self.refresh_filter_bar_items();
         self.multi_select_level
             .update(cx, |ms, cx| ms.clear_selection(cx));
         self.multi_select_category
@@ -937,6 +1235,17 @@ impl AuditDocument {
             .update(cx, |ms, cx| ms.clear_selection(cx));
         self.search_input
             .update(cx, |state, cx| state.set_value("", window, cx));
+        self.custom_date_range_picker.update(cx, |picker, cx| {
+            picker.set_date(Date::Range(None, None), window, cx);
+        });
+        self.custom_start_hour_dropdown
+            .update(cx, |dropdown, cx| dropdown.set_selected_index(Some(0), cx));
+        self.custom_start_minute_dropdown
+            .update(cx, |dropdown, cx| dropdown.set_selected_index(Some(0), cx));
+        self.custom_end_hour_dropdown
+            .update(cx, |dropdown, cx| dropdown.set_selected_index(Some(23), cx));
+        self.custom_end_minute_dropdown
+            .update(cx, |dropdown, cx| dropdown.set_selected_index(Some(59), cx));
         self.suppress_load = false;
 
         self.load_events(cx);
@@ -1053,9 +1362,7 @@ impl AuditDocument {
             .lines()
             .map(|line| {
                 let char_count = line.chars().count();
-                char_count
-                    .div_ceil(ESTIMATED_CHARS_PER_ROW)
-                    .max(1)
+                char_count.div_ceil(ESTIMATED_CHARS_PER_ROW).max(1)
             })
             .sum::<usize>()
             .max(1);
@@ -1105,21 +1412,55 @@ impl AuditDocument {
 
     fn time_range_items() -> Vec<DropdownItem> {
         vec![
-            DropdownItem::new("Last 15 min"),
-            DropdownItem::new("Last hour"),
-            DropdownItem::new("Last 24 h"),
-            DropdownItem::new("Last 7 days"),
+            DropdownItem::new("Last 5 min"),
+            DropdownItem::new("Last 30 min"),
+            DropdownItem::new("Last 1 h"),
+            DropdownItem::new("Last 3 h"),
+            DropdownItem::new("Last 12 h"),
+            DropdownItem::new("Custom"),
         ]
     }
 
     fn time_range_for_index(index: usize) -> Option<TimeRange> {
         match index {
-            0 => Some(TimeRange::Last15min),
-            1 => Some(TimeRange::LastHour),
-            2 => Some(TimeRange::Last24h),
-            3 => Some(TimeRange::Last7Days),
+            0 => Some(TimeRange::Last5min),
+            1 => Some(TimeRange::Last30min),
+            2 => Some(TimeRange::LastHour),
+            3 => Some(TimeRange::Last3Hours),
+            4 => Some(TimeRange::Last12Hours),
+            5 => Some(TimeRange::Custom),
             _ => None,
         }
+    }
+
+    fn timestamp_mode_items() -> Vec<DropdownItem> {
+        vec![DropdownItem::new("Local"), DropdownItem::new("UTC")]
+    }
+
+    fn timestamp_mode_for_index(index: usize) -> Option<TimestampDisplayMode> {
+        match index {
+            0 => Some(TimestampDisplayMode::Local),
+            1 => Some(TimestampDisplayMode::Utc),
+            _ => None,
+        }
+    }
+
+    fn hour_items() -> Vec<DropdownItem> {
+        (0..24)
+            .map(|hour| {
+                let value = format!("{hour:02}");
+                DropdownItem::with_value(value.clone(), value)
+            })
+            .collect()
+    }
+
+    fn minute_items() -> Vec<DropdownItem> {
+        (0..60)
+            .map(|minute| {
+                let value = format!("{minute:02}");
+                DropdownItem::with_value(value.clone(), value)
+            })
+            .collect()
     }
 
     fn level_items() -> Vec<DropdownItem> {
@@ -1277,13 +1618,8 @@ impl AuditDocument {
         }
     }
 
-    fn format_timestamp_ms(ms: i64) -> String {
-        let secs = ms / 1000;
-        let millis = ms % 1000;
-        let hours = (secs / 3600) % 24;
-        let minutes = (secs / 60) % 60;
-        let secs = secs % 60;
-        format!("{:02}:{:02}:{:02}.{:03}", hours, minutes, secs, millis)
+    fn format_timestamp_ms(&self, ms: i64) -> String {
+        format_timestamp_ms(ms, self.timestamp_mode)
     }
 
     fn format_connection_driver(
@@ -1334,6 +1670,10 @@ impl AuditDocument {
             self.clear_filters(window, cx);
             self.filter_bar.deactivate();
             self.focus_handle.focus(window);
+        } else if self.toolbar_index(ToolbarSlot::CustomApply) == Some(focused_index) {
+            if self.can_apply_custom_time_range(cx) {
+                self.apply_custom_time_range(cx);
+            }
         } else if self.toolbar_index(ToolbarSlot::Level) == Some(focused_index) {
             self.multi_select_level
                 .update(cx, |ms, cx| ms.toggle_open(cx));
@@ -2109,10 +2449,12 @@ impl AuditDocument {
         let theme = cx.theme().clone();
 
         // Search input.
+        let custom_range_visible = self.selected_time_range == Some(TimeRange::Custom);
+
         let search_control = div()
             .flex()
             .items_center()
-            .w(px(220.0))
+            .w(px(360.0))
             .rounded(Radii::SM)
             .when(self.slot_has_ring(ToolbarSlot::Search), |d| {
                 d.border_1().border_color(theme.ring)
@@ -2130,6 +2472,95 @@ impl AuditDocument {
                 d.border_1().border_color(theme.ring)
             })
             .child(self.dropdown_time_range.clone());
+
+        let timestamp_mode_control = div()
+            .rounded(Radii::SM)
+            .when(self.slot_has_ring(ToolbarSlot::Timezone), |d| {
+                d.border_1().border_color(theme.ring)
+            })
+            .child(self.dropdown_timestamp_mode.clone());
+
+        let can_apply_custom_time_range = self.can_apply_custom_time_range(cx);
+        let custom_apply_button = div()
+            .id("audit-custom-time-apply")
+            .h(Heights::BUTTON)
+            .flex()
+            .items_center()
+            .px(Spacing::SM)
+            .rounded(Radii::SM)
+            .border_1()
+            .border_color(if self.slot_has_ring(ToolbarSlot::CustomApply) {
+                theme.ring
+            } else {
+                theme.input
+            })
+            .when(can_apply_custom_time_range, |d| {
+                d.cursor_pointer()
+                    .hover(|d| d.bg(theme.secondary))
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.apply_custom_time_range(cx);
+                    }))
+            })
+            .when(!can_apply_custom_time_range, |d| d.opacity(0.45))
+            .child(Text::caption("Apply"));
+
+        let custom_time_controls = div()
+            .flex()
+            .items_center()
+            .gap_1()
+            .child(
+                div()
+                    .w(px(260.0))
+                    .rounded(Radii::SM)
+                    .when(self.slot_has_ring(ToolbarSlot::CustomStart), |d| {
+                        d.border_1().border_color(theme.ring)
+                    })
+                    .child(
+                        DatePicker::new(&self.custom_date_range_picker)
+                            .small()
+                            .placeholder("Select date range")
+                            .number_of_months(2),
+                    ),
+            )
+            .child(Text::caption("from"))
+            .child(
+                div()
+                    .w(px(72.0))
+                    .rounded(Radii::SM)
+                    .when(self.slot_has_ring(ToolbarSlot::CustomStart), |d| {
+                        d.border_1().border_color(theme.ring)
+                    })
+                    .child(self.custom_start_hour_dropdown.clone()),
+            )
+            .child(
+                div()
+                    .w(px(72.0))
+                    .rounded(Radii::SM)
+                    .when(self.slot_has_ring(ToolbarSlot::CustomStart), |d| {
+                        d.border_1().border_color(theme.ring)
+                    })
+                    .child(self.custom_start_minute_dropdown.clone()),
+            )
+            .child(Text::caption("to"))
+            .child(
+                div()
+                    .w(px(72.0))
+                    .rounded(Radii::SM)
+                    .when(self.slot_has_ring(ToolbarSlot::CustomEnd), |d| {
+                        d.border_1().border_color(theme.ring)
+                    })
+                    .child(self.custom_end_hour_dropdown.clone()),
+            )
+            .child(
+                div()
+                    .w(px(72.0))
+                    .rounded(Radii::SM)
+                    .when(self.slot_has_ring(ToolbarSlot::CustomEnd), |d| {
+                        d.border_1().border_color(theme.ring)
+                    })
+                    .child(self.custom_end_minute_dropdown.clone()),
+            )
+            .child(custom_apply_button);
 
         let level_control = div()
             .rounded(Radii::SM)
@@ -2237,7 +2668,12 @@ impl AuditDocument {
             let mut items = vec![
                 search_control.into_any_element(),
                 time_control.into_any_element(),
+                timestamp_mode_control.into_any_element(),
             ];
+
+            if custom_range_visible {
+                items.push(custom_time_controls.into_any_element());
+            }
 
             if !self.is_external_event_stream() {
                 items.extend([
@@ -2255,6 +2691,11 @@ impl AuditDocument {
 
             items
         })
+        .h(px(64.0))
+        .items_center()
+        .justify_center()
+        .py(Spacing::XS)
+        .flex_wrap()
     }
 
     fn render_event_list(&mut self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
@@ -2336,7 +2777,7 @@ impl AuditDocument {
         // When focus moves to the sidebar, the highlight disappears so the
         // user isn't confused by three simultaneous focus indicators.
         let is_selected = self.has_focus && self.selected_row == Some(row_index);
-        let timestamp = Self::format_timestamp_ms(event.created_at_epoch_ms);
+        let timestamp = self.format_timestamp_ms(event.created_at_epoch_ms);
         let summary = event.summary.clone().unwrap_or_default();
         let summary_display: AnyElement = if summary.is_empty() {
             Self::null_display(&theme).into_any_element()
@@ -2488,7 +2929,7 @@ impl AuditDocument {
         }
 
         let theme = cx.theme().clone();
-        let timestamp = Self::format_timestamp_ms(event.created_at_epoch_ms);
+        let timestamp = self.format_timestamp_ms(event.created_at_epoch_ms);
         let level = event.level.clone();
         let category = match Self::short_category_label(event.category.as_deref()) {
             "NULL" => None,
@@ -2636,7 +3077,7 @@ impl AuditDocument {
     ) -> AnyElement {
         let theme = cx.theme().clone();
         let row_event_id = event.id;
-        let timestamp = Self::format_timestamp_ms(event.created_at_epoch_ms);
+        let timestamp = self.format_timestamp_ms(event.created_at_epoch_ms);
         let source_name = event.connection_id.clone();
         let source_partition = event.action.clone();
         let event_id = event.object_id.clone();
@@ -2644,7 +3085,7 @@ impl AuditDocument {
             .error_message
             .as_deref()
             .and_then(|value| value.parse::<i64>().ok())
-            .map(Self::format_timestamp_ms);
+            .map(|value| self.format_timestamp_ms(value));
         let message = event.summary.clone().filter(|value| !value.is_empty());
         let details_json = event.details_json.clone().filter(|value| !value.is_empty());
 
@@ -2676,7 +3117,8 @@ impl AuditDocument {
                     }),
             )
             .when_some(message, |root, value| {
-                let message_input = self.ensure_external_message_input(row_event_id, &value, window, cx);
+                let message_input =
+                    self.ensure_external_message_input(row_event_id, &value, window, cx);
 
                 root.child(
                     div()
@@ -2698,15 +3140,11 @@ impl AuditDocument {
                         .gap_1p5()
                         .child(Label::new("Details"))
                         .child(
-                            div()
-                                .bg(theme.secondary)
-                                .p_2()
-                                .rounded(px(4.0))
-                                .child(
-                                    ReadonlyTextView::new(&details_input)
-                                        .w_full()
-                                        .h(Self::event_text_height(details_rows)),
-                                ),
+                            div().bg(theme.secondary).p_2().rounded(px(4.0)).child(
+                                ReadonlyTextView::new(&details_input)
+                                    .w_full()
+                                    .h(Self::event_text_height(details_rows)),
+                            ),
                         ),
                 )
             })
@@ -2904,9 +3342,10 @@ impl AuditDocument {
             .flex()
             .items_center()
             .gap(Spacing::SM)
-            .when(self.total_events > 0 && !self.is_external_event_stream(), |d| {
-                d.child(self.render_export_button(&theme, cx))
-            })
+            .when(
+                self.total_events > 0 && !self.is_external_event_stream(),
+                |d| d.child(self.render_export_button(&theme, cx)),
+            )
             .when_some(
                 self.status_message.clone().filter(|_| self.is_loading),
                 |d, _| d.child(Text::dim("Loading...")),

--- a/crates/dbflux_ui/src/ui/document/audit/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/audit/mod.rs
@@ -16,10 +16,12 @@ use crate::ui::components::multi_select::{MultiSelect, MultiSelectChanged};
 use crate::ui::components::toast::{PendingToast, flush_pending_toast};
 use crate::ui::icons::AppIcon;
 use crate::ui::tokens::{FontSizes, Heights, Radii, Spacing};
-use dbflux_components::controls::{GpuiInput as Input, InputEvent, InputState};
+use dbflux_components::controls::{
+    GpuiInput as Input, InputEvent, InputState, ReadonlyTextView, SelectableText,
+};
 use dbflux_components::primitives::{Icon, Label, Text, surface_raised};
 use dbflux_core::{
-    CollectionBrowseRequest, CollectionRef, Pagination, RefreshPolicy, Value,
+    CollectionRef, EventQuery, EventRecord, EventStreamTarget, Pagination, RefreshPolicy,
     observability::{EventCategory, EventOutcome, EventSeverity},
 };
 use dbflux_storage::repositories::audit::{AuditEventDto, AuditQueryFilter};
@@ -102,14 +104,9 @@ enum AuditDocumentSource {
     Internal {
         adapter: AuditSourceAdapter,
     },
-    CloudWatchLogGroup {
+    ExternalEventStream {
         profile_id: Uuid,
-        collection: CollectionRef,
-    },
-    CloudWatchLogStream {
-        profile_id: Uuid,
-        collection: CollectionRef,
-        log_stream: String,
+        target: EventStreamTarget,
     },
 }
 
@@ -125,7 +122,7 @@ enum ToolbarSlot {
     Clear,
 }
 
-struct CloudWatchLoadResult {
+struct LoadedEventPage {
     events: Vec<AuditEventDto>,
     total_events: u64,
 }
@@ -138,8 +135,8 @@ pub struct AuditDocument {
     events: Vec<AuditEventDto>,
     total_events: u64,
     expanded_event_ids: HashSet<i64>,
-    cloudwatch_message_inputs: HashMap<i64, Entity<InputState>>,
-    cloudwatch_details_inputs: HashMap<i64, Entity<InputState>>,
+    external_message_inputs: HashMap<i64, Entity<InputState>>,
+    external_details_inputs: HashMap<i64, Entity<InputState>>,
     pagination: Pagination,
     status_message: Option<String>,
     is_loading: bool,
@@ -201,47 +198,22 @@ impl AuditDocument {
         )
     }
 
-    pub fn new_for_cloudwatch_log_group(
+    pub fn new_for_event_stream(
         profile_id: Uuid,
-        collection: CollectionRef,
+        target: EventStreamTarget,
+        title: String,
         app_state: Entity<AppStateEntity>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let title = collection.name.clone();
-
         Self::new_with_source(
             app_state,
-            AuditDocumentSource::CloudWatchLogGroup {
+            AuditDocumentSource::ExternalEventStream {
                 profile_id,
-                collection,
+                target,
             },
             title,
-            "Filter pattern...",
-            window,
-            cx,
-        )
-    }
-
-    pub fn new_for_cloudwatch_log_stream(
-        profile_id: Uuid,
-        collection: CollectionRef,
-        log_stream: String,
-        app_state: Entity<AppStateEntity>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> Self {
-        let title = format!("{} · {}", collection.name, log_stream);
-
-        Self::new_with_source(
-            app_state,
-            AuditDocumentSource::CloudWatchLogStream {
-                profile_id,
-                collection,
-                log_stream,
-            },
-            title,
-            "Filter pattern...",
+            "Filter events...",
             window,
             cx,
         )
@@ -261,7 +233,7 @@ impl AuditDocument {
 
         let initial_time_range = Self::initial_time_range(&source);
         let time_range_placeholder =
-            if matches!(source, AuditDocumentSource::CloudWatchLogStream { .. }) {
+            if matches!(source, AuditDocumentSource::ExternalEventStream { .. }) {
                 "All time"
             } else {
                 "Last 24 h"
@@ -455,8 +427,8 @@ impl AuditDocument {
             events: Vec::new(),
             total_events: 0,
             expanded_event_ids: HashSet::new(),
-            cloudwatch_message_inputs: HashMap::new(),
-            cloudwatch_details_inputs: HashMap::new(),
+            external_message_inputs: HashMap::new(),
+            external_details_inputs: HashMap::new(),
             pagination: Pagination::Offset {
                 limit: DEFAULT_PAGE_SIZE,
                 offset: 0,
@@ -514,44 +486,22 @@ impl AuditDocument {
         doc
     }
 
-    pub fn is_cloudwatch_log_group(&self, profile_id: Uuid, collection: &CollectionRef) -> bool {
-        match &self.source {
-            AuditDocumentSource::CloudWatchLogGroup {
-                profile_id: doc_profile_id,
-                collection: doc_collection,
-            } => *doc_profile_id == profile_id && doc_collection == collection,
-            AuditDocumentSource::Internal { .. } => false,
-            AuditDocumentSource::CloudWatchLogStream { .. } => false,
-        }
-    }
-
-    pub fn is_cloudwatch_log_stream(
+    pub fn matches_event_stream(
         &self,
         profile_id: Uuid,
-        collection: &CollectionRef,
-        log_stream: &str,
+        target: &EventStreamTarget,
     ) -> bool {
         match &self.source {
-            AuditDocumentSource::CloudWatchLogStream {
+            AuditDocumentSource::ExternalEventStream {
                 profile_id: doc_profile_id,
-                collection: doc_collection,
-                log_stream: doc_log_stream,
-            } => {
-                *doc_profile_id == profile_id
-                    && doc_collection == collection
-                    && doc_log_stream == log_stream
-            }
-            AuditDocumentSource::Internal { .. }
-            | AuditDocumentSource::CloudWatchLogGroup { .. } => false,
+                target: doc_target,
+            } => *doc_profile_id == profile_id && doc_target == target,
+            AuditDocumentSource::Internal { .. } => false,
         }
     }
 
-    fn is_cloudwatch_source(&self) -> bool {
-        matches!(
-            self.source,
-            AuditDocumentSource::CloudWatchLogGroup { .. }
-                | AuditDocumentSource::CloudWatchLogStream { .. }
-        )
+    fn is_external_event_stream(&self) -> bool {
+        matches!(self.source, AuditDocumentSource::ExternalEventStream { .. })
     }
 
     fn toolbar_index(&self, slot: ToolbarSlot) -> Option<usize> {
@@ -564,14 +514,11 @@ impl AuditDocument {
             (AuditDocumentSource::Internal { .. }, ToolbarSlot::Refresh) => Some(5),
             (AuditDocumentSource::Internal { .. }, ToolbarSlot::RefreshPolicy) => Some(6),
             (AuditDocumentSource::Internal { .. }, ToolbarSlot::Clear) => Some(7),
-            (AuditDocumentSource::CloudWatchLogGroup { .. }, ToolbarSlot::Refresh)
-            | (AuditDocumentSource::CloudWatchLogStream { .. }, ToolbarSlot::Refresh) => Some(2),
-            (AuditDocumentSource::CloudWatchLogGroup { .. }, ToolbarSlot::RefreshPolicy)
-            | (AuditDocumentSource::CloudWatchLogStream { .. }, ToolbarSlot::RefreshPolicy) => {
+            (AuditDocumentSource::ExternalEventStream { .. }, ToolbarSlot::Refresh) => Some(2),
+            (AuditDocumentSource::ExternalEventStream { .. }, ToolbarSlot::RefreshPolicy) => {
                 Some(3)
             }
-            (AuditDocumentSource::CloudWatchLogGroup { .. }, ToolbarSlot::Clear)
-            | (AuditDocumentSource::CloudWatchLogStream { .. }, ToolbarSlot::Clear) => Some(4),
+            (AuditDocumentSource::ExternalEventStream { .. }, ToolbarSlot::Clear) => Some(4),
             _ => None,
         }
     }
@@ -650,16 +597,15 @@ impl AuditDocument {
 
     fn initial_time_range(source: &AuditDocumentSource) -> Option<usize> {
         match source {
-            AuditDocumentSource::CloudWatchLogStream { .. } => None,
-            AuditDocumentSource::Internal { .. }
-            | AuditDocumentSource::CloudWatchLogGroup { .. } => Some(2),
+            AuditDocumentSource::ExternalEventStream { .. } => None,
+            AuditDocumentSource::Internal { .. } => Some(2),
         }
     }
 
     fn default_filters_for_source(source: &AuditDocumentSource) -> AuditFilters {
         let mut filters = AuditFilters::default();
 
-        if !matches!(source, AuditDocumentSource::CloudWatchLogStream { .. }) {
+        if !matches!(source, AuditDocumentSource::ExternalEventStream { .. }) {
             let (start_ms, end_ms) = TimeRange::Last24h.to_filter_values();
             filters.start_ms = start_ms;
             filters.end_ms = end_ms;
@@ -669,188 +615,83 @@ impl AuditDocument {
     }
 
     fn source_loading_label(&self) -> &'static str {
-        if self.is_cloudwatch_source() {
-            "Loading log events..."
+        if self.is_external_event_stream() {
+            "Loading events..."
         } else {
             "Loading audit events..."
         }
     }
 
     fn source_error_heading(&self) -> &'static str {
-        if self.is_cloudwatch_source() {
-            "Failed to load log events"
+        if self.is_external_event_stream() {
+            "Failed to load events"
         } else {
             "Failed to load audit events"
         }
     }
 
     fn source_empty_label(&self) -> &'static str {
-        if self.is_cloudwatch_source() {
-            "No log events match the current filters."
+        if self.is_external_event_stream() {
+            "No events match the current filters."
         } else {
             "No audit events match the current filters."
         }
     }
 
     fn source_row_label(&self) -> &'static str {
-        if self.is_cloudwatch_source() {
+        if self.is_external_event_stream() {
             "events"
         } else {
             "rows"
         }
     }
 
-    fn cloudwatch_browse_request(
-        collection: CollectionRef,
-        filter_pattern: Option<String>,
-        start_ms: Option<i64>,
-        end_ms: Option<i64>,
-        pagination: Pagination,
-    ) -> CollectionBrowseRequest {
-        let mut request = CollectionBrowseRequest::new(collection).with_pagination(pagination);
-
-        let mut filter = serde_json::Map::new();
-
-        if let Some(pattern) = filter_pattern.filter(|value| !value.trim().is_empty()) {
-            filter.insert("filter_pattern".to_string(), JsonValue::String(pattern));
-        }
-
-        if let Some(start_ms) = start_ms {
-            filter.insert("start_ms".to_string(), json!(start_ms));
-        }
-
-        if let Some(end_ms) = end_ms {
-            filter.insert("end_ms".to_string(), json!(end_ms));
-        }
-
-        if !filter.is_empty() {
-            request = request.with_filter(JsonValue::Object(filter));
-        }
-
-        request
-    }
-
-    fn cloudwatch_stream_browse_request(
-        collection: CollectionRef,
-        log_stream: String,
-        filter_pattern: Option<String>,
-        start_ms: Option<i64>,
-        end_ms: Option<i64>,
-        pagination: Pagination,
-    ) -> CollectionBrowseRequest {
-        let mut request = CollectionBrowseRequest::new(collection).with_pagination(pagination);
-
-        let mut filter = serde_json::Map::new();
-
-        if let Some(pattern) = filter_pattern.filter(|value| !value.trim().is_empty()) {
-            filter.insert("filter_pattern".to_string(), JsonValue::String(pattern));
-        }
-
-        if let Some(start_ms) = start_ms {
-            filter.insert("start_ms".to_string(), json!(start_ms));
-        }
-
-        if let Some(end_ms) = end_ms {
-            filter.insert("end_ms".to_string(), json!(end_ms));
-        }
-
-        filter.insert("log_stream_names".to_string(), json!([log_stream]));
-        filter.insert("most_recent".to_string(), JsonValue::Bool(true));
-
-        request = request.with_filter(JsonValue::Object(filter));
-        request
-    }
-
-    fn cloudwatch_result_to_page(
-        result: dbflux_core::QueryResult,
-        collection: CollectionRef,
-        pagination_offset: u64,
-    ) -> CloudWatchLoadResult {
-        let has_next_page = result.next_page_token.is_some();
-        let events = result
-            .rows
-            .iter()
-            .enumerate()
-            .map(|(index, row)| {
-                Self::cloudwatch_row_to_event(row, &collection, pagination_offset, index)
-            })
+    fn external_page_to_loaded(page: dbflux_core::EventPage) -> LoadedEventPage {
+        let events = page
+            .events
+            .into_iter()
+            .map(Self::audit_event_from_record)
             .collect::<Vec<_>>();
-        let total_events = pagination_offset + events.len() as u64 + u64::from(has_next_page);
+        let total_events = page
+            .total
+            .map(|value| value as u64)
+            .unwrap_or_else(|| page.offset as u64 + events.len() as u64 + u64::from(page.has_more));
 
-        CloudWatchLoadResult {
+        LoadedEventPage {
             events,
             total_events,
         }
     }
 
-    fn cloudwatch_row_to_event(
-        row: &[Value],
-        collection: &CollectionRef,
-        pagination_offset: u64,
-        row_index: usize,
-    ) -> AuditEventDto {
-        let timestamp_ms = Self::int_cell(row, 0).unwrap_or_default();
-        let ingestion_time_ms = Self::int_cell(row, 1);
-        let log_stream_name = Self::text_cell(row, 2);
-        let message = Self::text_cell(row, 3);
-        let event_id = Self::text_cell(row, 4);
-        let message_details = Self::cloudwatch_message_details(message.as_deref());
-
-        let details_json = json!({
-            "log_group": collection.name,
-            "timestamp_ms": timestamp_ms,
-            "ingestion_time_ms": ingestion_time_ms,
-            "log_stream_name": log_stream_name,
-            "message": message_details,
-            "event_id": event_id,
-        })
-        .to_string();
-
+    fn audit_event_from_record(record: EventRecord) -> AuditEventDto {
         AuditEventDto {
-            id: (pagination_offset + row_index as u64 + 1) as i64,
-            actor_id: String::new(),
-            tool_id: "cloudwatch_log_event".to_string(),
+            id: record.id.unwrap_or_default(),
+            actor_id: record.actor_id.unwrap_or_default(),
+            tool_id: record.action.clone(),
             decision: String::new(),
             reason: None,
             profile_id: None,
             classification: None,
-            duration_ms: None,
-            created_at: timestamp_ms.to_string(),
-            created_at_epoch_ms: timestamp_ms,
-            level: None,
-            category: None,
-            action: log_stream_name,
-            outcome: None,
-            actor_type: None,
-            source_id: None,
-            summary: message,
-            connection_id: Some(collection.name.clone()),
-            database_name: Some(collection.database.clone()),
-            driver_id: Some("cloudwatch".to_string()),
-            object_type: Some("log_event".to_string()),
-            object_id: event_id,
-            details_json: Some(details_json),
-            error_code: None,
-            error_message: ingestion_time_ms.map(|value| value.to_string()),
-            session_id: None,
-            correlation_id: None,
-        }
-    }
-
-    fn int_cell(row: &[Value], index: usize) -> Option<i64> {
-        match row.get(index) {
-            Some(Value::Int(value)) => Some(*value),
-            Some(Value::Text(value)) => value.parse().ok(),
-            _ => None,
-        }
-    }
-
-    fn text_cell(row: &[Value], index: usize) -> Option<String> {
-        match row.get(index) {
-            Some(Value::Text(value)) if !value.is_empty() => Some(value.clone()),
-            Some(Value::Int(value)) => Some(value.to_string()),
-            Some(Value::Null) | None => None,
-            Some(value) => Some(value.to_string()),
+            duration_ms: record.duration_ms,
+            created_at: record.ts_ms.to_string(),
+            created_at_epoch_ms: record.ts_ms,
+            level: Some(record.level.as_str().to_string()),
+            category: Some(record.category.as_str().to_string()),
+            action: Some(record.action),
+            outcome: Some(record.outcome.as_str().to_string()),
+            actor_type: Some(record.actor_type.as_str().to_string()),
+            source_id: Some(record.source_id.as_str().to_string()),
+            summary: Some(record.summary),
+            connection_id: record.connection_id,
+            database_name: record.database_name,
+            driver_id: record.driver_id,
+            object_type: record.object_type,
+            object_id: record.object_id,
+            details_json: record.details_json,
+            error_code: record.error_code,
+            error_message: record.error_message,
+            session_id: record.session_id,
+            correlation_id: record.correlation_id,
         }
     }
 
@@ -985,16 +826,13 @@ impl AuditDocument {
                     let events = adapter.query_filter(&page_filter)?;
                     let total = adapter.count_filter(&count_filter)?;
 
-                    Ok::<_, String>(CloudWatchLoadResult {
+                    Ok::<_, String>(LoadedEventPage {
                         events,
                         total_events: total,
                     })
                 })
             }
-            AuditDocumentSource::CloudWatchLogGroup {
-                profile_id,
-                collection,
-            } => {
+            AuditDocumentSource::ExternalEventStream { profile_id, target } => {
                 let Some(connection) = self
                     .app_state
                     .read(cx)
@@ -1006,77 +844,27 @@ impl AuditDocument {
                     self.total_events = 0;
                     self.expanded_event_ids.clear();
                     self.is_loading = false;
-                    self.status_message =
-                        Some("Connection not found for this log group".to_string());
+                    self.status_message = Some("Connection not found for this event source".to_string());
                     cx.notify();
                     return;
                 };
 
-                let browse_request = Self::cloudwatch_browse_request(
-                    collection.clone(),
-                    self.filters.free_text.clone(),
-                    self.filters.start_ms,
-                    self.filters.end_ms,
-                    self.pagination.clone(),
-                );
-                let collection_for_task = collection.clone();
-                let pagination_offset = self.pagination.offset();
-
-                cx.background_executor().spawn(async move {
-                    let result = connection
-                        .browse_collection(&browse_request)
-                        .map_err(|error| format!("cloudwatch browse failed: {error}"))?;
-
-                    Ok::<_, String>(Self::cloudwatch_result_to_page(
-                        result,
-                        collection_for_task,
-                        pagination_offset,
-                    ))
-                })
-            }
-            AuditDocumentSource::CloudWatchLogStream {
-                profile_id,
-                collection,
-                log_stream,
-            } => {
-                let Some(connection) = self
-                    .app_state
-                    .read(cx)
-                    .connections()
-                    .get(profile_id)
-                    .map(|connected| connected.connection.clone())
-                else {
-                    self.events.clear();
-                    self.total_events = 0;
-                    self.expanded_event_ids.clear();
-                    self.is_loading = false;
-                    self.status_message =
-                        Some("Connection not found for this log stream".to_string());
-                    cx.notify();
-                    return;
+                let target = target.clone();
+                let query = EventQuery {
+                    from_ts_ms: self.filters.start_ms,
+                    to_ts_ms: self.filters.end_ms,
+                    free_text: self.filters.free_text.clone(),
+                    limit: Some(self.pagination_limit()),
+                    offset: Some(self.pagination_offset()),
+                    ..EventQuery::default()
                 };
 
-                let browse_request = Self::cloudwatch_stream_browse_request(
-                    collection.clone(),
-                    log_stream.clone(),
-                    self.filters.free_text.clone(),
-                    self.filters.start_ms,
-                    self.filters.end_ms,
-                    self.pagination.clone(),
-                );
-                let collection_for_task = collection.clone();
-                let pagination_offset = self.pagination.offset();
-
                 cx.background_executor().spawn(async move {
-                    let result = connection
-                        .browse_collection(&browse_request)
-                        .map_err(|error| format!("cloudwatch stream browse failed: {error}"))?;
+                    let page = connection
+                        .browse_event_stream(&target, &query)
+                        .map_err(|error| format!("external event stream browse failed: {error}"))?;
 
-                    Ok::<_, String>(Self::cloudwatch_result_to_page(
-                        result,
-                        collection_for_task,
-                        pagination_offset,
-                    ))
+                    Ok::<_, String>(Self::external_page_to_loaded(page))
                 })
             }
         };
@@ -1098,7 +886,7 @@ impl AuditDocument {
                         doc.status_message = None;
                         doc.expanded_event_ids
                             .retain(|event_id| visible_ids.contains(event_id));
-                        doc.retain_cloudwatch_inline_inputs(&visible_ids);
+                        doc.retain_external_inline_inputs(&visible_ids);
 
                         cx.notify();
                     })
@@ -1114,7 +902,7 @@ impl AuditDocument {
                         doc.events.clear();
                         doc.total_events = 0;
                         doc.expanded_event_ids.clear();
-                        doc.clear_cloudwatch_inline_inputs();
+                        doc.clear_external_inline_inputs();
                         doc.is_loading = false;
                         doc.status_message = Some(format!("Error loading events: {}", error));
 
@@ -1162,29 +950,29 @@ impl AuditDocument {
         cx.notify();
     }
 
-    fn retain_cloudwatch_inline_inputs(&mut self, visible_ids: &HashSet<i64>) {
-        Self::retain_cloudwatch_input_cache(&mut self.cloudwatch_message_inputs, visible_ids);
-        Self::retain_cloudwatch_input_cache(&mut self.cloudwatch_details_inputs, visible_ids);
+    fn retain_external_inline_inputs(&mut self, visible_ids: &HashSet<i64>) {
+        Self::retain_event_input_cache(&mut self.external_message_inputs, visible_ids);
+        Self::retain_event_input_cache(&mut self.external_details_inputs, visible_ids);
     }
 
-    fn retain_cloudwatch_input_cache<T>(cache: &mut HashMap<i64, T>, visible_ids: &HashSet<i64>) {
+    fn retain_event_input_cache<T>(cache: &mut HashMap<i64, T>, visible_ids: &HashSet<i64>) {
         cache.retain(|event_id, _| visible_ids.contains(event_id));
     }
 
-    fn clear_cloudwatch_inline_inputs(&mut self) {
-        self.cloudwatch_message_inputs.clear();
-        self.cloudwatch_details_inputs.clear();
+    fn clear_external_inline_inputs(&mut self) {
+        self.external_message_inputs.clear();
+        self.external_details_inputs.clear();
     }
 
-    fn ensure_cloudwatch_message_input(
+    fn ensure_external_message_input(
         &mut self,
         event_id: i64,
         message: &str,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Entity<InputState> {
-        Self::ensure_cloudwatch_text_input(
-            &mut self.cloudwatch_message_inputs,
+        Self::ensure_event_text_input(
+            &mut self.external_message_inputs,
             event_id,
             message,
             None,
@@ -1193,15 +981,15 @@ impl AuditDocument {
         )
     }
 
-    fn ensure_cloudwatch_details_input(
+    fn ensure_external_details_input(
         &mut self,
         event_id: i64,
         details_json: &str,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Entity<InputState> {
-        Self::ensure_cloudwatch_text_input(
-            &mut self.cloudwatch_details_inputs,
+        Self::ensure_event_text_input(
+            &mut self.external_details_inputs,
             event_id,
             details_json,
             Some("json"),
@@ -1210,7 +998,7 @@ impl AuditDocument {
         )
     }
 
-    fn ensure_cloudwatch_text_input(
+    fn ensure_event_text_input(
         cache: &mut HashMap<i64, Entity<InputState>>,
         event_id: i64,
         value: &str,
@@ -1220,9 +1008,9 @@ impl AuditDocument {
     ) -> Entity<InputState> {
         let value = value.to_string();
         let rows = if editor_mode.is_some() {
-            Self::cloudwatch_text_rows(&value, 4)
+            Self::event_text_rows(&value, 4)
         } else {
-            Self::cloudwatch_text_rows(&value, 2)
+            Self::event_text_rows(&value, 2)
         };
 
         let input = cache
@@ -1258,19 +1046,26 @@ impl AuditDocument {
         input
     }
 
-    fn cloudwatch_text_rows(value: &str, min_rows: usize) -> usize {
+    fn event_text_rows(value: &str, min_rows: usize) -> usize {
+        const ESTIMATED_CHARS_PER_ROW: usize = 80;
+
         let line_rows = value.lines().count().max(1);
         let wrap_rows = value
             .lines()
-            .map(|line| (line.chars().count() / 120).saturating_add(1))
+            .map(|line| {
+                let char_count = line.chars().count();
+                char_count
+                    .div_ceil(ESTIMATED_CHARS_PER_ROW)
+                    .max(1)
+            })
             .sum::<usize>()
             .max(1);
 
         line_rows.max(wrap_rows).max(min_rows)
     }
 
-    fn cloudwatch_text_height(rows: usize) -> Pixels {
-        px((rows as f32 * 22.0) + 16.0)
+    fn event_text_height(rows: usize) -> Pixels {
+        px((rows as f32 * 24.0) + 20.0)
     }
 
     fn go_to_prev_page(&mut self, cx: &mut Context<Self>) {
@@ -1505,12 +1300,6 @@ impl AuditDocument {
         } else {
             json.to_string()
         }
-    }
-
-    fn cloudwatch_message_details(message: Option<&str>) -> serde_json::Value {
-        message
-            .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
-            .unwrap_or_else(|| json!(message))
     }
 
     fn filter_by_correlation(&mut self, correlation_id: String, cx: &mut Context<Self>) {
@@ -2443,7 +2232,7 @@ impl AuditDocument {
                 time_control.into_any_element(),
             ];
 
-            if !self.is_cloudwatch_source() {
+            if !self.is_external_event_stream() {
                 items.extend([
                     level_control.into_any_element(),
                     category_control.into_any_element(),
@@ -2549,8 +2338,8 @@ impl AuditDocument {
         };
         let connection_driver =
             Self::format_connection_driver(&event.connection_id, &event.driver_id);
-        let log_stream = event.action.clone();
-        let cloudwatch_event_id = event.object_id.clone();
+        let event_action = event.action.clone();
+        let external_event_id = event.object_id.clone();
 
         // Background priority: selected (keyboard cursor) > expanded > default.
         // Use theme.list_active for the selected row — same token as key_value and sidebar.
@@ -2607,8 +2396,8 @@ impl AuditDocument {
                         .muted(),
                     )
                     .child(Text::code(timestamp))
-                    .when(self.is_cloudwatch_source(), |row| {
-                        row.when_some(log_stream.clone(), |row, value| {
+                    .when(self.is_external_event_stream(), |row| {
+                        row.when_some(event_action.clone(), |row, value| {
                             row.child(
                                 div()
                                     .px_1p5()
@@ -2624,7 +2413,7 @@ impl AuditDocument {
                             )
                         })
                     })
-                    .when(!self.is_cloudwatch_source(), |row| {
+                    .when(!self.is_external_event_stream(), |row| {
                         let level = event.level.as_deref();
                         let level_display: AnyElement = match level {
                             Some(l) => div()
@@ -2650,7 +2439,7 @@ impl AuditDocument {
                     })
                     .child(div().text_sm().flex_1().truncate().child(summary_display))
                     .when_some(
-                        cloudwatch_event_id.filter(|_| self.is_cloudwatch_source()),
+                        external_event_id.filter(|_| self.is_external_event_stream()),
                         |row, value| row.child(Text::caption(value)),
                     )
                     .when_some(
@@ -2687,8 +2476,8 @@ impl AuditDocument {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        if self.is_cloudwatch_source() {
-            return self.render_cloudwatch_inline_detail(event, window, cx);
+        if self.is_external_event_stream() {
+            return self.render_external_inline_detail(event, window, cx);
         }
 
         let theme = cx.theme().clone();
@@ -2832,7 +2621,7 @@ impl AuditDocument {
             .into_any_element()
     }
 
-    fn render_cloudwatch_inline_detail(
+    fn render_external_inline_detail(
         &mut self,
         event: AuditEventDto,
         window: &mut Window,
@@ -2841,10 +2630,10 @@ impl AuditDocument {
         let theme = cx.theme().clone();
         let row_event_id = event.id;
         let timestamp = Self::format_timestamp_ms(event.created_at_epoch_ms);
-        let log_group = event.connection_id.clone();
-        let log_stream = event.action.clone();
-        let log_event_id = event.object_id.clone();
-        let ingestion_time = event
+        let source_name = event.connection_id.clone();
+        let source_partition = event.action.clone();
+        let event_id = event.object_id.clone();
+        let secondary_timestamp = event
             .error_message
             .as_deref()
             .and_then(|value| value.parse::<i64>().ok())
@@ -2868,21 +2657,20 @@ impl AuditDocument {
                     .children(vec![
                         self.render_detail_field("Time", Some(timestamp), &theme)
                             .into_any_element(),
-                        self.render_detail_field("Log Group", log_group, &theme)
+                        self.render_detail_field("Source", source_name, &theme)
                             .into_any_element(),
-                        self.render_detail_field("Log Stream", log_stream, &theme)
+                        self.render_detail_field("Partition", source_partition, &theme)
                             .into_any_element(),
-                        self.render_detail_field("Event ID", log_event_id, &theme)
+                        self.render_detail_field("Event ID", event_id, &theme)
                             .into_any_element(),
                     ])
-                    .when_some(ingestion_time, |row, value| {
-                        row.child(self.render_detail_field("Ingestion Time", Some(value), &theme))
+                    .when_some(secondary_timestamp, |row, value| {
+                        row.child(self.render_detail_field("Secondary Time", Some(value), &theme))
                     }),
             )
             .when_some(message, |root, value| {
-                let message_input =
-                    self.ensure_cloudwatch_message_input(row_event_id, &value, window, cx);
-                let message_rows = Self::cloudwatch_text_rows(&value, 2);
+                let message_input = self.ensure_external_message_input(row_event_id, &value, window, cx);
+                let message_rows = Self::event_text_rows(&value, 2);
 
                 root.child(
                     div()
@@ -2890,20 +2678,17 @@ impl AuditDocument {
                         .gap_1p5()
                         .child(Label::new("Message"))
                         .child(
-                            div().h(Self::cloudwatch_text_height(message_rows)).child(
-                                Input::new(&message_input)
-                                    .appearance(false)
-                                    .w_full()
-                                    .h_full(),
-                            ),
+                            div()
+                                .h(Self::event_text_height(message_rows))
+                                .child(SelectableText::new(&message_input).w_full().h_full()),
                         ),
                 )
             })
             .when_some(details_json, |root, value| {
                 let pretty_details = Self::pretty_json(&value);
                 let details_input =
-                    self.ensure_cloudwatch_details_input(row_event_id, &pretty_details, window, cx);
-                let details_rows = Self::cloudwatch_text_rows(&pretty_details, 4);
+                    self.ensure_external_details_input(row_event_id, &pretty_details, window, cx);
+                let details_rows = Self::event_text_rows(&pretty_details, 4);
 
                 root.child(
                     div()
@@ -2915,13 +2700,8 @@ impl AuditDocument {
                                 .bg(theme.secondary)
                                 .p_2()
                                 .rounded(px(4.0))
-                                .h(Self::cloudwatch_text_height(details_rows))
-                                .child(
-                                    Input::new(&details_input)
-                                        .appearance(false)
-                                        .w_full()
-                                        .h_full(),
-                                ),
+                                .h(Self::event_text_height(details_rows))
+                                .child(ReadonlyTextView::new(&details_input).w_full().h_full()),
                         ),
                 )
             })
@@ -3119,7 +2899,7 @@ impl AuditDocument {
             .flex()
             .items_center()
             .gap(Spacing::SM)
-            .when(self.total_events > 0 && !self.is_cloudwatch_source(), |d| {
+            .when(self.total_events > 0 && !self.is_external_event_stream(), |d| {
                 d.child(self.render_export_button(&theme, cx))
             })
             .when_some(
@@ -3204,8 +2984,9 @@ mod tests {
     use super::AuditDocument;
     use std::collections::{HashMap, HashSet};
 
-    use dbflux_core::{CollectionRef, Pagination, Value, observability::EventCategory};
-    use serde_json::json;
+    use dbflux_core::{
+        EventActorType, EventCategory, EventOutcome, EventRecord, EventSeverity, EventSourceId,
+    };
 
     #[test]
     fn category_index_maps_none_to_all() {
@@ -3218,127 +2999,53 @@ mod tests {
     }
 
     #[test]
-    fn cloudwatch_browse_request_uses_filter_pattern_and_range() {
-        let request = AuditDocument::cloudwatch_browse_request(
-            CollectionRef::new("logs", "/aws/lambda/app"),
-            Some("ERROR".to_string()),
-            Some(10),
-            Some(20),
-            Pagination::Offset {
-                limit: 100,
-                offset: 0,
-            },
-        );
+    fn audit_event_from_record_preserves_event_stream_fields() {
+        let event = AuditDocument::audit_event_from_record(EventRecord {
+            id: Some(7),
+            ts_ms: 1000,
+            level: EventSeverity::Info,
+            category: EventCategory::System,
+            action: "partition-a".to_string(),
+            outcome: EventOutcome::Success,
+            actor_type: EventActorType::System,
+            actor_id: None,
+            source_id: EventSourceId::System,
+            connection_id: Some("source-a".to_string()),
+            database_name: Some("logs".to_string()),
+            driver_id: Some("cloudwatch".to_string()),
+            object_type: Some("event_stream".to_string()),
+            object_id: Some("event-123".to_string()),
+            summary: "hello".to_string(),
+            details_json: Some("{\"message\":\"hello\"}".to_string()),
+            error_code: None,
+            error_message: Some("2000".to_string()),
+            duration_ms: None,
+            session_id: None,
+            correlation_id: None,
+        });
 
-        assert_eq!(
-            request.filter,
-            Some(json!({
-                "filter_pattern": "ERROR",
-                "start_ms": 10,
-                "end_ms": 20,
-            }))
-        );
-    }
-
-    #[test]
-    fn cloudwatch_row_maps_into_audit_style_event() {
-        let event = AuditDocument::cloudwatch_row_to_event(
-            &[
-                Value::Int(1000),
-                Value::Int(2000),
-                Value::Text("2026/04/25/[$LATEST]abc".to_string()),
-                Value::Text("hello from cloudwatch".to_string()),
-                Value::Text("event-123".to_string()),
-            ],
-            &CollectionRef::new("logs", "/aws/lambda/app"),
-            200,
-            3,
-        );
-
-        assert_eq!(event.id, 204);
+        assert_eq!(event.id, 7);
         assert_eq!(event.created_at_epoch_ms, 1000);
-        assert_eq!(event.action.as_deref(), Some("2026/04/25/[$LATEST]abc"));
-        assert_eq!(event.summary.as_deref(), Some("hello from cloudwatch"));
+        assert_eq!(event.action.as_deref(), Some("partition-a"));
+        assert_eq!(event.summary.as_deref(), Some("hello"));
         assert_eq!(event.object_id.as_deref(), Some("event-123"));
-        assert_eq!(event.connection_id.as_deref(), Some("/aws/lambda/app"));
-        assert_eq!(event.driver_id.as_deref(), Some("cloudwatch"));
+        assert_eq!(event.connection_id.as_deref(), Some("source-a"));
     }
 
     #[test]
-    fn cloudwatch_row_embeds_valid_json_message_as_pretty_printable_details() {
-        let event = AuditDocument::cloudwatch_row_to_event(
-            &[
-                Value::Int(1000),
-                Value::Int(2000),
-                Value::Text("2026/04/25/[$LATEST]abc".to_string()),
-                Value::Text("{\"level\":\"info\",\"nested\":{\"ok\":true}}".to_string()),
-                Value::Text("event-123".to_string()),
-            ],
-            &CollectionRef::new("logs", "/aws/lambda/app"),
-            0,
-            0,
-        );
-
-        let details =
-            serde_json::from_str::<serde_json::Value>(event.details_json.as_deref().unwrap())
-                .unwrap();
-
-        assert_eq!(details["message"]["level"], json!("info"));
-        assert_eq!(details["message"]["nested"]["ok"], json!(true));
-    }
-
-    #[test]
-    fn cloudwatch_row_keeps_plain_text_message_as_string_in_details() {
-        let event = AuditDocument::cloudwatch_row_to_event(
-            &[
-                Value::Int(1000),
-                Value::Int(2000),
-                Value::Text("2026/04/25/[$LATEST]abc".to_string()),
-                Value::Text("plain text message".to_string()),
-                Value::Text("event-123".to_string()),
-            ],
-            &CollectionRef::new("logs", "/aws/lambda/app"),
-            0,
-            0,
-        );
-
-        let details =
-            serde_json::from_str::<serde_json::Value>(event.details_json.as_deref().unwrap())
-                .unwrap();
-
-        assert_eq!(details["message"], json!("plain text message"));
-    }
-
-    #[test]
-    fn cloudwatch_stream_browse_request_targets_exact_stream_and_latest_page() {
-        let request = AuditDocument::cloudwatch_stream_browse_request(
-            CollectionRef::new("logs", "/aws/lambda/app"),
-            "2026/04/25/[$LATEST]abc".to_string(),
-            None,
-            None,
-            None,
-            Pagination::Offset {
-                limit: 100,
-                offset: 0,
-            },
-        );
-
-        assert_eq!(
-            request.filter,
-            Some(json!({
-                "log_stream_names": ["2026/04/25/[$LATEST]abc"],
-                "most_recent": true,
-            }))
-        );
-    }
-
-    #[test]
-    fn retain_cloudwatch_input_cache_drops_non_visible_entries() {
+    fn retain_event_input_cache_drops_non_visible_entries() {
         let mut cache = HashMap::from([(1_i64, "message"), (2_i64, "details"), (3_i64, "extra")]);
         let visible_ids = HashSet::from([2_i64, 3_i64]);
 
-        AuditDocument::retain_cloudwatch_input_cache(&mut cache, &visible_ids);
+        AuditDocument::retain_event_input_cache(&mut cache, &visible_ids);
 
         assert_eq!(cache, HashMap::from([(2_i64, "details"), (3_i64, "extra")]));
+    }
+
+    #[test]
+    fn event_text_rows_adds_wrap_height_for_long_lines() {
+        let long_line = "x".repeat(161);
+
+        assert_eq!(AuditDocument::event_text_rows(&long_line, 2), 3);
     }
 }

--- a/crates/dbflux_ui/src/ui/document/audit/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/audit/mod.rs
@@ -6,29 +6,20 @@ mod source_adapter;
 pub use filters::{AuditFilters, TimeRange};
 pub use source_adapter::AuditSourceAdapter;
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use crate::app::AppStateEntity;
 use crate::keymap::{Command, ContextId};
 use crate::ui::components::dropdown::{Dropdown, DropdownItem, DropdownSelectionChanged};
 use crate::ui::components::filter_bar::{FilterBarItem, FilterBarMode, FilterBarState};
 use crate::ui::components::multi_select::{MultiSelect, MultiSelectChanged};
-// FilterBar item indices — used both when building the state and in dispatch_command.
-const FILTER_BAR_IDX_SEARCH: usize = 0;
-const FILTER_BAR_IDX_TIME: usize = 1;
-const FILTER_BAR_IDX_LEVEL: usize = 2;
-const FILTER_BAR_IDX_CATEGORY: usize = 3;
-const FILTER_BAR_IDX_OUTCOME: usize = 4;
-const FILTER_BAR_IDX_REFRESH: usize = 5;
-const FILTER_BAR_IDX_REFRESH_POLICY: usize = 6;
-const FILTER_BAR_IDX_CLEAR: usize = 7;
 use crate::ui::components::toast::{PendingToast, flush_pending_toast};
 use crate::ui::icons::AppIcon;
 use crate::ui::tokens::{FontSizes, Heights, Radii, Spacing};
 use dbflux_components::controls::{GpuiInput as Input, InputEvent, InputState};
 use dbflux_components::primitives::{Icon, Label, Text, surface_raised};
 use dbflux_core::{
-    Pagination, RefreshPolicy,
+    CollectionBrowseRequest, CollectionRef, Pagination, RefreshPolicy, Value,
     observability::{EventCategory, EventOutcome, EventSeverity},
 };
 use dbflux_storage::repositories::audit::{AuditEventDto, AuditQueryFilter};
@@ -38,6 +29,8 @@ use gpui_component::ActiveTheme;
 use gpui_component::Sizable;
 use gpui_component::button::{Button, ButtonVariants};
 use gpui_component::scroll::ScrollableElement;
+use serde_json::{Value as JsonValue, json};
+use uuid::Uuid;
 
 use super::chrome::{compact_top_bar, workspace_footer_bar};
 use super::types::{DocumentIcon, DocumentId, DocumentKind, DocumentState};
@@ -104,13 +97,49 @@ pub enum AuditDocumentEvent {
 
 const DEFAULT_PAGE_SIZE: u32 = 100;
 
+#[derive(Clone)]
+enum AuditDocumentSource {
+    Internal {
+        adapter: AuditSourceAdapter,
+    },
+    CloudWatchLogGroup {
+        profile_id: Uuid,
+        collection: CollectionRef,
+    },
+    CloudWatchLogStream {
+        profile_id: Uuid,
+        collection: CollectionRef,
+        log_stream: String,
+    },
+}
+
+#[derive(Clone, Copy)]
+enum ToolbarSlot {
+    Search,
+    Time,
+    Level,
+    Category,
+    Outcome,
+    Refresh,
+    RefreshPolicy,
+    Clear,
+}
+
+struct CloudWatchLoadResult {
+    events: Vec<AuditEventDto>,
+    total_events: u64,
+}
+
 /// Audit event viewer document.
 pub struct AuditDocument {
-    adapter: AuditSourceAdapter,
+    app_state: Entity<AppStateEntity>,
+    source: AuditDocumentSource,
     filters: AuditFilters,
     events: Vec<AuditEventDto>,
     total_events: u64,
     expanded_event_ids: HashSet<i64>,
+    cloudwatch_message_inputs: HashMap<i64, Entity<InputState>>,
+    cloudwatch_details_inputs: HashMap<i64, Entity<InputState>>,
     pagination: Pagination,
     status_message: Option<String>,
     is_loading: bool,
@@ -158,15 +187,91 @@ impl AuditDocument {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
+        let audit_repo = app_state.read(cx).storage_runtime().audit();
+
+        Self::new_with_source(
+            app_state,
+            AuditDocumentSource::Internal {
+                adapter: AuditSourceAdapter::new(audit_repo),
+            },
+            "Audit".to_string(),
+            "Search events...",
+            window,
+            cx,
+        )
+    }
+
+    pub fn new_for_cloudwatch_log_group(
+        profile_id: Uuid,
+        collection: CollectionRef,
+        app_state: Entity<AppStateEntity>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let title = collection.name.clone();
+
+        Self::new_with_source(
+            app_state,
+            AuditDocumentSource::CloudWatchLogGroup {
+                profile_id,
+                collection,
+            },
+            title,
+            "Filter pattern...",
+            window,
+            cx,
+        )
+    }
+
+    pub fn new_for_cloudwatch_log_stream(
+        profile_id: Uuid,
+        collection: CollectionRef,
+        log_stream: String,
+        app_state: Entity<AppStateEntity>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let title = format!("{} · {}", collection.name, log_stream);
+
+        Self::new_with_source(
+            app_state,
+            AuditDocumentSource::CloudWatchLogStream {
+                profile_id,
+                collection,
+                log_stream,
+            },
+            title,
+            "Filter pattern...",
+            window,
+            cx,
+        )
+    }
+
+    fn new_with_source(
+        app_state: Entity<AppStateEntity>,
+        source: AuditDocumentSource,
+        title: String,
+        search_placeholder: &'static str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let focus_handle = cx.focus_handle();
 
-        let search_input = cx.new(|cx| InputState::new(window, cx).placeholder("Search events..."));
+        let search_input = cx.new(|cx| InputState::new(window, cx).placeholder(search_placeholder));
+
+        let initial_time_range = Self::initial_time_range(&source);
+        let time_range_placeholder =
+            if matches!(source, AuditDocumentSource::CloudWatchLogStream { .. }) {
+                "All time"
+            } else {
+                "Last 24 h"
+            };
 
         let dropdown_time_range = cx.new(|_cx| {
             Dropdown::new("audit-time-range")
-                .placeholder("Last 24 h")
+                .placeholder(time_range_placeholder)
                 .items(Self::time_range_items())
-                .selected_index(Some(2))
+                .selected_index(initial_time_range)
         });
 
         let multi_select_level = cx.new(|cx| {
@@ -189,9 +294,6 @@ impl AuditDocument {
             ms.set_items(items, cx);
             ms
         });
-
-        let audit_repo = app_state.read(cx).storage_runtime().audit();
-        let adapter = AuditSourceAdapter::new(audit_repo);
 
         let search_sub = cx.subscribe(&search_input, |this, _, event: &InputEvent, cx| {
             match event {
@@ -323,25 +425,38 @@ impl AuditDocument {
             },
         );
 
-        // All navigable items in order: Search, Time, Level, Category, Outcome, Refresh, Clear.
-        // Indices must match the FILTER_BAR_IDX_* constants above.
-        let filter_bar = FilterBarState::new(vec![
+        let mut toolbar_items = vec![
             FilterBarItem::input("Search:", search_input.clone()),
             FilterBarItem::dropdown("Time:", dropdown_time_range.clone()),
-            FilterBarItem::button("Level"),
-            FilterBarItem::button("Category"),
-            FilterBarItem::button("Outcome"),
+        ];
+
+        if matches!(source, AuditDocumentSource::Internal { .. }) {
+            toolbar_items.extend([
+                FilterBarItem::button("Level"),
+                FilterBarItem::button("Category"),
+                FilterBarItem::button("Outcome"),
+            ]);
+        }
+
+        toolbar_items.extend([
             FilterBarItem::button_with_icon("Refresh", AppIcon::RefreshCcw),
             FilterBarItem::dropdown("Auto-refresh:", refresh_dropdown.clone()),
             FilterBarItem::button("Clear"),
         ]);
 
+        let filter_bar = FilterBarState::new(toolbar_items);
+
+        let filters = Self::default_filters_for_source(&source);
+
         Self {
-            adapter,
-            filters: Self::default_filters(),
+            app_state,
+            source,
+            filters,
             events: Vec::new(),
             total_events: 0,
             expanded_event_ids: HashSet::new(),
+            cloudwatch_message_inputs: HashMap::new(),
+            cloudwatch_details_inputs: HashMap::new(),
             pagination: Pagination::Offset {
                 limit: DEFAULT_PAGE_SIZE,
                 offset: 0,
@@ -349,7 +464,7 @@ impl AuditDocument {
             status_message: None,
             is_loading: false,
             id: DocumentId::new(),
-            title: "Audit".to_string(),
+            title,
             pending_initial_load: true,
             pending_toast: None,
             export_menu_open: false,
@@ -397,6 +512,73 @@ impl AuditDocument {
         doc.pending_initial_load = false;
 
         doc
+    }
+
+    pub fn is_cloudwatch_log_group(&self, profile_id: Uuid, collection: &CollectionRef) -> bool {
+        match &self.source {
+            AuditDocumentSource::CloudWatchLogGroup {
+                profile_id: doc_profile_id,
+                collection: doc_collection,
+            } => *doc_profile_id == profile_id && doc_collection == collection,
+            AuditDocumentSource::Internal { .. } => false,
+            AuditDocumentSource::CloudWatchLogStream { .. } => false,
+        }
+    }
+
+    pub fn is_cloudwatch_log_stream(
+        &self,
+        profile_id: Uuid,
+        collection: &CollectionRef,
+        log_stream: &str,
+    ) -> bool {
+        match &self.source {
+            AuditDocumentSource::CloudWatchLogStream {
+                profile_id: doc_profile_id,
+                collection: doc_collection,
+                log_stream: doc_log_stream,
+            } => {
+                *doc_profile_id == profile_id
+                    && doc_collection == collection
+                    && doc_log_stream == log_stream
+            }
+            AuditDocumentSource::Internal { .. }
+            | AuditDocumentSource::CloudWatchLogGroup { .. } => false,
+        }
+    }
+
+    fn is_cloudwatch_source(&self) -> bool {
+        matches!(
+            self.source,
+            AuditDocumentSource::CloudWatchLogGroup { .. }
+                | AuditDocumentSource::CloudWatchLogStream { .. }
+        )
+    }
+
+    fn toolbar_index(&self, slot: ToolbarSlot) -> Option<usize> {
+        match (&self.source, slot) {
+            (_, ToolbarSlot::Search) => Some(0),
+            (_, ToolbarSlot::Time) => Some(1),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Level) => Some(2),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Category) => Some(3),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Outcome) => Some(4),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Refresh) => Some(5),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::RefreshPolicy) => Some(6),
+            (AuditDocumentSource::Internal { .. }, ToolbarSlot::Clear) => Some(7),
+            (AuditDocumentSource::CloudWatchLogGroup { .. }, ToolbarSlot::Refresh)
+            | (AuditDocumentSource::CloudWatchLogStream { .. }, ToolbarSlot::Refresh) => Some(2),
+            (AuditDocumentSource::CloudWatchLogGroup { .. }, ToolbarSlot::RefreshPolicy)
+            | (AuditDocumentSource::CloudWatchLogStream { .. }, ToolbarSlot::RefreshPolicy) => {
+                Some(3)
+            }
+            (AuditDocumentSource::CloudWatchLogGroup { .. }, ToolbarSlot::Clear)
+            | (AuditDocumentSource::CloudWatchLogStream { .. }, ToolbarSlot::Clear) => Some(4),
+            _ => None,
+        }
+    }
+
+    fn slot_has_ring(&self, slot: ToolbarSlot) -> bool {
+        self.filter_bar.mode() == FilterBarMode::Navigating
+            && self.toolbar_index(slot) == Some(self.filter_bar.focused_index())
     }
 
     pub fn set_category_filter(&mut self, category: Option<EventCategory>, cx: &mut Context<Self>) {
@@ -466,12 +648,210 @@ impl AuditDocument {
         }));
     }
 
-    fn default_filters() -> AuditFilters {
+    fn initial_time_range(source: &AuditDocumentSource) -> Option<usize> {
+        match source {
+            AuditDocumentSource::CloudWatchLogStream { .. } => None,
+            AuditDocumentSource::Internal { .. }
+            | AuditDocumentSource::CloudWatchLogGroup { .. } => Some(2),
+        }
+    }
+
+    fn default_filters_for_source(source: &AuditDocumentSource) -> AuditFilters {
         let mut filters = AuditFilters::default();
-        let (start_ms, end_ms) = TimeRange::Last24h.to_filter_values();
-        filters.start_ms = start_ms;
-        filters.end_ms = end_ms;
+
+        if !matches!(source, AuditDocumentSource::CloudWatchLogStream { .. }) {
+            let (start_ms, end_ms) = TimeRange::Last24h.to_filter_values();
+            filters.start_ms = start_ms;
+            filters.end_ms = end_ms;
+        }
+
         filters
+    }
+
+    fn source_loading_label(&self) -> &'static str {
+        if self.is_cloudwatch_source() {
+            "Loading log events..."
+        } else {
+            "Loading audit events..."
+        }
+    }
+
+    fn source_error_heading(&self) -> &'static str {
+        if self.is_cloudwatch_source() {
+            "Failed to load log events"
+        } else {
+            "Failed to load audit events"
+        }
+    }
+
+    fn source_empty_label(&self) -> &'static str {
+        if self.is_cloudwatch_source() {
+            "No log events match the current filters."
+        } else {
+            "No audit events match the current filters."
+        }
+    }
+
+    fn source_row_label(&self) -> &'static str {
+        if self.is_cloudwatch_source() {
+            "events"
+        } else {
+            "rows"
+        }
+    }
+
+    fn cloudwatch_browse_request(
+        collection: CollectionRef,
+        filter_pattern: Option<String>,
+        start_ms: Option<i64>,
+        end_ms: Option<i64>,
+        pagination: Pagination,
+    ) -> CollectionBrowseRequest {
+        let mut request = CollectionBrowseRequest::new(collection).with_pagination(pagination);
+
+        let mut filter = serde_json::Map::new();
+
+        if let Some(pattern) = filter_pattern.filter(|value| !value.trim().is_empty()) {
+            filter.insert("filter_pattern".to_string(), JsonValue::String(pattern));
+        }
+
+        if let Some(start_ms) = start_ms {
+            filter.insert("start_ms".to_string(), json!(start_ms));
+        }
+
+        if let Some(end_ms) = end_ms {
+            filter.insert("end_ms".to_string(), json!(end_ms));
+        }
+
+        if !filter.is_empty() {
+            request = request.with_filter(JsonValue::Object(filter));
+        }
+
+        request
+    }
+
+    fn cloudwatch_stream_browse_request(
+        collection: CollectionRef,
+        log_stream: String,
+        filter_pattern: Option<String>,
+        start_ms: Option<i64>,
+        end_ms: Option<i64>,
+        pagination: Pagination,
+    ) -> CollectionBrowseRequest {
+        let mut request = CollectionBrowseRequest::new(collection).with_pagination(pagination);
+
+        let mut filter = serde_json::Map::new();
+
+        if let Some(pattern) = filter_pattern.filter(|value| !value.trim().is_empty()) {
+            filter.insert("filter_pattern".to_string(), JsonValue::String(pattern));
+        }
+
+        if let Some(start_ms) = start_ms {
+            filter.insert("start_ms".to_string(), json!(start_ms));
+        }
+
+        if let Some(end_ms) = end_ms {
+            filter.insert("end_ms".to_string(), json!(end_ms));
+        }
+
+        filter.insert("log_stream_names".to_string(), json!([log_stream]));
+        filter.insert("most_recent".to_string(), JsonValue::Bool(true));
+
+        request = request.with_filter(JsonValue::Object(filter));
+        request
+    }
+
+    fn cloudwatch_result_to_page(
+        result: dbflux_core::QueryResult,
+        collection: CollectionRef,
+        pagination_offset: u64,
+    ) -> CloudWatchLoadResult {
+        let has_next_page = result.next_page_token.is_some();
+        let events = result
+            .rows
+            .iter()
+            .enumerate()
+            .map(|(index, row)| {
+                Self::cloudwatch_row_to_event(row, &collection, pagination_offset, index)
+            })
+            .collect::<Vec<_>>();
+        let total_events = pagination_offset + events.len() as u64 + u64::from(has_next_page);
+
+        CloudWatchLoadResult {
+            events,
+            total_events,
+        }
+    }
+
+    fn cloudwatch_row_to_event(
+        row: &[Value],
+        collection: &CollectionRef,
+        pagination_offset: u64,
+        row_index: usize,
+    ) -> AuditEventDto {
+        let timestamp_ms = Self::int_cell(row, 0).unwrap_or_default();
+        let ingestion_time_ms = Self::int_cell(row, 1);
+        let log_stream_name = Self::text_cell(row, 2);
+        let message = Self::text_cell(row, 3);
+        let event_id = Self::text_cell(row, 4);
+        let message_details = Self::cloudwatch_message_details(message.as_deref());
+
+        let details_json = json!({
+            "log_group": collection.name,
+            "timestamp_ms": timestamp_ms,
+            "ingestion_time_ms": ingestion_time_ms,
+            "log_stream_name": log_stream_name,
+            "message": message_details,
+            "event_id": event_id,
+        })
+        .to_string();
+
+        AuditEventDto {
+            id: (pagination_offset + row_index as u64 + 1) as i64,
+            actor_id: String::new(),
+            tool_id: "cloudwatch_log_event".to_string(),
+            decision: String::new(),
+            reason: None,
+            profile_id: None,
+            classification: None,
+            duration_ms: None,
+            created_at: timestamp_ms.to_string(),
+            created_at_epoch_ms: timestamp_ms,
+            level: None,
+            category: None,
+            action: log_stream_name,
+            outcome: None,
+            actor_type: None,
+            source_id: None,
+            summary: message,
+            connection_id: Some(collection.name.clone()),
+            database_name: Some(collection.database.clone()),
+            driver_id: Some("cloudwatch".to_string()),
+            object_type: Some("log_event".to_string()),
+            object_id: event_id,
+            details_json: Some(details_json),
+            error_code: None,
+            error_message: ingestion_time_ms.map(|value| value.to_string()),
+            session_id: None,
+            correlation_id: None,
+        }
+    }
+
+    fn int_cell(row: &[Value], index: usize) -> Option<i64> {
+        match row.get(index) {
+            Some(Value::Int(value)) => Some(*value),
+            Some(Value::Text(value)) => value.parse().ok(),
+            _ => None,
+        }
+    }
+
+    fn text_cell(row: &[Value], index: usize) -> Option<String> {
+        match row.get(index) {
+            Some(Value::Text(value)) if !value.is_empty() => Some(value.clone()),
+            Some(Value::Int(value)) => Some(value.to_string()),
+            Some(Value::Null) | None => None,
+            Some(value) => Some(value.to_string()),
+        }
     }
 
     fn active_filter(&self, limit: Option<usize>, offset: Option<usize>) -> AuditQueryFilter {
@@ -588,7 +968,7 @@ impl AuditDocument {
         let request_id = self.load_request_id;
         self.is_loading = true;
         self.export_menu_open = false;
-        self.status_message = Some("Loading audit events...".to_string());
+        self.status_message = Some(self.source_loading_label().to_string());
         cx.notify();
 
         let page_filter = self.active_filter(
@@ -596,16 +976,113 @@ impl AuditDocument {
             Some(self.pagination_offset()),
         );
         let count_filter = self.active_filter(None, None);
-        let adapter = self.adapter.clone();
 
-        let task = cx.background_executor().spawn(async move {
-            let events = adapter.query_filter(&page_filter)?;
-            let total = adapter.count_filter(&count_filter)?;
-            Ok::<_, String>((events, total))
-        });
+        let task = match &self.source {
+            AuditDocumentSource::Internal { adapter } => {
+                let adapter = adapter.clone();
+
+                cx.background_executor().spawn(async move {
+                    let events = adapter.query_filter(&page_filter)?;
+                    let total = adapter.count_filter(&count_filter)?;
+
+                    Ok::<_, String>(CloudWatchLoadResult {
+                        events,
+                        total_events: total,
+                    })
+                })
+            }
+            AuditDocumentSource::CloudWatchLogGroup {
+                profile_id,
+                collection,
+            } => {
+                let Some(connection) = self
+                    .app_state
+                    .read(cx)
+                    .connections()
+                    .get(profile_id)
+                    .map(|connected| connected.connection.clone())
+                else {
+                    self.events.clear();
+                    self.total_events = 0;
+                    self.expanded_event_ids.clear();
+                    self.is_loading = false;
+                    self.status_message =
+                        Some("Connection not found for this log group".to_string());
+                    cx.notify();
+                    return;
+                };
+
+                let browse_request = Self::cloudwatch_browse_request(
+                    collection.clone(),
+                    self.filters.free_text.clone(),
+                    self.filters.start_ms,
+                    self.filters.end_ms,
+                    self.pagination.clone(),
+                );
+                let collection_for_task = collection.clone();
+                let pagination_offset = self.pagination.offset();
+
+                cx.background_executor().spawn(async move {
+                    let result = connection
+                        .browse_collection(&browse_request)
+                        .map_err(|error| format!("cloudwatch browse failed: {error}"))?;
+
+                    Ok::<_, String>(Self::cloudwatch_result_to_page(
+                        result,
+                        collection_for_task,
+                        pagination_offset,
+                    ))
+                })
+            }
+            AuditDocumentSource::CloudWatchLogStream {
+                profile_id,
+                collection,
+                log_stream,
+            } => {
+                let Some(connection) = self
+                    .app_state
+                    .read(cx)
+                    .connections()
+                    .get(profile_id)
+                    .map(|connected| connected.connection.clone())
+                else {
+                    self.events.clear();
+                    self.total_events = 0;
+                    self.expanded_event_ids.clear();
+                    self.is_loading = false;
+                    self.status_message =
+                        Some("Connection not found for this log stream".to_string());
+                    cx.notify();
+                    return;
+                };
+
+                let browse_request = Self::cloudwatch_stream_browse_request(
+                    collection.clone(),
+                    log_stream.clone(),
+                    self.filters.free_text.clone(),
+                    self.filters.start_ms,
+                    self.filters.end_ms,
+                    self.pagination.clone(),
+                );
+                let collection_for_task = collection.clone();
+                let pagination_offset = self.pagination.offset();
+
+                cx.background_executor().spawn(async move {
+                    let result = connection
+                        .browse_collection(&browse_request)
+                        .map_err(|error| format!("cloudwatch stream browse failed: {error}"))?;
+
+                    Ok::<_, String>(Self::cloudwatch_result_to_page(
+                        result,
+                        collection_for_task,
+                        pagination_offset,
+                    ))
+                })
+            }
+        };
 
         cx.spawn(async move |this, cx| match task.await {
-            Ok((events, total_events)) => {
+            Ok(page) => {
                 let _ = cx.update(|cx| {
                     this.update(cx, |doc, cx| {
                         if doc.load_request_id != request_id {
@@ -613,14 +1090,15 @@ impl AuditDocument {
                         }
 
                         let visible_ids: HashSet<i64> =
-                            events.iter().map(|event| event.id).collect();
+                            page.events.iter().map(|event| event.id).collect();
 
-                        doc.events = events;
-                        doc.total_events = total_events;
+                        doc.events = page.events;
+                        doc.total_events = page.total_events;
                         doc.is_loading = false;
                         doc.status_message = None;
                         doc.expanded_event_ids
                             .retain(|event_id| visible_ids.contains(event_id));
+                        doc.retain_cloudwatch_inline_inputs(&visible_ids);
 
                         cx.notify();
                     })
@@ -636,6 +1114,7 @@ impl AuditDocument {
                         doc.events.clear();
                         doc.total_events = 0;
                         doc.expanded_event_ids.clear();
+                        doc.clear_cloudwatch_inline_inputs();
                         doc.is_loading = false;
                         doc.status_message = Some(format!("Error loading events: {}", error));
 
@@ -655,7 +1134,7 @@ impl AuditDocument {
     }
 
     pub fn clear_filters(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.filters = Self::default_filters();
+        self.filters = Self::default_filters_for_source(&self.source);
         self.reset_pagination();
         self.export_menu_open = false;
 
@@ -681,6 +1160,117 @@ impl AuditDocument {
         }
 
         cx.notify();
+    }
+
+    fn retain_cloudwatch_inline_inputs(&mut self, visible_ids: &HashSet<i64>) {
+        Self::retain_cloudwatch_input_cache(&mut self.cloudwatch_message_inputs, visible_ids);
+        Self::retain_cloudwatch_input_cache(&mut self.cloudwatch_details_inputs, visible_ids);
+    }
+
+    fn retain_cloudwatch_input_cache<T>(cache: &mut HashMap<i64, T>, visible_ids: &HashSet<i64>) {
+        cache.retain(|event_id, _| visible_ids.contains(event_id));
+    }
+
+    fn clear_cloudwatch_inline_inputs(&mut self) {
+        self.cloudwatch_message_inputs.clear();
+        self.cloudwatch_details_inputs.clear();
+    }
+
+    fn ensure_cloudwatch_message_input(
+        &mut self,
+        event_id: i64,
+        message: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<InputState> {
+        Self::ensure_cloudwatch_text_input(
+            &mut self.cloudwatch_message_inputs,
+            event_id,
+            message,
+            None,
+            window,
+            cx,
+        )
+    }
+
+    fn ensure_cloudwatch_details_input(
+        &mut self,
+        event_id: i64,
+        details_json: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<InputState> {
+        Self::ensure_cloudwatch_text_input(
+            &mut self.cloudwatch_details_inputs,
+            event_id,
+            details_json,
+            Some("json"),
+            window,
+            cx,
+        )
+    }
+
+    fn ensure_cloudwatch_text_input(
+        cache: &mut HashMap<i64, Entity<InputState>>,
+        event_id: i64,
+        value: &str,
+        editor_mode: Option<&'static str>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Entity<InputState> {
+        let value = value.to_string();
+        let rows = if editor_mode.is_some() {
+            Self::cloudwatch_text_rows(&value, 4)
+        } else {
+            Self::cloudwatch_text_rows(&value, 2)
+        };
+
+        let input = cache
+            .entry(event_id)
+            .or_insert_with(|| {
+                let initial_value = value.clone();
+                let initial_rows = rows;
+
+                cx.new(|cx| {
+                    let mut state = if let Some(editor_mode) = editor_mode {
+                        InputState::new(window, cx)
+                            .code_editor(editor_mode)
+                            .line_number(false)
+                            .rows(initial_rows)
+                            .soft_wrap(true)
+                    } else {
+                        InputState::new(window, cx)
+                            .multi_line(true)
+                            .rows(initial_rows)
+                            .soft_wrap(true)
+                    };
+
+                    state.set_value(&initial_value, window, cx);
+                    state
+                })
+            })
+            .clone();
+
+        if input.read(cx).value().to_string() != value {
+            input.update(cx, |state, cx| state.set_value(value, window, cx));
+        }
+
+        input
+    }
+
+    fn cloudwatch_text_rows(value: &str, min_rows: usize) -> usize {
+        let line_rows = value.lines().count().max(1);
+        let wrap_rows = value
+            .lines()
+            .map(|line| (line.chars().count() / 120).saturating_add(1))
+            .sum::<usize>()
+            .max(1);
+
+        line_rows.max(wrap_rows).max(min_rows)
+    }
+
+    fn cloudwatch_text_height(rows: usize) -> Pixels {
+        px((rows as f32 * 22.0) + 16.0)
     }
 
     fn go_to_prev_page(&mut self, cx: &mut Context<Self>) {
@@ -917,6 +1507,12 @@ impl AuditDocument {
         }
     }
 
+    fn cloudwatch_message_details(message: Option<&str>) -> serde_json::Value {
+        message
+            .and_then(|value| serde_json::from_str::<serde_json::Value>(value).ok())
+            .unwrap_or_else(|| json!(message))
+    }
+
     fn filter_by_correlation(&mut self, correlation_id: String, cx: &mut Context<Self>) {
         self.filters.correlation_id = Some(correlation_id);
         self.reset_pagination();
@@ -932,30 +1528,25 @@ impl AuditDocument {
     /// Execute the button action for the currently focused FilterBar item.
     /// Only called when `activate_input` returned `false` (Button variant).
     fn execute_filter_bar_button(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        match self.filter_bar.focused_index() {
-            FILTER_BAR_IDX_REFRESH => {
-                self.refresh(cx);
-                self.filter_bar.deactivate();
-                self.focus_handle.focus(window);
-            }
-            FILTER_BAR_IDX_CLEAR => {
-                self.clear_filters(window, cx);
-                self.filter_bar.deactivate();
-                self.focus_handle.focus(window);
-            }
-            FILTER_BAR_IDX_LEVEL => {
-                self.multi_select_level
-                    .update(cx, |ms, cx| ms.toggle_open(cx));
-            }
-            FILTER_BAR_IDX_CATEGORY => {
-                self.multi_select_category
-                    .update(cx, |ms, cx| ms.toggle_open(cx));
-            }
-            FILTER_BAR_IDX_OUTCOME => {
-                self.multi_select_outcome
-                    .update(cx, |ms, cx| ms.toggle_open(cx));
-            }
-            _ => {}
+        let focused_index = self.filter_bar.focused_index();
+
+        if self.toolbar_index(ToolbarSlot::Refresh) == Some(focused_index) {
+            self.refresh(cx);
+            self.filter_bar.deactivate();
+            self.focus_handle.focus(window);
+        } else if self.toolbar_index(ToolbarSlot::Clear) == Some(focused_index) {
+            self.clear_filters(window, cx);
+            self.filter_bar.deactivate();
+            self.focus_handle.focus(window);
+        } else if self.toolbar_index(ToolbarSlot::Level) == Some(focused_index) {
+            self.multi_select_level
+                .update(cx, |ms, cx| ms.toggle_open(cx));
+        } else if self.toolbar_index(ToolbarSlot::Category) == Some(focused_index) {
+            self.multi_select_category
+                .update(cx, |ms, cx| ms.toggle_open(cx));
+        } else if self.toolbar_index(ToolbarSlot::Outcome) == Some(focused_index) {
+            self.multi_select_outcome
+                .update(cx, |ms, cx| ms.toggle_open(cx));
         }
     }
 
@@ -1510,7 +2101,16 @@ impl AuditDocument {
     }
 
     fn do_export(&mut self, format: String, cx: &mut Context<Self>) {
-        let adapter = self.adapter.clone();
+        let AuditDocumentSource::Internal { adapter } = &self.source else {
+            self.pending_toast = Some(PendingToast {
+                message: "Export is only available for the built-in audit viewer".to_string(),
+                is_error: true,
+            });
+            cx.notify();
+            return;
+        };
+
+        let adapter = adapter.clone();
         let filter = self.active_filter(None, None);
         let format_for_task = format.clone();
 
@@ -1712,19 +2312,13 @@ impl AuditDocument {
     fn render_toolbar(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme().clone();
 
-        // Compute which item (if any) has the keyboard focus ring.
-        let navigating = self.filter_bar.mode() == FilterBarMode::Navigating;
-        let focused_idx = self.filter_bar.focused_index();
-
-        let ring = |idx: usize| navigating && focused_idx == idx;
-
         // Search input.
         let search_control = div()
             .flex()
             .items_center()
             .w(px(220.0))
             .rounded(Radii::SM)
-            .when(ring(FILTER_BAR_IDX_SEARCH), |d| {
+            .when(self.slot_has_ring(ToolbarSlot::Search), |d| {
                 d.border_1().border_color(theme.ring)
             })
             .child(
@@ -1736,28 +2330,28 @@ impl AuditDocument {
         // Dropdown wrappers — ring goes around the whole labeled control.
         let time_control = div()
             .rounded(Radii::SM)
-            .when(ring(FILTER_BAR_IDX_TIME), |d| {
+            .when(self.slot_has_ring(ToolbarSlot::Time), |d| {
                 d.border_1().border_color(theme.ring)
             })
             .child(self.dropdown_time_range.clone());
 
         let level_control = div()
             .rounded(Radii::SM)
-            .when(ring(FILTER_BAR_IDX_LEVEL), |d| {
+            .when(self.slot_has_ring(ToolbarSlot::Level), |d| {
                 d.border_1().border_color(theme.ring)
             })
             .child(self.multi_select_level.clone());
 
         let category_control = div()
             .rounded(Radii::SM)
-            .when(ring(FILTER_BAR_IDX_CATEGORY), |d| {
+            .when(self.slot_has_ring(ToolbarSlot::Category), |d| {
                 d.border_1().border_color(theme.ring)
             })
             .child(self.multi_select_category.clone());
 
         let outcome_control = div()
             .rounded(Radii::SM)
-            .when(ring(FILTER_BAR_IDX_OUTCOME), |d| {
+            .when(self.slot_has_ring(ToolbarSlot::Outcome), |d| {
                 d.border_1().border_color(theme.ring)
             })
             .child(self.multi_select_outcome.clone());
@@ -1783,7 +2377,7 @@ impl AuditDocument {
             .rounded(Radii::SM)
             .bg(theme.background)
             .border_1()
-            .border_color(if ring(FILTER_BAR_IDX_REFRESH) {
+            .border_color(if self.slot_has_ring(ToolbarSlot::Refresh) {
                 theme.ring
             } else {
                 theme.input
@@ -1814,7 +2408,7 @@ impl AuditDocument {
                     .w(px(28.0))
                     .h_full()
                     .rounded_r(Radii::SM)
-                    .when(ring(FILTER_BAR_IDX_REFRESH_POLICY), |d| {
+                    .when(self.slot_has_ring(ToolbarSlot::RefreshPolicy), |d| {
                         d.border_1().border_color(theme.ring)
                     })
                     .child(self.refresh_dropdown.clone()),
@@ -1829,7 +2423,7 @@ impl AuditDocument {
             .px(Spacing::SM)
             .rounded(Radii::SM)
             .border_1()
-            .border_color(if ring(FILTER_BAR_IDX_CLEAR) {
+            .border_color(if self.slot_has_ring(ToolbarSlot::Clear) {
                 theme.ring
             } else {
                 gpui::transparent_black()
@@ -1843,28 +2437,37 @@ impl AuditDocument {
 
         let _ = window;
 
-        compact_top_bar(
-            &theme,
-            vec![
+        compact_top_bar(&theme, {
+            let mut items = vec![
                 search_control.into_any_element(),
                 time_control.into_any_element(),
-                level_control.into_any_element(),
-                category_control.into_any_element(),
-                outcome_control.into_any_element(),
+            ];
+
+            if !self.is_cloudwatch_source() {
+                items.extend([
+                    level_control.into_any_element(),
+                    category_control.into_any_element(),
+                    outcome_control.into_any_element(),
+                ]);
+            }
+
+            items.extend([
                 div().flex_1().into_any_element(),
                 refresh_btn.into_any_element(),
                 clear_btn.into_any_element(),
-            ],
-        )
+            ]);
+
+            items
+        })
     }
 
-    fn render_event_list(&mut self, cx: &mut Context<Self>) -> AnyElement {
+    fn render_event_list(&mut self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         if self.events.is_empty() && self.is_loading {
             return div()
                 .flex_1()
                 .items_center()
                 .justify_center()
-                .child(Text::muted("Loading audit events..."))
+                .child(Text::muted(self.source_loading_label()))
                 .into_any_element();
         }
 
@@ -1879,7 +2482,7 @@ impl AuditDocument {
                 .items_center()
                 .justify_center()
                 .gap_3()
-                .child(Text::heading("Failed to load audit events").danger())
+                .child(Text::heading(self.source_error_heading()).danger())
                 .child(Text::muted(self.status_message.clone().unwrap_or_default()))
                 .child(
                     Button::new("audit-retry")
@@ -1899,14 +2502,16 @@ impl AuditDocument {
                 .items_center()
                 .justify_center()
                 .gap_3()
-                .child(Text::muted("No audit events match the current filters."))
+                .child(Text::muted(self.source_empty_label()))
                 .into_any_element();
         }
 
-        let mut rows = Vec::with_capacity(self.events.len());
-        for (row_index, event) in self.events.iter().cloned().enumerate() {
+        let events = self.events.clone();
+        let mut rows = Vec::with_capacity(events.len());
+
+        for (row_index, event) in events.into_iter().enumerate() {
             rows.push(
-                self.render_event_row(row_index, event, cx)
+                self.render_event_row(row_index, event, window, cx)
                     .into_any_element(),
             );
         }
@@ -1922,12 +2527,13 @@ impl AuditDocument {
     }
 
     fn render_event_row(
-        &self,
+        &mut self,
         row_index: usize,
         event: AuditEventDto,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let theme = cx.theme();
+        let theme = cx.theme().clone();
         let event_id = event.id;
         let is_expanded = self.expanded_event_ids.contains(&event_id);
         // Only highlight the selected row when this document has GPUI focus.
@@ -1935,31 +2541,16 @@ impl AuditDocument {
         // user isn't confused by three simultaneous focus indicators.
         let is_selected = self.has_focus && self.selected_row == Some(row_index);
         let timestamp = Self::format_timestamp_ms(event.created_at_epoch_ms);
-        let level = event.level.as_deref();
-        let level_display: AnyElement = match level {
-            Some(l) => div()
-                .px_1p5()
-                .py_px()
-                .rounded(px(3.0))
-                .bg(Self::level_bg_color(Some(l), theme))
-                .flex_shrink_0()
-                .child(
-                    Text::label_sm(l.to_uppercase())
-                        .font_size(FontSizes::XS)
-                        .color(Self::level_color(Some(l), theme)),
-                )
-                .into_any_element(),
-            None => Self::null_display(theme).flex_shrink_0().into_any_element(),
-        };
         let summary = event.summary.clone().unwrap_or_default();
         let summary_display: AnyElement = if summary.is_empty() {
-            Self::null_display(theme).into_any_element()
+            Self::null_display(&theme).into_any_element()
         } else {
             Text::body(summary).into_any_element()
         };
-        let category = Self::short_category_label(event.category.as_deref());
         let connection_driver =
             Self::format_connection_driver(&event.connection_id, &event.driver_id);
+        let log_stream = event.action.clone();
+        let cloudwatch_event_id = event.object_id.clone();
 
         // Background priority: selected (keyboard cursor) > expanded > default.
         // Use theme.list_active for the selected row — same token as key_value and sidebar.
@@ -2016,16 +2607,59 @@ impl AuditDocument {
                         .muted(),
                     )
                     .child(Text::code(timestamp))
-                    .child(level_display)
-                    .child(Text::caption(category.to_string()))
+                    .when(self.is_cloudwatch_source(), |row| {
+                        row.when_some(log_stream.clone(), |row, value| {
+                            row.child(
+                                div()
+                                    .px_1p5()
+                                    .py_px()
+                                    .rounded(px(3.0))
+                                    .bg(theme.primary.opacity(0.15))
+                                    .max_w(px(240.0))
+                                    .child(
+                                        div()
+                                            .truncate()
+                                            .child(Text::label_sm(value).font_size(FontSizes::XS)),
+                                    ),
+                            )
+                        })
+                    })
+                    .when(!self.is_cloudwatch_source(), |row| {
+                        let level = event.level.as_deref();
+                        let level_display: AnyElement = match level {
+                            Some(l) => div()
+                                .px_1p5()
+                                .py_px()
+                                .rounded(px(3.0))
+                                .bg(Self::level_bg_color(Some(l), &theme))
+                                .flex_shrink_0()
+                                .child(
+                                    Text::label_sm(l.to_uppercase())
+                                        .font_size(FontSizes::XS)
+                                        .color(Self::level_color(Some(l), &theme)),
+                                )
+                                .into_any_element(),
+                            None => Self::null_display(&theme)
+                                .flex_shrink_0()
+                                .into_any_element(),
+                        };
+                        let category = Self::short_category_label(event.category.as_deref());
+
+                        row.child(level_display)
+                            .child(Text::caption(category.to_string()))
+                    })
                     .child(div().text_sm().flex_1().truncate().child(summary_display))
+                    .when_some(
+                        cloudwatch_event_id.filter(|_| self.is_cloudwatch_source()),
+                        |row, value| row.child(Text::caption(value)),
+                    )
                     .when_some(
                         connection_driver.filter(|value| !value.is_empty()),
                         |row, value| row.child(Text::caption(value)),
                     ),
             )
             .when(is_expanded, |root| {
-                root.child(self.render_inline_detail(event, cx))
+                root.child(self.render_inline_detail(event, window, cx))
             })
     }
 
@@ -2048,11 +2682,16 @@ impl AuditDocument {
     }
 
     fn render_inline_detail(
-        &self,
+        &mut self,
         event: AuditEventDto,
+        window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let theme = cx.theme();
+    ) -> AnyElement {
+        if self.is_cloudwatch_source() {
+            return self.render_cloudwatch_inline_detail(event, window, cx);
+        }
+
+        let theme = cx.theme().clone();
         let timestamp = Self::format_timestamp_ms(event.created_at_epoch_ms);
         let level = event.level.clone();
         let category = match Self::short_category_label(event.category.as_deref()) {
@@ -2106,26 +2745,30 @@ impl AuditDocument {
                     .flex_wrap()
                     .gap_4()
                     .children(vec![
-                        self.render_detail_field("Time", Some(timestamp), theme)
+                        self.render_detail_field("Time", Some(timestamp), &theme)
                             .into_any_element(),
-                        self.render_detail_field("Level", level, theme)
+                        self.render_detail_field("Level", level, &theme)
                             .into_any_element(),
-                        self.render_detail_field("Category", category, theme)
+                        self.render_detail_field("Category", category, &theme)
                             .into_any_element(),
-                        self.render_detail_field("Outcome", outcome, theme)
+                        self.render_detail_field("Outcome", outcome, &theme)
                             .into_any_element(),
-                        self.render_detail_field("Actor", Some(actor), theme)
+                        self.render_detail_field("Actor", Some(actor), &theme)
                             .into_any_element(),
-                        self.render_detail_field("Action", action, theme)
+                        self.render_detail_field("Action", action, &theme)
                             .into_any_element(),
-                        self.render_detail_field("Source", source, theme)
+                        self.render_detail_field("Source", source, &theme)
                             .into_any_element(),
                     ])
                     .when_some(connection_driver, |row, value| {
-                        row.child(self.render_detail_field("Connection/Driver", Some(value), theme))
+                        row.child(self.render_detail_field(
+                            "Connection/Driver",
+                            Some(value),
+                            &theme,
+                        ))
                     })
                     .when_some(duration, |row, value| {
-                        row.child(self.render_detail_field("Duration", Some(value), theme))
+                        row.child(self.render_detail_field("Duration", Some(value), &theme))
                     }),
             )
             .when_some(summary, |root, value| {
@@ -2186,6 +2829,103 @@ impl AuditDocument {
                         ),
                 )
             })
+            .into_any_element()
+    }
+
+    fn render_cloudwatch_inline_detail(
+        &mut self,
+        event: AuditEventDto,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let theme = cx.theme().clone();
+        let row_event_id = event.id;
+        let timestamp = Self::format_timestamp_ms(event.created_at_epoch_ms);
+        let log_group = event.connection_id.clone();
+        let log_stream = event.action.clone();
+        let log_event_id = event.object_id.clone();
+        let ingestion_time = event
+            .error_message
+            .as_deref()
+            .and_then(|value| value.parse::<i64>().ok())
+            .map(Self::format_timestamp_ms);
+        let message = event.summary.clone().filter(|value| !value.is_empty());
+        let details_json = event.details_json.clone().filter(|value| !value.is_empty());
+
+        div()
+            .px_4()
+            .pb_3()
+            .pt_1()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .bg(theme.secondary.opacity(0.35))
+            .child(
+                div()
+                    .flex()
+                    .flex_wrap()
+                    .gap_4()
+                    .children(vec![
+                        self.render_detail_field("Time", Some(timestamp), &theme)
+                            .into_any_element(),
+                        self.render_detail_field("Log Group", log_group, &theme)
+                            .into_any_element(),
+                        self.render_detail_field("Log Stream", log_stream, &theme)
+                            .into_any_element(),
+                        self.render_detail_field("Event ID", log_event_id, &theme)
+                            .into_any_element(),
+                    ])
+                    .when_some(ingestion_time, |row, value| {
+                        row.child(self.render_detail_field("Ingestion Time", Some(value), &theme))
+                    }),
+            )
+            .when_some(message, |root, value| {
+                let message_input =
+                    self.ensure_cloudwatch_message_input(row_event_id, &value, window, cx);
+                let message_rows = Self::cloudwatch_text_rows(&value, 2);
+
+                root.child(
+                    div()
+                        .flex_col()
+                        .gap_1p5()
+                        .child(Label::new("Message"))
+                        .child(
+                            div().h(Self::cloudwatch_text_height(message_rows)).child(
+                                Input::new(&message_input)
+                                    .appearance(false)
+                                    .w_full()
+                                    .h_full(),
+                            ),
+                        ),
+                )
+            })
+            .when_some(details_json, |root, value| {
+                let pretty_details = Self::pretty_json(&value);
+                let details_input =
+                    self.ensure_cloudwatch_details_input(row_event_id, &pretty_details, window, cx);
+                let details_rows = Self::cloudwatch_text_rows(&pretty_details, 4);
+
+                root.child(
+                    div()
+                        .flex_col()
+                        .gap_1p5()
+                        .child(Label::new("Details"))
+                        .child(
+                            div()
+                                .bg(theme.secondary)
+                                .p_2()
+                                .rounded(px(4.0))
+                                .h(Self::cloudwatch_text_height(details_rows))
+                                .child(
+                                    Input::new(&details_input)
+                                        .appearance(false)
+                                        .w_full()
+                                        .h_full(),
+                                ),
+                        ),
+                )
+            })
+            .into_any_element()
     }
 
     fn render_export_button(
@@ -2277,9 +3017,15 @@ impl AuditDocument {
         // Left: row count with icon — same as DataGridPanel.
         let left = {
             let row_count_label = if let Some((start, end)) = self.current_page_range() {
-                format!("{}-{} of {} rows", start, end, self.total_events)
+                format!(
+                    "{}-{} of {} {}",
+                    start,
+                    end,
+                    self.total_events,
+                    self.source_row_label()
+                )
             } else {
-                format!("{} rows", self.total_events)
+                format!("{} {}", self.total_events, self.source_row_label())
             };
 
             div()
@@ -2373,7 +3119,7 @@ impl AuditDocument {
             .flex()
             .items_center()
             .gap(Spacing::SM)
-            .when(self.total_events > 0, |d| {
+            .when(self.total_events > 0 && !self.is_cloudwatch_source(), |d| {
                 d.child(self.render_export_button(&theme, cx))
             })
             .when_some(
@@ -2446,7 +3192,7 @@ impl Render for AuditDocument {
                     .overflow_hidden()
                     .flex()
                     .flex_col()
-                    .child(self.render_event_list(cx))
+                    .child(self.render_event_list(window, cx))
                     .children(context_menu),
             )
             .child(self.render_status_bar(cx))
@@ -2456,7 +3202,10 @@ impl Render for AuditDocument {
 #[cfg(test)]
 mod tests {
     use super::AuditDocument;
-    use dbflux_core::observability::EventCategory;
+    use std::collections::{HashMap, HashSet};
+
+    use dbflux_core::{CollectionRef, Pagination, Value, observability::EventCategory};
+    use serde_json::json;
 
     #[test]
     fn category_index_maps_none_to_all() {
@@ -2466,5 +3215,130 @@ mod tests {
     #[test]
     fn category_index_maps_mcp_to_mcp_dropdown_entry() {
         assert_eq!(AuditDocument::category_index(Some(EventCategory::Mcp)), 7);
+    }
+
+    #[test]
+    fn cloudwatch_browse_request_uses_filter_pattern_and_range() {
+        let request = AuditDocument::cloudwatch_browse_request(
+            CollectionRef::new("logs", "/aws/lambda/app"),
+            Some("ERROR".to_string()),
+            Some(10),
+            Some(20),
+            Pagination::Offset {
+                limit: 100,
+                offset: 0,
+            },
+        );
+
+        assert_eq!(
+            request.filter,
+            Some(json!({
+                "filter_pattern": "ERROR",
+                "start_ms": 10,
+                "end_ms": 20,
+            }))
+        );
+    }
+
+    #[test]
+    fn cloudwatch_row_maps_into_audit_style_event() {
+        let event = AuditDocument::cloudwatch_row_to_event(
+            &[
+                Value::Int(1000),
+                Value::Int(2000),
+                Value::Text("2026/04/25/[$LATEST]abc".to_string()),
+                Value::Text("hello from cloudwatch".to_string()),
+                Value::Text("event-123".to_string()),
+            ],
+            &CollectionRef::new("logs", "/aws/lambda/app"),
+            200,
+            3,
+        );
+
+        assert_eq!(event.id, 204);
+        assert_eq!(event.created_at_epoch_ms, 1000);
+        assert_eq!(event.action.as_deref(), Some("2026/04/25/[$LATEST]abc"));
+        assert_eq!(event.summary.as_deref(), Some("hello from cloudwatch"));
+        assert_eq!(event.object_id.as_deref(), Some("event-123"));
+        assert_eq!(event.connection_id.as_deref(), Some("/aws/lambda/app"));
+        assert_eq!(event.driver_id.as_deref(), Some("cloudwatch"));
+    }
+
+    #[test]
+    fn cloudwatch_row_embeds_valid_json_message_as_pretty_printable_details() {
+        let event = AuditDocument::cloudwatch_row_to_event(
+            &[
+                Value::Int(1000),
+                Value::Int(2000),
+                Value::Text("2026/04/25/[$LATEST]abc".to_string()),
+                Value::Text("{\"level\":\"info\",\"nested\":{\"ok\":true}}".to_string()),
+                Value::Text("event-123".to_string()),
+            ],
+            &CollectionRef::new("logs", "/aws/lambda/app"),
+            0,
+            0,
+        );
+
+        let details =
+            serde_json::from_str::<serde_json::Value>(event.details_json.as_deref().unwrap())
+                .unwrap();
+
+        assert_eq!(details["message"]["level"], json!("info"));
+        assert_eq!(details["message"]["nested"]["ok"], json!(true));
+    }
+
+    #[test]
+    fn cloudwatch_row_keeps_plain_text_message_as_string_in_details() {
+        let event = AuditDocument::cloudwatch_row_to_event(
+            &[
+                Value::Int(1000),
+                Value::Int(2000),
+                Value::Text("2026/04/25/[$LATEST]abc".to_string()),
+                Value::Text("plain text message".to_string()),
+                Value::Text("event-123".to_string()),
+            ],
+            &CollectionRef::new("logs", "/aws/lambda/app"),
+            0,
+            0,
+        );
+
+        let details =
+            serde_json::from_str::<serde_json::Value>(event.details_json.as_deref().unwrap())
+                .unwrap();
+
+        assert_eq!(details["message"], json!("plain text message"));
+    }
+
+    #[test]
+    fn cloudwatch_stream_browse_request_targets_exact_stream_and_latest_page() {
+        let request = AuditDocument::cloudwatch_stream_browse_request(
+            CollectionRef::new("logs", "/aws/lambda/app"),
+            "2026/04/25/[$LATEST]abc".to_string(),
+            None,
+            None,
+            None,
+            Pagination::Offset {
+                limit: 100,
+                offset: 0,
+            },
+        );
+
+        assert_eq!(
+            request.filter,
+            Some(json!({
+                "log_stream_names": ["2026/04/25/[$LATEST]abc"],
+                "most_recent": true,
+            }))
+        );
+    }
+
+    #[test]
+    fn retain_cloudwatch_input_cache_drops_non_visible_entries() {
+        let mut cache = HashMap::from([(1_i64, "message"), (2_i64, "details"), (3_i64, "extra")]);
+        let visible_ids = HashSet::from([2_i64, 3_i64]);
+
+        AuditDocument::retain_cloudwatch_input_cache(&mut cache, &visible_ids);
+
+        assert_eq!(cache, HashMap::from([(2_i64, "details"), (3_i64, "extra")]));
     }
 }

--- a/crates/dbflux_ui/src/ui/document/code/completion.rs
+++ b/crates/dbflux_ui/src/ui/document/code/completion.rs
@@ -36,8 +36,8 @@ impl QueryCompletionProvider {
                 "pattern", "diff", "anomaly", "unnest", "unmask", "SOURCE",
             ],
             dbflux_core::QueryLanguage::OpenSearchPpl => &[
-                "source", "where", "fields", "stats", "sort", "head", "eval", "parse",
-                "dedup", "top", "rare", "join", "flatten", "fillnull", "rename",
+                "source", "where", "fields", "stats", "sort", "head", "eval", "parse", "dedup",
+                "top", "rare", "join", "flatten", "fillnull", "rename",
             ],
             dbflux_core::QueryLanguage::MongoQuery => &[
                 "db",

--- a/crates/dbflux_ui/src/ui/document/code/completion.rs
+++ b/crates/dbflux_ui/src/ui/document/code/completion.rs
@@ -22,6 +22,7 @@ impl QueryCompletionProvider {
     fn keyword_candidates(&self) -> &'static [&'static str] {
         match self.query_language {
             dbflux_core::QueryLanguage::Sql
+            | dbflux_core::QueryLanguage::OpenSearchSql
             | dbflux_core::QueryLanguage::Cql
             | dbflux_core::QueryLanguage::InfluxQuery => &[
                 "SELECT", "FROM", "WHERE", "JOIN", "LEFT", "RIGHT", "INNER", "OUTER", "ON",
@@ -29,6 +30,14 @@ impl QueryCompletionProvider {
                 "UPDATE", "SET", "DELETE", "CREATE", "ALTER", "DROP", "TRUNCATE", "BEGIN",
                 "COMMIT", "ROLLBACK", "COUNT", "SUM", "AVG", "MIN", "MAX", "DISTINCT", "AND", "OR",
                 "NOT", "NULL", "IS", "LIKE", "IN", "BETWEEN", "EXISTS",
+            ],
+            dbflux_core::QueryLanguage::CloudWatchLogsInsightsQl => &[
+                "fields", "filter", "parse", "stats", "sort", "limit", "display", "dedup",
+                "pattern", "diff", "anomaly", "unnest", "unmask", "SOURCE",
+            ],
+            dbflux_core::QueryLanguage::OpenSearchPpl => &[
+                "source", "where", "fields", "stats", "sort", "head", "eval", "parse",
+                "dedup", "top", "rare", "join", "flatten", "fillnull", "rename",
             ],
             dbflux_core::QueryLanguage::MongoQuery => &[
                 "db",

--- a/crates/dbflux_ui/src/ui/document/code/context_bar.rs
+++ b/crates/dbflux_ui/src/ui/document/code/context_bar.rs
@@ -102,12 +102,9 @@ impl CodeDocument {
 
         let query_language = self.effective_query_language(cx);
 
-        let completion_provider: Rc<dyn CompletionProvider> =
-            Rc::new(QueryCompletionProvider::new(
-                query_language,
-                self.app_state.clone(),
-                connection_id,
-            ));
+        let completion_provider: Rc<dyn CompletionProvider> = Rc::new(
+            QueryCompletionProvider::new(query_language, self.app_state.clone(), connection_id),
+        );
 
         self.input_state.update(cx, |state, _cx| {
             state.lsp.completion_provider = Some(completion_provider);
@@ -257,10 +254,16 @@ impl CodeDocument {
             .unwrap_or_default();
 
         let selected_query_mode = match self.exec_ctx.source.as_ref() {
-            Some(ExecutionSourceContext::CollectionWindow { query_mode, .. }) => query_mode
-                .clone()
-                .or_else(|| source_spec.as_ref().and_then(|spec| spec.default_query_mode.clone())),
-            None => source_spec.as_ref().and_then(|spec| spec.default_query_mode.clone()),
+            Some(ExecutionSourceContext::CollectionWindow { query_mode, .. }) => {
+                query_mode.clone().or_else(|| {
+                    source_spec
+                        .as_ref()
+                        .and_then(|spec| spec.default_query_mode.clone())
+                })
+            }
+            None => source_spec
+                .as_ref()
+                .and_then(|spec| spec.default_query_mode.clone()),
         };
 
         let selected_query_mode_index = selected_query_mode.as_ref().and_then(|selected| {
@@ -1092,23 +1095,26 @@ impl CodeDocument {
             .when(show_source_controls, |el| {
                 let source_spec = source_spec.as_ref();
 
-                el.when(source_spec.is_some_and(|spec| !spec.query_modes.is_empty()), |el| {
-                    el.child(Text::caption(
-                        source_spec
-                            .and_then(|spec| spec.query_mode_label.clone())
-                            .unwrap_or_else(|| "Syntax".to_string()),
-                    ))
-                    .child(div().min_w(px(180.0)).child(focus_frame(
-                        context_slot_is_keyboard_focused(
-                            self.focus_mode,
-                            self.context_bar_slot,
-                            ContextBarSlot::SourceQueryMode,
-                        ),
-                        Some(theme.ring),
-                        control_shell(self.source_query_mode_dropdown.clone(), cx),
-                        cx,
-                    )))
-                })
+                el.when(
+                    source_spec.is_some_and(|spec| !spec.query_modes.is_empty()),
+                    |el| {
+                        el.child(Text::caption(
+                            source_spec
+                                .and_then(|spec| spec.query_mode_label.clone())
+                                .unwrap_or_else(|| "Syntax".to_string()),
+                        ))
+                        .child(div().min_w(px(180.0)).child(focus_frame(
+                            context_slot_is_keyboard_focused(
+                                self.focus_mode,
+                                self.context_bar_slot,
+                                ContextBarSlot::SourceQueryMode,
+                            ),
+                            Some(theme.ring),
+                            control_shell(self.source_query_mode_dropdown.clone(), cx),
+                            cx,
+                        )))
+                    },
+                )
                 .child(Text::caption(
                     source_spec
                         .map(|spec| spec.targets_label.clone())

--- a/crates/dbflux_ui/src/ui/document/code/context_bar.rs
+++ b/crates/dbflux_ui/src/ui/document/code/context_bar.rs
@@ -19,11 +19,7 @@ fn context_slot_is_keyboard_focused(
     focus_mode == SqlQueryFocus::ContextBar && active_slot == slot
 }
 
-fn is_cloudwatch_driver_id(driver_id: Option<&str>) -> bool {
-    driver_id == Some("cloudwatch")
-}
-
-fn parse_cloudwatch_datetime_input(value: &str) -> Option<i64> {
+fn parse_source_datetime_input(value: &str) -> Option<i64> {
     let trimmed = value.trim();
 
     if trimmed.is_empty() {
@@ -116,21 +112,21 @@ impl CodeDocument {
         });
     }
 
-    fn current_driver_id(&self, cx: &App) -> Option<String> {
+    fn current_source_context_spec(&self, cx: &App) -> Option<dbflux_core::SourceContextSpec> {
         let connection_id = self.exec_ctx.connection_id.or(self.connection_id)?;
 
         self.app_state
             .read(cx)
             .connections()
             .get(&connection_id)
-            .map(|connected| connected.profile.driver_id())
+            .and_then(|connected| connected.connection.source_context_spec())
     }
 
-    pub(super) fn should_show_cloudwatch_source_controls(&self, cx: &App) -> bool {
-        is_cloudwatch_driver_id(self.current_driver_id(cx).as_deref())
+    pub(super) fn should_show_source_controls(&self, cx: &App) -> bool {
+        self.current_source_context_spec(cx).is_some()
     }
 
-    fn cloudwatch_log_group_items(&self, cx: &App) -> Vec<DropdownItem> {
+    fn source_target_items(&self, cx: &App) -> Vec<DropdownItem> {
         let Some(connection_id) = self.exec_ctx.connection_id.or(self.connection_id) else {
             return Vec::new();
         };
@@ -160,8 +156,8 @@ impl CodeDocument {
         items
     }
 
-    fn current_cloudwatch_log_groups(&self, cx: &App) -> Vec<String> {
-        self.cloudwatch_log_groups
+    fn current_source_targets(&self, cx: &App) -> Vec<String> {
+        self.source_targets
             .read(cx)
             .selected_values()
             .iter()
@@ -169,88 +165,87 @@ impl CodeDocument {
             .collect()
     }
 
-    pub(super) fn current_cloudwatch_source_context(
+    pub(super) fn current_source_context(
         &self,
         cx: &App,
     ) -> Result<ExecutionSourceContext, &'static str> {
-        let log_groups = self.current_cloudwatch_log_groups(cx);
-        let start_input = self.cloudwatch_start_input.read(cx).value().to_string();
-        let end_input = self.cloudwatch_end_input.read(cx).value().to_string();
+        let targets = self.current_source_targets(cx);
+        let start_input = self.source_start_input.read(cx).value().to_string();
+        let end_input = self.source_end_input.read(cx).value().to_string();
 
         if start_input.trim().is_empty()
             && end_input.trim().is_empty()
-            && let Some(source @ ExecutionSourceContext::CloudWatchLogs { .. }) =
-                self.exec_ctx.source.clone()
+            && let Some(source @ ExecutionSourceContext::CollectionWindow { .. }) = self.exec_ctx.source.clone()
         {
             return Ok(source);
         }
 
-        let start_ms = parse_cloudwatch_datetime_input(&start_input);
-        let end_ms = parse_cloudwatch_datetime_input(&end_input);
+        let start_ms = parse_source_datetime_input(&start_input);
+        let end_ms = parse_source_datetime_input(&end_input);
 
-        build_cloudwatch_source_context(&log_groups, start_ms, end_ms)
+        build_source_window_context(&targets, start_ms, end_ms)
     }
 
-    fn sync_cloudwatch_exec_context(&mut self, cx: &mut Context<Self>) {
-        if !self.should_show_cloudwatch_source_controls(cx) {
+    fn sync_source_exec_context(&mut self, cx: &mut Context<Self>) {
+        if !self.should_show_source_controls(cx) {
             self.exec_ctx.source = None;
             return;
         }
 
         let start_blank = self
-            .cloudwatch_start_input
+            .source_start_input
             .read(cx)
             .value()
             .trim()
             .is_empty();
-        let end_blank = self.cloudwatch_end_input.read(cx).value().trim().is_empty();
+        let end_blank = self.source_end_input.read(cx).value().trim().is_empty();
 
         if start_blank
             && end_blank
             && matches!(
                 self.exec_ctx.source,
-                Some(ExecutionSourceContext::CloudWatchLogs { .. })
+                Some(ExecutionSourceContext::CollectionWindow { .. })
             )
         {
             return;
         }
 
-        self.exec_ctx.source = self.current_cloudwatch_source_context(cx).ok();
+        self.exec_ctx.source = self.current_source_context(cx).ok();
     }
 
-    fn sync_cloudwatch_controls(&mut self, cx: &mut Context<Self>) {
-        let should_show = self.should_show_cloudwatch_source_controls(cx);
+    fn sync_source_controls(&mut self, cx: &mut Context<Self>) {
+        let should_show = self.should_show_source_controls(cx);
         let items = if should_show {
-            self.cloudwatch_log_group_items(cx)
+            self.source_target_items(cx)
         } else {
             Vec::new()
         };
 
         let selected_values = match self.exec_ctx.source.as_ref() {
-            Some(ExecutionSourceContext::CloudWatchLogs { log_groups, .. }) => log_groups.clone(),
+            Some(ExecutionSourceContext::CollectionWindow { targets, .. }) => targets.clone(),
             None => Vec::new(),
         };
 
-        self.cloudwatch_log_groups.update(cx, |multi_select, cx| {
+        self.source_targets.update(cx, |multi_select, cx| {
             multi_select.set_items(items, cx);
             multi_select.set_selected_values(&selected_values, cx);
         });
 
-        self.sync_cloudwatch_exec_context(cx);
+        self.sync_source_exec_context(cx);
     }
 
-    pub(super) fn on_cloudwatch_log_groups_changed(
+    pub(super) fn on_source_targets_changed(
         &mut self,
-        _selected_log_groups: Vec<String>,
+        _selected_targets: Vec<String>,
         cx: &mut Context<Self>,
     ) {
-        self.sync_cloudwatch_exec_context(cx);
+        self.sync_source_exec_context(cx);
         cx.emit(DocumentEvent::MetaChanged);
         cx.notify();
     }
 
-    pub(super) fn on_cloudwatch_time_range_changed(&mut self, cx: &mut Context<Self>) {
-        self.sync_cloudwatch_exec_context(cx);
+    pub(super) fn on_source_time_range_changed(&mut self, cx: &mut Context<Self>) {
+        self.sync_source_exec_context(cx);
         cx.emit(DocumentEvent::MetaChanged);
         cx.notify();
     }
@@ -373,7 +368,7 @@ impl CodeDocument {
             });
         }
 
-        self.sync_cloudwatch_controls(cx);
+        self.sync_source_controls(cx);
         self.update_completion_provider(cx);
 
         if did_change {
@@ -720,7 +715,7 @@ impl CodeDocument {
     // === Visibility helpers for render ===
 
     pub(super) fn should_show_database_dropdown(&self, cx: &App) -> bool {
-        if self.should_show_cloudwatch_source_controls(cx) {
+        if self.should_show_source_controls(cx) {
             return false;
         }
 
@@ -742,7 +737,7 @@ impl CodeDocument {
     }
 
     pub(super) fn should_show_schema_dropdown(&self, cx: &App) -> bool {
-        if self.should_show_cloudwatch_source_controls(cx) {
+        if self.should_show_source_controls(cx) {
             return false;
         }
 
@@ -773,10 +768,10 @@ impl CodeDocument {
 
         let mut slots = vec![ContextBarSlot::Connection];
 
-        if self.should_show_cloudwatch_source_controls(cx) {
-            slots.push(ContextBarSlot::CloudWatchLogGroups);
-            slots.push(ContextBarSlot::CloudWatchStart);
-            slots.push(ContextBarSlot::CloudWatchEnd);
+        if self.should_show_source_controls(cx) {
+            slots.push(ContextBarSlot::SourceTargets);
+            slots.push(ContextBarSlot::SourceStart);
+            slots.push(ContextBarSlot::SourceEnd);
             return slots;
         }
 
@@ -795,9 +790,7 @@ impl CodeDocument {
             ContextBarSlot::Connection => Some(&self.connection_dropdown),
             ContextBarSlot::Database => Some(&self.database_dropdown),
             ContextBarSlot::Schema => Some(&self.schema_dropdown),
-            ContextBarSlot::CloudWatchLogGroups
-            | ContextBarSlot::CloudWatchStart
-            | ContextBarSlot::CloudWatchEnd => None,
+            ContextBarSlot::SourceTargets | ContextBarSlot::SourceStart | ContextBarSlot::SourceEnd => None,
         }
     }
 
@@ -903,16 +896,16 @@ impl CodeDocument {
 
             Command::Execute => {
                 match self.context_bar_slot {
-                    ContextBarSlot::CloudWatchLogGroups => {
-                        self.cloudwatch_log_groups
+                    ContextBarSlot::SourceTargets => {
+                        self.source_targets
                             .update(cx, |multi_select, cx| multi_select.toggle_open(cx));
                     }
-                    ContextBarSlot::CloudWatchStart => {
-                        self.cloudwatch_start_input
+                    ContextBarSlot::SourceStart => {
+                        self.source_start_input
                             .update(cx, |state, cx| state.focus(window, cx));
                     }
-                    ContextBarSlot::CloudWatchEnd => {
-                        self.cloudwatch_end_input
+                    ContextBarSlot::SourceEnd => {
+                        self.source_end_input
                             .update(cx, |state, cx| state.focus(window, cx));
                     }
                     _ => {
@@ -979,9 +972,10 @@ impl CodeDocument {
 
         let theme = cx.theme();
 
-        let show_cloudwatch = self.should_show_cloudwatch_source_controls(cx);
+        let show_source_controls = self.should_show_source_controls(cx);
         let show_db = self.should_show_database_dropdown(cx);
         let show_schema = self.should_show_schema_dropdown(cx);
+        let source_spec = self.current_source_context_spec(cx);
 
         div()
             .id("exec-context-bar")
@@ -1015,42 +1009,57 @@ impl CodeDocument {
                         cx,
                     )),
             )
-            .when(show_cloudwatch, |el| {
-                el.child(Text::caption("Log groups:"))
+            .when(show_source_controls, |el| {
+                el.child(Text::caption(
+                    source_spec
+                        .as_ref()
+                        .map(|spec| spec.targets_label.clone())
+                        .unwrap_or_else(|| "Sources".to_string()),
+                ))
                     .child(div().min_w(px(260.0)).child(focus_frame(
                         context_slot_is_keyboard_focused(
                             self.focus_mode,
                             self.context_bar_slot,
-                            ContextBarSlot::CloudWatchLogGroups,
+                            ContextBarSlot::SourceTargets,
                         ),
                         Some(theme.ring),
-                        control_shell(self.cloudwatch_log_groups.clone(), cx),
+                        control_shell(self.source_targets.clone(), cx),
                         cx,
                     )))
-                    .child(Text::caption("Start:"))
+                    .child(Text::caption(
+                        source_spec
+                            .as_ref()
+                            .map(|spec| spec.start_label.clone())
+                            .unwrap_or_else(|| "Start".to_string()),
+                    ))
                     .child(div().min_w(px(180.0)).child(focus_frame(
                         context_slot_is_keyboard_focused(
                             self.focus_mode,
                             self.context_bar_slot,
-                            ContextBarSlot::CloudWatchStart,
+                            ContextBarSlot::SourceStart,
                         ),
                         Some(theme.ring),
-                        control_shell(Input::new(&self.cloudwatch_start_input), cx),
+                        control_shell(Input::new(&self.source_start_input), cx),
                         cx,
                     )))
-                    .child(Text::caption("End:"))
+                    .child(Text::caption(
+                        source_spec
+                            .as_ref()
+                            .map(|spec| spec.end_label.clone())
+                            .unwrap_or_else(|| "End".to_string()),
+                    ))
                     .child(div().min_w(px(180.0)).child(focus_frame(
                         context_slot_is_keyboard_focused(
                             self.focus_mode,
                             self.context_bar_slot,
-                            ContextBarSlot::CloudWatchEnd,
+                            ContextBarSlot::SourceEnd,
                         ),
                         Some(theme.ring),
-                        control_shell(Input::new(&self.cloudwatch_end_input), cx),
+                        control_shell(Input::new(&self.source_end_input), cx),
                         cx,
                     )))
             })
-            .when(!show_cloudwatch && show_db, |el| {
+            .when(!show_source_controls && show_db, |el| {
                 el.child(Text::caption("Database:")).child(
                     div()
                         .min_w(context_dropdown_min_width(1))
@@ -1066,7 +1075,7 @@ impl CodeDocument {
                         )),
                 )
             })
-            .when(!show_cloudwatch && show_schema, |el| {
+            .when(!show_source_controls && show_schema, |el| {
                 el.child(Text::caption("Schema:")).child(
                     div()
                         .min_w(context_dropdown_min_width(2))
@@ -1097,8 +1106,8 @@ impl CodeDocument {
 #[cfg(test)]
 mod tests {
     use super::{
-        ContextBarSlot, SqlQueryFocus, build_cloudwatch_source_context, context_dropdown_min_width,
-        context_slot_is_keyboard_focused, is_cloudwatch_driver_id, parse_cloudwatch_datetime_input,
+        ContextBarSlot, SqlQueryFocus, build_source_window_context, context_dropdown_min_width,
+        context_slot_is_keyboard_focused, parse_source_datetime_input,
     };
     use dbflux_core::ExecutionSourceContext;
     use gpui::px;
@@ -1134,48 +1143,41 @@ mod tests {
     }
 
     #[test]
-    fn cloudwatch_source_controls_are_driver_specific() {
-        assert!(is_cloudwatch_driver_id(Some("cloudwatch")));
-        assert!(!is_cloudwatch_driver_id(Some("postgres")));
-        assert!(!is_cloudwatch_driver_id(None));
+    fn source_datetime_inputs_parse_rfc3339_values() {
+        assert!(parse_source_datetime_input("2026-04-24T12:34:56Z").is_some());
+        assert!(parse_source_datetime_input("").is_none());
+        assert!(parse_source_datetime_input("not-a-date").is_none());
     }
 
     #[test]
-    fn cloudwatch_datetime_inputs_parse_rfc3339_values() {
-        assert!(parse_cloudwatch_datetime_input("2026-04-24T12:34:56Z").is_some());
-        assert!(parse_cloudwatch_datetime_input("").is_none());
-        assert!(parse_cloudwatch_datetime_input("not-a-date").is_none());
-    }
-
-    #[test]
-    fn valid_cloudwatch_source_context_requires_groups_and_ordered_bounds() {
+    fn valid_source_context_requires_targets_and_ordered_bounds() {
         let source =
-            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], Some(10), Some(20))
+            build_source_window_context(&["/aws/lambda/app".to_string()], Some(10), Some(20))
                 .expect("valid source context");
 
         match source {
-            ExecutionSourceContext::CloudWatchLogs {
-                log_groups,
+            ExecutionSourceContext::CollectionWindow {
+                targets,
                 start_ms,
                 end_ms,
             } => {
-                assert_eq!(log_groups, vec!["/aws/lambda/app"]);
+                assert_eq!(targets, vec!["/aws/lambda/app"]);
                 assert_eq!(start_ms, 10);
                 assert_eq!(end_ms, 20);
             }
         }
 
         assert_eq!(
-            build_cloudwatch_source_context(&[], Some(10), Some(20)).unwrap_err(),
-            "Select at least one log group"
+            build_source_window_context(&[], Some(10), Some(20)).unwrap_err(),
+            "Select at least one source"
         );
         assert_eq!(
-            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], None, Some(20))
+            build_source_window_context(&["/aws/lambda/app".to_string()], None, Some(20))
                 .unwrap_err(),
             "Start time is required"
         );
         assert_eq!(
-            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], Some(20), Some(10))
+            build_source_window_context(&["/aws/lambda/app".to_string()], Some(20), Some(10))
                 .unwrap_err(),
             "Start time must be earlier than end time"
         );

--- a/crates/dbflux_ui/src/ui/document/code/context_bar.rs
+++ b/crates/dbflux_ui/src/ui/document/code/context_bar.rs
@@ -11,12 +11,28 @@ fn context_dropdown_min_width(index: usize) -> Pixels {
     }
 }
 
-fn context_dropdown_is_keyboard_focused(
+fn context_slot_is_keyboard_focused(
     focus_mode: SqlQueryFocus,
-    context_bar_index: usize,
-    dropdown_index: usize,
+    active_slot: ContextBarSlot,
+    slot: ContextBarSlot,
 ) -> bool {
-    focus_mode == SqlQueryFocus::ContextBar && context_bar_index == dropdown_index
+    focus_mode == SqlQueryFocus::ContextBar && active_slot == slot
+}
+
+fn is_cloudwatch_driver_id(driver_id: Option<&str>) -> bool {
+    driver_id == Some("cloudwatch")
+}
+
+fn parse_cloudwatch_datetime_input(value: &str) -> Option<i64> {
+    let trimmed = value.trim();
+
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    dbflux_core::chrono::DateTime::parse_from_rfc3339(trimmed)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
 }
 
 impl CodeDocument {
@@ -98,6 +114,145 @@ impl CodeDocument {
         self.input_state.update(cx, |state, _cx| {
             state.lsp.completion_provider = Some(completion_provider);
         });
+    }
+
+    fn current_driver_id(&self, cx: &App) -> Option<String> {
+        let connection_id = self.exec_ctx.connection_id.or(self.connection_id)?;
+
+        self.app_state
+            .read(cx)
+            .connections()
+            .get(&connection_id)
+            .map(|connected| connected.profile.driver_id())
+    }
+
+    pub(super) fn should_show_cloudwatch_source_controls(&self, cx: &App) -> bool {
+        is_cloudwatch_driver_id(self.current_driver_id(cx).as_deref())
+    }
+
+    fn cloudwatch_log_group_items(&self, cx: &App) -> Vec<DropdownItem> {
+        let Some(connection_id) = self.exec_ctx.connection_id.or(self.connection_id) else {
+            return Vec::new();
+        };
+
+        let Some(connected) = self.app_state.read(cx).connections().get(&connection_id) else {
+            return Vec::new();
+        };
+
+        let schema = self
+            .exec_ctx
+            .database
+            .as_deref()
+            .and_then(|database| connected.schema_for_target_database(database))
+            .or(connected.schema.as_ref());
+
+        let Some(schema) = schema else {
+            return Vec::new();
+        };
+
+        let mut items = schema
+            .collections()
+            .iter()
+            .map(|collection| DropdownItem::with_value(&collection.name, &collection.name))
+            .collect::<Vec<_>>();
+
+        items.sort_by(|left, right| left.label.as_ref().cmp(right.label.as_ref()));
+        items
+    }
+
+    fn current_cloudwatch_log_groups(&self, cx: &App) -> Vec<String> {
+        self.cloudwatch_log_groups
+            .read(cx)
+            .selected_values()
+            .iter()
+            .map(|value| value.to_string())
+            .collect()
+    }
+
+    pub(super) fn current_cloudwatch_source_context(
+        &self,
+        cx: &App,
+    ) -> Result<ExecutionSourceContext, &'static str> {
+        let log_groups = self.current_cloudwatch_log_groups(cx);
+        let start_input = self.cloudwatch_start_input.read(cx).value().to_string();
+        let end_input = self.cloudwatch_end_input.read(cx).value().to_string();
+
+        if start_input.trim().is_empty()
+            && end_input.trim().is_empty()
+            && let Some(source @ ExecutionSourceContext::CloudWatchLogs { .. }) =
+                self.exec_ctx.source.clone()
+        {
+            return Ok(source);
+        }
+
+        let start_ms = parse_cloudwatch_datetime_input(&start_input);
+        let end_ms = parse_cloudwatch_datetime_input(&end_input);
+
+        build_cloudwatch_source_context(&log_groups, start_ms, end_ms)
+    }
+
+    fn sync_cloudwatch_exec_context(&mut self, cx: &mut Context<Self>) {
+        if !self.should_show_cloudwatch_source_controls(cx) {
+            self.exec_ctx.source = None;
+            return;
+        }
+
+        let start_blank = self
+            .cloudwatch_start_input
+            .read(cx)
+            .value()
+            .trim()
+            .is_empty();
+        let end_blank = self.cloudwatch_end_input.read(cx).value().trim().is_empty();
+
+        if start_blank
+            && end_blank
+            && matches!(
+                self.exec_ctx.source,
+                Some(ExecutionSourceContext::CloudWatchLogs { .. })
+            )
+        {
+            return;
+        }
+
+        self.exec_ctx.source = self.current_cloudwatch_source_context(cx).ok();
+    }
+
+    fn sync_cloudwatch_controls(&mut self, cx: &mut Context<Self>) {
+        let should_show = self.should_show_cloudwatch_source_controls(cx);
+        let items = if should_show {
+            self.cloudwatch_log_group_items(cx)
+        } else {
+            Vec::new()
+        };
+
+        let selected_values = match self.exec_ctx.source.as_ref() {
+            Some(ExecutionSourceContext::CloudWatchLogs { log_groups, .. }) => log_groups.clone(),
+            None => Vec::new(),
+        };
+
+        self.cloudwatch_log_groups.update(cx, |multi_select, cx| {
+            multi_select.set_items(items, cx);
+            multi_select.set_selected_values(&selected_values, cx);
+        });
+
+        self.sync_cloudwatch_exec_context(cx);
+    }
+
+    pub(super) fn on_cloudwatch_log_groups_changed(
+        &mut self,
+        _selected_log_groups: Vec<String>,
+        cx: &mut Context<Self>,
+    ) {
+        self.sync_cloudwatch_exec_context(cx);
+        cx.emit(DocumentEvent::MetaChanged);
+        cx.notify();
+    }
+
+    pub(super) fn on_cloudwatch_time_range_changed(&mut self, cx: &mut Context<Self>) {
+        self.sync_cloudwatch_exec_context(cx);
+        cx.emit(DocumentEvent::MetaChanged);
+        cx.notify();
     }
 
     pub(super) fn sync_context_dropdowns(&mut self, cx: &mut Context<Self>) {
@@ -218,6 +373,7 @@ impl CodeDocument {
             });
         }
 
+        self.sync_cloudwatch_controls(cx);
         self.update_completion_provider(cx);
 
         if did_change {
@@ -564,6 +720,10 @@ impl CodeDocument {
     // === Visibility helpers for render ===
 
     pub(super) fn should_show_database_dropdown(&self, cx: &App) -> bool {
+        if self.should_show_cloudwatch_source_controls(cx) {
+            return false;
+        }
+
         let Some(conn_id) = self.exec_ctx.connection_id else {
             return false;
         };
@@ -582,6 +742,10 @@ impl CodeDocument {
     }
 
     pub(super) fn should_show_schema_dropdown(&self, cx: &App) -> bool {
+        if self.should_show_cloudwatch_source_controls(cx) {
+            return false;
+        }
+
         let Some(conn_id) = self.exec_ctx.connection_id else {
             return false;
         };
@@ -601,55 +765,66 @@ impl CodeDocument {
 
     // === Context bar keyboard navigation ===
 
-    /// Returns the list of visible dropdown indices:
-    /// 0 = Connection (always), 1 = Database (if visible), 2 = Schema (if visible).
-    fn visible_dropdown_indices(&self, cx: &App) -> Vec<usize> {
+    /// Returns the visible context-bar slots for the current document.
+    fn visible_context_bar_slots(&self, cx: &App) -> Vec<ContextBarSlot> {
         if !self.query_language.supports_connection_context() {
             return Vec::new();
         }
 
-        let mut indices = vec![0]; // Connection is always visible
+        let mut slots = vec![ContextBarSlot::Connection];
+
+        if self.should_show_cloudwatch_source_controls(cx) {
+            slots.push(ContextBarSlot::CloudWatchLogGroups);
+            slots.push(ContextBarSlot::CloudWatchStart);
+            slots.push(ContextBarSlot::CloudWatchEnd);
+            return slots;
+        }
+
         if self.should_show_database_dropdown(cx) {
-            indices.push(1);
+            slots.push(ContextBarSlot::Database);
         }
         if self.should_show_schema_dropdown(cx) {
-            indices.push(2);
+            slots.push(ContextBarSlot::Schema);
         }
-        indices
+
+        slots
     }
 
-    fn dropdown_for_index(&self, index: usize) -> &Entity<Dropdown> {
-        match index {
-            0 => &self.connection_dropdown,
-            1 => &self.database_dropdown,
-            _ => &self.schema_dropdown,
+    fn dropdown_for_slot(&self, slot: ContextBarSlot) -> Option<&Entity<Dropdown>> {
+        match slot {
+            ContextBarSlot::Connection => Some(&self.connection_dropdown),
+            ContextBarSlot::Database => Some(&self.database_dropdown),
+            ContextBarSlot::Schema => Some(&self.schema_dropdown),
+            ContextBarSlot::CloudWatchLogGroups
+            | ContextBarSlot::CloudWatchStart
+            | ContextBarSlot::CloudWatchEnd => None,
         }
     }
 
     pub(super) fn enter_context_bar(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let visible = self.visible_dropdown_indices(cx);
+        let visible = self.visible_context_bar_slots(cx);
         if visible.is_empty() {
             return;
         }
 
         self.focus_mode = SqlQueryFocus::ContextBar;
-        self.context_bar_index = visible[0];
+        self.context_bar_slot = visible[0];
         self.focus_handle.focus(window);
         self.update_context_bar_focus_rings(cx);
         cx.notify();
     }
 
-    /// Clamp `context_bar_index` to a visible dropdown after connection changes.
+    /// Clamp `context_bar_slot` to a visible control after connection changes.
     fn revalidate_context_bar_index(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let visible = self.visible_dropdown_indices(cx);
+        let visible = self.visible_context_bar_slots(cx);
 
         if visible.is_empty() {
             self.exit_context_bar(window, cx);
             return;
         }
 
-        if !visible.contains(&self.context_bar_index) {
-            self.context_bar_index = visible[0];
+        if !visible.contains(&self.context_bar_slot) {
+            self.context_bar_slot = visible[0];
         }
 
         self.update_context_bar_focus_rings(cx);
@@ -669,15 +844,16 @@ impl CodeDocument {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        let visible = self.visible_dropdown_indices(cx);
+        let visible = self.visible_context_bar_slots(cx);
         if visible.is_empty() {
             self.exit_context_bar(window, cx);
             return true;
         }
 
         // If a dropdown is open, route j/k/Enter/Escape to it
-        let current_dropdown = self.dropdown_for_index(self.context_bar_index).clone();
-        if current_dropdown.read(cx).is_open() {
+        if let Some(current_dropdown) = self.dropdown_for_slot(self.context_bar_slot).cloned()
+            && current_dropdown.read(cx).is_open()
+        {
             match cmd {
                 Command::SelectNext => {
                     current_dropdown.update(cx, |dd, cx| dd.select_next_item(cx));
@@ -701,20 +877,24 @@ impl CodeDocument {
 
         match cmd {
             Command::FocusRight => {
-                if let Some(pos) = visible.iter().position(|&i| i == self.context_bar_index)
+                if let Some(pos) = visible
+                    .iter()
+                    .position(|&slot| slot == self.context_bar_slot)
                     && pos + 1 < visible.len()
                 {
-                    self.context_bar_index = visible[pos + 1];
+                    self.context_bar_slot = visible[pos + 1];
                     self.update_context_bar_focus_rings(cx);
                     cx.notify();
                 }
                 true
             }
             Command::FocusLeft => {
-                if let Some(pos) = visible.iter().position(|&i| i == self.context_bar_index)
+                if let Some(pos) = visible
+                    .iter()
+                    .position(|&slot| slot == self.context_bar_slot)
                     && pos > 0
                 {
-                    self.context_bar_index = visible[pos - 1];
+                    self.context_bar_slot = visible[pos - 1];
                     self.update_context_bar_focus_rings(cx);
                     cx.notify();
                 }
@@ -722,7 +902,27 @@ impl CodeDocument {
             }
 
             Command::Execute => {
-                current_dropdown.update(cx, |dd, cx| dd.toggle_open(cx));
+                match self.context_bar_slot {
+                    ContextBarSlot::CloudWatchLogGroups => {
+                        self.cloudwatch_log_groups
+                            .update(cx, |multi_select, cx| multi_select.toggle_open(cx));
+                    }
+                    ContextBarSlot::CloudWatchStart => {
+                        self.cloudwatch_start_input
+                            .update(cx, |state, cx| state.focus(window, cx));
+                    }
+                    ContextBarSlot::CloudWatchEnd => {
+                        self.cloudwatch_end_input
+                            .update(cx, |state, cx| state.focus(window, cx));
+                    }
+                    _ => {
+                        if let Some(current_dropdown) =
+                            self.dropdown_for_slot(self.context_bar_slot).cloned()
+                        {
+                            current_dropdown.update(cx, |dd, cx| dd.toggle_open(cx));
+                        }
+                    }
+                }
                 true
             }
 
@@ -742,21 +942,31 @@ impl CodeDocument {
         let theme = cx.theme();
         let active_color = theme.ring;
 
-        for idx in [0, 1, 2] {
-            let dropdown = self.dropdown_for_index(idx);
-            let color = if idx == self.context_bar_index {
-                Some(active_color)
-            } else {
-                None
-            };
-            dropdown.update(cx, |dd, cx| dd.set_focus_ring(color, cx));
+        for slot in [
+            ContextBarSlot::Connection,
+            ContextBarSlot::Database,
+            ContextBarSlot::Schema,
+        ] {
+            if let Some(dropdown) = self.dropdown_for_slot(slot) {
+                let color = if slot == self.context_bar_slot {
+                    Some(active_color)
+                } else {
+                    None
+                };
+                dropdown.update(cx, |dd, cx| dd.set_focus_ring(color, cx));
+            }
         }
     }
 
     fn clear_context_bar_focus_rings(&self, cx: &mut Context<Self>) {
-        for idx in [0, 1, 2] {
-            let dropdown = self.dropdown_for_index(idx);
-            dropdown.update(cx, |dd, cx| dd.set_focus_ring(None, cx));
+        for slot in [
+            ContextBarSlot::Connection,
+            ContextBarSlot::Database,
+            ContextBarSlot::Schema,
+        ] {
+            if let Some(dropdown) = self.dropdown_for_slot(slot) {
+                dropdown.update(cx, |dd, cx| dd.set_focus_ring(None, cx));
+            }
         }
     }
 
@@ -769,6 +979,7 @@ impl CodeDocument {
 
         let theme = cx.theme();
 
+        let show_cloudwatch = self.should_show_cloudwatch_source_controls(cx);
         let show_db = self.should_show_database_dropdown(cx);
         let show_schema = self.should_show_schema_dropdown(cx);
 
@@ -794,25 +1005,60 @@ impl CodeDocument {
                 div()
                     .min_w(context_dropdown_min_width(0))
                     .child(focus_frame(
-                        context_dropdown_is_keyboard_focused(
+                        context_slot_is_keyboard_focused(
                             self.focus_mode,
-                            self.context_bar_index,
-                            0,
+                            self.context_bar_slot,
+                            ContextBarSlot::Connection,
                         ),
                         Some(theme.ring),
                         control_shell(self.connection_dropdown.clone(), cx),
                         cx,
                     )),
             )
-            .when(show_db, |el| {
+            .when(show_cloudwatch, |el| {
+                el.child(Text::caption("Log groups:"))
+                    .child(div().min_w(px(260.0)).child(focus_frame(
+                        context_slot_is_keyboard_focused(
+                            self.focus_mode,
+                            self.context_bar_slot,
+                            ContextBarSlot::CloudWatchLogGroups,
+                        ),
+                        Some(theme.ring),
+                        control_shell(self.cloudwatch_log_groups.clone(), cx),
+                        cx,
+                    )))
+                    .child(Text::caption("Start:"))
+                    .child(div().min_w(px(180.0)).child(focus_frame(
+                        context_slot_is_keyboard_focused(
+                            self.focus_mode,
+                            self.context_bar_slot,
+                            ContextBarSlot::CloudWatchStart,
+                        ),
+                        Some(theme.ring),
+                        control_shell(Input::new(&self.cloudwatch_start_input), cx),
+                        cx,
+                    )))
+                    .child(Text::caption("End:"))
+                    .child(div().min_w(px(180.0)).child(focus_frame(
+                        context_slot_is_keyboard_focused(
+                            self.focus_mode,
+                            self.context_bar_slot,
+                            ContextBarSlot::CloudWatchEnd,
+                        ),
+                        Some(theme.ring),
+                        control_shell(Input::new(&self.cloudwatch_end_input), cx),
+                        cx,
+                    )))
+            })
+            .when(!show_cloudwatch && show_db, |el| {
                 el.child(Text::caption("Database:")).child(
                     div()
                         .min_w(context_dropdown_min_width(1))
                         .child(focus_frame(
-                            context_dropdown_is_keyboard_focused(
+                            context_slot_is_keyboard_focused(
                                 self.focus_mode,
-                                self.context_bar_index,
-                                1,
+                                self.context_bar_slot,
+                                ContextBarSlot::Database,
                             ),
                             Some(theme.ring),
                             control_shell(self.database_dropdown.clone(), cx),
@@ -820,15 +1066,15 @@ impl CodeDocument {
                         )),
                 )
             })
-            .when(show_schema, |el| {
+            .when(!show_cloudwatch && show_schema, |el| {
                 el.child(Text::caption("Schema:")).child(
                     div()
                         .min_w(context_dropdown_min_width(2))
                         .child(focus_frame(
-                            context_dropdown_is_keyboard_focused(
+                            context_slot_is_keyboard_focused(
                                 self.focus_mode,
-                                self.context_bar_index,
-                                2,
+                                self.context_bar_slot,
+                                ContextBarSlot::Schema,
                             ),
                             Some(theme.ring),
                             control_shell(self.schema_dropdown.clone(), cx),
@@ -850,7 +1096,11 @@ impl CodeDocument {
 
 #[cfg(test)]
 mod tests {
-    use super::{SqlQueryFocus, context_dropdown_is_keyboard_focused, context_dropdown_min_width};
+    use super::{
+        ContextBarSlot, SqlQueryFocus, build_cloudwatch_source_context, context_dropdown_min_width,
+        context_slot_is_keyboard_focused, is_cloudwatch_driver_id, parse_cloudwatch_datetime_input,
+    };
+    use dbflux_core::ExecutionSourceContext;
     use gpui::px;
 
     #[test]
@@ -866,20 +1116,68 @@ mod tests {
 
     #[test]
     fn only_active_context_bar_dropdown_reports_keyboard_focus() {
-        assert!(context_dropdown_is_keyboard_focused(
+        assert!(context_slot_is_keyboard_focused(
             SqlQueryFocus::ContextBar,
-            1,
-            1,
+            ContextBarSlot::Database,
+            ContextBarSlot::Database,
         ));
-        assert!(!context_dropdown_is_keyboard_focused(
+        assert!(!context_slot_is_keyboard_focused(
             SqlQueryFocus::ContextBar,
-            1,
-            0,
+            ContextBarSlot::Database,
+            ContextBarSlot::Connection,
         ));
-        assert!(!context_dropdown_is_keyboard_focused(
+        assert!(!context_slot_is_keyboard_focused(
             SqlQueryFocus::Editor,
-            1,
-            1,
+            ContextBarSlot::Database,
+            ContextBarSlot::Database,
         ));
+    }
+
+    #[test]
+    fn cloudwatch_source_controls_are_driver_specific() {
+        assert!(is_cloudwatch_driver_id(Some("cloudwatch")));
+        assert!(!is_cloudwatch_driver_id(Some("postgres")));
+        assert!(!is_cloudwatch_driver_id(None));
+    }
+
+    #[test]
+    fn cloudwatch_datetime_inputs_parse_rfc3339_values() {
+        assert!(parse_cloudwatch_datetime_input("2026-04-24T12:34:56Z").is_some());
+        assert!(parse_cloudwatch_datetime_input("").is_none());
+        assert!(parse_cloudwatch_datetime_input("not-a-date").is_none());
+    }
+
+    #[test]
+    fn valid_cloudwatch_source_context_requires_groups_and_ordered_bounds() {
+        let source =
+            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], Some(10), Some(20))
+                .expect("valid source context");
+
+        match source {
+            ExecutionSourceContext::CloudWatchLogs {
+                log_groups,
+                start_ms,
+                end_ms,
+            } => {
+                assert_eq!(log_groups, vec!["/aws/lambda/app"]);
+                assert_eq!(start_ms, 10);
+                assert_eq!(end_ms, 20);
+            }
+        }
+
+        assert_eq!(
+            build_cloudwatch_source_context(&[], Some(10), Some(20)).unwrap_err(),
+            "Select at least one log group"
+        );
+        assert_eq!(
+            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], None, Some(20))
+                .unwrap_err(),
+            "Start time is required"
+        );
+        assert_eq!(
+            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], Some(20), Some(10))
+                .unwrap_err(),
+            "Start time must be earlier than end time"
+        );
     }
 }

--- a/crates/dbflux_ui/src/ui/document/code/context_bar.rs
+++ b/crates/dbflux_ui/src/ui/document/code/context_bar.rs
@@ -100,9 +100,11 @@ impl CodeDocument {
             .connection_id
             .filter(|id| self.app_state.read(cx).connections().contains_key(id));
 
+        let query_language = self.effective_query_language(cx);
+
         let completion_provider: Rc<dyn CompletionProvider> =
             Rc::new(QueryCompletionProvider::new(
-                self.query_language.clone(),
+                query_language,
                 self.app_state.clone(),
                 connection_id,
             ));
@@ -120,6 +122,31 @@ impl CodeDocument {
             .connections()
             .get(&connection_id)
             .and_then(|connected| connected.connection.source_context_spec())
+    }
+
+    fn current_source_query_mode_value(&self, cx: &App) -> Option<String> {
+        let spec = self.current_source_context_spec(cx)?;
+
+        self.source_query_mode_dropdown
+            .read(cx)
+            .selected_value()
+            .map(|value| value.to_string())
+            .or(spec.default_query_mode)
+            .or_else(|| spec.query_modes.first().map(|mode| mode.value.clone()))
+    }
+
+    fn effective_query_language(&self, cx: &App) -> QueryLanguage {
+        let Some(spec) = self.current_source_context_spec(cx) else {
+            return self.query_language.clone();
+        };
+
+        let selected_mode = self.current_source_query_mode_value(cx);
+
+        spec.query_modes
+            .into_iter()
+            .find(|mode| Some(mode.value.as_str()) == selected_mode.as_deref())
+            .map(|mode| mode.query_language)
+            .unwrap_or_else(|| self.query_language.clone())
     }
 
     pub(super) fn should_show_source_controls(&self, cx: &App) -> bool {
@@ -169,6 +196,7 @@ impl CodeDocument {
         &self,
         cx: &App,
     ) -> Result<ExecutionSourceContext, &'static str> {
+        let query_mode = self.current_source_query_mode_value(cx);
         let targets = self.current_source_targets(cx);
         let start_input = self.source_start_input.read(cx).value().to_string();
         let end_input = self.source_end_input.read(cx).value().to_string();
@@ -184,7 +212,7 @@ impl CodeDocument {
         let start_ms = parse_source_datetime_input(&start_input);
         let end_ms = parse_source_datetime_input(&end_input);
 
-        build_source_window_context(&targets, start_ms, end_ms)
+        build_source_window_context(query_mode, &targets, start_ms, end_ms)
     }
 
     fn sync_source_exec_context(&mut self, cx: &mut Context<Self>) {
@@ -217,6 +245,35 @@ impl CodeDocument {
             Vec::new()
         };
 
+        let source_spec = self.current_source_context_spec(cx);
+        let query_mode_items = source_spec
+            .as_ref()
+            .map(|spec| {
+                spec.query_modes
+                    .iter()
+                    .map(|mode| DropdownItem::with_value(&mode.label, &mode.value))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+
+        let selected_query_mode = match self.exec_ctx.source.as_ref() {
+            Some(ExecutionSourceContext::CollectionWindow { query_mode, .. }) => query_mode
+                .clone()
+                .or_else(|| source_spec.as_ref().and_then(|spec| spec.default_query_mode.clone())),
+            None => source_spec.as_ref().and_then(|spec| spec.default_query_mode.clone()),
+        };
+
+        let selected_query_mode_index = selected_query_mode.as_ref().and_then(|selected| {
+            query_mode_items
+                .iter()
+                .position(|item| item.value.as_ref() == selected)
+        });
+
+        self.source_query_mode_dropdown.update(cx, |dropdown, cx| {
+            dropdown.set_items(query_mode_items, cx);
+            dropdown.set_selected_index(selected_query_mode_index, cx);
+        });
+
         let selected_values = match self.exec_ctx.source.as_ref() {
             Some(ExecutionSourceContext::CollectionWindow { targets, .. }) => targets.clone(),
             None => Vec::new(),
@@ -228,6 +285,18 @@ impl CodeDocument {
         });
 
         self.sync_source_exec_context(cx);
+    }
+
+    pub(super) fn on_source_query_mode_changed(
+        &mut self,
+        _item: &DropdownItem,
+        cx: &mut Context<Self>,
+    ) {
+        self.sync_source_exec_context(cx);
+        self.update_completion_provider(cx);
+        self.schedule_diagnostic_refresh(cx);
+        cx.emit(DocumentEvent::MetaChanged);
+        cx.notify();
     }
 
     pub(super) fn on_source_targets_changed(
@@ -765,6 +834,12 @@ impl CodeDocument {
         let mut slots = vec![ContextBarSlot::Connection];
 
         if self.should_show_source_controls(cx) {
+            if self
+                .current_source_context_spec(cx)
+                .is_some_and(|spec| !spec.query_modes.is_empty())
+            {
+                slots.push(ContextBarSlot::SourceQueryMode);
+            }
             slots.push(ContextBarSlot::SourceTargets);
             slots.push(ContextBarSlot::SourceStart);
             slots.push(ContextBarSlot::SourceEnd);
@@ -786,6 +861,7 @@ impl CodeDocument {
             ContextBarSlot::Connection => Some(&self.connection_dropdown),
             ContextBarSlot::Database => Some(&self.database_dropdown),
             ContextBarSlot::Schema => Some(&self.schema_dropdown),
+            ContextBarSlot::SourceQueryMode => Some(&self.source_query_mode_dropdown),
             ContextBarSlot::SourceTargets
             | ContextBarSlot::SourceStart
             | ContextBarSlot::SourceEnd => None,
@@ -894,6 +970,10 @@ impl CodeDocument {
 
             Command::Execute => {
                 match self.context_bar_slot {
+                    ContextBarSlot::SourceQueryMode => {
+                        self.source_query_mode_dropdown
+                            .update(cx, |dropdown, cx| dropdown.toggle_open(cx));
+                    }
                     ContextBarSlot::SourceTargets => {
                         self.source_targets
                             .update(cx, |multi_select, cx| multi_select.toggle_open(cx));
@@ -937,6 +1017,7 @@ impl CodeDocument {
             ContextBarSlot::Connection,
             ContextBarSlot::Database,
             ContextBarSlot::Schema,
+            ContextBarSlot::SourceQueryMode,
         ] {
             if let Some(dropdown) = self.dropdown_for_slot(slot) {
                 let color = if slot == self.context_bar_slot {
@@ -954,6 +1035,7 @@ impl CodeDocument {
             ContextBarSlot::Connection,
             ContextBarSlot::Database,
             ContextBarSlot::Schema,
+            ContextBarSlot::SourceQueryMode,
         ] {
             if let Some(dropdown) = self.dropdown_for_slot(slot) {
                 dropdown.update(cx, |dd, cx| dd.set_focus_ring(None, cx));
@@ -1008,9 +1090,27 @@ impl CodeDocument {
                     )),
             )
             .when(show_source_controls, |el| {
-                el.child(Text::caption(
+                let source_spec = source_spec.as_ref();
+
+                el.when(source_spec.is_some_and(|spec| !spec.query_modes.is_empty()), |el| {
+                    el.child(Text::caption(
+                        source_spec
+                            .and_then(|spec| spec.query_mode_label.clone())
+                            .unwrap_or_else(|| "Syntax".to_string()),
+                    ))
+                    .child(div().min_w(px(180.0)).child(focus_frame(
+                        context_slot_is_keyboard_focused(
+                            self.focus_mode,
+                            self.context_bar_slot,
+                            ContextBarSlot::SourceQueryMode,
+                        ),
+                        Some(theme.ring),
+                        control_shell(self.source_query_mode_dropdown.clone(), cx),
+                        cx,
+                    )))
+                })
+                .child(Text::caption(
                     source_spec
-                        .as_ref()
                         .map(|spec| spec.targets_label.clone())
                         .unwrap_or_else(|| "Sources".to_string()),
                 ))
@@ -1026,7 +1126,6 @@ impl CodeDocument {
                 )))
                 .child(Text::caption(
                     source_spec
-                        .as_ref()
                         .map(|spec| spec.start_label.clone())
                         .unwrap_or_else(|| "Start".to_string()),
                 ))
@@ -1042,7 +1141,6 @@ impl CodeDocument {
                 )))
                 .child(Text::caption(
                     source_spec
-                        .as_ref()
                         .map(|spec| spec.end_label.clone())
                         .unwrap_or_else(|| "End".to_string()),
                 ))
@@ -1149,35 +1247,64 @@ mod tests {
 
     #[test]
     fn valid_source_context_requires_targets_and_ordered_bounds() {
-        let source =
-            build_source_window_context(&["/aws/lambda/app".to_string()], Some(10), Some(20))
-                .expect("valid source context");
+        let source = build_source_window_context(
+            Some("cwli".to_string()),
+            &["/aws/lambda/app".to_string()],
+            Some(10),
+            Some(20),
+        )
+        .expect("valid source context");
 
         match source {
             ExecutionSourceContext::CollectionWindow {
                 targets,
                 start_ms,
                 end_ms,
+                query_mode,
             } => {
                 assert_eq!(targets, vec!["/aws/lambda/app"]);
                 assert_eq!(start_ms, 10);
                 assert_eq!(end_ms, 20);
+                assert_eq!(query_mode.as_deref(), Some("cwli"));
             }
         }
 
         assert_eq!(
-            build_source_window_context(&[], Some(10), Some(20)).unwrap_err(),
+            build_source_window_context(Some("cwli".to_string()), &[], Some(10), Some(20))
+                .unwrap_err(),
             "Select at least one source"
         );
         assert_eq!(
-            build_source_window_context(&["/aws/lambda/app".to_string()], None, Some(20))
-                .unwrap_err(),
+            build_source_window_context(
+                Some("cwli".to_string()),
+                &["/aws/lambda/app".to_string()],
+                None,
+                Some(20),
+            )
+            .unwrap_err(),
             "Start time is required"
         );
         assert_eq!(
-            build_source_window_context(&["/aws/lambda/app".to_string()], Some(20), Some(10))
-                .unwrap_err(),
+            build_source_window_context(
+                Some("cwli".to_string()),
+                &["/aws/lambda/app".to_string()],
+                Some(20),
+                Some(10),
+            )
+            .unwrap_err(),
             "Start time must be earlier than end time"
         );
+    }
+
+    #[test]
+    fn sql_source_context_allows_empty_targets() {
+        let source = build_source_window_context(Some("sql".to_string()), &[], Some(10), Some(20))
+            .expect("sql source context without explicit targets");
+
+        match source {
+            ExecutionSourceContext::CollectionWindow { targets, .. } => {
+                assert!(targets.is_empty());
+            }
+        }
     }
 }

--- a/crates/dbflux_ui/src/ui/document/code/context_bar.rs
+++ b/crates/dbflux_ui/src/ui/document/code/context_bar.rs
@@ -175,7 +175,8 @@ impl CodeDocument {
 
         if start_input.trim().is_empty()
             && end_input.trim().is_empty()
-            && let Some(source @ ExecutionSourceContext::CollectionWindow { .. }) = self.exec_ctx.source.clone()
+            && let Some(source @ ExecutionSourceContext::CollectionWindow { .. }) =
+                self.exec_ctx.source.clone()
         {
             return Ok(source);
         }
@@ -192,12 +193,7 @@ impl CodeDocument {
             return;
         }
 
-        let start_blank = self
-            .source_start_input
-            .read(cx)
-            .value()
-            .trim()
-            .is_empty();
+        let start_blank = self.source_start_input.read(cx).value().trim().is_empty();
         let end_blank = self.source_end_input.read(cx).value().trim().is_empty();
 
         if start_blank
@@ -790,7 +786,9 @@ impl CodeDocument {
             ContextBarSlot::Connection => Some(&self.connection_dropdown),
             ContextBarSlot::Database => Some(&self.database_dropdown),
             ContextBarSlot::Schema => Some(&self.schema_dropdown),
-            ContextBarSlot::SourceTargets | ContextBarSlot::SourceStart | ContextBarSlot::SourceEnd => None,
+            ContextBarSlot::SourceTargets
+            | ContextBarSlot::SourceStart
+            | ContextBarSlot::SourceEnd => None,
         }
     }
 
@@ -1016,48 +1014,48 @@ impl CodeDocument {
                         .map(|spec| spec.targets_label.clone())
                         .unwrap_or_else(|| "Sources".to_string()),
                 ))
-                    .child(div().min_w(px(260.0)).child(focus_frame(
-                        context_slot_is_keyboard_focused(
-                            self.focus_mode,
-                            self.context_bar_slot,
-                            ContextBarSlot::SourceTargets,
-                        ),
-                        Some(theme.ring),
-                        control_shell(self.source_targets.clone(), cx),
-                        cx,
-                    )))
-                    .child(Text::caption(
-                        source_spec
-                            .as_ref()
-                            .map(|spec| spec.start_label.clone())
-                            .unwrap_or_else(|| "Start".to_string()),
-                    ))
-                    .child(div().min_w(px(180.0)).child(focus_frame(
-                        context_slot_is_keyboard_focused(
-                            self.focus_mode,
-                            self.context_bar_slot,
-                            ContextBarSlot::SourceStart,
-                        ),
-                        Some(theme.ring),
-                        control_shell(Input::new(&self.source_start_input), cx),
-                        cx,
-                    )))
-                    .child(Text::caption(
-                        source_spec
-                            .as_ref()
-                            .map(|spec| spec.end_label.clone())
-                            .unwrap_or_else(|| "End".to_string()),
-                    ))
-                    .child(div().min_w(px(180.0)).child(focus_frame(
-                        context_slot_is_keyboard_focused(
-                            self.focus_mode,
-                            self.context_bar_slot,
-                            ContextBarSlot::SourceEnd,
-                        ),
-                        Some(theme.ring),
-                        control_shell(Input::new(&self.source_end_input), cx),
-                        cx,
-                    )))
+                .child(div().min_w(px(260.0)).child(focus_frame(
+                    context_slot_is_keyboard_focused(
+                        self.focus_mode,
+                        self.context_bar_slot,
+                        ContextBarSlot::SourceTargets,
+                    ),
+                    Some(theme.ring),
+                    control_shell(self.source_targets.clone(), cx),
+                    cx,
+                )))
+                .child(Text::caption(
+                    source_spec
+                        .as_ref()
+                        .map(|spec| spec.start_label.clone())
+                        .unwrap_or_else(|| "Start".to_string()),
+                ))
+                .child(div().min_w(px(180.0)).child(focus_frame(
+                    context_slot_is_keyboard_focused(
+                        self.focus_mode,
+                        self.context_bar_slot,
+                        ContextBarSlot::SourceStart,
+                    ),
+                    Some(theme.ring),
+                    control_shell(Input::new(&self.source_start_input), cx),
+                    cx,
+                )))
+                .child(Text::caption(
+                    source_spec
+                        .as_ref()
+                        .map(|spec| spec.end_label.clone())
+                        .unwrap_or_else(|| "End".to_string()),
+                ))
+                .child(div().min_w(px(180.0)).child(focus_frame(
+                    context_slot_is_keyboard_focused(
+                        self.focus_mode,
+                        self.context_bar_slot,
+                        ContextBarSlot::SourceEnd,
+                    ),
+                    Some(theme.ring),
+                    control_shell(Input::new(&self.source_end_input), cx),
+                    cx,
+                )))
             })
             .when(!show_source_controls && show_db, |el| {
                 el.child(Text::caption("Database:")).child(

--- a/crates/dbflux_ui/src/ui/document/code/execution.rs
+++ b/crates/dbflux_ui/src/ui/document/code/execution.rs
@@ -224,8 +224,8 @@ impl CodeDocument {
             }
         }
 
-        if self.should_show_cloudwatch_source_controls(cx) {
-            match self.current_cloudwatch_source_context(cx) {
+        if self.should_show_source_controls(cx) {
+            match self.current_source_context(cx) {
                 Ok(source) => {
                     self.exec_ctx.source = Some(source);
                 }
@@ -1285,19 +1285,19 @@ impl CodeDocument {
 #[cfg(test)]
 mod tests {
     use super::query_request_for_execution;
-    use crate::ui::document::code::build_cloudwatch_source_context;
+    use crate::ui::document::code::build_source_window_context;
     use dbflux_core::{ExecutionContext, ExecutionSourceContext};
     use uuid::Uuid;
 
     #[test]
-    fn cloudwatch_execution_request_uses_latest_editor_context() {
+    fn source_window_execution_request_uses_latest_editor_context() {
         let exec_ctx = ExecutionContext {
             connection_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             database: Some("logs".into()),
             schema: None,
             container: None,
             source: Some(
-                build_cloudwatch_source_context(
+                build_source_window_context(
                     &["/aws/lambda/app".to_string(), "/aws/ecs/api".to_string()],
                     Some(10),
                     Some(20),
@@ -1312,12 +1312,12 @@ mod tests {
         assert_eq!(request.database.as_deref(), Some("logs"));
 
         match request.execution_context.and_then(|ctx| ctx.source) {
-            Some(ExecutionSourceContext::CloudWatchLogs {
-                log_groups,
+            Some(ExecutionSourceContext::CollectionWindow {
+                targets,
                 start_ms,
                 end_ms,
             }) => {
-                assert_eq!(log_groups, vec!["/aws/lambda/app", "/aws/ecs/api"]);
+                assert_eq!(targets, vec!["/aws/lambda/app", "/aws/ecs/api"]);
                 assert_eq!(start_ms, 10);
                 assert_eq!(end_ms, 20);
             }
@@ -1326,31 +1326,31 @@ mod tests {
     }
 
     #[test]
-    fn cloudwatch_execution_blocks_when_log_groups_are_missing() {
+    fn source_window_execution_blocks_when_targets_are_missing() {
         assert_eq!(
-            build_cloudwatch_source_context(&[], Some(10), Some(20)).unwrap_err(),
-            "Select at least one log group"
+            build_source_window_context(&[], Some(10), Some(20)).unwrap_err(),
+            "Select at least one source"
         );
     }
 
     #[test]
-    fn cloudwatch_execution_blocks_when_bounds_are_missing() {
+    fn source_window_execution_blocks_when_bounds_are_missing() {
         assert_eq!(
-            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], None, Some(20))
+            build_source_window_context(&["/aws/lambda/app".to_string()], None, Some(20))
                 .unwrap_err(),
             "Start time is required"
         );
         assert_eq!(
-            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], Some(10), None)
+            build_source_window_context(&["/aws/lambda/app".to_string()], Some(10), None)
                 .unwrap_err(),
             "End time is required"
         );
     }
 
     #[test]
-    fn cloudwatch_execution_blocks_when_range_is_inverted() {
+    fn source_window_execution_blocks_when_range_is_inverted() {
         assert_eq!(
-            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], Some(20), Some(10))
+            build_source_window_context(&["/aws/lambda/app".to_string()], Some(20), Some(10))
                 .unwrap_err(),
             "Start time must be earlier than end time"
         );

--- a/crates/dbflux_ui/src/ui/document/code/execution.rs
+++ b/crates/dbflux_ui/src/ui/document/code/execution.rs
@@ -1298,6 +1298,7 @@ mod tests {
             container: None,
             source: Some(
                 build_source_window_context(
+                    Some("cwli".to_string()),
                     &["/aws/lambda/app".to_string(), "/aws/ecs/api".to_string()],
                     Some(10),
                     Some(20),
@@ -1316,10 +1317,12 @@ mod tests {
                 targets,
                 start_ms,
                 end_ms,
+                query_mode,
             }) => {
                 assert_eq!(targets, vec!["/aws/lambda/app", "/aws/ecs/api"]);
                 assert_eq!(start_ms, 10);
                 assert_eq!(end_ms, 20);
+                assert_eq!(query_mode.as_deref(), Some("cwli"));
             }
             other => panic!("unexpected execution source: {other:?}"),
         }
@@ -1328,7 +1331,8 @@ mod tests {
     #[test]
     fn source_window_execution_blocks_when_targets_are_missing() {
         assert_eq!(
-            build_source_window_context(&[], Some(10), Some(20)).unwrap_err(),
+            build_source_window_context(Some("cwli".to_string()), &[], Some(10), Some(20))
+                .unwrap_err(),
             "Select at least one source"
         );
     }
@@ -1336,13 +1340,23 @@ mod tests {
     #[test]
     fn source_window_execution_blocks_when_bounds_are_missing() {
         assert_eq!(
-            build_source_window_context(&["/aws/lambda/app".to_string()], None, Some(20))
-                .unwrap_err(),
+            build_source_window_context(
+                Some("cwli".to_string()),
+                &["/aws/lambda/app".to_string()],
+                None,
+                Some(20),
+            )
+            .unwrap_err(),
             "Start time is required"
         );
         assert_eq!(
-            build_source_window_context(&["/aws/lambda/app".to_string()], Some(10), None)
-                .unwrap_err(),
+            build_source_window_context(
+                Some("cwli".to_string()),
+                &["/aws/lambda/app".to_string()],
+                Some(10),
+                None,
+            )
+            .unwrap_err(),
             "End time is required"
         );
     }
@@ -1350,8 +1364,13 @@ mod tests {
     #[test]
     fn source_window_execution_blocks_when_range_is_inverted() {
         assert_eq!(
-            build_source_window_context(&["/aws/lambda/app".to_string()], Some(20), Some(10))
-                .unwrap_err(),
+            build_source_window_context(
+                Some("cwli".to_string()),
+                &["/aws/lambda/app".to_string()],
+                Some(20),
+                Some(10),
+            )
+            .unwrap_err(),
             "Start time must be earlier than end time"
         );
     }

--- a/crates/dbflux_ui/src/ui/document/code/execution.rs
+++ b/crates/dbflux_ui/src/ui/document/code/execution.rs
@@ -224,6 +224,19 @@ impl CodeDocument {
             }
         }
 
+        if self.should_show_cloudwatch_source_controls(cx) {
+            match self.current_cloudwatch_source_context(cx) {
+                Ok(source) => {
+                    self.exec_ctx.source = Some(source);
+                }
+                Err(message) => {
+                    self.exec_ctx.source = None;
+                    cx.toast_error(message, window);
+                    return;
+                }
+            }
+        }
+
         self.execute_query_internal(query, in_new_tab, window, cx);
     }
 
@@ -302,7 +315,7 @@ impl CodeDocument {
         cx.emit(DocumentEvent::ExecutionStarted);
         cx.notify();
 
-        let request = QueryRequest::new(query.clone()).with_database(active_database);
+        let request = query_request_for_execution(query.clone(), active_database, &self.exec_ctx);
 
         // Capture audit_service, task_target, and started_at before spawning so we can emit
         // audit events even if the document is closed before the deferred task runs.
@@ -1266,5 +1279,80 @@ impl CodeDocument {
             }
         })
         .detach();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::query_request_for_execution;
+    use crate::ui::document::code::build_cloudwatch_source_context;
+    use dbflux_core::{ExecutionContext, ExecutionSourceContext};
+    use uuid::Uuid;
+
+    #[test]
+    fn cloudwatch_execution_request_uses_latest_editor_context() {
+        let exec_ctx = ExecutionContext {
+            connection_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
+            database: Some("logs".into()),
+            schema: None,
+            container: None,
+            source: Some(
+                build_cloudwatch_source_context(
+                    &["/aws/lambda/app".to_string(), "/aws/ecs/api".to_string()],
+                    Some(10),
+                    Some(20),
+                )
+                .expect("valid source"),
+            ),
+        };
+
+        let request =
+            query_request_for_execution("fields @message".into(), Some("logs".into()), &exec_ctx);
+
+        assert_eq!(request.database.as_deref(), Some("logs"));
+
+        match request.execution_context.and_then(|ctx| ctx.source) {
+            Some(ExecutionSourceContext::CloudWatchLogs {
+                log_groups,
+                start_ms,
+                end_ms,
+            }) => {
+                assert_eq!(log_groups, vec!["/aws/lambda/app", "/aws/ecs/api"]);
+                assert_eq!(start_ms, 10);
+                assert_eq!(end_ms, 20);
+            }
+            other => panic!("unexpected execution source: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cloudwatch_execution_blocks_when_log_groups_are_missing() {
+        assert_eq!(
+            build_cloudwatch_source_context(&[], Some(10), Some(20)).unwrap_err(),
+            "Select at least one log group"
+        );
+    }
+
+    #[test]
+    fn cloudwatch_execution_blocks_when_bounds_are_missing() {
+        assert_eq!(
+            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], None, Some(20))
+                .unwrap_err(),
+            "Start time is required"
+        );
+        assert_eq!(
+            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], Some(10), None)
+                .unwrap_err(),
+            "End time is required"
+        );
+    }
+
+    #[test]
+    fn cloudwatch_execution_blocks_when_range_is_inverted() {
+        assert_eq!(
+            build_cloudwatch_source_context(&["/aws/lambda/app".to_string()], Some(20), Some(10))
+                .unwrap_err(),
+            "Start time must be earlier than end time"
+        );
     }
 }

--- a/crates/dbflux_ui/src/ui/document/code/file_ops.rs
+++ b/crates/dbflux_ui/src/ui/document/code/file_ops.rs
@@ -279,14 +279,14 @@ mod tests {
     use uuid::Uuid;
 
     #[test]
-    fn file_headers_remain_relational_only_when_cloudwatch_source_exists() {
+    fn file_headers_remain_relational_only_when_source_window_exists() {
         let exec_ctx = ExecutionContext {
             connection_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             database: Some("logs".into()),
             schema: None,
             container: None,
-            source: Some(ExecutionSourceContext::CloudWatchLogs {
-                log_groups: vec!["/aws/lambda/app".into()],
+            source: Some(ExecutionSourceContext::CollectionWindow {
+                targets: vec!["/aws/lambda/app".into()],
                 start_ms: 10,
                 end_ms: 20,
             }),

--- a/crates/dbflux_ui/src/ui/document/code/file_ops.rs
+++ b/crates/dbflux_ui/src/ui/document/code/file_ops.rs
@@ -289,6 +289,7 @@ mod tests {
                 targets: vec!["/aws/lambda/app".into()],
                 start_ms: 10,
                 end_ms: 20,
+                query_mode: Some("cwli".into()),
             }),
         };
 

--- a/crates/dbflux_ui/src/ui/document/code/file_ops.rs
+++ b/crates/dbflux_ui/src/ui/document/code/file_ops.rs
@@ -1,5 +1,23 @@
 use super::*;
 
+fn build_file_content_for_language(
+    editor_content: &str,
+    exec_ctx: &ExecutionContext,
+    language: QueryLanguage,
+) -> String {
+    if !language.supports_connection_context() {
+        return editor_content.to_string();
+    }
+
+    let header = exec_ctx.to_comment_header(language.clone());
+    if header.is_empty() {
+        return editor_content.to_string();
+    }
+
+    let body = CodeDocument::strip_existing_annotations(editor_content, language);
+    format!("{}\n{}", header, body)
+}
+
 impl CodeDocument {
     /// Save to the current path. If no path is set, redirects to Save As.
     pub fn save_file(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -216,18 +234,11 @@ impl CodeDocument {
     pub fn build_file_content(&self, cx: &App) -> String {
         let editor_content = self.input_state.read(cx).value().to_string();
 
-        let language = self.query_language.clone();
-        if !language.supports_connection_context() {
-            return editor_content;
-        }
-
-        let header = self.exec_ctx.to_comment_header(language.clone());
-        if header.is_empty() {
-            return editor_content;
-        }
-
-        let body = Self::strip_existing_annotations(&editor_content, language);
-        format!("{}\n{}", header, body)
+        build_file_content_for_language(
+            &editor_content,
+            &self.exec_ctx,
+            self.query_language.clone(),
+        )
     }
 
     /// Strip existing annotation comments from the beginning of content.
@@ -258,5 +269,35 @@ impl CodeDocument {
         } else {
             &content[last_annotation_end..]
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_file_content_for_language;
+    use dbflux_core::{ExecutionContext, ExecutionSourceContext, QueryLanguage};
+    use uuid::Uuid;
+
+    #[test]
+    fn file_headers_remain_relational_only_when_cloudwatch_source_exists() {
+        let exec_ctx = ExecutionContext {
+            connection_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
+            database: Some("logs".into()),
+            schema: None,
+            container: None,
+            source: Some(ExecutionSourceContext::CloudWatchLogs {
+                log_groups: vec!["/aws/lambda/app".into()],
+                start_ms: 10,
+                end_ms: 20,
+            }),
+        };
+
+        let content = build_file_content_for_language("SELECT 1;", &exec_ctx, QueryLanguage::Sql);
+
+        assert!(content.contains("-- @connection:"));
+        assert!(content.contains("-- @database: logs"));
+        assert!(!content.contains("log_groups"));
+        assert!(!content.contains("start_ms"));
+        assert!(!content.contains("end_ms"));
     }
 }

--- a/crates/dbflux_ui/src/ui/document/code/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/code/mod.rs
@@ -126,9 +126,7 @@ fn format_source_datetime_input(timestamp_ms: i64) -> String {
         .unwrap_or_default()
 }
 
-fn source_input_values_from_context(
-    source: &ExecutionSourceContext,
-) -> Option<(String, String)> {
+fn source_input_values_from_context(source: &ExecutionSourceContext) -> Option<(String, String)> {
     match source {
         ExecutionSourceContext::CollectionWindow {
             start_ms, end_ms, ..

--- a/crates/dbflux_ui/src/ui/document/code/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/code/mod.rs
@@ -87,17 +87,22 @@ enum ContextBarSlot {
     Connection,
     Database,
     Schema,
+    SourceQueryMode,
     SourceTargets,
     SourceStart,
     SourceEnd,
 }
 
 fn build_source_window_context(
+    query_mode: Option<String>,
     targets: &[String],
     start_ms: Option<i64>,
     end_ms: Option<i64>,
 ) -> Result<ExecutionSourceContext, &'static str> {
-    if targets.is_empty() {
+    let query_mode = query_mode.filter(|value| !value.trim().is_empty());
+    let requires_targets = query_mode.as_deref() != Some("sql");
+
+    if requires_targets && targets.is_empty() {
         return Err("Select at least one source");
     }
 
@@ -117,6 +122,7 @@ fn build_source_window_context(
         targets: targets.to_vec(),
         start_ms,
         end_ms,
+        query_mode,
     })
 }
 
@@ -174,6 +180,7 @@ pub struct CodeDocument {
     connection_dropdown: Entity<Dropdown>,
     database_dropdown: Entity<Dropdown>,
     schema_dropdown: Entity<Dropdown>,
+    source_query_mode_dropdown: Entity<Dropdown>,
     source_targets: Entity<MultiSelect>,
     source_start_input: Entity<InputState>,
     source_end_input: Entity<InputState>,
@@ -435,12 +442,24 @@ impl CodeDocument {
             Self::create_database_dropdown(&app_state, &exec_ctx, window, cx);
         let (schema_dropdown, schema_sub) =
             Self::create_schema_dropdown(&app_state, &exec_ctx, window, cx);
+        let source_query_mode_dropdown = cx.new(|_cx| {
+            Dropdown::new("ctx-source-query-mode")
+                .placeholder("Syntax")
+                .toolbar_style(true)
+        });
         let source_targets =
             cx.new(|_cx| MultiSelect::new("ctx-source-targets").placeholder("Sources"));
         let source_start_input =
             cx.new(|cx| InputState::new(window, cx).placeholder("2026-04-24T00:00:00Z"));
         let source_end_input =
             cx.new(|cx| InputState::new(window, cx).placeholder("2026-04-24T01:00:00Z"));
+        let source_query_mode_sub = cx.subscribe_in(
+            &source_query_mode_dropdown,
+            window,
+            |this, _, event: &DropdownSelectionChanged, _window, cx| {
+                this.on_source_query_mode_changed(&event.item, cx);
+            },
+        );
         let source_targets_sub = cx.subscribe(
             &source_targets,
             |this, entity, _event: &MultiSelectChanged, cx| {
@@ -478,7 +497,7 @@ impl CodeDocument {
 
         let refresh_policy = default_refresh;
 
-        Self {
+        let mut document = Self {
             id: doc_id,
             title: "Query 1".to_string(),
             state: DocumentState::Clean,
@@ -496,6 +515,7 @@ impl CodeDocument {
             connection_dropdown,
             database_dropdown,
             schema_dropdown,
+            source_query_mode_dropdown,
             source_targets,
             source_start_input,
             source_end_input,
@@ -504,6 +524,7 @@ impl CodeDocument {
                 conn_sub,
                 db_sub,
                 schema_sub,
+                source_query_mode_sub,
                 source_targets_sub,
                 source_start_sub,
                 source_end_sub,
@@ -544,7 +565,10 @@ impl CodeDocument {
             show_saved_label: false,
             _saved_label_timer: None,
             pending_error: None,
-        }
+        };
+
+        document.sync_context_dropdowns(cx);
+        document
     }
 
     pub fn can_auto_refresh(&self, cx: &App) -> bool {
@@ -1091,6 +1115,7 @@ mod tests {
             targets: vec!["/aws/lambda/app".to_string()],
             start_ms: 1_704_067_200_000,
             end_ms: 1_704_070_800_000,
+            query_mode: Some("cwli".to_string()),
         })
         .expect("source input values");
 

--- a/crates/dbflux_ui/src/ui/document/code/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/code/mod.rs
@@ -87,18 +87,18 @@ enum ContextBarSlot {
     Connection,
     Database,
     Schema,
-    CloudWatchLogGroups,
-    CloudWatchStart,
-    CloudWatchEnd,
+    SourceTargets,
+    SourceStart,
+    SourceEnd,
 }
 
-fn build_cloudwatch_source_context(
-    log_groups: &[String],
+fn build_source_window_context(
+    targets: &[String],
     start_ms: Option<i64>,
     end_ms: Option<i64>,
 ) -> Result<ExecutionSourceContext, &'static str> {
-    if log_groups.is_empty() {
-        return Err("Select at least one log group");
+    if targets.is_empty() {
+        return Err("Select at least one source");
     }
 
     let Some(start_ms) = start_ms else {
@@ -113,28 +113,28 @@ fn build_cloudwatch_source_context(
         return Err("Start time must be earlier than end time");
     }
 
-    Ok(ExecutionSourceContext::CloudWatchLogs {
-        log_groups: log_groups.to_vec(),
+    Ok(ExecutionSourceContext::CollectionWindow {
+        targets: targets.to_vec(),
         start_ms,
         end_ms,
     })
 }
 
-fn format_cloudwatch_datetime_input(timestamp_ms: i64) -> String {
+fn format_source_datetime_input(timestamp_ms: i64) -> String {
     dbflux_core::chrono::DateTime::from_timestamp_millis(timestamp_ms)
         .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
         .unwrap_or_default()
 }
 
-fn cloudwatch_input_values_from_source(
+fn source_input_values_from_context(
     source: &ExecutionSourceContext,
 ) -> Option<(String, String)> {
     match source {
-        ExecutionSourceContext::CloudWatchLogs {
+        ExecutionSourceContext::CollectionWindow {
             start_ms, end_ms, ..
         } => Some((
-            format_cloudwatch_datetime_input(*start_ms),
-            format_cloudwatch_datetime_input(*end_ms),
+            format_source_datetime_input(*start_ms),
+            format_source_datetime_input(*end_ms),
         )),
     }
 }
@@ -176,10 +176,10 @@ pub struct CodeDocument {
     connection_dropdown: Entity<Dropdown>,
     database_dropdown: Entity<Dropdown>,
     schema_dropdown: Entity<Dropdown>,
-    cloudwatch_log_groups: Entity<MultiSelect>,
-    cloudwatch_start_input: Entity<InputState>,
-    cloudwatch_end_input: Entity<InputState>,
-    pending_cloudwatch_input_values: Option<(String, String)>,
+    source_targets: Entity<MultiSelect>,
+    source_start_input: Entity<InputState>,
+    source_end_input: Entity<InputState>,
+    pending_source_input_values: Option<(String, String)>,
     _context_subscriptions: Vec<Subscription>,
 
     // Execution
@@ -437,40 +437,40 @@ impl CodeDocument {
             Self::create_database_dropdown(&app_state, &exec_ctx, window, cx);
         let (schema_dropdown, schema_sub) =
             Self::create_schema_dropdown(&app_state, &exec_ctx, window, cx);
-        let cloudwatch_log_groups =
-            cx.new(|_cx| MultiSelect::new("ctx-cloudwatch-log-groups").placeholder("Log groups"));
-        let cloudwatch_start_input =
+        let source_targets =
+            cx.new(|_cx| MultiSelect::new("ctx-source-targets").placeholder("Sources"));
+        let source_start_input =
             cx.new(|cx| InputState::new(window, cx).placeholder("2026-04-24T00:00:00Z"));
-        let cloudwatch_end_input =
+        let source_end_input =
             cx.new(|cx| InputState::new(window, cx).placeholder("2026-04-24T01:00:00Z"));
-        let cloudwatch_log_groups_sub = cx.subscribe(
-            &cloudwatch_log_groups,
+        let source_targets_sub = cx.subscribe(
+            &source_targets,
             |this, entity, _event: &MultiSelectChanged, cx| {
-                let selected_log_groups = entity
+                let selected_targets = entity
                     .read(cx)
                     .selected_values()
                     .iter()
                     .map(|value| value.to_string())
                     .collect::<Vec<_>>();
 
-                this.on_cloudwatch_log_groups_changed(selected_log_groups, cx);
+                this.on_source_targets_changed(selected_targets, cx);
             },
         );
-        let cloudwatch_start_sub = cx.subscribe_in(
-            &cloudwatch_start_input,
+        let source_start_sub = cx.subscribe_in(
+            &source_start_input,
             window,
             |this, _input, event: &InputEvent, _window, cx| {
                 if matches!(event, InputEvent::Change) {
-                    this.on_cloudwatch_time_range_changed(cx);
+                    this.on_source_time_range_changed(cx);
                 }
             },
         );
-        let cloudwatch_end_sub = cx.subscribe_in(
-            &cloudwatch_end_input,
+        let source_end_sub = cx.subscribe_in(
+            &source_end_input,
             window,
             |this, _input, event: &InputEvent, _window, cx| {
                 if matches!(event, InputEvent::Change) {
-                    this.on_cloudwatch_time_range_changed(cx);
+                    this.on_source_time_range_changed(cx);
                 }
             },
         );
@@ -498,17 +498,17 @@ impl CodeDocument {
             connection_dropdown,
             database_dropdown,
             schema_dropdown,
-            cloudwatch_log_groups,
-            cloudwatch_start_input,
-            cloudwatch_end_input,
-            pending_cloudwatch_input_values: None,
+            source_targets,
+            source_start_input,
+            source_end_input,
+            pending_source_input_values: None,
             _context_subscriptions: vec![
                 conn_sub,
                 db_sub,
                 schema_sub,
-                cloudwatch_log_groups_sub,
-                cloudwatch_start_sub,
-                cloudwatch_end_sub,
+                source_targets_sub,
+                source_start_sub,
+                source_end_sub,
                 app_state_sub,
             ],
             execution_history: Vec::new(),
@@ -632,10 +632,10 @@ impl CodeDocument {
 
     /// Set the execution context (e.g. parsed from file header).
     pub fn with_exec_ctx(mut self, ctx: ExecutionContext, cx: &mut Context<Self>) -> Self {
-        self.pending_cloudwatch_input_values = ctx
+        self.pending_source_input_values = ctx
             .source
             .as_ref()
-            .and_then(cloudwatch_input_values_from_source);
+            .and_then(source_input_values_from_context);
         self.connection_id = ctx.connection_id;
         self.exec_ctx = ctx;
         self.sync_context_dropdowns(cx);
@@ -1084,17 +1084,17 @@ impl CodeDocument {
 
 #[cfg(test)]
 mod tests {
-    use super::cloudwatch_input_values_from_source;
+    use super::source_input_values_from_context;
     use dbflux_core::ExecutionSourceContext;
 
     #[test]
-    fn cloudwatch_input_values_restore_start_and_end_strings() {
-        let values = cloudwatch_input_values_from_source(&ExecutionSourceContext::CloudWatchLogs {
-            log_groups: vec!["/aws/lambda/app".to_string()],
+    fn source_input_values_restore_start_and_end_strings() {
+        let values = source_input_values_from_context(&ExecutionSourceContext::CollectionWindow {
+            targets: vec!["/aws/lambda/app".to_string()],
             start_ms: 1_704_067_200_000,
             end_ms: 1_704_070_800_000,
         })
-        .expect("cloudwatch input values");
+        .expect("source input values");
 
         assert_eq!(values.0, "2024-01-01T00:00:00Z");
         assert_eq!(values.1, "2024-01-01T01:00:00Z");

--- a/crates/dbflux_ui/src/ui/document/code/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/code/mod.rs
@@ -5,6 +5,7 @@ use super::types::{DocumentId, DocumentState};
 use crate::app::{AppStateChanged, AppStateEntity};
 use crate::keymap::{Command, ContextId};
 use crate::ui::components::dropdown::{Dropdown, DropdownItem, DropdownSelectionChanged};
+use crate::ui::components::multi_select::{MultiSelect, MultiSelectChanged};
 use crate::ui::components::toast::ToastExt;
 use crate::ui::icons::AppIcon;
 use crate::ui::overlays::history_modal::{HistoryModal, HistoryQuerySelected};
@@ -19,9 +20,9 @@ use dbflux_core::observability::{
 };
 use dbflux_core::{
     DangerousAction, DangerousQueryKind, DbError, DiagnosticSeverity as CoreDiagnosticSeverity,
-    DriverCapabilities, EditorDiagnostic as CoreEditorDiagnostic, ExecutionContext, HistoryEntry,
-    OutputReceiver, QueryLanguage, QueryRequest, QueryResult, RefreshPolicy, SchemaLoadingStrategy,
-    TaskTarget, ValidationResult, detect_dangerous_query,
+    DriverCapabilities, EditorDiagnostic as CoreEditorDiagnostic, ExecutionContext,
+    ExecutionSourceContext, HistoryEntry, OutputReceiver, QueryLanguage, QueryRequest, QueryResult,
+    RefreshPolicy, SchemaLoadingStrategy, TaskTarget, ValidationResult, detect_dangerous_query,
 };
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -80,6 +81,74 @@ pub enum SqlQueryFocus {
     ContextBar,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+enum ContextBarSlot {
+    #[default]
+    Connection,
+    Database,
+    Schema,
+    CloudWatchLogGroups,
+    CloudWatchStart,
+    CloudWatchEnd,
+}
+
+fn build_cloudwatch_source_context(
+    log_groups: &[String],
+    start_ms: Option<i64>,
+    end_ms: Option<i64>,
+) -> Result<ExecutionSourceContext, &'static str> {
+    if log_groups.is_empty() {
+        return Err("Select at least one log group");
+    }
+
+    let Some(start_ms) = start_ms else {
+        return Err("Start time is required");
+    };
+
+    let Some(end_ms) = end_ms else {
+        return Err("End time is required");
+    };
+
+    if start_ms > end_ms {
+        return Err("Start time must be earlier than end time");
+    }
+
+    Ok(ExecutionSourceContext::CloudWatchLogs {
+        log_groups: log_groups.to_vec(),
+        start_ms,
+        end_ms,
+    })
+}
+
+fn format_cloudwatch_datetime_input(timestamp_ms: i64) -> String {
+    dbflux_core::chrono::DateTime::from_timestamp_millis(timestamp_ms)
+        .map(|dt| dt.format("%Y-%m-%dT%H:%M:%SZ").to_string())
+        .unwrap_or_default()
+}
+
+fn cloudwatch_input_values_from_source(
+    source: &ExecutionSourceContext,
+) -> Option<(String, String)> {
+    match source {
+        ExecutionSourceContext::CloudWatchLogs {
+            start_ms, end_ms, ..
+        } => Some((
+            format_cloudwatch_datetime_input(*start_ms),
+            format_cloudwatch_datetime_input(*end_ms),
+        )),
+    }
+}
+
+fn query_request_for_execution(
+    query: String,
+    active_database: Option<String>,
+    exec_ctx: &ExecutionContext,
+) -> QueryRequest {
+    QueryRequest::new(query)
+        .with_database(active_database)
+        .with_execution_context(Some(exec_ctx.clone()))
+}
+
 pub struct CodeDocument {
     // Identity
     id: DocumentId,
@@ -107,6 +176,10 @@ pub struct CodeDocument {
     connection_dropdown: Entity<Dropdown>,
     database_dropdown: Entity<Dropdown>,
     schema_dropdown: Entity<Dropdown>,
+    cloudwatch_log_groups: Entity<MultiSelect>,
+    cloudwatch_start_input: Entity<InputState>,
+    cloudwatch_end_input: Entity<InputState>,
+    pending_cloudwatch_input_values: Option<(String, String)>,
     _context_subscriptions: Vec<Subscription>,
 
     // Execution
@@ -132,7 +205,7 @@ pub struct CodeDocument {
     layout: SqlQueryLayout,
     focus_handle: FocusHandle,
     focus_mode: SqlQueryFocus,
-    context_bar_index: usize,
+    context_bar_slot: ContextBarSlot,
     results_maximized: bool,
 
     // Task runner (query execution)
@@ -364,6 +437,43 @@ impl CodeDocument {
             Self::create_database_dropdown(&app_state, &exec_ctx, window, cx);
         let (schema_dropdown, schema_sub) =
             Self::create_schema_dropdown(&app_state, &exec_ctx, window, cx);
+        let cloudwatch_log_groups =
+            cx.new(|_cx| MultiSelect::new("ctx-cloudwatch-log-groups").placeholder("Log groups"));
+        let cloudwatch_start_input =
+            cx.new(|cx| InputState::new(window, cx).placeholder("2026-04-24T00:00:00Z"));
+        let cloudwatch_end_input =
+            cx.new(|cx| InputState::new(window, cx).placeholder("2026-04-24T01:00:00Z"));
+        let cloudwatch_log_groups_sub = cx.subscribe(
+            &cloudwatch_log_groups,
+            |this, entity, _event: &MultiSelectChanged, cx| {
+                let selected_log_groups = entity
+                    .read(cx)
+                    .selected_values()
+                    .iter()
+                    .map(|value| value.to_string())
+                    .collect::<Vec<_>>();
+
+                this.on_cloudwatch_log_groups_changed(selected_log_groups, cx);
+            },
+        );
+        let cloudwatch_start_sub = cx.subscribe_in(
+            &cloudwatch_start_input,
+            window,
+            |this, _input, event: &InputEvent, _window, cx| {
+                if matches!(event, InputEvent::Change) {
+                    this.on_cloudwatch_time_range_changed(cx);
+                }
+            },
+        );
+        let cloudwatch_end_sub = cx.subscribe_in(
+            &cloudwatch_end_input,
+            window,
+            |this, _input, event: &InputEvent, _window, cx| {
+                if matches!(event, InputEvent::Change) {
+                    this.on_cloudwatch_time_range_changed(cx);
+                }
+            },
+        );
         let app_state_sub = cx.subscribe(&app_state, |this, _, _: &AppStateChanged, cx| {
             this.sync_context_dropdowns(cx);
         });
@@ -388,7 +498,19 @@ impl CodeDocument {
             connection_dropdown,
             database_dropdown,
             schema_dropdown,
-            _context_subscriptions: vec![conn_sub, db_sub, schema_sub, app_state_sub],
+            cloudwatch_log_groups,
+            cloudwatch_start_input,
+            cloudwatch_end_input,
+            pending_cloudwatch_input_values: None,
+            _context_subscriptions: vec![
+                conn_sub,
+                db_sub,
+                schema_sub,
+                cloudwatch_log_groups_sub,
+                cloudwatch_start_sub,
+                cloudwatch_end_sub,
+                app_state_sub,
+            ],
             execution_history: Vec::new(),
             active_execution_index: None,
             pending_result: None,
@@ -405,7 +527,7 @@ impl CodeDocument {
             layout: SqlQueryLayout::EditorOnly,
             focus_handle: cx.focus_handle(),
             focus_mode: SqlQueryFocus::Editor,
-            context_bar_index: 0,
+            context_bar_slot: ContextBarSlot::Connection,
             results_maximized: false,
             runner,
             refresh_policy,
@@ -510,6 +632,10 @@ impl CodeDocument {
 
     /// Set the execution context (e.g. parsed from file header).
     pub fn with_exec_ctx(mut self, ctx: ExecutionContext, cx: &mut Context<Self>) -> Self {
+        self.pending_cloudwatch_input_values = ctx
+            .source
+            .as_ref()
+            .and_then(cloudwatch_input_values_from_source);
         self.connection_id = ctx.connection_id;
         self.exec_ctx = ctx;
         self.sync_context_dropdowns(cx);
@@ -953,6 +1079,25 @@ impl CodeDocument {
         if let Err(err) = self.app_state.read(cx).audit_service().record(e) {
             log::warn!("Failed to emit dangerous query audit event: {}", err);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cloudwatch_input_values_from_source;
+    use dbflux_core::ExecutionSourceContext;
+
+    #[test]
+    fn cloudwatch_input_values_restore_start_and_end_strings() {
+        let values = cloudwatch_input_values_from_source(&ExecutionSourceContext::CloudWatchLogs {
+            log_groups: vec!["/aws/lambda/app".to_string()],
+            start_ms: 1_704_067_200_000,
+            end_ms: 1_704_070_800_000,
+        })
+        .expect("cloudwatch input values");
+
+        assert_eq!(values.0, "2024-01-01T00:00:00Z");
+        assert_eq!(values.1, "2024-01-01T01:00:00Z");
     }
 }
 

--- a/crates/dbflux_ui/src/ui/document/code/render.rs
+++ b/crates/dbflux_ui/src/ui/document/code/render.rs
@@ -620,6 +620,13 @@ impl Render for CodeDocument {
 
         self.process_pending_auto_refresh(window, cx);
 
+        if let Some((start_value, end_value)) = self.pending_cloudwatch_input_values.take() {
+            self.cloudwatch_start_input
+                .update(cx, |state, cx| state.set_value(&start_value, window, cx));
+            self.cloudwatch_end_input
+                .update(cx, |state, cx| state.set_value(&end_value, window, cx));
+        }
+
         if let Some(error) = self.pending_error.take() {
             cx.toast_error(error, window);
         }

--- a/crates/dbflux_ui/src/ui/document/code/render.rs
+++ b/crates/dbflux_ui/src/ui/document/code/render.rs
@@ -620,10 +620,10 @@ impl Render for CodeDocument {
 
         self.process_pending_auto_refresh(window, cx);
 
-        if let Some((start_value, end_value)) = self.pending_cloudwatch_input_values.take() {
-            self.cloudwatch_start_input
+        if let Some((start_value, end_value)) = self.pending_source_input_values.take() {
+            self.source_start_input
                 .update(cx, |state, cx| state.set_value(&start_value, window, cx));
-            self.cloudwatch_end_input
+            self.source_end_input
                 .update(cx, |state, cx| state.set_value(&end_value, window, cx));
         }
 

--- a/crates/dbflux_ui/src/ui/icons/mod.rs
+++ b/crates/dbflux_ui/src/ui/icons/mod.rs
@@ -330,7 +330,11 @@ impl AppIcon {
             QueryLanguage::MongoQuery => Self::BrandMongodb,
             QueryLanguage::RedisCommands => Self::BrandRedis,
             QueryLanguage::InfluxQuery => Self::BrandInfluxDb,
-            QueryLanguage::Sql | QueryLanguage::Cql => Self::Database,
+            QueryLanguage::Sql
+            | QueryLanguage::CloudWatchLogsInsightsQl
+            | QueryLanguage::OpenSearchPpl
+            | QueryLanguage::OpenSearchSql
+            | QueryLanguage::Cql => Self::Database,
             QueryLanguage::Cypher => Self::Database,
             QueryLanguage::Custom(_) => Self::FileCode,
         }

--- a/crates/dbflux_ui/src/ui/views/sidebar/code_generation.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/code_generation.rs
@@ -185,6 +185,8 @@ impl Sidebar {
             foreign_keys: None,
             constraints: None,
             sample_fields: None,
+            presentation: dbflux_core::CollectionPresentation::DataGrid,
+            child_items: None,
         };
 
         if let Some(gen_type) = SqlGenerationType::from_generator_id(generator_id) {

--- a/crates/dbflux_ui/src/ui/views/sidebar/context_menu.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/context_menu.rs
@@ -104,6 +104,16 @@ impl Sidebar {
                     [ContextMenuItem::item("Open", ContextMenuAction::Open)],
                 );
 
+                if self.collection_supports_child_picker(item_id, cx) {
+                    Self::append_menu_section(
+                        &mut items,
+                        [ContextMenuItem::item(
+                            "Browse Event Streams",
+                            ContextMenuAction::OpenChildPicker,
+                        )],
+                    );
+                }
+
                 Self::append_menu_section(
                     &mut items,
                     [
@@ -154,6 +164,16 @@ impl Sidebar {
                     [ContextMenuItem::item("Open", ContextMenuAction::Open)],
                 );
 
+                if self.collection_supports_child_picker(item_id, cx) {
+                    Self::append_menu_section(
+                        &mut items,
+                        [ContextMenuItem::item(
+                            "Browse Event Streams",
+                            ContextMenuAction::OpenChildPicker,
+                        )],
+                    );
+                }
+
                 Self::append_menu_section(
                     &mut items,
                     [ContextMenuItem::item(
@@ -162,37 +182,41 @@ impl Sidebar {
                     )],
                 );
 
-                Self::append_menu_section(
-                    &mut items,
-                    [ContextMenuItem::item(
-                        "Generate Query",
-                        ContextMenuAction::Submenu(vec![
-                            ContextMenuItem::item(
-                                "find",
-                                ContextMenuAction::GenerateCollectionCode(CollectionCodeKind::Find),
-                            ),
-                            ContextMenuItem::item(
-                                "insertOne",
-                                ContextMenuAction::GenerateCollectionCode(
-                                    CollectionCodeKind::InsertOne,
+                if !self.collection_is_event_stream(item_id, cx) {
+                    Self::append_menu_section(
+                        &mut items,
+                        [ContextMenuItem::item(
+                            "Generate Query",
+                            ContextMenuAction::Submenu(vec![
+                                ContextMenuItem::item(
+                                    "find",
+                                    ContextMenuAction::GenerateCollectionCode(
+                                        CollectionCodeKind::Find,
+                                    ),
                                 ),
-                            ),
-                            ContextMenuItem::item(
-                                "updateOne",
-                                ContextMenuAction::GenerateCollectionCode(
-                                    CollectionCodeKind::UpdateOne,
+                                ContextMenuItem::item(
+                                    "insertOne",
+                                    ContextMenuAction::GenerateCollectionCode(
+                                        CollectionCodeKind::InsertOne,
+                                    ),
                                 ),
-                            ),
-                            ContextMenuItem::item(
-                                "deleteOne",
-                                ContextMenuAction::GenerateCollectionCode(
-                                    CollectionCodeKind::DeleteOne,
+                                ContextMenuItem::item(
+                                    "updateOne",
+                                    ContextMenuAction::GenerateCollectionCode(
+                                        CollectionCodeKind::UpdateOne,
+                                    ),
                                 ),
-                            ),
-                        ]),
-                    )
-                    .with_icon(AppIcon::Code)],
-                );
+                                ContextMenuItem::item(
+                                    "deleteOne",
+                                    ContextMenuAction::GenerateCollectionCode(
+                                        CollectionCodeKind::DeleteOne,
+                                    ),
+                                ),
+                            ]),
+                        )
+                        .with_icon(AppIcon::Code)],
+                    );
+                }
 
                 // Drop collection gated on DDL capabilities
                 if self
@@ -658,6 +682,101 @@ impl Sidebar {
         conn.connection.metadata().ddl.clone()
     }
 
+    pub(super) fn collection_info_for_item(&self, item_id: &str, cx: &App) -> Option<TableInfo> {
+        let SchemaNodeId::Collection {
+            profile_id,
+            database,
+            name,
+        } = parse_node_id(item_id)?
+        else {
+            return None;
+        };
+
+        let state = self.app_state.read(cx);
+        let conn = state.connections().get(&profile_id)?;
+        let cache_key = (database.clone(), name.clone());
+
+        if let Some(details) = conn.table_details.get(&cache_key) {
+            return Some(details.clone());
+        }
+
+        conn.database_schemas
+            .get(&database)
+            .and_then(|schema| schema.tables.iter().find(|table| table.name == name))
+            .cloned()
+            .or_else(|| {
+                conn.schema.as_ref().and_then(|schema| {
+                    schema.collections().iter().find_map(|collection| {
+                        if collection.name != name {
+                            return None;
+                        }
+
+                        if collection
+                            .database
+                            .as_deref()
+                            .is_some_and(|db| db != database)
+                        {
+                            return None;
+                        }
+
+                        Some(TableInfo {
+                            name: collection.name.clone(),
+                            schema: Some(database.clone()),
+                            columns: None,
+                            indexes: collection.indexes.clone().map(IndexData::Document),
+                            foreign_keys: None,
+                            constraints: None,
+                            sample_fields: collection.sample_fields.clone(),
+                            presentation: collection.presentation,
+                            child_items: collection.child_items.clone(),
+                        })
+                    })
+                })
+            })
+    }
+
+    fn collection_supports_child_picker(&self, item_id: &str, cx: &App) -> bool {
+        self.collection_info_for_item(item_id, cx)
+            .is_some_and(|collection| {
+                collection.presentation == CollectionPresentation::EventStream
+                    || collection
+                        .child_items
+                        .as_ref()
+                        .is_some_and(|items| !items.is_empty())
+            })
+    }
+
+    fn collection_is_event_stream(&self, item_id: &str, cx: &App) -> bool {
+        self.collection_info_for_item(item_id, cx)
+            .is_some_and(|collection| {
+                collection.presentation == CollectionPresentation::EventStream
+            })
+    }
+
+    fn open_child_picker(&mut self, item_id: &str, cx: &mut Context<Self>) {
+        let pending = PendingAction::OpenChildPicker {
+            item_id: item_id.to_string(),
+        };
+
+        match self.ensure_table_details(item_id, pending, cx) {
+            TableDetailsStatus::Ready => {
+                self.pending_child_picker_item = Some(item_id.to_string());
+            }
+            TableDetailsStatus::Loading => {
+                self.pending_toast = Some(PendingToast {
+                    message: "Loading event streams...".to_string(),
+                    is_error: false,
+                });
+            }
+            TableDetailsStatus::NotFound => {
+                self.pending_toast = Some(PendingToast {
+                    message: "Event streams are not available for this collection".to_string(),
+                    is_error: true,
+                });
+            }
+        }
+    }
+
     pub fn context_menu_select_next(&mut self, cx: &mut Context<Self>) {
         if let Some(ref mut menu) = self.context_menu
             && let Some(next_index) = Self::next_selectable_index(&menu.items, menu.selected_index)
@@ -764,6 +883,9 @@ impl Sidebar {
                 } else {
                     self.browse_table(&item_id, cx);
                 }
+            }
+            ContextMenuAction::OpenChildPicker => {
+                self.open_child_picker(&item_id, cx);
             }
             ContextMenuAction::ViewSchema => {
                 self.set_expanded(&item_id, true, cx);

--- a/crates/dbflux_ui/src/ui/views/sidebar/context_menu.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/context_menu.rs
@@ -758,7 +758,18 @@ impl Sidebar {
             item_id: item_id.to_string(),
         };
 
-        match self.ensure_table_details(item_id, pending, cx) {
+        let status = match parse_node_id(item_id) {
+            Some(SchemaNodeId::Collection {
+                profile_id,
+                database,
+                name,
+            }) if self.collection_is_event_stream(item_id, cx) => {
+                self.ensure_collection_children(profile_id, &database, &name, pending, cx)
+            }
+            _ => self.ensure_table_details(item_id, pending, cx),
+        };
+
+        match status {
             TableDetailsStatus::Ready => {
                 self.pending_child_picker_item = Some(item_id.to_string());
             }

--- a/crates/dbflux_ui/src/ui/views/sidebar/expansion.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/expansion.rs
@@ -223,11 +223,24 @@ impl Sidebar {
             }
         }
 
-        if matches!(parsed, Some(SchemaNodeId::Collection { .. })) {
+        if let Some(SchemaNodeId::Collection {
+            profile_id,
+            database,
+            name,
+        }) = &parsed
+        {
             let pending = PendingAction::ExpandCollection {
                 item_id: item_id.to_string(),
             };
-            if matches!(
+
+            if self.collection_node_is_event_stream(*profile_id, database, name, cx) {
+                if matches!(
+                    self.ensure_collection_children(*profile_id, database, name, pending, cx),
+                    TableDetailsStatus::NotFound
+                ) {
+                    return false;
+                }
+            } else if matches!(
                 self.ensure_table_details(item_id, pending, cx),
                 TableDetailsStatus::NotFound
             ) {
@@ -319,6 +332,27 @@ impl Sidebar {
         true
     }
 
+    fn collection_node_is_event_stream(
+        &self,
+        profile_id: Uuid,
+        database: &str,
+        collection: &str,
+        cx: &App,
+    ) -> bool {
+        self.app_state
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .and_then(|connection| connection.schema_for_target_database(database))
+            .and_then(|schema| {
+                schema
+                    .collections()
+                    .iter()
+                    .find(|item| item.name == collection)
+            })
+            .is_some_and(|item| item.presentation == CollectionPresentation::EventStream)
+    }
+
     pub(super) fn rebuild_tree_with_overrides(&mut self, cx: &mut Context<Self>) {
         let selected_index = self.tree_state.read(cx).selected_index();
         self.active_databases = Self::extract_active_databases(self.app_state.read(cx));
@@ -382,6 +416,7 @@ impl Sidebar {
             if let Some(conn) = state.connections_mut().get_mut(&profile_id) {
                 conn.database_schemas.remove(db_name);
                 conn.table_details.retain(|(db, _), _| db != db_name);
+                conn.collection_children.retain(|(db, _), _| db != db_name);
                 conn.schema_types.retain(|key, _| key.database != db_name);
                 conn.schema_indexes.retain(|key, _| key.database != db_name);
                 conn.schema_foreign_keys
@@ -408,6 +443,7 @@ impl Sidebar {
             if let Some(conn) = state.connections_mut().get_mut(&profile_id) {
                 let key = (cache_db.to_string(), target.name.clone());
                 conn.table_details.remove(&key);
+                conn.collection_children.remove(&key);
 
                 if target.kind == SchemaObjectKind::Table {
                     let target_schema = target.schema.as_deref();

--- a/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
@@ -573,6 +573,7 @@ pub struct Sidebar {
     scripts_search_query: String,
     pending_toast: Option<PendingToast>,
     connections_focused: bool,
+    search_input_focused: bool,
     visible_entry_count: usize,
     /// User overrides for expansion state (item_id -> is_expanded)
     expansion_overrides: HashMap<String, bool>,
@@ -692,9 +693,20 @@ impl Sidebar {
             &connections_search_entity,
             window,
             |this, input_state, event: &InputEvent, _, cx| {
-                if matches!(event, InputEvent::Change) {
-                    this.connections_search_query = input_state.read(cx).value().to_string();
-                    this.refresh_tree(cx);
+                match event {
+                    InputEvent::Change => {
+                        this.connections_search_query = input_state.read(cx).value().to_string();
+                        this.refresh_tree(cx);
+                    }
+                    InputEvent::Focus => {
+                        this.search_input_focused = true;
+                        cx.notify();
+                    }
+                    InputEvent::Blur => {
+                        this.search_input_focused = false;
+                        cx.notify();
+                    }
+                    InputEvent::PressEnter { .. } => {}
                 }
             },
         );
@@ -704,9 +716,20 @@ impl Sidebar {
             &scripts_search_entity,
             window,
             |this, input_state, event: &InputEvent, _, cx| {
-                if matches!(event, InputEvent::Change) {
-                    this.scripts_search_query = input_state.read(cx).value().to_string();
-                    this.refresh_scripts_tree(cx);
+                match event {
+                    InputEvent::Change => {
+                        this.scripts_search_query = input_state.read(cx).value().to_string();
+                        this.refresh_scripts_tree(cx);
+                    }
+                    InputEvent::Focus => {
+                        this.search_input_focused = true;
+                        cx.notify();
+                    }
+                    InputEvent::Blur => {
+                        this.search_input_focused = false;
+                        cx.notify();
+                    }
+                    InputEvent::PressEnter { .. } => {}
                 }
             },
         );
@@ -751,6 +774,7 @@ impl Sidebar {
             scripts_search_query: String::new(),
             pending_toast: None,
             connections_focused: false,
+            search_input_focused: false,
             visible_entry_count,
             expansion_overrides: HashMap::new(),
             context_menu: None,
@@ -808,6 +832,25 @@ impl Sidebar {
         };
 
         input.read(cx).focus_handle(cx).is_focused(window)
+    }
+
+    pub fn search_input_has_focus_state(&self) -> bool {
+        self.search_input_focused
+    }
+
+    pub fn focus_active_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.active_tab {
+            SidebarTab::Connections => {
+                self.connections_search_input
+                    .update(cx, |input, cx| input.focus(window, cx));
+            }
+            SidebarTab::Scripts => {
+                self.scripts_search_input
+                    .update(cx, |input, cx| input.focus(window, cx));
+            }
+        }
+
+        cx.notify();
     }
 
     pub fn set_active_tab(&mut self, tab: SidebarTab, cx: &mut Context<Self>) {

--- a/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
@@ -510,6 +510,8 @@ struct ChildPickerState {
     page_size: usize,
     sort_column: ChildPickerSortColumn,
     sort_descending: bool,
+    selected_index: usize,
+    filter_focused: bool,
 }
 
 /// Result of checking whether table details are available.

--- a/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
@@ -57,6 +57,11 @@ pub enum SidebarEvent {
         profile_id: Uuid,
         collection: CollectionRef,
     },
+    OpenCloudWatchLogStream {
+        profile_id: Uuid,
+        collection: CollectionRef,
+        log_stream: String,
+    },
     OpenKeyValueDatabase {
         profile_id: Uuid,
         database: String,
@@ -532,6 +537,8 @@ fn compute_gutter_map(items: &[TreeItem]) -> HashMap<String, GutterInfo> {
 pub struct Sidebar {
     app_state: Entity<AppStateEntity>,
     tree_state: Entity<TreeState>,
+    connections_search_input: Entity<InputState>,
+    connections_search_query: String,
     active_tab: SidebarTab,
     scripts_tree_state: Entity<TreeState>,
     scripts_search_input: Entity<InputState>,
@@ -617,6 +624,8 @@ impl Sidebar {
         let visible_entry_count = Self::count_visible_entries(&items);
         let gutter_metadata = compute_gutter_map(&items);
         let tree_state = cx.new(|cx| TreeState::new(cx).items(items));
+        let connections_search_input = cx
+            .new(|cx| InputState::new(window, cx).placeholder("Filter connections and schema..."));
 
         let scripts_items = Self::build_initial_scripts_tree(app_state.read(cx));
         let scripts_gutter_metadata = compute_gutter_map(&scripts_items);
@@ -645,6 +654,18 @@ impl Sidebar {
                     this.cancel_rename(cx);
                 }
                 _ => {}
+            },
+        );
+
+        let connections_search_entity = connections_search_input.clone();
+        let connections_search_subscription = cx.subscribe_in(
+            &connections_search_entity,
+            window,
+            |this, input_state, event: &InputEvent, _, cx| {
+                if matches!(event, InputEvent::Change) {
+                    this.connections_search_query = input_state.read(cx).value().to_string();
+                    this.refresh_tree(cx);
+                }
             },
         );
 
@@ -692,6 +713,8 @@ impl Sidebar {
         Self {
             app_state,
             tree_state,
+            connections_search_input,
+            connections_search_query: String::new(),
             active_tab: SidebarTab::Connections,
             scripts_tree_state,
             scripts_search_input,
@@ -709,6 +732,7 @@ impl Sidebar {
             _subscriptions: vec![
                 app_state_subscription,
                 rename_subscription,
+                connections_search_subscription,
                 scripts_search_subscription,
                 tree_expansion_subscription,
             ],
@@ -743,6 +767,15 @@ impl Sidebar {
 
     pub fn active_tab(&self) -> SidebarTab {
         self.active_tab
+    }
+
+    pub fn search_input_is_focused(&self, window: &Window, cx: &App) -> bool {
+        let input = match self.active_tab {
+            SidebarTab::Connections => &self.connections_search_input,
+            SidebarTab::Scripts => &self.scripts_search_input,
+        };
+
+        input.read(cx).focus_handle(cx).is_focused(window)
     }
 
     pub fn set_active_tab(&mut self, tab: SidebarTab, cx: &mut Context<Self>) {
@@ -814,6 +847,9 @@ impl Sidebar {
             }
             SchemaNodeId::Collection { .. } => {
                 self.browse_collection(item_id, cx);
+            }
+            SchemaNodeId::CloudWatchLogStream { .. } => {
+                self.browse_cloudwatch_log_stream(item_id, cx);
             }
             SchemaNodeId::Profile { profile_id } => {
                 let is_connected = self
@@ -995,6 +1031,22 @@ impl Sidebar {
         }
     }
 
+    fn browse_cloudwatch_log_stream(&mut self, item_id: &str, cx: &mut Context<Self>) {
+        if let Some(SchemaNodeId::CloudWatchLogStream {
+            profile_id,
+            database,
+            log_group,
+            name,
+        }) = parse_node_id(item_id)
+        {
+            cx.emit(SidebarEvent::OpenCloudWatchLogStream {
+                profile_id,
+                collection: CollectionRef::new(database, log_group),
+                log_stream: name,
+            });
+        }
+    }
+
     fn toggle_item_expansion(&mut self, item_id: &str, cx: &mut Context<Self>) {
         let items = self.build_tree_items_with_overrides(cx);
         let currently_expanded = Self::find_item_expanded(&items, item_id).unwrap_or(false);
@@ -1016,6 +1068,7 @@ impl Sidebar {
 
 #[cfg(test)]
 mod tests {
+    use super::Sidebar;
     use super::{ContextMenuAction, ContextMenuItem, ItemIdParts, NODE_KIND_NONE, parse_node_kind};
     use crate::app::{ExternalDriverDiagnostic, ExternalDriverStage};
     use crate::ui::views::sidebar::operations::{
@@ -1023,10 +1076,57 @@ mod tests {
     };
     use dbflux_core::PrepareConnectError;
     use dbflux_core::{SchemaNodeId, SchemaNodeKind};
+    use gpui_component::tree::TreeItem;
     use uuid::Uuid;
 
     fn test_uuid() -> Uuid {
         Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()
+    }
+
+    fn cloudwatch_collection_item(profile_id: Uuid, name: &str) -> TreeItem {
+        TreeItem::new(
+            SchemaNodeId::Collection {
+                profile_id,
+                database: "logs".into(),
+                name: name.into(),
+            }
+            .to_string(),
+            name.to_string(),
+        )
+    }
+
+    fn cloudwatch_profile_tree(profile_id: Uuid) -> TreeItem {
+        TreeItem::new(
+            SchemaNodeId::Profile { profile_id }.to_string(),
+            "cloudwatch".to_string(),
+        )
+        .expanded(true)
+        .children(vec![
+            TreeItem::new(
+                SchemaNodeId::Database {
+                    profile_id,
+                    name: "logs".into(),
+                }
+                .to_string(),
+                "logs".to_string(),
+            )
+            .expanded(true)
+            .children(vec![
+                TreeItem::new(
+                    SchemaNodeId::CollectionsFolder {
+                        profile_id,
+                        database: "logs".into(),
+                    }
+                    .to_string(),
+                    "Collections (2)".to_string(),
+                )
+                .expanded(true)
+                .children(vec![
+                    cloudwatch_collection_item(profile_id, "/aws/lambda/app"),
+                    cloudwatch_collection_item(profile_id, "/aws/ecs/api"),
+                ]),
+            ]),
+        ])
     }
 
     #[test]
@@ -1036,6 +1136,19 @@ mod tests {
             database: None,
             schema: "public".into(),
             name: "users".into(),
+        };
+        let s = id.to_string();
+        let parsed: SchemaNodeId = s.parse().unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn cloudwatch_log_stream_id_roundtrip() {
+        let id = SchemaNodeId::CloudWatchLogStream {
+            profile_id: test_uuid(),
+            database: "logs".into(),
+            log_group: "/aws/lambda/app".into(),
+            name: "2026/04/25/[$LATEST]abc".into(),
         };
         let s = id.to_string();
         let parsed: SchemaNodeId = s.parse().unwrap();
@@ -1305,5 +1418,128 @@ mod tests {
 
         assert!(toast.is_error);
         assert_eq!(toast.message, "No driver registered for 'sqlite'");
+    }
+
+    #[test]
+    fn sidebar_tree_filter_keeps_matching_ancestors_visible() {
+        let profile_id = Uuid::new_v4();
+
+        let filtered =
+            Sidebar::apply_tree_filter(vec![cloudwatch_profile_tree(profile_id)], "lambda");
+
+        let profile = &filtered[0];
+        let database = &profile.children[0];
+        let collections = &database.children[0];
+
+        assert_eq!(profile.label.as_ref(), "cloudwatch");
+        assert_eq!(database.label.as_ref(), "logs");
+        assert_eq!(collections.label.as_ref(), "Collections (2)");
+        assert_eq!(collections.children.len(), 1);
+        assert_eq!(collections.children[0].label.as_ref(), "/aws/lambda/app");
+    }
+
+    #[test]
+    fn sidebar_tree_filter_matches_non_cloudwatch_nodes() {
+        let postgres_profile_id = Uuid::new_v4();
+        let items = vec![
+            TreeItem::new(
+                SchemaNodeId::Profile {
+                    profile_id: postgres_profile_id,
+                }
+                .to_string(),
+                "postgres".to_string(),
+            )
+            .expanded(true)
+            .children(vec![
+                TreeItem::new(
+                    SchemaNodeId::Database {
+                        profile_id: postgres_profile_id,
+                        name: "app".to_string(),
+                    }
+                    .to_string(),
+                    "app".to_string(),
+                )
+                .expanded(true)
+                .children(vec![TreeItem::new(
+                    SchemaNodeId::TablesFolder {
+                        profile_id: postgres_profile_id,
+                        schema: "public".to_string(),
+                    }
+                    .to_string(),
+                    "Tables (1)".to_string(),
+                )]),
+            ]),
+        ];
+
+        let filtered = Sidebar::apply_tree_filter(items, "postgres");
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].label.as_ref(), "postgres");
+    }
+
+    #[test]
+    fn sidebar_tree_filter_matches_loaded_descendants_and_preserves_path() {
+        let postgres_profile_id = Uuid::new_v4();
+        let items = vec![
+            TreeItem::new(
+                SchemaNodeId::Profile {
+                    profile_id: postgres_profile_id,
+                }
+                .to_string(),
+                "postgres".to_string(),
+            )
+            .expanded(true)
+            .children(vec![
+                TreeItem::new(
+                    SchemaNodeId::Database {
+                        profile_id: postgres_profile_id,
+                        name: "app".to_string(),
+                    }
+                    .to_string(),
+                    "app".to_string(),
+                )
+                .expanded(false)
+                .children(vec![
+                    TreeItem::new(
+                        SchemaNodeId::TablesFolder {
+                            profile_id: postgres_profile_id,
+                            schema: "public".to_string(),
+                        }
+                        .to_string(),
+                        "Tables (1)".to_string(),
+                    )
+                    .expanded(false)
+                    .children(vec![TreeItem::new(
+                        SchemaNodeId::Table {
+                            profile_id: postgres_profile_id,
+                            database: Some("app".to_string()),
+                            schema: "public".to_string(),
+                            name: "users".to_string(),
+                        }
+                        .to_string(),
+                        "users".to_string(),
+                    )]),
+                ]),
+            ]),
+        ];
+
+        let filtered = Sidebar::apply_tree_filter(items, "users");
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].label.as_ref(), "postgres");
+        assert_eq!(filtered[0].children[0].label.as_ref(), "app");
+        assert_eq!(
+            filtered[0].children[0].children[0].label.as_ref(),
+            "Tables (1)"
+        );
+        assert_eq!(
+            filtered[0].children[0].children[0].children[0]
+                .label
+                .as_ref(),
+            "users"
+        );
+        assert!(filtered[0].is_expanded());
+        assert!(filtered[0].children[0].is_expanded());
+        assert!(filtered[0].children[0].children[0].is_expanded());
     }
 }

--- a/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
@@ -692,22 +692,20 @@ impl Sidebar {
         let connections_search_subscription = cx.subscribe_in(
             &connections_search_entity,
             window,
-            |this, input_state, event: &InputEvent, _, cx| {
-                match event {
-                    InputEvent::Change => {
-                        this.connections_search_query = input_state.read(cx).value().to_string();
-                        this.refresh_tree(cx);
-                    }
-                    InputEvent::Focus => {
-                        this.search_input_focused = true;
-                        cx.notify();
-                    }
-                    InputEvent::Blur => {
-                        this.search_input_focused = false;
-                        cx.notify();
-                    }
-                    InputEvent::PressEnter { .. } => {}
+            |this, input_state, event: &InputEvent, _, cx| match event {
+                InputEvent::Change => {
+                    this.connections_search_query = input_state.read(cx).value().to_string();
+                    this.refresh_tree(cx);
                 }
+                InputEvent::Focus => {
+                    this.search_input_focused = true;
+                    cx.notify();
+                }
+                InputEvent::Blur => {
+                    this.search_input_focused = false;
+                    cx.notify();
+                }
+                InputEvent::PressEnter { .. } => {}
             },
         );
 
@@ -715,22 +713,20 @@ impl Sidebar {
         let scripts_search_subscription = cx.subscribe_in(
             &scripts_search_entity,
             window,
-            |this, input_state, event: &InputEvent, _, cx| {
-                match event {
-                    InputEvent::Change => {
-                        this.scripts_search_query = input_state.read(cx).value().to_string();
-                        this.refresh_scripts_tree(cx);
-                    }
-                    InputEvent::Focus => {
-                        this.search_input_focused = true;
-                        cx.notify();
-                    }
-                    InputEvent::Blur => {
-                        this.search_input_focused = false;
-                        cx.notify();
-                    }
-                    InputEvent::PressEnter { .. } => {}
+            |this, input_state, event: &InputEvent, _, cx| match event {
+                InputEvent::Change => {
+                    this.scripts_search_query = input_state.read(cx).value().to_string();
+                    this.refresh_scripts_tree(cx);
                 }
+                InputEvent::Focus => {
+                    this.search_input_focused = true;
+                    cx.notify();
+                }
+                InputEvent::Blur => {
+                    this.search_input_focused = false;
+                    cx.notify();
+                }
+                InputEvent::PressEnter { .. } => {}
             },
         );
 

--- a/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
@@ -24,10 +24,10 @@ use dbflux_core::{
     AddEnumValueRequest, AddForeignKeyRequest, CodeGenCapabilities, CodeGenScope,
     CollectionIndexInfo, CollectionRef, ConnectionTreeNode, ConnectionTreeNodeKind, ConstraintKind,
     CreateIndexRequest, CreateTypeRequest, CustomTypeInfo, CustomTypeKind, DatabaseCategory,
-    DropForeignKeyRequest, DropIndexRequest, DropTypeRequest, IndexData, IndexDirection,
-    QueryLanguage, ReindexRequest, SchemaCacheKey, SchemaForeignKeyInfo, SchemaIndexInfo,
-    SchemaLoadingStrategy, SchemaNodeId, SchemaNodeKind, SchemaSnapshot, TableInfo, TableRef,
-    TaskId, TypeDefinition, ViewInfo,
+    DropForeignKeyRequest, DropIndexRequest, DropTypeRequest, EventStreamTarget, IndexData,
+    IndexDirection, QueryLanguage, ReindexRequest, SchemaCacheKey, SchemaForeignKeyInfo,
+    SchemaIndexInfo, SchemaLoadingStrategy, SchemaNodeId, SchemaNodeKind, SchemaSnapshot,
+    TableInfo, TableRef, TaskId, TypeDefinition, ViewInfo,
 };
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -57,10 +57,10 @@ pub enum SidebarEvent {
         profile_id: Uuid,
         collection: CollectionRef,
     },
-    OpenCloudWatchLogStream {
+    OpenCollectionChild {
         profile_id: Uuid,
-        collection: CollectionRef,
-        log_stream: String,
+        target: EventStreamTarget,
+        title: String,
     },
     OpenKeyValueDatabase {
         profile_id: Uuid,
@@ -848,8 +848,8 @@ impl Sidebar {
             SchemaNodeId::Collection { .. } => {
                 self.browse_collection(item_id, cx);
             }
-            SchemaNodeId::CloudWatchLogStream { .. } => {
-                self.browse_cloudwatch_log_stream(item_id, cx);
+            SchemaNodeId::CollectionChild { .. } => {
+                self.browse_collection_child(item_id, cx);
             }
             SchemaNodeId::Profile { profile_id } => {
                 let is_connected = self
@@ -1031,18 +1031,24 @@ impl Sidebar {
         }
     }
 
-    fn browse_cloudwatch_log_stream(&mut self, item_id: &str, cx: &mut Context<Self>) {
-        if let Some(SchemaNodeId::CloudWatchLogStream {
+    fn browse_collection_child(&mut self, item_id: &str, cx: &mut Context<Self>) {
+        if let Some(SchemaNodeId::CollectionChild {
             profile_id,
             database,
-            log_group,
+            collection,
+            child_id,
             name,
         }) = parse_node_id(item_id)
         {
-            cx.emit(SidebarEvent::OpenCloudWatchLogStream {
+            let target = EventStreamTarget {
+                collection: CollectionRef::new(database, collection),
+                child_id: Some(child_id),
+            };
+
+            cx.emit(SidebarEvent::OpenCollectionChild {
                 profile_id,
-                collection: CollectionRef::new(database, log_group),
-                log_stream: name,
+                target,
+                title: name,
             });
         }
     }
@@ -1083,7 +1089,7 @@ mod tests {
         Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()
     }
 
-    fn cloudwatch_collection_item(profile_id: Uuid, name: &str) -> TreeItem {
+    fn event_stream_collection_item(profile_id: Uuid, name: &str) -> TreeItem {
         TreeItem::new(
             SchemaNodeId::Collection {
                 profile_id,
@@ -1095,7 +1101,7 @@ mod tests {
         )
     }
 
-    fn cloudwatch_profile_tree(profile_id: Uuid) -> TreeItem {
+    fn event_stream_profile_tree(profile_id: Uuid) -> TreeItem {
         TreeItem::new(
             SchemaNodeId::Profile { profile_id }.to_string(),
             "cloudwatch".to_string(),
@@ -1122,8 +1128,8 @@ mod tests {
                 )
                 .expanded(true)
                 .children(vec![
-                    cloudwatch_collection_item(profile_id, "/aws/lambda/app"),
-                    cloudwatch_collection_item(profile_id, "/aws/ecs/api"),
+                    event_stream_collection_item(profile_id, "/aws/lambda/app"),
+                    event_stream_collection_item(profile_id, "/aws/ecs/api"),
                 ]),
             ]),
         ])
@@ -1143,11 +1149,12 @@ mod tests {
     }
 
     #[test]
-    fn cloudwatch_log_stream_id_roundtrip() {
-        let id = SchemaNodeId::CloudWatchLogStream {
+    fn collection_child_id_roundtrip() {
+        let id = SchemaNodeId::CollectionChild {
             profile_id: test_uuid(),
             database: "logs".into(),
-            log_group: "/aws/lambda/app".into(),
+            collection: "/aws/lambda/app".into(),
+            child_id: "stream-1".into(),
             name: "2026/04/25/[$LATEST]abc".into(),
         };
         let s = id.to_string();
@@ -1425,7 +1432,7 @@ mod tests {
         let profile_id = Uuid::new_v4();
 
         let filtered =
-            Sidebar::apply_tree_filter(vec![cloudwatch_profile_tree(profile_id)], "lambda");
+            Sidebar::apply_tree_filter(vec![event_stream_profile_tree(profile_id)], "lambda");
 
         let profile = &filtered[0];
         let database = &profile.children[0];

--- a/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
@@ -22,12 +22,13 @@ use dbflux_components::controls::{GpuiInput as Input, InputEvent, InputState};
 use dbflux_components::primitives::Text;
 use dbflux_core::{
     AddEnumValueRequest, AddForeignKeyRequest, CodeGenCapabilities, CodeGenScope,
-    CollectionIndexInfo, CollectionRef, ConnectionTreeNode, ConnectionTreeNodeKind, ConstraintKind,
-    CreateIndexRequest, CreateTypeRequest, CustomTypeInfo, CustomTypeKind, DatabaseCategory,
-    DropForeignKeyRequest, DropIndexRequest, DropTypeRequest, EventStreamTarget, IndexData,
-    IndexDirection, QueryLanguage, ReindexRequest, SchemaCacheKey, SchemaForeignKeyInfo,
-    SchemaIndexInfo, SchemaLoadingStrategy, SchemaNodeId, SchemaNodeKind, SchemaSnapshot,
-    TableInfo, TableRef, TaskId, TypeDefinition, ViewInfo,
+    CollectionChildInfo, CollectionIndexInfo, CollectionPresentation, CollectionRef,
+    ConnectionTreeNode, ConnectionTreeNodeKind, ConstraintKind, CreateIndexRequest,
+    CreateTypeRequest, CustomTypeInfo, CustomTypeKind, DatabaseCategory, DropForeignKeyRequest,
+    DropIndexRequest, DropTypeRequest, EventStreamTarget, IndexData, IndexDirection, QueryLanguage,
+    ReindexRequest, SchemaCacheKey, SchemaForeignKeyInfo, SchemaIndexInfo, SchemaLoadingStrategy,
+    SchemaNodeId, SchemaNodeKind, SchemaSnapshot, TableInfo, TableRef, TaskId, TypeDefinition,
+    ViewInfo,
 };
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -189,6 +190,7 @@ impl ContextMenuItem {
 #[derive(Clone)]
 pub enum ContextMenuAction {
     Open,
+    OpenChildPicker,
     ViewSchema,
     GenerateCode(String),
     Connect,
@@ -260,6 +262,7 @@ impl ContextMenuAction {
     fn icon(&self) -> Option<AppIcon> {
         match self {
             Self::Open => Some(AppIcon::Eye),
+            Self::OpenChildPicker => Some(AppIcon::ScrollText),
             Self::ViewSchema => Some(AppIcon::Table),
             Self::GenerateCode(_) => Some(AppIcon::Code),
             Self::Connect => Some(AppIcon::Plug),
@@ -469,6 +472,9 @@ enum PendingAction {
     ExpandCollection {
         item_id: String,
     },
+    OpenChildPicker {
+        item_id: String,
+    },
 }
 
 impl PendingAction {
@@ -479,9 +485,31 @@ impl PendingAction {
             | Self::ExpandTypesFolder { item_id }
             | Self::ExpandSchemaIndexesFolder { item_id }
             | Self::ExpandSchemaForeignKeysFolder { item_id }
-            | Self::ExpandCollection { item_id } => item_id,
+            | Self::ExpandCollection { item_id }
+            | Self::OpenChildPicker { item_id } => item_id,
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChildPickerSortColumn {
+    Name,
+    LastEvent,
+}
+
+struct ChildPickerState {
+    profile_id: Uuid,
+    database: String,
+    collection: String,
+    title: String,
+    focus_handle: FocusHandle,
+    children: Vec<CollectionChildInfo>,
+    filter_input: Entity<InputState>,
+    filter_query: String,
+    page: usize,
+    page_size: usize,
+    sort_column: ChildPickerSortColumn,
+    sort_descending: bool,
 }
 
 /// Result of checking whether table details are available.
@@ -588,6 +616,8 @@ pub struct Sidebar {
     delete_confirm_modal: Option<DeleteConfirmState>,
     /// Whether the add menu dropdown is open
     add_menu_open: bool,
+    child_picker: Option<ChildPickerState>,
+    pending_child_picker_item: Option<String>,
     scripts_drop_target: Option<DropTarget>,
     gutter_metadata: HashMap<String, GutterInfo>,
     scripts_gutter_metadata: HashMap<String, GutterInfo>,
@@ -752,6 +782,8 @@ impl Sidebar {
             pending_delete_item: None,
             delete_confirm_modal: None,
             add_menu_open: false,
+            child_picker: None,
+            pending_child_picker_item: None,
             scripts_drop_target: None,
             gutter_metadata,
             scripts_gutter_metadata,

--- a/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
@@ -922,6 +922,28 @@ impl Sidebar {
             SchemaNodeId::CollectionChild { .. } => {
                 self.browse_collection_child(item_id, cx);
             }
+            SchemaNodeId::CollectionChildrenMore {
+                profile_id,
+                database,
+                collection,
+            } => {
+                let pending = PendingAction::ExpandCollection {
+                    item_id: SchemaNodeId::Collection {
+                        profile_id,
+                        database: database.clone(),
+                        name: collection.clone(),
+                    }
+                    .to_string(),
+                };
+
+                self.spawn_fetch_collection_children(
+                    profile_id,
+                    &database,
+                    &collection,
+                    pending,
+                    cx,
+                );
+            }
             SchemaNodeId::Profile { profile_id } => {
                 let is_connected = self
                     .app_state
@@ -1024,6 +1046,12 @@ impl Sidebar {
         self.set_selection_anchor(item_id);
 
         let node_kind = parse_node_kind(item_id);
+
+        if node_kind == SchemaNodeKind::CollectionChildrenMore && click_count == 1 {
+            self.execute_item(item_id, cx);
+            cx.notify();
+            return;
+        }
 
         if click_count == 2 {
             let is_key_value_db = matches!(

--- a/crates/dbflux_ui/src/ui/views/sidebar/operations.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/operations.rs
@@ -2525,13 +2525,15 @@ impl Sidebar {
     }
 
     pub(crate) fn connect_to_profile(&mut self, profile_id: Uuid, cx: &mut Context<Self>) {
-        let uses_pipeline = self
-            .app_state
-            .read(cx)
-            .profiles()
-            .iter()
-            .find(|p| p.id == profile_id)
-            .is_some_and(|p| p.uses_pipeline());
+        let uses_pipeline = {
+            let app_state = self.app_state.read(cx);
+
+            app_state
+                .profiles()
+                .iter()
+                .find(|p| p.id == profile_id)
+                .is_some_and(|p| app_state.profile_uses_connect_pipeline(p))
+        };
 
         if uses_pipeline {
             self.connect_via_pipeline(profile_id, cx);

--- a/crates/dbflux_ui/src/ui/views/sidebar/render.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/render.rs
@@ -156,7 +156,7 @@ impl Sidebar {
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let has_entries = self.visible_entry_count > 0;
-        let _theme = cx.theme();
+        let theme = cx.theme();
         let sidebar_for_root_drop = sidebar_entity.clone();
         let sidebar_for_clear_drop = sidebar_entity.clone();
 
@@ -165,6 +165,19 @@ impl Sidebar {
             .flex()
             .flex_col()
             .overflow_hidden()
+            .child(
+                div()
+                    .px(Spacing::SM)
+                    .py(Spacing::XS)
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .child(
+                        Input::new(&self.connections_search_input)
+                            .xsmall()
+                            .appearance(false)
+                            .cleanable(true),
+                    ),
+            )
             .when(has_entries, |el| {
                 el.child(
                     div()

--- a/crates/dbflux_ui/src/ui/views/sidebar/render.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/render.rs
@@ -174,7 +174,6 @@ impl Sidebar {
                     .child(
                         Input::new(&self.connections_search_input)
                             .xsmall()
-                            .appearance(false)
                             .cleanable(true),
                     ),
             )
@@ -275,12 +274,7 @@ impl Sidebar {
                     .py(Spacing::XS)
                     .border_b_1()
                     .border_color(theme.border)
-                    .child(
-                        Input::new(&search_input)
-                            .xsmall()
-                            .appearance(false)
-                            .cleanable(true),
-                    ),
+                    .child(Input::new(&search_input).xsmall().cleanable(true)),
             )
             // Tree or empty state
             .when(has_entries || has_search, |el| {
@@ -360,6 +354,10 @@ impl Render for Sidebar {
 
         if let Some(item_id) = self.pending_rename_item.take() {
             self.start_rename(&item_id, window, cx);
+        }
+
+        if let Some(item_id) = self.pending_child_picker_item.take() {
+            self.open_child_picker_modal(&item_id, window, cx);
         }
 
         let theme = cx.theme();

--- a/crates/dbflux_ui/src/ui/views/sidebar/render_overlays.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/render_overlays.rs
@@ -23,6 +23,40 @@ fn child_picker_filtered_total(picker: &ChildPickerState) -> usize {
         .count()
 }
 
+/// Returns the filtered + sorted children in current display order, ignoring pagination.
+fn sorted_visible_children(picker: &ChildPickerState) -> Vec<CollectionChildInfo> {
+    let query = picker.filter_query.to_lowercase();
+    let mut rows: Vec<CollectionChildInfo> = picker
+        .children
+        .iter()
+        .filter(|child| query.is_empty() || child.label.to_lowercase().contains(&query))
+        .cloned()
+        .collect();
+
+    match picker.sort_column {
+        ChildPickerSortColumn::Name => rows.sort_by(|left, right| left.label.cmp(&right.label)),
+        ChildPickerSortColumn::LastEvent => rows.sort_by(|left, right| {
+            left.last_event_ts_ms
+                .cmp(&right.last_event_ts_ms)
+                .then_with(|| left.label.cmp(&right.label))
+        }),
+    }
+
+    if picker.sort_descending {
+        rows.reverse();
+    }
+
+    rows
+}
+
+/// Adjusts `picker.page` so the row at `selected_index` falls within the visible page.
+fn ensure_selected_in_page(picker: &mut ChildPickerState) {
+    if picker.page_size == 0 {
+        return;
+    }
+    picker.page = picker.selected_index / picker.page_size;
+}
+
 impl Sidebar {
     pub(super) fn render_add_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
@@ -251,13 +285,29 @@ impl Sidebar {
         let filter_subscription = cx.subscribe_in(
             &input_for_subscription,
             window,
-            |this, input_state, event: &InputEvent, _, cx| {
-                if matches!(event, InputEvent::Change)
-                    && let Some(picker) = this.child_picker.as_mut()
-                {
-                    picker.filter_query = input_state.read(cx).value().to_string();
-                    picker.page = 0;
-                    cx.notify();
+            |this, input_state, event: &InputEvent, _, cx| match event {
+                InputEvent::Change => {
+                    if let Some(picker) = this.child_picker.as_mut() {
+                        picker.filter_query = input_state.read(cx).value().to_string();
+                        picker.page = 0;
+                        picker.selected_index = 0;
+                        cx.notify();
+                    }
+                }
+                InputEvent::Focus => {
+                    if let Some(picker) = this.child_picker.as_mut() {
+                        picker.filter_focused = true;
+                        cx.notify();
+                    }
+                }
+                InputEvent::Blur => {
+                    if let Some(picker) = this.child_picker.as_mut() {
+                        picker.filter_focused = false;
+                        cx.notify();
+                    }
+                }
+                InputEvent::PressEnter { .. } => {
+                    this.picker_execute(cx);
                 }
             },
         );
@@ -277,21 +327,25 @@ impl Sidebar {
             .or(collection.child_items)
             .unwrap_or_default();
 
+        let focus_handle = cx.focus_handle();
         self.child_picker = Some(ChildPickerState {
             profile_id,
             database,
             collection: name.clone(),
             title: format!("Event streams: {}", name),
-            focus_handle: cx.focus_handle(),
+            focus_handle: focus_handle.clone(),
             children,
             filter_input,
             filter_query: String::new(),
             page: 0,
-            page_size: 25,
+            page_size: 50,
             sort_column: ChildPickerSortColumn::LastEvent,
             sort_descending: true,
+            selected_index: 0,
+            filter_focused: false,
         });
 
+        focus_handle.focus(window);
         cx.notify();
     }
 
@@ -305,10 +359,108 @@ impl Sidebar {
         self.child_picker.is_some()
     }
 
+    pub fn child_picker_filter_is_focused(&self) -> bool {
+        self.child_picker
+            .as_ref()
+            .is_some_and(|picker| picker.filter_focused)
+    }
+
     pub fn child_picker_focus_handle(&self) -> Option<FocusHandle> {
         self.child_picker
             .as_ref()
             .map(|picker| picker.focus_handle.clone())
+    }
+
+    /// Total filtered/sorted row count, used to clamp the selection index.
+    fn child_picker_visible_total(picker: &ChildPickerState) -> usize {
+        child_picker_filtered_total(picker)
+    }
+
+    pub fn picker_select_next(&mut self, cx: &mut Context<Self>) {
+        if let Some(picker) = self.child_picker.as_mut() {
+            let total = Self::child_picker_visible_total(picker);
+            if total == 0 {
+                return;
+            }
+            picker.selected_index = (picker.selected_index + 1).min(total - 1);
+            ensure_selected_in_page(picker);
+            cx.notify();
+        }
+    }
+
+    pub fn picker_select_prev(&mut self, cx: &mut Context<Self>) {
+        if let Some(picker) = self.child_picker.as_mut() {
+            let total = Self::child_picker_visible_total(picker);
+            if total == 0 {
+                return;
+            }
+            picker.selected_index = picker.selected_index.saturating_sub(1);
+            ensure_selected_in_page(picker);
+            cx.notify();
+        }
+    }
+
+    pub fn picker_select_first(&mut self, cx: &mut Context<Self>) {
+        if let Some(picker) = self.child_picker.as_mut() {
+            picker.selected_index = 0;
+            ensure_selected_in_page(picker);
+            cx.notify();
+        }
+    }
+
+    pub fn picker_select_last(&mut self, cx: &mut Context<Self>) {
+        if let Some(picker) = self.child_picker.as_mut() {
+            let total = Self::child_picker_visible_total(picker);
+            if total == 0 {
+                return;
+            }
+            picker.selected_index = total - 1;
+            ensure_selected_in_page(picker);
+            cx.notify();
+        }
+    }
+
+    pub fn picker_focus_search(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(picker) = self.child_picker.as_ref() {
+            let filter_input = picker.filter_input.clone();
+            filter_input.update(cx, |input, cx| input.focus(window, cx));
+        }
+    }
+
+    pub fn picker_focus_list(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(picker) = self.child_picker.as_ref() {
+            picker.focus_handle.focus(window);
+            cx.notify();
+        }
+    }
+
+    pub fn picker_execute(&mut self, cx: &mut Context<Self>) {
+        let Some(picker) = self.child_picker.as_ref() else {
+            return;
+        };
+
+        let Some(child) = sorted_visible_children(picker)
+            .into_iter()
+            .nth(picker.selected_index)
+        else {
+            return;
+        };
+
+        let target = EventStreamTarget {
+            collection: CollectionRef::new(&picker.database, &picker.collection),
+            child_id: Some(child.id.clone()),
+        };
+
+        let profile_id = picker.profile_id;
+        let title = child.label.clone();
+
+        cx.emit(SidebarEvent::OpenCollectionChild {
+            profile_id,
+            target,
+            title,
+        });
+
+        self.close_child_picker(cx);
     }
 
     pub fn render_child_picker_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -317,36 +469,17 @@ impl Sidebar {
             return div();
         };
 
-        let query = picker.filter_query.to_lowercase();
-        let mut rows = picker
-            .children
-            .iter()
-            .filter(|child| query.is_empty() || child.label.to_lowercase().contains(&query))
-            .cloned()
-            .collect::<Vec<_>>();
+        let rows = sorted_visible_children(picker);
 
-        match picker.sort_column {
-            ChildPickerSortColumn::Name => rows.sort_by(|left, right| left.label.cmp(&right.label)),
-            ChildPickerSortColumn::LastEvent => rows.sort_by(|left, right| {
-                left.last_event_ts_ms
-                    .cmp(&right.last_event_ts_ms)
-                    .then_with(|| left.label.cmp(&right.label))
-            }),
-        }
-
-        if picker.sort_descending {
-            rows.reverse();
-        }
-
-        let total = child_picker_filtered_total(picker);
+        let total = rows.len();
         let page_count = total.max(1).div_ceil(picker.page_size);
         let page = picker.page.min(page_count.saturating_sub(1));
         let start = page.saturating_mul(picker.page_size);
         let end = (start + picker.page_size).min(total);
         let visible_rows = rows[start..end].to_vec();
+        let selected_index = picker.selected_index;
 
         let sidebar = cx.entity().clone();
-        let close_button_sidebar = sidebar.clone();
         let prev_sidebar = sidebar.clone();
         let next_sidebar = sidebar.clone();
         let name_sort_sidebar = sidebar.clone();
@@ -354,63 +487,39 @@ impl Sidebar {
         let profile_id = picker.profile_id;
         let database = picker.database.clone();
         let collection = picker.collection.clone();
-        let title = picker.title.clone();
+        let subtitle = picker.title.clone();
 
+        let can_prev = page > 0;
+        let can_next = page + 1 < page_count;
         let page_label = if total == 0 {
-            "0 streams".to_string()
+            "Page 0/0".to_string()
         } else {
-            format!("{}-{} of {}", start + 1, end, total)
+            format!("Page {}/{} ({}-{})", page + 1, page_count, start + 1, end)
         };
 
         div()
-            .track_focus(&picker.focus_handle)
             .flex()
             .flex_col()
-            .size_full()
-            .bg(theme.sidebar)
-            .border_1()
-            .border_color(theme.border)
-            .rounded(Radii::MD)
-            .shadow_lg()
+            .flex_1()
+            .min_h_0()
             .child(
                 div()
-                    .flex()
-                    .items_center()
-                    .justify_between()
-                    .px(Spacing::SM)
+                    .px(Spacing::MD)
+                    .pt(Spacing::SM)
+                    .child(Text::muted(subtitle).font_size(FontSizes::XS)),
+            )
+            .child(
+                div()
+                    .px(Spacing::MD)
                     .py(Spacing::SM)
-                    .border_b_1()
-                    .border_color(theme.border)
-                    .child(Text::body(title).font_size(FontSizes::SM))
-                    .child(
-                        div()
-                            .id("child-picker-close")
-                            .cursor_pointer()
-                            .px(Spacing::XS)
-                            .py(Spacing::XS)
-                            .rounded(Radii::SM)
-                            .hover(|d| d.bg(theme.secondary))
-                            .on_click(move |_, _, cx| {
-                                close_button_sidebar.update(cx, |this, cx| {
-                                    this.close_child_picker(cx);
-                                });
-                            })
-                            .child(Text::muted("Close").font_size(FontSizes::XS)),
-                    ),
-            )
-            .child(
-                div()
-                    .px(Spacing::SM)
-                    .py(Spacing::XS)
-                    .border_b_1()
-                    .border_color(theme.border)
-                    .child(Input::new(&picker.filter_input).xsmall().cleanable(true)),
+                    .child(Input::new(&picker.filter_input).cleanable(true)),
             )
             .child(
                 div()
                     .flex()
-                    .px(Spacing::SM)
+                    .px(Spacing::MD)
                     .py(Spacing::XS)
+                    .gap(Spacing::SM)
                     .border_b_1()
                     .border_color(theme.border)
                     .text_size(FontSizes::XS)
@@ -464,10 +573,11 @@ impl Sidebar {
             .child(
                 div()
                     .flex_1()
+                    .min_h_0()
                     .overflow_y_scrollbar()
                     .when(visible_rows.is_empty(), |el| {
                         el.child(
-                            div().px(Spacing::SM).py(Spacing::SM).child(
+                            div().px(Spacing::MD).py(Spacing::SM).child(
                                 Text::muted("No event streams found").font_size(FontSizes::SM),
                             ),
                         )
@@ -480,16 +590,17 @@ impl Sidebar {
                             let child_id = child.id.clone();
                             let child_label = child.label.clone();
                             let timestamp = format_child_timestamp(child.last_event_ts_ms);
+                            let absolute_index = start + row_index;
+                            let is_selected = absolute_index == selected_index;
 
                             div()
                                 .id(("child-picker-row", row_index))
                                 .flex()
-                                .gap(Spacing::XS)
-                                .px(Spacing::SM)
+                                .gap(Spacing::SM)
+                                .px(Spacing::MD)
                                 .py(Spacing::XS)
-                                .border_b_1()
-                                .border_color(theme.border)
                                 .cursor_pointer()
+                                .when(is_selected, |d| d.bg(theme.list_active))
                                 .hover(|d| d.bg(theme.list_active))
                                 .on_click(move |_, _, cx| {
                                     row_sidebar.update(cx, |this, cx| {
@@ -520,23 +631,22 @@ impl Sidebar {
                 div()
                     .flex()
                     .items_center()
-                    .justify_between()
-                    .px(Spacing::SM)
-                    .py(Spacing::XS)
+                    .justify_center()
+                    .gap(Spacing::SM)
+                    .px(Spacing::MD)
+                    .py(Spacing::SM)
                     .border_t_1()
                     .border_color(theme.border)
-                    .child(Text::muted(page_label).font_size(FontSizes::XS))
                     .child(
                         div()
+                            .id("child-picker-prev")
                             .flex()
-                            .gap(Spacing::XS)
-                            .child(
-                                div()
-                                    .id("child-picker-prev")
-                                    .cursor_pointer()
-                                    .px(Spacing::XS)
-                                    .py(Spacing::XS)
-                                    .rounded(Radii::SM)
+                            .items_center()
+                            .gap_1()
+                            .px(Spacing::XS)
+                            .rounded(Radii::SM)
+                            .when(can_prev, |d| {
+                                d.cursor_pointer()
                                     .hover(|d| d.bg(theme.secondary))
                                     .on_click(move |_, _, cx| {
                                         prev_sidebar.update(cx, |this, cx| {
@@ -546,15 +656,34 @@ impl Sidebar {
                                             cx.notify();
                                         });
                                     })
-                                    .child(Text::caption("Prev")),
-                            )
-                            .child(
-                                div()
-                                    .id("child-picker-next")
-                                    .cursor_pointer()
-                                    .px(Spacing::XS)
-                                    .py(Spacing::XS)
-                                    .rounded(Radii::SM)
+                            })
+                            .when(!can_prev, |d| d.opacity(0.5))
+                            .child(Icon::new(AppIcon::ChevronLeft).size(px(12.0)).color(
+                                if can_prev {
+                                    theme.foreground
+                                } else {
+                                    theme.muted_foreground
+                                },
+                            ))
+                            .child(Text::caption("Prev").font_size(FontSizes::XS).color(
+                                if can_prev {
+                                    theme.foreground
+                                } else {
+                                    theme.muted_foreground
+                                },
+                            )),
+                    )
+                    .child(Text::caption(page_label).font_size(FontSizes::XS))
+                    .child(
+                        div()
+                            .id("child-picker-next")
+                            .flex()
+                            .items_center()
+                            .gap_1()
+                            .px(Spacing::XS)
+                            .rounded(Radii::SM)
+                            .when(can_next, |d| {
+                                d.cursor_pointer()
                                     .hover(|d| d.bg(theme.secondary))
                                     .on_click(move |_, _, cx| {
                                         next_sidebar.update(cx, |this, cx| {
@@ -569,8 +698,22 @@ impl Sidebar {
                                             cx.notify();
                                         });
                                     })
-                                    .child(Text::caption("Next")),
-                            ),
+                            })
+                            .when(!can_next, |d| d.opacity(0.5))
+                            .child(Text::caption("Next").font_size(FontSizes::XS).color(
+                                if can_next {
+                                    theme.foreground
+                                } else {
+                                    theme.muted_foreground
+                                },
+                            ))
+                            .child(Icon::new(AppIcon::ChevronRight).size(px(12.0)).color(
+                                if can_next {
+                                    theme.foreground
+                                } else {
+                                    theme.muted_foreground
+                                },
+                            )),
                     ),
             )
     }

--- a/crates/dbflux_ui/src/ui/views/sidebar/render_overlays.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/render_overlays.rs
@@ -263,13 +263,27 @@ impl Sidebar {
         );
 
         self._subscriptions.push(filter_subscription);
+        let children = self
+            .app_state
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .and_then(|connection| {
+                connection
+                    .collection_children
+                    .get(&(database.clone(), name.clone()))
+                    .map(|cache| cache.items.clone())
+            })
+            .or(collection.child_items)
+            .unwrap_or_default();
+
         self.child_picker = Some(ChildPickerState {
             profile_id,
             database,
             collection: name.clone(),
             title: format!("Event streams: {}", name),
             focus_handle: cx.focus_handle(),
-            children: collection.child_items.unwrap_or_default(),
+            children,
             filter_input,
             filter_query: String::new(),
             page: 0,

--- a/crates/dbflux_ui/src/ui/views/sidebar/render_overlays.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/render_overlays.rs
@@ -1,6 +1,27 @@
 use super::*;
 use crate::platform;
 use dbflux_components::primitives::Icon;
+use gpui_component::scroll::ScrollableElement;
+
+fn format_child_timestamp(timestamp_ms: Option<i64>) -> String {
+    let Some(timestamp_ms) = timestamp_ms else {
+        return "-".to_string();
+    };
+
+    dbflux_core::chrono::DateTime::from_timestamp_millis(timestamp_ms)
+        .map(|timestamp| timestamp.format("%Y-%m-%d %H:%M:%S").to_string())
+        .unwrap_or_else(|| timestamp_ms.to_string())
+}
+
+fn child_picker_filtered_total(picker: &ChildPickerState) -> usize {
+    let query = picker.filter_query.to_lowercase();
+
+    picker
+        .children
+        .iter()
+        .filter(|child| query.is_empty() || child.label.to_lowercase().contains(&query))
+        .count()
+}
 
 impl Sidebar {
     pub(super) fn render_add_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -199,5 +220,344 @@ impl Sidebar {
                         .child("Import File"),
                 ),
         )
+    }
+
+    pub(super) fn open_child_picker_modal(
+        &mut self,
+        item_id: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(SchemaNodeId::Collection {
+            profile_id,
+            database,
+            name,
+        }) = parse_node_id(item_id)
+        else {
+            return;
+        };
+
+        let Some(collection) = self.collection_info_for_item(item_id, cx) else {
+            self.pending_toast = Some(PendingToast {
+                message: "Event streams are not available for this collection".to_string(),
+                is_error: true,
+            });
+            return;
+        };
+
+        let filter_input =
+            cx.new(|cx| InputState::new(window, cx).placeholder("Filter stream names..."));
+        let input_for_subscription = filter_input.clone();
+        let filter_subscription = cx.subscribe_in(
+            &input_for_subscription,
+            window,
+            |this, input_state, event: &InputEvent, _, cx| {
+                if matches!(event, InputEvent::Change)
+                    && let Some(picker) = this.child_picker.as_mut()
+                {
+                    picker.filter_query = input_state.read(cx).value().to_string();
+                    picker.page = 0;
+                    cx.notify();
+                }
+            },
+        );
+
+        self._subscriptions.push(filter_subscription);
+        self.child_picker = Some(ChildPickerState {
+            profile_id,
+            database,
+            collection: name.clone(),
+            title: format!("Event streams: {}", name),
+            focus_handle: cx.focus_handle(),
+            children: collection.child_items.unwrap_or_default(),
+            filter_input,
+            filter_query: String::new(),
+            page: 0,
+            page_size: 25,
+            sort_column: ChildPickerSortColumn::LastEvent,
+            sort_descending: true,
+        });
+
+        cx.notify();
+    }
+
+    pub fn close_child_picker(&mut self, cx: &mut Context<Self>) {
+        if self.child_picker.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    pub fn has_child_picker_open(&self) -> bool {
+        self.child_picker.is_some()
+    }
+
+    pub fn child_picker_focus_handle(&self) -> Option<FocusHandle> {
+        self.child_picker
+            .as_ref()
+            .map(|picker| picker.focus_handle.clone())
+    }
+
+    pub fn render_child_picker_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let Some(picker) = self.child_picker.as_ref() else {
+            return div();
+        };
+
+        let query = picker.filter_query.to_lowercase();
+        let mut rows = picker
+            .children
+            .iter()
+            .filter(|child| query.is_empty() || child.label.to_lowercase().contains(&query))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        match picker.sort_column {
+            ChildPickerSortColumn::Name => rows.sort_by(|left, right| left.label.cmp(&right.label)),
+            ChildPickerSortColumn::LastEvent => rows.sort_by(|left, right| {
+                left.last_event_ts_ms
+                    .cmp(&right.last_event_ts_ms)
+                    .then_with(|| left.label.cmp(&right.label))
+            }),
+        }
+
+        if picker.sort_descending {
+            rows.reverse();
+        }
+
+        let total = child_picker_filtered_total(picker);
+        let page_count = total.max(1).div_ceil(picker.page_size);
+        let page = picker.page.min(page_count.saturating_sub(1));
+        let start = page.saturating_mul(picker.page_size);
+        let end = (start + picker.page_size).min(total);
+        let visible_rows = rows[start..end].to_vec();
+
+        let sidebar = cx.entity().clone();
+        let close_button_sidebar = sidebar.clone();
+        let prev_sidebar = sidebar.clone();
+        let next_sidebar = sidebar.clone();
+        let name_sort_sidebar = sidebar.clone();
+        let last_event_sort_sidebar = sidebar.clone();
+        let profile_id = picker.profile_id;
+        let database = picker.database.clone();
+        let collection = picker.collection.clone();
+        let title = picker.title.clone();
+
+        let page_label = if total == 0 {
+            "0 streams".to_string()
+        } else {
+            format!("{}-{} of {}", start + 1, end, total)
+        };
+
+        div()
+            .track_focus(&picker.focus_handle)
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(theme.sidebar)
+            .border_1()
+            .border_color(theme.border)
+            .rounded(Radii::MD)
+            .shadow_lg()
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .px(Spacing::SM)
+                    .py(Spacing::SM)
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .child(Text::body(title).font_size(FontSizes::SM))
+                    .child(
+                        div()
+                            .id("child-picker-close")
+                            .cursor_pointer()
+                            .px(Spacing::XS)
+                            .py(Spacing::XS)
+                            .rounded(Radii::SM)
+                            .hover(|d| d.bg(theme.secondary))
+                            .on_click(move |_, _, cx| {
+                                close_button_sidebar.update(cx, |this, cx| {
+                                    this.close_child_picker(cx);
+                                });
+                            })
+                            .child(Text::muted("Close").font_size(FontSizes::XS)),
+                    ),
+            )
+            .child(
+                div()
+                    .px(Spacing::SM)
+                    .py(Spacing::XS)
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .child(Input::new(&picker.filter_input).xsmall().cleanable(true)),
+            )
+            .child(
+                div()
+                    .flex()
+                    .px(Spacing::SM)
+                    .py(Spacing::XS)
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .text_size(FontSizes::XS)
+                    .child(
+                        div()
+                            .id("child-picker-sort-name")
+                            .cursor_pointer()
+                            .on_click(move |_, _, cx| {
+                                name_sort_sidebar.update(cx, |this, cx| {
+                                    if let Some(picker) = this.child_picker.as_mut() {
+                                        if picker.sort_column == ChildPickerSortColumn::Name {
+                                            picker.sort_descending = !picker.sort_descending;
+                                        } else {
+                                            picker.sort_column = ChildPickerSortColumn::Name;
+                                            picker.sort_descending = false;
+                                        }
+
+                                        picker.page = 0;
+                                    }
+
+                                    cx.notify();
+                                });
+                            })
+                            .flex_1()
+                            .child(Text::caption("Stream name")),
+                    )
+                    .child(
+                        div()
+                            .id("child-picker-sort-last-event")
+                            .cursor_pointer()
+                            .on_click(move |_, _, cx| {
+                                last_event_sort_sidebar.update(cx, |this, cx| {
+                                    if let Some(picker) = this.child_picker.as_mut() {
+                                        if picker.sort_column == ChildPickerSortColumn::LastEvent {
+                                            picker.sort_descending = !picker.sort_descending;
+                                        } else {
+                                            picker.sort_column = ChildPickerSortColumn::LastEvent;
+                                            picker.sort_descending = true;
+                                        }
+
+                                        picker.page = 0;
+                                    }
+
+                                    cx.notify();
+                                });
+                            })
+                            .flex_1()
+                            .child(Text::caption("Last event")),
+                    ),
+            )
+            .child(
+                div()
+                    .flex_1()
+                    .overflow_y_scrollbar()
+                    .when(visible_rows.is_empty(), |el| {
+                        el.child(
+                            div().px(Spacing::SM).py(Spacing::SM).child(
+                                Text::muted("No event streams found").font_size(FontSizes::SM),
+                            ),
+                        )
+                    })
+                    .children(visible_rows.into_iter().enumerate().map(
+                        move |(row_index, child)| {
+                            let row_sidebar = sidebar.clone();
+                            let database = database.clone();
+                            let collection = collection.clone();
+                            let child_id = child.id.clone();
+                            let child_label = child.label.clone();
+                            let timestamp = format_child_timestamp(child.last_event_ts_ms);
+
+                            div()
+                                .id(("child-picker-row", row_index))
+                                .flex()
+                                .gap(Spacing::XS)
+                                .px(Spacing::SM)
+                                .py(Spacing::XS)
+                                .border_b_1()
+                                .border_color(theme.border)
+                                .cursor_pointer()
+                                .hover(|d| d.bg(theme.list_active))
+                                .on_click(move |_, _, cx| {
+                                    row_sidebar.update(cx, |this, cx| {
+                                        let target = EventStreamTarget {
+                                            collection: CollectionRef::new(&database, &collection),
+                                            child_id: Some(child_id.clone()),
+                                        };
+
+                                        cx.emit(SidebarEvent::OpenCollectionChild {
+                                            profile_id,
+                                            target,
+                                            title: child_label.clone(),
+                                        });
+
+                                        this.close_child_picker(cx);
+                                    });
+                                })
+                                .child(div().flex_1().child(Text::caption(child.label)))
+                                .child(
+                                    div()
+                                        .flex_1()
+                                        .child(Text::caption(timestamp).muted_foreground()),
+                                )
+                        },
+                    )),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .px(Spacing::SM)
+                    .py(Spacing::XS)
+                    .border_t_1()
+                    .border_color(theme.border)
+                    .child(Text::muted(page_label).font_size(FontSizes::XS))
+                    .child(
+                        div()
+                            .flex()
+                            .gap(Spacing::XS)
+                            .child(
+                                div()
+                                    .id("child-picker-prev")
+                                    .cursor_pointer()
+                                    .px(Spacing::XS)
+                                    .py(Spacing::XS)
+                                    .rounded(Radii::SM)
+                                    .hover(|d| d.bg(theme.secondary))
+                                    .on_click(move |_, _, cx| {
+                                        prev_sidebar.update(cx, |this, cx| {
+                                            if let Some(picker) = this.child_picker.as_mut() {
+                                                picker.page = picker.page.saturating_sub(1);
+                                            }
+                                            cx.notify();
+                                        });
+                                    })
+                                    .child(Text::caption("Prev")),
+                            )
+                            .child(
+                                div()
+                                    .id("child-picker-next")
+                                    .cursor_pointer()
+                                    .px(Spacing::XS)
+                                    .py(Spacing::XS)
+                                    .rounded(Radii::SM)
+                                    .hover(|d| d.bg(theme.secondary))
+                                    .on_click(move |_, _, cx| {
+                                        next_sidebar.update(cx, |this, cx| {
+                                            if let Some(picker) = this.child_picker.as_mut() {
+                                                let page_count =
+                                                    child_picker_filtered_total(picker)
+                                                        .max(1)
+                                                        .div_ceil(picker.page_size);
+                                                picker.page = (picker.page + 1)
+                                                    .min(page_count.saturating_sub(1));
+                                            }
+                                            cx.notify();
+                                        });
+                                    })
+                                    .child(Text::caption("Next")),
+                            ),
+                    ),
+            )
     }
 }

--- a/crates/dbflux_ui/src/ui/views/sidebar/render_tree.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/render_tree.rs
@@ -178,6 +178,7 @@ pub(super) fn render_tree_item(
                 | SchemaNodeKind::CustomType
                 | SchemaNodeKind::ScriptsFolder
                 | SchemaNodeKind::Collection
+                | SchemaNodeKind::CloudWatchLogStream
                 | SchemaNodeKind::CollectionsFolder
                 | SchemaNodeKind::DatabaseIndexesFolder
                 | SchemaNodeKind::CollectionFieldsFolder
@@ -960,6 +961,7 @@ fn resolve_node_icon(
         SchemaNodeKind::Constraint => (Some(AppIcon::Lock), "", params.color_yellow),
         SchemaNodeKind::CollectionsFolder => (Some(AppIcon::Folder), "", params.color_teal),
         SchemaNodeKind::Collection => (Some(AppIcon::Box), "", params.color_teal),
+        SchemaNodeKind::CloudWatchLogStream => (Some(AppIcon::ScrollText), "", params.color_teal),
         SchemaNodeKind::DatabaseIndexesFolder | SchemaNodeKind::CollectionIndexesFolder => {
             (Some(AppIcon::Hash), "", params.color_purple)
         }
@@ -1067,6 +1069,7 @@ fn resolve_label_color(
         | SchemaNodeKind::CollectionFieldsFolder
         | SchemaNodeKind::CollectionIndexesFolder => params.color_gray,
         SchemaNodeKind::Collection => params.color_teal,
+        SchemaNodeKind::CloudWatchLogStream => params.color_teal,
         SchemaNodeKind::CollectionField => params.color_blue,
         SchemaNodeKind::CollectionIndex => params.color_purple,
         SchemaNodeKind::ScriptsFolder => theme.foreground,

--- a/crates/dbflux_ui/src/ui/views/sidebar/render_tree.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/render_tree.rs
@@ -178,7 +178,7 @@ pub(super) fn render_tree_item(
                 | SchemaNodeKind::CustomType
                 | SchemaNodeKind::ScriptsFolder
                 | SchemaNodeKind::Collection
-                | SchemaNodeKind::CloudWatchLogStream
+                | SchemaNodeKind::CollectionChild
                 | SchemaNodeKind::CollectionsFolder
                 | SchemaNodeKind::DatabaseIndexesFolder
                 | SchemaNodeKind::CollectionFieldsFolder
@@ -961,7 +961,7 @@ fn resolve_node_icon(
         SchemaNodeKind::Constraint => (Some(AppIcon::Lock), "", params.color_yellow),
         SchemaNodeKind::CollectionsFolder => (Some(AppIcon::Folder), "", params.color_teal),
         SchemaNodeKind::Collection => (Some(AppIcon::Box), "", params.color_teal),
-        SchemaNodeKind::CloudWatchLogStream => (Some(AppIcon::ScrollText), "", params.color_teal),
+        SchemaNodeKind::CollectionChild => (Some(AppIcon::ScrollText), "", params.color_teal),
         SchemaNodeKind::DatabaseIndexesFolder | SchemaNodeKind::CollectionIndexesFolder => {
             (Some(AppIcon::Hash), "", params.color_purple)
         }
@@ -1069,7 +1069,7 @@ fn resolve_label_color(
         | SchemaNodeKind::CollectionFieldsFolder
         | SchemaNodeKind::CollectionIndexesFolder => params.color_gray,
         SchemaNodeKind::Collection => params.color_teal,
-        SchemaNodeKind::CloudWatchLogStream => params.color_teal,
+        SchemaNodeKind::CollectionChild => params.color_teal,
         SchemaNodeKind::CollectionField => params.color_blue,
         SchemaNodeKind::CollectionIndex => params.color_purple,
         SchemaNodeKind::ScriptsFolder => theme.foreground,

--- a/crates/dbflux_ui/src/ui/views/sidebar/table_loading.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/table_loading.rs
@@ -2,6 +2,8 @@ use super::*;
 use crate::ui::AsyncUpdateResultExt;
 use dbflux_core::TaskKind;
 
+const COLLECTION_CHILDREN_PAGE_SIZE: u32 = 50;
+
 impl Sidebar {
     pub(super) fn find_table_for_item<'a>(
         parts: &ItemIdParts,
@@ -107,6 +109,123 @@ impl Sidebar {
         } else {
             TableDetailsStatus::NotFound
         }
+    }
+
+    pub(super) fn ensure_collection_children(
+        &mut self,
+        profile_id: Uuid,
+        database: &str,
+        collection: &str,
+        pending_action: PendingAction,
+        cx: &mut Context<Self>,
+    ) -> TableDetailsStatus {
+        let item_id = pending_action.item_id().to_string();
+
+        if self.loading_items.contains(&item_id) {
+            return TableDetailsStatus::Loading;
+        }
+
+        let has_any_page = self
+            .app_state
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .is_some_and(|connection| {
+                connection
+                    .collection_children
+                    .contains_key(&(database.to_string(), collection.to_string()))
+            });
+
+        if has_any_page {
+            return TableDetailsStatus::Ready;
+        }
+
+        if self.spawn_fetch_collection_children(
+            profile_id,
+            database,
+            collection,
+            pending_action,
+            cx,
+        ) {
+            TableDetailsStatus::Loading
+        } else {
+            TableDetailsStatus::NotFound
+        }
+    }
+
+    pub(super) fn spawn_fetch_collection_children(
+        &mut self,
+        profile_id: Uuid,
+        database: &str,
+        collection: &str,
+        pending_action: PendingAction,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.loading_items.contains(pending_action.item_id()) {
+            return true;
+        }
+
+        let params = match self.app_state.read(cx).prepare_fetch_collection_children(
+            profile_id,
+            database,
+            collection,
+            COLLECTION_CHILDREN_PAGE_SIZE,
+        ) {
+            Ok(params) => params,
+            Err(error) => {
+                if error != "Collection children already fully cached" {
+                    log::warn!("Cannot fetch collection children: {}", error);
+                    self.pending_toast = Some(PendingToast {
+                        message: format!("Cannot load collection children: {}", error),
+                        is_error: true,
+                    });
+                    cx.notify();
+                }
+
+                return false;
+            }
+        };
+
+        let database_name = database.to_string();
+        let task_description = format!("Loading event streams: {}", collection);
+        let load_task_id = self.app_state.update(cx, |state, _| {
+            let (task_id, _) = state.start_task_for_profile(
+                TaskKind::LoadSchema,
+                task_description,
+                Some(profile_id),
+            );
+            task_id
+        });
+
+        let task = cx
+            .background_executor()
+            .spawn(async move { params.execute() });
+
+        self.spawn_fetch_with_result(
+            pending_action,
+            Some(load_task_id),
+            task,
+            "Failed to fetch collection children",
+            "Failed to load collection children",
+            |app_state, res, cx| {
+                app_state.update(cx, |state, cx| {
+                    state.set_collection_children_page(
+                        res.profile_id,
+                        res.database,
+                        res.collection,
+                        res.page,
+                    );
+                    cx.emit(AppStateChanged);
+                });
+            },
+            move |app_state, cx| {
+                app_state.update(cx, |state, state_cx| {
+                    state.finish_pending_operation(profile_id, Some(&database_name));
+                    state_cx.emit(AppStateChanged);
+                });
+            },
+            cx,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/dbflux_ui/src/ui/views/sidebar/table_loading.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/table_loading.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::ui::AsyncUpdateResultExt;
+use dbflux_core::TaskKind;
 
 impl Sidebar {
     pub(super) fn find_table_for_item<'a>(
@@ -112,6 +113,7 @@ impl Sidebar {
     fn spawn_fetch_with_result<R, F, G>(
         &mut self,
         pending_action: PendingAction,
+        task_id: Option<TaskId>,
         task: Task<Result<R, String>>,
         error_log_prefix: &'static str,
         error_toast_prefix: &'static str,
@@ -139,6 +141,12 @@ impl Sidebar {
                     Ok(res) => {
                         on_success(&app_state, res, cx);
 
+                        if let Some(task_id) = task_id {
+                            app_state.update(cx, |state, _| {
+                                state.complete_task(task_id);
+                            });
+                        }
+
                         sidebar.update(cx, |sidebar, cx| {
                             sidebar.loading_items.remove(&item_id);
                             sidebar.complete_pending_action(&item_id, cx);
@@ -146,6 +154,13 @@ impl Sidebar {
                     }
                     Err(e) => {
                         log::error!("{}: {}", error_log_prefix, e);
+
+                        if let Some(task_id) = task_id {
+                            let details = format!("{}: {}", error_toast_prefix, e);
+                            app_state.update(cx, |state, _| {
+                                state.fail_task_with_details(task_id, e.clone(), details);
+                            });
+                        }
 
                         sidebar.update(cx, |sidebar, cx| {
                             sidebar.loading_items.remove(&item_id);
@@ -200,6 +215,14 @@ impl Sidebar {
 
         let profile_id = parts.profile_id;
         let db_name = cache_db.clone();
+        let load_task_id = self.app_state.update(cx, |state, _| {
+            let (task_id, _) = state.start_task_for_profile(
+                TaskKind::LoadSchema,
+                format!("Loading event streams: {}", parts.object_name),
+                Some(parts.profile_id),
+            );
+            task_id
+        });
 
         let task = cx
             .background_executor()
@@ -207,6 +230,7 @@ impl Sidebar {
 
         self.spawn_fetch_with_result(
             pending_action,
+            Some(load_task_id),
             task,
             "Failed to fetch table details",
             "Failed to load table schema",
@@ -255,6 +279,7 @@ impl Sidebar {
 
         self.spawn_fetch_with_result(
             pending_action,
+            None,
             task,
             "Failed to fetch schema types",
             "Failed to load data types",
@@ -298,6 +323,7 @@ impl Sidebar {
 
         self.spawn_fetch_with_result(
             pending_action,
+            None,
             task,
             "Failed to fetch schema indexes",
             "Failed to load indexes",
@@ -341,6 +367,7 @@ impl Sidebar {
 
         self.spawn_fetch_with_result(
             pending_action,
+            None,
             task,
             "Failed to fetch schema foreign keys",
             "Failed to load foreign keys",
@@ -381,6 +408,9 @@ impl Sidebar {
             | PendingAction::ExpandSchemaForeignKeysFolder { item_id }
             | PendingAction::ExpandCollection { item_id } => {
                 self.expand_schema_folder(&item_id, cx);
+            }
+            PendingAction::OpenChildPicker { item_id } => {
+                self.pending_child_picker_item = Some(item_id);
             }
         }
     }

--- a/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
@@ -3,7 +3,13 @@ use super::*;
 impl Sidebar {
     pub(super) fn build_tree_items_with_overrides(&self, cx: &Context<Self>) -> Vec<TreeItem> {
         let items = Self::build_tree_items(self.app_state.read(cx));
-        self.apply_expansion_overrides(items)
+        let items = self.apply_expansion_overrides(items);
+
+        if self.connections_search_query.trim().is_empty() {
+            return items;
+        }
+
+        Self::apply_tree_filter(items, self.connections_search_query.trim())
     }
 
     pub(super) fn extract_active_databases(state: &AppState) -> HashMap<Uuid, String> {
@@ -17,6 +23,46 @@ impl Sidebar {
                     .map(|db| (*profile_id, db))
             })
             .collect()
+    }
+
+    fn is_cloudwatch_profile(state: &AppState, profile_id: Uuid) -> bool {
+        state
+            .profiles()
+            .iter()
+            .find(|profile| profile.id == profile_id)
+            .is_some_and(|profile| profile.kind() == dbflux_core::DbKind::CloudWatchLogs)
+    }
+
+    pub(crate) fn apply_tree_filter(items: Vec<TreeItem>, query: &str) -> Vec<TreeItem> {
+        let query = query.to_ascii_lowercase();
+
+        items
+            .into_iter()
+            .filter_map(|item| Self::filter_tree_item(item, &query))
+            .collect()
+    }
+
+    fn filter_tree_item(item: TreeItem, query: &str) -> Option<TreeItem> {
+        let item_id = item.id.to_string();
+        let item_label = item.label.clone();
+        let item_expanded = item.is_expanded();
+        let item_matches = item_label.to_string().to_ascii_lowercase().contains(query);
+
+        let children: Vec<TreeItem> = item
+            .children
+            .into_iter()
+            .filter_map(|child| Self::filter_tree_item(child, query))
+            .collect();
+
+        if !item_matches && children.is_empty() {
+            return None;
+        }
+
+        Some(
+            TreeItem::new(item_id, item_label)
+                .expanded(item_expanded || !children.is_empty())
+                .children(children),
+        )
     }
 
     fn apply_expansion_overrides(&self, items: Vec<TreeItem>) -> Vec<TreeItem> {
@@ -228,6 +274,7 @@ impl Sidebar {
                                     &db.name,
                                     db_schema,
                                     &connected.table_details,
+                                    Self::is_cloudwatch_profile(state, profile_id),
                                 )
                             } else {
                                 Self::build_db_schema_content(
@@ -300,6 +347,7 @@ impl Sidebar {
                                 &db.name,
                                 &db_schema,
                                 &connected.table_details,
+                                Self::is_cloudwatch_profile(state, profile_id),
                             )
                         } else {
                             Self::build_schema_children(
@@ -481,6 +529,7 @@ impl Sidebar {
         database_name: &str,
         db_schema: &dbflux_core::DbSchemaInfo,
         table_details: &HashMap<(String, String), TableInfo>,
+        is_cloudwatch_profile: bool,
     ) -> Vec<TreeItem> {
         let mut content = Vec::new();
 
@@ -489,7 +538,13 @@ impl Sidebar {
                 .tables
                 .iter()
                 .map(|coll| {
-                    Self::build_collection_item(profile_id, database_name, coll, table_details)
+                    Self::build_collection_item(
+                        profile_id,
+                        database_name,
+                        coll,
+                        table_details,
+                        is_cloudwatch_profile,
+                    )
                 })
                 .collect();
 
@@ -586,10 +641,14 @@ impl Sidebar {
         database_name: &str,
         collection: &dbflux_core::TableInfo,
         table_details: &HashMap<(String, String), TableInfo>,
+        is_cloudwatch_profile: bool,
     ) -> TreeItem {
         let coll_name = &collection.name;
         let cache_key = (database_name.to_string(), coll_name.clone());
         let effective = table_details.get(&cache_key).unwrap_or(collection);
+        let cloudwatch_stream_names = is_cloudwatch_profile
+            .then(|| Self::cloudwatch_stream_names(effective))
+            .flatten();
         let details_loaded = effective.sample_fields.is_some();
 
         let (field_children, field_count) = if let Some(fields) = effective.sample_fields.as_ref() {
@@ -657,30 +716,56 @@ impl Sidebar {
             (Vec::new(), 0)
         };
 
-        let collection_children = vec![
-            TreeItem::new(
-                SchemaNodeId::CollectionFieldsFolder {
-                    profile_id,
-                    database: database_name.to_string(),
-                    collection: coll_name.to_string(),
-                }
-                .to_string(),
-                format!("Fields ({})", field_count),
-            )
-            .expanded(false)
-            .children(field_children),
-            TreeItem::new(
-                SchemaNodeId::CollectionIndexesFolder {
-                    profile_id,
-                    database: database_name.to_string(),
-                    collection: coll_name.to_string(),
-                }
-                .to_string(),
-                format!("Indexes ({})", index_count),
-            )
-            .expanded(false)
-            .children(index_children),
-        ];
+        let collection_children = if let Some(stream_names) = cloudwatch_stream_names {
+            stream_names
+                .into_iter()
+                .map(|stream_name| {
+                    TreeItem::new(
+                        SchemaNodeId::CloudWatchLogStream {
+                            profile_id,
+                            database: database_name.to_string(),
+                            log_group: coll_name.to_string(),
+                            name: stream_name.clone(),
+                        }
+                        .to_string(),
+                        stream_name,
+                    )
+                })
+                .collect()
+        } else if is_cloudwatch_profile {
+            vec![TreeItem::new(
+                format!(
+                    "cloudwatch-loading|{}|{}|{}",
+                    profile_id, database_name, coll_name
+                ),
+                "Loading...".to_string(),
+            )]
+        } else {
+            vec![
+                TreeItem::new(
+                    SchemaNodeId::CollectionFieldsFolder {
+                        profile_id,
+                        database: database_name.to_string(),
+                        collection: coll_name.to_string(),
+                    }
+                    .to_string(),
+                    format!("Fields ({})", field_count),
+                )
+                .expanded(false)
+                .children(field_children),
+                TreeItem::new(
+                    SchemaNodeId::CollectionIndexesFolder {
+                        profile_id,
+                        database: database_name.to_string(),
+                        collection: coll_name.to_string(),
+                    }
+                    .to_string(),
+                    format!("Indexes ({})", index_count),
+                )
+                .expanded(false)
+                .children(index_children),
+            ]
+        };
 
         TreeItem::new(
             SchemaNodeId::Collection {
@@ -693,6 +778,18 @@ impl Sidebar {
         )
         .expanded(false)
         .children(collection_children)
+    }
+
+    fn cloudwatch_stream_names(collection: &TableInfo) -> Option<Vec<String>> {
+        let fields = collection.sample_fields.as_ref()?;
+
+        let stream_names = fields
+            .iter()
+            .filter(|field| field.common_type == "cloudwatch_log_stream")
+            .map(|field| field.name.clone())
+            .collect::<Vec<_>>();
+
+        Some(stream_names)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1223,6 +1320,63 @@ impl Sidebar {
         )
         .expanded(false)
         .children(table_sections)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Sidebar;
+    use dbflux_core::{FieldInfo, TableInfo};
+    use uuid::Uuid;
+
+    #[test]
+    fn cloudwatch_collection_item_keeps_placeholder_child_before_streams_load() {
+        let item = Sidebar::build_collection_item(
+            Uuid::new_v4(),
+            "logs",
+            &TableInfo {
+                name: "/aws/lambda/app".to_string(),
+                schema: None,
+                columns: None,
+                indexes: None,
+                foreign_keys: None,
+                constraints: None,
+                sample_fields: None,
+            },
+            &Default::default(),
+            true,
+        );
+
+        assert_eq!(item.label.as_ref(), "/aws/lambda/app");
+        assert_eq!(item.children.len(), 1);
+        assert_eq!(item.children[0].label.as_ref(), "Loading...");
+    }
+
+    #[test]
+    fn cloudwatch_collection_item_uses_loaded_stream_names_when_present() {
+        let item = Sidebar::build_collection_item(
+            Uuid::new_v4(),
+            "logs",
+            &TableInfo {
+                name: "/aws/lambda/app".to_string(),
+                schema: None,
+                columns: None,
+                indexes: None,
+                foreign_keys: None,
+                constraints: None,
+                sample_fields: Some(vec![FieldInfo {
+                    name: "2026/04/25/[$LATEST]abc".to_string(),
+                    common_type: "cloudwatch_log_stream".to_string(),
+                    occurrence_rate: None,
+                    nested_fields: None,
+                }]),
+            },
+            &Default::default(),
+            true,
+        );
+
+        assert_eq!(item.children.len(), 1);
+        assert_eq!(item.children[0].label.as_ref(), "2026/04/25/[$LATEST]abc");
     }
 }
 

--- a/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
@@ -724,54 +724,11 @@ impl Sidebar {
         };
 
         let collection_children = if effective.presentation == CollectionPresentation::EventStream {
-            match child_items {
-                Some(items) if !items.is_empty() => {
-                    let mut children: Vec<TreeItem> = items
-                        .into_iter()
-                        .map(|child| {
-                            TreeItem::new(
-                                SchemaNodeId::CollectionChild {
-                                    profile_id,
-                                    database: database_name.to_string(),
-                                    collection: coll_name.to_string(),
-                                    child_id: child.id,
-                                    name: child.label.clone(),
-                                }
-                                .to_string(),
-                                child.label,
-                            )
-                        })
-                        .collect();
-
-                    if has_more_children {
-                        children.push(TreeItem::new(
-                            SchemaNodeId::CollectionChildrenMore {
-                                profile_id,
-                                database: database_name.to_string(),
-                                collection: coll_name.to_string(),
-                            }
-                            .to_string(),
-                            "Load more streams...".to_string(),
-                        ));
-                    }
-
-                    children
-                }
-                Some(_) if has_more_children => vec![TreeItem::new(
-                    SchemaNodeId::CollectionChildrenMore {
-                        profile_id,
-                        database: database_name.to_string(),
-                        collection: coll_name.to_string(),
-                    }
-                    .to_string(),
-                    "Load more streams...".to_string(),
-                )],
-                Some(_) => vec![TreeItem::new(
-                    format!("collection-empty-streams:{profile_id}:{database_name}:{coll_name}"),
-                    "No event streams".to_string(),
-                )],
-                None => Vec::new(),
-            }
+            // Event-stream collections are leaves in the tree: streams are
+            // browsed exclusively through the dedicated picker modal, never
+            // inline. Suppressing children also removes the expand chevron.
+            let _ = (child_items, has_more_children);
+            Vec::new()
         } else {
             vec![
                 TreeItem::new(
@@ -1347,8 +1304,7 @@ impl Sidebar {
 mod tests {
     use super::Sidebar;
     use dbflux_core::{
-        CollectionChildInfo, CollectionChildrenCache, CollectionPresentation, FieldInfo,
-        SchemaNodeId, TableInfo,
+        CollectionChildInfo, CollectionChildrenCache, CollectionPresentation, FieldInfo, TableInfo,
     };
     use std::collections::HashMap;
     use uuid::Uuid;
@@ -1380,7 +1336,10 @@ mod tests {
     }
 
     #[test]
-    fn collection_item_uses_driver_provided_child_items_when_present() {
+    fn event_stream_collections_are_leaves_regardless_of_driver_child_items() {
+        // Event-stream collections are now leaves in the tree; their streams
+        // are reached exclusively through the picker modal so the row never
+        // shows an expand chevron.
         let item = Sidebar::build_collection_item(
             Uuid::new_v4(),
             "logs",
@@ -1409,12 +1368,13 @@ mod tests {
             &Default::default(),
         );
 
-        assert_eq!(item.children.len(), 1);
-        assert_eq!(item.children[0].label.as_ref(), "2026/04/25/[$LATEST]abc");
+        assert!(item.children.is_empty());
     }
 
     #[test]
-    fn collection_item_adds_load_more_when_child_page_has_next_token() {
+    fn event_stream_collections_stay_leaves_even_with_pending_pagination() {
+        // The presence of a `next_page_token` from the driver must not
+        // promote an event-stream collection to an expandable folder.
         let profile_id = Uuid::new_v4();
         let collection = "/aws/lambda/app".to_string();
         let mut child_cache = HashMap::new();
@@ -1449,17 +1409,7 @@ mod tests {
             &child_cache,
         );
 
-        assert_eq!(item.children.len(), 2);
-        assert_eq!(item.children[1].label.as_ref(), "Load more streams...");
-        assert_eq!(
-            item.children[1].id.as_ref(),
-            SchemaNodeId::CollectionChildrenMore {
-                profile_id,
-                database: "logs".to_string(),
-                collection,
-            }
-            .to_string()
-        );
+        assert!(item.children.is_empty());
     }
 }
 

--- a/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
@@ -25,14 +25,6 @@ impl Sidebar {
             .collect()
     }
 
-    fn is_cloudwatch_profile(state: &AppState, profile_id: Uuid) -> bool {
-        state
-            .profiles()
-            .iter()
-            .find(|profile| profile.id == profile_id)
-            .is_some_and(|profile| profile.kind() == dbflux_core::DbKind::CloudWatchLogs)
-    }
-
     pub(crate) fn apply_tree_filter(items: Vec<TreeItem>, query: &str) -> Vec<TreeItem> {
         let query = query.to_ascii_lowercase();
 
@@ -274,7 +266,6 @@ impl Sidebar {
                                     &db.name,
                                     db_schema,
                                     &connected.table_details,
-                                    Self::is_cloudwatch_profile(state, profile_id),
                                 )
                             } else {
                                 Self::build_db_schema_content(
@@ -332,6 +323,8 @@ impl Sidebar {
                                     foreign_keys: None,
                                     constraints: None,
                                     sample_fields: collection.sample_fields.clone(),
+                                    presentation: collection.presentation,
+                                    child_items: collection.child_items.clone(),
                                 })
                                 .collect::<Vec<_>>();
 
@@ -347,7 +340,6 @@ impl Sidebar {
                                 &db.name,
                                 &db_schema,
                                 &connected.table_details,
-                                Self::is_cloudwatch_profile(state, profile_id),
                             )
                         } else {
                             Self::build_schema_children(
@@ -529,7 +521,6 @@ impl Sidebar {
         database_name: &str,
         db_schema: &dbflux_core::DbSchemaInfo,
         table_details: &HashMap<(String, String), TableInfo>,
-        is_cloudwatch_profile: bool,
     ) -> Vec<TreeItem> {
         let mut content = Vec::new();
 
@@ -543,7 +534,6 @@ impl Sidebar {
                         database_name,
                         coll,
                         table_details,
-                        is_cloudwatch_profile,
                     )
                 })
                 .collect();
@@ -641,15 +631,12 @@ impl Sidebar {
         database_name: &str,
         collection: &dbflux_core::TableInfo,
         table_details: &HashMap<(String, String), TableInfo>,
-        is_cloudwatch_profile: bool,
     ) -> TreeItem {
         let coll_name = &collection.name;
         let cache_key = (database_name.to_string(), coll_name.clone());
         let effective = table_details.get(&cache_key).unwrap_or(collection);
-        let cloudwatch_stream_names = is_cloudwatch_profile
-            .then(|| Self::cloudwatch_stream_names(effective))
-            .flatten();
-        let details_loaded = effective.sample_fields.is_some();
+        let child_items = effective.child_items.clone().unwrap_or_default();
+        let details_loaded = effective.sample_fields.is_some() || !child_items.is_empty();
 
         let (field_children, field_count) = if let Some(fields) = effective.sample_fields.as_ref() {
             (
@@ -716,30 +703,23 @@ impl Sidebar {
             (Vec::new(), 0)
         };
 
-        let collection_children = if let Some(stream_names) = cloudwatch_stream_names {
-            stream_names
+        let collection_children = if !child_items.is_empty() {
+            child_items
                 .into_iter()
-                .map(|stream_name| {
+                .map(|child| {
                     TreeItem::new(
-                        SchemaNodeId::CloudWatchLogStream {
+                        SchemaNodeId::CollectionChild {
                             profile_id,
                             database: database_name.to_string(),
-                            log_group: coll_name.to_string(),
-                            name: stream_name.clone(),
+                            collection: coll_name.to_string(),
+                            child_id: child.id,
+                            name: child.label.clone(),
                         }
                         .to_string(),
-                        stream_name,
+                        child.label,
                     )
                 })
                 .collect()
-        } else if is_cloudwatch_profile {
-            vec![TreeItem::new(
-                format!(
-                    "cloudwatch-loading|{}|{}|{}",
-                    profile_id, database_name, coll_name
-                ),
-                "Loading...".to_string(),
-            )]
         } else {
             vec![
                 TreeItem::new(
@@ -778,18 +758,6 @@ impl Sidebar {
         )
         .expanded(false)
         .children(collection_children)
-    }
-
-    fn cloudwatch_stream_names(collection: &TableInfo) -> Option<Vec<String>> {
-        let fields = collection.sample_fields.as_ref()?;
-
-        let stream_names = fields
-            .iter()
-            .filter(|field| field.common_type == "cloudwatch_log_stream")
-            .map(|field| field.name.clone())
-            .collect::<Vec<_>>();
-
-        Some(stream_names)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1326,11 +1294,11 @@ impl Sidebar {
 #[cfg(test)]
 mod tests {
     use super::Sidebar;
-    use dbflux_core::{FieldInfo, TableInfo};
+    use dbflux_core::{CollectionChildInfo, CollectionPresentation, FieldInfo, TableInfo};
     use uuid::Uuid;
 
     #[test]
-    fn cloudwatch_collection_item_keeps_placeholder_child_before_streams_load() {
+    fn collection_item_builds_default_field_and_index_sections() {
         let item = Sidebar::build_collection_item(
             Uuid::new_v4(),
             "logs",
@@ -1342,18 +1310,20 @@ mod tests {
                 foreign_keys: None,
                 constraints: None,
                 sample_fields: None,
+                presentation: CollectionPresentation::DataGrid,
+                child_items: None,
             },
             &Default::default(),
-            true,
         );
 
         assert_eq!(item.label.as_ref(), "/aws/lambda/app");
-        assert_eq!(item.children.len(), 1);
-        assert_eq!(item.children[0].label.as_ref(), "Loading...");
+        assert_eq!(item.children.len(), 2);
+        assert!(item.children[0].label.as_ref().starts_with("Fields"));
+        assert!(item.children[1].label.as_ref().starts_with("Indexes"));
     }
 
     #[test]
-    fn cloudwatch_collection_item_uses_loaded_stream_names_when_present() {
+    fn collection_item_uses_driver_provided_child_items_when_present() {
         let item = Sidebar::build_collection_item(
             Uuid::new_v4(),
             "logs",
@@ -1366,13 +1336,18 @@ mod tests {
                 constraints: None,
                 sample_fields: Some(vec![FieldInfo {
                     name: "2026/04/25/[$LATEST]abc".to_string(),
-                    common_type: "cloudwatch_log_stream".to_string(),
+                    common_type: "text".to_string(),
                     occurrence_rate: None,
                     nested_fields: None,
                 }]),
+                presentation: CollectionPresentation::EventStream,
+                child_items: Some(vec![CollectionChildInfo {
+                    id: "stream-1".to_string(),
+                    label: "2026/04/25/[$LATEST]abc".to_string(),
+                    presentation: CollectionPresentation::EventStream,
+                }]),
             },
             &Default::default(),
-            true,
         );
 
         assert_eq!(item.children.len(), 1);

--- a/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
@@ -274,6 +274,7 @@ impl Sidebar {
                                     &db.name,
                                     db_schema,
                                     &connected.table_details,
+                                    &connected.collection_children,
                                 )
                             } else {
                                 Self::build_db_schema_content(
@@ -348,6 +349,7 @@ impl Sidebar {
                                 &db.name,
                                 &db_schema,
                                 &connected.table_details,
+                                &connected.collection_children,
                             )
                         } else {
                             Self::build_schema_children(
@@ -529,6 +531,7 @@ impl Sidebar {
         database_name: &str,
         db_schema: &dbflux_core::DbSchemaInfo,
         table_details: &HashMap<(String, String), TableInfo>,
+        collection_children_cache: &HashMap<(String, String), dbflux_core::CollectionChildrenCache>,
     ) -> Vec<TreeItem> {
         let mut content = Vec::new();
 
@@ -537,7 +540,13 @@ impl Sidebar {
                 .tables
                 .iter()
                 .map(|coll| {
-                    Self::build_collection_item(profile_id, database_name, coll, table_details)
+                    Self::build_collection_item(
+                        profile_id,
+                        database_name,
+                        coll,
+                        table_details,
+                        collection_children_cache,
+                    )
                 })
                 .collect();
 
@@ -634,11 +643,18 @@ impl Sidebar {
         database_name: &str,
         collection: &dbflux_core::TableInfo,
         table_details: &HashMap<(String, String), TableInfo>,
+        collection_children_cache: &HashMap<(String, String), dbflux_core::CollectionChildrenCache>,
     ) -> TreeItem {
         let coll_name = &collection.name;
         let cache_key = (database_name.to_string(), coll_name.clone());
         let effective = table_details.get(&cache_key).unwrap_or(collection);
-        let child_items = effective.child_items.clone();
+        let paged_children = collection_children_cache.get(&cache_key);
+        let child_items = paged_children
+            .map(|cache| cache.items.clone())
+            .or_else(|| effective.child_items.clone());
+        let has_more_children = paged_children
+            .and_then(|cache| cache.next_page_token.as_ref())
+            .is_some();
         let details_loaded = effective.sample_fields.is_some()
             || child_items.as_ref().is_some_and(|items| !items.is_empty());
 
@@ -709,22 +725,47 @@ impl Sidebar {
 
         let collection_children = if effective.presentation == CollectionPresentation::EventStream {
             match child_items {
-                Some(items) if !items.is_empty() => items
-                    .into_iter()
-                    .map(|child| {
-                        TreeItem::new(
-                            SchemaNodeId::CollectionChild {
+                Some(items) if !items.is_empty() => {
+                    let mut children: Vec<TreeItem> = items
+                        .into_iter()
+                        .map(|child| {
+                            TreeItem::new(
+                                SchemaNodeId::CollectionChild {
+                                    profile_id,
+                                    database: database_name.to_string(),
+                                    collection: coll_name.to_string(),
+                                    child_id: child.id,
+                                    name: child.label.clone(),
+                                }
+                                .to_string(),
+                                child.label,
+                            )
+                        })
+                        .collect();
+
+                    if has_more_children {
+                        children.push(TreeItem::new(
+                            SchemaNodeId::CollectionChildrenMore {
                                 profile_id,
                                 database: database_name.to_string(),
                                 collection: coll_name.to_string(),
-                                child_id: child.id,
-                                name: child.label.clone(),
                             }
                             .to_string(),
-                            child.label,
-                        )
-                    })
-                    .collect(),
+                            "Load more streams...".to_string(),
+                        ));
+                    }
+
+                    children
+                }
+                Some(_) if has_more_children => vec![TreeItem::new(
+                    SchemaNodeId::CollectionChildrenMore {
+                        profile_id,
+                        database: database_name.to_string(),
+                        collection: coll_name.to_string(),
+                    }
+                    .to_string(),
+                    "Load more streams...".to_string(),
+                )],
                 Some(_) => vec![TreeItem::new(
                     format!("collection-empty-streams:{profile_id}:{database_name}:{coll_name}"),
                     "No event streams".to_string(),
@@ -1305,7 +1346,11 @@ impl Sidebar {
 #[cfg(test)]
 mod tests {
     use super::Sidebar;
-    use dbflux_core::{CollectionChildInfo, CollectionPresentation, FieldInfo, TableInfo};
+    use dbflux_core::{
+        CollectionChildInfo, CollectionChildrenCache, CollectionPresentation, FieldInfo,
+        SchemaNodeId, TableInfo,
+    };
+    use std::collections::HashMap;
     use uuid::Uuid;
 
     #[test]
@@ -1324,6 +1369,7 @@ mod tests {
                 presentation: CollectionPresentation::DataGrid,
                 child_items: None,
             },
+            &Default::default(),
             &Default::default(),
         );
 
@@ -1360,10 +1406,60 @@ mod tests {
                 }]),
             },
             &Default::default(),
+            &Default::default(),
         );
 
         assert_eq!(item.children.len(), 1);
         assert_eq!(item.children[0].label.as_ref(), "2026/04/25/[$LATEST]abc");
+    }
+
+    #[test]
+    fn collection_item_adds_load_more_when_child_page_has_next_token() {
+        let profile_id = Uuid::new_v4();
+        let collection = "/aws/lambda/app".to_string();
+        let mut child_cache = HashMap::new();
+        child_cache.insert(
+            ("logs".to_string(), collection.clone()),
+            CollectionChildrenCache {
+                items: vec![CollectionChildInfo {
+                    id: "stream-1".to_string(),
+                    label: "stream-1".to_string(),
+                    last_event_ts_ms: Some(1),
+                    presentation: CollectionPresentation::EventStream,
+                }],
+                next_page_token: Some("next".to_string()),
+            },
+        );
+
+        let item = Sidebar::build_collection_item(
+            profile_id,
+            "logs",
+            &TableInfo {
+                name: collection.clone(),
+                schema: None,
+                columns: None,
+                indexes: None,
+                foreign_keys: None,
+                constraints: None,
+                sample_fields: None,
+                presentation: CollectionPresentation::EventStream,
+                child_items: None,
+            },
+            &Default::default(),
+            &child_cache,
+        );
+
+        assert_eq!(item.children.len(), 2);
+        assert_eq!(item.children[1].label.as_ref(), "Load more streams...");
+        assert_eq!(
+            item.children[1].id.as_ref(),
+            SchemaNodeId::CollectionChildrenMore {
+                profile_id,
+                database: "logs".to_string(),
+                collection,
+            }
+            .to_string()
+        );
     }
 }
 

--- a/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
@@ -39,20 +39,28 @@ impl Sidebar {
         let item_label = item.label.clone();
         let item_expanded = item.is_expanded();
         let item_matches = item_label.to_string().to_ascii_lowercase().contains(query);
+        let original_children = item.children;
 
-        let children: Vec<TreeItem> = item
-            .children
+        if item_matches {
+            return Some(
+                TreeItem::new(item_id, item_label)
+                    .expanded(item_expanded)
+                    .children(original_children),
+            );
+        }
+
+        let children: Vec<TreeItem> = original_children
             .into_iter()
             .filter_map(|child| Self::filter_tree_item(child, query))
             .collect();
 
-        if !item_matches && children.is_empty() {
+        if children.is_empty() {
             return None;
         }
 
         Some(
             TreeItem::new(item_id, item_label)
-                .expanded(item_expanded || !children.is_empty())
+                .expanded(true)
                 .children(children),
         )
     }
@@ -529,12 +537,7 @@ impl Sidebar {
                 .tables
                 .iter()
                 .map(|coll| {
-                    Self::build_collection_item(
-                        profile_id,
-                        database_name,
-                        coll,
-                        table_details,
-                    )
+                    Self::build_collection_item(profile_id, database_name, coll, table_details)
                 })
                 .collect();
 
@@ -635,8 +638,9 @@ impl Sidebar {
         let coll_name = &collection.name;
         let cache_key = (database_name.to_string(), coll_name.clone());
         let effective = table_details.get(&cache_key).unwrap_or(collection);
-        let child_items = effective.child_items.clone().unwrap_or_default();
-        let details_loaded = effective.sample_fields.is_some() || !child_items.is_empty();
+        let child_items = effective.child_items.clone();
+        let details_loaded = effective.sample_fields.is_some()
+            || child_items.as_ref().is_some_and(|items| !items.is_empty());
 
         let (field_children, field_count) = if let Some(fields) = effective.sample_fields.as_ref() {
             (
@@ -703,23 +707,30 @@ impl Sidebar {
             (Vec::new(), 0)
         };
 
-        let collection_children = if !child_items.is_empty() {
-            child_items
-                .into_iter()
-                .map(|child| {
-                    TreeItem::new(
-                        SchemaNodeId::CollectionChild {
-                            profile_id,
-                            database: database_name.to_string(),
-                            collection: coll_name.to_string(),
-                            child_id: child.id,
-                            name: child.label.clone(),
-                        }
-                        .to_string(),
-                        child.label,
-                    )
-                })
-                .collect()
+        let collection_children = if effective.presentation == CollectionPresentation::EventStream {
+            match child_items {
+                Some(items) if !items.is_empty() => items
+                    .into_iter()
+                    .map(|child| {
+                        TreeItem::new(
+                            SchemaNodeId::CollectionChild {
+                                profile_id,
+                                database: database_name.to_string(),
+                                collection: coll_name.to_string(),
+                                child_id: child.id,
+                                name: child.label.clone(),
+                            }
+                            .to_string(),
+                            child.label,
+                        )
+                    })
+                    .collect(),
+                Some(_) => vec![TreeItem::new(
+                    format!("collection-empty-streams:{profile_id}:{database_name}:{coll_name}"),
+                    "No event streams".to_string(),
+                )],
+                None => Vec::new(),
+            }
         } else {
             vec![
                 TreeItem::new(
@@ -1344,6 +1355,7 @@ mod tests {
                 child_items: Some(vec![CollectionChildInfo {
                     id: "stream-1".to_string(),
                     label: "2026/04/25/[$LATEST]abc".to_string(),
+                    last_event_ts_ms: Some(1_776_777_600_000),
                     presentation: CollectionPresentation::EventStream,
                 }]),
             },

--- a/crates/dbflux_ui/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions.rs
@@ -8,6 +8,12 @@ enum OpenDocumentDecision {
     OpenNew,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CollectionDocumentPresentation {
+    DataGrid,
+    AuditLike,
+}
+
 fn decide_open_document(
     has_connection: bool,
     existing_id: Option<crate::ui::document::DocumentId>,
@@ -21,6 +27,15 @@ fn decide_open_document(
     }
 
     OpenDocumentDecision::OpenNew
+}
+
+fn collection_document_presentation_for_driver(
+    driver_id: Option<&str>,
+) -> CollectionDocumentPresentation {
+    match driver_id {
+        Some("cloudwatch") => CollectionDocumentPresentation::AuditLike,
+        _ => CollectionDocumentPresentation::DataGrid,
+    }
 }
 
 impl Workspace {
@@ -410,13 +425,32 @@ impl Workspace {
             .connections()
             .contains_key(&profile_id);
 
+        let presentation = self
+            .app_state
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .map(|connected| {
+                collection_document_presentation_for_driver(Some(
+                    connected.connection.metadata().id.as_str(),
+                ))
+            })
+            .unwrap_or(CollectionDocumentPresentation::DataGrid);
+
         let existing_id = if has_connection {
             self.tab_manager
                 .read(cx)
                 .documents()
                 .iter()
-                .find(|doc| {
-                    doc.is_collection(&collection, cx) && doc.connection_id(cx) == Some(profile_id)
+                .find(|doc| match presentation {
+                    CollectionDocumentPresentation::DataGrid => {
+                        doc.is_collection(&collection, cx)
+                            && doc.connection_id(cx) == Some(profile_id)
+                    }
+                    CollectionDocumentPresentation::AuditLike => {
+                        matches!(doc, DocumentHandle::Audit { entity, .. }
+                                if entity.read(cx).is_cloudwatch_log_group(profile_id, &collection))
+                    }
                 })
                 .map(|doc| doc.id())
         } else {
@@ -442,17 +476,32 @@ impl Workspace {
             OpenDocumentDecision::OpenNew => {}
         }
 
-        // Create a DataDocument for the collection
-        let doc = cx.new(|cx| {
-            DataDocument::new_for_collection(
-                profile_id,
-                collection.clone(),
-                self.app_state.clone(),
-                window,
-                cx,
-            )
-        });
-        let handle = DocumentHandle::data(doc, cx);
+        let handle = match presentation {
+            CollectionDocumentPresentation::DataGrid => {
+                let doc = cx.new(|cx| {
+                    DataDocument::new_for_collection(
+                        profile_id,
+                        collection.clone(),
+                        self.app_state.clone(),
+                        window,
+                        cx,
+                    )
+                });
+                DocumentHandle::data(doc, cx)
+            }
+            CollectionDocumentPresentation::AuditLike => {
+                let doc = cx.new(|cx| {
+                    crate::ui::document::AuditDocument::new_for_cloudwatch_log_group(
+                        profile_id,
+                        collection.clone(),
+                        self.app_state.clone(),
+                        window,
+                        cx,
+                    )
+                });
+                DocumentHandle::audit(doc, cx)
+            }
+        };
 
         self.tab_manager.update(cx, |mgr, cx| {
             mgr.open(handle, cx);
@@ -463,6 +512,68 @@ impl Workspace {
             collection.database,
             collection.name
         );
+    }
+
+    pub(super) fn open_cloudwatch_log_stream_document(
+        &mut self,
+        profile_id: uuid::Uuid,
+        collection: dbflux_core::CollectionRef,
+        log_stream: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        use crate::ui::components::toast::ToastExt;
+
+        let has_connection = self
+            .app_state
+            .read(cx)
+            .connections()
+            .contains_key(&profile_id);
+
+        let existing_id = if has_connection {
+            self.tab_manager
+                .read(cx)
+                .documents()
+                .iter()
+                .find(|doc| {
+                    matches!(doc, DocumentHandle::Audit { entity, .. }
+                        if entity
+                            .read(cx)
+                            .is_cloudwatch_log_stream(profile_id, &collection, &log_stream))
+                })
+                .map(|doc| doc.id())
+        } else {
+            None
+        };
+
+        match decide_open_document(has_connection, existing_id) {
+            OpenDocumentDecision::ErrorNoConnection => {
+                cx.toast_error("No active connection for this log stream", window);
+                return;
+            }
+            OpenDocumentDecision::FocusExisting(id) => {
+                self.tab_manager.update(cx, |mgr, cx| {
+                    mgr.activate(id, cx);
+                });
+                return;
+            }
+            OpenDocumentDecision::OpenNew => {}
+        }
+
+        let doc = cx.new(|cx| {
+            crate::ui::document::AuditDocument::new_for_cloudwatch_log_stream(
+                profile_id,
+                collection.clone(),
+                log_stream.clone(),
+                self.app_state.clone(),
+                window,
+                cx,
+            )
+        });
+
+        self.tab_manager.update(cx, |mgr, cx| {
+            mgr.open(DocumentHandle::audit(doc, cx), cx);
+        });
     }
 
     pub(super) fn open_key_value_document(
@@ -1232,7 +1343,10 @@ impl Workspace {
 
 #[cfg(test)]
 mod tests {
-    use super::{OpenDocumentDecision, decide_open_document};
+    use super::{
+        CollectionDocumentPresentation, OpenDocumentDecision,
+        collection_document_presentation_for_driver, decide_open_document,
+    };
     use crate::ui::document::DocumentId;
     use uuid::Uuid;
 
@@ -1253,6 +1367,18 @@ mod tests {
     fn decide_open_document_opens_new_when_connected_and_no_existing_tab() {
         let decision = decide_open_document(true, None);
         assert_eq!(decision, OpenDocumentDecision::OpenNew);
+    }
+
+    #[test]
+    fn collection_presentation_routes_cloudwatch_to_audit_like_view() {
+        assert_eq!(
+            collection_document_presentation_for_driver(Some("cloudwatch")),
+            CollectionDocumentPresentation::AuditLike,
+        );
+        assert_eq!(
+            collection_document_presentation_for_driver(Some("mongodb")),
+            CollectionDocumentPresentation::DataGrid,
+        );
     }
 
     // --- strip_annotation_header ---

--- a/crates/dbflux_ui/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions.rs
@@ -44,7 +44,10 @@ fn collection_document_presentation_for_connection(
                 .iter()
                 .find(|entry| {
                     entry.name == collection.name
-                        && entry.database.as_deref().unwrap_or(collection.database.as_str())
+                        && entry
+                            .database
+                            .as_deref()
+                            .unwrap_or(collection.database.as_str())
                             == collection.database.as_str()
                 })
                 .map(|entry| entry.presentation)
@@ -451,7 +454,9 @@ impl Workspace {
             .read(cx)
             .connections()
             .get(&profile_id)
-            .map(|connected| collection_document_presentation_for_connection(connected, &collection))
+            .map(|connected| {
+                collection_document_presentation_for_connection(connected, &collection)
+            })
             .unwrap_or(CollectionDocumentPresentation::DataGrid);
 
         let existing_id = if has_connection {
@@ -466,13 +471,13 @@ impl Workspace {
                     }
                     CollectionDocumentPresentation::AuditLike => {
                         matches!(doc, DocumentHandle::Audit { entity, .. }
-                                if entity.read(cx).matches_event_stream(
-                                    profile_id,
-                                    &dbflux_core::EventStreamTarget {
-                                        collection: collection.clone(),
-                                        child_id: None,
-                                    },
-                                ))
+                        if entity.read(cx).matches_event_stream(
+                            profile_id,
+                            &dbflux_core::EventStreamTarget {
+                                collection: collection.clone(),
+                                child_id: None,
+                            },
+                        ))
                     }
                 })
                 .map(|doc| doc.id())
@@ -1368,9 +1373,7 @@ impl Workspace {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        OpenDocumentDecision, decide_open_document,
-    };
+    use super::{OpenDocumentDecision, decide_open_document};
     use crate::ui::document::DocumentId;
     use uuid::Uuid;
 

--- a/crates/dbflux_ui/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions.rs
@@ -29,12 +29,33 @@ fn decide_open_document(
     OpenDocumentDecision::OpenNew
 }
 
-fn collection_document_presentation_for_driver(
-    driver_id: Option<&str>,
+fn collection_document_presentation_for_connection(
+    connected: &crate::app::ConnectedProfile,
+    collection: &dbflux_core::CollectionRef,
 ) -> CollectionDocumentPresentation {
-    match driver_id {
-        Some("cloudwatch") => CollectionDocumentPresentation::AuditLike,
-        _ => CollectionDocumentPresentation::DataGrid,
+    let schema = connected
+        .schema_for_target_database(collection.database.as_str())
+        .or(connected.schema.as_ref());
+
+    let presentation = schema
+        .and_then(|schema| {
+            schema
+                .collections()
+                .iter()
+                .find(|entry| {
+                    entry.name == collection.name
+                        && entry.database.as_deref().unwrap_or(collection.database.as_str())
+                            == collection.database.as_str()
+                })
+                .map(|entry| entry.presentation)
+        })
+        .unwrap_or(dbflux_core::CollectionPresentation::DataGrid);
+
+    match presentation {
+        dbflux_core::CollectionPresentation::DataGrid => CollectionDocumentPresentation::DataGrid,
+        dbflux_core::CollectionPresentation::EventStream => {
+            CollectionDocumentPresentation::AuditLike
+        }
     }
 }
 
@@ -430,11 +451,7 @@ impl Workspace {
             .read(cx)
             .connections()
             .get(&profile_id)
-            .map(|connected| {
-                collection_document_presentation_for_driver(Some(
-                    connected.connection.metadata().id.as_str(),
-                ))
-            })
+            .map(|connected| collection_document_presentation_for_connection(connected, &collection))
             .unwrap_or(CollectionDocumentPresentation::DataGrid);
 
         let existing_id = if has_connection {
@@ -449,7 +466,13 @@ impl Workspace {
                     }
                     CollectionDocumentPresentation::AuditLike => {
                         matches!(doc, DocumentHandle::Audit { entity, .. }
-                                if entity.read(cx).is_cloudwatch_log_group(profile_id, &collection))
+                                if entity.read(cx).matches_event_stream(
+                                    profile_id,
+                                    &dbflux_core::EventStreamTarget {
+                                        collection: collection.clone(),
+                                        child_id: None,
+                                    },
+                                ))
                     }
                 })
                 .map(|doc| doc.id())
@@ -491,9 +514,13 @@ impl Workspace {
             }
             CollectionDocumentPresentation::AuditLike => {
                 let doc = cx.new(|cx| {
-                    crate::ui::document::AuditDocument::new_for_cloudwatch_log_group(
+                    crate::ui::document::AuditDocument::new_for_event_stream(
                         profile_id,
-                        collection.clone(),
+                        dbflux_core::EventStreamTarget {
+                            collection: collection.clone(),
+                            child_id: None,
+                        },
+                        collection.name.clone(),
                         self.app_state.clone(),
                         window,
                         cx,
@@ -514,11 +541,11 @@ impl Workspace {
         );
     }
 
-    pub(super) fn open_cloudwatch_log_stream_document(
+    pub(super) fn open_event_stream_document(
         &mut self,
         profile_id: uuid::Uuid,
-        collection: dbflux_core::CollectionRef,
-        log_stream: String,
+        target: dbflux_core::EventStreamTarget,
+        title: String,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -537,9 +564,7 @@ impl Workspace {
                 .iter()
                 .find(|doc| {
                     matches!(doc, DocumentHandle::Audit { entity, .. }
-                        if entity
-                            .read(cx)
-                            .is_cloudwatch_log_stream(profile_id, &collection, &log_stream))
+                        if entity.read(cx).matches_event_stream(profile_id, &target))
                 })
                 .map(|doc| doc.id())
         } else {
@@ -548,7 +573,7 @@ impl Workspace {
 
         match decide_open_document(has_connection, existing_id) {
             OpenDocumentDecision::ErrorNoConnection => {
-                cx.toast_error("No active connection for this log stream", window);
+                cx.toast_error("No active connection for this event source", window);
                 return;
             }
             OpenDocumentDecision::FocusExisting(id) => {
@@ -561,10 +586,10 @@ impl Workspace {
         }
 
         let doc = cx.new(|cx| {
-            crate::ui::document::AuditDocument::new_for_cloudwatch_log_stream(
+            crate::ui::document::AuditDocument::new_for_event_stream(
                 profile_id,
-                collection.clone(),
-                log_stream.clone(),
+                target.clone(),
+                title.clone(),
                 self.app_state.clone(),
                 window,
                 cx,
@@ -1344,8 +1369,7 @@ impl Workspace {
 #[cfg(test)]
 mod tests {
     use super::{
-        CollectionDocumentPresentation, OpenDocumentDecision,
-        collection_document_presentation_for_driver, decide_open_document,
+        OpenDocumentDecision, decide_open_document,
     };
     use crate::ui::document::DocumentId;
     use uuid::Uuid;
@@ -1367,18 +1391,6 @@ mod tests {
     fn decide_open_document_opens_new_when_connected_and_no_existing_tab() {
         let decision = decide_open_document(true, None);
         assert_eq!(decision, OpenDocumentDecision::OpenNew);
-    }
-
-    #[test]
-    fn collection_presentation_routes_cloudwatch_to_audit_like_view() {
-        assert_eq!(
-            collection_document_presentation_for_driver(Some("cloudwatch")),
-            CollectionDocumentPresentation::AuditLike,
-        );
-        assert_eq!(
-            collection_document_presentation_for_driver(Some("mongodb")),
-            CollectionDocumentPresentation::DataGrid,
-        );
     }
 
     // --- strip_annotation_header ---
@@ -1668,6 +1680,8 @@ mod tests {
                     foreign_keys: None,
                     constraints: None,
                     sample_fields: None,
+                    presentation: dbflux_core::CollectionPresentation::DataGrid,
+                    child_items: None,
                 },
                 TableInfo {
                     name: "orders".to_string(),
@@ -1677,6 +1691,8 @@ mod tests {
                     foreign_keys: None,
                     constraints: None,
                     sample_fields: None,
+                    presentation: dbflux_core::CollectionPresentation::DataGrid,
+                    child_items: None,
                 },
             ],
             views: vec![ViewInfo {
@@ -1726,6 +1742,8 @@ mod tests {
                     foreign_keys: None,
                     constraints: None,
                     sample_fields: None,
+                    presentation: dbflux_core::CollectionPresentation::DataGrid,
+                    child_items: None,
                 }],
                 views: vec![],
                 custom_types: None,
@@ -1768,6 +1786,8 @@ mod tests {
                     indexes: None,
                     validator: None,
                     is_capped: false,
+                    presentation: dbflux_core::CollectionPresentation::DataGrid,
+                    child_items: None,
                 },
                 CollectionInfo {
                     name: "orders".to_string(),
@@ -1778,6 +1798,8 @@ mod tests {
                     indexes: None,
                     validator: None,
                     is_capped: false,
+                    presentation: dbflux_core::CollectionPresentation::DataGrid,
+                    child_items: None,
                 },
             ],
             ..Default::default()

--- a/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
@@ -1,7 +1,39 @@
 use super::*;
 
+fn sidebar_tree_command_is_blocked_by_search_focus(cmd: Command) -> bool {
+    matches!(
+        cmd,
+        Command::SelectNext
+            | Command::SelectPrev
+            | Command::SelectFirst
+            | Command::SelectLast
+            | Command::Execute
+            | Command::ExpandCollapse
+            | Command::ColumnLeft
+            | Command::ColumnRight
+            | Command::Cancel
+            | Command::Rename
+            | Command::Delete
+            | Command::CreateFolder
+            | Command::SidebarNextTab
+            | Command::OpenItemMenu
+            | Command::ExtendSelectNext
+            | Command::ExtendSelectPrev
+            | Command::ToggleSelection
+            | Command::MoveSelectedUp
+            | Command::MoveSelectedDown
+    )
+}
+
 impl CommandDispatcher for Workspace {
     fn dispatch(&mut self, cmd: Command, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        if self.focus_target == FocusTarget::Sidebar
+            && self.sidebar.read(cx).search_input_is_focused(window, cx)
+            && sidebar_tree_command_is_blocked_by_search_focus(cmd)
+        {
+            return false;
+        }
+
         // When context menu is open, only allow menu-related commands
         if self.focus_target == FocusTarget::Sidebar
             && self.sidebar.read(cx).has_context_menu_open()
@@ -723,5 +755,40 @@ impl CommandDispatcher for Workspace {
                 true
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sidebar_tree_command_is_blocked_by_search_focus;
+    use crate::keymap::Command;
+
+    #[test]
+    fn sidebar_search_focus_blocks_tree_navigation_commands() {
+        assert!(sidebar_tree_command_is_blocked_by_search_focus(
+            Command::SelectNext
+        ));
+        assert!(sidebar_tree_command_is_blocked_by_search_focus(
+            Command::Execute
+        ));
+        assert!(sidebar_tree_command_is_blocked_by_search_focus(
+            Command::Delete
+        ));
+        assert!(sidebar_tree_command_is_blocked_by_search_focus(
+            Command::MoveSelectedDown
+        ));
+    }
+
+    #[test]
+    fn sidebar_search_focus_leaves_unrelated_commands_available() {
+        assert!(!sidebar_tree_command_is_blocked_by_search_focus(
+            Command::RunQuery
+        ));
+        assert!(!sidebar_tree_command_is_blocked_by_search_focus(
+            Command::ToggleSidebar
+        ));
+        assert!(!sidebar_tree_command_is_blocked_by_search_focus(
+            Command::OpenSettings
+        ));
     }
 }

--- a/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
@@ -622,7 +622,12 @@ impl CommandDispatcher for Workspace {
             }
 
             Command::FocusSearch => {
-                if self.focus_target == FocusTarget::Document {
+                if self.focus_target == FocusTarget::Sidebar {
+                    self.sidebar.update(cx, |sidebar, cx| {
+                        sidebar.focus_active_search(window, cx);
+                    });
+                    true
+                } else if self.focus_target == FocusTarget::Document {
                     if let Some(doc) = self.tab_manager.read(cx).active_document().cloned() {
                         doc.dispatch_command(Command::FocusSearch, window, cx);
                     }

--- a/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
@@ -27,6 +27,47 @@ fn sidebar_tree_command_is_blocked_by_search_focus(cmd: Command) -> bool {
 
 impl CommandDispatcher for Workspace {
     fn dispatch(&mut self, cmd: Command, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        if self.sidebar.read(cx).has_child_picker_open() {
+            match cmd {
+                Command::SelectNext => {
+                    self.sidebar.update(cx, |s, cx| s.picker_select_next(cx));
+                    return true;
+                }
+                Command::SelectPrev => {
+                    self.sidebar.update(cx, |s, cx| s.picker_select_prev(cx));
+                    return true;
+                }
+                Command::SelectFirst => {
+                    self.sidebar.update(cx, |s, cx| s.picker_select_first(cx));
+                    return true;
+                }
+                Command::SelectLast => {
+                    self.sidebar.update(cx, |s, cx| s.picker_select_last(cx));
+                    return true;
+                }
+                Command::Execute => {
+                    self.sidebar.update(cx, |s, cx| s.picker_execute(cx));
+                    return true;
+                }
+                Command::FocusSearch => {
+                    self.sidebar
+                        .update(cx, |s, cx| s.picker_focus_search(window, cx));
+                    return true;
+                }
+                Command::Cancel => {
+                    if self.sidebar.read(cx).child_picker_filter_is_focused() {
+                        // Pop focus back to the list so subsequent Cancel closes the modal.
+                        self.sidebar
+                            .update(cx, |s, cx| s.picker_focus_list(window, cx));
+                    } else {
+                        self.sidebar.update(cx, |s, cx| s.close_child_picker(cx));
+                    }
+                    return true;
+                }
+                _ => return false,
+            }
+        }
+
         if self.focus_target == FocusTarget::Sidebar
             && self.sidebar.read(cx).search_input_is_focused(window, cx)
             && sidebar_tree_command_is_blocked_by_search_focus(cmd)

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -904,6 +904,12 @@ impl Workspace {
             return ContextId::TextInput;
         }
 
+        if self.focus_target == FocusTarget::Sidebar
+            && self.sidebar.read(cx).search_input_has_focus_state()
+        {
+            return ContextId::TextInput;
+        }
+
         // When focused on document area, delegate context to the active document
         if self.focus_target == FocusTarget::Document
             && let Some(doc) = self.tab_manager.read(cx).active_document()
@@ -927,6 +933,10 @@ impl Workspace {
         self.sidebar.update(cx, |sidebar, cx| {
             sidebar.set_connections_focused(target == FocusTarget::Sidebar, cx);
         });
+
+        if target == FocusTarget::Sidebar {
+            self.focus_handle.focus(window);
+        }
 
         if target == FocusTarget::Document
             && let Some(doc) = self.tab_manager.read(cx).active_document().cloned()

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -892,6 +892,15 @@ impl Workspace {
             return ContextId::CommandPalette;
         }
 
+        if self.sidebar.read(cx).has_child_picker_open() {
+            // When the filter input inside the picker is focused, defer to the
+            // text-input keymap so typing does not trigger list navigation.
+            if self.sidebar.read(cx).child_picker_filter_is_focused() {
+                return ContextId::TextInput;
+            }
+            return ContextId::EventStreamsPicker;
+        }
+
         if self.sql_preview_modal.read(cx).is_visible() {
             return ContextId::SqlPreviewModal;
         }
@@ -1095,7 +1104,14 @@ impl Workspace {
                         });
                     }
                     pipeline::PipelineProgressEvent::WatchClosed { last_state } => {
-                        if !matches!(last_state, dbflux_core::PipelineState::Connected) {
+                        if matches!(last_state, dbflux_core::PipelineState::Connected) {
+                            // The pipeline completed successfully but the watch channel sender
+                            // was dropped before the poll task could observe it via changed().
+                            // Treat this as Completed: the connection succeeded.
+                            this.login_modal.update(cx, |modal, cx| {
+                                modal.close(cx);
+                            });
+                        } else {
                             this.login_modal.update(cx, |modal, cx| {
                                 modal.apply_pipeline_state(
                                     &pipeline_profile_name,

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -445,15 +445,15 @@ impl Workspace {
                 } => {
                     this.open_collection_document(*profile_id, collection.clone(), window, cx);
                 }
-                SidebarEvent::OpenCloudWatchLogStream {
+                SidebarEvent::OpenCollectionChild {
                     profile_id,
-                    collection,
-                    log_stream,
+                    target,
+                    title,
                 } => {
-                    this.open_cloudwatch_log_stream_document(
+                    this.open_event_stream_document(
                         *profile_id,
-                        collection.clone(),
-                        log_stream.clone(),
+                        target.clone(),
+                        title.clone(),
                         window,
                         cx,
                     );

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -445,6 +445,19 @@ impl Workspace {
                 } => {
                     this.open_collection_document(*profile_id, collection.clone(), window, cx);
                 }
+                SidebarEvent::OpenCloudWatchLogStream {
+                    profile_id,
+                    collection,
+                    log_stream,
+                } => {
+                    this.open_cloudwatch_log_stream_document(
+                        *profile_id,
+                        collection.clone(),
+                        log_stream.clone(),
+                        window,
+                        cx,
+                    );
+                }
                 SidebarEvent::OpenKeyValueDatabase {
                     profile_id,
                     database,

--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::keymap::ContextId;
 use crate::platform;
 use crate::ui::components::modal_frame::ModalFrame;
 use crate::ui::tokens::FontSizes;
@@ -609,6 +610,8 @@ impl Render for Workspace {
                             });
                         },
                     )
+                    .context_id(ContextId::EventStreamsPicker)
+                    .icon(AppIcon::ScrollText)
                     .title("Event Streams")
                     .width(px(1000.0))
                     .height(px(720.0))

--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::platform;
+use crate::ui::components::modal_frame::ModalFrame;
 use crate::ui::tokens::FontSizes;
 use dbflux_components::composites::{PanelHeaderVariant, panel_header_collapsible_variant};
 use dbflux_components::primitives::{Icon, Text, overlay_bg};
@@ -62,6 +63,7 @@ impl Render for Workspace {
         let header_size = px(25.0);
         let sidebar_context_menu = self.sidebar.read(cx).context_menu_state().cloned();
         let tab_context_menu = self.tab_bar.read(cx).context_menu_state().cloned();
+        let child_picker_open = self.sidebar.read(cx).has_child_picker_open();
 
         // Linux CSD title bar: render only when the compositor has negotiated CSD mode.
         let linux_title_bar = platform::render_csd_title_bar(window, cx, "DBFlux");
@@ -585,6 +587,36 @@ impl Render for Workspace {
                 {
                     root
                 }
+            })
+            .when(child_picker_open, |root| {
+                let sidebar_entity = self.sidebar.clone();
+                let focus_handle = self
+                    .sidebar
+                    .read(cx)
+                    .child_picker_focus_handle()
+                    .unwrap_or_else(|| self.focus_handle.clone());
+                let content = self.sidebar.update(cx, |sidebar, cx| {
+                    sidebar.render_child_picker_content(cx).into_any_element()
+                });
+
+                root.child(
+                    ModalFrame::new(
+                        "event-stream-child-picker",
+                        &focus_handle,
+                        move |_window, cx| {
+                            sidebar_entity.update(cx, |sidebar, cx| {
+                                sidebar.close_child_picker(cx);
+                            });
+                        },
+                    )
+                    .title("Event Streams")
+                    .width(px(1000.0))
+                    .height(px(720.0))
+                    .top_offset(px(60.0))
+                    .block_scroll()
+                    .child(content)
+                    .render(cx),
+                )
             })
             // Context menu rendered at workspace level for proper positioning
             .when_some(sidebar_context_menu, |this, menu| {

--- a/crates/dbflux_ui/src/ui/windows/connection_manager/form.rs
+++ b/crates/dbflux_ui/src/ui/windows/connection_manager/form.rs
@@ -331,7 +331,10 @@ impl ConnectionManagerWindow {
                 *tunnel = ssh_tunnel;
                 *profile_id = ssh_tunnel_profile_id;
             }
-            DbConfig::SQLite { .. } | DbConfig::DynamoDB { .. } | DbConfig::External { .. } => {}
+            DbConfig::SQLite { .. }
+            | DbConfig::DynamoDB { .. }
+            | DbConfig::CloudWatchLogs { .. }
+            | DbConfig::External { .. } => {}
         }
 
         Some(config)

--- a/crates/dbflux_ui/src/ui/windows/connection_manager/mod.rs
+++ b/crates/dbflux_ui/src/ui/windows/connection_manager/mod.rs
@@ -41,6 +41,10 @@ fn auth_profile_needs_login(
         )
 }
 
+fn uses_aws_auth_profile_dropdown(driver_id: Option<&str>) -> bool {
+    matches!(driver_id, Some("dynamodb") | Some("cloudwatch"))
+}
+
 /// Focus state for driver selection screen
 #[derive(Clone, Copy, PartialEq, Default)]
 enum DriverFocus {
@@ -2375,16 +2379,16 @@ impl ConnectionManagerWindow {
             self.selected_auth_profile_id = selection;
             self.selected_ssm_auth_profile_id = selection;
 
-            self.sync_dynamodb_fields_from_auth_profile(window, cx);
+            self.sync_aws_driver_fields_from_auth_profile(window, cx);
         }
     }
 
-    fn sync_dynamodb_fields_from_auth_profile(
+    fn sync_aws_driver_fields_from_auth_profile(
         &mut self,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.selected_driver_id() != Some("dynamodb") {
+        if !uses_aws_auth_profile_dropdown(self.selected_driver_id()) {
             return;
         }
 
@@ -2893,6 +2897,7 @@ impl EventEmitter<DismissEvent> for ConnectionManagerWindow {}
 mod tests {
     use super::ConnectionManagerWindow;
     use super::auth_profile_needs_login;
+    use super::uses_aws_auth_profile_dropdown;
     use dbflux_core::AuthSessionState;
 
     // --- parse_hook_ids ---
@@ -2993,5 +2998,13 @@ mod tests {
             Some(&AuthSessionState::LoginRequired)
         ));
         assert!(!auth_profile_needs_login(true, None));
+    }
+
+    #[test]
+    fn aws_auth_profile_dropdown_is_enabled_for_dynamodb_and_cloudwatch() {
+        assert!(uses_aws_auth_profile_dropdown(Some("dynamodb")));
+        assert!(uses_aws_auth_profile_dropdown(Some("cloudwatch")));
+        assert!(!uses_aws_auth_profile_dropdown(Some("postgres")));
+        assert!(!uses_aws_auth_profile_dropdown(None));
     }
 }

--- a/crates/dbflux_ui/src/ui/windows/connection_manager/render.rs
+++ b/crates/dbflux_ui/src/ui/windows/connection_manager/render.rs
@@ -13,7 +13,10 @@ use gpui_component::ActiveTheme;
 use gpui_component::checkbox::Checkbox;
 use gpui_component::{Icon, IconName};
 
-use super::{ActiveTab, ConnectionManagerWindow, EditState, FormFocus, TestStatus, View};
+use super::{
+    ActiveTab, ConnectionManagerWindow, EditState, FormFocus, TestStatus, View,
+    uses_aws_auth_profile_dropdown,
+};
 
 impl ConnectionManagerWindow {
     pub(super) fn render_focus_shell(
@@ -402,7 +405,9 @@ impl ConnectionManagerWindow {
         ring_color: Hsla,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        if !is_ssh_tab && field_def.id == "profile" && self.selected_driver_id() == Some("dynamodb")
+        if !is_ssh_tab
+            && field_def.id == "profile"
+            && uses_aws_auth_profile_dropdown(self.selected_driver_id())
         {
             let field_enabled = self.is_field_enabled(field_def);
 
@@ -419,9 +424,6 @@ impl ConnectionManagerWindow {
                                 MouseButton::Left,
                                 cx.listener(|this, _, _, cx| {
                                     this.begin_inline_editor_interaction(cx);
-                                    this.auth_profile_dropdown.update(cx, |dropdown, cx| {
-                                        dropdown.open(cx);
-                                    });
                                 }),
                             )
                         })

--- a/crates/dbflux_ui/src/ui/windows/settings/proxies.rs
+++ b/crates/dbflux_ui/src/ui/windows/settings/proxies.rs
@@ -98,33 +98,9 @@ impl ProxyFormNav {
     }
 
     #[cfg(test)]
-    pub(super) fn move_up(&mut self) {
-        let rows = self.form_rows();
-        self.nav.move_up(&rows);
-    }
-
-    #[cfg(test)]
     pub(super) fn move_right(&mut self) {
         let rows = self.form_rows();
         self.nav.move_right(&rows);
-    }
-
-    #[cfg(test)]
-    pub(super) fn move_left(&mut self) {
-        let rows = self.form_rows();
-        self.nav.move_left(&rows);
-    }
-
-    #[cfg(test)]
-    pub(super) fn move_first(&mut self) {
-        let rows = self.form_rows();
-        self.nav.move_first(&rows);
-    }
-
-    #[cfg(test)]
-    pub(super) fn move_last(&mut self) {
-        let rows = self.form_rows();
-        self.nav.move_last(&rows);
     }
 
     pub(super) fn is_input_field(field: ProxyFormField) -> bool {

--- a/crates/dbflux_ui/src/ui/windows/settings/ssh_tunnels.rs
+++ b/crates/dbflux_ui/src/ui/windows/settings/ssh_tunnels.rs
@@ -88,33 +88,15 @@ impl SshFormNav {
     }
 
     #[cfg(test)]
-    pub(super) fn move_up(&mut self) {
-        let rows = self.form_rows();
-        self.nav.move_up(&rows);
-    }
-
-    #[cfg(test)]
     pub(super) fn move_right(&mut self) {
         let rows = self.form_rows();
         self.nav.move_right(&rows);
     }
 
     #[cfg(test)]
-    pub(super) fn move_left(&mut self) {
-        let rows = self.form_rows();
-        self.nav.move_left(&rows);
-    }
-
-    #[cfg(test)]
     pub(super) fn tab_next(&mut self) {
         let rows = self.form_rows();
         self.nav.tab_next(&rows);
-    }
-
-    #[cfg(test)]
-    pub(super) fn tab_prev(&mut self) {
-        let rows = self.form_rows();
-        self.nav.tab_prev(&rows);
     }
 
     #[cfg(test)]

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -99,6 +99,8 @@ Navigate to **Workspace → Audit**. The unified audit view supports:
 - Filtering by actor, tool/action, date range, decision, category
 - Exporting filtered results to CSV or JSON
 
+The same `AuditDocument` UI shell is also reused for driver-backed external event streams when a driver declares them through generic core abstractions (`CollectionPresentation`, `CollectionChildInfo`, `EventStreamTarget`). The UI must not special-case concrete drivers to open or render those streams.
+
 ### Directly via SQLite
 
 The database is a standard SQLite file. Query it directly:


### PR DESCRIPTION
## Summary

- add built-in CloudWatch Logs integration in DBFlux with real AWS-backed browsing, editor-driven querying, and event-stream navigation
- support CloudWatch editor workflows across Logs Insights QL, OpenSearch PPL, and OpenSearch SQL using generic source-context controls
- let users continue investigation from CloudWatch sources through dedicated timeline-style tabs and keyboard-friendly sidebar/filter flows

## What does this resolve?

- Resolves #39
- Resolves #40
- Resolves #41

## How was this solved?

- Added the built-in CloudWatch driver and connected it to the existing AWS auth/access pipeline instead of creating a separate one-off workflow.
- Reused generic DBFlux seams for source context, event-stream presentation, and workspace documents so the UI stays driver-agnostic.
- Extended code documents with CloudWatch source selection and query-mode selection, then mapped those modes to AWS `StartQuery` semantics.
- Reused the audit-style document workflow for CloudWatch event-stream investigation so result exploration stays tab-based and consistent with existing workspace patterns.
- Added sidebar keyboard focus improvements so the active filter can be reached directly during CloudWatch-heavy navigation.

## Validation

- `cargo check --workspace`
- `cargo test -p dbflux_core -p dbflux_ui -p dbflux_driver_cloudwatch --lib`
- reviewed the end-to-end branch diff against `dev` to confirm the PR covers CloudWatch browsing, query execution, and investigation flows

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [x] X11
- [x] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
