### PR TITLE
fix(ui): make Ctrl+Enter run the query in the code editor

### DIFF
--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -17,6 +17,7 @@ use dbflux_ipc::{
 use dbflux_ui::AppStateEntity;
 use dbflux_ui::assets::Assets;
 use dbflux_ui::ipc_server::IpcServer;
+use dbflux_ui::keymap::input_context_keybindings;
 use dbflux_ui::platform;
 use dbflux_ui::ui::overlays::command_palette::command_palette_keybindings;
 use dbflux_ui::ui::views::workspace::Workspace;
@@ -261,6 +262,7 @@ fn run_gui() {
         let window_handle = cx
             .open_window(main_window_options, |window, cx| {
                 cx.bind_keys(command_palette_keybindings());
+                cx.bind_keys(input_context_keybindings());
 
                 let workspace = cx.new(|cx| Workspace::new(app_state.clone(), window, cx));
 

--- a/crates/dbflux_ui/src/keymap/actions.rs
+++ b/crates/dbflux_ui/src/keymap/actions.rs
@@ -1,4 +1,4 @@
-use gpui::actions;
+use gpui::{KeyBinding, actions};
 
 actions!(
     dbflux,
@@ -66,6 +66,22 @@ actions!(
         SaveFileAs,
     ]
 );
+
+/// Keybindings that shadow `gpui-component` input defaults inside the "Input"
+/// context so that Ctrl+Enter / Ctrl+Shift+Enter run the active query instead of
+/// inserting a newline.
+///
+/// `gpui-component` binds `secondary-enter` (== Ctrl+Enter on Linux/Windows,
+/// Cmd+Enter on macOS) to its internal `Enter` action, which in multi-line mode
+/// inserts a newline. Registering these bindings after `gpui_component::init`
+/// makes them take precedence at the same context depth.
+pub fn input_context_keybindings() -> Vec<KeyBinding> {
+    let ctx = Some("Input");
+    vec![
+        KeyBinding::new("ctrl-enter", RunQuery, ctx),
+        KeyBinding::new("ctrl-shift-enter", RunQueryInNewTab, ctx),
+    ]
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/dbflux_ui/src/keymap/actions.rs
+++ b/crates/dbflux_ui/src/keymap/actions.rs
@@ -86,9 +86,65 @@ pub fn input_context_keybindings() -> Vec<KeyBinding> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui::{KeyContext, Keymap, Keystroke};
 
     #[test]
     fn actions_module_compiles() {
         let _ = ToggleCommandPalette;
+    }
+
+    #[test]
+    fn input_context_keybindings_shape() {
+        let bindings = input_context_keybindings();
+        assert_eq!(bindings.len(), 2);
+
+        let ctrl_enter = Keystroke::parse("ctrl-enter").unwrap();
+        let ctrl_shift_enter = Keystroke::parse("ctrl-shift-enter").unwrap();
+
+        assert!(
+            bindings[0].match_keystrokes(&[ctrl_enter]) == Some(false)
+                && bindings[0].action().partial_eq(&RunQuery),
+        );
+        assert!(
+            bindings[1].match_keystrokes(&[ctrl_shift_enter]) == Some(false)
+                && bindings[1].action().partial_eq(&RunQueryInNewTab),
+        );
+    }
+
+    // Regression test for the Ctrl+Enter conflict on Linux/Windows:
+    // `gpui-component` registers `secondary-enter` (== ctrl-enter on non-mac)
+    // in the "Input" context, which would otherwise consume Ctrl+Enter and
+    // insert a newline. Adding our binding afterwards at the same context
+    // depth must win.
+    //
+    // On macOS `secondary` resolves to `cmd`, so the two keystrokes don't
+    // collide and the override is unnecessary — the precedence claim here
+    // doesn't apply, hence the cfg gate.
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn input_context_keybindings_override_secondary_enter() {
+        gpui::actions!(dbflux_test_only, [PriorEnterBinding]);
+
+        let mut keymap = Keymap::default();
+        // Stand-in for the gpui-component binding registered during its init.
+        keymap.add_bindings([KeyBinding::new(
+            "secondary-enter",
+            PriorEnterBinding,
+            Some("Input"),
+        )]);
+        // Our override, registered later.
+        keymap.add_bindings(input_context_keybindings());
+
+        let typed = [Keystroke::parse("ctrl-enter").unwrap()];
+        let context_stack = [KeyContext::parse("Input").unwrap()];
+        let (matches, _pending) = keymap.bindings_for_input(&typed, &context_stack);
+
+        let top = matches
+            .first()
+            .expect("ctrl-enter should match at least one binding in the Input context");
+        assert!(
+            top.action().partial_eq(&RunQuery),
+            "RunQuery must take precedence over the earlier secondary-enter binding",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Ctrl+Enter inside the code editor on Windows (and Linux) inserted a newline instead of running the active query. This restores the documented behavior so Ctrl+Enter → Run Query and Ctrl+Shift+Enter → Run Query in New Tab work everywhere a `gpui-component` input is focused.

## What does this resolve?

- User-visible regression: Ctrl+Enter not running the query in the code editor on Windows. Reported in conversation, no tracking issue.
- Resolves #

## How was this solved?

`gpui-component` registers `KeyBinding::new("secondary-enter", Enter, Some("Input"))` (see `gpui-component-0.5.0/src/input/state.rs:119`). In GPUI, `secondary` resolves to `ctrl` on Linux/Windows and `cmd` on macOS, so on non-mac platforms Ctrl+Enter matches that binding first. The handler is `state.rs:1142`: in multi-line mode it inserts a newline and does **not** propagate, so the `on_key_down` listener on the workspace (which dispatches our internal keymap) never sees Ctrl+Enter.

The fix is to shadow that binding in the same `"Input"` context after `gpui_component::init` runs. GPUI's `bindings_for_input` sorts matches by context depth and, at the same depth, by registration order — later wins (`gpui-0.2.2/src/keymap.rs:165`). So:

- `crates/dbflux_ui/src/keymap/actions.rs` — new helper `input_context_keybindings()` returning `ctrl-enter → RunQuery` and `ctrl-shift-enter → RunQueryInNewTab` scoped to the `"Input"` context.
- `crates/dbflux/src/main.rs` — call `cx.bind_keys(input_context_keybindings())` right after `cx.bind_keys(command_palette_keybindings())` at window open.

The dispatched `keymap::RunQuery` action bubbles up to the existing `on_action(&keymap::RunQuery)` handler in `views/workspace/render.rs:412`, which already forwards `Command::RunQuery` to the active document. Single code path with the non-input case.

Side effect: in any other `gpui-component` input within the main window (e.g. command palette search), Ctrl+Enter will dispatch RunQuery instead of inserting a newline. Inputs in separate windows (Connection Manager, Settings) are unaffected because actions don't cross window boundaries. Worth flagging in review in case Connection-Manager-style behavior is desired inside the main window too.

## Validation

- `cargo check -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws` — clean.
- `cargo clippy -p dbflux_ui -p dbflux --features ... -- -D warnings` — clean.
- `cargo fmt --all` — clean.
- `cargo test -p dbflux_ui --lib keymap::actions::tests` — 3 passed (see below).
- Manual: Windows release build, focused in the SQL editor, Ctrl+Enter now runs the query (previously: newline inserted).
- Not retested on macOS — bindings only target non-mac semantics; on macOS Ctrl+Enter is what `defaults.rs` already maps to RunQuery and there is no `gpui-component` `secondary-enter` conflict (secondary == cmd there).

### Tests

Two regression tests sit next to `input_context_keybindings()` in `crates/dbflux_ui/src/keymap/actions.rs`:

- `input_context_keybindings_shape` — pins the helper's contract (2 bindings: `ctrl-enter → RunQuery`, `ctrl-shift-enter → RunQueryInNewTab`).
- `input_context_keybindings_override_secondary_enter` — builds a real `gpui::Keymap`, registers a stand-in `secondary-enter` binding **first** (mimicking what `gpui-component`'s input init does), then layers our bindings, and asserts `bindings_for_input(["ctrl-enter"], ["Input"])` returns `RunQuery` as the highest-precedence match. This pins down the invariant the fix relies on: at the same context depth, the later-added binding wins. `cfg`-gated to non-mac because `secondary` ≡ `cmd` on macOS and there is no collision to assert against.

Negative-path check performed locally: temporarily replacing the helper body with `Vec::new()` makes both tests fail with the expected messages (`assertion left == right failed: left: 0, right: 2` and `RunQuery must take precedence over the earlier secondary-enter binding`). Tests pass again once the helper is restored.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [ ] Linux
- [ ] macOS
- [x] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed — two unit tests in `keymap::actions::tests`, both verified to fail without the fix
- [x] I documented follow-up work or known limitations when applicable — see the side-effect note above

---

**Disclosure:** this PR was prepared with the help of Claude Code (Anthropic). The binding-conflict analysis, the patch, the tests, and the PR text were generated by Claude, then reviewed by the author and built/verified on Windows before submission. The same attribution is also present in the commits (`Co-Authored-By: Claude`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)