### PR TITLE
fix(focus): restore previous focus target after closing palette / history modal

### DIFF
--- a/crates/dbflux_ui/src/ui/document/code/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/code/mod.rs
@@ -7,7 +7,7 @@ use crate::keymap::{Command, ContextId};
 use crate::ui::components::dropdown::{Dropdown, DropdownItem, DropdownSelectionChanged};
 use crate::ui::components::toast::ToastExt;
 use crate::ui::icons::AppIcon;
-use crate::ui::overlays::history_modal::{HistoryModal, HistoryQuerySelected};
+use crate::ui::overlays::history_modal::{HistoryModal, HistoryModalClosed, HistoryQuerySelected};
 use crate::ui::tokens::{FontSizes, Heights, Radii, Spacing};
 use dbflux_core::observability::actions as audit_actions;
 use dbflux_core::observability::{
@@ -127,6 +127,7 @@ pub struct CodeDocument {
     history_modal: Entity<HistoryModal>,
     _history_subscriptions: Vec<Subscription>,
     pending_set_query: Option<HistoryQuerySelected>,
+    pending_history_focus_restore: bool,
 
     // Layout/focus
     layout: SqlQueryLayout,
@@ -280,6 +281,12 @@ impl CodeDocument {
             },
         );
 
+        let history_closed_sub =
+            cx.subscribe(&history_modal, |this, _, _: &HistoryModalClosed, cx| {
+                this.pending_history_focus_restore = true;
+                cx.notify();
+            });
+
         let runner = {
             let mut r = DocumentTaskRunner::new(app_state.clone());
             if let Some(pid) = connection_id {
@@ -400,8 +407,9 @@ impl CodeDocument {
             result_tab_counter: 0,
             run_in_new_tab: false,
             history_modal,
-            _history_subscriptions: vec![query_selected_sub],
+            _history_subscriptions: vec![query_selected_sub, history_closed_sub],
             pending_set_query: None,
+            pending_history_focus_restore: false,
             layout: SqlQueryLayout::EditorOnly,
             focus_handle: cx.focus_handle(),
             focus_mode: SqlQueryFocus::Editor,

--- a/crates/dbflux_ui/src/ui/document/code/render.rs
+++ b/crates/dbflux_ui/src/ui/document/code/render.rs
@@ -656,6 +656,10 @@ impl Render for CodeDocument {
 
         self.process_pending_auto_refresh(window, cx);
 
+        if std::mem::take(&mut self.pending_history_focus_restore) {
+            self.focus(window, cx);
+        }
+
         if let Some(error) = self.pending_error.take() {
             cx.toast_error(error, window);
         }

--- a/crates/dbflux_ui/src/ui/overlays/history_modal.rs
+++ b/crates/dbflux_ui/src/ui/overlays/history_modal.rs
@@ -19,6 +19,9 @@ pub struct HistoryQuerySelected {
     pub saved_query_id: Option<Uuid>,
 }
 
+#[derive(Clone)]
+pub struct HistoryModalClosed;
+
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct QuerySaved {
@@ -160,9 +163,13 @@ impl HistoryModal {
     }
 
     pub fn close(&mut self, cx: &mut Context<Self>) {
+        let was_visible = self.visible;
         self.visible = false;
         self.selected_index = None;
         self.editing_id = None;
+        if was_visible {
+            cx.emit(HistoryModalClosed);
+        }
         cx.notify();
     }
 
@@ -854,6 +861,7 @@ impl Render for HistoryModal {
 }
 
 impl EventEmitter<HistoryQuerySelected> for HistoryModal {}
+impl EventEmitter<HistoryModalClosed> for HistoryModal {}
 impl EventEmitter<QuerySaved> for HistoryModal {}
 
 fn filter_history_entries(

--- a/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
@@ -180,7 +180,7 @@ impl CommandDispatcher for Workspace {
             Command::Cancel => {
                 if self.command_palette.read(cx).is_visible() {
                     self.command_palette.update(cx, |p, cx| p.hide(cx));
-                    self.focus_handle.focus(window);
+                    self.set_focus(self.focus_target, window, cx);
                     return true;
                 }
 

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -935,7 +935,7 @@ impl Workspace {
             self.command_palette.update(cx, |palette, cx| {
                 palette.hide(cx);
             });
-            self.focus_handle.focus(window);
+            self.set_focus(self.focus_target, window, cx);
         }
     }
 

--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -91,7 +91,7 @@ impl Render for Workspace {
 
         if self.needs_focus_restore {
             self.needs_focus_restore = false;
-            self.focus_handle.focus(window);
+            self.set_focus(self.focus_target, window, cx);
         }
 
         let sidebar_dock = self.sidebar_dock.clone();


### PR DESCRIPTION
## Summary

When the command palette or the saved-queries / history modal closes, focus jumps to the workspace root `FocusHandle` instead of returning to the panel that was active before the overlay opened. With the SQL editor as the previous focus this is especially visible: after `Esc` the next keystroke lands in no input at all — typed characters are silently dropped.

## Why

`Workspace` already remembers the previous panel via `focus_target` (Document / Sidebar / BackgroundTasks) and neither overlay touches it. The fix is to route every overlay-close path through `set_focus(self.focus_target, ...)`, which already knows how to descend into the active document and re-focus its `InputState`.

Three palette-close paths now restore focus correctly:

- `dispatch.rs` — `Command::Cancel` while the palette is visible (Esc).
- `workspace/mod.rs` — `toggle_command_palette` close branch (repeat `Ctrl+Shift+P`).
- `workspace/render.rs` — deferred `needs_focus_restore` handling triggered by the `CommandPaletteClosed` subscription (backdrop click).

The history modal had no equivalent close signal. Add a `HistoryModalClosed` event emitted from `HistoryModal::close()` (only on visible → hidden transitions), subscribe to it in `CodeDocument`, set a `pending_history_focus_restore` flag, and re-focus the document in the next render. This covers every close path uniformly: `Esc` routed through the document, `Ctrl+P` re-press, backdrop click, and selecting an item from the list.

## Test plan

- [ ] Focus SQL editor → `Ctrl+Shift+P` → `Esc` → typing inserts characters into the editor.
- [ ] Focus SQL editor → `Ctrl+Shift+P` → `Ctrl+Shift+P` again → typing inserts into the editor.
- [ ] Focus SQL editor → `Ctrl+Shift+P` → click on backdrop → typing inserts into the editor.
- [ ] Focus SQL editor → `Ctrl+P` (saved queries) → `Esc` → typing inserts into the editor.
- [ ] Focus SQL editor → `Ctrl+P` → `Ctrl+P` again → typing inserts into the editor.
- [ ] Focus SQL editor → `Ctrl+P` → click backdrop → typing inserts into the editor.
- [ ] Focus SQL editor → `Ctrl+P` → select an item → resulting query lands in editor, focus is in the editor.
- [ ] Sidebar / BackgroundTasks: same scenarios — focus returns to the panel that owned it before the overlay opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)