### PR TITLE
feat(query): execute multi-statement scripts where the driver supports it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,16 +14,16 @@ For the branching model, version rules, tag flow, and release procedure, use `do
 
 ```bash
 cargo check --workspace              # Fast type checking
-cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,aws  # Debug build
-cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,aws --release  # Release build
-cargo run -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,aws    # Run app
+cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,mssql,aws  # Debug build
+cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,mssql,aws --release  # Release build
+cargo run -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,mssql,aws    # Run app
 
 # MCP server (AI integration) - included by default
 cargo build -p dbflux  # MCP included in default features
 ./target/debug/dbflux mcp --client-id test-client
 
 # Build without MCP support (smaller binary, no AI integration)
-cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,lua,aws
+cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,mssql,lua,aws
 
 cargo fmt --all                      # Format
 cargo clippy --workspace -- -D warnings  # Lint
@@ -495,6 +495,7 @@ MCP provides a preview-before-execute workflow for schema changes:
 - PostgreSQL: All DDL is transactional (except `CREATE INDEX CONCURRENTLY`)
 - MySQL: DDL is NOT transactional; rewrites entire table for most `ALTER TABLE` ops
 - SQLite: Limited `ALTER TABLE` support (only `ADD COLUMN`, `RENAME`); `DROP COLUMN` requires table recreation
+- SQL Server (MSSQL): DDL is transactional (can run inside a transaction and roll back)
 
 **Reference**: See `crates/dbflux_mcp_server/docs/DDL_SAFETY.md` for complete safety guide with classification matrix.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,16 @@ For the branching model, version rules, tag flow, and release procedure, use `do
 
 ```bash
 cargo check --workspace              # Fast type checking
-cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws  # Debug build
-cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws --release  # Release build
-cargo run -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws    # Run app
+cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,mssql,aws  # Debug build
+cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,mssql,aws --release  # Release build
+cargo run -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,mssql,aws    # Run app
 
 # MCP server (AI integration) - included by default
 cargo build -p dbflux  # MCP included in default features
 ./target/debug/dbflux mcp --client-id test-client
 
 # Build without MCP support (smaller binary, no AI integration)
-cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mongodb,redis,dynamodb,lua,aws
+cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mongodb,redis,dynamodb,mssql,lua,aws
 
 cargo fmt --all                      # Format
 cargo clippy --workspace -- -D warnings  # Lint

--- a/crates/dbflux_core/src/driver/capabilities.rs
+++ b/crates/dbflux_core/src/driver/capabilities.rs
@@ -365,6 +365,11 @@ bitflags! {
         /// Driver supports prepared statements / parameterized queries.
         const PREPARED_STATEMENTS = 1 << 8;
 
+        /// Driver can execute a batch of multiple statements submitted as a
+        /// single query (e.g. several SQL statements separated by `;`),
+        /// producing one result set per statement.
+        const MULTI_STATEMENT = 1 << 47;
+
         // === Schema features ===
 
         /// Driver supports views.
@@ -789,6 +794,223 @@ impl QueryLanguage {
                 | QueryLanguage::Cql
         )
     }
+
+    /// Splits a query buffer into individual executable statements.
+    ///
+    /// For SQL-family languages (`editor_mode() == "sql"`) the buffer is split
+    /// on `;`, skipping separators that appear inside single-quoted strings,
+    /// double-quoted / backtick-quoted identifiers, line comments (`--`), block
+    /// comments (`/* */`, nestable), and PostgreSQL dollar-quoted bodies
+    /// (`$tag$ ... $tag$`). Empty statements (only whitespace) are dropped.
+    ///
+    /// For every other language the trimmed buffer is returned as a single
+    /// statement, since they do not use `;`-delimited batches.
+    pub fn split_statements(&self, text: &str) -> Vec<String> {
+        if self.editor_mode() != "sql" {
+            let trimmed = text.trim();
+            return if trimmed.is_empty() {
+                Vec::new()
+            } else {
+                vec![trimmed.to_string()]
+            };
+        }
+
+        split_sql_statements(text)
+    }
+
+    /// Number of executable statements in `text`.
+    ///
+    /// See [`QueryLanguage::split_statements`] for the parsing rules.
+    pub fn statement_count(&self, text: &str) -> usize {
+        self.split_statements(text).len()
+    }
+}
+
+/// `;`-delimited SQL statement splitter that is aware of strings, identifiers,
+/// comments, and dollar-quoted bodies. See [`QueryLanguage::split_statements`].
+fn split_sql_statements(text: &str) -> Vec<String> {
+    let chars: Vec<char> = text.chars().collect();
+    let len = chars.len();
+
+    let mut statements = Vec::new();
+    let mut current = String::new();
+    let mut index = 0;
+
+    while index < len {
+        let ch = chars[index];
+
+        // Line comment: -- ... up to end of line.
+        if ch == '-' && index + 1 < len && chars[index + 1] == '-' {
+            while index < len && chars[index] != '\n' {
+                current.push(chars[index]);
+                index += 1;
+            }
+            continue;
+        }
+
+        // Block comment: /* ... */ with PostgreSQL-style nesting.
+        if ch == '/' && index + 1 < len && chars[index + 1] == '*' {
+            current.push('/');
+            current.push('*');
+            index += 2;
+
+            let mut depth = 1;
+            while index < len && depth > 0 {
+                if chars[index] == '/' && index + 1 < len && chars[index + 1] == '*' {
+                    depth += 1;
+                    current.push('/');
+                    current.push('*');
+                    index += 2;
+                } else if chars[index] == '*' && index + 1 < len && chars[index + 1] == '/' {
+                    depth -= 1;
+                    current.push('*');
+                    current.push('/');
+                    index += 2;
+                } else {
+                    current.push(chars[index]);
+                    index += 1;
+                }
+            }
+            continue;
+        }
+
+        // Single-quoted string literal ('' and backslash escapes).
+        if ch == '\'' {
+            current.push(ch);
+            index += 1;
+
+            while index < len {
+                let inner = chars[index];
+
+                if inner == '\\' && index + 1 < len {
+                    current.push(inner);
+                    current.push(chars[index + 1]);
+                    index += 2;
+                    continue;
+                }
+
+                if inner == '\'' {
+                    if index + 1 < len && chars[index + 1] == '\'' {
+                        current.push('\'');
+                        current.push('\'');
+                        index += 2;
+                        continue;
+                    }
+
+                    current.push('\'');
+                    index += 1;
+                    break;
+                }
+
+                current.push(inner);
+                index += 1;
+            }
+            continue;
+        }
+
+        // Quoted identifier: "..." (standard SQL) or `...` (MySQL).
+        if ch == '"' || ch == '`' {
+            let quote = ch;
+            current.push(ch);
+            index += 1;
+
+            while index < len {
+                let inner = chars[index];
+                current.push(inner);
+                index += 1;
+
+                if inner == quote {
+                    if index < len && chars[index] == quote {
+                        current.push(quote);
+                        index += 1;
+                        continue;
+                    }
+                    break;
+                }
+            }
+            continue;
+        }
+
+        // Dollar-quoted string: $tag$ ... $tag$ (PostgreSQL).
+        if ch == '$'
+            && let Some(tag_end) = dollar_tag_end(&chars, index)
+        {
+            let tag: String = chars[index..=tag_end].iter().collect();
+            let tag_len = tag.chars().count();
+
+            current.push_str(&tag);
+            index = tag_end + 1;
+
+            while index < len {
+                if chars[index] == '$' && matches_tag(&chars, index, &tag) {
+                    current.push_str(&tag);
+                    index += tag_len;
+                    break;
+                }
+
+                current.push(chars[index]);
+                index += 1;
+            }
+            continue;
+        }
+
+        // Statement terminator.
+        if ch == ';' {
+            let trimmed = current.trim();
+            if !trimmed.is_empty() {
+                statements.push(trimmed.to_string());
+            }
+            current.clear();
+            index += 1;
+            continue;
+        }
+
+        current.push(ch);
+        index += 1;
+    }
+
+    let trimmed = current.trim();
+    if !trimmed.is_empty() {
+        statements.push(trimmed.to_string());
+    }
+
+    statements
+}
+
+/// If `chars[start]` opens a dollar-quote tag, returns the index of the closing
+/// `$` of that opening tag. The tag identifier must be empty (`$$`) or a valid
+/// identifier (letters, digits, underscore, not starting with a digit), which
+/// also prevents misreading parameter placeholders such as `$1`.
+fn dollar_tag_end(chars: &[char], start: usize) -> Option<usize> {
+    let mut index = start + 1;
+
+    while index < chars.len() {
+        let ch = chars[index];
+
+        if ch == '$' {
+            return Some(index);
+        }
+
+        let is_first = index == start + 1;
+        let valid = ch == '_' || ch.is_alphabetic() || (ch.is_ascii_digit() && !is_first);
+        if !valid {
+            return None;
+        }
+
+        index += 1;
+    }
+
+    None
+}
+
+/// Whether `tag` matches the characters starting at `chars[index]`.
+fn matches_tag(chars: &[char], index: usize, tag: &str) -> bool {
+    let tag_chars: Vec<char> = tag.chars().collect();
+    if index + tag_chars.len() > chars.len() {
+        return false;
+    }
+
+    chars[index..index + tag_chars.len()] == tag_chars[..]
 }
 
 // ============================================================================
