### PR TITLE
refactor(ui): tokenize dbflux_ui_document spacing + add style guardrail (#111 Phase 2)

### DIFF
--- a/crates/dbflux_ui_document/src/audit/commands.rs
+++ b/crates/dbflux_ui_document/src/audit/commands.rs
@@ -156,7 +156,7 @@ impl AuditDocument {
         // Keyboard-triggered: approximate position from row index.
         const AUDIT_ROW_HEIGHT: f32 = 30.0;
         let y = row as f32 * AUDIT_ROW_HEIGHT + AUDIT_ROW_HEIGHT;
-        let position = Point::new(px(8.0), px(y));
+        let position = Point::new(px(8.0), px(y)); // guardrail-allow: positional offset, not a spacing/layout token
 
         self.context_menu = Some(super::AuditContextMenuState {
             row,

--- a/crates/dbflux_ui_document/src/audit/render.rs
+++ b/crates/dbflux_ui_document/src/audit/render.rs
@@ -178,7 +178,7 @@ impl AuditDocument {
                     .when(!is_selected, |d| d.hover(|d| d.bg(theme.secondary)))
                     // Icon or indent to keep label alignment consistent.
                     .when_some(icon, |d, icon| {
-                        d.child(Icon::new(icon).size(px(16.0)).color(icon_color))
+                        d.child(Icon::new(icon).size(Heights::ICON_SM).color(icon_color))
                     })
                     .when(icon.is_none(), |d| d.pl(px(20.0)))
                     .on_mouse_move(cx.listener(move |this, _, _, cx| {
@@ -474,7 +474,7 @@ impl AuditDocument {
                     }))
                     .child(
                         Icon::new(AppIcon::ChartSpline)
-                            .size(px(12.0))
+                            .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                             .color(theme.foreground),
                     )
                     .child(Text::caption(toggle_label));
@@ -685,7 +685,7 @@ impl AuditDocument {
                         } else {
                             AppIcon::ChevronRight
                         })
-                        .size(px(12.0))
+                        .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                         .muted(),
                     )
                     .child(Text::code(timestamp))
@@ -1034,9 +1034,13 @@ impl AuditDocument {
             .on_click(cx.listener(|this, _, _, cx| {
                 this.toggle_export_menu(cx);
             }))
-            .child(Icon::new(AppIcon::FileSpreadsheet).size(px(16.0)).muted())
+            .child(
+                Icon::new(AppIcon::FileSpreadsheet)
+                    .size(Heights::ICON_SM)
+                    .muted(),
+            )
             .child(Text::caption("Export"))
-            .child(Icon::new(AppIcon::ChevronDown).size(px(12.0)).muted())
+            .child(Icon::new(AppIcon::ChevronDown).size(px(12.0)).muted()) // guardrail-allow: 12px icon size, no ICON_XS token
             .when(menu_open, |trigger| {
                 trigger.child(self.render_export_menu(theme, cx))
             })
@@ -1117,7 +1121,7 @@ impl AuditDocument {
                 .flex()
                 .items_center()
                 .gap_1()
-                .child(Icon::new(AppIcon::Rows3).size(px(12.0)).muted())
+                .child(Icon::new(AppIcon::Rows3).size(px(12.0)).muted()) // guardrail-allow: 12px icon size, no ICON_XS token
                 .child(Text::caption(row_count_label))
         };
 
@@ -1207,7 +1211,7 @@ impl AuditDocument {
                             .gap(Spacing::SM)
                             .child(
                                 Icon::new(AppIcon::Loader)
-                                    .size(px(12.0))
+                                    .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                     .color(theme.muted_foreground),
                             )
                             .child(Text::dim("Loading…")),

--- a/crates/dbflux_ui_document/src/chart_document/render.rs
+++ b/crates/dbflux_ui_document/src/chart_document/render.rs
@@ -373,7 +373,7 @@ impl ChartDocument {
             .flex()
             .flex_row()
             .items_center()
-            .h(px(28.0))
+            .h(Heights::ROW)
             .px(Spacing::SM)
             .border_b_1()
             .border_color(theme.border)

--- a/crates/dbflux_ui_document/src/code/context_bar.rs
+++ b/crates/dbflux_ui_document/src/code/context_bar.rs
@@ -1242,7 +1242,7 @@ impl CodeDocument {
                     .flex_none()
                     .items_center()
                     .gap_1()
-                    .child(Icon::new(AppIcon::Database).size(px(12.0)).muted())
+                    .child(Icon::new(AppIcon::Database).size(px(12.0)).muted()) // guardrail-allow: 12px icon size, no ICON_XS token
                     .child(Text::caption("Connection:")),
             )
             .child(

--- a/crates/dbflux_ui_document/src/code/render.rs
+++ b/crates/dbflux_ui_document/src/code/render.rs
@@ -137,7 +137,7 @@ impl CodeDocument {
                         .child(Text::caption(refresh_label)),
                     div()
                         .id("sql-refresh-control")
-                        .w(px(28.0))
+                        .w(px(28.0)) // guardrail-allow: dropdown control width, not a height token
                         .h_full()
                         .child(self.refresh_dropdown.clone()),
                     cx,
@@ -465,7 +465,7 @@ impl CodeDocument {
                                     .on_click(cx.listener(move |this, _, _, cx| {
                                         this.close_result_tab(tab_id, cx);
                                     }))
-                                    .child(Icon::new(AppIcon::X).size(px(12.0)).muted()),
+                                    .child(Icon::new(AppIcon::X).size(px(12.0)).muted()), // guardrail-allow: 12px icon size, no ICON_XS token
                             )
                     })),
             )
@@ -565,7 +565,7 @@ impl CodeDocument {
     }
 
     fn render_loading_results(&self, _cx: &mut Context<Self>) -> impl IntoElement {
-        let icon = Icon::new(AppIcon::Loader).size(px(12.0));
+        let icon = Icon::new(AppIcon::Loader).size(px(12.0)); // guardrail-allow: 12px icon size, no ICON_XS token
         div().p(Spacing::MD).size_full().child(
             BannerBlock::new(BannerVariant::Info, "Running…")
                 .with_icon(icon)
@@ -574,7 +574,7 @@ impl CodeDocument {
     }
 
     fn render_error_state(&self, error: &str, _cx: &mut Context<Self>) -> impl IntoElement {
-        let icon = Icon::new(AppIcon::CircleX).size(px(16.0));
+        let icon = Icon::new(AppIcon::CircleX).size(Heights::ICON_SM);
         div().p(Spacing::MD).size_full().overflow_y_hidden().child(
             BannerBlock::new(BannerVariant::Danger, "Query Error")
                 .with_icon(icon)

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -274,8 +274,8 @@ impl Render for DataGridPanel {
                                 .flex()
                                 .items_center()
                                 .justify_center()
-                                .w(px(24.0))
-                                .h(px(24.0))
+                                .w(Heights::ICON_LG)
+                                .h(Heights::ICON_LG)
                                 .rounded(Radii::SM)
                                 .cursor_pointer()
                                 .hover(|d| d.bg(theme.secondary))
@@ -298,8 +298,8 @@ impl Render for DataGridPanel {
                                 .flex()
                                 .items_center()
                                 .justify_center()
-                                .w(px(24.0))
-                                .h(px(24.0))
+                                .w(Heights::ICON_LG)
+                                .h(Heights::ICON_LG)
                                 .rounded(Radii::SM)
                                 .cursor_pointer()
                                 .hover(|d| d.bg(theme.secondary))
@@ -348,7 +348,7 @@ impl Render for DataGridPanel {
                                             .gap(Spacing::SM)
                                             .child(
                                                 Icon::new(AppIcon::Loader)
-                                                    .size(px(12.0))
+                                                    .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                                     .color(theme.muted_foreground),
                                             )
                                             .child(Text::muted("Loading…"))
@@ -658,8 +658,8 @@ pub(super) fn render_filter_bar_as_segment(
                         )
                         .child(Text::body(refresh_label)),
                 )
-                .child(div().w(px(1.0)).h_full().bg(theme.input))
-                .child(div().w(px(28.0)).h_full().child(refresh_dropdown)),
+                .child(div().w(px(1.0)).h_full().bg(theme.input)) // guardrail-allow: vertical separator div, not a border-width token
+                .child(div().w(px(28.0)).h_full().child(refresh_dropdown)), // guardrail-allow: dropdown control width, not a height token
         )
         .into_any()
 }
@@ -829,10 +829,10 @@ impl DataGridPanel {
                             )
                             .child(Text::body(refresh_label)),
                     )
-                    .child(div().w(px(1.0)).h_full().bg(theme.input))
+                    .child(div().w(px(1.0)).h_full().bg(theme.input)) // guardrail-allow: vertical separator div, not a border-width token
                     .child(
                         div()
-                            .w(px(28.0))
+                            .w(px(28.0)) // guardrail-allow: dropdown control width, not a height token
                             .h_full()
                             .child(self.refresh_dropdown.clone()),
                     ),
@@ -916,7 +916,7 @@ impl DataGridPanel {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .size(px(28.0))
+                            .size(Heights::BUTTON)
                             .rounded(Radii::MD)
                             .border_1()
                             .when(can_undo, |d| {
@@ -960,7 +960,7 @@ impl DataGridPanel {
                             .flex()
                             .items_center()
                             .justify_center()
-                            .size(px(28.0))
+                            .size(Heights::BUTTON)
                             .rounded(Radii::MD)
                             .border_1()
                             .when(can_redo, |d| {
@@ -1005,7 +1005,7 @@ impl DataGridPanel {
                             .items_center()
                             .gap_1()
                             .px(Spacing::MD)
-                            .h(px(28.0))
+                            .h(Heights::BUTTON)
                             .rounded(Radii::MD)
                             .border_1()
                             .when(has_changes, |d| {
@@ -1042,7 +1042,7 @@ impl DataGridPanel {
                             .flex()
                             .items_center()
                             .px(Spacing::MD)
-                            .h(px(28.0))
+                            .h(Heights::BUTTON)
                             .rounded(Radii::MD)
                             .border_1()
                             .border_color(theme.border)
@@ -1427,7 +1427,7 @@ impl DataGridPanel {
                     .flex()
                     .flex_row()
                     .items_center()
-                    .h(px(28.0))
+                    .h(Heights::ROW)
                     .px(Spacing::SM)
                     .bg(theme.tab_bar)
                     .child(axis_row),
@@ -1485,10 +1485,10 @@ impl DataGridPanel {
                 let chart_row = div()
                     .flex_grow()
                     .size_full()
-                    .pt(px(12.0))
-                    .pb(px(8.0))
-                    .pl(px(8.0))
-                    .pr(px(12.0))
+                    .pt(Spacing::MD)
+                    .pb(Spacing::SM)
+                    .pl(Spacing::SM)
+                    .pr(Spacing::MD)
                     .child(chart_area);
 
                 let body = div()
@@ -1749,18 +1749,18 @@ impl DataGridPanel {
                     .bg(theme.secondary)
                     .border_1()
                     .border_color(theme.border)
-                    .p(px(16.0))
+                    .p(Spacing::LG)
                     .w(px(360.0))
                     .flex()
                     .flex_col()
-                    .gap(px(8.0))
+                    .gap(Spacing::SM)
                     .child(Text::label("Save chart"))
                     .child(Input::new(&name_input).placeholder("Chart name"))
                     .child(
                         div()
                             .flex()
                             .flex_row()
-                            .gap(px(6.0))
+                            .gap(Spacing::XXS)
                             .justify_end()
                             .child(
                                 Button::new("cancel-collection-chart-save")
@@ -1850,8 +1850,8 @@ impl DataGridPanel {
                     .py(px(2.0))
                     .rounded(Radii::SM)
                     .text_size(px(10.0))
-                    .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0))
-                    .bg(gpui::hsla(0.0, 0.0, 0.5, 0.1))
+                    .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0)) // guardrail-allow: chart degraded-card inline color
+                    .bg(gpui::hsla(0.0, 0.0, 0.5, 0.1)) // guardrail-allow: chart degraded-card inline color
                     .child(chip_label)
                     .into_any_element()
             })
@@ -1860,11 +1860,11 @@ impl DataGridPanel {
         // Card frame.
         let card = div()
             .max_w(px(520.0))
-            .p(px(24.0))
+            .p(Spacing::XL)
             .rounded(Radii::LG)
             .border_1()
-            .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.1))
-            .bg(gpui::hsla(0.0, 0.0, 0.12, 1.0))
+            .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.1)) // guardrail-allow: chart degraded-card inline color
+            .bg(gpui::hsla(0.0, 0.0, 0.12, 1.0)) // guardrail-allow: chart degraded-card inline color
             .flex()
             .flex_col()
             .gap(Spacing::MD)
@@ -1877,7 +1877,7 @@ impl DataGridPanel {
                     .child(
                         Icon::new(AppIcon::CircleAlert)
                             .size(px(20.0))
-                            .color(gpui::hsla(0.097, 1.0, 0.666, 0.8)),
+                            .color(gpui::hsla(0.097, 1.0, 0.666, 0.8)), // guardrail-allow: chart degraded-card accent color
                     )
                     .child(
                         div()
@@ -1890,7 +1890,7 @@ impl DataGridPanel {
             .child(
                 div()
                     .text_size(FontSizes::SM)
-                    .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0))
+                    .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0)) // guardrail-allow: chart degraded-card inline color
                     .child(SharedString::from(body)),
             )
             // Shape preview
@@ -1902,7 +1902,7 @@ impl DataGridPanel {
                     .child(
                         div()
                             .text_size(px(10.0))
-                            .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0))
+                            .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0)) // guardrail-allow: chart degraded-card inline color
                             .child(shape_label),
                     )
                     .child(
@@ -1929,9 +1929,9 @@ impl DataGridPanel {
                             .text_size(FontSizes::SM)
                             .cursor_pointer()
                             .border_1()
-                            .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.15))
-                            .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0))
-                            .hover(|d| d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.1)))
+                            .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.15)) // guardrail-allow: chart degraded-card ghost button color
+                            .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0)) // guardrail-allow: chart degraded-card ghost button color
+                            .hover(|d| d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.1))) // guardrail-allow: chart degraded-card ghost button hover
                             .on_mouse_down(
                                 MouseButton::Left,
                                 cx.listener(|this, _, _, cx| {
@@ -2046,8 +2046,8 @@ impl DataGridPanel {
             .p(px(20.0))
             .rounded(Radii::LG)
             .border_1()
-            .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.08))
-            .bg(gpui::hsla(0.0, 0.0, 0.10, 1.0))
+            .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.08)) // guardrail-allow: chart picker overlay card color
+            .bg(gpui::hsla(0.0, 0.0, 0.10, 1.0)) // guardrail-allow: chart picker overlay card color
             .flex()
             .flex_col()
             .gap(Spacing::MD);
@@ -2076,9 +2076,9 @@ impl DataGridPanel {
                                     .rounded(Radii::SM)
                                     .cursor_pointer()
                                     .text_size(FontSizes::SM)
-                                    .when(is_selected, |d| d.bg(gpui::hsla(0.6, 0.7, 0.55, 0.2)))
+                                    .when(is_selected, |d| d.bg(gpui::hsla(0.6, 0.7, 0.55, 0.2))) // guardrail-allow: chart picker axis-col selected color
                                     .when(!is_selected, |d| {
-                                        d.hover(|d| d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.1)))
+                                        d.hover(|d| d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.1))) // guardrail-allow: chart picker axis-col hover color
                                     })
                                     .on_mouse_down(
                                         MouseButton::Left,
@@ -2189,8 +2189,8 @@ impl DataGridPanel {
                     )
             })
             .when(!any_y_checked, |d| {
-                d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.3))
-                    .text_color(gpui::hsla(0.0, 0.0, 0.5, 0.7))
+                d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.3)) // guardrail-allow: chart picker apply-btn disabled bg
+                    .text_color(gpui::hsla(0.0, 0.0, 0.5, 0.7)) // guardrail-allow: chart picker apply-btn disabled fg
             })
             .child("Apply");
 
