### PR TITLE
fix(keymap): remove `:` binding that swallows colon input on Windows

### DIFF
--- a/crates/dbflux_ui/src/keymap/defaults.rs
+++ b/crates/dbflux_ui/src/keymap/defaults.rs
@@ -36,10 +36,6 @@ fn global_layer() -> KeymapLayer {
         KeyChord::new("p", Modifiers::ctrl_shift()),
         Command::ToggleCommandPalette,
     );
-    layer.bind(
-        KeyChord::new(":", Modifiers::none()),
-        Command::ToggleCommandPalette,
-    );
 
     // Tab management
     layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);


### PR DESCRIPTION
## Summary

Drop the Global keymap binding of `:` (no modifiers) → `ToggleCommandPalette` in `crates/dbflux_ui/src/keymap/defaults.rs`. On Windows the binding intercepts every typed colon, breaking the SQL editor (`:param` for bind parameters) and any other text input.

## Why

GPUI's Windows keyboard pipeline collapses shifted OEM keys into their shifted ASCII form and clears the shift modifier (see `gpui-0.2.2/src/platform/windows/keyboard.rs::get_keystroke_key` — `VK_OEM_1` is in the `need_to_convert_to_shifted_key` list). So `Shift+;` becomes `Keystroke { key: ":", modifiers: { shift: false } }`, which exactly matches `KeyChord::new(":", Modifiers::none())`. The `Editor` context falls back to `Global`, so the workspace listener resolves the chord and dispatches `ToggleCommandPalette` before the focused `InputState` ever sees the character.

On macOS and Linux the binding never worked anyway — there the keystroke stays `{ key: ";", modifiers: { shift: true } }` and the chord doesn't match. Removing it costs nothing; `Ctrl+Shift+P` still opens the palette everywhere.

No other unmodified printable-character bindings live in `Global`. `/`, `[`, `]` exist only in `Sidebar` / `Results` / `HistoryModal` / `ContextBar` / `Audit` layers, none of which accept text input.

## Test plan

- [ ] On Windows: focus the SQL editor and type `SELECT * FROM t WHERE id = :id` — characters land in the editor, command palette does not appear.
- [ ] On Windows: `Ctrl+Shift+P` still opens the command palette.
- [ ] On macOS / Linux: behaviour is unchanged (the binding was a no-op there).
- [ ] `cargo test -p dbflux_ui --lib keymap` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)