### PR TITLE
chore(build): speed up builds with mold linker and nextest

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,15 @@
+# Build linker configuration for the Linux x86_64 host triple.
+#
+# Requires `mold` on PATH. The Nix dev shell (`nix develop`) provides it, and
+# CI installs it (tests.yml, style.yml, release.yml build-linux). For non-Nix
+# local setups, install it via your system package manager (e.g. `mold`).
+#
+# IMPORTANT: this applies to ALL builds for this triple, including
+# `cargo build --release`. Linux x86_64 release artifacts are therefore linked
+# with mold (functionally equivalent binary). Other triples — Windows (msvc),
+# macOS, and Linux aarch64 — are unaffected and keep their default linker.
+
+[target.x86_64-unknown-linux-gnu]
+# Use the mold linker through the default cc driver. Drastically reduces link
+# time and peak memory when linking the 60+ workspace crates.
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,8 +293,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Build the x86_64 target on the Apple Silicon runner via cross
+          # compilation. GitHub's Intel macOS runner is ~5x slower; arm64 ->
+          # x86_64 is a trivial same-OS cross (universal SDK, shared linker),
+          # so this cuts the Intel build from ~1h to the arm64 build's time.
           - arch: amd64
-            runs_on: macos-15-intel
+            runs_on: macos-14
             target: x86_64-apple-darwin
           - arch: arm64
             runs_on: macos-14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            mold \
             pkg-config \
             libssl-dev \
             libdbus-1-dev \

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -44,6 +44,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            mold \
             pkg-config \
             libssl-dev \
             libdbus-1-dev \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            mold \
             pkg-config \
             libssl-dev \
             libdbus-1-dev \
@@ -58,6 +59,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
+            mold \
             pkg-config \
             libssl-dev \
             libdbus-1-dev \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,11 +32,22 @@ cargo test --workspace test_name     # Single test
 cargo test -p dbflux_core            # Tests in specific crate
 cargo test -p dbflux_driver_dynamodb --test live_integration -- --ignored  # Docker-backed live tests
 
+# Faster test runner (provided by the Nix dev shell). Does NOT run doctests.
+cargo nextest run --workspace        # All tests (unit + integration)
+cargo test --doc --workspace         # Doctests (run separately)
+cargo nextest run -p dbflux_driver_sqlite --run-ignored all  # Include #[ignore]d live tests
+
 # Nix
 nix develop                          # Enter dev shell
 nix build                            # Build package
 nix run                              # Run directly
 ```
+
+**Linux build requirement**: `.cargo/config.toml` links the
+`x86_64-unknown-linux-gnu` target with `-fuse-ld=mold`, so the `mold` linker
+must be on `PATH` for any local `cargo build`/`test`/`check`. The Nix dev shell
+and CI provide it; non-Nix Linux setups must install `mold` via their package
+manager. Windows and macOS use their default linker and are unaffected.
 
 ## Rust Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,22 @@ cargo test --workspace test_name     # Single test
 cargo test -p dbflux_core            # Tests in specific crate
 cargo test -p dbflux_driver_dynamodb --test live_integration -- --ignored  # Docker-backed live tests
 
+# Faster test runner (provided by the Nix dev shell). Does NOT run doctests.
+cargo nextest run --workspace        # All tests (unit + integration)
+cargo test --doc --workspace         # Doctests (run separately)
+cargo nextest run -p dbflux_driver_sqlite --run-ignored all  # Include #[ignore]d live tests
+
 # Nix
 nix develop                          # Enter dev shell
 nix build                            # Build package
 nix run                              # Run directly
 ```
+
+**Linux build requirement**: `.cargo/config.toml` links the
+`x86_64-unknown-linux-gnu` target with `-fuse-ld=mold`, so the `mold` linker
+must be on `PATH` for any local `cargo build`/`test`/`check`. The Nix dev shell
+and CI provide it; non-Nix Linux setups must install `mold` via their package
+manager. Windows and macOS use their default linker and are unaffected.
 
 ## Rust Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,12 +21,21 @@ cargo build
 cargo run
 ```
 
+On Linux, the [`mold`](https://github.com/rui314/mold) linker is **required** for local builds: `.cargo/config.toml` links the `x86_64-unknown-linux-gnu` target with `-fuse-ld=mold` to cut link time and memory across the workspace. Install it via your package manager (e.g. `apt install mold`); the Nix dev shell provides it automatically. Windows and macOS are unaffected.
+
 Before opening a PR run:
 
 ```bash
 cargo fmt --all -- --check
 cargo clippy --workspace -- -D warnings
 cargo test --workspace
+```
+
+Tests can also be run with [`cargo-nextest`](https://nexte.st) (faster on this workspace, provided by the Nix dev shell). Note nextest does not run doctests:
+
+```bash
+cargo nextest run --workspace
+cargo test --doc --workspace
 ```
 
 A Nix dev shell is available: `nix develop`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,15 @@ dbg_macro = "warn"
 todo = "warn"
 unimplemented = "warn"
 indexing_slicing = "warn"
+
+# Development build profile tuned for memory and link speed.
+# Full debug info (debug = 2) is the main driver of peak RAM and disk usage
+# when linking this many crates; line tables keep backtraces usable at a
+# fraction of the cost.
+[profile.dev]
+debug = "line-tables-only"
+
+# Dependencies rarely need debugging; dropping their debug info entirely is a
+# large reduction in target/ size and link-time memory.
+[profile.dev.package."*"]
+debug = false

--- a/README.md
+++ b/README.md
@@ -254,19 +254,26 @@ curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/uninst
 
 ### Prerequisites
 
+On Linux, the `mold` linker is **required** for local builds: the repo's
+`.cargo/config.toml` links the `x86_64-unknown-linux-gnu` target with
+`-fuse-ld=mold` to cut link time and memory across the 60+ workspace crates.
+The Nix dev shell provides it automatically; for non-Nix setups install it via
+your package manager (included below). Windows and macOS use their default
+linker and are unaffected.
+
 **Ubuntu/Debian:**
 ```bash
