### PR TITLE
fix(ui): respect platform sign for results horizontal wheel scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Fixes
+
+* Results table horizontal trackpad / wheel scroll now respects the
+  platform sign convention (macOS "natural scrolling" preference,
+  Linux / Windows scroll direction) and the body shifts on the same
+  frame as the scrollbar, removing the one-frame lag that read as
+  jitter during trackpad momentum. Follow-up to #60.
+
 ## [0.6.0-dev.0] - 2026-05-12
 
 ### Features

--- a/crates/dbflux_ui/src/ui/components/data_table/state.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/state.rs
@@ -434,8 +434,12 @@ impl DataTableState {
     /// dropped. Trackpads and Magic Mouse emit horizontal deltas that users
     /// expect to scroll the table sideways, so we forward them here.
     ///
-    /// `delta_x` follows the standard convention: positive moves content
-    /// left (scrolls right). Returns true if the offset actually changed.
+    /// `delta_x` is the raw platform delta in pixels and is added directly
+    /// to `handle.offset.x`, matching `gpui::paint_scroll_listener` and
+    /// `gpui_component::scroll::ScrollableMask`. On macOS this means the
+    /// system's "natural scrolling" preference is respected automatically
+    /// because AppKit already encodes the user's preferred sign into
+    /// `NSEvent.scrollingDeltaX`. Returns true if the offset actually changed.
     pub fn apply_horizontal_wheel_delta(&self, delta_x: Pixels) -> bool {
         if delta_x == px(0.0) {
             return false;
@@ -443,19 +447,19 @@ impl DataTableState {
 
         let viewport_width = self.viewport_size.width - SCROLLBAR_WIDTH;
         let content_width = px(self.total_content_width());
-        let max_offset = (content_width - viewport_width).max(px(0.0));
-        if max_offset <= px(0.0) {
+        let min_offset_x = -(content_width - viewport_width).max(px(0.0));
+        if min_offset_x >= px(0.0) {
             return false;
         }
 
-        let current_offset = -self.horizontal_scroll_handle.offset().x;
-        let new_offset = (current_offset + delta_x).clamp(px(0.0), max_offset);
-        if (new_offset - current_offset).abs() <= px(0.0) {
+        let current = self.horizontal_scroll_handle.offset();
+        let new_x = (current.x + delta_x).clamp(min_offset_x, px(0.0));
+        if new_x == current.x {
             return false;
         }
 
         self.horizontal_scroll_handle
-            .set_offset(Point::new(-new_offset, px(0.0)));
+            .set_offset(Point::new(new_x, current.y));
         true
     }
 

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -445,23 +445,34 @@ impl gpui::Render for DataTable {
         // handle. The handle is owned by a 1px phantom scroller at the bottom
         // (so the gpui-component scrollbar can drive it), which means
         // horizontal wheel events landing on the header or body would
-        // otherwise be lost. Trackpads and Magic Mouse emit a non-zero
-        // delta.x for horizontal gestures. Vertical deltas are left untouched
-        // so the body's uniform_list keeps handling them; we deliberately do
-        // not synthesise a horizontal delta from shift+wheel because the
-        // uniform_list consumes delta.y first and we would end up scrolling
-        // both axes at once.
+        // otherwise be lost. The body's uniform_list still consumes delta.y
+        // natively. We deliberately do not synthesise a horizontal delta
+        // from shift+wheel because the list consumes delta.y first and we
+        // would end up scrolling both axes at once.
+        //
+        // After updating the scroll handle we synchronously bump
+        // `state.horizontal_offset` so the body shift (`ml(-h_offset)`) and
+        // the scrollbar move on the same frame; otherwise the canvas-based
+        // sync runs one frame later and the table reads as jittery during
+        // trackpad momentum.
         let state_for_wheel = self.state.clone();
-        let on_scroll_wheel =
-            move |event: &ScrollWheelEvent, _window: &mut Window, cx: &mut App| {
-                let delta_x = event.delta.pixel_delta(px(16.0)).x;
-                if delta_x == px(0.0) {
-                    return;
+        let on_scroll_wheel = move |event: &ScrollWheelEvent, window: &mut Window, cx: &mut App| {
+            let delta_x = event.delta.pixel_delta(window.line_height()).x;
+            if delta_x == px(0.0) {
+                return;
+            }
+            let consumed = state_for_wheel.update(cx, |state, cx| {
+                if state.apply_horizontal_wheel_delta(delta_x) {
+                    state.sync_horizontal_offset(cx);
+                    true
+                } else {
+                    false
                 }
-                state_for_wheel.update(cx, |state, _| {
-                    state.apply_horizontal_wheel_delta(delta_x);
-                });
-            };
+            });
+            if consumed {
+                cx.stop_propagation();
+            }
+        };
 
         let inner_table = div()
             .id("table-inner")


### PR DESCRIPTION
## Summary

Follow-up to #60. The horizontal wheel/trackpad forwarder added there scrolls the results table in the **opposite** direction of what the OS asks for on every platform, and the body shift visibly lags the scrollbar by one frame during trackpad momentum on macOS.

## What does this resolve?

- macOS, "natural scrolling" enabled (default): two-finger swipe left scrolls the table **left** instead of right (and vice versa). With natural scrolling disabled the inversion is the other way around — both settings are wrong.
- All platforms: during trackpad momentum the scrollbar leads the table body by one frame, which reads as horizontal jitter and doesn't match how other macOS apps scroll.

No issue is open for this; it's reported in follow-up to #60 (which closed #58).

## How was this solved?

### Direction

GPUI's `ScrollHandle.offset.x` convention is `0` at the left edge and *more negative* as the content scrolls right. Both `gpui::paint_scroll_listener` (`gpui-0.2.2/src/elements/div.rs:2446`) and `gpui_component::scroll::ScrollableMask` (`gpui-component-0.5.1/src/scroll/scrollable_mask.rs:147`) implement the wheel path the same way:

```rust
offset.x += delta.x;
scroll_handle.set_offset(offset);
```

On macOS, AppKit already encodes the "natural scrolling" preference into the sign of `NSEvent.scrollingDeltaX`, which GPUI passes through verbatim (`gpui-0.2.2/src/platform/mac/events.rs:225`). Adding `delta.x` directly to `handle.offset.x` is therefore correct for both natural-on and natural-off out of the box.

PR #60 instead computed a positive "logical" offset, added `delta_x` to it, then negated before `set_offset`, which is equivalent to `handle.offset.x -= delta.x` — the sign is flipped relative to the canonical pattern, so the table scrolls opposite to the OS preference on every platform.

`apply_horizontal_wheel_delta` is rewritten to mirror `ScrollableMask`:

```rust
let current = self.horizontal_scroll_handle.offset();
let new_x = (current.x + delta_x).clamp(min_offset_x, px(0.0));
self.horizontal_scroll_handle.set_offset(Point::new(new_x, current.y));
```

The `y` component is preserved (the previous code zeroed it).

### Jitter

The wheel handler in #60 only mutated `scroll_handle.offset`. The body uses `ml(-h_offset)` where `h_offset = state.horizontal_offset`, and that field is updated by a canvas-driven sync that runs *next* frame. The scrollbar reads the handle directly, so during trackpad momentum the scrollbar moves immediately while the body lags by one frame. After applying the delta the handler now calls `state.sync_horizontal_offset(cx)` synchronously, so the body shift and the scrollbar move on the same frame. The canvas-based sync stays for scrollbar-drag (its original purpose).

`pixel_delta(px(16.0))` is replaced with `pixel_delta(window.line_height())` to match `gpui-component::scrollable_mask` and GPUI's native scroll listeners. Trackpads emit `Pixels` so the argument is unused on a Magic Mouse / Trackpad; this only affects wheel mice, where it aligns the step size with the rest of the app.

`cx.stop_propagation()` is called when the delta was consumed, also matching `ScrollableMask`.

## Validation

- `cargo fmt --all -- --check` — clean.
- `cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws` — builds.
- `cargo test -p dbflux_ui --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws --lib` — 401/401 pass.
- `cargo clippy --workspace -- -D warnings` fails on six pre-existing `unused_imports` / `unused_variables` warnings in `crates/dbflux_ui/src/platform.rs` that exist on `main` independent of this PR (verified by `git stash` and re-running). They are out of scope for this fix.
- Manual: macOS 14, MacBook trackpad, both "natural scrolling" enabled and disabled. Two-finger horizontal swipe now scrolls the table in the direction the OS requests in both modes, and the body / scrollbar stay in lockstep during momentum.
- Regression checks: vertical wheel still scrolls the body via `uniform_list`; `Shift+Wheel` continues to be ignored by the forwarder (the prior `restrict_scroll_to_axis` flag on the list is unchanged); dragging the horizontal scrollbar still works.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [ ] Linux
- [x] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed (no new tests — the regression is platform-event-driven and not reachable from `cargo test` without a real wheel event source; covered by manual validation)
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I applied the appropriate labels

## Labels to apply

`ui:bug`, `platform:macos` (regression is most visible on macOS but the fix is platform-agnostic).