### PR TITLE
fix(release): build macOS with vendored OpenSSL to fix x86_64 cross-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -323,7 +323,11 @@ jobs:
           cache-on-failure: true
 
       - name: Build DBFlux
-        run: cargo build --release --features "$FEATURES" --target ${{ matrix.target }}
+        # vendored-openssl makes ssh2/libssh2 compile OpenSSL from source for the
+        # target instead of linking the runner's system OpenSSL. Required to
+        # cross-compile x86_64 on the Apple Silicon runner (no x86_64 OpenSSL is
+        # present), and keeps both macOS binaries self-contained at runtime.
+        run: cargo build --release --features "$FEATURES,vendored-openssl" --target ${{ matrix.target }}
 
       - name: Create app bundle
         run: |


### PR DESCRIPTION
## What

Enable the existing `vendored-openssl` feature for both macOS release builds.

## Why

The macOS x86_64 build now cross-compiles on the Apple Silicon runner (#80). That broke `v0.6.0-dev.5`: `ssh2`/libssh2 pulls `openssl-sys`, which could not find an x86_64 OpenSSL on the arm64 runner (only the arm64 Homebrew one is present), failing with *"Could not find directory of OpenSSL installation"*.

## Fix

Build with `--features "$FEATURES,vendored-openssl"`, which routes `dbflux -> dbflux_ssh -> ssh2/vendored-openssl` so OpenSSL is compiled from source for the target via `cc` (cross-compiles cleanly). Applied to both arches so the arm64 and x86_64 binaries stay consistent and self-contained at runtime (no Homebrew OpenSSL dependency on end-user machines).

## Validation

Only exercised by `release.yml` (tags / workflow_dispatch). The failing `v0.6.0-dev.5` release must be re-cut after this lands.