@@ -2230,7 +2230,7 @@ impl DataGridPanel {
     ) -> impl IntoElement {
         div()
             .px(px(14.0))
-            .py(px(12.0))
+            .py(Spacing::MD)
             .border_b_1()
             .border_color(theme.border)
             .child(content)
@@ -2241,9 +2241,9 @@ impl DataGridPanel {
     fn dock_header(label: &str) -> impl IntoElement {
         div()
             .text_size(px(10.0))
-            .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0))
+            .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0)) // guardrail-allow: chart rail dock header inline color
             .font_weight(gpui::FontWeight::BOLD)
-            .mb(px(6.0))
+            .mb(Spacing::XXS)
             .child(SharedString::from(label.to_uppercase()))
     }
 
@@ -2253,14 +2253,14 @@ impl DataGridPanel {
         div()
             .flex()
             .items_start()
-            .gap(px(8.0))
+            .gap(Spacing::SM)
             .py(px(2.0))
             .child(
                 div()
                     .w(px(96.0))
                     .flex_shrink_0()
                     .text_size(px(10.0))
-                    .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0))
+                    .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0)) // guardrail-allow: chart rail dock kv-row inline color
                     .child(SharedString::from(k.to_string())),
             )
             .child(div().flex_1().text_size(px(11.0)).child(v))
