### PR TITLE
feat(ui): unify document toolbar styling with shared primitives

### DIFF
--- a/crates/dbflux_components/src/composites/split_toolbar_action.rs
+++ b/crates/dbflux_components/src/composites/split_toolbar_action.rs
@@ -17,14 +17,14 @@ pub fn split_toolbar_action(
         .h(Heights::BUTTON)
         .rounded(Radii::SM)
         .border_1()
-        .border_color(theme.border)
+        .border_color(theme.input)
         .bg(theme.background)
         .child(div().flex_1().h_full().child(main))
         .child(
             div()
                 .h_full()
                 .border_l_1()
-                .border_color(theme.border)
+                .border_color(theme.input)
                 .child(trailing),
         )
 }

--- a/crates/dbflux_ui/src/ui/document/audit/render.rs
+++ b/crates/dbflux_ui/src/ui/document/audit/render.rs
@@ -24,7 +24,9 @@ use gpui_component::Sizable;
 use gpui_component::button::ButtonVariants;
 use gpui_component::scroll::ScrollableElement;
 
-use super::super::chrome::{compact_top_bar, workspace_footer_bar};
+use super::super::chrome::{
+    ToolbarButton, ToolbarButtonVariant, compact_top_bar, workspace_footer_bar,
+};
 use super::super::types::DocumentState;
 
 impl AuditDocument {
@@ -292,28 +294,13 @@ impl AuditDocument {
             .child(self.dropdown_timestamp_mode.clone());
 
         let can_apply_custom_time_range = self.can_apply_custom_time_range(cx);
-        let custom_apply_button = div()
-            .id("audit-custom-time-apply")
-            .h(Heights::BUTTON)
-            .flex()
-            .items_center()
-            .px(Spacing::SM)
-            .rounded(Radii::SM)
-            .border_1()
-            .border_color(if self.slot_has_ring(ToolbarSlot::CustomApply) {
-                theme.ring
-            } else {
-                theme.input
-            })
-            .when(can_apply_custom_time_range, |d| {
-                d.cursor_pointer()
-                    .hover(|d| d.bg(theme.secondary))
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.apply_custom_time_range(cx);
-                    }))
-            })
-            .when(!can_apply_custom_time_range, |d| d.opacity(0.45))
-            .child(Text::caption("Apply"));
+        let custom_apply_button = ToolbarButton::new("audit-custom-time-apply")
+            .label("Apply")
+            .focused(self.slot_has_ring(ToolbarSlot::CustomApply))
+            .disabled(!can_apply_custom_time_range)
+            .on_click(cx.listener(|this, _, _, cx| {
+                this.apply_custom_time_range(cx);
+            }));
 
         let custom_time_controls = div()
             .flex()
@@ -455,25 +442,13 @@ impl AuditDocument {
             );
 
         // Clear button.
-        let clear_btn = div()
-            .id("audit-clear-btn")
-            .h(Heights::BUTTON)
-            .flex()
-            .items_center()
-            .px(Spacing::SM)
-            .rounded(Radii::SM)
-            .border_1()
-            .border_color(if self.slot_has_ring(ToolbarSlot::Clear) {
-                theme.ring
-            } else {
-                gpui::transparent_black()
-            })
-            .cursor_pointer()
-            .hover(|d| d.bg(theme.secondary))
+        let clear_btn = ToolbarButton::new("audit-clear-btn")
+            .label("Clear")
+            .variant(ToolbarButtonVariant::Ghost)
+            .focused(self.slot_has_ring(ToolbarSlot::Clear))
             .on_click(cx.listener(|this, _, window, cx| {
                 this.clear_filters(window, cx);
-            }))
-            .child(Text::caption("Clear"));
+            }));
 
         let _ = window;
 

--- a/crates/dbflux_ui/src/ui/document/chrome.rs
+++ b/crates/dbflux_ui/src/ui/document/chrome.rs
@@ -1,8 +1,11 @@
-use crate::ui::tokens::{Heights, Spacing};
-use dbflux_components::primitives::Text;
+use crate::ui::tokens::{Heights, Radii, Spacing};
+use dbflux_components::icon::IconSource;
+use dbflux_components::primitives::{Icon, Text};
 use gpui::prelude::*;
 use gpui::*;
+use gpui_component::ActiveTheme;
 use gpui_component::theme::Theme;
