### PR TITLE
fix(data-grid): make column name primary, clean MySQL/DynamoDB type labels

### DIFF
--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -2969,6 +2969,8 @@ fn items_to_query_result(
 
     if items.is_empty() {
         // Emit PK columns even with no rows so UI can show CRUD actions.
+        // With no items there's nothing to infer the attribute type from, so
+        // leave `type_name` empty — the UI hides the chip when it's blank.
         let columns = field_names
             .iter()
             .map(|name| {
@@ -2976,7 +2978,7 @@ fn items_to_query_result(
                     || key_schema.sort_key.as_deref() == Some(name.as_str());
                 ColumnMeta {
                     name: name.clone(),
-                    type_name: "DynamoDB".to_string(),
+                    type_name: String::new(),
                     kind: ColumnKind::Unknown,
                     nullable: true,
                     is_primary_key,
@@ -2996,7 +2998,7 @@ fn items_to_query_result(
 
             ColumnMeta {
                 name: name.clone(),
-                type_name: "DynamoDB".to_string(),
+                type_name: infer_field_type_label(items, name),
                 kind: ColumnKind::Unknown,
                 nullable: true,
                 is_primary_key,
@@ -3027,6 +3029,54 @@ fn crud_result_to_query_result(result: dbflux_core::CrudResult) -> QueryResult {
     let mut query_result = QueryResult::json(Vec::new(), Vec::new(), std::time::Duration::ZERO);
     query_result.affected_rows = Some(result.affected_rows);
     query_result
+}
+
+/// Map a DynamoDB `AttributeValue` to a short, user-facing type label
+/// (`String`, `Number`, `Boolean`, `Binary`, `List`, `Map`, `String Set`,
+/// `Number Set`, `Binary Set`, `Null`). Used for column headers when the
+/// driver has no static schema and must infer types from sampled items.
+fn attribute_value_type_label(value: &AttributeValue) -> &'static str {
+    if value.as_s().is_ok() {
+        "String"
+    } else if value.as_n().is_ok() {
+        "Number"
+    } else if value.as_bool().is_ok() {
+        "Boolean"
+    } else if value.as_b().is_ok() {
+        "Binary"
+    } else if value.as_ss().is_ok() {
+        "String Set"
+    } else if value.as_ns().is_ok() {
+        "Number Set"
+    } else if value.as_bs().is_ok() {
+        "Binary Set"
+    } else if value.as_l().is_ok() {
+        "List"
+    } else if value.as_m().is_ok() {
+        "Map"
+    } else if value.as_null().is_ok() {
+        "Null"
+    } else {
+        ""
+    }
+}
+
+/// Infer the canonical DynamoDB type label for `field_name` from the first
+/// item in `items` that contains a non-null value for it. Returns an empty
+/// string if no item carries the field with a typed value.
+fn infer_field_type_label(
+    items: &[std::collections::HashMap<String, AttributeValue>],
+    field_name: &str,
+) -> String {
+    for item in items {
+        if let Some(attr) = item.get(field_name) {
+            let label = attribute_value_type_label(attr);
+            if !label.is_empty() {
+                return label.to_string();
+            }
+        }
+    }
+    String::new()
 }
 
 fn attribute_value_to_value(value: &AttributeValue) -> Value {

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -769,6 +769,109 @@ struct ExtractedMysqlConfig {
     ssh_tunnel: Option<SshTunnelConfig>,
 }
 
+/// Map a MySQL column to a canonical SQL type label (e.g. `VARCHAR`,
+/// `BIGINT UNSIGNED`, `DECIMAL(10,2)`, `DATETIME`, `ENUM`).
+///
+/// The raw MySQL protocol type enum (`MYSQL_TYPE_VAR_STRING`, …) is not a
+/// user-facing label; mapping it here keeps driver internals out of the UI.
+fn mysql_type_to_sql_label(col: &mysql::Column) -> String {
+    use mysql::consts::{ColumnFlags, ColumnType as CT};
+
+    let col_type = col.column_type();
+    let flags = col.flags();
+    let is_unsigned = flags.contains(ColumnFlags::UNSIGNED_FLAG);
+    let is_binary = flags.contains(ColumnFlags::BINARY_FLAG);
+    let is_enum = flags.contains(ColumnFlags::ENUM_FLAG);
+    let is_set = flags.contains(ColumnFlags::SET_FLAG);
+
+    let unsigned_suffix = if is_unsigned { " UNSIGNED" } else { "" };
+
+    match col_type {
+        CT::MYSQL_TYPE_TINY => {
+            // TINYINT(1) is MySQL's idiomatic boolean; preserve the display width
+            // so users can tell it apart from a regular TINYINT.
+            if col.column_length() == 1 && !is_unsigned {
+                "TINYINT(1)".to_string()
+            } else {
+                format!("TINYINT{}", unsigned_suffix)
+            }
+        }
+        CT::MYSQL_TYPE_SHORT => format!("SMALLINT{}", unsigned_suffix),
+        CT::MYSQL_TYPE_INT24 => format!("MEDIUMINT{}", unsigned_suffix),
+        CT::MYSQL_TYPE_LONG => format!("INT{}", unsigned_suffix),
+        CT::MYSQL_TYPE_LONGLONG => format!("BIGINT{}", unsigned_suffix),
+
+        CT::MYSQL_TYPE_FLOAT => "FLOAT".to_string(),
+        CT::MYSQL_TYPE_DOUBLE => "DOUBLE".to_string(),
+
+        CT::MYSQL_TYPE_DECIMAL | CT::MYSQL_TYPE_NEWDECIMAL => {
+            let scale = col.decimals() as u32;
+            // column_length encodes the textual width including the sign and the
+            // decimal point — subtract them to recover the actual precision.
+            let raw_len = col.column_length();
+            let overhead = if scale > 0 { 2 } else { 1 };
+            let precision = raw_len.saturating_sub(overhead);
+            if precision > 0 {
+                format!("DECIMAL({},{})", precision, scale)
+            } else {
+                "DECIMAL".to_string()
+            }
+        }
+
+        CT::MYSQL_TYPE_DATE => "DATE".to_string(),
+        CT::MYSQL_TYPE_TIME | CT::MYSQL_TYPE_TIME2 => "TIME".to_string(),
+        CT::MYSQL_TYPE_DATETIME | CT::MYSQL_TYPE_DATETIME2 => "DATETIME".to_string(),
+        CT::MYSQL_TYPE_TIMESTAMP | CT::MYSQL_TYPE_TIMESTAMP2 => "TIMESTAMP".to_string(),
+        CT::MYSQL_TYPE_YEAR => "YEAR".to_string(),
+
+        CT::MYSQL_TYPE_BIT => "BIT".to_string(),
+        CT::MYSQL_TYPE_JSON => "JSON".to_string(),
+        CT::MYSQL_TYPE_GEOMETRY => "GEOMETRY".to_string(),
+        CT::MYSQL_TYPE_NULL => "NULL".to_string(),
+        CT::MYSQL_TYPE_ENUM => "ENUM".to_string(),
+        CT::MYSQL_TYPE_SET => "SET".to_string(),
+
+        CT::MYSQL_TYPE_VARCHAR | CT::MYSQL_TYPE_VAR_STRING => {
+            if is_enum {
+                "ENUM".to_string()
+            } else if is_set {
+                "SET".to_string()
+            } else if is_binary {
+                "VARBINARY".to_string()
+            } else {
+                "VARCHAR".to_string()
+            }
+        }
+        CT::MYSQL_TYPE_STRING => {
+            if is_enum {
+                "ENUM".to_string()
+            } else if is_set {
+                "SET".to_string()
+            } else if is_binary {
+                "BINARY".to_string()
+            } else {
+                "CHAR".to_string()
+            }
+        }
+
+        // BLOB family: the protocol uses one enum per size class for both the
+        // binary BLOB types and their textual counterparts. The BINARY_FLAG bit
+        // disambiguates them.
+        CT::MYSQL_TYPE_TINY_BLOB => {
+            if is_binary { "TINYBLOB" } else { "TINYTEXT" }.to_string()
+        }
+        CT::MYSQL_TYPE_MEDIUM_BLOB => {
+            if is_binary { "MEDIUMBLOB" } else { "MEDIUMTEXT" }.to_string()
+        }
+        CT::MYSQL_TYPE_LONG_BLOB => {
+            if is_binary { "LONGBLOB" } else { "LONGTEXT" }.to_string()
+        }
+        CT::MYSQL_TYPE_BLOB => if is_binary { "BLOB" } else { "TEXT" }.to_string(),
+
+        _ => "UNKNOWN".to_string(),
+    }
+}
+
 /// Map a MySQL column type to a semantic `ColumnKind`.
 fn mysql_type_to_kind(col_type: mysql::consts::ColumnType) -> ColumnKind {
     use mysql::consts::ColumnType as CT;
@@ -1596,7 +1699,7 @@ impl Connection for MysqlConnection {
             .iter()
             .map(|col| ColumnMeta {
                 name: col.name_str().to_string(),
-                type_name: format!("{:?}", col.column_type()),
+                type_name: mysql_type_to_sql_label(col),
                 kind: mysql_type_to_kind(col.column_type()),
                 nullable: true,
                 is_primary_key: false,

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -857,15 +857,14 @@ fn mysql_type_to_sql_label(col: &mysql::Column) -> String {
         // BLOB family: the protocol uses one enum per size class for both the
         // binary BLOB types and their textual counterparts. The BINARY_FLAG bit
         // disambiguates them.
-        CT::MYSQL_TYPE_TINY_BLOB => {
-            if is_binary { "TINYBLOB" } else { "TINYTEXT" }.to_string()
+        CT::MYSQL_TYPE_TINY_BLOB => if is_binary { "TINYBLOB" } else { "TINYTEXT" }.to_string(),
+        CT::MYSQL_TYPE_MEDIUM_BLOB => if is_binary {
+            "MEDIUMBLOB"
+        } else {
+            "MEDIUMTEXT"
         }
-        CT::MYSQL_TYPE_MEDIUM_BLOB => {
-            if is_binary { "MEDIUMBLOB" } else { "MEDIUMTEXT" }.to_string()
-        }
-        CT::MYSQL_TYPE_LONG_BLOB => {
-            if is_binary { "LONGBLOB" } else { "LONGTEXT" }.to_string()
-        }
+        .to_string(),
+        CT::MYSQL_TYPE_LONG_BLOB => if is_binary { "LONGBLOB" } else { "LONGTEXT" }.to_string(),
         CT::MYSQL_TYPE_BLOB => if is_binary { "BLOB" } else { "TEXT" }.to_string(),
 
         _ => "UNKNOWN".to_string(),

--- a/crates/dbflux_ui/src/ui/components/data_table/state.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/state.rs
@@ -11,7 +11,7 @@ use super::clipboard;
 use super::events::{DataTableEvent, Direction, Edge, SortState};
 use super::model::{EditBuffer, TableModel};
 use super::selection::{CellCoord, SelectionState};
-use super::theme::{DEFAULT_COLUMN_WIDTH, SCROLLBAR_WIDTH};
+use super::theme::{DEFAULT_COLUMN_WIDTH, MIN_COLUMN_WIDTH, SCROLLBAR_WIDTH};
 use crate::ui::components::dropdown::{
     Dropdown, DropdownDismissed, DropdownItem, DropdownSelectionChanged,
 };
@@ -85,7 +85,16 @@ impl DataTableState {
     pub fn new(model: Arc<TableModel>, cx: &mut Context<Self>) -> Self {
         let col_count = model.col_count();
         let row_count = model.row_count();
-        let column_widths = vec![DEFAULT_COLUMN_WIDTH; col_count];
+        let column_widths: Vec<f32> = (0..col_count)
+            .map(|ix| {
+                let name_len = model
+                    .columns
+                    .get(ix)
+                    .map(|c| c.title.chars().count())
+                    .unwrap_or(0);
+                Self::initial_column_width(name_len)
+            })
+            .collect();
         let column_offsets = Self::calculate_offsets(&column_widths);
 
         let mut edit_buffer = EditBuffer::new();
@@ -112,6 +121,18 @@ impl DataTableState {
             is_insertable: false,
             enum_options: std::collections::HashMap::new(),
         }
+    }
+
+    /// Compute the initial width for a column so the header name has room to render
+    /// without being truncated. The estimate uses ~7.5px per character for the
+    /// medium-weight 13px header font, plus padding for the cell, the sort indicator,
+    /// and a small buffer for the type chip / badges. Clamped to MIN_COLUMN_WIDTH.
+    fn initial_column_width(name_chars: usize) -> f32 {
+        const CHAR_WIDTH_PX: f32 = 7.5;
+        const HEADER_FIXED_OVERHEAD_PX: f32 = 56.0;
+
+        let name_width = name_chars as f32 * CHAR_WIDTH_PX + HEADER_FIXED_OVERHEAD_PX;
+        name_width.max(DEFAULT_COLUMN_WIDTH).max(MIN_COLUMN_WIDTH)
     }
 
     fn calculate_offsets(widths: &[f32]) -> Vec<f32> {

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -767,18 +767,13 @@ impl DataTable {
                             // Column name — primary affordance, never shrinks.
                             // It pushes the (secondary) type label out of the cell
                             // before its own characters get truncated.
-                            .child(
-                                div()
-                                    .flex_shrink_0()
-                                    .whitespace_nowrap()
-                                    .child(Text::label_sm(col_spec.title.to_string()).color(
-                                        if is_sorted {
-                                            theme.primary
-                                        } else {
-                                            theme.foreground
-                                        },
-                                    )),
-                            )
+                            .child(div().flex_shrink_0().whitespace_nowrap().child(
+                                Text::label_sm(col_spec.title.to_string()).color(if is_sorted {
+                                    theme.primary
+                                } else {
+                                    theme.foreground
+                                }),
+                            ))
                             // Type label — dimmed metadata. Shrinks and truncates
                             // first when the cell runs out of horizontal space.
                             .when_some(
@@ -795,9 +790,7 @@ impl DataTable {
                                             .child(
                                                 Text::body(label)
                                                     .font_size(FontSizes::XS)
-                                                    .color(
-                                                        theme.muted_foreground.opacity(0.6),
-                                                    ),
+                                                    .color(theme.muted_foreground.opacity(0.6)),
                                             ),
                                     )
                                 },

--- a/crates/dbflux_ui/src/ui/components/data_table/table.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/table.rs
@@ -740,44 +740,65 @@ impl DataTable {
                             .flex_row()
                             .items_center()
                             .gap_1()
+                            .min_w_0()
+                            .flex_1()
                             .overflow_hidden()
-                            // PK badge — shown as a small "PK" label in accent color
+                            // PK / FK badges — secondary metadata, same dim styling
+                            // as the type label so they sit clearly below the name
+                            // in the visual hierarchy.
                             .when(is_pk, |d| {
                                 d.child(
-                                    Text::body("PK")
-                                        .font_size(FontSizes::XS)
-                                        .color(theme.accent),
+                                    div().flex_shrink_0().child(
+                                        Text::body("PK")
+                                            .font_size(FontSizes::XS)
+                                            .color(theme.muted_foreground.opacity(0.6)),
+                                    ),
                                 )
                             })
-                            // FK badge — shown as a small "FK" label in muted color
                             .when(is_fk, |d| {
                                 d.child(
-                                    Text::body("FK")
-                                        .font_size(FontSizes::XS)
-                                        .color(theme.muted_foreground),
+                                    div().flex_shrink_0().child(
+                                        Text::body("FK")
+                                            .font_size(FontSizes::XS)
+                                            .color(theme.muted_foreground.opacity(0.6)),
+                                    ),
                                 )
                             })
+                            // Column name — primary affordance, never shrinks.
+                            // It pushes the (secondary) type label out of the cell
+                            // before its own characters get truncated.
                             .child(
                                 div()
-                                    .overflow_hidden()
-                                    .text_ellipsis()
+                                    .flex_shrink_0()
                                     .whitespace_nowrap()
                                     .child(Text::label_sm(col_spec.title.to_string()).color(
                                         if is_sorted {
                                             theme.primary
                                         } else {
-                                            theme.table_head_foreground
+                                            theme.foreground
                                         },
                                     )),
                             )
-                            // Type label — dimmed suffix showing the real SQL type.
+                            // Type label — dimmed metadata. Shrinks and truncates
+                            // first when the cell runs out of horizontal space.
                             .when_some(
                                 (!type_label.is_empty()).then_some(type_label),
                                 |d, label| {
                                     d.child(
-                                        Text::body(label)
-                                            .font_size(FontSizes::XS)
-                                            .color(theme.muted_foreground.opacity(0.6)),
+                                        div()
+                                            .flex()
+                                            .min_w_0()
+                                            .flex_1()
+                                            .overflow_hidden()
+                                            .text_ellipsis()
+                                            .whitespace_nowrap()
+                                            .child(
+                                                Text::body(label)
+                                                    .font_size(FontSizes::XS)
+                                                    .color(
+                                                        theme.muted_foreground.opacity(0.6),
+                                                    ),
+                                            ),
                                     )
                                 },
                             ),


### PR DESCRIPTION
Closes #73.

## Summary

The data grid column header treated the name, PK/FK badges, and the type chip as equal-weight siblings, so long type labels — most visibly MySQL's raw `MYSQL_TYPE_VAR_STRING` — pushed the actual column name out of view. After this change the name is the primary affordance and the metadata chips share a single muted styling that sits clearly below it. MySQL and DynamoDB also stop leaking raw debug / placeholder strings into the type chip.

## UI

- Column name renders with `theme.foreground` and `flex_shrink_0`, so it never gets ellipsized in favor of secondary chrome.
- Type label is wrapped in a `flex_1 min_w_0 overflow_hidden text_ellipsis` container — it is the first thing to shrink when the cell runs out of space.
- PK / FK badges share the same dim `muted_foreground.opacity(0.6)` as the type label so all metadata sits at the same subordinate visual level.
- Initial column width considers the header text length (`name_chars * 7.5 + 56px`, floored at `DEFAULT_COLUMN_WIDTH`) so the name fits without a manual resize on first open.

## Drivers

- **MySQL**: replace `format!(\"{:?}\", col.column_type())` with a new `mysql_type_to_sql_label`, which maps the protocol enum + column flags to canonical SQL labels (`VARCHAR`, `BIGINT UNSIGNED`, `DECIMAL(p,s)`, `DATETIME`, `TINYINT(1)`, `ENUM` / `SET`, `BLOB` vs `TEXT`, …).
- **DynamoDB**: replace the literal `\"DynamoDB\"` placeholder with a type inferred from the first sampled item (`String`, `Number`, `Boolean`, `Binary`, `List`, `Map`, `String Set`, `Number Set`, `Binary Set`, `Null`); empty string when no items are available so the UI hides the chip.
- Audited Postgres, SQLite, MongoDB, Redis, CloudWatch, and InfluxDB — they already emit canonical labels, no changes needed.

## Test plan

- [ ] Open a MySQL table in the data grid; column headers show canonical SQL types, not `MYSQL_TYPE_*`.
- [ ] Open a Postgres / SQLite table; headers unchanged.
- [ ] Query a DynamoDB table with sampled items; type chip shows `String` / `Number` / `Boolean` / `Map` / … instead of `DynamoDB`.
- [ ] Open a DynamoDB table with no items; type chip is hidden, PK badge still appears.
- [ ] Open a table with very long column names; the name is fully visible, the type chip truncates with an ellipsis when the cell is too narrow.
- [ ] PK and FK badges read at the same visual weight as the type label, clearly subordinate to the column name.