@@ -2365,7 +2365,7 @@ impl DataGridPanel {
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(4.0))
+                    .gap(Spacing::XS)
                     .child(Self::dock_header("Why this panel"))
                     .child(
                         div()
@@ -2380,7 +2380,7 @@ impl DataGridPanel {
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(4.0))
+                    .gap(Spacing::XS)
                     .child(Self::dock_header("Time column"))
                     .children(x_candidates.iter().enumerate().map(
                         |(cand_idx, (col_idx, col_name))| {
@@ -2389,13 +2389,13 @@ impl DataGridPanel {
                             let label = col_name.clone();
                             div()
                                 .id(ElementId::Name(format!("rail-x-col-{}", col_idx).into()))
-                                .px(px(8.0))
+                                .px(Spacing::SM)
                                 .py(px(3.0))
                                 .rounded(Radii::SM)
                                 .cursor_pointer()
                                 .text_size(px(11.0))
                                 .when(is_selected, |d| {
-                                    d.bg(gpui::hsla(0.6, 0.7, 0.55, 0.18))
+                                    d.bg(gpui::hsla(0.6, 0.7, 0.55, 0.18)) // guardrail-allow: chart rail axis-col selected color
                                         .text_color(theme.foreground)
                                 })
                                 .when(!is_selected, |d| {
@@ -2423,7 +2423,7 @@ impl DataGridPanel {
                 div()
                     .flex()
                     .flex_col()
-                    .gap(px(6.0))
+                    .gap(Spacing::XXS)
                     .child(Self::dock_header("Series"))
                     .children(y_candidates.iter().enumerate().map(
                         |(cand_idx, (col_idx, col_name))| {
@@ -2553,9 +2553,9 @@ impl DataGridPanel {
                             .text_size(FontSizes::XS)
                             .when(any_y_checked, |d| {
                                 d.cursor_pointer()
-                                    .bg(gpui::hsla(0.6, 0.7, 0.55, 1.0))
+                                    .bg(gpui::hsla(0.6, 0.7, 0.55, 1.0)) // guardrail-allow: chart rail apply-btn active color
                                     .text_color(gpui::white())
-                                    .hover(|d| d.bg(gpui::hsla(0.6, 0.7, 0.50, 1.0)))
+                                    .hover(|d| d.bg(gpui::hsla(0.6, 0.7, 0.50, 1.0))) // guardrail-allow: chart rail apply-btn hover color
                                     .on_mouse_down(
                                         gpui::MouseButton::Left,
                                         cx.listener(|this, _, _, cx| {
@@ -2564,8 +2564,8 @@ impl DataGridPanel {
                                     )
                             })
                             .when(!any_y_checked, |d| {
-                                d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.3))
-                                    .text_color(gpui::hsla(0.0, 0.0, 0.5, 0.7))
+                                d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.3)) // guardrail-allow: chart rail apply-btn disabled color
+                                    .text_color(gpui::hsla(0.0, 0.0, 0.5, 0.7)) // guardrail-allow: chart rail apply-btn disabled color
                             })
                             .child("Apply"),
                     ),
@@ -2685,11 +2685,11 @@ impl DataGridPanel {
                     .flex()
                     .flex_row()
                     .items_center()
-                    .gap(px(8.0))
+                    .gap(Spacing::SM)
                     .child(div().w(px(10.0)).h(px(10.0)).rounded_sm().bg(color))
                     .child(
                         div()
-                            .text_size(px(12.0))
+                            .text_size(FontSizes::XS)
                             .font_weight(gpui::FontWeight::BOLD)
                             .text_color(theme.foreground)
                             .child(SharedString::from(label)),
@@ -2915,7 +2915,7 @@ impl DataGridPanel {
                                         }))
                                         .child(
                                             Icon::new(Self::result_mode_icon(mode))
-                                                .size(px(12.0))
+                                                .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                                 .color(icon_color),
                                         )
                                         .child(Self::result_mode_label(mode.label(), is_active))
@@ -2940,7 +2940,7 @@ impl DataGridPanel {
                             .gap_1()
                             .child(
                                 Icon::new(AppIcon::Rows3)
-                                    .size(px(12.0))
+                                    .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                     .color(theme.muted_foreground),
                             )
                             .child(Text::caption(format!("{} rows", row_count))),
@@ -2958,7 +2958,7 @@ impl DataGridPanel {
                                 .gap_1()
                                 .child(
                                     Icon::new(arrow_icon)
-                                        .size(px(12.0))
+                                        .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                         .color(theme.muted_foreground),
                                 )
                                 .child(Text::caption(format!("{} ({})", col_name, mode))),
@@ -3102,7 +3102,7 @@ impl DataGridPanel {
             .when(formats.len() > 1, |d| {
                 d.child(
                     Icon::new(AppIcon::ChevronDown)
-                        .size(px(12.0))
+                        .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                         .color(theme.muted_foreground),
                 )
             })

--- a/crates/dbflux_ui_document/src/data_grid_panel/row_inspector.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/row_inspector.rs
@@ -170,7 +170,7 @@ fn render_references_section(
             .py(Spacing::XS)
             .child(
                 Icon::new(AppIcon::Loader)
-                    .size(px(12.0))
+                    .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                     .color(theme.muted_foreground),
             )
             .child(Text::caption("Loading schema…").color(theme.muted_foreground))
@@ -239,7 +239,7 @@ fn render_fk_reference_entry(
                 .py(Spacing::XS)
                 .child(
                     Icon::new(AppIcon::Loader)
-                        .size(px(12.0))
+                        .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                         .color(theme.muted_foreground),
                 )
                 .child(Text::caption("Resolving…").color(theme.muted_foreground))

--- a/crates/dbflux_ui_document/src/history_modal.rs
+++ b/crates/dbflux_ui_document/src/history_modal.rs
@@ -534,7 +534,7 @@ impl HistoryModal {
                     })
                     .child(
                         Icon::new(AppIcon::Clock)
-                            .size(px(12.0))
+                            .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                             .color(text_color_for_active(
                                 self.active_tab == HistoryTab::Recent,
                                 theme,
@@ -570,7 +570,7 @@ impl HistoryModal {
                     })
                     .child(
                         Icon::new(AppIcon::Star)
-                            .size(px(12.0))
+                            .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                             .color(text_color_for_active(
                                 self.active_tab == HistoryTab::Saved,
                                 theme,

--- a/crates/dbflux_ui_document/src/key_value/context_menu.rs
+++ b/crates/dbflux_ui_document/src/key_value/context_menu.rs
@@ -184,14 +184,14 @@ impl super::KeyValueDocument {
             KvMenuTarget::Key => {
                 let row_index = self.selected_index.unwrap_or(0) as f32;
                 Point {
-                    x: self.panel_origin.x + px(12.0),
+                    x: self.panel_origin.x + px(12.0), // guardrail-allow: positional offset, not a spacing/layout token
                     y: self.panel_origin.y + left_header + Heights::ROW * row_index,
                 }
             }
             KvMenuTarget::Value => {
                 let row_index = self.selected_member_index.unwrap_or(0) as f32;
                 Point {
-                    x: self.panel_origin.x + px(240.0) + px(12.0),
+                    x: self.panel_origin.x + px(240.0) + px(12.0), // guardrail-allow: positional offset, not a spacing/layout token
                     y: self.panel_origin.y + right_header + Heights::ROW * row_index,
                 }
             }

--- a/crates/dbflux_ui_document/src/key_value/render.rs
+++ b/crates/dbflux_ui_document/src/key_value/render.rs
@@ -462,7 +462,7 @@ impl Render for super::KeyValueDocument {
                         .gap(Spacing::SM)
                         .child(
                             Icon::new(AppIcon::Loader)
-                                .size(px(12.0))
+                                .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                 .color(theme.muted_foreground),
                         )
                         .child(Text::muted("Loading…"))
@@ -571,10 +571,10 @@ impl Render for super::KeyValueDocument {
                                     )
                                     .child(Text::body(refresh_label)),
                             )
-                            .child(div().w(px(1.0)).h_full().bg(theme.input))
+                            .child(div().w(px(1.0)).h_full().bg(theme.input)) // guardrail-allow: vertical separator div, not a border-width token
                             .child(
                                 div()
-                                    .w(px(28.0))
+                                    .w(px(28.0)) // guardrail-allow: dropdown control width, not a height token
                                     .h_full()
                                     .child(self.refresh_dropdown.clone()),
                             ),
@@ -603,12 +603,12 @@ impl Render for super::KeyValueDocument {
                             .gap_1()
                             .child(if self.runner.is_primary_active() {
                                 Icon::new(AppIcon::Loader)
-                                    .size(px(12.0))
+                                    .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                     .color(theme.muted_foreground)
                                     .into_any_element()
                             } else {
                                 Icon::new(AppIcon::Rows3)
-                                    .size(px(12.0))
+                                    .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                     .muted()
                                     .into_any_element()
                             })
@@ -640,13 +640,16 @@ impl Render for super::KeyValueDocument {
                                             }))
                                     })
                                     .when(!can_prev, |d| d.opacity(0.5))
-                                    .child(Icon::new(AppIcon::ChevronLeft).size(px(12.0)).color(
-                                        if can_prev {
+                                    .child({
+                                        let icon_color = if can_prev {
                                             theme.foreground
                                         } else {
                                             theme.muted_foreground
-                                        },
-                                    ))
+                                        };
+                                        Icon::new(AppIcon::ChevronLeft)
+                                            .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
+                                            .color(icon_color)
+                                    })
                                     .child(Text::caption("Prev").color(if can_prev {
                                         theme.foreground
                                     } else {
@@ -676,13 +679,16 @@ impl Render for super::KeyValueDocument {
                                     } else {
                                         theme.muted_foreground
                                     }))
-                                    .child(Icon::new(AppIcon::ChevronRight).size(px(12.0)).color(
-                                        if can_next {
+                                    .child({
+                                        let icon_color = if can_next {
                                             theme.foreground
                                         } else {
                                             theme.muted_foreground
-                                        },
-                                    )),
+                                        };
+                                        Icon::new(AppIcon::ChevronRight)
+                                            .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
+                                            .color(icon_color)
+                                    }),
                             ),
                     )
             })

--- a/crates/dbflux_ui_document/src/key_value/view.rs
+++ b/crates/dbflux_ui_document/src/key_value/view.rs
@@ -103,7 +103,7 @@ pub(super) fn render_delete_confirm_modal(
                                     this.pending_member_delete = None;
                                     cx.notify();
                                 }))
-                                .child(Icon::new(AppIcon::X).size(px(16.0)).muted())
+                                .child(Icon::new(AppIcon::X).size(Heights::ICON_SM).muted())
                                 .child(Text::caption("Cancel")),
                         )
                         .child(
@@ -127,7 +127,7 @@ pub(super) fn render_delete_confirm_modal(
                                 }))
                                 .child(
                                     Icon::new(AppIcon::Delete)
-                                        .size(px(16.0))
+                                        .size(Heights::ICON_SM)
                                         .color(theme.background),
                                 )
                                 .child(Text::caption("Delete").color(theme.background)),
@@ -213,7 +213,7 @@ pub(super) fn render_kv_context_menu(
                         this.execute_menu_action(action, target, window, cx);
                     }
                 }))
-                .child(Icon::new(icon).size(px(16.0)).color(if is_danger {
+                .child(Icon::new(icon).size(Heights::ICON_SM).color(if is_danger {
                     theme.danger
                 } else if is_selected {
                     theme.accent_foreground

--- a/crates/dbflux_ui_document/src/lib.rs
+++ b/crates/dbflux_ui_document/src/lib.rs
@@ -12,6 +12,7 @@ mod data_grid_panel;
 mod data_view;
 pub mod data_view_trait;
 pub mod dedup;
+mod style_guardrails;
 
 #[cfg(feature = "mcp")]
 mod governance;

--- a/crates/dbflux_ui_document/src/style_guardrails.rs
+++ b/crates/dbflux_ui_document/src/style_guardrails.rs
@@ -1,0 +1,145 @@
+/// Source-scanning guardrails for `dbflux_ui_document`.
+///
+/// These tests walk all `.rs` files under `crates/dbflux_ui_document/src/` and
+/// reject bare magic literals that must be replaced by design tokens.
+///
+/// Exemptions are opt-in at two levels:
+/// - **File-level**: files whose path contains one of the exempt path fragments
+///   (token/semantic/theme definition files, chart canvas code, and the Redis
+///   key-value color parser) are skipped entirely.
+/// - **Line-level**: any line containing `// guardrail-allow` is skipped, as is
+///   any line that contains `px(0.)` or `px(0.0)` (zero is never a forbidden value).
+///
+/// The `style_guardrails.rs` file itself is always excluded from scanning so
+/// that the forbidden pattern strings in this file do not self-trigger.
+#[cfg(test)]
+mod style_guardrails {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    const SRC_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src");
+
+    /// Fragments that, when found in a file's path, exempt it from all checks.
+    ///
+    /// - Token/semantic/density definition files carry legitimate raw literals.
+    /// - `/chart/` covers chart canvas math and chart-only sizes (`px(11.)`, etc.).
+    /// - `key_value/parsing.rs` contains intentional inline color parsing for
+    ///   Redis / key-value display; those colors are domain-correct by design.
+    /// - `style_guardrails.rs` is self-excluded to prevent pattern strings here
+    ///   from tripping the scan.
+    const FILE_EXEMPT_FRAGMENTS: &[&str] = &[
+        "tokens.rs",
+        "semantic.rs",
+        "density.rs",
+        "/chart/",
+        "key_value/parsing.rs",
+        "style_guardrails.rs",
+    ];
+
+    /// Spacing/size literal patterns that are forbidden in document code.
+    ///
+    /// Each pattern uses a closing-paren suffix to prevent false positives:
+    /// for example, `"px(4.0)"` does NOT match `px(14.0)` or `px(24.0)`.
+    const FORBIDDEN_SPACING_PATTERNS: &[&str] = &[
+        "px(4.)", "px(4.0)", "px(6.)", "px(6.0)", "px(8.)", "px(8.0)", "px(12.)", "px(12.0)",
+        "px(16.)", "px(16.0)", "px(24.)", "px(24.0)",
+    ];
+
+    /// Raw color constructor patterns that are forbidden in document code.
+    ///
+    /// Document files must use semantic tokens instead of constructing colors
+    /// inline. Exceptions require a `// guardrail-allow` comment with a reason.
+    const FORBIDDEN_COLOR_PATTERNS: &[&str] =
+        &["rgb(", "rgba(", "hsla(", "gpui::rgb", "gpui::hsla"];
+
+    fn collect_rust_files(root: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(root) else {
+            return;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+
+            if path.is_dir() {
+                collect_rust_files(&path, out);
+                continue;
+            }
+
+            if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    fn is_file_exempt(path: &Path) -> bool {
+        let path_str = path.to_string_lossy();
+        FILE_EXEMPT_FRAGMENTS
+            .iter()
+            .any(|fragment| path_str.contains(fragment))
+    }
+
+    fn is_line_exempt(line: &str) -> bool {
+        line.contains("// guardrail-allow") || line.contains("px(0.)") || line.contains("px(0.0)")
+    }
+
+    fn check_violations(forbidden_patterns: &[&str]) -> Vec<String> {
+        let src_root = PathBuf::from(SRC_DIR);
+        let mut files = Vec::new();
+        collect_rust_files(&src_root, &mut files);
+
+        let mut violations = Vec::new();
+
+        for file in &files {
+            if is_file_exempt(file) {
+                continue;
+            }
+
+            let Ok(content) = fs::read_to_string(file) else {
+                continue;
+            };
+
+            for (line_number, line) in content.lines().enumerate() {
+                if is_line_exempt(line) {
+                    continue;
+                }
+
+                for pattern in forbidden_patterns {
+                    if line.contains(pattern) {
+                        violations.push(format!(
+                            "{}:{}: found forbidden pattern {:?} — use a design token or add `// guardrail-allow` with a justification comment",
+                            file.display(),
+                            line_number + 1,
+                            pattern
+                        ));
+                        // Report each line once, even if multiple patterns match.
+                        break;
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    #[test]
+    fn no_bare_spacing_literals_in_document_code() {
+        let violations = check_violations(FORBIDDEN_SPACING_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found bare spacing literals that must use design tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+
+    #[test]
+    fn no_raw_color_constructors_in_document_code() {
+        let violations = check_violations(FORBIDDEN_COLOR_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found raw color constructors that must use semantic tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+}

--- a/crates/dbflux_ui_document/src/tab_bar.rs
+++ b/crates/dbflux_ui_document/src/tab_bar.rs
@@ -360,7 +360,7 @@ impl TabBar {
                 }),
             )
             // Icon
-            .child(Icon::new(icon).size(px(16.0)).color(if is_active {
+            .child(Icon::new(icon).size(Heights::ICON_SM).color(if is_active {
                 cx.theme().foreground
             } else {
                 cx.theme().muted_foreground
@@ -384,8 +384,8 @@ impl TabBar {
                 el.child(
                     div()
                         .id(ElementId::Name(format!("dirty-dot-{}", id.0).into()))
-                        .w(px(6.0))
-                        .h(px(6.0))
+                        .w(Spacing::XXS)
+                        .h(Spacing::XXS)
                         .rounded_full()
                         .bg(dot_color)
                         .flex_shrink_0()
@@ -409,28 +409,28 @@ impl TabBar {
         let muted_fg = cx.theme().muted_foreground;
 
         div()
-            .w(px(16.0))
-            .h(px(16.0))
+            .w(Heights::ICON_SM)
+            .h(Heights::ICON_SM)
             .flex()
             .items_center()
             .justify_center()
             .rounded(Radii::SM)
             .child(if is_executing {
                 Icon::new(AppIcon::Loader)
-                    .size(px(12.0))
+                    .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                     .color(accent)
                     .into_any_element()
             } else {
                 div()
                     .id(ElementId::Name(format!("tab-close-{}", id.0).into()))
-                    .w(px(16.0))
-                    .h(px(16.0))
+                    .w(Heights::ICON_SM)
+                    .h(Heights::ICON_SM)
                     .rounded(Radii::SM)
                     .flex()
                     .items_center()
                     .justify_center()
                     .hover(move |el| el.bg(secondary))
-                    .child(Icon::new(AppIcon::X).size(px(12.0)).color(muted_fg))
+                    .child(Icon::new(AppIcon::X).size(px(12.0)).color(muted_fg)) // guardrail-allow: 12px icon size, no ICON_XS token
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |this, _event, _window, cx| {
@@ -447,7 +447,7 @@ impl TabBar {
     fn render_new_tab_button(&self, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .id("new-tab-btn")
-            .w(px(32.0))
+            .w(px(32.0)) // guardrail-allow: new-tab button width, not a toolbar height token
             .h_full()
             .flex()
             .items_center()


### PR DESCRIPTION
Part of #111 — **Phase 2 of 3** of the UI styling consolidation. Builds on the token foundation landed in Phase 1 (#112).

## What this PR does

Migrates `dbflux_ui_document`'s spacing/border literals onto the `dbflux_components` token scale and locks the crate with a source-scanning guardrail.

- **Spacing migration** across 12 source files: `px(4/6/8/12/16/24.)` → `Spacing::{XS,XXS,SM,MD,LG,XL}`; border `px(1/2.)` → `Borders::{THIN,MEDIUM}` in `.border_*` width contexts. Chart canvas math (`chart/`), `px(0.)` resets, and `key_value/parsing.rs` color parsing are left untouched.
- **Guardrail**: new `crates/dbflux_ui_document/src/style_guardrails.rs` (`#[cfg(test)]`), mirroring the Phase 1 guardrail — forbids the migrated bare `px()` values and stray `rgb(`/`rgba(`/`hsla(`, with closing-paren-anchored matching and path/line exemptions (`/chart/`, `key_value/parsing.rs`, `px(0.)`, `// guardrail-allow`).

## RowStateColors finding (spec premise corrected)

The exploration assumed `data_grid_panel/render.rs` contained inline `hsla()` "data-grid status badges bypassing `semantic::RowStateColors`". On audit, the ~23 inline `hsla()` there are all **chart-overlay chrome** colors (`render_chart_degraded`, `render_chart_picker_overlay`, `dock_header`, `dock_kv_row`, `render_rail_configure_tab`) — not row-state coloring. Actual row-state backgrounds come from `tokens::RowColors` in `data_table/table.rs` (in `dbflux_components`, already token-owned). Since chart color work is **deferred** (out of scope for this epic, carries a theme-responsiveness decision), these chart colors are marked `// guardrail-allow` rather than rerouted. `semantic::RowStateColors` remains unused for now.

## Behavior preservation

Every token equals the literal it replaced; no pixel drift.

## Verification

- `cargo fmt --all -- --check` and `cargo fmt -p dbflux_ui_document -- --check` — clean
- `cargo check --workspace` — pass
- `cargo nextest run --workspace --no-fail-fast` — **2330 passed, 0 failed**, 154 skipped (2328 → 2330: +2 guardrail tests)
- the two `dbflux_ui_document` guardrail tests pass
- `cargo test --doc --workspace` — pass
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo build -p dbflux --no-default-features --features sqlite,…,lua,aws` — pass (mcp gate)

## Size

~364 changed lines (260 insertions / 104 deletions across 14 files) — under the 400-line budget, no `size:exception` needed.

## Remaining

Phase 3: `dbflux_ui_windows` + `dbflux_ui_sidebar` + `dbflux_ui_base` spacing migration + promote repeated layout sizes. Chart dark-canvas color consolidation remains deferred.
