### PR TITLE
feat(chart): add ChartColors theme palette struct (#115 PR1)

### DIFF
--- a/crates/dbflux_components/src/semantic.rs
+++ b/crates/dbflux_components/src/semantic.rs
@@ -279,6 +279,115 @@ impl RowStateColors {
 }
 
 // ---------------------------------------------------------------------------
+// ChartColors
+// ---------------------------------------------------------------------------
+
+/// Semantic colors for chart chrome: inspector overlays, axis-bar pills,
+/// legend, and stats dock.
+///
+/// `dark()` and `mirage()` reproduce today's hardcoded canvas literals so the
+/// visual output on those themes is unchanged. `light()` provides legible Ayu
+/// Light equivalents.
+///
+/// All values are self-contained per-theme hex/hsl literals — they do NOT
+/// derive from `cx.theme()` at runtime so the struct can be constructed without
+/// a live render context (e.g., in unit tests and `for_current` dispatch).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ChartColors {
+    /// Panel / overlay background (inspector, readout overlay).
+    pub panel_bg: Hsla,
+    /// Panel / overlay border.
+    pub panel_border: Hsla,
+    /// Label text (muted descriptors, axis tick labels).
+    pub label_fg: Hsla,
+    /// Primary value text (high-contrast numbers and identifiers).
+    pub value_fg: Hsla,
+    /// Secondary / muted text (counters, de-emphasised stats).
+    pub muted_fg: Hsla,
+    /// Row / item hover background.
+    pub hover_bg: Hsla,
+    /// Pill / chip background (axis-bar column pills).
+    pub pill_bg: Hsla,
+    /// Pill / chip border.
+    pub pill_border: Hsla,
+    /// Checkbox checked fill (axis-bar toggle).
+    pub checkbox_checked: Hsla,
+    /// Stats accent — cyan-family highlight for the stats dock value.
+    pub stats_accent: Hsla,
+}
+
+impl ChartColors {
+    /// Chart chrome tokens for the Ayu Dark palette.
+    ///
+    /// Values reproduce the hardcoded canvas literals present before this
+    /// struct was introduced, preserving visual parity on Dark.
+    pub fn dark() -> Self {
+        Self {
+            panel_bg: hsla(0.0, 0.0, 0.08, 1.0),
+            panel_border: hsla(0.0, 0.0, 1.0, 0.08),
+            label_fg: hsla(0.0, 0.0, 0.55, 1.0),
+            value_fg: hsla(0.0, 0.0, 0.90, 1.0),
+            muted_fg: hsla(0.0, 0.0, 0.45, 1.0),
+            hover_bg: hsla(0.0, 0.0, 1.0, 0.06),
+            pill_bg: hsla(0.0, 0.0, 1.0, 0.06),
+            pill_border: hsla(0.0, 0.0, 1.0, 0.12),
+            checkbox_checked: hsla(0.55, 0.7, 0.5, 1.0),
+            stats_accent: from_hex(0x95E6CB, 1.0),
+        }
+    }
+
+    /// Chart chrome tokens for the Ayu Mirage palette.
+    ///
+    /// Values are the Mirage equivalents of the Dark literals, preserving
+    /// visual parity on Mirage.
+    pub fn mirage() -> Self {
+        Self {
+            panel_bg: hsla(0.0, 0.0, 0.10, 1.0),
+            panel_border: hsla(0.0, 0.0, 1.0, 0.08),
+            label_fg: hsla(0.0, 0.0, 0.58, 1.0),
+            value_fg: hsla(0.0, 0.0, 0.92, 1.0),
+            muted_fg: hsla(0.0, 0.0, 0.48, 1.0),
+            hover_bg: hsla(0.0, 0.0, 1.0, 0.06),
+            pill_bg: hsla(0.0, 0.0, 1.0, 0.06),
+            pill_border: hsla(0.0, 0.0, 1.0, 0.12),
+            checkbox_checked: hsla(0.55, 0.7, 0.5, 1.0),
+            stats_accent: from_hex(0x95E6CB, 1.0),
+        }
+    }
+
+    /// Chart chrome tokens for the Ayu Light palette.
+    ///
+    /// Values are hand-picked Ayu Light equivalents ensuring legibility on a
+    /// light background. `stats_accent` uses Ayu Light's cyan (#4CBF99) and
+    /// `checkbox_checked` uses the Light info/chart-1 blue (#399EE6).
+    pub fn light() -> Self {
+        Self {
+            panel_bg: from_hex(0xF7F8FA, 1.0),
+            panel_border: from_hex(0xD9DEE8, 1.0),
+            label_fg: from_hex(0x787E85, 1.0),
+            value_fg: from_hex(0x5C6166, 1.0),
+            muted_fg: from_hex(0xABB0B6, 1.0),
+            hover_bg: from_hex(0x5C6166, 0.06),
+            pill_bg: from_hex(0x5C6166, 0.06),
+            pill_border: from_hex(0xD9DEE8, 1.0),
+            checkbox_checked: from_hex(0x399EE6, 1.0),
+            stats_accent: from_hex(0x4CBF99, 1.0),
+        }
+    }
+
+    /// Return the `ChartColors` for the currently active theme.
+    ///
+    /// Reads `ThemeSettingGlobal` from `cx`; falls back to Dark when absent.
+    pub fn for_current(cx: &App) -> Self {
+        match ThemeSettingGlobal::get(cx) {
+            ThemeSetting::Dark => Self::dark(),
+            ThemeSetting::Mirage => Self::mirage(),
+            ThemeSetting::Light => Self::light(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -389,5 +498,68 @@ mod tests {
         assert_eq!(BannerColors::dark().info_fg.a, 1.0);
         assert_eq!(BannerColors::mirage().info_fg.a, 1.0);
         assert_eq!(BannerColors::light().info_fg.a, 1.0);
+    }
+
+    /// All 10 ChartColors fields must be populated (non-zero alpha) for Dark.
+    #[test]
+    fn chart_colors_dark_all_fields_populated() {
+        let c = ChartColors::dark();
+        assert!(c.panel_bg.a > 0.0);
+        assert!(c.panel_border.a > 0.0);
+        assert!(c.label_fg.a > 0.0);
+        assert!(c.value_fg.a > 0.0);
+        assert!(c.muted_fg.a > 0.0);
+        assert!(c.hover_bg.a > 0.0);
+        assert!(c.pill_bg.a > 0.0);
+        assert!(c.pill_border.a > 0.0);
+        assert!(c.checkbox_checked.a > 0.0);
+        assert!(c.stats_accent.a > 0.0);
+    }
+
+    /// All 10 ChartColors fields must be populated (non-zero alpha) for Mirage.
+    #[test]
+    fn chart_colors_mirage_all_fields_populated() {
+        let c = ChartColors::mirage();
+        assert!(c.panel_bg.a > 0.0);
+        assert!(c.panel_border.a > 0.0);
+        assert!(c.label_fg.a > 0.0);
+        assert!(c.value_fg.a > 0.0);
+        assert!(c.muted_fg.a > 0.0);
+        assert!(c.hover_bg.a > 0.0);
+        assert!(c.pill_bg.a > 0.0);
+        assert!(c.pill_border.a > 0.0);
+        assert!(c.checkbox_checked.a > 0.0);
+        assert!(c.stats_accent.a > 0.0);
+    }
+
+    /// All 10 ChartColors fields must be populated (non-zero alpha) for Light.
+    #[test]
+    fn chart_colors_light_all_fields_populated() {
+        let c = ChartColors::light();
+        assert!(c.panel_bg.a > 0.0);
+        assert!(c.panel_border.a > 0.0);
+        assert!(c.label_fg.a > 0.0);
+        assert!(c.value_fg.a > 0.0);
+        assert!(c.muted_fg.a > 0.0);
+        assert!(c.hover_bg.a > 0.0);
+        assert!(c.pill_bg.a > 0.0);
+        assert!(c.pill_border.a > 0.0);
+        assert!(c.checkbox_checked.a > 0.0);
+        assert!(c.stats_accent.a > 0.0);
+    }
+
+    /// `for_current` must dispatch to the matching constructor for each theme.
+    #[gpui::test]
+    fn chart_colors_for_current_dispatches_to_correct_variant(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            ThemeSettingGlobal::set(cx, ThemeSetting::Dark);
+            assert_eq!(ChartColors::for_current(cx), ChartColors::dark());
+
+            ThemeSettingGlobal::set(cx, ThemeSetting::Mirage);
+            assert_eq!(ChartColors::for_current(cx), ChartColors::mirage());
+
+            ThemeSettingGlobal::set(cx, ThemeSetting::Light);
+            assert_eq!(ChartColors::for_current(cx), ChartColors::light());
+        });
     }
 }


### PR DESCRIPTION
Part of #115 — **PR1 of 3** of making charts theme-responsive (deferred follow-up from the styling consolidation epic #111).

## What this PR does

Adds a `ChartColors` semantic struct in `crates/dbflux_components/src/semantic.rs`, mirroring the existing `RowStateColors`/`BannerColors` pattern: `dark()` / `mirage()` / `light()` / `for_current(cx)`. It bundles the 10 chart-chrome color roles consumed by the element factories in later PRs:

`panel_bg`, `panel_border`, `label_fg`, `value_fg`, `muted_fg`, `hover_bg`, `pill_bg`, `pill_border`, `checkbox_checked`, `stats_accent`.

Dark/Mirage reproduce today's hardcoded chart literals (so those themes stay visually equivalent); Light uses the Ayu Light equivalents. `stats_accent` maps to the cyan accent (`#95E6CB` dark / `#4CBF99` light); `checkbox_checked` is the existing blue (Light → `#399EE6`).

## Scope

Purely additive — `ChartColors` is **not consumed yet**. PR2 wires the `engine.rs` canvas/series-palette to the theme; PR3 threads `ChartColors` into the element factories and removes the chart `// guardrail-allow` exemptions. Zero behavior change in this PR.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace` + `cargo check -p dbflux_components --no-default-features` — pass (domain-free preserved)
- `cargo nextest run --workspace` — **2340 passed, 0 failed** (2336 → 2340: +4 ChartColors unit tests)
- `cargo clippy --workspace -- -D warnings` — clean (no dead-code warning; `pub` API items)

## Remaining

PR2: `engine.rs` — series palette from `theme.chart_1..5` at render time + canvas chrome via `cx.theme()`. PR3: element factories + `data_grid_panel/render.rs` overlays consume `ChartColors`/`cx.theme()`, remove the 23 chart `guardrail-allow` lines, tighten the `/chart/` guardrail exemption to `engine.rs` only. Visual QA on Dark/Mirage/Light gates PR2 & PR3.