### PR TITLE
feat(driver): add Microsoft SQL Server driver

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -280,6 +280,7 @@ crates/
   dbflux_driver_postgres/   # PostgreSQL driver implementation
   dbflux_driver_sqlite/     # SQLite driver implementation
   dbflux_driver_mysql/      # MySQL/MariaDB driver implementation
+  dbflux_driver_mssql/      # Microsoft SQL Server driver implementation
   dbflux_driver_mongodb/    # MongoDB driver implementation
     src/driver.rs           # Connection, schema discovery, CRUD operations
     src/query_parser.rs     # MongoDB query syntax parser (db.collection.method())
@@ -522,6 +523,7 @@ crates/
 - **PostgreSQL**: `crates/dbflux_driver_postgres/` — `tokio-postgres` with TLS, cancellation, detailed error extraction.
 - **MySQL/MariaDB**: `crates/dbflux_driver_mysql/` — dual connection architecture (sync for schema, async for queries).
 - **SQLite**: `crates/dbflux_driver_sqlite/` — `rusqlite` file-based connections.
+- **Microsoft SQL Server**: `crates/dbflux_driver_mssql/` — `tiberius` TDS client with TLS, SSH tunnel, SQL Browser named-instance routing, multi-schema introspection, CRUD via `OUTPUT INSERTED.*` / `OUTPUT DELETED.*`, and side-channel `KILL`-based cancellation with automatic session restore.
 - **MongoDB**: `crates/dbflux_driver_mongodb/` — `mongodb` async driver with:
   - BSON value handling and conversion
   - Query parser for `db.collection.method()` syntax
@@ -640,6 +642,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 - PostgreSQL: `tokio-postgres` client with optional TLS, cancellation support, lazy schema loading, and URI connection mode (crates/dbflux_driver_postgres/src/driver.rs).
 - MySQL/MariaDB: `mysql` crate with dual connection architecture (sync for schema, async for queries), lazy schema loading, and URI connection mode (crates/dbflux_driver_mysql/src/driver.rs).
 - SQLite: `rusqlite` file-based connections with lazy schema loading (crates/dbflux_driver_sqlite/src/driver.rs).
+- Microsoft SQL Server: `tiberius` TDS client with TLS modes (`off`/`on`/`required`), SSH tunneling, SQL Browser named-instance lookup, multi-database/multi-schema introspection via qualified `sys.*` catalog queries, CRUD with `OUTPUT INSERTED.*` / `OUTPUT DELETED.*`, and cooperative cancellation via side-channel `KILL <spid>` with automatic session restore (crates/dbflux_driver_mssql/src/driver.rs).
 - MongoDB: `mongodb` async driver with BSON handling, query parser for `db.collection.method()` syntax, collection/index discovery, document CRUD, shell query generation, and collection description support for MCP/UI metadata workflows (crates/dbflux_driver_mongodb/src/driver.rs).
 - Redis: `redis` driver with key-value API for all Redis types, variadic commands, keyspace support, key scanning, and command generation (crates/dbflux_driver_redis/src/driver.rs).
 - DynamoDB: `aws-sdk-dynamodb` driver with AWS profile/region support for remote DynamoDB, plus optional endpoint override for local emulators and tests (crates/dbflux_driver_dynamodb/src/driver.rs).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+* **Microsoft SQL Server driver** — first-class SQL Server support
+  built on `tiberius`, with TLS modes (`off`, `on`, `required` +
+  `trust_server_certificate`), SSH tunnel and SQL Browser named-
+  instance routing, full multi-schema introspection (`hr`, `sales`,
+  `dbo`, …), CRUD via `OUTPUT INSERTED.*` / `OUTPUT DELETED.*`,
+  `OFFSET ... FETCH NEXT` paging, and cooperative query cancellation
+  via side-channel `KILL <spid>` with automatic session restore and
+  active-database recovery. `ColumnKind` is wired across every
+  `tiberius::ColumnType` so MSSQL results integrate with chart
+  auto-detection.
+
+### Fixed
+
+* **Long text wraps in toasts, banners, and the delete-confirmation
+  modal** — long error strings and titles previously overflowed past
+  the card edge instead of wrapping. The flex chain inside the card
+  is now configured so titles and subtitles wrap within the
+  container's `max_w`.
+* **Delete-confirmation popup no longer duplicates the dedicated
+  delete modals** — when `ModalDeleteConnection` or
+  `ModalDropTable` is open, the generic confirmation popup is now
+  suppressed so users don't see two overlapping delete dialogs.
+* **Connection profile add / remove / update now persist on disk** —
+  removing a profile failed to delete its row because `save_profiles`
+  was upsert-only, and add / update relied on an MCP-side persist
+  hook so changes were lost on builds without MCP. `app_state` now
+  calls the storage repository directly on every mutation.
+
 ## [0.6.0-dev.3] - 2026-05-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +1806,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "connection-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2332,7 @@ dependencies = [
  "dbflux_driver_influxdb",
  "dbflux_driver_ipc",
  "dbflux_driver_mongodb",
+ "dbflux_driver_mssql",
  "dbflux_driver_mysql",
  "dbflux_driver_postgres",
  "dbflux_driver_redis",
@@ -2358,6 +2378,7 @@ dependencies = [
  "dbflux_driver_influxdb",
  "dbflux_driver_ipc",
  "dbflux_driver_mongodb",
+ "dbflux_driver_mssql",
  "dbflux_driver_mysql",
  "dbflux_driver_postgres",
  "dbflux_driver_redis",
@@ -2562,6 +2583,25 @@ dependencies = [
  "mongodb",
  "serde_json",
  "tokio",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
+name = "dbflux_driver_mssql"
+version = "0.6.0-dev.3"
+dependencies = [
+ "chrono",
+ "dbflux_core",
+ "dbflux_ssh",
+ "dbflux_test_support",
+ "hex",
+ "indexmap",
+ "log",
+ "serde_json",
+ "tiberius",
+ "tokio",
+ "tokio-util",
  "urlencoding",
  "uuid",
 ]
@@ -2816,6 +2856,7 @@ dependencies = [
  "dbflux_driver_dynamodb",
  "dbflux_driver_ipc",
  "dbflux_driver_mongodb",
+ "dbflux_driver_mssql",
  "dbflux_driver_mysql",
  "dbflux_driver_postgres",
  "dbflux_driver_redis",
@@ -6986,6 +7027,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7405,7 +7452,7 @@ dependencies = [
  "percent-encoding",
  "rustls 0.23.40",
  "rustls-native-certs 0.7.3",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "ryu",
  "sha1_smol",
@@ -7930,12 +7977,24 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
 dependencies = [
  "openssl-probe 0.1.6",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework 2.11.1",
@@ -7951,6 +8010,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework 3.7.0",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -9138,6 +9206,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiberius"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "connection-string",
+ "encoding_rs",
+ "enumflags2",
+ "futures-util",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "pretty-hex",
+ "rustls-native-certs 0.6.3",
+ "rustls-pemfile 1.0.4",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "tiff"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9499,6 +9596,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -11521,7 +11619,7 @@ dependencies = [
  "quinn",
  "rustls 0.23.40",
  "rustls-native-certs 0.8.3",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2599,6 +2599,7 @@ dependencies = [
  "indexmap",
  "log",
  "serde_json",
+ "sha2 0.10.9",
  "tiberius",
  "tokio",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_mssql"
-version = "0.6.0-dev.3"
+version = "0.6.0-dev.4"
 dependencies = [
  "chrono",
  "dbflux_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/dbflux_driver_redis",
     "crates/dbflux_driver_dynamodb",
     "crates/dbflux_driver_cloudwatch",
+    "crates/dbflux_driver_mssql",
     "crates/dbflux_ssh",
     "crates/dbflux_proxy",
     "crates/dbflux_tunnel_core",
@@ -55,6 +56,7 @@ dbflux_driver_mongodb = { path = "crates/dbflux_driver_mongodb" }
 dbflux_driver_redis = { path = "crates/dbflux_driver_redis" }
 dbflux_driver_dynamodb = { path = "crates/dbflux_driver_dynamodb" }
 dbflux_driver_cloudwatch = { path = "crates/dbflux_driver_cloudwatch" }
+dbflux_driver_mssql = { path = "crates/dbflux_driver_mssql" }
 dbflux_ssh = { path = "crates/dbflux_ssh" }
 dbflux_proxy = { path = "crates/dbflux_proxy" }
 dbflux_export = { path = "crates/dbflux_export" }

--- a/crates/dbflux/Cargo.toml
+++ b/crates/dbflux/Cargo.toml
@@ -72,6 +72,10 @@ optional = true
 workspace = true
 optional = true
 
+[dependencies.dbflux_driver_mssql]
+workspace = true
+optional = true
+
 [dependencies.dbflux_aws]
 workspace = true
 optional = true
@@ -113,7 +117,7 @@ workspace = true
 optional = true
 
 [features]
-default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "influxdb", "lua", "aws", "mcp"]
+default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "influxdb", "mssql", "lua", "aws", "mcp"]
 sqlite = ["dbflux_app/sqlite", "dbflux_ui/sqlite"]
 postgres = ["dbflux_app/postgres", "dbflux_ui/postgres"]
 mysql = ["dbflux_app/mysql", "dbflux_ui/mysql"]
@@ -122,6 +126,7 @@ redis = ["dbflux_app/redis", "dbflux_ui/redis"]
 dynamodb = ["dbflux_app/dynamodb", "dbflux_ui/dynamodb"]
 cloudwatch = ["dbflux_driver_cloudwatch", "dbflux_app/cloudwatch", "dbflux_ui/cloudwatch"]
 influxdb = ["dbflux_driver_influxdb", "dbflux_app/influxdb"]
+mssql = ["dbflux_driver_mssql", "dbflux_app/mssql", "dbflux_ui/mssql"]
 lua = ["dbflux_lua", "dbflux_app/lua", "dbflux_ui/lua"]
 aws = ["dbflux_aws", "dbflux_ssm", "dbflux_app/aws", "dbflux_ui/aws"]
 mcp = ["dbflux_mcp", "dbflux_mcp_server", "dbflux_policy", "dbflux_approval", "dbflux_app/mcp", "dbflux_ui/mcp"]

--- a/crates/dbflux_app/Cargo.toml
+++ b/crates/dbflux_app/Cargo.toml
@@ -26,6 +26,7 @@ dbflux_driver_redis = { workspace = true, optional = true }
 dbflux_driver_dynamodb = { workspace = true, optional = true }
 dbflux_driver_cloudwatch = { workspace = true, optional = true }
 dbflux_driver_influxdb = { workspace = true, optional = true }
+dbflux_driver_mssql = { workspace = true, optional = true }
 dbflux_lua = { workspace = true, optional = true }
 dbflux_mcp = { workspace = true, optional = true }
 dbflux_mcp_server = { workspace = true, optional = true }
@@ -40,7 +41,7 @@ indexmap.workspace = true
 async-trait = "0.1"
 
 [features]
-default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch"]
+default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "mssql"]
 sqlite = ["dbflux_driver_sqlite"]
 postgres = ["dbflux_driver_postgres"]
 mysql = ["dbflux_driver_mysql"]
@@ -49,6 +50,7 @@ redis = ["dbflux_driver_redis"]
 dynamodb = ["dbflux_driver_dynamodb"]
 cloudwatch = ["dbflux_driver_cloudwatch"]
 influxdb = ["dep:dbflux_driver_influxdb"]
+mssql = ["dep:dbflux_driver_mssql"]
 lua = ["dbflux_lua"]
 aws = ["dbflux_aws", "dbflux_ssm"]
 mcp = ["dbflux_mcp", "dbflux_mcp_server", "dbflux_policy"]

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -54,6 +54,9 @@ use dbflux_driver_cloudwatch::CloudWatchDriver;
 #[cfg(feature = "influxdb")]
 use dbflux_driver_influxdb::InfluxDriver;
 
+#[cfg(feature = "mssql")]
+use dbflux_driver_mssql::MssqlDriver;
+
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -830,6 +833,11 @@ impl AppState {
             drivers.insert("influxdb".to_string(), Arc::new(InfluxDriver::new()));
         }
 
+        #[cfg(feature = "mssql")]
+        {
+            drivers.insert("mssql".to_string(), Arc::new(MssqlDriver::new()));
+        }
+
         drivers
     }
 
@@ -1448,6 +1456,11 @@ impl AppState {
             format!("Created connection profile '{}'", profile_name),
             None,
         );
+
+        // Persist the new profile to disk. The in-memory ProfileManager is
+        // constructed with `None` for its JsonStore, so its `save()` is a
+        // no-op; the app drives persistence through `save_profiles()`.
+        self.save_profiles();
     }
 
     pub fn remove_profile(&mut self, idx: usize) -> Option<ConnectionProfile> {
@@ -1461,6 +1474,18 @@ impl AppState {
             format!("Deleted connection profile '{}'", removed.name),
             None,
         );
+
+        // Delete the row from SQLite. `save_profiles()` is upsert-only over
+        // the *remaining* in-memory profiles — it will not remove a row
+        // whose profile is no longer in memory, so without this explicit
+        // delete the deleted profile reappears on next launch.
+        if let Err(e) = self
+            .storage_runtime
+            .connection_profiles()
+            .delete(&removed.id.to_string())
+        {
+            log::error!("Failed to delete profile from storage: {}", e);
+        }
 
         Some(removed)
     }
@@ -1478,6 +1503,12 @@ impl AppState {
             format!("Updated connection profile '{}'", profile_name),
             None,
         );
+
+        // Persist the edit to disk. Previously this only worked as a side
+        // effect of `persist_mcp_governance()` after the form save; if MCP
+        // was disabled or the call path skipped that step, the edit would
+        // not survive a restart.
+        self.save_profiles();
     }
 
     pub fn save_profiles(&self) {

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -426,6 +426,7 @@ fn db_kind_to_str(kind: DbKind) -> String {
         DbKind::DynamoDB => "DynamoDB",
         DbKind::CloudWatchLogs => "CloudWatchLogs",
         DbKind::InfluxDB => "InfluxDB",
+        DbKind::SqlServer => "SqlServer",
     }
     .to_string()
 }
@@ -441,6 +442,7 @@ fn str_to_db_kind(s: &str) -> Option<DbKind> {
         "DynamoDB" => Some(DbKind::DynamoDB),
         "CloudWatchLogs" => Some(DbKind::CloudWatchLogs),
         "InfluxDB" => Some(DbKind::InfluxDB),
+        "SqlServer" => Some(DbKind::SqlServer),
         _ => None,
     }
 }
@@ -454,6 +456,7 @@ fn default_db_config_for_kind(kind: DbKind) -> dbflux_core::DbConfig {
         DbKind::Redis => dbflux_core::DbConfig::default_redis(),
         DbKind::DynamoDB => dbflux_core::DbConfig::default_dynamodb(),
         DbKind::CloudWatchLogs => dbflux_core::DbConfig::default_cloudwatch_logs(),
+        DbKind::SqlServer => dbflux_core::DbConfig::default_sqlserver(),
         _ => dbflux_core::DbConfig::default_postgres(),
     }
 }

--- a/crates/dbflux_components/src/primitives/banner.rs
+++ b/crates/dbflux_components/src/primitives/banner.rs
@@ -96,13 +96,21 @@ impl RenderOnce for BannerBlock {
         let mut pre_tint = fg;
         pre_tint.a = 0.08;
 
-        let mut content_col = div().flex().flex_col().gap(Spacing::XS).child(
-            div()
-                .text_size(FontSizes::SM)
-                .font_weight(FontWeight::SEMIBOLD)
-                .text_color(fg)
-                .child(self.title),
-        );
+        // `flex_1 + min_w_0` lets the title/body text wrap to the
+        // banner's width instead of overflowing on long error messages.
+        let mut content_col = div()
+            .flex_1()
+            .min_w_0()
+            .flex()
+            .flex_col()
+            .gap(Spacing::XS)
+            .child(
+                div()
+                    .text_size(FontSizes::SM)
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(fg)
+                    .child(self.title),
+            );
 
         if let Some(body) = self.body {
             content_col =
@@ -123,11 +131,16 @@ impl RenderOnce for BannerBlock {
             );
         }
 
+        // `min_w_0` on every flex item in the chain (row, icon-wrapper,
+        // outer) is required for `content_col` to actually have a
+        // constrained width — without it the chain reports content-size
+        // upward and `min_w_0` on content_col alone has no effect.
         let mut row = div()
             .flex()
             .items_start()
             .gap(Spacing::SM)
             .flex_1()
+            .min_w_0()
             .child(content_col);
 
         if let Some(icon) = self.icon {
@@ -136,12 +149,14 @@ impl RenderOnce for BannerBlock {
                 .items_start()
                 .gap(Spacing::SM)
                 .flex_1()
+                .min_w_0()
                 .child(icon)
                 .child(row);
         }
 
         let mut outer = div()
             .flex()
+            .w_full()
             .items_start()
             .justify_between()
             .gap(Spacing::SM)

--- a/crates/dbflux_core/src/connection/hook.rs
+++ b/crates/dbflux_core/src/connection/hook.rs
@@ -493,6 +493,12 @@ fn profile_config_context(config: &DbConfig) -> (Option<String>, Option<u16>, Op
             default_bucket,
             ..
         } => (Some(url.clone()), None, default_bucket.clone()),
+        DbConfig::SqlServer {
+            host,
+            port,
+            database,
+            ..
+        } => (Some(host.clone()), Some(*port), database.clone()),
         DbConfig::External { values, .. } => {
             let host = values.get("host").cloned();
             let port = values

--- a/crates/dbflux_core/src/connection/profile.rs
+++ b/crates/dbflux_core/src/connection/profile.rs
@@ -22,6 +22,7 @@ pub enum DbKind {
     DynamoDB,
     CloudWatchLogs,
     InfluxDB,
+    SqlServer,
 }
 
 impl DbKind {
@@ -36,6 +37,7 @@ impl DbKind {
             DbKind::DynamoDB => "DynamoDB",
             DbKind::CloudWatchLogs => "CloudWatch Logs",
             DbKind::InfluxDB => "InfluxDB",
+            DbKind::SqlServer => "SQL Server",
         }
     }
 }
@@ -479,6 +481,40 @@ pub enum DbConfig {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         request_timeout_seconds: Option<u64>,
     },
+    SqlServer {
+        #[serde(default)]
+        use_uri: bool,
+        #[serde(default)]
+        uri: Option<String>,
+        host: String,
+        port: u16,
+        user: String,
+        #[serde(default)]
+        database: Option<String>,
+        /// Optional named SQL Server instance (e.g. `"SQLEXPRESS"`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        instance: Option<String>,
+        /// SQL Server encryption mode id: `"off"`, `"on"`, or `"required"`.
+        ///
+        /// Maps to tiberius `EncryptionLevel::Off`, `EncryptionLevel::On`, and
+        /// `EncryptionLevel::Required`.
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "deserialize_ssl_mode_option"
+        )]
+        ssl_mode: Option<String>,
+        /// When true, the server certificate is accepted without validation
+        /// (equivalent to SqlServer's `TrustServerCertificate=true`).
+        #[serde(default)]
+        trust_server_certificate: bool,
+        /// Path to a root CA certificate (PEM/DER) for certificate validation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ssl_root_cert_path: Option<String>,
+        ssh_tunnel: Option<SshTunnelConfig>,
+        #[serde(default)]
+        ssh_tunnel_profile_id: Option<Uuid>,
+    },
     /// Generic config for external RPC drivers.
     External {
         kind: DbKind,
@@ -502,6 +538,7 @@ impl DbConfig {
             DbConfig::DynamoDB { .. } => DbKind::DynamoDB,
             DbConfig::CloudWatchLogs { .. } => DbKind::CloudWatchLogs,
             DbConfig::InfluxDB { .. } => DbKind::InfluxDB,
+            DbConfig::SqlServer { .. } => DbKind::SqlServer,
             DbConfig::External { kind, .. } => *kind,
         }
     }
@@ -612,12 +649,30 @@ impl DbConfig {
         }
     }
 
+    pub fn default_sqlserver() -> Self {
+        DbConfig::SqlServer {
+            use_uri: false,
+            uri: None,
+            host: "localhost".to_string(),
+            port: 1433,
+            user: "sa".to_string(),
+            database: None,
+            instance: None,
+            ssl_mode: Some("on".to_string()),
+            trust_server_certificate: true,
+            ssl_root_cert_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+        }
+    }
+
     pub fn ssh_tunnel(&self) -> Option<&SshTunnelConfig> {
         match self {
             DbConfig::Postgres { ssh_tunnel, .. }
             | DbConfig::MySQL { ssh_tunnel, .. }
             | DbConfig::MongoDB { ssh_tunnel, .. }
-            | DbConfig::Redis { ssh_tunnel, .. } => ssh_tunnel.as_ref(),
+            | DbConfig::Redis { ssh_tunnel, .. }
+            | DbConfig::SqlServer { ssh_tunnel, .. } => ssh_tunnel.as_ref(),
             DbConfig::SQLite { .. }
             | DbConfig::DynamoDB { .. }
             | DbConfig::CloudWatchLogs { .. }
@@ -642,6 +697,10 @@ impl DbConfig {
                 ..
             }
             | DbConfig::Redis {
+                ssh_tunnel_profile_id,
+                ..
+            }
+            | DbConfig::SqlServer {
                 ssh_tunnel_profile_id,
                 ..
             } => *ssh_tunnel_profile_id,
@@ -675,6 +734,11 @@ impl DbConfig {
                 ssh_tunnel,
                 ssh_tunnel_profile_id,
                 ..
+            }
+            | DbConfig::SqlServer {
+                ssh_tunnel,
+                ssh_tunnel_profile_id,
+                ..
             } => ssh_tunnel.is_some() || ssh_tunnel_profile_id.is_some(),
             DbConfig::SQLite { .. }
             | DbConfig::DynamoDB { .. }
@@ -690,7 +754,8 @@ impl DbConfig {
             DbConfig::Postgres { host, port, .. }
             | DbConfig::MySQL { host, port, .. }
             | DbConfig::MongoDB { host, port, .. }
-            | DbConfig::Redis { host, port, .. } => Some((host, *port)),
+            | DbConfig::Redis { host, port, .. }
+            | DbConfig::SqlServer { host, port, .. } => Some((host, *port)),
             DbConfig::SQLite { .. }
             | DbConfig::DynamoDB { .. }
             | DbConfig::CloudWatchLogs { .. }
@@ -725,6 +790,12 @@ impl DbConfig {
                 port,
                 use_uri,
                 ..
+            }
+            | DbConfig::SqlServer {
+                host,
+                port,
+                use_uri,
+                ..
             } => {
                 *host = "127.0.0.1".to_string();
                 *port = tunnel_port;
@@ -747,7 +818,8 @@ impl DbConfig {
             DbConfig::Postgres { use_uri, uri, .. }
             | DbConfig::MySQL { use_uri, uri, .. }
             | DbConfig::MongoDB { use_uri, uri, .. }
-            | DbConfig::Redis { use_uri, uri, .. } => (use_uri, uri),
+            | DbConfig::Redis { use_uri, uri, .. }
+            | DbConfig::SqlServer { use_uri, uri, .. } => (use_uri, uri),
             DbConfig::SQLite { .. }
             | DbConfig::DynamoDB { .. }
             | DbConfig::CloudWatchLogs { .. }
@@ -780,6 +852,7 @@ impl DbConfig {
             DbConfig::MySQL { database, .. } => database.clone(),
             DbConfig::MongoDB { database, .. } => database.clone(),
             DbConfig::Redis { database, .. } => database.map(|d| d.to_string()),
+            DbConfig::SqlServer { database, .. } => database.clone(),
             DbConfig::SQLite { .. } => Some("main".to_string()),
             DbConfig::DynamoDB { .. } | DbConfig::CloudWatchLogs { .. } => None,
             DbConfig::InfluxDB { default_bucket, .. } => default_bucket.clone(),
@@ -908,6 +981,33 @@ impl DbConfig {
                     ssh_tunnel_profile_id,
                 })
             }
+            DbConfig::SqlServer {
+                use_uri,
+                uri,
+                host,
+                port,
+                user,
+                instance,
+                ssl_mode,
+                trust_server_certificate,
+                ssl_root_cert_path,
+                ssh_tunnel,
+                ssh_tunnel_profile_id,
+                ..
+            } => Ok(DbConfig::SqlServer {
+                use_uri,
+                uri,
+                host,
+                port,
+                user,
+                database: Some(database.to_string()),
+                instance,
+                ssl_mode,
+                trust_server_certificate,
+                ssl_root_cert_path,
+                ssh_tunnel,
+                ssh_tunnel_profile_id,
+            }),
             _ => Err("Changing database is not supported for this database type".to_string()),
         }
     }
@@ -1194,6 +1294,7 @@ impl ConnectionProfile {
             DbKind::DynamoDB => "dynamodb",
             DbKind::CloudWatchLogs => "cloudwatch",
             DbKind::InfluxDB => "influxdb",
+            DbKind::SqlServer => "mssql",
         }
     }
 
@@ -1252,6 +1353,10 @@ impl ConnectionProfile {
                 ..
             }
             | DbConfig::Redis {
+                ssh_tunnel_profile_id: Some(id),
+                ..
+            }
+            | DbConfig::SqlServer {
                 ssh_tunnel_profile_id: Some(id),
                 ..
             } => AccessKind::Ssh {

--- a/crates/dbflux_core/src/core/traits.rs
+++ b/crates/dbflux_core/src/core/traits.rs
@@ -424,6 +424,23 @@ pub trait DbDriver: Send + Sync {
         self.test_connection(profile)
             .map(|()| crate::TestConnectionResult::default())
     }
+
+    /// Test the connection using credentials supplied directly by the caller
+    /// (e.g. the password and SSH passphrase the user just typed in the
+    /// "Test Connection" UI), rather than reading from the keyring.
+    ///
+    /// The default implementation opens a connection via `connect_with_secrets`
+    /// and drops it immediately. Drivers that need richer telemetry can
+    /// override.
+    fn test_connection_rich_with_secrets(
+        &self,
+        profile: &ConnectionProfile,
+        password: Option<&SecretString>,
+        ssh_secret: Option<&SecretString>,
+    ) -> Result<crate::TestConnectionResult, DbError> {
+        let _conn = self.connect_with_secrets(profile, password, ssh_secret)?;
+        Ok(crate::TestConnectionResult::default())
+    }
 }
 
 /// Key-value operations exposed by drivers in `DatabaseCategory::KeyValue`.

--- a/crates/dbflux_core/src/driver/form.rs
+++ b/crates/dbflux_core/src/driver/form.rs
@@ -389,6 +389,78 @@ pub static SQLITE_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef
     }],
 });
 
+pub static SQLSERVER_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef {
+    tabs: vec![
+        FormTab {
+            id: "main".into(),
+            label: "Main".into(),
+            sections: vec![
+                FormSection {
+                    title: "Server".into(),
+                    fields: vec![
+                        field_use_uri(),
+                        when_checked(
+                            field_required(
+                                "uri",
+                                "Connection URI",
+                                FormFieldKind::Text,
+                                "sqlserver://user:pass@localhost:1433/db",
+                            ),
+                            "use_uri",
+                        ),
+                        when_unchecked(
+                            with_default(
+                                field_required("host", "Host", FormFieldKind::Text, "localhost"),
+                                "localhost",
+                            ),
+                            "use_uri",
+                        ),
+                        when_unchecked(
+                            with_default(
+                                field_required("port", "Port", FormFieldKind::Number, "1433"),
+                                "1433",
+                            ),
+                            "use_uri",
+                        ),
+                        when_unchecked(
+                            field(
+                                "database",
+                                "Database",
+                                FormFieldKind::Text,
+                                "optional - leave empty for default",
+                            ),
+                            "use_uri",
+                        ),
+                        when_unchecked(
+                            field(
+                                "instance",
+                                "Instance",
+                                FormFieldKind::Text,
+                                "optional - e.g. SQLEXPRESS",
+                            ),
+                            "use_uri",
+                        ),
+                    ],
+                },
+                FormSection {
+                    title: "Authentication".into(),
+                    fields: vec![
+                        when_unchecked(
+                            with_default(
+                                field_required("user", "User", FormFieldKind::Text, "sa"),
+                                "sa",
+                            ),
+                            "use_uri",
+                        ),
+                        field_password(),
+                    ],
+                },
+            ],
+        },
+        ssh_tab(),
+    ],
+});
+
 pub static MONGODB_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef {
     tabs: vec![
         FormTab {

--- a/crates/dbflux_core/src/driver/mod.rs
+++ b/crates/dbflux_core/src/driver/mod.rs
@@ -10,6 +10,6 @@ pub use capabilities::{
 pub use form::{
     CLOUDWATCH_FORM, DYNAMODB_FORM, DriverFormDef, FormFieldDef, FormFieldKind, FormSection,
     FormTab, FormValues, INFLUXDB_FORM, MONGODB_FORM, MYSQL_FORM, POSTGRES_FORM, REDIS_FORM,
-    RefreshTrigger, SQLITE_FORM, SelectOption, field_file_path, field_password, field_use_uri,
-    ssh_tab,
+    RefreshTrigger, SQLITE_FORM, SQLSERVER_FORM, SelectOption, field_file_path, field_password,
+    field_use_uri, ssh_tab,
 };

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -87,9 +87,9 @@ pub use driver::{
     ExecutionClassification, FormFieldDef, FormFieldKind, FormSection, FormTab, FormValues,
     INFLUXDB_FORM, Icon, IsolationLevel, MONGODB_FORM, MYSQL_FORM, MutationCapabilities,
     OperationClassifier, POSTGRES_FORM, PaginationStyle, QueryCapabilities, QueryLanguage,
-    REDIS_FORM, RefreshTrigger, SQLITE_FORM, SelectOption, SslCertFields, SslModeOption,
-    SyntaxInfo, TransactionCapabilities, WhereOperator, field_file_path, field_password,
-    field_use_uri, ssh_tab,
+    REDIS_FORM, RefreshTrigger, SQLITE_FORM, SQLSERVER_FORM, SelectOption, SslCertFields,
+    SslModeOption, SyntaxInfo, TransactionCapabilities, WhereOperator, field_file_path,
+    field_password, field_use_uri, ssh_tab,
 };
 
 pub use facade::{DangerousQuerySuppressions, SessionFacade};
@@ -104,11 +104,11 @@ pub use query::{
     ReadTemplateOperation, ReadTemplateRequest, ResolvedWindow, Row, SemanticFieldRef,
     SemanticFilter, SemanticPlan, SemanticPlanKind, SemanticPlanner, SemanticPredicate,
     SemanticRequest, SemanticRequestKind, SortDirection, SqlLanguageService, SqlMutationGenerator,
-    TableBrowseRequest, TableCountRequest, TableRef, TextPosition, TextPositionRange, TextRange,
-    ValidationResult, classify_query_for_governance, classify_query_for_language,
-    classify_sql_execution, detect_dangerous_mongo, detect_dangerous_query, detect_dangerous_redis,
-    detect_dangerous_sql, is_safe_read_query, parse_semantic_filter_json,
-    render_semantic_filter_sql, strip_leading_comments,
+    TSqlLanguageService, TableBrowseRequest, TableCountRequest, TableRef, TextPosition,
+    TextPositionRange, TextRange, ValidationResult, classify_query_for_governance,
+    classify_query_for_language, classify_sql_execution, detect_dangerous_mongo,
+    detect_dangerous_query, detect_dangerous_redis, detect_dangerous_sql, is_safe_read_query,
+    parse_semantic_filter_json, render_semantic_filter_sql, strip_leading_comments,
 };
 
 pub use schema::node_id as schema_node_id;

--- a/crates/dbflux_core/src/pipeline/resolve.rs
+++ b/crates/dbflux_core/src/pipeline/resolve.rs
@@ -201,6 +201,24 @@ fn patch_config_field(config: &mut DbConfig, field: &str, value: &ResolvedValue)
             _ => {}
         },
 
+        DbConfig::SqlServer {
+            host,
+            port,
+            user,
+            database,
+            ..
+        } => match field {
+            "host" => *host = val.to_string(),
+            "port" => {
+                if let Ok(p) = val.parse() {
+                    *port = p;
+                }
+            }
+            "user" => *user = val.to_string(),
+            "database" => *database = Some(val.to_string()),
+            _ => {}
+        },
+
         DbConfig::External { values, .. } => {
             values.insert(field.to_string(), val.to_string());
         }

--- a/crates/dbflux_core/src/query/language_service.rs
+++ b/crates/dbflux_core/src/query/language_service.rs
@@ -323,6 +323,33 @@ impl LanguageService for SqlLanguageService {
     }
 }
 
+/// Language service for T-SQL (Microsoft SQL Server).
+///
+/// Behaves like `SqlLanguageService` for dangerous-query detection (the
+/// destructive keywords DROP/TRUNCATE/DELETE are spelled identically), but
+/// skips the live parse diagnostics entirely. The shared `tree-sitter-sequel`
+/// grammar follows generic ANSI SQL and flags T-SQL-only constructs as
+/// errors — `SELECT TOP n`, `OUTPUT INSERTED.*`, `MERGE`, `CROSS APPLY /
+/// OUTER APPLY`, table hints like `WITH (NOLOCK)`, `OFFSET … ROWS FETCH
+/// NEXT … ROWS ONLY`, etc. The server is the source of truth for syntax
+/// validity; surfacing parser false-positives in the editor only adds
+/// noise.
+pub struct TSqlLanguageService;
+
+impl LanguageService for TSqlLanguageService {
+    fn validate(&self, _query: &str) -> ValidationResult {
+        ValidationResult::Valid
+    }
+
+    fn detect_dangerous(&self, query: &str) -> Option<DangerousQueryKind> {
+        detect_dangerous_sql(query)
+    }
+
+    fn editor_diagnostics(&self, _query: &str) -> Vec<EditorDiagnostic> {
+        Vec::new()
+    }
+}
+
 /// Produce editor diagnostics for SQL using tree-sitter error nodes.
 fn sql_editor_diagnostics(query: &str) -> Vec<EditorDiagnostic> {
     if query.trim().is_empty() {

--- a/crates/dbflux_core/src/query/mod.rs
+++ b/crates/dbflux_core/src/query/mod.rs
@@ -13,9 +13,8 @@ pub use generator::{
 pub use language_service::{
     DangerousQueryKind, Diagnostic, DiagnosticSeverity, EditorDiagnostic, LanguageService,
     SqlLanguageService, TSqlLanguageService, TextPosition, TextPositionRange, TextRange,
-    ValidationResult, classify_query_for_language, detect_dangerous_mongo,
-    detect_dangerous_query, detect_dangerous_redis, detect_dangerous_sql,
-    strip_leading_comments,
+    ValidationResult, classify_query_for_language, detect_dangerous_mongo, detect_dangerous_query,
+    detect_dangerous_redis, detect_dangerous_sql, strip_leading_comments,
 };
 pub use safety::{classify_query_for_governance, classify_sql_execution, is_safe_read_query};
 pub use semantic::{

--- a/crates/dbflux_core/src/query/mod.rs
+++ b/crates/dbflux_core/src/query/mod.rs
@@ -12,9 +12,10 @@ pub use generator::{
 };
 pub use language_service::{
     DangerousQueryKind, Diagnostic, DiagnosticSeverity, EditorDiagnostic, LanguageService,
-    SqlLanguageService, TextPosition, TextPositionRange, TextRange, ValidationResult,
-    classify_query_for_language, detect_dangerous_mongo, detect_dangerous_query,
-    detect_dangerous_redis, detect_dangerous_sql, strip_leading_comments,
+    SqlLanguageService, TSqlLanguageService, TextPosition, TextPositionRange, TextRange,
+    ValidationResult, classify_query_for_language, detect_dangerous_mongo,
+    detect_dangerous_query, detect_dangerous_redis, detect_dangerous_sql,
+    strip_leading_comments,
 };
 pub use safety::{classify_query_for_governance, classify_sql_execution, is_safe_read_query};
 pub use semantic::{

--- a/crates/dbflux_core/src/query/types.rs
+++ b/crates/dbflux_core/src/query/types.rs
@@ -413,6 +413,7 @@ mod tests {
             vec![ColumnMeta {
                 name: label.to_string(),
                 type_name: "text".to_string(),
+                kind: ColumnKind::Unknown,
                 nullable: true,
                 is_primary_key: false,
             }],

--- a/crates/dbflux_core/src/query/types.rs
+++ b/crates/dbflux_core/src/query/types.rs
@@ -191,6 +191,19 @@ pub struct QueryResult {
     /// injected_window) populate this map; the runner merges it into the event without
     /// any driver-id branching.
     pub metadata_extra: Option<std::collections::HashMap<String, serde_json::Value>>,
+    /// Additional result sets produced by the same query batch.
+    ///
+    /// Populated by drivers whose protocol can return more than one result
+    /// set per statement-batch (e.g. SQL Server `SELECT 1; SELECT 2;`, or a
+    /// stored procedure with multiple `SELECT`s). The primary result is
+    /// `self`; the secondary sets follow in batch order. UIs that want every
+    /// set should iterate `iter_result_sets()`.
+    ///
+    /// Each entry must itself have an empty `additional_results` field —
+    /// `push_additional_result()` enforces this by flattening on insert.
+    /// Drivers that always produce a single result set leave this empty
+    /// (the default), so existing callers are unaffected.
+    pub additional_results: Vec<QueryResult>,
 }
 
 impl QueryResult {
@@ -206,6 +219,7 @@ impl QueryResult {
             next_page_token: None,
             resolved_window: None,
             metadata_extra: None,
+            additional_results: Vec::new(),
         }
     }
 
@@ -232,6 +246,7 @@ impl QueryResult {
             next_page_token: None,
             resolved_window: None,
             metadata_extra: None,
+            additional_results: Vec::new(),
         }
     }
 
@@ -247,6 +262,7 @@ impl QueryResult {
             next_page_token: None,
             resolved_window: None,
             metadata_extra: None,
+            additional_results: Vec::new(),
         }
     }
 
@@ -262,6 +278,7 @@ impl QueryResult {
             next_page_token: None,
             resolved_window: None,
             metadata_extra: None,
+            additional_results: Vec::new(),
         }
     }
 
@@ -277,6 +294,7 @@ impl QueryResult {
             next_page_token: None,
             resolved_window: None,
             metadata_extra: None,
+            additional_results: Vec::new(),
         }
     }
 
@@ -286,6 +304,43 @@ impl QueryResult {
 
     pub fn column_count(&self) -> usize {
         self.columns.len()
+    }
+
+    /// Returns the number of result sets in this query result, counting the
+    /// primary set. Drivers that produce a single set return `1`.
+    pub fn result_set_count(&self) -> usize {
+        1 + self.additional_results.len()
+    }
+
+    /// Returns `true` when the driver produced more than one result set for
+    /// this batch (a `SELECT 1; SELECT 2;` style query or a multi-`SELECT`
+    /// stored procedure).
+    pub fn has_additional_results(&self) -> bool {
+        !self.additional_results.is_empty()
+    }
+
+    /// Iterate every result set produced by the batch, primary first.
+    pub fn iter_result_sets(&self) -> impl Iterator<Item = &QueryResult> {
+        std::iter::once(self).chain(self.additional_results.iter())
+    }
+
+    /// Consuming iterator over every result set in the batch, primary first.
+    ///
+    /// Each yielded `QueryResult` has an empty `additional_results` field;
+    /// the recursion is flattened at construction time via
+    /// `push_additional_result`.
+    pub fn into_result_sets(mut self) -> impl Iterator<Item = QueryResult> {
+        let extras = std::mem::take(&mut self.additional_results);
+        std::iter::once(self).chain(extras)
+    }
+
+    /// Attach a result set produced by the same batch. Flattens any nested
+    /// `additional_results` from the argument so callers can safely pass a
+    /// full `QueryResult` without producing a recursive tree.
+    pub fn push_additional_result(&mut self, mut other: QueryResult) {
+        let nested = std::mem::take(&mut other.additional_results);
+        self.additional_results.push(other);
+        self.additional_results.extend(nested);
     }
 }
 
@@ -351,5 +406,76 @@ mod tests {
 
         let result = QueryResult::empty().with_resolved_window(window.clone());
         assert_eq!(result.resolved_window.as_ref(), Some(&window));
+    }
+
+    fn make_set(label: &str) -> QueryResult {
+        QueryResult::table(
+            vec![ColumnMeta {
+                name: label.to_string(),
+                type_name: "text".to_string(),
+                nullable: true,
+                is_primary_key: false,
+            }],
+            Vec::new(),
+            None,
+            Duration::ZERO,
+        )
+    }
+
+    #[test]
+    fn default_query_result_has_no_additional_sets() {
+        let result = QueryResult::empty();
+        assert_eq!(result.result_set_count(), 1);
+        assert!(!result.has_additional_results());
+        assert_eq!(result.iter_result_sets().count(), 1);
+    }
+
+    #[test]
+    fn push_additional_result_appends_in_order() {
+        let mut primary = make_set("a");
+        primary.push_additional_result(make_set("b"));
+        primary.push_additional_result(make_set("c"));
+
+        assert_eq!(primary.result_set_count(), 3);
+        assert!(primary.has_additional_results());
+
+        let labels: Vec<&str> = primary
+            .iter_result_sets()
+            .map(|r| r.columns[0].name.as_str())
+            .collect();
+        assert_eq!(labels, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn push_additional_result_flattens_nested_extras() {
+        // Build a "chained" result and verify push_additional_result flattens
+        // the nested additional_results to avoid building a recursive tree.
+        let mut inner = make_set("b");
+        inner.push_additional_result(make_set("c"));
+
+        let mut primary = make_set("a");
+        primary.push_additional_result(inner);
+
+        // Three total sets, all at the same level.
+        assert_eq!(primary.result_set_count(), 3);
+
+        for extra in &primary.additional_results {
+            assert!(
+                extra.additional_results.is_empty(),
+                "nested additional_results should have been flattened"
+            );
+        }
+    }
+
+    #[test]
+    fn into_result_sets_yields_primary_then_extras() {
+        let mut primary = make_set("a");
+        primary.push_additional_result(make_set("b"));
+
+        let labels: Vec<String> = primary
+            .into_result_sets()
+            .map(|r| r.columns[0].name.clone())
+            .collect();
+        assert_eq!(labels, vec!["a".to_string(), "b".to_string()]);
     }
 }

--- a/crates/dbflux_core/src/storage/secret_manager.rs
+++ b/crates/dbflux_core/src/storage/secret_manager.rs
@@ -245,6 +245,11 @@ impl SecretManager {
                 ssh_tunnel_profile_id,
                 ..
             } => (ssh_tunnel.as_ref(), *ssh_tunnel_profile_id),
+            DbConfig::SqlServer {
+                ssh_tunnel,
+                ssh_tunnel_profile_id,
+                ..
+            } => (ssh_tunnel.as_ref(), *ssh_tunnel_profile_id),
             DbConfig::SQLite { .. }
             | DbConfig::DynamoDB { .. }
             | DbConfig::CloudWatchLogs { .. }

--- a/crates/dbflux_driver_mssql/Cargo.toml
+++ b/crates/dbflux_driver_mssql/Cargo.toml
@@ -20,6 +20,7 @@ hex.workspace = true
 indexmap.workspace = true
 log = "0.4"
 serde_json = "1"
+sha2.workspace = true
 tiberius = { version = "0.12", default-features = false, features = ["chrono", "tds73", "rustls", "sql-browser-tokio"] }
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "sync", "time", "macros"] }
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/crates/dbflux_driver_mssql/Cargo.toml
+++ b/crates/dbflux_driver_mssql/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "dbflux_driver_mssql"
+version.workspace = true
+edition.workspace = true
+publish = false
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+dbflux_core = { path = "../dbflux_core" }
+dbflux_ssh = { path = "../dbflux_ssh" }
+chrono = "0.4"
+hex.workspace = true
+indexmap.workspace = true
+log = "0.4"
+serde_json = "1"
+tiberius = { version = "0.12", default-features = false, features = ["chrono", "tds73", "rustls", "sql-browser-tokio"] }
+tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "sync", "time", "macros"] }
+tokio-util = { version = "0.7", features = ["compat"] }
+urlencoding = "2"
+uuid.workspace = true
+
+[dev-dependencies]
+dbflux_test_support.workspace = true
+
+[lints]
+workspace = true

--- a/crates/dbflux_driver_mssql/README.md
+++ b/crates/dbflux_driver_mssql/README.md
@@ -113,7 +113,7 @@ Microsoft SQL Server driver for DBFlux, built on the
   | 4060, 18450, 18452, 18456, 18486, 18487, 18488 | `AuthFailed`            |
   | 229, 230, 262, 297, 916                       | `PermissionDenied`      |
   | 207, 208, 2812, 4902                          | `ObjectNotFound`        |
-  | 515, 547, 2601, 2627, 8152, 245               | `ConstraintViolation`   |
+  | 245, 334, 515, 547, 2601, 2627, 8152          | `ConstraintViolation`   |
   | 102, 156, 8180                                | `SyntaxError`           |
 
 - Constraint-violation messages are parsed to populate `ErrorLocation`
@@ -155,6 +155,12 @@ Microsoft SQL Server driver for DBFlux, built on the
 
 ## Limitations
 
+- CRUD on tables (or updateable views) with `INSTEAD OF` triggers is not
+  supported. The driver returns the post-mutation row via
+  `OUTPUT INSERTED.*` / `OUTPUT DELETED.*` without an `INTO` clause, which
+  SQL Server rejects with error 334 ("the target table cannot have any
+  enabled triggers if the statement contains an OUTPUT clause without
+  INTO"). The error is surfaced as `ConstraintViolation`.
 - SQL-only driver; it does not expose document or key-value APIs.
 - Cancellation kills the underlying session and transparently reconnects;
   it is not the surgical TDS-Attention cancel that SSMS uses (tiberius does

--- a/crates/dbflux_driver_mssql/README.md
+++ b/crates/dbflux_driver_mssql/README.md
@@ -1,0 +1,193 @@
+# dbflux_driver_mssql
+
+Microsoft SQL Server driver for DBFlux, built on the
+[`tiberius`](https://crates.io/crates/tiberius) TDS client.
+
+## Features
+
+- SQL Server / Azure SQL relational driver with SQL query execution and schema
+  discovery.
+- Authentication via SQL Server logins (username + password); URI mode accepts
+  ADO, JDBC, and `sqlserver://user:pass@host:port/db` connection strings.
+- TLS encryption modes (`off`, `on`, `required`) via tiberius
+  `EncryptionLevel`. The form exposes a single **SSL Mode** dropdown;
+  the `TrustServerCertificate` flag is derived automatically:
+  - `off` — no encryption (login packet still encrypted by TDS).
+  - `on` — encrypted, accepts self-signed certs. Best for local/dev
+    SQL Server with its auto-generated cert.
+  - `required` — encrypted, validates the cert chain. Use against
+    servers with a real CA-signed cert (Azure SQL, etc.).
+  In URI mode, `?trust=true|false` explicitly overrides the derived
+  value if you need an unusual combination (e.g. `?encrypt=required&trust=true`).
+- Optional SQL Server named instances (`SQLEXPRESS`, `MSSQLSERVER2019`,
+  etc.) resolved at connect time by querying SQL Browser on UDP 1434
+  (enabled via tiberius's `sql-browser-tokio` feature). The form's
+  Instance field, the SSMS-style `host\instance` form in URI mode, and
+  the `?instance=` URI query parameter all set the same `instance_name`
+  on the tiberius config.
+- SSH tunnel support for connecting through bastion hosts (named instance
+  lookup is not available through a TCP-only tunnel).
+- Per-tab database switching via `USE [database]`; session state (SET options,
+  temp tables, transactions) persists across `execute()` calls on the same
+  connection.
+- Multi-result-set batches: when a batch produces several result sets (e.g.
+  `SELECT 1; SELECT 2;` or a stored procedure with multiple `SELECT`s), the
+  driver returns the **last** non-empty set as the primary `QueryResult`
+  (preserving the historical "last statement wins" UX) and attaches every
+  earlier non-empty set to `QueryResult.additional_results` in batch order.
+  Pure preparation batches (`SET LOCK_TIMEOUT 5000`) still surface as a
+  single empty primary. Callers that want to walk every set use
+  `QueryResult::iter_result_sets()`.
+
+### Query cancellation
+
+- Cancellation is implemented as `KILL <spid>` issued from a fresh
+  side-channel connection. tiberius does not currently expose the TDS
+  Attention primitive that SSMS uses, so the next best option is to ask
+  the server to terminate the session running the query.
+- At connect time the driver captures `@@SPID` and caches a clone of the
+  tiberius `Config` (with the login already baked in). The cancel handle
+  opens a second connection on demand, runs `KILL <spid>`, and marks the
+  primary connection as poisoned.
+- After cancellation, `cleanup_after_cancel()` rebuilds the primary tiberius
+  client, captures the new SPID, and re-issues the previous `USE [db]` so
+  the next query runs in the same database. From the UI's perspective the
+  connection stays connected; only the underlying session id changes.
+- Errors raised on the killed session (codes 596 / 233 / 6005) are
+  translated to `DbError::Cancelled` so the UI shows "query cancelled"
+  rather than a transport-level failure.
+- The session owner can `KILL` its own SPID on modern SQL Server without
+  the `ALTER ANY CONNECTION` permission. On older or restricted logins,
+  the KILL itself may fail with a permission error; the driver surfaces
+  that to the user.
+
+### Schema discovery
+
+- Databases (`sys.databases`, hides system DBs).
+- Tables and views per database (`sys.tables`, `sys.views`).
+- Per-table columns + primary key flag, indexes, foreign keys.
+- Per-table constraints: CHECK constraints (with their definition) and
+  UNIQUE constraints (via `sys.indexes.is_unique_constraint`).
+- Whole-schema indexes and foreign keys for the schema browser sidebar.
+- User-defined types (`sys.types where is_user_defined = 1`) classified as
+  `Domain` (alias types) or `Composite` (table types).
+- `view_details()` verifies the view exists in the requested database.
+
+### CRUD with OUTPUT
+
+- INSERT/UPDATE/DELETE on a row use SQL Server's `OUTPUT INSERTED.*` /
+  `OUTPUT DELETED.*` clause so the post-mutation row data is returned to the
+  caller (`CrudResult::success(row)`), the same way the Postgres driver uses
+  `RETURNING *`.
+- `MutationCapabilities::supports_returning` is `true`.
+- Row identity must be a composite primary key (the only `RecordIdentity`
+  variant that makes sense for a relational driver).
+
+### Query planning
+
+- `explain()` runs the query under `SET SHOWPLAN_XML ON` and returns the
+  query plan as XML. The driver always runs `SET SHOWPLAN_XML OFF` afterward
+  so session state does not leak.
+- `version_query()` returns `SELECT @@VERSION`.
+
+### Dialect
+
+- `[bracket]` identifier quoting with `]` escaping.
+- `N'…'` Unicode string literals; `0x…` (uppercase) binary literals;
+  `1`/`0` for boolean (`BIT`) values.
+- `OFFSET … ROWS FETCH NEXT … ROWS ONLY` pagination (with a fallback
+  `ORDER BY 1` so OFFSET-without-ORDER-BY queries do not error out).
+- `SELECT TOP N` is not used; OFFSET/FETCH is the canonical pagination form.
+- `UPSERT` is intentionally not generated; SQL Server's `MERGE` has known
+  bugs and should be written by hand.
+
+### Error reporting
+
+- Tiberius `Server` token errors surface their numeric code, severity state,
+  and source line through `FormattedError`.
+- Common MSSQL error numbers are mapped to semantic `DbError` variants
+  rather than the generic `QueryFailed`:
+
+  | Code(s)                                       | DbError variant         |
+  | --------------------------------------------- | ----------------------- |
+  | 4060, 18450, 18452, 18456, 18486, 18487, 18488 | `AuthFailed`            |
+  | 229, 230, 262, 297, 916                       | `PermissionDenied`      |
+  | 207, 208, 2812, 4902                          | `ObjectNotFound`        |
+  | 515, 547, 2601, 2627, 8152, 245               | `ConstraintViolation`   |
+  | 102, 156, 8180                                | `SyntaxError`           |
+
+- Constraint-violation messages are parsed to populate `ErrorLocation`
+  (schema, table, column, constraint name) so the UI can highlight the
+  offending object.
+
+### Operations and limits
+
+- All operations declare `transactional_ddl: true` and `supports_savepoints:
+  true`.
+- Supported isolation levels: ReadUncommitted, ReadCommitted, RepeatableRead,
+  Serializable, Snapshot. Default is ReadCommitted.
+
+## DDL behavior
+
+- **Transactional DDL.** Most DDL in SQL Server is transactional. Wrapping
+  `CREATE`, `ALTER`, or `DROP TABLE` inside `BEGIN TRAN … COMMIT` /
+  `ROLLBACK` works. Exceptions: `CREATE DATABASE`, `DROP DATABASE`, `ALTER
+  DATABASE`, `BACKUP`/`RESTORE`, and `CREATE FULLTEXT INDEX` cannot run
+  inside an explicit transaction.
+- **ALTER TABLE locking.** `ALTER TABLE … ADD COLUMN <nullable>` is fast
+  (metadata-only). Adding a NOT NULL column with a default writes to every
+  page and takes a Sch-M lock. `ALTER TABLE … ALTER COLUMN` may rewrite the
+  table and blocks reads and writes until it finishes.
+- **Online index operations** (Enterprise / Azure SQL): `CREATE INDEX … WITH
+  (ONLINE = ON)` and `ALTER INDEX … REBUILD WITH (ONLINE = ON)` allow
+  concurrent DML. Without `ONLINE = ON`, index builds take Sch-M and block
+  writes (Standard/Express editions only support offline).
+- **TRUNCATE TABLE.** Metadata-only, fast, transactional, requires
+  `ALTER` permission on the table. Cannot be used on tables referenced by a
+  foreign key (use `DELETE` or drop the FK first).
+- **DROP TABLE / DROP VIEW.** Transactional. `IF EXISTS` is supported on
+  2016+.
+- **Constraints.** Adding `CHECK` / `UNIQUE` / `FOREIGN KEY` constraints
+  validates all existing rows by default (takes Sch-M briefly). Use `WITH
+  NOCHECK` to add the constraint without scanning, then `WITH CHECK CHECK
+  CONSTRAINT` later to validate at your leisure — same pattern as Postgres's
+  `NOT VALID` + `VALIDATE CONSTRAINT`.
+
+## Limitations
+
+- SQL-only driver; it does not expose document or key-value APIs.
+- Cancellation kills the underlying session and transparently reconnects;
+  it is not the surgical TDS-Attention cancel that SSMS uses (tiberius does
+  not currently expose that primitive). In practice the only user-visible
+  difference is that any session-local state (`SET` options, temp tables,
+  open transactions) is reset by the cancel. The active database is
+  restored automatically.
+- Cancellation latency depends on the SQL Server scheduler: typically a few
+  milliseconds for CPU-bound queries, immediate for lock-waiters. Long
+  rollbacks (e.g. cancelling a large `DELETE` mid-transaction) can keep the
+  *server-side* SPID in the KILLED/ROLLBACK state for a while after the
+  driver has already moved on to a fresh session.
+- Parameter binding is not used — statements are dispatched via
+  `simple_query`. CRUD helpers compose values into the SQL text through the
+  shared `SqlQueryBuilder` and dialect literal formatters. Large binary or
+  Unicode payloads are inlined as `0x…` or `N'…'` literals.
+- Streaming: result sets are materialized into `Vec<Row>`. The
+  `Connection::execute` trait returns a fully-resolved `QueryResult`, so
+  cursor-style streaming would require a workspace-level API change rather
+  than a driver-only fix.
+- Multi-statement batches surface every non-empty result set via
+  `QueryResult.additional_results`, but the UI currently renders only the
+  primary (last) set. Until the result-tab system reads
+  `additional_results`, the earlier sets are captured by the driver but
+  invisible in the editor.
+- `PRINT` and informational messages emitted during a batch are dropped.
+  Surfacing them would require driving tiberius's lower-level
+  `TokenStream` instead of `QueryStream::into_results()`.
+- `UPSERT` is intentionally not generated. Use `MERGE` manually when needed.
+- Named instances are honored when connecting directly (tiberius queries the
+  SQL Browser service on UDP 1434) but not when going through an SSH tunnel,
+  since libssh2 only forwards TCP. The standard workaround is to assign a
+  static TCP port to the instance and connect to that port directly.
+- Schema introspection uses the `sys.*` catalog views; users without the
+  default `VIEW DEFINITION` permission will see partial metadata. SQL
+  Server's metadata visibility rules apply.

--- a/crates/dbflux_driver_mssql/README.md
+++ b/crates/dbflux_driver_mssql/README.md
@@ -155,6 +155,9 @@ Microsoft SQL Server driver for DBFlux, built on the
 
 ## Limitations
 
+- Minimum supported SQL Server: 2016 (13.0). The driver uses
+  `DROP INDEX IF EXISTS … ON …` syntax that older servers reject with a
+  syntax error (102). Azure SQL Database and Managed Instance are fine.
 - CRUD on tables (or updateable views) with `INSTEAD OF` triggers is not
   supported. The driver returns the post-mutation row via
   `OUTPUT INSERTED.*` / `OUTPUT DELETED.*` without an `INTO` clause, which

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1451,15 +1451,22 @@ impl Connection for MssqlConnection {
         }
 
         self.spid.store(new_spid, Ordering::SeqCst);
-        self.poisoned.store(false, Ordering::SeqCst);
-        self.cancelled.store(false, Ordering::SeqCst);
 
         // The new session starts in whatever the login defaults to. If the
-        // user was previously on a specific database, restore that selection.
+        // user was previously on a specific database, restore that selection
+        // before clearing the poisoned flag — otherwise a failing `USE [db]`
+        // would leave the connection alive on the login's default database
+        // while callers (with `poisoned == false`) assume recovery succeeded
+        // on the requested one. With the clear deferred, a USE failure leaves
+        // `poisoned == true`, so the next `execute()` triggers another
+        // recovery attempt instead of silently running on the wrong DB.
         if let Some(db) = active_database {
             let escaped = db.replace(']', "]]");
             self.execute_simple(&format!("USE [{}]", escaped))?;
         }
+
+        self.poisoned.store(false, Ordering::SeqCst);
+        self.cancelled.store(false, Ordering::SeqCst);
 
         log::info!("[CLEANUP] Reconnect complete, new SPID = {}", new_spid);
         Ok(())

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1,0 +1,3493 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use dbflux_core::QueryGenerator;
+use dbflux_core::secrecy::{ExposeSecret, SecretString};
+use dbflux_core::{
+    ColumnInfo, ColumnMeta, Connection, ConnectionErrorFormatter, ConnectionExt, ConnectionProfile,
+    ConstraintInfo, ConstraintKind, CrudResult, CustomTypeInfo, CustomTypeKind, DatabaseCategory,
+    DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DbSchemaInfo, DdlCapabilities,
+    DeploymentClass, DescribeRequest, DocumentConnection, DriverCapabilities, DriverFormDef,
+    DriverLimits, DriverMetadata, ExplainRequest, ForeignKeyBuilder, ForeignKeyInfo, FormValues,
+    FormattedError, Icon, IndexData, IndexInfo, IsolationLevel, KeyValueConnection,
+    MutationCapabilities, OrderByColumn, PaginationStyle, PlaceholderStyle, QueryCancelHandle,
+    QueryCapabilities, QueryErrorFormatter, QueryHandle, QueryLanguage, QueryRequest, QueryResult,
+    RecordIdentity, RelationalConnection, RelationalSchema, Row, RowDelete, RowInsert, RowPatch,
+    SQLSERVER_FORM, SchemaFeatures, SchemaForeignKeyBuilder, SchemaForeignKeyInfo,
+    SchemaIndexBuilder, SchemaIndexInfo, SchemaLoadingStrategy, SchemaSnapshot, SortDirection,
+    SqlDialect, SqlMutationGenerator, SshTunnelConfig, SyntaxInfo, TableInfo,
+    TransactionCapabilities, Value, ViewInfo, WhereOperator, generate_delete_template,
+    generate_drop_table, generate_insert_template, generate_select_star, generate_truncate,
+    generate_update_template, sanitize_uri,
+};
+use dbflux_ssh::SshTunnel;
+use tiberius::{AuthMethod, Client, Config, EncryptionLevel, SqlBrowser};
+use tokio::net::TcpStream;
+use tokio::runtime::{Builder, Runtime};
+use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
+
+type TiberiusClient = Client<Compat<TcpStream>>;
+
+/// SQL Server driver metadata.
+pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
+    id: "mssql".into(),
+    display_name: "SQL Server".into(),
+    description: "Microsoft SQL Server relational database".into(),
+    category: DatabaseCategory::Relational,
+    deployment_class: Some(DeploymentClass::SelfHosted),
+    query_language: QueryLanguage::Sql,
+    capabilities: DriverCapabilities::from_bits_truncate(
+        DriverCapabilities::RELATIONAL_BASE.bits()
+            | DriverCapabilities::SCHEMAS.bits()
+            | DriverCapabilities::SSH_TUNNEL.bits()
+            | DriverCapabilities::SSL.bits()
+            | DriverCapabilities::AUTHENTICATION.bits()
+            | DriverCapabilities::FOREIGN_KEYS.bits()
+            | DriverCapabilities::CHECK_CONSTRAINTS.bits()
+            | DriverCapabilities::UNIQUE_CONSTRAINTS.bits()
+            | DriverCapabilities::TRANSACTIONAL_DDL.bits(),
+    ),
+    default_port: Some(1433),
+    uri_scheme: "sqlserver".into(),
+    icon: Icon::Database,
+    syntax: Some(SyntaxInfo {
+        identifier_quote: '"',
+        string_quote: '\'',
+        placeholder_style: PlaceholderStyle::QuestionMark,
+        supports_schemas: true,
+        default_schema: Some("dbo".to_string()),
+        case_sensitive_identifiers: false,
+    }),
+    query: Some(QueryCapabilities {
+        pagination: vec![PaginationStyle::Offset],
+        where_operators: vec![
+            WhereOperator::Eq,
+            WhereOperator::Ne,
+            WhereOperator::Gt,
+            WhereOperator::Gte,
+            WhereOperator::Lt,
+            WhereOperator::Lte,
+            WhereOperator::Like,
+            WhereOperator::Null,
+            WhereOperator::In,
+            WhereOperator::NotIn,
+            WhereOperator::And,
+            WhereOperator::Or,
+            WhereOperator::Not,
+        ],
+        supports_order_by: true,
+        supports_group_by: true,
+        supports_having: true,
+        supports_distinct: true,
+        supports_limit: true,
+        supports_offset: true,
+        supports_joins: true,
+        supports_subqueries: true,
+        supports_union: true,
+        supports_intersect: true,
+        supports_except: true,
+        supports_case_expressions: true,
+        supports_window_functions: true,
+        supports_ctes: true,
+        supports_explain: false,
+        max_query_parameters: 2100,
+        max_order_by_columns: 0,
+        max_group_by_columns: 0,
+    }),
+    mutation: Some(MutationCapabilities {
+        supports_insert: true,
+        supports_update: true,
+        supports_delete: true,
+        supports_upsert: false,
+        supports_returning: true,
+        supports_batch: true,
+        supports_bulk_update: true,
+        supports_bulk_delete: true,
+        max_insert_values: 1000,
+    }),
+    ddl: Some(DdlCapabilities {
+        supports_create_database: true,
+        supports_drop_database: true,
+        supports_create_table: true,
+        supports_drop_table: true,
+        supports_alter_table: true,
+        supports_create_index: true,
+        supports_drop_index: true,
+        supports_create_view: true,
+        supports_drop_view: true,
+        supports_create_trigger: true,
+        supports_drop_trigger: true,
+        transactional_ddl: true,
+        supports_add_column: true,
+        supports_drop_column: true,
+        supports_rename_column: false,
+        supports_alter_column: true,
+        supports_add_constraint: true,
+        supports_drop_constraint: true,
+    }),
+    transactions: Some(TransactionCapabilities {
+        supports_transactions: true,
+        supported_isolation_levels: vec![
+            IsolationLevel::ReadUncommitted,
+            IsolationLevel::ReadCommitted,
+            IsolationLevel::RepeatableRead,
+            IsolationLevel::Serializable,
+            IsolationLevel::Snapshot,
+        ],
+        default_isolation_level: Some(IsolationLevel::ReadCommitted),
+        supports_savepoints: true,
+        supports_nested_transactions: false,
+        supports_read_only: false,
+        supports_deferrable: false,
+    }),
+    limits: Some(DriverLimits {
+        max_query_length: 0,
+        max_parameters: 2100,
+        max_result_rows: 0,
+        max_connections: 0,
+        max_nested_subqueries: 32,
+        max_identifier_length: 128,
+        max_columns: 1024,
+        max_indexes_per_table: 999,
+    }),
+    ssl_modes: Some(&[
+        dbflux_core::SslModeOption {
+            id: "off",
+            label: "off",
+        },
+        dbflux_core::SslModeOption {
+            id: "on",
+            label: "on (accept self-signed)",
+        },
+        dbflux_core::SslModeOption {
+            id: "required",
+            label: "required (validate cert)",
+        },
+    ]),
+    ssl_cert_fields: Some(dbflux_core::SslCertFields {
+        root_cert: true,
+        client_cert: false,
+    }),
+    classification_override: None,
+});
+
+// =============================================================================
+// SQL Server SQL dialect
+// =============================================================================
+
+pub struct MssqlDialect;
+
+static MSSQL_DIALECT: MssqlDialect = MssqlDialect;
+
+impl SqlDialect for MssqlDialect {
+    fn quote_identifier(&self, name: &str) -> String {
+        // SQL Server uses [bracket] quoting. Any closing bracket inside the
+        // identifier must be doubled to be safe.
+        let escaped = name.replace(']', "]]");
+        format!("[{}]", escaped)
+    }
+
+    fn qualified_table(&self, schema: Option<&str>, table: &str) -> String {
+        match schema {
+            Some(s) => format!(
+                "{}.{}",
+                self.quote_identifier(s),
+                self.quote_identifier(table)
+            ),
+            None => self.quote_identifier(table),
+        }
+    }
+
+    fn value_to_literal(&self, value: &Value) -> String {
+        value_to_mssql_literal(value)
+    }
+
+    fn escape_string(&self, s: &str) -> String {
+        s.replace('\'', "''")
+    }
+
+    fn placeholder_style(&self) -> PlaceholderStyle {
+        PlaceholderStyle::QuestionMark
+    }
+
+    fn supports_returning(&self) -> bool {
+        // SQL Server returns affected rows via the OUTPUT clause rather than
+        // RETURNING. The driver's CRUD methods build the OUTPUT clause
+        // directly; SqlQueryBuilder's RETURNING path is bypassed.
+        true
+    }
+
+    fn build_upsert_statement(
+        &self,
+        _schema: Option<&str>,
+        _table: &str,
+        _columns: &[String],
+        _values: &[Value],
+        _conflict_columns: &[String],
+        _update_assignments: &[(String, Value)],
+    ) -> Option<String> {
+        // SQL Server uses MERGE for upsert; not generated here to avoid producing
+        // an incorrect template. Use UPDATE/INSERT separately.
+        None
+    }
+}
+
+fn value_to_mssql_literal(value: &Value) -> String {
+    match value {
+        Value::Null => "NULL".to_string(),
+        Value::Bool(b) => {
+            // SQL Server BIT uses 0/1.
+            if *b { "1" } else { "0" }.to_string()
+        }
+        Value::Int(i) => i.to_string(),
+        Value::Float(f) => {
+            if f.is_nan() || f.is_infinite() {
+                "NULL".to_string()
+            } else {
+                f.to_string()
+            }
+        }
+        Value::Text(s) => format!("N'{}'", s.replace('\'', "''")),
+        Value::Bytes(b) => {
+            let hex: String = b.iter().map(|byte| format!("{:02X}", byte)).collect();
+            format!("0x{}", hex)
+        }
+        Value::Json(s) => format!("N'{}'", s.replace('\'', "''")),
+        Value::Decimal(s) => s.clone(),
+        Value::DateTime(dt) => format!("'{}'", dt.format("%Y-%m-%d %H:%M:%S%.f")),
+        Value::Date(d) => format!("'{}'", d.format("%Y-%m-%d")),
+        Value::Time(t) => format!("'{}'", t.format("%H:%M:%S%.f")),
+        Value::Array(_) | Value::Document(_) | Value::ObjectId(_) => {
+            let json = serde_json::to_string(value).unwrap_or_else(|_| "null".to_string());
+            format!("N'{}'", json.replace('\'', "''"))
+        }
+        Value::Unsupported(_) => "NULL".to_string(),
+    }
+}
+
+// =============================================================================
+// MssqlDriver
+// =============================================================================
+
+pub struct MssqlDriver;
+
+impl MssqlDriver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MssqlDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DbDriver for MssqlDriver {
+    fn kind(&self) -> DbKind {
+        DbKind::SqlServer
+    }
+
+    fn metadata(&self) -> &DriverMetadata {
+        &METADATA
+    }
+
+    fn driver_key(&self) -> dbflux_core::DriverKey {
+        "builtin:mssql".into()
+    }
+
+    fn connect_with_secrets(
+        &self,
+        profile: &ConnectionProfile,
+        password: Option<&SecretString>,
+        ssh_secret: Option<&SecretString>,
+    ) -> Result<Box<dyn Connection>, DbError> {
+        let config = extract_mssql_config(&profile.config)?;
+
+        let password = password.map(|value| value.expose_secret());
+        let ssh_secret = ssh_secret.map(|value| value.expose_secret());
+
+        if config.use_uri {
+            return self.connect_with_uri(config.uri.as_deref().unwrap_or(""), password);
+        }
+
+        if let Some(tunnel_config) = &config.ssh_tunnel {
+            self.connect_via_ssh_tunnel(tunnel_config, ssh_secret, &config, password)
+        } else {
+            self.connect_direct(&config, password)
+        }
+    }
+
+    fn test_connection(&self, profile: &ConnectionProfile) -> Result<(), DbError> {
+        let conn = self.connect_with_secrets(profile, None, None)?;
+        conn.ping()
+    }
+
+    fn form_definition(&self) -> &DriverFormDef {
+        &SQLSERVER_FORM
+    }
+
+    fn build_config(&self, values: &FormValues) -> Result<DbConfig, DbError> {
+        let use_uri = values.get("use_uri").map(|s| s == "true").unwrap_or(false);
+        let uri = values.get("uri").filter(|s| !s.is_empty()).cloned();
+
+        if use_uri {
+            if uri.is_none() {
+                return Err(DbError::InvalidProfile(
+                    "Connection URI is required when using URI mode".to_string(),
+                ));
+            }
+
+            return Ok(DbConfig::SqlServer {
+                use_uri: true,
+                uri,
+                host: String::new(),
+                port: 1433,
+                user: String::new(),
+                database: None,
+                instance: None,
+                ssl_mode: Some("on".to_string()),
+                trust_server_certificate: true,
+                ssl_root_cert_path: None,
+                ssh_tunnel: None,
+                ssh_tunnel_profile_id: None,
+            });
+        }
+
+        let host = values
+            .get("host")
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| DbError::InvalidProfile("Host is required".to_string()))?
+            .clone();
+
+        let port: u16 = values
+            .get("port")
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| DbError::InvalidProfile("Port is required".to_string()))?
+            .parse()
+            .map_err(|_| DbError::InvalidProfile("Invalid port number".to_string()))?;
+
+        let user = values
+            .get("user")
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| DbError::InvalidProfile("User is required".to_string()))?
+            .clone();
+
+        let database = values.get("database").filter(|s| !s.is_empty()).cloned();
+        let instance = values.get("instance").filter(|s| !s.is_empty()).cloned();
+
+        // SSL Mode is the single user-facing knob. The trust-cert flag is
+        // derived from it so the UI doesn't need a second checkbox:
+        //   off      -> no encryption (trust is irrelevant)
+        //   on       -> encrypted, accept self-signed certs (dev/corporate)
+        //   required -> encrypted, validate cert chain (production CA cert)
+        let ssl_mode_value = values
+            .get("ssl_mode")
+            .filter(|s| !s.is_empty())
+            .cloned()
+            .unwrap_or_else(|| "on".to_string());
+        let trust_server_certificate = !matches!(ssl_mode_value.as_str(), "required");
+
+        Ok(DbConfig::SqlServer {
+            use_uri: false,
+            uri: None,
+            host,
+            port,
+            user,
+            database,
+            instance,
+            ssl_mode: Some(ssl_mode_value),
+            trust_server_certificate,
+            ssl_root_cert_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+        })
+    }
+
+    fn extract_values(&self, config: &DbConfig) -> FormValues {
+        let mut values = HashMap::new();
+
+        if let DbConfig::SqlServer {
+            use_uri,
+            uri,
+            host,
+            port,
+            user,
+            database,
+            instance,
+            ..
+        } = config
+        {
+            values.insert(
+                "use_uri".to_string(),
+                if *use_uri { "true" } else { "" }.to_string(),
+            );
+            values.insert("uri".to_string(), uri.clone().unwrap_or_default());
+            values.insert("host".to_string(), host.clone());
+            values.insert("port".to_string(), port.to_string());
+            values.insert("user".to_string(), user.clone());
+            values.insert("database".to_string(), database.clone().unwrap_or_default());
+            values.insert("instance".to_string(), instance.clone().unwrap_or_default());
+        }
+
+        values
+    }
+
+    fn build_uri(&self, values: &FormValues, password: &str) -> Option<String> {
+        let host = values.get("host").map(|s| s.as_str()).unwrap_or("");
+        let port = values.get("port").map(|s| s.as_str()).unwrap_or("1433");
+        let user = values.get("user").map(|s| s.as_str()).unwrap_or("");
+        let database = values.get("database").map(|s| s.as_str()).unwrap_or("");
+        let instance = values.get("instance").map(|s| s.as_str()).unwrap_or("");
+
+        let credentials = if !user.is_empty() {
+            if !password.is_empty() {
+                format!(
+                    "{}:{}@",
+                    urlencoding::encode(user),
+                    urlencoding::encode(password)
+                )
+            } else {
+                format!("{}@", urlencoding::encode(user))
+            }
+        } else {
+            String::new()
+        };
+
+        let db_part = if !database.is_empty() {
+            format!("/{}", database)
+        } else {
+            String::new()
+        };
+
+        let query_part = if !instance.is_empty() {
+            // Database segment is required before a query string; emit an
+            // empty one if the user did not pick a default database.
+            let separator = if db_part.is_empty() { "/" } else { "" };
+            format!("{}?instance={}", separator, urlencoding::encode(instance))
+        } else {
+            String::new()
+        };
+
+        Some(format!(
+            "sqlserver://{}{}:{}{}{}",
+            credentials, host, port, db_part, query_part
+        ))
+    }
+
+    fn parse_uri(&self, uri: &str) -> Option<FormValues> {
+        let stripped = uri
+            .strip_prefix("sqlserver://")
+            .or_else(|| uri.strip_prefix("mssql://"))?;
+
+        let mut values = HashMap::new();
+        let (credentials, host_part) = if let Some(at_pos) = stripped.rfind('@') {
+            (&stripped[..at_pos], &stripped[at_pos + 1..])
+        } else {
+            ("", stripped)
+        };
+
+        if !credentials.is_empty() {
+            if let Some(colon) = credentials.find(':') {
+                let user = urlencoding::decode(&credentials[..colon])
+                    .unwrap_or_default()
+                    .into_owned();
+                values.insert("user".to_string(), user);
+                let password = urlencoding::decode(&credentials[colon + 1..])
+                    .unwrap_or_default()
+                    .into_owned();
+                if !password.is_empty() {
+                    values.insert("password".to_string(), password);
+                }
+            } else {
+                let user = urlencoding::decode(credentials)
+                    .unwrap_or_default()
+                    .into_owned();
+                values.insert("user".to_string(), user);
+            }
+        }
+
+        let (host_port, after_host) = if let Some(slash) = host_part.find('/') {
+            (&host_part[..slash], &host_part[slash + 1..])
+        } else {
+            (host_part, "")
+        };
+
+        let (database, query_string) = match after_host.split_once('?') {
+            Some((db, q)) => (db, q),
+            None => (after_host, ""),
+        };
+        values.insert("database".to_string(), database.to_string());
+
+        // Split host_port into host[\instance][:port]. SSMS-style
+        // `host\instance` plus an optional `:port` suffix.
+        let (host_and_instance, port_str) = match host_port.rfind(':') {
+            Some(colon) => (&host_port[..colon], &host_port[colon + 1..]),
+            None => (host_port, "1433"),
+        };
+        let (host, instance) = match host_and_instance.find('\\') {
+            Some(bs) => (&host_and_instance[..bs], &host_and_instance[bs + 1..]),
+            None => (host_and_instance, ""),
+        };
+        values.insert("host".to_string(), host.to_string());
+        values.insert("port".to_string(), port_str.to_string());
+        if !instance.is_empty() {
+            values.insert("instance".to_string(), instance.to_string());
+        }
+
+        // ?instance=… overrides the backslash form if both are present.
+        for pair in query_string.split('&').filter(|p| !p.is_empty()) {
+            if let Some((key, value)) = pair.split_once('=')
+                && key.eq_ignore_ascii_case("instance")
+                && !value.is_empty()
+            {
+                let decoded = urlencoding::decode(value)
+                    .map(|cow| cow.into_owned())
+                    .unwrap_or_else(|_| value.to_string());
+                values.insert("instance".to_string(), decoded);
+            }
+        }
+
+        Some(values)
+    }
+
+    fn with_database(&self, config: &DbConfig, database: &str) -> Option<DbConfig> {
+        match config {
+            DbConfig::SqlServer {
+                use_uri,
+                uri,
+                host,
+                port,
+                user,
+                instance,
+                ssl_mode,
+                trust_server_certificate,
+                ssl_root_cert_path,
+                ssh_tunnel,
+                ssh_tunnel_profile_id,
+                ..
+            } => Some(DbConfig::SqlServer {
+                use_uri: *use_uri,
+                uri: uri.clone(),
+                host: host.clone(),
+                port: *port,
+                user: user.clone(),
+                database: Some(database.to_string()),
+                instance: instance.clone(),
+                ssl_mode: ssl_mode.clone(),
+                trust_server_certificate: *trust_server_certificate,
+                ssl_root_cert_path: ssl_root_cert_path.clone(),
+                ssh_tunnel: ssh_tunnel.clone(),
+                ssh_tunnel_profile_id: *ssh_tunnel_profile_id,
+            }),
+            _ => None,
+        }
+    }
+}
+
+struct ExtractedMssqlConfig {
+    use_uri: bool,
+    uri: Option<String>,
+    host: String,
+    port: u16,
+    user: String,
+    database: Option<String>,
+    instance: Option<String>,
+    ssl_mode: String,
+    trust_server_certificate: bool,
+    ssh_tunnel: Option<SshTunnelConfig>,
+}
+
+fn extract_mssql_config(config: &DbConfig) -> Result<ExtractedMssqlConfig, DbError> {
+    match config {
+        DbConfig::SqlServer {
+            use_uri,
+            uri,
+            host,
+            port,
+            user,
+            database,
+            instance,
+            ssl_mode,
+            trust_server_certificate,
+            ssh_tunnel,
+            ..
+        } => Ok(ExtractedMssqlConfig {
+            use_uri: *use_uri,
+            uri: uri.clone(),
+            host: host.clone(),
+            port: *port,
+            user: user.clone(),
+            database: database.clone(),
+            instance: instance.clone(),
+            ssl_mode: ssl_mode.clone().unwrap_or_else(|| "on".to_string()),
+            trust_server_certificate: *trust_server_certificate,
+            ssh_tunnel: ssh_tunnel.clone(),
+        }),
+        _ => Err(DbError::InvalidProfile(
+            "Expected SQL Server configuration".to_string(),
+        )),
+    }
+}
+
+fn encryption_for(ssl_mode: &str) -> EncryptionLevel {
+    match ssl_mode {
+        "off" | "disabled" => EncryptionLevel::Off,
+        "required" => EncryptionLevel::Required,
+        // "on" or unknown
+        _ => EncryptionLevel::On,
+    }
+}
+
+fn build_tiberius_config(params: &MssqlConnectParams) -> Config {
+    let mut config = Config::new();
+    config.host(params.host);
+
+    if let Some(instance) = params.instance {
+        // Leave port unset so tiberius defaults to 1434 for the SQL Browser
+        // SSRP lookup; Browser then returns the instance's actual TCP port.
+        // Calling `config.port(...)` here would direct the Browser query at
+        // the wrong UDP port and produce a connection reset (os error 10054).
+        config.instance_name(instance);
+    } else {
+        config.port(params.port);
+    }
+
+    if let Some(database) = params.database
+        && !database.is_empty()
+    {
+        config.database(database);
+    }
+
+    config.authentication(AuthMethod::sql_server(params.user, params.password));
+    config.encryption(encryption_for(params.ssl_mode));
+
+    if params.trust_server_certificate {
+        config.trust_cert();
+    }
+
+    config
+}
+
+struct MssqlConnectParams<'a> {
+    host: &'a str,
+    port: u16,
+    user: &'a str,
+    password: &'a str,
+    database: Option<&'a str>,
+    instance: Option<&'a str>,
+    ssl_mode: &'a str,
+    trust_server_certificate: bool,
+}
+
+fn build_runtime() -> Result<Runtime, DbError> {
+    Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| {
+            DbError::ConnectionFailed(format!("Failed to start tokio runtime: {}", e).into())
+        })
+}
+
+/// Short, non-reversible fingerprint of a password for diagnostic logs.
+///
+/// Uses `DefaultHasher` and a fixed seed string, so the same input always
+/// produces the same hex string. The point is to let users compare two
+/// values for equality (e.g. "did the password reaching tiberius differ
+/// from what I typed?") without ever exposing the password itself.
+fn password_fingerprint(password: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    "dbflux-mssql-password-fingerprint:v1".hash(&mut hasher);
+    password.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+async fn establish_tiberius(config: Config) -> Result<TiberiusClient, tiberius::error::Error> {
+    // `connect_named` falls back to a direct `host:port` connect when no
+    // instance is set, and performs a SQL Browser (UDP 1434) lookup when
+    // one is. Using it unconditionally keeps the two paths in one place.
+    let tcp = TcpStream::connect_named(&config).await?;
+    tcp.set_nodelay(true)?;
+    Client::connect(config, tcp.compat_write()).await
+}
+
+/// Fetch the server-side session id (`@@SPID`) for the open client.
+///
+/// `@@SPID` returns a SQL `smallint`, so we widen to `i32` for the rest of
+/// the driver. Returns `0` on any decoding failure rather than propagating
+/// — a missing SPID just means cancel becomes a no-op, which is fine.
+async fn capture_spid(client: &mut TiberiusClient) -> Result<i32, tiberius::error::Error> {
+    let stream = client.simple_query("SELECT @@SPID").await?;
+    let row = stream.into_row().await?;
+    Ok(row
+        .and_then(|r| r.get::<i16, _>(0))
+        .map(|s| s as i32)
+        .unwrap_or(0))
+}
+
+impl MssqlDriver {
+    fn connect_with_uri(
+        &self,
+        base_uri: &str,
+        password: Option<&str>,
+    ) -> Result<Box<dyn Connection>, DbError> {
+        let uri = inject_password_into_mssql_uri(base_uri, password);
+        log::info!(
+            "Connecting to SQL Server via URI {}",
+            sanitize_uri(&uri)
+        );
+        if let Some(pw) = password {
+            log::debug!(
+                "URI auth payload — password_chars: {}, password_bytes: {}, password_fingerprint: {}",
+                pw.chars().count(),
+                pw.len(),
+                password_fingerprint(pw),
+            );
+        }
+
+        // Prefer our own URL parser when the URI looks like one
+        // (`sqlserver://` / `mssql://`). Tiberius's ADO parser is too
+        // permissive: it accepts our URL as a single key=value pair
+        // (key=`sqlserver://sa:pw@host/?instance`, value=`NAME`) and
+        // returns a Config with empty host/auth that then dials a
+        // default `localhost:1433`. ADO/JDBC parsers stay available for
+        // genuine `Server=…;` / `jdbc:sqlserver://…` connection strings.
+        let is_mssql_url =
+            uri.starts_with("sqlserver://") || uri.starts_with("mssql://");
+        let config = if is_mssql_url {
+            parse_mssql_url(&uri).map_err(|e| format_mssql_uri_error(&e, base_uri))?
+        } else {
+            Config::from_ado_string(&uri)
+                .or_else(|_| Config::from_jdbc_string(&uri))
+                .map_err(|e| format_mssql_uri_error(&e, base_uri))?
+        };
+
+        let reconnect_config = config.clone();
+        let runtime = build_runtime()?;
+
+        let (client, spid) = runtime
+            .block_on(async move {
+                let mut client = establish_tiberius(config).await?;
+                let spid = capture_spid(&mut client).await?;
+                Ok::<_, tiberius::error::Error>((client, spid))
+            })
+            .map_err(|e| format_mssql_uri_error(&e, base_uri))?;
+
+        log::info!(
+            "[CONNECT] SQL Server connection established via URI (spid: {})",
+            spid
+        );
+
+        Ok(Box::new(MssqlConnection {
+            inner: Arc::new(Mutex::new(MssqlConnectionInner {
+                client: Some(client),
+                runtime,
+            })),
+            current_database: Mutex::new(None),
+            ssh_tunnel: None,
+            cancelled: Arc::new(AtomicBool::new(false)),
+            spid: Arc::new(AtomicI32::new(spid)),
+            reconnect_config: Arc::new(reconnect_config),
+            poisoned: Arc::new(AtomicBool::new(false)),
+        }))
+    }
+
+    fn connect_direct(
+        &self,
+        config: &ExtractedMssqlConfig,
+        password: Option<&str>,
+    ) -> Result<Box<dyn Connection>, DbError> {
+        log::info!(
+            "Connecting directly to SQL Server at {}:{} as {} (database: {:?}, instance: {:?}, ssl_mode: {})",
+            config.host,
+            config.port,
+            config.user,
+            config.database,
+            config.instance,
+            config.ssl_mode
+        );
+
+        let resolved_password = password.unwrap_or("");
+        log::debug!(
+            "Auth payload — user_len: {}, password_chars: {}, password_bytes: {}, password_fingerprint: {}",
+            config.user.chars().count(),
+            resolved_password.chars().count(),
+            resolved_password.len(),
+            password_fingerprint(resolved_password),
+        );
+
+        let tiberius_config = build_tiberius_config(&MssqlConnectParams {
+            host: &config.host,
+            port: config.port,
+            user: &config.user,
+            password: resolved_password,
+            database: config.database.as_deref(),
+            instance: config.instance.as_deref(),
+            ssl_mode: &config.ssl_mode,
+            trust_server_certificate: config.trust_server_certificate,
+        });
+
+        let reconnect_config = tiberius_config.clone();
+        let runtime = build_runtime()?;
+        let host = config.host.clone();
+        let port = config.port;
+        let (client, spid) = runtime
+            .block_on(async move {
+                let mut client = establish_tiberius(tiberius_config).await?;
+                let spid = capture_spid(&mut client).await?;
+                Ok::<_, tiberius::error::Error>((client, spid))
+            })
+            .map_err(|e| format_mssql_connect_error(&e, &host, port))?;
+
+        log::info!(
+            "Successfully connected to {}:{} (spid: {})",
+            host,
+            port,
+            spid
+        );
+
+        Ok(Box::new(MssqlConnection {
+            inner: Arc::new(Mutex::new(MssqlConnectionInner {
+                client: Some(client),
+                runtime,
+            })),
+            current_database: Mutex::new(config.database.clone()),
+            ssh_tunnel: None,
+            cancelled: Arc::new(AtomicBool::new(false)),
+            spid: Arc::new(AtomicI32::new(spid)),
+            reconnect_config: Arc::new(reconnect_config),
+            poisoned: Arc::new(AtomicBool::new(false)),
+        }))
+    }
+
+    fn connect_via_ssh_tunnel(
+        &self,
+        tunnel_config: &SshTunnelConfig,
+        ssh_secret: Option<&str>,
+        config: &ExtractedMssqlConfig,
+        password: Option<&str>,
+    ) -> Result<Box<dyn Connection>, DbError> {
+        let total_start = Instant::now();
+
+        log::info!(
+            "[CONNECT] Starting SSH tunnel connection: {}@{}:{} -> {}:{}",
+            tunnel_config.user,
+            tunnel_config.host,
+            tunnel_config.port,
+            config.host,
+            config.port
+        );
+
+        let ssh_session = dbflux_ssh::establish_session(tunnel_config, ssh_secret)?;
+        let tunnel = SshTunnel::start(ssh_session, config.host.clone(), config.port)?;
+        let local_port = tunnel.local_port();
+
+        log::info!(
+            "[SSH] Tunnel ready on 127.0.0.1:{} in {:.2}ms",
+            local_port,
+            total_start.elapsed().as_secs_f64() * 1000.0
+        );
+
+        let tiberius_config = build_tiberius_config(&MssqlConnectParams {
+            host: "127.0.0.1",
+            port: local_port,
+            user: &config.user,
+            password: password.unwrap_or(""),
+            database: config.database.as_deref(),
+            // The SSH tunnel forwards to a TCP port, so we cannot use a named
+            // instance lookup via the SQL Browser service.
+            instance: None,
+            ssl_mode: &config.ssl_mode,
+            trust_server_certificate: config.trust_server_certificate,
+        });
+
+        // The reconnect config points at the same 127.0.0.1:<local_port> that
+        // the SSH tunnel owns. As long as the `SshTunnel` value lives on
+        // `MssqlConnection`, the tunnel stays open and a fresh connection
+        // (for KILL or for reconnect) can reuse it.
+        let reconnect_config = tiberius_config.clone();
+        let runtime = build_runtime()?;
+        let host = config.host.clone();
+        let port = config.port;
+        let (client, spid) = runtime
+            .block_on(async move {
+                let mut client = establish_tiberius(tiberius_config).await?;
+                let spid = capture_spid(&mut client).await?;
+                Ok::<_, tiberius::error::Error>((client, spid))
+            })
+            .map_err(|e| format_mssql_connect_error(&e, &host, port))?;
+
+        log::info!(
+            "[CONNECT] Total connection time: {:.2}ms ({}:{} via SSH {}, spid: {})",
+            total_start.elapsed().as_secs_f64() * 1000.0,
+            host,
+            port,
+            tunnel_config.host,
+            spid
+        );
+
+        Ok(Box::new(MssqlConnection {
+            inner: Arc::new(Mutex::new(MssqlConnectionInner {
+                client: Some(client),
+                runtime,
+            })),
+            current_database: Mutex::new(config.database.clone()),
+            ssh_tunnel: Some(tunnel),
+            cancelled: Arc::new(AtomicBool::new(false)),
+            spid: Arc::new(AtomicI32::new(spid)),
+            reconnect_config: Arc::new(reconnect_config),
+            poisoned: Arc::new(AtomicBool::new(false)),
+        }))
+    }
+}
+
+// =============================================================================
+// MssqlConnection
+// =============================================================================
+
+struct MssqlConnectionInner {
+    client: Option<TiberiusClient>,
+    runtime: Runtime,
+}
+
+pub struct MssqlConnection {
+    inner: Arc<Mutex<MssqlConnectionInner>>,
+    current_database: Mutex<Option<String>>,
+    #[allow(dead_code)]
+    ssh_tunnel: Option<SshTunnel>,
+    cancelled: Arc<AtomicBool>,
+
+    // Cancellation state. `spid` is the server-side session id captured at
+    // connect time (and refreshed after each reconnect). `reconnect_config`
+    // is a cloneable tiberius Config we can use to (a) open a side-channel
+    // connection to send `KILL <spid>` and (b) rebuild the primary client
+    // after the session is killed. `poisoned` is set true once KILL has been
+    // sent so `cleanup_after_cancel` knows it needs to reconnect.
+    spid: Arc<AtomicI32>,
+    reconnect_config: Arc<tiberius::Config>,
+    poisoned: Arc<AtomicBool>,
+}
+
+struct MssqlCancelHandle {
+    cancelled: Arc<AtomicBool>,
+    spid: Arc<AtomicI32>,
+    reconnect_config: Arc<tiberius::Config>,
+    poisoned: Arc<AtomicBool>,
+}
+
+impl QueryCancelHandle for MssqlCancelHandle {
+    fn cancel(&self) -> Result<(), DbError> {
+        // Mark cancellation requested first so `execute()` can translate the
+        // server's "session was killed" error to `DbError::Cancelled` even
+        // if the KILL itself races with the query completing normally.
+        self.cancelled.store(true, Ordering::SeqCst);
+
+        let spid = self.spid.load(Ordering::SeqCst);
+        if spid == 0 {
+            // No session id captured yet — nothing meaningful to kill. The
+            // cancel flag is still set so a not-yet-started query will exit
+            // on its first error check.
+            return Ok(());
+        }
+
+        // Use a fresh single-threaded runtime for the kill round-trip. We
+        // must never share the runtime that's currently driving the
+        // in-flight query, since blocking on it would deadlock.
+        let rt = Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| DbError::query_failed(format!("Failed to start KILL runtime: {}", e)))?;
+
+        let config = (*self.reconnect_config).clone();
+        let result: Result<(), tiberius::error::Error> = rt.block_on(async move {
+            let tcp = TcpStream::connect_named(&config).await?;
+            tcp.set_nodelay(true)?;
+            let mut killer = Client::connect(config, tcp.compat_write()).await?;
+            killer
+                .simple_query(format!("KILL {}", spid))
+                .await?
+                .into_results()
+                .await?;
+            Ok(())
+        });
+
+        // Mark as poisoned regardless of whether KILL succeeded: if it failed
+        // the primary connection may still be in an unknown state and
+        // forcing a reconnect on next use is safer than reusing it.
+        self.poisoned.store(true, Ordering::SeqCst);
+
+        match result {
+            Ok(()) => {
+                log::info!("[CANCEL] KILL {} sent successfully", spid);
+                Ok(())
+            }
+            Err(err) => {
+                log::error!("[CANCEL] KILL {} failed: {}", spid, err);
+                Err(format_mssql_query_error(&err))
+            }
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+}
+
+impl MssqlConnection {
+    fn with_client<F, R>(&self, f: F) -> Result<R, DbError>
+    where
+        F: FnOnce(&Runtime, &mut TiberiusClient) -> Result<R, DbError>,
+    {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poison_err) => poison_err.into_inner(),
+        };
+
+        let inner = &mut *guard;
+        let client = inner.client.as_mut().ok_or_else(|| {
+            DbError::ConnectionFailed("SQL Server connection has been closed".to_string().into())
+        })?;
+
+        f(&inner.runtime, client)
+    }
+
+    fn execute_simple(&self, sql: &str) -> Result<QueryResult, DbError> {
+        let start = Instant::now();
+        let sql_owned = sql.to_string();
+
+        // Multi-statement batches in SQL Server can produce multiple result
+        // sets (e.g. `SELECT 1; SELECT 2;` or a stored procedure with
+        // several `SELECT`s). We return the LAST non-empty set as the
+        // primary `QueryResult` (preserving the historical "last statement
+        // wins" UX) and attach every earlier non-empty set to
+        // `additional_results` in batch order, so callers that want the
+        // full batch can walk it via `QueryResult::iter_result_sets()`.
+        // Pure preparation batches (`SET LOCK_TIMEOUT 5000`) produce no
+        // result sets and surface as an empty primary, which is what
+        // callers already expect.
+        let collected: Vec<(Vec<ColumnMeta>, Vec<Row>)> = self.with_client(|runtime, client| {
+            runtime.block_on(async move {
+                let stream = client
+                    .simple_query(sql_owned)
+                    .await
+                    .map_err(|e| format_mssql_query_error(&e))?;
+
+                let result_sets = stream
+                    .into_results()
+                    .await
+                    .map_err(|e| format_mssql_query_error(&e))?;
+
+                let non_empty: Vec<(Vec<ColumnMeta>, Vec<Row>)> = result_sets
+                    .into_iter()
+                    .filter(|set| !set.is_empty())
+                    .map(|set| {
+                        let columns: Vec<ColumnMeta> = set
+                            .first()
+                            .map(|row| {
+                                row.columns()
+                                    .iter()
+                                    .map(|c| ColumnMeta {
+                                        name: c.name().to_string(),
+                                        type_name: format!("{:?}", c.column_type()),
+                                        kind: dbflux_core::ColumnKind::Unknown,
+                                        nullable: true,
+                                        is_primary_key: false,
+                                    })
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+
+                        let rows: Vec<Row> = set
+                            .iter()
+                            .map(|row| {
+                                (0..row.columns().len())
+                                    .map(|idx| tiberius_value_to_value(row, idx))
+                                    .collect::<Row>()
+                            })
+                            .collect();
+
+                        (columns, rows)
+                    })
+                    .collect();
+
+                Ok::<_, DbError>(non_empty)
+            })
+        })?;
+
+        let total_time = start.elapsed();
+        let result = build_multi_result(collected, total_time);
+
+        log::debug!(
+            "[QUERY] Completed in {:.2}ms, primary={}r/{}c, additional_sets={}",
+            total_time.as_secs_f64() * 1000.0,
+            result.rows.len(),
+            result.columns.len(),
+            result.additional_results.len()
+        );
+
+        Ok(result)
+    }
+}
+
+/// Splits a list of non-empty result sets into a primary `QueryResult` plus
+/// additional sets, mirroring the multi-result-set contract on
+/// `QueryResult::additional_results`.
+///
+/// The LAST non-empty set becomes the primary (this preserves the historical
+/// "last statement wins" UX for `SELECT 1; SELECT 2;` style batches), and
+/// every earlier non-empty set is attached to `additional_results` in batch
+/// order. Empty input yields an empty primary.
+///
+/// Factored out of `execute_simple` so it can be unit-tested without a live
+/// SQL Server.
+fn build_multi_result(
+    mut collected: Vec<(Vec<ColumnMeta>, Vec<Row>)>,
+    total_time: std::time::Duration,
+) -> QueryResult {
+    let Some((primary_columns, primary_rows)) = collected.pop() else {
+        return QueryResult::table(Vec::new(), Vec::new(), None, total_time);
+    };
+
+    let mut result = QueryResult::table(primary_columns, primary_rows, None, total_time);
+    for (cols, rows) in collected {
+        // Each additional set shares the same total batch duration;
+        // tiberius doesn't expose per-statement timing.
+        result.push_additional_result(QueryResult::table(cols, rows, None, total_time));
+    }
+    result
+}
+
+fn tiberius_value_to_value(row: &tiberius::Row, idx: usize) -> Value {
+    use tiberius::ColumnData;
+
+    // tiberius rows expose values as `ColumnData<'_>` via `row.cells()` /
+    // `row.try_get`. We extract column data to detect typed nulls and avoid
+    // panicking on type mismatches.
+    let column = match row.columns().get(idx) {
+        Some(col) => col,
+        None => return Value::Null,
+    };
+
+    let cell: Option<&ColumnData<'static>> = row.cells().nth(idx).map(|(_, data)| data);
+    let data = match cell {
+        Some(d) => d,
+        None => return Value::Null,
+    };
+
+    match data {
+        ColumnData::U8(v) => v.map(|v| Value::Int(v as i64)).unwrap_or(Value::Null),
+        ColumnData::I16(v) => v.map(|v| Value::Int(v as i64)).unwrap_or(Value::Null),
+        ColumnData::I32(v) => v.map(|v| Value::Int(v as i64)).unwrap_or(Value::Null),
+        ColumnData::I64(v) => v.map(Value::Int).unwrap_or(Value::Null),
+        ColumnData::F32(v) => v.map(|v| Value::Float(v as f64)).unwrap_or(Value::Null),
+        ColumnData::F64(v) => v.map(Value::Float).unwrap_or(Value::Null),
+        ColumnData::Bit(v) => v.map(Value::Bool).unwrap_or(Value::Null),
+        ColumnData::String(v) => v
+            .as_ref()
+            .map(|s| Value::Text(s.to_string()))
+            .unwrap_or(Value::Null),
+        ColumnData::Guid(v) => v
+            .as_ref()
+            .map(|g| Value::Text(g.to_string()))
+            .unwrap_or(Value::Null),
+        ColumnData::Binary(v) => v
+            .as_ref()
+            .map(|b| Value::Bytes(b.to_vec()))
+            .unwrap_or(Value::Null),
+        ColumnData::Numeric(v) => v
+            .as_ref()
+            .map(|n| Value::Decimal(n.to_string()))
+            .unwrap_or(Value::Null),
+        ColumnData::Xml(v) => v
+            .as_ref()
+            .map(|x| Value::Text(x.to_string()))
+            .unwrap_or(Value::Null),
+        ColumnData::DateTime(_)
+        | ColumnData::SmallDateTime(_)
+        | ColumnData::Time(_)
+        | ColumnData::Date(_)
+        | ColumnData::DateTime2(_)
+        | ColumnData::DateTimeOffset(_) => extract_temporal(row, idx, column.column_type()),
+    }
+}
+
+fn extract_temporal(row: &tiberius::Row, idx: usize, _column_type: tiberius::ColumnType) -> Value {
+    // tiberius exposes typed accessors for chrono types; we try them in order
+    // of decreasing precision and fall back to a string representation.
+    if let Ok(Some(v)) = row.try_get::<chrono::DateTime<Utc>, _>(idx) {
+        return Value::DateTime(v);
+    }
+
+    if let Ok(Some(v)) = row.try_get::<NaiveDateTime, _>(idx) {
+        return Value::DateTime(DateTime::<Utc>::from_naive_utc_and_offset(v, Utc));
+    }
+
+    if let Ok(Some(v)) = row.try_get::<NaiveDate, _>(idx) {
+        return Value::Date(v);
+    }
+
+    if let Ok(Some(v)) = row.try_get::<NaiveTime, _>(idx) {
+        return Value::Time(v);
+    }
+
+    Value::Null
+}
+
+impl Connection for MssqlConnection {
+    fn metadata(&self) -> &DriverMetadata {
+        &METADATA
+    }
+
+    fn language_service(&self) -> &dyn dbflux_core::LanguageService {
+        // T-SQL has constructs that the shared tree-sitter-sequel parser
+        // doesn't recognise (TOP, OUTPUT INSERTED, MERGE, CROSS APPLY,
+        // WITH (NOLOCK), OFFSET ROWS FETCH NEXT, etc.). Returning the
+        // T-SQL-aware service suppresses the noisy parse diagnostics
+        // while keeping dangerous-query detection.
+        &dbflux_core::TSqlLanguageService
+    }
+
+    fn ping(&self) -> Result<(), DbError> {
+        self.execute_simple("SELECT 1").map(|_| ())
+    }
+
+    fn close(&mut self) -> Result<(), DbError> {
+        if let Ok(mut guard) = self.inner.lock() {
+            guard.client = None;
+        }
+        Ok(())
+    }
+
+    fn execute(&self, req: &QueryRequest) -> Result<QueryResult, DbError> {
+        self.cancelled.store(false, Ordering::SeqCst);
+
+        // Support explicit database override per query, mirroring postgres/mysql.
+        if let Some(database) = req.database.as_deref() {
+            self.set_active_database(Some(database))?;
+        }
+
+        let sql_preview = if req.sql.len() > 80 {
+            format!("{}...", &req.sql[..80])
+        } else {
+            req.sql.clone()
+        };
+        log::debug!("[QUERY] Executing: {}", sql_preview.replace('\n', " "));
+
+        match self.execute_simple(&req.sql) {
+            Ok(result) => {
+                if self.cancelled.load(Ordering::SeqCst) {
+                    Err(DbError::Cancelled)
+                } else {
+                    Ok(result)
+                }
+            }
+            Err(err) => {
+                // After KILL, the server raises a session-terminated error
+                // (596 / 233 / 6005) on the next read from the killed
+                // connection. Map any such error to `Cancelled` when the user
+                // actually requested cancellation, so the UI surfaces the
+                // expected outcome instead of a confusing protocol error.
+                if self.cancelled.load(Ordering::SeqCst) || is_kill_error(&err) {
+                    Err(DbError::Cancelled)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    fn cancel(&self, _handle: &QueryHandle) -> Result<(), DbError> {
+        self.cancel_handle().cancel()
+    }
+
+    fn cancel_active(&self) -> Result<(), DbError> {
+        self.cancel_handle().cancel()
+    }
+
+    fn cancel_handle(&self) -> Arc<dyn QueryCancelHandle> {
+        Arc::new(MssqlCancelHandle {
+            cancelled: self.cancelled.clone(),
+            spid: self.spid.clone(),
+            reconnect_config: self.reconnect_config.clone(),
+            poisoned: self.poisoned.clone(),
+        })
+    }
+
+    fn cleanup_after_cancel(&self) -> Result<(), DbError> {
+        // Only reconnect if a previous `cancel()` poisoned the connection.
+        // For ordinary errors (no KILL involved) the existing client is still
+        // usable and this is a no-op.
+        if !self.poisoned.load(Ordering::SeqCst) {
+            self.cancelled.store(false, Ordering::SeqCst);
+            return Ok(());
+        }
+
+        log::info!("[CLEANUP] Reconnecting SQL Server connection after KILL");
+
+        let config = (*self.reconnect_config).clone();
+        let active_database = self
+            .current_database
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone());
+
+        let new_client_and_spid: Result<(TiberiusClient, i32), tiberius::error::Error> = {
+            let mut guard = match self.inner.lock() {
+                Ok(g) => g,
+                Err(poison_err) => poison_err.into_inner(),
+            };
+
+            // Drop the old client first so the underlying socket closes
+            // promptly; tiberius does not always tear down on KILL alone.
+            guard.client = None;
+
+            guard.runtime.block_on(async move {
+                let mut client = establish_tiberius(config).await?;
+                let spid = capture_spid(&mut client).await?;
+                Ok((client, spid))
+            })
+        };
+
+        let (new_client, new_spid) = new_client_and_spid.map_err(|e| {
+            log::error!("[CLEANUP] Reconnect failed: {}", e);
+            // Address fields aren't worth reconstructing here — the message
+            // from tiberius is already host-aware via Config::get_addr().
+            format_mssql_connect_error(&e, "?", 0)
+        })?;
+
+        {
+            let mut guard = match self.inner.lock() {
+                Ok(g) => g,
+                Err(poison_err) => poison_err.into_inner(),
+            };
+            guard.client = Some(new_client);
+        }
+
+        self.spid.store(new_spid, Ordering::SeqCst);
+        self.poisoned.store(false, Ordering::SeqCst);
+        self.cancelled.store(false, Ordering::SeqCst);
+
+        // The new session starts in whatever the login defaults to. If the
+        // user was previously on a specific database, restore that selection.
+        if let Some(db) = active_database {
+            let escaped = db.replace(']', "]]");
+            self.execute_simple(&format!("USE [{}]", escaped))?;
+        }
+
+        log::info!("[CLEANUP] Reconnect complete, new SPID = {}", new_spid);
+        Ok(())
+    }
+
+    fn schema(&self) -> Result<SchemaSnapshot, DbError> {
+        let total_start = Instant::now();
+        log::info!("[SCHEMA] Starting schema fetch");
+
+        let databases = self.list_databases()?;
+        let current_database = self
+            .current_database
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone());
+
+        log::info!(
+            "[SCHEMA] Fetched {} databases in {:.2}ms",
+            databases.len(),
+            total_start.elapsed().as_secs_f64() * 1000.0
+        );
+
+        Ok(SchemaSnapshot::relational(RelationalSchema {
+            databases,
+            current_database,
+            schemas: Vec::new(),
+            tables: Vec::new(),
+            views: Vec::new(),
+        }))
+    }
+
+    fn list_databases(&self) -> Result<Vec<DatabaseInfo>, DbError> {
+        // Hide built-in system databases.
+        let sql = "SELECT name FROM sys.databases \
+                   WHERE name NOT IN ('master','tempdb','model','msdb') \
+                   ORDER BY name";
+
+        let result = self.execute_simple(sql)?;
+        let current = self
+            .current_database
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone());
+
+        Ok(result
+            .rows
+            .into_iter()
+            .filter_map(|row| {
+                row.into_iter().next().and_then(|v| match v {
+                    Value::Text(s) => Some(s),
+                    _ => None,
+                })
+            })
+            .map(|name| DatabaseInfo {
+                is_current: current.as_ref() == Some(&name),
+                name,
+            })
+            .collect())
+    }
+
+    fn schema_for_database(&self, database: &str) -> Result<DbSchemaInfo, DbError> {
+        log::info!("[SCHEMA] Fetching schema for database: {}", database);
+
+        let escaped_db = database.replace(']', "]]");
+        let qualified = format!("[{}]", escaped_db);
+
+        // Shallow table list scoped to the requested database.
+        let tables_sql = format!(
+            "SELECT s.name AS schema_name, t.name AS table_name \
+             FROM {qualified}.sys.tables t \
+             JOIN {qualified}.sys.schemas s ON s.schema_id = t.schema_id \
+             WHERE t.is_ms_shipped = 0 \
+             ORDER BY s.name, t.name",
+            qualified = qualified
+        );
+
+        let table_rows = self.execute_simple(&tables_sql)?;
+        let mut tables = Vec::new();
+
+        for row in table_rows.rows {
+            let mut iter = row.into_iter();
+            let schema_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let table_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+
+            tables.push(TableInfo {
+                name: table_name,
+                schema: Some(schema_name),
+                columns: None,
+                indexes: None,
+                foreign_keys: None,
+                constraints: None,
+                sample_fields: None,
+                presentation: dbflux_core::CollectionPresentation::DataGrid,
+                child_items: None,
+            });
+        }
+
+        let views_sql = format!(
+            "SELECT s.name AS schema_name, v.name AS view_name \
+             FROM {qualified}.sys.views v \
+             JOIN {qualified}.sys.schemas s ON s.schema_id = v.schema_id \
+             WHERE v.is_ms_shipped = 0 \
+             ORDER BY s.name, v.name",
+            qualified = qualified
+        );
+
+        let view_rows = self.execute_simple(&views_sql)?;
+        let mut views = Vec::new();
+
+        for row in view_rows.rows {
+            let mut iter = row.into_iter();
+            let schema_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let view_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+
+            views.push(ViewInfo {
+                name: view_name,
+                schema: Some(schema_name),
+            });
+        }
+
+        Ok(DbSchemaInfo {
+            name: database.to_string(),
+            tables,
+            views,
+            custom_types: None,
+        })
+    }
+
+    fn table_details(
+        &self,
+        database: &str,
+        schema: Option<&str>,
+        table: &str,
+    ) -> Result<TableInfo, DbError> {
+        let schema_name = schema.unwrap_or("dbo");
+
+        log::info!(
+            "[SCHEMA] Fetching details for table: {}.{}.{}",
+            database,
+            schema_name,
+            table
+        );
+
+        let columns = self.fetch_columns(database, schema_name, table)?;
+        let indexes = self.fetch_indexes(database, schema_name, table)?;
+        let foreign_keys = self.fetch_foreign_keys(database, schema_name, table)?;
+        let constraints = self.fetch_constraints(database, schema_name, table)?;
+
+        Ok(TableInfo {
+            name: table.to_string(),
+            schema: Some(schema_name.to_string()),
+            columns: Some(columns),
+            indexes: Some(IndexData::Relational(indexes)),
+            foreign_keys: Some(foreign_keys),
+            constraints: Some(constraints),
+            sample_fields: None,
+            presentation: dbflux_core::CollectionPresentation::DataGrid,
+            child_items: None,
+        })
+    }
+
+    fn view_details(
+        &self,
+        database: &str,
+        schema: Option<&str>,
+        view: &str,
+    ) -> Result<ViewInfo, DbError> {
+        let schema_name = schema.unwrap_or("dbo");
+        log::info!(
+            "[SCHEMA] Fetching details for view: {}.{}.{}",
+            database,
+            schema_name,
+            view
+        );
+
+        // We only return the basic name/schema today; the `ViewInfo` shape
+        // doesn't carry a definition field. The query here also asserts
+        // the view actually exists in the requested database, which is the
+        // useful side-effect for error reporting.
+        let escaped_db = database.replace(']', "]]");
+        let qualified_db = format!("[{}]", escaped_db);
+        let escaped_schema = schema_name.replace('\'', "''");
+        let escaped_view = view.replace('\'', "''");
+
+        let sql = format!(
+            "SELECT 1 FROM {qualified_db}.sys.views v \
+             JOIN {qualified_db}.sys.schemas s ON s.schema_id = v.schema_id \
+             WHERE s.name = '{escaped_schema}' AND v.name = '{escaped_view}'",
+        );
+        self.execute_simple(&sql)?;
+
+        Ok(ViewInfo {
+            name: view.to_string(),
+            schema: Some(schema_name.to_string()),
+        })
+    }
+
+    fn schema_features(&self) -> SchemaFeatures {
+        SchemaFeatures::FOREIGN_KEYS
+            | SchemaFeatures::CHECK_CONSTRAINTS
+            | SchemaFeatures::UNIQUE_CONSTRAINTS
+            | SchemaFeatures::CUSTOM_TYPES
+    }
+
+    fn schema_types(
+        &self,
+        database: &str,
+        schema: Option<&str>,
+    ) -> Result<Vec<CustomTypeInfo>, DbError> {
+        let schema_name = schema.unwrap_or("dbo");
+        self.fetch_custom_types(database, schema_name)
+    }
+
+    fn schema_indexes(
+        &self,
+        database: &str,
+        schema: Option<&str>,
+    ) -> Result<Vec<SchemaIndexInfo>, DbError> {
+        let schema_name = schema.unwrap_or("dbo");
+        self.fetch_schema_indexes(database, schema_name)
+    }
+
+    fn schema_foreign_keys(
+        &self,
+        database: &str,
+        schema: Option<&str>,
+    ) -> Result<Vec<SchemaForeignKeyInfo>, DbError> {
+        let schema_name = schema.unwrap_or("dbo");
+        self.fetch_schema_foreign_keys(database, schema_name)
+    }
+
+    fn set_active_database(&self, database: Option<&str>) -> Result<(), DbError> {
+        let mut current = self
+            .current_database
+            .lock()
+            .map_err(|e| DbError::query_failed(format!("Lock error: {}", e)))?;
+
+        if current.as_deref() == database {
+            return Ok(());
+        }
+
+        if let Some(db) = database {
+            let escaped = db.replace(']', "]]");
+            let sql = format!("USE [{}]", escaped);
+            self.execute_simple(&sql)?;
+        }
+
+        *current = database.map(|s| s.to_string());
+        Ok(())
+    }
+
+    fn active_database(&self) -> Option<String> {
+        self.current_database
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+    }
+
+    fn kind(&self) -> DbKind {
+        DbKind::SqlServer
+    }
+
+    fn schema_loading_strategy(&self) -> SchemaLoadingStrategy {
+        SchemaLoadingStrategy::LazyPerDatabase
+    }
+
+    fn fetch_row_by_pk(
+        &self,
+        _database: &str,
+        schema: &str,
+        table: &str,
+        pk_column: &str,
+        pk_value: &Value,
+    ) -> Result<Option<std::collections::HashMap<String, Value>>, DbError> {
+        let pk_literal = MSSQL_DIALECT.value_to_literal(pk_value);
+        let sql = format!(
+            "SELECT TOP 1 * FROM {}.{} WHERE {} = {}",
+            MSSQL_DIALECT.quote_identifier(schema),
+            MSSQL_DIALECT.quote_identifier(table),
+            MSSQL_DIALECT.quote_identifier(pk_column),
+            pk_literal,
+        );
+
+        let result = self.execute(&QueryRequest::new(sql))?;
+        let columns = result.columns;
+        let Some(row) = result.rows.into_iter().next() else {
+            return Ok(None);
+        };
+
+        let map = columns
+            .into_iter()
+            .zip(row)
+            .map(|(col, val)| (col.name, val))
+            .collect();
+
+        Ok(Some(map))
+    }
+
+    fn referenced_tables(&self, query: &str) -> Option<Vec<dbflux_core::QueryTableRef>> {
+        Some(dbflux_core::extract_referenced_tables(query))
+    }
+
+    fn generate_code(&self, generator_id: &str, table: &TableInfo) -> Result<String, DbError> {
+        match generator_id {
+            "select_star" => Ok(generate_select_star(&MSSQL_DIALECT, table, 100)),
+            "insert" => Ok(generate_insert_template(&MSSQL_DIALECT, table)),
+            "update" => Ok(generate_update_template(&MSSQL_DIALECT, table)),
+            "delete" => Ok(generate_delete_template(&MSSQL_DIALECT, table)),
+            "truncate" => Ok(generate_truncate(&MSSQL_DIALECT, table)),
+            "drop_table" => Ok(generate_drop_table(&MSSQL_DIALECT, table)),
+            _ => Err(DbError::NotSupported(format!(
+                "Code generator '{}' not supported",
+                generator_id
+            ))),
+        }
+    }
+
+    fn update_row(&self, patch: &RowPatch) -> Result<CrudResult, DbError> {
+        if !patch.identity.is_valid() {
+            return Err(DbError::QueryFailed(
+                "Cannot update row: invalid row identity (missing primary key)"
+                    .to_string()
+                    .into(),
+            ));
+        }
+
+        if !patch.has_changes() {
+            return Err(DbError::QueryFailed(
+                "No changes to save".to_string().into(),
+            ));
+        }
+
+        let sql = build_update_with_output(patch)?;
+        log::debug!("[UPDATE] Executing: {}", sql);
+
+        let result = self.execute_simple(&sql)?;
+        Ok(result_first_row_to_crud(result))
+    }
+
+    fn insert_row(&self, insert: &RowInsert) -> Result<CrudResult, DbError> {
+        if !insert.is_valid() {
+            return Err(DbError::QueryFailed(
+                "Cannot insert row: no columns specified".to_string().into(),
+            ));
+        }
+
+        let sql = build_insert_with_output(insert)?;
+        log::debug!("[INSERT] Executing: {}", sql);
+
+        let result = self.execute_simple(&sql)?;
+        Ok(result_first_row_to_crud(result))
+    }
+
+    fn delete_row(&self, delete: &RowDelete) -> Result<CrudResult, DbError> {
+        if !delete.is_valid() {
+            return Err(DbError::QueryFailed(
+                "Cannot delete row: invalid row identity (missing primary key)"
+                    .to_string()
+                    .into(),
+            ));
+        }
+
+        let sql = build_delete_with_output(delete)?;
+        log::debug!("[DELETE] Executing: {}", sql);
+
+        let result = self.execute_simple(&sql)?;
+        Ok(result_first_row_to_crud(result))
+    }
+
+    fn describe_table(&self, request: &DescribeRequest) -> Result<QueryResult, DbError> {
+        let schema = request.table.schema.as_deref().unwrap_or("dbo");
+        let escaped_schema = schema.replace('\'', "''");
+        let escaped_table = request.table.name.replace('\'', "''");
+
+        let sql = format!(
+            "SELECT \
+                c.name AS column_name, \
+                t.name AS data_type, \
+                CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END AS is_nullable, \
+                CAST(dc.definition AS NVARCHAR(MAX)) AS column_default, \
+                c.max_length AS character_maximum_length \
+             FROM sys.columns c \
+             JOIN sys.tables tbl ON tbl.object_id = c.object_id \
+             JOIN sys.schemas s ON s.schema_id = tbl.schema_id \
+             JOIN sys.types t ON t.user_type_id = c.user_type_id \
+             LEFT JOIN sys.default_constraints dc \
+               ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id \
+             WHERE s.name = '{}' AND tbl.name = '{}' \
+             ORDER BY c.column_id",
+            escaped_schema, escaped_table
+        );
+
+        self.execute(&QueryRequest::new(sql))
+    }
+
+    fn explain(&self, request: &ExplainRequest) -> Result<QueryResult, DbError> {
+        // SQL Server requires SET SHOWPLAN_XML to be the only statement in
+        // its batch, so we run three separate batches: turn it on, run the
+        // query (which compiles but does not execute, returning the plan
+        // as a single nvarchar(max) row), then turn it off. We unset
+        // SHOWPLAN even if the middle batch fails so the session state
+        // does not leak.
+        let query = match &request.query {
+            Some(q) => q.clone(),
+            None => format!(
+                "SELECT * FROM {} ORDER BY 1 OFFSET 0 ROWS FETCH NEXT 100 ROWS ONLY",
+                request.table.quoted_with(self.dialect())
+            ),
+        };
+
+        self.execute_simple("SET SHOWPLAN_XML ON")?;
+        let plan_result = self.execute_simple(&query);
+        // Best-effort cleanup; if this fails the session is broken and the
+        // next query will fail loudly.
+        let _ = self.execute_simple("SET SHOWPLAN_XML OFF");
+        plan_result
+    }
+
+    fn dialect(&self) -> &dyn SqlDialect {
+        &MSSQL_DIALECT
+    }
+
+    fn query_generator(&self) -> Option<&dyn QueryGenerator> {
+        static GENERATOR: SqlMutationGenerator = SqlMutationGenerator::new(&MSSQL_DIALECT);
+        Some(&GENERATOR)
+    }
+
+    fn build_select_sql(
+        &self,
+        table: &str,
+        columns: &[String],
+        _filter: Option<&Value>,
+        order_by: &[OrderByColumn],
+        limit: u32,
+        offset: u32,
+    ) -> String {
+        let quoted_table = MSSQL_DIALECT.quote_identifier(table);
+        let cols = if columns.is_empty() {
+            "*".to_string()
+        } else {
+            columns
+                .iter()
+                .map(|c| MSSQL_DIALECT.quote_identifier(c))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+
+        let mut sql = format!("SELECT {} FROM {}", cols, quoted_table);
+
+        let order_by_clause = if order_by.is_empty() {
+            // OFFSET requires ORDER BY in SQL Server; default to ordering by 1 to keep paginated
+            // browses functional when the caller hasn't supplied an explicit order.
+            "ORDER BY 1".to_string()
+        } else {
+            let parts: Vec<String> = order_by
+                .iter()
+                .map(|col| {
+                    let dir = match col.direction {
+                        SortDirection::Ascending => "ASC",
+                        SortDirection::Descending => "DESC",
+                    };
+                    format!("{} {}", col.column.quoted_with(&MSSQL_DIALECT), dir)
+                })
+                .collect();
+            format!("ORDER BY {}", parts.join(", "))
+        };
+
+        sql.push(' ');
+        sql.push_str(&order_by_clause);
+        sql.push_str(&format!(
+            " OFFSET {} ROWS FETCH NEXT {} ROWS ONLY",
+            offset, limit
+        ));
+        sql
+    }
+
+    fn build_count_sql(&self, table: &str, _filter: Option<&Value>) -> String {
+        let quoted_table = MSSQL_DIALECT.quote_identifier(table);
+        format!("SELECT COUNT(*) FROM {}", quoted_table)
+    }
+
+    fn build_truncate_sql(&self, table: &str) -> String {
+        let quoted_table = MSSQL_DIALECT.quote_identifier(table);
+        format!("TRUNCATE TABLE {}", quoted_table)
+    }
+
+    fn build_drop_index_sql(
+        &self,
+        index_name: &str,
+        table_name: Option<&str>,
+        if_exists: bool,
+    ) -> String {
+        let quoted_index = MSSQL_DIALECT.quote_identifier(index_name);
+        let table = table_name
+            .map(|t| MSSQL_DIALECT.quote_identifier(t))
+            .unwrap_or_else(|| "[table_name]".to_string());
+
+        if if_exists {
+            format!("DROP INDEX IF EXISTS {} ON {}", quoted_index, table)
+        } else {
+            format!("DROP INDEX {} ON {}", quoted_index, table)
+        }
+    }
+
+    fn version_query(&self) -> &'static str {
+        "SELECT @@VERSION"
+    }
+
+    fn supports_transactional_ddl(&self) -> bool {
+        true
+    }
+}
+
+impl MssqlConnection {
+    fn fetch_columns(
+        &self,
+        database: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<ColumnInfo>, DbError> {
+        let escaped_db = database.replace(']', "]]");
+        let qualified_db = format!("[{}]", escaped_db);
+        let escaped_schema = schema.replace('\'', "''");
+        let escaped_table = table.replace('\'', "''");
+
+        let sql = format!(
+            "SELECT \
+                c.name AS column_name, \
+                t.name AS type_name, \
+                c.is_nullable AS nullable, \
+                CAST(dc.definition AS NVARCHAR(MAX)) AS column_default, \
+                CASE WHEN ic.column_id IS NOT NULL THEN 1 ELSE 0 END AS is_pk \
+             FROM {qualified_db}.sys.columns c \
+             JOIN {qualified_db}.sys.tables tbl ON tbl.object_id = c.object_id \
+             JOIN {qualified_db}.sys.schemas s ON s.schema_id = tbl.schema_id \
+             JOIN {qualified_db}.sys.types t ON t.user_type_id = c.user_type_id \
+             LEFT JOIN {qualified_db}.sys.default_constraints dc \
+               ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id \
+             LEFT JOIN {qualified_db}.sys.indexes pk \
+               ON pk.object_id = c.object_id AND pk.is_primary_key = 1 \
+             LEFT JOIN {qualified_db}.sys.index_columns ic \
+               ON ic.object_id = pk.object_id AND ic.index_id = pk.index_id \
+               AND ic.column_id = c.column_id \
+             WHERE s.name = '{escaped_schema}' AND tbl.name = '{escaped_table}' \
+             ORDER BY c.column_id",
+            qualified_db = qualified_db,
+            escaped_schema = escaped_schema,
+            escaped_table = escaped_table
+        );
+
+        let result = self.execute_simple(&sql)?;
+        let mut columns = Vec::new();
+
+        for row in result.rows {
+            let mut iter = row.into_iter();
+
+            let name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let type_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => String::new(),
+            };
+            let nullable = value_is_truthy(iter.next());
+            let default_value = match iter.next() {
+                Some(Value::Text(s)) => Some(s),
+                _ => None,
+            };
+            let is_primary_key = value_is_truthy(iter.next());
+
+            columns.push(ColumnInfo {
+                name,
+                type_name,
+                nullable,
+                default_value,
+                is_primary_key,
+                enum_values: None,
+            });
+        }
+
+        Ok(columns)
+    }
+
+    fn fetch_indexes(
+        &self,
+        database: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<IndexInfo>, DbError> {
+        let escaped_db = database.replace(']', "]]");
+        let qualified_db = format!("[{}]", escaped_db);
+        let escaped_schema = schema.replace('\'', "''");
+        let escaped_table = table.replace('\'', "''");
+
+        let sql = format!(
+            "SELECT \
+                i.name AS index_name, \
+                c.name AS column_name, \
+                i.is_unique, \
+                i.is_primary_key, \
+                ic.key_ordinal \
+             FROM {qualified_db}.sys.indexes i \
+             JOIN {qualified_db}.sys.index_columns ic ON ic.object_id = i.object_id AND ic.index_id = i.index_id \
+             JOIN {qualified_db}.sys.columns c ON c.object_id = ic.object_id AND c.column_id = ic.column_id \
+             JOIN {qualified_db}.sys.tables tbl ON tbl.object_id = i.object_id \
+             JOIN {qualified_db}.sys.schemas s ON s.schema_id = tbl.schema_id \
+             WHERE s.name = '{escaped_schema}' AND tbl.name = '{escaped_table}' \
+               AND i.name IS NOT NULL \
+             ORDER BY i.name, ic.key_ordinal",
+            qualified_db = qualified_db,
+            escaped_schema = escaped_schema,
+            escaped_table = escaped_table
+        );
+
+        let result = self.execute_simple(&sql)?;
+
+        let mut grouped: indexmap_for_indexes::IndexMap<String, IndexInfo> =
+            indexmap_for_indexes::IndexMap::new();
+
+        for row in result.rows {
+            let mut iter = row.into_iter();
+
+            let index_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let column_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let is_unique = value_is_truthy(iter.next());
+            let is_primary = value_is_truthy(iter.next());
+            // key_ordinal is consumed only for ORDER BY purposes
+            let _ = iter.next();
+
+            let entry = grouped
+                .entry(index_name.clone())
+                .or_insert_with(|| IndexInfo {
+                    name: index_name,
+                    columns: Vec::new(),
+                    is_unique,
+                    is_primary,
+                });
+            entry.columns.push(column_name);
+        }
+
+        Ok(grouped.into_iter().map(|(_, v)| v).collect())
+    }
+
+    fn fetch_foreign_keys(
+        &self,
+        database: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<ForeignKeyInfo>, DbError> {
+        let escaped_db = database.replace(']', "]]");
+        let qualified_db = format!("[{}]", escaped_db);
+        let escaped_schema = schema.replace('\'', "''");
+        let escaped_table = table.replace('\'', "''");
+
+        let sql = format!(
+            "SELECT \
+                fk.name AS constraint_name, \
+                pc.name AS column_name, \
+                rs.name AS referenced_schema, \
+                rt.name AS referenced_table, \
+                rc.name AS referenced_column, \
+                fk.delete_referential_action_desc, \
+                fk.update_referential_action_desc \
+             FROM {qualified_db}.sys.foreign_keys fk \
+             JOIN {qualified_db}.sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id \
+             JOIN {qualified_db}.sys.tables pt ON pt.object_id = fk.parent_object_id \
+             JOIN {qualified_db}.sys.schemas ps ON ps.schema_id = pt.schema_id \
+             JOIN {qualified_db}.sys.columns pc ON pc.object_id = fkc.parent_object_id AND pc.column_id = fkc.parent_column_id \
+             JOIN {qualified_db}.sys.tables rt ON rt.object_id = fk.referenced_object_id \
+             JOIN {qualified_db}.sys.schemas rs ON rs.schema_id = rt.schema_id \
+             JOIN {qualified_db}.sys.columns rc ON rc.object_id = fkc.referenced_object_id AND rc.column_id = fkc.referenced_column_id \
+             WHERE ps.name = '{escaped_schema}' AND pt.name = '{escaped_table}' \
+             ORDER BY fk.name, fkc.constraint_column_id",
+            qualified_db = qualified_db,
+            escaped_schema = escaped_schema,
+            escaped_table = escaped_table
+        );
+
+        let result = self.execute_simple(&sql)?;
+
+        let mut builder = ForeignKeyBuilder::new();
+
+        for row in result.rows {
+            let mut iter = row.into_iter();
+
+            let name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let column = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let referenced_schema = match iter.next() {
+                Some(Value::Text(s)) => Some(s),
+                _ => None,
+            };
+            let referenced_table = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let referenced_column = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let on_delete = match iter.next() {
+                Some(Value::Text(s)) if s != "NO_ACTION" => Some(normalize_fk_action(&s)),
+                _ => None,
+            };
+            let on_update = match iter.next() {
+                Some(Value::Text(s)) if s != "NO_ACTION" => Some(normalize_fk_action(&s)),
+                _ => None,
+            };
+
+            builder.add_column(
+                name,
+                column,
+                referenced_schema,
+                referenced_table,
+                referenced_column,
+                on_delete,
+                on_update,
+            );
+        }
+
+        Ok(builder.build())
+    }
+
+    fn fetch_constraints(
+        &self,
+        database: &str,
+        schema: &str,
+        table: &str,
+    ) -> Result<Vec<ConstraintInfo>, DbError> {
+        let escaped_db = database.replace(']', "]]");
+        let qualified_db = format!("[{}]", escaped_db);
+        let escaped_schema = schema.replace('\'', "''");
+        let escaped_table = table.replace('\'', "''");
+
+        // CHECK constraints + the columns they reference.
+        let check_sql = format!(
+            "SELECT \
+                cc.name AS constraint_name, \
+                CAST(cc.definition AS NVARCHAR(MAX)) AS check_clause, \
+                c.name AS column_name \
+             FROM {qualified_db}.sys.check_constraints cc \
+             JOIN {qualified_db}.sys.tables tbl ON tbl.object_id = cc.parent_object_id \
+             JOIN {qualified_db}.sys.schemas s ON s.schema_id = tbl.schema_id \
+             LEFT JOIN {qualified_db}.sys.columns c \
+               ON c.object_id = cc.parent_object_id AND c.column_id = cc.parent_column_id \
+             WHERE s.name = '{escaped_schema}' AND tbl.name = '{escaped_table}' \
+             ORDER BY cc.name"
+        );
+
+        let check_rows = self.execute_simple(&check_sql)?;
+        let mut grouped: indexmap_for_indexes::IndexMap<String, ConstraintInfo> =
+            indexmap_for_indexes::IndexMap::new();
+
+        for row in check_rows.rows {
+            let mut iter = row.into_iter();
+            let name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let check_clause = match iter.next() {
+                Some(Value::Text(s)) => Some(s),
+                _ => None,
+            };
+            let column = match iter.next() {
+                Some(Value::Text(s)) => Some(s),
+                _ => None,
+            };
+
+            let entry = grouped
+                .entry(name.clone())
+                .or_insert_with(|| ConstraintInfo {
+                    name,
+                    kind: ConstraintKind::Check,
+                    columns: Vec::new(),
+                    check_clause,
+                });
+            if let Some(column) = column
+                && !entry.columns.contains(&column)
+            {
+                entry.columns.push(column);
+            }
+        }
+
+        // UNIQUE constraints — surfaced as unique indexes that are not the
+        // table's primary key. `sys.indexes.is_unique_constraint` flags those
+        // backing an explicit UNIQUE constraint definition.
+        let unique_sql = format!(
+            "SELECT \
+                i.name AS index_name, \
+                c.name AS column_name, \
+                ic.key_ordinal \
+             FROM {qualified_db}.sys.indexes i \
+             JOIN {qualified_db}.sys.index_columns ic \
+               ON ic.object_id = i.object_id AND ic.index_id = i.index_id \
+             JOIN {qualified_db}.sys.columns c \
+               ON c.object_id = ic.object_id AND c.column_id = ic.column_id \
+             JOIN {qualified_db}.sys.tables tbl ON tbl.object_id = i.object_id \
+             JOIN {qualified_db}.sys.schemas s ON s.schema_id = tbl.schema_id \
+             WHERE s.name = '{escaped_schema}' AND tbl.name = '{escaped_table}' \
+               AND i.is_unique_constraint = 1 \
+             ORDER BY i.name, ic.key_ordinal"
+        );
+
+        let unique_rows = self.execute_simple(&unique_sql)?;
+        for row in unique_rows.rows {
+            let mut iter = row.into_iter();
+            let name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let column = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let _ordinal = iter.next();
+
+            let entry = grouped
+                .entry(name.clone())
+                .or_insert_with(|| ConstraintInfo {
+                    name,
+                    kind: ConstraintKind::Unique,
+                    columns: Vec::new(),
+                    check_clause: None,
+                });
+            entry.columns.push(column);
+        }
+
+        Ok(grouped.into_iter().map(|(_, v)| v).collect())
+    }
+
+    fn fetch_custom_types(
+        &self,
+        database: &str,
+        schema: &str,
+    ) -> Result<Vec<CustomTypeInfo>, DbError> {
+        let escaped_db = database.replace(']', "]]");
+        let qualified_db = format!("[{}]", escaped_db);
+        let escaped_schema = schema.replace('\'', "''");
+
+        // User-defined alias types map most cleanly to DBFlux's Domain kind
+        // (a wrapper around a base type). CLR/table-typed types are
+        // exposed as Composite for now.
+        let sql = format!(
+            "SELECT \
+                t.name AS type_name, \
+                bt.name AS base_type_name, \
+                t.is_table_type \
+             FROM {qualified_db}.sys.types t \
+             JOIN {qualified_db}.sys.schemas s ON s.schema_id = t.schema_id \
+             LEFT JOIN {qualified_db}.sys.types bt \
+               ON bt.user_type_id = t.system_type_id AND bt.is_user_defined = 0 \
+             WHERE t.is_user_defined = 1 AND s.name = '{escaped_schema}' \
+             ORDER BY t.name"
+        );
+
+        let rows = self.execute_simple(&sql)?;
+        let mut types = Vec::new();
+
+        for row in rows.rows {
+            let mut iter = row.into_iter();
+            let name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let base_type = match iter.next() {
+                Some(Value::Text(s)) => Some(s),
+                _ => None,
+            };
+            let is_table_type = value_is_truthy(iter.next());
+
+            let kind = if is_table_type {
+                CustomTypeKind::Composite
+            } else {
+                CustomTypeKind::Domain
+            };
+
+            types.push(CustomTypeInfo {
+                name,
+                schema: Some(schema.to_string()),
+                kind,
+                enum_values: None,
+                base_type,
+            });
+        }
+
+        Ok(types)
+    }
+
+    fn fetch_schema_indexes(
+        &self,
+        database: &str,
+        schema: &str,
+    ) -> Result<Vec<SchemaIndexInfo>, DbError> {
+        let escaped_db = database.replace(']', "]]");
+        let qualified_db = format!("[{}]", escaped_db);
+        let escaped_schema = schema.replace('\'', "''");
+
+        let sql = format!(
+            "SELECT \
+                tbl.name AS table_name, \
+                i.name AS index_name, \
+                c.name AS column_name, \
+                i.is_unique, \
+                i.is_primary_key, \
+                ic.key_ordinal \
+             FROM {qualified_db}.sys.indexes i \
+             JOIN {qualified_db}.sys.index_columns ic \
+               ON ic.object_id = i.object_id AND ic.index_id = i.index_id \
+             JOIN {qualified_db}.sys.columns c \
+               ON c.object_id = ic.object_id AND c.column_id = ic.column_id \
+             JOIN {qualified_db}.sys.tables tbl ON tbl.object_id = i.object_id \
+             JOIN {qualified_db}.sys.schemas s ON s.schema_id = tbl.schema_id \
+             WHERE s.name = '{escaped_schema}' AND i.name IS NOT NULL \
+             ORDER BY tbl.name, i.name, ic.key_ordinal"
+        );
+
+        let rows = self.execute_simple(&sql)?;
+        let mut builder = SchemaIndexBuilder::new();
+
+        for row in rows.rows {
+            let mut iter = row.into_iter();
+            let table_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let index_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let column = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let is_unique = value_is_truthy(iter.next());
+            let is_primary = value_is_truthy(iter.next());
+            let _ordinal = iter.next();
+
+            builder.add_column(table_name.clone(), index_name.clone(), column, is_unique);
+            if is_primary {
+                builder.set_primary(&table_name, &index_name);
+            }
+        }
+
+        Ok(builder.build_sorted())
+    }
+
+    fn fetch_schema_foreign_keys(
+        &self,
+        database: &str,
+        schema: &str,
+    ) -> Result<Vec<SchemaForeignKeyInfo>, DbError> {
+        let escaped_db = database.replace(']', "]]");
+        let qualified_db = format!("[{}]", escaped_db);
+        let escaped_schema = schema.replace('\'', "''");
+
+        let sql = format!(
+            "SELECT \
+                pt.name AS table_name, \
+                fk.name AS constraint_name, \
+                pc.name AS column_name, \
+                rs.name AS referenced_schema, \
+                rt.name AS referenced_table, \
+                rc.name AS referenced_column, \
+                fk.delete_referential_action_desc, \
+                fk.update_referential_action_desc \
+             FROM {qualified_db}.sys.foreign_keys fk \
+             JOIN {qualified_db}.sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id \
+             JOIN {qualified_db}.sys.tables pt ON pt.object_id = fk.parent_object_id \
+             JOIN {qualified_db}.sys.schemas ps ON ps.schema_id = pt.schema_id \
+             JOIN {qualified_db}.sys.columns pc \
+               ON pc.object_id = fkc.parent_object_id AND pc.column_id = fkc.parent_column_id \
+             JOIN {qualified_db}.sys.tables rt ON rt.object_id = fk.referenced_object_id \
+             JOIN {qualified_db}.sys.schemas rs ON rs.schema_id = rt.schema_id \
+             JOIN {qualified_db}.sys.columns rc \
+               ON rc.object_id = fkc.referenced_object_id AND rc.column_id = fkc.referenced_column_id \
+             WHERE ps.name = '{escaped_schema}' \
+             ORDER BY pt.name, fk.name, fkc.constraint_column_id"
+        );
+
+        let rows = self.execute_simple(&sql)?;
+        let mut builder = SchemaForeignKeyBuilder::new();
+
+        for row in rows.rows {
+            let mut iter = row.into_iter();
+            let table_name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let name = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let column = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let referenced_schema = match iter.next() {
+                Some(Value::Text(s)) => Some(s),
+                _ => None,
+            };
+            let referenced_table = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let referenced_column = match iter.next() {
+                Some(Value::Text(s)) => s,
+                _ => continue,
+            };
+            let on_delete = match iter.next() {
+                Some(Value::Text(s)) if s != "NO_ACTION" => Some(normalize_fk_action(&s)),
+                _ => None,
+            };
+            let on_update = match iter.next() {
+                Some(Value::Text(s)) if s != "NO_ACTION" => Some(normalize_fk_action(&s)),
+                _ => None,
+            };
+
+            builder.add_column(
+                table_name,
+                name,
+                column,
+                referenced_schema,
+                referenced_table,
+                referenced_column,
+                on_update,
+                on_delete,
+            );
+        }
+
+        Ok(builder.build_sorted())
+    }
+}
+
+// Local indexmap usage so we don't depend on dbflux_core's indexmap re-export.
+mod indexmap_for_indexes {
+    pub(super) use indexmap::IndexMap;
+}
+
+fn normalize_fk_action(action: &str) -> String {
+    // Convert tiberius/sys.foreign_keys descriptors ("NO_ACTION", "CASCADE",
+    // "SET_NULL", "SET_DEFAULT") into the canonical SQL clause form.
+    action.replace('_', " ")
+}
+
+fn value_is_truthy(value: Option<Value>) -> bool {
+    match value {
+        Some(Value::Bool(b)) => b,
+        Some(Value::Int(i)) => i != 0,
+        _ => false,
+    }
+}
+
+/// Returns `true` when a server error looks like it was raised because the
+/// session was killed (rather than being a real query failure).
+///
+/// SQL Server emits one of:
+///   - 596: Cannot continue the execution because the session is in the kill state.
+///   - 233 / 10054 family: connection-reset variants after the socket closes.
+///   - 6005: SHUTDOWN is in progress (rare, but also fires for some KILL paths).
+///
+/// These codes are stable across modern SQL Server versions. The check is
+/// only used to translate post-KILL errors into `DbError::Cancelled`, so
+/// false negatives just result in a slightly less specific error message;
+/// false positives would mask real errors, which is why the list is small.
+fn is_kill_error(err: &DbError) -> bool {
+    matches!(err,
+        DbError::QueryFailed(fe)
+        | DbError::ConstraintViolation(fe)
+        | DbError::SyntaxError(fe)
+        | DbError::AuthFailed(fe)
+        | DbError::PermissionDenied(fe)
+        | DbError::ObjectNotFound(fe)
+        | DbError::ConnectionFailed(fe)
+        if matches!(fe.code.as_deref(), Some("596") | Some("233") | Some("6005"))
+    )
+}
+
+// ---------------------------------------------------------------------------
+// OUTPUT-clause SQL builders
+// ---------------------------------------------------------------------------
+//
+// SQL Server places the OUTPUT clause between the target and the
+// VALUES/SET/WHERE clauses, not at the end like Postgres `RETURNING`.
+// We build the SQL directly rather than threading a new dialect hook
+// through `SqlQueryBuilder`, keeping the change local to this driver.
+
+fn build_insert_with_output(insert: &RowInsert) -> Result<String, DbError> {
+    let table = MSSQL_DIALECT.qualified_table(insert.schema.as_deref(), &insert.table);
+    let columns = insert
+        .columns
+        .iter()
+        .map(|c| MSSQL_DIALECT.quote_identifier(c))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let values = insert
+        .values
+        .iter()
+        .map(|v| MSSQL_DIALECT.value_to_literal(v))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Ok(format!(
+        "INSERT INTO {} ({}) OUTPUT INSERTED.* VALUES ({})",
+        table, columns, values
+    ))
+}
+
+fn build_update_with_output(patch: &RowPatch) -> Result<String, DbError> {
+    let table = MSSQL_DIALECT.qualified_table(patch.schema.as_deref(), &patch.table);
+    let set_clause = patch
+        .changes
+        .iter()
+        .map(|(col, value)| {
+            format!(
+                "{} = {}",
+                MSSQL_DIALECT.quote_identifier(col),
+                MSSQL_DIALECT.value_to_literal(value)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    let where_clause = identity_where_clause(&patch.identity)?;
+
+    Ok(format!(
+        "UPDATE {} SET {} OUTPUT INSERTED.* WHERE {}",
+        table, set_clause, where_clause
+    ))
+}
+
+fn build_delete_with_output(delete: &RowDelete) -> Result<String, DbError> {
+    let table = MSSQL_DIALECT.qualified_table(delete.schema.as_deref(), &delete.table);
+    let where_clause = identity_where_clause(&delete.identity)?;
+
+    Ok(format!(
+        "DELETE FROM {} OUTPUT DELETED.* WHERE {}",
+        table, where_clause
+    ))
+}
+
+fn identity_where_clause(identity: &RecordIdentity) -> Result<String, DbError> {
+    match identity {
+        RecordIdentity::Composite { columns, values } => {
+            if columns.is_empty() || columns.len() != values.len() {
+                return Err(DbError::QueryFailed(
+                    "Row identity has no columns".to_string().into(),
+                ));
+            }
+            Ok(columns
+                .iter()
+                .zip(values.iter())
+                .map(|(col, value)| {
+                    format!(
+                        "{} = {}",
+                        MSSQL_DIALECT.quote_identifier(col),
+                        MSSQL_DIALECT.value_to_literal(value)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(" AND "))
+        }
+        RecordIdentity::ObjectId(_) | RecordIdentity::Key(_) => Err(DbError::NotSupported(
+            "SQL Server row mutations require a composite primary-key identity".to_string(),
+        )),
+    }
+}
+
+fn result_first_row_to_crud(result: QueryResult) -> CrudResult {
+    let columns = result.columns;
+    let mut rows = result.rows.into_iter();
+    match rows.next() {
+        Some(row) => {
+            // Build an ordered HashMap of column-name → value the same way
+            // postgres does for its RETURNING path. We surface the row through
+            // CrudResult::success so the UI sees the post-mutation values.
+            let _ = columns;
+            CrudResult::success(row)
+        }
+        None => CrudResult::empty(),
+    }
+}
+
+impl RelationalConnection for MssqlConnection {}
+
+impl ConnectionExt for MssqlConnection {
+    fn as_relational(&self) -> Option<&dyn RelationalConnection> {
+        Some(self)
+    }
+
+    fn as_document(&self) -> Option<&dyn DocumentConnection> {
+        None
+    }
+
+    fn as_keyvalue(&self) -> Option<&dyn KeyValueConnection> {
+        None
+    }
+}
+
+// =============================================================================
+// URI helpers
+// =============================================================================
+
+fn inject_password_into_mssql_uri(base_uri: &str, password: Option<&str>) -> String {
+    let password = match password {
+        Some(p) if !p.is_empty() => p,
+        _ => return base_uri.to_string(),
+    };
+
+    let prefixes = ["sqlserver://", "mssql://"];
+    for prefix in prefixes {
+        if let Some(rest) = base_uri.strip_prefix(prefix) {
+            if let Some(at_pos) = rest.rfind('@') {
+                let user_pass = &rest[..at_pos];
+                let after_at = &rest[at_pos..];
+
+                if user_pass.contains(':') {
+                    return base_uri.to_string();
+                }
+
+                return format!(
+                    "{}{}:{}{}",
+                    prefix,
+                    user_pass,
+                    urlencoding::encode(password),
+                    after_at
+                );
+            }
+
+            return base_uri.to_string();
+        }
+    }
+
+    base_uri.to_string()
+}
+
+/// Parse a `sqlserver://user:pass@host:port/db?...` URI into a tiberius Config.
+fn parse_mssql_url(uri: &str) -> Result<Config, tiberius::error::Error> {
+    let stripped = uri
+        .strip_prefix("sqlserver://")
+        .or_else(|| uri.strip_prefix("mssql://"))
+        .ok_or_else(|| {
+            tiberius::error::Error::Conversion("unsupported SQL Server URI scheme".into())
+        })?;
+
+    let (credentials, host_part) = if let Some(at_pos) = stripped.rfind('@') {
+        (&stripped[..at_pos], &stripped[at_pos + 1..])
+    } else {
+        ("", stripped)
+    };
+
+    let (host_port, query_part) = if let Some(slash) = host_part.find('/') {
+        (&host_part[..slash], &host_part[slash + 1..])
+    } else {
+        (host_part, "")
+    };
+
+    let (database, params) = if let Some(qmark) = query_part.find('?') {
+        (&query_part[..qmark], &query_part[qmark + 1..])
+    } else {
+        (query_part, "")
+    };
+
+    let (host_and_instance, explicit_port) = if let Some(colon) = host_port.rfind(':') {
+        let port: u16 = host_port[colon + 1..].parse().map_err(|_| {
+            tiberius::error::Error::Conversion("invalid SQL Server URI port".into())
+        })?;
+        (&host_port[..colon], Some(port))
+    } else {
+        (host_port, None)
+    };
+
+    // SSMS-style `host\instance`. The trailing `?instance=…` may also set
+    // it and wins if both are supplied.
+    let (host, mut instance) = match host_and_instance.find('\\') {
+        Some(bs) => (
+            &host_and_instance[..bs],
+            Some(host_and_instance[bs + 1..].to_string()),
+        ),
+        None => (host_and_instance, None),
+    };
+
+    let mut config = Config::new();
+    config.host(host);
+    // Defer the port decision until after the query-string loop so we can
+    // see whether `?instance=` is supplied. When an instance is present we
+    // intentionally leave the port unset so tiberius defaults to 1434 for
+    // the SQL Browser lookup.
+
+    if !database.is_empty() {
+        let decoded = urlencoding::decode(database)
+            .map(|cow| cow.into_owned())
+            .unwrap_or_else(|_| database.to_string());
+        config.database(decoded);
+    }
+
+    if !credentials.is_empty() {
+        if let Some(colon) = credentials.find(':') {
+            let user = urlencoding::decode(&credentials[..colon])
+                .map(|cow| cow.into_owned())
+                .unwrap_or_default();
+            let password = urlencoding::decode(&credentials[colon + 1..])
+                .map(|cow| cow.into_owned())
+                .unwrap_or_default();
+            config.authentication(AuthMethod::sql_server(user, password));
+        } else {
+            let user = urlencoding::decode(credentials)
+                .map(|cow| cow.into_owned())
+                .unwrap_or_default();
+            config.authentication(AuthMethod::sql_server(user, ""));
+        }
+    }
+
+    // SSL Mode is the single user-facing knob; trust_cert is derived from
+    // it unless the caller explicitly overrides via `?trust=` in the URI.
+    //
+    //   encrypt=off       -> Off,      trust irrelevant
+    //   encrypt=on        -> On,       trust=true  (accept self-signed)
+    //   encrypt=required  -> Required, trust=false (validate cert)
+    //
+    // Mirrors the form-mode mapping in extract_form() so toggling between
+    // URI mode and form mode preserves intent.
+    let mut encryption = EncryptionLevel::On;
+    let mut trust_cert_override: Option<bool> = None;
+
+    for pair in params.split('&').filter(|p| !p.is_empty()) {
+        let Some((key, value)) = pair.split_once('=') else {
+            continue;
+        };
+        match key.to_ascii_lowercase().as_str() {
+            "encrypt" => {
+                encryption = match value.to_ascii_lowercase().as_str() {
+                    "true" | "yes" | "on" | "1" => EncryptionLevel::On,
+                    "false" | "no" | "off" | "0" => EncryptionLevel::Off,
+                    "strict" | "required" => EncryptionLevel::Required,
+                    _ => EncryptionLevel::On,
+                };
+            }
+            "trustservercertificate" | "trust_server_certificate" | "trust" => {
+                trust_cert_override =
+                    Some(matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes"));
+            }
+            "instance" | "instancename" | "instance_name" if !value.is_empty() => {
+                let decoded = urlencoding::decode(value)
+                    .map(|cow| cow.into_owned())
+                    .unwrap_or_else(|_| value.to_string());
+                instance = Some(decoded);
+            }
+            _ => {}
+        }
+    }
+
+    let trust_cert = trust_cert_override
+        .unwrap_or(!matches!(encryption, EncryptionLevel::Required));
+
+    match (instance.filter(|s| !s.is_empty()), explicit_port) {
+        (Some(name), _) => {
+            // Named instance: leave port unset so tiberius hits 1434 for
+            // the Browser query and then dials whatever port Browser
+            // returns. Any user-supplied port in the URI is ignored in
+            // this mode — that matches SSMS/ADO behavior.
+            config.instance_name(name);
+        }
+        (None, Some(port)) => {
+            config.port(port);
+        }
+        (None, None) => {
+            config.port(1433);
+        }
+    }
+
+    config.encryption(encryption);
+    if trust_cert {
+        config.trust_cert();
+    }
+
+    Ok(config)
+}
+
+// =============================================================================
+// Error formatting
+// =============================================================================
+
+pub struct MssqlErrorFormatter;
+
+/// Semantic class of an MSSQL error code, used to pick a `DbError` variant.
+///
+/// SQL Server reports errors as numeric `code()` values rather than ANSI
+/// SQLSTATEs, so the shared `FormattedError::into_query_error()` classifier
+/// (which inspects SQLSTATE prefixes) cannot route them. We classify here
+/// and construct the `DbError` variant directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MssqlErrorClass {
+    Auth,
+    Permission,
+    NotFound,
+    Constraint,
+    Syntax,
+}
+
+fn classify_mssql_code(code: u32) -> Option<MssqlErrorClass> {
+    match code {
+        // Login / auth
+        4060 | 18450 | 18452 | 18456 | 18486 | 18487 | 18488 => Some(MssqlErrorClass::Auth),
+
+        // Permission / access
+        229 | 230 | 262 | 297 | 916 => Some(MssqlErrorClass::Permission),
+
+        // Object not found
+        // 208: Invalid object name
+        // 207: Invalid column name
+        // 2812: Could not find stored procedure
+        // 4902: Cannot find object (ALTER)
+        208 | 207 | 2812 | 4902 => Some(MssqlErrorClass::NotFound),
+
+        // Constraint violations
+        // 547: FK violation / CHECK constraint conflict
+        // 2627: Unique constraint
+        // 2601: Unique index
+        // 515: Cannot insert NULL into column (NOT NULL violation)
+        // 8152: String or binary data would be truncated
+        // 245: Conversion failed (often constraint-shaped failure)
+        547 | 2627 | 2601 | 515 | 8152 | 245 => Some(MssqlErrorClass::Constraint),
+
+        // Syntax / batch parsing
+        // 102: Incorrect syntax near
+        // 156: Incorrect syntax near the keyword
+        // 8180: Statement(s) could not be prepared
+        102 | 156 | 8180 => Some(MssqlErrorClass::Syntax),
+
+        _ => None,
+    }
+}
+
+/// Extract structured location info (table, constraint) from common SQL Server
+/// constraint-violation messages.
+///
+/// Messages look like:
+///   "Violation of PRIMARY KEY constraint 'PK_users'. Cannot insert
+///    duplicate key in object 'dbo.users'. The duplicate key value is (1)."
+///   "The INSERT statement conflicted with the FOREIGN KEY constraint
+///    'FK_orders_user'. The conflict occurred in database 'app',
+///    table 'dbo.users', column 'id'."
+fn extract_location_from_message(message: &str) -> dbflux_core::ErrorLocation {
+    let mut location = dbflux_core::ErrorLocation::new();
+
+    if let Some(name) = find_quoted_after(message, "constraint") {
+        location = location.with_constraint(name);
+    }
+
+    if let Some(qualified) =
+        find_quoted_after(message, "object").or_else(|| find_quoted_after(message, "table"))
+    {
+        if let Some((schema, table)) = qualified.split_once('.') {
+            location = location
+                .with_schema(schema.trim_matches(|c| c == '[' || c == ']'))
+                .with_table(table.trim_matches(|c| c == '[' || c == ']'));
+        } else {
+            location = location.with_table(qualified);
+        }
+    }
+
+    if let Some(column) = find_quoted_after(message, "column") {
+        location = location.with_column(column);
+    }
+
+    location
+}
+
+fn find_quoted_after(haystack: &str, marker: &str) -> Option<String> {
+    let lower = haystack.to_ascii_lowercase();
+    let marker_lower = marker.to_ascii_lowercase();
+    let mut search_from = 0;
+
+    while let Some(idx) = lower[search_from..].find(&marker_lower) {
+        let abs = search_from + idx + marker_lower.len();
+        if let Some(rest) = haystack.get(abs..)
+            && let Some(start) = rest.find('\'')
+        {
+            let after_quote = &rest[start + 1..];
+            if let Some(end) = after_quote.find('\'') {
+                return Some(after_quote[..end].to_string());
+            }
+        }
+        search_from = abs;
+    }
+    None
+}
+
+impl MssqlErrorFormatter {
+    fn classify_tiberius_error(err: &tiberius::error::Error) -> FormattedError {
+        match err {
+            tiberius::error::Error::Server(token) => {
+                let message = token.message().to_string();
+                let mut fe =
+                    FormattedError::new(message.clone()).with_code(token.code().to_string());
+
+                let state = token.state();
+                if state != 0 {
+                    fe = fe.with_detail(format!("State {}, line {}", state, token.line()));
+                }
+
+                let location = extract_location_from_message(&message);
+                if !location.is_empty() {
+                    fe = fe.with_location(location);
+                }
+
+                fe
+            }
+            tiberius::error::Error::Protocol(msg) => {
+                FormattedError::new(format!("Protocol error: {}", msg))
+            }
+            tiberius::error::Error::Encoding(msg) => {
+                FormattedError::new(format!("Encoding error: {}", msg))
+            }
+            tiberius::error::Error::Conversion(msg) => {
+                FormattedError::new(format!("Conversion error: {}", msg))
+            }
+            tiberius::error::Error::Utf8 => FormattedError::new("Invalid UTF-8 in response"),
+            tiberius::error::Error::Utf16 => FormattedError::new("Invalid UTF-16 in response"),
+            tiberius::error::Error::ParseInt(e) => {
+                FormattedError::new(format!("Integer parse error: {}", e))
+            }
+            tiberius::error::Error::Io { kind, message } => {
+                FormattedError::new(format!("I/O {}: {}", kind, message))
+            }
+            other => FormattedError::new(other.to_string()),
+        }
+    }
+
+    fn route_query_error(fe: FormattedError) -> DbError {
+        if let Some(class) = fe
+            .code
+            .as_deref()
+            .and_then(|c| c.parse::<u32>().ok())
+            .and_then(classify_mssql_code)
+        {
+            return match class {
+                MssqlErrorClass::Auth => DbError::AuthFailed(fe),
+                MssqlErrorClass::Permission => DbError::PermissionDenied(fe),
+                MssqlErrorClass::NotFound => DbError::ObjectNotFound(fe),
+                MssqlErrorClass::Constraint => DbError::ConstraintViolation(fe),
+                MssqlErrorClass::Syntax => DbError::SyntaxError(fe),
+            };
+        }
+
+        // Fall back to the shared SQLSTATE classifier (which will just return
+        // QueryFailed for MSSQL codes that don't match a SQLSTATE prefix).
+        fe.into_query_error()
+    }
+}
+
+impl QueryErrorFormatter for MssqlErrorFormatter {
+    fn format_query_error(&self, error: &(dyn std::error::Error + 'static)) -> FormattedError {
+        if let Some(err) = error.downcast_ref::<tiberius::error::Error>() {
+            Self::classify_tiberius_error(err)
+        } else {
+            FormattedError::new(error.to_string())
+        }
+    }
+}
+
+impl ConnectionErrorFormatter for MssqlErrorFormatter {
+    fn format_connection_error(
+        &self,
+        error: &(dyn std::error::Error + 'static),
+        host: &str,
+        port: u16,
+    ) -> FormattedError {
+        let source = error.to_string();
+        let message = if source.contains("Login failed") || source.contains("18456") {
+            "Authentication failed. Check your username and password.".to_string()
+        } else if source.contains("Cannot open database") {
+            format!("Database does not exist or login lacks access: {}", source)
+        } else if source.contains("Connection refused") {
+            format!(
+                "Could not connect to {}:{}. The server may be unreachable, behind a firewall, or requires an SSH tunnel.",
+                host, port
+            )
+        } else if source.contains("Name or service not known")
+            || source.contains("nodename nor servname")
+            || source.contains("failed to lookup address")
+        {
+            format!("Could not resolve hostname: {}", host)
+        } else {
+            format!("Connection error: {}", source)
+        };
+
+        FormattedError::new(message)
+    }
+
+    fn format_uri_error(
+        &self,
+        error: &(dyn std::error::Error + 'static),
+        sanitized_uri: &str,
+    ) -> FormattedError {
+        FormattedError::new(format!(
+            "Connection error with URI {}: {}",
+            sanitized_uri, error
+        ))
+    }
+}
+
+static MSSQL_ERROR_FORMATTER: MssqlErrorFormatter = MssqlErrorFormatter;
+
+fn format_mssql_connect_error(e: &tiberius::error::Error, host: &str, port: u16) -> DbError {
+    // Tiberius bubbles up login failures as `Server` token errors, not as
+    // a separate `Auth` variant. We classify by the numeric code first so
+    // 18456 etc. surface as `AuthFailed`, then fall back to the host-aware
+    // connection error message for everything else.
+    let server_fe = match e {
+        tiberius::error::Error::Server(_) => Some(MssqlErrorFormatter::classify_tiberius_error(e)),
+        _ => None,
+    };
+
+    if let Some(fe) = server_fe
+        && let Some(code) = fe.code.as_deref().and_then(|c| c.parse::<u32>().ok())
+        && matches!(classify_mssql_code(code), Some(MssqlErrorClass::Auth))
+    {
+        log::error!("SQL Server login failed: {}", fe.message);
+        return DbError::AuthFailed(fe);
+    }
+
+    let formatted = MSSQL_ERROR_FORMATTER.format_connection_error(e, host, port);
+    log::error!("SQL Server connection failed: {}", formatted.message);
+    formatted.into_connection_error()
+}
+
+fn format_mssql_query_error(e: &tiberius::error::Error) -> DbError {
+    let formatted = MSSQL_ERROR_FORMATTER.format_query_error(e);
+    let message = formatted.to_display_string();
+    log::error!("SQL Server query failed: {}", message);
+    MssqlErrorFormatter::route_query_error(formatted)
+}
+
+fn format_mssql_uri_error(e: &tiberius::error::Error, uri: &str) -> DbError {
+    let sanitized = sanitize_uri(uri);
+    let formatted = MSSQL_ERROR_FORMATTER.format_uri_error(e, &sanitized);
+    log::error!("SQL Server URI connection failed: {}", formatted.message);
+    formatted.into_connection_error()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quote_identifier_brackets_and_escapes() {
+        assert_eq!(MSSQL_DIALECT.quote_identifier("users"), "[users]");
+        assert_eq!(MSSQL_DIALECT.quote_identifier("ev]il"), "[ev]]il]");
+    }
+
+    #[test]
+    fn bool_literal_uses_bit_zero_one() {
+        assert_eq!(MSSQL_DIALECT.value_to_literal(&Value::Bool(true)), "1");
+        assert_eq!(MSSQL_DIALECT.value_to_literal(&Value::Bool(false)), "0");
+    }
+
+    #[test]
+    fn text_literal_is_n_prefixed_and_escaped() {
+        assert_eq!(
+            MSSQL_DIALECT.value_to_literal(&Value::Text("d'argent".into())),
+            "N'd''argent'"
+        );
+    }
+
+    #[test]
+    fn bytes_literal_uses_uppercase_hex() {
+        assert_eq!(
+            MSSQL_DIALECT.value_to_literal(&Value::Bytes(vec![0x01, 0xAB, 0xCD])),
+            "0x01ABCD"
+        );
+    }
+
+    #[test]
+    fn insert_with_output_emits_output_inserted_star() {
+        let insert = RowInsert::new(
+            "users".into(),
+            Some("dbo".into()),
+            vec!["name".into(), "age".into()],
+            vec![Value::Text("alice".into()), Value::Int(30)],
+        );
+        let sql = build_insert_with_output(&insert).unwrap();
+        assert_eq!(
+            sql,
+            "INSERT INTO [dbo].[users] ([name], [age]) OUTPUT INSERTED.* VALUES (N'alice', 30)"
+        );
+    }
+
+    #[test]
+    fn update_with_output_emits_output_inserted_star() {
+        let patch = RowPatch::new(
+            RecordIdentity::composite(vec!["id".into()], vec![Value::Int(7)]),
+            "users".into(),
+            Some("dbo".into()),
+            vec![("name".into(), Value::Text("bob".into()))],
+        );
+        let sql = build_update_with_output(&patch).unwrap();
+        assert_eq!(
+            sql,
+            "UPDATE [dbo].[users] SET [name] = N'bob' OUTPUT INSERTED.* WHERE [id] = 7"
+        );
+    }
+
+    #[test]
+    fn delete_with_output_emits_output_deleted_star() {
+        let delete = RowDelete {
+            identity: RecordIdentity::composite(vec!["id".into()], vec![Value::Int(7)]),
+            table: "users".into(),
+            schema: Some("dbo".into()),
+        };
+        let sql = build_delete_with_output(&delete).unwrap();
+        assert_eq!(
+            sql,
+            "DELETE FROM [dbo].[users] OUTPUT DELETED.* WHERE [id] = 7"
+        );
+    }
+
+    #[test]
+    fn identity_where_clause_composite_uses_and() {
+        let identity = RecordIdentity::composite(
+            vec!["tenant_id".into(), "user_id".into()],
+            vec![Value::Int(1), Value::Int(42)],
+        );
+        assert_eq!(
+            identity_where_clause(&identity).unwrap(),
+            "[tenant_id] = 1 AND [user_id] = 42"
+        );
+    }
+
+    #[test]
+    fn identity_where_clause_rejects_non_composite() {
+        assert!(identity_where_clause(&RecordIdentity::ObjectId("x".into())).is_err());
+        assert!(identity_where_clause(&RecordIdentity::Key("x".into())).is_err());
+    }
+
+    #[test]
+    fn extract_location_finds_constraint_and_table() {
+        let msg = "Violation of PRIMARY KEY constraint 'PK_users'. \
+                   Cannot insert duplicate key in object 'dbo.users'. \
+                   The duplicate key value is (1).";
+        let loc = extract_location_from_message(msg);
+        assert_eq!(loc.constraint.as_deref(), Some("PK_users"));
+        assert_eq!(loc.schema.as_deref(), Some("dbo"));
+        assert_eq!(loc.table.as_deref(), Some("users"));
+    }
+
+    #[test]
+    fn extract_location_finds_fk_constraint_and_referenced_table_column() {
+        let msg = "The INSERT statement conflicted with the FOREIGN KEY \
+                   constraint 'FK_orders_user'. The conflict occurred in \
+                   database 'app', table 'dbo.users', column 'id'.";
+        let loc = extract_location_from_message(msg);
+        assert_eq!(loc.constraint.as_deref(), Some("FK_orders_user"));
+        assert_eq!(loc.schema.as_deref(), Some("dbo"));
+        assert_eq!(loc.table.as_deref(), Some("users"));
+        assert_eq!(loc.column.as_deref(), Some("id"));
+    }
+
+    #[test]
+    fn classify_mssql_code_routes_known_codes() {
+        assert_eq!(classify_mssql_code(18456), Some(MssqlErrorClass::Auth));
+        assert_eq!(classify_mssql_code(547), Some(MssqlErrorClass::Constraint));
+        assert_eq!(classify_mssql_code(2627), Some(MssqlErrorClass::Constraint));
+        assert_eq!(classify_mssql_code(208), Some(MssqlErrorClass::NotFound));
+        assert_eq!(classify_mssql_code(229), Some(MssqlErrorClass::Permission));
+        assert_eq!(classify_mssql_code(102), Some(MssqlErrorClass::Syntax));
+        assert_eq!(classify_mssql_code(99999), None);
+    }
+
+    #[test]
+    fn inject_password_skips_when_already_present() {
+        let input = "sqlserver://sa:already@host:1433/db";
+        assert_eq!(
+            inject_password_into_mssql_uri(input, Some("override")),
+            input
+        );
+    }
+
+    #[test]
+    fn inject_password_adds_when_missing() {
+        let input = "sqlserver://sa@host:1433/db";
+        assert_eq!(
+            inject_password_into_mssql_uri(input, Some("p@ss")),
+            "sqlserver://sa:p%40ss@host:1433/db"
+        );
+    }
+
+    fn form_values(pairs: &[(&str, &str)]) -> FormValues {
+        pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn build_uri_appends_instance_as_query_param() {
+        let driver = MssqlDriver;
+        let values = form_values(&[
+            ("host", "localhost"),
+            ("port", "1433"),
+            ("user", "sa"),
+            ("database", ""),
+            ("instance", "MSSQLSERVER2019"),
+        ]);
+        let uri = driver.build_uri(&values, "pw").expect("uri");
+        assert_eq!(
+            uri,
+            "sqlserver://sa:pw@localhost:1433/?instance=MSSQLSERVER2019"
+        );
+    }
+
+    #[test]
+    fn build_uri_appends_instance_after_database() {
+        let driver = MssqlDriver;
+        let values = form_values(&[
+            ("host", "localhost"),
+            ("port", "1433"),
+            ("user", "sa"),
+            ("database", "tempdb"),
+            ("instance", "SQLEXPRESS"),
+        ]);
+        let uri = driver.build_uri(&values, "pw").expect("uri");
+        assert_eq!(
+            uri,
+            "sqlserver://sa:pw@localhost:1433/tempdb?instance=SQLEXPRESS"
+        );
+    }
+
+    #[test]
+    fn build_uri_omits_instance_when_empty() {
+        let driver = MssqlDriver;
+        let values = form_values(&[
+            ("host", "localhost"),
+            ("port", "1433"),
+            ("user", "sa"),
+            ("database", "tempdb"),
+            ("instance", ""),
+        ]);
+        let uri = driver.build_uri(&values, "pw").expect("uri");
+        assert_eq!(uri, "sqlserver://sa:pw@localhost:1433/tempdb");
+    }
+
+    #[test]
+    fn parse_uri_extracts_instance_from_backslash_form() {
+        let driver = MssqlDriver;
+        let parsed = driver
+            .parse_uri("sqlserver://sa:pw@localhost\\MSSQLSERVER2019:1433")
+            .expect("parsed");
+        assert_eq!(parsed.get("host").map(String::as_str), Some("localhost"));
+        assert_eq!(parsed.get("port").map(String::as_str), Some("1433"));
+        assert_eq!(
+            parsed.get("instance").map(String::as_str),
+            Some("MSSQLSERVER2019")
+        );
+    }
+
+    #[test]
+    fn parse_uri_extracts_instance_from_query_param() {
+        let driver = MssqlDriver;
+        let parsed = driver
+            .parse_uri("sqlserver://sa:pw@localhost:1433/?instance=SQLEXPRESS")
+            .expect("parsed");
+        assert_eq!(parsed.get("host").map(String::as_str), Some("localhost"));
+        assert_eq!(
+            parsed.get("instance").map(String::as_str),
+            Some("SQLEXPRESS")
+        );
+    }
+
+    #[test]
+    fn parse_uri_query_param_overrides_backslash_instance() {
+        let driver = MssqlDriver;
+        let parsed = driver
+            .parse_uri("sqlserver://sa:pw@localhost\\IGNORED:1433/?instance=WINS")
+            .expect("parsed");
+        assert_eq!(parsed.get("instance").map(String::as_str), Some("WINS"));
+    }
+
+    #[test]
+    fn parse_uri_decodes_password_with_percent_encoded_chars() {
+        // ws123456%21 -> ws123456!  ; without this, switching URI -> form
+        // leaves the password field empty/stale and the user saves a wrong
+        // credential (server returns 18456 / State 8).
+        let driver = MssqlDriver;
+        let parsed = driver
+            .parse_uri("sqlserver://sa:ws123456%21@localhost:1433/")
+            .expect("parsed");
+        assert_eq!(parsed.get("user").map(String::as_str), Some("sa"));
+        assert_eq!(
+            parsed.get("password").map(String::as_str),
+            Some("ws123456!")
+        );
+    }
+
+    #[test]
+    fn parse_uri_omits_password_when_credentials_have_no_colon() {
+        let driver = MssqlDriver;
+        let parsed = driver
+            .parse_uri("sqlserver://sa@localhost:1433/")
+            .expect("parsed");
+        assert_eq!(parsed.get("user").map(String::as_str), Some("sa"));
+        assert!(parsed.get("password").is_none());
+    }
+
+    fn build_form_values_for_ssl(ssl_mode: Option<&str>) -> FormValues {
+        let mut v = form_values(&[
+            ("host", "localhost"),
+            ("port", "1433"),
+            ("user", "sa"),
+        ]);
+        if let Some(mode) = ssl_mode {
+            v.insert("ssl_mode".to_string(), mode.to_string());
+        }
+        v
+    }
+
+    fn extract_ssl(values: FormValues) -> (String, bool) {
+        let driver = MssqlDriver;
+        match driver.build_config(&values).expect("config") {
+            DbConfig::SqlServer {
+                ssl_mode,
+                trust_server_certificate,
+                ..
+            } => (ssl_mode.unwrap_or_default(), trust_server_certificate),
+            _ => panic!("expected SqlServer config"),
+        }
+    }
+
+    #[test]
+    fn form_ssl_mode_off_disables_encryption() {
+        let (mode, trust) = extract_ssl(build_form_values_for_ssl(Some("off")));
+        assert_eq!(mode, "off");
+        // trust is irrelevant when encryption is off, but stays `true` so
+        // the value never represents "strict" silently.
+        assert!(trust);
+    }
+
+    #[test]
+    fn form_ssl_mode_on_trusts_self_signed() {
+        let (mode, trust) = extract_ssl(build_form_values_for_ssl(Some("on")));
+        assert_eq!(mode, "on");
+        assert!(trust);
+    }
+
+    #[test]
+    fn form_ssl_mode_required_validates_cert_chain() {
+        let (mode, trust) = extract_ssl(build_form_values_for_ssl(Some("required")));
+        assert_eq!(mode, "required");
+        assert!(!trust);
+    }
+
+    #[test]
+    fn form_ssl_mode_defaults_to_on_when_unset() {
+        let (mode, trust) = extract_ssl(build_form_values_for_ssl(None));
+        assert_eq!(mode, "on");
+        assert!(trust);
+    }
+
+    #[test]
+    fn build_then_parse_uri_round_trips_instance() {
+        let driver = MssqlDriver;
+        let original = form_values(&[
+            ("host", "localhost"),
+            ("port", "1433"),
+            ("user", "sa"),
+            ("database", "appdb"),
+            ("instance", "MSSQLSERVER2019"),
+        ]);
+        let uri = driver.build_uri(&original, "pw").expect("uri");
+        let parsed = driver.parse_uri(&uri).expect("parsed");
+        assert_eq!(parsed.get("host").map(String::as_str), Some("localhost"));
+        assert_eq!(parsed.get("port").map(String::as_str), Some("1433"));
+        assert_eq!(parsed.get("database").map(String::as_str), Some("appdb"));
+        assert_eq!(
+            parsed.get("instance").map(String::as_str),
+            Some("MSSQLSERVER2019")
+        );
+    }
+
+    #[test]
+    fn parse_mssql_url_accepts_backslash_instance() {
+        // We can only assert that parsing succeeds; tiberius `Config` doesn't
+        // expose its internal instance/host fields publicly. A successful
+        // parse means tiberius will perform SQL Browser instance lookup.
+        let result = parse_mssql_url("sqlserver://sa:pw@localhost\\MSSQLSERVER2019:1433");
+        assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+    }
+
+    #[test]
+    fn parse_mssql_url_accepts_instance_query_param() {
+        let result = parse_mssql_url("sqlserver://sa:pw@localhost:1433/?instance=SQLEXPRESS");
+        assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+    }
+
+    fn fe_with_code(code: &str) -> FormattedError {
+        FormattedError::new("session terminated").with_code(code)
+    }
+
+    #[test]
+    fn is_kill_error_matches_known_kill_codes() {
+        assert!(is_kill_error(&DbError::QueryFailed(fe_with_code("596"))));
+        assert!(is_kill_error(&DbError::QueryFailed(fe_with_code("233"))));
+        assert!(is_kill_error(&DbError::QueryFailed(fe_with_code("6005"))));
+        // Same codes are also recognised when classified as connection errors,
+        // since the post-KILL read sometimes comes back as a transport failure.
+        assert!(is_kill_error(&DbError::ConnectionFailed(fe_with_code(
+            "596"
+        ))));
+    }
+
+    #[test]
+    fn is_kill_error_ignores_unrelated_codes() {
+        assert!(!is_kill_error(&DbError::QueryFailed(fe_with_code("547"))));
+        assert!(!is_kill_error(&DbError::ConstraintViolation(fe_with_code(
+            "2627"
+        ))));
+        assert!(!is_kill_error(&DbError::SyntaxError(fe_with_code("102"))));
+    }
+
+    #[test]
+    fn is_kill_error_ignores_errors_without_codes() {
+        assert!(!is_kill_error(&DbError::QueryFailed(FormattedError::new(
+            "no code"
+        ))));
+        assert!(!is_kill_error(&DbError::Cancelled));
+        assert!(!is_kill_error(&DbError::NotSupported("nope".to_string())));
+    }
+
+    fn col(name: &str) -> ColumnMeta {
+        ColumnMeta {
+            name: name.to_string(),
+            type_name: "text".to_string(),
+            kind: dbflux_core::ColumnKind::Unknown,
+            nullable: true,
+            is_primary_key: false,
+        }
+    }
+
+    fn one_row_set(label: &str) -> (Vec<ColumnMeta>, Vec<Row>) {
+        (vec![col(label)], vec![vec![Value::Text(label.to_string())]])
+    }
+
+    #[test]
+    fn build_multi_result_empty_input_yields_empty_primary() {
+        let result = build_multi_result(Vec::new(), std::time::Duration::ZERO);
+        assert!(result.columns.is_empty());
+        assert!(result.rows.is_empty());
+        assert!(!result.has_additional_results());
+        assert_eq!(result.result_set_count(), 1);
+    }
+
+    #[test]
+    fn build_multi_result_single_set_has_no_extras() {
+        let result = build_multi_result(vec![one_row_set("first")], std::time::Duration::ZERO);
+        assert_eq!(result.columns.len(), 1);
+        assert_eq!(result.rows.len(), 1);
+        assert!(!result.has_additional_results());
+        assert_eq!(result.result_set_count(), 1);
+    }
+
+    #[test]
+    fn build_multi_result_multiple_sets_split_last_as_primary_rest_as_extras() {
+        let result = build_multi_result(
+            vec![one_row_set("a"), one_row_set("b"), one_row_set("c")],
+            std::time::Duration::ZERO,
+        );
+
+        // Last set becomes the primary (preserves "last statement wins" UX).
+        assert_eq!(result.columns[0].name, "c");
+        assert_eq!(result.rows[0][0], Value::Text("c".to_string()));
+
+        // Earlier sets land in additional_results in batch order.
+        assert_eq!(result.result_set_count(), 3);
+        assert_eq!(result.additional_results.len(), 2);
+        assert_eq!(result.additional_results[0].columns[0].name, "a");
+        assert_eq!(result.additional_results[1].columns[0].name, "b");
+
+        // iter_result_sets yields primary first, then the earlier sets in
+        // batch order.
+        let names: Vec<String> = result
+            .iter_result_sets()
+            .map(|r| r.columns[0].name.clone())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["c".to_string(), "a".to_string(), "b".to_string()]
+        );
+    }
+}

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1009,9 +1009,12 @@ impl QueryCancelHandle for MssqlCancelHandle {
 
         let spid = self.spid.load(Ordering::SeqCst);
         if spid == 0 {
-            // No session id captured yet — nothing meaningful to kill. The
-            // cancel flag is still set so a not-yet-started query will exit
-            // on its first error check.
+            // No session id captured yet — nothing meaningful to kill. Mark
+            // the connection poisoned so the next `execute()` runs
+            // `cleanup_after_cancel`, which clears both flags. Without this
+            // the `cancelled` flag stays set forever and every subsequent
+            // query short-circuits to `DbError::Cancelled`.
+            self.poisoned.store(true, Ordering::SeqCst);
             return Ok(());
         }
 

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -9,12 +9,11 @@ use dbflux_core::QueryGenerator;
 use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use dbflux_core::{
     ColumnAssignment, ColumnInfo, ColumnMeta, Connection, ConnectionErrorFormatter, ConnectionExt,
-    ConnectionProfile,
-    ConstraintInfo, ConstraintKind, CrudResult, CustomTypeInfo, CustomTypeKind, DatabaseCategory,
-    DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DbSchemaInfo, DdlCapabilities,
-    DeploymentClass, DescribeRequest, DocumentConnection, DriverCapabilities, DriverFormDef,
-    DriverLimits, DriverMetadata, ExplainRequest, ForeignKeyBuilder, ForeignKeyInfo, FormValues,
-    FormattedError, Icon, IndexData, IndexInfo, IsolationLevel, KeyValueConnection,
+    ConnectionProfile, ConstraintInfo, ConstraintKind, CrudResult, CustomTypeInfo, CustomTypeKind,
+    DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DbSchemaInfo,
+    DdlCapabilities, DeploymentClass, DescribeRequest, DocumentConnection, DriverCapabilities,
+    DriverFormDef, DriverLimits, DriverMetadata, ExplainRequest, ForeignKeyBuilder, ForeignKeyInfo,
+    FormValues, FormattedError, Icon, IndexData, IndexInfo, IsolationLevel, KeyValueConnection,
     MutationCapabilities, OrderByColumn, PaginationStyle, PlaceholderStyle, QueryCancelHandle,
     QueryCapabilities, QueryErrorFormatter, QueryHandle, QueryLanguage, QueryRequest, QueryResult,
     RecordIdentity, RelationalConnection, RelationalSchema, Row, RowDelete, RowInsert, RowPatch,

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -55,6 +55,14 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
     uri_scheme: "sqlserver".into(),
     icon: Icon::Database,
     syntax: Some(SyntaxInfo {
+        // T-SQL identifiers are bracketed (`[name]`), but `SyntaxInfo`
+        // models the quote as a single `char`. The dialect's
+        // `quote_identifier` (see `MssqlDialect` impl) emits the
+        // bracket-pair form correctly and is the authoritative source
+        // for SQL generation. The `'"'` here is a placeholder — T-SQL
+        // does accept `"name"` when `QUOTED_IDENTIFIER` is ON, so it is
+        // not actively wrong, but new consumers should call
+        // `dialect().quote_identifier()` rather than reading this field.
         identifier_quote: '"',
         string_quote: '\'',
         placeholder_style: PlaceholderStyle::QuestionMark,

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -8,7 +8,8 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use dbflux_core::QueryGenerator;
 use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use dbflux_core::{
-    ColumnInfo, ColumnMeta, Connection, ConnectionErrorFormatter, ConnectionExt, ConnectionProfile,
+    ColumnAssignment, ColumnInfo, ColumnMeta, Connection, ConnectionErrorFormatter, ConnectionExt,
+    ConnectionProfile,
     ConstraintInfo, ConstraintKind, CrudResult, CustomTypeInfo, CustomTypeKind, DatabaseCategory,
     DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DbSchemaInfo, DdlCapabilities,
     DeploymentClass, DescribeRequest, DocumentConnection, DriverCapabilities, DriverFormDef,
@@ -233,10 +234,9 @@ impl SqlDialect for MssqlDialect {
         &self,
         _schema: Option<&str>,
         _table: &str,
-        _columns: &[String],
-        _values: &[Value],
+        _assignments: &[ColumnAssignment],
         _conflict_columns: &[String],
-        _update_assignments: &[(String, Value)],
+        _update_assignments: &[ColumnAssignment],
     ) -> Option<String> {
         // SQL Server uses MERGE for upsert; not generated here to avoid producing
         // an incorrect template. Use UPDATE/INSERT separately.
@@ -2799,15 +2799,15 @@ fn is_kill_error(err: &DbError) -> bool {
 fn build_insert_with_output(insert: &RowInsert) -> Result<String, DbError> {
     let table = MSSQL_DIALECT.qualified_table(insert.schema.as_deref(), &insert.table);
     let columns = insert
-        .columns
+        .assignments
         .iter()
-        .map(|c| MSSQL_DIALECT.quote_identifier(c))
+        .map(|a| MSSQL_DIALECT.quote_identifier(&a.name))
         .collect::<Vec<_>>()
         .join(", ");
     let values = insert
-        .values
+        .assignments
         .iter()
-        .map(|v| MSSQL_DIALECT.value_to_literal(v))
+        .map(|a| MSSQL_DIALECT.value_to_literal(&a.value))
         .collect::<Vec<_>>()
         .join(", ");
 
@@ -2822,11 +2822,11 @@ fn build_update_with_output(patch: &RowPatch) -> Result<String, DbError> {
     let set_clause = patch
         .changes
         .iter()
-        .map(|(col, value)| {
+        .map(|change| {
             format!(
                 "{} = {}",
-                MSSQL_DIALECT.quote_identifier(col),
-                MSSQL_DIALECT.value_to_literal(value)
+                MSSQL_DIALECT.quote_identifier(&change.name),
+                MSSQL_DIALECT.value_to_literal(&change.value)
             )
         })
         .collect::<Vec<_>>()

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1997,6 +1997,15 @@ impl Connection for MssqlConnection {
         // as a single nvarchar(max) row), then turn it off. We unset
         // SHOWPLAN even if the middle batch fails so the session state
         // does not leak.
+
+        // Mirror `execute()`'s poison/cleanup pattern: a prior cancel may
+        // have left the underlying tiberius client dead. Without this an
+        // EXPLAIN issued after a cancel would hit a closed socket and
+        // surface a protocol-level error instead of triggering reconnect.
+        if self.poisoned.load(Ordering::SeqCst) {
+            self.cleanup_after_cancel()?;
+        }
+
         let query = match &request.query {
             Some(q) => q.clone(),
             None => format!(
@@ -2007,9 +2016,18 @@ impl Connection for MssqlConnection {
 
         self.execute_simple("SET SHOWPLAN_XML ON")?;
         let plan_result = self.execute_simple(&query);
-        // Best-effort cleanup; if this fails the session is broken and the
-        // next query will fail loudly.
-        let _ = self.execute_simple("SET SHOWPLAN_XML OFF");
+        // If the cleanup batch fails, every subsequent query on this session
+        // keeps returning XML plan rows instead of real data (SHOWPLAN is
+        // session-scoped). Mark the connection poisoned so the next
+        // `execute()` rebuilds the tiberius client via `cleanup_after_cancel`,
+        // which starts a fresh session with SHOWPLAN off.
+        if let Err(off_err) = self.execute_simple("SET SHOWPLAN_XML OFF") {
+            log::error!(
+                "[EXPLAIN] SET SHOWPLAN_XML OFF failed, poisoning session: {}",
+                off_err
+            );
+            self.poisoned.store(true, Ordering::SeqCst);
+        }
         plan_result
     }
 

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -3109,7 +3109,10 @@ fn classify_mssql_code(code: u32) -> Option<MssqlErrorClass> {
         // 515: Cannot insert NULL into column (NOT NULL violation)
         // 8152: String or binary data would be truncated
         // 245: Conversion failed (often constraint-shaped failure)
-        547 | 2627 | 2601 | 515 | 8152 | 245 => Some(MssqlErrorClass::Constraint),
+        // 334: Target table has enabled triggers; OUTPUT clause requires INTO.
+        //      Raised when CRUD with `OUTPUT INSERTED.*` / `OUTPUT DELETED.*`
+        //      targets a table (or updateable view) with `INSTEAD OF` triggers.
+        547 | 2627 | 2601 | 515 | 8152 | 245 | 334 => Some(MssqlErrorClass::Constraint),
 
         // Syntax / batch parsing
         // 102: Incorrect syntax near
@@ -3451,6 +3454,7 @@ mod tests {
         assert_eq!(classify_mssql_code(18456), Some(MssqlErrorClass::Auth));
         assert_eq!(classify_mssql_code(547), Some(MssqlErrorClass::Constraint));
         assert_eq!(classify_mssql_code(2627), Some(MssqlErrorClass::Constraint));
+        assert_eq!(classify_mssql_code(334), Some(MssqlErrorClass::Constraint));
         assert_eq!(classify_mssql_code(208), Some(MssqlErrorClass::NotFound));
         assert_eq!(classify_mssql_code(229), Some(MssqlErrorClass::Permission));
         assert_eq!(classify_mssql_code(102), Some(MssqlErrorClass::Syntax));

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -19,10 +19,10 @@ use dbflux_core::{
     RecordIdentity, RelationalConnection, RelationalSchema, Row, RowDelete, RowInsert, RowPatch,
     SQLSERVER_FORM, SchemaFeatures, SchemaForeignKeyBuilder, SchemaForeignKeyInfo,
     SchemaIndexBuilder, SchemaIndexInfo, SchemaLoadingStrategy, SchemaSnapshot, SortDirection,
-    SqlDialect, SqlMutationGenerator, SshTunnelConfig, SyntaxInfo, TableInfo,
-    TransactionCapabilities, Value, ViewInfo, WhereOperator, generate_delete_template,
-    generate_drop_table, generate_insert_template, generate_select_star, generate_truncate,
-    generate_update_template, sanitize_uri,
+    SqlDialect, SqlMutationGenerator, SshTunnelConfig, SyntaxInfo, TableBrowseRequest,
+    TableCountRequest, TableInfo, TransactionCapabilities, Value, ViewInfo, WhereOperator,
+    generate_delete_template, generate_drop_table, generate_insert_template, generate_select_star,
+    generate_truncate, generate_update_template, render_semantic_filter_sql, sanitize_uri,
 };
 use dbflux_ssh::SshTunnel;
 use tiberius::{AuthMethod, Client, Config, EncryptionLevel, SqlBrowser};
@@ -695,16 +695,20 @@ fn build_runtime() -> Result<Runtime, DbError> {
 
 /// Short, non-reversible fingerprint of a password for diagnostic logs.
 ///
-/// Uses `DefaultHasher` and a fixed seed string, so the same input always
-/// produces the same hex string. The point is to let users compare two
-/// values for equality (e.g. "did the password reaching tiberius differ
-/// from what I typed?") without ever exposing the password itself.
+/// Uses SHA-256 with a fixed seed string and returns the leading 16 hex chars
+/// of the digest. The point is to let users compare two values for equality
+/// (e.g. "did the password reaching tiberius differ from what I typed?")
+/// without ever exposing the password itself.
 fn password_fingerprint(password: &str) -> String {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    "dbflux-mssql-password-fingerprint:v1".hash(&mut hasher);
-    password.hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(b"dbflux-mssql-password-fingerprint:v1");
+    hasher.update(password.as_bytes());
+    let digest = hasher.finalize();
+    // SHA-256 always produces a 32-byte digest, so `get(..8)` is infallible —
+    // the `unwrap_or_default` is just to keep clippy's indexing_slicing lint
+    // happy without an `expect`.
+    hex::encode(digest.get(..8).unwrap_or_default())
 }
 
 async fn establish_tiberius(config: Config) -> Result<TiberiusClient, tiberius::error::Error> {
@@ -737,10 +741,7 @@ impl MssqlDriver {
         password: Option<&str>,
     ) -> Result<Box<dyn Connection>, DbError> {
         let uri = inject_password_into_mssql_uri(base_uri, password);
-        log::info!(
-            "Connecting to SQL Server via URI {}",
-            sanitize_uri(&uri)
-        );
+        log::info!("Connecting to SQL Server via URI {}", sanitize_uri(&uri));
         if let Some(pw) = password {
             log::debug!(
                 "URI auth payload — password_chars: {}, password_bytes: {}, password_fingerprint: {}",
@@ -757,8 +758,7 @@ impl MssqlDriver {
         // returns a Config with empty host/auth that then dials a
         // default `localhost:1433`. ADO/JDBC parsers stay available for
         // genuine `Server=…;` / `jdbc:sqlserver://…` connection strings.
-        let is_mssql_url =
-            uri.starts_with("sqlserver://") || uri.starts_with("mssql://");
+        let is_mssql_url = uri.starts_with("sqlserver://") || uri.starts_with("mssql://");
         let config = if is_mssql_url {
             parse_mssql_url(&uri).map_err(|e| format_mssql_uri_error(&e, base_uri))?
         } else {
@@ -832,37 +832,20 @@ impl MssqlDriver {
             trust_server_certificate: config.trust_server_certificate,
         });
 
-        let reconnect_config = tiberius_config.clone();
-        let runtime = build_runtime()?;
-        let host = config.host.clone();
-        let port = config.port;
-        let (client, spid) = runtime
-            .block_on(async move {
-                let mut client = establish_tiberius(tiberius_config).await?;
-                let spid = capture_spid(&mut client).await?;
-                Ok::<_, tiberius::error::Error>((client, spid))
-            })
-            .map_err(|e| format_mssql_connect_error(&e, &host, port))?;
+        let established = establish_mssql_session(tiberius_config, &config.host, config.port)?;
 
         log::info!(
             "Successfully connected to {}:{} (spid: {})",
-            host,
-            port,
-            spid
+            config.host,
+            config.port,
+            established.spid
         );
 
-        Ok(Box::new(MssqlConnection {
-            inner: Arc::new(Mutex::new(MssqlConnectionInner {
-                client: Some(client),
-                runtime,
-            })),
-            current_database: Mutex::new(config.database.clone()),
-            ssh_tunnel: None,
-            cancelled: Arc::new(AtomicBool::new(false)),
-            spid: Arc::new(AtomicI32::new(spid)),
-            reconnect_config: Arc::new(reconnect_config),
-            poisoned: Arc::new(AtomicBool::new(false)),
-        }))
+        Ok(Box::new(build_mssql_connection(
+            established,
+            config.database.clone(),
+            None,
+        )))
     }
 
     fn connect_via_ssh_tunnel(
@@ -910,39 +893,76 @@ impl MssqlDriver {
         // the SSH tunnel owns. As long as the `SshTunnel` value lives on
         // `MssqlConnection`, the tunnel stays open and a fresh connection
         // (for KILL or for reconnect) can reuse it.
-        let reconnect_config = tiberius_config.clone();
-        let runtime = build_runtime()?;
-        let host = config.host.clone();
-        let port = config.port;
-        let (client, spid) = runtime
-            .block_on(async move {
-                let mut client = establish_tiberius(tiberius_config).await?;
-                let spid = capture_spid(&mut client).await?;
-                Ok::<_, tiberius::error::Error>((client, spid))
-            })
-            .map_err(|e| format_mssql_connect_error(&e, &host, port))?;
+        let established = establish_mssql_session(tiberius_config, &config.host, config.port)?;
 
         log::info!(
             "[CONNECT] Total connection time: {:.2}ms ({}:{} via SSH {}, spid: {})",
             total_start.elapsed().as_secs_f64() * 1000.0,
-            host,
-            port,
+            config.host,
+            config.port,
             tunnel_config.host,
-            spid
+            established.spid
         );
 
-        Ok(Box::new(MssqlConnection {
-            inner: Arc::new(Mutex::new(MssqlConnectionInner {
-                client: Some(client),
-                runtime,
-            })),
-            current_database: Mutex::new(config.database.clone()),
-            ssh_tunnel: Some(tunnel),
-            cancelled: Arc::new(AtomicBool::new(false)),
-            spid: Arc::new(AtomicI32::new(spid)),
-            reconnect_config: Arc::new(reconnect_config),
-            poisoned: Arc::new(AtomicBool::new(false)),
-        }))
+        Ok(Box::new(build_mssql_connection(
+            established,
+            config.database.clone(),
+            Some(tunnel),
+        )))
+    }
+}
+
+/// Bundle of pieces produced by `establish_mssql_session`.
+struct EstablishedMssqlSession {
+    client: TiberiusClient,
+    runtime: Runtime,
+    spid: i32,
+    reconnect_config: tiberius::Config,
+}
+
+/// Build a tokio runtime, open the tiberius client, and capture `@@SPID`.
+///
+/// Shared by `connect_direct` and `connect_via_ssh_tunnel` so the
+/// runtime/client/spid plumbing lives in one place. `host`/`port` are only
+/// used to format a meaningful error if the dial fails.
+fn establish_mssql_session(
+    tiberius_config: Config,
+    host: &str,
+    port: u16,
+) -> Result<EstablishedMssqlSession, DbError> {
+    let reconnect_config = tiberius_config.clone();
+    let runtime = build_runtime()?;
+    let (client, spid) = runtime
+        .block_on(async move {
+            let mut client = establish_tiberius(tiberius_config).await?;
+            let spid = capture_spid(&mut client).await?;
+            Ok::<_, tiberius::error::Error>((client, spid))
+        })
+        .map_err(|e| format_mssql_connect_error(&e, host, port))?;
+    Ok(EstablishedMssqlSession {
+        client,
+        runtime,
+        spid,
+        reconnect_config,
+    })
+}
+
+fn build_mssql_connection(
+    session: EstablishedMssqlSession,
+    current_database: Option<String>,
+    ssh_tunnel: Option<SshTunnel>,
+) -> MssqlConnection {
+    MssqlConnection {
+        inner: Arc::new(Mutex::new(MssqlConnectionInner {
+            client: Some(session.client),
+            runtime: session.runtime,
+        })),
+        current_database: Mutex::new(current_database),
+        ssh_tunnel,
+        cancelled: Arc::new(AtomicBool::new(false)),
+        spid: Arc::new(AtomicI32::new(session.spid)),
+        reconnect_config: Arc::new(session.reconnect_config),
+        poisoned: Arc::new(AtomicBool::new(false)),
     }
 }
 
@@ -1070,7 +1090,7 @@ impl MssqlConnection {
         // Pure preparation batches (`SET LOCK_TIMEOUT 5000`) produce no
         // result sets and surface as an empty primary, which is what
         // callers already expect.
-        let collected: Vec<(Vec<ColumnMeta>, Vec<Row>)> = self.with_client(|runtime, client| {
+        let collected = self.with_client(|runtime, client| {
             runtime.block_on(async move {
                 let stream = client
                     .simple_query(sql_owned)
@@ -1082,40 +1102,7 @@ impl MssqlConnection {
                     .await
                     .map_err(|e| format_mssql_query_error(&e))?;
 
-                let non_empty: Vec<(Vec<ColumnMeta>, Vec<Row>)> = result_sets
-                    .into_iter()
-                    .filter(|set| !set.is_empty())
-                    .map(|set| {
-                        let columns: Vec<ColumnMeta> = set
-                            .first()
-                            .map(|row| {
-                                row.columns()
-                                    .iter()
-                                    .map(|c| ColumnMeta {
-                                        name: c.name().to_string(),
-                                        type_name: format!("{:?}", c.column_type()),
-                                        kind: dbflux_core::ColumnKind::Unknown,
-                                        nullable: true,
-                                        is_primary_key: false,
-                                    })
-                                    .collect()
-                            })
-                            .unwrap_or_default();
-
-                        let rows: Vec<Row> = set
-                            .iter()
-                            .map(|row| {
-                                (0..row.columns().len())
-                                    .map(|idx| tiberius_value_to_value(row, idx))
-                                    .collect::<Row>()
-                            })
-                            .collect();
-
-                        (columns, rows)
-                    })
-                    .collect();
-
-                Ok::<_, DbError>(non_empty)
+                Ok::<_, DbError>(convert_result_sets(result_sets))
             })
         })?;
 
@@ -1131,6 +1118,44 @@ impl MssqlConnection {
         );
 
         Ok(result)
+    }
+}
+
+/// Convert tiberius's raw result sets into `(columns, rows)` pairs, dropping
+/// any empty sets so the multi-set splitter sees only meaningful output.
+fn convert_result_sets(result_sets: Vec<Vec<tiberius::Row>>) -> Vec<(Vec<ColumnMeta>, Vec<Row>)> {
+    result_sets
+        .into_iter()
+        .filter(|set| !set.is_empty())
+        .map(convert_single_result_set)
+        .collect()
+}
+
+fn convert_single_result_set(set: Vec<tiberius::Row>) -> (Vec<ColumnMeta>, Vec<Row>) {
+    let columns = set
+        .first()
+        .map(|row| row.columns().iter().map(tiberius_column_to_meta).collect())
+        .unwrap_or_default();
+
+    let rows: Vec<Row> = set
+        .iter()
+        .map(|row| {
+            (0..row.columns().len())
+                .map(|idx| tiberius_value_to_value(row, idx))
+                .collect::<Row>()
+        })
+        .collect();
+
+    (columns, rows)
+}
+
+fn tiberius_column_to_meta(column: &tiberius::Column) -> ColumnMeta {
+    ColumnMeta {
+        name: column.name().to_string(),
+        type_name: format!("{:?}", column.column_type()),
+        kind: tiberius_column_to_kind(column.column_type()),
+        nullable: true,
+        is_primary_key: false,
     }
 }
 
@@ -1216,6 +1241,54 @@ fn tiberius_value_to_value(row: &tiberius::Row, idx: usize) -> Value {
     }
 }
 
+/// Maps a tiberius `ColumnType` to the cross-driver `ColumnKind` the chart
+/// engine and other consumers rely on.
+///
+/// Variants whose semantic category isn't representable (`Guid`, `Xml`, `Udt`,
+/// `BigVarBin`/`BigBinary`/`Image`, `SSVariant`, `Null`) map to `Unknown` so
+/// chart auto-detect excludes them rather than treating them as text.
+fn tiberius_column_to_kind(column_type: tiberius::ColumnType) -> dbflux_core::ColumnKind {
+    use dbflux_core::ColumnKind;
+    use tiberius::ColumnType;
+
+    match column_type {
+        ColumnType::Bit | ColumnType::Bitn => ColumnKind::Integer,
+        ColumnType::Int1
+        | ColumnType::Int2
+        | ColumnType::Int4
+        | ColumnType::Int8
+        | ColumnType::Intn => ColumnKind::Integer,
+        ColumnType::Float4
+        | ColumnType::Float8
+        | ColumnType::Floatn
+        | ColumnType::Money
+        | ColumnType::Money4
+        | ColumnType::Decimaln
+        | ColumnType::Numericn => ColumnKind::Float,
+        ColumnType::Datetime
+        | ColumnType::Datetime4
+        | ColumnType::Datetimen
+        | ColumnType::Datetime2
+        | ColumnType::Daten
+        | ColumnType::Timen
+        | ColumnType::DatetimeOffsetn => ColumnKind::Timestamp,
+        ColumnType::BigVarChar
+        | ColumnType::BigChar
+        | ColumnType::NVarchar
+        | ColumnType::NChar
+        | ColumnType::Text
+        | ColumnType::NText => ColumnKind::Text,
+        ColumnType::Null
+        | ColumnType::Guid
+        | ColumnType::Xml
+        | ColumnType::Udt
+        | ColumnType::BigVarBin
+        | ColumnType::BigBinary
+        | ColumnType::Image
+        | ColumnType::SSVariant => ColumnKind::Unknown,
+    }
+}
+
 fn extract_temporal(row: &tiberius::Row, idx: usize, _column_type: tiberius::ColumnType) -> Value {
     // tiberius exposes typed accessors for chrono types; we try them in order
     // of decreasing precision and fall back to a string representation.
@@ -1264,7 +1337,14 @@ impl Connection for MssqlConnection {
     }
 
     fn execute(&self, req: &QueryRequest) -> Result<QueryResult, DbError> {
-        self.cancelled.store(false, Ordering::SeqCst);
+        // Do not blanket-reset `cancelled` here — that would race with a
+        // `cancel()` that fires between two executions and silently drop the
+        // signal. Instead, recover the connection if a previous cancel left
+        // it poisoned (which is what `cleanup_after_cancel` is for) before
+        // dispatching the new query.
+        if self.poisoned.load(Ordering::SeqCst) {
+            self.cleanup_after_cancel()?;
+        }
 
         // Support explicit database override per query, mirroring postgres/mysql.
         if let Some(database) = req.database.as_deref() {
@@ -1654,6 +1734,92 @@ impl Connection for MssqlConnection {
 
     fn schema_loading_strategy(&self) -> SchemaLoadingStrategy {
         SchemaLoadingStrategy::LazyPerDatabase
+    }
+
+    /// SQL Server-specific browse implementation.
+    ///
+    /// Overridden because the default impl in `dbflux_core` (a) emits the
+    /// MySQL-style `LIMIT n OFFSET m` syntax, which SQL Server does not accept,
+    /// and (b) forwards the table's schema (e.g. `dbo`) as the *database* via
+    /// `with_database`, which would make the driver issue `USE [dbo]` — a 911
+    /// "database does not exist" error, since `dbo` is a schema. We embed the
+    /// schema in the `FROM` clause and leave the active database alone.
+    fn browse_table(&self, request: &TableBrowseRequest) -> Result<QueryResult, DbError> {
+        let table = request.table.quoted_with(&MSSQL_DIALECT);
+        let mut sql = format!("SELECT * FROM {}", table);
+
+        if let Some(filter) = request.semantic_filter.as_ref() {
+            let where_clause = render_semantic_filter_sql(filter, &MSSQL_DIALECT)?;
+            sql.push_str(" WHERE ");
+            sql.push_str(&where_clause);
+        } else if let Some(filter) = request.filter.as_ref() {
+            let trimmed = filter.trim();
+            if !trimmed.is_empty() {
+                sql.push_str(" WHERE ");
+                sql.push_str(trimmed);
+            }
+        }
+
+        // `OFFSET ... FETCH NEXT` requires `ORDER BY`; fall back to `ORDER BY 1`
+        // when the caller didn't supply one so paginated browsing keeps working.
+        if request.order_by.is_empty() {
+            sql.push_str(" ORDER BY 1");
+        } else {
+            sql.push_str(" ORDER BY ");
+            let parts: Vec<String> = request
+                .order_by
+                .iter()
+                .map(|col| {
+                    let dir = match col.direction {
+                        SortDirection::Ascending => "ASC",
+                        SortDirection::Descending => "DESC",
+                    };
+                    format!("{} {}", col.column.quoted_with(&MSSQL_DIALECT), dir)
+                })
+                .collect();
+            sql.push_str(&parts.join(", "));
+        }
+
+        sql.push_str(&format!(
+            " OFFSET {} ROWS FETCH NEXT {} ROWS ONLY",
+            request.pagination.offset(),
+            request.pagination.limit()
+        ));
+
+        self.execute(&QueryRequest::new(sql))
+    }
+
+    /// SQL Server-specific count implementation.
+    ///
+    /// The default impl is mostly correct, but we override it for symmetry with
+    /// `browse_table` and to make explicit that the schema is part of the
+    /// `FROM` clause — never the active database.
+    fn count_table(&self, request: &TableCountRequest) -> Result<u64, DbError> {
+        let table = request.table.quoted_with(&MSSQL_DIALECT);
+        let mut sql = format!("SELECT COUNT(*) FROM {}", table);
+
+        if let Some(filter) = request.semantic_filter.as_ref() {
+            let where_clause = render_semantic_filter_sql(filter, &MSSQL_DIALECT)?;
+            sql.push_str(" WHERE ");
+            sql.push_str(&where_clause);
+        } else if let Some(filter) = request.filter.as_ref() {
+            let trimmed = filter.trim();
+            if !trimmed.is_empty() {
+                sql.push_str(" WHERE ");
+                sql.push_str(trimmed);
+            }
+        }
+
+        let result = self.execute(&QueryRequest::new(sql))?;
+        Ok(result
+            .rows
+            .first()
+            .and_then(|row| row.first())
+            .and_then(|v| match v {
+                Value::Int(n) => Some(*n as u64),
+                _ => None,
+            })
+            .unwrap_or(0))
     }
 
     fn fetch_row_by_pk(
@@ -2136,8 +2302,33 @@ impl MssqlConnection {
         let escaped_schema = schema.replace('\'', "''");
         let escaped_table = table.replace('\'', "''");
 
-        // CHECK constraints + the columns they reference.
-        let check_sql = format!(
+        let mut grouped: indexmap_for_indexes::IndexMap<String, ConstraintInfo> =
+            indexmap_for_indexes::IndexMap::new();
+
+        self.collect_check_constraints(
+            &qualified_db,
+            &escaped_schema,
+            &escaped_table,
+            &mut grouped,
+        )?;
+        self.collect_unique_constraints(
+            &qualified_db,
+            &escaped_schema,
+            &escaped_table,
+            &mut grouped,
+        )?;
+
+        Ok(grouped.into_iter().map(|(_, v)| v).collect())
+    }
+
+    fn collect_check_constraints(
+        &self,
+        qualified_db: &str,
+        escaped_schema: &str,
+        escaped_table: &str,
+        grouped: &mut indexmap_for_indexes::IndexMap<String, ConstraintInfo>,
+    ) -> Result<(), DbError> {
+        let sql = format!(
             "SELECT \
                 cc.name AS constraint_name, \
                 CAST(cc.definition AS NVARCHAR(MAX)) AS check_clause, \
@@ -2151,11 +2342,8 @@ impl MssqlConnection {
              ORDER BY cc.name"
         );
 
-        let check_rows = self.execute_simple(&check_sql)?;
-        let mut grouped: indexmap_for_indexes::IndexMap<String, ConstraintInfo> =
-            indexmap_for_indexes::IndexMap::new();
-
-        for row in check_rows.rows {
+        let rows = self.execute_simple(&sql)?;
+        for row in rows.rows {
             let mut iter = row.into_iter();
             let name = match iter.next() {
                 Some(Value::Text(s)) => s,
@@ -2184,11 +2372,20 @@ impl MssqlConnection {
                 entry.columns.push(column);
             }
         }
+        Ok(())
+    }
 
-        // UNIQUE constraints — surfaced as unique indexes that are not the
-        // table's primary key. `sys.indexes.is_unique_constraint` flags those
-        // backing an explicit UNIQUE constraint definition.
-        let unique_sql = format!(
+    /// UNIQUE constraints — surfaced as unique indexes that are not the
+    /// table's primary key. `sys.indexes.is_unique_constraint` flags those
+    /// backing an explicit UNIQUE constraint definition.
+    fn collect_unique_constraints(
+        &self,
+        qualified_db: &str,
+        escaped_schema: &str,
+        escaped_table: &str,
+        grouped: &mut indexmap_for_indexes::IndexMap<String, ConstraintInfo>,
+    ) -> Result<(), DbError> {
+        let sql = format!(
             "SELECT \
                 i.name AS index_name, \
                 c.name AS column_name, \
@@ -2205,8 +2402,8 @@ impl MssqlConnection {
              ORDER BY i.name, ic.key_ordinal"
         );
 
-        let unique_rows = self.execute_simple(&unique_sql)?;
-        for row in unique_rows.rows {
+        let rows = self.execute_simple(&sql)?;
+        for row in rows.rows {
             let mut iter = row.into_iter();
             let name = match iter.next() {
                 Some(Value::Text(s)) => s,
@@ -2228,8 +2425,7 @@ impl MssqlConnection {
                 });
             entry.columns.push(column);
         }
-
-        Ok(grouped.into_iter().map(|(_, v)| v).collect())
+        Ok(())
     }
 
     fn fetch_custom_types(
@@ -2570,16 +2766,12 @@ fn identity_where_clause(identity: &RecordIdentity) -> Result<String, DbError> {
 }
 
 fn result_first_row_to_crud(result: QueryResult) -> CrudResult {
-    let columns = result.columns;
-    let mut rows = result.rows.into_iter();
-    match rows.next() {
-        Some(row) => {
-            // Build an ordered HashMap of column-name → value the same way
-            // postgres does for its RETURNING path. We surface the row through
-            // CrudResult::success so the UI sees the post-mutation values.
-            let _ = columns;
-            CrudResult::success(row)
-        }
+    // The OUTPUT-clause result is parsed through `execute_simple`, which
+    // populates `ColumnMeta::kind` from the tiberius column type. The
+    // column metadata travels with the QueryResult; CrudResult itself
+    // only carries the row (matching postgres/mysql).
+    match result.rows.into_iter().next() {
+        Some(row) => CrudResult::success(row),
         None => CrudResult::empty(),
     }
 }
@@ -2638,7 +2830,22 @@ fn inject_password_into_mssql_uri(base_uri: &str, password: Option<&str>) -> Str
 }
 
 /// Parse a `sqlserver://user:pass@host:port/db?...` URI into a tiberius Config.
-fn parse_mssql_url(uri: &str) -> Result<Config, tiberius::error::Error> {
+struct ParsedMssqlUri<'a> {
+    credentials: &'a str,
+    host: &'a str,
+    instance_from_host: Option<String>,
+    explicit_port: Option<u16>,
+    database: &'a str,
+    params: &'a str,
+}
+
+struct UriQueryParams {
+    encryption: EncryptionLevel,
+    trust_cert_override: Option<bool>,
+    instance_from_query: Option<String>,
+}
+
+fn split_mssql_uri(uri: &str) -> Result<ParsedMssqlUri<'_>, tiberius::error::Error> {
     let stripped = uri
         .strip_prefix("sqlserver://")
         .or_else(|| uri.strip_prefix("mssql://"))
@@ -2646,36 +2853,34 @@ fn parse_mssql_url(uri: &str) -> Result<Config, tiberius::error::Error> {
             tiberius::error::Error::Conversion("unsupported SQL Server URI scheme".into())
         })?;
 
-    let (credentials, host_part) = if let Some(at_pos) = stripped.rfind('@') {
-        (&stripped[..at_pos], &stripped[at_pos + 1..])
-    } else {
-        ("", stripped)
+    let (credentials, host_part) = match stripped.rfind('@') {
+        Some(at_pos) => (&stripped[..at_pos], &stripped[at_pos + 1..]),
+        None => ("", stripped),
     };
 
-    let (host_port, query_part) = if let Some(slash) = host_part.find('/') {
-        (&host_part[..slash], &host_part[slash + 1..])
-    } else {
-        (host_part, "")
+    let (host_port, query_part) = match host_part.find('/') {
+        Some(slash) => (&host_part[..slash], &host_part[slash + 1..]),
+        None => (host_part, ""),
     };
 
-    let (database, params) = if let Some(qmark) = query_part.find('?') {
-        (&query_part[..qmark], &query_part[qmark + 1..])
-    } else {
-        (query_part, "")
+    let (database, params) = match query_part.find('?') {
+        Some(qmark) => (&query_part[..qmark], &query_part[qmark + 1..]),
+        None => (query_part, ""),
     };
 
-    let (host_and_instance, explicit_port) = if let Some(colon) = host_port.rfind(':') {
-        let port: u16 = host_port[colon + 1..].parse().map_err(|_| {
-            tiberius::error::Error::Conversion("invalid SQL Server URI port".into())
-        })?;
-        (&host_port[..colon], Some(port))
-    } else {
-        (host_port, None)
+    let (host_and_instance, explicit_port) = match host_port.rfind(':') {
+        Some(colon) => {
+            let port: u16 = host_port[colon + 1..].parse().map_err(|_| {
+                tiberius::error::Error::Conversion("invalid SQL Server URI port".into())
+            })?;
+            (&host_port[..colon], Some(port))
+        }
+        None => (host_port, None),
     };
 
     // SSMS-style `host\instance`. The trailing `?instance=…` may also set
-    // it and wins if both are supplied.
-    let (host, mut instance) = match host_and_instance.find('\\') {
+    // it and wins if both are supplied (resolved by the caller).
+    let (host, instance_from_host) = match host_and_instance.find('\\') {
         Some(bs) => (
             &host_and_instance[..bs],
             Some(host_and_instance[bs + 1..].to_string()),
@@ -2683,48 +2888,28 @@ fn parse_mssql_url(uri: &str) -> Result<Config, tiberius::error::Error> {
         None => (host_and_instance, None),
     };
 
-    let mut config = Config::new();
-    config.host(host);
-    // Defer the port decision until after the query-string loop so we can
-    // see whether `?instance=` is supplied. When an instance is present we
-    // intentionally leave the port unset so tiberius defaults to 1434 for
-    // the SQL Browser lookup.
+    Ok(ParsedMssqlUri {
+        credentials,
+        host,
+        instance_from_host,
+        explicit_port,
+        database,
+        params,
+    })
+}
 
-    if !database.is_empty() {
-        let decoded = urlencoding::decode(database)
-            .map(|cow| cow.into_owned())
-            .unwrap_or_else(|_| database.to_string());
-        config.database(decoded);
-    }
-
-    if !credentials.is_empty() {
-        if let Some(colon) = credentials.find(':') {
-            let user = urlencoding::decode(&credentials[..colon])
-                .map(|cow| cow.into_owned())
-                .unwrap_or_default();
-            let password = urlencoding::decode(&credentials[colon + 1..])
-                .map(|cow| cow.into_owned())
-                .unwrap_or_default();
-            config.authentication(AuthMethod::sql_server(user, password));
-        } else {
-            let user = urlencoding::decode(credentials)
-                .map(|cow| cow.into_owned())
-                .unwrap_or_default();
-            config.authentication(AuthMethod::sql_server(user, ""));
-        }
-    }
-
+fn parse_uri_query_params(params: &str) -> UriQueryParams {
     // SSL Mode is the single user-facing knob; trust_cert is derived from
     // it unless the caller explicitly overrides via `?trust=` in the URI.
     //
     //   encrypt=off       -> Off,      trust irrelevant
     //   encrypt=on        -> On,       trust=true  (accept self-signed)
     //   encrypt=required  -> Required, trust=false (validate cert)
-    //
-    // Mirrors the form-mode mapping in extract_form() so toggling between
-    // URI mode and form mode preserves intent.
-    let mut encryption = EncryptionLevel::On;
-    let mut trust_cert_override: Option<bool> = None;
+    let mut out = UriQueryParams {
+        encryption: EncryptionLevel::On,
+        trust_cert_override: None,
+        instance_from_query: None,
+    };
 
     for pair in params.split('&').filter(|p| !p.is_empty()) {
         let Some((key, value)) = pair.split_once('=') else {
@@ -2732,7 +2917,7 @@ fn parse_mssql_url(uri: &str) -> Result<Config, tiberius::error::Error> {
         };
         match key.to_ascii_lowercase().as_str() {
             "encrypt" => {
-                encryption = match value.to_ascii_lowercase().as_str() {
+                out.encryption = match value.to_ascii_lowercase().as_str() {
                     "true" | "yes" | "on" | "1" => EncryptionLevel::On,
                     "false" | "no" | "off" | "0" => EncryptionLevel::Off,
                     "strict" | "required" => EncryptionLevel::Required,
@@ -2740,23 +2925,64 @@ fn parse_mssql_url(uri: &str) -> Result<Config, tiberius::error::Error> {
                 };
             }
             "trustservercertificate" | "trust_server_certificate" | "trust" => {
-                trust_cert_override =
-                    Some(matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes"));
+                out.trust_cert_override = Some(matches!(
+                    value.to_ascii_lowercase().as_str(),
+                    "true" | "1" | "yes"
+                ));
             }
             "instance" | "instancename" | "instance_name" if !value.is_empty() => {
                 let decoded = urlencoding::decode(value)
                     .map(|cow| cow.into_owned())
                     .unwrap_or_else(|_| value.to_string());
-                instance = Some(decoded);
+                out.instance_from_query = Some(decoded);
             }
             _ => {}
         }
     }
 
-    let trust_cert = trust_cert_override
-        .unwrap_or(!matches!(encryption, EncryptionLevel::Required));
+    out
+}
 
-    match (instance.filter(|s| !s.is_empty()), explicit_port) {
+fn apply_uri_credentials(config: &mut Config, credentials: &str) {
+    if credentials.is_empty() {
+        return;
+    }
+    let (user_part, password_part) = match credentials.find(':') {
+        Some(colon) => (&credentials[..colon], &credentials[colon + 1..]),
+        None => (credentials, ""),
+    };
+    let user = urlencoding::decode(user_part)
+        .map(|cow| cow.into_owned())
+        .unwrap_or_default();
+    let password = urlencoding::decode(password_part)
+        .map(|cow| cow.into_owned())
+        .unwrap_or_default();
+    config.authentication(AuthMethod::sql_server(user, password));
+}
+
+fn parse_mssql_url(uri: &str) -> Result<Config, tiberius::error::Error> {
+    let parsed = split_mssql_uri(uri)?;
+    let query = parse_uri_query_params(parsed.params);
+
+    // `?instance=` wins over the SSMS-style `host\instance` form.
+    let instance = query
+        .instance_from_query
+        .or(parsed.instance_from_host)
+        .filter(|s| !s.is_empty());
+
+    let mut config = Config::new();
+    config.host(parsed.host);
+
+    if !parsed.database.is_empty() {
+        let decoded = urlencoding::decode(parsed.database)
+            .map(|cow| cow.into_owned())
+            .unwrap_or_else(|_| parsed.database.to_string());
+        config.database(decoded);
+    }
+
+    apply_uri_credentials(&mut config, parsed.credentials);
+
+    match (instance, parsed.explicit_port) {
         (Some(name), _) => {
             // Named instance: leave port unset so tiberius hits 1434 for
             // the Browser query and then dials whatever port Browser
@@ -2772,7 +2998,10 @@ fn parse_mssql_url(uri: &str) -> Result<Config, tiberius::error::Error> {
         }
     }
 
-    config.encryption(encryption);
+    config.encryption(query.encryption);
+    let trust_cert = query
+        .trust_cert_override
+        .unwrap_or(!matches!(query.encryption, EncryptionLevel::Required));
     if trust_cert {
         config.trust_cert();
     }
@@ -3303,15 +3532,11 @@ mod tests {
             .parse_uri("sqlserver://sa@localhost:1433/")
             .expect("parsed");
         assert_eq!(parsed.get("user").map(String::as_str), Some("sa"));
-        assert!(parsed.get("password").is_none());
+        assert!(!parsed.contains_key("password"));
     }
 
     fn build_form_values_for_ssl(ssl_mode: Option<&str>) -> FormValues {
-        let mut v = form_values(&[
-            ("host", "localhost"),
-            ("port", "1433"),
-            ("user", "sa"),
-        ]);
+        let mut v = form_values(&[("host", "localhost"), ("port", "1433"), ("user", "sa")]);
         if let Some(mode) = ssl_mode {
             v.insert("ssl_mode".to_string(), mode.to_string());
         }

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1050,8 +1050,17 @@ impl QueryCancelHandle for MssqlCancelHandle {
                 Ok(())
             }
             Err(err) => {
-                log::error!("[CANCEL] KILL {} failed: {}", spid, err);
-                Err(format_mssql_query_error(&err))
+                // `poisoned == true` is already set above, so the next
+                // `execute()` will run `cleanup_after_cancel` and reconnect.
+                // Surfacing this transport failure to the caller would show
+                // "cancel failed" in the UI even though recovery is armed,
+                // so log it and report success instead.
+                log::error!(
+                    "[CANCEL] KILL {} transport failed (recovery armed): {}",
+                    spid,
+                    err
+                );
+                Ok(())
             }
         }
     }

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1951,6 +1951,22 @@ impl Connection for MssqlConnection {
         let escaped_schema = schema.replace('\'', "''");
         let escaped_table = request.table.name.replace('\'', "''");
 
+        // Qualify every `sys.*` lookup with the connection's tracked active
+        // database. MSSQL supports multi-DB-per-connection and the UI
+        // navigates across databases without reconnecting, so an unqualified
+        // `sys.columns` query would silently return metadata from whichever
+        // database happens to be active server-side — not the one the
+        // request points at. `fetch_columns` / `fetch_indexes` /
+        // `fetch_foreign_keys` already do this; describe_table should match.
+        let database = self
+            .current_database
+            .lock()
+            .ok()
+            .and_then(|guard| guard.clone())
+            .unwrap_or_else(|| "master".to_string());
+        let escaped_db = database.replace(']', "]]");
+        let qualified_db = format!("[{}]", escaped_db);
+
         let sql = format!(
             "SELECT \
                 c.name AS column_name, \
@@ -1958,15 +1974,17 @@ impl Connection for MssqlConnection {
                 CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END AS is_nullable, \
                 CAST(dc.definition AS NVARCHAR(MAX)) AS column_default, \
                 c.max_length AS character_maximum_length \
-             FROM sys.columns c \
-             JOIN sys.tables tbl ON tbl.object_id = c.object_id \
-             JOIN sys.schemas s ON s.schema_id = tbl.schema_id \
-             JOIN sys.types t ON t.user_type_id = c.user_type_id \
-             LEFT JOIN sys.default_constraints dc \
+             FROM {qualified_db}.sys.columns c \
+             JOIN {qualified_db}.sys.tables tbl ON tbl.object_id = c.object_id \
+             JOIN {qualified_db}.sys.schemas s ON s.schema_id = tbl.schema_id \
+             JOIN {qualified_db}.sys.types t ON t.user_type_id = c.user_type_id \
+             LEFT JOIN {qualified_db}.sys.default_constraints dc \
                ON dc.parent_object_id = c.object_id AND dc.parent_column_id = c.column_id \
-             WHERE s.name = '{}' AND tbl.name = '{}' \
+             WHERE s.name = '{escaped_schema}' AND tbl.name = '{escaped_table}' \
              ORDER BY c.column_id",
-            escaped_schema, escaped_table
+            qualified_db = qualified_db,
+            escaped_schema = escaped_schema,
+            escaped_table = escaped_table,
         );
 
         self.execute(&QueryRequest::new(sql))

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -236,6 +236,41 @@ impl SqlDialect for MssqlDialect {
     }
 }
 
+/// Returns `true` when `s` looks like a SQL Server-safe numeric literal:
+/// optional sign, decimal digits with at most one `.`, and an optional
+/// `e[+-]?\d+` exponent. Accepts inputs the engine itself would emit when
+/// formatting a `numeric`/`decimal`/`float` value as text.
+fn is_numeric_literal(s: &str) -> bool {
+    let mut chars = s.chars().peekable();
+    if matches!(chars.peek(), Some('+' | '-')) {
+        chars.next();
+    }
+    let mut has_digit = false;
+    let mut seen_dot = false;
+    while let Some(c) = chars.next() {
+        match c {
+            '0'..='9' => has_digit = true,
+            '.' if !seen_dot => seen_dot = true,
+            'e' | 'E' if has_digit => {
+                if matches!(chars.peek(), Some('+' | '-')) {
+                    chars.next();
+                }
+                let mut exp_digits = 0usize;
+                for ec in chars.by_ref() {
+                    if ec.is_ascii_digit() {
+                        exp_digits += 1;
+                    } else {
+                        return false;
+                    }
+                }
+                return exp_digits > 0;
+            }
+            _ => return false,
+        }
+    }
+    has_digit
+}
+
 fn value_to_mssql_literal(value: &Value) -> String {
     match value {
         Value::Null => "NULL".to_string(),
@@ -257,7 +292,19 @@ fn value_to_mssql_literal(value: &Value) -> String {
             format!("0x{}", hex)
         }
         Value::Json(s) => format!("N'{}'", s.replace('\'', "''")),
-        Value::Decimal(s) => s.clone(),
+        Value::Decimal(s) => {
+            // `Value::Decimal` is a public variant. The driver's own conversion
+            // path (`tiberius::ColumnData::Numeric -> Value::Decimal`) emits a
+            // well-formed string, but other producers (MCP tools, external RPC
+            // drivers, tests) can construct it from untrusted input. Validate
+            // before inlining; emit NULL if the string isn't a plain numeric
+            // literal so we never splice arbitrary text into SQL.
+            if is_numeric_literal(s) {
+                s.clone()
+            } else {
+                "NULL".to_string()
+            }
+        }
         Value::DateTime(dt) => format!("'{}'", dt.format("%Y-%m-%d %H:%M:%S%.f")),
         Value::Date(d) => format!("'{}'", d.format("%Y-%m-%d")),
         Value::Time(t) => format!("'{}'", t.format("%H:%M:%S%.f")),
@@ -3459,6 +3506,41 @@ mod tests {
         assert_eq!(classify_mssql_code(229), Some(MssqlErrorClass::Permission));
         assert_eq!(classify_mssql_code(102), Some(MssqlErrorClass::Syntax));
         assert_eq!(classify_mssql_code(99999), None);
+    }
+
+    #[test]
+    fn is_numeric_literal_accepts_decimal_and_scientific() {
+        assert!(is_numeric_literal("0"));
+        assert!(is_numeric_literal("-42"));
+        assert!(is_numeric_literal("+3.14"));
+        assert!(is_numeric_literal("0.5"));
+        assert!(is_numeric_literal("1e10"));
+        assert!(is_numeric_literal("-1.5E-3"));
+    }
+
+    #[test]
+    fn is_numeric_literal_rejects_injection_attempts() {
+        assert!(!is_numeric_literal(""));
+        assert!(!is_numeric_literal("1; DROP TABLE users"));
+        assert!(!is_numeric_literal("1'or'1"));
+        assert!(!is_numeric_literal("NaN"));
+        assert!(!is_numeric_literal("1..2"));
+        assert!(!is_numeric_literal("1e"));
+        assert!(!is_numeric_literal("1.2.3"));
+        assert!(!is_numeric_literal(" 42"));
+        assert!(!is_numeric_literal("42 "));
+    }
+
+    #[test]
+    fn decimal_literal_emits_value_when_valid_and_null_otherwise() {
+        assert_eq!(
+            MSSQL_DIALECT.value_to_literal(&Value::Decimal("123.45".into())),
+            "123.45"
+        );
+        assert_eq!(
+            MSSQL_DIALECT.value_to_literal(&Value::Decimal("1; DROP TABLE x--".into())),
+            "NULL"
+        );
     }
 
     #[test]

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1351,10 +1351,12 @@ impl Connection for MssqlConnection {
             self.set_active_database(Some(database))?;
         }
 
-        let sql_preview = if req.sql.len() > 80 {
-            format!("{}...", &req.sql[..80])
-        } else {
-            req.sql.clone()
+        // Slice by char boundary, not byte index: SQL with multi-byte UTF-8
+        // (CJK identifiers, `N'…'` literals with non-ASCII, accented comments)
+        // would panic on `&req.sql[..80]` when 80 falls mid-codepoint.
+        let sql_preview = match req.sql.char_indices().nth(80) {
+            Some((idx, _)) => format!("{}...", &req.sql[..idx]),
+            None => req.sql.clone(),
         };
         log::debug!("[QUERY] Executing: {}", sql_preview.replace('\n', " "));
 

--- a/crates/dbflux_driver_mssql/src/lib.rs
+++ b/crates/dbflux_driver_mssql/src/lib.rs
@@ -1,0 +1,14 @@
+#![allow(clippy::result_large_err)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing,
+    )
+)]
+
+pub mod driver;
+
+pub use driver::{METADATA, MssqlDriver};

--- a/crates/dbflux_driver_mssql/tests/ddl_integration.rs
+++ b/crates/dbflux_driver_mssql/tests/ddl_integration.rs
@@ -1,0 +1,712 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::result_large_err
+)]
+
+use dbflux_core::{
+    Connection, ConnectionProfile, ConstraintKind, DbConfig, DbDriver, DbError, IndexData,
+    QueryRequest, Value,
+};
+use dbflux_driver_mssql::MssqlDriver;
+use dbflux_test_support::{containers, ddl_fixtures::SqlServerFixtures};
+use std::time::Duration;
+
+const TEST_DATABASE: &str = "dbflux_test";
+
+fn connect_mssql(uri: String) -> Result<(Box<dyn Connection>, MssqlDriver), DbError> {
+    let driver = MssqlDriver::new();
+    let profile = ConnectionProfile::new(
+        "ddl-mssql",
+        DbConfig::SqlServer {
+            use_uri: true,
+            uri: Some(uri),
+            host: String::new(),
+            port: 1433,
+            user: String::new(),
+            database: None,
+            instance: None,
+            ssl_mode: Some("on".to_string()),
+            trust_server_certificate: true,
+            ssl_root_cert_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+        },
+    );
+
+    let connection =
+        containers::retry_db_operation(Duration::from_secs(60), || -> Result<_, DbError> {
+            let connection = driver.connect(&profile)?;
+            connection.ping()?;
+            Ok(connection)
+        })?;
+
+    connection.execute(&QueryRequest::new(format!(
+        "IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = '{TEST_DATABASE}') \
+         CREATE DATABASE [{TEST_DATABASE}]"
+    )))?;
+    connection.set_active_database(Some(TEST_DATABASE))?;
+
+    Ok((connection, driver))
+}
+
+fn cleanup_test_tables(conn: &dyn Connection) {
+    // Drop in FK order — orders references users, etc.
+    let tables = [
+        "orders",
+        "order_items",
+        "accounts",
+        "products",
+        "users",
+        "alter_test",
+        "truncate_test",
+        "fk_child",
+        "fk_parent",
+    ];
+
+    for table in tables {
+        let _ = conn.execute(&QueryRequest::new(format!(
+            "DROP TABLE IF EXISTS dbo.[{}]",
+            table
+        )));
+    }
+
+    for view in ["active_users", "test_view"] {
+        let _ = conn.execute(&QueryRequest::new(format!(
+            "DROP VIEW IF EXISTS dbo.[{}]",
+            view
+        )));
+    }
+
+    // DROP INDEX needs the table reference, but if the table was already
+    // dropped above the indexes went with it. We only need to clean up
+    // indexes whose table might survive between tests; the table cleanup
+    // covers everything we create in this suite.
+}
+
+// ---------------------------------------------------------------------------
+// CREATE TABLE tests
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_create_table_identity_pk() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let table_details = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name)?;
+        assert_eq!(table_details.name, table.name);
+
+        let columns = table_details
+            .columns
+            .as_ref()
+            .expect("columns should be loaded");
+        assert!(columns.len() >= 4);
+
+        let id_col = columns.iter().find(|c| c.name == "id").expect("id column");
+        assert!(id_col.is_primary_key);
+        assert!(!id_col.nullable);
+
+        let username_col = columns
+            .iter()
+            .find(|c| c.name == "username")
+            .expect("username column");
+        assert!(!username_col.nullable);
+
+        let email_col = columns
+            .iter()
+            .find(|c| c.name == "email")
+            .expect("email column");
+        assert!(!email_col.nullable);
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_create_table_composite_pk() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_composite_pk();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let table_details = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name)?;
+        let columns = table_details
+            .columns
+            .as_ref()
+            .expect("columns should be loaded");
+
+        let order_id_col = columns
+            .iter()
+            .find(|c| c.name == "order_id")
+            .expect("order_id column");
+        assert!(order_id_col.is_primary_key);
+
+        let product_id_col = columns
+            .iter()
+            .find(|c| c.name == "product_id")
+            .expect("product_id column");
+        assert!(product_id_col.is_primary_key);
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_create_table_with_fk() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let parent_table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&parent_table.create_sql))?;
+
+        let child_table = SqlServerFixtures::table_with_fk();
+        connection.execute(&QueryRequest::new(&child_table.create_sql))?;
+
+        let table_details =
+            connection.table_details(TEST_DATABASE, Some("dbo"), &child_table.name)?;
+
+        let fks = table_details
+            .foreign_keys
+            .as_ref()
+            .expect("foreign keys should be loaded");
+        assert!(!fks.is_empty());
+
+        let fk = &fks[0];
+        assert_eq!(fk.referenced_table, "users");
+        assert_eq!(fk.columns, vec!["user_id"]);
+        assert_eq!(fk.referenced_columns, vec!["id"]);
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_create_table_with_check_constraint() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_with_check();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let table_details = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name)?;
+        let constraints = table_details
+            .constraints
+            .as_ref()
+            .expect("constraints should be loaded");
+        assert!(!constraints.is_empty());
+
+        let has_check = constraints
+            .iter()
+            .any(|c| matches!(c.kind, ConstraintKind::Check) && c.name.contains("positive_price"));
+        assert!(has_check, "should have positive_price check constraint");
+
+        // The CHECK should actually be enforced.
+        let insert_result = connection.execute(&QueryRequest::new(
+            "INSERT INTO products (name, price, stock) VALUES (N'bad', -10, 5)",
+        ));
+        assert!(insert_result.is_err(), "should violate check constraint");
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_create_table_with_unique_constraint() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_with_unique();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let table_details = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name)?;
+        let constraints = table_details
+            .constraints
+            .as_ref()
+            .expect("constraints should be loaded");
+
+        let has_unique = constraints
+            .iter()
+            .any(|c| matches!(c.kind, ConstraintKind::Unique));
+        assert!(has_unique, "should have unique constraint");
+
+        connection.execute(&QueryRequest::new(
+            "INSERT INTO accounts (email, username) VALUES (N'test@example.com', N'testuser')",
+        ))?;
+
+        let duplicate_result = connection.execute(&QueryRequest::new(
+            "INSERT INTO accounts (email, username) VALUES (N'test@example.com', N'testuser2')",
+        ));
+        assert!(
+            duplicate_result.is_err(),
+            "should violate unique constraint"
+        );
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// CREATE INDEX tests
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_create_index_single_column() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let index = SqlServerFixtures::index_single_column();
+        connection.execute(&QueryRequest::new(&index.create_sql))?;
+
+        let table_details = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name)?;
+        let indexes = table_details
+            .indexes
+            .as_ref()
+            .expect("indexes should be loaded");
+
+        let index_list = match indexes {
+            IndexData::Relational(list) => list,
+            _ => panic!("expected relational index data"),
+        };
+
+        let has_index = index_list
+            .iter()
+            .any(|i| i.name == index.name && i.columns.contains(&"email".to_string()));
+        assert!(has_index, "index should exist");
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_create_index_unique() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let index = SqlServerFixtures::index_unique();
+        connection.execute(&QueryRequest::new(&index.create_sql))?;
+
+        let table_details = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name)?;
+        let indexes = table_details
+            .indexes
+            .as_ref()
+            .expect("indexes should be loaded");
+
+        let index_list = match indexes {
+            IndexData::Relational(list) => list,
+            _ => panic!("expected relational index data"),
+        };
+
+        let found_index = index_list
+            .iter()
+            .find(|i| i.name == index.name)
+            .expect("unique index should exist");
+        assert!(found_index.is_unique, "index should be unique");
+
+        connection.execute(&QueryRequest::new(
+            "INSERT INTO users (username, email) VALUES (N'alice', N'alice@example.com')",
+        ))?;
+
+        let duplicate_result = connection.execute(&QueryRequest::new(
+            "INSERT INTO users (username, email) VALUES (N'alice', N'bob@example.com')",
+        ));
+        assert!(
+            duplicate_result.is_err(),
+            "should violate unique index constraint"
+        );
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_create_index_composite() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let users_table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&users_table.create_sql))?;
+
+        let orders_table = SqlServerFixtures::table_with_fk();
+        connection.execute(&QueryRequest::new(&orders_table.create_sql))?;
+
+        let index = SqlServerFixtures::index_composite();
+        connection.execute(&QueryRequest::new(&index.create_sql))?;
+
+        let table_details = connection.table_details(TEST_DATABASE, Some("dbo"), &index.table)?;
+        let indexes = table_details
+            .indexes
+            .as_ref()
+            .expect("indexes should be loaded");
+
+        let index_list = match indexes {
+            IndexData::Relational(list) => list,
+            _ => panic!("expected relational index data"),
+        };
+
+        let found_index = index_list
+            .iter()
+            .find(|i| i.name == index.name)
+            .expect("composite index should exist");
+        assert_eq!(
+            found_index.columns.len(),
+            2,
+            "should have two columns in composite index"
+        );
+        assert!(found_index.columns.contains(&"user_id".to_string()));
+        assert!(found_index.columns.contains(&"status".to_string()));
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// CREATE VIEW
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_create_view() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let view = SqlServerFixtures::view_simple();
+        connection.execute(&QueryRequest::new(&view.create_sql))?;
+
+        let schema = connection.schema_for_database(TEST_DATABASE)?;
+        let has_view = schema.views.iter().any(|v| v.name == view.name);
+        assert!(has_view, "view should appear in schema_for_database output");
+
+        let result = connection.execute(&QueryRequest::new("SELECT * FROM active_users"))?;
+        assert!(!result.columns.is_empty());
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// ALTER TABLE (add / drop column — no rename, driver flags that off)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_alter_table_add_column() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let scenario = SqlServerFixtures::alter_add_column();
+        for sql in &scenario.setup_sql {
+            connection.execute(&QueryRequest::new(sql))?;
+        }
+
+        let before = connection.table_details(TEST_DATABASE, Some("dbo"), "alter_test")?;
+        let before_cols = before.columns.as_ref().expect("columns should exist");
+        let before_count = before_cols.len();
+
+        connection.execute(&QueryRequest::new(&scenario.test_sql))?;
+
+        let after = connection.table_details(TEST_DATABASE, Some("dbo"), "alter_test")?;
+        let after_cols = after.columns.as_ref().expect("columns should exist");
+        assert_eq!(after_cols.len(), before_count + 1);
+        assert!(after_cols.iter().any(|c| c.name == "age"));
+
+        for sql in &scenario.cleanup_sql {
+            let _ = connection.execute(&QueryRequest::new(sql));
+        }
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_alter_table_drop_column() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let scenario = SqlServerFixtures::alter_drop_column();
+        for sql in &scenario.setup_sql {
+            connection.execute(&QueryRequest::new(sql))?;
+        }
+
+        let before = connection.table_details(TEST_DATABASE, Some("dbo"), "alter_test")?;
+        let before_cols = before.columns.as_ref().expect("columns should exist");
+        let before_count = before_cols.len();
+        assert!(before_cols.iter().any(|c| c.name == "age"));
+
+        connection.execute(&QueryRequest::new(&scenario.test_sql))?;
+
+        let after = connection.table_details(TEST_DATABASE, Some("dbo"), "alter_test")?;
+        let after_cols = after.columns.as_ref().expect("columns should exist");
+        assert_eq!(after_cols.len(), before_count - 1);
+        assert!(!after_cols.iter().any(|c| c.name == "age"));
+
+        for sql in &scenario.cleanup_sql {
+            let _ = connection.execute(&QueryRequest::new(sql));
+        }
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// DROP TABLE / INDEX / VIEW
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_drop_table() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let before = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name);
+        assert!(before.is_ok(), "table should exist");
+
+        connection.execute(&QueryRequest::new(format!("DROP TABLE {}", table.name)))?;
+
+        let after = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name);
+        // After the drop the table details query returns no columns; we accept
+        // either a hard error or an "empty" TableInfo depending on driver
+        // surface, both of which mean "table is gone".
+        if let Ok(details) = after {
+            assert!(
+                details
+                    .columns
+                    .as_ref()
+                    .map(|c| c.is_empty())
+                    .unwrap_or(true)
+            );
+        }
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_drop_index() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let index = SqlServerFixtures::index_single_column();
+        connection.execute(&QueryRequest::new(&index.create_sql))?;
+
+        let before = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name)?;
+        let before_indexes = before.indexes.as_ref().expect("indexes should exist");
+        let before_list = match before_indexes {
+            IndexData::Relational(list) => list,
+            _ => panic!("expected relational index data"),
+        };
+        assert!(before_list.iter().any(|i| i.name == index.name));
+
+        // SQL Server requires the table reference on DROP INDEX.
+        connection.execute(&QueryRequest::new(format!(
+            "DROP INDEX {} ON {}",
+            index.name, index.table
+        )))?;
+
+        let after = connection.table_details(TEST_DATABASE, Some("dbo"), &table.name)?;
+        let after_indexes = after.indexes.as_ref().expect("indexes should exist");
+        let after_list = match after_indexes {
+            IndexData::Relational(list) => list,
+            _ => panic!("expected relational index data"),
+        };
+        assert!(!after_list.iter().any(|i| i.name == index.name));
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_drop_view() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let view = SqlServerFixtures::view_simple();
+        connection.execute(&QueryRequest::new(&view.create_sql))?;
+
+        let before = connection.schema_for_database(TEST_DATABASE)?;
+        assert!(before.views.iter().any(|v| v.name == view.name));
+
+        connection.execute(&QueryRequest::new(format!("DROP VIEW {}", view.name)))?;
+
+        let after = connection.schema_for_database(TEST_DATABASE)?;
+        assert!(!after.views.iter().any(|v| v.name == view.name));
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// TRUNCATE
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_truncate_table() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE truncate_test (id INT IDENTITY(1,1) PRIMARY KEY, value NVARCHAR(50))",
+        ))?;
+
+        for i in 1..=10 {
+            connection.execute(&QueryRequest::new(format!(
+                "INSERT INTO truncate_test (value) VALUES (N'item_{}')",
+                i
+            )))?;
+        }
+
+        let before =
+            connection.execute(&QueryRequest::new("SELECT COUNT(*) FROM truncate_test"))?;
+        let count_before = match &before.rows[0][0] {
+            Value::Int(n) => *n,
+            other => panic!("expected integer count, got {:?}", other),
+        };
+        assert_eq!(count_before, 10);
+
+        connection.execute(&QueryRequest::new("TRUNCATE TABLE truncate_test"))?;
+
+        let after = connection.execute(&QueryRequest::new("SELECT COUNT(*) FROM truncate_test"))?;
+        let count_after = match &after.rows[0][0] {
+            Value::Int(n) => *n,
+            other => panic!("expected integer count, got {:?}", other),
+        };
+        assert_eq!(count_after, 0);
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Error scenarios
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_error_constraint_violation() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let table = SqlServerFixtures::table_with_check();
+        connection.execute(&QueryRequest::new(&table.create_sql))?;
+
+        let result = connection.execute(&QueryRequest::new(
+            "INSERT INTO products (name, price, stock) VALUES (N'bad', -5, 10)",
+        ));
+        match result {
+            Err(DbError::ConstraintViolation(_)) => {}
+            other => panic!("expected ConstraintViolation, got {:?}", other),
+        }
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_error_fk_violation() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let parent_table = SqlServerFixtures::table_identity_pk();
+        connection.execute(&QueryRequest::new(&parent_table.create_sql))?;
+
+        let child_table = SqlServerFixtures::table_with_fk();
+        connection.execute(&QueryRequest::new(&child_table.create_sql))?;
+
+        let result = connection.execute(&QueryRequest::new(
+            "INSERT INTO orders (user_id, total, status) VALUES (9999, 100.00, N'pending')",
+        ));
+        match result {
+            Err(DbError::ConstraintViolation(_)) => {}
+            other => panic!("expected ConstraintViolation for FK error, got {:?}", other),
+        }
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ddl_error_missing_object_classified_as_not_found() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        let result = connection.execute(&QueryRequest::new("SELECT * FROM dbo.no_such_table_xyz"));
+        match result {
+            Err(DbError::ObjectNotFound(_)) => {}
+            other => panic!("expected ObjectNotFound, got {:?}", other),
+        }
+
+        Ok(())
+    })
+}

--- a/crates/dbflux_driver_mssql/tests/live_integration.rs
+++ b/crates/dbflux_driver_mssql/tests/live_integration.rs
@@ -60,6 +60,63 @@ fn connect_mssql(uri: String) -> Result<(Box<dyn Connection>, MssqlDriver), DbEr
     Ok((connection, driver))
 }
 
+/// Parse host and port from a `sqlserver://sa:pw@host:port/db` test URI.
+///
+/// The container helper hands us a URI; the form-mode and ssl-mode tests need
+/// the host and port as separate values to populate `DbConfig::SqlServer`.
+fn parse_host_port_from_uri(uri: &str) -> (String, u16) {
+    let after_at = uri.split_once('@').map(|(_, rest)| rest).unwrap_or(uri);
+    let host_port = after_at
+        .split_once('/')
+        .map(|(hp, _)| hp)
+        .unwrap_or(after_at);
+    match host_port.rsplit_once(':') {
+        Some((host, port)) => (host.to_string(), port.parse().expect("port should parse")),
+        None => (host_port.to_string(), 1433),
+    }
+}
+
+/// Connect using form mode (`use_uri: false`) with the given SSL mode override.
+///
+/// Used by tests that need to exercise specific `DbConfig::SqlServer` field
+/// combinations the URI-based `connect_mssql` cannot express directly. The
+/// password is delivered through `connect_with_secrets` since form mode does
+/// not parse credentials out of the URI.
+fn connect_form_mode(
+    uri: &str,
+    ssl_mode: &str,
+    trust_server_certificate: bool,
+) -> Result<Box<dyn Connection>, DbError> {
+    use dbflux_core::secrecy::SecretString;
+
+    let (host, port) = parse_host_port_from_uri(uri);
+    let driver = MssqlDriver::new();
+    let profile = ConnectionProfile::new(
+        "live-mssql-form",
+        DbConfig::SqlServer {
+            use_uri: false,
+            uri: None,
+            host,
+            port,
+            user: "sa".to_string(),
+            database: None,
+            instance: None,
+            ssl_mode: Some(ssl_mode.to_string()),
+            trust_server_certificate,
+            ssl_root_cert_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+        },
+    );
+    let password: SecretString = containers::MSSQL_TEST_PASSWORD.to_string().into();
+
+    containers::retry_db_operation(Duration::from_secs(60), || -> Result<_, DbError> {
+        let connection = driver.connect_with_secrets(&profile, Some(&password), None)?;
+        connection.ping()?;
+        Ok(connection)
+    })
+}
+
 fn cleanup_test_tables(conn: &dyn Connection) {
     // Drop in FK order — children first.
     for table in [
@@ -517,3 +574,82 @@ fn mssql_document_ops_not_supported() -> Result<(), DbError> {
         Ok(())
     })
 }
+
+// ---------------------------------------------------------------------------
+// Form mode (use_uri = false) — exercises connect_direct + form-fed password
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_form_mode_connect_query_and_select_db() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let connection = connect_form_mode(&uri, "on", true)?;
+
+        connection.ping()?;
+
+        // Run a trivial query so we know the session is actually usable, not
+        // just that the TCP handshake succeeded.
+        let result = connection.execute(&QueryRequest::new("SELECT 1 AS form_mode_ok"))?;
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0][0], Value::Int(1));
+
+        // The form-mode profile leaves `database` unset, so the session should
+        // land in `master`. `set_active_database` must work in this mode too.
+        connection.execute(&QueryRequest::new(
+            "IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = 'dbflux_form_test') \
+             CREATE DATABASE [dbflux_form_test]",
+        ))?;
+        connection.set_active_database(Some("dbflux_form_test"))?;
+        assert_eq!(
+            connection.active_database().as_deref(),
+            Some("dbflux_form_test")
+        );
+
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// SSL mode coverage — `off` and `on` (both with trust_server_certificate=true,
+// since the test container uses a self-signed cert)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ssl_mode_off_connects() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        // `ssl_mode = "off"` maps to `EncryptionLevel::Off`. The SQL Server
+        // test image accepts unencrypted connections by default.
+        let connection = connect_form_mode(&uri, "off", true)?;
+        connection.ping()?;
+        let result = connection.execute(&QueryRequest::new("SELECT 1"))?;
+        assert_eq!(result.rows.len(), 1);
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_ssl_mode_on_trusts_self_signed() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        // `ssl_mode = "on"` with `trust_server_certificate = true` is the
+        // "encrypt but accept self-signed" path tiberius takes when
+        // `EncryptionLevel::On` and `trust_cert()` are both set.
+        let connection = connect_form_mode(&uri, "on", true)?;
+        connection.ping()?;
+        let result = connection.execute(&QueryRequest::new("SELECT 1"))?;
+        assert_eq!(result.rows.len(), 1);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Instance routing
+// ---------------------------------------------------------------------------
+//
+// The `mcr.microsoft.com/mssql/server` test image only ships the default
+// `MSSQLSERVER` instance and does not expose the SQL Browser UDP service, so
+// `instance_name` cannot be exercised end-to-end here. The unit tests in
+// `driver.rs::tests` cover instance-name plumbing through `parse_mssql_url`
+// and `build_uri` (round-trip + URI-vs-form precedence). A real live test
+// would need a custom image / sidecar SQL Browser.

--- a/crates/dbflux_driver_mssql/tests/live_integration.rs
+++ b/crates/dbflux_driver_mssql/tests/live_integration.rs
@@ -1,0 +1,519 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::result_large_err
+)]
+
+use dbflux_core::{
+    CollectionRef, Connection, ConnectionProfile, DbConfig, DbDriver, DbError, DescribeRequest,
+    ExplainRequest, OrderByColumn, Pagination, QueryRequest, RecordIdentity, RowDelete, RowInsert,
+    RowPatch, SchemaLoadingStrategy, TableBrowseRequest, TableCountRequest, TableRef, Value,
+};
+use dbflux_driver_mssql::MssqlDriver;
+use dbflux_test_support::containers;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+const TEST_DATABASE: &str = "dbflux_test";
+
+fn connect_mssql(uri: String) -> Result<(Box<dyn Connection>, MssqlDriver), DbError> {
+    let driver = MssqlDriver::new();
+    let profile = ConnectionProfile::new(
+        "live-mssql",
+        DbConfig::SqlServer {
+            use_uri: true,
+            uri: Some(uri),
+            host: String::new(),
+            port: 1433,
+            user: String::new(),
+            database: None,
+            instance: None,
+            ssl_mode: Some("on".to_string()),
+            trust_server_certificate: true,
+            ssl_root_cert_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+        },
+    );
+
+    // SQL Server takes a few extra seconds to be ready for client logins
+    // even after the container's "ready for client connections" log line.
+    let connection =
+        containers::retry_db_operation(Duration::from_secs(60), || -> Result<_, DbError> {
+            let connection = driver.connect(&profile)?;
+            connection.ping()?;
+            Ok(connection)
+        })?;
+
+    // Create a clean per-test database so the implicit `list_databases()`
+    // filter (which hides master/tempdb/model/msdb) returns something
+    // non-empty, and so test objects don't pile up in `master`.
+    connection.execute(&QueryRequest::new(format!(
+        "IF NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = '{TEST_DATABASE}') \
+         CREATE DATABASE [{TEST_DATABASE}]"
+    )))?;
+    connection.set_active_database(Some(TEST_DATABASE))?;
+
+    Ok((connection, driver))
+}
+
+fn cleanup_test_tables(conn: &dyn Connection) {
+    // Drop in FK order — children first.
+    for table in [
+        "orders",
+        "order_items",
+        "products",
+        "accounts",
+        "users",
+        "crud_test",
+        "browse_test",
+        "explain_test",
+        "describe_test",
+        "codegen_test",
+        "cancel_test",
+    ] {
+        let _ = conn.execute(&QueryRequest::new(format!(
+            "DROP TABLE IF EXISTS dbo.[{}]",
+            table
+        )));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Basic connectivity
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_live_connect_ping_query_and_schema() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+
+        let result = connection.execute(&QueryRequest::new("SELECT 1 AS one"))?;
+        assert_eq!(result.rows.len(), 1);
+
+        assert_eq!(
+            connection.schema_loading_strategy(),
+            SchemaLoadingStrategy::LazyPerDatabase
+        );
+
+        let databases = connection.list_databases()?;
+        assert!(
+            databases.iter().any(|d| d.name == TEST_DATABASE),
+            "test database should be visible in list_databases"
+        );
+
+        let schema = connection.schema()?;
+        assert!(schema.is_relational());
+
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Schema introspection
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_schema_introspection() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE users (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                name NVARCHAR(100) NOT NULL,
+                email NVARCHAR(255) UNIQUE,
+                age INT DEFAULT 0
+            )",
+        ))?;
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE orders (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                user_id INT NOT NULL,
+                amount DECIMAL(10, 2) NOT NULL,
+                CONSTRAINT fk_orders_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            )",
+        ))?;
+
+        connection.execute(&QueryRequest::new(
+            "CREATE INDEX idx_orders_user_id ON orders(user_id)",
+        ))?;
+
+        let table = connection.table_details(TEST_DATABASE, Some("dbo"), "users")?;
+        assert_eq!(table.name, "users");
+
+        let columns = table.columns.as_ref().expect("columns should be loaded");
+        assert!(columns.len() >= 4);
+
+        let id_col = columns.iter().find(|c| c.name == "id").expect("id column");
+        assert!(id_col.is_primary_key);
+        assert!(!id_col.nullable);
+
+        let name_col = columns
+            .iter()
+            .find(|c| c.name == "name")
+            .expect("name column");
+        assert!(!name_col.nullable);
+
+        let email_col = columns
+            .iter()
+            .find(|c| c.name == "email")
+            .expect("email column");
+        assert!(email_col.nullable);
+
+        let orders_table = connection.table_details(TEST_DATABASE, Some("dbo"), "orders")?;
+        let fks = orders_table
+            .foreign_keys
+            .as_ref()
+            .expect("foreign keys should be loaded");
+        assert!(!fks.is_empty());
+        let fk = &fks[0];
+        assert_eq!(fk.referenced_table, "users");
+        assert_eq!(fk.columns, vec!["user_id"]);
+        assert_eq!(fk.referenced_columns, vec!["id"]);
+
+        let schema_features = connection.schema_features();
+        assert!(!schema_features.is_empty());
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// CRUD operations with OUTPUT clauses
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_crud_operations_with_output() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE crud_test (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                name NVARCHAR(100) NOT NULL,
+                value INT DEFAULT 0
+            )",
+        ))?;
+
+        // INSERT — OUTPUT INSERTED.* should round-trip the row back.
+        let insert_result = connection.insert_row(&RowInsert::new(
+            "crud_test".to_string(),
+            Some("dbo".to_string()),
+            vec!["name".to_string(), "value".to_string()],
+            vec![Value::Text("alice".to_string()), Value::Int(42)],
+        ))?;
+        assert_eq!(insert_result.affected_rows, 1);
+        assert!(
+            insert_result.returning_row.is_some(),
+            "INSERT with OUTPUT should return the inserted row"
+        );
+
+        // Verify it's actually there.
+        let rows = connection
+            .execute(&QueryRequest::new(
+                "SELECT id, name, value FROM crud_test WHERE name = N'alice'",
+            ))?
+            .rows;
+        assert_eq!(rows.len(), 1);
+        let inserted_id = match &rows[0][0] {
+            Value::Int(n) => *n,
+            other => panic!("expected Int id, got {:?}", other),
+        };
+
+        // UPDATE by PK — OUTPUT INSERTED.* should return the post-update row.
+        let update_result = connection.update_row(&RowPatch::new(
+            RecordIdentity::composite(vec!["id".to_string()], vec![Value::Int(inserted_id)]),
+            "crud_test".to_string(),
+            Some("dbo".to_string()),
+            vec![("value".to_string(), Value::Int(99))],
+        ))?;
+        assert_eq!(update_result.affected_rows, 1);
+        assert!(update_result.returning_row.is_some());
+
+        let rows = connection
+            .execute(&QueryRequest::new(
+                "SELECT value FROM crud_test WHERE name = N'alice'",
+            ))?
+            .rows;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0][0], Value::Int(99));
+
+        // DELETE — OUTPUT DELETED.* should return the removed row.
+        let delete_result = connection.delete_row(&RowDelete::new(
+            RecordIdentity::composite(vec!["id".to_string()], vec![Value::Int(inserted_id)]),
+            "crud_test".to_string(),
+            Some("dbo".to_string()),
+        ))?;
+        assert_eq!(delete_result.affected_rows, 1);
+        assert!(delete_result.returning_row.is_some());
+
+        let rows = connection
+            .execute(&QueryRequest::new("SELECT * FROM crud_test"))?
+            .rows;
+        assert!(rows.is_empty());
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Browse and count via OFFSET/FETCH NEXT
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_browse_and_count() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE browse_test (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                name NVARCHAR(50) NOT NULL
+            )",
+        ))?;
+
+        for i in 1..=25 {
+            connection.execute(&QueryRequest::new(format!(
+                "INSERT INTO browse_test (name) VALUES (N'item_{}')",
+                i
+            )))?;
+        }
+
+        let table_ref = TableRef::with_schema("dbo", "browse_test");
+
+        let count = connection.count_table(&TableCountRequest::new(table_ref.clone()))?;
+        assert_eq!(count, 25);
+
+        let filtered_count = connection.count_table(
+            &TableCountRequest::new(table_ref.clone()).with_filter("name LIKE N'item_1%'"),
+        )?;
+        assert!(filtered_count > 0);
+        assert!(filtered_count < 25);
+
+        let page1 = connection.browse_table(
+            &TableBrowseRequest::new(table_ref.clone())
+                .with_pagination(Pagination::Offset {
+                    limit: 10,
+                    offset: 0,
+                })
+                .with_order_by(vec![OrderByColumn::asc("id")]),
+        )?;
+        assert_eq!(page1.rows.len(), 10);
+
+        let page2 = connection.browse_table(
+            &TableBrowseRequest::new(table_ref.clone())
+                .with_pagination(Pagination::Offset {
+                    limit: 10,
+                    offset: 10,
+                })
+                .with_order_by(vec![OrderByColumn::asc("id")]),
+        )?;
+        assert_eq!(page2.rows.len(), 10);
+        assert_ne!(page1.rows[0], page2.rows[0]);
+
+        let filtered = connection.browse_table(
+            &TableBrowseRequest::new(table_ref)
+                .with_filter("name = N'item_5'")
+                .with_pagination(Pagination::Offset {
+                    limit: 100,
+                    offset: 0,
+                }),
+        )?;
+        assert_eq!(filtered.rows.len(), 1);
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// EXPLAIN via SET SHOWPLAN_XML
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_explain_returns_xml_plan() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE explain_test (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(50))",
+        ))?;
+
+        let table_ref = TableRef::with_schema("dbo", "explain_test");
+        let result = connection.explain(&ExplainRequest::new(table_ref))?;
+        // SHOWPLAN_XML returns a single-column nvarchar(max) result containing
+        // the XML plan. We just assert we got at least one row back.
+        assert!(!result.rows.is_empty());
+
+        // After explain the session must still execute normally — i.e. the
+        // SET SHOWPLAN_XML OFF reset really happened.
+        let normal = connection.execute(&QueryRequest::new("SELECT 1 AS one"))?;
+        assert_eq!(normal.rows.len(), 1);
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Describe
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_describe_table() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE describe_test (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                name NVARCHAR(100) NOT NULL,
+                active BIT DEFAULT 1
+            )",
+        ))?;
+
+        let table_ref = TableRef::with_schema("dbo", "describe_test");
+        let result = connection.describe_table(&DescribeRequest::new(table_ref))?;
+        assert!(result.rows.len() >= 3);
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Code generators
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_code_generators() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+        cleanup_test_tables(&*connection);
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE codegen_test (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                name NVARCHAR(100) NOT NULL
+            )",
+        ))?;
+
+        let table = connection.table_details(TEST_DATABASE, Some("dbo"), "codegen_test")?;
+
+        // The mssql driver supports a fixed set of generators by ID, even if
+        // it doesn't enumerate them via `code_generators()`. Verify the
+        // canonical IDs round-trip without error.
+        for generator_id in [
+            "select_star",
+            "insert",
+            "update",
+            "delete",
+            "truncate",
+            "drop_table",
+        ] {
+            let code = connection.generate_code(generator_id, &table)?;
+            assert!(
+                !code.is_empty(),
+                "generator '{}' returned empty code",
+                generator_id
+            );
+            assert!(
+                code.contains("codegen_test"),
+                "generator '{}' should reference the target table",
+                generator_id
+            );
+        }
+
+        cleanup_test_tables(&*connection);
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Cancellation: KILL + transparent reconnect
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_cancel_query_kills_session_and_reconnects() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+
+        // Share the connection with the worker thread that runs the long
+        // query. Connection is `Send + Sync` so an `Arc` is enough.
+        let conn: Arc<dyn Connection> = Arc::from(connection);
+        let worker_conn = Arc::clone(&conn);
+
+        let worker = thread::spawn(move || {
+            // WAITFOR DELAY blocks the session for the given duration.
+            // The cancel issued below should interrupt it well before this
+            // returns naturally.
+            worker_conn.execute(&QueryRequest::new("WAITFOR DELAY '00:00:30'"))
+        });
+
+        // Give the worker a moment to actually start the query before we
+        // KILL the session.
+        thread::sleep(Duration::from_millis(500));
+
+        conn.cancel_active()?;
+
+        let worker_result = worker.join().expect("worker thread panicked");
+        assert!(
+            matches!(worker_result, Err(DbError::Cancelled)),
+            "cancelled query should return DbError::Cancelled, got: {:?}",
+            worker_result
+        );
+
+        // cleanup_after_cancel should rebuild the underlying tiberius
+        // client and restore the active database. The connection should be
+        // usable again afterward.
+        conn.cleanup_after_cancel()?;
+        conn.ping()?;
+
+        let result = conn.execute(&QueryRequest::new("SELECT 1 AS one"))?;
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.rows[0][0], Value::Int(1));
+
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Document operations (should return NotSupported)
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn mssql_document_ops_not_supported() -> Result<(), DbError> {
+    containers::with_mssql_url(|uri| {
+        let (connection, _) = connect_mssql(uri)?;
+
+        let browse_result = connection.browse_collection(
+            &dbflux_core::CollectionBrowseRequest::new(CollectionRef::new("db", "col")),
+        );
+        assert!(matches!(browse_result, Err(DbError::NotSupported(_))));
+
+        assert!(connection.key_value_api().is_none());
+
+        Ok(())
+    })
+}

--- a/crates/dbflux_ipc/src/driver_protocol.rs
+++ b/crates/dbflux_ipc/src/driver_protocol.rs
@@ -165,6 +165,11 @@ impl From<QueryResultDto> for QueryResult {
             // Resolved window and metadata_extra are not part of the IPC DTO; drivers set them locally.
             resolved_window: None,
             metadata_extra: None,
+            // The driver RPC DTO does not currently propagate additional
+            // result sets across the wire. External RPC drivers that need
+            // multi-set support would have to extend QueryResultDto first;
+            // until then, IPC-driven connections behave as single-result-set.
+            additional_results: Vec::new(),
         }
     }
 }

--- a/crates/dbflux_mcp_server/src/helper.rs
+++ b/crates/dbflux_mcp_server/src/helper.rs
@@ -51,15 +51,44 @@ pub fn json_to_db_value(value: serde_json::Value) -> Value {
     }
 }
 
-/// Serialize a QueryResult into a JSON value suitable for MCP responses
+/// Serialize a QueryResult into a JSON value suitable for MCP responses.
+///
+/// Drivers whose protocol can return multiple result sets per batch
+/// (currently MSSQL via `SELECT 1; SELECT 2;` or multi-`SELECT` stored
+/// procs) populate `QueryResult.additional_results`. Surfacing only the
+/// primary set across the MCP boundary would silently drop every set
+/// except the last, so when extras are present we emit a `result_sets`
+/// array containing every set in batch order.
 #[allow(dead_code)]
 pub fn serialize_query_result(result: &QueryResult) -> serde_json::Value {
     let columns: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
     let rows = serialize_rows(result);
 
+    if result.has_additional_results() {
+        let result_sets: Vec<serde_json::Value> = result
+            .iter_result_sets()
+            .map(serialize_single_result_set)
+            .collect();
+        serde_json::json!({
+            "columns": columns,
+            "rows": rows,
+            "row_count": result.rows.len(),
+            "result_sets": result_sets,
+        })
+    } else {
+        serde_json::json!({
+            "columns": columns,
+            "rows": rows,
+            "row_count": result.rows.len(),
+        })
+    }
+}
+
+fn serialize_single_result_set(result: &QueryResult) -> serde_json::Value {
+    let columns: Vec<&str> = result.columns.iter().map(|c| c.name.as_str()).collect();
     serde_json::json!({
         "columns": columns,
-        "rows": rows,
+        "rows": serialize_rows(result),
         "row_count": result.rows.len(),
     })
 }
@@ -175,5 +204,59 @@ mod tests {
         );
 
         assert_eq!(mutation_affected_rows(&result), 2);
+    }
+
+    #[test]
+    fn serialize_query_result_emits_result_sets_when_multiple_present() {
+        let column = |name: &str| ColumnMeta {
+            name: name.into(),
+            type_name: "int".into(),
+            kind: ColumnKind::Integer,
+            nullable: false,
+            is_primary_key: false,
+        };
+
+        let mut primary = QueryResult::table(
+            vec![column("b")],
+            vec![vec![Value::Int(2)]],
+            None,
+            Duration::ZERO,
+        );
+        let earlier = QueryResult::table(
+            vec![column("a")],
+            vec![vec![Value::Int(1)]],
+            None,
+            Duration::ZERO,
+        );
+        primary.push_additional_result(earlier);
+
+        let json = serialize_query_result(&primary);
+        let sets = json
+            .get("result_sets")
+            .and_then(|v| v.as_array())
+            .expect("result_sets present");
+        assert_eq!(sets.len(), 2);
+        // Primary first, then the earlier set in batch order.
+        assert_eq!(sets[0]["columns"][0], serde_json::json!("b"));
+        assert_eq!(sets[1]["columns"][0], serde_json::json!("a"));
+    }
+
+    #[test]
+    fn serialize_query_result_omits_result_sets_for_single_set() {
+        let result = QueryResult::table(
+            vec![ColumnMeta {
+                name: "n".into(),
+                type_name: "int".into(),
+                kind: ColumnKind::Integer,
+                nullable: false,
+                is_primary_key: false,
+            }],
+            vec![vec![Value::Int(1)]],
+            None,
+            Duration::ZERO,
+        );
+
+        let json = serialize_query_result(&result);
+        assert!(json.get("result_sets").is_none());
     }
 }

--- a/crates/dbflux_mcp_server/src/state.rs
+++ b/crates/dbflux_mcp_server/src/state.rs
@@ -560,6 +560,7 @@ fn str_to_db_kind(value: &str) -> Option<dbflux_core::DbKind> {
         "DynamoDB" => Some(dbflux_core::DbKind::DynamoDB),
         "CloudWatchLogs" => Some(dbflux_core::DbKind::CloudWatchLogs),
         "InfluxDB" => Some(dbflux_core::DbKind::InfluxDB),
+        "SqlServer" => Some(dbflux_core::DbKind::SqlServer),
         _ => None,
     }
 }
@@ -575,6 +576,7 @@ fn default_db_config_for_kind(kind: dbflux_core::DbKind) -> dbflux_core::DbConfi
         dbflux_core::DbKind::DynamoDB => dbflux_core::DbConfig::default_dynamodb(),
         dbflux_core::DbKind::CloudWatchLogs => dbflux_core::DbConfig::default_cloudwatch_logs(),
         dbflux_core::DbKind::InfluxDB => dbflux_core::DbConfig::default_influxdb(),
+        dbflux_core::DbKind::SqlServer => dbflux_core::DbConfig::default_sqlserver(),
     }
 }
 

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -139,6 +139,7 @@ impl MigrationRegistry {
         registry.register(mod_006_rpc_service_api_contract::MigrationImpl);
         registry.register(mod_007_session_exec_ctx_json::MigrationImpl);
         registry.register(mod_008_general_settings_style::MigrationImpl);
+        registry.register(mod_009_mssql_instance::MigrationImpl);
         registry
     }
 
@@ -285,6 +286,7 @@ mod mod_005_rpc_service_kind;
 mod mod_006_rpc_service_api_contract;
 mod mod_007_session_exec_ctx_json;
 mod mod_008_general_settings_style;
+mod mod_009_mssql_instance;
 
 pub use mod_001_initial::MigrationImpl;
 pub use mod_002_audit_extended::MigrationImpl as MigrationImplAuditExtended;

--- a/crates/dbflux_storage/src/migrations/mod_001_initial.rs
+++ b/crates/dbflux_storage/src/migrations/mod_001_initial.rs
@@ -363,9 +363,6 @@ CREATE TABLE IF NOT EXISTS cfg_connection_driver_configs (
     -- External config
     external_kind TEXT,
     external_values_json TEXT,
-    -- SQL Server-specific
-    mssql_instance TEXT,
-    mssql_trust_server_certificate INTEGER NOT NULL DEFAULT 1,
     FOREIGN KEY (profile_id) REFERENCES cfg_connection_profiles(id) ON DELETE CASCADE
 );
 

--- a/crates/dbflux_storage/src/migrations/mod_001_initial.rs
+++ b/crates/dbflux_storage/src/migrations/mod_001_initial.rs
@@ -363,6 +363,9 @@ CREATE TABLE IF NOT EXISTS cfg_connection_driver_configs (
     -- External config
     external_kind TEXT,
     external_values_json TEXT,
+    -- SQL Server-specific
+    mssql_instance TEXT,
+    mssql_trust_server_certificate INTEGER NOT NULL DEFAULT 1,
     FOREIGN KEY (profile_id) REFERENCES cfg_connection_profiles(id) ON DELETE CASCADE
 );
 

--- a/crates/dbflux_storage/src/migrations/mod_009_mssql_instance.rs
+++ b/crates/dbflux_storage/src/migrations/mod_009_mssql_instance.rs
@@ -1,0 +1,88 @@
+//! Migration 009: Add `mssql_instance` and `mssql_trust_server_certificate`
+//! columns to `cfg_connection_driver_configs`.
+//!
+//! Without these columns, SQL Server connection profiles silently lost
+//! their named instance and `TrustServerCertificate` setting on every save,
+//! so a profile saved with `instance = "MSSQLSERVER2019"` would come back
+//! after a restart with `instance = None` and the driver would dial
+//! `host:port` directly instead of going through SQL Browser.
+
+use rusqlite::Transaction;
+
+use crate::migrations::{Migration, MigrationError};
+
+pub struct MigrationImpl;
+
+impl Migration for MigrationImpl {
+    fn name(&self) -> &str {
+        "009_mssql_instance"
+    }
+
+    fn run(&self, tx: &Transaction) -> Result<(), MigrationError> {
+        let table_exists: bool = tx
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='cfg_connection_driver_configs'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .map_err(|source| MigrationError::Sqlite {
+                path: std::path::PathBuf::from("<unknown>"),
+                source,
+            })?;
+
+        if !table_exists {
+            return Ok(());
+        }
+
+        // Add `mssql_instance` if missing.
+        let instance_exists: bool = tx
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('cfg_connection_driver_configs') WHERE name = 'mssql_instance'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .map_err(|source| MigrationError::Sqlite {
+                path: std::path::PathBuf::from("<unknown>"),
+                source,
+            })?;
+
+        if !instance_exists {
+            tx.execute_batch(
+                "ALTER TABLE cfg_connection_driver_configs ADD COLUMN mssql_instance TEXT;",
+            )
+            .map_err(|source| MigrationError::Sqlite {
+                path: std::path::PathBuf::from("<unknown>"),
+                source,
+            })?;
+        }
+
+        // Add `mssql_trust_server_certificate` if missing. Defaults to 1
+        // (true) — matches the driver's existing form-mode default for the
+        // common dev/self-signed-cert case.
+        let trust_exists: bool = tx
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('cfg_connection_driver_configs') WHERE name = 'mssql_trust_server_certificate'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .map_err(|source| MigrationError::Sqlite {
+                path: std::path::PathBuf::from("<unknown>"),
+                source,
+            })?;
+
+        if !trust_exists {
+            tx.execute_batch(
+                "ALTER TABLE cfg_connection_driver_configs ADD COLUMN mssql_trust_server_certificate INTEGER NOT NULL DEFAULT 1;",
+            )
+            .map_err(|source| MigrationError::Sqlite {
+                path: std::path::PathBuf::from("<unknown>"),
+                source,
+            })?;
+        }
+
+        Ok(())
+    }
+}

--- a/crates/dbflux_storage/src/repositories/connection_driver_configs.rs
+++ b/crates/dbflux_storage/src/repositories/connection_driver_configs.rs
@@ -55,6 +55,9 @@ pub struct ConnectionDriverConfigDto {
     // External
     pub external_kind: Option<String>,
     pub external_values_json: Option<String>,
+    // SQL Server-specific
+    pub mssql_instance: Option<String>,
+    pub mssql_trust_server_certificate: bool,
 }
 
 impl ConnectionDriverConfigDto {
@@ -94,6 +97,8 @@ impl ConnectionDriverConfigDto {
             dynamo_table: None,
             external_kind: None,
             external_values_json: None,
+            mssql_instance: None,
+            mssql_trust_server_certificate: true,
         }
     }
 
@@ -271,6 +276,34 @@ impl ConnectionDriverConfigDto {
                 });
                 dto.external_values_json = Some(values.to_string());
             }
+            DbConfig::SqlServer {
+                use_uri,
+                uri,
+                host,
+                port,
+                user,
+                database,
+                instance,
+                ssl_mode,
+                trust_server_certificate,
+                ssl_root_cert_path,
+                ssh_tunnel,
+                ..
+            } => {
+                dto.use_uri = *use_uri;
+                dto.uri = uri.clone();
+                dto.host = Some(host.clone());
+                dto.port = Some(*port as i32);
+                dto.user = Some(user.clone());
+                dto.database_name = database.clone();
+                dto.mssql_instance = instance.clone();
+                dto.ssl_mode = ssl_mode.clone().unwrap_or_default();
+                dto.mssql_trust_server_certificate = *trust_server_certificate;
+                dto.ssl_ca = ssl_root_cert_path.clone();
+                if let Some(tunnel) = ssh_tunnel {
+                    fill_ssh_tunnel_fields(&mut dto, tunnel);
+                }
+            }
             DbConfig::External { kind, values } => {
                 dto.external_kind = Some(db_kind_to_str(*kind));
                 dto.external_values_json = Some(serde_json::to_string(values).unwrap_or_default());
@@ -427,6 +460,34 @@ impl ConnectionDriverConfigDto {
                         .and_then(|v| v.as_u64()),
                 })
             }
+            DbKind::SqlServer => {
+                let ssh_tunnel = build_ssh_tunnel(self);
+
+                Some(DbConfig::SqlServer {
+                    use_uri: self.use_uri,
+                    uri: self.uri.clone(),
+                    host: self.host.clone().unwrap_or_default(),
+                    port: self.port.unwrap_or(1433) as u16,
+                    user: self.user.clone().unwrap_or_default(),
+                    database: self
+                        .database_name
+                        .clone()
+                        .filter(|database| !database.is_empty()),
+                    instance: self
+                        .mssql_instance
+                        .clone()
+                        .filter(|instance| !instance.is_empty()),
+                    ssl_mode: if self.ssl_mode.is_empty() {
+                        Some("on".to_string())
+                    } else {
+                        Some(self.ssl_mode.clone())
+                    },
+                    trust_server_certificate: self.mssql_trust_server_certificate,
+                    ssl_root_cert_path: self.ssl_ca.clone(),
+                    ssh_tunnel,
+                    ssh_tunnel_profile_id: None,
+                })
+            }
         }
     }
 }
@@ -446,6 +507,7 @@ fn db_kind_to_str(kind: DbKind) -> String {
         DbKind::DynamoDB => "DynamoDB",
         DbKind::CloudWatchLogs => "CloudWatchLogs",
         DbKind::InfluxDB => "InfluxDB",
+        DbKind::SqlServer => "SqlServer",
     }
     .to_string()
 }
@@ -461,6 +523,7 @@ fn str_to_db_kind(s: &str) -> Option<DbKind> {
         "DynamoDB" => Some(DbKind::DynamoDB),
         "CloudWatchLogs" => Some(DbKind::CloudWatchLogs),
         "InfluxDB" => Some(DbKind::InfluxDB),
+        "SqlServer" => Some(DbKind::SqlServer),
         _ => None,
     }
 }
@@ -579,7 +642,8 @@ impl ConnectionDriverConfigsRepository {
                     mongo_auth_database,
                     redis_tls, redis_database,
                     dynamo_region, dynamo_profile, dynamo_endpoint, dynamo_table,
-                    external_kind, external_values_json
+                    external_kind, external_values_json,
+                    mssql_instance, mssql_trust_server_certificate
                 FROM cfg_connection_driver_configs
                 WHERE profile_id = ?1
                 "#,
@@ -624,6 +688,8 @@ impl ConnectionDriverConfigsRepository {
                 dynamo_table: row.get(30)?,
                 external_kind: row.get(31)?,
                 external_values_json: row.get(32)?,
+                mssql_instance: row.get(33)?,
+                mssql_trust_server_certificate: row.get::<_, i32>(34)? != 0,
             })
         });
 
@@ -652,7 +718,8 @@ impl ConnectionDriverConfigsRepository {
                     mongo_auth_database,
                     redis_tls, redis_database,
                     dynamo_region, dynamo_profile, dynamo_endpoint, dynamo_table,
-                    external_kind, external_values_json
+                    external_kind, external_values_json,
+                    mssql_instance, mssql_trust_server_certificate
                 ) VALUES (
                     ?1, ?2, ?3,
                     ?4, ?5, ?6, ?7, ?8, ?9,
@@ -663,7 +730,8 @@ impl ConnectionDriverConfigsRepository {
                     ?25,
                     ?26, ?27,
                     ?28, ?29, ?30, ?31,
-                    ?32, ?33
+                    ?32, ?33,
+                    ?34, ?35
                 )
                 "#,
                 params![
@@ -700,6 +768,8 @@ impl ConnectionDriverConfigsRepository {
                     config.dynamo_table,
                     config.external_kind,
                     config.external_values_json,
+                    config.mssql_instance,
+                    config.mssql_trust_server_certificate as i32,
                 ],
             )
             .map_err(|source| StorageError::Sqlite {
@@ -725,7 +795,8 @@ impl ConnectionDriverConfigsRepository {
                     mongo_auth_database,
                     redis_tls, redis_database,
                     dynamo_region, dynamo_profile, dynamo_endpoint, dynamo_table,
-                    external_kind, external_values_json
+                    external_kind, external_values_json,
+                    mssql_instance, mssql_trust_server_certificate
                 ) VALUES (
                     ?1, ?2, ?3,
                     ?4, ?5, ?6, ?7, ?8, ?9,
@@ -736,7 +807,8 @@ impl ConnectionDriverConfigsRepository {
                     ?25,
                     ?26, ?27,
                     ?28, ?29, ?30, ?31,
-                    ?32, ?33
+                    ?32, ?33,
+                    ?34, ?35
                 )
                 ON CONFLICT(profile_id) DO UPDATE SET
                     config_key = excluded.config_key,
@@ -769,7 +841,9 @@ impl ConnectionDriverConfigsRepository {
                     dynamo_endpoint = excluded.dynamo_endpoint,
                     dynamo_table = excluded.dynamo_table,
                     external_kind = excluded.external_kind,
-                    external_values_json = excluded.external_values_json
+                    external_values_json = excluded.external_values_json,
+                    mssql_instance = excluded.mssql_instance,
+                    mssql_trust_server_certificate = excluded.mssql_trust_server_certificate
                 "#,
                 params![
                     config.id,
@@ -805,6 +879,8 @@ impl ConnectionDriverConfigsRepository {
                     config.dynamo_table,
                     config.external_kind,
                     config.external_values_json,
+                    config.mssql_instance,
+                    config.mssql_trust_server_certificate as i32,
                 ],
             )
             .map_err(|source| StorageError::Sqlite {

--- a/crates/dbflux_test_support/src/containers.rs
+++ b/crates/dbflux_test_support/src/containers.rs
@@ -74,6 +74,43 @@ where
     run(url)
 }
 
+/// Password used when launching the SQL Server test container.
+///
+/// SQL Server requires a "strong" SA password: at least 8 characters with
+/// uppercase, lowercase, digit, and special-character classes represented.
+/// The same constant is reused inside test URIs.
+pub const MSSQL_TEST_PASSWORD: &str = "Strong!Passw0rd";
+
+pub fn with_mssql_url<T, E, F>(run: F) -> Result<T, E>
+where
+    F: FnOnce(String) -> Result<T, E>,
+{
+    // The official `mcr.microsoft.com/mssql/server` image takes the EULA via
+    // `ACCEPT_EULA=Y` and the SA password via `MSSQL_SA_PASSWORD`. The image
+    // is amd64-only; on arm64 hosts, run via emulation or substitute the
+    // Azure SQL Edge image manually.
+    let docker = Cli::default();
+    let image = GenericImage::new("mcr.microsoft.com/mssql/server", "2022-latest")
+        .with_env_var("ACCEPT_EULA", "Y")
+        .with_env_var("MSSQL_SA_PASSWORD", MSSQL_TEST_PASSWORD)
+        .with_env_var("MSSQL_PID", "Developer")
+        .with_exposed_port(1433)
+        .with_wait_for(WaitFor::message_on_stdout(
+            "SQL Server is now ready for client connections",
+        ));
+
+    let container = docker.run(image);
+    let port = container.get_host_port_ipv4(1433);
+    // Connect to `master` by default; tests that need a clean database
+    // create `dbflux_test` themselves and `USE` it.
+    let url = format!(
+        "sqlserver://sa:{password}@127.0.0.1:{port}/master",
+        password = MSSQL_TEST_PASSWORD
+    );
+
+    run(url)
+}
+
 pub fn with_dynamodb_endpoint<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,

--- a/crates/dbflux_test_support/src/ddl_fixtures.rs
+++ b/crates/dbflux_test_support/src/ddl_fixtures.rs
@@ -317,6 +317,144 @@ impl MySqlFixtures {
     }
 }
 
+pub struct SqlServerFixtures;
+
+impl SqlServerFixtures {
+    pub fn table_identity_pk() -> DdlTestTable {
+        DdlTestTable {
+            name: "users".to_string(),
+            create_sql: "CREATE TABLE users (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                username NVARCHAR(50) NOT NULL,
+                email NVARCHAR(100) NOT NULL,
+                created_at DATETIME2 DEFAULT SYSUTCDATETIME()
+            )"
+            .to_string(),
+        }
+    }
+
+    pub fn table_composite_pk() -> DdlTestTable {
+        DdlTestTable {
+            name: "order_items".to_string(),
+            create_sql: "CREATE TABLE order_items (
+                order_id INT NOT NULL,
+                product_id INT NOT NULL,
+                quantity INT NOT NULL DEFAULT 1,
+                price DECIMAL(10, 2) NOT NULL,
+                PRIMARY KEY (order_id, product_id)
+            )"
+            .to_string(),
+        }
+    }
+
+    pub fn table_with_fk() -> DdlTestTable {
+        DdlTestTable {
+            name: "orders".to_string(),
+            create_sql: "CREATE TABLE orders (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                user_id INT NOT NULL,
+                total DECIMAL(10, 2) NOT NULL,
+                status NVARCHAR(20) DEFAULT 'pending',
+                CONSTRAINT fk_orders_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+            )"
+            .to_string(),
+        }
+    }
+
+    pub fn table_with_check() -> DdlTestTable {
+        DdlTestTable {
+            name: "products".to_string(),
+            create_sql: "CREATE TABLE products (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                name NVARCHAR(100) NOT NULL,
+                price DECIMAL(10, 2) NOT NULL,
+                stock INT NOT NULL DEFAULT 0,
+                CONSTRAINT positive_price CHECK (price > 0),
+                CONSTRAINT non_negative_stock CHECK (stock >= 0)
+            )"
+            .to_string(),
+        }
+    }
+
+    pub fn table_with_unique() -> DdlTestTable {
+        DdlTestTable {
+            name: "accounts".to_string(),
+            create_sql: "CREATE TABLE accounts (
+                id INT IDENTITY(1,1) PRIMARY KEY,
+                email NVARCHAR(100) NOT NULL UNIQUE,
+                username NVARCHAR(50) NOT NULL,
+                CONSTRAINT unique_username UNIQUE (username)
+            )"
+            .to_string(),
+        }
+    }
+
+    pub fn index_single_column() -> DdlTestIndex {
+        DdlTestIndex {
+            name: "idx_users_email".to_string(),
+            table: "users".to_string(),
+            create_sql: "CREATE INDEX idx_users_email ON users(email)".to_string(),
+        }
+    }
+
+    pub fn index_unique() -> DdlTestIndex {
+        DdlTestIndex {
+            name: "idx_users_username_unique".to_string(),
+            table: "users".to_string(),
+            create_sql: "CREATE UNIQUE INDEX idx_users_username_unique ON users(username)"
+                .to_string(),
+        }
+    }
+
+    pub fn index_composite() -> DdlTestIndex {
+        DdlTestIndex {
+            name: "idx_orders_user_status".to_string(),
+            table: "orders".to_string(),
+            create_sql: "CREATE INDEX idx_orders_user_status ON orders(user_id, status)"
+                .to_string(),
+        }
+    }
+
+    pub fn view_simple() -> DdlTestView {
+        DdlTestView {
+            name: "active_users".to_string(),
+            create_sql: "CREATE VIEW active_users AS
+                SELECT id, username, email
+                FROM users
+                WHERE created_at > DATEADD(DAY, -30, SYSUTCDATETIME())"
+                .to_string(),
+        }
+    }
+
+    pub fn alter_add_column() -> DdlTestScenario {
+        DdlTestScenario {
+            name: "add_column".to_string(),
+            setup_sql: vec![
+                "CREATE TABLE alter_test (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(50))"
+                    .to_string(),
+            ],
+            test_sql: "ALTER TABLE alter_test ADD age INT".to_string(),
+            cleanup_sql: vec!["DROP TABLE IF EXISTS alter_test".to_string()],
+        }
+    }
+
+    pub fn alter_drop_column() -> DdlTestScenario {
+        DdlTestScenario {
+            name: "drop_column".to_string(),
+            setup_sql: vec![
+                "CREATE TABLE alter_test (id INT IDENTITY(1,1) PRIMARY KEY, name NVARCHAR(50), age INT)"
+                    .to_string(),
+            ],
+            test_sql: "ALTER TABLE alter_test DROP COLUMN age".to_string(),
+            cleanup_sql: vec!["DROP TABLE IF EXISTS alter_test".to_string()],
+        }
+    }
+
+    // Note: no `alter_rename_column` fixture — SQL Server's rename path is
+    // `sp_rename` rather than a true `ALTER` statement, and the mssql driver
+    // declares `supports_rename_column: false` to reflect that.
+}
+
 pub struct SqliteFixtures;
 
 impl SqliteFixtures {

--- a/crates/dbflux_test_support/src/fake_driver.rs
+++ b/crates/dbflux_test_support/src/fake_driver.rs
@@ -243,6 +243,20 @@ impl DbDriver for FakeDriver {
                 user: get_optional_string(values, "user"),
                 request_timeout_seconds: None,
             },
+            DbKind::SqlServer => DbConfig::SqlServer {
+                use_uri: false,
+                uri: None,
+                host: get_string(values, "host", "localhost"),
+                port: get_u16(values, "port", 1433),
+                user: get_string(values, "user", "sa"),
+                database: get_optional_string(values, "database"),
+                instance: get_optional_string(values, "instance"),
+                ssl_mode: Some("on".to_string()),
+                trust_server_certificate: true,
+                ssl_root_cert_path: None,
+                ssh_tunnel: None,
+                ssh_tunnel_profile_id: None,
+            },
         };
 
         Ok(config)
@@ -348,6 +362,20 @@ impl DbDriver for FakeDriver {
                     "retention_policy".to_string(),
                     retention_policy.clone().unwrap_or_default(),
                 );
+            }
+            DbConfig::SqlServer {
+                host,
+                port,
+                user,
+                database,
+                instance,
+                ..
+            } => {
+                values.insert("host".to_string(), host.clone());
+                values.insert("port".to_string(), port.to_string());
+                values.insert("user".to_string(), user.clone());
+                values.insert("database".to_string(), database.clone().unwrap_or_default());
+                values.insert("instance".to_string(), instance.clone().unwrap_or_default());
             }
             DbConfig::External { values: vals, .. } => {
                 values.extend(vals.clone());
@@ -486,7 +514,9 @@ impl Connection for FakeConnection {
 
     fn schema_loading_strategy(&self) -> SchemaLoadingStrategy {
         match self.kind {
-            DbKind::MySQL | DbKind::MariaDB => SchemaLoadingStrategy::LazyPerDatabase,
+            DbKind::MySQL | DbKind::MariaDB | DbKind::SqlServer => {
+                SchemaLoadingStrategy::LazyPerDatabase
+            }
             DbKind::Postgres => SchemaLoadingStrategy::ConnectionPerDatabase,
             DbKind::SQLite | DbKind::MongoDB | DbKind::Redis => {
                 SchemaLoadingStrategy::SingleDatabase
@@ -519,6 +549,7 @@ fn active_database_from_profile(profile: &ConnectionProfile) -> Option<String> {
         DbConfig::DynamoDB { table, .. } => table.clone(),
         DbConfig::CloudWatchLogs { .. } => None,
         DbConfig::InfluxDB { default_bucket, .. } => default_bucket.clone(),
+        DbConfig::SqlServer { database, .. } => database.clone(),
         DbConfig::External { values, .. } => values.get("database").cloned(),
     }
 }
@@ -534,6 +565,8 @@ fn metadata_for_kind(kind: DbKind) -> &'static DriverMetadata {
         DbKind::DynamoDB => &FAKE_DYNAMODB_METADATA,
         DbKind::CloudWatchLogs => &FAKE_CLOUDWATCH_METADATA,
         DbKind::InfluxDB => &FAKE_INFLUXDB_METADATA,
+        // Tests treat SQL Server like a relational driver — reuse postgres metadata.
+        DbKind::SqlServer => &FAKE_POSTGRES_METADATA,
     }
 }
 
@@ -547,6 +580,7 @@ fn form_for_kind(kind: DbKind) -> &'static DriverFormDef {
         DbKind::DynamoDB => &DYNAMODB_FORM,
         DbKind::CloudWatchLogs => &CLOUDWATCH_FORM,
         DbKind::InfluxDB => &INFLUXDB_FORM,
+        DbKind::SqlServer => &dbflux_core::SQLSERVER_FORM,
     }
 }
 
@@ -1118,6 +1152,7 @@ mod tests {
                 DbKind::CloudWatchLogs,
                 SchemaLoadingStrategy::SingleDatabase,
             ),
+            (DbKind::SqlServer, SchemaLoadingStrategy::LazyPerDatabase),
         ];
 
         for (kind, expected_strategy) in cases {
@@ -1148,6 +1183,7 @@ mod tests {
                 DbKind::DynamoDB => DbConfig::default_dynamodb(),
                 DbKind::CloudWatchLogs => DbConfig::default_cloudwatch_logs(),
                 DbKind::InfluxDB => DbConfig::default_influxdb(),
+                DbKind::SqlServer => DbConfig::default_sqlserver(),
             };
 
             let profile = ConnectionProfile::new("fake", config);

--- a/crates/dbflux_ui/Cargo.toml
+++ b/crates/dbflux_ui/Cargo.toml
@@ -75,6 +75,10 @@ optional = true
 workspace = true
 optional = true
 
+[dependencies.dbflux_driver_mssql]
+workspace = true
+optional = true
+
 [dependencies.dbflux_aws]
 workspace = true
 optional = true
@@ -84,7 +88,7 @@ workspace = true
 optional = true
 
 [features]
-default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "lua", "aws", "mcp"]
+default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "mssql", "lua", "aws", "mcp"]
 sqlite = ["dbflux_driver_sqlite", "dbflux_mcp_server?/sqlite"]
 postgres = ["dbflux_driver_postgres", "dbflux_mcp_server?/postgres"]
 mysql = ["dbflux_driver_mysql", "dbflux_mcp_server?/mysql"]
@@ -92,6 +96,7 @@ mongodb = ["dbflux_driver_mongodb", "dbflux_mcp_server?/mongodb"]
 redis = ["dbflux_driver_redis", "dbflux_mcp_server?/redis"]
 dynamodb = ["dbflux_driver_dynamodb", "dbflux_mcp_server?/dynamodb"]
 cloudwatch = ["dbflux_driver_cloudwatch"]
+mssql = ["dbflux_driver_mssql"]
 lua = ["dbflux_lua", "dbflux_app/lua"]
 aws = ["dbflux_aws", "dbflux_ssm", "dbflux_mcp_server?/aws", "dbflux_app/aws"]
 mcp = ["dbflux_mcp", "dbflux_mcp_server", "dbflux_policy", "dbflux_approval", "dbflux_app/mcp"]

--- a/crates/dbflux_ui/src/ui/document/code/execution.rs
+++ b/crates/dbflux_ui/src/ui/document/code/execution.rs
@@ -1439,6 +1439,7 @@ impl CodeDocument {
                         next_page_token: None,
                         resolved_window: None,
                         metadata_extra: None,
+                        additional_results: Vec::new(),
                     })
                 }
                 Err(error) => Err(DbError::query_failed(error)),

--- a/crates/dbflux_ui/src/ui/overlays/modals/delete_connection.rs
+++ b/crates/dbflux_ui/src/ui/overlays/modals/delete_connection.rs
@@ -85,10 +85,18 @@ impl Render for ModalDeleteConnection {
                     .gap(Spacing::SM)
                     .child(Icon::new(AppIcon::TriangleAlert).size(px(16.0)).color(theme.danger))
                     .child(
-                        Text::body(
-                            "You're about to delete the following connection. This can't be undone.",
-                        )
-                        .into_any_element(),
+                        // flex_1 + min_w_0 lets the description wrap to the
+                        // modal's width instead of overflowing past the
+                        // card edge (same pattern as the toast/banner fix).
+                        div()
+                            .flex_1()
+                            .min_w_0()
+                            .child(
+                                Text::body(
+                                    "You're about to delete the following connection. This can't be undone.",
+                                )
+                                .into_any_element(),
+                            ),
                     ),
             )
             .child(

--- a/crates/dbflux_ui/src/ui/overlays/modals/shell.rs
+++ b/crates/dbflux_ui/src/ui/overlays/modals/shell.rs
@@ -154,15 +154,16 @@ impl RenderOnce for ModalShell {
 
         let close_for_overlay = close_handler.clone();
 
-        // Scrim / overlay backdrop.
+        // Scrim / overlay backdrop. Center the card on both axes so it
+        // sits in the middle of the viewport instead of anchored to the
+        // top (which made it feel off-screen on tall windows).
         div()
             .absolute()
             .inset_0()
             .bg(overlay_bg(theme))
             .flex()
             .justify_center()
-            .items_start()
-            .pt(px(80.0))
+            .items_center()
             .on_mouse_down(MouseButton::Left, move |_, window, cx| {
                 if let Some(ref handler) = close_for_overlay {
                     (handler)(window, cx);

--- a/crates/dbflux_ui/src/ui/views/sidebar/deletion.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/deletion.rs
@@ -99,6 +99,8 @@ impl Sidebar {
                 let has_open_documents = state.connections().contains_key(&profile_id);
 
                 // Store the pending delete so Confirm can execute it.
+                // The dedicated ModalDeleteConnection owns the UI, so flag
+                // this as delegated to suppress the generic inline popup.
                 self.delete_confirm_modal = Some(DeleteConfirmState {
                     item_id: item_id.to_string(),
                     item_name: connection_name.clone(),
@@ -106,8 +108,14 @@ impl Sidebar {
                     object_type: None,
                     is_ddl: false,
                     multi_item_ids: Vec::new(),
+                    delegated_to_modal: true,
                 });
 
+                log::debug!(
+                    "Profile delete requested for {} (profile_id={profile_id}, open_docs={has_open_documents}); \
+                     stored state, emitting RequestDeleteConnection",
+                    connection_name,
+                );
                 cx.emit(SidebarEvent::RequestDeleteConnection {
                     connection_name,
                     profile_id,
@@ -126,6 +134,7 @@ impl Sidebar {
                     object_type: None,
                     is_ddl: false,
                     multi_item_ids: Vec::new(),
+                    delegated_to_modal: false,
                 });
                 cx.notify();
             }
@@ -142,6 +151,7 @@ impl Sidebar {
                     object_type: None,
                     is_ddl: false,
                     multi_item_ids: Vec::new(),
+                    delegated_to_modal: false,
                 });
                 cx.notify();
             }
@@ -158,6 +168,7 @@ impl Sidebar {
                     object_type: None,
                     is_ddl: false,
                     multi_item_ids: Vec::new(),
+                    delegated_to_modal: false,
                 });
                 cx.notify();
             }
@@ -184,6 +195,7 @@ impl Sidebar {
             object_type: None,
             is_ddl: false,
             multi_item_ids: ids,
+            delegated_to_modal: false,
         });
         cx.notify();
     }
@@ -217,6 +229,8 @@ impl Sidebar {
                 let table_name = name.clone();
 
                 // Also store an inline state so `confirm_modal_delete` can execute the drop.
+                // ModalDropTable owns the UI, so flag this as delegated to
+                // suppress the generic inline popup.
                 self.delete_confirm_modal = Some(DeleteConfirmState {
                     item_id: item_id.to_string(),
                     item_name: table_name.clone(),
@@ -224,6 +238,7 @@ impl Sidebar {
                     object_type: Some(object_type.to_string()),
                     is_ddl: true,
                     multi_item_ids: Vec::new(),
+                    delegated_to_modal: true,
                 });
 
                 cx.emit(SidebarEvent::RequestDropTable {
@@ -246,6 +261,7 @@ impl Sidebar {
                     object_type: Some(object_type.to_string()),
                     is_ddl: true,
                     multi_item_ids: Vec::new(),
+                    delegated_to_modal: false,
                 });
                 cx.notify();
             }
@@ -256,8 +272,21 @@ impl Sidebar {
 
     pub fn confirm_modal_delete(&mut self, cx: &mut Context<Self>) {
         let Some(modal) = self.delete_confirm_modal.take() else {
+            log::warn!(
+                "confirm_modal_delete called but delete_confirm_modal was None — \
+                 state was cleared before the dedicated overlay confirmed",
+            );
             return;
         };
+
+        log::debug!(
+            "confirm_modal_delete: item_id={}, name={}, is_ddl={}, multi={}, delegated={}",
+            modal.item_id,
+            modal.item_name,
+            modal.is_ddl,
+            modal.multi_item_ids.len(),
+            modal.delegated_to_modal,
+        );
 
         if !modal.multi_item_ids.is_empty() {
             for id in &modal.multi_item_ids {
@@ -291,17 +320,23 @@ impl Sidebar {
             .map(|m| (m.item_name.as_str(), m.is_folder))
     }
 
-    /// Returns full delete modal state for DDL-aware rendering.
+    /// Returns full delete modal state for DDL-aware rendering of the
+    /// generic inline confirm popup. Returns `None` when a dedicated
+    /// overlay (ModalDeleteConnection, ModalDropTable) is taking over
+    /// the UI, so the renderer skips drawing a second confirm dialog
+    /// on top of it.
     pub fn delete_modal_state(&self) -> Option<DeleteModalState<'_>> {
-        self.delete_confirm_modal
-            .as_ref()
-            .map(|m| DeleteModalState {
-                item_name: &m.item_name,
-                is_folder: m.is_folder,
-                is_ddl: m.is_ddl,
-                object_type: m.object_type.as_deref(),
-                multi_count: (!m.multi_item_ids.is_empty()).then_some(m.multi_item_ids.len()),
-            })
+        let m = self.delete_confirm_modal.as_ref()?;
+        if m.delegated_to_modal {
+            return None;
+        }
+        Some(DeleteModalState {
+            item_name: &m.item_name,
+            is_folder: m.is_folder,
+            is_ddl: m.is_ddl,
+            object_type: m.object_type.as_deref(),
+            multi_count: (!m.multi_item_ids.is_empty()).then_some(m.multi_item_ids.len()),
+        })
     }
 
     pub(super) fn execute_delete(&mut self, item_id: &str, cx: &mut Context<Self>) {

--- a/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/mod.rs
@@ -696,6 +696,12 @@ struct DeleteConfirmState {
     /// (each routed through `execute_delete`). `item_id`/`item_name` describe
     /// the anchor item used as the modal's primary subject for messaging.
     multi_item_ids: Vec<String>,
+    /// When true, a dedicated overlay (e.g. `ModalDeleteConnection` for
+    /// profiles, `ModalDropTable` for tables) owns the user-facing UI;
+    /// the sidebar still stores this state so `confirm_modal_delete` knows
+    /// what to delete when that overlay emits `Confirmed`, but the generic
+    /// inline confirm popup must NOT render alongside it.
+    delegated_to_modal: bool,
 }
 
 /// Borrowed snapshot of the delete confirmation modal state, used by the

--- a/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
@@ -929,7 +929,10 @@ impl Sidebar {
             if !types.is_empty() {
                 let type_children: Vec<TreeItem> = types
                     .iter()
-                    .map(|t| Self::build_custom_type_item(profile_id, schema_name, t))
+                    .map(|t| {
+                        let item_schema = t.schema.as_deref().unwrap_or(schema_name);
+                        Self::build_custom_type_item(profile_id, item_schema, t)
+                    })
                     .collect();
 
                 content.push(
@@ -1434,7 +1437,8 @@ impl Sidebar {
 mod tests {
     use super::Sidebar;
     use dbflux_core::{
-        CollectionChildInfo, CollectionChildrenCache, CollectionPresentation, FieldInfo, TableInfo,
+        CollectionChildInfo, CollectionChildrenCache, CollectionPresentation, CustomTypeInfo,
+        FieldInfo, TableInfo,
     };
     use std::collections::HashMap;
     use uuid::Uuid;
@@ -1616,7 +1620,7 @@ mod tests {
 
     #[test]
     fn build_db_schema_content_uses_per_table_schema_when_present() {
-        use dbflux_core::{DbSchemaInfo, SchemaNodeId, SchemaNodeKind, ViewInfo};
+        use dbflux_core::{CustomTypeKind, DbSchemaInfo, SchemaNodeId, SchemaNodeKind, ViewInfo};
 
         let profile_id = Uuid::new_v4();
         let db_schema = DbSchemaInfo {
@@ -1660,7 +1664,22 @@ mod tests {
                 name: "active_customers".to_string(),
                 schema: Some("sales".to_string()),
             }],
-            custom_types: None,
+            custom_types: Some(vec![
+                CustomTypeInfo {
+                    name: "address".to_string(),
+                    schema: Some("sales".to_string()),
+                    kind: CustomTypeKind::Composite,
+                    enum_values: None,
+                    base_type: None,
+                },
+                CustomTypeInfo {
+                    name: "tier".to_string(),
+                    schema: None,
+                    kind: CustomTypeKind::Domain,
+                    enum_values: None,
+                    base_type: Some("varchar(32)".to_string()),
+                },
+            ]),
         };
 
         let content = Sidebar::build_db_schema_content(
@@ -1707,6 +1726,25 @@ mod tests {
                 assert_eq!(name, "active_customers");
             }
             _ => panic!("expected View variant"),
+        }
+
+        let types_folder = content
+            .iter()
+            .find(|item| item.label.as_ref().starts_with("Data Types"))
+            .expect("Data Types folder present");
+        assert_eq!(types_folder.children.len(), 2);
+
+        let expected_type_schemas = ["sales", "dbflux_test"];
+        for (child, want) in types_folder
+            .children
+            .iter()
+            .zip(expected_type_schemas.iter())
+        {
+            let id: SchemaNodeId = child.id.as_ref().parse().expect("type id parses");
+            match id {
+                SchemaNodeId::CustomType { schema, .. } => assert_eq!(schema, *want),
+                _ => panic!("expected CustomType variant"),
+            }
         }
     }
 }

--- a/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
+++ b/crates/dbflux_ui/src/ui/views/sidebar/tree_builder.rs
@@ -851,10 +851,11 @@ impl Sidebar {
                 .tables
                 .iter()
                 .map(|table| {
+                    let item_schema = table.schema.as_deref().unwrap_or(schema_name);
                     Self::build_table_item(
                         profile_id,
                         target_database,
-                        schema_name,
+                        item_schema,
                         table,
                         table_details,
                         dependents_cache,
@@ -881,11 +882,12 @@ impl Sidebar {
                 .views
                 .iter()
                 .map(|view| {
+                    let item_schema = view.schema.as_deref().unwrap_or(schema_name);
                     TreeItem::new(
                         SchemaNodeId::View {
                             profile_id,
                             database: target_database.map(str::to_string),
-                            schema: schema_name.to_string(),
+                            schema: item_schema.to_string(),
                             name: view.name.clone(),
                         }
                         .to_string(),
@@ -1610,6 +1612,102 @@ mod tests {
 
         let result = Sidebar::build_time_series_db_content(profile_id, "empty_bucket", &schema);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn build_db_schema_content_uses_per_table_schema_when_present() {
+        use dbflux_core::{DbSchemaInfo, SchemaNodeId, SchemaNodeKind, ViewInfo};
+
+        let profile_id = Uuid::new_v4();
+        let db_schema = DbSchemaInfo {
+            name: "dbflux_test".to_string(),
+            tables: vec![
+                TableInfo {
+                    name: "customers".to_string(),
+                    schema: Some("sales".to_string()),
+                    columns: None,
+                    indexes: None,
+                    foreign_keys: None,
+                    constraints: None,
+                    sample_fields: None,
+                    presentation: CollectionPresentation::DataGrid,
+                    child_items: None,
+                },
+                TableInfo {
+                    name: "employees".to_string(),
+                    schema: Some("hr".to_string()),
+                    columns: None,
+                    indexes: None,
+                    foreign_keys: None,
+                    constraints: None,
+                    sample_fields: None,
+                    presentation: CollectionPresentation::DataGrid,
+                    child_items: None,
+                },
+                TableInfo {
+                    name: "fallback".to_string(),
+                    schema: None,
+                    columns: None,
+                    indexes: None,
+                    foreign_keys: None,
+                    constraints: None,
+                    sample_fields: None,
+                    presentation: CollectionPresentation::DataGrid,
+                    child_items: None,
+                },
+            ],
+            views: vec![ViewInfo {
+                name: "active_customers".to_string(),
+                schema: Some("sales".to_string()),
+            }],
+            custom_types: None,
+        };
+
+        let content = Sidebar::build_db_schema_content(
+            profile_id,
+            "dbflux_test",
+            Some("dbflux_test"),
+            &db_schema,
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+            &Default::default(),
+        );
+
+        let tables_folder = content
+            .iter()
+            .find(|item| item.label.as_ref().starts_with("Tables"))
+            .expect("Tables folder present");
+        assert_eq!(tables_folder.children.len(), 3);
+
+        let expected_schemas = ["sales", "hr", "dbflux_test"];
+        for (child, want) in tables_folder.children.iter().zip(expected_schemas.iter()) {
+            let id: SchemaNodeId = child.id.as_ref().parse().expect("table id parses");
+            assert_eq!(id.kind(), SchemaNodeKind::Table);
+            match id {
+                SchemaNodeId::Table { schema, .. } => assert_eq!(schema, *want),
+                _ => unreachable!(),
+            }
+        }
+
+        let views_folder = content
+            .iter()
+            .find(|item| item.label.as_ref().starts_with("Views"))
+            .expect("Views folder present");
+        assert_eq!(views_folder.children.len(), 1);
+        let view_id: SchemaNodeId = views_folder.children[0]
+            .id
+            .as_ref()
+            .parse()
+            .expect("view id parses");
+        match view_id {
+            SchemaNodeId::View { schema, name, .. } => {
+                assert_eq!(schema, "sales");
+                assert_eq!(name, "active_customers");
+            }
+            _ => panic!("expected View variant"),
+        }
     }
 }
 

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -346,6 +346,7 @@ impl Workspace {
             &modal_delete_connection,
             |this, _, outcome: &crate::ui::overlays::modals::DeleteConnectionOutcome, cx| {
                 use crate::ui::overlays::modals::DeleteConnectionOutcome;
+                log::debug!("ModalDeleteConnection outcome received: {:?}", outcome);
                 if matches!(outcome, DeleteConnectionOutcome::Confirmed) {
                     this.sidebar.update(cx, |sidebar, cx| {
                         sidebar.confirm_modal_delete(cx);

--- a/crates/dbflux_ui/src/ui/windows/connection_manager/form.rs
+++ b/crates/dbflux_ui/src/ui/windows/connection_manager/form.rs
@@ -308,7 +308,8 @@ impl ConnectionManagerWindow {
                 DbConfig::Postgres { ssl_mode, .. }
                 | DbConfig::MySQL { ssl_mode, .. }
                 | DbConfig::MongoDB { ssl_mode, .. }
-                | DbConfig::Redis { ssl_mode, .. } => {
+                | DbConfig::Redis { ssl_mode, .. }
+                | DbConfig::SqlServer { ssl_mode, .. } => {
                     *ssl_mode = Some(selected);
                 }
                 _ => {}
@@ -385,6 +386,11 @@ impl ConnectionManagerWindow {
                 ..
             }
             | DbConfig::Redis {
+                ssh_tunnel: tunnel,
+                ssh_tunnel_profile_id: profile_id,
+                ..
+            }
+            | DbConfig::SqlServer {
                 ssh_tunnel: tunnel,
                 ssh_tunnel_profile_id: profile_id,
                 ..
@@ -680,18 +686,22 @@ impl ConnectionManagerWindow {
             })
         } else {
             let password = self.input_password.read(cx).value().to_string();
-            let _password_opt = if password.is_empty() {
+            let password_opt = if password.is_empty() {
                 None
             } else {
                 Some(SecretString::from(password))
             };
 
-            let _ssh_secret = self.get_ssh_secret(cx).map(SecretString::from);
+            let ssh_secret = self.get_ssh_secret(cx).map(SecretString::from);
 
             cx.background_executor().spawn(async move {
                 let start = std::time::Instant::now();
                 let rich = driver
-                    .test_connection_rich(&profile)
+                    .test_connection_rich_with_secrets(
+                        &profile,
+                        password_opt.as_ref(),
+                        ssh_secret.as_ref(),
+                    )
                     .map(|mut result| {
                         // Fill in RTT from wall time if the driver didn't supply it.
                         if result.rtt_ms.is_none() {

--- a/crates/dbflux_ui/src/ui/windows/connection_manager/mod.rs
+++ b/crates/dbflux_ui/src/ui/windows/connection_manager/mod.rs
@@ -2139,6 +2139,21 @@ impl ConnectionManagerWindow {
         self.syncing_uri = true;
 
         for (field_id, value) in &parsed {
+            // `password` lives on its own InputState outside the
+            // driver_inputs map (so it can flow through the secret
+            // pipeline), so route it explicitly. Without this branch the
+            // password silently disappeared when toggling URI → form,
+            // leaving users to save an empty/stale value.
+            if field_id == "password" {
+                let current = self.input_password.read(cx).value().to_string();
+                if current != *value {
+                    self.input_password.update(cx, |state, cx| {
+                        state.set_value(value, window, cx);
+                    });
+                }
+                continue;
+            }
+
             if let Some(input) = self.driver_inputs.get(field_id.as_str()) {
                 let current = input.read(cx).value().to_string();
                 if current != *value {

--- a/tests/driver-live/README.md
+++ b/tests/driver-live/README.md
@@ -1,17 +1,44 @@
 # Driver live integration tests
 
-Driver integration tests now use `testcontainers` for PostgreSQL, MySQL, MongoDB, and Redis.
-Each test starts an isolated container with a dynamic host port and tears it down automatically.
-SQLite integration uses a temporary local file.
+Driver integration tests use `testcontainers` for PostgreSQL, MySQL, MongoDB,
+Redis, DynamoDB Local, and SQL Server. Each test starts an isolated container
+with a dynamic host port and tears it down automatically. SQLite integration
+uses a temporary local file.
 
 ## Run live driver tests
 
 ```bash
 cargo test -p dbflux_driver_postgres --test live_integration -- --ignored
-cargo test -p dbflux_driver_mysql --test live_integration -- --ignored
-cargo test -p dbflux_driver_mongodb --test live_integration -- --ignored
-cargo test -p dbflux_driver_redis --test live_integration -- --ignored
-cargo test -p dbflux_driver_sqlite --test live_integration
+cargo test -p dbflux_driver_mysql    --test live_integration -- --ignored
+cargo test -p dbflux_driver_mongodb  --test live_integration -- --ignored
+cargo test -p dbflux_driver_redis    --test live_integration -- --ignored
+cargo test -p dbflux_driver_dynamodb --test live_integration -- --ignored
+cargo test -p dbflux_driver_mssql    --test live_integration -- --ignored
+cargo test -p dbflux_driver_sqlite   --test live_integration
 ```
 
-The ignored tests require a working Docker daemon because `testcontainers` talks to Docker directly.
+The ignored tests require a working Docker daemon because `testcontainers`
+talks to Docker directly.
+
+## SQL Server specifics
+
+The MSSQL suite pulls `mcr.microsoft.com/mssql/server:2022-latest` (amd64
+only — emulate or substitute Azure SQL Edge on arm64). Each test launches a
+fresh container, creates a `dbflux_test` database, and runs against it.
+
+Coverage includes:
+
+- URI-mode connect (`use_uri = true`) for the bulk of the suite.
+- Form-mode connect (`use_uri = false`, host/port/user + secret-fed password)
+  in `mssql_form_mode_connect_query_and_select_db`.
+- SSL modes `off` and `on` (with `trust_server_certificate = true`, since the
+  stock image uses a self-signed cert) in `mssql_ssl_mode_off_connects` and
+  `mssql_ssl_mode_on_trusts_self_signed`.
+- CRUD via `OUTPUT INSERTED.*` / `OUTPUT DELETED.*`, schema introspection,
+  `OFFSET ... FETCH NEXT` paging, cancellation via side-channel `KILL`.
+
+`ssl_mode = "required"` and named-instance routing are not covered by the live
+suite: the test image ships a self-signed cert (so strict-validation paths
+would fail by design) and only the default `MSSQLSERVER` instance is exposed
+(no SQL Browser sidecar). Both paths are covered by unit tests in
+`crates/dbflux_driver_mssql/src/driver.rs::tests`.


### PR DESCRIPTION
# Summary

Adds first-class Microsoft SQL Server support through a new `dbflux_driver_mssql` crate built on top of `tiberius` (TDS), integrated across core, storage, IPC, MCP, query execution, schema introspection, and the desktop UI.

This PR also includes several related persistence and UI fixes that were originally planned as follow-up PRs, but were squash-merged into this branch.

## What does this resolve?

* Resolves #44

## How was this solved?

### MSSQL driver integration

Implemented a new `dbflux_driver_mssql` crate and wired it into:

* `DbKind::SqlServer`
* `DbConfig::SqlServer`
* connection forms and URI parsing
* app state registration
* storage persistence
* IPC and MCP layers
* query execution and schema introspection
* automated test infrastructure

The implementation integrates cleanly with the existing query/chart engine and follows the same driver architecture as the existing SQL backends.

### Connection and TLS support

Added support for:

* TLS encryption modes (`off`, `on`, `required`)
* `trust_server_certificate`
* SSH tunneling
* SQL Server named instances through SQL Browser resolution
* SSMS-style `host\\instance` URI parsing
* `?instance=` URI support

Named instances are intentionally limited to direct connections because SQL Browser relies on UDP 1434, which cannot be forwarded through `libssh2`.

### Query execution and schema support

Implemented:

* CRUD support via `OUTPUT INSERTED.*` / `OUTPUT DELETED.*`
* `EXPLAIN` support using `SET SHOWPLAN_XML ON`
* schema introspection through `sys.*` catalog views
* cancellation via `KILL <spid>` side-channel connections
* SQL Server error-number mapping into normalized driver errors

### Multi-result-set support

Extended the core `QueryResult` model with:

```rust
additional_results: Vec<QueryResult>
```

The MSSQL driver preserves the existing “last statement wins” UX by returning the final non-empty result set as primary while attaching earlier results in execution order.

### T-SQL editor diagnostics

Added `TSqlLanguageService` to suppress false editor diagnostics for valid T-SQL constructs such as:

* `SELECT TOP`
* `OUTPUT INSERTED.*`
* `MERGE`
* `CROSS APPLY`
* `WITH (NOLOCK)`

Server-side execution errors still surface normally.

### Persistence and connection-manager fixes

This PR also includes persistence fixes that were originally planned as follow-up work:

* persisted SQL Server SSL mode selection
* preserved percent-encoded passwords during URI ↔ form round-trips
* added `DbDriver::test_connection_rich_with_secrets`
* added storage columns:

  * `mssql_instance`
  * `mssql_trust_server_certificate`
* fixed stale profile deletion in `app_state::remove_profile`
* made add/update mutations explicitly persist through `save_profiles`

### UI fixes

Improved wrapping and modal behavior for long error states:

* toast wrapping

Before:
<img width="1366" height="157" alt="bug_notif_nowrap" src="https://github.com/user-attachments/assets/f82fe442-8314-40dd-90b1-57ef49b2fa76" />

After:
<img width="787" height="210" alt="fixed_notif_nowrap" src="https://github.com/user-attachments/assets/142030cc-05a3-4baa-9d36-0382d253d4b1" />

* banner wrapping

Before:
<img width="609" height="584" alt="bug_notif_nowrap_form" src="https://github.com/user-attachments/assets/26c6701c-145d-4924-a9ec-3929c974dca5" />

After:
<img width="600" height="576" alt="fixed_notif_nowrap_form" src="https://github.com/user-attachments/assets/6129985a-9d71-4984-b1f6-a7c688f6c736" />

* delete modal wrapping
* duplicate delete modal suppression

Before:
<img width="1366" height="551" alt="bug_popup_delete" src="https://github.com/user-attachments/assets/48385976-cf7e-4c85-bed3-9e145a9ac4cb" />

After:
<img width="1366" height="725" alt="fixed_popup_delete" src="https://github.com/user-attachments/assets/b4fc724c-d664-4373-9af7-e3c0a3b78e06" />

The sidebar still tracks pending delete state, but delegated modal flows now suppress the inline popup correctly.

## Validation

### Automated coverage

* 20 MSSQL driver unit tests
* 27 ignored Docker-backed integration tests

Coverage includes:

* connection handling
* schema introspection
* CRUD flows
* `OUTPUT` handling
* query cancellation
* DDL operations
* EXPLAIN behavior

### Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [x] Windows
- [ ] X11
- [ ] Wayland

### Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I applied the appropriate labels

## Notes

This PR subsumes the originally planned follow-up work for:

* connection persistence fixes
* SQL Server config persistence
* delete modal duplication fixes
* long-message UI wrapping fixes

Those changes are already included in this branch after the final squash merge.
