### PR TITLE
docs: refresh v0.6 documentation + fix capability bit collision and DynamoDB upsert

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,16 +14,16 @@ For the branching model, version rules, tag flow, and release procedure, use `do
 
 ```bash
 cargo check --workspace              # Fast type checking
-cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,mssql,aws  # Debug build
-cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,mssql,aws --release  # Release build
-cargo run -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,mssql,aws    # Run app
+cargo build -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws  # Debug build
+cargo build -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws --release  # Release build
+cargo run -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws    # Run app
 
 # MCP server (AI integration) - included by default
 cargo build -p dbflux  # MCP included in default features
 ./target/debug/dbflux mcp --client-id test-client
 
 # Build without MCP support (smaller binary, no AI integration)
-cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mongodb,redis,dynamodb,influxdb,mssql,lua,aws
+cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,lua,aws
 
 cargo fmt --all                      # Format
 cargo clippy --workspace -- -D warnings  # Lint

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,8 +4,97 @@
 
 - DBFlux is a keyboard-first database client built with Rust and GPUI, focused on fast workflows and a clean desktop UI (README.md).
 - The repo is a Rust workspace with a UI app crate plus shared core types, driver implementations, and supporting libraries (Cargo.toml, crates/).
-- Supports multiple database paradigms: relational (SQL), document (MongoDB, DynamoDB), key-value, graph, time-series, and wide-column stores.
+- Supports multiple database paradigms: relational (SQL), document (MongoDB, DynamoDB), key-value (Redis), time-series (InfluxDB), log-stream (CloudWatch Logs), graph, and wide-column stores.
 - This is the canonical top-level document for project structure, architecture overview, crate boundaries, key files, and the cross-crate map. Other top-level docs should link here instead of duplicating that material.