+use gpui_component::tooltip::Tooltip;
 
 /// Toolbar bar that matches the DataGridPanel toolbar exactly:
 /// `h(Heights::TOOLBAR)` / `bg(theme.secondary)` / `border_b_1`.
@@ -59,4 +62,202 @@ pub(crate) fn workspace_footer_bar(
         .child(div().flex().items_center().gap(Spacing::SM).child(left))
         .child(div().flex().items_center().gap(Spacing::SM).child(center))
         .child(div().flex().items_center().gap(Spacing::SM).child(right))
+}
+
+/// Boxed click handler for [`ToolbarButton`], produced by `cx.listener(...)`.
+type ToolbarClickHandler = Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>;
+
+/// Visual variants for [`ToolbarButton`], codifying the DataGridPanel reference
+/// style so every toolbar shares one button language.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolbarButtonVariant {
+    /// Bordered neutral control — the data-grid reference look.
+    Default,
+    /// Filled accent button for the primary action of a toolbar.
+    Primary,
+    /// Filled danger button for inline destructive or cancel actions.
+    Danger,
+    /// Borderless low-emphasis button.
+    Ghost,
+}
+
+/// Shared toolbar button matching the DataGridPanel reference style: 28 px tall,
+/// square corners, a 16 px icon, a caption-sized label, and a focus ring driven
+/// by the caller's keyboard-focus state.
+///
+/// Callers supply behavior (`on_click`, `disabled`, `focused`) and content
+/// (`icon`, `label`, `tooltip`); the variant decides the color treatment.
+#[derive(IntoElement)]
+pub(crate) struct ToolbarButton {
+    id: ElementId,
+    icon: Option<IconSource>,
+    label: Option<SharedString>,
+    variant: ToolbarButtonVariant,
+    focused: bool,
+    disabled: bool,
+    tooltip: Option<SharedString>,
+    on_click: Option<ToolbarClickHandler>,
+}
+
+impl ToolbarButton {
+    pub(crate) fn new(id: impl Into<ElementId>) -> Self {
+        Self {
+            id: id.into(),
+            icon: None,
+            label: None,
+            variant: ToolbarButtonVariant::Default,
+            focused: false,
+            disabled: false,
+            tooltip: None,
+            on_click: None,
+        }
+    }
+
+    pub(crate) fn icon(mut self, icon: impl Into<IconSource>) -> Self {
+        self.icon = Some(icon.into());
+        self
+    }
+
+    pub(crate) fn label(mut self, label: impl Into<SharedString>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub(crate) fn variant(mut self, variant: ToolbarButtonVariant) -> Self {
+        self.variant = variant;
+        self
+    }
+
+    pub(crate) fn focused(mut self, focused: bool) -> Self {
+        self.focused = focused;
+        self
+    }
+
+    pub(crate) fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub(crate) fn tooltip(mut self, tooltip: impl Into<SharedString>) -> Self {
+        self.tooltip = Some(tooltip.into());
+        self
+    }
+
+    pub(crate) fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(Box::new(handler));
+        self
+    }
+}
+
+impl RenderOnce for ToolbarButton {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let theme = cx.theme();
+
+        let foreground = theme.foreground;
+        let muted = theme.muted_foreground;
+        let background = theme.background;
+        let secondary = theme.secondary;
+        let accent_hover = theme.accent.opacity(0.08);
+        let ring = theme.ring;
+        let input = theme.input;
+        let primary = theme.primary;
+        let danger = theme.danger;
+        let transparent = gpui::transparent_black();
+
+        let ToolbarButton {
+            id,
+            icon,
+            label,
+            variant,
+            focused,
+            disabled,
+            tooltip,
+            on_click,
+        } = self;
+
+        let content_color = match variant {
+            ToolbarButtonVariant::Default | ToolbarButtonVariant::Ghost => {
+                if disabled {
+                    muted
+                } else {
+                    foreground
+                }
+            }
+            ToolbarButtonVariant::Primary => {
+                if disabled {
+                    muted
+                } else {
+                    background
+                }
+            }
+            ToolbarButtonVariant::Danger => background,
+        };
+
+        let bg_color = match variant {
+            ToolbarButtonVariant::Default => background,
+            ToolbarButtonVariant::Ghost => transparent,
+            ToolbarButtonVariant::Primary => {
+                if disabled {
+                    secondary
+                } else {
+                    primary
+                }
+            }
+            ToolbarButtonVariant::Danger => danger,
+        };
+
+        let border_color = match (variant, focused) {
+            (_, true) => ring,
+            (ToolbarButtonVariant::Default, false) => input,
+            _ => transparent,
+        };
+
+        let mut el = div()
+            .id(id)
+            .flex()
+            .items_center()
+            .gap_1()
+            .h(Heights::CONTROL)
+            .px(Spacing::SM)
+            .rounded(Radii::SM)
+            .border_1()
+            .border_color(border_color)
+            .bg(bg_color)
+            .text_color(content_color);
+
+        if !disabled {
+            el = match variant {
+                ToolbarButtonVariant::Primary | ToolbarButtonVariant::Danger => {
+                    el.hover(|d| d.opacity(0.9))
+                }
+                ToolbarButtonVariant::Default => el.hover(move |d| d.bg(accent_hover)),
+                ToolbarButtonVariant::Ghost => {
+                    el.hover(move |d| d.bg(secondary).text_color(foreground))
+                }
+            };
+        }
+
+        if disabled {
+            el = el.cursor_not_allowed();
+        } else if let Some(handler) = on_click {
+            el = el.cursor_pointer().on_click(handler);
+        }
+
+        if let Some(tip) = tooltip {
+            el = el.tooltip(move |window, cx| Tooltip::new(tip.clone()).build(window, cx));
+        }
+
+        if let Some(icon_source) = icon {
+            el = el.child(Icon::new(icon_source).small().color(content_color));
+        }
+
+        if let Some(label) = label {
+            el = el.child(Text::caption(label).color(content_color));
+        }
+
+        el
+    }
 }

