### PR TITLE
feat(chart): add Bar, Scatter, Area, Stacked Bar and Pie chart types; fix Flux on InfluxDB

### DIFF
--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -563,6 +563,43 @@ impl ChartView {
         cx.notify();
     }
 
+    /// The padded Y ceiling used when rendering a `StackedBar` chart.
+    ///
+    /// `RenderModel.y_max` stores per-series maxima, which underestimate the top
+    /// of a stack. This recomputes the true ceiling by summing the visible
+    /// series at each shared point index and adding the same 8% headroom render
+    /// uses, so the render path and the hover hit-test agree on the Y scale. It
+    /// is recomputed from the current hidden set, so toggling series off keeps
+    /// the scale correct.
+    fn stacked_y_max(&self) -> f64 {
+        let model = &self.render_model;
+        let y_min = model.y_min;
+
+        let visible: Vec<usize> = (0..model.decimated.len())
+            .filter(|i| !self.hidden.contains(i))
+            .collect();
+
+        let max_points = model.decimated.iter().map(|s| s.len()).max().unwrap_or(0);
+
+        let stacked_max = (0..max_points)
+            .map(|pt_idx| {
+                visible
+                    .iter()
+                    .filter_map(|&s| model.decimated[s].get(pt_idx).map(|(_, y)| *y))
+                    .filter(|y| y.is_finite())
+                    .sum::<f64>()
+            })
+            .fold(f64::NEG_INFINITY, f64::max);
+
+        let stacked_max = if stacked_max.is_finite() {
+            stacked_max
+        } else {
+            model.y_max
+        };
+
+        stacked_max + (stacked_max - y_min).abs() * 0.08
+    }
+
     /// Re-evaluate which series the cursor hovers over and update
     /// `focused_series_idx` with a 2 px dead-band to dampen jitter.
     ///