@@ -1598,6 +1820,111 @@ impl DriverMetadataBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn split_statements_single_sql() {
+        let stmts = QueryLanguage::Sql.split_statements("SELECT 1");
+        assert_eq!(stmts, vec!["SELECT 1".to_string()]);
+        assert_eq!(QueryLanguage::Sql.statement_count("SELECT 1"), 1);
+    }
+
+    #[test]
+    fn split_statements_trailing_semicolon_is_single() {
+        assert_eq!(QueryLanguage::Sql.statement_count("SELECT 1;"), 1);
+        assert_eq!(QueryLanguage::Sql.statement_count("SELECT 1;  \n  "), 1);
+    }
+
+    #[test]
+    fn split_statements_multiple_sql() {
+        let stmts = QueryLanguage::Sql.split_statements("SELECT 1; SELECT 2;");
+        assert_eq!(stmts, vec!["SELECT 1".to_string(), "SELECT 2".to_string()]);
+        assert_eq!(QueryLanguage::Sql.statement_count("SELECT 1; SELECT 2"), 2);
+    }
+
+    #[test]
+    fn split_statements_empty_segments_dropped() {
+        assert_eq!(QueryLanguage::Sql.statement_count(";;SELECT 1;;"), 1);
+        assert_eq!(QueryLanguage::Sql.statement_count("   ;  ; "), 0);
+    }
+
+    #[test]
+    fn split_statements_ignores_semicolon_in_string() {
+        let stmts = QueryLanguage::Sql.split_statements("SELECT 'a;b'; SELECT 2");
+        assert_eq!(
+            stmts,
+            vec!["SELECT 'a;b'".to_string(), "SELECT 2".to_string()]
+        );
+    }
+
+    #[test]
+    fn split_statements_ignores_escaped_quote_in_string() {
+        let stmts = QueryLanguage::Sql.split_statements("SELECT 'it''s; ok'; SELECT 2");
+        assert_eq!(stmts.len(), 2);
+        assert_eq!(stmts[0], "SELECT 'it''s; ok'");
+    }
+
+    #[test]
+    fn split_statements_ignores_semicolon_in_identifier() {
+        let stmts = QueryLanguage::Sql.split_statements("SELECT \"a;b\" FROM t; SELECT 2");
+        assert_eq!(stmts.len(), 2);
+        assert_eq!(stmts[0], "SELECT \"a;b\" FROM t");
+    }
+
+    #[test]
+    fn split_statements_ignores_semicolon_in_line_comment() {
+        let stmts = QueryLanguage::Sql.split_statements("SELECT 1 -- a; b\n; SELECT 2");
+        assert_eq!(stmts.len(), 2);
+        assert_eq!(stmts[1], "SELECT 2");
+    }
+
+    #[test]
+    fn split_statements_ignores_semicolon_in_block_comment() {
+        let stmts =
+            QueryLanguage::Sql.split_statements("SELECT 1 /* a; /* nested; */ b */; SELECT 2");
+        assert_eq!(stmts.len(), 2);
+    }
+
+    #[test]
+    fn split_statements_ignores_semicolon_in_dollar_quote() {
+        let body = "CREATE FUNCTION f() RETURNS int AS $$ BEGIN; RETURN 1; END; $$ LANGUAGE plpgsql; SELECT 2";
+        let stmts = QueryLanguage::Sql.split_statements(body);
+        assert_eq!(stmts.len(), 2);
+        assert!(stmts[0].contains("BEGIN; RETURN 1; END;"));
+        assert_eq!(stmts[1], "SELECT 2");
+    }
+
+    #[test]
+    fn split_statements_tagged_dollar_quote() {
+        let body = "SELECT $tag$ a;b $tag$; SELECT 2";
+        let stmts = QueryLanguage::Sql.split_statements(body);
+        assert_eq!(stmts.len(), 2);
+        assert_eq!(stmts[0], "SELECT $tag$ a;b $tag$");
+    }
+
+    #[test]
+    fn split_statements_dollar_placeholder_is_not_quote() {
+        let stmts = QueryLanguage::Sql.split_statements("SELECT $1; SELECT $2");
+        assert_eq!(
+            stmts,
+            vec!["SELECT $1".to_string(), "SELECT $2".to_string()]
+        );
+    }
+
+    #[test]
+    fn split_statements_non_sql_is_single() {
+        let text = "db.coll.find({a: 1}); db.coll.find({b: 2})";
+        assert_eq!(QueryLanguage::MongoQuery.statement_count(text), 1);
+        assert_eq!(
+            QueryLanguage::RedisCommands.statement_count("GET a\nGET b"),
+            1
+        );
+    }
+
+    #[test]
+    fn split_statements_empty_is_zero() {
+        assert_eq!(QueryLanguage::Sql.statement_count("   \n  "), 0);
+        assert_eq!(QueryLanguage::MongoQuery.statement_count(""), 0);
+    }
 
     #[test]
     fn test_category_names() {

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -51,7 +51,8 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
             | DriverCapabilities::CHECK_CONSTRAINTS.bits()
             | DriverCapabilities::UNIQUE_CONSTRAINTS.bits()
             | DriverCapabilities::TRANSACTIONAL_DDL.bits()
-            | DriverCapabilities::ROUTINES.bits(),
+            | DriverCapabilities::ROUTINES.bits()
+            | DriverCapabilities::MULTI_STATEMENT.bits(),
     ),
     default_port: Some(1433),
     uri_scheme: "sqlserver".into(),

