### PR TITLE
fix(ui): restore editor focus after dismissing completion popup with Esc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to DBFlux will be documented in this file.
 
+## [Unreleased]
+
+### Features
+
+* Logger now initialises at the very start of `run_gui()` so startup
+  diagnostics (IPC socket binding, auth token init) reach the log sink.
+  Setting `DBFLUX_LOG_FILE` redirects all `log::*!` output to the given
+  file in append mode — useful on Windows where the GUI subsystem hides
+  stderr.
+
 ## [0.5.0] – 2026-05-11
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ All notable changes to DBFlux will be documented in this file.
   file in append mode — useful on Windows where the GUI subsystem hides
   stderr.
 
+### Fixes
+
+* SQL editor keeps focus after dismissing the completion popup with Esc.
+  gpui-component's `CompletionMenu::hide` clears the menu but the
+  follow-up re-render drops `window.focus` even though the input still
+  owned it synchronously; the editor pane now re-focuses its input on
+  the next tick so typing keeps working.
+
 ## [0.5.0] – 2026-05-11
 
 ### Features

--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -28,9 +28,39 @@ use interprocess::local_socket::{
     prelude::*,
 };
 use log::info;
+use std::fs::OpenOptions;
 use std::io::{self, Read, Write};
+use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
+
+/// Initialise the global logger early — before any code that calls `log::*!`
+/// macros, otherwise those records are silently dropped.
+///
+/// When `DBFLUX_LOG_FILE` is set, log lines are appended to that file (created
+/// if missing) instead of stderr. Useful on Windows where the GUI subsystem
+/// makes stderr invisible.
+fn init_logging() {
+    let mut builder =
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"));
+    builder.format_timestamp_millis();
+
+    if let Some(path) = std::env::var_os("DBFLUX_LOG_FILE").map(PathBuf::from) {
+        match OpenOptions::new().create(true).append(true).open(&path) {
+            Ok(file) => {
+                builder.target(env_logger::Target::Pipe(Box::new(file)));
+            }
+            Err(err) => {
+                eprintln!(
+                    "Failed to open DBFLUX_LOG_FILE={:?}: {} — falling back to stderr",
+                    path, err
+                );
+            }
+        }
+    }
+
+    builder.init();
+}
 
 /// Global holder for the audit service, used by the panic hook.
 /// The panic hook needs access to the audit service, which is created
@@ -212,6 +242,8 @@ fn send_focus_request<S: Read + Write>(stream: &mut S, request_id: u64) -> io::R
 }
 
 fn run_gui() {
+    init_logging();
+
     let auth_token = match init_process_auth_tokens() {
         Ok(token) => token,
         Err(error) => {
@@ -224,10 +256,6 @@ fn run_gui() {
         Ok(l) => l,
         Err(()) => std::process::exit(1),
     };
-
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
-        .format_timestamp_millis()
-        .init();
 
     info!("IPC socket bound successfully");
 

--- a/crates/dbflux_ui/src/ui/document/code/render.rs
+++ b/crates/dbflux_ui/src/ui/document/code/render.rs
@@ -314,6 +314,34 @@ impl CodeDocument {
                         cx.emit(DocumentEvent::RequestFocus);
                     }),
                 )
+                // gpui-component's completion menu hides itself on Esc via
+                // InputState::escape but never restores focus to the editor
+                // input. Synchronously the input still owns focus when we
+                // observe Esc, but the menu's cx.notify() + the resulting
+                // re-render reset window.focus before the next paint — so we
+                // refocus on the next tick rather than inline.
+                .on_key_down(cx.listener(|this, event: &gpui::KeyDownEvent, window, cx| {
+                    if event.keystroke.key != "escape"
+                        || event.keystroke.modifiers.alt
+                        || event.keystroke.modifiers.control
+                        || event.keystroke.modifiers.shift
+                        || event.keystroke.modifiers.platform
+                        || event.keystroke.modifiers.function
+                    {
+                        return;
+                    }
+                    if this.focus_mode != SqlQueryFocus::Editor {
+                        return;
+                    }
+                    let input = this.input_state.clone();
+                    cx.spawn_in(window, async move |_this, cx| {
+                        cx.update(|window, cx| {
+                            input.update(cx, |state, cx| state.focus(window, cx));
+                        })
+                        .ok();
+                    })
+                    .detach();
+                }))
                 .child(
                     div().flex_1().min_h_0().overflow_hidden().child(
                         Input::new(&self.input_state)


### PR DESCRIPTION
## Summary

The SQL editor silently lost keyboard focus after pressing **Esc** to
dismiss the completion popup — focus_mode and the focus frame still said
"Editor", but typing did nothing.

This PR adds an `on_key_down` handler on the editor pane that re-focuses
the input on the next tick, and (as supporting infrastructure for
diagnosing this kind of bug on Windows) makes `env_logger` honour a
`DBFLUX_LOG_FILE` override.

## What does this resolve?

- A regression where pressing Esc to dismiss the SQL editor's completion
  popup would close the popup but break further input until the user
  clicked back into the editor.
- The closely related diagnostic gap: on Windows the GUI subsystem hides
  stderr, so reproducing focus bugs required other instrumentation.

## How was this solved?

**Root cause.** gpui-component's `CompletionMenu::hide` (invoked from
`InputState::escape` → `handle_action_for_context_menu`) only flips its
`open` flag and calls `cx.notify()`. The re-render that follows drops
`window.focus` before the next paint — even though the input still
owned focus synchronously when Esc was observed. Confirmed by logging
both phases:

```
[ESC-DEBUG] outer-pane key_down(escape): input_focused_now=true
[ESC-DEBUG] deferred refocus: input_focused_before_refocus=false
```

**Fix (`render_editor`).** Catch Esc in `on_key_down` and schedule a
re-focus via `cx.spawn_in`. Doing it inline does not help: `Window::focus`
early-returns when the handle is already focused, and by the time the
re-render clears it our synchronous call has already returned. The
deferred task runs on the next foreground tick and puts focus back.

**Logging change.** `env_logger::init()` now runs at the top of
`run_gui()` instead of after IPC/socket setup, and `DBFLUX_LOG_FILE`
redirects output to that file (append mode). Useful on Windows where
stderr is invisible under the GUI subsystem.

## Validation

- Reproduced on Windows: typing a letter to open the completion popup,
  then Esc to dismiss it — without the fix, the next character is
  dropped; with the fix, the editor stays usable.
- `DBFLUX_LOG_FILE` instrumentation logs (above) show the timing of the
  focus loss and confirm the deferred refocus restores it.
- `cargo fmt --all -- --check`
- `cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws`
- `cargo clippy -p dbflux -p dbflux_ui --lib -- -D warnings`
- `cargo test -p dbflux_ui --lib` — 398 / 398 pass

### Regression test note

I prototyped an integration test using a harness mirroring `render_editor`
(stub `CompletionProvider`, `simulate_input("S")`, `simulate_keystrokes("escape")`,
assert focus). It passes with the fix, but it also passes if the production
handler is reverted, because the harness owns its own copy of the
`on_key_down` body. Faithfully testing the production codepath would
require either standing up a full `CodeDocument` + `AppStateEntity` + a
fake connection so the menu actually opens, or extracting the handler
into a shared helper purely for tests. Both seemed disproportionate for
the size of the fix, so I dropped the test rather than ship a false
positive. Happy to revisit if a maintainer prefers one of those routes.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests (the existing dbflux_ui suite)
- [ ] Linux
- [ ] macOS
- [x] Windows
- [ ] X11
- [ ] Wayland

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed (see Regression test note above)
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

- `ui:bug`
- `platform:windows`