### PR TITLE
fix(ui): show horizontal scrollbar immediately when results overflow viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Fixes
+
+* Results data grid shows the horizontal scrollbar immediately when
+  the columns are wider than the viewport. gpui-component scrollbars
+  render fully transparent at idle and only fade in after a scroll
+  event; the horizontal axis is driven by a 1px phantom scroller that
+  never receives the wheel, so previously the bar stayed invisible
+  until the user arrowed past the right edge. The horizontal scrollbar
+  is now configured with `ScrollbarShow::Always`.
+
 ## [0.6.0-dev.0] - 2026-05-12
 
 ### Features

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -12,7 +12,7 @@ use gpui::{
     ListSizingBehavior, MouseButton, MouseDownEvent, ParentElement, StatefulInteractiveElement,
     Styled, Window, actions, canvas, div, px, uniform_list,
 };
-use gpui_component::scroll::Scrollbar;
+use gpui_component::scroll::{Scrollbar, ScrollbarShow};
 use gpui_component::{ActiveTheme, Sizable};
 
 use super::events::{DataTableEvent, Direction, Edge};
@@ -598,7 +598,7 @@ impl gpui::Render for DataTable {
                     .track_scroll(&horizontal_scroll_handle)
                     .child(div().min_w(px(total_width)).h(px(1.0))),
             )
-            // Scrollbars as absolute overlays
+            // Scrollbars as absolute overlays.
             .child(
                 div()
                     .absolute()
@@ -610,6 +610,10 @@ impl gpui::Render for DataTable {
                         this.child(Scrollbar::vertical(&vertical_scroll_handle))
                     }),
             )
+            // Horizontal scrollbar uses `ScrollbarShow::Always` because the phantom
+            // scroller that owns the handle is 1px tall and never captures the wheel,
+            // so the bar would otherwise stay transparent until the user navigates
+            // off-screen with the keyboard.
             .child(
                 div()
                     .absolute()
@@ -617,7 +621,10 @@ impl gpui::Render for DataTable {
                     .right_0()
                     .bottom_0()
                     .h(SCROLLBAR_WIDTH)
-                    .child(Scrollbar::horizontal(&horizontal_scroll_handle)),
+                    .child(
+                        Scrollbar::horizontal(&horizontal_scroll_handle)
+                            .scrollbar_show(ScrollbarShow::Always),
+                    ),
             )
     }
 }


### PR DESCRIPTION
## Summary

Make the data-table horizontal scrollbar visible immediately when the
results are wider than the viewport, instead of waiting for the user to
arrow past the right edge.

## What does this resolve?

- A user-reported regression where running a query with many columns
  shows no horizontal scrollbar in the results pane. Scrolling
  horizontally only becomes possible after clicking a row and pressing
  the right-arrow key — there is no way to know overflow exists or to
  drag the bar, because the bar itself is invisible.
- No tracked issue yet.

## How was this solved?

`gpui-component`'s `Scrollbar` is a hover-style bar: at idle every part
is `transparent_black()` and it only fades in once `last_scroll_time` is
set by a scroll event. The vertical axis trips that signal naturally
because the body's `uniform_list` captures the mouse wheel. The
horizontal axis cannot: it is owned by a 1px "phantom scroller" div
(`#table-hscroll-owner`) sized to `min_w(total_width)`, intentionally
1px tall so it never captures the wheel. With the bar transparent, the
user cannot drag it either, so the only path that flips
`last_scroll_offset` is `state.scroll_to_column` invoked by keyboard
navigation.

The fix configures the horizontal `Scrollbar` with
`ScrollbarShow::Always`, which forces `style_for_hovered_bar` whenever
content overflows the viewport. The "hide if scroll area ≤ container"
guard inside `gpui-component` still applies, so no bar is drawn when
columns already fit. The vertical scrollbar is unchanged because its
existing hover-fade-out behavior works fine — the wheel already drives
it.

Diff is one extra `.scrollbar_show(...)` call and the matching
`ScrollbarShow` import in
`crates/dbflux_ui/src/ui/components/data_table/table.rs`, plus a
`CHANGELOG.md` entry under `## [Unreleased]` / `### Fixes`.

## Validation

- `cargo check -p dbflux_ui` — passes (only pre-existing
  Windows-specific warnings in `crates/dbflux_ui/src/platform.rs`).
- `cargo test -p dbflux_ui --no-run` — builds.
- Manual: ran a query whose result set is wider than the visible
  viewport. The horizontal scrollbar is now drawn immediately under the
  body, its thumb sized to the overflow ratio, draggable from the
  first frame. When the columns fit, the bar is absent as before.
- Confirmed by reading `gpui-component-0.5.0/src/scroll/scrollbar.rs`
  that the `is_always_to_show` branch in `Scrollbar::prepaint` selects
  the visible hover-bar style; the early "scroll area ≤ container"
  guard at line 573 still hides the bar when there is no overflow.

## Where was this tested?

- [x] Local development environment
- [ ] Automated tests
- [ ] Linux
- [ ] macOS
- [x] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed (visual regression; no unit
      test added — the behavior is owned by the third-party
      `gpui-component` and gated on its private state machine)
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

- `ui:bug`
