### PR TITLE
fix(audit): expand row detail full width and reveal custom range inputs

### DIFF
--- a/crates/dbflux_ui/src/ui/document/audit/mod.rs
+++ b/crates/dbflux_ui/src/ui/document/audit/mod.rs
@@ -336,6 +336,23 @@ impl AuditDocument {
             },
         );
 
+        // The panel emits `TimeRangeChanged` only when the effective window
+        // changes, which never happens for the "Custom…" selection (it waits
+        // for Apply). Subscribe directly to the preset dropdown so the toolbar
+        // reveals the custom date/time inputs as soon as Custom is picked.
+        let preset_selection_sub = cx.subscribe(
+            &dropdown_time_range,
+            |this, _, event: &DropdownSelectionChanged, cx| {
+                let Some(range) = TimeRangePanel::time_range_for_index(event.index) else {
+                    return;
+                };
+
+                this.selected_time_range = Some(range);
+                this.refresh_filter_bar_items();
+                cx.notify();
+            },
+        );
+
         let timestamp_mode_sub = cx.subscribe(
             &dropdown_timestamp_mode,
             |this, _, event: &DropdownSelectionChanged, cx| {
@@ -505,6 +522,7 @@ impl AuditDocument {
             _subscriptions: vec![
                 search_sub,
                 time_range_sub,
+                preset_selection_sub,
                 timestamp_mode_sub,
                 level_sub,
                 category_sub,

--- a/crates/dbflux_ui/src/ui/document/audit/render.rs
+++ b/crates/dbflux_ui/src/ui/document/audit/render.rs
@@ -796,6 +796,7 @@ impl AuditDocument {
             .filter(|value| !value.is_empty());
 
         div()
+            .w_full()
             .px_4()
             .pb_3()
             .pt_1()
@@ -917,6 +918,7 @@ impl AuditDocument {
         let details_json = event.details_json.clone().filter(|value| !value.is_empty());
 
         div()
+            .w_full()
             .px_4()
             .pb_3()
             .pt_1()


### PR DESCRIPTION
## What

Fixes two visual/interaction bugs in the Audit document viewer.

### 1. Expanded row detail clipped mid-UI

The expanded audit log detail panels (`render_inline_detail` and `render_external_inline_detail`) were not constrained to the full row width, so the `secondary.opacity(0.35)` background and the field content shrank to fit and got cut off across the middle of the viewport.

Fix: add `.w_full()` to both inline detail containers.

### 2. "Custom" date range never opened its inputs

Selecting **Custom…** in the time-range dropdown did nothing — the date picker and hour/minute dropdowns never appeared.

Root cause: `TimeRangePanel` intentionally does **not** emit `TimeRangeChanged` when `Custom` is selected (it waits for *Apply*, since there's no concrete window yet). But `AuditDocument` only refreshed its toolbar on `TimeRangeChanged`, so `selected_time_range` never became `Custom` and `toolbar_items_for_state` never added the custom inputs.

Fix: subscribe directly to the preset dropdown (`DropdownSelectionChanged`) so selecting `Custom` updates `selected_time_range` and rebuilds the filter bar with the date picker and hour/minute dropdowns immediately.

## Testing

- `cargo check -p dbflux_ui` passes.
- Runtime behavior verified by reasoning about the subscription flow; not yet validated visually in a running app.