--- a/crates/dbflux_ui/src/ui/document/code/render.rs
+++ b/crates/dbflux_ui/src/ui/document/code/render.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::ui::components::toast::{Toast, copy_action, now_hms};
+use crate::ui::document::chrome::{ToolbarButton, ToolbarButtonVariant, compact_top_bar};
 use dbflux_components::composites::split_toolbar_action;
 use dbflux_components::controls::Button;
 use dbflux_components::helpers::text_color_for_active;
@@ -8,7 +9,6 @@ use dbflux_components::primitives::{
     surface_panel,
 };
 use gpui_component::scroll::ScrollableElement;
-use gpui_component::tooltip::Tooltip;
 
 fn code_pane_is_focused(focus_mode: SqlQueryFocus, pane: SqlQueryFocus) -> bool {
     focus_mode == pane
@@ -16,7 +16,7 @@ fn code_pane_is_focused(focus_mode: SqlQueryFocus, pane: SqlQueryFocus) -> bool 
 
 impl CodeDocument {
     fn render_toolbar(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = cx.theme();
+        let theme = cx.theme().clone();
         let is_executing = self.state == DocumentState::Executing;
         let is_preflight = self.drift_preflight_running;
         let is_db_language = self.query_language.supports_connection_context();
@@ -44,16 +44,8 @@ impl CodeDocument {
             (AppIcon::Play, "Run", true)
         };
 
-        let btn_bg = theme.secondary;
-        let secondary_hover = theme.secondary_hover;
-        let primary = theme.primary;
         let accent = theme.accent;
         let fg = theme.foreground;
-        let bg = theme.background;
-        let muted_fg = theme.muted_foreground;
-        let danger = theme.danger;
-        let border = theme.border;
-        let tab_bar = theme.tab_bar;
 
         let execution_time = self
             .active_execution_index
@@ -78,87 +70,44 @@ impl CodeDocument {
             "Ctrl+Enter"
         };
 
-        div()
+        compact_top_bar(&theme, std::iter::empty::<AnyElement>())
             .id("sql-toolbar")
-            .flex()
-            .items_center()
-            .gap(Spacing::SM)
-            .px(Spacing::SM)
-            .py(Spacing::XS)
-            .border_b_1()
-            .border_color(border)
-            .bg(tab_bar)
             .when(!is_read_only, |el| {
                 el.child(
-                    div()
-                        .id("run-query-btn")
-                        .flex()
-                        .items_center()
-                        .gap_1()
-                        .px(Spacing::SM)
-                        .py(Spacing::XS)
-                        .rounded(Radii::SM)
-                        .cursor_pointer()
-                        .when(run_enabled, |d| {
-                            d.bg(if is_executing { danger } else { primary })
-                                .hover(|d| d.opacity(0.9))
+                    ToolbarButton::new("run-query-btn")
+                        .icon(run_icon)
+                        .label(run_label)
+                        .variant(if is_executing {
+                            ToolbarButtonVariant::Danger
+                        } else {
+                            ToolbarButtonVariant::Primary
                         })
-                        .when(!run_enabled, |d| d.bg(btn_bg).cursor_not_allowed())
+                        .disabled(!run_enabled)
                         .on_click(cx.listener(move |this, _, window, cx| {
                             if this.state == DocumentState::Executing {
                                 this.cancel_query(cx);
                             } else {
                                 this.run_query(window, cx);
                             }
-                        }))
-                        .child(Icon::new(run_icon).size(px(12.0)).color(if run_enabled {
-                            bg
-                        } else {
-                            muted_fg
-                        }))
-                        .child(if run_enabled {
-                            Text::caption(run_label).color(bg)
-                        } else {
-                            Text::caption(run_label).muted_foreground()
-                        }),
+                        })),
                 )
             })
             .when(!is_read_only && is_db_language && !is_executing, |el| {
                 el.child(
-                    div()
-                        .id("run-in-new-tab-btn")
-                        .flex()
-                        .items_center()
-                        .gap_1()
-                        .px(Spacing::SM)
-                        .py(Spacing::XS)
-                        .rounded(Radii::SM)
-                        .cursor_pointer()
-                        .bg(btn_bg)
-                        .hover(|d| d.bg(secondary_hover))
+                    ToolbarButton::new("run-in-new-tab-btn")
+                        .icon(AppIcon::SquarePlay)
+                        .label("New tab")
                         .on_click(cx.listener(|this, _, window, cx| {
                             this.run_query_in_new_tab(window, cx);
-                        }))
-                        .child(Icon::new(AppIcon::SquarePlay).size(px(12.0)).color(fg))
-                        .child(Text::body("New tab").font_size(FontSizes::SM)),
+                        })),
                 )
                 .child(
-                    div()
-                        .id("run-selection-btn")
-                        .flex()
-                        .items_center()
-                        .gap_1()
-                        .px(Spacing::SM)
-                        .py(Spacing::XS)
-                        .rounded(Radii::SM)
-                        .cursor_pointer()
-                        .bg(btn_bg)
-                        .hover(|d| d.bg(secondary_hover))
+                    ToolbarButton::new("run-selection-btn")
+                        .icon(AppIcon::ScrollText)
+                        .label("Selection")
                         .on_click(cx.listener(|this, _, window, cx| {
                             this.run_selected_query(window, cx);
-                        }))
-                        .child(Icon::new(AppIcon::ScrollText).size(px(12.0)).color(fg))
-                        .child(Text::body("Selection").font_size(FontSizes::SM)),
+                        })),
                 )
             })
             .when(!is_read_only, |el| el.child(Text::caption(shortcut_hint)))
