### PR TITLE
feat(workspace): add workspace-level inspector rail; migrate row inspector

### DIFF
--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -970,6 +970,7 @@ fn load_general_settings(
         confirm_dangerous_queries: dto.confirm_dangerous_queries != 0,
         dangerous_requires_where: dto.dangerous_requires_where != 0,
         dangerous_requires_preview: dto.dangerous_requires_preview != 0,
+        workspace_inspector_width_px: None,
     }
 }
 

--- a/crates/dbflux_core/src/config/app.rs
+++ b/crates/dbflux_core/src/config/app.rs
@@ -344,6 +344,12 @@ pub struct GeneralSettings {
 
     #[serde(default)]
     pub dangerous_requires_preview: bool,
+
+    // -- Inspector --
+    /// Persisted width (in CSS pixels) of the workspace-level inspector rail.
+    /// `None` → use `INSPECTOR_DEFAULT_WIDTH`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_inspector_width_px: Option<f32>,
 }
 
 impl Default for GeneralSettings {
@@ -366,6 +372,7 @@ impl Default for GeneralSettings {
             confirm_dangerous_queries: true,
             dangerous_requires_where: true,
             dangerous_requires_preview: false,
+            workspace_inspector_width_px: None,
         }
     }
 }
@@ -1625,6 +1632,32 @@ mod tests {
                 &HashMap::new(),
             ),
             "caller is responsible for stripping empty-string values before calling"
+        );
+    }
+
+    #[test]
+    fn general_settings_inspector_width_round_trips() {
+        let settings = super::GeneralSettings {
+            workspace_inspector_width_px: Some(400.0),
+            ..super::GeneralSettings::default()
+        };
+        let json = serde_json::to_string(&settings).expect("serialize");
+        let deserialized: super::GeneralSettings =
+            serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(
+            deserialized.workspace_inspector_width_px,
+            Some(400.0),
+            "width must round-trip through JSON"
+        );
+    }
+
+    #[test]
+    fn general_settings_inspector_width_defaults_to_none_when_missing() {
+        let json = r#"{"theme":"dark","style":"default","restore_session_on_startup":true,"reopen_last_connections":false,"default_focus_on_startup":"sidebar","max_history_entries":1000,"auto_save_interval_ms":2000,"default_refresh_policy":"manual","default_refresh_interval_secs":5,"max_concurrent_background_tasks":8,"auto_refresh_pause_on_error":true,"auto_refresh_only_if_visible":false,"confirm_dangerous_queries":true,"dangerous_requires_where":true}"#;
+        let settings: super::GeneralSettings = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(
+            settings.workspace_inspector_width_px, None,
+            "missing field must deserialize to None"
         );
     }
 }

--- a/crates/dbflux_ui/src/ui/document/code/execution.rs
+++ b/crates/dbflux_ui/src/ui/document/code/execution.rs
@@ -1101,6 +1101,12 @@ impl CodeDocument {
                         generation_type: *generation_type,
                     });
                 }
+                DataGridEvent::OpenInspector { title, content } => {
+                    cx.emit(DocumentEvent::OpenInspector {
+                        title: title.clone(),
+                        content: content.clone(),
+                    });
+                }
             },
         );
 

--- a/crates/dbflux_ui/src/ui/document/data_document.rs
+++ b/crates/dbflux_ui/src/ui/document/data_document.rs
@@ -31,6 +31,11 @@ pub enum DataDocumentEvent {
         context: Box<SqlPreviewContext>,
         generation_type: crate::ui::overlays::sql_preview_modal::SqlGenerationType,
     },
+    /// Request to mount content into the workspace-level inspector rail.
+    OpenInspector {
+        title: SharedString,
+        content: AnyView,
+    },
 }
 
 impl DataDocument {
@@ -61,6 +66,12 @@ impl DataDocument {
                         cx.emit(DataDocumentEvent::RequestSqlPreview {
                             context: context.clone(),
                             generation_type: *generation_type,
+                        });
+                    }
+                    DataGridEvent::OpenInspector { title, content } => {
+                        cx.emit(DataDocumentEvent::OpenInspector {
+                            title: title.clone(),
+                            content: content.clone(),
                         });
                     }
                     _ => {}
@@ -105,6 +116,12 @@ impl DataDocument {
                             generation_type: *generation_type,
                         });
                     }
+                    DataGridEvent::OpenInspector { title, content } => {
+                        cx.emit(DataDocumentEvent::OpenInspector {
+                            title: title.clone(),
+                            content: content.clone(),
+                        });
+                    }
                     _ => {}
                 },
             );
@@ -145,6 +162,12 @@ impl DataDocument {
                         cx.emit(DataDocumentEvent::RequestSqlPreview {
                             context: context.clone(),
                             generation_type: *generation_type,
+                        });
+                    }
+                    DataGridEvent::OpenInspector { title, content } => {
+                        cx.emit(DataDocumentEvent::OpenInspector {
+                            title: title.clone(),
+                            content: content.clone(),
                         });
                     }
                     _ => {}

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/context_menu.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/context_menu.rs
@@ -2295,10 +2295,10 @@ impl DataGridPanel {
         cx.notify();
     }
 
