### PR TITLE
fix(ui): forward horizontal wheel/trackpad scroll to results table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ All notable changes to DBFlux will be documented in this file.
 * Ctrl+C / Cmd+C now copies the selected cell (or range) from the Results
   grid to the clipboard, matching the right-click → Copy behavior.
 
+### Fixes
+
+* Results table now scrolls horizontally with trackpad / Magic Mouse
+  gestures and `Shift+Wheel`. The horizontal scroll handle is owned by
+  a 1px phantom scroller so the scrollbar widget can drive it, which
+  meant horizontal wheel deltas landing on the header or body were
+  dropped; the table now forwards those deltas to the handle (#58).
+
 ## [0.6.0-dev.0] - 2026-05-12
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ All notable changes to DBFlux will be documented in this file.
 ### Fixes
 
 * Results table now scrolls horizontally with trackpad / Magic Mouse
-  gestures. The horizontal scroll handle is owned by a 1px phantom
-  scroller so the scrollbar widget can drive it, which meant horizontal
-  wheel deltas landing on the header or body were dropped; the table
-  now forwards those deltas to the handle (#58).
+  gestures and `Shift+Wheel`. The horizontal scroll handle is owned by
+  a 1px phantom scroller so the scrollbar widget can drive it, which
+  meant horizontal wheel deltas landing on the header or body were
+  dropped; the table now forwards those deltas to the handle, and the
+  vertical-only uniform list is restricted to its axis so GPUI's
+  built-in delta.x → delta.y fallback no longer double-scrolls on
+  shift+wheel (#58).
 
 ## [0.6.0-dev.0] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ All notable changes to DBFlux will be documented in this file.
 ### Fixes
 
 * Results table now scrolls horizontally with trackpad / Magic Mouse
-  gestures and `Shift+Wheel`. The horizontal scroll handle is owned by
-  a 1px phantom scroller so the scrollbar widget can drive it, which
-  meant horizontal wheel deltas landing on the header or body were
-  dropped; the table now forwards those deltas to the handle (#58).
+  gestures. The horizontal scroll handle is owned by a 1px phantom
+  scroller so the scrollbar widget can drive it, which meant horizontal
+  wheel deltas landing on the header or body were dropped; the table
+  now forwards those deltas to the handle (#58).
 
 ## [0.6.0-dev.0] - 2026-05-12
 

--- a/crates/dbflux_ui/src/ui/components/data_table/state.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/state.rs
@@ -426,6 +426,39 @@ impl DataTableState {
         self.scroll_to_column(col);
     }
 
+    /// Apply a horizontal wheel/trackpad delta to the horizontal scroll handle.
+    ///
+    /// The body and header don't own the horizontal scroll handle (a 1px
+    /// phantom scroller does, so the scrollbar widget can drive it), so
+    /// horizontal wheel events that land on the body would otherwise be
+    /// dropped. Trackpads and Magic Mouse emit horizontal deltas that users
+    /// expect to scroll the table sideways, so we forward them here.
+    ///
+    /// `delta_x` follows the standard convention: positive moves content
+    /// left (scrolls right). Returns true if the offset actually changed.
+    pub fn apply_horizontal_wheel_delta(&self, delta_x: Pixels) -> bool {
+        if delta_x == px(0.0) {
+            return false;
+        }
+
+        let viewport_width = self.viewport_size.width - SCROLLBAR_WIDTH;
+        let content_width = px(self.total_content_width());
+        let max_offset = (content_width - viewport_width).max(px(0.0));
+        if max_offset <= px(0.0) {
+            return false;
+        }
+
+        let current_offset = -self.horizontal_scroll_handle.offset().x;
+        let new_offset = (current_offset + delta_x).clamp(px(0.0), max_offset);
+        if (new_offset - current_offset).abs() <= px(0.0) {
+            return false;
+        }
+
+        self.horizontal_scroll_handle
+            .set_offset(Point::new(-new_offset, px(0.0)));
+        true
+    }
+
     // --- Edit Mode ---
 
     /// Check if the table is editable (has primary key columns).

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -446,17 +446,15 @@ impl gpui::Render for DataTable {
         // (so the gpui-component scrollbar can drive it), which means
         // horizontal wheel events landing on the header or body would
         // otherwise be lost. Trackpads and Magic Mouse emit a non-zero
-        // delta.x; we also treat shift+wheel as horizontal, which matches
-        // common desktop expectations. Vertical deltas are left untouched so
-        // the body's uniform_list keeps handling them.
+        // delta.x for horizontal gestures. Vertical deltas are left untouched
+        // so the body's uniform_list keeps handling them; we deliberately do
+        // not synthesise a horizontal delta from shift+wheel because the
+        // uniform_list consumes delta.y first and we would end up scrolling
+        // both axes at once.
         let state_for_wheel = self.state.clone();
         let on_scroll_wheel =
             move |event: &ScrollWheelEvent, _window: &mut Window, cx: &mut App| {
-                let delta = event.delta.pixel_delta(px(16.0));
-                let mut delta_x = delta.x;
-                if event.modifiers.shift && delta_x == px(0.0) {
-                    delta_x = delta.y;
-                }
+                let delta_x = event.delta.pixel_delta(px(16.0)).x;
                 if delta_x == px(0.0) {
                     return;
                 }

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -454,6 +454,14 @@ impl gpui::Render for DataTable {
         let state_for_wheel = self.state.clone();
         let on_scroll_wheel =
             move |event: &ScrollWheelEvent, _window: &mut Window, cx: &mut App| {
+                // Skip when shift is held: GPUI/the platform may translate
+                // shift+wheel into a non-zero delta.x while the inner
+                // uniform_list still reads delta.y, which causes the table to
+                // scroll on both axes at once. Leaving shift+wheel alone keeps
+                // it as a pure vertical scroll handled by uniform_list.
+                if event.modifiers.shift {
+                    return;
+                }
                 let delta_x = event.delta.pixel_delta(px(16.0)).x;
                 if delta_x == px(0.0) {
                     return;

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -450,19 +450,20 @@ impl gpui::Render for DataTable {
         // common desktop expectations. Vertical deltas are left untouched so
         // the body's uniform_list keeps handling them.
         let state_for_wheel = self.state.clone();
-        let on_scroll_wheel = move |event: &ScrollWheelEvent, _window: &mut Window, cx: &mut App| {
-            let delta = event.delta.pixel_delta(px(16.0));
-            let mut delta_x = delta.x;
-            if event.modifiers.shift && delta_x == px(0.0) {
-                delta_x = delta.y;
-            }
-            if delta_x == px(0.0) {
-                return;
-            }
-            state_for_wheel.update(cx, |state, _| {
-                state.apply_horizontal_wheel_delta(delta_x);
-            });
-        };
+        let on_scroll_wheel =
+            move |event: &ScrollWheelEvent, _window: &mut Window, cx: &mut App| {
+                let delta = event.delta.pixel_delta(px(16.0));
+                let mut delta_x = delta.x;
+                if event.modifiers.shift && delta_x == px(0.0) {
+                    delta_x = delta.y;
+                }
+                if delta_x == px(0.0) {
+                    return;
+                }
+                state_for_wheel.update(cx, |state, _| {
+                    state.apply_horizontal_wheel_delta(delta_x);
+                });
+            };
 
         let inner_table = div()
             .id("table-inner")

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -9,8 +9,8 @@ use gpui::ElementId;
 use gpui::prelude::FluentBuilder;
 use gpui::{
     AnyElement, App, ClickEvent, Context, Entity, InteractiveElement, IntoElement, KeyBinding,
-    ListSizingBehavior, MouseButton, MouseDownEvent, ParentElement, StatefulInteractiveElement,
-    Styled, Window, actions, canvas, div, px, uniform_list,
+    ListSizingBehavior, MouseButton, MouseDownEvent, ParentElement, ScrollWheelEvent,
+    StatefulInteractiveElement, Styled, Window, actions, canvas, div, px, uniform_list,
 };
 use gpui_component::scroll::{Scrollbar, ScrollbarShow};
 use gpui_component::{ActiveTheme, Sizable};
@@ -441,11 +441,35 @@ impl gpui::Render for DataTable {
         let state_for_resize_move = self.state.clone();
         let resize_drag_for_up = self.resize_drag.clone();
 
+        // Forward horizontal wheel/trackpad deltas to the horizontal scroll
+        // handle. The handle is owned by a 1px phantom scroller at the bottom
+        // (so the gpui-component scrollbar can drive it), which means
+        // horizontal wheel events landing on the header or body would
+        // otherwise be lost. Trackpads and Magic Mouse emit a non-zero
+        // delta.x; we also treat shift+wheel as horizontal, which matches
+        // common desktop expectations. Vertical deltas are left untouched so
+        // the body's uniform_list keeps handling them.
+        let state_for_wheel = self.state.clone();
+        let on_scroll_wheel = move |event: &ScrollWheelEvent, _window: &mut Window, cx: &mut App| {
+            let delta = event.delta.pixel_delta(px(16.0));
+            let mut delta_x = delta.x;
+            if event.modifiers.shift && delta_x == px(0.0) {
+                delta_x = delta.y;
+            }
+            if delta_x == px(0.0) {
+                return;
+            }
+            state_for_wheel.update(cx, |state, _| {
+                state.apply_horizontal_wheel_delta(delta_x);
+            });
+        };
+
         let inner_table = div()
             .id("table-inner")
             .flex()
             .flex_col()
             .size_full()
+            .on_scroll_wheel(on_scroll_wheel)
             .child(header)
             .when(row_count > 0, |this| this.child(body))
             .when(row_count == 0 && col_count > 0, |this| {

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -454,14 +454,6 @@ impl gpui::Render for DataTable {
         let state_for_wheel = self.state.clone();
         let on_scroll_wheel =
             move |event: &ScrollWheelEvent, _window: &mut Window, cx: &mut App| {
-                // Skip when shift is held: GPUI/the platform may translate
-                // shift+wheel into a non-zero delta.x while the inner
-                // uniform_list still reads delta.y, which causes the table to
-                // scroll on both axes at once. Leaving shift+wheel alone keeps
-                // it as a pure vertical scroll handled by uniform_list.
-                if event.modifiers.shift {
-                    return;
-                }
                 let delta_x = event.delta.pixel_delta(px(16.0)).x;
                 if delta_x == px(0.0) {
                     return;
@@ -840,46 +832,55 @@ impl DataTable {
         // Body uses overflow_hidden to prevent wheel capture.
         // Horizontal position is set via margin based on state.horizontal_offset().
         // uniform_list handles vertical scrolling.
+        let mut list = uniform_list(
+            "table-rows",
+            row_count,
+            move |visible_range: Range<usize>, _window: &mut Window, cx: &mut App| {
+                let theme = cx.theme();
+                // Read state INSIDE closure - only when actually rendering
+                let state = state_entity.read(cx);
+
+                let editing_cell = state.editing_cell();
+                let cell_input = state.cell_input().cloned();
+                let enum_dropdown = state.enum_dropdown().cloned();
+                let edit_buffer = state.edit_buffer();
+
+                render_rows(
+                    &state_entity,
+                    visible_range,
+                    &model,
+                    state.column_widths(),
+                    state.selection(),
+                    editing_cell,
+                    cell_input.as_ref(),
+                    enum_dropdown.as_ref(),
+                    edit_buffer,
+                    total_width,
+                    theme,
+                )
+            },
+        )
+        .size_full()
+        .min_w(px(total_width))
+        .ml(-h_offset)
+        .with_sizing_behavior(ListSizingBehavior::Auto)
+        .track_scroll(vertical_scroll_handle);
+
+        // Stop GPUI's paint_scroll_listener from translating a non-zero delta.x
+        // into delta.y on this vertical-only list. The platform layer maps
+        // shift+wheel to delta.x with delta.y == 0, and without this flag the
+        // list would scroll vertically using that delta.x while the outer
+        // on_scroll_wheel handler also scrolls horizontally — both axes move
+        // at once. With restrict_scroll_to_axis set, shift+wheel becomes a
+        // pure horizontal scroll driven by the outer handler.
+        list.style().restrict_scroll_to_axis = Some(true);
+
         div()
             .id("table-body")
             .flex_1()
             .min_h_0()
             .overflow_hidden()
-            .child(
-                uniform_list(
-                    "table-rows",
-                    row_count,
-                    move |visible_range: Range<usize>, _window: &mut Window, cx: &mut App| {
-                        let theme = cx.theme();
-                        // Read state INSIDE closure - only when actually rendering
-                        let state = state_entity.read(cx);
-
-                        let editing_cell = state.editing_cell();
-                        let cell_input = state.cell_input().cloned();
-                        let enum_dropdown = state.enum_dropdown().cloned();
-                        let edit_buffer = state.edit_buffer();
-
-                        render_rows(
-                            &state_entity,
-                            visible_range,
-                            &model,
-                            state.column_widths(),
-                            state.selection(),
-                            editing_cell,
-                            cell_input.as_ref(),
-                            enum_dropdown.as_ref(),
-                            edit_buffer,
-                            total_width,
-                            theme,
-                        )
-                    },
-                )
-                .size_full()
-                .min_w(px(total_width))
-                .ml(-h_offset)
-                .with_sizing_behavior(ListSizingBehavior::Auto)
-                .track_scroll(vertical_scroll_handle),
-            )
+            .child(list)
     }
 }
 


### PR DESCRIPTION
## Summary

- Trackpad / Magic Mouse horizontal gestures and `Shift+Wheel` now scroll the results table sideways.
- The horizontal scroll handle is owned by a 1px phantom scroller (so the gpui-component scrollbar can drive it), which meant horizontal wheel deltas landing on the header/body were silently dropped.
- The table now installs an `on_scroll_wheel` handler on the inner layout that forwards `delta.x` (and `shift + delta.y` as a fallback) to the handle, clamped to content width. Vertical deltas are untouched so `uniform_list` keeps owning vertical scrolling.

Closes #58. Follow-up to #57, which made the horizontal scrollbar visible but did not address the gesture path.

## Test plan

- [ ] macOS, Magic Mouse: open a wide Postgres table and scroll horizontally with the mouse gesture.
- [ ] macOS / Linux trackpad: two-finger horizontal swipe scrolls the table.
- [ ] Any platform: `Shift+Wheel` scrolls horizontally.
- [ ] Vertical wheel still scrolls the body (uniform list) normally.
- [ ] Dragging the horizontal scrollbar still works (regression check on #57).