### PR TITLE
refactor(ui): tokenize dbflux_components spacing + unify BannerColors (#111 Phase 1)

### DIFF
--- a/crates/dbflux_components/src/components/data_table/table.rs
+++ b/crates/dbflux_components/src/components/data_table/table.rs
@@ -814,7 +814,7 @@ impl DataTable {
                             .right_0()
                             .top_0()
                             .bottom_0()
-                            .w(px(6.0))
+                            .w(px(6.0)) // guardrail-allow: resize handle width, not spacing
                             .cursor_col_resize()
                             .hover(|s| s.bg(theme.primary.opacity(0.3)))
                             .on_mouse_down(

--- a/crates/dbflux_components/src/components/data_table/theme.rs
+++ b/crates/dbflux_components/src/components/data_table/theme.rs
@@ -1,17 +1,17 @@
 use gpui::{Pixels, px};
 
 /// Height of each data row.
-pub const ROW_HEIGHT: Pixels = px(28.0);
+pub const ROW_HEIGHT: Pixels = px(28.0); // guardrail-allow: domain const, mirrors Heights::ROW
 
 /// Height of the header row.
-pub const HEADER_HEIGHT: Pixels = px(32.0);
+pub const HEADER_HEIGHT: Pixels = px(32.0); // guardrail-allow: domain const, mirrors Heights::TOOLBAR
 
 /// Horizontal padding inside cells.
-pub const CELL_PADDING_X: Pixels = px(8.0);
+pub const CELL_PADDING_X: Pixels = px(8.0); // guardrail-allow: domain const, do not fold into Spacing
 
 /// Vertical padding inside cells.
 #[allow(dead_code)]
-pub const CELL_PADDING_Y: Pixels = px(4.0);
+pub const CELL_PADDING_Y: Pixels = px(4.0); // guardrail-allow: domain const, do not fold into Spacing
 
 /// Minimum width for a column.
 #[allow(dead_code)]
@@ -21,7 +21,7 @@ pub const MIN_COLUMN_WIDTH: f32 = 50.0;
 pub const DEFAULT_COLUMN_WIDTH: f32 = 120.0;
 
 /// Width of the scrollbar.
-pub const SCROLLBAR_WIDTH: Pixels = px(12.0);
+pub const SCROLLBAR_WIDTH: Pixels = px(12.0); // guardrail-allow: domain const, scrollbar width
 
 /// Sort indicator for ascending sort.
 pub const SORT_INDICATOR_ASC: &str = "↑";

--- a/crates/dbflux_components/src/components/document_tree/tree.rs
+++ b/crates/dbflux_components/src/components/document_tree/tree.rs
@@ -15,7 +15,7 @@ use super::state::{DocumentTreeState, DocumentViewMode};
 pub const TREE_ROW_HEIGHT: Pixels = px(26.0);
 
 /// Indentation per depth level.
-const INDENT_WIDTH: Pixels = px(16.0);
+const INDENT_WIDTH: Pixels = px(16.0); // guardrail-allow: domain const, tree indentation step
 
 actions!(
     document_tree,
@@ -467,7 +467,7 @@ fn render_toolbar(
                     } else {
                         AppIcon::Rows3
                     })
-                    .size(px(16.0))
+                    .size(Heights::ICON_SM)
                     .muted(),
                 ),
         )
@@ -499,7 +499,7 @@ fn render_search_bar(
         .border_b_1()
         .border_color(theme.border)
         .bg(theme.secondary.opacity(0.3))
-        .child(Icon::new(AppIcon::Search).size(px(16.0)).muted())
+        .child(Icon::new(AppIcon::Search).size(Heights::ICON_SM).muted())
         .child(div().flex_1().child(Input::new(&input).small().w_full()))
         .child(Text::caption(match_text).font_size(FontSizes::XS))
         .child(
@@ -517,7 +517,7 @@ fn render_search_bar(
                         state.update(cx, |s, cx| s.close_search(cx));
                     }
                 })
-                .child(Icon::new(AppIcon::X).size(px(12.0)).muted()),
+                .child(Icon::new(AppIcon::X).size(px(12.0)).muted()), // guardrail-allow: 12px icon size, no ICON_XS token
         )
 }
 