-    /// Build an `InspectorSnapshot` from the given row/col and open or update
-    /// the `RowInspector` overlay.
+    /// Build an `InspectorSnapshot` from the given row/col and emit
+    /// `DataGridEvent::OpenInspector` so the workspace mounts the content.
     pub(super) fn open_row_inspector(&mut self, row: usize, col: usize, cx: &mut Context<Self>) {
-        use super::row_inspector::{InspectorCell, InspectorSnapshot, RowInspector};
+        use super::row_inspector::{InspectorCell, InspectorSnapshot, RowInspectorContent};
         use crate::ui::components::data_table::model::ColumnKind;
 
         let Some(table_state) = &self.table_state else {
@@ -2349,47 +2349,39 @@ impl DataGridPanel {
         let snapshot = InspectorSnapshot {
             cells: cells.clone(),
             focused_col: col,
-            row_label,
         };
 
         // Build per-FK reference entries from the cached TableInfo.foreign_keys.
         let fk_references = self.build_fk_references(&cells, cx);
         let has_fk_lookups = !fk_references.is_empty();
 
-        if let Some(inspector) = &self.row_inspector {
-            inspector.update(cx, |insp, cx| {
-                insp.open(snapshot, cx);
-            });
-            let inspector_entity = inspector.clone();
-            self.fire_fk_resolution(fk_references, inspector_entity, cx);
-        } else {
-            let inspector = cx.new(|cx| RowInspector::new(snapshot, cx));
-
-            if !has_fk_lookups {
-                // No FK columns: mark references as ready (empty).
-                inspector.update(cx, |insp, cx| {
-                    insp.set_references(Vec::new(), cx);
-                });
+        // Reuse the existing content entity or create a new one.
+        let content = match &self.row_inspector_content {
+            Some(existing) => {
+                existing.update(cx, |c, cx| c.open(snapshot, cx));
+                existing.clone()
             }
-            // When has_fk_lookups, fire_fk_resolution below sets references.
+            None => {
+                let new_content = cx.new(|cx| RowInspectorContent::new(snapshot, cx));
+                if !has_fk_lookups {
+                    new_content.update(cx, |c, cx| c.set_references(Vec::new(), cx));
+                }
+                self.row_inspector_content = Some(new_content.clone());
+                new_content
+            }
+        };
 
-            let close_subscription = cx.subscribe(
-                &inspector,
-                |this, _, event: &super::row_inspector::RowInspectorEvent, cx| match event {
-                    super::row_inspector::RowInspectorEvent::CloseRequested => {
-                        this.row_inspector = None;
-                        this.row_inspector_subscription = None;
-                        cx.notify();
-                    }
-                },
-            );
+        // Fire FK resolution against the (possibly reused) content entity.
+        self.fire_fk_resolution(fk_references, content.clone(), cx);
 
-            let inspector_entity = inspector.clone();
-            self.row_inspector = Some(inspector);
-            self.row_inspector_subscription = Some(close_subscription);
-            self.fire_fk_resolution(fk_references, inspector_entity, cx);
-            cx.notify();
-        }
+        // Tell the workspace to mount/replace the inspector rail.
+        let title = SharedString::from(row_label);
+        let content_view = AnyView::from(content);
+        cx.emit(DataGridEvent::OpenInspector {
+            title,
+            content: content_view,
+        });
+        cx.notify();
     }
 
     /// Build the list of FK lookups for the current row from the schema cache.
@@ -2467,7 +2459,7 @@ impl DataGridPanel {
     fn fire_fk_resolution(
         &self,
         references: Vec<super::row_inspector::FkReference>,
-        inspector_entity: Entity<super::row_inspector::RowInspector>,
+        inspector_entity: Entity<super::row_inspector::RowInspectorContent>,
         cx: &mut Context<Self>,
     ) {
         use super::row_inspector::FkReference;

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/mod.rs
@@ -133,6 +133,11 @@ pub enum DataGridEvent {
         context: Box<SqlPreviewContext>,
         generation_type: crate::ui::overlays::sql_preview_modal::SqlGenerationType,
     },
+    /// Request to mount arbitrary content into the workspace-level inspector rail.
+    OpenInspector {
+        title: SharedString,
+        content: AnyView,
+    },
 }
 
 /// Internal state for grid loading/ready/error.
@@ -359,12 +364,8 @@ pub struct DataGridPanel {
     document_preview_modal: Entity<DocumentPreviewModal>,
     pending_document_preview: Option<PendingDocumentPreview>,
 
-    // Row inspector overlay panel
-    row_inspector: Option<Entity<row_inspector::RowInspector>>,
-    /// Retains the subscription to the inspector's close events.
-    /// Without storage the RAII Subscription drops immediately and the
-    /// X button (and Esc) silently fail to close the panel.
-    row_inspector_subscription: Option<Subscription>,
+    // Row inspector content entity (workspace owns the chrome/lifecycle).
+    row_inspector_content: Option<Entity<row_inspector::RowInspectorContent>>,
 
     export_menu_open: bool,
 }
@@ -760,8 +761,7 @@ impl DataGridPanel {
             document_tree_subscription: None,
             document_preview_modal,
             pending_document_preview: None,
-            row_inspector: None,
-            row_inspector_subscription: None,
+            row_inspector_content: None,
             export_menu_open: false,
         }
     }

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/render.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/render.rs
@@ -374,10 +374,6 @@ impl Render for DataGridPanel {
             .when(self.document_preview_modal.read(cx).is_visible(), |d| {
                 d.child(self.document_preview_modal.clone())
             })
-            // Row inspector overlay — rendered as an absolute panel on the right edge
-            .when_some(self.row_inspector.clone(), |d, inspector| {
-                d.child(inspector)
-            })
     }
 }
 

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/row_inspector.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/row_inspector.rs
@@ -1,11 +1,17 @@
-//! Row Inspector — a 320px slide-in panel showing full row data, column
-//! metadata, and FK-referenced values for the selected row.
+//! Row Inspector content for the workspace-level inspector rail.
+//!
+//! # `RowInspectorContent`
+//!
+//! Content-only entity that renders the scrollable ROW / REFERENCES / COLUMN
+//! sections.  All chrome (title bar, close button, resize grip, drag mask) is
+//! owned by `WorkspaceInspector` in `workspace/inspector.rs`.
 //!
 //! # Opening
 //!
-//! Call `RowInspector::open` with an `InspectorSnapshot` built from the
-//! current selection. The inspector renders itself as an overlay positioned
-//! absolutely at the right edge of the grid panel.
+//! `DataGridPanel::open_row_inspector` builds an `InspectorSnapshot`, creates
+//! or updates a `RowInspectorContent` entity, and emits
+//! `DataGridEvent::OpenInspector` so the workspace mounts it in the inspector
+//! rail.
 //!
 //! # Sections
 //!
@@ -14,9 +20,8 @@
 //! - **REFERENCES** — FK-resolved values; each FK resolves asynchronously.
 
 use crate::ui::icons::AppIcon;
-use crate::ui::tokens::{Heights, Radii, Spacing};
-use dbflux_components::primitives::{BannerBlock, BannerVariant, Icon, LoadingState, Text};
-use dbflux_components::tokens::Widths;
+use crate::ui::tokens::Spacing;
+use dbflux_components::primitives::{Icon, LoadingState, Text};
 use dbflux_core::Value;
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -46,8 +51,6 @@ pub struct InspectorSnapshot {
     pub cells: Vec<InspectorCell>,
     /// Index of the column that was focused when the inspector opened.
     pub focused_col: usize,
-    /// Human-readable row identifier (e.g. "Row 3" or PK value).
-    pub row_label: String,
 }
 
 // ---------------------------------------------------------------------------
@@ -69,279 +72,6 @@ pub struct FkReference {
     pub value: Value,
     /// Async resolution state for the referenced row.
     pub row: LoadingState<HashMap<String, Value>>,
-}
-
-// ---------------------------------------------------------------------------
-// RowInspector entity
-// ---------------------------------------------------------------------------
-
-/// Overlay inspector panel for the selected row.
-pub struct RowInspector {
-    snapshot: InspectorSnapshot,
-    /// Per-FK reference entries; each resolves independently.
-    references: Vec<FkReference>,
-    /// True when the references list has been populated (even if empty).
-    references_ready: bool,
-    close_requested: bool,
-    focus_handle: FocusHandle,
-    /// Current panel width. Persists across re-renders within the same
-    /// inspector lifetime; reset to the default each time `RowInspector::new`
-    /// is called.
-    width: Pixels,
-    is_resizing: bool,
-    resize_start_x: Option<Pixels>,
-    resize_start_width: Option<Pixels>,
-}
-
-const INSPECTOR_MIN_WIDTH: Pixels = px(240.0);
-const INSPECTOR_MAX_WIDTH: Pixels = px(1280.0);
-
-impl EventEmitter<RowInspectorEvent> for RowInspector {}
-
-#[derive(Debug, Clone)]
-pub enum RowInspectorEvent {
-    CloseRequested,
-}
-
-impl RowInspector {
-    pub fn new(snapshot: InspectorSnapshot, cx: &mut Context<Self>) -> Self {
-        Self {
-            snapshot,
-            references: Vec::new(),
-            references_ready: false,
-            close_requested: false,
-            focus_handle: cx.focus_handle(),
-            width: Widths::INSPECTOR,
-            is_resizing: false,
-            resize_start_x: None,
-            resize_start_width: None,
-        }
-    }
-
-    /// Update the snapshot for a new row selection while keeping the panel open.
-    pub fn open(&mut self, snapshot: InspectorSnapshot, cx: &mut Context<Self>) {
-        self.snapshot = snapshot;
-        self.references = Vec::new();
-        self.references_ready = false;
-        self.close_requested = false;
-        cx.notify();
-    }
-
-    /// Set the resolved FK references after an async lookup completes.
-    ///
-    /// Called from the DataGridPanel after all per-FK fetches return.
-    pub fn set_references(&mut self, references: Vec<FkReference>, cx: &mut Context<Self>) {
-        self.references = references;
-        self.references_ready = true;
-        cx.notify();
-    }
-
-    /// Update the resolution state for a single FK reference by index.
-    ///
-    /// Called when one async fetch completes while others are still in flight.
-    pub fn resolve_reference(
-        &mut self,
-        index: usize,
-        result: Result<Option<HashMap<String, Value>>, String>,
-        cx: &mut Context<Self>,
-    ) {
-        let Some(fk_ref) = self.references.get_mut(index) else {
-            return;
-        };
-
-        fk_ref.row = match result {
-            Ok(Some(map)) => LoadingState::Loaded(map),
-            Ok(None) => LoadingState::Loaded(HashMap::new()),
-            Err(msg) => LoadingState::Failed {
-                message: msg.into(),
-            },
-        };
-
-        cx.notify();
-    }
-
-    /// Request to close the panel (emits `CloseRequested`).
-    pub fn request_close(&mut self, cx: &mut Context<Self>) {
-        self.close_requested = true;
-        cx.emit(RowInspectorEvent::CloseRequested);
-    }
-}
-
-impl Focusable for RowInspector {
-    fn focus_handle(&self, _cx: &App) -> FocusHandle {
-        self.focus_handle.clone()
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Render
-// ---------------------------------------------------------------------------
-
-impl Render for RowInspector {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = cx.theme();
-        let snapshot = self.snapshot.clone();
-        let close_entity = cx.entity().clone();
-        let has_fk = snapshot.cells.iter().any(|c| c.is_foreign_key);
-
-        // Resize grip + fullscreen drag mask.
-        //
-        // The grip itself is a 6 px column on the inspector's left edge that
-        // captures mouse_down. While `is_resizing` is true we render a
-        // sibling div with `.absolute().inset_0()` and `.size_full()` on top
-        // of the data grid (but *behind* the inspector visually because the
-        // inspector is rendered AFTER it). That mask owns the move/up
-        // handlers, so the drag tracks the cursor everywhere — not just
-        // inside the 6 px column — and releases cleanly even if the cursor
-        // ends up outside the inspector.
-        const GRIP_WIDTH: Pixels = px(6.0);
-        let content_width = self.width - GRIP_WIDTH;
-        let grip = div()
-            .id("inspector-grip")
-            .h_full()
-            .w(GRIP_WIDTH)
-            .flex_shrink_0()
-            .cursor_col_resize()
-            .hover(|el| el.bg(theme.accent.opacity(0.3)))
-            .when(self.is_resizing, |el| el.bg(theme.primary))
-            .on_mouse_down(
-                MouseButton::Left,
-                cx.listener(|this, event: &MouseDownEvent, _, cx| {
-                    this.is_resizing = true;
-                    this.resize_start_x = Some(event.position.x);
-                    this.resize_start_width = Some(this.width);
-                    cx.notify();
-                }),
-            );
-
-        // Outer wrapper covers the entire data-grid panel so the drag mask
-        // can track the cursor anywhere (not just inside the inspector's
-        // own bounds). When not resizing, it has no handlers and clicks
-        // pass through to the grid.
-        let outer = div().absolute().inset_0().when(self.is_resizing, |el| {
-            el.cursor_col_resize()
-                .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, _, cx| {
-                    if !this.is_resizing {
-                        return;
-                    }
-                    let Some(start_x) = this.resize_start_x else {
-                        return;
-                    };
-                    let Some(start_width) = this.resize_start_width else {
-                        return;
-                    };
-                    let delta = event.position.x - start_x;
-                    let new_width =
-                        (start_width - delta).clamp(INSPECTOR_MIN_WIDTH, INSPECTOR_MAX_WIDTH);
-                    this.width = new_width;
-                    cx.notify();
-                }))
-                .on_mouse_up(
-                    MouseButton::Left,
-                    cx.listener(|this, _, _, cx| {
-                        this.is_resizing = false;
-                        this.resize_start_x = None;
-                        this.resize_start_width = None;
-                        cx.notify();
-                    }),
-                )
-        });
-
-        let panel = div()
-            .absolute()
-            .right_0()
-            .top_0()
-            .bottom_0()
-            .w(self.width)
-            .flex()
-            .flex_row()
-            .bg(theme.background)
-            .border_l_1()
-            .border_color(theme.border)
-            .track_focus(&self.focus_handle)
-            .on_scroll_wheel(|_, _, cx| {
-                cx.stop_propagation();
-            })
-            .child(grip)
-            .child(
-                div()
-                    .h_full()
-                    .w(content_width)
-                    .flex()
-                    .flex_col()
-                    .overflow_hidden()
-                    // Header
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .justify_between()
-                            .h(Heights::TOOLBAR)
-                            .px(Spacing::SM)
-                            .border_b_1()
-                            .border_color(theme.border)
-                            .child(
-                                Text::caption(snapshot.row_label.clone())
-                                    .color(theme.muted_foreground),
-                            )
-                            .child(
-                                div()
-                                    .id("inspector-close")
-                                    .w(px(20.0))
-                                    .h(px(20.0))
-                                    .flex()
-                                    .items_center()
-                                    .justify_center()
-                                    .rounded(Radii::SM)
-                                    .cursor_pointer()
-                                    .text_color(theme.muted_foreground)
-                                    .hover(|d| d.bg(theme.secondary).text_color(theme.foreground))
-                                    .on_click(move |_, _, cx| {
-                                        close_entity.update(cx, |inspector, cx| {
-                                            inspector.request_close(cx);
-                                        });
-                                    })
-                                    .child("\u{00d7}"),
-                            ),
-                    )
-                    // Scrollable body
-                    .child(
-                        div()
-                            .id("inspector-body")
-                            .flex_1()
-                            .overflow_y_scroll()
-                            .flex()
-                            .flex_col()
-                            .child(render_section_header("ROW", theme))
-                            .children(
-                                snapshot
-                                    .cells
-                                    .iter()
-                                    .map(|cell| render_row_entry(cell, theme)),
-                            )
-                            .when(has_fk, |d| {
-                                d.child(render_section_header("REFERENCES", theme)).child(
-                                    render_references_section(
-                                        &self.references,
-                                        self.references_ready,
-                                        theme,
-                                    ),
-                                )
-                            })
-                            .child(render_section_header("COLUMN", theme))
-                            .when_some(
-                                snapshot.cells.get(
-                                    snapshot
-                                        .focused_col
-                                        .min(snapshot.cells.len().saturating_sub(1)),
-                                ),
-                                |d, cell| d.child(render_column_metadata(cell, theme)),
-                            ),
-                    ),
-            );
-
-        outer.child(panel)
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -631,14 +361,268 @@ fn render_meta_row(
 }
 
 // ---------------------------------------------------------------------------
+// RowInspectorContent entity
+// ---------------------------------------------------------------------------
+
+/// Content-only inspector for the workspace-level inspector rail.
+///
+/// Unlike `RowInspector`, `RowInspectorContent` renders ONLY the scrollable
+/// body (ROW / REFERENCES / COLUMN sections).  All chrome — title bar, close
+/// button, resize grip, and drag mask — is owned by `WorkspaceInspector`.
+pub struct RowInspectorContent {
+    snapshot: InspectorSnapshot,
+    references: Vec<FkReference>,
+    references_ready: bool,
+    focus_handle: FocusHandle,
+}
+
+#[derive(Clone, Debug)]
+pub enum RowInspectorContentEvent {
+    // Reserved for future use (no Close — workspace owns lifecycle now).
+}
+
+impl EventEmitter<RowInspectorContentEvent> for RowInspectorContent {}
+
+impl RowInspectorContent {
+    pub fn new(snapshot: InspectorSnapshot, cx: &mut Context<Self>) -> Self {
+        Self {
+            snapshot,
+            references: Vec::new(),
+            references_ready: false,
+            focus_handle: cx.focus_handle(),
+        }
+    }
+
+    /// Replace the snapshot for a new row selection while keeping the entity alive.
+    pub fn open(&mut self, snapshot: InspectorSnapshot, cx: &mut Context<Self>) {
+        self.snapshot = snapshot;
+        self.references = Vec::new();
+        self.references_ready = false;
+        cx.notify();
+    }
+
+    /// Set the resolved FK references after an async lookup completes.
+    pub fn set_references(&mut self, references: Vec<FkReference>, cx: &mut Context<Self>) {
+        self.references = references;
+        self.references_ready = true;
+        cx.notify();
+    }
+
+    /// Update the resolution state for a single FK reference by index.
+    ///
+    /// Out-of-bounds index is silently ignored (same behaviour as `RowInspector`).
+    pub fn resolve_reference(
+        &mut self,
+        index: usize,
+        result: Result<Option<HashMap<String, Value>>, String>,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(fk_ref) = self.references.get_mut(index) else {
+            return;
+        };
+
+        fk_ref.row = match result {
+            Ok(Some(map)) => LoadingState::Loaded(map),
+            Ok(None) => LoadingState::Loaded(HashMap::new()),
+            Err(msg) => LoadingState::Failed {
+                message: msg.into(),
+            },
+        };
+
+        cx.notify();
+    }
+
+    /// Whether the references list has been populated (even if empty).
+    #[cfg(test)]
+    pub fn references_ready(&self) -> bool {
+        self.references_ready
+    }
+
+    /// Number of FK references.
+    #[cfg(test)]
+    pub fn references_len(&self) -> usize {
+        self.references.len()
+    }
+}
+
+impl Focusable for RowInspectorContent {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl Render for RowInspectorContent {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let snapshot = self.snapshot.clone();
+        let has_fk = snapshot.cells.iter().any(|c| c.is_foreign_key);
+
+        div()
+            .id("row-inspector-content")
+            .size_full()
+            .flex()
+            .flex_col()
+            .overflow_y_scroll()
+            .track_focus(&self.focus_handle)
+            .child(render_section_header("ROW", theme))
+            .children(
+                snapshot
+                    .cells
+                    .iter()
+                    .map(|cell| render_row_entry(cell, theme)),
+            )
+            .when(has_fk, |d| {
+                d.child(render_section_header("REFERENCES", theme)).child(
+                    render_references_section(&self.references, self.references_ready, theme),
+                )
+            })
+            .child(render_section_header("COLUMN", theme))
+            .when_some(
+                snapshot.cells.get(
+                    snapshot
+                        .focused_col
+                        .min(snapshot.cells.len().saturating_sub(1)),
+                ),
+                |d, cell| d.child(render_column_metadata(cell, theme)),
+            )
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
-    use super::summarize_row;
+    use super::{
+        FkReference, InspectorCell, InspectorSnapshot, RowInspectorContent, summarize_row,
+    };
+    use dbflux_components::primitives::LoadingState;
     use dbflux_core::Value;
+    use gpui::{AppContext as _, TestAppContext};
     use std::collections::HashMap;
+
+    fn make_snapshot() -> InspectorSnapshot {
+        InspectorSnapshot {
+            cells: vec![InspectorCell {
+                name: "id".to_string(),
+                value: Value::Int(1),
+                is_primary_key: true,
+                is_foreign_key: false,
+                type_label: "integer".to_string(),
+                nullable: false,
+            }],
+            focused_col: 0,
+        }
+    }
+
+    #[gpui::test]
+    fn row_inspector_content_open_updates_snapshot(cx: &mut TestAppContext) {
+        let entity = cx.new(|cx| RowInspectorContent::new(make_snapshot(), cx));
+
+        let new_snap = InspectorSnapshot {
+            cells: vec![InspectorCell {
+                name: "name".to_string(),
+                value: Value::Text("Alice".to_string()),
+                is_primary_key: false,
+                is_foreign_key: false,
+                type_label: "text".to_string(),
+                nullable: true,
+            }],
+            focused_col: 0,
+        };
+
+        cx.update(|cx| {
+            entity.update(cx, |content, cx| {
+                content.open(new_snap, cx);
+            });
+        });
+
+        cx.read(|cx| {
+            let content = entity.read(cx);
+            assert_eq!(content.snapshot.cells[0].name, "name");
+            assert!(!content.references_ready(), "open resets references_ready");
+        });
+    }
+
+    #[gpui::test]
+    fn row_inspector_content_set_references(cx: &mut TestAppContext) {
+        let entity = cx.new(|cx| RowInspectorContent::new(make_snapshot(), cx));
+
+        cx.read(|cx| {
+            assert!(!entity.read(cx).references_ready());
+        });
+
+        let fk_refs = vec![FkReference {
+            column: "user_id".to_string(),
+            target_schema: None,
+            target_table: "users".to_string(),
+            target_pk: "id".to_string(),
+            value: Value::Int(42),
+            row: LoadingState::Loading,
+        }];
+
+        cx.update(|cx| {
+            entity.update(cx, |content, cx| {
+                content.set_references(fk_refs, cx);
+            });
+        });
+
+        cx.read(|cx| {
+            let content = entity.read(cx);
+            assert!(content.references_ready());
+            assert_eq!(content.references_len(), 1);
+        });
+    }
+
+    #[gpui::test]
+    fn row_inspector_content_resolve_reference(cx: &mut TestAppContext) {
+        let entity = cx.new(|cx| RowInspectorContent::new(make_snapshot(), cx));
+
+        let fk_refs = vec![FkReference {
+            column: "user_id".to_string(),
+            target_schema: None,
+            target_table: "users".to_string(),
+            target_pk: "id".to_string(),
+            value: Value::Int(1),
+            row: LoadingState::Loading,
+        }];
+
+        cx.update(|cx| {
+            entity.update(cx, |content, cx| {
+                content.set_references(fk_refs, cx);
+                let mut resolved = HashMap::new();
+                resolved.insert("name".to_string(), Value::Text("Alice".to_string()));
+                content.resolve_reference(0, Ok(Some(resolved)), cx);
+            });
+        });
+
+        cx.read(|cx| {
+            let content = entity.read(cx);
+            match &content.references[0].row {
+                LoadingState::Loaded(map) => {
+                    assert_eq!(map.get("name"), Some(&Value::Text("Alice".to_string())));
+                }
+                other => panic!("expected Loaded, got {:?}", other),
+            }
+        });
+    }
+
+    #[gpui::test]
+    fn row_inspector_content_resolve_reference_out_of_bounds_is_noop(cx: &mut TestAppContext) {
+        let entity = cx.new(|cx| RowInspectorContent::new(make_snapshot(), cx));
+
+        // Should not panic when index is out of bounds
+        cx.update(|cx| {
+            entity.update(cx, |content, cx| {
+                content.resolve_reference(99, Ok(None), cx);
+            });
+        });
+
+        cx.read(|cx| {
+            assert_eq!(entity.read(cx).references_len(), 0);
+        });
+    }
 
     fn map_from(pairs: &[(&str, &str)]) -> HashMap<String, Value> {
         pairs

--- a/crates/dbflux_ui/src/ui/document/handle.rs
+++ b/crates/dbflux_ui/src/ui/document/handle.rs
@@ -360,6 +360,12 @@ impl DocumentHandle {
                         context: context.clone(),
                         generation_type: *generation_type,
                     },
+                    DataDocumentEvent::OpenInspector { title, content } => {
+                        DocumentEvent::OpenInspector {
+                            title: title.clone(),
+                            content: content.clone(),
+                        }
+                    }
                 };
                 callback(&doc_event, cx);
             }),
@@ -395,5 +401,10 @@ pub enum DocumentEvent {
     RequestSqlPreview {
         context: Box<SqlPreviewContext>,
         generation_type: crate::ui::overlays::sql_preview_modal::SqlGenerationType,
+    },
+    /// Request to mount content into the workspace-level inspector rail.
+    OpenInspector {
+        title: gpui::SharedString,
+        content: gpui::AnyView,
     },
 }

--- a/crates/dbflux_ui/src/ui/document/tab_manager.rs
+++ b/crates/dbflux_ui/src/ui/document/tab_manager.rs
@@ -59,6 +59,12 @@ impl TabManager {
                         generation_type: *generation_type,
                     });
                 }
