### PR TITLE
fix(data-grid): commit pending inserts on save

### DIFF
--- a/crates/dbflux_ui/src/ui/components/data_table/state.rs
+++ b/crates/dbflux_ui/src/ui/components/data_table/state.rs
@@ -871,14 +871,15 @@ impl DataTableState {
     /// Emits a single SaveAllRequested event with all pending deletes, inserts, and dirty rows.
     pub fn request_save_all(&mut self, cx: &mut Context<Self>) {
         let pending_deletes = self.edit_buffer.pending_delete_rows();
-        let pending_inserts = self.edit_buffer.pending_insert_rows();
         let dirty_rows = self.edit_buffer.dirty_rows();
+        // Use array indices into `pending_inserts`, not virtual row indices.
+        // `commit_insert_*` looks up data via `get_pending_insert_by_idx`, which
+        // indexes the array directly; passing virtual indices silently misses.
+        let insert_indices: Vec<usize> = (0..self.edit_buffer.pending_inserts().len()).collect();
 
-        if pending_deletes.is_empty() && pending_inserts.is_empty() && dirty_rows.is_empty() {
+        if pending_deletes.is_empty() && insert_indices.is_empty() && dirty_rows.is_empty() {
             return;
         }
-
-        let insert_indices: Vec<usize> = pending_inserts.iter().map(|(idx, _)| *idx).collect();
 
         cx.emit(DataTableEvent::SaveAllRequested {
             pending_deletes,


### PR DESCRIPTION
## Summary

Inserting a new row in the data grid was a silent no-op (no toast, no error, no log) on any table with existing rows. Updates and deletes worked fine. Root cause was an index-kind mismatch in the save-all event.

## What does this resolve?

- Resolves #74

## How was this solved?

\`DataTableState::request_save_all\` was emitting **virtual row indices** (\`base_row_count + i\`) in the \`SaveAllRequested\` event's \`pending_inserts\` field, but the consumer (\`commit_insert_table\` / \`commit_insert_collection\`) feeds that value into \`EditBuffer::get_pending_insert_by_idx\`, which indexes the \`pending_inserts\` array directly. On any non-empty table the lookup returned \`None\` and the commit returned silently. Empty tables happened to work because \`virtual_idx == array_idx\` when \`base_row_count == 0\`.

Fix: emit array indices (\`0..pending_inserts.len()\`) so the lookup hits the correct entry regardless of base row count.

Single-file, 5-line change. No semantic change for the other branches (deletes still use base row indices; dirty rows still use base row indices).

## Validation

- \`cargo check -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws\` -> clean.
- Manual: needs a real DB connection to fully repro; happy-path covered by inspection — \`get_pending_insert_by_idx(0)\` now returns the cells, \`commit_insert_table\` builds the INSERT, and the existing success path clears the pending insert and refreshes.

## Where was this tested?

- [x] Local development environment
- [ ] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated \`CHANGELOG.md\` under \`## [Unreleased]\` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Known follow-ups (out of scope)

- \`commit_insert_table\` / \`commit_insert_collection\` async callbacks do not chain \`process_next_batch_op\` after success or failure (unlike \`handle_save_result\`). For multi-insert batches only the first insert runs; subsequent inserts and dirty rows stay pending. Worth a follow-up issue.
- #76 — separate Postgres bug: inserting into \`text[]\` columns is encoded as \`::jsonb\` and rejected by the server. Surfaced while testing this fix; intentionally not bundled.

## Labels to apply

- ui:bug
- kind:sql