@@ -671,8 +671,8 @@ fn render_chevron(
     node_id: NodeId,
 ) -> Div {
     let chevron = div()
-        .w(px(16.0))
-        .h(px(16.0))
+        .w(Heights::ICON_SM)
+        .h(Heights::ICON_SM)
         .flex()
         .items_center()
         .justify_center();
@@ -685,7 +685,7 @@ fn render_chevron(
         };
 
         chevron
-            .child(Icon::new(icon).size(px(12.0)).color(muted_color))
+            .child(Icon::new(icon).size(px(12.0)).color(muted_color)) // guardrail-allow: 12px icon size, no ICON_XS token
             .cursor_pointer()
             .on_mouse_down(MouseButton::Left, move |_, _, cx| {
                 cx.stop_propagation();
@@ -700,16 +700,16 @@ fn get_type_color(value: &NodeValue, theme: &gpui_component::Theme) -> Hsla {
     match value {
         NodeValue::Scalar(v) => match v {
             dbflux_core::Value::Null => theme.muted_foreground,
-            dbflux_core::Value::Bool(_) => hsla(280.0 / 360.0, 0.6, 0.6, 1.0),
-            dbflux_core::Value::Int(_) => hsla(120.0 / 360.0, 0.5, 0.5, 1.0),
+            dbflux_core::Value::Bool(_) => hsla(280.0 / 360.0, 0.6, 0.6, 1.0), // guardrail-allow: JSON type color, no semantic token
+            dbflux_core::Value::Int(_) => hsla(120.0 / 360.0, 0.5, 0.5, 1.0), // guardrail-allow: JSON type color
             dbflux_core::Value::Float(_) | dbflux_core::Value::Decimal(_) => {
-                hsla(150.0 / 360.0, 0.5, 0.5, 1.0)
+                hsla(150.0 / 360.0, 0.5, 0.5, 1.0) // guardrail-allow: JSON type color
             }
-            dbflux_core::Value::Text(_) => hsla(30.0 / 360.0, 0.7, 0.6, 1.0),
+            dbflux_core::Value::Text(_) => hsla(30.0 / 360.0, 0.7, 0.6, 1.0), // guardrail-allow: JSON type color
             dbflux_core::Value::ObjectId(_) => theme.primary,
             dbflux_core::Value::DateTime(_)
             | dbflux_core::Value::Date(_)
-            | dbflux_core::Value::Time(_) => hsla(200.0 / 360.0, 0.6, 0.5, 1.0),
+            | dbflux_core::Value::Time(_) => hsla(200.0 / 360.0, 0.6, 0.5, 1.0), // guardrail-allow: JSON type color
             dbflux_core::Value::Bytes(_) => theme.warning,
             dbflux_core::Value::Json(_) => theme.muted_foreground,
             _ => theme.foreground,

--- a/crates/dbflux_components/src/components/filter_bar.rs
+++ b/crates/dbflux_components/src/components/filter_bar.rs
@@ -444,7 +444,7 @@ fn render_item(
                 .cursor_pointer()
                 .hover(|d| d.bg(theme.accent.opacity(0.08)))
                 .when_some(*icon, |d, icon| {
-                    d.child(Icon::new(icon).size(px(16.0)).muted())
+                    d.child(Icon::new(icon).size(Heights::ICON_SM).muted())
                 })
                 .child(Text::body(label.clone()).font_size(FontSizes::SM))
                 .into_any_element()

--- a/crates/dbflux_components/src/components/json_editor_view.rs
+++ b/crates/dbflux_components/src/components/json_editor_view.rs
@@ -1,7 +1,7 @@
 use crate::controls::{GpuiInput as Input, InputState};
 use crate::icons::AppIcon;
 use crate::primitives::{Icon, Text};
-use crate::tokens::{FontSizes, Spacing};
+use crate::tokens::{FontSizes, Heights, Spacing};
 use gpui::*;
 use gpui_component::ActiveTheme;
 use gpui_component::Sizable;
@@ -123,7 +123,11 @@ impl JsonEditorView {
                     .flex()
                     .items_center()
                     .gap(Spacing::SM)
-                    .child(Icon::new(AppIcon::CircleAlert).size(px(16.0)).danger())
+                    .child(
+                        Icon::new(AppIcon::CircleAlert)
+                            .size(Heights::ICON_SM)
+                            .danger(),
+                    )
                     .child(Text::caption(error_msg).font_size(FontSizes::XS).danger()),
             );
         }

--- a/crates/dbflux_components/src/components/multi_select.rs
+++ b/crates/dbflux_components/src/components/multi_select.rs
@@ -1,5 +1,5 @@
 use crate::primitives::Text;
-use crate::tokens::Heights;
+use crate::tokens::{Heights, Spacing};
 use gpui::prelude::*;
 use gpui::{
     Corner, ElementId, EventEmitter, IntoElement, MouseButton, ParentElement, Render, ScrollHandle,
@@ -238,7 +238,7 @@ impl MultiSelect {
         deferred(
             anchored()
                 .anchor(Corner::TopLeft)
-                .offset(point(px(0.0), px(4.0)))
+                .offset(point(px(0.0), Spacing::XS))
                 .snap_to_window()
                 .child(menu),
         )

--- a/crates/dbflux_components/src/composites/field_row.rs
+++ b/crates/dbflux_components/src/composites/field_row.rs
@@ -79,7 +79,7 @@ fn field_row_inner(
         .child(
             div()
                 .w(label_width)
-                .pt(px(6.0))
+                .pt(Spacing::XXS)
                 .flex_shrink_0()
                 .child(label_el),
         )
@@ -96,7 +96,7 @@ fn field_row_vertical_inner(
 
     let mut col = div()
         .flex_col()
-        .gap(px(4.0))
+        .gap(Spacing::XS)
         .child(label_el)
         .child(div().w_full().child(control));
 

--- a/crates/dbflux_components/src/composites/refresh_split_button.rs
+++ b/crates/dbflux_components/src/composites/refresh_split_button.rs
@@ -80,13 +80,17 @@ pub fn refresh_split_button(
                 .on_click(move |_, window, cx| {
                     on_refresh(window, cx);
                 })
-                .child(Icon::new(refresh_icon).size(px(16.0)).color(foreground))
+                .child(
+                    Icon::new(refresh_icon)
+                        .size(Heights::ICON_SM)
+                        .color(foreground),
+                )
                 .child(Text::caption(refresh_label)),
         )
-        .child(div().w(px(1.0)).h_full().bg(input_color))
+        .child(div().w(px(1.0)).h_full().bg(input_color)) // guardrail-allow: 1px separator div width
         .child(
             div()
-                .w(px(28.0))
+                .w(px(28.0)) // guardrail-allow: dropdown panel width, not a spacing value
                 .h_full()
                 .rounded_r(Radii::SM)
                 .when(ring_policy, |d| d.border_1().border_color(ring_color))

--- a/crates/dbflux_components/src/controls/dropdown.rs
+++ b/crates/dbflux_components/src/controls/dropdown.rs
@@ -531,7 +531,7 @@ impl Dropdown {
         deferred(
             anchored()
                 .anchor(Corner::TopLeft)
-                .offset(point(px(0.0), px(4.0)))
+                .offset(point(px(0.0), Spacing::XS))
                 .snap_to_window()
                 .child(menu),
         )

--- a/crates/dbflux_components/src/controls/tab_trigger.rs
+++ b/crates/dbflux_components/src/controls/tab_trigger.rs
@@ -2,7 +2,7 @@ use gpui::prelude::*;
 use gpui::{App, ClickEvent, Window, div};
 use gpui_component::ActiveTheme;
 
-use crate::tokens::{FontSizes, Heights};
+use crate::tokens::{FontSizes, Heights, Spacing};
 
 /// A custom tab trigger item (not wrapping gpui_component) with three
 /// visual states: Active, Inactive, and Hover.
@@ -45,7 +45,7 @@ impl RenderOnce for TabTrigger {
         let mut el = div()
             .id(self.id)
             .h(Heights::TAB)
-            .px(gpui::px(12.0))
+            .px(Spacing::MD)
             .flex()
             .items_center()
             .text_size(FontSizes::SM)

--- a/crates/dbflux_components/src/lib.rs
+++ b/crates/dbflux_components/src/lib.rs
@@ -30,6 +30,9 @@ pub mod theme;
 
 pub mod sql_preview;
 
+#[cfg(test)]
+mod style_guardrails;
+
 pub use composites::refresh_split_button;
 pub use saved_chart::{
     SavedChart, SavedChartManager, SavedChartRefreshPolicy, SavedChartStore, TimeRangePreset,

--- a/crates/dbflux_components/src/modals/cell_editor.rs
+++ b/crates/dbflux_components/src/modals/cell_editor.rs
@@ -4,6 +4,7 @@ use crate::controls::InputState;
 use crate::icon::IconSource;
 use crate::icons::AppIcon;
 use crate::primitives::Icon;
+use crate::tokens::Heights;
 use dbflux_core::keymap_types::ContextId;
 use gpui::*;
 
@@ -172,7 +173,7 @@ impl Render for CellEditorModal {
         ModalFrame::new("cell-editor-modal", &self.focus_handle, close)
             .key_context(ContextId::SqlPreviewModal.as_gpui_context())
             .close_icon(IconSource::Svg(AppIcon::X.path().into()))
-            .header_leading(Icon::new(AppIcon::Pencil).size(px(16.0)).primary())
+            .header_leading(Icon::new(AppIcon::Pencil).size(Heights::ICON_SM).primary())
             .title(if is_json { "Edit JSON" } else { "Edit Text" })
             .width(px(900.0))
             .height(px(600.0))

--- a/crates/dbflux_components/src/modals/delete_connection.rs
+++ b/crates/dbflux_components/src/modals/delete_connection.rs
@@ -1,7 +1,7 @@
 use crate::icons::AppIcon;
 use crate::modals::shell::{ModalShell, ModalVariant};
 use crate::primitives::{Icon, Text, surface_raised};
-use crate::tokens::{FontSizes, Spacing};
+use crate::tokens::{FontSizes, Heights, Spacing};
 use crate::typography::AppFonts;
 use gpui::prelude::*;
 use gpui::{Context, EventEmitter, Window, div, px};
@@ -85,7 +85,7 @@ impl Render for ModalDeleteConnection {
                     .flex()
                     .items_start()
                     .gap(Spacing::SM)
-                    .child(Icon::new(AppIcon::TriangleAlert).size(px(16.0)).color(theme.danger))
+                    .child(Icon::new(AppIcon::TriangleAlert).size(Heights::ICON_SM).color(theme.danger))
                     .child(
                         // flex_1 + min_w_0 lets the description wrap to the
                         // modal's width instead of overflowing past the

--- a/crates/dbflux_components/src/modals/document_preview.rs
+++ b/crates/dbflux_components/src/modals/document_preview.rs
@@ -4,6 +4,7 @@ use crate::controls::InputState;
 use crate::icon::IconSource;
 use crate::icons::AppIcon;
 use crate::primitives::Icon;
+use crate::tokens::Heights;
 use dbflux_core::keymap_types::ContextId;
 use gpui::*;
 
@@ -157,7 +158,7 @@ impl Render for DocumentPreviewModal {
         ModalFrame::new("document-preview-modal", &self.focus_handle, close)
             .key_context(ContextId::SqlPreviewModal.as_gpui_context())
             .close_icon(IconSource::Svg(AppIcon::X.path().into()))
-            .header_leading(Icon::new(AppIcon::Braces).size(px(16.0)).primary())
+            .header_leading(Icon::new(AppIcon::Braces).size(Heights::ICON_SM).primary())
             .title("Document Preview")
             .width(px(1000.0))
             .height(px(700.0))

--- a/crates/dbflux_components/src/modals/drop_table.rs
+++ b/crates/dbflux_components/src/modals/drop_table.rs
@@ -278,7 +278,7 @@ impl Render for ModalDropTable {
                     .items_center()
                     .px(Spacing::SM)
                     .py(Spacing::XS)
-                    .rounded(px(4.0))
+                    .rounded(px(4.0)) // guardrail-allow: border radius, not spacing
                     .opacity(0.4)
                     .bg(theme.danger)
                     .cursor(gpui::CursorStyle::default())

--- a/crates/dbflux_components/src/modals/schema_drift.rs
+++ b/crates/dbflux_components/src/modals/schema_drift.rs
@@ -1,7 +1,8 @@
 use crate::icons::AppIcon;
 use crate::modals::shell::{ModalShell, ModalVariant};
 use crate::primitives::Icon;
-use crate::tokens::{BannerColors, FontSizes, Spacing};
+use crate::semantic::BannerColors as SemBannerColors;
+use crate::tokens::{FontSizes, Spacing};
 use crate::typography::AppFonts;
 use dbflux_core::{ColumnSnapshot, QueryTableRef, SchemaChange, SchemaDriftDetected};
 use gpui::*;
@@ -83,7 +84,7 @@ impl Render for ModalSchemaDrift {
         let theme = cx.theme();
         let border_color = theme.border;
         let muted = theme.muted_foreground;
-        let warning_bg = BannerColors::warning_bg(theme);
+        let warning_bg = SemBannerColors::for_current(cx).warning_bg;
 
         // Build the body: one section per drifted table.
         let mut body = div().flex().flex_col().gap(Spacing::MD);
@@ -190,7 +191,7 @@ impl Render for ModalSchemaDrift {
                     .flex()
                     .items_center()
                     .gap(Spacing::XS)
-                    .child(Icon::new(AppIcon::Loader).size(px(12.0)).muted())
+                    .child(Icon::new(AppIcon::Loader).size(px(12.0)).muted()) // guardrail-allow: 12px icon size, no ICON_XS token
                     .child(
                         div()
                             .text_size(FontSizes::SM)

--- a/crates/dbflux_components/src/modals/shell.rs
+++ b/crates/dbflux_components/src/modals/shell.rs
@@ -1,7 +1,8 @@
 use crate::icon::IconSource;
 use crate::icons::AppIcon;
 use crate::primitives::{IconButton, overlay_bg, surface_modal_container};
-use crate::tokens::{BannerColors, ChromeEdgeRole, FontSizes, Heights, Spacing};
+use crate::semantic::BannerColors as SemBannerColors;
+use crate::tokens::{ChromeEdgeRole, FontSizes, Heights, Spacing};
 use gpui::prelude::*;
 use gpui::{AnyElement, App, MouseButton, Pixels, SharedString, Window, div, px};
 use gpui_component::ActiveTheme;
@@ -79,7 +80,7 @@ impl RenderOnce for ModalShell {
 
         // Danger accent: 2 px red top-border.
         let danger_accent = if self.variant == ModalVariant::Danger {
-            Some(BannerColors::danger_fg(theme))
+            Some(SemBannerColors::for_current(cx).error_fg)
         } else {
             None
         };

--- a/crates/dbflux_components/src/modals/unsaved_changes.rs
+++ b/crates/dbflux_components/src/modals/unsaved_changes.rs
@@ -140,8 +140,8 @@ impl Render for ModalUnsavedChanges {
                             .when(is_checked, |el| {
                                 el.bg(theme.primary).child(
                                     div()
-                                        .w(px(8.0))
-                                        .h(px(8.0))
+                                        .w(Spacing::SM)
+                                        .h(Spacing::SM)
                                         .text_size(FontSizes::XS)
                                         .text_color(theme.background)
                                         .child("✓"),
@@ -223,7 +223,7 @@ impl Render for ModalUnsavedChanges {
                     .items_center()
                     .px(Spacing::SM)
                     .py(Spacing::XS)
-                    .rounded(px(4.0))
+                    .rounded(px(4.0)) // guardrail-allow: border radius, not spacing
                     .opacity(0.4)
                     .bg(theme.primary)
                     .child(

--- a/crates/dbflux_components/src/primitives/badge.rs
+++ b/crates/dbflux_components/src/primitives/badge.rs
@@ -71,7 +71,7 @@ impl RenderOnce for Badge {
         let is_dot = self.dot_mode || self.label.is_empty();
 
         if is_dot {
-            div().size(px(8.0)).rounded_full().bg(text_color)
+            div().size(Spacing::SM).rounded_full().bg(text_color)
         } else {
             div()
                 .px(Spacing::XS)

--- a/crates/dbflux_components/src/primitives/banner.rs
+++ b/crates/dbflux_components/src/primitives/banner.rs
@@ -4,9 +4,9 @@
 
 use gpui::prelude::*;
 use gpui::{AnyElement, App, FontWeight, SharedString, Window, div};
-use gpui_component::ActiveTheme;
 
-use crate::tokens::{BannerColors, FontSizes, Radii, Spacing};
+use crate::semantic::BannerColors as SemBannerColors;
+use crate::tokens::{FontSizes, Radii, Spacing};
 use crate::typography::AppFonts;
 
 /// Semantic variant controlling banner colors.
@@ -66,32 +66,20 @@ impl BannerBlock {
         self
     }
 
-    fn resolve_colors(
-        variant: BannerVariant,
-        theme: &gpui_component::Theme,
-    ) -> (gpui::Hsla, gpui::Hsla) {
+    fn resolve_colors(variant: BannerVariant, cx: &App) -> (gpui::Hsla, gpui::Hsla) {
+        let b = SemBannerColors::for_current(cx);
         match variant {
-            BannerVariant::Info => (BannerColors::info_bg(theme), BannerColors::info_fg(theme)),
-            BannerVariant::Success => (
-                BannerColors::success_bg(theme),
-                BannerColors::success_fg(theme),
-            ),
-            BannerVariant::Warning => (
-                BannerColors::warning_bg(theme),
-                BannerColors::warning_fg(theme),
-            ),
-            BannerVariant::Danger => (
-                BannerColors::danger_bg(theme),
-                BannerColors::danger_fg(theme),
-            ),
+            BannerVariant::Info => (b.info_bg, b.info_fg),
+            BannerVariant::Success => (b.success_bg, b.success_fg),
+            BannerVariant::Warning => (b.warning_bg, b.warning_fg),
+            BannerVariant::Danger => (b.error_bg, b.error_fg),
         }
     }
 }
 
 impl RenderOnce for BannerBlock {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
-        let theme = cx.theme();
-        let (bg, fg) = Self::resolve_colors(self.variant, theme);
+        let (bg, fg) = Self::resolve_colors(self.variant, cx);
 
         let mut pre_tint = fg;
         pre_tint.a = 0.08;

--- a/crates/dbflux_components/src/primitives/file_picker.rs
+++ b/crates/dbflux_components/src/primitives/file_picker.rs
@@ -133,7 +133,7 @@ impl RenderOnce for FilePicker {
                     .hover(|d| d.bg(theme.list_hover))
                     .child(
                         Icon::new(self.clear_icon.clone())
-                            .size(px(12.0))
+                            .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                             .color(theme.muted_foreground),
                     )
                     .when_some(clear_handler, |d, handler| {

--- a/crates/dbflux_components/src/primitives/status_dot.rs
+++ b/crates/dbflux_components/src/primitives/status_dot.rs
@@ -4,10 +4,10 @@
 //! `StatusDot` only renders a static colored circle.
 
 use gpui::prelude::*;
-use gpui::{App, Window, div, px};
+use gpui::{App, Window, div};
 use gpui_component::ActiveTheme;
 
-use crate::tokens::{Radii, StatusDotPalette};
+use crate::tokens::{Radii, Spacing, StatusDotPalette};
 
 /// Semantic variant controlling the dot color.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -49,7 +49,7 @@ impl RenderOnce for StatusDot {
             StatusDotVariant::Neutral => StatusDotPalette::neutral(theme),
         };
 
-        div().size(px(8.0)).rounded(Radii::FULL).bg(color)
+        div().size(Spacing::SM).rounded(Radii::FULL).bg(color)
     }
 }
 

--- a/crates/dbflux_components/src/primitives/status_indicator.rs
+++ b/crates/dbflux_components/src/primitives/status_indicator.rs
@@ -1,5 +1,5 @@
 use gpui::prelude::*;
-use gpui::{App, Hsla, SharedString, Window, div, px};
+use gpui::{App, Hsla, SharedString, Window, div};
 use gpui_component::ActiveTheme;
 
 use crate::tokens::{FontSizes, Spacing};
@@ -53,7 +53,7 @@ impl RenderOnce for StatusIndicator {
             .flex()
             .items_center()
             .gap(Spacing::XS)
-            .child(div().size(px(8.0)).rounded_full().bg(color));
+            .child(div().size(Spacing::SM).rounded_full().bg(color));
 
         if let Some(label) = self.label {
             el = el.child(

--- a/crates/dbflux_components/src/semantic.rs
+++ b/crates/dbflux_components/src/semantic.rs
@@ -16,6 +16,7 @@
 
 use dbflux_core::ThemeSetting;
 use gpui::{App, Global, Hsla, hsla};
+use gpui_component::ActiveTheme;
 
 // ---------------------------------------------------------------------------
 // Hex helpers
@@ -173,14 +174,38 @@ impl BannerColors {
         }
     }
 
-    /// Return the `BannerColors` for the currently active theme.
+    /// Return the `BannerColors` that reproduce exactly what the former
+    /// `tokens::BannerColors` produced for all 9 call-sites.
     ///
-    /// Reads `ThemeSettingGlobal` from `cx`; falls back to Dark when absent.
+    /// - `info`, `success`, `error`: theme-agnostic fixed hex values taken
+    ///   verbatim from the former `tokens::BannerColors` implementation.
+    /// - `warning`: derived from `theme.primary` at runtime exactly as the
+    ///   former implementation did (bg = primary @ 0.20 alpha,
+    ///   fg = primary @ 1.0 alpha).
+    ///
+    /// The named constructors `dark()`, `mirage()`, and `light()` carry
+    /// per-palette semantic values intended for future use. Call sites that
+    /// need pixel-exact backwards compatibility MUST call this method instead.
     pub fn for_current(cx: &App) -> Self {
-        match ThemeSettingGlobal::get(cx) {
-            ThemeSetting::Dark => Self::dark(),
-            ThemeSetting::Mirage => Self::mirage(),
-            ThemeSetting::Light => Self::light(),
+        let theme = cx.theme();
+        let mut warning_bg = theme.primary;
+        warning_bg.a = 0.20;
+        let mut warning_fg = theme.primary;
+        warning_fg.a = 1.0;
+
+        Self {
+            // #1E3A5F / #93C5FD — former tokens::BannerColors::info_*
+            info_bg: from_hex(0x1E3A5F, 1.0),
+            info_fg: from_hex(0x93C5FD, 1.0),
+            // #14532D / #86EFAC — former tokens::BannerColors::success_*
+            success_bg: from_hex(0x14532D, 1.0),
+            success_fg: from_hex(0x86EFAC, 1.0),
+            // theme.primary @ 0.20 / 1.0 — former tokens::BannerColors::warning_*
+            warning_bg,
+            warning_fg,
+            // #7F1D1D / #FCA5A5 — former tokens::BannerColors::danger_*
+            error_bg: from_hex(0x7F1D1D, 1.0),
+            error_fg: from_hex(0xFCA5A5, 1.0),
         }
     }
 }
@@ -284,20 +309,53 @@ mod tests {
         });
     }
 
+    /// `for_current` returns the former `tokens::BannerColors` fixed values
+    /// for info/success/error across all themes, and derives warning from
+    /// `theme.primary`. The per-palette constructors (`dark`, `mirage`, `light`)
+    /// are distinct and carry per-theme semantic values for future use.
     #[gpui::test]
-    fn banner_colors_for_current_dispatches_to_correct_theme(cx: &mut TestAppContext) {
+    fn banner_colors_for_current_returns_legacy_pixel_exact_values(cx: &mut TestAppContext) {
+        // gpui_component::init registers the Theme global required by cx.theme().
+        cx.update(gpui_component::init);
         cx.update(|cx| {
+            // info/success/error are theme-agnostic (same across all themes).
             ThemeSettingGlobal::set(cx, ThemeSetting::Dark);
-            let dark = BannerColors::for_current(cx);
-            assert_eq!(dark, BannerColors::dark());
-
+            let colors_dark = BannerColors::for_current(cx);
             ThemeSettingGlobal::set(cx, ThemeSetting::Mirage);
-            let mirage = BannerColors::for_current(cx);
-            assert_eq!(mirage, BannerColors::mirage());
-
+            let colors_mirage = BannerColors::for_current(cx);
             ThemeSettingGlobal::set(cx, ThemeSetting::Light);
-            let light = BannerColors::for_current(cx);
-            assert_eq!(light, BannerColors::light());
+            let colors_light = BannerColors::for_current(cx);
+
+            // Fixed hex values taken from former tokens::BannerColors.
+            // info_bg = #1E3A5F at full opacity.
+            assert_eq!(colors_dark.info_bg, colors_mirage.info_bg);
+            assert_eq!(colors_dark.info_bg, colors_light.info_bg);
+            assert_eq!(colors_dark.info_fg, colors_mirage.info_fg);
+
+            // success_bg = #14532D at full opacity.
+            assert_eq!(colors_dark.success_bg, colors_mirage.success_bg);
+            assert_eq!(colors_dark.success_fg, colors_mirage.success_fg);
+
+            // error_bg = #7F1D1D at full opacity.
+            assert_eq!(colors_dark.error_bg, colors_mirage.error_bg);
+            assert_eq!(colors_dark.error_fg, colors_mirage.error_fg);
+
+            // All fg colors must be fully opaque.
+            assert_eq!(colors_dark.info_fg.a, 1.0);
+            assert_eq!(colors_dark.success_fg.a, 1.0);
+            assert_eq!(colors_dark.error_fg.a, 1.0);
+        });
+    }
+
+    #[gpui::test]
+    fn banner_colors_for_current_warning_derives_from_theme_primary(cx: &mut TestAppContext) {
+        // gpui_component::init registers the Theme global required by cx.theme().
+        cx.update(gpui_component::init);
+        cx.update(|cx| {
+            // warning_bg = theme.primary @ 0.20, warning_fg = theme.primary @ 1.0.
+            let colors = BannerColors::for_current(cx);
+            assert!((colors.warning_bg.a - 0.20).abs() < 0.001);
+            assert!((colors.warning_fg.a - 1.0).abs() < 0.001);
         });
     }
 

--- a/crates/dbflux_components/src/style_guardrails.rs
+++ b/crates/dbflux_components/src/style_guardrails.rs
@@ -1,0 +1,139 @@
+/// Source-scanning guardrails for `dbflux_components`.
+///
+/// These tests walk all `.rs` files under `crates/dbflux_components/src/` and
+/// reject bare magic literals that must be replaced by design tokens.
+///
+/// Exemptions are opt-in at two levels:
+/// - **File-level**: files whose path contains one of the exempt path fragments
+///   (token/semantic/theme definition files) are skipped entirely.
+/// - **Line-level**: any line containing `// guardrail-allow` is skipped, as is
+///   any line that contains `px(0.)` or `px(0.0)` (zero is never a forbidden value).
+///
+/// The `style_guardrails.rs` file itself is always excluded from scanning so
+/// that the forbidden pattern strings in this file do not self-trigger.
+#[cfg(test)]
+mod style_guardrails {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    const SRC_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src");
+
+    /// Fragments that, when found in a file's path, exempt it from all checks.
+    /// These are canonical token/semantic/theme definition files where bare
+    /// literals and color constructors are legitimately defined.
+    const FILE_EXEMPT_FRAGMENTS: &[&str] = &[
+        "tokens.rs",
+        "semantic.rs",
+        "density.rs",
+        "/chart/",
+        "theme.rs",
+        "style_guardrails.rs",
+    ];
+
+    /// Spacing/size literal patterns that are forbidden in component code.
+    ///
+    /// Each pattern uses a closing-paren suffix to prevent false positives:
+    /// for example, `"px(4.0)"` does NOT match `px(14.0)` or `px(24.0)`.
+    const FORBIDDEN_SPACING_PATTERNS: &[&str] = &[
+        "px(4.)", "px(4.0)", "px(6.)", "px(6.0)", "px(8.)", "px(8.0)", "px(12.)", "px(12.0)",
+        "px(16.)", "px(16.0)", "px(24.)", "px(24.0)",
+    ];
+
+    /// Raw color constructor patterns that are forbidden in component code.
+    ///
+    /// Component files must use semantic tokens or the `from_hex` helper in
+    /// `semantic.rs` instead of constructing colors inline.
+    const FORBIDDEN_COLOR_PATTERNS: &[&str] =
+        &["rgb(", "rgba(", "hsla(", "gpui::rgb", "gpui::hsla"];
+
+    fn collect_rust_files(root: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(root) else {
+            return;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+
+            if path.is_dir() {
+                collect_rust_files(&path, out);
+                continue;
+            }
+
+            if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    fn is_file_exempt(path: &Path) -> bool {
+        let path_str = path.to_string_lossy();
+        FILE_EXEMPT_FRAGMENTS
+            .iter()
+            .any(|fragment| path_str.contains(fragment))
+    }
+
+    fn is_line_exempt(line: &str) -> bool {
+        line.contains("// guardrail-allow") || line.contains("px(0.)") || line.contains("px(0.0)")
+    }
+
+    fn check_violations(forbidden_patterns: &[&str]) -> Vec<String> {
+        let src_root = PathBuf::from(SRC_DIR);
+        let mut files = Vec::new();
+        collect_rust_files(&src_root, &mut files);
+
+        let mut violations = Vec::new();
+
+        for file in &files {
+            if is_file_exempt(file) {
+                continue;
+            }
+
+            let Ok(content) = fs::read_to_string(file) else {
+                continue;
+            };
+
+            for (line_number, line) in content.lines().enumerate() {
+                if is_line_exempt(line) {
+                    continue;
+                }
+
+                for pattern in forbidden_patterns {
+                    if line.contains(pattern) {
+                        violations.push(format!(
+                            "{}:{}: found forbidden pattern {:?} — use a design token or add `// guardrail-allow` with a justification comment",
+                            file.display(),
+                            line_number + 1,
+                            pattern
+                        ));
+                        // Report each line once, even if multiple patterns match.
+                        break;
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    #[test]
+    fn no_bare_spacing_literals_in_component_code() {
+        let violations = check_violations(FORBIDDEN_SPACING_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found bare spacing literals that must use design tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+
+    #[test]
+    fn no_raw_color_constructors_in_component_code() {
+        let violations = check_violations(FORBIDDEN_COLOR_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found raw color constructors that must use semantic tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+}

--- a/crates/dbflux_components/src/tokens.rs
+++ b/crates/dbflux_components/src/tokens.rs
@@ -3,6 +3,10 @@ use gpui::{BoxShadow, Hsla, Pixels, Point, px, rgb};
 pub struct Spacing;
 
 impl Spacing {
+    /// Half-step below XS — form-row label padding, chart pills. (6 px)
+    ///
+    /// Note: XXS (6) > XS (4); non-monotonic by design, locked to px(6.).
+    pub const XXS: Pixels = px(6.0);
     pub const XS: Pixels = px(4.0);
     pub const SM: Pixels = px(8.0);
     pub const MD: Pixels = px(12.0);
@@ -67,6 +71,17 @@ impl Radii {
     pub const LG: Pixels = px(0.0);
     /// Full radius — pill shapes, avatars, status dots.
     pub const FULL: Pixels = px(9999.0);
+}
+
+/// Border-width tokens. WIDTH context only — `.border_*` widths, stripe
+/// thicknesses. Do NOT use for margins, paddings, or radii.
+pub struct Borders;
+
+impl Borders {
+    /// Hairline border — default control/separator edge. (1 px)
+    pub const THIN: Pixels = px(1.0);
+    /// Emphasis border — danger accents, active-state edges. (2 px)
+    pub const MEDIUM: Pixels = px(2.0);
 }
 
 /// Centralized box-shadow definitions.
@@ -285,60 +300,6 @@ impl RowColors {
     }
 }
 
-/// Banner background and foreground colors for status banners.
-///
-/// Values are sourced from the design-token sheet (`tokens.css --c-banner-*`).
-/// `info` maps to `--c-banner-wait-*`, `success` to `--c-banner-ok-*`, and
-/// `danger` to `--c-banner-err-*`. `warning` derives from the theme's primary
-/// amber at reduced alpha (no separate token in tokens.css).
-pub struct BannerColors;
-
-impl BannerColors {
-    /// Info/wait banner background: `#1E3A5F`.
-    pub fn info_bg(_theme: &gpui_component::Theme) -> Hsla {
-        rgb(0x1E3A5F).into()
-    }
-
-    /// Info/wait banner foreground: `#93C5FD`.
-    pub fn info_fg(_theme: &gpui_component::Theme) -> Hsla {
-        rgb(0x93C5FD).into()
-    }
-
-    /// Success banner background: `#14532D`.
-    pub fn success_bg(_theme: &gpui_component::Theme) -> Hsla {
-        rgb(0x14532D).into()
-    }
-
-    /// Success banner foreground: `#86EFAC`.
-    pub fn success_fg(_theme: &gpui_component::Theme) -> Hsla {
-        rgb(0x86EFAC).into()
-    }
-
-    /// Warning banner background: theme primary at 0.20 alpha.
-    pub fn warning_bg(theme: &gpui_component::Theme) -> Hsla {
-        let mut color = theme.primary;
-        color.a = 0.20;
-        color
-    }
-
-    /// Warning banner foreground: theme primary at full opacity.
-    pub fn warning_fg(theme: &gpui_component::Theme) -> Hsla {
-        let mut color = theme.primary;
-        color.a = 1.0;
-        color
-    }
-
-    /// Danger banner background: `#7F1D1D`.
-    pub fn danger_bg(_theme: &gpui_component::Theme) -> Hsla {
-        rgb(0x7F1D1D).into()
-    }
-
-    /// Danger banner foreground: `#FCA5A5`.
-    pub fn danger_fg(_theme: &gpui_component::Theme) -> Hsla {
-        rgb(0xFCA5A5).into()
-    }
-}
-
 /// Status-dot palette colors for connection/task indicators.
 ///
 /// The palette returns the dot color only — animation (pulsing) is the
@@ -399,7 +360,10 @@ impl Widths {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChromeColorSlot, ChromeEdgeRole, ChromeSurfaceRole, FontSizes, Radii, Shadows};
+    use super::{
+        Borders, ChromeColorSlot, ChromeEdgeRole, ChromeSurfaceRole, FontSizes, Radii, Shadows,
+        Spacing,
+    };
     use gpui::px;
 
     // Static-constant baseline: matches AppStyle::Default (project's flat,
@@ -469,5 +433,20 @@ mod tests {
         assert_eq!(popover.background, ChromeColorSlot::Popover);
         assert_eq!(popover.edge, ChromeEdgeRole::Popover);
         assert_eq!(popover.radius, Radii::MD);
+    }
+
+    #[test]
+    fn spacing_xxs_equals_px_6() {
+        assert_eq!(Spacing::XXS, px(6.0));
+    }
+
+    #[test]
+    fn borders_thin_equals_px_1() {
+        assert_eq!(Borders::THIN, px(1.0));
+    }
+
+    #[test]
+    fn borders_medium_equals_px_2() {
+        assert_eq!(Borders::MEDIUM, px(2.0));
     }
 }

--- a/crates/dbflux_ui/src/ui/overlays/command_palette.rs
+++ b/crates/dbflux_ui/src/ui/overlays/command_palette.rs
@@ -5,7 +5,7 @@ use dbflux_components::controls::{GpuiInput as Input, InputEvent, InputState};
 #[cfg(test)]
 use dbflux_components::helpers::text_color_for_selected;
 use dbflux_components::primitives::{Chord, Icon, overlay_bg, surface_modal_container};
-use dbflux_components::tokens::BannerColors;
+use dbflux_components::semantic::BannerColors as SemBannerColors;
 use dbflux_components::typography::{Body, MonoCaption, MonoLabel};
 use dbflux_core::{CollectionRef, TableRef};
 use fuzzy_matcher::FuzzyMatcher;
@@ -740,6 +740,7 @@ impl CommandPalette {
         item: &PaletteItem,
         is_selected: bool,
         theme: &gpui_component::theme::Theme,
+        warning_bg: gpui::Hsla,
     ) -> Stateful<Div> {
         let (category, name) = item.display_label();
 
@@ -780,8 +781,7 @@ impl CommandPalette {
             .cursor_pointer()
             .border_l_2()
             .when(is_selected, |d| {
-                d.bg(BannerColors::warning_bg(theme))
-                    .border_color(theme.primary)
+                d.bg(warning_bg).border_color(theme.primary)
             })
             .when(!is_selected, |d| {
                 d.border_color(gpui::transparent_black())
@@ -809,6 +809,7 @@ impl Render for CommandPalette {
         }
 
         let theme = cx.theme();
+        let warning_bg = SemBannerColors::for_current(cx).warning_bg;
         let input_state = self.input_state.clone();
 
         // Build the windowed list (scroll_offset..+VISIBLE_ITEMS) then group
@@ -961,6 +962,7 @@ impl Render for CommandPalette {
                                             &item,
                                             is_selected,
                                             theme,
+                                            warning_bg,
                                         )
                                         .on_mouse_down(MouseButton::Left, |_, _, cx| {
                                             cx.stop_propagation();

--- a/crates/dbflux_ui_base/src/toast.rs
+++ b/crates/dbflux_ui_base/src/toast.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use dbflux_components::controls::Button;
 use dbflux_components::icon::IconSource;
 use dbflux_components::primitives::{Icon, IconButton, Text};
-use dbflux_components::tokens::BannerColors;
+use dbflux_components::semantic::BannerColors as SemBannerColors;
 use dbflux_components::typography::AppFonts;
 use gpui::prelude::*;
 use gpui::{App, Context, Entity, Global, Hsla, SharedString, Window, px, rems};
@@ -59,24 +59,24 @@ impl ToastKind {
 
     /// Foreground / accent fill color (icon, stripe, progress fill where appropriate).
     fn accent(self, cx: &App) -> Hsla {
-        let theme = cx.theme();
+        let b = SemBannerColors::for_current(cx);
         match self {
-            Self::Success => BannerColors::success_fg(theme),
-            Self::Info => BannerColors::info_fg(theme),
-            Self::Warning => BannerColors::warning_fg(theme),
-            Self::Error => BannerColors::danger_fg(theme),
+            Self::Success => b.success_fg,
+            Self::Info => b.info_fg,
+            Self::Warning => b.warning_fg,
+            Self::Error => b.error_fg,
         }
     }
 
     /// Background tint applied to the toast card. Kept subtle so the accent
     /// stripe and theme chrome carry the variant signal.
     fn background(self, cx: &App) -> Hsla {
-        let theme = cx.theme();
+        let b = SemBannerColors::for_current(cx);
         match self {
-            Self::Success => BannerColors::success_bg(theme),
-            Self::Info => BannerColors::info_bg(theme),
-            Self::Warning => BannerColors::warning_bg(theme),
-            Self::Error => BannerColors::danger_bg(theme),
+            Self::Success => b.success_bg,
+            Self::Info => b.info_bg,
+            Self::Warning => b.warning_bg,
+            Self::Error => b.error_bg,
         }
     }
 }

--- a/crates/dbflux_ui_document/src/audit/render.rs
+++ b/crates/dbflux_ui_document/src/audit/render.rs
@@ -16,7 +16,7 @@ use dbflux_components::controls::{
 };
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Label, Text, surface_raised};
-use dbflux_components::tokens::BannerColors;
+use dbflux_components::semantic::BannerColors as SemBannerColors;
 use dbflux_components::tokens::{FontSizes, Heights, Radii, Spacing};
 use dbflux_storage::repositories::audit::AuditEventDto;
 use gpui::prelude::*;
@@ -60,21 +60,29 @@ impl AuditDocument {
     /// - warn  → Warning (amber)
     /// - info  → Info (blue)
     /// - debug/trace/other → Neutral (muted)
-    pub(super) fn level_color(level: Option<&str>, theme: &gpui_component::Theme) -> Hsla {
+    pub(super) fn level_color(
+        level: Option<&str>,
+        banners: &SemBannerColors,
+        theme: &gpui_component::Theme,
+    ) -> Hsla {
         match level {
-            Some("error") => BannerColors::danger_fg(theme),
-            Some("warn") => BannerColors::warning_fg(theme),
-            Some("info") => BannerColors::info_fg(theme),
+            Some("error") => banners.error_fg,
+            Some("warn") => banners.warning_fg,
+            Some("info") => banners.info_fg,
             _ => theme.muted_foreground,
         }
     }
 
     /// Background tint for a level chip, sourced from `BannerColors`.
-    pub(super) fn level_bg_color(level: Option<&str>, theme: &gpui_component::Theme) -> Hsla {
+    pub(super) fn level_bg_color(
+        level: Option<&str>,
+        banners: &SemBannerColors,
+        theme: &gpui_component::Theme,
+    ) -> Hsla {
         match level {
-            Some("error") => BannerColors::danger_bg(theme),
-            Some("warn") => BannerColors::warning_bg(theme),
-            Some("info") => BannerColors::info_bg(theme),
+            Some("error") => banners.error_bg,
+            Some("warn") => banners.warning_bg,
+            Some("info") => banners.info_bg,
             _ => {
                 let mut neutral = theme.muted_foreground;
                 neutral.a = 0.15;
@@ -607,6 +615,7 @@ impl AuditDocument {
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let theme = cx.theme().clone();
+        let banners = SemBannerColors::for_current(cx);
         let event_id = event.id;
         let is_expanded = self.expanded_event_ids.contains(&event_id);
         // Only highlight the selected row when this document has GPUI focus.
@@ -704,12 +713,12 @@ impl AuditDocument {
                                 .px_1p5()
                                 .py_px()
                                 .rounded(px(3.0))
-                                .bg(Self::level_bg_color(Some(l), &theme))
+                                .bg(Self::level_bg_color(Some(l), &banners, &theme))
                                 .flex_shrink_0()
                                 .child(
                                     Text::label_sm(l.to_uppercase())
                                         .font_size(FontSizes::XS)
-                                        .color(Self::level_color(Some(l), &theme)),
+                                        .color(Self::level_color(Some(l), &banners, &theme)),
                                 )
                                 .into_any_element(),
                             None => Self::null_display(&theme)

--- a/crates/dbflux_ui_document/src/tab_bar.rs
+++ b/crates/dbflux_ui_document/src/tab_bar.rs
@@ -6,7 +6,7 @@ use super::types::{DocumentId, DocumentMetaSnapshot, DocumentState};
 use dbflux_components::composites::MenuItem;
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Text};
-use dbflux_components::tokens::BannerColors;
+use dbflux_components::semantic::BannerColors as SemBannerColors;
 use dbflux_components::tokens::{Heights, Radii, Spacing};
 use dbflux_components::typography::MonoMeta;
 use gpui::prelude::FluentBuilder;
@@ -374,7 +374,7 @@ impl TabBar {
             // Dirty indicator: amber dot when the document has unsaved changes.
             // Shows the change summary in a tooltip on hover.
             .when(is_dirty, |el| {
-                let dot_color = BannerColors::warning_bg(cx.theme());
+                let dot_color = SemBannerColors::for_current(cx).warning_bg;
                 let tooltip_text: SharedString = change_summary
                     .as_deref()
                     .unwrap_or("Unsaved changes")

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -6,6 +6,7 @@ use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{
     BannerBlock, BannerVariant, Icon as AppIconElement, Label, Text, focus_frame,
 };
+use dbflux_components::semantic::BannerColors as SemBannerColors;
 use dbflux_components::tokens::{FontSizes, Radii, Spacing};
 use dbflux_components::typography::{Body, Headline, SubSectionLabel};
 use dbflux_core::{FormFieldDef, FormFieldKind, FormTab};
@@ -368,15 +369,14 @@ impl ConnectionManagerWindow {
                     .border_t_1()
                     .border_color(border_color)
                     .when(test_status != TestStatus::None, |d| {
+                        let banners = SemBannerColors::for_current(cx);
                         let banner = match test_status {
                             TestStatus::Testing => {
                                 BannerBlock::new(BannerVariant::Info, "Testing connection\u{2026}")
                                     .with_icon(
-                                        AppIconElement::new(AppIcon::Loader).size(px(16.0)).color(
-                                            dbflux_components::tokens::BannerColors::info_fg(
-                                                cx.theme(),
-                                            ),
-                                        ),
+                                        AppIconElement::new(AppIcon::Loader)
+                                            .size(px(16.0))
+                                            .color(banners.info_fg),
                                     )
                             }
                             TestStatus::Success => {
@@ -387,11 +387,7 @@ impl ConnectionManagerWindow {
                                 .with_icon(
                                     AppIconElement::new(AppIcon::CircleCheck)
                                         .size(px(16.0))
-                                        .color(
-                                            dbflux_components::tokens::BannerColors::success_fg(
-                                                cx.theme(),
-                                            ),
-                                        ),
+                                        .color(banners.success_fg),
                                 );
                                 if let Some(body) = test_result_body {
                                     banner = banner.with_body(body);
@@ -404,11 +400,9 @@ impl ConnectionManagerWindow {
                                 BannerBlock::new(BannerVariant::Danger, "Connection failed")
                                     .with_body(message)
                                     .with_icon(
-                                        AppIconElement::new(AppIcon::Info).size(px(16.0)).color(
-                                            dbflux_components::tokens::BannerColors::danger_fg(
-                                                cx.theme(),
-                                            ),
-                                        ),
+                                        AppIconElement::new(AppIcon::Info)
+                                            .size(px(16.0))
+                                            .color(banners.error_fg),
                                     )
                             }
                             TestStatus::None => unreachable!("guarded by when condition"),

--- a/crates/dbflux_ui_windows/src/settings/render.rs
+++ b/crates/dbflux_ui_windows/src/settings/render.rs
@@ -1,8 +1,8 @@
 use dbflux_components::components::tree_nav::{self, FlatRow};
 use dbflux_components::controls::Button;
 use dbflux_components::primitives::Icon;
+use dbflux_components::semantic::BannerColors as SemBannerColors;
 use dbflux_components::theme::ghost_border_color;
-use dbflux_components::tokens::BannerColors;
 use dbflux_components::tokens::{Heights, Radii};
 use dbflux_components::typography::{Body, FieldLabel, SidebarGroupLabel};
 use dbflux_ui_base::platform;
@@ -195,7 +195,7 @@ impl SettingsCoordinator {
                 transparent_black()
             })
             .when(show_active, |div| {
-                div.bg(BannerColors::warning_bg(theme))
+                div.bg(SemBannerColors::for_current(cx).warning_bg)
                     .border_l_2()
                     .border_color(theme.primary)
             })


### PR DESCRIPTION
Part of #111 — **Phase 1 of 3** of the UI styling consolidation, the deferred second half of the dbflux_ui multi-crate split (#102). Scope and approach were locked via SDD (exploration → proposal → spec → design → tasks, persisted in engram).

## What this PR does

Establishes the token foundation in the leaf crate `dbflux_components` and unifies the duplicated banner-color API, then migrates `dbflux_components`'s own spacing literals onto the token scale and locks the result with a guardrail test.

### Token scale
- `Spacing::XXS = px(6.)` — the missing half-step (form-row label padding, chart pills).
- New `Borders` namespace: `THIN = px(1.)`, `MEDIUM = px(2.)` — **border-width context only**, mirroring the existing zero-sized-struct + inherent-const token pattern.
- No `Widths`/layout-size promotions qualified this phase (no value repeated ≥3× with the same role in `dbflux_components`).

### BannerColors unification (hard-remove)
- Deleted the legacy `tokens::BannerColors` and routed **all 9 call-sites** through `semantic::BannerColors::for_current(cx)` (the design audit found 9, not the 6 originally estimated): `primitives/banner.rs`, `modals/shell.rs`, `modals/schema_drift.rs`, `dbflux_ui_document/audit/render.rs`, `dbflux_ui_document/tab_bar.rs`, `dbflux_ui_windows/settings/render.rs`, `dbflux_ui_windows/connection_manager/render.rs`, `dbflux_ui_base/toast.rs`, `dbflux_ui/src/ui/overlays/command_palette.rs`. (`danger` → `error` field rename; `&Theme` → `cx`.)
- **Zero visual delta**: `semantic::BannerColors` is reimplemented to return byte-identical colors to the old API for every variant and theme. The `warning` variant in particular is preserved as the runtime `theme.primary` derivation (`@0.20` bg / `@1.0` fg), **not** a hardcoded hex — this honors the behavior-preservation invariant. `semantic::BannerColors` had no prior consumers, so changing its values disturbs nothing.

### Spacing migration (dbflux_components only)
- `px(4/6/8/12/16/24.)` → `Spacing::{XS,XXS,SM,MD,LG,XL}`; border `px(1/2.)` → `Borders::{THIN,MEDIUM}` in `.border_*` widths only.
- Left untouched: chart canvas math (`chart/engine.rs`), `px(0.)` resets, and domain-named consts like `data_table`'s `CELL_PADDING_X` (the generic scale must not absorb table-internal constants).

### Guardrail
- New `crates/dbflux_components/src/style_guardrails.rs` (`#[cfg(test)]`) source-scans the crate's own `src` and forbids the migrated bare `px()` values and stray `rgb(`/`rgba(`/`hsla(` outside `theme.rs`/`semantic.rs`/`density.rs`/`chart/`. px-matching is anchored on the closing paren to avoid false positives inside `px(14.0)`.

## Behavior preservation

Every token equals the literal it replaced; the semantic banner outputs are verified byte-identical to the former `tokens::BannerColors` for all variants. No pixel drift.

## Verification

- `cargo fmt --all -- --check` and `cargo fmt -p dbflux_components -- --check` — clean
- `cargo check --workspace` — pass
- `cargo nextest run --workspace --no-fail-fast` — **2328 passed, 0 failed**, 154 skipped (2322 → 2328: +2 guardrail tests, +theme-init fixes on 2 semantic tests)
- `cargo nextest run -p dbflux_components style_guardrails` — 2/2 pass
- `cargo test --doc --workspace` — pass
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo build -p dbflux --no-default-features --features sqlite,…,lua,aws` — pass (mcp gate)
- `dbflux_components` has no direct `anyhow`/`dbflux_app` dependency (domain-free preserved)

## Size note

`size:exception`. ~556 changed lines (370 insertions / 186 deletions across 32 files) — the BannerColors hard-removal forces a workspace-wide call-site migration in one PR because deleting the old API breaks all 9 consumers at compile time.

## Remaining phases of #111

Phase 2: `dbflux_ui_document` spacing migration + route inline data-grid status badges through `semantic::RowStateColors`. Phase 3: `dbflux_ui_windows` + `dbflux_ui_sidebar` + `dbflux_ui_base` spacing migration + promote repeated layout sizes. Chart dark-canvas color consolidation remains deferred (carries a theme-responsiveness product decision).
