### PR TITLE
feat(ui): platform-aware keybindings (Cmd on macOS, Ctrl elsewhere)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+* **Platform-aware keybindings** — application-level shortcuts now use
+  Cmd on macOS and Ctrl on Linux/Windows: command palette
+  (`Cmd/Ctrl+Shift+P`), new/close/switch tab, run query, save, open
+  script/history, export results, toggle sidebar, audit viewer, and
+  Results cell copy. vim-style navigation (`Ctrl+h/j/k/l`, `Ctrl+u/d`)
+  and `Ctrl+Tab` / `Ctrl+Shift+Tab` stay literal Ctrl on every platform,
+  along with focus shortcuts (`Ctrl+Shift+1..4`) that would clash with
+  macOS screenshot bindings and `Ctrl+M` which would clash with
+  window-minimize on macOS. Inline data-table commands (Copy, Save row,
+  Select all, Undo/Redo) use GPUI's `secondary-` modifier so they pick
+  the right key per platform. Command-palette shortcut labels and the
+  SQL editor / save-row hints now reflect the platform modifier. Closes
+  #63.
+
 ## [0.6.0-dev.0] - 2026-05-12
 
 ### Features

--- a/crates/dbflux_app/src/keymap/chord.rs
+++ b/crates/dbflux_app/src/keymap/chord.rs
@@ -43,6 +43,43 @@ impl Modifiers {
         }
     }
 