-sudo apt install pkg-config libssl-dev libdbus-1-dev libxkbcommon-dev
+sudo apt install pkg-config libssl-dev libdbus-1-dev libxkbcommon-dev mold
 ```
 
 **Fedora:**
 ```bash
-sudo dnf install pkg-config openssl-devel dbus-devel libxkbcommon-devel
+sudo dnf install pkg-config openssl-devel dbus-devel libxkbcommon-devel mold
 ```
 
 **Arch:**
 ```bash
-sudo pacman -S pkg-config openssl dbus libxkbcommon
+sudo pacman -S pkg-config openssl dbus libxkbcommon mold
 ```
 
 **macOS:**
@@ -300,6 +307,24 @@ cargo check --workspace                    # Type checking
 cargo clippy --workspace -- -D warnings    # Lint
 cargo fmt --all                            # Format
 cargo test --workspace                     # Tests
+```
+
+### Faster tests with nextest
+
+[`cargo-nextest`](https://nexte.st) is the recommended test runner for this
+workspace: it runs each test in its own process across a global pool, which is
+noticeably faster than `cargo test` on a workspace this size. The Nix dev shell
+provides it; otherwise install it from <https://nexte.st/docs/installation>.
+
+```bash
+cargo nextest run --workspace              # unit + integration tests
+cargo test --doc --workspace               # doctests (nextest does not run these)
+```
+
+Live integration tests (normally `#[ignore]`d) use a different flag under nextest:
+
+```bash
+cargo nextest run -p dbflux_driver_sqlite --run-ignored all
 ```
 
 ### Nix Development Shell

--- a/default.nix
+++ b/default.nix
@@ -37,6 +37,10 @@ let
     cmake
     makeWrapper
     openssl.dev
+    # Required by .cargo/config.toml, which links the x86_64-unknown-linux-gnu
+    # target with -fuse-ld=mold. Needed by every cargo invocation over this tree
+    # (package builds and dev shells), so it lives here and is inherited.
+    mold
   ];
 
   # Library path for runtime
@@ -217,6 +221,9 @@ in
         ++ [
           pkgs.rust-analyzer
           pkgs.python3
+          # Faster, process-isolated test runner: `cargo nextest run`.
+          # (mold is already provided via nativeBuildInputs above.)
+          pkgs.cargo-nextest
         ];
 
       inherit buildInputs;

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,10 @@
               rustToolchain
               pkgs.rust-analyzer
               opensslStatic.dev
+              # Faster, process-isolated test runner for the large workspace.
+              # Run with `cargo nextest run` (doctests still need `cargo test --doc`).
+              # mold is inherited from dbflux.nativeBuildInputs (see default.nix).
+              pkgs.cargo-nextest
             ];
 
             buildInputs = dbflux.buildInputs;


### PR DESCRIPTION
## What

Reduce CPU/RAM/time pressure when building, testing, or checking the 60+ crate workspace, and cut release wall-clock time.

### Local / CI build optimization
- **mold linker**: `.cargo/config.toml` links the `x86_64-unknown-linux-gnu` target with `-fuse-ld=mold`. mold is added as a build-time input in `default.nix` (inherited by package builds and both dev shells) and installed in the Linux CI jobs that link (`tests.yml`, `style.yml` clippy job, `release.yml` build-linux).
- **dev profile**: `[profile.dev]` uses `debug = "line-tables-only"` and dependencies drop debug info entirely (`[profile.dev.package."*"] debug = false`), the main driver of peak RAM and `target/` size.
- **cargo-nextest**: added to both dev shells as a faster, process-isolated test runner.
- **docs**: README, CONTRIBUTING, AGENTS.md and CLAUDE.md document the mold requirement and nextest usage.

### Release pipeline
- **macOS x86_64 cross-compile**: build `x86_64-apple-darwin` on the `macos-14` Apple Silicon runner instead of GitHub's slow Intel runner. arm64 -> x86_64 is a trivial same-OS cross compile (universal SDK, shared linker). This was the release bottleneck (~1h vs ~12m for arm64); the change brings total release wall-clock to ~30 min.

## Why

Local builds/tests were saturating all cores and using 10GB+ RAM (GNU `ld` linking 60+ crates was the main sink). Separately, releases took ~1h, dominated entirely by the macOS Intel build on GitHub's slow Intel runner.

## Scope / impact

- mold only affects the **Linux x86_64** target. Windows (msvc), macOS, and Linux aarch64 keep their default linker.
- The mold rustflag applies to **all profiles**, so **Linux amd64 release binaries are now mold-linked** (functionally equivalent ELF).
- Linux CI runners now install `mold`; non-Nix Linux contributors must install it locally (documented).
- macOS Intel binaries are now **cross-compiled** on Apple Silicon. Functionally equivalent, but worth a `workflow_dispatch` smoke run before relying on a real tag (watch C/cmake-based deps).

## Notes

- nextest does **not** run doctests — `cargo test --doc` is still required separately (documented).
- CI test jobs still use `cargo test`; migrating them to nextest is intentionally out of scope.
- The "fork PRs don't trigger CI" question is a repo setting (`approval_policy: first_time_contributors`), not a workflow change — out of scope for this PR by design.