+                DocumentEvent::OpenInspector { title, content } => {
+                    cx.emit(TabManagerEvent::OpenInspector {
+                        title: title.clone(),
+                        content: content.clone(),
+                    });
+                }
                 _ => {}
             });
         });
@@ -373,6 +379,11 @@ pub enum TabManagerEvent {
     RequestSqlPreview {
         context: Box<crate::ui::overlays::sql_preview_modal::SqlPreviewContext>,
         generation_type: crate::ui::overlays::sql_preview_modal::SqlGenerationType,
+    },
+    /// Request to mount content into the workspace-level inspector rail.
+    OpenInspector {
+        title: gpui::SharedString,
+        content: gpui::AnyView,
     },
 }
 

--- a/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
@@ -280,10 +280,19 @@ impl CommandDispatcher for Workspace {
                     return true;
                 }
 
-                // Route Cancel to active document (handles modals, edit modes, etc.)
+                // Route Cancel to active document (handles modals, edit modes, etc.).
                 if let Some(doc) = self.tab_manager.read(cx).active_document().cloned()
                     && doc.dispatch_command(Command::Cancel, window, cx)
                 {
+                    return true;
+                }
+
+                // Workspace-level inspector close fallback.
+                // Only fires after the document has declined Cancel.
+                if self.workspace_inspector.read(cx).is_open() {
+                    self.workspace_inspector.update(cx, |insp, cx| {
+                        insp.close(cx);
+                    });
                     return true;
                 }
 