@@ -184,8 +133,8 @@ impl CodeDocument {
                                 this.run_query(window, cx);
                             }
                         }))
-                        .child(Icon::new(refresh_icon).size(px(12.0)).color(fg))
-                        .child(Text::body(refresh_label)),
+                        .child(Icon::new(refresh_icon).small().color(fg))
+                        .child(Text::caption(refresh_label)),
                     div()
                         .id("sql-refresh-control")
                         .w(px(28.0))
@@ -209,13 +158,6 @@ impl CodeDocument {
         is_read_only: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let theme = cx.theme();
-        let secondary = theme.secondary;
-        let secondary_hover = theme.secondary_hover;
-        let muted_fg = theme.muted_foreground;
-        let fg = theme.foreground;
-
-        let is_file_backed = self.is_file_backed();
         let is_db_language = self.query_language.supports_connection_context();
 
         div()
@@ -225,65 +167,33 @@ impl CodeDocument {
             // Save button — hidden for read-only documents
             .when(!is_read_only, |el| {
                 el.child(
-                    div()
-                        .id("toolbar-save-btn")
-                        .h(Heights::BUTTON)
-                        .flex()
-                        .items_center()
-                        .gap_1()
-                        .px(Spacing::SM)
-                        .rounded(Radii::SM)
-                        .cursor_pointer()
-                        .bg(secondary)
-                        .hover(|d| d.bg(secondary_hover))
+                    ToolbarButton::new("toolbar-save-btn")
+                        .icon(AppIcon::Save)
+                        .tooltip("Save")
                         .on_click(cx.listener(|this, _, window, cx| {
                             if this.is_file_backed() {
                                 this.save_file(window, cx);
                             } else {
                                 this.save_file_as(window, cx);
                             }
-                        }))
-                        .tooltip(|window, cx| Tooltip::new("Save").build(window, cx))
-                        .child(
-                            Icon::new(AppIcon::Save)
-                                .size(px(12.0))
-                                .color(if is_file_backed { fg } else { muted_fg }),
-                        ),
+                        })),
                 )
             })
             // Format button — hidden for read-only documents (no formatter available)
             .when(!is_read_only, |el| {
                 el.child(
-                    div()
-                        .id("toolbar-format-btn")
-                        .h(Heights::BUTTON)
-                        .flex()
-                        .items_center()
-                        .gap_1()
-                        .px(Spacing::SM)
-                        .rounded(Radii::SM)
-                        .cursor_not_allowed()
-                        .bg(secondary)
-                        .tooltip(|window, cx| {
-                            Tooltip::new("Formatter unavailable").build(window, cx)
-                        })
-                        .child(Icon::new(AppIcon::Zap).size(px(12.0)).color(muted_fg)),
+                    ToolbarButton::new("toolbar-format-btn")
+                        .icon(AppIcon::Zap)
+                        .tooltip("Formatter unavailable")
+                        .disabled(true),
                 )
             })
             // History button — hidden for read-only documents
             .when(!is_read_only, |el| {
                 el.child(
-                    div()
-                        .id("toolbar-history-btn")
-                        .h(Heights::BUTTON)
-                        .flex()
-                        .items_center()
-                        .gap_1()
-                        .px(Spacing::SM)
-                        .rounded(Radii::SM)
-                        .cursor_pointer()
-                        .bg(secondary)
-                        .hover(|d| d.bg(secondary_hover))
+                    ToolbarButton::new("toolbar-history-btn")
+                        .icon(AppIcon::History)
+                        .tooltip("Query history")
                         .on_click(cx.listener(|this, _, window, cx| {
                             let is_open = this.history_modal.read(cx).is_visible();
                             if is_open {
@@ -292,53 +202,29 @@ impl CodeDocument {
                                 this.history_modal
                                     .update(cx, |modal, cx| modal.open(window, cx));
                             }
-                        }))
-                        .tooltip(|window, cx| Tooltip::new("Query history").build(window, cx))
-                        .child(Icon::new(AppIcon::History).size(px(12.0)).color(fg)),
+                        })),
                 )
             })
             // Explain button — hidden for read-only documents
             .when(!is_read_only && is_db_language, |el| {
                 el.child(
-                    div()
-                        .id("toolbar-explain-btn")
-                        .h(Heights::BUTTON)
-                        .flex()
-                        .items_center()
-                        .gap_1()
-                        .px(Spacing::SM)
-                        .rounded(Radii::SM)
-                        .cursor_pointer()
-                        .bg(secondary)
-                        .hover(|d| d.bg(secondary_hover))
+                    ToolbarButton::new("toolbar-explain-btn")
+                        .icon(AppIcon::Info)
+                        .tooltip("Explain query")
                         .on_click(cx.listener(|this, _, window, cx| {
                             this.run_explain(window, cx);
-                        }))
-                        .tooltip(|window, cx| Tooltip::new("Explain query").build(window, cx))
-                        .child(Icon::new(AppIcon::Info).size(px(12.0)).color(fg)),
+                        })),
                 )
             })
             // Chart button — hidden for read-only documents
             .when(!is_read_only, |el| {
                 el.child(
-                    div()
-                        .id("toolbar-chart-btn")
-                        .h(Heights::BUTTON)
-                        .flex()
-                        .items_center()
-                        .gap_1()
-                        .px(Spacing::SM)
-                        .rounded(Radii::SM)
-                        .cursor_pointer()
-                        .bg(secondary)
-                        .hover(|d| d.bg(secondary_hover))
+                    ToolbarButton::new("toolbar-chart-btn")
+                        .icon(AppIcon::ChartSpline)
+                        .tooltip("Open current query in a chart document")
                         .on_click(cx.listener(|this, _, _window, cx| {
                             this.emit_chart_this_query(cx);
-                        }))
-                        .tooltip(|window, cx| {
-                            Tooltip::new("Open current query in a chart document").build(window, cx)
-                        })
-                        .child(Icon::new(AppIcon::ChartSpline).size(px(12.0)).color(fg)),
+                        })),
                 )
             })
     }