@@ -685,7 +722,10 @@ impl ChartView {
             let cursor_sx = f32::from(hover_x);
             let cursor_sy = f32::from(hover_y);
 
-            let y_range_local = (self.render_model.y_max - y_min).max(1.0);
+            // Use the same stacked Y ceiling render uses, not the per-series
+            // RenderModel.y_max, so segment boundaries line up with the bars.
+            let stacked_y_max = self.stacked_y_max();
+            let y_range_local = (stacked_y_max - y_min).max(1.0);
             let data_to_screen_y = |dy: f64| -> f32 {
                 plot_y0 + plot_h
                     - ((dy - y_min) / y_range_local * plot_h as f64) as f32
@@ -704,7 +744,7 @@ impl ChartView {
 
                 // Cursor is inside this bar column. Find which series segment
                 // the cursor's Y lands in by checking stacked segment boundaries.
-                let baseline = if y_min <= 0.0 && self.render_model.y_max >= 0.0 {
+                let baseline = if y_min <= 0.0 && stacked_y_max >= 0.0 {
                     0.0_f64
                 } else {
                     y_min
@@ -936,33 +976,7 @@ impl Render for ChartView {
         // For StackedBar, compute the true y ceiling by summing visible series
         // at each shared point index. Baseline = 0 when in range, else y_min.
         let (y_max, y_range, stacked_y_ticks) = if matches!(kind, ChartKind::StackedBar) {
-            let visible: Vec<usize> = (0..model.decimated.len())
-                .filter(|i| !self.hidden.contains(i))
-                .collect();
-
-            let max_points = model
-                .decimated
-                .iter()
-                .map(|s| s.len())
-                .max()
-                .unwrap_or(0);
-
-            let stacked_max = (0..max_points)
-                .map(|pt_idx| {
-                    visible
-                        .iter()
-                        .filter_map(|&s| model.decimated[s].get(pt_idx).map(|(_, y)| *y))
-                        .filter(|y| y.is_finite())
-                        .sum::<f64>()
-                })
-                .fold(f64::NEG_INFINITY, f64::max);
-
-            let stacked_max = if stacked_max.is_finite() {
-                stacked_max
-            } else {
-                y_max
-            };
-            let padded_max = stacked_max + (stacked_max - y_min).abs() * 0.08;
+            let padded_max = self.stacked_y_max();
             let new_range = (padded_max - y_min).max(1.0);
             let ticks = ticks_numeric(y_min, padded_max, 5);
             (padded_max, new_range, Some(ticks))

--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -690,10 +690,7 @@ impl ChartView {
         // StackedBar: full-width single bars per x slot. Find the x column
         // under the cursor, then pick the series whose stacked segment the
         // cursor's Y falls inside for the most precise focus.
-        if matches!(
-            self.spec.kind,
-            crate::chart::spec::ChartKind::StackedBar
-        ) {
+        if matches!(self.spec.kind, crate::chart::spec::ChartKind::StackedBar) {
             let visible: Vec<usize> = (0..self.render_model.decimated.len())
                 .filter(|i| !self.hidden.contains(i))
                 .collect();
@@ -727,8 +724,7 @@ impl ChartView {
             let stacked_y_max = self.stacked_y_max();
             let y_range_local = (stacked_y_max - y_min).max(1.0);
             let data_to_screen_y = |dy: f64| -> f32 {
-                plot_y0 + plot_h
-                    - ((dy - y_min) / y_range_local * plot_h as f64) as f32
+                plot_y0 + plot_h - ((dy - y_min) / y_range_local * plot_h as f64) as f32
             };
 
             // Use the first visible series as x-position anchor.
@@ -736,9 +732,7 @@ impl ChartView {
             for pt_idx in 0..self.render_model.decimated[anchor].len() {
                 let (x, _) = self.render_model.decimated[anchor][pt_idx];
                 let bar_center = data_to_screen_x(x);
-                if cursor_sx < bar_center - bar_w / 2.0
-                    || cursor_sx > bar_center + bar_w / 2.0
-                {
+                if cursor_sx < bar_center - bar_w / 2.0 || cursor_sx > bar_center + bar_w / 2.0 {
                     continue;
                 }
 
@@ -752,8 +746,7 @@ impl ChartView {
                 let mut cumulative = baseline;
 
                 for &s_idx in &visible {
-                    let Some(&(_, y)) = self.render_model.decimated[s_idx].get(pt_idx)
-                    else {
+                    let Some(&(_, y)) = self.render_model.decimated[s_idx].get(pt_idx) else {
                         break;
                     };
                     let seg_bottom_sy = data_to_screen_y(cumulative);
@@ -1006,10 +999,7 @@ impl Render for ChartView {
 
         // For StackedBar, override the Y ticks with the stacked-range ticks so
         // both the gridlines and tick labels reflect the true stacked ceiling.
-        let effective_y_ticks = stacked_y_ticks
-            .as_ref()
-            .unwrap_or(&model.y_ticks)
-            .clone();
+        let effective_y_ticks = stacked_y_ticks.as_ref().unwrap_or(&model.y_ticks).clone();
 
         // Tick label strings for in-canvas painting (Y data order; painting handles positioning).
         let y_tick_labels: Vec<(f64, SharedString)> = effective_y_ticks
@@ -1264,8 +1254,7 @@ impl Render for ChartView {
 
                                         // Pass 2 — focused series at 2.2 px on top.
                                         if !hidden_canvas.contains(&focused_idx)
-                                            && let Some(pts) =
-                                                decimated_canvas.get(focused_idx)
+                                            && let Some(pts) = decimated_canvas.get(focused_idx)
                                         {
                                             let color = palette_canvas
                                                 .get(focused_idx)
@@ -1587,12 +1576,7 @@ fn paint_bars<FX, FY>(
         .collect();
     let num_visible = visible.len().max(1);
 
-    let max_points = decimated
-        .iter()
-        .map(|s| s.len())
-        .max()
-        .unwrap_or(1)
-        .max(1);
+    let max_points = decimated.iter().map(|s| s.len()).max().unwrap_or(1).max(1);
 
     let slot_w = plot_w / max_points as f32;
     let group_w = slot_w * 0.8;
@@ -1678,12 +1662,7 @@ fn paint_stacked_bars<FX, FY>(
 
     // Bar width: one slot per X position (single full-width column per x,
     // since the series stack rather than sit side-by-side).
-    let max_points = decimated
-        .iter()
-        .map(|s| s.len())
-        .max()
-        .unwrap_or(1)
-        .max(1);
+    let max_points = decimated.iter().map(|s| s.len()).max().unwrap_or(1).max(1);
 
     let slot_w = plot_w / max_points as f32;
     let bar_w = (slot_w * 0.8).max(1.0);
@@ -2010,20 +1989,14 @@ fn paint_area<FX, FY>(
                 let (xn, _) = pts[pts.len() - 1];
 
                 let mut builder = PathBuilder::fill();
-                builder.move_to(point(
-                    gpui::px(data_to_screen_x(x0)),
-                    gpui::px(baseline_sy),
-                ));
+                builder.move_to(point(gpui::px(data_to_screen_x(x0)), gpui::px(baseline_sy)));
                 for &(x, y) in pts {
                     builder.line_to(point(
                         gpui::px(data_to_screen_x(x)),
                         gpui::px(data_to_screen_y(y)),
                     ));
                 }
-                builder.line_to(point(
-                    gpui::px(data_to_screen_x(xn)),
-                    gpui::px(baseline_sy),
-                ));
+                builder.line_to(point(gpui::px(data_to_screen_x(xn)), gpui::px(baseline_sy)));
                 builder.close();
                 if let Ok(path) = builder.build() {
                     window.paint_path(path, fill_color);
@@ -2041,8 +2014,7 @@ fn paint_area<FX, FY>(
             } else {
                 1.0_f32
             };
-            let stroke_color =
-                gpui::hsla(base_color.h, base_color.s, base_color.l, stroke_alpha);
+            let stroke_color = gpui::hsla(base_color.h, base_color.s, base_color.l, stroke_alpha);
 
             if pts.len() == 1 {
                 // Single-point fallback: a square marker, same as the Line arm.
@@ -2965,10 +2937,7 @@ mod tests {
 
         let view =
             ChartView::build(&result, spec).expect("build with StackedBar kind must not fail");
-        assert_eq!(
-            view.kind(),
-            crate::chart::spec::ChartKind::StackedBar
-        );
+        assert_eq!(view.kind(), crate::chart::spec::ChartKind::StackedBar);
     }
 
     /// `ChartView::build` with `ChartKind::Pie` must not panic.

--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -650,6 +650,165 @@ impl ChartView {
             return;
         }
 
+        // StackedBar: full-width single bars per x slot. Find the x column
+        // under the cursor, then pick the series whose stacked segment the
+        // cursor's Y falls inside for the most precise focus.
+        if matches!(
+            self.spec.kind,
+            crate::chart::spec::ChartKind::StackedBar
+        ) {
+            let visible: Vec<usize> = (0..self.render_model.decimated.len())
+                .filter(|i| !self.hidden.contains(i))
+                .collect();
+            if visible.is_empty() {
+                return;
+            }
+
+            let max_points = self
+                .render_model
+                .decimated
+                .iter()
+                .map(|s| s.len())
+                .max()
+                .unwrap_or(1)
+                .max(1);
+
+            let x_pad = plot_w * (0.5 / max_points as f32);
+            let usable_w = (plot_w - 2.0 * x_pad).max(1.0);
+            let slot_w = plot_w / max_points as f32;
+            let bar_w = (slot_w * 0.8).max(1.0);
+
+            let data_to_screen_x = |dx: f64| -> f32 {
+                plot_x0 + x_pad + ((dx - x_min) / x_range * usable_w as f64) as f32
+            };
+
+            let cursor_sx = f32::from(hover_x);
+            let cursor_sy = f32::from(hover_y);
+
+            let y_range_local = (self.render_model.y_max - y_min).max(1.0);
+            let data_to_screen_y = |dy: f64| -> f32 {
+                plot_y0 + plot_h
+                    - ((dy - y_min) / y_range_local * plot_h as f64) as f32
+            };
+
+            // Use the first visible series as x-position anchor.
+            let anchor = visible[0];
+            for pt_idx in 0..self.render_model.decimated[anchor].len() {
+                let (x, _) = self.render_model.decimated[anchor][pt_idx];
+                let bar_center = data_to_screen_x(x);
+                if cursor_sx < bar_center - bar_w / 2.0
+                    || cursor_sx > bar_center + bar_w / 2.0
+                {
+                    continue;
+                }
+
+                // Cursor is inside this bar column. Find which series segment
+                // the cursor's Y lands in by checking stacked segment boundaries.
+                let baseline = if y_min <= 0.0 && self.render_model.y_max >= 0.0 {
+                    0.0_f64
+                } else {
+                    y_min
+                };
+                let mut cumulative = baseline;
+
+                for &s_idx in &visible {
+                    let Some(&(_, y)) = self.render_model.decimated[s_idx].get(pt_idx)
+                    else {
+                        break;
+                    };
+                    let seg_bottom_sy = data_to_screen_y(cumulative);
+                    cumulative += y;
+                    let seg_top_sy = data_to_screen_y(cumulative);
+
+                    let (top, bot) = if seg_top_sy <= seg_bottom_sy {
+                        (seg_top_sy, seg_bottom_sy)
+                    } else {
+                        (seg_bottom_sy, seg_top_sy)
+                    };
+
+                    if cursor_sy >= top && cursor_sy <= bot {
+                        self.focused_series_idx = s_idx;
+                        return;
+                    }
+                }
+
+                // Cursor in the column but outside all segments: focus topmost.
+                if let Some(&s_idx) = visible.last() {
+                    self.focused_series_idx = s_idx;
+                }
+                return;
+            }
+
+            return;
+        }
+
+        // Pie: focus by angle from the pie centre.
+        if matches!(self.spec.kind, crate::chart::spec::ChartKind::Pie) {
+            let pie_cx = plot_x0 + plot_w / 2.0;
+            let pie_cy = plot_y0 + plot_h / 2.0;
+            let base_radius = (plot_w.min(plot_h) * 0.4).max(1.0);
+
+            let cursor_sx = f32::from(hover_x);
+            let cursor_sy = f32::from(hover_y);
+
+            let dx = (cursor_sx - pie_cx) as f64;
+            let dy = (cursor_sy - pie_cy) as f64;
+            let dist = (dx * dx + dy * dy).sqrt() as f32;
+
+            // Only respond when cursor is inside the pie disc.
+            if dist > base_radius * 1.1 {
+                return;
+            }
+
+            let cursor_angle = (dy).atan2(dx); // atan2(y, x) in [-π, π]
+
+            // Normalise to [0, 2π) from –π/2 start (same as paint_pie).
+            let start_offset = -std::f64::consts::FRAC_PI_2;
+            let normalise = |angle: f64| -> f64 {
+                let a = angle - start_offset;
+                a.rem_euclid(2.0 * std::f64::consts::PI)
+            };
+            let cursor_norm = normalise(cursor_angle);
+
+            let visible: Vec<usize> = (0..self.render_model.decimated.len())
+                .filter(|i| !self.hidden.contains(i))
+                .collect();
+
+            let totals: Vec<(usize, f64)> = visible
+                .iter()
+                .filter_map(|&s_idx| {
+                    let total: f64 = self.render_model.decimated[s_idx]
+                        .iter()
+                        .map(|(_, y)| *y)
+                        .filter(|y| y.is_finite())
+                        .sum();
+                    if total > 0.0 {
+                        Some((s_idx, total))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            let grand_total: f64 = totals.iter().map(|(_, t)| t).sum();
+            if grand_total <= 0.0 {
+                return;
+            }
+
+            let mut accumulated = 0.0_f64;
+            for &(s_idx, total) in &totals {
+                let sweep = (total / grand_total) * 2.0 * std::f64::consts::PI;
+                let end_norm = accumulated + sweep;
+                if cursor_norm >= accumulated && cursor_norm < end_norm {
+                    self.focused_series_idx = s_idx;
+                    return;
+                }
+                accumulated = end_norm;
+            }
+
+            return;
+        }
+
         // Scatter charts focus by the nearest discrete point (2D distance),
         // since there is no connecting line to project onto. Focus only switches
         // when a point is within a small pixel tolerance of the cursor.
@@ -764,21 +923,57 @@ impl Render for ChartView {
         let x_range = (x_max - x_min).max(1.0);
         let y_range = (y_max - y_min).max(1.0);
 
-        // Bar charts need breathing room the line chart does not: vertical
+        // Bar-family charts need breathing room the line chart does not: vertical
         // headroom so the tallest bar never touches the top border, and a
         // horizontal inset of half a column so the first and last bars sit fully
         // inside the plot instead of being clipped against its edges. Line keeps
         // the full range — its points are meant to reach the edges.
-        let is_bar = matches!(kind, ChartKind::Bar);
+        //
+        // StackedBar also needs the bar layout, but uses a stacked y-range
+        // rather than the individual-series y_max stored in the RenderModel.
+        let needs_bar_layout = matches!(kind, ChartKind::Bar | ChartKind::StackedBar);
 
-        let (y_max, y_range) = if is_bar {
+        // For StackedBar, compute the true y ceiling by summing visible series
+        // at each shared point index. Baseline = 0 when in range, else y_min.
+        let (y_max, y_range, stacked_y_ticks) = if matches!(kind, ChartKind::StackedBar) {
+            let visible: Vec<usize> = (0..model.decimated.len())
+                .filter(|i| !self.hidden.contains(i))
+                .collect();
+
+            let max_points = model
+                .decimated
+                .iter()
+                .map(|s| s.len())
+                .max()
+                .unwrap_or(0);
+
+            let stacked_max = (0..max_points)
+                .map(|pt_idx| {
+                    visible
+                        .iter()
+                        .filter_map(|&s| model.decimated[s].get(pt_idx).map(|(_, y)| *y))
+                        .filter(|y| y.is_finite())
+                        .sum::<f64>()
+                })
+                .fold(f64::NEG_INFINITY, f64::max);
+
+            let stacked_max = if stacked_max.is_finite() {
+                stacked_max
+            } else {
+                y_max
+            };
+            let padded_max = stacked_max + (stacked_max - y_min).abs() * 0.08;
+            let new_range = (padded_max - y_min).max(1.0);
+            let ticks = ticks_numeric(y_min, padded_max, 5);
+            (padded_max, new_range, Some(ticks))
+        } else if needs_bar_layout {
             let padded_max = y_max + y_range * 0.08;
-            (padded_max, (padded_max - y_min).max(1.0))
+            (padded_max, (padded_max - y_min).max(1.0), None)
         } else {
-            (y_max, y_range)
+            (y_max, y_range, None)
         };
 
-        let bar_x_inset_fraction: f32 = if is_bar {
+        let bar_x_inset_fraction: f32 = if needs_bar_layout {
             let max_points = model
                 .decimated
                 .iter()
@@ -795,9 +990,15 @@ impl Render for ChartView {
         let decimated = model.decimated.clone();
         let x_is_time = spec.x_axis.kind == AxisKind::Time;
 
+        // For StackedBar, override the Y ticks with the stacked-range ticks so
+        // both the gridlines and tick labels reflect the true stacked ceiling.
+        let effective_y_ticks = stacked_y_ticks
+            .as_ref()
+            .unwrap_or(&model.y_ticks)
+            .clone();
+
         // Tick label strings for in-canvas painting (Y data order; painting handles positioning).
-        let y_tick_labels: Vec<(f64, SharedString)> = model
-            .y_ticks
+        let y_tick_labels: Vec<(f64, SharedString)> = effective_y_ticks
             .iter()
             .map(|t| (t.value, SharedString::from(t.label.clone())))
             .collect();
@@ -811,7 +1012,7 @@ impl Render for ChartView {
         // Clone for canvas closure.
         let decimated_canvas = decimated.clone();
         let palette_canvas = palette.clone();
-        let y_ticks_canvas = model.y_ticks.clone();
+        let y_ticks_canvas = effective_y_ticks;
         let hover_x_canvas = hover_x;
         let y_tick_labels_canvas = y_tick_labels.clone();
         let hidden_canvas = self.hidden.clone();
@@ -939,7 +1140,11 @@ impl Render for ChartView {
                                 };
 
                                 // --- Horizontal gridlines at each Y tick ---
-                                for tick in &y_ticks_canvas {
+                                // Pie has no axes — skip all gridlines and tick labels.
+                                for tick in y_ticks_canvas
+                                    .iter()
+                                    .filter(|_| !matches!(kind_canvas, ChartKind::Pie))
+                                {
                                     let sy = data_to_screen_y(tick.value);
                                     window.paint_quad(fill(
                                         gpui::Bounds {
@@ -954,7 +1159,10 @@ impl Render for ChartView {
                                 }
 
                                 // --- Vertical gridlines at each X tick ---
-                                for tick in &x_ticks_dynamic {
+                                for tick in x_ticks_dynamic
+                                    .iter()
+                                    .filter(|_| !matches!(kind_canvas, ChartKind::Pie))
+                                {
                                     let sx = data_to_screen_x(tick.value);
                                     window.paint_quad(fill(
                                         gpui::Bounds {
@@ -1090,10 +1298,43 @@ impl Render for ChartView {
                                             &data_to_screen_y,
                                         );
                                     }
+                                    ChartKind::StackedBar => {
+                                        paint_stacked_bars(
+                                            window,
+                                            &decimated_canvas,
+                                            &palette_canvas,
+                                            &hidden_canvas,
+                                            focused_idx,
+                                            plot_w,
+                                            y_min,
+                                            y_max,
+                                            &data_to_screen_x,
+                                            &data_to_screen_y,
+                                        );
+                                    }
+                                    ChartKind::Pie => {
+                                        paint_pie(
+                                            window,
+                                            &decimated_canvas,
+                                            &palette_canvas,
+                                            &hidden_canvas,
+                                            focused_idx,
+                                            plot_x0,
+                                            plot_y0,
+                                            plot_w,
+                                            plot_h,
+                                        );
+                                    }
                                 }
 
-                                // --- Crosshair (dashed, amber #FFB454 at 0.7 opacity) ---
-                                if let Some(hx) = hover_x_canvas {
+                                // --- Crosshair and hover dots ---
+                                //
+                                // Pie has no X/Y axes, so crosshair and readout are skipped.
+                                // StackedBar and Bar show the crosshair but not hover dots.
+                                // Line and Area show both.
+                                if let Some(hx) = hover_x_canvas
+                                    .filter(|_| !matches!(kind_canvas, ChartKind::Pie))
+                                {
                                     let sx = f32::from(hx);
                                     if sx >= plot_x0 && sx <= plot_x0 + plot_w {
                                         paint_dashed_vline(
@@ -1115,9 +1356,10 @@ impl Render for ChartView {
 
                                         for (s_idx, pts) in decimated_canvas.iter().enumerate() {
                                             // Hover dots are shown for Line and Area only.
-                                            // Bar and Scatter skip them — Bar uses the crosshair
-                                            // + readout overlay; Scatter paints discrete points
-                                            // that already act as their own indicators.
+                                            // Bar, StackedBar, and Scatter skip them:
+                                            // bar kinds rely on the crosshair + readout overlay;
+                                            // Scatter paints discrete points that are already
+                                            // their own indicators.
                                             if !matches!(
                                                 kind_canvas,
                                                 ChartKind::Line | ChartKind::Area
@@ -1205,12 +1447,16 @@ impl Render for ChartView {
 
                                 // --- In-canvas Y-axis tick labels ---
                                 // Right-aligned in the MARGIN_LEFT column.
+                                // Pie has no axes — skip all tick labels.
                                 let tick_color = gpui::hsla(0.0, 0.0, 0.55, 1.0);
                                 let tick_font = font("Zed Mono");
                                 let tick_size = gpui::px(10.0);
                                 let line_height = gpui::px(12.0);
 
-                                for (value, label) in &y_tick_labels_canvas {
+                                for (value, label) in y_tick_labels_canvas
+                                    .iter()
+                                    .filter(|_| !matches!(kind_canvas, ChartKind::Pie))
+                                {
                                     let sy = data_to_screen_y(*value);
                                     let run = TextRun {
                                         len: label.len(),
@@ -1242,7 +1488,10 @@ impl Render for ChartView {
                                 // Centered below each tick, in the MARGIN_BOTTOM band.
                                 let x_baseline_y = plot_y0 + plot_h + 10.0;
 
-                                for tick in &x_ticks_dynamic {
+                                for tick in x_ticks_dynamic
+                                    .iter()
+                                    .filter(|_| !matches!(kind_canvas, ChartKind::Pie))
+                                {
                                     let value = tick.value;
                                     let label = SharedString::from(tick.label.clone());
                                     let sx = data_to_screen_x(value);
@@ -1368,6 +1617,222 @@ fn paint_bars<FX, FY>(
                 color,
             ));
         }
+    }
+}
+
+/// Paint stacked vertical bars for every visible series.
+///
+/// Unlike `paint_bars` (which groups series side-by-side), stacked bars pile
+/// series on top of each other at each X position. The visual footprint per
+/// X slot is a single full-width bar column, with each series' segment sitting
+/// on the cumulative total of the series below it.
+///
+/// The Y axis **must** have already been rescaled to the maximum stack sum
+/// before calling this function — `render()` does this for `ChartKind::StackedBar`.
+///
+/// Series with mismatched lengths are handled safely: iteration stops at the
+/// shortest series at each point index.
+#[allow(clippy::too_many_arguments)]
+fn paint_stacked_bars<FX, FY>(
+    window: &mut Window,
+    decimated: &[Vec<(f64, f64)>],
+    palette: &[Hsla],
+    hidden: &HashSet<usize>,
+    focused_idx: usize,
+    plot_w: f32,
+    y_min: f64,
+    y_max: f64,
+    data_to_screen_x: &FX,
+    data_to_screen_y: &FY,
+) where
+    FX: Fn(f64) -> f32,
+    FY: Fn(f64) -> f32,
+{
+    let baseline = if y_min <= 0.0 && y_max >= 0.0 {
+        0.0
+    } else {
+        y_min
+    };
+
+    let visible: Vec<usize> = (0..decimated.len())
+        .filter(|i| !hidden.contains(i))
+        .collect();
+    let num_visible = visible.len();
+    if num_visible == 0 {
+        return;
+    }
+
+    // Bar width: one slot per X position (single full-width column per x,
+    // since the series stack rather than sit side-by-side).
+    let max_points = decimated
+        .iter()
+        .map(|s| s.len())
+        .max()
+        .unwrap_or(1)
+        .max(1);
+
+    let slot_w = plot_w / max_points as f32;
+    let bar_w = (slot_w * 0.8).max(1.0);
+
+    let fallback = gpui::hsla(0.6, 0.6, 0.5, 1.0);
+
+    // Iterate over x positions using the first visible series as the anchor.
+    // For each x position, collect the y values from all visible series in order.
+    let anchor_series = visible[0];
+    let n_points = decimated[anchor_series].len();
+
+    for pt_idx in 0..n_points {
+        let (x, _) = decimated[anchor_series][pt_idx];
+        let bar_center_sx = data_to_screen_x(x);
+        let bar_left = bar_center_sx - bar_w / 2.0;
+
+        // Accumulate from the baseline upward, one segment per visible series.
+        let mut cumulative = baseline;
+
+        for &s_idx in &visible {
+            let Some(&(_, y)) = decimated[s_idx].get(pt_idx) else {
+                // This series has fewer points — skip remaining series for this slot.
+                break;
+            };
+
+            let seg_bottom_sy = data_to_screen_y(cumulative);
+            let seg_top_sy = data_to_screen_y(cumulative + y);
+            cumulative += y;
+
+            let (rect_top, rect_h) = if seg_top_sy <= seg_bottom_sy {
+                (seg_top_sy, seg_bottom_sy - seg_top_sy)
+            } else {
+                (seg_bottom_sy, seg_top_sy - seg_bottom_sy)
+            };
+
+            let base_color = palette.get(s_idx).copied().unwrap_or(fallback);
+            let color = if num_visible > 1 && s_idx != focused_idx {
+                gpui::hsla(base_color.h, base_color.s, base_color.l, 0.55)
+            } else {
+                base_color
+            };
+
+            window.paint_quad(fill(
+                gpui::Bounds {
+                    origin: point(gpui::px(bar_left), gpui::px(rect_top)),
+                    size: gpui::Size {
+                        width: gpui::px(bar_w),
+                        height: gpui::px(rect_h.max(1.0)),
+                    },
+                },
+                color,
+            ));
+        }
+    }
+}
+
+/// Paint a pie chart: one wedge per visible series, sized proportional to the
+/// sum of that series' Y values.
+///
+/// Wedges are drawn by subdividing each arc into small line segments (~2°
+/// steps) to avoid pitfalls with GPUI's arc_to large-arc handling. The focused
+/// series is drawn at full opacity and slightly larger radius; non-focused
+/// slices are slightly dimmed.
+///
+/// When all visible series totals are ≤ 0, nothing is painted.
+#[allow(clippy::too_many_arguments)]
+fn paint_pie(
+    window: &mut Window,
+    decimated: &[Vec<(f64, f64)>],
+    palette: &[Hsla],
+    hidden: &HashSet<usize>,
+    focused_idx: usize,
+    plot_x0: f32,
+    plot_y0: f32,
+    plot_w: f32,
+    plot_h: f32,
+) {
+    let visible: Vec<usize> = (0..decimated.len())
+        .filter(|i| !hidden.contains(i))
+        .collect();
+
+    // Sum each visible series; skip series with non-positive totals.
+    let totals: Vec<(usize, f64)> = visible
+        .iter()
+        .filter_map(|&s_idx| {
+            let total: f64 = decimated[s_idx]
+                .iter()
+                .map(|(_, y)| *y)
+                .filter(|y| y.is_finite())
+                .sum();
+            if total > 0.0 {
+                Some((s_idx, total))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if totals.is_empty() {
+        return;
+    }
+
+    let grand_total: f64 = totals.iter().map(|(_, t)| t).sum();
+    if grand_total <= 0.0 {
+        return;
+    }
+
+    let cx = plot_x0 + plot_w / 2.0;
+    let cy = plot_y0 + plot_h / 2.0;
+    let base_radius = (plot_w.min(plot_h) * 0.4).max(1.0);
+
+    // Each slice spans [start_angle, end_angle] in radians (0 = right, CCW).
+    let fallback = gpui::hsla(0.6, 0.6, 0.5, 1.0);
+    let mut start_angle: f64 = -std::f64::consts::FRAC_PI_2; // Start from the top.
+
+    for &(s_idx, total) in &totals {
+        let fraction = total / grand_total;
+        let sweep = fraction * 2.0 * std::f64::consts::PI;
+        let end_angle = start_angle + sweep;
+
+        let is_focused = s_idx == focused_idx;
+        let radius = if is_focused {
+            base_radius * 1.04
+        } else {
+            base_radius
+        };
+        let base_color = palette.get(s_idx).copied().unwrap_or(fallback);
+        let alpha = if is_focused { 1.0_f32 } else { 0.75_f32 };
+        let color = gpui::hsla(base_color.h, base_color.s, base_color.l, alpha);
+
+        // Subdivide the arc into 2-degree segments to avoid large-arc pitfalls.
+        const STEP: f64 = 2.0 * std::f64::consts::PI / 180.0; // 2 degrees
+
+        let mut builder = PathBuilder::fill();
+
+        // Start from the centre and trace the wedge outline.
+        builder.move_to(point(gpui::px(cx), gpui::px(cy)));
+
+        let mut angle = start_angle;
+        let first_x = cx + (radius as f64 * angle.cos()) as f32;
+        let first_y = cy + (radius as f64 * angle.sin()) as f32;
+        builder.line_to(point(gpui::px(first_x), gpui::px(first_y)));
+
+        // Trace the arc rim by small straight segments.
+        while angle < end_angle - STEP * 0.5 {
+            angle = (angle + STEP).min(end_angle);
+            let rim_x = cx + (radius as f64 * angle.cos()) as f32;
+            let rim_y = cy + (radius as f64 * angle.sin()) as f32;
+            builder.line_to(point(gpui::px(rim_x), gpui::px(rim_y)));
+        }
+
+        // Ensure the final point lands exactly on end_angle.
+        let last_x = cx + (radius as f64 * end_angle.cos()) as f32;
+        let last_y = cy + (radius as f64 * end_angle.sin()) as f32;
+        builder.line_to(point(gpui::px(last_x), gpui::px(last_y)));
+
+        builder.close();
+
+        if let Ok(path) = builder.build() {
+            window.paint_path(path, color);
+        }
+
+        start_angle = end_angle;
     }
 }
 
@@ -2459,5 +2924,63 @@ mod tests {
 
         let view = ChartView::build(&result, spec).expect("build with Area kind must not fail");
         assert_eq!(view.kind(), crate::chart::spec::ChartKind::Area);
+    }
+
+    /// `ChartView::build` with `ChartKind::StackedBar` must not panic.
+    ///
+    /// StackedBar shares the same kind-agnostic `RenderModel` as Bar; the
+    /// stacked-y-range override and stacking geometry are applied in `render`.
+    #[test]
+    fn build_with_stacked_bar_kind_does_not_panic() {
+        let rows = vec![
+            vec![Value::Int(0), Value::Float(1.0), Value::Float(2.0)],
+            vec![Value::Int(1000), Value::Float(3.0), Value::Float(4.0)],
+        ];
+        let result = QueryResult::table(
+            vec![
+                make_col("t", ColumnKind::Timestamp),
+                make_col("a", ColumnKind::Float),
+                make_col("b", ColumnKind::Float),
+            ],
+            rows,
+            None,
+            Duration::ZERO,
+        );
+        let mut spec = simple_spec(0, &[1, 2]);
+        spec.kind = crate::chart::spec::ChartKind::StackedBar;
+
+        let view =
+            ChartView::build(&result, spec).expect("build with StackedBar kind must not fail");
+        assert_eq!(
+            view.kind(),
+            crate::chart::spec::ChartKind::StackedBar
+        );
+    }
+
+    /// `ChartView::build` with `ChartKind::Pie` must not panic.
+    ///
+    /// Pie shares the same kind-agnostic `RenderModel`; the wedge geometry
+    /// and axis suppression are applied in `render`.
+    #[test]
+    fn build_with_pie_kind_does_not_panic() {
+        let rows = vec![
+            vec![Value::Int(0), Value::Float(10.0), Value::Float(20.0)],
+            vec![Value::Int(1000), Value::Float(15.0), Value::Float(25.0)],
+        ];
+        let result = QueryResult::table(
+            vec![
+                make_col("t", ColumnKind::Timestamp),
+                make_col("a", ColumnKind::Float),
+                make_col("b", ColumnKind::Float),
+            ],
+            rows,
+            None,
+            Duration::ZERO,
+        );
+        let mut spec = simple_spec(0, &[1, 2]);
+        spec.kind = crate::chart::spec::ChartKind::Pie;
+
+        let view = ChartView::build(&result, spec).expect("build with Pie kind must not fail");
+        assert_eq!(view.kind(), crate::chart::spec::ChartKind::Pie);
     }
 }

--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -1077,6 +1077,19 @@ impl Render for ChartView {
                                             &data_to_screen_y,
                                         );
                                     }
+                                    ChartKind::Area => {
+                                        paint_area(
+                                            window,
+                                            &decimated_canvas,
+                                            &palette_canvas,
+                                            &hidden_canvas,
+                                            focused_idx,
+                                            y_min,
+                                            y_max,
+                                            &data_to_screen_x,
+                                            &data_to_screen_y,
+                                        );
+                                    }
                                 }
 
                                 // --- Crosshair (dashed, amber #FFB454 at 0.7 opacity) ---
@@ -1101,7 +1114,14 @@ impl Render for ChartView {
                                             + ((sx - plot_x0) as f64 / plot_w as f64) * x_range;
 
                                         for (s_idx, pts) in decimated_canvas.iter().enumerate() {
-                                            if !matches!(kind_canvas, ChartKind::Line) {
+                                            // Hover dots are shown for Line and Area only.
+                                            // Bar and Scatter skip them — Bar uses the crosshair
+                                            // + readout overlay; Scatter paints discrete points
+                                            // that already act as their own indicators.
+                                            if !matches!(
+                                                kind_canvas,
+                                                ChartKind::Line | ChartKind::Area
+                                            ) {
                                                 break;
                                             }
                                             if hidden_canvas.contains(&s_idx) {
@@ -1409,6 +1429,174 @@ fn paint_scatter<FX, FY>(
             let sx = data_to_screen_x(x);
             let sy = data_to_screen_y(y);
             paint_filled_circle(window, sx, sy, radius, color);
+        }
+    }
+}
+
+/// Paint every visible series as a filled area chart.
+///
+/// Each series is drawn in two passes to achieve the stacked visual effect of
+/// fill behind a stroke line:
+///
+/// 1. **Fill pass**: a closed path from the first-point baseline, through all
+///    data points, back down to the last-point baseline, filled with the series
+///    colour at low alpha. Non-focused series use a lower alpha (~0.12) so they
+///    recede behind the focused series (~0.22).
+/// 2. **Stroke pass**: the data-point polyline only (no baseline edges), at
+///    1.6 px for non-focused and 2.2 px for the focused series.
+///
+/// The baseline follows the same rule as `paint_bars`: `y = 0.0` when zero
+/// falls inside `[y_min, y_max]`, otherwise `y = y_min`.
+///
+/// Single-point series are handled gracefully — the fill degenerates to a
+/// vertical line segment and the stroke paints a square marker, matching the
+/// Line arm's single-point fallback.
+#[allow(clippy::too_many_arguments)]
+fn paint_area<FX, FY>(
+    window: &mut Window,
+    decimated: &[Vec<(f64, f64)>],
+    palette: &[Hsla],
+    hidden: &HashSet<usize>,
+    focused_idx: usize,
+    y_min: f64,
+    y_max: f64,
+    data_to_screen_x: &FX,
+    data_to_screen_y: &FY,
+) where
+    FX: Fn(f64) -> f32,
+    FY: Fn(f64) -> f32,
+{
+    let baseline = if y_min <= 0.0 && y_max >= 0.0 {
+        0.0
+    } else {
+        y_min
+    };
+    let baseline_sy = data_to_screen_y(baseline);
+
+    let fallback = gpui::hsla(0.6, 0.6, 0.5, 1.0);
+
+    let visible: Vec<usize> = (0..decimated.len())
+        .filter(|i| !hidden.contains(i))
+        .collect();
+    let num_visible = visible.len();
+
+    // Two passes: non-focused first so the focused series composites on top.
+    for pass in 0..2usize {
+        for &s_idx in &visible {
+            let is_focused = s_idx == focused_idx;
+            if pass == 0 && is_focused {
+                continue;
+            }
+            if pass == 1 && !is_focused {
+                continue;
+            }
+
+            let pts = &decimated[s_idx];
+            if pts.is_empty() {
+                continue;
+            }
+
+            let base_color = palette.get(s_idx).copied().unwrap_or(fallback);
+
+            // --- Fill pass ---
+            let fill_alpha = if num_visible > 1 && !is_focused {
+                0.12
+            } else {
+                0.22
+            };
+            let fill_color = gpui::hsla(base_color.h, base_color.s, base_color.l, fill_alpha);
+
+            if pts.len() == 1 {
+                // Single-point: fill a thin vertical rect from the data point to the baseline.
+                let sx = data_to_screen_x(pts[0].0);
+                let sy = data_to_screen_y(pts[0].1);
+                let (rect_top, rect_h) = if sy <= baseline_sy {
+                    (sy, baseline_sy - sy)
+                } else {
+                    (baseline_sy, sy - baseline_sy)
+                };
+                window.paint_quad(fill(
+                    gpui::Bounds {
+                        origin: point(gpui::px(sx - 1.0), gpui::px(rect_top)),
+                        size: gpui::Size {
+                            width: gpui::px(2.0),
+                            height: gpui::px(rect_h.max(1.0)),
+                        },
+                    },
+                    fill_color,
+                ));
+            } else {
+                // Build a closed filled path: baseline→first, data points, last→baseline.
+                let (x0, _) = pts[0];
+                let (xn, _) = pts[pts.len() - 1];
+
+                let mut builder = PathBuilder::fill();
+                builder.move_to(point(
+                    gpui::px(data_to_screen_x(x0)),
+                    gpui::px(baseline_sy),
+                ));
+                for &(x, y) in pts {
+                    builder.line_to(point(
+                        gpui::px(data_to_screen_x(x)),
+                        gpui::px(data_to_screen_y(y)),
+                    ));
+                }
+                builder.line_to(point(
+                    gpui::px(data_to_screen_x(xn)),
+                    gpui::px(baseline_sy),
+                ));
+                builder.close();
+                if let Ok(path) = builder.build() {
+                    window.paint_path(path, fill_color);
+                }
+            }
+
+            // --- Stroke pass (data-line only, no baseline edges) ---
+            let stroke_w = if num_visible > 1 && !is_focused {
+                1.6_f32
+            } else {
+                2.2_f32
+            };
+            let stroke_alpha = if num_visible > 1 && !is_focused {
+                0.6_f32
+            } else {
+                1.0_f32
+            };
+            let stroke_color =
+                gpui::hsla(base_color.h, base_color.s, base_color.l, stroke_alpha);
+
+            if pts.len() == 1 {
+                // Single-point fallback: a square marker, same as the Line arm.
+                let half = stroke_w * 1.5;
+                let sx = data_to_screen_x(pts[0].0);
+                let sy = data_to_screen_y(pts[0].1);
+                window.paint_quad(fill(
+                    gpui::Bounds {
+                        origin: point(gpui::px(sx - half), gpui::px(sy - half)),
+                        size: gpui::Size {
+                            width: gpui::px(half * 2.0),
+                            height: gpui::px(half * 2.0),
+                        },
+                    },
+                    stroke_color,
+                ));
+            } else {
+                let mut builder = PathBuilder::stroke(gpui::px(stroke_w));
+                let (x0, y0) = pts[0];
+                builder.move_to(point(
+                    gpui::px(data_to_screen_x(x0)),
+                    gpui::px(data_to_screen_y(y0)),
+                ));
+                for &(x, y) in pts.iter().skip(1) {
+                    builder.line_to(point(
+                        gpui::px(data_to_screen_x(x)),
+                        gpui::px(data_to_screen_y(y)),
+                    ));
+                }
+                if let Ok(path) = builder.build() {
+                    window.paint_path(path, stroke_color);
+                }
+            }
         }
     }
 }
@@ -2245,5 +2433,31 @@ mod tests {
         assert_eq!(s1.min, 10.0);
         assert_eq!(s1.max, 30.0);
         assert_eq!(s1.last, 30.0);
+    }
+
+    /// `ChartView::build` with `ChartKind::Area` must not panic.
+    ///
+    /// Area shares the same kind-agnostic `RenderModel` as Line; the Area-specific
+    /// geometry (filled paths + stroke) is produced later in `render`.
+    #[test]
+    fn build_with_area_kind_does_not_panic() {
+        let rows = vec![
+            vec![Value::Int(0), Value::Float(1.0)],
+            vec![Value::Int(1000), Value::Float(2.0)],
+        ];
+        let result = QueryResult::table(
+            vec![
+                make_col("t", ColumnKind::Timestamp),
+                make_col("v", ColumnKind::Float),
+            ],
+            rows,
+            None,
+            Duration::ZERO,
+        );
+        let mut spec = simple_spec(0, &[1]);
+        spec.kind = crate::chart::spec::ChartKind::Area;
+
+        let view = ChartView::build(&result, spec).expect("build with Area kind must not fail");
+        assert_eq!(view.kind(), crate::chart::spec::ChartKind::Area);
     }
 }

--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -394,6 +394,21 @@ impl ChartView {
         })
     }
 
+    /// Switch the chart kind in place. Cheap — the `RenderModel` is kind-agnostic
+    /// (decimated points, ticks, and bounds are identical for Line and Bar), so
+    /// only `render` needs to re-run.
+    pub fn set_kind(&mut self, kind: crate::chart::spec::ChartKind, cx: &mut Context<Self>) {
+        if self.spec.kind != kind {
+            self.spec.kind = kind;
+            cx.notify();
+        }
+    }
+
+    /// The current chart kind.
+    pub fn kind(&self) -> crate::chart::spec::ChartKind {
+        self.spec.kind
+    }
+
     /// Update legend visibility. Cheap — does not rebuild the render model.
     pub fn set_legend_visible(&mut self, visible: bool, cx: &mut Context<Self>) {
         self.spec.legend_visible = visible;
@@ -584,6 +599,57 @@ impl ChartView {
 
         let cursor_data_x = x_min + (rel_x as f64 / plot_w as f64) * x_range;
 
+        // Bar charts focus by column: the series whose bar sits horizontally
+        // under the cursor wins across the bar's full height — not only near its
+        // top where the data point lives (which is how the line hit-test below
+        // works). This mirrors the geometry in `paint_bars`, including the bar
+        // x-inset, so the hit area matches the painted bars exactly.
+        if matches!(self.spec.kind, crate::chart::spec::ChartKind::Bar) {
+            let visible: Vec<usize> = (0..self.render_model.decimated.len())
+                .filter(|i| !self.hidden.contains(i))
+                .collect();
+            if visible.is_empty() {
+                return;
+            }
+
+            let num_visible = visible.len();
+            let max_points = self
+                .render_model
+                .decimated
+                .iter()
+                .map(|s| s.len())
+                .max()
+                .unwrap_or(1)
+                .max(1);
+
+            let x_pad = plot_w * (0.5 / max_points as f32);
+            let usable_w = (plot_w - 2.0 * x_pad).max(1.0);
+            let slot_w = plot_w / max_points as f32;
+            let group_w = slot_w * 0.8;
+            let bar_w = (group_w / num_visible as f32).max(1.0);
+
+            let data_to_screen_x = |dx: f64| -> f32 {
+                plot_x0 + x_pad + ((dx - x_min) / x_range * usable_w as f64) as f32
+            };
+
+            let cursor_sx = f32::from(hover_x);
+
+            for (group_pos, &s_idx) in visible.iter().enumerate() {
+                let offset = group_pos as f32 * bar_w - group_w / 2.0;
+                for &(x, _) in &self.render_model.decimated[s_idx] {
+                    let bar_left = data_to_screen_x(x) + offset;
+                    let bar_right = bar_left + bar_w * 0.92;
+                    if cursor_sx >= bar_left && cursor_sx <= bar_right {
+                        self.focused_series_idx = s_idx;
+                        return;
+                    }
+                }
+            }
+
+            // Cursor fell in a gap between bars: keep the current focus.
+            return;
+        }
+
         let data_to_screen_y =
             |dy: f64| -> f32 { plot_y0 + plot_h - ((dy - y_min) / y_range * plot_h as f64) as f32 };
 
@@ -642,19 +708,21 @@ impl Render for ChartView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         use crate::chart::spec::ChartKind;
 
-        // Non-Line chart kinds render a placeholder frame. The full Bar and
-        // Scatter implementations ship in the next change once the seams are
-        // in place. This branch must never panic.
-        let is_placeholder = match self.spec.kind {
-            ChartKind::Line => false,
-            ChartKind::Bar | ChartKind::Scatter => true,
+        let kind = self.spec.kind;
+
+        // `Line` and `Bar` share the same plot frame (axes, gridlines, ticks)
+        // and only differ in how each series is painted. `Scatter` still renders
+        // a placeholder frame until its paint arm lands. This branch must never
+        // panic.
+        let is_placeholder = match kind {
+            ChartKind::Line | ChartKind::Bar => false,
+            ChartKind::Scatter => true,
         };
 
         if is_placeholder {
-            let label = match self.spec.kind {
-                ChartKind::Bar => "Bar chart coming soon",
+            let label = match kind {
                 ChartKind::Scatter => "Scatter chart coming soon",
-                ChartKind::Line => unreachable!(),
+                ChartKind::Line | ChartKind::Bar => unreachable!(),
             };
             return div()
                 .flex()
@@ -682,6 +750,33 @@ impl Render for ChartView {
         let x_range = (x_max - x_min).max(1.0);
         let y_range = (y_max - y_min).max(1.0);
 
+        // Bar charts need breathing room the line chart does not: vertical
+        // headroom so the tallest bar never touches the top border, and a
+        // horizontal inset of half a column so the first and last bars sit fully
+        // inside the plot instead of being clipped against its edges. Line keeps
+        // the full range — its points are meant to reach the edges.
+        let is_bar = matches!(kind, ChartKind::Bar);
+
+        let (y_max, y_range) = if is_bar {
+            let padded_max = y_max + y_range * 0.08;
+            (padded_max, (padded_max - y_min).max(1.0))
+        } else {
+            (y_max, y_range)
+        };
+
+        let bar_x_inset_fraction: f32 = if is_bar {
+            let max_points = model
+                .decimated
+                .iter()
+                .map(|s| s.len())
+                .max()
+                .unwrap_or(1)
+                .max(1);
+            0.5 / max_points as f32
+        } else {
+            0.0
+        };
+
         let palette = model.palette_colors.clone();
         let decimated = model.decimated.clone();
         let x_is_time = spec.x_axis.kind == AxisKind::Time;
@@ -706,6 +801,8 @@ impl Render for ChartView {
         let hover_x_canvas = hover_x;
         let y_tick_labels_canvas = y_tick_labels.clone();
         let hidden_canvas = self.hidden.clone();
+        let kind_canvas = kind;
+        let bar_x_inset_canvas = bar_x_inset_fraction;
 
         // Shared plot-area bounds: written by the canvas prepaint closure,
         // read here to compute the readout and inside the on_mouse_move
@@ -800,8 +897,15 @@ impl Render for ChartView {
                                 let plot_w = (w - MARGIN_LEFT - MARGIN_RIGHT).max(1.0);
                                 let plot_h = (h - MARGIN_TOP - MARGIN_BOTTOM).max(1.0);
 
+                                // Bars inset both edges by half a column so the
+                                // first/last bar fits; Line uses the full width
+                                // (inset fraction is 0).
+                                let x_pad = plot_w * bar_x_inset_canvas;
+                                let usable_w = (plot_w - 2.0 * x_pad).max(1.0);
                                 let data_to_screen_x = |dx: f64| -> f32 {
-                                    plot_x0 + ((dx - x_min) / x_range * plot_w as f64) as f32
+                                    plot_x0
+                                        + x_pad
+                                        + ((dx - x_min) / x_range * usable_w as f64) as f32
                                 };
                                 let data_to_screen_y = |dy: f64| -> f32 {
                                     // Y is inverted: top = y_max, bottom = y_min.
@@ -850,80 +954,107 @@ impl Render for ChartView {
                                     ));
                                 }
 
-                                // --- Series polylines (two-pass) ---
+                                // --- Series painting ---
                                 //
-                                // Pass 1: all non-focused series at 2.0 px so they
-                                // render below the focused line.
-                                // Pass 2: focused series at 2.8 px, composited on top.
-                                let paint_series =
-                                    |pts: &[(f64, f64)],
-                                     color: Hsla,
-                                     stroke_w: f32,
-                                     window: &mut Window| {
-                                        if pts.is_empty() {
-                                            return;
-                                        }
-                                        if pts.len() == 1 {
-                                            // Single-point fallback: paint a square whose
-                                            // side scales with stroke width.
-                                            let half = stroke_w * 1.5;
-                                            let sx = data_to_screen_x(pts[0].0);
-                                            let sy = data_to_screen_y(pts[0].1);
-                                            window.paint_quad(fill(
-                                                gpui::Bounds {
-                                                    origin: point(
-                                                        gpui::px(sx - half),
-                                                        gpui::px(sy - half),
-                                                    ),
-                                                    size: gpui::Size {
-                                                        width: gpui::px(half * 2.0),
-                                                        height: gpui::px(half * 2.0),
-                                                    },
-                                                },
-                                                color,
-                                            ));
-                                        } else {
-                                            let mut builder =
-                                                PathBuilder::stroke(gpui::px(stroke_w));
-                                            let (x0, y0) = pts[0];
-                                            builder.move_to(point(
-                                                gpui::px(data_to_screen_x(x0)),
-                                                gpui::px(data_to_screen_y(y0)),
-                                            ));
-                                            for &(x, y) in pts.iter().skip(1) {
-                                                builder.line_to(point(
-                                                    gpui::px(data_to_screen_x(x)),
-                                                    gpui::px(data_to_screen_y(y)),
-                                                ));
-                                            }
-                                            if let Ok(path) = builder.build() {
-                                                window.paint_path(path, color);
-                                            }
-                                        }
-                                    };
+                                // Line and Bar share the plot frame painted above
+                                // and differ only in per-series geometry: Line draws
+                                // polylines (focused series composited on top); Bar
+                                // draws grouped vertical bars anchored at the zero
+                                // baseline.
+                                match kind_canvas {
+                                    ChartKind::Line => {
+                                        // Pass 1: non-focused series below the focused
+                                        // line. Pass 2: focused series composited on top.
+                                        let paint_series =
+                                            |pts: &[(f64, f64)],
+                                             color: Hsla,
+                                             stroke_w: f32,
+                                             window: &mut Window| {
+                                                if pts.is_empty() {
+                                                    return;
+                                                }
+                                                if pts.len() == 1 {
+                                                    // Single-point fallback: paint a square
+                                                    // whose side scales with stroke width.
+                                                    let half = stroke_w * 1.5;
+                                                    let sx = data_to_screen_x(pts[0].0);
+                                                    let sy = data_to_screen_y(pts[0].1);
+                                                    window.paint_quad(fill(
+                                                        gpui::Bounds {
+                                                            origin: point(
+                                                                gpui::px(sx - half),
+                                                                gpui::px(sy - half),
+                                                            ),
+                                                            size: gpui::Size {
+                                                                width: gpui::px(half * 2.0),
+                                                                height: gpui::px(half * 2.0),
+                                                            },
+                                                        },
+                                                        color,
+                                                    ));
+                                                } else {
+                                                    let mut builder =
+                                                        PathBuilder::stroke(gpui::px(stroke_w));
+                                                    let (x0, y0) = pts[0];
+                                                    builder.move_to(point(
+                                                        gpui::px(data_to_screen_x(x0)),
+                                                        gpui::px(data_to_screen_y(y0)),
+                                                    ));
+                                                    for &(x, y) in pts.iter().skip(1) {
+                                                        builder.line_to(point(
+                                                            gpui::px(data_to_screen_x(x)),
+                                                            gpui::px(data_to_screen_y(y)),
+                                                        ));
+                                                    }
+                                                    if let Ok(path) = builder.build() {
+                                                        window.paint_path(path, color);
+                                                    }
+                                                }
+                                            };
 
-                                // Pass 1 — non-focused, non-hidden series at 1.4 px.
-                                for (s_idx, pts) in decimated_canvas.iter().enumerate() {
-                                    if s_idx == focused_idx || hidden_canvas.contains(&s_idx) {
-                                        continue;
+                                        // Pass 1 — non-focused, non-hidden series at 1.4 px.
+                                        for (s_idx, pts) in decimated_canvas.iter().enumerate() {
+                                            if s_idx == focused_idx
+                                                || hidden_canvas.contains(&s_idx)
+                                            {
+                                                continue;
+                                            }
+                                            let color = palette_canvas
+                                                .get(s_idx)
+                                                .copied()
+                                                .unwrap_or(gpui::hsla(0.6, 0.6, 0.5, 1.0));
+                                            paint_series(pts, color, 1.4, window);
+                                        }
+
+                                        // Pass 2 — focused series at 2.2 px on top.
+                                        if !hidden_canvas.contains(&focused_idx)
+                                            && let Some(pts) =
+                                                decimated_canvas.get(focused_idx)
+                                        {
+                                            let color = palette_canvas
+                                                .get(focused_idx)
+                                                .copied()
+                                                .unwrap_or(gpui::hsla(0.6, 0.6, 0.5, 1.0));
+                                            paint_series(pts, color, 2.2, window);
+                                        }
                                     }
-                                    let color = palette_canvas
-                                        .get(s_idx)
-                                        .copied()
-                                        .unwrap_or(gpui::hsla(0.6, 0.6, 0.5, 1.0));
-                                    paint_series(pts, color, 1.4, window);
-                                }
-
-                                // Pass 2 — focused series at 2.2 px (composited on top).
-                                // Skip if the focused series is hidden.
-                                if !hidden_canvas.contains(&focused_idx)
-                                    && let Some(pts) = decimated_canvas.get(focused_idx)
-                                {
-                                    let color = palette_canvas
-                                        .get(focused_idx)
-                                        .copied()
-                                        .unwrap_or(gpui::hsla(0.6, 0.6, 0.5, 1.0));
-                                    paint_series(pts, color, 2.2, window);
+                                    ChartKind::Bar => {
+                                        paint_bars(
+                                            window,
+                                            &decimated_canvas,
+                                            &palette_canvas,
+                                            &hidden_canvas,
+                                            focused_idx,
+                                            plot_w,
+                                            y_min,
+                                            y_max,
+                                            &data_to_screen_x,
+                                            &data_to_screen_y,
+                                        );
+                                    }
+                                    // Scatter renders the placeholder frame above and
+                                    // never reaches this paint closure.
+                                    ChartKind::Scatter => {}
                                 }
 
                                 // --- Crosshair (dashed, amber #FFB454 at 0.7 opacity) ---
@@ -940,12 +1071,17 @@ impl Render for ChartView {
                                             3.0,
                                         );
 
-                                        // --- Hover dots per series ---
+                                        // --- Hover dots per series (Line only) ---
                                         // Two-pass: fill background first, then stroke series color.
+                                        // Bar charts rely on the crosshair plus the readout
+                                        // overlay; per-point dots would float off the bars.
                                         let cursor_data_x = x_min
                                             + ((sx - plot_x0) as f64 / plot_w as f64) * x_range;
 
                                         for (s_idx, pts) in decimated_canvas.iter().enumerate() {
+                                            if matches!(kind_canvas, ChartKind::Bar) {
+                                                break;
+                                            }
                                             if hidden_canvas.contains(&s_idx) {
                                                 continue;
                                             }
@@ -1106,6 +1242,92 @@ impl Render for ChartView {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Paint grouped vertical bars for every visible series.
+///
+/// Each X position owns a slot whose width derives from the densest series so
+/// bars stay inside their column even when series have differing point counts.
+/// Within a slot, visible series are laid out side by side (grouped, never
+/// overlapping). Bars are anchored at the zero baseline when zero lies inside
+/// the value range, otherwise at the data minimum so a positive-only series
+/// still grows from the axis floor.
+///
+/// Non-focused series are dimmed when more than one series is visible, mirroring
+/// the emphasis the Line arm gives the focused polyline.
+#[allow(clippy::too_many_arguments)]
+fn paint_bars<FX, FY>(
+    window: &mut Window,
+    decimated: &[Vec<(f64, f64)>],
+    palette: &[Hsla],
+    hidden: &HashSet<usize>,
+    focused_idx: usize,
+    plot_w: f32,
+    y_min: f64,
+    y_max: f64,
+    data_to_screen_x: &FX,
+    data_to_screen_y: &FY,
+) where
+    FX: Fn(f64) -> f32,
+    FY: Fn(f64) -> f32,
+{
+    let baseline = if y_min <= 0.0 && y_max >= 0.0 {
+        0.0
+    } else {
+        y_min
+    };
+    let baseline_sy = data_to_screen_y(baseline);
+
+    let visible: Vec<usize> = (0..decimated.len())
+        .filter(|i| !hidden.contains(i))
+        .collect();
+    let num_visible = visible.len().max(1);
+
+    let max_points = decimated
+        .iter()
+        .map(|s| s.len())
+        .max()
+        .unwrap_or(1)
+        .max(1);
+
+    let slot_w = plot_w / max_points as f32;
+    let group_w = slot_w * 0.8;
+    let bar_w = (group_w / num_visible as f32).max(1.0);
+
+    let fallback = gpui::hsla(0.6, 0.6, 0.5, 1.0);
+
+    for (group_pos, &s_idx) in visible.iter().enumerate() {
+        let base_color = palette.get(s_idx).copied().unwrap_or(fallback);
+        let color = if num_visible > 1 && s_idx != focused_idx {
+            gpui::hsla(base_color.h, base_color.s, base_color.l, 0.55)
+        } else {
+            base_color
+        };
+
+        let offset = group_pos as f32 * bar_w - group_w / 2.0;
+
+        for &(x, y) in &decimated[s_idx] {
+            let bar_left = data_to_screen_x(x) + offset;
+            let value_sy = data_to_screen_y(y);
+
+            let (rect_top, rect_height) = if value_sy <= baseline_sy {
+                (value_sy, baseline_sy - value_sy)
+            } else {
+                (baseline_sy, value_sy - baseline_sy)
+            };
+
+            window.paint_quad(fill(
+                gpui::Bounds {
+                    origin: point(gpui::px(bar_left), gpui::px(rect_top)),
+                    size: gpui::Size {
+                        width: gpui::px(bar_w * 0.92),
+                        height: gpui::px(rect_height.max(1.0)),
+                    },
+                },
+                color,
+            ));
+        }
+    }
+}
 
 /// Paint a vertical dashed line using short filled quads.
 ///
@@ -1704,8 +1926,8 @@ mod tests {
 
     /// `ChartView::build` with `ChartKind::Bar` must not panic.
     ///
-    /// The Bar paint arm renders a placeholder; it must never call `panic!()` or
-    /// `todo!()`. This test drives the implementation of the placeholder branch.
+    /// Bar shares the kind-agnostic `RenderModel` with Line, so `build` succeeds
+    /// identically; the Bar-specific geometry is produced later in `render`.
     #[test]
     fn build_with_bar_kind_does_not_panic() {
         let rows = vec![
@@ -1748,6 +1970,29 @@ mod tests {
         spec.kind = crate::chart::spec::ChartKind::Scatter;
 
         let _ = ChartView::build(&result, spec).expect("build with Scatter kind must not fail");
+    }
+
+    /// `ChartView::build` defaults the kind from the spec, and `kind()` reflects it.
+    #[test]
+    fn build_preserves_bar_kind_in_spec() {
+        let rows = vec![
+            vec![Value::Int(0), Value::Float(1.0)],
+            vec![Value::Int(1000), Value::Float(2.0)],
+        ];
+        let result = QueryResult::table(
+            vec![
+                make_col("t", ColumnKind::Timestamp),
+                make_col("v", ColumnKind::Float),
+            ],
+            rows,
+            None,
+            Duration::ZERO,
+        );
+        let mut spec = simple_spec(0, &[1]);
+        spec.kind = crate::chart::spec::ChartKind::Bar;
+
+        let view = ChartView::build(&result, spec).expect("build should succeed");
+        assert_eq!(view.kind(), crate::chart::spec::ChartKind::Bar);
     }
 
     // T-CE-G04: source_indices tracking tests

--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -650,6 +650,45 @@ impl ChartView {
             return;
         }
 
+        // Scatter charts focus by the nearest discrete point (2D distance),
+        // since there is no connecting line to project onto. Focus only switches
+        // when a point is within a small pixel tolerance of the cursor.
+        if matches!(self.spec.kind, crate::chart::spec::ChartKind::Scatter) {
+            let data_to_screen_x =
+                |dx: f64| -> f32 { plot_x0 + ((dx - x_min) / x_range * plot_w as f64) as f32 };
+            let data_to_screen_y = |dy: f64| -> f32 {
+                plot_y0 + plot_h - ((dy - y_min) / y_range * plot_h as f64) as f32
+            };
+
+            let cursor_sx = f32::from(hover_x);
+            let cursor_sy = f32::from(hover_y);
+
+            const FOCUS_TOLERANCE_PX: f32 = 18.0;
+            let mut best: Option<(usize, f32)> = None;
+
+            for (s_idx, pts) in self.render_model.decimated.iter().enumerate() {
+                if self.hidden.contains(&s_idx) {
+                    continue;
+                }
+                for &(x, y) in pts {
+                    let dx = data_to_screen_x(x) - cursor_sx;
+                    let dy = data_to_screen_y(y) - cursor_sy;
+                    let dist_sq = dx * dx + dy * dy;
+                    if best.is_none_or(|(_, b)| dist_sq < b) {
+                        best = Some((s_idx, dist_sq));
+                    }
+                }
+            }
+
+            if let Some((idx, dist_sq)) = best
+                && dist_sq <= FOCUS_TOLERANCE_PX * FOCUS_TOLERANCE_PX
+            {
+                self.focused_series_idx = idx;
+            }
+
+            return;
+        }
+
         let data_to_screen_y =
             |dy: f64| -> f32 { plot_y0 + plot_h - ((dy - y_min) / y_range * plot_h as f64) as f32 };
 
@@ -710,33 +749,8 @@ impl Render for ChartView {
 
         let kind = self.spec.kind;
 
-        // `Line` and `Bar` share the same plot frame (axes, gridlines, ticks)
-        // and only differ in how each series is painted. `Scatter` still renders
-        // a placeholder frame until its paint arm lands. This branch must never
-        // panic.
-        let is_placeholder = match kind {
-            ChartKind::Line | ChartKind::Bar => false,
-            ChartKind::Scatter => true,
-        };
-
-        if is_placeholder {
-            let label = match kind {
-                ChartKind::Scatter => "Scatter chart coming soon",
-                ChartKind::Line | ChartKind::Bar => unreachable!(),
-            };
-            return div()
-                .flex()
-                .flex_col()
-                .size_full()
-                .items_center()
-                .justify_center()
-                .border_1()
-                .border_color(gpui::hsla(0.0, 0.0, 0.5, 0.4))
-                .rounded(gpui::px(4.0))
-                .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0))
-                .text_size(FontSizes::SM)
-                .child(label);
-        }
+        // Line, Bar, and Scatter all share the same plot frame (axes, gridlines,
+        // ticks) and differ only in how each series is painted further below.
 
         let model = &self.render_model;
         let spec = &self.spec;
@@ -1052,9 +1066,17 @@ impl Render for ChartView {
                                             &data_to_screen_y,
                                         );
                                     }
-                                    // Scatter renders the placeholder frame above and
-                                    // never reaches this paint closure.
-                                    ChartKind::Scatter => {}
+                                    ChartKind::Scatter => {
+                                        paint_scatter(
+                                            window,
+                                            &decimated_canvas,
+                                            &palette_canvas,
+                                            &hidden_canvas,
+                                            focused_idx,
+                                            &data_to_screen_x,
+                                            &data_to_screen_y,
+                                        );
+                                    }
                                 }
 
                                 // --- Crosshair (dashed, amber #FFB454 at 0.7 opacity) ---
@@ -1079,7 +1101,7 @@ impl Render for ChartView {
                                             + ((sx - plot_x0) as f64 / plot_w as f64) * x_range;
 
                                         for (s_idx, pts) in decimated_canvas.iter().enumerate() {
-                                            if matches!(kind_canvas, ChartKind::Bar) {
+                                            if !matches!(kind_canvas, ChartKind::Line) {
                                                 break;
                                             }
                                             if hidden_canvas.contains(&s_idx) {
@@ -1325,6 +1347,68 @@ fn paint_bars<FX, FY>(
                 },
                 color,
             ));
+        }
+    }
+}
+
+/// Paint a filled disk at `(cx, cy)` with radius `r`.
+///
+/// GPUI's `PathBuilder` has no first-class circle, so the disk is built from two
+/// half-arcs (top and bottom semicircles).
+fn paint_filled_circle(window: &mut Window, cx: f32, cy: f32, r: f32, color: Hsla) {
+    let radii = point(gpui::px(r), gpui::px(r));
+    let right = point(gpui::px(cx + r), gpui::px(cy));
+    let left = point(gpui::px(cx - r), gpui::px(cy));
+
+    let mut builder = PathBuilder::fill();
+    builder.move_to(right);
+    builder.arc_to(radii, gpui::px(0.0), false, true, left);
+    builder.arc_to(radii, gpui::px(0.0), false, true, right);
+    builder.close();
+
+    if let Ok(path) = builder.build() {
+        window.paint_path(path, color);
+    }
+}
+
+/// Paint every visible series as a cloud of discrete points (no connecting
+/// line). The focused series is drawn at full opacity with a slightly larger
+/// radius; non-focused series are dimmed and smaller, mirroring the emphasis
+/// the Line and Bar arms give the focused series.
+fn paint_scatter<FX, FY>(
+    window: &mut Window,
+    decimated: &[Vec<(f64, f64)>],
+    palette: &[Hsla],
+    hidden: &HashSet<usize>,
+    focused_idx: usize,
+    data_to_screen_x: &FX,
+    data_to_screen_y: &FY,
+) where
+    FX: Fn(f64) -> f32,
+    FY: Fn(f64) -> f32,
+{
+    let fallback = gpui::hsla(0.6, 0.6, 0.5, 1.0);
+
+    let visible: Vec<usize> = (0..decimated.len())
+        .filter(|i| !hidden.contains(i))
+        .collect();
+    let num_visible = visible.len();
+
+    for &s_idx in &visible {
+        let base_color = palette.get(s_idx).copied().unwrap_or(fallback);
+        let (color, radius) = if num_visible > 1 && s_idx != focused_idx {
+            (
+                gpui::hsla(base_color.h, base_color.s, base_color.l, 0.45),
+                2.5_f32,
+            )
+        } else {
+            (base_color, 3.5_f32)
+        };
+
+        for &(x, y) in &decimated[s_idx] {
+            let sx = data_to_screen_x(x);
+            let sy = data_to_screen_y(y);
+            paint_filled_circle(window, sx, sy, radius, color);
         }
     }
 }

--- a/crates/dbflux_components/src/chart/spec.rs
+++ b/crates/dbflux_components/src/chart/spec.rs
@@ -15,6 +15,17 @@ pub enum ChartKind {
     Line,
     Bar,
     Scatter,
+    /// Filled line chart: the area between the series line and the baseline is
+    /// shaded. Shares all of Line's geometry and hover behaviour.
+    Area,
+    /// Stacked vertical bars: each X position shows one bar per series,
+    /// stacked cumulatively rather than grouped side-by-side. The Y axis is
+    /// re-scaled at render time to the maximum stack sum, since the precomputed
+    /// `RenderModel.y_max` reflects individual-series maxima only.
+    StackedBar,
+    /// Pie chart: no X/Y axes; each visible series becomes one wedge sized by
+    /// the sum of that series' Y values. Focus by angle from the pie centre.
+    Pie,
 }
 
 /// Axis classification used to pick the appropriate tick and label format.

--- a/crates/dbflux_components/src/chart/spec.rs
+++ b/crates/dbflux_components/src/chart/spec.rs
@@ -3,11 +3,8 @@
 use dbflux_core::ColumnKind;
 use serde::{Deserialize, Serialize};
 
-/// Extension seam for chart kinds.
-///
-/// `Line` and `Bar` are fully implemented; `Scatter` is declared here and still
-/// renders a placeholder frame until its paint arm lands, so adding it is purely
-/// additive.
+/// Chart rendering kinds. `Line`, `Bar`, and `Scatter` are all fully
+/// implemented and share the same kind-agnostic render model.
 ///
 /// `#[serde(default)]` on the containing `ChartSpec.kind` field ensures that
 /// existing serialized `ChartSpec` JSON without a `kind` key deserializes to

--- a/crates/dbflux_components/src/chart/spec.rs
+++ b/crates/dbflux_components/src/chart/spec.rs
@@ -5,8 +5,9 @@ use serde::{Deserialize, Serialize};
 
 /// Extension seam for chart kinds.
 ///
-/// Only `Line` is fully implemented in v0.6. `Bar` and `Scatter` are declared
-/// here so the next change is purely additive.
+/// `Line` and `Bar` are fully implemented; `Scatter` is declared here and still
+/// renders a placeholder frame until its paint arm lands, so adding it is purely
+/// additive.
 ///
 /// `#[serde(default)]` on the containing `ChartSpec.kind` field ensures that
 /// existing serialized `ChartSpec` JSON without a `kind` key deserializes to

--- a/crates/dbflux_components/src/chart/spec.rs
+++ b/crates/dbflux_components/src/chart/spec.rs
@@ -398,16 +398,34 @@ mod tests {
         assert_eq!(b.aggregation, AggKind::None);
     }
 
-    // Seam preservation: these references ensure ChartKind::Bar, ChartKind::Scatter,
-    // and AggKind remain reachable and cannot silently disappear.
+    // Seam preservation: these references ensure ChartKind variants remain
+    // reachable and cannot silently disappear across refactors.
     #[test]
-    fn seam_chart_kind_bar_and_scatter_are_reachable() {
-        // This test exists solely so the compiler will catch removal of these variants.
+    fn seam_chart_kind_all_variants_are_reachable() {
+        // This test exists solely so the compiler will catch removal of variants.
         let _bar = ChartKind::Bar;
         let _scatter = ChartKind::Scatter;
+        let _area = ChartKind::Area;
+        let _stacked = ChartKind::StackedBar;
+        let _pie = ChartKind::Pie;
         assert_ne!(ChartKind::Bar, ChartKind::Line);
         assert_ne!(ChartKind::Scatter, ChartKind::Line);
+        assert_ne!(ChartKind::Area, ChartKind::Line);
+        assert_ne!(ChartKind::StackedBar, ChartKind::Line);
+        assert_ne!(ChartKind::Pie, ChartKind::Line);
         assert_ne!(ChartKind::Bar, ChartKind::Scatter);
+    }
+
+    #[test]
+    fn chart_kind_serde_round_trip_new_variants() {
+        // Verify that StackedBar and Pie survive a JSON round-trip so persisted
+        // ChartSpec documents can be read back after these variants are added.
+        let kinds = [ChartKind::Area, ChartKind::StackedBar, ChartKind::Pie];
+        for kind in kinds {
+            let json = serde_json::to_string(&kind).expect("serialize");
+            let back: ChartKind = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(kind, back, "round-trip failed for {:?}", kind);
+        }
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/dbflux_driver_influxdb/src/http.rs
+++ b/crates/dbflux_driver_influxdb/src/http.rs
@@ -87,6 +87,26 @@ pub fn build_v2_flux_url(base: &str, org: &str) -> String {
     format!("{base}/api/v2/query?org={org_enc}")
 }
 
+/// Build the JSON body for a v2 Flux query request.
+///
+/// The `dialect.annotations` request is required: without it, InfluxDB v2
+/// returns annotation-free CSV (header + data only), so the response parser
+/// cannot recover column types and every column degrades to text — which in
+/// turn breaks chart auto-detection (no Timestamp / numeric columns). We request
+/// all three annotations the CSV parser understands.
+pub fn build_flux_request_body(query: &str) -> serde_json::Value {
+    serde_json::json!({
+        "query": query,
+        "type": "flux",
+        "dialect": {
+            "annotations": ["datatype", "group", "default"],
+            "header": true,
+            "delimiter": ",",
+            "dateTimeFormat": "RFC3339"
+        }
+    })
+}
+
 /// Build the Authorization header value for the given credentials.
 ///
 /// v2 tokens use the `Token <value>` scheme. v1 credentials use HTTP Basic
@@ -186,8 +206,14 @@ impl HttpClient {
     }
 
     /// Issue a POST request with a Flux query body.
+    ///
+    /// The `dialect.annotations` request is required: without it, InfluxDB v2
+    /// returns annotation-free CSV (header + data only), so the response parser
+    /// cannot recover column types and every column degrades to text — which in
+    /// turn breaks chart auto-detection (no Timestamp / numeric columns). We
+    /// request all three annotations the CSV parser understands.
     fn post_flux(&self, url: &str, query: &str) -> Result<HttpResponseBody, HttpError> {
-        let body = serde_json::json!({ "query": query, "type": "flux" });
+        let body = build_flux_request_body(query);
 
         let mut req = self
             .client
@@ -302,6 +328,25 @@ mod tests {
         assert!(
             url.contains("org=my-org"),
             "must carry org param, got: {url}"
+        );
+    }
+
+    #[test]
+    fn flux_request_body_requests_datatype_annotations() {
+        let body = build_flux_request_body("from(bucket: \"b\") |> range(start: -1h)");
+
+        assert_eq!(body["type"], "flux");
+        assert_eq!(body["query"], "from(bucket: \"b\") |> range(start: -1h)");
+
+        let annotations = body["dialect"]["annotations"]
+            .as_array()
+            .expect("annotations must be an array");
+
+        // The datatype annotation is what lets the CSV parser recover column
+        // types (Timestamp / Float); without it, charts cannot auto-detect.
+        assert!(
+            annotations.iter().any(|a| a == "datatype"),
+            "dialect must request the datatype annotation, got: {annotations:?}"
         );
     }
 

--- a/crates/dbflux_ui/src/ui/document/chart/shell.rs
+++ b/crates/dbflux_ui/src/ui/document/chart/shell.rs
@@ -15,7 +15,7 @@ pub enum ChartRailTab {
 
 use super::host::{ChartHost, HostAdapter};
 use dbflux_components::chart::{
-    AxisPill, BindingSpec, ChartDetection, ChartSpec, ChartView, DataPointRef,
+    AxisPill, BindingSpec, ChartDetection, ChartKind, ChartSpec, ChartView, DataPointRef,
     ManualChartSelection, SourceRowRef, detect_chart_columns,
 };
 use dbflux_core::{ColumnKind, ColumnMeta, QueryResult};
@@ -90,6 +90,11 @@ pub struct ChartShell {
     // ---- AxisBar state ----
     /// Which AxisBar pill picker is currently open.
     pub(crate) axis_open_pill: Option<AxisPill>,
+
+    // ---- chart kind ----
+    /// User-selected chart kind (Line, Bar, …). Applied to every `ChartSpec`
+    /// the shell produces, so it survives rebuilds triggered by binding edits.
+    chart_kind: ChartKind,
 }
 
 impl ChartShell {
@@ -123,6 +128,7 @@ impl ChartShell {
             chart_rail_picker_x_col: 0,
             chart_rail_picker_y_checked: Vec::new(),
             axis_open_pill: None,
+            chart_kind: ChartKind::default(),
         }
     }
 
@@ -209,6 +215,7 @@ impl ChartShell {
         }?;
 
         spec.legend_visible = self.chart_legend_visible && spec.series.len() > 1;
+        spec.kind = self.chart_kind;
 
         match ChartView::build(result, spec) {
             Ok(chart_view) => {
@@ -307,6 +314,30 @@ impl ChartShell {
         cx.notify();
     }
 
+    /// The currently selected chart kind.
+    pub fn chart_kind(&self) -> ChartKind {
+        self.chart_kind
+    }
+
+    /// Switch the chart kind (Line, Bar, …).
+    ///
+    /// Because the `ChartView` render model is kind-agnostic, an existing live
+    /// view is updated in place rather than rebuilt. When no view exists yet the
+    /// kind is stored and applied on the next `ensure_chart_view`.
+    pub fn set_chart_kind(&mut self, kind: ChartKind, cx: &mut Context<Self>) {
+        if self.chart_kind == kind {
+            return;
+        }
+
+        self.chart_kind = kind;
+
+        if let Some(chart_entity) = self.chart_view.clone() {
+            chart_entity.update(cx, |view, cx| view.set_kind(kind, cx));
+        }
+
+        cx.notify();
+    }
+
     /// Toggle the open/closed state of an AxisBar pill picker.
     ///
     /// Clicking the same pill again closes it (toggle). Clicking a different
@@ -336,8 +367,9 @@ impl ChartShell {
     pub fn current_chart_spec(&self, columns: &[dbflux_core::ColumnMeta]) -> ChartSpec {
         // Manual selection takes priority.
         if let Some(manual) = &self.chart_manual_selection
-            && let Some(spec) = ChartSpec::from_manual_selection(manual, columns, 10_000)
+            && let Some(mut spec) = ChartSpec::from_manual_selection(manual, columns, 10_000)
         {
+            spec.kind = self.chart_kind;
             return spec;
         }
 
@@ -346,15 +378,16 @@ impl ChartShell {
             time_col,
             numeric_cols,
         }) = &self.chart_detection
-            && let Some(spec) =
+            && let Some(mut spec) =
                 ChartSpec::from_detection(*time_col, numeric_cols.clone(), columns, 10_000)
         {
+            spec.kind = self.chart_kind;
             return spec;
         }
 
         // Minimal placeholder.
         ChartSpec {
-            kind: dbflux_components::chart::ChartKind::Line,
+            kind: self.chart_kind,
             x_axis: dbflux_components::chart::AxisSpec {
                 column_index: 0,
                 label: String::new(),

--- a/crates/dbflux_ui/src/ui/document/chart/toolbar.rs
+++ b/crates/dbflux_ui/src/ui/document/chart/toolbar.rs
@@ -20,7 +20,7 @@ use crate::ui::common::time_range::view::TimeRangePanel;
 use crate::ui::components::dropdown::Dropdown;
 use crate::ui::icons::AppIcon;
 use crate::ui::tokens::{FontSizes, Radii, Spacing};
-use dbflux_components::chart::{format_resolution, format_x_value};
+use dbflux_components::chart::{ChartKind, format_resolution, format_x_value};
 use dbflux_components::primitives::Icon;
 use gpui::prelude::*;
 use gpui::*;
@@ -31,6 +31,8 @@ use std::sync::Arc;
 pub type RangePresetHandler = Arc<dyn Fn(usize, &mut Window, &mut App)>;
 /// Handler called when the Stats button, PNG button, or Save button is clicked.
 pub type ActionHandler = Arc<dyn Fn(&mut Window, &mut App)>;
+/// Handler called when a chart-kind chip is clicked; receives the chosen kind.
+pub type ChartKindHandler = Arc<dyn Fn(ChartKind, &mut Window, &mut App)>;
 
 /// All read-only state the toolbar needs to render itself.
 ///
@@ -74,6 +76,8 @@ pub struct ChartToolbarHandlers {
     pub on_png_export: ActionHandler,
     /// Called when the "Save chart" button is clicked.
     pub on_save_chart: ActionHandler,
+    /// Called when a chart-kind chip (Line / Bar) is clicked.
+    pub on_select_chart_kind: ChartKindHandler,
 }
 
 /// Render the chart toolbar row.
@@ -94,12 +98,13 @@ pub fn render_chart_toolbar(
     let primary_fg = theme.primary_foreground;
 
     // --- Read rail state from the shell ---
-    let (chart_view_entity, rail_open, rail_tab) = {
+    let (chart_view_entity, rail_open, rail_tab, current_kind) = {
         let shell = ctx.chart_shell.read(cx);
         (
             shell.chart_view().cloned(),
             shell.chart_rail_open,
             shell.chart_rail_tab,
+            shell.chart_kind(),
         )
     };
 
@@ -232,6 +237,59 @@ pub fn render_chart_toolbar(
             .child(label)
     };
 
+    // --- Chart kind chips (Line | Bar) ---
+    let on_select_kind = handlers.on_select_chart_kind.clone();
+    let kind_options: [(ChartKind, &'static str); 2] =
+        [(ChartKind::Line, "Line"), (ChartKind::Bar, "Bar")];
+    let num_kinds = kind_options.len();
+
+    let kind_chips = div()
+        .flex()
+        .items_center()
+        .border_1()
+        .border_color(border)
+        .rounded(Radii::SM)
+        .overflow_hidden()
+        .children(
+            kind_options
+                .into_iter()
+                .enumerate()
+                .map(|(i, (kind, label))| {
+                    let is_active = kind == current_kind;
+                    let is_last = i == num_kinds - 1;
+                    let handler = on_select_kind.clone();
+
+                    let mut chip = div()
+                        .id(ElementId::Name(format!("chart-kind-{label}").into()))
+                        .px(px(8.0))
+                        .py(px(3.0))
+                        .text_size(px(11.0))
+                        .font(font("JetBrains Mono"))
+                        .cursor_pointer()
+                        .when(is_active, |d| {
+                            d.bg(primary)
+                                .text_color(primary_fg)
+                                .font_weight(FontWeight::SEMIBOLD)
+                        })
+                        .when(!is_active, |d| {
+                            d.text_color(muted).hover(move |d| d.bg(secondary))
+                        })
+                        .when(!is_last, |d| d.border_r_1().border_color(border))
+                        .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                            handler(kind, window, cx);
+                        })
+                        .child(label);
+
+                    if i == 0 {
+                        chip = chip.rounded_tl(Radii::SM).rounded_bl(Radii::SM);
+                    } else if is_last {
+                        chip = chip.rounded_tr(Radii::SM).rounded_br(Radii::SM);
+                    }
+
+                    chip
+                }),
+        );
+
     let is_stats_active = rail_open && rail_tab == ChartRailTab::Stats;
     let on_stats = handlers.on_toggle_stats_rail.clone();
     let on_png = handlers.on_png_export.clone();
@@ -317,6 +375,22 @@ pub fn render_chart_toolbar(
                 .child(SharedString::from(format!("{row_count} pts")))
                 .child("\u{00b7}")
                 .child(resolution_label),
+        )
+        .child(vdivider(border))
+        // Chart kind selector (Line | Bar)
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(4.0))
+                .child(
+                    div()
+                        .text_size(px(10.0))
+                        .text_color(muted)
+                        .font_weight(FontWeight::BOLD)
+                        .child("TYPE"),
+                )
+                .child(kind_chips),
         )
         .child(vdivider(border))
         .child(stats_btn)

--- a/crates/dbflux_ui/src/ui/document/chart/toolbar.rs
+++ b/crates/dbflux_ui/src/ui/document/chart/toolbar.rs
@@ -239,8 +239,11 @@ pub fn render_chart_toolbar(
 
     // --- Chart kind chips (Line | Bar) ---
     let on_select_kind = handlers.on_select_chart_kind.clone();
-    let kind_options: [(ChartKind, &'static str); 2] =
-        [(ChartKind::Line, "Line"), (ChartKind::Bar, "Bar")];
+    let kind_options: [(ChartKind, &'static str); 3] = [
+        (ChartKind::Line, "Line"),
+        (ChartKind::Bar, "Bar"),
+        (ChartKind::Scatter, "Scatter"),
+    ];
     let num_kinds = kind_options.len();
 
     let kind_chips = div()

--- a/crates/dbflux_ui/src/ui/document/chart/toolbar.rs
+++ b/crates/dbflux_ui/src/ui/document/chart/toolbar.rs
@@ -239,11 +239,13 @@ pub fn render_chart_toolbar(
 
     // --- Chart kind chips (Line | Bar) ---
     let on_select_kind = handlers.on_select_chart_kind.clone();
-    let kind_options: [(ChartKind, &'static str); 4] = [
+    let kind_options: [(ChartKind, &'static str); 6] = [
         (ChartKind::Line, "Line"),
         (ChartKind::Bar, "Bar"),
         (ChartKind::Scatter, "Scatter"),
         (ChartKind::Area, "Area"),
+        (ChartKind::StackedBar, "Stacked"),
+        (ChartKind::Pie, "Pie"),
     ];
     let num_kinds = kind_options.len();
 

--- a/crates/dbflux_ui/src/ui/document/chart/toolbar.rs
+++ b/crates/dbflux_ui/src/ui/document/chart/toolbar.rs
@@ -239,10 +239,11 @@ pub fn render_chart_toolbar(
 
     // --- Chart kind chips (Line | Bar) ---
     let on_select_kind = handlers.on_select_chart_kind.clone();
-    let kind_options: [(ChartKind, &'static str); 3] = [
+    let kind_options: [(ChartKind, &'static str); 4] = [
         (ChartKind::Line, "Line"),
         (ChartKind::Bar, "Bar"),
         (ChartKind::Scatter, "Scatter"),
+        (ChartKind::Area, "Area"),
     ];
     let num_kinds = kind_options.len();
 

--- a/crates/dbflux_ui/src/ui/document/chart_document/render.rs
+++ b/crates/dbflux_ui/src/ui/document/chart_document/render.rs
@@ -209,6 +209,7 @@ impl ChartDocument {
                 .unwrap_or(0);
 
             let shell_for_stats = self.chart_shell.clone();
+            let shell_for_kind = self.chart_shell.clone();
             let weak_self_for_png = cx.weak_entity();
             let weak_self_for_save = cx.weak_entity();
             let weak_self_for_range = cx.weak_entity();
@@ -260,6 +261,9 @@ impl ChartDocument {
                             this.open_name_prompt(window, cx);
                         });
                     }
+                }),
+                on_select_chart_kind: Arc::new(move |kind, _window, cx| {
+                    shell_for_kind.update(cx, |s, cx| s.set_chart_kind(kind, cx));
                 }),
             };
 

--- a/crates/dbflux_ui/src/ui/document/code/context_bar.rs
+++ b/crates/dbflux_ui/src/ui/document/code/context_bar.rs
@@ -32,6 +32,29 @@ fn parse_source_datetime_input(value: &str) -> Option<i64> {
         .map(|dt| dt.timestamp_millis())
 }
 
+/// Resolve which query-mode value the Syntax dropdown should show when the
+/// context bar re-syncs, preserving a user's in-progress choice.
+///
+/// Precedence: a mode committed in the execution context, then the mode
+/// currently shown in the dropdown, then the spec default. The preferred value
+/// is only kept when the current spec still offers it (`available`); otherwise
+/// it falls back to the spec default. This is what prevents an `AppStateChanged`
+/// event from resetting a freshly-picked Flux selection back to the spec default
+/// (InfluxQL on InfluxDB v2).
+fn resolve_query_mode_selection(
+    committed: Option<&str>,
+    current_dropdown: Option<&str>,
+    available: &[String],
+    spec_default: Option<&str>,
+) -> Option<String> {
+    let preferred = committed.or(current_dropdown);
+
+    preferred
+        .filter(|mode| available.iter().any(|candidate| candidate == mode))
+        .map(|mode| mode.to_string())
+        .or_else(|| spec_default.map(|mode| mode.to_string()))
+}
+
 impl CodeDocument {
     // === Context dropdown creation ===
 
@@ -241,13 +264,17 @@ impl CodeDocument {
         let start_blank = self.source_start_input.read(cx).value().trim().is_empty();
         let end_blank = self.source_end_input.read(cx).value().trim().is_empty();
 
-        if start_blank
-            && end_blank
-            && matches!(
-                self.exec_ctx.source,
-                Some(ExecutionSourceContext::CollectionWindow { .. })
-            )
-        {
+        if start_blank && end_blank {
+            // Time bounds not entered yet: keep any existing window, but sync its
+            // query_mode with the dropdown so switching syntax (e.g. to Flux) is
+            // not lost while waiting for a time range. Without this, the stored
+            // mode stays stale and the query is routed with the old language.
+            let mode = self.current_source_query_mode_value(cx);
+            if let Some(ExecutionSourceContext::CollectionWindow { query_mode, .. }) =
+                self.exec_ctx.source.as_mut()
+            {
+                *query_mode = mode;
+            }
             return;
         }
 
@@ -287,18 +314,36 @@ impl CodeDocument {
             })
             .unwrap_or_default();
 
-        let selected_query_mode = match self.exec_ctx.source.as_ref() {
-            Some(ExecutionSourceContext::CollectionWindow { query_mode, .. }) => {
-                query_mode.clone().or_else(|| {
-                    source_spec
-                        .as_ref()
-                        .and_then(|spec| spec.default_query_mode.clone())
-                })
-            }
-            None => source_spec
-                .as_ref()
-                .and_then(|spec| spec.default_query_mode.clone()),
+        // Preserve the syntax the user already picked. An AppStateChanged event
+        // (schema reload, another connection changing state, etc.) must not
+        // silently reset the dropdown to the spec default — which is what
+        // happened to Flux on InfluxDB v2, whose default mode is InfluxQL.
+        let current_dropdown_mode = self
+            .source_query_mode_dropdown
+            .read(cx)
+            .selected_value()
+            .map(|value| value.to_string());
+
+        let committed_mode = match self.exec_ctx.source.as_ref() {
+            Some(ExecutionSourceContext::CollectionWindow { query_mode, .. }) => query_mode.clone(),
+            None => None,
         };
+
+        let available_modes: Vec<String> = query_mode_items
+            .iter()
+            .map(|item| item.value.to_string())
+            .collect();
+
+        let spec_default = source_spec
+            .as_ref()
+            .and_then(|spec| spec.default_query_mode.clone());
+
+        let selected_query_mode = resolve_query_mode_selection(
+            committed_mode.as_deref(),
+            current_dropdown_mode.as_deref(),
+            &available_modes,
+            spec_default.as_deref(),
+        );
 
         let selected_query_mode_index = selected_query_mode.as_ref().and_then(|selected| {
             query_mode_items
@@ -1437,10 +1482,46 @@ impl CodeDocument {
 mod tests {
     use super::{
         ContextBarSlot, SqlQueryFocus, build_source_window_context, context_dropdown_min_width,
-        context_slot_is_keyboard_focused, parse_source_datetime_input,
+        context_slot_is_keyboard_focused, parse_source_datetime_input, resolve_query_mode_selection,
     };
     use dbflux_core::ExecutionSourceContext;
     use gpui::px;
+
+    #[test]
+    fn query_mode_selection_prefers_committed_then_dropdown() {
+        let available = vec!["influxql".to_string(), "flux".to_string()];
+
+        // A committed mode wins over the dropdown and the default.
+        assert_eq!(
+            resolve_query_mode_selection(Some("flux"), Some("influxql"), &available, Some("influxql")),
+            Some("flux".to_string())
+        );
+
+        // No committed mode: the current dropdown choice is preserved over the
+        // default — this is the AppStateChanged reset the fix prevents.
+        assert_eq!(
+            resolve_query_mode_selection(None, Some("flux"), &available, Some("influxql")),
+            Some("flux".to_string())
+        );
+    }
+
+    #[test]
+    fn query_mode_selection_falls_back_to_default() {
+        let available = vec!["influxql".to_string(), "flux".to_string()];
+
+        // Nothing committed and nothing in the dropdown: use the spec default.
+        assert_eq!(
+            resolve_query_mode_selection(None, None, &available, Some("influxql")),
+            Some("influxql".to_string())
+        );
+
+        // A preferred mode the current spec no longer offers falls back to the
+        // default rather than selecting an absent value.
+        assert_eq!(
+            resolve_query_mode_selection(Some("sql"), None, &available, Some("influxql")),
+            Some("influxql".to_string())
+        );
+    }
 
     #[test]
     fn connection_dropdown_keeps_widest_shell() {

--- a/crates/dbflux_ui/src/ui/document/code/context_bar.rs
+++ b/crates/dbflux_ui/src/ui/document/code/context_bar.rs
@@ -119,19 +119,26 @@ impl CodeDocument {
         })
     }
 
-    fn update_completion_provider(&mut self, cx: &mut Context<Self>) {
+    /// Re-bind the editor to the effective query language: completion provider
+    /// and syntax highlighter. Called whenever the language can change (Syntax
+    /// dropdown, connection change), so switching to e.g. Flux drops the SQL
+    /// grammar (and, via run_diagnostics, the SQL squiggles) instead of keeping
+    /// the document's initial language.
+    fn sync_editor_language(&mut self, cx: &mut Context<Self>) {
         let connection_id = self
             .connection_id
             .filter(|id| self.app_state.read(cx).connections().contains_key(id));
 
         let query_language = self.effective_query_language(cx);
+        let editor_mode = query_language.editor_mode();
 
         let completion_provider: Rc<dyn CompletionProvider> = Rc::new(
             QueryCompletionProvider::new(query_language, self.app_state.clone(), connection_id),
         );
 
-        self.input_state.update(cx, |state, _cx| {
+        self.input_state.update(cx, |state, cx| {
             state.lsp.completion_provider = Some(completion_provider);
+            state.set_highlighter(editor_mode, cx);
         });
     }
 
@@ -159,7 +166,7 @@ impl CodeDocument {
             .or_else(|| spec.query_modes.first().map(|mode| mode.value.clone()))
     }
 
-    fn effective_query_language(&self, cx: &App) -> QueryLanguage {
+    pub(super) fn effective_query_language(&self, cx: &App) -> QueryLanguage {
         let Some(spec) = self.current_source_context_spec(cx) else {
             return self.query_language.clone();
         };
@@ -388,7 +395,7 @@ impl CodeDocument {
         cx: &mut Context<Self>,
     ) {
         self.sync_source_exec_context(cx);
-        self.update_completion_provider(cx);
+        self.sync_editor_language(cx);
         self.schedule_diagnostic_refresh(cx);
         cx.emit(DocumentEvent::MetaChanged);
         cx.notify();
@@ -561,7 +568,7 @@ impl CodeDocument {
         }
 
         self.sync_source_controls(cx);
-        self.update_completion_provider(cx);
+        self.sync_editor_language(cx);
 
         if did_change {
             cx.emit(DocumentEvent::MetaChanged);
@@ -1482,7 +1489,8 @@ impl CodeDocument {
 mod tests {
     use super::{
         ContextBarSlot, SqlQueryFocus, build_source_window_context, context_dropdown_min_width,
-        context_slot_is_keyboard_focused, parse_source_datetime_input, resolve_query_mode_selection,
+        context_slot_is_keyboard_focused, parse_source_datetime_input,
+        resolve_query_mode_selection,
     };
     use dbflux_core::ExecutionSourceContext;
     use gpui::px;
@@ -1493,7 +1501,12 @@ mod tests {
 
         // A committed mode wins over the dropdown and the default.
         assert_eq!(
-            resolve_query_mode_selection(Some("flux"), Some("influxql"), &available, Some("influxql")),
+            resolve_query_mode_selection(
+                Some("flux"),
+                Some("influxql"),
+                &available,
+                Some("influxql")
+            ),
             Some("flux".to_string())
         );
 

--- a/crates/dbflux_ui/src/ui/document/code/diagnostics.rs
+++ b/crates/dbflux_ui/src/ui/document/code/diagnostics.rs
@@ -40,12 +40,23 @@ impl CodeDocument {
     fn run_diagnostics(&mut self, cx: &mut Context<Self>) {
         let query_text = self.input_state.read(cx).value().to_string();
 
-        let diagnostics = if let Some(conn_id) = self.connection_id {
-            if let Some(connected) = self.app_state.read(cx).connections().get(&conn_id) {
-                connected
-                    .connection
-                    .language_service()
-                    .editor_diagnostics(&query_text)
+        // The connection's language service validates with the SQL tree-sitter
+        // grammar. Only run it when the effective query language actually uses
+        // the SQL editor mode; for Flux, Mongo, Redis, etc. the SQL parser would
+        // flag the whole query as invalid. Falling through with an empty list
+        // still clears any stale diagnostics below.
+        let language_is_sql = self.effective_query_language(cx).editor_mode() == "sql";
+
+        let diagnostics = if language_is_sql {
+            if let Some(conn_id) = self.connection_id {
+                if let Some(connected) = self.app_state.read(cx).connections().get(&conn_id) {
+                    connected
+                        .connection
+                        .language_service()
+                        .editor_diagnostics(&query_text)
+                } else {
+                    Vec::new()
+                }
             } else {
                 Vec::new()
             }

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/render.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/render.rs
@@ -1275,6 +1275,7 @@ impl DataGridPanel {
 
         // Capture clones for the handlers before borrowing self mutably.
         let shell_for_stats = chart_shell.clone();
+        let shell_for_kind = chart_shell.clone();
         let time_range_panel_for_preset = self.chart_source_time_range_panel.clone();
 
         let ctx = ChartToolbarContext {
@@ -1326,6 +1327,9 @@ impl DataGridPanel {
                         this.open_collection_chart_save(window, cx);
                     });
                 }
+            }),
+            on_select_chart_kind: Arc::new(move |kind, _window, cx| {
+                shell_for_kind.update(cx, |s, cx| s.set_chart_kind(kind, cx));
             }),
         };
 

--- a/crates/dbflux_ui/src/ui/icons/mod.rs
+++ b/crates/dbflux_ui/src/ui/icons/mod.rs
@@ -403,6 +403,9 @@ impl AppIcon {
             ChartKind::Line => Self::ChartSpline,
             ChartKind::Bar => Self::ChartColumnBig,
             ChartKind::Scatter => Self::ChartNetwork,
+            ChartKind::Area => Self::ChartArea,
+            ChartKind::StackedBar => Self::ChartColumnBig,
+            ChartKind::Pie => Self::ChartPie,
         }
     }
 


### PR DESCRIPTION
## What

Adds five new chart kinds and fixes several issues that prevented charting Flux query results on InfluxDB v2.

### New chart types (`dbflux_components` chart engine + `dbflux_ui` toolbar)

`ChartKind` now covers **Line, Bar, Scatter, Area, Stacked Bar, Pie**, all selectable from the new **TYPE** segmented control in the chart toolbar (wired from both `ChartDocument` and `DataGridPanel`).

- **Bar** — grouped vertical bars anchored at the zero baseline (or the data minimum when zero is outside the range). Vertical headroom and a half-column horizontal inset so the tallest bar never touches the top and edge bars are not clipped. Focus is column-based (the bar under the cursor, across its full height).
- **Scatter** — discrete points per series; focus by nearest 2D point.
- **Area** — filled line chart (fill to baseline + line on top); inherits Line's hover/proximity focus.
- **Stacked Bar** — bars stacked per X position. The Y axis is re-scaled at render time to the summed stack ceiling (the precomputed model max reflects per-series maxima only) and the Y ticks are regenerated to match.
- **Pie** — no axes; one wedge per visible series, sized by the sum of that series' Y values. Wedges drawn via arc subdivision; focus by angle.

The render model is kind-agnostic, so switching kind updates in place without a rebuild.

### Fixes

- **fix(chart): Stacked Bar hover focus** — the hover hit-test now uses the same stacked Y ceiling render uses (extracted `ChartView::stacked_y_max`), so segment boundaries line up with the bars; recomputed from the visible set so toggling series stays correct.
- **fix(editor): preserve chosen query syntax (Flux)** — on InfluxDB v2 the Syntax dropdown silently reverted to InfluxQL on `AppStateChanged`, and Flux ran via the InfluxQL endpoint. The dropdown now preserves the user's selection (`resolve_query_mode_selection`), and a mode-only change is persisted into the execution context even before time bounds are entered.
- **fix(influxdb): request datatype annotations for Flux** — the v2 Flux POST sent no `dialect`, so InfluxDB returned annotation-free CSV and every column degraded to text, making the Chart view unavailable. The request now asks for the `datatype`/`group`/`default` annotations the parser needs.
- **fix(editor): non-SQL grammar/diagnostics** — Flux (and other non-SQL languages) were highlighted with the SQL grammar and underlined by the SQL tree-sitter diagnostics. Highlighting and diagnostics are now gated on the effective query language's editor mode; non-SQL languages get plain-text editing with no diagnostics (intentional — no Flux grammar/linter exists).

## Why

The chart subsystem previously shipped only Line; Bar/Scatter were declared seam variants. This completes the chart-type set. The Flux/InfluxDB fixes were found while testing the new charts against a live InfluxDB v2 instance.

## Testing

- `cargo clippy --workspace -- -D warnings` clean (verified on the full driver feature set).
- `cargo nextest run` — chart engine (104 tests), InfluxDB driver (87 tests), and editor code module (26 tests) all pass. New unit tests added for: per-kind build, the query-mode precedence helper, and the Flux request body annotations.

## Notes / known limitations

- The `table` column in pivoted Flux results is typed numeric and may appear as an extra series in auto-detection (deselectable via the Y picker).
- Non-SQL languages intentionally lose syntax highlighting and diagnostics rather than showing incorrect SQL ones.
- Large change (~1.5k lines); commits are organized one per feature/fix if a per-commit review is preferred.