+
+## Architecture at a Glance
+
+The text below is exhaustive but dense; these three diagrams give the mental model first. They are conceptual — exact symbol names live in the sections that follow.
+
+### Layered crate map
+
+Dependencies point downward. `dbflux_core` is the dependency-free contract layer every other crate builds on; the UI never depends on a concrete driver crate (see [Driver/UI decoupling](#driver-system)).
+
+```mermaid
+flowchart TB
+    subgraph Shell["Binary shell"]
+        bin["dbflux<br/>(main, CLI, single-instance IPC,<br/>mcp subcommand)"]
+    end
+
+    subgraph UI["Presentation — dbflux_ui"]
+        ui["Workspace, documents, overlays,<br/>components, keymap, settings,<br/>connection manager"]
+    end
+
+    subgraph Runtime["Runtime / domain — dbflux_app"]
+        app["AppState, managers, hooks,<br/>auth registry, access manager,<br/>rpc_services, config loader"]
+    end
+
+    subgraph Core["Contracts — dbflux_core"]
+        core["DbDriver / Connection traits,<br/>DriverMetadata, Value, schema,<br/>query, pipeline, storage models"]
+    end
+
+    subgraph Drivers["Driver implementations"]
+        drv["postgres · mysql · sqlite · mssql<br/>mongodb · redis · dynamodb<br/>influxdb · cloudwatch · ipc (RPC)"]
+    end
+
+    subgraph Support["Supporting libraries"]
+        sup["storage · audit · policy · approval<br/>mcp · export · lua · aws · ssm<br/>ssh · proxy · tunnel_core · ipc"]
+    end
+
+    bin --> ui --> app --> core
+    drv --> core
+    sup --> core
+    app --> drv
+    app --> sup
+    ui -. "generic seams only" .-> core
+```
+
+### Query flow
+
+A query travels from the editor document to a driver `Connection` and back to a result view chosen by `DatabaseCategory` — the UI never branches on a driver id.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant CD as CodeDocument<br/>(code/execution.rs)
+    participant LS as language_service<br/>(dangerous-query check)
+    participant Conn as Connection<br/>(driver impl)
+    participant RP as ResultPanel + DataGridPanel
+    participant V as View (by DatabaseCategory)
+
+    U->>CD: Run query (Cmd/Ctrl+Enter)
+    CD->>LS: classify statement(s)
+    alt dangerous (DELETE/DROP/TRUNCATE/FLUSH…)
+        LS-->>CD: needs confirmation
+        CD->>U: confirmation dialog
+    end
+    CD->>Conn: execute (on background executor)
+    Note over Conn: multi-statement split when<br/>MULTI_STATEMENT capability is set
+    Conn-->>CD: QueryResult(s)
+    CD->>RP: mount result(s)
+    RP->>V: Table / Document tree / Key-value<br/>(per metadata.category)
+    V-->>U: rendered result
+```
+
+### Connection flow
+
+Connecting runs a provider-agnostic pre-connect pipeline before the driver opens, with optional tunneling/managed access and lifecycle hooks at each phase.
+
+```mermaid
+flowchart TB
+    start["Connect from<br/>Connection Manager / sidebar"] --> prep["AppState::prepare_pipeline_input<br/>(provider-agnostic input)"]
+    prep --> pre{{"PreConnect hooks"}}
+    pre --> auth["Pipeline: Authenticating<br/>(DynAuthProvider, e.g. AWS SSO)"]
+    auth --> values["Pipeline: ResolvingValues<br/>(ValueRef → env/secret/param/auth)"]
+    values --> access["Pipeline: OpeningAccess"]
+    access --> tunnel{"Access kind?"}
+    tunnel -->|Direct| connect
+    tunnel -->|SSH / Proxy| t1["dbflux_tunnel_core::Tunnel<br/>(local port forward)"] --> connect
+    tunnel -->|Managed aws-ssm| t2["AccessManager<br/>(SSM tunnel)"] --> connect
+    connect["DbDriver::connect → Connection"] --> schema["Lazy schema fetch<br/>(names first, details on expand)"]
+    schema --> post{{"PostConnect hooks"}}
+    post --> ready["Sidebar populated · ready to query"]
+```
 
 ## Tech Stack
 
@@ -315,6 +404,11 @@ crates/
     src/query_parser.rs     # JSON command envelope parser for DynamoDB operations
     src/query_generator.rs  # Mutation -> DynamoDB command envelope generator
     tests/live_integration.rs # Docker-backed integration tests (DynamoDB Local)
+  dbflux_driver_influxdb/   # InfluxDB driver (v1 + v2)
+    src/driver.rs           # Connection, bucket/measurement discovery, query execution
+    src/query_generator.rs  # InfluxQL (v1) and Flux (v2) query/template generation
+  dbflux_driver_cloudwatch/ # AWS CloudWatch Logs driver (DatabaseCategory::LogStream)
+    src/driver.rs           # Log group/stream discovery, EventStreamTarget, CollectionPresentation::EventStream
   dbflux_aws/               # AWS auth providers + Secrets Manager/SSM value providers
     src/auth.rs             # AWS SSO/shared/static providers and SSO login flow
     src/config.rs           # ~/.aws/config parser/cache and profile write-back helpers
@@ -447,15 +541,16 @@ crates/
 
 - Sidebar: `crates/dbflux_ui/src/ui/views/sidebar/` displays two tabs — Connections (schema tree with folder organization, drag-drop, multi-selection) and Scripts (file/folder management for saved query files, script hooks, and other user files). Switch tabs with `q` or `e` keys. Shows tables/collections, columns, indexes per database category with lazy loading.
 - Driver-owned child resources under collections/containers are published through generic `CollectionChildInfo` metadata. The sidebar must not infer driver-specific children from names, field types, or driver IDs.
+- Routines (functions, procedures, aggregates, window functions) appear as a per-schema "Routines" folder when the driver sets the `ROUTINES` capability and populates the `schema_routines` seam. The UI renders the folder generically; it does not special-case any driver.
 - Sidebar dock: `crates/dbflux_ui/src/ui/dock/sidebar_dock.rs` provides collapsible, resizable sidebar with ToggleSidebar command (Ctrl+B).
 - Connection tree: `crates/dbflux_core/src/connection/tree.rs` models folders and connections as a tree structure with persistence via `connection_tree_store.rs`.
 
 ### Driver System
 
 - **Driver capabilities**: `crates/dbflux_core/src/driver/capabilities.rs` defines:
-  - `DatabaseCategory`: Relational, Document, KeyValue, Graph, TimeSeries, WideColumn
-  - `QueryLanguage`: SQL, MongoQuery, RedisCommands, Cypher, InfluxQuery, CQL (with editor mode, placeholder, comment prefix)
-  - `DriverCapabilities`: bitflags for features like PAGINATION, TRANSACTIONS, NESTED_DOCUMENTS, etc.
+  - `DatabaseCategory`: Relational, Document, KeyValue, Graph, TimeSeries, WideColumn, LogStream
+  - `QueryLanguage`: Sql, CloudWatchLogsInsightsQl, OpenSearchPpl, OpenSearchSql, MongoQuery, RedisCommands, Cypher, InfluxQuery, Flux, Cql, Lua, Python, Bash (each carries editor mode, placeholder, comment prefix)
+  - `DriverCapabilities`: `u64` bitflags for features like PAGINATION, TRANSACTIONS, NESTED_DOCUMENTS, MULTI_STATEMENT, ROUTINES, STORED_PROCEDURES, etc.
   - `DriverMetadata`: static driver info (id, name, category, query_language, capabilities, icon)
 - **Error formatting**: `crates/dbflux_core/src/core/error_formatter.rs` provides `ErrorFormatter` trait for driver-specific error messages with context (detail, hint, column, table, constraint).
 - Core domain API: `crates/dbflux_core/src/core/traits.rs` defines `DbDriver`, `Connection`, SQL generation, cancellation contracts, and generic driver-to-UI seams such as `EventStreamTarget` and `SourceContextSpec`.
@@ -589,6 +684,14 @@ crates/
   - Mutation support for single and multi-item paths (`put`, `update`, `delete`), with single-item upsert and bounded retry handling for unprocessed batch writes
   - JSON command-envelope parser for execute mode (`scan`, `query`, `put`, `update`, `delete`) and mutation query generation (`DynamoQueryGenerator`)
   - Current limits: no query cancellation, no PartiQL/transaction API surface, and no `update many + upsert` combination
+- **InfluxDB**: `crates/dbflux_driver_influxdb/` — `DatabaseCategory::TimeSeries` driver covering both InfluxDB v1 and v2:
+  - v1 speaks InfluxQL; v2 exposes Flux in addition to InfluxQL (`QueryGenerator` emits Flux only when `version == V2`)
+  - Bucket/database and measurement discovery mapped to the schema model, with pagination and CSV/JSON export
+  - Read-oriented: no transactions; mutation generation is limited compared with the relational drivers
+- **CloudWatch Logs**: `crates/dbflux_driver_cloudwatch/` — `DatabaseCategory::LogStream` driver for AWS CloudWatch Logs:
+  - Log group/stream discovery exposed as collections; log groups open as event streams via `CollectionPresentation::EventStream` and a generic `EventStreamTarget`, consumed by the `AuditDocument`/log-stream viewer without any driver-specific UI branch
+  - Query modes (Logs Insights QL, OpenSearch PPL/SQL) are surfaced through `SourceContextSpec`; `DriverMetadata.query_language` defaults to `Sql` for editor behavior
+  - Authentication through the AWS auth stack; no query cancellation yet
 
 ### Driver README policy
 
@@ -665,7 +768,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 - Startup: `main` creates `AppState` and `Workspace`, restores the previous session (tabs from `session.json`), and opens the main window. If no tabs are restored, focus defaults to the sidebar (crates/dbflux/src/main.rs, crates/dbflux_ui/src/ui/views/workspace/).
 - External driver bootstrap: at startup, DBFlux reads `cfg_services` from `~/.local/share/dbflux/dbflux.db`, probes each service, and only registers services that complete the RPC handshake (`Hello`) successfully.
 - Connect flow: `AppState::prepare_pipeline_input` builds a provider-agnostic pre-connect pipeline input. The pipeline runs auth/session validation, dynamic value resolution, and managed/direct access setup before driver connect + schema fetch. Supports form-based configuration, direct URI input, optional proxy/SSH, and managed access (`aws-ssm`). Connection hooks still run at each phase (PreConnect, PostConnect, PreDisconnect, PostDisconnect).
-- Query flow: `CodeDocument` submits database queries to a `Connection` implementation when the active `QueryLanguage` supports connection context. The query language (SQL/MongoDB/etc) is determined by driver metadata. Results are rendered in result tabs within the document. Dangerous queries (DELETE without WHERE, DROP, TRUNCATE) trigger confirmation dialogs (handled in `code/execution.rs`).
+- Query flow: `CodeDocument` submits database queries to a `Connection` implementation when the active `QueryLanguage` supports connection context. The query language (SQL/MongoDB/etc) is determined by driver metadata. Results are rendered in result tabs within the document. Dangerous queries (DELETE without WHERE, DROP, TRUNCATE) trigger confirmation dialogs (handled in `code/execution.rs`). When the driver advertises the `MULTI_STATEMENT` capability, a script containing several statements separated by `;` is executed as a batch, producing one result set per statement.
 - Script flow: `CodeDocument` executes Lua, Python, and Bash documents as script hooks rather than database queries. Script runs create a local output channel, stream live text into a document-owned buffer, and keep the final output as a text result when execution completes.
 - View mode selection: `DataGridPanel` (in `document/data_grid_panel/`) automatically selects appropriate view mode based on database category—Table view for relational databases, Document tree view for document databases like MongoDB and DynamoDB, key-value view for Redis. Event-stream-like document containers are opened through `CollectionPresentation::EventStream` rather than UI-side driver checks. Context menus include "Copy as Query" for generating driver-specific mutation statements/envelopes via `QueryGenerator`.
 - Query preview: `SqlPreviewModal` (in `overlays/sql_preview_modal.rs`) routes relational read/DML previews through `QueryGenerator` for row, table, and view previews, while DDL stays on `CodeGenerator`. Non-SQL languages (MongoDB, Redis) still use generic preview mode with static text and language-specific syntax highlighting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+* **DriverCapabilities bit collision** — `MULTI_STATEMENT` and `ROUTINES`
+  were both defined as `1 << 47` in the same bitflags, so a driver
+  advertising one silently advertised the other. `MULTI_STATEMENT` now
+  occupies bit 48, with a regression test asserting the bits are
+  distinct.
+* **DynamoDB upsert capability** — `MutationCapabilities.supports_upsert`
+  was `false` even though the driver implements single-item upsert
+  (`PutItem`) and only rejects `many + upsert`. The flag is now `true`,
+  so the MCP write tool no longer rejects a supported operation.
+
 ## [0.6.0-dev.6] - 2026-05-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,16 @@ For the branching model, version rules, tag flow, and release procedure, use `do
 
 ```bash
 cargo check --workspace              # Fast type checking
-cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,mssql,aws  # Debug build
-cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,mssql,aws --release  # Release build
-cargo run -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,mssql,aws    # Run app
+cargo build -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws  # Debug build
+cargo build -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws --release  # Release build
+cargo run -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws    # Run app
 
 # MCP server (AI integration) - included by default
 cargo build -p dbflux  # MCP included in default features
 ./target/debug/dbflux mcp --client-id test-client
 
 # Build without MCP support (smaller binary, no AI integration)
-cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mongodb,redis,dynamodb,mssql,lua,aws
+cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,lua,aws
 
 cargo fmt --all                      # Format
 cargo clippy --workspace -- -D warnings  # Lint

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ The long-term goal is to provide a fully open-source alternative to DBeaver, sup
 
 ## Documentation
 
-- [Architecture](ARCHITECTURE.md)
+- [Usage Guide](docs/USAGE.md) — getting started: connect, query, chart, export
+- [Architecture](ARCHITECTURE.md) — layered diagrams, query/connection flow, crate map
+- [Drivers Overview](docs/DRIVERS.md) — supported databases, capabilities, limitations
+- [Charts](docs/CHARTS.md) — chart types, column kinds, axis auto-detection
 - [Contributing](CONTRIBUTING.md)
 - [Release Process](docs/RELEASE.md)
 - [Code Style](CODE_STYLE.md)
@@ -181,7 +184,7 @@ git clone https://github.com/0xErwin1/dbflux.git
 cd dbflux
 
 # Recommended: build with the full default feature set
-cargo build --release --features sqlite,postgres,mysql,mongodb,redis,dynamodb,cloudwatch,influxdb,lua,aws,mcp
+cargo build --release --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,lua,aws,mcp
 
 # Minimal build (relational drivers only, no AI/MCP, no Lua)
 cargo build --release --no-default-features --features sqlite,postgres,mysql
@@ -208,12 +211,15 @@ curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/uninst
 - **PostgreSQL** with SSL/TLS modes (Disable, Prefer, Require)
 - **MySQL** / MariaDB
 - **SQLite** for local database files
+- **Microsoft SQL Server** (TDS) with TLS, SQL Browser named-instance routing, and multi-schema introspection
 - **MongoDB** with collection browsing, document CRUD, and shell query generation
 - **Redis** with key browsing for all types (String, Hash, List, Set, Sorted Set, Stream)
 - **DynamoDB** with table browsing, item CRUD, and AWS authentication
+- **InfluxDB** v1 and v2 (InfluxQL on v1, InfluxQL + Flux on v2)
 - **CloudWatch Logs** with log group/stream browsing and event streaming
-- SSH tunnel support with key, password, and agent authentication
-- Reusable SSH tunnel profiles
+- **External drivers over RPC** (register out-of-process drivers via the [Driver RPC Protocol](docs/DRIVER_RPC_PROTOCOL.md))
+
+See [docs/DRIVERS.md](docs/DRIVERS.md) for a full capability matrix and per-driver limitations.
 
 ### User Interface
 
@@ -221,14 +227,43 @@ curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/uninst
 - Collapsible, resizable sidebar with ToggleSidebar command (Ctrl+B)
 - Schema tree browser with lazy loading for large databases
 - Schema-level metadata: indexes, foreign keys, constraints, custom types (PostgreSQL)
-- Multi-tab SQL editor with syntax highlighting
+- Stored procedures / routines folder per schema (drivers that expose them)
+- Multi-tab SQL editor with syntax highlighting and multi-statement execution (one result set per statement, where the driver supports it)
 - Virtualized data table with column resizing, horizontal scrolling, and sorting
 - Table browser with WHERE filters, custom LIMIT, and pagination
+- Workspace inspector rail for row/document details
 - "Copy as Query" context menu to copy INSERT/UPDATE/DELETE as SQL, MongoDB shell, or Redis commands
 - Query preview modal with language-specific syntax highlighting
 - Command palette with fuzzy search
 - Custom toast notification system with auto-dismiss
 - Background task panel
+- Session restore: open tabs are restored on startup with conflict detection for externally modified files
+
+### Charts & Visualization
+
+- Chart any query or collection result: Line, Bar, Scatter, Area, Stacked Bar, and Pie
+- Automatic axis detection from column kinds (timestamp X axis, numeric Y series) — no per-driver heuristics
+- Saved charts that reopen as their own document tab
+- See [docs/CHARTS.md](docs/CHARTS.md) for details
+
+### Connectivity & Access
+
+- SSH tunnels with key, password, and agent authentication; reusable SSH tunnel profiles
+- SOCKS5 / HTTP CONNECT proxy tunnels with reusable proxy profiles
+- Managed access providers (AWS SSM) for connecting without exposing ports
+- Provider-driven auth profiles (e.g. AWS SSO/shared/static), with import from `~/.aws/config`
+- Connection hooks at PreConnect/PostConnect/PreDisconnect/PostDisconnect, runnable as a command, a script, or in-process Lua
+
+### AI & MCP Integration
+
+- Built-in Model Context Protocol (MCP) server (`dbflux mcp`) for AI clients
+- Governance layer: operation classification, role/policy engine, trusted clients, and human approval flow for write/destructive operations
+- See [docs/MCP_AI_INTEGRATION.md](docs/MCP_AI_INTEGRATION.md)
+
+### Audit & Scripting
+
+- SQLite-backed audit log for queries, connections, hooks, scripts, MCP, governance, and config events, with redaction and query fingerprinting — see [docs/AUDIT.md](docs/AUDIT.md)
+- Lua, Python, and Bash scripts run as documents with live streamed output — see [docs/LUA.md](docs/LUA.md)
 
 ### Keyboard Navigation
 

--- a/crates/dbflux_core/src/driver/capabilities.rs
+++ b/crates/dbflux_core/src/driver/capabilities.rs
@@ -368,7 +368,7 @@ bitflags! {
         /// Driver can execute a batch of multiple statements submitted as a
         /// single query (e.g. several SQL statements separated by `;`),
         /// producing one result set per statement.
-        const MULTI_STATEMENT = 1 << 47;
+        const MULTI_STATEMENT = 1 << 48;
 
         // === Schema features ===
 
@@ -1983,6 +1983,16 @@ mod tests {
             DriverCapabilities::ROUTINES.bits(),
             1u64 << 47,
             "ROUTINES must be bit 47"
+        );
+        assert_eq!(
+            DriverCapabilities::MULTI_STATEMENT.bits(),
+            1u64 << 48,
+            "MULTI_STATEMENT must be bit 48"
+        );
+        assert_eq!(
+            DriverCapabilities::ROUTINES.bits() & DriverCapabilities::MULTI_STATEMENT.bits(),
+            0,
+            "ROUTINES and MULTI_STATEMENT must not share a bit"
         );
         assert!(
             DatabaseCategory::Relational

--- a/crates/dbflux_driver_cloudwatch/README.md
+++ b/crates/dbflux_driver_cloudwatch/README.md
@@ -1,15 +1,27 @@
 # dbflux_driver_cloudwatch
 
+AWS CloudWatch Logs driver for DBFlux, built on the [`aws-sdk-cloudwatchlogs`](https://crates.io/crates/aws-sdk-cloudwatchlogs) SDK.
+
 ## Features
 
-- Built-in CloudWatch Logs driver registration for DBFlux connection profiles.
-- AWS region/profile/endpoint form handling aligned with the existing DynamoDB AWS connection flow.
-- CloudWatch query execution through `StartQuery` with editor-managed time range and log-group source context.
-- CloudWatch query documents can run Logs Insights QL, OpenSearch PPL, and OpenSearch SQL.
-- Schema discovery enumerates log groups and exposes log streams as event-stream children.
+- Log-streaming driver classified as `DatabaseCategory::LogStream`; `deployment_class` is `CloudManaged`. The only declared capability is `AUTHENTICATION`.
+- AWS connection configuration via region, named profile, and optional endpoint override, aligned with the DynamoDB AWS connection flow.
+- Query execution through `StartQuery` + polling `GetQueryResults` (poll interval 500 ms, up to 120 attempts), with an editor-managed source context that supplies the target log groups and time range.
+- Three query syntaxes selectable from the source-context "Syntax" dropdown:
+  - CloudWatch Logs Insights QL (`cwli`, the default) — `QueryLanguage::CloudWatchLogsInsightsQl`.
+  - OpenSearch PPL (`ppl`) — `QueryLanguage::OpenSearchPpl`.
+  - OpenSearch SQL (`sql`) — `QueryLanguage::OpenSearchSql`.
+  These map to the SDK's `Cwli`, `Ppl`, and `Sql` query-language values.
+- Source-context spec (`SourceContextSpec`) exposes a "Log groups" target selector and Start/End time-range controls; CWLI and PPL queries pass the selected log groups to `StartQuery` via `set_log_group_names`.
+- Schema discovery enumerates log groups (`fetch_log_groups`) as the single logical database (`SchemaLoadingStrategy::SingleDatabase`, default database `logs`).
+- Log streams are surfaced as paginated collection children (`collection_children` over `fetch_log_stream_page`) and open as event streams (`CollectionPresentation::EventStream`).
+- Event-stream browsing (`browse_event_stream` / `EventStreamTarget`) backed by `FilterLogEvents`, with a default 24-hour browse window and support for filter pattern, stream-name prefix, explicit stream names, and a most-recent toggle.
+- Insights column names are classified into semantic `ColumnKind`s (e.g. `@timestamp`, `@ingestionTime` recognized as timestamps) for chart auto-detection.
 
 ## Limitations
 
-- Query cancellation is not implemented yet.
-- OpenSearch SQL queries must declare their queried log groups in the SQL text because the CloudWatch API does not accept external log-group parameters for SQL mode.
-- Editor syntax highlighting remains generic; mode selection currently focuses on execution semantics and completion keywords.
+- Query cancellation is not implemented; `cancel()` returns `NotSupported`.
+- OpenSearch SQL mode does not receive external log groups: SQL queries must declare their queried log groups in the SQL text, because the CloudWatch API does not accept external log-group parameters for SQL mode (only CWLI and PPL get `set_log_group_names`).
+- Editor syntax highlighting remains generic (`query_language` is reported as `Sql` at the metadata level); mode selection drives execution semantics and completion keywords rather than per-mode highlighting.
+- Read-only: no mutation, DDL, transaction, or pagination capabilities are declared (`query`, `mutation`, `ddl`, `transactions`, `limits` are all `None`); `schema_features` is empty.
+- No SSL form (TLS handled by the AWS SDK transport).

--- a/crates/dbflux_driver_dynamodb/README.md
+++ b/crates/dbflux_driver_dynamodb/README.md
@@ -1,17 +1,29 @@
 # dbflux_driver_dynamodb
 
+AWS DynamoDB driver for DBFlux, built on the [`aws-sdk-dynamodb`](https://crates.io/crates/aws-sdk-dynamodb) SDK.
+
 ## Features
 
-- DynamoDB document driver using `aws-sdk-dynamodb` with region/profile configuration and optional endpoint override.
-- Table discovery with `ListTables`/`DescribeTable`, including PK/SK and GSI/LSI key metadata mapped into DBFlux schema abstractions.
-- Native command envelope execution for `scan`, `query`, `put`, `update`, and `delete`.
-- Read options for index targeting, consistent read control, and filter translation fallback policy.
-- Mutation support for single-item and many-item paths, including bounded retry for unprocessed batch writes.
-- Single-item upsert support with conditional update + put fallback.
+- Managed NoSQL driver classified as `DatabaseCategory::Document` with a `QueryLanguage::Custom("DynamoDB")` command envelope; the editor uses a DynamoDB-specific syntax, not SQL.
+- AWS connection configuration via region, named profile, and optional endpoint override (for DynamoDB Local or VPC endpoints). `deployment_class` is `CloudManaged`.
+- Table discovery with `ListTables` and `DescribeTable`, mapping partition key (PK), sort key (SK), and Global/Local Secondary Index (GSI/LSI) key metadata into DBFlux schema abstractions.
+- Native command envelope execution for `scan`, `query`, `put`, `update`, and `delete`. The query generator emits scan-shaped preview envelopes and notes that execution may optimize to `Query` when the filter matches the table key schema.
+- Read options for index targeting, consistent-read control, and a filter-translation fallback policy (server-side filter vs. client-side fallback; client filtering is rejected when the fallback policy is set to reject).
+- WHERE operators in semantic filters: `Eq`, `Ne`, `Gt`, `Gte`, `Lt`, `Lte`, `In`, `NotIn`, and logical `And`/`Or` (see Limitations for `Not`).
+- Mutations: insert (`put`), update, and delete (`INSERT`/`UPDATE`/`DELETE`). Batch writes support up to 25 items (`max_insert_values: 25`, `supports_batch: true`) with bounded retry for unprocessed batch-write items.
+- Single-item upsert support via a conditional update with a put fallback; the key map is resolved from either the filter or the update payload (partition key required, sort key required when the table defines one).
+- Many-item update path (`update` with `many=true`) using a shared update expression.
+- Nested documents and arrays mapped into the document-tree view (`NESTED_DOCUMENTS`, `ARRAYS`).
+- DDL: drop table (`supports_drop_table: true`).
+- Pagination via page tokens (`PaginationStyle::PageToken`).
 
 ## Limitations
 
-- Query cancellation is not supported.
-- Command envelope API does not expose PartiQL or DynamoDB transaction operations.
-- `update` with `many=true` and `upsert=true` is not supported.
-- Pagination in DBFlux collection browsing currently remains offset-based at the core request level.
+- Query cancellation is not supported; the driver returns `NotSupported` for cancel requests.
+- The command envelope API does not expose PartiQL or DynamoDB transaction operations; transactions are disabled (`supports_transactions: false`).
+- Single-item upsert is supported (`supports_upsert: true`); `update` with `many=true` and `upsert=true` together is rejected (`update_many_with_upsert`).
+- Bulk update and bulk delete are not supported (`supports_bulk_update: false`, `supports_bulk_delete: false`), and `RETURNING` is not supported.
+- Semantic filters do not support `NOT` expressions or operators outside the supported set; unsupported operators return `NotSupported`.
+- No SSL form (TLS is handled by the AWS SDK transport), no schemas, and no DDL beyond drop-table (no create/alter table, no index creation).
+- Aggregate requests are not supported by the semantic planner.
+- Collection browsing in the core request layer remains offset-based, while the underlying API is page-token based.

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -300,7 +300,9 @@ pub static DYNAMODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driver
         supports_insert: true,
         supports_update: true,
         supports_delete: true,
-        supports_upsert: false,
+        // Single-item upsert is supported (PutItem is an upsert). The execution
+        // path rejects only `many && upsert`; see `update_many_with_upsert`.
+        supports_upsert: true,
         supports_returning: false,
         supports_batch: true,
         supports_bulk_update: false,

--- a/crates/dbflux_driver_influxdb/README.md
+++ b/crates/dbflux_driver_influxdb/README.md
@@ -4,6 +4,7 @@ InfluxDB driver for DBFlux.
 
 ## Features
 
+- **Time-series category** — classified as `DatabaseCategory::TimeSeries` with `QueryLanguage::InfluxQuery` as the default editor language. Declared capabilities are `AUTHENTICATION`, `MULTIPLE_DATABASES`, `PAGINATION`, `EXPORT_CSV`, and `EXPORT_JSON`. Connections use the `http` URI scheme on default port 8086, with TLS provided by the rustls-backed HTTP client.
 - **InfluxDB v1 and v2** — both API versions are supported in a single driver crate.
 - **InfluxQL on both versions** — the v1 query language works on v1 and via the v2 compatibility endpoint.
 - **Flux on v2** — Flux queries are available when the connection is configured for v2.
@@ -17,9 +18,12 @@ InfluxDB driver for DBFlux.
 - **Multi-statement InfluxQL** — when a query contains multiple statements separated by `;` (e.g. `SHOW MEASUREMENTS; SHOW SERIES`), all results are concatenated into a single result set. A synthetic `statement_index` integer column is prepended to distinguish rows from different statements.
 - **"Query Measurement" context menu** — right-clicking a measurement in the sidebar shows "Query Measurement". The action opens a new code document pre-populated with a template query (`SELECT * FROM ...` for InfluxQL, `from(bucket: ...) |> range(...)` for Flux).
 - **"New Query" context menu on buckets** — right-clicking a bucket/database node shows "New Query", opening a blank code document with the connection activated.
+- **Read-template generation** — `InfluxQueryGenerator` produces select-all and per-measurement read templates for both InfluxQL and Flux (used by the context-menu actions and copy-as-query), version-aware via the connection's configured version and default bucket.
 
 ## Limitations
 
+- **No query cancellation** — `cancel()` returns `NotSupported`; in-flight queries cannot be aborted from the UI (`QUERY_CANCELLATION` is not declared).
+- **No mutation generation** — `QueryGenerator::generate_mutation` always returns `None`; only read templates are generated, consistent with the read-only query API.
 - **Flux not supported on v1** — attempting to run a Flux query against a v1 connection returns an error immediately, without making an HTTP call.
 - **No INSERT/UPDATE/DELETE** — InfluxDB's query API is read-only. Data ingestion uses the Line Protocol write API which is not exposed by this driver.
 - **No transactions** — InfluxDB does not support transactions.

--- a/crates/dbflux_driver_mongodb/README.md
+++ b/crates/dbflux_driver_mongodb/README.md
@@ -1,15 +1,29 @@
 # dbflux_driver_mongodb
 
+MongoDB document driver for DBFlux.
+
 ## Features
 
-- MongoDB document driver with collection browsing, counting, and document CRUD flows.
-- Supports MongoDB shell-style query parsing (`db.collection.method(...)`) and mutation query generation.
-- Exposes document-focused schema metadata (fields and indexes).
-- Supports SSH tunneling and URI/manual connection modes.
-- Includes aggregation capability flags and document-tree-friendly value mapping.
+- Document driver classified as `DatabaseCategory::Document` with the `MongoQuery` query language; the editor uses MongoDB shell syntax, not SQL.
+- Connection modes: manual (host/port/credentials/database) and URI mode. URI mode accepts `mongodb://` and `mongodb+srv://` connection strings (SRV records are parsed for replica-set discovery).
+- Multiple logical databases (`MULTIPLE_DATABASES`) with collection browsing and document counting.
+- Authentication (`AUTHENTICATION`) and TLS/SSL with three modes (`off`, `on`, `verify`), supporting a root certificate and optional client certificate.
+- SSH tunnel support for reaching MongoDB through a bastion host.
+- Shell-style query parsing for `db.collection.method(...)` and `db.method(...)` forms, with a JSON-document fallback for backward compatibility. Supported methods: `find`, `findOne`, `aggregate`, `count`/`countDocuments`, `insertOne`, `insertMany`, `updateOne`, `updateMany`, `deleteOne`, `deleteMany`. Parse errors carry byte-offset positions for editor diagnostics.
+- Aggregation pipelines (`AGGREGATION`); query capabilities advertise order-by, group-by, having, limit, and offset.
+- WHERE operators: `Eq`, `Ne`, `Gt`, `Gte`, `Lt`, `Lte`, `In`, `NotIn`, and the logical `And`/`Or`/`Not`.
+- Pagination via cursor and page-token styles (`PaginationStyle::Cursor`, `PaginationStyle::PageToken`).
+- Document-focused schema metadata: collection fields and indexes (`INDEXES`), with nested documents and arrays mapped into the document-tree view (`NESTED_DOCUMENTS`, `ARRAYS`).
+- Mutations: insert, update (including upsert), and delete (`supports_upsert: true`). The `MongoShellGenerator` emits `insertOne`/`insertMany`, `updateOne`/`updateMany` (with `{ upsert: true }`), and `deleteOne`/`deleteMany` for previews and copy-as-query.
+- DDL: drop database, drop collection, create index, and drop index.
+- JSON export of results (`EXPORT_JSON`).
 
 ## Limitations
 
-- SQL syntax is not supported; queries must use MongoDB shell-style syntax.
-- Query cancellation is not supported.
-- Parser coverage is intentionally scoped to supported command patterns, not the full interactive shell language.
+- SQL is not supported; queries must use MongoDB shell-style syntax (or the JSON fallback).
+- Query cancellation is not supported (`QUERY_CANCELLATION` is not set).
+- `RETURNING` is not supported; mutation capabilities also report no batch, no bulk update, and no bulk delete at the capability level (`supports_batch`, `supports_bulk_update`, `supports_bulk_delete` are all `false`), even though the generator can emit `updateMany`/`deleteMany` text.
+- Parser coverage is intentionally scoped to the supported method set above, not the full interactive shell language; `distinct` is not surfaced as a query capability (`supports_distinct: false`).
+- No joins, subqueries, unions, CTEs, window functions, or `EXPLAIN` at the query-capability level.
+- Transactions are advertised at the capability level (`supports_transactions: true`) but without isolation levels, savepoints, nested transactions, read-only, or deferrable support.
+- DDL is not transactional (`transactional_ddl: false`); create-database, create-collection, alter, views, and triggers are not supported.

--- a/crates/dbflux_driver_redis/README.md
+++ b/crates/dbflux_driver_redis/README.md
@@ -1,15 +1,35 @@
 # dbflux_driver_redis
 
+Redis key-value driver for DBFlux, built on the [`redis`](https://crates.io/crates/redis) crate.
+
 ## Features
 
-- Redis key-value driver covering string, hash, list, set, sorted set, and stream operations.
-- Supports key scanning, key type discovery, TTL operations, key rename, and bulk key get.
-- Supports multiple logical databases (`SELECT`) and Redis command-language execution.
-- Supports authentication, SSL/TLS, SSH tunneling, and URI/manual connection modes.
-- Includes command generation for key-value mutations.
+- Key-value driver classified as `DatabaseCategory::KeyValue` with the `RedisCommands` query language; the editor uses Redis command syntax, not SQL.
+- Connection modes: manual (host/port/user/password/database) and URI mode. URI mode accepts `redis://` and `rediss://` connection strings.
+- Multiple logical databases via `SELECT <db>` (`MULTIPLE_DATABASES`). The active database index is tracked on the connection.
+- Authentication with optional username + password (`AUTHENTICATION`).
+- TLS/SSL with three modes (`off`, `on`, `verify`):
+  - `off` — plain `redis://` connection.
+  - `on` — `rediss://` with the certificate trusted without chain validation (insecure marker).
+  - `verify` — `rediss://` with a supplied root certificate and optional client certificate/key, built through `Client::build_with_tls`.
+- SSH tunnel support for reaching Redis through a bastion host (manual mode only; see Limitations).
+- Key browsing and discovery:
+  - Cursor-based key scanning (`KV_SCAN`, `PaginationStyle::Cursor`).
+  - Per-key type discovery (`KV_KEY_TYPES`) across string, hash, list, set, sorted set, and stream.
+  - TTL inspection (`KV_TTL`) and value size reporting (`KV_VALUE_SIZE`).
+  - Existence checks (`KV_GET`/`KV_EXISTS`), key rename (`KV_RENAME`), and bulk get of multiple keys (`KV_BULK_GET`).
+- Value type coverage: strings, hashes, lists, sets, sorted sets, and streams, including stream range reads, stream entry add, and stream entry delete (`KV_STREAM_RANGE`, `KV_STREAM_ADD`, `KV_STREAM_DELETE`).
+- Configurable stream preview limit exposed as a connection setting.
+- Mutations: insert, update, delete, batch operations, and bulk delete. The `RedisCommandGenerator` emits Redis commands for set/delete, hash set/delete, list push/set/remove, set add/remove, sorted-set add/remove, and stream add/delete, for use in previews and copy-as-command.
+- JSON export of results (`EXPORT_JSON`).
 
 ## Limitations
 
-- SQL syntax is not supported; use Redis command syntax.
-- Query cancellation is not supported.
-- SSH tunneling is not supported when URI mode is enabled.
+- SQL is not supported; queries must be written as Redis commands.
+- Query cancellation is not supported (`QUERY_CANCELLATION` is not set); long-running commands cannot be aborted from the UI.
+- No upsert (`supports_upsert: false`), no `RETURNING`, and no bulk update (`supports_bulk_update: false`).
+- DDL capabilities are all disabled (no tables, views, indexes, schemas) — this is a key-value store, not relational.
+- Transactions are advertised at the capability level (`supports_transactions: true`) but without isolation levels, savepoints, nested transactions, read-only, or deferrable support.
+- Pub/Sub is not exposed (`PUBSUB` capability is not set).
+- SSH tunneling is not available when URI mode is enabled; the tunnel path is wired only for manual connection mode.
+- Stream consumer groups are not modeled; only range reads, entry add, and entry delete are supported.

--- a/docs/CHARTS.md
+++ b/docs/CHARTS.md
@@ -1,0 +1,236 @@
+# DBFlux Charting
+
+DBFlux can turn a query result into a chart. The charting engine is fully
+driver-agnostic: it inspects only the structured column metadata that every
+driver populates, never a driver identifier or a database-specific type-name
+string. This document describes the supported chart types, how the engine
+auto-detects axes, how charts are persisted, and how a chart is created from
+the UI.
+
+## Overview
+
+The chart engine lives in the `dbflux_components` crate under
+`crates/dbflux_components/src/chart/`. Its `mod.rs` describes the full
+pipeline:
+
+1. `detect` — auto-detects suitable columns from a `QueryResult` using
+   `ColumnKind` semantics only.
+2. `spec` — chart and series specification types, plus constructors for
+   detection-driven and manual column selection.
+3. `decimate` — LTTB (Largest-Triangle-Three-Buckets) downsampling to keep
+   painting fast on large datasets.
+4. `axis` — tick generation and label formatting for numeric and time axes.
+5. `legend` — element factory for the legend row.
+6. `engine` — `ChartView`, the GPUI entity that owns chart state and renders
+   the canvas.
+
+The standalone chart document UI lives in
+`crates/dbflux_ui/src/ui/document/chart_document/` (`mod.rs`, `render.rs`,
+`pane.rs`). A `ChartDocument` owns a query, a connection, a chart spec, and a
+`ChartShell`, and hosts its rendering through the shared `ResultPanel` chrome
+in `crates/dbflux_components/src/result_panel/`.
+
+## Chart types
+
+Chart kinds are defined by the `ChartKind` enum in
+`crates/dbflux_components/src/chart/spec.rs`:
+
+| Variant | Description |
+|---------|-------------|
+| `Line` | Line chart. The default kind (`#[default]`); also the kind chosen by every `ChartSpec` constructor. |
+| `Bar` | Bar chart. |
+| `Scatter` | Scatter chart. |
+| `Area` | Filled line chart; the area between the series line and the baseline is shaded. Shares Line's geometry and hover behaviour. |
+| `StackedBar` | Stacked vertical bars. Each X position shows one bar per series, stacked cumulatively rather than grouped side-by-side. The Y axis is re-scaled at render time to the maximum stack sum. |
+| `Pie` | Pie chart. No X/Y axes; each visible series becomes one wedge sized by the sum of that series' Y values. |
+
+`ChartKind` carries `#[serde(default)]` semantics on the containing
+`ChartSpec.kind` field, so serialized chart specs that predate the `kind` field
+deserialize to `Line`.
+
+## ColumnKind and axis auto-detection
+
+### ColumnKind
+
+Auto-detection is driven entirely by the `ColumnKind` enum defined in
+`crates/dbflux_core/src/query/types.rs`:
+
+| Variant | Meaning |
+|---------|---------|
+| `Timestamp` | A date/time or timestamp column. |
+| `Float` | A floating-point numeric column. |
+| `Integer` | An integer numeric column. |
+| `Text` | A text/string column. |
+| `Unknown` | The driver could not classify this column. |
+
+Each driver is responsible for setting `ColumnMeta::kind` on every column it
+returns (see the "Adding a New Driver" rules in `CLAUDE.md`). Columns left as
+`Unknown` are never used as chart axes or series.
+
+### Auto-detection rules
+
+`detect_chart_columns` in `crates/dbflux_components/src/chart/detect.rs` applies
+these rules, in order, to a `QueryResult`:
+
+1. If the result has zero rows, return `EmptyResult`.
+2. Pick the leftmost column with `kind == Timestamp` as the X axis. If none
+   exists, return `NoTimeColumn`.
+3. Collect every other column with `kind == Float` or `kind == Integer`, in
+   column order, as the numeric Y series. If none remain, return
+   `NoNumericSeries`.
+4. Otherwise return `Ok { time_col, numeric_cols }`.
+
+The outcome is the `ChartDetection` enum, whose variants are `Ok`,
+`NoTimeColumn`, `NoNumericSeries`, and `EmptyResult`.
+
+### Why `type_name` and driver IDs are never inspected
+
+The module-level documentation in `detect.rs` states that the detection module
+is the boundary between the query-result model and the chart engine, and that it
+inspects `ColumnKind` values — never `type_name` strings or driver identifiers.
+The `detect_chart_columns` function reads only `column.kind`; it never reads
+`column.type_name`, `column.name`, or any driver ID. This keeps the engine
+fully decoupled from specific drivers, matching the driver/UI decoupling rule in
+`CLAUDE.md`: a driver makes its columns chartable purely by classifying them
+with the correct `ColumnKind`.
+
+Because `Unknown` is neither `Timestamp` nor `Float`/`Integer`, an unclassified
+column can be neither an auto-detected X axis nor an auto-detected series. This
+is intentional: it forces drivers to classify columns rather than letting the
+engine guess from type strings.
+
+### Axis-kind inference
+
+When a `ChartSpec` is built, the X axis kind is inferred from the X column's
+`ColumnKind`: `Timestamp` maps to `AxisKind::Time` (ticks formatted as
+dates/times), everything else maps to `AxisKind::Numeric` (decimal ticks). The
+`AxisSpec.unit` field is currently always `None`; it is a forward-compatibility
+seam for future driver-supplied unit metadata.
+
+### Numeric value extraction
+
+When the engine extracts a numeric value from a cell (`extract_f64` in
+`engine.rs`), it handles several `Value` shapes:
+
+- `Value::Int` → cast to `f64`.
+- `Value::Float` → used directly when finite; non-finite values are dropped.
+- `Value::Decimal` (stored as a string to preserve precision) → parsed lossily
+  to `f64`, dropping non-finite or unparseable values. Drivers that classify
+  `NUMERIC`/`DECIMAL` columns as `ColumnKind::Float` (for example PostgreSQL
+  `NUMERIC`, MSSQL `DECIMAL`) flow through this path.
+- `Value::Bool` → `true` maps to `1.0`, `false` to `0.0`, so `BIT`/`BOOLEAN`
+  columns that some drivers classify as `Integer` (for example MSSQL `BIT`)
+  remain plottable.
+- `Value::Text` is parsed only for the time axis, as an RFC 3339 timestamp.
+- `Value::Null` and all other shapes yield no value.
+
+## Saved charts
+
+A persisted chart is a `SavedChart` record, defined in
+`crates/dbflux_components/src/saved_chart.rs`. Saved charts are stored as JSON
+in `~/.config/dbflux/saved_charts.json` through `SavedChartStore` (a
+`JsonStore<SavedChart>` type alias) and managed by `SavedChartManager`.
+
+A `SavedChart` persists:
+
+- `id`, `name`, `profile_id` — identity, display name, and owning connection
+  profile.
+- `source` — a `SavedChartSource`, either `Query { query }` (a query string
+  executed inside a `ChartDocument`) or `Collection { collection_ref,
+  time_window }` (a collection-browse source).
+- `chart_spec` and `bindings` — the full rendering configuration (`ChartSpec`
+  and `BindingSpec`).
+- `time_range_preset`, `refresh_policy`, `created_at`, `updated_at`.
+
+Only the query string (or collection reference) is persisted; raw result data
+is never stored.
+
+### Opening a saved chart
+
+`Workspace::open_saved_chart` (in
+`crates/dbflux_ui/src/ui/views/workspace/actions.rs`) routes by source type:
+
+- `Query` sources open a standalone `ChartDocument` via
+  `ChartDocument::from_saved`. `from_saved` and `validate_saved_source` reject
+  `Collection` sources; the workspace validates the source before allocating the
+  entity.
+- `Collection` sources do not open a `ChartDocument`; they re-open the
+  underlying `DataDocument` in chart mode via `open_collection_document`.
+
+### Deduplication
+
+Open chart documents are deduplicated through the `DocumentKey::Chart {
+saved_chart_id: Uuid }` variant in
+`crates/dbflux_ui/src/ui/document/dedup.rs`. Before opening a saved chart,
+`open_saved_chart` calls `tab_manager.find_by_key(&DocumentKey::Chart { ... })`
+and activates the existing tab instead of opening a duplicate. A chart document
+created from an ad-hoc "Chart this query" action is not yet linked to a saved ID
+and therefore is not deduplicated until it is saved.
+
+## Creating a chart in the UI
+
+There are two entry points.
+
+### Chart this query
+
+A data grid's context menu offers a "Chart this query" item. The item is gated
+by `can_chart_from_context_menu` in
+`crates/dbflux_ui/src/ui/document/data_grid_panel/context_menu.rs`, which
+requires both:
+
+1. The panel's source is a `QueryResult` with a non-empty original query, and
+2. `detect_chart_columns` on the current result returns `Ok`.
+
+Selecting the item calls `Workspace::open_chart_from_query`, which constructs a
+`ChartDocument::new` seeded with the query and connection, wraps it in a
+`PaneHandle` via `ChartDocument::into_pane`, and opens it as a new tab. A
+non-empty query causes the document to auto-execute on its first render.
+
+### Open chart...
+
+The "Open chart..." command lists saved charts (built by
+`build_saved_chart_palette_items`) for the active profile, and opens the
+selected chart via `open_saved_chart` as described above.
+
+### Saving
+
+Inside a `ChartDocument`, the Save toolbar button opens a name prompt and then
+calls `confirm_save`, which builds a `ChartSpec` from the last result (using
+`detect_chart_columns` / `ChartSpec::from_detection` when detection succeeds)
+and upserts a `SavedChart` into the app state's `saved_charts` manager. Saving
+reuses the existing `saved_chart_id` when present so the record is overwritten
+rather than duplicated.
+
+```mermaid
+flowchart TD
+    QR[QueryResult with ColumnMeta.kind] --> DET[detect_chart_columns]
+    DET -->|Ok time_col, numeric_cols| SPEC[ChartSpec::from_detection]
+    DET -->|NoTimeColumn / NoNumericSeries / EmptyResult| NA[Chart this query unavailable]
+    SPEC --> CD[ChartDocument + ChartShell]
+    CD --> CV[ChartView render]
+    CD -->|Save| SC[SavedChart in saved_charts.json]
+    SC -->|Open chart...| CD
+```
+
+## Limitations
+
+These limitations are grounded in the current code, not assumptions:
+
+- Auto-detection requires at least one `Timestamp` column to pick an X axis;
+  without one, `detect_chart_columns` returns `NoTimeColumn` and "Chart this
+  query" is unavailable. (Manual selection through `BindingSpec` /
+  `ChartSpec::from_bindings` can use a non-timestamp X column, which is then
+  classified as an `AxisKind::Numeric` axis.)
+- Columns with `ColumnKind::Unknown` are excluded from auto-detection entirely.
+- `Collection`-source saved charts cannot be opened as a `ChartDocument`; they
+  re-open the underlying `DataDocument` in chart mode instead. Passing a
+  `Collection` source to `ChartDocument::from_saved` returns an error.
+- `AxisSpec.unit` is always `None` in this version; drivers do not yet supply
+  unit metadata.
+- Every `ChartSpec` constructor (`from_detection`, `from_bindings`,
+  `from_manual_selection`) produces a spec with `kind = ChartKind::Line`; the
+  other chart kinds are selected after construction.
+- Series decimation uses an LTTB threshold whose default is 10,000 points
+  (`default_decimation_threshold`).
+</content>
+</invoke>

--- a/docs/DRIVERS.md
+++ b/docs/DRIVERS.md
@@ -1,0 +1,126 @@
+# DBFlux Drivers
+
+This document is a comparative overview of the database drivers shipped with
+DBFlux. For per-driver details, follow the link to each driver crate's
+`README.md`. For the internal driver architecture (traits, registration, the
+`DbDriver`/`Connection` seam), see the **Driver System** section of
+[`ARCHITECTURE.md`](../ARCHITECTURE.md).
+
+## How drivers are abstracted
+
+Every driver exposes a `DriverMetadata` value (defined in
+`crates/dbflux_core/src/driver/capabilities.rs`). The UI is driver-agnostic and
+adapts purely from this metadata. The relevant fields are:
+
+- **`DatabaseCategory`** — selects the view model and terminology. Values:
+  `Relational`, `Document`, `KeyValue`, `Graph`, `TimeSeries`, `WideColumn`,
+  `LogStream`. (Not every value has a shipping driver.)
+- **`QueryLanguage`** — drives editor mode, placeholder text, and query parsing.
+  Values include `Sql`, `MongoQuery`, `RedisCommands`, `Cypher`, `InfluxQuery`,
+  `Flux`, `Cql`, `CloudWatchLogsInsightsQl`, `OpenSearchPpl`, `OpenSearchSql`,
+  the script languages `Lua` / `Python` / `Bash`, and `Custom(String)`.
+- **`DriverCapabilities`** — a `u64` bitflag set declaring supported features
+  (transactions, pagination, schemas, key-value operations, etc.). Convenience
+  bases `RELATIONAL_BASE`, `DOCUMENT_BASE`, and `KEYVALUE_BASE` group the common
+  flags for each category.
+
+The capability flags listed below are exactly the ones each driver's
+`DriverMetadata` sets in code; nothing is inferred.
+
+## Comparison
+
+| Driver | Category | Query language | Key capabilities | Notes / limitations |
+| --- | --- | --- | --- | --- |
+| PostgreSQL | Relational | SQL | Relational base + schemas, SSH tunnel, SSL, auth, foreign keys, check/unique constraints, custom types, `RETURNING`, transactional DDL, routines, multi-statement | Full SQL driver; routine viewer is read-only; transactional DDL except `CREATE INDEX CONCURRENTLY`. |
+| MySQL | Relational | SQL | Relational base + SSH tunnel, SSL, auth, foreign keys, check/unique constraints, routines, multi-statement | DDL is non-transactional; multi-statement scripts split text-based and run sequentially; routine listing covers FUNCTION/PROCEDURE only. |
+| MariaDB | Relational | SQL | Same crate and capabilities as MySQL | Registered as a separate `mariadb` metadata sharing the MySQL implementation. |
+| SQLite | Relational | SQL | Views, indexes, foreign keys, check/unique constraints, prepared statements, insert/update/delete, pagination, sorting, filtering, CSV/JSON export, query cancellation, transactional DDL, multi-statement | Embedded file driver: no network, SSH tunnel, or TLS; no multi-schema namespace. |
+| SQL Server | Relational | SQL | Relational base + schemas, SSH tunnel, SSL, auth, foreign keys, check/unique constraints, transactional DDL, routines, multi-statement | Built on `tiberius`; named-instance lookup unavailable through SSH tunnel; multi-result-set batches return the last set as primary. |
+| MongoDB | Document | MongoQuery | Document base + aggregation, SSH tunnel, indexes | MongoDB shell-style syntax only (no SQL); no query cancellation; parser scoped to supported command patterns. |
+| Redis | Key-Value | RedisCommands | Key-value base + multiple databases, TTL, key types, value size, rename, bulk get, stream range/add/delete, auth, SSH tunnel, SSL | Redis command syntax only (no SQL); no query cancellation; SSH tunneling unavailable in URI mode. |
+| DynamoDB | Document | Custom("DynamoDB") | Auth, pagination, filtering, insert/update/delete, nested documents, arrays | AWS-managed; native command envelope (`scan`/`query`/`put`/`update`/`delete`); no PartiQL/transactions; no query cancellation; `update many+upsert` unsupported. |
+| CloudWatch Logs | Log Stream | Sql (metadata default) | Auth | AWS-managed; executes Logs Insights QL, OpenSearch PPL, and OpenSearch SQL via editor-managed source context; no query cancellation yet. |
+| InfluxDB | Time Series | InfluxQuery | Auth, multiple databases, pagination, CSV/JSON export | v1 and v2 in one crate; InfluxQL on both, Flux on v2 only; read-only (no INSERT/UPDATE/DELETE); no transactions. |
+
+## Per-driver summary
+
+### PostgreSQL
+
+Full SQL driver with schema discovery, stored routines (read-only viewer), SSL,
+SSH tunneling, query cancellation via cancel tokens, transactional DDL, and
+PostgreSQL-specific code generation. Multi-statement scripts run as a batch via
+the simple query protocol. See
+[`crates/dbflux_driver_postgres/README.md`](../crates/dbflux_driver_postgres/README.md).
+
+### MySQL / MariaDB
+
+One crate implements both MySQL and MariaDB. Supports SQL execution, schema
+discovery, query cancellation via `KILL QUERY`, code generation, and routine
+discovery for functions and procedures. DDL is not transactional and
+multi-statement splitting is text-based. See
+[`crates/dbflux_driver_mysql/README.md`](../crates/dbflux_driver_mysql/README.md).
+
+### SQLite
+
+Embedded, file-based driver with schema discovery, query cancellation via
+interrupt handles, transactional DDL, and code generation. No network transport,
+SSH tunneling, or TLS, and no multi-schema namespace. See
+[`crates/dbflux_driver_sqlite/README.md`](../crates/dbflux_driver_sqlite/README.md).
+
+### SQL Server
+
+Built on the `tiberius` TDS client. Supports SQL Server / Azure SQL, TLS modes,
+named instances (resolved via SQL Browser), SSH tunneling, per-tab database
+switching, and multi-result-set batches. See
+[`crates/dbflux_driver_mssql/README.md`](../crates/dbflux_driver_mssql/README.md).
+
+### MongoDB
+
+Document driver with collection browsing, document CRUD, MongoDB shell-style
+query parsing, aggregation, and document-focused schema metadata. SQL is not
+supported and query cancellation is unavailable. See
+[`crates/dbflux_driver_mongodb/README.md`](../crates/dbflux_driver_mongodb/README.md).
+
+### Redis
+
+Key-value driver covering strings, hashes, lists, sets, sorted sets, and
+streams, plus key scanning, TTL operations, rename, bulk get, and multiple
+logical databases. SQL is not supported and SSH tunneling is unavailable in URI
+mode. See
+[`crates/dbflux_driver_redis/README.md`](../crates/dbflux_driver_redis/README.md).
+
+### DynamoDB
+
+AWS NoSQL driver built on `aws-sdk-dynamodb` with region/profile/endpoint
+configuration. Table discovery maps PK/SK and GSI/LSI metadata; execution uses a
+native command envelope (`scan`, `query`, `put`, `update`, `delete`). PartiQL and
+DynamoDB transactions are not exposed. See
+[`crates/dbflux_driver_dynamodb/README.md`](../crates/dbflux_driver_dynamodb/README.md).
+
+### CloudWatch Logs
+
+AWS CloudWatch Logs driver executing queries through `StartQuery` with
+editor-managed time range and log-group source context. Query documents can run
+Logs Insights QL, OpenSearch PPL, and OpenSearch SQL; schema discovery enumerates
+log groups and exposes log streams as event-stream children. Its
+`DriverMetadata.query_language` is set to `Sql` as the default editor mode while
+the actual mode is chosen per query document. See
+[`crates/dbflux_driver_cloudwatch/README.md`](../crates/dbflux_driver_cloudwatch/README.md).
+
+### InfluxDB
+
+Time-series driver supporting both InfluxDB v1 and v2 in one crate. InfluxQL runs
+on both versions; Flux runs on v2 only. The query API is read-only (no
+INSERT/UPDATE/DELETE, no transactions), with optional default bucket/database and
+per-query bucket routing. See
+[`crates/dbflux_driver_influxdb/README.md`](../crates/dbflux_driver_influxdb/README.md).
+
+## External RPC drivers
+
+DBFlux can load drivers that run out-of-process and communicate over local IPC,
+implemented through `dbflux_driver_ipc` and hosted via `dbflux_driver_host`.
+These drivers register with the synthetic ID format `rpc:<socket_id>` and supply
+their own `DriverMetadata` (category, query language, capabilities) over the
+wire, so the UI treats them exactly like built-in drivers. For the discovery
+handshake, service lifecycle, and protocol details, see
+[`docs/DRIVER_RPC_PROTOCOL.md`](DRIVER_RPC_PROTOCOL.md).

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,399 @@
+# DBFlux Usage Guide
+
+A practical, end-user introduction to working with DBFlux: connecting to a
+database, browsing its schema, running queries, working with results, charting,
+and the keyboard model.
+
+DBFlux is keyboard-first. Almost every action has both a mouse affordance and a
+keyboard binding. The keybindings listed in this guide are the application
+defaults; they can be customized from Settings.
+
+---
+
+## 1. First Launch and Creating a Connection
+
+On startup DBFlux restores your previous session (open tabs). On a fresh
+install there is nothing to restore, so focus defaults to the sidebar.
+
+### Opening the Connection Manager
+
+Open the Connection Manager to create or edit connections:
+
+- From the sidebar, press `c`.
+- Or use the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P` on macOS) and run
+  **Open Connection Manager**.
+
+### Choosing a driver
+
+The Connection Manager presents a driver picker. Available drivers depend on the
+features the binary was built with; the standard build includes SQLite,
+PostgreSQL, MySQL/MariaDB, MongoDB, Redis, DynamoDB, Microsoft SQL Server, and
+AWS-backed integrations. Externally registered RPC drivers also appear here when
+configured (see `docs/RPC_SERVICES_CONFIG.md`).
+
+Use `/` to filter the driver list, `j`/`k` (or arrow keys) to move, and `Enter`
+to select.
+
+### Form mode vs. direct URI
+
+Each driver provides its own connection form. The form is dynamic: it shows only
+the fields that driver actually needs. Most relational drivers support two ways
+to supply connection details:
+
+- **Form-based**: individual fields (host, port, database, user, etc.).
+- **Direct URI**: a single connection-string field.
+
+File-backed drivers such as SQLite use a file-path form instead.
+
+### Access tab: direct, SSH, proxy, managed
+
+The **Access** tab controls how DBFlux reaches the database:
+
+- **Direct** — connect straight to the host from the Main tab fields. Direct
+  mode can still resolve Secret/Parameter/Auth value sources for individual
+  fields.
+- **SSH** — tunnel the connection through an SSH host. SSH tunnel profiles are
+  managed centrally in Settings and selected per connection.
+- **Proxy** — route through a SOCKS5 or HTTP CONNECT proxy. Proxy and SSH are
+  mutually exclusive for a single connection.
+- **Managed** — provider-managed access (for example `aws-ssm`), where DBFlux
+  opens access through an external provider before connecting.
+
+When you connect, DBFlux runs a pre-connect pipeline: authentication and session
+validation, dynamic value resolution, then managed/direct access setup, followed
+by the driver connect and an initial schema fetch. Connection hooks (if
+configured) run at the PreConnect, PostConnect, PreDisconnect, and PostDisconnect
+phases. See the Settings overview for where hooks are defined.
+
+---
+
+## 2. Browsing the Schema
+
+The sidebar has two tabs:
+
+- **Connections** — the schema tree (databases, schemas, tables/collections,
+  columns, indexes, and — where the driver supports it — a Routines folder).
+- **Scripts** — file and folder management for saved query files, script hooks,
+  and other user files.
+
+Switch between the two tabs with `q` or `e`.
+
+### Navigating the tree
+
+- `j`/`k` (or `Down`/`Up`) — move the selection.
+- `h` collapses, `l` expands the current node. `Space` toggles expand/collapse.
+- `g` jumps to the first item, `Shift+g` to the last; `Home`/`End` do the same.
+- `Ctrl+d`/`Ctrl+u` (or `PageDown`/`PageUp`) — page through long lists.
+- `/` focuses the sidebar search/filter.
+- `Enter` opens the selected item (for example, a table opens a data grid).
+- `r` refreshes the schema; `d` disconnects the active connection.
+- `m` opens the context menu for the selected item.
+
+### Lazy loading
+
+Schema is loaded lazily. On connect, DBFlux fetches shallow metadata (names).
+Detailed metadata — columns, indexes, and similar — is fetched on demand when you
+expand a node. This keeps the initial connection fast on large databases.
+
+### Routines / stored procedures
+
+For drivers that advertise routine support (PostgreSQL is the first
+implementation), the schema tree includes a **Routines** folder containing
+functions, procedures, aggregates, and window routines. Opening a routine opens a
+read-only code document showing its definition. The document is non-editable but
+you can still select and copy its text; execution and mutation controls are
+hidden.
+
+---
+
+## 3. Running Queries
+
+Open a new query tab with `Ctrl+n` (`Cmd+n` on macOS), or open a script file with
+`Ctrl+o`. The editor's query language (SQL, MongoDB query syntax, Redis commands,
+etc.) is determined by the active connection's driver, which also drives syntax
+highlighting and the placeholder text.
+
+### Executing
+
+- `Ctrl+Enter` (`Cmd+Enter`) — **Run Query**.
+- `Ctrl+Shift+Enter` (`Cmd+Shift+Enter`) — **Run Query in New Tab**.
+
+If a non-empty text selection exists, only the selected text runs. With no
+selection, the full editor buffer is used.
+
+### Multi-statement scripts
+
+When you run with no selection and the buffer contains multiple `;`-separated
+statements, and the active driver advertises batch support, DBFlux shows a
+confirmation dialog (`Run entire script (N statements)?`) before executing. On
+confirmation each statement's result set is rendered in its own result tab.
+
+Statement splitting is language-aware for SQL-family languages: separators inside
+strings, identifiers, line/block comments, and PostgreSQL dollar-quoted bodies are
+not treated as statement boundaries. Non-SQL languages remain single-statement.
+Batch support is per-driver — among the built-in SQL drivers, PostgreSQL,
+MySQL/MariaDB, SQLite, and Microsoft SQL Server support it. A selection always
+runs as-is and never triggers the script confirmation.
+
+### Dangerous-query confirmation
+
+DBFlux detects dangerous operations across languages — SQL `DELETE`/`DROP`/
+`TRUNCATE` and `DELETE`/`UPDATE` without a `WHERE`, MongoDB `deleteMany`/`drop`,
+Redis `FLUSHALL`/`FLUSHDB`/`KEYS` — and prompts for confirmation before running.
+This behavior is governed by settings: dangerous-query confirmation can be turned
+off, a `WHERE` clause can be required for `DELETE`/`UPDATE`, and Redis
+`FLUSHALL`/`FLUSHDB` can be disabled entirely (in which case those commands are
+blocked rather than confirmed).
+
+### Scripts (Lua / Python / Bash)
+
+Lua, Python, and Bash documents execute as scripts rather than database queries.
+Their output streams live into the document's output area while running, and the
+final output is kept as a text result. See `docs/LUA.md` for the embedded Lua
+runtime.
+
+---
+
+## 4. Working with Results
+
+Results render in result tabs inside the document. The view mode is chosen
+automatically from the database category:
+
+- **Table view** for relational databases.
+- **Document tree view** for document databases (for example MongoDB, DynamoDB).
+- **Key-value view** for Redis.
+
+Event-stream-style containers open as event streams when the driver declares that
+presentation.
+
+### Navigating the data grid
+
+When the results panel has focus:
+
+- `j`/`k` (or `Down`/`Up`) — move between rows.
+- `h`/`l` (or `Left`/`Right`) — move between columns.
+- `g`/`Shift+g` (or `Home`/`End`) — first / last row.
+- `Ctrl+d`/`Ctrl+u` (or `PageDown`/`PageUp`) — page through rows.
+- `[` / `]` — previous / next page of results (pagination).
+- `f` focuses the toolbar; `/` focuses the search/filter.
+- `z` toggles collapsing the panel.
+- `m` (or `Shift+F10`) opens the row/cell context menu.
+
+### Editing and CRUD
+
+In the data grid:
+
+- `o` — add a row.
+- `x` — delete the selected row.
+- `r` — rename / edit (context-dependent).
+- `y` — copy the selected row.
+- `Ctrl+c` (`Cmd+c`) — copy the selected cell(s) to the clipboard.
+
+### Copy as Query
+
+The result context menu includes **Copy as Query**, which generates a
+driver-specific mutation statement (or envelope, for non-SQL drivers) from the
+selected row using the driver's own query generator.
+
+### Exporting
+
+Press `Ctrl+e` (`Cmd+e`) in the results panel, or run **Export Results** from the
+command palette. The available formats depend on the result shape and include:
+
+- **CSV**
+- **JSON (pretty)** and **JSON (compact)**
+- **Text**
+- **Binary** (for binary-shaped results)
+
+---
+
+## 5. Charting Results
+
+Any query that produces tabular results can be charted. In the query editor
+toolbar, click the chart button (tooltip: "Open current query in a chart
+document") to open the current query in a chart document.
+
+Charts use the column kind metadata supplied by the driver to auto-detect axes
+(time columns, numeric columns, and so on). The supported chart kinds are:
+
+- **Line**
+- **Bar**
+- **Scatter**
+- **Area**
+- **Stacked Bar**
+- **Pie**
+
+Charts can be saved per connection profile. To reopen a saved chart, run **Open
+Chart...** from the command palette (`OpenSavedChart`), which lists the saved
+charts for the current profile in a fuzzy overlay.
+
+---
+
+## 6. Saved Queries and History
+
+DBFlux keeps a history of completed queries and lets you save named queries.
+
+- `Alt+h` (in the editor) toggles the query history dropdown.
+- `Ctrl+s` (`Cmd+s`) — **Save** the current query.
+- `Ctrl+Shift+s` (`Cmd+Shift+s`) — **Save File As**.
+- `Ctrl+p` (`Cmd+p`, in the editor) — open the saved-queries browser.
+
+Inside the history modal you can navigate with `Ctrl+j`/`Ctrl+k` (or arrow keys),
+open an entry with `Enter`, and use the local mnemonics `Ctrl+f` (toggle
+favorite), `Ctrl+r` (rename), and `Ctrl+d` (delete). `/` focuses the modal
+search.
+
+---
+
+## 7. Keyboard Reference
+
+DBFlux uses a layered, context-aware keymap. The active layer depends on which
+panel has focus. Bindings written with the **primary** modifier use `Cmd` on
+macOS and `Ctrl` on every other platform; bindings written with literal `Ctrl`
+stay `Ctrl` on all platforms (to avoid clashing with macOS system shortcuts).
+
+### Global (available regardless of focus)
+
+| Keys | Action |
+|------|--------|
+| `Ctrl+Shift+P` / `Cmd+Shift+P` | Toggle command palette |
+| `Ctrl+n` / `Cmd+n` | New query tab |
+| `Ctrl+w` / `Cmd+w` | Close current tab |
+| `Ctrl+Tab` / `Ctrl+Shift+Tab` | Next / previous tab |
+| `Ctrl+1` .. `Ctrl+9` / `Cmd+1` .. `Cmd+9` | Switch to tab N |
+| `Ctrl+o` / `Cmd+o` | Open script file |
+| `Ctrl+Enter` / `Cmd+Enter` | Run query |
+| `Ctrl+Shift+Enter` / `Cmd+Shift+Enter` | Run query in new tab |
+| `Escape` | Cancel / close modal |
+| `Tab` / `Shift+Tab` | Cycle focus forward / backward |
+| `Ctrl+Shift+1` | Focus sidebar |
+| `Ctrl+Shift+2` | Focus editor |
+| `Ctrl+Shift+3` | Focus results |
+| `Ctrl+Shift+4` | Focus background tasks |
+| `Ctrl+Shift+A` / `Cmd+Shift+A` | Open audit viewer |
+| `Ctrl+b` / `Cmd+b` | Toggle sidebar |
+| `Ctrl+m` | Open tab context menu |
+
+### Sidebar
+
+| Keys | Action |
+|------|--------|
+| `q` / `e` | Switch sidebar tab (Connections / Scripts) |
+| `/` | Focus search |
+| `j` / `k` (or `Down` / `Up`) | Select next / previous |
+| `h` / `l` | Collapse / expand node |
+| `Space` | Expand / collapse |
+| `g` / `Shift+g` (or `Home` / `End`) | First / last item |
+| `Ctrl+d` / `Ctrl+u` (or `PageDown` / `PageUp`) | Page down / up |
+| `Enter` | Open / execute item |
+| `r` | Refresh schema |
+| `c` | Open Connection Manager |
+| `d` | Disconnect |
+| `m` | Open item menu |
+| `Shift+j` / `Shift+k` | Extend selection down / up |
+| `Space` (with Shift) | Toggle selection |
+| `Ctrl+j` / `Ctrl+k` | Move selected item down / up |
+| `Shift+r` | Rename |
+| `x` | Delete |
+| `Shift+n` | Create folder |
+| `Ctrl+l` | Focus panel to the right |
+
+### Editor
+
+| Keys | Action |
+|------|--------|
+| `Ctrl+h` / `Ctrl+j` / `Ctrl+k` | Focus left / down / up panel |
+| `Alt+h` | Toggle history dropdown |
+| `Ctrl+p` / `Cmd+p` | Open saved queries |
+| `Ctrl+s` / `Cmd+s` | Save query |
+| `Ctrl+Shift+s` / `Cmd+Shift+s` | Save file as |
+| `Enter` | Focus / execute |
+
+(Unmodified letters are intentionally left to the text input so typing works.)
+
+### Results
+
+| Keys | Action |
+|------|--------|
+| `Ctrl+h` / `Ctrl+k` / `Ctrl+l` | Focus left / up / right panel |
+| `Ctrl+j` | Focus toolbar |
+| `j` / `k` (or `Down` / `Up`) | Next / previous row |
+| `h` / `l` (or `Left` / `Right`) | Column left / right |
+| `g` / `Shift+g` (or `Home` / `End`) | First / last row |
+| `Ctrl+d` / `Ctrl+u` (or `PageDown` / `PageUp`) | Page down / up |
+| `]` / `[` | Next / previous results page |
+| `Ctrl+e` / `Cmd+e` | Export results |
+| `f` | Focus toolbar |
+| `/` | Focus search/filter |
+| `x` | Delete row |
+| `r` | Rename / edit |
+| `o` | Add row |
+| `y` | Copy row |
+| `Ctrl+c` / `Cmd+c` | Copy cell(s) |
+| `z` | Toggle panel collapse |
+| `m` (or `Shift+F10`) | Open context menu |
+
+### Background Tasks
+
+| Keys | Action |
+|------|--------|
+| `Ctrl+h` / `Ctrl+j` / `Ctrl+k` | Focus left / down / up panel |
+| `j` / `k` (or `Down` / `Up`) | Select next / previous |
+| `g` / `Shift+g` (or `Home` / `End`) | First / last |
+| `Ctrl+d` / `Ctrl+u` (or `PageDown` / `PageUp`) | Page down / up |
+| `z` | Toggle panel collapse |
+
+### Command palette
+
+| Keys | Action |
+|------|--------|
+| `j` / `k` (or `Down` / `Up`) | Select next / previous |
+| `Enter` | Execute |
+| `Escape` | Cancel |
+
+### Context menu
+
+| Keys | Action |
+|------|--------|
+| `j` / `k` (or `Down` / `Up`) | Move down / up |
+| `Enter` / `l` (or `Right`) | Select / enter submenu |
+| `Escape` / `h` (or `Left`) | Back / close |
+
+### History modal
+
+| Keys | Action |
+|------|--------|
+| `Ctrl+j` / `Ctrl+k` (or `Down` / `Up`) | Select next / previous |
+| `Enter` | Open entry |
+| `Ctrl+f` | Toggle favorite |
+| `Ctrl+r` | Rename |
+| `Ctrl+d` | Delete |
+| `/` | Focus search |
+| `Ctrl+s` / `Cmd+s` | Save query |
+
+---
+
+## 8. Settings Overview
+
+Settings is organized into eight sections:
+
+1. **General** — application-wide preferences (including the dangerous-query
+   confirmation behavior).
+2. **Keybindings** — view and customize the keymap.
+3. **Auth Profiles** — provider-driven authentication profiles (for example AWS;
+   supports importing provider-discovered profiles).
+4. **Proxies** — SOCKS5 / HTTP CONNECT proxy profiles.
+5. **SSH Tunnels** — SSH tunnel profiles selectable per connection.
+6. **Services** — externally registered RPC services (drivers and auth
+   providers). See `docs/RPC_SERVICES_CONFIG.md`.
+7. **Hooks** — global connection-hook definitions (Command, Script, and Lua
+   modes). Per-profile phase bindings live in the Connection Manager's Hooks tab.
+8. **Drivers** — per-driver settings overrides.
+
+### Related documentation
+
+- Connection hooks and the embedded Lua runtime: `docs/LUA.md`
+- AI client integration (MCP): `docs/MCP_AI_INTEGRATION.md`
+- Audit log and event schema: `docs/AUDIT.md`
+- External RPC drivers/services: `docs/RPC_SERVICES_CONFIG.md`,
+  `docs/DRIVER_RPC_PROTOCOL.md`


### PR DESCRIPTION
## What

Refreshes the documentation for the v0.6 feature wave and fixes two driver-capability bugs found while mapping recent changes to the docs.

### Documentation
- **ARCHITECTURE.md**: new "Architecture at a Glance" section with three Mermaid diagrams (layered crate map, query flow, connection flow). Added the missing `dbflux_driver_influxdb` and `dbflux_driver_cloudwatch` crates to the directory tree and Driver Implementations. Corrected the `DatabaseCategory` list (was missing `LogStream`) and the `QueryLanguage` list. Added routines and multi-statement notes.
- **README.md**: added SQL Server and InfluxDB to database support; new feature sections for Charts & Visualization, Connectivity & Access, AI & MCP, and Audit & Scripting; fixed the build feature flags; linked the new docs.
- **New docs**: `docs/CHARTS.md` (chart types, `ColumnKind`, axis auto-detection, saved charts), `docs/DRIVERS.md` (capability matrix + per-driver limitations), `docs/USAGE.md` (getting-started guide + keybinding reference).
- Expanded the thin driver READMEs (redis, mongodb, cloudwatch, influxdb) to Features/Limitations parity, and aligned the build feature flags in `CLAUDE.md` and `AGENTS.md` with the default set.

### Fixes
- **DriverCapabilities bit collision**: `MULTI_STATEMENT` and `ROUTINES` were both `1 << 47` in the same `bitflags`, so a driver advertising one silently advertised the other. `MULTI_STATEMENT` moved to bit 48, with a regression test asserting the bits are distinct.
- **DynamoDB upsert capability**: `MutationCapabilities.supports_upsert` was `false` despite the driver implementing single-item upsert (`PutItem`) and only rejecting `many + upsert`. The MCP write tool gates on this flag, so it wrongly rejected a supported operation. Set to `true` and corrected the driver README.

## Why

The documentation had drifted behind several v0.6 features (charts, SQL Server, InfluxDB, CloudWatch, routines, multi-statement). While verifying claims against the code, the two capability bugs surfaced.

## Testing
- `cargo test -p dbflux_core` (capabilities suite, incl. new regression test) — passing
- `cargo check -p dbflux_driver_dynamodb` — passing

## Notes
- `CloudWatch` driver metadata still reports `QueryLanguage::Sql` as the default editor mode (real modes are surfaced via `SourceContextSpec`). Left unchanged as it is a cosmetic editor-default decision, not a functional bug.