### PR TITLE
fix(driver:postgres): typed ARRAY literals for array columns (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ All notable changes to DBFlux will be documented in this file.
   `ColumnKind` is numeric (e.g. PostgreSQL `NUMERIC`, MSSQL `DECIMAL`,
   MSSQL `BIT`) now render correctly instead of producing an empty series
   with no error.
+* **PostgreSQL array columns accept inserts and updates** — saving a row
+  into a `text[]` / `int4[]` / etc. column failed with `expression is of
+  type jsonb` because the dialect emitted `'<json>'::jsonb` regardless of
+  the destination type. Per-column type metadata now flows from the UI
+  data grid and MCP write tools through `RowInsert`/`RowPatch`/
+  `SqlUpdateRequest`/`SqlUpsertRequest` to the dialect, which emits
+  `ARRAY[...]::elem[]` for array columns and keeps `::jsonb` for JSON
+  columns. The IPC wire format stays backward compatible via serde
+  shims, so older driver peers keep working.
 
 ## [0.6.0-dev.3] - 2026-05-16
 

--- a/crates/dbflux_core/src/data/crud.rs
+++ b/crates/dbflux_core/src/data/crud.rs
@@ -81,8 +81,82 @@ impl RecordIdentity {
 /// Legacy alias for backward compatibility.
 pub type RowIdentity = RecordIdentity;
 
+/// A single column assignment: name, value, and optional driver-reported type.
+///
+/// The optional `type_name` is the raw database type as reported by the driver
+/// (e.g. PostgreSQL's `_text` for `text[]`, `jsonb`, `int4`). Dialects use it
+/// to choose the correct literal syntax — for instance, PostgreSQL needs
+/// `ARRAY['a','b']::text[]` for array columns rather than the generic `::jsonb`
+/// fallback used when no type is known.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnAssignment {
+    pub name: String,
+    pub value: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub type_name: Option<String>,
+}
+
+impl ColumnAssignment {
+    pub fn new(name: impl Into<String>, value: Value) -> Self {
+        Self {
+            name: name.into(),
+            value,
+            type_name: None,
+        }
+    }
+
+    pub fn typed(name: impl Into<String>, value: Value, type_name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            value,
+            type_name: Some(type_name.into()),
+        }
+    }
+
+    pub fn with_type_opt(mut self, type_name: Option<String>) -> Self {
+        self.type_name = type_name;
+        self
+    }
+}
+
+impl From<(String, Value)> for ColumnAssignment {
+    fn from((name, value): (String, Value)) -> Self {
+        Self {
+            name,
+            value,
+            type_name: None,
+        }
+    }
+}
+
+impl From<(&str, Value)> for ColumnAssignment {
+    fn from((name, value): (&str, Value)) -> Self {
+        Self {
+            name: name.to_string(),
+            value,
+            type_name: None,
+        }
+    }
+}
+
+/// Wire shape for RowPatch — kept stable for IPC backward compatibility.
+///
+/// Old peers serialize/deserialize `changes` as `Vec<(String, Value)>` and
+/// don't know about `change_types`. The `#[serde(default)]` on `change_types`
+/// lets newer messages flow without breaking older peers.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RowPatchWire {
+    identity: RowIdentity,
+    table: String,
+    schema: Option<String>,
+    changes: Vec<(String, Value)>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    change_types: Vec<Option<String>>,
+}
+
 /// Changes to apply to a single row via UPDATE.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "RowPatchWire", into = "RowPatchWire")]
 pub struct RowPatch {
     /// Unique identification of the row to update.
     pub identity: RowIdentity,
@@ -93,16 +167,35 @@ pub struct RowPatch {
     /// Schema name.
     pub schema: Option<String>,
 
-    /// Column changes: (column_name, new_value).
-    pub changes: Vec<(String, Value)>,
+    /// Column changes, each carrying name, value, and optional type metadata.
+    pub changes: Vec<ColumnAssignment>,
 }
 
 impl RowPatch {
+    /// Construct a RowPatch from `(column, value)` pairs without type info.
+    ///
+    /// Drivers that need type-aware literal emission (e.g. Postgres arrays)
+    /// should construct via [`Self::with_typed_changes`] instead so the
+    /// dialect can pick the right literal syntax.
     pub fn new(
         identity: RowIdentity,
         table: String,
         schema: Option<String>,
         changes: Vec<(String, Value)>,
+    ) -> Self {
+        Self {
+            identity,
+            table,
+            schema,
+            changes: changes.into_iter().map(ColumnAssignment::from).collect(),
+        }
+    }
+
+    pub fn with_typed_changes(
+        identity: RowIdentity,
+        table: String,
+        schema: Option<String>,
+        changes: Vec<ColumnAssignment>,
     ) -> Self {
         Self {
             identity,
@@ -117,8 +210,77 @@ impl RowPatch {
     }
 }
 
+impl From<RowPatchWire> for RowPatch {
+    fn from(wire: RowPatchWire) -> Self {
+        let RowPatchWire {
+            identity,
+            table,
+            schema,
+            changes,
+            change_types,
+        } = wire;
+
+        let changes = changes
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (name, value))| ColumnAssignment {
+                name,
+                value,
+                type_name: change_types.get(idx).cloned().flatten(),
+            })
+            .collect();
+
+        Self {
+            identity,
+            table,
+            schema,
+            changes,
+        }
+    }
+}
+
+impl From<RowPatch> for RowPatchWire {
+    fn from(patch: RowPatch) -> Self {
+        let mut changes = Vec::with_capacity(patch.changes.len());
+        let mut change_types = Vec::with_capacity(patch.changes.len());
+        let mut any_typed = false;
+
+        for assignment in patch.changes {
+            if assignment.type_name.is_some() {
+                any_typed = true;
+            }
+            change_types.push(assignment.type_name);
+            changes.push((assignment.name, assignment.value));
+        }
+
+        if !any_typed {
+            change_types.clear();
+        }
+
+        Self {
+            identity: patch.identity,
+            table: patch.table,
+            schema: patch.schema,
+            changes,
+            change_types,
+        }
+    }
+}
+
+/// Wire shape for RowInsert — kept stable for IPC backward compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RowInsertWire {
+    table: String,
+    schema: Option<String>,
+    columns: Vec<String>,
+    values: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    column_types: Vec<Option<String>>,
+}
+
 /// Data for INSERT operation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "RowInsertWire", into = "RowInsertWire")]
 pub struct RowInsert {
     /// Table name.
     pub table: String,
@@ -126,14 +288,16 @@ pub struct RowInsert {
     /// Schema name.
     pub schema: Option<String>,
 
-    /// Column names for the values being inserted.
-    pub columns: Vec<String>,
-
-    /// Values to insert (same order as `columns`).
-    pub values: Vec<Value>,
+    /// Columns being inserted, each carrying name, value, and optional type metadata.
+    pub assignments: Vec<ColumnAssignment>,
 }
 
 impl RowInsert {
+    /// Convenience constructor that takes parallel `columns`/`values` slices
+    /// and produces assignments without type information.
+    ///
+    /// Drivers that need type-aware literal emission (e.g. Postgres arrays)
+    /// should construct via [`Self::with_typed_assignments`] instead.
     pub fn new(
         table: String,
         schema: Option<String>,
@@ -145,16 +309,105 @@ impl RowInsert {
             values.len(),
             "RowInsert: columns and values must have same length"
         );
+        let assignments = columns
+            .into_iter()
+            .zip(values)
+            .map(|(name, value)| ColumnAssignment {
+                name,
+                value,
+                type_name: None,
+            })
+            .collect();
         Self {
             table,
             schema,
-            columns,
-            values,
+            assignments,
+        }
+    }
+
+    pub fn with_typed_assignments(
+        table: String,
+        schema: Option<String>,
+        assignments: Vec<ColumnAssignment>,
+    ) -> Self {
+        Self {
+            table,
+            schema,
+            assignments,
         }
     }
 
     pub fn is_valid(&self) -> bool {
-        !self.columns.is_empty() && self.columns.len() == self.values.len()
+        !self.assignments.is_empty()
+    }
+
+    /// Column names in declared order. Allocates; prefer iterating `assignments` directly.
+    pub fn column_names(&self) -> Vec<String> {
+        self.assignments.iter().map(|a| a.name.clone()).collect()
+    }
+
+    /// Values in declared order. Allocates; prefer iterating `assignments` directly.
+    pub fn values(&self) -> Vec<Value> {
+        self.assignments.iter().map(|a| a.value.clone()).collect()
+    }
+}
+
+impl From<RowInsertWire> for RowInsert {
+    fn from(wire: RowInsertWire) -> Self {
+        let RowInsertWire {
+            table,
+            schema,
+            columns,
+            values,
+            column_types,
+        } = wire;
+
+        let assignments = columns
+            .into_iter()
+            .zip(values)
+            .enumerate()
+            .map(|(idx, (name, value))| ColumnAssignment {
+                name,
+                value,
+                type_name: column_types.get(idx).cloned().flatten(),
+            })
+            .collect();
+
+        Self {
+            table,
+            schema,
+            assignments,
+        }
+    }
+}
+
+impl From<RowInsert> for RowInsertWire {
+    fn from(insert: RowInsert) -> Self {
+        let mut columns = Vec::with_capacity(insert.assignments.len());
+        let mut values = Vec::with_capacity(insert.assignments.len());
+        let mut column_types = Vec::with_capacity(insert.assignments.len());
+        let mut any_typed = false;
+
+        for assignment in insert.assignments {
+            if assignment.type_name.is_some() {
+                any_typed = true;
+            }
+            column_types.push(assignment.type_name);
+            columns.push(assignment.name);
+            values.push(assignment.value);
+        }
+
+        if !any_typed {
+            column_types.clear();
+        }
+
+        Self {
+            table: insert.table,
+            schema: insert.schema,
+            columns,
+            values,
+            column_types,
+        }
     }
 }
 
@@ -171,8 +424,21 @@ pub struct RowDelete {
     pub schema: Option<String>,
 }
 
+/// Wire shape for SqlUpdateRequest — kept stable for IPC backward compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SqlUpdateRequestWire {
+    table: String,
+    schema: Option<String>,
+    filter: SemanticFilter,
+    changes: Vec<(String, Value)>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    change_types: Vec<Option<String>>,
+    returning: Option<Vec<String>>,
+}
+
 /// Changes to apply to rows selected by a semantic filter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "SqlUpdateRequestWire", into = "SqlUpdateRequestWire")]
 pub struct SqlUpdateRequest {
     /// Table name.
     pub table: String,
@@ -183,8 +449,8 @@ pub struct SqlUpdateRequest {
     /// Shared filter contract selecting the target rows.
     pub filter: SemanticFilter,
 
-    /// Column changes: (column_name, new_value).
-    pub changes: Vec<(String, Value)>,
+    /// Column changes, each carrying name, value, and optional type metadata.
+    pub changes: Vec<ColumnAssignment>,
 
     /// Columns to return when the dialect supports RETURNING-style clauses.
     pub returning: Option<Vec<String>>,
@@ -206,8 +472,24 @@ pub struct SqlDeleteRequest {
     pub returning: Option<Vec<String>>,
 }
 
+/// Wire shape for SqlUpsertRequest — kept stable for IPC backward compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SqlUpsertRequestWire {
+    table: String,
+    schema: Option<String>,
+    columns: Vec<String>,
+    values: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    column_types: Vec<Option<String>>,
+    conflict_columns: Vec<String>,
+    update_assignments: Vec<(String, Value)>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    update_assignment_types: Vec<Option<String>>,
+}
+
 /// Inserts a row and updates matching rows when a conflict occurs.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(from = "SqlUpsertRequestWire", into = "SqlUpsertRequestWire")]
 pub struct SqlUpsertRequest {
     /// Table name.
     pub table: String,
@@ -215,25 +497,41 @@ pub struct SqlUpsertRequest {
     /// Schema name.
     pub schema: Option<String>,
 
-    /// Column names for the values being inserted.
-    pub columns: Vec<String>,
-
-    /// Values to insert (same order as `columns`).
-    pub values: Vec<Value>,
+    /// Columns being inserted, each carrying name, value, and optional type metadata.
+    pub assignments: Vec<ColumnAssignment>,
 
     /// Columns that define the conflict target.
     pub conflict_columns: Vec<String>,
 
     /// Column changes to apply when a conflict occurs.
-    pub update_assignments: Vec<(String, Value)>,
+    pub update_assignments: Vec<ColumnAssignment>,
 }
 
 impl SqlUpdateRequest {
+    /// Convenience constructor from `(name, value)` pairs without type info.
+    ///
+    /// Use [`Self::with_typed_changes`] when type metadata is available so
+    /// dialects can emit type-aware literals (e.g. Postgres `ARRAY[...]::T[]`).
     pub fn new(
         table: String,
         schema: Option<String>,
         filter: SemanticFilter,
         changes: Vec<(String, Value)>,
+    ) -> Self {
+        Self {
+            table,
+            schema,
+            filter,
+            changes: changes.into_iter().map(ColumnAssignment::from).collect(),
+            returning: None,
+        }
+    }
+
+    pub fn with_typed_changes(
+        table: String,
+        schema: Option<String>,
+        filter: SemanticFilter,
+        changes: Vec<ColumnAssignment>,
     ) -> Self {
         Self {
             table,
@@ -254,6 +552,66 @@ impl SqlUpdateRequest {
     }
 }
 
+impl From<SqlUpdateRequestWire> for SqlUpdateRequest {
+    fn from(wire: SqlUpdateRequestWire) -> Self {
+        let SqlUpdateRequestWire {
+            table,
+            schema,
+            filter,
+            changes,
+            change_types,
+            returning,
+        } = wire;
+
+        let changes = changes
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (name, value))| ColumnAssignment {
+                name,
+                value,
+                type_name: change_types.get(idx).cloned().flatten(),
+            })
+            .collect();
+
+        Self {
+            table,
+            schema,
+            filter,
+            changes,
+            returning,
+        }
+    }
+}
+
+impl From<SqlUpdateRequest> for SqlUpdateRequestWire {
+    fn from(req: SqlUpdateRequest) -> Self {
+        let mut changes = Vec::with_capacity(req.changes.len());
+        let mut change_types = Vec::with_capacity(req.changes.len());
+        let mut any_typed = false;
+
+        for assignment in req.changes {
+            if assignment.type_name.is_some() {
+                any_typed = true;
+            }
+            change_types.push(assignment.type_name);
+            changes.push((assignment.name, assignment.value));
+        }
+
+        if !any_typed {
+            change_types.clear();
+        }
+
+        Self {
+            table: req.table,
+            schema: req.schema,
+            filter: req.filter,
+            changes,
+            change_types,
+            returning: req.returning,
+        }
+    }
+}
+
 impl SqlDeleteRequest {
     pub fn new(table: String, schema: Option<String>, filter: SemanticFilter) -> Self {
         Self {
@@ -271,6 +629,9 @@ impl SqlDeleteRequest {
 }
 
 impl SqlUpsertRequest {
+    /// Convenience constructor that takes parallel `columns`/`values` slices
+    /// and `(name, value)` update assignments. Use
+    /// [`Self::with_typed_assignments`] when type metadata is available.
     pub fn new(
         table: String,
         schema: Option<String>,
@@ -285,20 +646,138 @@ impl SqlUpsertRequest {
             "SqlUpsertRequest: columns and values must have same length"
         );
 
+        let assignments = columns
+            .into_iter()
+            .zip(values)
+            .map(|(name, value)| ColumnAssignment {
+                name,
+                value,
+                type_name: None,
+            })
+            .collect();
+
         Self {
             table,
             schema,
-            columns,
-            values,
+            assignments,
+            conflict_columns,
+            update_assignments: update_assignments
+                .into_iter()
+                .map(ColumnAssignment::from)
+                .collect(),
+        }
+    }
+
+    pub fn with_typed_assignments(
+        table: String,
+        schema: Option<String>,
+        assignments: Vec<ColumnAssignment>,
+        conflict_columns: Vec<String>,
+        update_assignments: Vec<ColumnAssignment>,
+    ) -> Self {
+        Self {
+            table,
+            schema,
+            assignments,
             conflict_columns,
             update_assignments,
         }
     }
 
     pub fn is_valid(&self) -> bool {
-        !self.columns.is_empty()
-            && self.columns.len() == self.values.len()
-            && !self.conflict_columns.is_empty()
+        !self.assignments.is_empty() && !self.conflict_columns.is_empty()
+    }
+}
+
+impl From<SqlUpsertRequestWire> for SqlUpsertRequest {
+    fn from(wire: SqlUpsertRequestWire) -> Self {
+        let SqlUpsertRequestWire {
+            table,
+            schema,
+            columns,
+            values,
+            column_types,
+            conflict_columns,
+            update_assignments,
+            update_assignment_types,
+        } = wire;
+
+        let assignments = columns
+            .into_iter()
+            .zip(values)
+            .enumerate()
+            .map(|(idx, (name, value))| ColumnAssignment {
+                name,
+                value,
+                type_name: column_types.get(idx).cloned().flatten(),
+            })
+            .collect();
+
+        let update_assignments = update_assignments
+            .into_iter()
+            .enumerate()
+            .map(|(idx, (name, value))| ColumnAssignment {
+                name,
+                value,
+                type_name: update_assignment_types.get(idx).cloned().flatten(),
+            })
+            .collect();
+
+        Self {
+            table,
+            schema,
+            assignments,
+            conflict_columns,
+            update_assignments,
+        }
+    }
+}
+
+impl From<SqlUpsertRequest> for SqlUpsertRequestWire {
+    fn from(req: SqlUpsertRequest) -> Self {
+        fn split_assignments(
+            assignments: Vec<ColumnAssignment>,
+        ) -> (Vec<String>, Vec<Value>, Vec<Option<String>>) {
+            let mut names = Vec::with_capacity(assignments.len());
+            let mut values = Vec::with_capacity(assignments.len());
+            let mut types = Vec::with_capacity(assignments.len());
+            let mut any_typed = false;
+
+            for a in assignments {
+                if a.type_name.is_some() {
+                    any_typed = true;
+                }
+                types.push(a.type_name);
+                names.push(a.name);
+                values.push(a.value);
+            }
+
+            if !any_typed {
+                types.clear();
+            }
+
+            (names, values, types)
+        }
+
+        let (columns, values, column_types) = split_assignments(req.assignments);
+        let (update_columns, update_values, update_assignment_types) =
+            split_assignments(req.update_assignments);
+
+        let update_assignments = update_columns
+            .into_iter()
+            .zip(update_values)
+            .collect::<Vec<_>>();
+
+        Self {
+            table: req.table,
+            schema: req.schema,
+            columns,
+            values,
+            column_types,
+            conflict_columns: req.conflict_columns,
+            update_assignments,
+            update_assignment_types,
+        }
     }
 }
 

--- a/crates/dbflux_core/src/data/mod.rs
+++ b/crates/dbflux_core/src/data/mod.rs
@@ -3,9 +3,9 @@ pub(crate) mod key_value;
 pub(crate) mod view;
 
 pub use crud::{
-    CrudResult, DocumentDelete, DocumentFilter, DocumentInsert, DocumentUpdate, MutationRequest,
-    RecordIdentity, RowDelete, RowIdentity, RowInsert, RowPatch, RowState, SqlDeleteRequest,
-    SqlUpdateRequest, SqlUpsertRequest,
+    ColumnAssignment, CrudResult, DocumentDelete, DocumentFilter, DocumentInsert, DocumentUpdate,
+    MutationRequest, RecordIdentity, RowDelete, RowIdentity, RowInsert, RowPatch, RowState,
+    SqlDeleteRequest, SqlUpdateRequest, SqlUpsertRequest,
 };
 pub use key_value::{
     HashDeleteRequest, HashSetRequest, KeyBulkGetRequest, KeyDeleteRequest, KeyEntry,

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -70,9 +70,9 @@ pub use core::{
 };
 
 pub use data::{
-    CrudResult, DataViewKind, DocumentDelete, DocumentFilter, DocumentInsert, DocumentUpdate,
-    HashDeleteRequest, HashSetRequest, KeyBulkGetRequest, KeyDeleteRequest, KeyEntry,
-    KeyExistsRequest, KeyExpireRequest, KeyGetRequest, KeyGetResult, KeyPersistRequest,
+    ColumnAssignment, CrudResult, DataViewKind, DocumentDelete, DocumentFilter, DocumentInsert,
+    DocumentUpdate, HashDeleteRequest, HashSetRequest, KeyBulkGetRequest, KeyDeleteRequest,
+    KeyEntry, KeyExistsRequest, KeyExpireRequest, KeyGetRequest, KeyGetResult, KeyPersistRequest,
     KeyRenameRequest, KeyScanPage, KeyScanRequest, KeySetRequest, KeyTtlRequest, KeyType,
     KeyTypeRequest, ListEnd, ListPushRequest, ListRemoveRequest, ListSetRequest, MutationRequest,
     RecordIdentity, RowDelete, RowIdentity, RowInsert, RowPatch, RowState, SetAddRequest,

--- a/crates/dbflux_core/src/sql/dialect.rs
+++ b/crates/dbflux_core/src/sql/dialect.rs
@@ -32,6 +32,18 @@ pub trait SqlDialect: Send + Sync {
     /// Convert a Value to a SQL literal string.
     fn value_to_literal(&self, value: &Value) -> String;
 
+    /// Convert a Value to a SQL literal string, optionally guided by the
+    /// target column's driver-reported type name.
+    ///
+    /// Default implementation ignores the type and delegates to
+    /// [`Self::value_to_literal`]. Dialects override this to handle cases
+    /// where the destination column type is needed to pick the right literal
+    /// syntax — e.g. PostgreSQL needs `ARRAY[...]::text[]` for `text[]`
+    /// columns instead of the generic `::jsonb` fallback.
+    fn value_to_literal_typed(&self, value: &Value, _col_type: Option<&str>) -> String {
+        self.value_to_literal(value)
+    }
+
     /// Escape a string for use inside a single-quoted literal.
     fn escape_string(&self, s: &str) -> String;
 
@@ -65,10 +77,9 @@ pub trait SqlDialect: Send + Sync {
         &self,
         _schema: Option<&str>,
         _table: &str,
-        _columns: &[String],
-        _values: &[Value],
+        _assignments: &[crate::data::crud::ColumnAssignment],
         _conflict_columns: &[String],
-        _update_assignments: &[(String, Value)],
+        _update_assignments: &[crate::data::crud::ColumnAssignment],
     ) -> Option<String> {
         None
     }
@@ -147,24 +158,23 @@ impl SqlDialect for DefaultSqlDialect {
         &self,
         schema: Option<&str>,
         table: &str,
-        columns: &[String],
-        values: &[Value],
+        assignments: &[crate::data::crud::ColumnAssignment],
         conflict_columns: &[String],
-        update_assignments: &[(String, Value)],
+        update_assignments: &[crate::data::crud::ColumnAssignment],
     ) -> Option<String> {
-        if columns.is_empty() || columns.len() != values.len() || conflict_columns.is_empty() {
+        if assignments.is_empty() || conflict_columns.is_empty() {
             return None;
         }
 
         let table = self.qualified_table(schema, table);
-        let columns = columns
+        let columns = assignments
             .iter()
-            .map(|column| self.quote_identifier(column))
+            .map(|a| self.quote_identifier(&a.name))
             .collect::<Vec<_>>()
             .join(", ");
-        let values = values
+        let values = assignments
             .iter()
-            .map(|value| self.value_to_literal(value))
+            .map(|a| self.value_to_literal_typed(&a.value, a.type_name.as_deref()))
             .collect::<Vec<_>>()
             .join(", ");
         let conflict_columns = conflict_columns
@@ -182,11 +192,11 @@ impl SqlDialect for DefaultSqlDialect {
 
         let update_clause = update_assignments
             .iter()
-            .map(|(column, value)| {
+            .map(|a| {
                 format!(
                     "{} = {}",
-                    self.quote_identifier(column),
-                    self.value_to_literal(value)
+                    self.quote_identifier(&a.name),
+                    self.value_to_literal_typed(&a.value, a.type_name.as_deref())
                 )
             })
             .collect::<Vec<_>>()

--- a/crates/dbflux_core/src/sql/query_builder.rs
+++ b/crates/dbflux_core/src/sql/query_builder.rs
@@ -1,7 +1,7 @@
 use crate::Value;
 use crate::data::crud::{
-    RecordIdentity, RowDelete, RowInsert, RowPatch, SqlDeleteRequest, SqlUpdateRequest,
-    SqlUpsertRequest,
+    ColumnAssignment, RecordIdentity, RowDelete, RowInsert, RowPatch, SqlDeleteRequest,
+    SqlUpdateRequest, SqlUpsertRequest,
 };
 use crate::render_semantic_filter_sql;
 use crate::sql::dialect::SqlDialect;
@@ -77,7 +77,7 @@ impl<'a> SqlQueryBuilder<'a> {
     /// Returns SQL like: `INSERT INTO "table" ("col1", "col2") VALUES (val1, val2)`
     /// If `with_returning` is true and dialect supports it, appends `RETURNING *`.
     pub fn build_insert(&self, insert: &RowInsert, with_returning: bool) -> Option<String> {
-        if insert.columns.is_empty() {
+        if insert.assignments.is_empty() {
             return None;
         }
 
@@ -85,19 +85,22 @@ impl<'a> SqlQueryBuilder<'a> {
             .dialect
             .qualified_table(insert.schema.as_deref(), &insert.table);
 
-        let columns: Vec<String> = insert
-            .columns
+        let columns_str = insert
+            .assignments
             .iter()
-            .map(|c| self.dialect.quote_identifier(c))
-            .collect();
-        let columns_str = columns.join(", ");
+            .map(|a| self.dialect.quote_identifier(&a.name))
+            .collect::<Vec<_>>()
+            .join(", ");
 
-        let values: Vec<String> = insert
-            .values
+        let values_str = insert
+            .assignments
             .iter()
-            .map(|v| self.dialect.value_to_literal(v))
-            .collect();
-        let values_str = values.join(", ");
+            .map(|a| {
+                self.dialect
+                    .value_to_literal_typed(&a.value, a.type_name.as_deref())
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
 
         let mut sql = format!(
             "INSERT INTO {} ({}) VALUES ({})",
@@ -120,8 +123,7 @@ impl<'a> SqlQueryBuilder<'a> {
         self.dialect.build_upsert_statement(
             upsert.schema.as_deref(),
             &upsert.table,
-            &upsert.columns,
-            &upsert.values,
+            &upsert.assignments,
             &upsert.conflict_columns,
             &upsert.update_assignments,
         )
@@ -222,22 +224,24 @@ impl<'a> SqlQueryBuilder<'a> {
         }
     }
 
-    /// Build SET clause for UPDATE.
+    /// Build SET clause for UPDATE from typed assignments.
     ///
-    /// Returns `"col1" = val1, "col2" = val2`.
-    pub fn build_set_clause(&self, changes: &[(String, Value)]) -> String {
-        let assignments: Vec<String> = changes
+    /// Returns `"col1" = val1, "col2" = val2`. When an assignment carries a
+    /// `type_name`, the dialect is asked to format the literal with that hint
+    /// (e.g. PostgreSQL emits `ARRAY[...]::text[]` for array columns).
+    pub fn build_set_clause(&self, changes: &[ColumnAssignment]) -> String {
+        changes
             .iter()
-            .map(|(col, val)| {
+            .map(|a| {
                 format!(
                     "{} = {}",
-                    self.dialect.quote_identifier(col),
-                    self.dialect.value_to_literal(val)
+                    self.dialect.quote_identifier(&a.name),
+                    self.dialect
+                        .value_to_literal_typed(&a.value, a.type_name.as_deref())
                 )
             })
-            .collect();
-
-        assignments.join(", ")
+            .collect::<Vec<_>>()
+            .join(", ")
     }
 
     /// Build column list for INSERT.
@@ -310,8 +314,8 @@ mod tests {
         let builder = SqlQueryBuilder::new(&dialect);
 
         let changes = vec![
-            ("name".to_string(), Value::Text("Alice".to_string())),
-            ("age".to_string(), Value::Int(30)),
+            ColumnAssignment::new("name", Value::Text("Alice".to_string())),
+            ColumnAssignment::new("age", Value::Int(30)),
         ];
 
         let set_clause = builder.build_set_clause(&changes);

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -356,24 +356,23 @@ impl SqlDialect for MysqlDialect {
         &self,
         schema: Option<&str>,
         table: &str,
-        columns: &[String],
-        values: &[Value],
+        assignments: &[dbflux_core::ColumnAssignment],
         _conflict_columns: &[String],
-        update_assignments: &[(String, Value)],
+        update_assignments: &[dbflux_core::ColumnAssignment],
     ) -> Option<String> {
-        if columns.is_empty() || columns.len() != values.len() {
+        if assignments.is_empty() {
             return None;
         }
 
         let table = self.qualified_table(schema, table);
-        let columns = columns
+        let columns = assignments
             .iter()
-            .map(|column| self.quote_identifier(column))
+            .map(|a| self.quote_identifier(&a.name))
             .collect::<Vec<_>>()
             .join(", ");
-        let values = values
+        let values = assignments
             .iter()
-            .map(|value| self.value_to_literal(value))
+            .map(|a| self.value_to_literal_typed(&a.value, a.type_name.as_deref()))
             .collect::<Vec<_>>()
             .join(", ");
 
@@ -386,11 +385,11 @@ impl SqlDialect for MysqlDialect {
 
         let update_clause = update_assignments
             .iter()
-            .map(|(column, value)| {
+            .map(|a| {
                 format!(
                     "{} = {}",
-                    self.quote_identifier(column),
-                    self.value_to_literal(value)
+                    self.quote_identifier(&a.name),
+                    self.value_to_literal_typed(&a.value, a.type_name.as_deref())
                 )
             })
             .collect::<Vec<_>>()
@@ -2147,9 +2146,9 @@ impl Connection for MysqlConnection {
 
         let select_sql = if last_id > 0 {
             let first_col = insert
-                .columns
+                .assignments
                 .first()
-                .map(|c| MYSQL_DIALECT.quote_identifier(c))
+                .map(|a| MYSQL_DIALECT.quote_identifier(&a.name))
                 .unwrap_or_else(|| "`id`".to_string());
             let table = MYSQL_DIALECT.qualified_table(insert.schema.as_deref(), &insert.table);
 
@@ -2158,7 +2157,7 @@ impl Connection for MysqlConnection {
                 table, first_col, last_id
             )
         } else {
-            let identity = RecordIdentity::composite(insert.columns.clone(), insert.values.clone());
+            let identity = RecordIdentity::composite(insert.column_names(), insert.values());
             builder
                 .build_select_by_identity(insert.schema.as_deref(), &insert.table, &identity)
                 .ok_or_else(|| DbError::query_failed("Failed to build SELECT query".to_string()))?

--- a/crates/dbflux_driver_postgres/src/driver.rs
+++ b/crates/dbflux_driver_postgres/src/driver.rs
@@ -214,6 +214,10 @@ impl SqlDialect for PostgresDialect {
         value_to_pg_literal(value)
     }
 
+    fn value_to_literal_typed(&self, value: &Value, col_type: Option<&str>) -> String {
+        value_to_pg_literal_typed(value, col_type)
+    }
+
     fn escape_string(&self, s: &str) -> String {
         pg_escape_string(s)
     }
@@ -246,24 +250,23 @@ impl SqlDialect for PostgresDialect {
         &self,
         schema: Option<&str>,
         table: &str,
-        columns: &[String],
-        values: &[Value],
+        assignments: &[dbflux_core::ColumnAssignment],
         conflict_columns: &[String],
-        update_assignments: &[(String, Value)],
+        update_assignments: &[dbflux_core::ColumnAssignment],
     ) -> Option<String> {
-        if columns.is_empty() || columns.len() != values.len() || conflict_columns.is_empty() {
+        if assignments.is_empty() || conflict_columns.is_empty() {
             return None;
         }
 
         let table = self.qualified_table(schema, table);
-        let columns = columns
+        let columns = assignments
             .iter()
-            .map(|column| self.quote_identifier(column))
+            .map(|a| self.quote_identifier(&a.name))
             .collect::<Vec<_>>()
             .join(", ");
-        let values = values
+        let values = assignments
             .iter()
-            .map(|value| self.value_to_literal(value))
+            .map(|a| self.value_to_literal_typed(&a.value, a.type_name.as_deref()))
             .collect::<Vec<_>>()
             .join(", ");
         let conflict_columns = conflict_columns
@@ -281,11 +284,11 @@ impl SqlDialect for PostgresDialect {
 
         let update_clause = update_assignments
             .iter()
-            .map(|(column, value)| {
+            .map(|a| {
                 format!(
                     "{} = {}",
-                    self.quote_identifier(column),
-                    self.value_to_literal(value)
+                    self.quote_identifier(&a.name),
+                    self.value_to_literal_typed(&a.value, a.type_name.as_deref())
                 )
             })
             .collect::<Vec<_>>()
@@ -2760,6 +2763,121 @@ fn needs_postgres_text_comparison_cast(type_name: &str) -> bool {
     normalized == "uuid" || normalized == "tsvector" || normalized == "tsquery"
 }
 
+/// Convert a Value to a safe PostgreSQL literal string, guided by the target
+/// column's driver-reported type.
+///
+/// When the column is an array type, this emits a typed `ARRAY[...]::T[]`
+/// literal so that round-trip insert/update against `text[]`, `int4[]`, etc.
+/// works regardless of whether the cell value arrived as `Value::Array`
+/// (untouched from the driver) or `Value::Json(s)` (user edited the cell as
+/// a JSON array text). For non-array columns it falls back to the untyped
+/// formatter.
+fn value_to_pg_literal_typed(value: &Value, col_type: Option<&str>) -> String {
+    if let Some(ty) = col_type
+        && let Some(elem_type) = pg_array_element_type(ty)
+    {
+        return format_pg_array_literal(value, elem_type);
+    }
+
+    value_to_pg_literal(value)
+}
+
+/// Returns the canonical PostgreSQL element type for an array column type,
+/// or None if the type is not an array.
+///
+/// Accepts both the internal name (`_text`, `_int4`) returned by the
+/// `postgres` crate via `Type::name()` and the SQL-level name (`text[]`,
+/// `int4[]`) that may come from other paths like `information_schema`.
+fn pg_array_element_type(type_name: &str) -> Option<&'static str> {
+    let normalized = type_name.trim().to_ascii_lowercase();
+
+    let elem = if let Some(stripped) = normalized.strip_prefix('_') {
+        stripped
+    } else if let Some(stripped) = normalized.strip_suffix("[]") {
+        stripped.trim()
+    } else {
+        return None;
+    };
+
+    // Map driver-reported element names to a canonical PostgreSQL type name
+    // suitable for use in an `::T[]` cast. Unknown element types fall back
+    // to `text` — safer than failing the literal emission, and the server
+    // will reject the cast if it really doesn't fit.
+    Some(match elem {
+        "bool" | "boolean" => "boolean",
+        "int2" | "smallint" => "int2",
+        "int4" | "integer" | "int" => "int4",
+        "int8" | "bigint" => "int8",
+        "float4" | "real" => "float4",
+        "float8" | "double precision" => "float8",
+        "numeric" | "decimal" => "numeric",
+        "text" => "text",
+        "varchar" | "character varying" => "varchar",
+        "bpchar" | "character" => "bpchar",
+        "uuid" => "uuid",
+        "json" => "json",
+        "jsonb" => "jsonb",
+        "date" => "date",
+        "time" => "time",
+        "timestamp" => "timestamp",
+        "timestamptz" => "timestamptz",
+        "inet" => "inet",
+        "citext" => "citext",
+        "name" => "name",
+        _ => "text",
+    })
+}
+
+/// Build a typed `ARRAY[...]::elem[]` literal for the given value and
+/// element type.
+///
+/// Accepts:
+/// - `Value::Null` — emitted as `NULL::elem[]`.
+/// - `Value::Array(items)` — items formatted individually as untyped PG
+///   literals.
+/// - `Value::Json(s)` — `s` is parsed as a JSON array (so a user-edited cell
+///   containing `["a","b"]` round-trips). Falls back to a Json fallback if
+///   parsing fails.
+/// - Any other variant — passed through `value_to_pg_literal` and wrapped as
+///   `ARRAY[<lit>]::elem[]`.
+fn format_pg_array_literal(value: &Value, elem_type: &str) -> String {
+    match value {
+        Value::Null => format!("NULL::{}[]", elem_type),
+
+        Value::Array(items) => {
+            let lits: Vec<String> = items.iter().map(value_to_pg_literal).collect();
+            format!("ARRAY[{}]::{}[]", lits.join(", "), elem_type)
+        }
+
+        Value::Json(s) => match serde_json::from_str::<JsonValue>(s) {
+            Ok(JsonValue::Array(items)) => {
+                let lits: Vec<String> = items.iter().map(json_value_to_pg_literal).collect();
+                format!("ARRAY[{}]::{}[]", lits.join(", "), elem_type)
+            }
+            // Non-array JSON for an array column is a real type mismatch —
+            // surface it by letting the server reject the cast rather than
+            // silently mangling the data.
+            _ => format!("{}::{}[]", pg_quote_string(s), elem_type),
+        },
+
+        other => format!("ARRAY[{}]::{}[]", value_to_pg_literal(other), elem_type),
+    }
+}
+
+/// Convert a JSON scalar to a PostgreSQL literal suitable as an array element.
+fn json_value_to_pg_literal(value: &JsonValue) -> String {
+    match value {
+        JsonValue::Null => "NULL".to_string(),
+        JsonValue::Bool(b) => if *b { "TRUE" } else { "FALSE" }.to_string(),
+        JsonValue::Number(n) => n.to_string(),
+        JsonValue::String(s) => pg_quote_string(s),
+        // Nested objects/arrays in a flat array column don't have a clean
+        // mapping; pass the raw JSON text through as a quoted string and let
+        // the server error if the destination element type can't take it.
+        JsonValue::Array(_) | JsonValue::Object(_) => pg_quote_string(&value.to_string()),
+    }
+}
+
 /// Convert a Value to a safe PostgreSQL literal string.
 ///
 /// Uses escaped single-quoted literals for readable generated SQL.
@@ -3890,6 +4008,123 @@ mod tests {
         };
 
         assert!(generator.generate_create_type(&request).is_none());
+    }
+
+    // ===== Array literal emission (#76) =====
+
+    use super::{format_pg_array_literal, pg_array_element_type, value_to_pg_literal_typed};
+
+    #[test]
+    fn pg_array_element_type_handles_internal_and_sql_names() {
+        assert_eq!(pg_array_element_type("_text"), Some("text"));
+        assert_eq!(pg_array_element_type("_int4"), Some("int4"));
+        assert_eq!(pg_array_element_type("text[]"), Some("text"));
+        assert_eq!(pg_array_element_type("integer[]"), Some("int4"));
+        assert_eq!(pg_array_element_type("BIGINT[]"), Some("int8"));
+        assert_eq!(pg_array_element_type("text"), None);
+        assert_eq!(pg_array_element_type("jsonb"), None);
+    }
+
+    #[test]
+    fn array_literal_from_value_array() {
+        let value = Value::Array(vec![
+            Value::Text("Espacio".into()),
+            Value::Text("hola".into()),
+        ]);
+        let sql = format_pg_array_literal(&value, "text");
+        assert_eq!(sql, "ARRAY['Espacio', 'hola']::text[]");
+    }
+
+    #[test]
+    fn array_literal_from_json_array_string() {
+        // Cell was edited as JSON text in the data grid.
+        let value = Value::Json(r#"["Espacio","hola"]"#.into());
+        let sql = format_pg_array_literal(&value, "text");
+        assert_eq!(sql, "ARRAY['Espacio', 'hola']::text[]");
+    }
+
+    #[test]
+    fn array_literal_int_elements() {
+        let value = Value::Json(r#"[1, 2, 3]"#.into());
+        let sql = format_pg_array_literal(&value, "int4");
+        assert_eq!(sql, "ARRAY[1, 2, 3]::int4[]");
+    }
+
+    #[test]
+    fn array_literal_null() {
+        let sql = format_pg_array_literal(&Value::Null, "text");
+        assert_eq!(sql, "NULL::text[]");
+    }
+
+    #[test]
+    fn array_literal_empty() {
+        let value = Value::Array(vec![]);
+        let sql = format_pg_array_literal(&value, "text");
+        assert_eq!(sql, "ARRAY[]::text[]");
+    }
+
+    #[test]
+    fn array_literal_escapes_single_quotes() {
+        let value = Value::Array(vec![Value::Text("it's".into())]);
+        let sql = format_pg_array_literal(&value, "text");
+        assert_eq!(sql, "ARRAY['it''s']::text[]");
+    }
+
+    #[test]
+    fn typed_literal_falls_back_to_jsonb_for_jsonb_column() {
+        let value = Value::Json(r#"{"k":1}"#.into());
+        let sql = value_to_pg_literal_typed(&value, Some("jsonb"));
+        assert_eq!(sql, "'{\"k\":1}'::jsonb");
+    }
+
+    #[test]
+    fn typed_literal_no_type_info_uses_default() {
+        let value = Value::Text("hi".into());
+        let sql = value_to_pg_literal_typed(&value, None);
+        assert_eq!(sql, "'hi'");
+    }
+
+    #[test]
+    fn typed_literal_routes_text_array_via_array_path() {
+        let value = Value::Array(vec![Value::Text("a".into())]);
+        let sql = value_to_pg_literal_typed(&value, Some("_text"));
+        assert_eq!(sql, "ARRAY['a']::text[]");
+    }
+
+    #[test]
+    fn typed_literal_null_for_array_column() {
+        // When the column type is known to be an array, emit `NULL::elem[]`
+        // explicitly. Bare `NULL` would also work in INSERT/UPDATE column
+        // position because the server infers from the destination, but an
+        // explicit cast is safer in expression contexts (e.g. COALESCE).
+        let sql = value_to_pg_literal_typed(&Value::Null, Some("_text"));
+        assert_eq!(sql, "NULL::text[]");
+    }
+
+    #[test]
+    fn typed_literal_null_no_type_info_stays_bare() {
+        let sql = value_to_pg_literal_typed(&Value::Null, None);
+        assert_eq!(sql, "NULL");
+    }
+
+    #[test]
+    fn pg_array_element_type_covers_common_string_aliases() {
+        assert_eq!(pg_array_element_type("_varchar"), Some("varchar"));
+        assert_eq!(pg_array_element_type("_bpchar"), Some("bpchar"));
+        assert_eq!(pg_array_element_type("varchar[]"), Some("varchar"));
+        assert_eq!(
+            pg_array_element_type("character varying[]"),
+            Some("varchar")
+        );
+    }
+
+    #[test]
+    fn array_literal_wraps_scalar_value_for_array_column() {
+        // Fallback path: caller passed a scalar where an array was expected.
+        // The dialect wraps it as a single-element ARRAY[...] literal and
+        // lets the server validate the element type.
+        let sql = format_pg_array_literal(&Value::Text("solo".into()), "text");
+        assert_eq!(sql, "ARRAY['solo']::text[]");
     }
 }
 

--- a/crates/dbflux_driver_postgres/tests/live_integration.rs
+++ b/crates/dbflux_driver_postgres/tests/live_integration.rs
@@ -7,9 +7,11 @@
 )]
 
 use dbflux_core::{
-    CollectionRef, ConnectionProfile, DbConfig, DbDriver, DbError, DescribeRequest, ExplainRequest,
-    OrderByColumn, Pagination, QueryRequest, RecordIdentity, RowDelete, RowInsert, RowPatch,
-    SchemaLoadingStrategy, TableBrowseRequest, TableCountRequest, TableRef, Value,
+    CollectionRef, ColumnAssignment, ConnectionProfile, DbConfig, DbDriver, DbError,
+    DescribeRequest, ExplainRequest, MutationRequest, OrderByColumn, Pagination, QueryRequest,
+    RecordIdentity, RowDelete, RowInsert, RowPatch, SchemaLoadingStrategy, SemanticFilter,
+    SemanticRequest, SqlUpdateRequest, SqlUpsertRequest, TableBrowseRequest, TableCountRequest,
+    TableRef, Value, WhereOperator,
 };
 use dbflux_driver_postgres::PostgresDriver;
 use dbflux_test_support::containers;
@@ -434,6 +436,308 @@ fn postgres_document_ops_not_supported() -> Result<(), DbError> {
         assert!(matches!(browse_result, Err(DbError::NotSupported(_))));
 
         assert!(connection.key_value_api().is_none());
+
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Typed array literal emission (#76)
+//
+// Regression: prior to typed dialect plumbing, inserting/updating a `text[]`
+// or `int4[]` column emitted `'<json>'::jsonb`, which Postgres rejected with
+// `column "..." is of type text[] but expression is of type jsonb`.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn postgres_array_columns_round_trip() -> Result<(), DbError> {
+    containers::with_postgres_url(|uri| {
+        let (connection, _) = connect_postgres(uri)?;
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE array_round_trip (
+                id SERIAL PRIMARY KEY,
+                tags TEXT[] NOT NULL,
+                scores INTEGER[] NOT NULL,
+                meta JSONB NOT NULL
+            )",
+        ))?;
+
+        // 1. Insert with Value::Array — simulates "round-trip from PG read,
+        //    untouched by the user" (the original #76 repro path).
+        let insert_array_form = RowInsert::with_typed_assignments(
+            "array_round_trip".to_string(),
+            Some("public".to_string()),
+            vec![
+                ColumnAssignment::typed(
+                    "tags",
+                    Value::Array(vec![
+                        Value::Text("Espacio".to_string()),
+                        Value::Text("hola".to_string()),
+                    ]),
+                    "_text",
+                ),
+                ColumnAssignment::typed(
+                    "scores",
+                    Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]),
+                    "_int4",
+                ),
+                ColumnAssignment::typed("meta", Value::Json(r#"{"k":"v"}"#.to_string()), "jsonb"),
+            ],
+        );
+        let inserted = connection.insert_row(&insert_array_form)?;
+        assert_eq!(inserted.affected_rows, 1);
+
+        // 2. Insert with Value::Json(json-array-string) — simulates "user
+        //    edited the cell as JSON text in the data grid".
+        let insert_json_form = RowInsert::with_typed_assignments(
+            "array_round_trip".to_string(),
+            Some("public".to_string()),
+            vec![
+                ColumnAssignment::typed(
+                    "tags",
+                    Value::Json(r#"["foo","bar"]"#.to_string()),
+                    "_text",
+                ),
+                ColumnAssignment::typed("scores", Value::Json("[10, 20]".to_string()), "_int4"),
+                ColumnAssignment::typed(
+                    "meta",
+                    Value::Json(r#"{"edited":true}"#.to_string()),
+                    "jsonb",
+                ),
+            ],
+        );
+        let inserted = connection.insert_row(&insert_json_form)?;
+        assert_eq!(inserted.affected_rows, 1);
+
+        let rows = connection
+            .execute(&QueryRequest::new(
+                "SELECT tags, scores FROM array_round_trip ORDER BY id",
+            ))?
+            .rows;
+        assert_eq!(rows.len(), 2);
+
+        match &rows[0][0] {
+            Value::Array(arr) => {
+                assert_eq!(
+                    arr,
+                    &vec![
+                        Value::Text("Espacio".to_string()),
+                        Value::Text("hola".to_string()),
+                    ]
+                );
+            }
+            other => panic!("expected text[] array, got {:?}", other),
+        }
+        match &rows[0][1] {
+            Value::Array(arr) => {
+                assert_eq!(arr, &vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+            }
+            other => panic!("expected int4[] array, got {:?}", other),
+        }
+        match &rows[1][0] {
+            Value::Array(arr) => {
+                assert_eq!(
+                    arr,
+                    &vec![
+                        Value::Text("foo".to_string()),
+                        Value::Text("bar".to_string()),
+                    ]
+                );
+            }
+            other => panic!("expected text[] array from JSON form, got {:?}", other),
+        }
+
+        // 3. UPDATE with a typed Array assignment — same dialect path.
+        let update_result = connection.update_row(&RowPatch::with_typed_changes(
+            RecordIdentity::composite(vec!["id".to_string()], vec![Value::Int(1)]),
+            "array_round_trip".to_string(),
+            Some("public".to_string()),
+            vec![ColumnAssignment::typed(
+                "tags",
+                Value::Array(vec![Value::Text("updated".to_string())]),
+                "_text",
+            )],
+        ))?;
+        assert_eq!(update_result.affected_rows, 1);
+
+        let rows = connection
+            .execute(&QueryRequest::new(
+                "SELECT tags FROM array_round_trip WHERE id = 1",
+            ))?
+            .rows;
+        match &rows[0][0] {
+            Value::Array(arr) => {
+                assert_eq!(arr, &vec![Value::Text("updated".to_string())]);
+            }
+            other => panic!("expected updated text[] array, got {:?}", other),
+        }
+
+        // 4. Empty array round-trip.
+        let insert_empty = RowInsert::with_typed_assignments(
+            "array_round_trip".to_string(),
+            Some("public".to_string()),
+            vec![
+                ColumnAssignment::typed("tags", Value::Array(vec![]), "_text"),
+                ColumnAssignment::typed("scores", Value::Array(vec![]), "_int4"),
+                ColumnAssignment::typed("meta", Value::Json("{}".to_string()), "jsonb"),
+            ],
+        );
+        connection.insert_row(&insert_empty)?;
+
+        let rows = connection
+            .execute(&QueryRequest::new(
+                "SELECT tags, scores FROM array_round_trip ORDER BY id DESC LIMIT 1",
+            ))?
+            .rows;
+        assert!(matches!(&rows[0][0], Value::Array(arr) if arr.is_empty()));
+        assert!(matches!(&rows[0][1], Value::Array(arr) if arr.is_empty()));
+
+        Ok(())
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Typed array literal emission via semantic update/upsert (#76, MCP path)
+//
+// Exercises the SqlUpdateRequest / SqlUpsertRequest plumbing that the MCP
+// `update_records` and `upsert_record` tools go through, ensuring the typed
+// dialect path is reached and array columns succeed end-to-end.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn postgres_semantic_update_and_upsert_array_columns() -> Result<(), DbError> {
+    containers::with_postgres_url(|uri| {
+        let (connection, _) = connect_postgres(uri)?;
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE semantic_array_test (
+                id INTEGER PRIMARY KEY,
+                tags TEXT[] NOT NULL,
+                meta JSONB NOT NULL
+            )",
+        ))?;
+
+        // Seed a row to update.
+        connection.insert_row(&RowInsert::with_typed_assignments(
+            "semantic_array_test".to_string(),
+            Some("public".to_string()),
+            vec![
+                ColumnAssignment::new("id", Value::Int(1)),
+                ColumnAssignment::typed(
+                    "tags",
+                    Value::Array(vec![Value::Text("a".to_string())]),
+                    "_text",
+                ),
+                ColumnAssignment::typed("meta", Value::Json("{}".to_string()), "jsonb"),
+            ],
+        ))?;
+
+        // Semantic UPDATE via SqlUpdateRequest::with_typed_changes — what the
+        // MCP `update_records` tool builds after resolve_column_types.
+        let filter = SemanticFilter::compare("id", WhereOperator::Eq, Value::Int(1));
+        let update = SqlUpdateRequest::with_typed_changes(
+            "semantic_array_test".to_string(),
+            Some("public".to_string()),
+            filter,
+            vec![ColumnAssignment::typed(
+                "tags",
+                Value::Array(vec![
+                    Value::Text("x".to_string()),
+                    Value::Text("y".to_string()),
+                ]),
+                "_text",
+            )],
+        );
+
+        connection.execute_semantic_request(&SemanticRequest::Mutation(
+            MutationRequest::sql_update_many(update),
+        ))?;
+
+        let rows = connection
+            .execute(&QueryRequest::new(
+                "SELECT tags FROM semantic_array_test WHERE id = 1",
+            ))?
+            .rows;
+        match &rows[0][0] {
+            Value::Array(arr) => {
+                assert_eq!(
+                    arr,
+                    &vec![Value::Text("x".to_string()), Value::Text("y".to_string())]
+                );
+            }
+            other => panic!("expected updated text[] array, got {:?}", other),
+        }
+
+        // Semantic UPSERT via SqlUpsertRequest::with_typed_assignments —
+        // exercises both insert-side and on-conflict-update typed literals.
+        let upsert = SqlUpsertRequest::with_typed_assignments(
+            "semantic_array_test".to_string(),
+            Some("public".to_string()),
+            vec![
+                ColumnAssignment::new("id", Value::Int(1)),
+                ColumnAssignment::typed(
+                    "tags",
+                    Value::Array(vec![Value::Text("upserted".to_string())]),
+                    "_text",
+                ),
+                ColumnAssignment::typed("meta", Value::Json(r#"{"v":2}"#.to_string()), "jsonb"),
+            ],
+            vec!["id".to_string()],
+            vec![ColumnAssignment::typed(
+                "tags",
+                Value::Array(vec![Value::Text("upserted".to_string())]),
+                "_text",
+            )],
+        );
+
+        connection.execute_semantic_request(&SemanticRequest::Mutation(
+            MutationRequest::sql_upsert(upsert),
+        ))?;
+
+        let rows = connection
+            .execute(&QueryRequest::new(
+                "SELECT tags FROM semantic_array_test WHERE id = 1",
+            ))?
+            .rows;
+        match &rows[0][0] {
+            Value::Array(arr) => {
+                assert_eq!(arr, &vec![Value::Text("upserted".to_string())]);
+            }
+            other => panic!("expected upserted text[] array, got {:?}", other),
+        }
+
+        // Also exercise an insert via upsert (new id, no conflict).
+        let upsert_new = SqlUpsertRequest::with_typed_assignments(
+            "semantic_array_test".to_string(),
+            Some("public".to_string()),
+            vec![
+                ColumnAssignment::new("id", Value::Int(2)),
+                ColumnAssignment::typed(
+                    "tags",
+                    Value::Array(vec![Value::Text("new".to_string())]),
+                    "_text",
+                ),
+                ColumnAssignment::typed("meta", Value::Json("{}".to_string()), "jsonb"),
+            ],
+            vec!["id".to_string()],
+            vec![],
+        );
+
+        connection.execute_semantic_request(&SemanticRequest::Mutation(
+            MutationRequest::sql_upsert(upsert_new),
+        ))?;
+
+        let rows = connection
+            .execute(&QueryRequest::new(
+                "SELECT tags FROM semantic_array_test WHERE id = 2",
+            ))?
+            .rows;
+        assert!(
+            matches!(&rows[0][0], Value::Array(arr) if arr == &vec![Value::Text("new".to_string())])
+        );
 
         Ok(())
     })

--- a/crates/dbflux_driver_sqlite/src/driver.rs
+++ b/crates/dbflux_driver_sqlite/src/driver.rs
@@ -189,24 +189,23 @@ impl SqlDialect for SqliteDialect {
         &self,
         schema: Option<&str>,
         table: &str,
-        columns: &[String],
-        values: &[Value],
+        assignments: &[dbflux_core::ColumnAssignment],
         conflict_columns: &[String],
-        update_assignments: &[(String, Value)],
+        update_assignments: &[dbflux_core::ColumnAssignment],
     ) -> Option<String> {
-        if columns.is_empty() || columns.len() != values.len() || conflict_columns.is_empty() {
+        if assignments.is_empty() || conflict_columns.is_empty() {
             return None;
         }
 
         let table = self.qualified_table(schema, table);
-        let columns = columns
+        let columns = assignments
             .iter()
-            .map(|column| self.quote_identifier(column))
+            .map(|a| self.quote_identifier(&a.name))
             .collect::<Vec<_>>()
             .join(", ");
-        let values = values
+        let values = assignments
             .iter()
-            .map(|value| self.value_to_literal(value))
+            .map(|a| self.value_to_literal_typed(&a.value, a.type_name.as_deref()))
             .collect::<Vec<_>>()
             .join(", ");
         let conflict_columns = conflict_columns
@@ -224,11 +223,11 @@ impl SqlDialect for SqliteDialect {
 
         let update_clause = update_assignments
             .iter()
-            .map(|(column, value)| {
+            .map(|a| {
                 format!(
                     "{} = {}",
-                    self.quote_identifier(column),
-                    self.value_to_literal(value)
+                    self.quote_identifier(&a.name),
+                    self.value_to_literal_typed(&a.value, a.type_name.as_deref())
                 )
             })
             .collect::<Vec<_>>()

--- a/crates/dbflux_mcp_server/src/tools/write.rs
+++ b/crates/dbflux_mcp_server/src/tools/write.rs
@@ -6,11 +6,12 @@
 //! - `upsert_record`: Insert or update on conflict
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use dbflux_core::{
-    DatabaseCategory, DocumentFilter, DocumentInsert, DocumentUpdate, MutationRequest, RowInsert,
-    SemanticRequest, SqlUpdateRequest, SqlUpsertRequest, TableRef, Value,
-    parse_semantic_filter_json,
+    ColumnAssignment, Connection, DatabaseCategory, DocumentFilter, DocumentInsert, DocumentUpdate,
+    MutationRequest, RowInsert, SemanticRequest, SqlUpdateRequest, SqlUpsertRequest, TableRef,
+    Value, parse_semantic_filter_json,
 };
 use rmcp::{
     ErrorData,
@@ -221,6 +222,70 @@ impl DbFluxServer {
             .await
     }
 
+    /// Resolve a `column_name → driver_type_name` map for the target table.
+    ///
+    /// Uses [`Connection::describe_table`] (a cheap, table-scoped query —
+    /// not a full schema snapshot) and parses the result. Returns an empty
+    /// map if the driver doesn't support the operation or the lookup fails;
+    /// callers should treat that as "no type info available" and emit
+    /// untyped literals.
+    ///
+    /// Without this lookup, mutations against typed columns (e.g. Postgres
+    /// `text[]`) emit `::jsonb` literals and fail at the server. With it,
+    /// the dialect can pick `ARRAY[...]::text[]` and the insert/update
+    /// succeeds.
+    async fn resolve_column_types(
+        connection: Arc<dyn Connection>,
+        table_ref: &TableRef,
+    ) -> BTreeMap<String, String> {
+        use dbflux_core::DescribeRequest;
+
+        let request = DescribeRequest::new(table_ref.clone());
+
+        let result = Self::execute_connection_blocking(connection, move |conn| {
+            conn.describe_table(&request)
+                .map_err(|e| format!("describe_table failed: {}", e))
+        })
+        .await;
+
+        let Ok(query_result) = result else {
+            return BTreeMap::new();
+        };
+
+        // Find the indices of the column-name and type-name columns. Driver
+        // implementations of describe_table return different result shapes
+        // (Postgres uses `column_name`/`data_type`, MySQL uses `Field`/`Type`,
+        // SQLite uses `name`/`type`), so try the known synonyms.
+        let name_idx = query_result
+            .columns
+            .iter()
+            .position(|c| matches!(c.name.as_str(), "column_name" | "Field" | "name"));
+        let type_idx = query_result
+            .columns
+            .iter()
+            .position(|c| matches!(c.name.as_str(), "data_type" | "Type" | "type"));
+
+        let (Some(name_idx), Some(type_idx)) = (name_idx, type_idx) else {
+            return BTreeMap::new();
+        };
+
+        query_result
+            .rows
+            .iter()
+            .filter_map(|row| {
+                let name = match row.get(name_idx)? {
+                    Value::Text(s) => s.clone(),
+                    _ => return None,
+                };
+                let type_name = match row.get(type_idx)? {
+                    Value::Text(s) => s.clone(),
+                    _ => return None,
+                };
+                Some((name, type_name))
+            })
+            .collect()
+    }
+
     async fn insert_record_impl(
         state: ServerState,
         connection_id: &str,
@@ -254,22 +319,25 @@ impl DbFluxServer {
         }
 
         let table_ref = TableRef::from_qualified(table);
+        let column_types = Self::resolve_column_types(connection.clone(), &table_ref).await;
 
         let mut inserted_count = 0;
         let mut returned_records = Vec::new();
 
         for record in records {
-            let columns: Vec<String> = record.keys().cloned().collect();
-            let values: Vec<Value> = record
-                .values()
-                .map(|v| json_to_db_value(v.clone()))
+            let assignments: Vec<ColumnAssignment> = record
+                .iter()
+                .map(|(name, value)| ColumnAssignment {
+                    name: name.clone(),
+                    value: json_to_db_value(value.clone()),
+                    type_name: column_types.get(name).cloned(),
+                })
                 .collect();
 
-            let row_insert = RowInsert::new(
+            let row_insert = RowInsert::with_typed_assignments(
                 table_ref.name.clone(),
                 table_ref.schema.clone(),
-                columns,
-                values,
+                assignments,
             );
 
             let result = Self::execute_connection_blocking(connection.clone(), move |connection| {
@@ -323,7 +391,15 @@ impl DbFluxServer {
             }));
         }
 
-        let mutation = Self::build_relational_update_mutation(table, filter, set, returning)?;
+        let table_ref = TableRef::from_qualified(table);
+        let column_types = Self::resolve_column_types(connection.clone(), &table_ref).await;
+        let mutation = Self::build_relational_update_mutation(
+            table_ref,
+            filter,
+            set,
+            returning,
+            &column_types,
+        )?;
         let result = Self::execute_connection_blocking(connection.clone(), move |connection| {
             connection
                 .execute_semantic_request(&SemanticRequest::Mutation(mutation))
@@ -339,10 +415,11 @@ impl DbFluxServer {
     }
 
     fn build_relational_update_mutation(
-        table: &str,
+        table_ref: TableRef,
         filter: &serde_json::Value,
         set: &serde_json::Value,
         returning: Option<&[String]>,
+        column_types: &BTreeMap<String, String>,
     ) -> Result<MutationRequest, String> {
         let semantic_filter = parse_semantic_filter_json(filter)?
             .ok_or_else(|| UpdateRecordsParams::UPDATE_WHERE_REQUIRED_ERROR.to_string())?;
@@ -351,15 +428,21 @@ impl DbFluxServer {
             .as_object()
             .ok_or_else(|| "SET must be a JSON object".to_string())?;
 
-        let changes: Vec<(String, Value)> = set_obj
+        let changes: Vec<ColumnAssignment> = set_obj
             .iter()
-            .map(|(col, val)| (col.clone(), json_to_db_value(val.clone())))
+            .map(|(col, val)| ColumnAssignment {
+                name: col.clone(),
+                value: json_to_db_value(val.clone()),
+                type_name: column_types.get(col).cloned(),
+            })
             .collect();
 
-        let table_ref = TableRef::from_qualified(table);
-
-        let mut update =
-            SqlUpdateRequest::new(table_ref.name, table_ref.schema, semantic_filter, changes);
+        let mut update = SqlUpdateRequest::with_typed_changes(
+            table_ref.name,
+            table_ref.schema,
+            semantic_filter,
+            changes,
+        );
 
         if let Some(returning) = returning
             && !returning.is_empty()
@@ -417,12 +500,17 @@ impl DbFluxServer {
                 conflict_columns,
                 update_on_conflict,
             )?,
-            DatabaseCategory::Relational => Self::build_relational_upsert_mutation(
-                table,
-                record,
-                conflict_columns,
-                update_on_conflict,
-            )?,
+            DatabaseCategory::Relational => {
+                let table_ref = TableRef::from_qualified(table);
+                let column_types = Self::resolve_column_types(connection.clone(), &table_ref).await;
+                Self::build_relational_upsert_mutation(
+                    table_ref,
+                    record,
+                    conflict_columns,
+                    update_on_conflict,
+                    &column_types,
+                )?
+            }
             _ => {
                 return Err(format!(
                     "Upsert is not supported for {:?} databases",
@@ -442,10 +530,11 @@ impl DbFluxServer {
     }
 
     fn build_relational_upsert_mutation(
-        table: &str,
+        table_ref: TableRef,
         record: &serde_json::Value,
         conflict_columns: &[String],
         update_on_conflict: Option<&serde_json::Value>,
+        column_types: &BTreeMap<String, String>,
     ) -> Result<MutationRequest, String> {
         let obj = record
             .as_object()
@@ -464,25 +553,31 @@ impl DbFluxServer {
             }
         }
 
-        let columns: Vec<String> = obj.keys().cloned().collect();
-        let values: Vec<Value> = obj
-            .values()
-            .map(|value| json_to_db_value(value.clone()))
+        let assignments: Vec<ColumnAssignment> = obj
+            .iter()
+            .map(|(name, value)| ColumnAssignment {
+                name: name.clone(),
+                value: json_to_db_value(value.clone()),
+                type_name: column_types.get(name).cloned(),
+            })
             .collect();
 
-        let update_assignments =
-            Self::parse_upsert_assignments(obj, conflict_columns, update_on_conflict)?;
+        let update_assignments = Self::parse_upsert_assignments(
+            obj,
+            conflict_columns,
+            update_on_conflict,
+            column_types,
+        )?;
 
-        let table_ref = TableRef::from_qualified(table);
-
-        Ok(MutationRequest::sql_upsert(SqlUpsertRequest::new(
-            table_ref.name,
-            table_ref.schema,
-            columns,
-            values,
-            conflict_columns.to_vec(),
-            update_assignments,
-        )))
+        Ok(MutationRequest::sql_upsert(
+            SqlUpsertRequest::with_typed_assignments(
+                table_ref.name,
+                table_ref.schema,
+                assignments,
+                conflict_columns.to_vec(),
+                update_assignments,
+            ),
+        ))
     }
 
     fn build_document_upsert_mutation(
@@ -536,13 +631,18 @@ impl DbFluxServer {
         record: &serde_json::Map<String, serde_json::Value>,
         conflict_columns: &[String],
         update_on_conflict: Option<&serde_json::Value>,
-    ) -> Result<Vec<(String, Value)>, String> {
+        column_types: &BTreeMap<String, String>,
+    ) -> Result<Vec<ColumnAssignment>, String> {
         let assignment_json =
             Self::parse_upsert_assignment_json(record, conflict_columns, update_on_conflict)?;
 
         Ok(assignment_json
             .into_iter()
-            .map(|(column, value)| (column, json_to_db_value(value)))
+            .map(|(column, value)| ColumnAssignment {
+                type_name: column_types.get(&column).cloned(),
+                name: column,
+                value: json_to_db_value(value),
+            })
             .collect())
     }
 
@@ -651,10 +751,11 @@ mod tests {
     #[test]
     fn test_build_relational_update_mutation_uses_semantic_filter_and_returning() {
         let mutation = DbFluxServer::build_relational_update_mutation(
-            "public.users",
+            TableRef::from_qualified("public.users"),
             &serde_json::json!({"status": "active"}),
             &serde_json::json!({"archived": true}),
             Some(&["id".to_string(), "archived".to_string()]),
+            &BTreeMap::new(),
         )
         .expect("relational update mutation should build");
 
@@ -674,10 +775,11 @@ mod tests {
     #[test]
     fn test_build_relational_upsert_mutation_preserves_custom_update_values() {
         let mutation = DbFluxServer::build_relational_upsert_mutation(
-            "public.users",
+            TableRef::from_qualified("public.users"),
             &serde_json::json!({"id": 1, "name": "Ada", "visits": 3}),
             &["id".to_string()],
             Some(&serde_json::json!({"name": "Grace", "visits": 4})),
+            &BTreeMap::new(),
         )
         .expect("relational upsert mutation should build");
 
@@ -692,12 +794,14 @@ mod tests {
         assert!(
             upsert
                 .update_assignments
-                .contains(&("name".to_string(), Value::Text("Grace".to_string())))
+                .iter()
+                .any(|a| a.name == "name" && a.value == Value::Text("Grace".to_string()))
         );
         assert!(
             upsert
                 .update_assignments
-                .contains(&("visits".to_string(), Value::Int(4)))
+                .iter()
+                .any(|a| a.name == "visits" && a.value == Value::Int(4))
         );
     }
 

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/context_menu.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/context_menu.rs
@@ -3983,6 +3983,12 @@ impl DataGridPanel {
         let visual_order = buffer.compute_visual_order();
 
         let col_names: Vec<String> = self.result.columns.iter().map(|c| c.name.clone()).collect();
+        let col_types: Vec<String> = self
+            .result
+            .columns
+            .iter()
+            .map(|c| c.type_name.clone())
+            .collect();
 
         let row_values: Vec<Value> = match visual_order.get(visual_row).copied() {
             Some(VisualRowSource::Base(base_idx)) => {
@@ -4011,11 +4017,21 @@ impl DataGridPanel {
                     return None;
                 }
 
-                let insert = RowInsert::new(
+                let assignments: Vec<dbflux_core::ColumnAssignment> = col_names
+                    .iter()
+                    .zip(row_values.iter())
+                    .zip(col_types.iter())
+                    .map(|((name, value), type_name)| dbflux_core::ColumnAssignment {
+                        name: name.clone(),
+                        value: value.clone(),
+                        type_name: Some(type_name.clone()),
+                    })
+                    .collect();
+
+                let insert = RowInsert::with_typed_assignments(
                     table.name.clone(),
                     table.schema.clone(),
-                    col_names,
-                    row_values,
+                    assignments,
                 );
                 Some(MutationRequest::SqlInsert(insert))
             }
@@ -4048,16 +4064,27 @@ impl DataGridPanel {
 
                 let identity = RowIdentity::new(pk_columns, pk_values);
 
-                let changes: Vec<(String, Value)> = col_names
+                let changes: Vec<dbflux_core::ColumnAssignment> = col_names
                     .into_iter()
                     .zip(row_values)
+                    .zip(col_types)
                     .enumerate()
                     .filter(|(idx, _)| !pk_indices.contains(idx))
-                    .map(|(_, pair)| pair)
+                    .map(
+                        |(_, ((name, value), type_name))| dbflux_core::ColumnAssignment {
+                            name,
+                            value,
+                            type_name: Some(type_name),
+                        },
+                    )
                     .collect();
 
-                let patch =
-                    RowPatch::new(identity, table.name.clone(), table.schema.clone(), changes);
+                let patch = RowPatch::with_typed_changes(
+                    identity,
+                    table.name.clone(),
+                    table.schema.clone(),
+                    changes,
+                );
                 Some(MutationRequest::SqlUpdate(patch))
             }
 

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/mutations.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/mutations.rs
@@ -4,8 +4,8 @@ use crate::ui::AsyncUpdateResultExt;
 use crate::ui::components::document_tree::NodeId;
 use crate::ui::components::toast::{Toast, copy_action, now_hms};
 use dbflux_core::{
-    CollectionRef, DocumentFilter, DocumentUpdate, Pagination, QueryResult, RowDelete, RowIdentity,
-    RowInsert, RowPatch, RowState, TableRef, TaskKind, Value,
+    CollectionRef, ColumnAssignment, DocumentFilter, DocumentUpdate, Pagination, QueryResult,
+    RowDelete, RowIdentity, RowInsert, RowPatch, RowState, TableRef, TaskKind, Value,
 };
 use gpui::*;
 use std::collections::BTreeMap;
@@ -447,19 +447,20 @@ impl DataGridPanel {
 
         let identity = RowIdentity::new(pk_columns, pk_values);
 
-        let change_values: Vec<(String, Value)> = changes
+        let change_values: Vec<ColumnAssignment> = changes
             .iter()
             .filter_map(|&(col_idx, cell_value)| {
-                model
-                    .columns
-                    .get(col_idx)
-                    .map(|col| (col.title.to_string(), cell_value.to_value()))
+                model.columns.get(col_idx).map(|col| ColumnAssignment {
+                    name: col.title.to_string(),
+                    value: cell_value.to_value(),
+                    type_name: Some(col.type_name.to_string()),
+                })
             })
             .collect();
 
         if change_values
             .iter()
-            .any(|(_, value)| matches!(value, Value::Unsupported(_)))
+            .any(|a| matches!(a.value, Value::Unsupported(_)))
         {
             let message = "Cannot save row: unsupported values are read-only".to_string();
             log::error!("[SAVE] {}", message);
@@ -478,7 +479,7 @@ impl DataGridPanel {
             return;
         }
 
-        let patch = RowPatch::new(
+        let patch = RowPatch::with_typed_changes(
             identity,
             table_ref.name.clone(),
             table_ref.schema.clone(),
@@ -880,12 +881,11 @@ impl DataGridPanel {
             return;
         };
 
-        let (columns, values) = {
+        let assignments: Vec<ColumnAssignment> = {
             let state = table_state.read(cx);
             let model = state.model();
 
-            let mut columns = Vec::new();
-            let mut values = Vec::new();
+            let mut assignments = Vec::new();
 
             for (col_idx, cell) in cells.iter().enumerate() {
                 let value = cell.to_value();
@@ -895,15 +895,18 @@ impl DataGridPanel {
                 }
 
                 if let Some(col) = model.columns.get(col_idx) {
-                    columns.push(col.title.to_string());
-                    values.push(value);
+                    assignments.push(ColumnAssignment {
+                        name: col.title.to_string(),
+                        value,
+                        type_name: Some(col.type_name.to_string()),
+                    });
                 }
             }
 
-            (columns, values)
+            assignments
         };
 
-        if columns.is_empty() {
+        if assignments.is_empty() {
             self.pending_toast = Some(PendingToast {
                 message: "Cannot insert: no values provided".to_string(),
                 is_error: true,
@@ -912,11 +915,10 @@ impl DataGridPanel {
             return;
         }
 
-        let insert = RowInsert::new(
+        let insert = RowInsert::with_typed_assignments(
             table_ref.name.clone(),
             table_ref.schema.clone(),
-            columns,
-            values,
+            assignments,
         );
 
         let (task_id, _cancel_token) =


### PR DESCRIPTION
## Summary

Postgres inserts/updates into array columns (`text[]`, `int4[]`, ...) failed with `expression is of type jsonb` because the dialect emitted `'<json>'::jsonb` for `Value::Array` and `Value::Json` regardless of the target column type. Plumb per-column type metadata end to end through a new `ColumnAssignment` struct and a typed dialect method, then route Postgres array columns to `ARRAY[...]::elem[]`. UI data grid and MCP write tools both populate the new type field.

## Changes

- New `ColumnAssignment { name, value, type_name }`.
- `RowInsert`, `RowPatch`, `SqlUpdateRequest`, `SqlUpsertRequest` refactored to use it (serde shims preserve IPC wire compatibility — old peers ignore the new optional fields).
- `SqlDialect::value_to_literal_typed(value, col_type)` with a default delegating to `value_to_literal`. PostgreSQL overrides it.
- `SqlDialect::build_upsert_statement` signature takes `&[ColumnAssignment]` for both insert-side and on-conflict-update slots; all dialects (Default, PG, MySQL, SQLite) use the typed formatter.
- PostgreSQL dialect detects array types (`_text`/`_int4`/`text[]`/`character varying[]`/...) and emits `ARRAY[...]::elem[]`. Accepts both `Value::Array` (driver round-trip) and `Value::Json(json-array-string)` (data-grid edited cell). Falls back to existing `::jsonb` for non-array columns.
- Data grid (`mutations.rs`, `context_menu.rs`) populates `type_name` from `ColumnSpec`/`ColumnMeta`.
- MCP write tools (`insert_record`, `update_records`, `upsert_record`) resolve a column-name → driver-type-name map via `describe_table` (cheap, table-scoped, not a full schema snapshot) before building assignments, so AI-driven mutations into array columns succeed the same way as the data grid.

## Test plan

- [x] `cargo test --workspace --lib` — all green (incl. 14 new unit tests in `dbflux_driver_postgres`).
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Live integration `postgres_array_columns_round_trip` — `text[]` / `int4[]` / `jsonb` insert/update via `RowInsert`/`RowPatch` (data-grid path), with empty arrays and JSON-string edited form.
- [x] Live integration `postgres_semantic_update_and_upsert_array_columns` — `text[]` / `jsonb` via `SqlUpdateRequest` and `SqlUpsertRequest` (MCP path), including both conflict-update and new-insert upsert branches.

## Notes

- IPC wire format is backward compatible. Old peers serialize/deserialize the legacy `Vec<(String, Value)>` shape without the new `*_types` fields (`#[serde(default, skip_serializing_if = "Vec::is_empty")]`).
- No new dependencies.

Closes #76.