### PR TITLE
fix(query): resolve drift-check schema via cache/editor, not hardcoded "public"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Normalize all text files to LF in the repo and in working trees.
+#
+# Without this, Windows contributors with `core.autocrlf=true` see CRLF in
+# their working tree while the repo (and tools like `cargo fmt`, which writes
+# LF per `rustfmt.toml`) speak LF. The first format run rewrites every file
+# from CRLF to LF in the working tree and `git status` flags every one as
+# modified — even though committing would be a no-op. Pinning `eol=lf`
+# repo-wide removes that mismatch for everyone.
+
+* text=auto eol=lf
+
+# Common binary types — never touch.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.icns  binary
+*.webp  binary
+*.svg   text eol=lf
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.otf   binary
+*.zip   binary
+*.gz    binary
+*.tar   binary
+*.7z    binary
+*.pdf   binary
+*.dylib binary
+*.so    binary
+*.dll   binary
+*.exe   binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Fixes
+
+* Schema-drift preflight no longer reports phantom "all columns removed"
+  for queries whose table lives outside `public`. The fresh fetch is now
+  steered to the right schema via a layered precedence (query qualifier
+  → cached `TableInfo.schema` → editor toolbar's schema → `public`
+  fallback), and the checker defensively skips any entry whose driver
+  lookup returns zero columns — preventing the empty `TableInfo` from
+  poisoning the autocomplete and table-detail caches via the
+  "Refresh & re-run" path.
+
+### Chores
+
+* Pin EOL to LF via `.gitattributes` (`* text=auto eol=lf`) so
+  `cargo fmt` no longer desyncs Windows working trees that default to
+  `core.autocrlf=true`.
+
 ## [0.6.0-dev.0] - 2026-05-12
 
 ### Features