--- a/crates/dbflux_ui/src/ui/document/data_grid_panel/render.rs
+++ b/crates/dbflux_ui/src/ui/document/data_grid_panel/render.rs
@@ -4,6 +4,7 @@ use super::{
 use crate::ui::common::time_range::view::TimeRangePanel;
 use crate::ui::components::data_table::SortState as TableSortState;
 use crate::ui::components::toast::{Toast, copy_action, now_hms};
+use crate::ui::document::chrome::compact_top_bar;
 use crate::ui::document::data_view::DataViewMode;
 use crate::ui::document::result_view::ResultViewMode;
 use crate::ui::icons::AppIcon;
@@ -684,16 +685,7 @@ impl DataGridPanel {
             "Refresh"
         };
 
-        div()
-            .flex()
-            .flex_wrap()
-            .items_center()
-            .gap(Spacing::SM)
-            .min_h(Heights::TOOLBAR)
-            .px(Spacing::SM)
-            .border_b_1()
-            .border_color(theme.border)
-            .bg(theme.secondary)
+        compact_top_bar(theme, std::iter::empty::<AnyElement>())
             .child(
                 div()
                     .flex()
@@ -791,7 +783,7 @@ impl DataGridPanel {
             .child(
                 div()
                     .id("refresh-action-btn")
-                    .h(Heights::ROW_COMPACT)
+                    .h(Heights::CONTROL)
                     .flex()
                     .items_center()
                     .gap_0()


### PR DESCRIPTION
## What

Unifies the visual language of the document toolbars (editor, audit, data grid) which had diverged in colors, fonts, button styles, icon sizes and control heights.

Introduces a shared `ToolbarButton` primitive in `dbflux_ui/src/ui/document/chrome.rs` (variants `Default` / `Primary` / `Danger` / `Ghost`) that codifies the **DataGridPanel (table) toolbar as the reference style**:

- 28px control height (`Heights::CONTROL`)
- square corners (`Radii::SM`)
- 16px icons (`Icon::small()`)
- `Text::caption` labels (13px)
- `theme.input` border with a `theme.ring` focus ring
- `accent.opacity(0.08)` hover

## Why

The editor, audit and table toolbars looked inconsistent across the app — different backgrounds, button treatments, icon sizes and heights. The table toolbar was chosen as the ideal reference, and the unified control height was set to 28px.

## Changes

- **`chrome.rs`**: new `ToolbarButton` builder + `ToolbarButtonVariant` (and a `ToolbarClickHandler` type alias to keep clippy's `type_complexity` happy under `-D warnings`).
- **`code/render.rs`** (editor — the biggest divergence): container moved from `theme.tab_bar` + `py(XS)` to the shared `compact_top_bar` (`theme.secondary`, `min_h(TOOLBAR)`, `flex_wrap`); icons 12px → 16px; `Run` = `Primary`/`Danger`, `New tab`/`Selection` and the secondary actions (Save/Format/History/Explain/Chart) = `Default`.
- **`audit/render.rs`**: `Apply` → `Default`, `Clear` → `Ghost`.
- **`data_grid_panel/render.rs`** (reference, minimal): container routed through `compact_top_bar` (no visual change); refresh control bumped `ROW_COMPACT` → `CONTROL` (24 → 28px).
- **`composites/split_toolbar_action.rs`**: border `theme.border` → `theme.input` so refresh split controls match across views.

## Notes

- Toolbar button labels are standardized on `Text::caption` (13px); this slightly shrinks the table "Refresh" label from 14 → 13px.
- Minor cosmetic behavior change: the editor `Save` button no longer dims when the document is not file-backed (it now uses `foreground` like the rest). It remains clickable as before.
- Out of scope (left for a follow-up): toolbar inputs (already consistent, ring-on-focus), the table edit toolbar (`render_edit_toolbar`, 44px / `Radii::MD`), and extending the primitive to the rest of the app (settings, connection manager).

## Verification

- `cargo check --workspace` — clean (exit 0)
- `cargo clippy -p dbflux_components -p dbflux_ui` — no warnings
- `cargo fmt` applied