### PR TITLE
feat(ui): copy selected Results cell with Ctrl+C / Cmd+C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+* Ctrl+C / Cmd+C now copies the selected cell (or range) from the Results
+  grid to the clipboard, matching the right-click → Copy behavior.
+
 ## [0.6.0-dev.0] - 2026-05-12
 
 ### Features

--- a/crates/dbflux_app/src/keymap/command.rs
+++ b/crates/dbflux_app/src/keymap/command.rs
@@ -75,6 +75,7 @@ pub enum Command {
     ResultsAddRow,
     ResultsDuplicateRow,
     ResultsCopyRow,
+    ResultsCopyCell,
     ResultsSetNull,
     // Context menu
     OpenContextMenu,
@@ -208,6 +209,7 @@ impl Command {
             Command::ResultsAddRow => "Add Row",
             Command::ResultsDuplicateRow => "Duplicate Row",
             Command::ResultsCopyRow => "Copy Row",
+            Command::ResultsCopyCell => "Copy Cell",
             Command::ResultsSetNull => "Set Cell to NULL",
             Command::OpenContextMenu => "Open Context Menu",
             Command::MenuUp => "Menu Up",
@@ -299,6 +301,7 @@ impl Command {
             | Command::ResultsAddRow
             | Command::ResultsDuplicateRow
             | Command::ResultsCopyRow
+            | Command::ResultsCopyCell
             | Command::ResultsSetNull
             | Command::OpenContextMenu
             | Command::MenuUp

--- a/crates/dbflux_ui/src/keymap/defaults.rs
+++ b/crates/dbflux_ui/src/keymap/defaults.rs
@@ -389,6 +389,27 @@ fn results_layer() -> KeymapLayer {
         Command::ResultsCopyRow,
     );
 
+    // Copy selected cell(s) to clipboard — Cmd+C on macOS, Ctrl+C elsewhere.
+    // GPUI reports cmd vs ctrl on separate modifier fields, so we pick one
+    // per platform rather than binding both (which would let Ctrl+C trigger
+    // copy on macOS, violating the platform convention).
+    #[cfg(target_os = "macos")]
+    layer.bind(
+        KeyChord {
+            key: "c".to_string(),
+            modifiers: Modifiers {
+                platform: true,
+                ..Modifiers::none()
+            },
+        },
+        Command::ResultsCopyCell,
+    );
+    #[cfg(not(target_os = "macos"))]
+    layer.bind(
+        KeyChord::new("c", Modifiers::ctrl()),
+        Command::ResultsCopyCell,
+    );
+
     // Toggle panel collapse
     layer.bind(KeyChord::new("z", Modifiers::none()), Command::TogglePanel);
 

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -107,8 +107,10 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("ctrl-shift-end", SelectToBottom, Some(CONTEXT)),
         KeyBinding::new("ctrl-a", SelectAll, Some(CONTEXT)),
         KeyBinding::new("escape", ClearSelection, Some(CONTEXT)),
-        // Copy
-        KeyBinding::new("ctrl-c", Copy, Some(CONTEXT)),
+        // Copy — `secondary-c` resolves to Cmd+C on macOS and Ctrl+C
+        // elsewhere, matching platform conventions. A literal `ctrl-c` here
+        // would fire on macOS Ctrl+C too, which is wrong.
+        KeyBinding::new("secondary-c", Copy, Some(CONTEXT)),
         KeyBinding::new("y y", Copy, Some(CONTEXT)),
         KeyBinding::new("shift-y shift-y", CopyRow, Some(CONTEXT)),
         // Edit mode

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/navigation.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/navigation.rs
@@ -639,6 +639,10 @@ impl DataGridPanel {
                 }
                 true
             }
+            Command::ResultsCopyCell => {
+                self.handle_copy(window, cx);
+                true
+            }
             _ => false,
         }
     }

--- a/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/dispatch.rs
@@ -767,7 +767,7 @@ impl CommandDispatcher for Workspace {
                 false
             }
 