--- a/crates/dbflux_core/src/schema/drift_check.rs
+++ b/crates/dbflux_core/src/schema/drift_check.rs
@@ -50,9 +50,30 @@ pub fn check_drift_sync(
 /// Check whether any tables referenced by `query` have drifted since they were
 /// last cached in `table_details`.
 ///
+/// `default_schema` is the caller's hint for which schema to introspect when
+/// the query does not qualify the table (e.g. the editor's active schema
+/// selector). It is only consulted as a tertiary fallback — the cached
+/// `TableInfo.schema` takes precedence because it records the exact schema
+/// the table was originally loaded from.
+///
+/// **Schema resolution precedence per table reference:**
+/// 1. Explicit qualifier in the query (`FROM public.users`).
+/// 2. The cached entry's `schema` field, when an entry exists. The cache is
+///    populated by sidebar/refresh paths that always know the right schema,
+///    so the cached entry is the authoritative pointer to where the table
+///    actually lives.
+/// 3. The caller-supplied `default_schema` (toolbar selection).
+/// 4. `"public"` as a last-resort driver-friendly fallback.
+///
 /// **Trigger rules:**
 /// - If the driver's `referenced_tables` returns `None`, return `Skip`.
 /// - For each referenced table:
+///   - If the fresh fetch returns no columns at all, skip the entry silently.
+///     A real table with zero columns is essentially impossible; an empty
+///     result almost always means the schema lookup was wrong (search path,
+///     dropped table, search-path race). Reporting "all columns removed"
+///     would be noise, and writing the empty `TableInfo` into the cache
+///     would poison autocomplete and the table-detail view.
 ///   - If no cache entry exists, this is a first encounter — add to `refreshes`
 ///     and proceed silently (no diff possible).
 ///   - If the entry exists and fingerprints match, add to `refreshes` for a
@@ -72,6 +93,7 @@ pub fn check_schema_drift(
     table_details: &std::collections::HashMap<(String, String), TableInfo>,
     query: &str,
     database: &str,
+    default_schema: Option<&str>,
 ) -> DriftOutcome {
     let table_refs = match connection.referenced_tables(query) {
         None => return DriftOutcome::Skip,
@@ -82,18 +104,42 @@ pub fn check_schema_drift(
     let mut refreshes: Vec<(TableKey, TableInfo)> = Vec::new();
 
     for table_ref in &table_refs {
-        let schema = table_ref.schema.as_deref().unwrap_or("public");
         let table_name = &table_ref.table;
         let effective_db = table_ref.database.as_deref().unwrap_or(database);
-
         let cache_key: TableKey = (effective_db.to_string(), table_name.clone());
+        let cached = table_details.get(&cache_key);
+
+        let schema = table_ref
+            .schema
+            .as_deref()
+            .or_else(|| cached.and_then(|c| c.schema.as_deref()))
+            .or(default_schema)
+            .unwrap_or("public");
 
         let fresh = match connection.table_details(effective_db, Some(schema), table_name) {
             Ok(info) => info,
             Err(_) => continue,
         };
 
-        match table_details.get(&cache_key) {
+        let fresh_has_columns = fresh.columns.as_deref().is_some_and(|c| !c.is_empty());
+        if !fresh_has_columns {
+            // Treat empty/None fresh columns as "schema lookup did not resolve
+            // a real table" — most commonly a wrong schema (search path, the
+            // user selected a different schema than where the table lives) or
+            // a dropped table. Either way, do not surface a phantom diff and
+            // do not write the empty TableInfo into the cache.
+            log::warn!(
+                "[DRIFT] fresh fetch for {effective_db}.{schema}.{table_name} returned no \
+                 columns; skipping (cached had {} cols)",
+                cached
+                    .and_then(|c| c.columns.as_deref())
+                    .map(|c| c.len())
+                    .unwrap_or(0)
+            );
+            continue;
+        }
+
+        match cached {
             None => {
                 // First encounter — populate cache silently, no drift to report.
                 refreshes.push((cache_key, fresh));
@@ -221,5 +267,379 @@ mod tests {
         assert!(changes.iter().any(
             |c| matches!(c, crate::schema::SchemaChange::ColumnRemoved(s) if s.name == "email")
         ));
+    }
+
+    // --- check_schema_drift integration: schema resolution & defensive guard ---
+    //
+    // These tests exercise the orchestration around `check_drift_sync`:
+    //   1. Which schema is passed to `connection.table_details()` for the fresh
+    //      fetch (the bug fixed here was a hardcoded "public" fallback).
+    //   2. The defensive skip when the fresh fetch yields no columns.
+    //
+    // A minimal in-module mock implements just enough of `Connection`. The
+    // mock returns the configured `TableInfo` when the driver is asked about a
+    // `(db, schema, table)` triple it knows, and `Ok(empty)` otherwise — this
+    // mirrors how PostgreSQL's `get_columns` behaves when the table does not
+    // live in the queried schema.
+
+    use crate::{
+        DbError, DbKind, DefaultSqlDialect, DriverCapabilities, DriverMetadata, QueryHandle,
+        QueryLanguage, QueryRequest, QueryResult, SchemaLoadingStrategy, SchemaSnapshot,
+        SqlDialect,
+    };
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    fn minimal_metadata() -> DriverMetadata {
+        DriverMetadata {
+            id: "mock".to_string(),
+            display_name: "Mock".to_string(),
+            description: "test".to_string(),
+            category: crate::DatabaseCategory::Relational,
+            deployment_class: None,
+            query_language: QueryLanguage::Sql,
+            capabilities: DriverCapabilities::empty(),
+            default_port: None,
+            uri_scheme: "mock".to_string(),
+            icon: crate::Icon::Database,
+            syntax: None,
+            query: None,
+            mutation: None,
+            ddl: None,
+            transactions: None,
+            limits: None,
+            ssl_modes: None,
+            ssl_cert_fields: None,
+            classification_override: None,
+        }
+    }
+
+    /// Driver mock that returns configured `TableInfo` for known
+    /// `(database, schema, table)` triples and an empty `TableInfo` otherwise.
+    struct MockDriver {
+        metadata: DriverMetadata,
+        refs: Vec<QueryTableRef>,
+        known: HashMap<(String, String, String), TableInfo>,
+        last_lookups: Mutex<Vec<(String, Option<String>, String)>>,
+    }
+
+    impl MockDriver {
+        fn new(refs: Vec<QueryTableRef>) -> Self {
+            Self {
+                metadata: minimal_metadata(),
+                refs,
+                known: HashMap::new(),
+                last_lookups: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn with_table(mut self, db: &str, schema: &str, table: &str, info: TableInfo) -> Self {
+            self.known.insert(
+                (db.to_string(), schema.to_string(), table.to_string()),
+                info,
+            );
+            self
+        }
+    }
+
+    impl Connection for MockDriver {
+        fn metadata(&self) -> &DriverMetadata {
+            &self.metadata
+        }
+        fn ping(&self) -> Result<(), DbError> {
+            Ok(())
+        }
+        fn close(&mut self) -> Result<(), DbError> {
+            Ok(())
+        }
+        fn execute(&self, _req: &QueryRequest) -> Result<QueryResult, DbError> {
+            Err(DbError::NotSupported("mock".into()))
+        }
+        fn cancel(&self, _handle: &QueryHandle) -> Result<(), DbError> {
+            Ok(())
+        }
+        fn schema(&self) -> Result<SchemaSnapshot, DbError> {
+            Ok(SchemaSnapshot::default())
+        }
+        fn kind(&self) -> DbKind {
+            DbKind::Postgres
+        }
+        fn schema_loading_strategy(&self) -> SchemaLoadingStrategy {
+            SchemaLoadingStrategy::LazyPerDatabase
+        }
+        fn dialect(&self) -> &dyn SqlDialect {
+            &DefaultSqlDialect
+        }
+
+        fn referenced_tables(&self, _query: &str) -> Option<Vec<QueryTableRef>> {
+            Some(self.refs.clone())
+        }
+
+        fn table_details(
+            &self,
+            database: &str,
+            schema: Option<&str>,
+            table: &str,
+        ) -> Result<TableInfo, DbError> {
+            self.last_lookups.lock().unwrap().push((
+                database.to_string(),
+                schema.map(String::from),
+                table.to_string(),
+            ));
+
+            let key = (
+                database.to_string(),
+                schema.unwrap_or("").to_string(),
+                table.to_string(),
+            );
+
+            if let Some(info) = self.known.get(&key) {
+                return Ok(info.clone());
+            }
+
+            // Mirror PostgreSQL: looking up a table in the wrong schema is not
+            // an error, it returns an empty column list.
+            Ok(TableInfo {
+                name: table.to_string(),
+                schema: schema.map(String::from),
+                columns: Some(Vec::new()),
+                indexes: None,
+                foreign_keys: None,
+                constraints: None,
+                sample_fields: None,
+                presentation: Default::default(),
+                child_items: None,
+            })
+        }
+    }
+
+    fn make_table_in(schema: &str, name: &str, columns: Vec<ColumnInfo>) -> TableInfo {
+        TableInfo {
+            name: name.to_string(),
+            schema: Some(schema.to_string()),
+            columns: Some(columns),
+            indexes: None,
+            foreign_keys: None,
+            constraints: None,
+            sample_fields: None,
+            presentation: Default::default(),
+            child_items: None,
+        }
+    }
+
+    /// The original bug: cached entry sits in `analytics`, query is unqualified,
+    /// editor toolbar's schema is `public` (the document default). Without the
+    /// fix, the fresh fetch is forced through `public` and reports all columns
+    /// as removed. With the fix, the cached entry's `schema` field steers the
+    /// fresh fetch to `analytics`, so the fingerprints match and no drift is
+    /// reported.
+    #[test]
+    fn cached_schema_overrides_default_schema_for_fresh_fetch() {
+        let table_in_analytics = make_table_in(
+            "analytics",
+            "events",
+            vec![col("id", "integer", false, true)],
+        );
+
+        let mut cache: std::collections::HashMap<(String, String), TableInfo> =
+            std::collections::HashMap::new();
+        cache.insert(
+            ("app_db".to_string(), "events".to_string()),
+            table_in_analytics.clone(),
+        );
+
+        let driver: Arc<dyn Connection> = Arc::new(
+            MockDriver::new(vec![QueryTableRef {
+                database: None,
+                schema: None,
+                table: "events".to_string(),
+            }])
+            .with_table("app_db", "analytics", "events", table_in_analytics),
+        );
+
+        let outcome = check_schema_drift(
+            &driver,
+            &cache,
+            "select * from events",
+            "app_db",
+            Some("public"),
+        );
+
+        match outcome {
+            DriftOutcome::Refresh(entries) => {
+                assert_eq!(entries.len(), 1);
+                let (_, info) = &entries[0];
+                assert_eq!(info.schema.as_deref(), Some("analytics"));
+            }
+            DriftOutcome::Skip => panic!("expected Refresh, got Skip"),
+            DriftOutcome::Drift(_) => panic!(
+                "must not report drift when cached.schema steers fresh fetch to the right schema"
+            ),
+        }
+    }
+
+    /// When no cache entry exists yet and the query is unqualified, fall back
+    /// to the caller-supplied default schema (the editor's toolbar selection).
+    #[test]
+    fn default_schema_used_when_cache_is_empty_and_query_unqualified() {
+        let cache: std::collections::HashMap<(String, String), TableInfo> =
+            std::collections::HashMap::new();
+
+        let table = make_table_in(
+            "analytics",
+            "tbl_v",
+            vec![col("id", "integer", false, true)],
+        );
+
+        let mock_driver = Arc::new(
+            MockDriver::new(vec![QueryTableRef {
+                database: None,
+                schema: None,
+                table: "tbl_v".to_string(),
+            }])
+            .with_table("db", "analytics", "tbl_v", table.clone()),
+        );
+        let driver: Arc<dyn Connection> = mock_driver.clone();
+
+        let outcome = check_schema_drift(
+            &driver,
+            &cache,
+            "select * from tbl_v",
+            "db",
+            Some("analytics"),
+        );
+
+        assert!(matches!(outcome, DriftOutcome::Refresh(_)));
+
+        let lookups = mock_driver.last_lookups.lock().unwrap();
+        assert_eq!(lookups.len(), 1);
+        assert_eq!(lookups[0].1.as_deref(), Some("analytics"));
+    }
+
+    /// Defensive skip: if the fresh fetch resolves to a schema where the
+    /// table doesn't exist, the driver returns an empty column list. The
+    /// drift checker must silently drop the entry instead of reporting
+    /// "all columns removed" and corrupting the cache.
+    #[test]
+    fn empty_fresh_columns_do_not_emit_diff_or_refresh() {
+        // Cached entry has columns but no recorded schema (mimics a driver
+        // that returns `schema: None` for the cached TableInfo). With the
+        // cached-schema fallback unavailable, the only remaining hint is
+        // the default `"public"` — which the mock driver does not know,
+        // so the fresh fetch comes back empty.
+        let mut cached_without_schema = make_table_in(
+            "public",
+            "tbl_v",
+            vec![
+                col("id", "integer", false, true),
+                col("name", "text", true, false),
+            ],
+        );
+        cached_without_schema.schema = None;
+
+        let mut cache: std::collections::HashMap<(String, String), TableInfo> =
+            std::collections::HashMap::new();
+        cache.insert(
+            ("db".to_string(), "tbl_v".to_string()),
+            cached_without_schema,
+        );
+
+        let driver: Arc<dyn Connection> = Arc::new(MockDriver::new(vec![QueryTableRef {
+            database: None,
+            schema: None,
+            table: "tbl_v".to_string(),
+        }]));
+
+        let outcome = check_schema_drift(&driver, &cache, "select * from tbl_v", "db", None);
+
+        match outcome {
+            DriftOutcome::Refresh(entries) => {
+                assert!(
+                    entries.is_empty(),
+                    "empty fresh must not be written into the cache"
+                );
+            }
+            DriftOutcome::Skip => panic!("driver supports referenced_tables — must not Skip"),
+            DriftOutcome::Drift(_) => {
+                panic!("empty fresh columns must not surface as a phantom diff")
+            }
+        }
+    }
+
+    /// First-encounter with an empty fresh result also gets skipped — we must
+    /// never persist a zero-column `TableInfo` into the cache, since the
+    /// sidebar and autocomplete treat `Some(vec![])` as "loaded with no
+    /// columns" and stop trying to fetch real data.
+    #[test]
+    fn empty_fresh_columns_skipped_on_first_encounter() {
+        let cache: std::collections::HashMap<(String, String), TableInfo> =
+            std::collections::HashMap::new();
+
+        let driver: Arc<dyn Connection> = Arc::new(MockDriver::new(vec![QueryTableRef {
+            database: None,
+            schema: None,
+            table: "tbl_v".to_string(),
+        }]));
+
+        let outcome =
+            check_schema_drift(&driver, &cache, "select * from tbl_v", "db", Some("public"));
+
+        match outcome {
+            DriftOutcome::Refresh(entries) => {
+                assert!(
+                    entries.is_empty(),
+                    "first-encounter cache writes must skip empty TableInfo to avoid poisoning"
+                );
+            }
+            other => panic!(
+                "expected empty Refresh; got {:?}",
+                match other {
+                    DriftOutcome::Skip => "Skip",
+                    DriftOutcome::Drift(_) => "Drift",
+                    DriftOutcome::Refresh(_) => unreachable!(),
+                }
+            ),
+        }
+    }
+
+    /// Query qualifier still wins over cached schema and default schema.
+    #[test]
+    fn explicit_query_schema_wins_over_cached_and_default() {
+        let table_in_analytics = make_table_in(
+            "analytics",
+            "tbl_v",
+            vec![col("id", "integer", false, true)],
+        );
+        let table_in_public =
+            make_table_in("public", "tbl_v", vec![col("id", "bigint", false, true)]);
+
+        let mut cache: std::collections::HashMap<(String, String), TableInfo> =
+            std::collections::HashMap::new();
+        cache.insert(
+            ("db".to_string(), "tbl_v".to_string()),
+            table_in_analytics.clone(),
+        );
+
+        let mock_driver = Arc::new(
+            MockDriver::new(vec![QueryTableRef {
+                database: None,
+                schema: Some("public".to_string()),
+                table: "tbl_v".to_string(),
+            }])
+            .with_table("db", "analytics", "tbl_v", table_in_analytics)
+            .with_table("db", "public", "tbl_v", table_in_public),
+        );
+        let driver: Arc<dyn Connection> = mock_driver.clone();
+
+        let _ = check_schema_drift(
+            &driver,
+            &cache,
+            "select * from public.tbl_v",
+            "db",
+            Some("analytics"),
+        );
+
+        let lookups = mock_driver.last_lookups.lock().unwrap();
+        assert_eq!(lookups[0].1.as_deref(), Some("public"));
     }
 }

--- a/crates/dbflux_ui/src/ui/document/code/execution.rs
+++ b/crates/dbflux_ui/src/ui/document/code/execution.rs
@@ -310,13 +310,21 @@ impl CodeDocument {
             })
             .unwrap_or_else(|| "default".to_string());
 
+        let default_schema = self.exec_ctx.schema.clone();
+
         self.drift_preflight_running = true;
         cx.notify();
 
         let query_capture = query.clone();
 
         let task = cx.background_executor().spawn(async move {
-            check_schema_drift(&connection, &table_details, &query, &database)
+            check_schema_drift(
+                &connection,
+                &table_details,
+                &query,
+                &database,
+                default_schema.as_deref(),
+            )
         });
 
         cx.spawn(async move |this, cx| {


### PR DESCRIPTION
## Summary

Fixes a schema-drift preflight regression that fired a false "Schema has changed since this query was opened" modal — with **every column reported as `removed`** — for any unqualified query whose table lives outside the `public` schema. Clicking *Refresh & re-run* then poisoned the local cache with the empty `TableInfo`, blanking out autocomplete and the table-detail view until the user manually refreshed from the sidebar; the very next query reproduced the loop.

The fix is two-part:

1. Layered schema resolution in `check_schema_drift` so the fresh fetch is sent to the right schema.
2. A defensive guard that skips drift entries whose driver lookup returns zero columns, so the cache can never be poisoned through this path again.

Plus one repo-hygiene chore (`.gitattributes` pinning LF) that came up while preparing the patch on Windows.

## What does this resolve?

Reported in private review with a screenshot showing all 32 columns of a non-`public`-schema table marked `removed` against a PostgreSQL connection. Repro:

- The "Schema has changed" preflight modal misreports every column as removed when the query references a table outside `public` and is unqualified (e.g. `SELECT … FROM events` while the toolbar's Schema selector is on `analytics`).
- Subsequent "Refresh & re-run" overwrites the cached `TableInfo` with the empty result, breaking autocomplete and the column tree until a manual sidebar refresh.
- After a sidebar refresh, the next unqualified query reproduces the modal — endless cycle.

No upstream issue tracker reference.

## Root cause

`crates/dbflux_core/src/schema/drift_check.rs` (pre-fix line 85):

```rust
let schema = table_ref.schema.as_deref().unwrap_or("public");
```

The lightweight query parser at `crates/dbflux_core/src/schema/query_parser.rs` returns `QueryTableRef { schema: None, … }` for an unqualified `FROM events`. The drift checker then unconditionally falls back to `"public"`, calls `connection.table_details(db, Some("public"), "events")`, and the PostgreSQL driver's `get_columns` (`crates/dbflux_driver_postgres/src/driver.rs:2319`) issues:

```sql
SELECT … FROM pg_attribute a
JOIN pg_class c ON c.oid = a.attrelid
JOIN pg_namespace n ON n.oid = c.relnamespace
WHERE n.nspname = $1 AND c.relname = $2 …
```

For a table that lives in a non-`public` schema, this returns zero rows → `Ok(TableInfo { columns: Some(vec![]) })`. The fingerprint differs from the cached version (which holds the real columns from when the sidebar opened the table with the correct schema), so `diff_table_info` reports each column as `ColumnRemoved`. The modal's "Refresh & re-run" path at `crates/dbflux_ui/src/ui/document/code/execution.rs:1558-1562` then writes that empty `TableInfo` into `ConnectedProfile.table_details`, which is the same map autocomplete and `Sidebar::ensure_table_details` read from — hence the downstream blanking.

The drift checker also ignored the editor toolbar's `exec_ctx.schema` selector entirely, so even when the user *had* told the editor "I'm working in this schema", the drift preflight didn't know about it.

## How was this solved?

### `crates/dbflux_core/src/schema/drift_check.rs`

- Added a `default_schema: Option<&str>` parameter.
- Replaced the hardcoded `unwrap_or("public")` with a layered precedence — falling back to the cached entry's own `schema` field whenever a cached `TableInfo` exists, and to the caller-supplied `default_schema` otherwise:

  ```rust
  let schema = table_ref
      .schema
      .as_deref()
      .or_else(|| cached.and_then(|c| c.schema.as_deref()))
      .or(default_schema)
      .unwrap_or("public");
  ```

  The cached `TableInfo.schema` is the right authority because the only paths that populate the cache (`Sidebar::spawn_fetch_table_details`, `refresh_schema_object`) fetch with the schema from the sidebar tree node, where the schema is unambiguous.

- Added a defensive early-`continue` when the fresh fetch comes back with `columns: None` or `Some(vec![])`. A real table can't have zero columns; the much more likely interpretations are wrong-schema lookup, dropped table, or search-path race — none of which should produce a phantom diff or persist an empty `TableInfo` into the cache. Skipped entries get a `log::warn!` so the diagnostic is preserved.

### `crates/dbflux_ui/src/ui/document/code/execution.rs`

- `start_drift_preflight` now captures `self.exec_ctx.schema` (the toolbar's Schema dropdown) and forwards it as `default_schema` to `check_schema_drift`.

### `.gitattributes` (chore)

Pins `* text=auto eol=lf` plus a binary-extensions list. `rustfmt.toml` is configured `newline_style = "Unix"`, so `cargo fmt` writes LF; without `.gitattributes`, contributors on Windows whose global git config has `core.autocrlf=true` (the Git for Windows default) see hundreds of files flagged as modified after the first format run, even though `git diff --cached --stat` would be empty. Repo-level `eol=lf` removes the failure mode for everyone regardless of OS or local git config.

## Validation

### What I actually ran

- `cargo fmt --all -- --check` — clean.
- `cargo check -p dbflux_core --tests` and `cargo check -p dbflux_ui --features "sqlite,postgres,mysql,mongodb,redis,dynamodb,aws"` — clean.
- `cargo clippy -p dbflux_core -- -D warnings` — clean.
- `cargo test -p dbflux_core --lib schema::` — 43/43 pass.

### Tests added (5 new integration tests in `drift_check.rs`)

A minimal `MockDriver` implementing `Connection` is added to the `mod tests` block. It captures every call to `table_details` so assertions can verify which schema was actually queried. Coverage:

| Test | What it locks in |
|---|---|
| `cached_schema_overrides_default_schema_for_fresh_fetch` | Reproduces the original bug — without the cached-schema fallback the test fails with `DriftOutcome::Drift` and the assertion message *"must not report drift when cached.schema steers fresh fetch to the right schema"*. |
| `default_schema_used_when_cache_is_empty_and_query_unqualified` | First-encounter lookup uses the caller's `default_schema` (the toolbar selection) instead of `"public"`. |
| `explicit_query_schema_wins_over_cached_and_default` | Sanity check that a qualified `FROM public.events` still routes to `public`. (Passes against the buggy code too — explicit qualifiers were never broken.) |
| `empty_fresh_columns_do_not_emit_diff_or_refresh` | Defensive guard: cached has columns, fresh returns empty → outcome is empty `Refresh`, not `Drift`. |
| `empty_fresh_columns_skipped_on_first_encounter` | Defensive guard: no cache entry, fresh returns empty → empty `Refresh`, never persists the empty `TableInfo`. |

I confirmed the suite is meaningful by reverting just the function body (keeping the new signature so it compiles) and re-running:

```
running 9 tests
test schema::drift_check::tests::cached_schema_overrides_default_schema_for_fresh_fetch ... FAILED
test schema::drift_check::tests::default_schema_used_when_cache_is_empty_and_query_unqualified ... FAILED
test schema::drift_check::tests::empty_fresh_columns_do_not_emit_diff_or_refresh ... FAILED
test schema::drift_check::tests::empty_fresh_columns_skipped_on_first_encounter ... FAILED
test schema::drift_check::tests::explicit_query_schema_wins_over_cached_and_default ... ok
…
test result: FAILED. 5 passed; 4 failed
```

With the fix restored: 9/9 pass.

### What I did NOT do

- I did not run the app interactively against a live PostgreSQL instance to confirm the bug disappears end-to-end. The bug report came from a user-provided screenshot of the modal, and the fix is locked in by tests that reproduce the exact failure path; I think that's sufficient evidence, but a maintainer with a quick repro setup may want to spot-check.
- I did not verify on Linux or macOS. The change is platform-independent in principle, and CI should cover the rest.

### Pre-existing failures noted but not addressed

- `cargo clippy --workspace -- -D warnings` fails inside `dbflux_proxy` with `clippy::large_enum_variant` on `enum ProxiedStream`. **Verified** on a clean checkout of `upstream/main` (stashed my changes, checked out upstream's `dbflux_proxy/`, ran clippy, got the same error). Not a regression from this branch.
- `cargo test -p dbflux_core --lib` reports 6 failures under `connection::hook::tests::execute_*` on Windows (subprocess / shell tests). I did **not** explicitly verify these on upstream's untouched `main` — I'm flagging them based on the test names being unrelated to my changes. If a maintainer wants confirmation either way, please ping and I'll bisect.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests (5 new integration tests + the existing `check_drift_sync` suite)
- [ ] Linux
- [ ] macOS
- [x] Windows (build / test / clippy / fmt only — no manual UI verification)
- [ ] X11
- [ ] Wayland

## Checklist

- [x] I verified the change against the affected user flow(s) — via tests, not interactive UI
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable (the cache key is `(database, table_name)` — schema-name collisions across same-named tables are still possible; out of scope for this fix and noted here for awareness)
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` (one entry under `### Fixes`, one under `### Chores`)
- [x] I applied the appropriate labels (see below)

## Labels to apply

- `query:bug` (drift detection lives under the query subsystem)
- `driver:postgres` (most affected; the bug is reproducible against any driver where tables can live outside `public`)
- `kind:sql`
- `platform:windows` (only because the chore part — `.gitattributes` — fixes a Windows-specific contributor pain point; the bug fix itself is platform-independent)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