+    /// Platform-aware "primary" modifier: Cmd on macOS, Ctrl elsewhere.
+    ///
+    /// Use this for application-level commands (palette, save, copy, new tab,
+    /// run query, …) where the convention is Cmd on macOS but Ctrl everywhere
+    /// else. For vim-style navigation (Ctrl+hjkl, Ctrl+u/d) and bindings that
+    /// would clash with macOS system shortcuts (Cmd+M, Cmd+Shift+3/4), keep
+    /// using [`Modifiers::ctrl`] / [`Modifiers::ctrl_shift`] instead.
+    pub fn primary() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            Self {
+                platform: true,
+                ..Default::default()
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Self::ctrl()
+        }
+    }
+
+    /// Primary + Shift: Cmd+Shift on macOS, Ctrl+Shift elsewhere.
+    pub fn primary_shift() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            Self {
+                platform: true,
+                shift: true,
+                ..Default::default()
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Self::ctrl_shift()
+        }
+    }
+
     #[allow(dead_code)]
     pub fn has_any(&self) -> bool {
         self.ctrl || self.alt || self.shift || self.platform
@@ -128,8 +165,13 @@ impl KeyChord {
 
 impl fmt::Display for KeyChord {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Order: Cmd, Ctrl, Alt, Shift — matches the convention used in
+        // user-facing docs (e.g. "Cmd+Shift+P", "Ctrl+Shift+P").
         let mut parts = Vec::new();
 
+        if self.modifiers.platform {
+            parts.push("Cmd");
+        }
         if self.modifiers.ctrl {
             parts.push("Ctrl");
         }
@@ -138,9 +180,6 @@ impl fmt::Display for KeyChord {
         }
         if self.modifiers.shift {
             parts.push("Shift");
-        }
-        if self.modifiers.platform {
-            parts.push("Cmd");
         }
 
         let key_display = match self.key.as_str() {
@@ -215,5 +254,33 @@ mod tests {
     fn test_display() {
         let chord = KeyChord::new("p", Modifiers::ctrl_shift());
         assert_eq!(chord.to_string(), "Ctrl+Shift+p");
+    }
+
+    #[test]
+    fn test_display_cmd_first() {
+        let chord = KeyChord {
+            key: "p".to_string(),
+            modifiers: Modifiers {
+                platform: true,
+                shift: true,
+                ..Modifiers::none()
+            },
+        };
+        assert_eq!(chord.to_string(), "Cmd+Shift+p");
+    }
+
+    #[test]
+    fn test_primary_modifier_per_platform() {
+        let m = Modifiers::primary();
+        #[cfg(target_os = "macos")]
+        {
+            assert!(m.platform);
+            assert!(!m.ctrl);
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert!(m.ctrl);
+            assert!(!m.platform);
+        }
     }
 }

--- a/crates/dbflux_ui/src/keymap/actions.rs
+++ b/crates/dbflux_ui/src/keymap/actions.rs
@@ -68,19 +68,35 @@ actions!(
 );
 
 /// Keybindings that shadow `gpui-component` input defaults inside the "Input"
-/// context so that Ctrl+Enter / Ctrl+Shift+Enter run the active query instead of
-/// inserting a newline.
+/// context so that the primary modifier + Enter runs the active query instead
+/// of inserting a newline.
 ///
 /// `gpui-component` binds `secondary-enter` (== Ctrl+Enter on Linux/Windows,
-/// Cmd+Enter on macOS) to its internal `Enter` action, which in multi-line mode
-/// inserts a newline. Registering these bindings after `gpui_component::init`
-/// makes them take precedence at the same context depth.
+/// Cmd+Enter on macOS) to its internal `Enter` action, which in multi-line
+/// mode inserts a newline. Registering these bindings after
+/// `gpui_component::init` makes them take precedence at the same context
+/// depth.
+///
+/// We bind the platform-appropriate keystroke directly (`cmd-enter` on macOS,
+/// `ctrl-enter` elsewhere) rather than the abstract `secondary-` form so the
+/// macOS Ctrl+Enter stays free for editor interrupt semantics and matches the
+/// Cmd convention used by `results_layer` for ResultsCopyCell.
 pub fn input_context_keybindings() -> Vec<KeyBinding> {
     let ctx = Some("Input");
-    vec![
-        KeyBinding::new("ctrl-enter", RunQuery, ctx),
-        KeyBinding::new("ctrl-shift-enter", RunQueryInNewTab, ctx),
-    ]
+    #[cfg(target_os = "macos")]
+    {
+        vec![
+            KeyBinding::new("cmd-enter", RunQuery, ctx),
+            KeyBinding::new("cmd-shift-enter", RunQueryInNewTab, ctx),
+        ]
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        vec![
+            KeyBinding::new("ctrl-enter", RunQuery, ctx),
+            KeyBinding::new("ctrl-shift-enter", RunQueryInNewTab, ctx),
+        ]
+    }
 }
 
 #[cfg(test)]
@@ -98,29 +114,32 @@ mod tests {
         let bindings = input_context_keybindings();
         assert_eq!(bindings.len(), 2);
 
-        let ctrl_enter = Keystroke::parse("ctrl-enter").unwrap();
-        let ctrl_shift_enter = Keystroke::parse("ctrl-shift-enter").unwrap();
+        #[cfg(target_os = "macos")]
+        let (run, run_new) = (
+            Keystroke::parse("cmd-enter").unwrap(),
+            Keystroke::parse("cmd-shift-enter").unwrap(),
+        );
+        #[cfg(not(target_os = "macos"))]
+        let (run, run_new) = (
+            Keystroke::parse("ctrl-enter").unwrap(),
+            Keystroke::parse("ctrl-shift-enter").unwrap(),
+        );
 
         assert!(
-            bindings[0].match_keystrokes(&[ctrl_enter]) == Some(false)
+            bindings[0].match_keystrokes(&[run]) == Some(false)
                 && bindings[0].action().partial_eq(&RunQuery),
         );
         assert!(
-            bindings[1].match_keystrokes(&[ctrl_shift_enter]) == Some(false)
+            bindings[1].match_keystrokes(&[run_new]) == Some(false)
                 && bindings[1].action().partial_eq(&RunQueryInNewTab),
         );
     }
 
-    // Regression test for the Ctrl+Enter conflict on Linux/Windows:
-    // `gpui-component` registers `secondary-enter` (== ctrl-enter on non-mac)
-    // in the "Input" context, which would otherwise consume Ctrl+Enter and
-    // insert a newline. Adding our binding afterwards at the same context
-    // depth must win.
-    //
-    // On macOS `secondary` resolves to `cmd`, so the two keystrokes don't
-    // collide and the override is unnecessary — the precedence claim here
-    // doesn't apply, hence the cfg gate.
-    #[cfg(not(target_os = "macos"))]
+    // Regression test for the run-query / newline conflict:
+    // `gpui-component` registers `secondary-enter` in the "Input" context
+    // (== Ctrl+Enter on Linux/Windows, Cmd+Enter on macOS), which would
+    // otherwise consume the run-query chord and insert a newline. Our binding
+    // is registered afterwards at the same context depth so it must win.
     #[test]
     fn input_context_keybindings_override_secondary_enter() {
         gpui::actions!(dbflux_test_only, [PriorEnterBinding]);
@@ -135,13 +154,19 @@ mod tests {
         // Our override, registered later.
         keymap.add_bindings(input_context_keybindings());
 
-        let typed = [Keystroke::parse("ctrl-enter").unwrap()];
+        #[cfg(target_os = "macos")]
+        let run_keystroke = "cmd-enter";
+        #[cfg(not(target_os = "macos"))]
+        let run_keystroke = "ctrl-enter";
+
+        let typed = [Keystroke::parse(run_keystroke).unwrap()];
         let context_stack = [KeyContext::parse("Input").unwrap()];
         let (matches, _pending) = keymap.bindings_for_input(&typed, &context_stack);
 
-        let top = matches
-            .first()
-            .expect("ctrl-enter should match at least one binding in the Input context");
+        let top = matches.first().expect(
+            "the primary-modifier+Enter chord should match at least one binding in the \
+             Input context",
+        );
         assert!(
             top.action().partial_eq(&RunQuery),
             "RunQuery must take precedence over the earlier secondary-enter binding",

--- a/crates/dbflux_ui/src/keymap/defaults.rs
+++ b/crates/dbflux_ui/src/keymap/defaults.rs
@@ -32,18 +32,24 @@ pub fn default_keymap() -> &'static KeymapStack {
 fn global_layer() -> KeymapLayer {
     let mut layer = KeymapLayer::new(ContextId::Global);
 
-    // Command palette
+    // Command palette — Cmd+Shift+P on macOS, Ctrl+Shift+P elsewhere.
     layer.bind(
-        KeyChord::new("p", Modifiers::ctrl_shift()),
+        KeyChord::new("p", Modifiers::primary_shift()),
         Command::ToggleCommandPalette,
     );
 
-    // Tab management
-    layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);
+    // Tab management — primary modifier (Cmd on macOS, Ctrl elsewhere).
     layer.bind(
-        KeyChord::new("w", Modifiers::ctrl()),
+        KeyChord::new("n", Modifiers::primary()),
+        Command::NewQueryTab,
+    );
+    layer.bind(
+        KeyChord::new("w", Modifiers::primary()),
         Command::CloseCurrentTab,
     );
+    // Ctrl+Tab / Ctrl+Shift+Tab stay literal Ctrl on every platform — that is
+    // the long-standing tabbed-UI idiom (browsers, terminals). Cmd+Tab on
+    // macOS is the system app switcher and must not be shadowed.
     layer.bind(KeyChord::new("tab", Modifiers::ctrl()), Command::NextTab);
     layer.bind(
         KeyChord::new("tab", Modifiers::ctrl_shift()),
@@ -51,21 +57,24 @@ fn global_layer() -> KeymapLayer {
     );
     for i in 1..=9 {
         layer.bind(
-            KeyChord::new(i.to_string(), Modifiers::ctrl()),
+            KeyChord::new(i.to_string(), Modifiers::primary()),
             Command::SwitchToTab(i),
         );
     }
 
     // File operations
     layer.bind(
-        KeyChord::new("o", Modifiers::ctrl()),
+        KeyChord::new("o", Modifiers::primary()),
         Command::OpenScriptFile,
     );
 
     // Query execution
-    layer.bind(KeyChord::new("enter", Modifiers::ctrl()), Command::RunQuery);
     layer.bind(
-        KeyChord::new("enter", Modifiers::ctrl_shift()),
+        KeyChord::new("enter", Modifiers::primary()),
+        Command::RunQuery,
+    );
+    layer.bind(
+        KeyChord::new("enter", Modifiers::primary_shift()),
         Command::RunQueryInNewTab,
     );
 
@@ -82,7 +91,10 @@ fn global_layer() -> KeymapLayer {
         Command::CycleFocusBackward,
     );
 
-    // Direct focus shortcuts
+    // Direct focus shortcuts — stay Ctrl+Shift+1..4 on every platform.
+    // Cmd+Shift+3 and Cmd+Shift+4 are reserved by macOS for screenshots, so
+    // switching the whole group to the primary modifier would silently break
+    // two of the four bindings on Mac.
     layer.bind(
         KeyChord::new("1", Modifiers::ctrl_shift()),
         Command::FocusSidebar,
@@ -100,19 +112,20 @@ fn global_layer() -> KeymapLayer {
         Command::FocusBackgroundTasks,
     );
 
-    // Open audit viewer (Ctrl+Shift+A)
+    // Open audit viewer
     layer.bind(
-        KeyChord::new("a", Modifiers::ctrl_shift()),
+        KeyChord::new("a", Modifiers::primary_shift()),
         Command::OpenAuditViewer,
     );
 
-    // Toggle sidebar (Ctrl+B)
+    // Toggle sidebar
     layer.bind(
-        KeyChord::new("b", Modifiers::ctrl()),
+        KeyChord::new("b", Modifiers::primary()),
         Command::ToggleSidebar,
     );
 
-    // Tab context menu
+    // Tab context menu — stays Ctrl+M everywhere: Cmd+M is the system
+    // "minimize window" shortcut on macOS.
     layer.bind(KeyChord::new("m", Modifiers::ctrl()), Command::OpenTabMenu);
 
     layer
@@ -121,7 +134,10 @@ fn global_layer() -> KeymapLayer {
 fn sidebar_layer() -> KeymapLayer {
     let mut layer = KeymapLayer::new(ContextId::Sidebar);
 
-    layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);
+    layer.bind(
+        KeyChord::new("n", Modifiers::primary()),
+        Command::NewQueryTab,
+    );
     layer.bind(KeyChord::new("/", Modifiers::none()), Command::FocusSearch);
     layer.bind(
         KeyChord::new("q", Modifiers::none()),
@@ -243,12 +259,12 @@ fn editor_layer() -> KeymapLayer {
         Command::ToggleHistoryDropdown,
     );
     layer.bind(
-        KeyChord::new("p", Modifiers::ctrl()),
+        KeyChord::new("p", Modifiers::primary()),
         Command::OpenSavedQueries,
     );
-    layer.bind(KeyChord::new("s", Modifiers::ctrl()), Command::SaveQuery);
+    layer.bind(KeyChord::new("s", Modifiers::primary()), Command::SaveQuery);
     layer.bind(
-        KeyChord::new("s", Modifiers::ctrl_shift()),
+        KeyChord::new("s", Modifiers::primary_shift()),
         Command::SaveFileAs,
     );
 
@@ -295,6 +311,10 @@ fn history_modal_layer() -> KeymapLayer {
     layer.bind(KeyChord::new("enter", Modifiers::none()), Command::Execute);
     layer.bind(KeyChord::new("escape", Modifiers::none()), Command::Cancel);
 
+    // Local mnemonics — Ctrl on every platform. Mapping these to the primary
+    // modifier would clash with macOS conventions (Cmd+F = system Find,
+    // Cmd+R = reload/run) without giving the user anything they didn't already
+    // have via the standard Save command below.
     layer.bind(KeyChord::new("d", Modifiers::ctrl()), Command::Delete);
     layer.bind(
         KeyChord::new("f", Modifiers::ctrl()),
@@ -302,7 +322,7 @@ fn history_modal_layer() -> KeymapLayer {
     );
     layer.bind(KeyChord::new("r", Modifiers::ctrl()), Command::Rename);
     layer.bind(KeyChord::new("/", Modifiers::none()), Command::FocusSearch);
-    layer.bind(KeyChord::new("s", Modifiers::ctrl()), Command::SaveQuery);
+    layer.bind(KeyChord::new("s", Modifiers::primary()), Command::SaveQuery);
 
     layer
 }
@@ -310,9 +330,12 @@ fn history_modal_layer() -> KeymapLayer {
 fn results_layer() -> KeymapLayer {
     let mut layer = KeymapLayer::new(ContextId::Results);
 
-    layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);
+    layer.bind(
+        KeyChord::new("n", Modifiers::primary()),
+        Command::NewQueryTab,
+    );
 
-    // Panel navigation (Ctrl+hjkl)
+    // Panel navigation (Ctrl+hjkl) — vim-style, literal Ctrl on every platform.
     layer.bind(KeyChord::new("h", Modifiers::ctrl()), Command::FocusLeft);
     layer.bind(KeyChord::new("j", Modifiers::ctrl()), Command::FocusToolbar);
     layer.bind(KeyChord::new("k", Modifiers::ctrl()), Command::FocusUp);
@@ -366,7 +389,7 @@ fn results_layer() -> KeymapLayer {
 
     // Export
     layer.bind(
-        KeyChord::new("e", Modifiers::ctrl()),
+        KeyChord::new("e", Modifiers::primary()),
         Command::ExportResults,
     );
 
@@ -390,23 +413,10 @@ fn results_layer() -> KeymapLayer {
     );
 
     // Copy selected cell(s) to clipboard — Cmd+C on macOS, Ctrl+C elsewhere.
-    // GPUI reports cmd vs ctrl on separate modifier fields, so we pick one
-    // per platform rather than binding both (which would let Ctrl+C trigger
-    // copy on macOS, violating the platform convention).
-    #[cfg(target_os = "macos")]
+    // GPUI reports cmd vs ctrl on separate modifier fields, so binding only
+    // the platform-correct chord keeps Ctrl+C on macOS from triggering copy.
     layer.bind(
-        KeyChord {
-            key: "c".to_string(),
-            modifiers: Modifiers {
-                platform: true,
-                ..Modifiers::none()
-            },
-        },
-        Command::ResultsCopyCell,
-    );
-    #[cfg(not(target_os = "macos"))]
-    layer.bind(
-        KeyChord::new("c", Modifiers::ctrl()),
+        KeyChord::new("c", Modifiers::primary()),
         Command::ResultsCopyCell,
     );
 
@@ -460,9 +470,12 @@ fn context_menu_layer() -> KeymapLayer {
 fn background_tasks_layer() -> KeymapLayer {
     let mut layer = KeymapLayer::new(ContextId::BackgroundTasks);
 
-    layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);
+    layer.bind(
+        KeyChord::new("n", Modifiers::primary()),
+        Command::NewQueryTab,
+    );
 
-    // Panel navigation (Ctrl+hjkl)
+    // Panel navigation (Ctrl+hjkl) — vim-style, literal Ctrl on every platform.
     layer.bind(KeyChord::new("h", Modifiers::ctrl()), Command::FocusLeft);
     layer.bind(KeyChord::new("j", Modifiers::ctrl()), Command::FocusDown);
     layer.bind(KeyChord::new("k", Modifiers::ctrl()), Command::FocusUp);
@@ -550,7 +563,10 @@ fn connection_manager_layer() -> KeymapLayer {
 fn form_navigation_layer() -> KeymapLayer {
     let mut layer = KeymapLayer::new(ContextId::FormNavigation);
 
-    layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);
+    layer.bind(
+        KeyChord::new("n", Modifiers::primary()),
+        Command::NewQueryTab,
+    );
 
     layer.bind(KeyChord::new("j", Modifiers::none()), Command::SelectNext);
     layer.bind(KeyChord::new("k", Modifiers::none()), Command::SelectPrev);
@@ -565,7 +581,10 @@ fn form_navigation_layer() -> KeymapLayer {
 fn text_input_layer() -> KeymapLayer {
     let mut layer = KeymapLayer::new(ContextId::TextInput);
 
-    layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);
+    layer.bind(
+        KeyChord::new("n", Modifiers::primary()),
+        Command::NewQueryTab,
+    );
 
     // Escape exits text input mode
     layer.bind(KeyChord::new("escape", Modifiers::none()), Command::Cancel);
@@ -576,20 +595,26 @@ fn text_input_layer() -> KeymapLayer {
 fn context_bar_layer() -> KeymapLayer {
     let mut layer = KeymapLayer::new(ContextId::ContextBar);
 
-    // Commands that should pass through to the workspace/document
-    layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);
-    layer.bind(KeyChord::new("enter", Modifiers::ctrl()), Command::RunQuery);
+    // Commands that should pass through to the workspace/document.
     layer.bind(
-        KeyChord::new("enter", Modifiers::ctrl_shift()),
+        KeyChord::new("n", Modifiers::primary()),
+        Command::NewQueryTab,
+    );
+    layer.bind(
+        KeyChord::new("enter", Modifiers::primary()),
+        Command::RunQuery,
+    );
+    layer.bind(
+        KeyChord::new("enter", Modifiers::primary_shift()),
         Command::RunQueryInNewTab,
     );
     layer.bind(
-        KeyChord::new("w", Modifiers::ctrl()),
+        KeyChord::new("w", Modifiers::primary()),
         Command::CloseCurrentTab,
     );
-    layer.bind(KeyChord::new("s", Modifiers::ctrl()), Command::SaveQuery);
+    layer.bind(KeyChord::new("s", Modifiers::primary()), Command::SaveQuery);
     layer.bind(
-        KeyChord::new("s", Modifiers::ctrl_shift()),
+        KeyChord::new("s", Modifiers::primary_shift()),
         Command::SaveFileAs,
     );
 
@@ -721,7 +746,10 @@ fn audit_layer() -> KeymapLayer {
 fn dropdown_layer() -> KeymapLayer {
     let mut layer = KeymapLayer::new(ContextId::Dropdown);
 
-    layer.bind(KeyChord::new("n", Modifiers::ctrl()), Command::NewQueryTab);
+    layer.bind(
+        KeyChord::new("n", Modifiers::primary()),
+        Command::NewQueryTab,
+    );
 
     // Navigation within dropdown
     layer.bind(KeyChord::new("j", Modifiers::none()), Command::SelectNext);
@@ -748,7 +776,7 @@ mod tests {
     fn test_default_keymap_resolves_global() {
         let keymap = default_keymap();
 
-        let chord = KeyChord::new("p", Modifiers::ctrl_shift());
+        let chord = KeyChord::new("p", Modifiers::primary_shift());
         assert_eq!(
             keymap.resolve(ContextId::Global, &chord),
             Some(Command::ToggleCommandPalette)
@@ -777,19 +805,19 @@ mod tests {
         let keymap = default_keymap();
 
         let alt_h = KeyChord::new("h", Modifiers::alt());
-        let ctrl_p = KeyChord::new("p", Modifiers::ctrl());
-        let ctrl_s = KeyChord::new("s", Modifiers::ctrl());
+        let primary_p = KeyChord::new("p", Modifiers::primary());
+        let primary_s = KeyChord::new("s", Modifiers::primary());
 
         assert_eq!(
             keymap.resolve(ContextId::Editor, &alt_h),
             Some(Command::ToggleHistoryDropdown)
         );
         assert_eq!(
-            keymap.resolve(ContextId::Editor, &ctrl_p),
+            keymap.resolve(ContextId::Editor, &primary_p),
             Some(Command::OpenSavedQueries)
         );
         assert_eq!(
-            keymap.resolve(ContextId::Editor, &ctrl_s),
+            keymap.resolve(ContextId::Editor, &primary_s),
             Some(Command::SaveQuery)
         );
     }
@@ -798,25 +826,25 @@ mod tests {
     fn test_global_fallback_from_sidebar() {
         let keymap = default_keymap();
 
-        let ctrl_enter = KeyChord::new("enter", Modifiers::ctrl());
+        let primary_enter = KeyChord::new("enter", Modifiers::primary());
         assert_eq!(
-            keymap.resolve(ContextId::Sidebar, &ctrl_enter),
+            keymap.resolve(ContextId::Sidebar, &primary_enter),
             Some(Command::RunQuery)
         );
     }
 
     #[test]
-    fn test_ctrl_n_available_in_sidebar_and_text_input() {
+    fn test_primary_n_available_in_sidebar_and_text_input() {
         let keymap = default_keymap();
 
-        let ctrl_n = KeyChord::new("n", Modifiers::ctrl());
+        let primary_n = KeyChord::new("n", Modifiers::primary());
 
         assert_eq!(
-            keymap.resolve(ContextId::Sidebar, &ctrl_n),
+            keymap.resolve(ContextId::Sidebar, &primary_n),
             Some(Command::NewQueryTab)
         );
         assert_eq!(
-            keymap.resolve(ContextId::TextInput, &ctrl_n),
+            keymap.resolve(ContextId::TextInput, &primary_n),
             Some(Command::NewQueryTab)
         );
     }
@@ -825,8 +853,34 @@ mod tests {
     fn test_command_palette_no_fallback() {
         let keymap = default_keymap();
 
-        let ctrl_enter = KeyChord::new("enter", Modifiers::ctrl());
-        assert_eq!(keymap.resolve(ContextId::CommandPalette, &ctrl_enter), None);
+        let primary_enter = KeyChord::new("enter", Modifiers::primary());
+        assert_eq!(
+            keymap.resolve(ContextId::CommandPalette, &primary_enter),
+            None
+        );
+    }
+
+    /// On macOS the literal Ctrl+C must not trigger ResultsCopyCell — the
+    /// platform convention is Cmd+C, and Ctrl+C is reserved for editor
+    /// interrupt semantics. See the per-platform branch in `results_layer`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_results_copy_uses_cmd_not_ctrl() {
+        let keymap = default_keymap();
+        let ctrl_c = KeyChord::new("c", Modifiers::ctrl());
+        assert_eq!(keymap.resolve(ContextId::Results, &ctrl_c), None);
+
+        let cmd_c = KeyChord {
+            key: "c".to_string(),
+            modifiers: Modifiers {
+                platform: true,
+                ..Modifiers::none()
+            },
+        };
+        assert_eq!(
+            keymap.resolve(ContextId::Results, &cmd_c),
+            Some(Command::ResultsCopyCell)
+        );
     }
 
     /// Regression test for the "missing letters in the SQL editor after

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -105,29 +105,35 @@ pub fn init(cx: &mut App) {
         KeyBinding::new("shift-end", SelectToLineEnd, Some(CONTEXT)),
         KeyBinding::new("ctrl-shift-home", SelectToTop, Some(CONTEXT)),
         KeyBinding::new("ctrl-shift-end", SelectToBottom, Some(CONTEXT)),
-        KeyBinding::new("ctrl-a", SelectAll, Some(CONTEXT)),
+        // `secondary-*` is GPUI's platform-aware modifier: Cmd on macOS,
+        // Ctrl elsewhere. Use it for the system-standard commands so macOS
+        // gets the expected Cmd shortcut without binding the literal Ctrl
+        // chord too (which would shadow editor interrupt semantics on Mac).
+        KeyBinding::new("secondary-a", SelectAll, Some(CONTEXT)),
         KeyBinding::new("escape", ClearSelection, Some(CONTEXT)),
-        // Copy — `secondary-c` resolves to Cmd+C on macOS and Ctrl+C
-        // elsewhere, matching platform conventions. A literal `ctrl-c` here
-        // would fire on macOS Ctrl+C too, which is wrong.
+        // Copy
         KeyBinding::new("secondary-c", Copy, Some(CONTEXT)),
         KeyBinding::new("y y", Copy, Some(CONTEXT)),
         KeyBinding::new("shift-y shift-y", CopyRow, Some(CONTEXT)),
         // Edit mode
         KeyBinding::new("enter", StartEdit, Some(CONTEXT)),
         KeyBinding::new("f2", StartEdit, Some(CONTEXT)),
-        KeyBinding::new("ctrl-enter", SaveRow, Some(CONTEXT)),
+        KeyBinding::new("secondary-enter", SaveRow, Some(CONTEXT)),
         // Row operations (vim-style)
         KeyBinding::new("d d", DeleteRow, Some(CONTEXT)),
         KeyBinding::new("delete", DeleteRow, Some(CONTEXT)),
         KeyBinding::new("a a", AddRow, Some(CONTEXT)),
         KeyBinding::new("shift-a shift-a", DuplicateRow, Some(CONTEXT)),
+        // SetNull — local mnemonic ("N" for NULL). Kept as literal Ctrl on
+        // every platform; this isn't a system-standard shortcut and reusing
+        // Cmd+N on macOS would clash with NewQueryTab.
         KeyBinding::new("ctrl-n", SetNull, Some(CONTEXT)),
-        // Undo/Redo (vim-style + standard)
+        // Undo/Redo: standard Cmd/Ctrl variants via `secondary-`, plus
+        // vim-style `u` / `ctrl-r` kept literal as familiar editor aliases.
         KeyBinding::new("u", Undo, Some(CONTEXT)),
-        KeyBinding::new("ctrl-z", Undo, Some(CONTEXT)),
+        KeyBinding::new("secondary-z", Undo, Some(CONTEXT)),
         KeyBinding::new("ctrl-r", Redo, Some(CONTEXT)),
-        KeyBinding::new("ctrl-shift-z", Redo, Some(CONTEXT)),
+        KeyBinding::new("secondary-shift-z", Redo, Some(CONTEXT)),
     ]);
 }
 

--- a/crates/dbflux_ui/src/ui/document/code/render.rs
+++ b/crates/dbflux_ui/src/ui/document/code/render.rs
@@ -62,6 +62,15 @@ impl CodeDocument {
                     .map(|finished| finished.duration_since(r.started_at))
             });
 
+        // Keep this label in sync with the RunQuery binding (Cmd+Enter on
+        // macOS, Ctrl+Enter elsewhere) registered in `keymap::defaults`.
+        #[cfg(target_os = "macos")]
+        let shortcut_hint = if is_db_language {
+            "Cmd+Enter (selection/full)"
+        } else {
+            "Cmd+Enter"
+        };
+        #[cfg(not(target_os = "macos"))]
         let shortcut_hint = if is_db_language {
             "Ctrl+Enter (selection/full)"
         } else {

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/render.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/render.rs
@@ -13,6 +13,13 @@ use gpui::prelude::*;
 use gpui::*;
 use gpui_component::ActiveTheme;
 
+// Save-row shortcut hint: matches the SaveRow binding in the data-table
+// component (`secondary-enter` — Cmd+Enter on macOS, Ctrl+Enter elsewhere).
+#[cfg(target_os = "macos")]
+const SAVE_ROW_SHORTCUT_HINT: &str = "Cmd+↵";
+#[cfg(not(target_os = "macos"))]
+const SAVE_ROW_SHORTCUT_HINT: &str = "Ctrl+↵";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DataGridContentMode {
     EmptyFallback,
@@ -746,7 +753,7 @@ impl DataGridPanel {
                             } else {
                                 theme.muted_foreground
                             }))
-                            .child(Text::caption("Ctrl+↵").color(if has_changes {
+                            .child(Text::caption(SAVE_ROW_SHORTCUT_HINT).color(if has_changes {
                                 theme.primary_foreground.opacity(0.7)
                             } else {
                                 theme.muted_foreground.opacity(0.5)

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -1074,10 +1074,15 @@ impl Workspace {
     }
 
     fn default_commands() -> Vec<PaletteCommand> {
-        // Shortcut labels for the command palette. Keep these in sync with the
-        // primary-modifier bindings in `keymap::defaults`: app-level commands
-        // use Cmd on macOS / Ctrl elsewhere, while the literal-Ctrl bindings
-        // (Ctrl+Tab, Ctrl+Shift+1..4) stay the same on every platform.
+        // Shortcut labels for the command palette. The strings here are in
+        // the kebab-case form expected by `palette_shortcut_parts` so they
+        // render as a multi-badge `Chord` (e.g. `[Ctrl] + [N]`) rather than a
+        // single collapsed token.
+        //
+        // The primary-modifier bindings in `keymap::defaults` use Cmd on
+        // macOS and Ctrl elsewhere, so the labels below mirror that. Bindings
+        // kept literal on every platform (Ctrl+Tab, Ctrl+Shift+1..4) keep
+        // `ctrl-` here as well.
         struct ShortcutLabels {
             new_query_tab: &'static str,
             run_query: &'static str,
@@ -1094,31 +1099,31 @@ impl Workspace {
 
         #[cfg(target_os = "macos")]
         const SC: ShortcutLabels = ShortcutLabels {
-            new_query_tab: "Cmd+N",
-            run_query: "Cmd+Enter",
-            run_query_in_new_tab: "Cmd+Shift+Enter",
-            save_query: "Cmd+S",
-            save_file_as: "Cmd+Shift+S",
-            open_script_file: "Cmd+O",
-            open_history: "Cmd+P",
-            close_tab: "Cmd+W",
-            export_results: "Cmd+E",
-            toggle_sidebar: "Cmd+B",
-            open_audit_viewer: "Cmd+Shift+A",
+            new_query_tab: "cmd-n",
+            run_query: "cmd-enter",
+            run_query_in_new_tab: "cmd-shift-enter",
+            save_query: "cmd-s",
+            save_file_as: "cmd-shift-s",
+            open_script_file: "cmd-o",
+            open_history: "cmd-p",
+            close_tab: "cmd-w",
+            export_results: "cmd-e",
+            toggle_sidebar: "cmd-b",
+            open_audit_viewer: "cmd-shift-a",
         };
         #[cfg(not(target_os = "macos"))]
         const SC: ShortcutLabels = ShortcutLabels {
-            new_query_tab: "Ctrl+N",
-            run_query: "Ctrl+Enter",
-            run_query_in_new_tab: "Ctrl+Shift+Enter",
-            save_query: "Ctrl+S",
-            save_file_as: "Ctrl+Shift+S",
-            open_script_file: "Ctrl+O",
-            open_history: "Ctrl+P",
-            close_tab: "Ctrl+W",
-            export_results: "Ctrl+E",
-            toggle_sidebar: "Ctrl+B",
-            open_audit_viewer: "Ctrl+Shift+A",
+            new_query_tab: "ctrl-n",
+            run_query: "ctrl-enter",
+            run_query_in_new_tab: "ctrl-shift-enter",
+            save_query: "ctrl-s",
+            save_file_as: "ctrl-shift-s",
+            open_script_file: "ctrl-o",
+            open_history: "ctrl-p",
+            close_tab: "ctrl-w",
+            export_results: "ctrl-e",
+            toggle_sidebar: "ctrl-b",
+            open_audit_viewer: "ctrl-shift-a",
         };
 
         vec![
@@ -1136,13 +1141,13 @@ impl Workspace {
             PaletteCommand::new("open_history", "Open Query History", "Editor")
                 .with_shortcut(SC.open_history),
             PaletteCommand::new("cancel_query", "Cancel Running Query", "Editor")
-                .with_shortcut("Esc"),
+                .with_shortcut("esc"),
             // Tabs — Ctrl+Tab / Ctrl+Shift+Tab stay literal Ctrl on every
             // platform (Cmd+Tab is the macOS app switcher).
             PaletteCommand::new("close_tab", "Close Current Tab", "Tabs")
                 .with_shortcut(SC.close_tab),
-            PaletteCommand::new("next_tab", "Next Tab", "Tabs").with_shortcut("Ctrl+Tab"),
-            PaletteCommand::new("prev_tab", "Previous Tab", "Tabs").with_shortcut("Ctrl+Shift+Tab"),
+            PaletteCommand::new("next_tab", "Next Tab", "Tabs").with_shortcut("ctrl-tab"),
+            PaletteCommand::new("prev_tab", "Previous Tab", "Tabs").with_shortcut("ctrl-shift-tab"),
             // Results
             PaletteCommand::new("export_results", "Export Results", "Results")
                 .with_shortcut(SC.export_results),
@@ -1157,13 +1162,13 @@ impl Workspace {
             // Focus — Ctrl+Shift+1..4 stay literal Ctrl on every platform
             // (Cmd+Shift+3/4 are macOS screenshot shortcuts).
             PaletteCommand::new("focus_sidebar", "Focus Sidebar", "Focus")
-                .with_shortcut("Ctrl+Shift+1"),
+                .with_shortcut("ctrl-shift-1"),
             PaletteCommand::new("focus_editor", "Focus Editor", "Focus")
-                .with_shortcut("Ctrl+Shift+2"),
+                .with_shortcut("ctrl-shift-2"),
             PaletteCommand::new("focus_results", "Focus Results", "Focus")
-                .with_shortcut("Ctrl+Shift+3"),
+                .with_shortcut("ctrl-shift-3"),
             PaletteCommand::new("focus_tasks", "Focus Tasks Panel", "Focus")
-                .with_shortcut("Ctrl+Shift+4"),
+                .with_shortcut("ctrl-shift-4"),
             // View
             PaletteCommand::new("toggle_sidebar", "Toggle Sidebar", "View")
                 .with_shortcut(SC.toggle_sidebar),

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -1074,28 +1074,78 @@ impl Workspace {
     }
 
     fn default_commands() -> Vec<PaletteCommand> {
+        // Shortcut labels for the command palette. Keep these in sync with the
+        // primary-modifier bindings in `keymap::defaults`: app-level commands
+        // use Cmd on macOS / Ctrl elsewhere, while the literal-Ctrl bindings
+        // (Ctrl+Tab, Ctrl+Shift+1..4) stay the same on every platform.
+        struct ShortcutLabels {
+            new_query_tab: &'static str,
+            run_query: &'static str,
+            run_query_in_new_tab: &'static str,
+            save_query: &'static str,
+            save_file_as: &'static str,
+            open_script_file: &'static str,
+            open_history: &'static str,
+            close_tab: &'static str,
+            export_results: &'static str,
+            toggle_sidebar: &'static str,
+            open_audit_viewer: &'static str,
+        }
+
+        #[cfg(target_os = "macos")]
+        const SC: ShortcutLabels = ShortcutLabels {
+            new_query_tab: "Cmd+N",
+            run_query: "Cmd+Enter",
+            run_query_in_new_tab: "Cmd+Shift+Enter",
+            save_query: "Cmd+S",
+            save_file_as: "Cmd+Shift+S",
+            open_script_file: "Cmd+O",
+            open_history: "Cmd+P",
+            close_tab: "Cmd+W",
+            export_results: "Cmd+E",
+            toggle_sidebar: "Cmd+B",
+            open_audit_viewer: "Cmd+Shift+A",
+        };
+        #[cfg(not(target_os = "macos"))]
+        const SC: ShortcutLabels = ShortcutLabels {
+            new_query_tab: "Ctrl+N",
+            run_query: "Ctrl+Enter",
+            run_query_in_new_tab: "Ctrl+Shift+Enter",
+            save_query: "Ctrl+S",
+            save_file_as: "Ctrl+Shift+S",
+            open_script_file: "Ctrl+O",
+            open_history: "Ctrl+P",
+            close_tab: "Ctrl+W",
+            export_results: "Ctrl+E",
+            toggle_sidebar: "Ctrl+B",
+            open_audit_viewer: "Ctrl+Shift+A",
+        };
+
         vec![
             // Editor
-            PaletteCommand::new("new_query_tab", "New Query Tab", "Editor").with_shortcut("Ctrl+N"),
-            PaletteCommand::new("run_query", "Run Query", "Editor").with_shortcut("Ctrl+Enter"),
+            PaletteCommand::new("new_query_tab", "New Query Tab", "Editor")
+                .with_shortcut(SC.new_query_tab),
+            PaletteCommand::new("run_query", "Run Query", "Editor").with_shortcut(SC.run_query),
             PaletteCommand::new("run_query_in_new_tab", "Run Query in New Tab", "Editor")
-                .with_shortcut("Ctrl+Shift+Enter"),
-            PaletteCommand::new("save_query", "Save Query", "Editor").with_shortcut("Ctrl+S"),
+                .with_shortcut(SC.run_query_in_new_tab),
+            PaletteCommand::new("save_query", "Save Query", "Editor").with_shortcut(SC.save_query),
             PaletteCommand::new("save_file_as", "Save File As", "Editor")
-                .with_shortcut("Ctrl+Shift+S"),
+                .with_shortcut(SC.save_file_as),
             PaletteCommand::new("open_script_file", "Open Script File", "Editor")
-                .with_shortcut("Ctrl+O"),
+                .with_shortcut(SC.open_script_file),
             PaletteCommand::new("open_history", "Open Query History", "Editor")
-                .with_shortcut("Ctrl+P"),
+                .with_shortcut(SC.open_history),
             PaletteCommand::new("cancel_query", "Cancel Running Query", "Editor")
                 .with_shortcut("Esc"),
-            // Tabs
-            PaletteCommand::new("close_tab", "Close Current Tab", "Tabs").with_shortcut("Ctrl+W"),
+            // Tabs — Ctrl+Tab / Ctrl+Shift+Tab stay literal Ctrl on every
+            // platform (Cmd+Tab is the macOS app switcher).
+            PaletteCommand::new("close_tab", "Close Current Tab", "Tabs")
+                .with_shortcut(SC.close_tab),
             PaletteCommand::new("next_tab", "Next Tab", "Tabs").with_shortcut("Ctrl+Tab"),
             PaletteCommand::new("prev_tab", "Previous Tab", "Tabs").with_shortcut("Ctrl+Shift+Tab"),
             // Results
             PaletteCommand::new("export_results", "Export Results", "Results")
-                .with_shortcut("Ctrl+E"),
+                .with_shortcut(SC.export_results),
             // Connections
             PaletteCommand::new(
                 "open_connection_manager",
@@ -1104,7 +1154,8 @@ impl Workspace {
             ),
             PaletteCommand::new("disconnect", "Disconnect Current", "Connections"),
             PaletteCommand::new("refresh_schema", "Refresh Schema", "Connections"),
-            // Focus
+            // Focus — Ctrl+Shift+1..4 stay literal Ctrl on every platform
+            // (Cmd+Shift+3/4 are macOS screenshot shortcuts).
             PaletteCommand::new("focus_sidebar", "Focus Sidebar", "Focus")
                 .with_shortcut("Ctrl+Shift+1"),
             PaletteCommand::new("focus_editor", "Focus Editor", "Focus")
@@ -1114,7 +1165,8 @@ impl Workspace {
             PaletteCommand::new("focus_tasks", "Focus Tasks Panel", "Focus")
                 .with_shortcut("Ctrl+Shift+4"),
             // View
-            PaletteCommand::new("toggle_sidebar", "Toggle Sidebar", "View").with_shortcut("Ctrl+B"),
+            PaletteCommand::new("toggle_sidebar", "Toggle Sidebar", "View")
+                .with_shortcut(SC.toggle_sidebar),
             PaletteCommand::new("toggle_editor", "Toggle Editor Panel", "View"),
             PaletteCommand::new("toggle_results", "Toggle Results Panel", "View"),
             PaletteCommand::new("toggle_tasks", "Toggle Tasks Panel", "View"),
@@ -1126,7 +1178,7 @@ impl Workspace {
             #[cfg(feature = "mcp")]
             PaletteCommand::new("refresh_mcp_governance", "Refresh MCP Governance", "View"),
             PaletteCommand::new("open_audit_viewer", "Open Audit Viewer", "View")
-                .with_shortcut("Ctrl+Shift+A"),
+                .with_shortcut(SC.open_audit_viewer),
         ]
     }
 


### PR DESCRIPTION
## Summary

Application-level keyboard shortcuts now use Cmd on macOS and Ctrl on
Linux/Windows, following platform conventions. The seam is a new
`Modifiers::primary()` helper that collapses the per-call cfg pattern
introduced in #59 for the Results copy-cell binding.

vim-style navigation, `Ctrl+Tab`, and a handful of shortcuts that would
clash with system bindings on macOS (Cmd+M minimize, Cmd+Shift+3/4
screenshots) stay literal Ctrl on every platform.

## What does this resolve?

- Resolves #63

## How was this solved?

Five focused commits, each one a logical step:

1. **`feat(keymap): platform-aware primary modifier for app commands`**
   Adds `Modifiers::primary()` / `primary_shift()` in
   `dbflux_app::keymap::chord` (Cmd on macOS, Ctrl on Linux/Windows) and
   routes the app-level bindings through them in
   `dbflux_ui::keymap::defaults` + the Input-context override in
   `keymap::actions`. The existing `#[cfg(target_os = "macos")]` branch
   from #59 collapses into the helper. `KeyChord`'s `Display` order
   swaps to Cmd-first so labels read `Cmd+Shift+P` rather than
   `Shift+Cmd+P`.

2. **`feat(data-table): use secondary modifier for system-standard chords`**
   In `data_table::init`, the system-standard bindings (SelectAll,
   SaveRow, Undo, Redo) switch to GPUI's `secondary-*` modifier (Cmd on
   macOS, Ctrl elsewhere). Copy already used this. Vim aliases (`u`,
   `ctrl-r` Redo) and local mnemonics (`ctrl-n` SetNull) stay literal.

3. **`fix(ui): platform-aware editor and save-row shortcut hints`**
   The SQL editor toolbar caption and the data-grid save-row caption
   are cfg-gated so they read `Cmd+Enter` / `Cmd+↵` on macOS and
   `Ctrl+Enter` / `Ctrl+↵` elsewhere.

4. **`fix(ui): platform-aware palette shortcut labels`**
   `Workspace::default_commands()` builds the palette descriptor list
   with cfg-gated shortcut labels so macOS shows Cmd-prefixed strings.

5. **`fix(ui): kebab-case palette shortcut labels for chord rendering`**
   Per maintainer feedback: `palette_shortcut_parts` splits on `-` to
   build a multi-badge `Chord`. The previous `+`-form labels (`"Ctrl+N"`)
   were not split and rendered as one collapsed token. This commit
   switches the labels to kebab-case (`cmd-n` / `ctrl-n`, `ctrl-tab`,
   `ctrl-shift-1`, `esc`) so chords render as `[Ctrl] + [N]`.

Carve-outs that stay literal Ctrl on every platform — matching the
maintainer's note in #63 plus a few extras grounded in macOS system
conventions:

| Carve-out | Why |
|---|---|
| `Ctrl+h/j/k/l` focus nav, `Ctrl+u/d` page nav | vim/tmux idiom, as flagged on the issue |
| `Ctrl+Tab` / `Ctrl+Shift+Tab` | tabbed-UI idiom, as flagged on the issue (Cmd+Tab is the macOS app switcher) |
| `Ctrl+Shift+1..4` focus shortcuts | Cmd+Shift+3/4 are reserved by macOS for screenshots |
| `Ctrl+M` tab menu | Cmd+M is the system "minimize window" shortcut on macOS |
| History-modal local mnemonics (`Ctrl+D`/`Ctrl+F`/`Ctrl+R`) | Reusing Cmd here would clash with system Find/Reload |
| Data-table `ctrl-n` SetNull, `ctrl-r` Redo, `u` Undo | local mnemonics / vim aliases, not system-standard chords |

## Validation

```
cargo fmt --all -- --check        # ok
cargo check --workspace            # ok
cargo test -p dbflux_app keymap    # 12 passed
cargo test -p dbflux_ui --lib keymap        # 12 passed
cargo test -p dbflux_ui --lib command_palette  # 8 passed
```

New tests added in this branch:

- `chord::tests::test_display_cmd_first` — Display puts Cmd before Shift
- `chord::tests::test_primary_modifier_per_platform` — `primary()` resolves
  to `platform` on macOS, `ctrl` elsewhere
- `keymap::defaults::tests::macos_results_copy_uses_cmd_not_ctrl` —
  literal Ctrl+C does not trigger Results copy-cell on macOS

The pre-existing
`input_context_keybindings_override_secondary_enter` test was
generalized to run on macOS too (it had been gated to `not(macos)`).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [ ] Linux
- [x] macOS (manual smoke testing by author)
- [x] Windows (manual smoke testing by author)

## Known limitation (pre-existing, tracked separately)

While smoke-testing on macOS and Windows it was confirmed that
`Ctrl+Shift+1..4` (the direct focus shortcuts) don't move focus. This
pre-dates this PR — the bindings have always been the same on every
platform and the chord never matches the runtime keystroke. Root cause:
GPUI normalizes `Shift+digit` chords away from the digit on macOS and
Windows (intentionally, for non-US layouts), so the keystroke that
reaches `Workspace::on_key_down` doesn't match the
`KeyChord("N", Modifiers::ctrl_shift())` stored in `KeymapStack`.

Filed as a separate issue with the full root-cause analysis and three
alternative fixes: **#65**. Keeping it out of this PR so the
platform-modifier work stays reviewable on its own and the fix can get
its own platform-specific test coverage.

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I applied the appropriate labels (see below)

## Labels to apply

- `ui:feature` — application-level keyboard shortcut conventions
- `platform:macos` — the change is observable on macOS specifically
- `platform:windows` — labels stay correct on Windows too

🤖 Generated with [Claude Code](https://claude.com/claude-code)