### PR TITLE
fix(ui): make Ctrl+Shift+1..4 focus shortcuts fire on macOS/Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+* **Focus shortcuts on macOS/Windows** — `Ctrl+Shift+1..4` (Focus
+  Sidebar / Editor / Results / Tasks) now fire on every platform. GPUI
+  normalizes `Shift`+digit chords at the platform layer (e.g. macOS
+  delivers `Ctrl+Shift+2` as `@` with `shift=false`), so the literal
+  `KeymapStack` matchers never matched the runtime keystroke. The four
+  shortcuts are now registered as native GPUI key bindings, which GPUI
+  normalizes per platform/layout at registration time. The `KeymapStack`
+  entries are retained solely as the command-palette shortcut-label
+  source.
+
 ## [0.6.0-dev.6] - 2026-05-20
 
 ### Added

--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -17,7 +17,7 @@ use dbflux_ipc::{
 use dbflux_ui::AppStateEntity;
 use dbflux_ui::assets::Assets;
 use dbflux_ui::ipc_server::IpcServer;
-use dbflux_ui::keymap::input_context_keybindings;
+use dbflux_ui::keymap::{input_context_keybindings, workspace_keybindings};
 use dbflux_ui::platform;
 use dbflux_ui::ui::overlays::command_palette::command_palette_keybindings;
 use dbflux_ui::ui::views::workspace::Workspace;
@@ -296,6 +296,7 @@ fn run_gui() {
             .open_window(main_window_options, |window, cx| {
                 cx.bind_keys(command_palette_keybindings());
                 cx.bind_keys(input_context_keybindings());
+                cx.bind_keys(workspace_keybindings());
 
                 let workspace = cx.new(|cx| Workspace::new(app_state.clone(), window, cx));
 

--- a/crates/dbflux_ui/src/keymap/actions.rs
+++ b/crates/dbflux_ui/src/keymap/actions.rs
@@ -67,6 +67,40 @@ actions!(
     ]
 );
 
+/// GPUI native bindings for the four workspace pane-focus shortcuts.
+///
+/// ## Why this function exists (GitHub #65)
+///
+/// GPUI normalizes Ctrl+Shift+digit chords at the platform layer (via
+/// `PlatformKeyboardMapper::map_key_equivalent`) before the custom `KeymapStack`
+/// structural matcher ever sees them. On macOS, for example, Ctrl+Shift+2 is
+/// delivered as key `"@"` with `shift = false`, so the literal
+/// `KeyChord::new("2", Modifiers::ctrl_shift())` in `defaults.rs` never matches.
+/// Registering the chords as native GPUI `KeyBinding`s (via `cx.bind_keys`) lets
+/// GPUI apply the same per-platform/layout normalization to both the registered
+/// chord and the incoming keystroke, so they always match regardless of OS.
+///
+/// ## Why `ctrl-shift` on every platform (no `#[cfg]`)
+///
+/// `Cmd+Shift+3` and `Cmd+Shift+4` are reserved by macOS for screenshot
+/// operations. Switching to the primary modifier would silently break two of the
+/// four bindings on macOS. The full group stays on `ctrl-shift` across all
+/// platforms for consistency.
+///
+/// ## Scope: only these four digit chords
+///
+/// Only the four focus-pane shortcuts go through GPUI native bindings. All
+/// letter-based and other chords remain in the `KeymapStack` system in
+/// `defaults.rs` and are unaffected by this function.
+pub fn workspace_keybindings() -> Vec<KeyBinding> {
+    vec![
+        KeyBinding::new("ctrl-shift-1", FocusSidebar, None),
+        KeyBinding::new("ctrl-shift-2", FocusEditor, None),
+        KeyBinding::new("ctrl-shift-3", FocusResults, None),
+        KeyBinding::new("ctrl-shift-4", FocusBackgroundTasks, None),
+    ]
+}
+
 /// Keybindings that shadow `gpui-component` input defaults inside the "Input"
 /// context so that the primary modifier + Enter runs the active query instead
 /// of inserting a newline.
@@ -132,6 +166,37 @@ mod tests {
         assert!(
             bindings[1].match_keystrokes(&[run_new]) == Some(false)
                 && bindings[1].action().partial_eq(&RunQueryInNewTab),
+        );
+    }
+
+    // Regression test for the GPUI shift-digit normalization bug (GitHub #65):
+    // GPUI normalizes Ctrl+Shift+digit chords at the platform layer before
+    // KeymapStack sees them, so literal KeymapStack entries for ctrl-shift-1..4
+    // never fire at runtime. `workspace_keybindings()` registers the same chords
+    // as native GPUI KeyBindings so GPUI's internal normalization applies to both
+    // the registered chord and the incoming keystroke, making them match.
+    //
+    // This test exercises the Keymap-level match path to catch any recurrence of
+    // the normalization regression. Note: it proves binding-side normalization but
+    // not the full platform-event path (no easy way to synthesize the
+    // platform-mangled key in a unit test — see design notes for #65).
+    #[test]
+    fn workspace_keybindings_ctrl_shift_2_resolves_to_focus_editor() {
+        let mut keymap = Keymap::default();
+        keymap.add_bindings(workspace_keybindings());
+
+        let typed = [Keystroke::parse("ctrl-shift-2").unwrap()];
+        // Global context: workspace bindings use None (no context restriction).
+        let context_stack: &[KeyContext] = &[];
+        let (matches, _pending) = keymap.bindings_for_input(&typed, context_stack);
+
+        let top = matches.first().expect(
+            "ctrl-shift-2 should match at least one binding when registered via \
+             workspace_keybindings()",
+        );
+        assert!(
+            top.action().partial_eq(&FocusEditor),
+            "FocusEditor must be the top-ranked match for ctrl-shift-2 (GitHub #65 regression guard)",
         );
     }
 

--- a/crates/dbflux_ui/src/keymap/defaults.rs
+++ b/crates/dbflux_ui/src/keymap/defaults.rs
@@ -95,6 +95,19 @@ fn global_layer() -> KeymapLayer {
     // Cmd+Shift+3 and Cmd+Shift+4 are reserved by macOS for screenshots, so
     // switching the whole group to the primary modifier would silently break
     // two of the four bindings on Mac.
+    //
+    // IMPORTANT — these four entries are retained as a no-op label source only.
+    //
+    // (a) Actual keystroke dispatch is owned by `workspace_keybindings()` in
+    //     `actions.rs`, registered via `cx.bind_keys` as native GPUI bindings.
+    //     GPUI normalizes Ctrl+Shift+digit chords at the platform layer before
+    //     KeymapStack sees them (see GitHub #65), so these structural matchers
+    //     never fire at runtime.
+    // (b) These entries serve one live purpose: supplying the shortcut label in
+    //     the command palette. `shortcut_for_command` reads KeymapStack (not the
+    //     GPUI keymap), so removing these entries would drop the "Ctrl+Shift+N"
+    //     hints from the palette. Do not remove them until the command palette is
+    //     updated to read GPUI native bindings.
     layer.bind(
         KeyChord::new("1", Modifiers::ctrl_shift()),
         Command::FocusSidebar,


### PR DESCRIPTION
## Summary

The four direct focus shortcuts — `Ctrl+Shift+1` (Focus Sidebar),
`Ctrl+Shift+2` (Focus Editor), `Ctrl+Shift+3` (Focus Results),
`Ctrl+Shift+4` (Focus Tasks) — never fired on macOS and Windows (and
likely Linux). This makes them work on every platform.

## What does this resolve?

- Resolves #65

## How was this solved?

GPUI normalizes `Shift`+digit chords at the platform layer: on macOS
`Ctrl+Shift+2` arrives as `key="@"` with `shift=false`, and on Windows
`need_to_convert_to_shifted_key` drops `shift` for `VK_0..VK_9`. Our
custom `KeymapStack` stored the literal `KeyChord::new("2", ctrl_shift())`
and matched it structurally in `Workspace::on_key_down`, so the mangled
runtime keystroke never matched — the `on_action` listeners already
present in `Workspace::render` were dead code.

The fix follows the existing `input_context_keybindings()` /
`command_palette_keybindings()` precedent: a new `workspace_keybindings()`
returns the four shortcuts as native GPUI `KeyBinding`s, registered via
`cx.bind_keys` at window init. GPUI's `PlatformKeyboardMapper` normalizes
each chord per platform/layout at registration time, so the same
`ctrl-shift-N` string matches across US and non-US layouts and the
existing listeners come alive.

`KeymapStack` stays the source of truth for all other (letter-based)
chords. The four `defaults.rs` entries are retained as a documented
no-op fallback so the command palette keeps displaying the shortcut
labels (`shortcut_for_command` reads `KeymapStack`, not the GPUI keymap).

The modifier stays `Ctrl+Shift` on all platforms by design —
`Cmd+Shift+3/4` are reserved by macOS for screenshots.

### Known limitation

The regression test exercises GPUI's binding-side normalization via
`bindings_for_input`; it does not synthesize the raw platform-mangled
keystroke (`@`). The fix is correct precisely because GPUI normalizes
both the registered binding and the lookup through the same path. A
manual smoke-test on macOS is still worthwhile.

## Validation

Run in `crates/`:

- `cargo test -p dbflux_ui` — 475 passed, 0 failed (incl. new
  `workspace_keybindings_ctrl_shift_2_resolves_to_focus_editor`)
- `cargo check --workspace` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all` — no changes

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated \`CHANGELOG.md\` under \`## [Unreleased]\` if this is user-visible
- [ ] I applied the appropriate labels (see CONTRIBUTING.md)

## Labels to apply

Suggested (per issue #65): \`ui:bug\`, \`platform:macos\`, \`platform:windows\`