--- a/crates/dbflux_ui/src/ui/views/workspace/inspector.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/inspector.rs
@@ -1,0 +1,278 @@
+//! Workspace-level inspector rail.
+//!
+//! `WorkspaceInspector` is a persistent right-edge panel that renders arbitrary
+//! `AnyView` content supplied by the event chain originating from
+//! `DataGridPanel::open_row_inspector`.  The workspace owns this entity for
+//! its entire lifetime; the inspector stays open across tab switches.
+//!
+//! # Resize
+//!
+//! The left-edge grip (6 px) starts the drag on `mouse_down`.  Move and up
+//! events are captured by a workspace-root drag mask (an absolute overlay
+//! rendered only while `is_resizing == true`) so the cursor is tracked
+//! anywhere on screen.  When the drag ends the inspector emits
+//! `ResizeCommitted(final_width)` so the workspace can persist the width.
+//!
+//! # ESC / close
+//!
+//! The × button calls `close()` directly.  ESC is handled in
+//! `workspace/dispatch.rs` as a fallback after the active document declines
+//! Cancel: it calls `close()` and returns `true`.
+
+use crate::ui::tokens::{Heights, Radii, Spacing};
+use dbflux_components::primitives::Text;
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::ActiveTheme;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+pub const INSPECTOR_MIN_WIDTH: Pixels = px(240.0);
+pub const INSPECTOR_MAX_WIDTH: Pixels = px(1280.0);
+pub const INSPECTOR_DEFAULT_WIDTH: Pixels = px(360.0);
+pub const INSPECTOR_GRIP_WIDTH: Pixels = px(6.0);
+
+// ---------------------------------------------------------------------------
+// Entity
+// ---------------------------------------------------------------------------
+
+/// Workspace-level inspector rail.
+pub struct WorkspaceInspector {
+    content: Option<AnyView>,
+    title: SharedString,
+    width: Pixels,
+    is_open: bool,
+    is_resizing: bool,
+    resize_start_x: Option<Pixels>,
+    resize_start_width: Option<Pixels>,
+    focus_handle: FocusHandle,
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+pub enum WorkspaceInspectorEvent {
+    /// Drag finished — caller persists the new width.
+    ResizeCommitted(Pixels),
+    /// User clicked close (×) or dispatched ESC fallback.
+    Closed,
+}
+
+impl EventEmitter<WorkspaceInspectorEvent> for WorkspaceInspector {}
+
+// ---------------------------------------------------------------------------
+// Implementation
+// ---------------------------------------------------------------------------
+
+impl WorkspaceInspector {
+    pub fn new(initial_width: Pixels, cx: &mut Context<Self>) -> Self {
+        let width = initial_width.clamp(INSPECTOR_MIN_WIDTH, INSPECTOR_MAX_WIDTH);
+        Self {
+            content: None,
+            title: SharedString::default(),
+            width,
+            is_open: false,
+            is_resizing: false,
+            resize_start_x: None,
+            resize_start_width: None,
+            focus_handle: cx.focus_handle(),
+        }
+    }
+
+    pub fn is_open(&self) -> bool {
+        self.is_open
+    }
+
+    pub fn is_resizing(&self) -> bool {
+        self.is_resizing
+    }
+
+    pub fn width(&self) -> Pixels {
+        self.width
+    }
+
+    pub fn title(&self) -> &SharedString {
+        &self.title
+    }
+
+    /// Open / replace the inspector content. Reuses the rail if already open.
+    pub fn open_with(&mut self, content: AnyView, title: SharedString, cx: &mut Context<Self>) {
+        self.content = Some(content);
+        self.title = title;
+        self.is_open = true;
+        cx.notify();
+    }
+
+    /// Close the rail and emit `Closed`.
+    pub fn close(&mut self, cx: &mut Context<Self>) {
+        self.is_open = false;
+        self.content = None;
+        self.is_resizing = false;
+        self.resize_start_x = None;
+        self.resize_start_width = None;
+        cx.emit(WorkspaceInspectorEvent::Closed);
+        cx.notify();
+    }
+
+    // -- Resize handlers driven by the workspace-level drag mask --
+
+    /// Called on mouse_down on the grip; starts the resize gesture.
+    pub(crate) fn begin_resize(&mut self, event: &MouseDownEvent, cx: &mut Context<Self>) {
+        self.is_resizing = true;
+        self.resize_start_x = Some(event.position.x);
+        self.resize_start_width = Some(self.width);
+        cx.notify();
+    }
+
+    /// Simulate a drag-start at a given x position.
+    ///
+    /// Equivalent to the user pressing the left mouse button on the grip at
+    /// `position_x`. Provided for testing without constructing `MouseDownEvent`.
+    pub fn fake_begin_resize_at(&mut self, position_x: Pixels, cx: &mut Context<Self>) {
+        self.is_resizing = true;
+        self.resize_start_x = Some(position_x);
+        self.resize_start_width = Some(self.width);
+        cx.notify();
+    }
+
+    /// Called on mouse_move via the workspace drag mask.
+    pub fn update_resize(&mut self, position_x: Pixels, cx: &mut Context<Self>) {
+        if !self.is_resizing {
+            return;
+        }
+        let Some(start_x) = self.resize_start_x else {
+            return;
+        };
+        let Some(start_width) = self.resize_start_width else {
+            return;
+        };
+        // Drag-left grows the rail (rail lives on the right edge).
+        let delta = position_x - start_x;
+        let new_width = (start_width - delta).clamp(INSPECTOR_MIN_WIDTH, INSPECTOR_MAX_WIDTH);
+        self.width = new_width;
+        cx.notify();
+    }
+
+    /// Called on mouse_up via the workspace drag mask; commits the resize.
+    pub fn finish_resize(&mut self, cx: &mut Context<Self>) {
+        if !self.is_resizing {
+            return;
+        }
+        let final_width = self.width;
+        self.is_resizing = false;
+        self.resize_start_x = None;
+        self.resize_start_width = None;
+        cx.emit(WorkspaceInspectorEvent::ResizeCommitted(final_width));
+        cx.notify();
+    }
+}
+
+impl Focusable for WorkspaceInspector {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Render
+// ---------------------------------------------------------------------------
+
+impl Render for WorkspaceInspector {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme().clone();
+        let content_width = self.width - INSPECTOR_GRIP_WIDTH;
+        let is_resizing = self.is_resizing;
+        let title = self.title.clone();
+        let content = self.content.clone();
+        let close_entity = cx.entity().clone();
+
+        // Build header inline to avoid split-borrow issues with render_header.
+        let header = {
+            let theme2 = theme.clone();
+            let close_entity2 = close_entity.clone();
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .h(Heights::TOOLBAR)
+                .px(Spacing::SM)
+                .flex_shrink_0()
+                .border_b_1()
+                .border_color(theme2.border)
+                .child(Text::caption(title).color(theme2.muted_foreground))
+                .child(
+                    div()
+                        .id("workspace-inspector-close")
+                        .w(px(20.0))
+                        .h(px(20.0))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .rounded(Radii::SM)
+                        .cursor_pointer()
+                        .text_color(theme2.muted_foreground)
+                        .hover(move |d| d.bg(theme2.secondary).text_color(theme2.foreground))
+                        .on_click(move |_, _, cx| {
+                            close_entity2.update(cx, |inspector, cx| {
+                                inspector.close(cx);
+                            });
+                        })
+                        .child("\u{00d7}"),
+                )
+        };
+
+        // Outer flex_row: grip (resize handle) + body (header + content host).
+        div()
+            .id("workspace-inspector")
+            .h_full()
+            .w(self.width)
+            .flex_shrink_0()
+            .flex()
+            .flex_row()
+            .bg(theme.background)
+            .border_l_1()
+            .border_color(theme.border)
+            .track_focus(&self.focus_handle)
+            .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
+            // Grip (left edge, INSPECTOR_GRIP_WIDTH px).
+            // mouse_down starts the drag; move/up are owned by the workspace drag mask
+            // so cursor tracking works even after the cursor leaves this column.
+            .child(
+                div()
+                    .id("workspace-inspector-grip")
+                    .h_full()
+                    .w(INSPECTOR_GRIP_WIDTH)
+                    .flex_shrink_0()
+                    .cursor_col_resize()
+                    .hover(|el| el.bg(theme.accent.opacity(0.3)))
+                    .when(is_resizing, |el| el.bg(theme.primary))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, event: &MouseDownEvent, _, cx| {
+                            this.begin_resize(event, cx);
+                        }),
+                    ),
+            )
+            .child(
+                div()
+                    .h_full()
+                    .w(content_width)
+                    .flex()
+                    .flex_col()
+                    .overflow_hidden()
+                    .child(header)
+                    .child(
+                        div()
+                            .id("workspace-inspector-body")
+                            .flex_1()
+                            .min_h_0()
+                            .overflow_hidden()
+                            .when_some(content, |el, view| el.child(view)),
+                    ),
+            )
+    }
+}

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -1,7 +1,10 @@
 mod actions;
 mod dispatch;