-            Command::ResultsAddRow | Command::ResultsCopyRow => {
+            Command::ResultsAddRow | Command::ResultsCopyRow | Command::ResultsCopyCell => {
                 if let Some(doc) = self.tab_manager.read(cx).active_document().cloned() {
                     doc.dispatch_command(cmd, window, cx);
                 }


### PR DESCRIPTION
## Summary

Adds a Ctrl+C (Windows/Linux) / Cmd+C (macOS) keyboard shortcut that copies the currently selected cell — or the selected cell range — from the Results grid to the clipboard. Previously, copying a single cell value was only reachable through right-click → Copy.

## What does this resolve?

User-reported gap: keyboard-first workflow forced users back to the mouse just to copy a cell value out of a query result. The vim-style `y` already copies a row (`ResultsCopyRow`), but there was no canonical platform shortcut for a single cell.

- Resolves #

## How was this solved?

Routed the shortcut through DBFlux's `Command` pipeline so it follows the same flow as `ResultsCopyRow` / `ResultsAddRow`, and reuses the existing `handle_copy` helper that the context-menu Copy item already calls:

- `dbflux_app::keymap::command` — new `Command::ResultsCopyCell` (enum, display name, category).
- `dbflux_ui::keymap::defaults` — binds the chord in the `Results` layer. Gated by `target_os`: `Modifiers::platform()` on macOS, `Modifiers::ctrl()` elsewhere — so Ctrl+C does **not** trigger copy on macOS (which would violate platform convention).
- `workspace::dispatch` — `ResultsCopyCell` joins `ResultsAddRow`/`ResultsCopyRow` in the active-document routing branch.
- `DataGridPanel::dispatch_command` — handles `ResultsCopyCell` by calling the pre-existing `handle_copy`, which delegates to `clipboard::copy_selection` (TSV-formatted, multi-row friendly).
- `data_table::table::init` — the GPUI-level fallback binding switched from literal `"ctrl-c"` to `"secondary-c"`, so the same platform mapping applies if the Command path is ever bypassed.

While editing a cell the active context is `TextInput`, so the binding doesn't trigger and gpui-component's native input copy takes over — the right behavior.

### Question for the maintainer

This is the first binding in DBFlux's keymap to follow the platform convention (Cmd on macOS, Ctrl on Windows/Linux). Everywhere else in `crates/dbflux_ui/src/keymap/defaults.rs` uses `Modifiers::ctrl()` unconditionally, meaning macOS users currently press **Ctrl**+N, **Ctrl**+W, **Ctrl**+Enter, **Ctrl**+E, etc.

Two reasonable directions — would appreciate your call before this expands:

1. **Adopt platform-correct modifiers everywhere.** Treat this PR as the start, and follow up with a sweep migrating the other shortcuts to a cross-platform helper (e.g. add `Modifiers::primary()` that resolves to `platform` on macOS / `ctrl` elsewhere, plus an equivalent for the GPUI-side `secondary-X` strings). Most native macOS apps expect Cmd; this is the path of least surprise for Mac users.
2. **Keep everything on Ctrl for consistency.** Revert this PR's `target_os` split, bind Ctrl+C unconditionally, and document that DBFlux is intentionally Ctrl-first across all platforms (as e.g. some Linux-leaning tooling does). This loses Mac-native feel but keeps muscle memory portable and the codebase uniform.

I leaned toward (1) here because Copy is the most ingrained platform-convention shortcut and gpui-component's input handling already uses `secondary-c`/`secondary-v`/`secondary-x` for text editing on macOS — so the data-table behaving differently from inputs in the same window would be jarring. But if the project's intent is (2), happy to revert the cfg gate to a single Ctrl+C binding and leave the broader migration for a future RFC.

## Validation

- `cargo check --workspace` — clean
- `cargo test -p dbflux_ui --lib keymap` — 11 passed, including `results_layer_owns_navigation_and_crud_letters` (existing regression test still happy with the new binding)
- Manual: clicking a cell in the data grid and pressing the platform shortcut copies its value; pressing the wrong platform shortcut (Ctrl+C on macOS) no longer fires, confirming the cfg gate works
- Multi-cell range selection produces TSV via the existing `copy_selection` path (no new clipboard code introduced)

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [ ] Linux
- [x] macOS
- [x] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed (keymap tests cover the Results layer; existing tests pass)
- [x] I documented follow-up work or known limitations when applicable (see maintainer question above)
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` — this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

- `ui:feature`