--- a/crates/dbflux_driver_mysql/README.md
+++ b/crates/dbflux_driver_mysql/README.md
@@ -9,10 +9,12 @@
 - Includes SQL/code generation for CRUD, indexes, foreign keys, and table DDL operations.
 - Routine discovery: lists stored procedures and user-defined functions from `information_schema.ROUTINES` including parameter types and return type hints (Functions only).
 - Routine definition: retrieves the full `CREATE FUNCTION` or `CREATE PROCEDURE` body via `SHOW CREATE FUNCTION`/`SHOW CREATE PROCEDURE` (read-only; definition is not editable or executable in the viewer).
+- Multi-statement scripts (several `;`-separated statements) are split and executed statement by statement, each through the typed prepared path, returning one result set per statement.
 
 ## Limitations
 
 - SQL-only driver; it does not expose document or key-value APIs.
+- A multi-statement script runs each statement sequentially rather than as one atomic server-side batch; statement splitting is text-based and may missplit stored-program bodies that embed `;` (e.g. `CREATE PROCEDURE ... BEGIN ... END`).
 - Cancellation depends on server permissions and connection state when `KILL QUERY` is issued.
 - Code generation is scoped to supported MySQL/MariaDB constructs; unsupported generator IDs return `NotSupported`.
 - Routine listing covers only FUNCTION and PROCEDURE types. MySQL aggregate functions (registered via `CREATE AGGREGATE FUNCTION` UDF plugin) and window functions are not surfaced in `information_schema.ROUTINES` and are therefore not listed.

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -44,7 +44,8 @@ pub static MYSQL_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMet
             | DriverCapabilities::FOREIGN_KEYS.bits()
             | DriverCapabilities::CHECK_CONSTRAINTS.bits()
             | DriverCapabilities::UNIQUE_CONSTRAINTS.bits()
-            | DriverCapabilities::ROUTINES.bits(),
+            | DriverCapabilities::ROUTINES.bits()
+            | DriverCapabilities::MULTI_STATEMENT.bits(),
     ),
     default_port: Some(3306),
     uri_scheme: "mysql".into(),
@@ -194,7 +195,8 @@ pub static MARIADB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverM
             | DriverCapabilities::FOREIGN_KEYS.bits()
             | DriverCapabilities::CHECK_CONSTRAINTS.bits()
             | DriverCapabilities::UNIQUE_CONSTRAINTS.bits()
-            | DriverCapabilities::ROUTINES.bits(),
+            | DriverCapabilities::ROUTINES.bits()
+            | DriverCapabilities::MULTI_STATEMENT.bits(),
     ),
     default_port: Some(3306),
     uri_scheme: "mariadb".into(),
@@ -1687,89 +1689,31 @@ impl Connection for MysqlConnection {
             state.current_database = Some(db.clone());
         }
 