+pub mod inspector;
 pub mod pipeline;
 mod render;
+
+pub use inspector::{WorkspaceInspector, WorkspaceInspectorEvent};
 
 use crate::app::{AppStateChanged, AppStateEntity};
 use dbflux_core::observability::actions::CONFIG_CHANGE;
@@ -246,6 +249,9 @@ pub struct Workspace {
 
     tab_manager: Entity<TabManager>,
     tab_bar: Entity<TabBar>,
+
+    workspace_inspector: Entity<inspector::WorkspaceInspector>,
+    _workspace_inspector_subscription: Subscription,
 
     #[cfg(feature = "mcp")]
     mcp_approvals_view: Entity<McpApprovalsView>,
@@ -820,6 +826,29 @@ impl Workspace {
         )
         .detach();
 
+        // Create the workspace inspector with the persisted width (or default).
+        let initial_inspector_width = {
+            let settings = app_state.read(cx).general_settings();
+            settings
+                .workspace_inspector_width_px
+                .map(px)
+                .unwrap_or(inspector::INSPECTOR_DEFAULT_WIDTH)
+        };
+        let workspace_inspector =
+            cx.new(|cx| inspector::WorkspaceInspector::new(initial_inspector_width, cx));
+
+        let workspace_inspector_subscription = cx.subscribe(
+            &workspace_inspector,
+            |this, _, event: &inspector::WorkspaceInspectorEvent, cx| match event {
+                inspector::WorkspaceInspectorEvent::ResizeCommitted(px_width) => {
+                    this.persist_inspector_width(*px_width, cx);
+                }
+                inspector::WorkspaceInspectorEvent::Closed => {
+                    cx.notify();
+                }
+            },
+        );
+
         cx.subscribe_in(
             &tab_manager,
             window,
@@ -835,6 +864,11 @@ impl Workspace {
                     } => {
                         this.sql_preview_modal.update(cx, |modal, cx| {
                             modal.open(context.as_ref().clone(), *generation_type, window, cx);
+                        });
+                    }
+                    TabManagerEvent::OpenInspector { title, content } => {
+                        this.workspace_inspector.update(cx, |insp, cx| {
+                            insp.open_with(content.clone(), title.clone(), cx);
                         });
                     }
                     TabManagerEvent::Activated(new_id) => {
@@ -879,6 +913,8 @@ impl Workspace {
             shutdown_overlay,
             tab_manager,
             tab_bar,
+            workspace_inspector,
+            _workspace_inspector_subscription: workspace_inspector_subscription,
             #[cfg(feature = "mcp")]
             mcp_approvals_view,
             modal_delete_connection,
@@ -1339,6 +1375,21 @@ impl Workspace {
         self.pipeline_progress = Some(progress);
         self._pipeline_subscription = Some(subscription);
         cx.notify();
+    }
+
+    /// Persist the inspector width to `GeneralSettings` and save to disk.
+    fn persist_inspector_width(&mut self, width: Pixels, cx: &mut Context<Self>) {
+        let runtime = self.app_state.read(cx).storage_runtime();
+        let mut settings = self.app_state.read(cx).general_settings().clone();
+        settings.workspace_inspector_width_px = Some(f32::from(width));
+
+        if let Err(e) = dbflux_app::config_loader::save_general_settings(runtime, &settings) {
+            log::warn!("Failed to persist inspector width: {}", e);
+        }
+
+        self.app_state.update(cx, |state, _cx| {
+            state.update_general_settings(settings);
+        });
     }
 
     /// Get next focus target, skipping sidebar if collapsed

--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -76,6 +76,9 @@ impl Render for Workspace {
         let tab_bar = self.tab_bar.clone();
         let has_tabs = !self.tab_manager.read(cx).is_empty();
         let active_doc_element = self.render_active_document(cx);
+        let inspector_open = self.workspace_inspector.read(cx).is_open();
+        let inspector_resizing = self.workspace_inspector.read(cx).is_resizing();
+        let inspector_entity = self.workspace_inspector.clone();
 
         let tasks_expanded = self.tasks_state.is_expanded();
         let tasks_focused = self.focus_target == FocusTarget::BackgroundTasks;
@@ -154,17 +157,30 @@ impl Render for Workspace {
                                     }),
                                 )
                                 .child(tab_bar)
-                                .when_some(active_doc_element, |el, doc| {
-                                    el.child(
-                                        div()
-                                            .flex()
-                                            .flex_col()
-                                            .flex_1()
-                                            .min_h_0()
-                                            .overflow_hidden()
-                                            .child(doc),
-                                    )
-                                }),
+                                // doc + inspector live in a flex_row under the tab bar.
+                                .child(
+                                    div()
+                                        .id("document-content-row")
+                                        .flex()
+                                        .flex_row()
+                                        .flex_1()
+                                        .min_h_0()
+                                        .overflow_hidden()
+                                        .when_some(active_doc_element, |el, doc| {
+                                            el.child(
+                                                div()
+                                                    .flex()
+                                                    .flex_col()
+                                                    .flex_1()
+                                                    .min_h_0()
+                                                    .overflow_hidden()
+                                                    .child(doc),
+                                            )
+                                        })
+                                        .when(inspector_open, |el| {
+                                            el.child(inspector_entity.clone())
+                                        }),
+                                ),
                         ),
                 )
                 .child(
@@ -600,6 +616,31 @@ impl Render for Workspace {
                     .bottom_0()
                     .child(toast_host),
             )
+            // Drag mask — rendered only while inspector grip is being dragged.
+            // Sits above document/inspector content so cursor tracking works
+            // anywhere on screen, but below toast host and shutdown overlay.
+            .when(inspector_resizing, |root| {
+                root.child(
+                    div()
+                        .id("workspace-inspector-drag-mask")
+                        .absolute()
+                        .inset_0()
+                        .cursor_col_resize()
+                        .on_mouse_move(cx.listener(move |this, event: &MouseMoveEvent, _, cx| {
+                            this.workspace_inspector.update(cx, |insp, cx| {
+                                insp.update_resize(event.position.x, cx);
+                            });
+                        }))
+                        .on_mouse_up(
+                            MouseButton::Left,
+                            cx.listener(move |this, _, _, cx| {
+                                this.workspace_inspector.update(cx, |insp, cx| {
+                                    insp.finish_resize(cx);
+                                });
+                            }),
+                        ),
+                )
+            })
             // Shutdown overlay (rendered above everything during shutdown)
             .child(self.shutdown_overlay.clone())
             .when(cfg!(feature = "mcp"), |root| {

--- a/crates/dbflux_ui/tests/workspace_inspector.rs
+++ b/crates/dbflux_ui/tests/workspace_inspector.rs
@@ -1,0 +1,142 @@
+//! Integration tests for `WorkspaceInspector`.
+
+use dbflux_ui::ui::views::workspace::inspector::{
+    INSPECTOR_DEFAULT_WIDTH, INSPECTOR_MAX_WIDTH, INSPECTOR_MIN_WIDTH, WorkspaceInspector,
+};
+use gpui::prelude::*;
+use gpui::{AnyView, Context, Render, SharedString, TestAppContext, Window, div, px};
+
+struct DummyContent;
+
+impl Render for DummyContent {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+    }
+}
+
+#[gpui::test]
+fn inspector_starts_closed(cx: &mut TestAppContext) {
+    let inspector = cx.new(|cx| WorkspaceInspector::new(INSPECTOR_DEFAULT_WIDTH, cx));
+    cx.read(|cx| {
+        let insp = inspector.read(cx);
+        assert!(!insp.is_open(), "inspector must start closed");
+        assert!(!insp.is_resizing());
+        assert_eq!(insp.width(), INSPECTOR_DEFAULT_WIDTH);
+    });
+}
+
+#[gpui::test]
+fn inspector_clamps_initial_width_to_min(cx: &mut TestAppContext) {
+    let inspector = cx.new(|cx| WorkspaceInspector::new(px(10.0), cx));
+    cx.read(|cx| {
+        assert_eq!(inspector.read(cx).width(), INSPECTOR_MIN_WIDTH);
+    });
+}
+
+#[gpui::test]
+fn inspector_clamps_initial_width_to_max(cx: &mut TestAppContext) {
+    let inspector = cx.new(|cx| WorkspaceInspector::new(px(9999.0), cx));
+    cx.read(|cx| {
+        assert_eq!(inspector.read(cx).width(), INSPECTOR_MAX_WIDTH);
+    });
+}
+
+#[gpui::test]
+fn inspector_opens_with_title(cx: &mut TestAppContext) {
+    let inspector = cx.new(|cx| WorkspaceInspector::new(INSPECTOR_DEFAULT_WIDTH, cx));
+
+    cx.update(|cx| {
+        inspector.update(cx, |insp, cx| {
+            let view = cx.new(|_| DummyContent);
+            insp.open_with(AnyView::from(view), SharedString::from("Row 1"), cx);
+        });
+    });
+
+    cx.read(|cx| {
+        let insp = inspector.read(cx);
+        assert!(insp.is_open());
+        assert_eq!(insp.title().as_ref(), "Row 1");
+    });
+}
+
+#[gpui::test]
+fn inspector_close_sets_is_open_false(cx: &mut TestAppContext) {
+    let inspector = cx.new(|cx| WorkspaceInspector::new(INSPECTOR_DEFAULT_WIDTH, cx));
+
+    cx.update(|cx| {
+        inspector.update(cx, |insp, cx| {
+            let view = cx.new(|_| DummyContent);
+            insp.open_with(AnyView::from(view), SharedString::from("Row 1"), cx);
+        });
+        inspector.update(cx, |insp, cx| {
+            insp.close(cx);
+        });
+    });
+
+    cx.read(|cx| {
+        assert!(!inspector.read(cx).is_open());
+    });
+}
+
+#[gpui::test]
+fn inspector_resize_clamps_to_min_max(cx: &mut TestAppContext) {
+    let inspector = cx.new(|cx| WorkspaceInspector::new(INSPECTOR_DEFAULT_WIDTH, cx));
+
+    cx.update(|cx| {
+        inspector.update(cx, |insp, cx| {
+            // Simulate drag start at x=500, then move far right (clamps to min)
+            insp.fake_begin_resize_at(px(500.0), cx);
+            insp.update_resize(px(900.0), cx);
+        });
+    });
+
+    cx.read(|cx| {
+        assert_eq!(inspector.read(cx).width(), INSPECTOR_MIN_WIDTH);
+    });
+}
+
+#[gpui::test]
+fn inspector_begin_update_finish_resize(cx: &mut TestAppContext) {
+    let inspector = cx.new(|cx| WorkspaceInspector::new(INSPECTOR_DEFAULT_WIDTH, cx));
+
+    cx.update(|cx| {
+        inspector.update(cx, |insp, cx| {
+            // Simulate drag start at x=500, move 20px left (grows width by 20)
+            let fake_event_x = px(500.0);
+            insp.fake_begin_resize_at(fake_event_x, cx);
+            insp.update_resize(fake_event_x - px(20.0), cx);
+        });
+    });
+
+    cx.read(|cx| {
+        let insp = inspector.read(cx);
+        assert!(insp.is_resizing());
+        assert_eq!(insp.width(), INSPECTOR_DEFAULT_WIDTH + px(20.0));
+    });
+
+    cx.update(|cx| {
+        inspector.update(cx, |insp, cx| {
+            insp.finish_resize(cx);
+        });
+    });
+
+    cx.read(|cx| {
+        let insp = inspector.read(cx);
+        assert!(!insp.is_resizing());
+    });
+}
+
+#[gpui::test]
+fn inspector_update_resize_noop_when_not_resizing(cx: &mut TestAppContext) {
+    let inspector = cx.new(|cx| WorkspaceInspector::new(INSPECTOR_DEFAULT_WIDTH, cx));
+
+    cx.update(|cx| {
+        inspector.update(cx, |insp, cx| {
+            insp.update_resize(px(0.0), cx);
+        });
+    });
+
+    cx.read(|cx| {
+        assert_eq!(inspector.read(cx).width(), INSPECTOR_DEFAULT_WIDTH);
+    });
+}


### PR DESCRIPTION
## Summary

- Extract a workspace-level `WorkspaceInspector` that owns the rail frame (resize grip, drag mask, close button, focus, persistent width) and accepts arbitrary content via a new `OpenInspector { title, content: AnyView }` event chain.
- Migrate the row inspector: `RowInspectorContent` is now a pure content entity emitted through the new chain; the data grid panel no longer owns the rail or its drag mask.
- Persist the rail width across sessions in `GeneralSettings.workspace_inspector_width_px`.

## What changed

**New entity** (`crates/dbflux_ui/src/ui/views/workspace/inspector.rs`):
- `WorkspaceInspector` with `Option<AnyView>` slot, title, width, focus handle, and the resize state machine.
- Constants `INSPECTOR_MIN_WIDTH=240`, `_MAX_WIDTH=1280`, `_DEFAULT_WIDTH=360`, `_GRIP_WIDTH=6`.
- Events `ResizeCommitted(Pixels)` (workspace persists the new width) and `Closed`.

**Workspace integration**:
- `document-area` becomes a tab bar over a `flex_row` of `[active_doc (flex_1) | inspector (fixed width, when open)]`.
- Drag mask is a workspace-root absolute overlay rendered only while resizing — fixes the previous grid-local mask that lost events when the cursor exited the grid.
- `Command::Cancel` falls back to closing the inspector only after the active document's Cancel handler declines, preserving in-cell editing.

**Event chain** (mirrors `RequestSqlPreview`):
`DataGridEvent::OpenInspector` → `DataDocumentEvent::OpenInspector` → `DocumentEvent::OpenInspector` → `TabManagerEvent::OpenInspector` → `Workspace.workspace_inspector.open_with(view, title, cx)`. CodeDocument's result-tab grid is wired into the same chain so query-result row inspection works without extra plumbing.

**Row inspector migration**:
- New `RowInspectorContent` (same file) holds snapshot, FK references, ready flag. `Render` returns only the scrollable body — no chrome, no grip, no close button, no overlay.
- `DataGridPanel::open_row_inspector` reuses/creates the content entity, fires FK resolution against it, then emits `DataGridEvent::OpenInspector`.
- Old `RowInspector` struct, `RowInspectorEvent`, frame fields, and `INSPECTOR_*_WIDTH` constants removed (now in `workspace/inspector.rs`).

**Settings**:
- `GeneralSettings.workspace_inspector_width_px: Option<f32>` with serde default + skip-when-none.
- Loaded in `Workspace::new`; written through `save_general_settings` + `app_state.update_general_settings` on `ResizeCommitted`.

## Test plan

- [x] \`cargo check --workspace\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo test -p dbflux_core --lib general_settings\` (2/2 — settings round-trip)
- [x] \`cargo test -p dbflux_ui --test workspace_inspector\` (8/8 — entity state transitions)
- [x] \`cargo test -p dbflux_ui --lib\` (402/402)
- [ ] Manual: open row inspector from the data grid; resize grip works smoothly with cursor tracking across the whole window
- [ ] Manual: ESC closes the inspector when no document handler consumes it; in-cell editing keeps priority
- [ ] Manual: switch tabs while the inspector is open — content stays
- [ ] Manual: close, restart app, open inspector again — width is restored
- [ ] Manual: open row inspector from a query result grid (CodeDocument) — content shows in the rail

## Follow-up

The schema visualization branch (\`feat/schema-visualization\`) will rebase onto main once this lands and add a \`SchemaInspector\` content entity that emits \`OpenInspector\` on table double-click — no workspace changes required.