### PR TITLE
refactor(ui): tokenize windows/sidebar/base spacing + layout consts (#111 Phase 3)

### DIFF
--- a/crates/dbflux_components/src/tokens.rs
+++ b/crates/dbflux_components/src/tokens.rs
@@ -356,6 +356,24 @@ pub struct Widths;
 impl Widths {
     /// Width of the row inspector overlay panel.
     pub const INSPECTOR: Pixels = px(320.0);
+
+    /// Label column width in settings form grid rows (drivers, hooks sections).
+    ///
+    /// Applied to the fixed-width left column that holds field labels and
+    /// dropdown controls in two-column settings forms. (220 px)
+    pub const SETTINGS_FORM_LABEL: Pixels = px(220.0);
+
+    /// Dropdown column width in connection manager form rows.
+    ///
+    /// Applied to dropdown and field-control wrappers in the connection manager
+    /// tabs (hooks, render, access, drivers). (240 px)
+    pub const CM_FORM_DROPDOWN: Pixels = px(240.0);
+
+    /// Left list-panel width in settings sections with a master/detail layout.
+    ///
+    /// Applied to the left panel (`border_r_1`) listing selectable items in
+    /// MCP (clients, roles, policies) and driver settings sections. (300 px)
+    pub const SETTINGS_LIST_PANEL: Pixels = px(300.0);
 }
 
 #[cfg(test)]

--- a/crates/dbflux_ui_base/src/lib.rs
+++ b/crates/dbflux_ui_base/src/lib.rs
@@ -13,6 +13,8 @@ pub mod sql_preview_modal;
 pub mod sso_wizard;
 pub mod toast;
 
+mod style_guardrails;
+
 #[cfg(feature = "mcp")]
 pub use app_state_entity::McpRuntimeEventRaised;
 pub use app_state_entity::{AppStateChanged, AppStateEntity, AuthProfileCreated};

--- a/crates/dbflux_ui_base/src/modal_frame.rs
+++ b/crates/dbflux_ui_base/src/modal_frame.rs
@@ -3,6 +3,7 @@ use dbflux_components::composites::ModalFrame as ComponentModalFrame;
 use dbflux_components::icon::IconSource;
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::Icon;
+use dbflux_components::tokens::Heights;
 use gpui::*;
 
 /// Compatibility wrapper over the component-owned modal frame.
@@ -22,7 +23,7 @@ impl ModalFrame {
     ) -> Self {
         let inner = ComponentModalFrame::new(id, focus_handle, on_close)
             .key_context(ContextId::SqlPreviewModal.as_gpui_context())
-            .header_leading(Icon::new(AppIcon::X).size(px(16.0)).primary())
+            .header_leading(Icon::new(AppIcon::X).size(Heights::ICON_SM).primary())
             .close_icon(IconSource::Svg(AppIcon::X.path().into()));
 
         Self { inner }
@@ -36,7 +37,7 @@ impl ModalFrame {
     pub fn icon(mut self, icon: AppIcon) -> Self {
         self.inner = self
             .inner
-            .header_leading(Icon::new(icon).size(px(16.0)).primary());
+            .header_leading(Icon::new(icon).size(Heights::ICON_SM).primary());
         self
     }
 

--- a/crates/dbflux_ui_base/src/platform.rs
+++ b/crates/dbflux_ui_base/src/platform.rs
@@ -7,6 +7,8 @@ use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Text};
 #[cfg(target_os = "linux")]
 use dbflux_components::tokens::ChromeColors;
+#[cfg(target_os = "linux")]
+use dbflux_components::tokens::{Heights, Spacing};
 use gpui::{
     App, ClickEvent, Decorations, InteractiveElement, IntoElement, ParentElement, SharedString,
     Stateful, Styled, Window, WindowDecorations, WindowKind, WindowOptions, div, px,
@@ -142,7 +144,7 @@ pub fn render_csd_title_bar_with_crumbs(
                 .on_mouse_down(gpui::MouseButton::Left, move |_, window, _cx| {
                     handler(window);
                 })
-                .child(Icon::new(icon).size(px(16.0)).muted())
+                .child(Icon::new(icon).size(Heights::ICON_SM).muted())
         };
 
         let mut title_bar = div()
@@ -182,12 +184,18 @@ pub fn render_csd_title_bar_with_crumbs(
 
         for crumb in crumbs {
             drag_area = drag_area
-                .child(div().w(px(1.0)).h(px(12.0)).bg(sep_color).flex_shrink_0())
+                .child(
+                    div()
+                        .w(px(1.0))
+                        .h(Spacing::MD)
+                        .bg(sep_color)
+                        .flex_shrink_0(),
+                )
                 .child({
-                    let mut crumb_el = div().flex().flex_row().items_center().gap(px(4.0));
+                    let mut crumb_el = div().flex().flex_row().items_center().gap(Spacing::XS);
 
                     if let Some(icon) = crumb.icon {
-                        crumb_el = crumb_el.child(Icon::new(icon).size(px(12.0)).muted());
+                        crumb_el = crumb_el.child(Icon::new(icon).size(Spacing::MD).muted());
                     }
 
                     crumb_el.child(Text::label_sm(crumb.label.clone()))

--- a/crates/dbflux_ui_base/src/sql_preview_modal.rs
+++ b/crates/dbflux_ui_base/src/sql_preview_modal.rs
@@ -3,7 +3,7 @@ use crate::modal_frame::ModalFrame;
 use dbflux_components::controls::{GpuiInput as Input, InputState};
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Text};
-use dbflux_components::tokens::{FontSizes, Radii, Spacing};
+use dbflux_components::tokens::{FontSizes, Heights, Radii, Spacing};
 // SqlGenerationType and SqlPreviewContext now live in dbflux_components;
 // re-export here so existing call-sites via this module path are unchanged.
 pub use dbflux_components::{SqlGenerationType, SqlPreviewContext};
@@ -616,7 +616,11 @@ impl Render for SqlPreviewModal {
                     .on_click(cx.listener(|this, _, window, cx| {
                         this.regenerate_sql(window, cx);
                     }))
-                    .child(Icon::new(AppIcon::RefreshCcw).size(px(16.0)).muted())
+                    .child(
+                        Icon::new(AppIcon::RefreshCcw)
+                            .size(Heights::ICON_SM)
+                            .muted(),
+                    )
                     .child(Text::body("Refresh").font_size(FontSizes::SM)),
             );
         }
@@ -641,7 +645,7 @@ impl Render for SqlPreviewModal {
                     }))
                     .child(
                         Icon::new(AppIcon::Layers)
-                            .size(px(16.0))
+                            .size(Heights::ICON_SM)
                             .color(theme.primary_foreground),
                     )
                     .child(Text::caption("Copy").color(theme.primary_foreground)),

--- a/crates/dbflux_ui_base/src/style_guardrails.rs
+++ b/crates/dbflux_ui_base/src/style_guardrails.rs
@@ -1,0 +1,141 @@
+/// Source-scanning guardrails for `dbflux_ui_base`.
+///
+/// These tests walk all `.rs` files under `crates/dbflux_ui_base/src/` and
+/// reject bare magic literals that must be replaced by design tokens.
+///
+/// Exemptions are opt-in at two levels:
+/// - **File-level**: files whose path contains one of the exempt path fragments
+///   (token/semantic/theme definition files) are skipped entirely.
+/// - **Line-level**: any line containing `// guardrail-allow` is skipped, as is
+///   any line that contains `px(0.)` or `px(0.0)` (zero is never a forbidden value).
+///
+/// The `style_guardrails.rs` file itself is always excluded from scanning so
+/// that the forbidden pattern strings in this file do not self-trigger.
+#[cfg(test)]
+mod style_guardrails {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    const SRC_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src");
+
+    /// Fragments that, when found in a file's path, exempt it from all checks.
+    ///
+    /// - Token/semantic/density definition files carry legitimate raw literals.
+    /// - `/chart/` covers chart canvas math and chart-only sizes.
+    /// - `style_guardrails.rs` is self-excluded to prevent pattern strings here
+    ///   from tripping the scan.
+    const FILE_EXEMPT_FRAGMENTS: &[&str] = &[
+        "tokens.rs",
+        "semantic.rs",
+        "density.rs",
+        "/chart/",
+        "style_guardrails.rs",
+    ];
+
+    /// Spacing/size literal patterns that are forbidden in base UI code.
+    ///
+    /// Each pattern uses a closing-paren suffix to prevent false positives:
+    /// for example, `"px(4.0)"` does NOT match `px(14.0)` or `px(24.0)`.
+    const FORBIDDEN_SPACING_PATTERNS: &[&str] = &[
+        "px(4.)", "px(4.0)", "px(6.)", "px(6.0)", "px(8.)", "px(8.0)", "px(12.)", "px(12.0)",
+        "px(16.)", "px(16.0)", "px(24.)", "px(24.0)",
+    ];
+
+    /// Raw color constructor patterns that are forbidden in base UI code.
+    ///
+    /// Base UI files must use semantic tokens instead of constructing colors
+    /// inline. Exceptions require a `// guardrail-allow` comment with a reason.
+    const FORBIDDEN_COLOR_PATTERNS: &[&str] =
+        &["rgb(", "rgba(", "hsla(", "gpui::rgb", "gpui::hsla"];
+
+    fn collect_rust_files(root: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(root) else {
+            return;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+
+            if path.is_dir() {
+                collect_rust_files(&path, out);
+                continue;
+            }
+
+            if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    fn is_file_exempt(path: &Path) -> bool {
+        let path_str = path.to_string_lossy();
+        FILE_EXEMPT_FRAGMENTS
+            .iter()
+            .any(|fragment| path_str.contains(fragment))
+    }
+
+    fn is_line_exempt(line: &str) -> bool {
+        line.contains("// guardrail-allow") || line.contains("px(0.)") || line.contains("px(0.0)")
+    }
+
+    fn check_violations(forbidden_patterns: &[&str]) -> Vec<String> {
+        let src_root = PathBuf::from(SRC_DIR);
+        let mut files = Vec::new();
+        collect_rust_files(&src_root, &mut files);
+
+        let mut violations = Vec::new();
+
+        for file in &files {
+            if is_file_exempt(file) {
+                continue;
+            }
+
+            let Ok(content) = fs::read_to_string(file) else {
+                continue;
+            };
+
+            for (line_number, line) in content.lines().enumerate() {
+                if is_line_exempt(line) {
+                    continue;
+                }
+
+                for pattern in forbidden_patterns {
+                    if line.contains(pattern) {
+                        violations.push(format!(
+                            "{}:{}: found forbidden pattern {:?} — use a design token or add `// guardrail-allow` with a justification comment",
+                            file.display(),
+                            line_number + 1,
+                            pattern
+                        ));
+                        // Report each line once, even if multiple patterns match.
+                        break;
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    #[test]
+    fn no_bare_spacing_literals_in_base_code() {
+        let violations = check_violations(FORBIDDEN_SPACING_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found bare spacing literals that must use design tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+
+    #[test]
+    fn no_raw_color_constructors_in_base_code() {
+        let violations = check_violations(FORBIDDEN_COLOR_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found raw color constructors that must use semantic tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+}

--- a/crates/dbflux_ui_base/src/toast.rs
+++ b/crates/dbflux_ui_base/src/toast.rs
@@ -13,7 +13,7 @@ use gpui_component::ActiveTheme;
 
 use crate::AsyncUpdateResultExt;
 use dbflux_components::icons::AppIcon;
-use dbflux_components::tokens::{FontSizes, Radii, Spacing};
+use dbflux_components::tokens::{FontSizes, Heights, Radii, Spacing};
 
 /// Wall-clock snapshot used as the default `meta_right` timestamp on toasts.
 /// Captured once at build time — no tick/loop logic.
@@ -418,11 +418,11 @@ impl ToastHost {
         // Title row: icon · title · subtitle · spacer · meta_right · close
         let icon_element = match icon_source {
             IconSource::Svg(path) => Icon::new(IconSource::Svg(path))
-                .size(px(16.0))
+                .size(Heights::ICON_SM)
                 .color(accent)
                 .into_any_element(),
             IconSource::Named(name) => Icon::new(name)
-                .size(px(16.0))
+                .size(Heights::ICON_SM)
                 .color(accent)
                 .into_any_element(),
         };
@@ -460,7 +460,7 @@ impl ToastHost {
             ("toast-close", toast_id),
             IconSource::Svg(AppIcon::X.path().into()),
         )
-        .icon_size(px(12.0))
+        .icon_size(Spacing::MD)
         .on_click(cx.listener(move |host, _, _, cx| {
             host.dismiss(toast_id, cx);
         }));
@@ -483,7 +483,7 @@ impl ToastHost {
             .shadow_lg();
 
         // Left accent stripe — fills the toast height.
-        let stripe = gpui::div().w(px(4.0)).flex_shrink_0().bg(stripe_bg);
+        let stripe = gpui::div().w(Spacing::XS).flex_shrink_0().bg(stripe_bg);
 
         let mut content = gpui::div()
             .flex_1()

--- a/crates/dbflux_ui_sidebar/src/lib.rs
+++ b/crates/dbflux_ui_sidebar/src/lib.rs
@@ -9,6 +9,7 @@ mod render_footer;
 mod render_overlays;
 mod render_tree;
 mod selection;
+mod style_guardrails;
 mod table_loading;
 mod tree_builder;
 

--- a/crates/dbflux_ui_sidebar/src/render_overlays.rs
+++ b/crates/dbflux_ui_sidebar/src/render_overlays.rs
@@ -1,5 +1,6 @@
 use super::*;
 use dbflux_components::primitives::Icon;
+use dbflux_components::tokens::Heights;
 use dbflux_ui_base::platform;
 use gpui_component::scroll::ScrollableElement;
 
@@ -126,7 +127,7 @@ impl Sidebar {
                         .flex()
                         .items_center()
                         .gap(Spacing::SM)
-                        .child(Icon::new(AppIcon::Folder).size(px(16.0)).muted())
+                        .child(Icon::new(AppIcon::Folder).size(Heights::ICON_SM).muted())
                         .child("New Folder"),
                 ),
         )
@@ -170,7 +171,7 @@ impl Sidebar {
                         .flex()
                         .items_center()
                         .gap(Spacing::SM)
-                        .child(Icon::new(AppIcon::Plug).size(px(16.0)).muted())
+                        .child(Icon::new(AppIcon::Plug).size(Heights::ICON_SM).muted())
                         .child("New Connection"),
                 ),
         )
@@ -204,7 +205,11 @@ impl Sidebar {
                         .flex()
                         .items_center()
                         .gap(Spacing::SM)
-                        .child(Icon::new(AppIcon::ScrollText).size(px(16.0)).muted())
+                        .child(
+                            Icon::new(AppIcon::ScrollText)
+                                .size(Heights::ICON_SM)
+                                .muted(),
+                        )
                         .child("New File"),
                 ),
         )
@@ -227,7 +232,7 @@ impl Sidebar {
                         .flex()
                         .items_center()
                         .gap(Spacing::SM)
-                        .child(Icon::new(AppIcon::Folder).size(px(16.0)).muted())
+                        .child(Icon::new(AppIcon::Folder).size(Heights::ICON_SM).muted())
                         .child("New Folder"),
                 ),
         )
@@ -250,7 +255,7 @@ impl Sidebar {
                         .flex()
                         .items_center()
                         .gap(Spacing::SM)
-                        .child(Icon::new(AppIcon::Download).size(px(16.0)).muted())
+                        .child(Icon::new(AppIcon::Download).size(Heights::ICON_SM).muted())
                         .child("Import File"),
                 ),
         )
@@ -658,7 +663,7 @@ impl Sidebar {
                                     })
                             })
                             .when(!can_prev, |d| d.opacity(0.5))
-                            .child(Icon::new(AppIcon::ChevronLeft).size(px(12.0)).color(
+                            .child(Icon::new(AppIcon::ChevronLeft).size(Spacing::MD).color(
                                 if can_prev {
                                     theme.foreground
                                 } else {
@@ -707,7 +712,7 @@ impl Sidebar {
                                     theme.muted_foreground
                                 },
                             ))
-                            .child(Icon::new(AppIcon::ChevronRight).size(px(12.0)).color(
+                            .child(Icon::new(AppIcon::ChevronRight).size(Spacing::MD).color(
                                 if can_next {
                                     theme.foreground
                                 } else {

--- a/crates/dbflux_ui_sidebar/src/render_tree.rs
+++ b/crates/dbflux_ui_sidebar/src/render_tree.rs
@@ -96,7 +96,7 @@ pub(super) fn render_tree_item(
                 .py(Spacing::XS)
                 .child(
                     Icon::new(AppIcon::Loader)
-                        .size(px(12.0))
+                        .size(Spacing::MD)
                         .color(theme.muted_foreground),
                 )
                 .child(Text::caption("Loading…").color(theme.muted_foreground)),

--- a/crates/dbflux_ui_sidebar/src/style_guardrails.rs
+++ b/crates/dbflux_ui_sidebar/src/style_guardrails.rs
@@ -1,0 +1,141 @@
+/// Source-scanning guardrails for `dbflux_ui_sidebar`.
+///
+/// These tests walk all `.rs` files under `crates/dbflux_ui_sidebar/src/` and
+/// reject bare magic literals that must be replaced by design tokens.
+///
+/// Exemptions are opt-in at two levels:
+/// - **File-level**: files whose path contains one of the exempt path fragments
+///   (token/semantic/theme definition files) are skipped entirely.
+/// - **Line-level**: any line containing `// guardrail-allow` is skipped, as is
+///   any line that contains `px(0.)` or `px(0.0)` (zero is never a forbidden value).
+///
+/// The `style_guardrails.rs` file itself is always excluded from scanning so
+/// that the forbidden pattern strings in this file do not self-trigger.
+#[cfg(test)]
+mod style_guardrails {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    const SRC_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src");
+
+    /// Fragments that, when found in a file's path, exempt it from all checks.
+    ///
+    /// - Token/semantic/density definition files carry legitimate raw literals.
+    /// - `/chart/` covers chart canvas math and chart-only sizes.
+    /// - `style_guardrails.rs` is self-excluded to prevent pattern strings here
+    ///   from tripping the scan.
+    const FILE_EXEMPT_FRAGMENTS: &[&str] = &[
+        "tokens.rs",
+        "semantic.rs",
+        "density.rs",
+        "/chart/",
+        "style_guardrails.rs",
+    ];
+
+    /// Spacing/size literal patterns that are forbidden in sidebar code.
+    ///
+    /// Each pattern uses a closing-paren suffix to prevent false positives:
+    /// for example, `"px(4.0)"` does NOT match `px(14.0)` or `px(24.0)`.
+    const FORBIDDEN_SPACING_PATTERNS: &[&str] = &[
+        "px(4.)", "px(4.0)", "px(6.)", "px(6.0)", "px(8.)", "px(8.0)", "px(12.)", "px(12.0)",
+        "px(16.)", "px(16.0)", "px(24.)", "px(24.0)",
+    ];
+
+    /// Raw color constructor patterns that are forbidden in sidebar code.
+    ///
+    /// Sidebar files must use semantic tokens instead of constructing colors
+    /// inline. Exceptions require a `// guardrail-allow` comment with a reason.
+    const FORBIDDEN_COLOR_PATTERNS: &[&str] =
+        &["rgb(", "rgba(", "hsla(", "gpui::rgb", "gpui::hsla"];
+
+    fn collect_rust_files(root: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(root) else {
+            return;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+
+            if path.is_dir() {
+                collect_rust_files(&path, out);
+                continue;
+            }
+
+            if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    fn is_file_exempt(path: &Path) -> bool {
+        let path_str = path.to_string_lossy();
+        FILE_EXEMPT_FRAGMENTS
+            .iter()
+            .any(|fragment| path_str.contains(fragment))
+    }
+
+    fn is_line_exempt(line: &str) -> bool {
+        line.contains("// guardrail-allow") || line.contains("px(0.)") || line.contains("px(0.0)")
+    }
+
+    fn check_violations(forbidden_patterns: &[&str]) -> Vec<String> {
+        let src_root = PathBuf::from(SRC_DIR);
+        let mut files = Vec::new();
+        collect_rust_files(&src_root, &mut files);
+
+        let mut violations = Vec::new();
+
+        for file in &files {
+            if is_file_exempt(file) {
+                continue;
+            }
+
+            let Ok(content) = fs::read_to_string(file) else {
+                continue;
+            };
+
+            for (line_number, line) in content.lines().enumerate() {
+                if is_line_exempt(line) {
+                    continue;
+                }
+
+                for pattern in forbidden_patterns {
+                    if line.contains(pattern) {
+                        violations.push(format!(
+                            "{}:{}: found forbidden pattern {:?} — use a design token or add `// guardrail-allow` with a justification comment",
+                            file.display(),
+                            line_number + 1,
+                            pattern
+                        ));
+                        // Report each line once, even if multiple patterns match.
+                        break;
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    #[test]
+    fn no_bare_spacing_literals_in_sidebar_code() {
+        let violations = check_violations(FORBIDDEN_SPACING_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found bare spacing literals that must use design tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+
+    #[test]
+    fn no_raw_color_constructors_in_sidebar_code() {
+        let violations = check_violations(FORBIDDEN_COLOR_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found raw color constructors that must use semantic tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+}

--- a/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
@@ -3,7 +3,7 @@ use dbflux_components::controls::DropdownItem;
 use dbflux_components::controls::{Button, Input};
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Label, Status, StatusIndicator, Text};
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Radii, Widths};
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::ActiveTheme;
@@ -48,7 +48,7 @@ impl ConnectionManagerWindow {
                         .child(Label::new("Access Method"))
                         .child(
                             div()
-                                .min_w(px(240.0))
+                                .min_w(Widths::CM_FORM_DROPDOWN)
                                 .child(self.access_method_dropdown.clone()),
                         ),
                 ),

--- a/crates/dbflux_ui_windows/src/connection_manager/hooks_tab.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/hooks_tab.rs
@@ -1,6 +1,6 @@
 use super::*;
 use dbflux_components::primitives::Text;
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Radii, Widths};
 use gpui::prelude::FluentBuilder;
 use gpui_component::ActiveTheme;
 
@@ -100,7 +100,7 @@ impl ConnectionManagerWindow {
                     .child(div().w(px(160.0)).text_sm().child("Pre-connect hook"))
                     .child(
                         div()
-                            .w(px(240.0))
+                            .w(Widths::CM_FORM_DROPDOWN)
                             .child(self.conn_pre_hook_dropdown.clone()),
                     ),
             )
@@ -119,7 +119,7 @@ impl ConnectionManagerWindow {
                     .child(div().w(px(160.0)).text_sm().child("Post-connect hook"))
                     .child(
                         div()
-                            .w(px(240.0))
+                            .w(Widths::CM_FORM_DROPDOWN)
                             .child(self.conn_post_hook_dropdown.clone()),
                     ),
             )
@@ -138,7 +138,7 @@ impl ConnectionManagerWindow {
                     .child(div().w(px(160.0)).text_sm().child("Pre-disconnect hook"))
                     .child(
                         div()
-                            .w(px(240.0))
+                            .w(Widths::CM_FORM_DROPDOWN)
                             .child(self.conn_pre_disconnect_hook_dropdown.clone()),
                     ),
             )
@@ -157,7 +157,7 @@ impl ConnectionManagerWindow {
                     .child(div().w(px(160.0)).text_sm().child("Post-disconnect hook"))
                     .child(
                         div()
-                            .w(px(240.0))
+                            .w(Widths::CM_FORM_DROPDOWN)
                             .child(self.conn_post_disconnect_hook_dropdown.clone()),
                     ),
             )

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -7,7 +7,7 @@ use dbflux_components::primitives::{
     BannerBlock, BannerVariant, Icon as AppIconElement, Label, Text, focus_frame,
 };
 use dbflux_components::semantic::BannerColors as SemBannerColors;
-use dbflux_components::tokens::{FontSizes, Radii, Spacing};
+use dbflux_components::tokens::{FontSizes, Heights, Radii, Spacing};
 use dbflux_components::typography::{Body, Headline, SubSectionLabel};
 use dbflux_core::{FormFieldDef, FormFieldKind, FormTab};
 use dbflux_ui_base::platform;
@@ -57,7 +57,7 @@ impl ConnectionManagerWindow {
             .child(
                 div()
                     .w(FIELD_LABEL_WIDTH)
-                    .pt(px(6.0))
+                    .pt(Spacing::XXS)
                     .flex_shrink_0()
                     .child(label_el),
             )
@@ -322,7 +322,7 @@ impl ConnectionManagerWindow {
                             .when_some(brand_icon, |el, icon| {
                                 el.child(
                                     AppIconElement::new(icon)
-                                        .size(px(24.0))
+                                        .size(Heights::ICON_LG)
                                         .color(theme.foreground),
                                 )
                             })
@@ -375,7 +375,7 @@ impl ConnectionManagerWindow {
                                 BannerBlock::new(BannerVariant::Info, "Testing connection\u{2026}")
                                     .with_icon(
                                         AppIconElement::new(AppIcon::Loader)
-                                            .size(px(16.0))
+                                            .size(Heights::ICON_SM)
                                             .color(banners.info_fg),
                                     )
                             }
@@ -386,7 +386,7 @@ impl ConnectionManagerWindow {
                                 )
                                 .with_icon(
                                     AppIconElement::new(AppIcon::CircleCheck)
-                                        .size(px(16.0))
+                                        .size(Heights::ICON_SM)
                                         .color(banners.success_fg),
                                 );
                                 if let Some(body) = test_result_body {
@@ -401,7 +401,7 @@ impl ConnectionManagerWindow {
                                     .with_body(message)
                                     .with_icon(
                                         AppIconElement::new(AppIcon::Info)
-                                            .size(px(16.0))
+                                            .size(Heights::ICON_SM)
                                             .color(banners.error_fg),
                                     )
                             }
@@ -765,8 +765,8 @@ impl ConnectionManagerWindow {
                                 )
                                 .child(
                                     div()
-                                        .w(px(16.0))
-                                        .h(px(16.0))
+                                        .w(Heights::ICON_SM)
+                                        .h(Heights::ICON_SM)
                                         .rounded(px(3.0))
                                         .border_2()
                                         .border_color(cx.theme().muted_foreground)
@@ -779,8 +779,8 @@ impl ConnectionManagerWindow {
                                         .when(is_selected, |d| {
                                             d.child(
                                                 div()
-                                                    .w(px(8.0))
-                                                    .h(px(8.0))
+                                                    .w(Spacing::SM)
+                                                    .h(Spacing::SM)
                                                     .rounded(px(1.0))
                                                     .bg(cx.theme().primary_foreground),
                                             )
@@ -1091,8 +1091,8 @@ impl ConnectionManagerWindow {
 
         div()
             .id(toggle_id)
-            .w(px(32.0))
-            .h(px(32.0))
+            .w(Heights::TOOLBAR)
+            .h(Heights::TOOLBAR)
             .flex()
             .items_center()
             .justify_center()
@@ -1101,7 +1101,7 @@ impl ConnectionManagerWindow {
             .hover(move |d| d.bg(secondary))
             .child(
                 AppIconElement::new(icon)
-                    .size(px(16.0))
+                    .size(Heights::ICON_SM)
                     .color(muted_foreground),
             )
     }

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -4,7 +4,7 @@ use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{
     FilePicker, Icon as AppIconElement, Label, SegmentedControl, SegmentedItem, Text,
 };
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Radii, Widths};
 use dbflux_core::FormFieldKind;
 use gpui::prelude::*;
 use gpui::*;
@@ -658,7 +658,7 @@ impl ConnectionManagerWindow {
                                                     default_val
                                                 ))),
                                         )
-                                        .child(div().w(px(240.0)).child(dropdown))
+                                        .child(div().w(Widths::CM_FORM_DROPDOWN).child(dropdown))
                                         .into_any_element(),
                                 )
                             }

--- a/crates/dbflux_ui_windows/src/lib.rs
+++ b/crates/dbflux_ui_windows/src/lib.rs
@@ -7,3 +7,5 @@
 pub mod connection_manager;
 pub mod settings;
 pub mod ssh_shared;
+
+mod style_guardrails;

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -10,7 +10,7 @@ use dbflux_components::controls::{Dropdown, DropdownItem, DropdownSelectionChang
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::focus_frame;
 use dbflux_components::primitives::{Icon as FluxIcon, Label, Text};
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Heights, Radii, Spacing};
 use dbflux_core::{
     AccessKind, AuthProfile, FetchOptionsError, FetchOptionsRequest, FormFieldKind,
     ImportableProfile, RefreshTrigger,
@@ -1380,7 +1380,7 @@ impl AuthProfilesSection {
         div()
             .m_4()
             .p_3()
-            .rounded(px(8.0))
+            .rounded(Spacing::SM)
             .border_1()
             .border_color(theme.primary)
             .bg(theme.secondary)
@@ -1395,7 +1395,7 @@ impl AuthProfilesSection {
                     .gap_2()
                     .child(
                         FluxIcon::new(AppIcon::Info)
-                            .size(px(16.0))
+                            .size(Heights::ICON_SM)
                             .color(theme.primary),
                     )
                     .child(

--- a/crates/dbflux_ui_windows/src/settings/drivers.rs
+++ b/crates/dbflux_ui_windows/src/settings/drivers.rs
@@ -9,7 +9,7 @@ use dbflux_components::controls::InputEvent;
 use dbflux_components::controls::{Button, Checkbox, Input};
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Badge, BadgeVariant, Icon, Label};
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Heights, Radii, Widths};
 use dbflux_components::typography::{
     Body, FieldLabel, MonoCaption, MonoLabel, MonoMeta, PanelTitle, SubSectionLabel,
 };
@@ -700,7 +700,7 @@ impl DriversSection {
         }
 
         div()
-            .w(px(300.0))
+            .w(Widths::SETTINGS_LIST_PANEL)
             .h_full()
             .min_h_0()
             .border_r_1()
@@ -757,7 +757,7 @@ impl DriversSection {
                                     .child(
                                         div().mt(px(2.0)).child(
                                             Icon::new(AppIcon::from_icon(entry.metadata.icon))
-                                                .size(px(16.0))
+                                                .size(Heights::ICON_SM)
                                                 .muted(),
                                         ),
                                     )
@@ -955,7 +955,7 @@ impl DriversSection {
                             .flex()
                             .items_center()
                             .gap_3()
-                            .child(div().w(px(220.0)))
+                            .child(div().w(Widths::SETTINGS_FORM_LABEL))
                             .child(div().w(px(160.0)).child(FieldLabel::new("Override Value"))),
                     )
                     .child(
@@ -1008,7 +1008,11 @@ impl DriversSection {
                                             )),
                                     ),
                             )
-                            .child(div().w(px(220.0)).child(Label::new("Refresh policy")))
+                            .child(
+                                div()
+                                    .w(Widths::SETTINGS_FORM_LABEL)
+                                    .child(Label::new("Refresh policy")),
+                            )
                             .child(
                                 div()
                                     .min_w(px(160.0))
@@ -1098,7 +1102,7 @@ impl DriversSection {
                             )
                             .child(
                                 div()
-                                    .w(px(220.0))
+                                    .w(Widths::SETTINGS_FORM_LABEL)
                                     .child(Label::new("Refresh interval (sec)")),
                             )
                             .child(
@@ -1151,7 +1155,7 @@ impl DriversSection {
                             .gap_3()
                             .child(
                                 div()
-                                    .w(px(220.0))
+                                    .w(Widths::SETTINGS_FORM_LABEL)
                                     .child(Label::new("Confirm dangerous queries")),
                             )
                             .child(
@@ -1193,7 +1197,11 @@ impl DriversSection {
                             .flex()
                             .items_center()
                             .gap_3()
-                            .child(div().w(px(220.0)).child(Label::new("Require WHERE")))
+                            .child(
+                                div()
+                                    .w(Widths::SETTINGS_FORM_LABEL)
+                                    .child(Label::new("Require WHERE")),
+                            )
                             .child(
                                 div()
                                     .w(px(160.0))
@@ -1233,7 +1241,11 @@ impl DriversSection {
                             .flex()
                             .items_center()
                             .gap_3()
-                            .child(div().w(px(220.0)).child(Label::new("Require preview")))
+                            .child(
+                                div()
+                                    .w(Widths::SETTINGS_FORM_LABEL)
+                                    .child(Label::new("Require preview")),
+                            )
                             .child(
                                 div()
                                     .w(px(160.0))
@@ -1358,7 +1370,11 @@ impl DriversSection {
                                                 .gap_1()
                                                 .opacity(if enabled { 1.0 } else { 0.6 })
                                                 .child(Label::new(field.label.clone()))
-                                                .child(div().w(px(240.0)).child(dropdown))
+                                                .child(
+                                                    div()
+                                                        .w(Widths::CM_FORM_DROPDOWN)
+                                                        .child(dropdown),
+                                                )
                                                 .into_any_element(),
                                         )
                                     }

--- a/crates/dbflux_ui_windows/src/settings/hooks.rs
+++ b/crates/dbflux_ui_windows/src/settings/hooks.rs
@@ -3,7 +3,7 @@ use dbflux_components::controls::{Button, Checkbox, Input};
 use dbflux_components::controls::{InputEvent, InputState};
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Label};
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Heights, Radii, Spacing, Widths};
 use dbflux_components::typography::{Body, MonoCaption, MonoLabel, PanelTitle};
 use dbflux_core::{
     ConnectionHook, HookExecutionMode, HookFailureMode, HookKind, ScriptLanguage, ScriptSource,
@@ -1281,9 +1281,13 @@ impl HooksSection {
                                     .flex()
                                     .items_start()
                                     .gap_2()
-                                    .child(div().mt(px(2.0)).child(
-                                        Icon::new(AppIcon::SquareTerminal).size(px(16.0)).muted(),
-                                    ))
+                                    .child(
+                                        div().mt(px(2.0)).child(
+                                            Icon::new(AppIcon::SquareTerminal)
+                                                .size(Heights::ICON_SM)
+                                                .muted(),
+                                        ),
+                                    )
                                     .child(
                                         div()
                                             .flex()
@@ -1343,7 +1347,7 @@ impl HooksSection {
                             .flex_col()
                             .gap_1()
                             .child(Label::new("Type"))
-                            .child(div().w(px(220.0)).child(self.hook_kind_dropdown.clone())),
+                            .child(div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_kind_dropdown.clone())),
                     )
                     .when(hook_kind == HookKindSelection::Command, |container| {
                         container.child(
@@ -1387,7 +1391,7 @@ impl HooksSection {
                                             .child(Label::new("Language"))
                                             .child(
                                                 div()
-                                                    .w(px(220.0))
+                                                    .w(Widths::SETTINGS_FORM_LABEL)
                                                     .child(self.script_language_dropdown.clone()),
                                             ),
                                     )
@@ -1522,7 +1526,7 @@ impl HooksSection {
                             .gap_1()
                             .child(Label::new("Execution Mode"))
                             .child(Body::new("Detached runs in background and does not block connect/disconnect").color(theme.muted_foreground))
-                            .child(div().w(px(220.0)).child(self.hook_execution_mode_dropdown.clone())),
+                            .child(div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_execution_mode_dropdown.clone())),
                     )
                     })
                     .when(!is_lua && self.selected_hook_execution_mode(cx) == HookExecutionMode::Detached, |container| {
@@ -1582,14 +1586,14 @@ impl HooksSection {
                                     .gap_2()
                                     .px_3()
                                     .py_2()
-                                    .rounded(px(6.0))
+                                    .rounded(Spacing::XXS)
                                     .bg(theme.warning.opacity(0.12))
                                     .border_1()
                                     .border_color(theme.warning.opacity(0.3))
                                     .child(
                                         div().mt(px(1.0)).child(
                                             Icon::new(AppIcon::TriangleAlert)
-                                                .size(px(16.0))
+                                                .size(Heights::ICON_SM)
                                                 .warning(),
                                         ),
                                     )
@@ -1637,7 +1641,7 @@ impl HooksSection {
                             .flex_col()
                             .gap_1()
                             .child(Label::new("On Failure"))
-                            .child(div().w(px(220.0)).child(self.hook_failure_dropdown.clone())),
+                            .child(div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_failure_dropdown.clone())),
                     )),
             None,
             theme,

--- a/crates/dbflux_ui_windows/src/settings/keybindings.rs
+++ b/crates/dbflux_ui_windows/src/settings/keybindings.rs
@@ -2,7 +2,7 @@ use dbflux_app::keymap::{ContextId, KeyChord};
 use dbflux_components::controls::Input;
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{BannerBlock, BannerVariant, Chord, Icon as FluxIcon};
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Heights, Radii, Spacing};
 use dbflux_components::typography::{Body, FieldLabel, MonoCaption};
 use dbflux_ui_base::keymap::default_keymap;
 use gpui::prelude::*;
@@ -150,7 +150,7 @@ impl KeybindingsSection {
                         .gap_2()
                         .child(
                             FluxIcon::new(AppIcon::Search)
-                                .size(px(16.0))
+                                .size(Heights::ICON_SM)
                                 .color(muted_foreground),
                         )
                         .child(
@@ -217,7 +217,7 @@ impl KeybindingsSection {
                                     // Chevron icon
                                     .child(
                                         div()
-                                            .w(px(16.0))
+                                            .w(Heights::ICON_SM)
                                             .flex()
                                             .items_center()
                                             .justify_center()
@@ -227,7 +227,7 @@ impl KeybindingsSection {
                                                 } else {
                                                     AppIcon::ChevronRight
                                                 })
-                                                .size(px(16.0))
+                                                .size(Heights::ICON_SM)
                                                 .color(muted_foreground),
                                             ),
                                     )
@@ -313,7 +313,7 @@ impl KeybindingsSection {
             .items_center()
             .py_1()
             .px_2()
-            .rounded_r(px(4.0))
+            .rounded_r(Spacing::XS)
             .gap_4()
             .cursor_pointer()
             .bg(if is_selected {

--- a/crates/dbflux_ui_windows/src/settings/mcp_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/mcp_section.rs
@@ -6,7 +6,7 @@ use dbflux_components::controls::DropdownItem;
 use dbflux_components::controls::{Button, Checkbox, Input};
 use dbflux_components::controls::{InputEvent, InputState};
 use dbflux_components::primitives::Label;
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Radii, Widths};
 use dbflux_components::typography::{Body, FieldLabel, MonoCaption, MonoMeta, SubSectionLabel};
 use dbflux_mcp::{PolicyRoleDto, ToolPolicyDto, TrustedClientDto};
 use dbflux_ui_base::keymap::key_chord_from_gpui;
@@ -749,7 +749,7 @@ impl McpSection {
         let selected = self.selected_client_id.clone();
 
         let list = div()
-            .w(px(300.0))
+            .w(Widths::SETTINGS_LIST_PANEL)
             .h_full()
             .border_r_1()
             .border_color(theme.border)
@@ -878,7 +878,7 @@ impl McpSection {
         let selected = self.selected_role_id.clone();
 
         let list = div()
-            .w(px(300.0))
+            .w(Widths::SETTINGS_LIST_PANEL)
             .h_full()
             .border_r_1()
             .border_color(theme.border)
@@ -1015,7 +1015,7 @@ impl McpSection {
         let selected = self.selected_policy_id.clone();
 
         let list = div()
-            .w(px(300.0))
+            .w(Widths::SETTINGS_LIST_PANEL)
             .h_full()
             .border_r_1()
             .border_color(theme.border)

--- a/crates/dbflux_ui_windows/src/settings/mod.rs
+++ b/crates/dbflux_ui_windows/src/settings/mod.rs
@@ -31,6 +31,7 @@ use about_section::AboutSection;
 use audit_section::AuditSection;
 use auth_profiles_section::AuthProfilesSection;
 use dbflux_components::components::tree_nav::TreeNav;
+use dbflux_components::tokens::Spacing;
 use dbflux_ui_base::AppStateEntity;
 use drivers_section::DriversSection;
 use general_section::GeneralSection;
@@ -51,7 +52,7 @@ pub use self::section_trait::{SettingsSection, SettingsSectionId};
 const SETTINGS_SIDEBAR_DEFAULT_WIDTH: Pixels = px(220.0);
 const SETTINGS_SIDEBAR_MIN_WIDTH: Pixels = px(180.0);
 const SETTINGS_SIDEBAR_MAX_WIDTH: Pixels = px(420.0);
-const SETTINGS_SIDEBAR_GRIP_WIDTH: Pixels = px(4.0);
+const SETTINGS_SIDEBAR_GRIP_WIDTH: Pixels = Spacing::XS;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SettingsFocus {

--- a/crates/dbflux_ui_windows/src/settings/proxies_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/proxies_section.rs
@@ -9,7 +9,7 @@ use dbflux_components::controls::{GpuiInput as Input, InputEvent, InputState};
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::focus_frame;
 use dbflux_components::primitives::{Icon as FluxIcon, Label};
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Heights, Radii};
 use dbflux_components::typography::{Body, MonoCaption, MonoMeta, PanelTitle};
 use dbflux_core::{ProxyKind, ProxyProfile};
 use dbflux_ui_base::{AppStateChanged, AppStateEntity};
@@ -233,7 +233,7 @@ impl ProxiesSection {
             })
             .child(
                 FluxIcon::new(icon_name)
-                    .size(px(16.0))
+                    .size(Heights::ICON_SM)
                     .color(theme.muted_foreground),
             )
     }

--- a/crates/dbflux_ui_windows/src/settings/rpc_services.rs
+++ b/crates/dbflux_ui_windows/src/settings/rpc_services.rs
@@ -909,9 +909,13 @@ impl ServicesSection {
                                     .flex()
                                     .items_start()
                                     .gap_2()
-                                    .child(div().mt(px(2.0)).child(
-                                        PrimitiveIcon::new(AppIcon::Plug).size(px(16.0)).muted(),
-                                    ))
+                                    .child(
+                                        div().mt(px(2.0)).child(
+                                            PrimitiveIcon::new(AppIcon::Plug)
+                                                .size(Heights::ICON_SM)
+                                                .muted(),
+                                        ),
+                                    )
                                     .child(
                                         div()
                                             .flex()

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
@@ -10,7 +10,7 @@ use dbflux_components::controls::{GpuiInput as Input, InputState};
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::focus_frame;
 use dbflux_components::primitives::{Icon as FluxIcon, Label};
-use dbflux_components::tokens::Radii;
+use dbflux_components::tokens::{Heights, Radii};
 use dbflux_components::typography::{Body, MonoCaption, MonoMeta, PanelTitle};
 use dbflux_core::SshTunnelProfile;
 use dbflux_ui_base::{AppStateChanged, AppStateEntity};
@@ -325,7 +325,7 @@ impl SshTunnelsSection {
             })
             .child(
                 FluxIcon::new(icon_name)
-                    .size(px(16.0))
+                    .size(Heights::ICON_SM)
                     .color(theme.muted_foreground),
             )
     }

--- a/crates/dbflux_ui_windows/src/ssh_shared.rs
+++ b/crates/dbflux_ui_windows/src/ssh_shared.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use dbflux_components::tokens::{Heights, Spacing};
 use dbflux_core::{SshAuthMethod, SshTunnelConfig};
 use gpui::prelude::*;
 use gpui::{Hsla, px};
@@ -67,8 +68,8 @@ pub fn get_ssh_secret(
 
 pub fn render_radio_button(selected: bool, primary: Hsla, border: Hsla) -> impl IntoElement {
     gpui::div()
-        .w(px(16.0))
-        .h(px(16.0))
+        .w(Heights::ICON_SM)
+        .h(Heights::ICON_SM)
         .rounded_full()
         .border_2()
         .border_color(if selected { primary } else { border })
@@ -78,8 +79,8 @@ pub fn render_radio_button(selected: bool, primary: Hsla, border: Hsla) -> impl 
                     .absolute()
                     .top(px(3.0))
                     .left(px(3.0))
-                    .w(px(6.0))
-                    .h(px(6.0))
+                    .w(Spacing::XXS)
+                    .h(Spacing::XXS)
                     .rounded_full()
                     .bg(primary),
             )

--- a/crates/dbflux_ui_windows/src/style_guardrails.rs
+++ b/crates/dbflux_ui_windows/src/style_guardrails.rs
@@ -1,0 +1,141 @@
+/// Source-scanning guardrails for `dbflux_ui_windows`.
+///
+/// These tests walk all `.rs` files under `crates/dbflux_ui_windows/src/` and
+/// reject bare magic literals that must be replaced by design tokens.
+///
+/// Exemptions are opt-in at two levels:
+/// - **File-level**: files whose path contains one of the exempt path fragments
+///   (token/semantic/theme definition files) are skipped entirely.
+/// - **Line-level**: any line containing `// guardrail-allow` is skipped, as is
+///   any line that contains `px(0.)` or `px(0.0)` (zero is never a forbidden value).
+///
+/// The `style_guardrails.rs` file itself is always excluded from scanning so
+/// that the forbidden pattern strings in this file do not self-trigger.
+#[cfg(test)]
+mod style_guardrails {
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    const SRC_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src");
+
+    /// Fragments that, when found in a file's path, exempt it from all checks.
+    ///
+    /// - Token/semantic/density definition files carry legitimate raw literals.
+    /// - `/chart/` covers chart canvas math and chart-only sizes.
+    /// - `style_guardrails.rs` is self-excluded to prevent pattern strings here
+    ///   from tripping the scan.
+    const FILE_EXEMPT_FRAGMENTS: &[&str] = &[
+        "tokens.rs",
+        "semantic.rs",
+        "density.rs",
+        "/chart/",
+        "style_guardrails.rs",
+    ];
+
+    /// Spacing/size literal patterns that are forbidden in windows code.
+    ///
+    /// Each pattern uses a closing-paren suffix to prevent false positives:
+    /// for example, `"px(4.0)"` does NOT match `px(14.0)` or `px(24.0)`.
+    const FORBIDDEN_SPACING_PATTERNS: &[&str] = &[
+        "px(4.)", "px(4.0)", "px(6.)", "px(6.0)", "px(8.)", "px(8.0)", "px(12.)", "px(12.0)",
+        "px(16.)", "px(16.0)", "px(24.)", "px(24.0)",
+    ];
+
+    /// Raw color constructor patterns that are forbidden in windows code.
+    ///
+    /// Windows files must use semantic tokens instead of constructing colors
+    /// inline. Exceptions require a `// guardrail-allow` comment with a reason.
+    const FORBIDDEN_COLOR_PATTERNS: &[&str] =
+        &["rgb(", "rgba(", "hsla(", "gpui::rgb", "gpui::hsla"];
+
+    fn collect_rust_files(root: &Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(root) else {
+            return;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+
+            if path.is_dir() {
+                collect_rust_files(&path, out);
+                continue;
+            }
+
+            if path.extension().is_some_and(|ext| ext == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    fn is_file_exempt(path: &Path) -> bool {
+        let path_str = path.to_string_lossy();
+        FILE_EXEMPT_FRAGMENTS
+            .iter()
+            .any(|fragment| path_str.contains(fragment))
+    }
+
+    fn is_line_exempt(line: &str) -> bool {
+        line.contains("// guardrail-allow") || line.contains("px(0.)") || line.contains("px(0.0)")
+    }
+
+    fn check_violations(forbidden_patterns: &[&str]) -> Vec<String> {
+        let src_root = PathBuf::from(SRC_DIR);
+        let mut files = Vec::new();
+        collect_rust_files(&src_root, &mut files);
+
+        let mut violations = Vec::new();
+
+        for file in &files {
+            if is_file_exempt(file) {
+                continue;
+            }
+
+            let Ok(content) = fs::read_to_string(file) else {
+                continue;
+            };
+
+            for (line_number, line) in content.lines().enumerate() {
+                if is_line_exempt(line) {
+                    continue;
+                }
+
+                for pattern in forbidden_patterns {
+                    if line.contains(pattern) {
+                        violations.push(format!(
+                            "{}:{}: found forbidden pattern {:?} — use a design token or add `// guardrail-allow` with a justification comment",
+                            file.display(),
+                            line_number + 1,
+                            pattern
+                        ));
+                        // Report each line once, even if multiple patterns match.
+                        break;
+                    }
+                }
+            }
+        }
+
+        violations
+    }
+
+    #[test]
+    fn no_bare_spacing_literals_in_windows_code() {
+        let violations = check_violations(FORBIDDEN_SPACING_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found bare spacing literals that must use design tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+
+    #[test]
+    fn no_raw_color_constructors_in_windows_code() {
+        let violations = check_violations(FORBIDDEN_COLOR_PATTERNS);
+
+        assert!(
+            violations.is_empty(),
+            "Found raw color constructors that must use semantic tokens:\n{}",
+            violations.join("\n")
+        );
+    }
+}


### PR DESCRIPTION
Part of #111 — **Phase 3 of 3 (final)** of the UI styling consolidation. Completes the structural tokenization started in #112 (Phase 1) and #113 (Phase 2).

## What this PR does

Migrates the three remaining UI crates onto the token scale and promotes the repeated layout widths to named constants.

- **Spacing migration** in `dbflux_ui_windows`, `dbflux_ui_sidebar`, and `dbflux_ui_base`: `px(4/6/8/12/16/24.)` → `Spacing::{XS,XXS,SM,MD,LG,XL}`; border `px(1/2.)` → `Borders::{THIN,MEDIUM}` in `.border_*` widths. `px(0.)` resets and domain-named consts left untouched.
- **Layout-size promotion**: three values repeated ≥3× with the same role are promoted to named consts in `dbflux_components::tokens::Widths` (plain `Pixels` consts — `dbflux_components` stays domain-free):
  - `SETTINGS_FORM_LABEL = px(220.)`
  - `CM_FORM_DROPDOWN = px(240.)`
  - `SETTINGS_LIST_PANEL = px(300.)`
  
  One-off and multi-role sizes (`px(280.)` — two roles × 2 each, below threshold; `px(360.)`, `px(420.)`; and the distinct `SETTINGS_SIDEBAR_DEFAULT_WIDTH`) were correctly left local.
- **Guardrails**: per-crate `style_guardrails.rs` added to all three crates, mirroring Phases 1–2.

## Behavior preservation

Every token/const equals the literal it replaced (each promoted `Widths` const is byte-identical to the `px()` it replaces). No pixel drift.

## Verification

- `cargo fmt --all -- --check` (+ `-p` per crate) — clean
- `cargo check --workspace` — pass
- `cargo nextest run --workspace --no-fail-fast` — **2336 passed, 0 failed**, 154 skipped (2330 → 2336: +6 guardrail tests)
- all 10 `style_guardrails` tests (5 crates × 2) pass
- `cargo test --doc --workspace` — pass
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo build -p dbflux --no-default-features --features sqlite,…,lua,aws` — pass (mcp gate)
- `dbflux_components` still has no direct `anyhow`/`dbflux_app` dependency (the `Widths` additions are const-only)

## Size

`size:exception`. ~666 changed lines (578 insertions / 88 deletions across 27 files) — the three new ~141-line guardrail modules account for most of the insertions.

## Epic #111 status

This closes the **structural** styling consolidation: every UI crate now consumes the `dbflux_components` token scale and is locked by a source-scanning guardrail, and the duplicated `BannerColors` API is gone. The only remaining piece is the deliberately **deferred** chart dark-canvas color consolidation, which carries a product decision about whether charts should respond to the active theme.
