### PR TITLE
fix(ui): keep editor focus after running a query

### DIFF
--- a/crates/dbflux_ui/src/keymap/defaults.rs
+++ b/crates/dbflux_ui/src/keymap/defaults.rs
@@ -773,4 +773,51 @@ mod tests {
         let ctrl_enter = KeyChord::new("enter", Modifiers::ctrl());
         assert_eq!(keymap.resolve(ContextId::CommandPalette, &ctrl_enter), None);
     }
+
+    /// Regression test for the "missing letters in the SQL editor after
+    /// Ctrl+Enter" bug: while focus is on the editor input, the Editor
+    /// keymap layer must not consume plain ASCII letters — they have to fall
+    /// through to gpui-component's `InputState` so they get inserted as text.
+    #[test]
+    fn editor_layer_does_not_steal_unmodified_letters() {
+        let keymap = default_keymap();
+        for letter in ['h', 'j', 'k', 'l', 'o', 'r', 's', 'v', 'x', 'y'] {
+            let chord = KeyChord::new(letter.to_string(), Modifiers::none());
+            assert_eq!(
+                keymap.resolve(ContextId::Editor, &chord),
+                None,
+                "Editor layer must not bind unmodified `{letter}` — it would be \
+                 swallowed by Workspace::on_key_down before the SQL input ever \
+                 sees the keystroke",
+            );
+        }
+    }
+
+    /// Pairs with `editor_layer_does_not_steal_unmodified_letters`: these
+    /// single-letter bindings are intentionally claimed by the Results layer,
+    /// which is exactly why `CodeDocument::process_pending_result` must keep
+    /// `focus_mode = Editor` while the input is focused — otherwise the same
+    /// letters would get routed here and never reach the editor.
+    #[test]
+    fn results_layer_owns_navigation_and_crud_letters() {
+        let keymap = default_keymap();
+        let expectations: &[(char, Command)] = &[
+            ('h', Command::ColumnLeft),
+            ('l', Command::ColumnRight),
+            ('j', Command::SelectNext),
+            ('k', Command::SelectPrev),
+            ('r', Command::Rename),
+            ('o', Command::ResultsAddRow),
+            ('x', Command::Delete),
+        ];
+        for (letter, expected) in expectations {
+            let chord = KeyChord::new(letter.to_string(), Modifiers::none());
+            assert_eq!(
+                keymap.resolve(ContextId::Results, &chord),
+                Some(*expected),
+                "Results layer must keep `{letter}` → {expected:?} so the \
+                 typing-vs-grid focus invariant in CodeDocument stays meaningful",
+            );
+        }
+    }
 }

--- a/crates/dbflux_ui/src/ui/document/code/execution.rs
+++ b/crates/dbflux_ui/src/ui/document/code/execution.rs
@@ -708,7 +708,20 @@ impl CodeDocument {
                     self.layout = SqlQueryLayout::Split;
                 }
 
-                self.focus_mode = SqlQueryFocus::Results;
+                // Only flip the internal focus_mode to Results when the user is
+                // not actively typing in the editor input. Otherwise the GPUI
+                // focus stays on the input but our key-routing thinks Results
+                // is active, so Workspace::on_key_down sends single-letter keys
+                // (l, r, o, x, …) through the Results keymap layer and steals
+                // them from the editor.
+                let input_focused = self
+                    .input_state
+                    .read(cx)
+                    .focus_handle(cx)
+                    .is_focused(window);
+                if !input_focused {
+                    self.focus_mode = SqlQueryFocus::Results;
+                }
 
                 // Emit audit event for successful execution (query or script)
                 let summary = if is_script {

--- a/crates/dbflux_ui/src/ui/document/code/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/code/mod.rs
@@ -736,6 +736,8 @@ impl CodeDocument {
             // Special handling for FocusUp to exit results
             if cmd == Command::FocusUp {
                 self.focus_mode = SqlQueryFocus::Editor;
+                self.input_state
+                    .update(cx, |state, cx| state.focus(window, cx));
                 cx.notify();
                 return true;
             }
@@ -777,6 +779,9 @@ impl CodeDocument {
                 if self.focus_mode == SqlQueryFocus::Editor && !self.result_tabs.is_empty() =>
             {
                 self.focus_mode = SqlQueryFocus::Results;
+                if let Some(grid) = self.active_result_grid() {
+                    grid.update(cx, |g, cx| g.focus_active_view(window, cx));
+                }
                 cx.notify();
                 true
             }


### PR DESCRIPTION
## Summary

Fix a bug where single letters (most visibly `l`, `r`, `o`, `x`) silently
disappear when the user keeps typing in the SQL editor right after pressing
Ctrl+Enter.

Reproducer:

1. Type `select version();` and run it with Ctrl+Enter.
2. Within ~5 seconds, type `select version();` again.
3. Observe you get `seect vesin` instead — `l`, `r`, `o` were swallowed.

## Root cause

`process_pending_result` always switched the document's internal `focus_mode`
to `Results` once a query completed, even when the gpui-level focus stayed on
the editor input. `Workspace::on_key_down` derives `active_context()` from
`focus_mode`, so subsequent keystrokes were routed through the **Results**
keymap layer where single letters are bound to grid commands
(`l → ColumnRight`, `r → Rename`, `o → ResultsAddRow`, `x → Delete`, …).
`dispatch()` returned `true` for any matched binding and called
`stop_propagation()`, so the keystroke never reached the editor's
`input_handler.dispatch_input` — the letter was lost.

The keys that disappear in the reproducer (`l`, `r`, `o`) are exactly the
ones bound without modifiers in the Results layer.

## Fix

- `CodeDocument::process_pending_result`: only flip `focus_mode` to
  `Results` when the editor input is **not** currently focused. If the user
  is still typing, leave `focus_mode = Editor` so single letters fall
  through to the input.
- `CodeDocument::dispatch_command`: when manually navigating between editor
  and results via `Command::FocusUp` / `Command::FocusDown`, also move
  gpui-level focus to the corresponding view. Without this the same
  mismatch could be reproduced by Ctrl+J followed by typing.

The fix is gpui-focus-aware, so it doesn't regress the case where the user
clicks into the data grid after a query — gpui focus is on the grid, the
gate is false, and `focus_mode` flips to `Results` as before.

## Tests

Two regression tests in `keymap::defaults::tests` pin the contracts the
fix relies on:

- `editor_layer_does_not_steal_unmodified_letters` — fails if anyone adds
  an unmodified single-letter binding to the Editor layer (which would
  re-introduce a similar bug from the editor side).
- `results_layer_owns_navigation_and_crud_letters` — fails if the
  `l`/`r`/`o`/`x` bindings disappear from the Results layer, which would
  make the focus gate dead code and should prompt a re-evaluation.

## Test plan

- [x] `cargo test -p dbflux_ui --lib keymap::defaults::tests` — all 8 pass.
- [x] Manual: type `select version();`, Ctrl+Enter, immediately type
  `select version();` again — the second query is now entered intact.
- [x] Manual: Ctrl+J to focus the result grid, j/k/l navigation still works.
- [x] Manual: Ctrl+K from the grid returns focus to the editor input and
  typing continues to work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)