-        // Prepare the statement to get column metadata
-        let stmt = state
-            .conn
-            .prep(&req.sql)
-            .map_err(|e| format_mysql_query_error(&e))?;
-
-        // Extract column metadata from the prepared statement
-        let columns: Vec<ColumnMeta> = stmt
-            .columns()
-            .iter()
-            .map(|col| ColumnMeta {
-                name: col.name_str().to_string(),
-                type_name: mysql_type_to_sql_label(col),
-                kind: mysql_type_to_kind(col.column_type()),
-                nullable: true,
-                is_primary_key: false,
-            })
-            .collect();
-
-        // Execute the prepared statement
-        let result: Result<Vec<mysql::Row>, mysql::Error> = state.conn.exec(&stmt, ());
-
-        let query_time = start.elapsed();
-
-        match result {
-            Ok(rows) => {
-                if rows.is_empty() {
-                    // Check if it was a SELECT that returned 0 rows vs an INSERT/UPDATE
-                    let sql_upper = req.sql.trim().to_uppercase();
-                    if sql_upper.starts_with("SELECT")
-                        || sql_upper.starts_with("SHOW")
-                        || sql_upper.starts_with("DESCRIBE")
-                    {
-                        log::debug!(
-                            "[QUERY] Completed in {:.2}ms, 0 rows",
-                            query_time.as_secs_f64() * 1000.0
-                        );
-                        return Ok(QueryResult::table(columns, Vec::new(), None, query_time));
-                    } else {
-                        // Non-SELECT query, get affected rows from conn
-                        let affected = state.conn.affected_rows();
-                        log::debug!(
-                            "[QUERY] Completed in {:.2}ms, {} rows affected",
-                            query_time.as_secs_f64() * 1000.0,
-                            affected
-                        );
-                        return Ok(QueryResult::table(
-                            columns,
-                            Vec::new(),
-                            Some(affected),
-                            query_time,
-                        ));
-                    }
-                }
-
-                // Convert rows
-                let result_rows: Vec<Row> = rows
-                    .iter()
-                    .map(|row| {
-                        let row_cols = row.columns_ref();
-                        row_cols
-                            .iter()
-                            .enumerate()
-                            .map(|(i, col)| mysql_value_to_value(row, i, col))
-                            .collect()
-                    })
-                    .collect();
-
-                log::debug!(
-                    "[QUERY] Completed in {:.2}ms, {} rows",
-                    query_time.as_secs_f64() * 1000.0,
-                    result_rows.len()
-                );
-
-                Ok(QueryResult::table(columns, result_rows, None, query_time))
+        // The mysql prepared-statement protocol rejects a batch with more than
+        // one command, so a script must be split and run statement by
+        // statement, each through the typed prepared path. Each statement
+        // becomes a result set; the first is primary and the rest are attached
+        // as additional results.
+        let statements = QueryLanguage::Sql.split_statements(&req.sql);
+        if statements.len() > 1 {
+            let mut result_sets: Vec<QueryResult> = Vec::with_capacity(statements.len());
+            for statement in &statements {
+                result_sets.push(mysql_execute_one_statement(
+                    &mut state.conn,
+                    statement,
+                    start,
+                    &self.cancelled,
+                )?);
             }
-            Err(e) => {
-                if self.cancelled.load(Ordering::SeqCst) {
-                    return Err(DbError::Cancelled);
-                }
-                Err(format_mysql_query_error(&e))
+
+            let mut primary = result_sets.remove(0);
+            for extra in result_sets {
+                primary.push_additional_result(extra);
             }
+            return Ok(primary);
         }
+
+        mysql_execute_one_statement(&mut state.conn, &req.sql, start, &self.cancelled)
     }
 
     fn cancel_active(&self) -> Result<(), DbError> {
@@ -2610,6 +2554,100 @@ impl ConnectionExt for MysqlConnection {
 
     fn as_keyvalue(&self) -> Option<&dyn KeyValueConnection> {
         None
+    }
+}
+
+/// Executes a single MySQL statement and returns its result set.
+///
+/// SELECT/SHOW/DESCRIBE statements return rows; everything else reports the
+/// affected-row count. This is the per-statement unit used both for a lone
+/// query and for each statement of a multi-statement batch (a script), since
+/// the prepared-statement protocol rejects multi-command batches.
+fn mysql_execute_one_statement(
+    conn: &mut Conn,
+    sql: &str,
+    start: Instant,
+    cancelled: &AtomicBool,
+) -> Result<QueryResult, DbError> {
+    // Prepare the statement to get column metadata
+    let stmt = conn.prep(sql).map_err(|e| format_mysql_query_error(&e))?;
+
+    // Extract column metadata from the prepared statement
+    let columns: Vec<ColumnMeta> = stmt
+        .columns()
+        .iter()
+        .map(|col| ColumnMeta {
+            name: col.name_str().to_string(),
+            type_name: mysql_type_to_sql_label(col),
+            kind: mysql_type_to_kind(col.column_type()),
+            nullable: true,
+            is_primary_key: false,
+        })
+        .collect();
+
+    // Execute the prepared statement
+    let result: Result<Vec<mysql::Row>, mysql::Error> = conn.exec(&stmt, ());
+
+    let query_time = start.elapsed();
+
+    match result {
+        Ok(rows) => {
+            if rows.is_empty() {
+                // Check if it was a SELECT that returned 0 rows vs an INSERT/UPDATE
+                let sql_upper = sql.trim().to_uppercase();
+                if sql_upper.starts_with("SELECT")
+                    || sql_upper.starts_with("SHOW")
+                    || sql_upper.starts_with("DESCRIBE")
+                {
+                    log::debug!(
+                        "[QUERY] Completed in {:.2}ms, 0 rows",
+                        query_time.as_secs_f64() * 1000.0
+                    );
+                    return Ok(QueryResult::table(columns, Vec::new(), None, query_time));
+                } else {
+                    // Non-SELECT query, get affected rows from conn
+                    let affected = conn.affected_rows();
+                    log::debug!(
+                        "[QUERY] Completed in {:.2}ms, {} rows affected",
+                        query_time.as_secs_f64() * 1000.0,
+                        affected
+                    );
+                    return Ok(QueryResult::table(
+                        columns,
+                        Vec::new(),
+                        Some(affected),
+                        query_time,
+                    ));
+                }
+            }
+
+            // Convert rows
+            let result_rows: Vec<Row> = rows
+                .iter()
+                .map(|row| {
+                    let row_cols = row.columns_ref();
+                    row_cols
+                        .iter()
+                        .enumerate()
+                        .map(|(i, col)| mysql_value_to_value(row, i, col))
+                        .collect()
+                })
+                .collect();
+
+            log::debug!(
+                "[QUERY] Completed in {:.2}ms, {} rows",
+                query_time.as_secs_f64() * 1000.0,
+                result_rows.len()
+            );
+
+            Ok(QueryResult::table(columns, result_rows, None, query_time))
+        }
+        Err(e) => {
+            if cancelled.load(Ordering::SeqCst) {
+                return Err(DbError::Cancelled);
+            }
+            Err(format_mysql_query_error(&e))
+        }
     }
 }
 

--- a/crates/dbflux_driver_postgres/README.md
+++ b/crates/dbflux_driver_postgres/README.md
@@ -8,8 +8,11 @@
 - Supports authentication, SSL, SSH tunneling, and URI/manual connection modes.
 - Supports query cancellation through PostgreSQL cancel tokens.
 - Includes PostgreSQL-specific SQL/code generation for CRUD, indexes, reindex, foreign keys, and type operations.
+- Multi-statement scripts (several `;`-separated statements) run as a batch via the simple query protocol, returning one result set per statement.
 
 ## Limitations
+
+- Batched (multi-statement) result columns carry no type metadata; values are returned as text and chart auto-detection is disabled for them. Run a single statement to get fully typed columns.
 
 - SQL-only driver; it does not expose document or key-value APIs.
 - Routine definitions for aggregate and window functions are synthesized from catalog metadata because `pg_get_functiondef` does not support them.

--- a/crates/dbflux_driver_postgres/src/driver.rs
+++ b/crates/dbflux_driver_postgres/src/driver.rs
@@ -31,7 +31,7 @@ use dbflux_core::{
 use dbflux_ssh::SshTunnel;
 use native_tls::TlsConnector;
 use postgres::types::{FromSql, Kind, Type};
-use postgres::{CancelToken as PgCancelToken, Client, NoTls};
+use postgres::{CancelToken as PgCancelToken, Client, NoTls, SimpleQueryMessage};
 use postgres_native_tls::MakeTlsConnector;
 use serde_json::Value as JsonValue;
 use uuid::Uuid;
@@ -56,7 +56,8 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
             | DriverCapabilities::CUSTOM_TYPES.bits()
             | DriverCapabilities::RETURNING.bits()
             | DriverCapabilities::TRANSACTIONAL_DDL.bits()
-            | DriverCapabilities::ROUTINES.bits(),
+            | DriverCapabilities::ROUTINES.bits()
+            | DriverCapabilities::MULTI_STATEMENT.bits(),
     ),
     default_port: Some(5432),
     uri_scheme: "postgresql".into(),
@@ -1381,15 +1382,23 @@ impl Connection for PostgresConnection {
             sql_preview.replace('\n', " ")
         );
 
-        let (columns, rows) = {
-            let mut client = match self.client.lock() {
-                Ok(guard) => guard,
-                Err(poison_err) => {
-                    log::warn!("[CLEANUP] Recovering from poisoned mutex during cleanup");
-                    poison_err.into_inner()
-                }
-            };
+        let mut client = match self.client.lock() {
+            Ok(guard) => guard,
+            Err(poison_err) => {
+                log::warn!("[CLEANUP] Recovering from poisoned mutex during cleanup");
+                poison_err.into_inner()
+            }
+        };
 
+        // A multi-statement batch cannot use the extended (prepared) protocol,
+        // which rejects more than one command per statement (SQLSTATE 42601).
+        // Route it through the simple query protocol, which executes the whole
+        // batch and returns one result set per statement.
+        if QueryLanguage::Sql.statement_count(&req.sql) > 1 {
+            return execute_statement_batch(&mut client, &req.sql, query_id, start, req.limit);
+        }
+
+        let (columns, rows) = {
             // Prepare the statement first to get column metadata
             let stmt = client.prepare(&req.sql).map_err(|e| {
                 if e.code() == Some(&postgres::error::SqlState::QUERY_CANCELED) {
@@ -1425,6 +1434,8 @@ impl Connection for PostgresConnection {
 
             (columns, rows)
         };
+
+        drop(client);
 
         let query_time = start.elapsed();
 
@@ -3501,6 +3512,127 @@ fn format_pg_query_error(e: &postgres::Error) -> DbError {
     let message = formatted.to_display_string();
     log::error!("PostgreSQL query failed: {}", message);
     formatted.into_query_error()
+}
+
+/// Executes a multi-statement batch via the simple query protocol.
+///
+/// The extended (prepared) protocol used by [`PostgresConnection::execute`]
+/// rejects batches with more than one command (SQLSTATE 42601), so a script
+/// must go through `simple_query`. The trade-off is that the simple protocol
+/// returns every value as text and carries no type metadata, so result columns
+/// are reported with [`ColumnKind::Unknown`]. Each statement in the batch
+/// becomes a separate result set; the first is the primary result and the rest
+/// are attached as `additional_results`.
+fn execute_statement_batch(
+    client: &mut Client,
+    sql: &str,
+    query_id: Uuid,
+    start: Instant,
+    limit: Option<u32>,
+) -> Result<QueryResult, DbError> {
+    let messages = client.simple_query(sql).map_err(|e| {
+        if e.code() == Some(&postgres::error::SqlState::QUERY_CANCELED) {
+            log::info!("[QUERY] Batch query {} was cancelled", query_id);
+            DbError::Cancelled
+        } else {
+            format_pg_query_error(&e)
+        }
+    })?;
+
+    let total_time = start.elapsed();
+    let mut result_sets = simple_query_messages_to_results(messages, total_time, limit);
+
+    log::debug!(
+        "[QUERY] Batch completed in {:.2}ms, {} result set(s)",
+        total_time.as_secs_f64() * 1000.0,
+        result_sets.len()
+    );
+
+    if result_sets.is_empty() {
+        return Ok(QueryResult::table(Vec::new(), Vec::new(), None, total_time));
+    }
+
+    let mut primary = result_sets.remove(0);
+    for extra in result_sets {
+        primary.push_additional_result(extra);
+    }
+
+    Ok(primary)
+}
+
+/// Groups the flat stream of [`SimpleQueryMessage`]s into one [`QueryResult`]
+/// per statement. A `CommandComplete` closes the current statement: if it
+/// produced rows the result is a table, otherwise it reports the affected-row
+/// count. Row values arrive as text and columns are typed `Unknown`.
+fn simple_query_messages_to_results(
+    messages: Vec<SimpleQueryMessage>,
+    total_time: std::time::Duration,
+    limit: Option<u32>,
+) -> Vec<QueryResult> {
+    let row_limit = limit.unwrap_or(u32::MAX) as usize;
+
+    let mut results = Vec::new();
+    let mut columns: Option<Vec<ColumnMeta>> = None;
+    let mut rows: Vec<Row> = Vec::new();
+
+    for message in messages {
+        match message {
+            SimpleQueryMessage::Row(row) => {
+                if columns.is_none() {
+                    columns = Some(
+                        row.columns()
+                            .iter()
+                            .map(|col| ColumnMeta {
+                                name: col.name().to_string(),
+                                type_name: String::new(),
+                                kind: ColumnKind::Unknown,
+                                nullable: true,
+                                is_primary_key: false,
+                            })
+                            .collect(),
+                    );
+                }
+
+                if rows.len() < row_limit {
+                    let values = (0..row.columns().len())
+                        .map(|i| match row.get(i) {
+                            Some(text) => Value::Text(text.to_string()),
+                            None => Value::Null,
+                        })
+                        .collect();
+                    rows.push(values);
+                }
+            }
+            SimpleQueryMessage::CommandComplete(affected) => {
+                let statement_columns = columns.take().unwrap_or_default();
+                let statement_rows = std::mem::take(&mut rows);
+                let returned_rows = !statement_columns.is_empty();
+
+                let affected_rows = if returned_rows { None } else { Some(affected) };
+
+                results.push(QueryResult::table(
+                    statement_columns,
+                    statement_rows,
+                    affected_rows,
+                    total_time,
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    // Guard against a trailing row group that never received a CommandComplete.
+    if columns.is_some() || !rows.is_empty() {
+        let statement_columns = columns.take().unwrap_or_default();
+        results.push(QueryResult::table(
+            statement_columns,
+            std::mem::take(&mut rows),
+            None,
+            total_time,
+        ));
+    }
+
+    results
 }
 
 fn format_pg_uri_error(e: &postgres::Error, uri: &str) -> DbError {

--- a/crates/dbflux_driver_sqlite/README.md
+++ b/crates/dbflux_driver_sqlite/README.md
@@ -6,6 +6,7 @@
 - Supports SQL execution, schema discovery, views, indexes, foreign keys, check constraints, and unique constraints.
 - Supports query cancellation via SQLite interrupt handles.
 - Includes SQL/code generation for CRUD, indexes, reindex, create table, and drop table.
+- Multi-statement scripts (several `;`-separated statements) are split and executed statement by statement, each through the typed prepared path, returning one result set per statement. (`rusqlite::prepare` only parses the first statement of a string, so a script must be split.)
 
 ## Limitations
 

--- a/crates/dbflux_driver_sqlite/src/driver.rs
+++ b/crates/dbflux_driver_sqlite/src/driver.rs
@@ -54,7 +54,8 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
             | DriverCapabilities::EXPORT_CSV.bits()
             | DriverCapabilities::EXPORT_JSON.bits()
             | DriverCapabilities::QUERY_CANCELLATION.bits()
-            | DriverCapabilities::TRANSACTIONAL_DDL.bits(),
+            | DriverCapabilities::TRANSACTIONAL_DDL.bits()
+            | DriverCapabilities::MULTI_STATEMENT.bits(),
     ),
     default_port: None,
     uri_scheme: "sqlite".into(),
@@ -655,122 +656,31 @@ impl Connection for SqliteConnection {
             .lock()
             .map_err(|e| DbError::query_failed(format!("Lock error: {}", e)))?;
 
-        let stmt_result = conn.prepare(&req.sql);
-
-        let mut stmt = match stmt_result {
-            Ok(s) => s,
-            Err(e) => {
-                if self.cancelled.load(Ordering::SeqCst) {
-                    log::info!("[QUERY] SQLite query was interrupted");
-                    return Err(DbError::Cancelled);
-                }
-                return Err(format_sqlite_query_error(&e));
-            }
-        };
-
-        // Check if this is a SELECT, PRAGMA, or EXPLAIN statement (returns rows) or a DDL/DML statement
-        let sql_trimmed = req.sql.trim().to_uppercase();
-        let is_query = sql_trimmed.starts_with("SELECT")
-            || sql_trimmed.starts_with("PRAGMA")
-            || sql_trimmed.starts_with("EXPLAIN");
-
-        if is_query {
-            // For SELECT statements, use query() to get rows.
-            // Use Statement::columns() (requires the `column_decltype` rusqlite feature)
-            // to get declared type strings, then apply SQLite affinity heuristics to
-            // populate ColumnKind. Columns whose declared type is NULL (dynamic columns
-            // or expressions) fall back to ColumnKind::Unknown.
-            let column_count = stmt.column_count();
-            let col_meta: Vec<(String, String, ColumnKind)> = stmt
-                .columns()
-                .into_iter()
-                .map(|col| {
-                    let name = col.name().to_string();
-                    let decl = col.decl_type().unwrap_or("");
-                    let type_name = if decl.is_empty() {
-                        "TEXT".to_string()
-                    } else {
-                        decl.to_uppercase()
-                    };
-                    let kind = kind_from_decltype(col.decl_type());
-                    (name, type_name, kind)
-                })
-                .collect();
-            let columns: Vec<ColumnMeta> = col_meta
-                .into_iter()
-                .map(|(name, type_name, kind)| ColumnMeta {
-                    name,
-                    type_name,
-                    kind,
-                    nullable: true,
-                    is_primary_key: false,
-                })
-                .collect();
-
-            let mut rows: Vec<Row> = Vec::new();
-            let query_result = stmt.query([]);
-
-            let mut result_rows = match query_result {
-                Ok(r) => r,
-                Err(e) => {
-                    if self.cancelled.load(Ordering::SeqCst) {
-                        log::info!("[QUERY] SQLite query was interrupted");
-                        return Err(DbError::Cancelled);
-                    }
-                    return Err(format_sqlite_query_error(&e));
-                }
-            };
-
-            loop {
-                let next_result = result_rows.next();
-
-                match next_result {
-                    Ok(Some(row)) => {
-                        let mut values: Vec<Value> = Vec::with_capacity(column_count);
-                        for i in 0..column_count {
-                            let value = sqlite_value_to_value(row, i);
-                            values.push(value);
-                        }
-                        rows.push(values);
-
-                        if let Some(limit) = req.limit
-                            && rows.len() >= limit as usize
-                        {
-                            break;
-                        }
-                    }
-                    Ok(None) => break,
-                    Err(e) => {
-                        if self.cancelled.load(Ordering::SeqCst) {
-                            log::info!("[QUERY] SQLite query was interrupted during iteration");
-                            return Err(DbError::Cancelled);
-                        }
-                        return Err(format_sqlite_query_error(&e));
-                    }
-                }
+        // `rusqlite::prepare` only parses the first statement of a
+        // multi-statement string and silently ignores the rest. To run a
+        // script we split it and execute each statement on its own, keeping
+        // the typed single-statement path for the common case.
+        let statements = QueryLanguage::Sql.split_statements(&req.sql);
+        if statements.len() > 1 {
+            let mut result_sets: Vec<QueryResult> = Vec::with_capacity(statements.len());
+            for statement in &statements {
+                result_sets.push(execute_one_statement(
+                    &conn,
+                    statement,
+                    req.limit,
+                    start,
+                    &self.cancelled,
+                )?);
             }
 
-            Ok(QueryResult::table(columns, rows, None, start.elapsed()))
-        } else {
-            // For DDL/DML statements (CREATE, DROP, INSERT, UPDATE, DELETE, etc.),
-            // use execute() which properly handles non-row-returning statements
-            let affected = stmt.execute([]).map_err(|e| {
-                if self.cancelled.load(Ordering::SeqCst) {
-                    log::info!("[QUERY] SQLite query was interrupted");
-                    DbError::Cancelled
-                } else {
-                    format_sqlite_query_error(&e)
-                }
-            })?;
-
-            // Return empty result for DDL/DML
-            Ok(QueryResult::table(
-                vec![],
-                vec![],
-                Some(affected as u64),
-                start.elapsed(),
-            ))
+            let mut primary = result_sets.remove(0);
+            for extra in result_sets {
+                primary.push_additional_result(extra);
+            }
+            return Ok(primary);
         }
+
+        execute_one_statement(&conn, &req.sql, req.limit, start, &self.cancelled)
     }
 
     fn cancel(&self, _handle: &QueryHandle) -> Result<(), DbError> {
@@ -1792,6 +1702,137 @@ impl SqliteConnection {
         }
 
         Ok(all_fks)
+    }
+}
+
+/// Executes a single SQLite statement and returns its result set.
+///
+/// SELECT/PRAGMA/EXPLAIN statements return rows; everything else reports the
+/// affected-row count. This is the per-statement unit used both for a lone
+/// query and for each statement of a multi-statement batch (a script), since
+/// `rusqlite::prepare` only parses the first statement of a string.
+fn execute_one_statement(
+    conn: &RusqliteConnection,
+    sql: &str,
+    limit: Option<u32>,
+    start: Instant,
+    cancelled: &AtomicBool,
+) -> Result<QueryResult, DbError> {
+    let stmt_result = conn.prepare(sql);
+
+    let mut stmt = match stmt_result {
+        Ok(s) => s,
+        Err(e) => {
+            if cancelled.load(Ordering::SeqCst) {
+                log::info!("[QUERY] SQLite query was interrupted");
+                return Err(DbError::Cancelled);
+            }
+            return Err(format_sqlite_query_error(&e));
+        }
+    };
+
+    // Check if this is a SELECT, PRAGMA, or EXPLAIN statement (returns rows) or a DDL/DML statement
+    let sql_trimmed = sql.trim().to_uppercase();
+    let is_query = sql_trimmed.starts_with("SELECT")
+        || sql_trimmed.starts_with("PRAGMA")
+        || sql_trimmed.starts_with("EXPLAIN");
+
+    if is_query {
+        // For SELECT statements, use query() to get rows.
+        // Use Statement::columns() (requires the `column_decltype` rusqlite feature)
+        // to get declared type strings, then apply SQLite affinity heuristics to
+        // populate ColumnKind. Columns whose declared type is NULL (dynamic columns
+        // or expressions) fall back to ColumnKind::Unknown.
+        let column_count = stmt.column_count();
+        let col_meta: Vec<(String, String, ColumnKind)> = stmt
+            .columns()
+            .into_iter()
+            .map(|col| {
+                let name = col.name().to_string();
+                let decl = col.decl_type().unwrap_or("");
+                let type_name = if decl.is_empty() {
+                    "TEXT".to_string()
+                } else {
+                    decl.to_uppercase()
+                };
+                let kind = kind_from_decltype(col.decl_type());
+                (name, type_name, kind)
+            })
+            .collect();
+        let columns: Vec<ColumnMeta> = col_meta
+            .into_iter()
+            .map(|(name, type_name, kind)| ColumnMeta {
+                name,
+                type_name,
+                kind,
+                nullable: true,
+                is_primary_key: false,
+            })
+            .collect();
+
+        let mut rows: Vec<Row> = Vec::new();
+        let query_result = stmt.query([]);
+
+        let mut result_rows = match query_result {
+            Ok(r) => r,
+            Err(e) => {
+                if cancelled.load(Ordering::SeqCst) {
+                    log::info!("[QUERY] SQLite query was interrupted");
+                    return Err(DbError::Cancelled);
+                }
+                return Err(format_sqlite_query_error(&e));
+            }
+        };
+
+        loop {
+            let next_result = result_rows.next();
+
+            match next_result {
+                Ok(Some(row)) => {
+                    let mut values: Vec<Value> = Vec::with_capacity(column_count);
+                    for i in 0..column_count {
+                        let value = sqlite_value_to_value(row, i);
+                        values.push(value);
+                    }
+                    rows.push(values);
+
+                    if let Some(row_limit) = limit
+                        && rows.len() >= row_limit as usize
+                    {
+                        break;
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => {
+                    if cancelled.load(Ordering::SeqCst) {
+                        log::info!("[QUERY] SQLite query was interrupted during iteration");
+                        return Err(DbError::Cancelled);
+                    }
+                    return Err(format_sqlite_query_error(&e));
+                }
+            }
+        }
+
+        Ok(QueryResult::table(columns, rows, None, start.elapsed()))
+    } else {
+        // For DDL/DML statements (CREATE, DROP, INSERT, UPDATE, DELETE, etc.),
+        // use execute() which properly handles non-row-returning statements
+        let affected = stmt.execute([]).map_err(|e| {
+            if cancelled.load(Ordering::SeqCst) {
+                log::info!("[QUERY] SQLite query was interrupted");
+                DbError::Cancelled
+            } else {
+                format_sqlite_query_error(&e)
+            }
+        })?;
+
+        // Return empty result for DDL/DML
+        Ok(QueryResult::table(
+            vec![],
+            vec![],
+            Some(affected as u64),
+            start.elapsed(),
+        ))
     }
 }
 

--- a/crates/dbflux_ui/src/ui/document/code/execution.rs
+++ b/crates/dbflux_ui/src/ui/document/code/execution.rs
@@ -150,8 +150,65 @@ impl CodeDocument {
     }
 
     fn run_query_impl(&mut self, in_new_tab: bool, window: &mut Window, cx: &mut Context<Self>) {
-        let query = self.selected_or_full_query(window, cx);
+        // A selection always runs as-is, without the script confirmation.
+        if let Some(query) = self.selected_query(window, cx) {
+            self.run_query_text(query, in_new_tab, window, cx);
+            return;
+        }
+
+        let query = self.input_state.read(cx).value().to_string();
+
+        // No selection means the whole buffer runs. When it holds more than one
+        // statement and the driver can execute batches, confirm before running
+        // the entire script.
+        if let Some(statement_count) = self.script_statement_count(&query, cx) {
+            self.pending_script_confirm = Some(PendingScriptConfirm {
+                query,
+                in_new_tab,
+                statement_count,
+            });
+            cx.notify();
+            return;
+        }
+
         self.run_query_text(query, in_new_tab, window, cx);
+    }
+
+    /// Returns the statement count when `query` is a multi-statement script and
+    /// the active connection's driver advertises `MULTI_STATEMENT`.
+    ///
+    /// Returns `None` for a single statement or a driver that cannot execute
+    /// batches, in which case no confirmation is shown.
+    fn script_statement_count(&self, query: &str, cx: &Context<Self>) -> Option<usize> {
+        let count = self.query_language.statement_count(query);
+        if count <= 1 {
+            return None;
+        }
+
+        let conn_id = self.connection_id?;
+        let app_state = self.app_state.read(cx);
+        let connected = app_state.connections().get(&conn_id)?;
+
+        let supports_batch = connected
+            .connection
+            .metadata()
+            .capabilities
+            .contains(DriverCapabilities::MULTI_STATEMENT);
+
+        supports_batch.then_some(count)
+    }
+
+    pub(super) fn confirm_script_query(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(pending) = self.pending_script_confirm.take() else {
+            return;
+        };
+
+        self.run_query_text(pending.query, pending.in_new_tab, window, cx);
+    }
+
+    pub(super) fn cancel_script_query(&mut self, cx: &mut Context<Self>) {
+        self.pending_script_confirm = None;
+        cx.notify();
     }
 
     fn run_query_text(
@@ -1067,6 +1124,14 @@ impl CodeDocument {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // A multi-statement batch yields one result set per statement. Give
+        // each its own tab so every statement's output is visible, rather than
+        // surfacing only the primary set.
+        if result.has_additional_results() {
+            self.create_result_tabs_for_batch(result, query, window, cx);
+            return;
+        }
+
         let should_create_new_tab = self.run_in_new_tab
             || self.result_tabs.is_empty()
             || self.active_result_index.is_none();
@@ -1082,6 +1147,33 @@ impl CodeDocument {
             tab.grid.update(cx, |g, cx| {
                 g.set_query_result(result, query.clone(), profile_id, cx)
             });
+        }
+    }
+
+    /// Creates one result tab per result set of a multi-statement batch.
+    ///
+    /// The first new tab is activated so the user lands on the first
+    /// statement's output. Each set is rendered on its own, so the per-set
+    /// `additional_results` is stripped from the primary before display.
+    fn create_result_tabs_for_batch(
+        &mut self,
+        result: Arc<QueryResult>,
+        query: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.run_in_new_tab = false;
+
+        let first_new_index = self.result_tabs.len();
+
+        for set in result.iter_result_sets() {
+            let mut single = set.clone();
+            single.additional_results.clear();
+            self.create_result_tab(Arc::new(single), query.clone(), window, cx);
+        }
+
+        if first_new_index < self.result_tabs.len() {
+            self.active_result_index = Some(first_new_index);
         }
     }
 

--- a/crates/dbflux_ui/src/ui/document/code/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/code/mod.rs
@@ -279,6 +279,9 @@ pub struct CodeDocument {
     // Dangerous query confirmation
     pending_dangerous_query: Option<PendingDangerousQuery>,
 
+    // Multi-statement script confirmation
+    pending_script_confirm: Option<PendingScriptConfirm>,
+
     // Schema drift detection
     schema_drift_modal: Entity<ModalSchemaDrift>,
     _schema_drift_subscriptions: Vec<Subscription>,
@@ -330,6 +333,16 @@ struct PendingDangerousQuery {
     query: String,
     kind: DangerousQueryKind,
     in_new_tab: bool,
+}
+
+/// Pending confirmation for running a whole multi-statement script.
+///
+/// Raised when the user runs without a selection, the buffer holds more than
+/// one statement, and the driver advertises `MULTI_STATEMENT`.
+struct PendingScriptConfirm {
+    query: String,
+    in_new_tab: bool,
+    statement_count: usize,
 }
 
 /// Action resolved by the schema-drift modal.
@@ -701,6 +714,7 @@ impl CodeDocument {
             _refresh_subscriptions: vec![refresh_policy_sub],
             is_active_tab: true,
             pending_dangerous_query: None,
+            pending_script_confirm: None,
             schema_drift_modal,
             _schema_drift_subscriptions: vec![
                 drift_refresh_sub,

--- a/crates/dbflux_ui/src/ui/document/code/render.rs
+++ b/crates/dbflux_ui/src/ui/document/code/render.rs
@@ -718,6 +718,76 @@ impl CodeDocument {
             ))
     }
 
+    fn render_script_confirm_modal(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let entity = cx.entity().clone();
+        let entity_cancel = cx.entity().clone();
+
+        let statement_count = self
+            .pending_script_confirm
+            .as_ref()
+            .map(|p| p.statement_count)
+            .unwrap_or(0);
+        let message = format!(
+            "No text is selected, so the entire script will run as {} statements in order. Continue?",
+            statement_count
+        );
+
+        div()
+            .id("script-confirm-modal-overlay")
+            .absolute()
+            .inset_0()
+            .bg(overlay_bg(theme))
+            .flex()
+            .items_center()
+            .justify_center()
+            .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                cx.stop_propagation();
+            })
+            .child(
+                surface_panel(cx)
+                    .rounded(Radii::MD)
+                    .min_w(px(350.0))
+                    .max_w(px(500.0))
+                    .flex()
+                    .flex_col()
+                    .gap(Spacing::MD)
+                    .p(Spacing::MD)
+                    .child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_2()
+                            .child(Icon::new(AppIcon::TriangleAlert).size(px(20.0)).warning())
+                            .child(Text::heading("Run entire script")),
+                    )
+                    .child(Text::caption(message))
+                    .child(
+                        div().flex().justify_end().items_center().child(
+                            div()
+                                .flex()
+                                .gap(Spacing::SM)
+                                .child(Button::new("script-confirm-cancel-btn", "Cancel").on_click(
+                                    move |_, _, cx| {
+                                        entity_cancel.update(cx, |doc, cx| {
+                                            doc.cancel_script_query(cx);
+                                        });
+                                    },
+                                ))
+                                .child(
+                                    Button::new("script-confirm-run-btn", "Run Script").on_click(
+                                        move |_, window, cx| {
+                                            entity.update(cx, |doc, cx| {
+                                                doc.confirm_script_query(window, cx);
+                                            });
+                                        },
+                                    ),
+                                ),
+                        ),
+                    ),
+            )
+    }
+
     fn render_dangerous_query_modal(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let entity = cx.entity().clone();
@@ -960,6 +1030,9 @@ impl Render for CodeDocument {
             .child(self.history_modal.clone())
             .when(self.pending_dangerous_query.is_some(), |el| {
                 el.child(self.render_dangerous_query_modal(cx))
+            })
+            .when(self.pending_script_confirm.is_some(), |el| {
+                el.child(self.render_script_confirm_modal(cx))
             })
             .when(drift_modal_visible, |el| {
                 el.child(self.schema_drift_modal.clone())


### PR DESCRIPTION
## What

Adds support for executing a whole script (multiple `;`-separated statements) when no text is selected, gated behind a confirmation dialog, for the SQL drivers whose engine supports batches.

This fixes the PostgreSQL error `Syntax error: cannot insert multiple commands into a prepared statement. Code: 42601`, which occurred because every user query was sent through the extended (prepared) protocol — which rejects multi-command batches.

## Why

Running scripts is normal usage for a database client. Previously a multi-statement buffer either errored (Postgres/MySQL) or silently ran only the first statement (SQLite).

## How

**Core (`dbflux_core`)** — driver-agnostic seam:
- `QueryLanguage::split_statements` / `statement_count`: SQL-family aware splitter that skips `;` inside single-quoted strings, quoted identifiers, line (`--`) and nested block (`/* */`) comments, and PostgreSQL dollar-quoted bodies (`$tag$ … $tag$`); `$1` placeholders are not treated as dollar-quotes. Non-SQL languages stay single-statement.
- New `DriverCapabilities::MULTI_STATEMENT` flag.
- 14 unit tests for the splitter.

**Drivers** (each declares `MULTI_STATEMENT` and returns one result set per statement via `QueryResult.additional_results`):
- **Postgres**: multi-statement batches run through the simple query protocol. Batched result columns carry no type metadata (values returned as text, `ColumnKind::Unknown`); single statements keep the typed prepared path.
- **MySQL/MariaDB** and **SQLite**: split client-side and execute each statement through the existing typed prepared path. Also fixes SQLite previously executing only the first statement of a script.
- **MSSQL**: already executed batches natively (`simple_query` + `additional_results`); only the capability flag was missing.

**UI (`dbflux_ui`)** — stays driver-agnostic:
- Running without a selection shows a "Run entire script (N statements)?" confirmation when the buffer is multi-statement **and** the active driver advertises `MULTI_STATEMENT` (reuses the dangerous-query modal pattern). A selection, or a single statement, runs directly.
- Multiple result sets render as one result tab per statement.

**Docs**: driver READMEs updated with the new capability and its limitations; `CLAUDE.md` / `AGENTS.md` add the `mssql` build feature (and MSSQL to the DDL behavior list in AGENTS.md).

## Testing

- `cargo check --workspace` OK, `cargo clippy` clean on core + SQL drivers.
- `cargo test` green for `dbflux_core` (598+) and the SQL drivers' non-ignored suites.
- Docker-backed live driver tests (`#[ignore]`) were not run.

## Notes / follow-up

- Statement splitting is text-based; it may missplit stored-program bodies that embed `;` outside dollar-quoting (e.g. MySQL `CREATE PROCEDURE … BEGIN … END`). Documented in the MySQL README.