### PR TITLE
feat(chart): make engine.rs canvas + palette theme-responsive (#115 PR2)

### DIFF
--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -10,9 +10,10 @@ use std::rc::Rc;
 
 use gpui::prelude::*;
 use gpui::{
-    AnyElement, Bounds, Context, Hsla, PathBuilder, Pixels, Render, SharedString, TextRun, Window,
-    canvas, div, fill, font, point,
+    AnyElement, App, Bounds, Context, Hsla, PathBuilder, Pixels, Render, SharedString, TextRun,
+    Window, canvas, div, fill, font, point,
 };
+use gpui_component::ActiveTheme;
 
 use crate::chart::axis::{TickLabel, ticks_log, ticks_numeric, ticks_time};
 use crate::chart::decimate::{lttb, lttb_with_indices};
@@ -20,6 +21,7 @@ use crate::chart::spec::{AxisKind, ChartSpec, YScale};
 use crate::chart::stats::{
     SeriesStats, compute_series_stats, hit_test_focused_series, interpolate_y_at_x,
 };
+use crate::semantic::ChartColors;
 use crate::tokens::FontSizes;
 use dbflux_core::{ColumnKind, QueryResult, Value};
 
@@ -44,65 +46,24 @@ pub enum ChartBuildError {
 }
 
 // ---------------------------------------------------------------------------
-// Palette
+// Palette helpers
 // ---------------------------------------------------------------------------
 
-/// Design-aligned palette: exact Ayu Dark chart tokens from `tokens.css`.
+/// Map a color slot index to the active theme's chart palette.
 ///
-/// HSL values computed from the hex palette:
-///   #59C2FF → h=0.578, s=1.0,  l=0.673   (chart-1 cyan)
-///   #AAD94C → h=0.228, s=0.673, l=0.572  (chart-2 lime)
-///   #FFB454 → h=0.097, s=1.0,  l=0.666   (chart-3 amber / primary)
-///   #F07178 → h=0.985, s=0.819, l=0.694  (chart-4 rose)
-///   #D2A6FF → h=0.758, s=1.0,  l=0.826   (chart-5 lavender)
-pub const CHART_PALETTE: &[Hsla] = &[
-    Hsla {
-        h: 0.578,
-        s: 1.0,
-        l: 0.673,
-        a: 1.0,
-    }, // #59C2FF chart-1 cyan
-    Hsla {
-        h: 0.228,
-        s: 0.673,
-        l: 0.572,
-        a: 1.0,
-    }, // #AAD94C chart-2 lime
-    Hsla {
-        h: 0.097,
-        s: 1.0,
-        l: 0.666,
-        a: 1.0,
-    }, // #FFB454 chart-3 amber
-    Hsla {
-        h: 0.985,
-        s: 0.819,
-        l: 0.694,
-        a: 1.0,
-    }, // #F07178 chart-4 rose
-    Hsla {
-        h: 0.758,
-        s: 1.0,
-        l: 0.826,
-        a: 1.0,
-    }, // #D2A6FF chart-5 lavender
-];
-
-/// Accent cyan — #95E6CB (min/max/avg stat values in the Stats dock).
-pub const CHART_ACCENT_CYAN: Hsla = Hsla {
-    h: 0.444,
-    s: 0.618,
-    l: 0.741,
-    a: 1.0,
-};
-
-/// Accent primary — #FFB454 (p99 stat value, matches theme primary).
-pub const CHART_ACCENT_PRIMARY: Hsla = Hsla {
-    h: 0.097,
-    s: 1.0,
-    l: 0.666,
-    a: 1.0,
-};
+/// `slot % 5` selects one of `theme.chart_1..chart_5`. Out-of-bounds slots
+/// (unreachable in practice) fall back to a neutral mid-grey so paint does not
+/// crash even if the series list is somehow malformed.
+#[inline]
+fn theme_chart_color(theme: &gpui_component::theme::Theme, slot: u8) -> Hsla {
+    match slot % 5 {
+        0 => theme.chart_1,
+        1 => theme.chart_2,
+        2 => theme.chart_3,
+        3 => theme.chart_4,
+        _ => theme.chart_5,
+    }
+}
 
 // ---------------------------------------------------------------------------
 // RenderModel
@@ -112,8 +73,8 @@ pub const CHART_ACCENT_PRIMARY: Hsla = Hsla {
 pub(crate) struct RenderModel {
     /// Decimated (x, y) pairs per series — in data space (f64, f64).
     pub decimated: Vec<Vec<(f64, f64)>>,
-    /// Resolved palette colour per series.
-    pub palette_colors: Vec<Hsla>,
+    /// Raw color-slot indices per series (theme-resolved at render time).
+    pub palette_slots: Vec<u8>,
     /// X-axis tick labels rendered below the plot area.
     pub x_ticks: Vec<TickLabel>,
     /// Y-axis tick labels rendered to the left of the plot area.
@@ -378,16 +339,9 @@ impl ChartView {
             ticks_numeric(y_min, y_max, 5)
         };
 
-        // --- Palette colours ---
+        // --- Palette slots (theme-resolved at render time) ---
 
-        let palette_colors: Vec<Hsla> = spec
-            .series
-            .iter()
-            .map(|s| {
-                let idx = s.color_slot as usize % CHART_PALETTE.len();
-                CHART_PALETTE[idx]
-            })
-            .collect();
+        let palette_slots: Vec<u8> = spec.series.iter().map(|s| s.color_slot).collect();
 
         // Compute per-series stats over the post-decimation points.
         let series_stats: Vec<Option<SeriesStats>> = decimated
@@ -397,7 +351,7 @@ impl ChartView {
 
         let render_model = RenderModel {
             decimated,
-            palette_colors,
+            palette_slots,
             x_ticks,
             y_ticks,
             x_min,
@@ -484,13 +438,15 @@ impl ChartView {
         self.spec.x_axis.kind == AxisKind::Time
     }
 
-    /// Resolved palette colour for the series at `idx`. Returns a neutral grey
-    /// when `idx` is out of range.
-    pub fn series_color(&self, idx: usize) -> Hsla {
+    /// Resolved palette colour for the series at `idx`, derived from the active theme.
+    ///
+    /// Returns a neutral grey when `idx` is out of range.
+    pub fn series_color(&self, idx: usize, cx: &App) -> Hsla {
+        let theme = cx.theme();
         self.render_model
-            .palette_colors
+            .palette_slots
             .get(idx)
-            .copied()
+            .map(|&slot| theme_chart_color(theme, slot))
             .unwrap_or(Hsla {
                 h: 0.0,
                 s: 0.0,
@@ -514,9 +470,17 @@ impl ChartView {
         &self.spec.series
     }
 
-    /// Resolved palette colours, indexed parallel to `spec_series()`.
-    pub fn palette_colors(&self) -> &[Hsla] {
-        &self.render_model.palette_colors
+    /// Resolved palette colours for all series, derived from the active theme at call time.
+    ///
+    /// Returns an owned `Vec<Hsla>` since the colours are no longer stored — they are
+    /// derived on demand from `cx.theme()` so they reflect the currently active theme.
+    pub fn resolved_palette(&self, cx: &App) -> Vec<Hsla> {
+        let theme = cx.theme();
+        self.render_model
+            .palette_slots
+            .iter()
+            .map(|&slot| theme_chart_color(theme, slot))
+            .collect()
     }
 
     /// Source row indices, per series, for each decimated point.
@@ -1118,7 +1082,12 @@ impl Render for ChartView {
             0.0
         };
 
-        let palette = model.palette_colors.clone();
+        let theme = cx.theme();
+        let palette: Vec<Hsla> = model
+            .palette_slots
+            .iter()
+            .map(|&slot| theme_chart_color(theme, slot))
+            .collect();
         let decimated = model.decimated.clone();
         let x_is_time = spec.x_axis.kind == AxisKind::Time;
 
@@ -1178,6 +1147,9 @@ impl Render for ChartView {
         // The `spec.legend_visible` field is preserved for future use / API compat.
         let legend: Option<AnyElement> = None;
 
+        // Resolve per-theme chrome colors for the readout overlay.
+        let readout_colors = ChartColors::for_current(cx);
+
         let plot_bounds_for_hover = plot_bounds_rc.clone();
 
         div()
@@ -1234,6 +1206,9 @@ impl Render for ChartView {
                                 let ox = f32::from(b.origin.x);
                                 let oy = f32::from(b.origin.y);
 
+                                // Resolve theme tokens once at the start of each paint pass.
+                                let theme = cx.theme();
+
                                 // Plot area occupies the right portion of the canvas;
                                 // the left MARGIN_LEFT is reserved for Y-axis tick labels.
                                 let plot_x0 = ox + MARGIN_LEFT;
@@ -1279,6 +1254,7 @@ impl Render for ChartView {
                                 // Pie has no axes — skip all gridlines and tick labels.
                                 // `tick.value` is in projection space (log1p or linear);
                                 // use the projection-space mapper, not data_to_screen_y.
+                                let gridline_color = theme.border;
                                 for tick in y_ticks_canvas
                                     .iter()
                                     .filter(|_| !matches!(kind_canvas, ChartKind::Pie))
@@ -1298,7 +1274,7 @@ impl Render for ChartView {
                                                 height: gpui::px(1.0),
                                             },
                                         },
-                                        gpui::hsla(0.0, 0.0, 0.5, 0.18),
+                                        gridline_color,
                                     ));
                                 }
 
@@ -1316,7 +1292,7 @@ impl Render for ChartView {
                                                 height: gpui::px(plot_h),
                                             },
                                         },
-                                        gpui::hsla(0.0, 0.0, 0.5, 0.18),
+                                        gridline_color,
                                     ));
                                 }
 
@@ -1480,12 +1456,16 @@ impl Render for ChartView {
                                 {
                                     let sx = f32::from(hx);
                                     if sx >= plot_x0 && sx <= plot_x0 + plot_w {
+                                        let crosshair_color = Hsla {
+                                            a: 0.7,
+                                            ..theme.primary
+                                        };
                                         paint_dashed_vline(
                                             window,
                                             sx,
                                             plot_y0,
                                             plot_y0 + plot_h,
-                                            gpui::hsla(0.097, 1.0, 0.666, 0.7),
+                                            crosshair_color,
                                             2.0,
                                             3.0,
                                         );
@@ -1557,10 +1537,7 @@ impl Render for ChartView {
                                             );
                                             fill_builder.close();
                                             if let Ok(path) = fill_builder.build() {
-                                                window.paint_path(
-                                                    path,
-                                                    gpui::hsla(0.56, 0.17, 0.07, 1.0),
-                                                );
+                                                window.paint_path(path, theme.background);
                                             }
 
                                             let mut stroke_builder =
@@ -1591,7 +1568,7 @@ impl Render for ChartView {
                                 // --- In-canvas Y-axis tick labels ---
                                 // Right-aligned in the MARGIN_LEFT column.
                                 // Pie has no axes — skip all tick labels.
-                                let tick_color = gpui::hsla(0.0, 0.0, 0.55, 1.0);
+                                let tick_color = theme.muted_foreground;
                                 let tick_font = font("Zed Mono");
                                 let tick_size = gpui::px(10.0);
                                 let line_height = gpui::px(12.0);
@@ -1673,7 +1650,9 @@ impl Render for ChartView {
                         .absolute()
                         .size_full()
                     })
-                    .when_some(readout, |container, r| container.child(readout_overlay(r))),
+                    .when_some(readout, |container, r| {
+                        container.child(readout_overlay(r, readout_colors))
+                    }),
             )
             // Legend row (below canvas)
             .when_some(legend, |d, leg| d.child(leg))
@@ -2448,7 +2427,10 @@ pub fn format_y_value(y: f64) -> String {
 ///
 /// Layout: top 18px fixed; left clamped so the panel stays inside the plot area.
 /// Min-width 200px; one header row (time + optional offset) then one row per series.
-fn readout_overlay(r: HoverReadout) -> impl IntoElement {
+///
+/// `colors` is derived from `ChartColors::for_current(cx)` at the render call site
+/// so the overlay matches the active theme.
+fn readout_overlay(r: HoverReadout, colors: ChartColors) -> impl IntoElement {
     const PANEL_MIN_WIDTH: f32 = 200.0;
     const PANEL_GAP: f32 = 12.0;
 
@@ -2474,9 +2456,9 @@ fn readout_overlay(r: HoverReadout) -> impl IntoElement {
         .gap(gpui::px(2.0))
         .px(gpui::px(10.0))
         .py(gpui::px(8.0))
-        .bg(gpui::hsla(0.0, 0.0, 0.09, 1.0))
+        .bg(colors.panel_bg)
         .border_1()
-        .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.18))
+        .border_color(colors.panel_border)
         .rounded(gpui::px(6.0))
         .text_size(FontSizes::XS)
         .overflow_hidden()
@@ -2485,18 +2467,14 @@ fn readout_overlay(r: HoverReadout) -> impl IntoElement {
             div()
                 .flex()
                 .items_center()
-                .text_color(gpui::hsla(0.0, 0.0, 0.85, 1.0))
+                .text_color(colors.value_fg)
                 .font_weight(gpui::FontWeight::SEMIBOLD)
                 .child(r.header_time)
                 .when_some(r.header_offset, |d, offset| {
-                    d.child(
-                        div()
-                            .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0))
-                            .child(offset),
-                    )
+                    d.child(div().text_color(colors.label_fg).child(offset))
                 }),
         )
-        // One row per series; focused row gets semibold + slightly brighter bg.
+        // One row per series; focused row gets semibold.
         .children(r.series.into_iter().enumerate().map(move |(idx, entry)| {
             let is_focused = idx == focused_idx;
             div()
@@ -2511,15 +2489,11 @@ fn readout_overlay(r: HoverReadout) -> impl IntoElement {
                 .child(
                     div()
                         .flex_1()
-                        .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0))
+                        .text_color(colors.label_fg)
                         .child(entry.label),
                 )
                 // Value (foreground)
-                .child(
-                    div()
-                        .text_color(gpui::hsla(0.0, 0.0, 0.95, 1.0))
-                        .child(entry.y_label),
-                )
+                .child(div().text_color(colors.value_fg).child(entry.y_label))
         }))
 }
 
@@ -2743,7 +2717,7 @@ mod tests {
     }
 
     #[test]
-    fn build_assigns_palette_colors() {
+    fn build_assigns_palette_slots() {
         let rows = vec![vec![Value::Int(0), Value::Float(1.0), Value::Float(2.0)]];
         let result = QueryResult::table(
             vec![
@@ -2757,7 +2731,7 @@ mod tests {
         );
         let spec = simple_spec(0, &[1, 2]);
         let view = ChartView::build(&result, spec).expect("build should succeed");
-        assert_eq!(view.render_model.palette_colors.len(), 2);
+        assert_eq!(view.render_model.palette_slots.len(), 2);
     }
 
     #[test]
@@ -3018,8 +2992,8 @@ mod tests {
             "y_ticks must be non-empty"
         );
 
-        // Palette colours resolved for both series.
-        assert_eq!(view.render_model.palette_colors.len(), 2);
+        // Palette slot indices stored for both series (theme-resolved at render time).
+        assert_eq!(view.render_model.palette_slots.len(), 2);
 
         // Series stats over post-decimation (= all) points.
         let s0 = view.render_model.series_stats[0].expect("series 0 stats present");

--- a/crates/dbflux_components/src/chart/mod.rs
+++ b/crates/dbflux_components/src/chart/mod.rs
@@ -30,10 +30,7 @@ pub use data_source::{
     ChartSourceError, MetricSource, TimeWindow, resolve_source,
 };
 pub use detect::{ChartDetection, detect_chart_columns};
-pub use engine::{
-    CHART_ACCENT_CYAN, CHART_ACCENT_PRIMARY, CHART_PALETTE, ChartBuildError, ChartView,
-    format_x_value, format_y_value,
-};
+pub use engine::{ChartBuildError, ChartView, format_x_value, format_y_value};
 pub use point_inspector::{DataPointRef, SourceRowRef, point_inspector_element};
 pub use spec::{
     AggKind, AxisKind, AxisSpec, BindingSpec, ChartKind, ChartSpec, ManualChartSelection,

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -6,9 +6,8 @@ use crate::data_view::DataViewMode;
 use crate::result_view::ResultViewMode;
 use dbflux_components::chart::legend::legend_element;
 use dbflux_components::chart::{
-    CHART_ACCENT_CYAN, CHART_ACCENT_PRIMARY, ChartDetection, ManualChartSelection, SeriesSpec,
-    SeriesStats, count_columns_for_why, format_resolution, format_span, format_x_value,
-    format_y_value,
+    ChartDetection, ManualChartSelection, SeriesSpec, SeriesStats, count_columns_for_why,
+    format_resolution, format_span, format_x_value, format_y_value,
 };
 use dbflux_components::chart::{SourceRowRef, point_inspector_element};
 use dbflux_components::common::time_range::view::TimeRangePanel;
@@ -1689,7 +1688,7 @@ impl DataGridPanel {
 
         let cv = chart_entity.read(cx);
         let series = cv.spec_series().to_vec();
-        let palette = cv.palette_colors().to_vec();
+        let palette = cv.resolved_palette(cx);
         let stats = cv.series_stats().to_vec();
         let focused_idx = cv.focused_series_idx();
 
@@ -1947,6 +1946,7 @@ impl DataGridPanel {
                         } else {
                             "Pick time column…"
                         };
+                        let primary = cx.theme().primary;
                         d.child(
                             div()
                                 .id("cd-pick-column")
@@ -1955,9 +1955,9 @@ impl DataGridPanel {
                                 .rounded(Radii::SM)
                                 .text_size(FontSizes::SM)
                                 .cursor_pointer()
-                                .bg(CHART_ACCENT_PRIMARY.opacity(0.9))
+                                .bg(primary.opacity(0.9))
                                 .text_color(gpui::black())
-                                .hover(|d| d.bg(CHART_ACCENT_PRIMARY))
+                                .hover(move |d| d.bg(primary))
                                 .on_mouse_down(
                                     MouseButton::Left,
                                     cx.listener(|this, _, _, cx| {
@@ -1995,6 +1995,8 @@ impl DataGridPanel {
     /// Contains the X-axis column selector, Y-axis checkboxes, and Apply button.
     /// Extracted from the old inline degraded view so the card action button can toggle it.
     fn render_chart_picker_overlay(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+        let primary = cx.theme().primary;
+
         let y_candidates: Vec<(usize, String)> = self
             .result
             .columns
@@ -2166,9 +2168,9 @@ impl DataGridPanel {
             .text_size(FontSizes::SM)
             .when(any_y_checked, |d| {
                 d.cursor_pointer()
-                    .bg(CHART_ACCENT_PRIMARY.opacity(0.9))
+                    .bg(primary.opacity(0.9))
                     .text_color(gpui::black())
-                    .hover(|d| d.bg(CHART_ACCENT_PRIMARY))
+                    .hover(move |d| d.bg(primary))
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(move |this, _, _, cx| {
@@ -2602,7 +2604,7 @@ impl DataGridPanel {
             let view = cv.read(cx);
             let s = view.series_stats().get(focused_idx).copied().flatten();
             let label = view.series_label(focused_idx).to_string();
-            let color = view.series_color(focused_idx);
+            let color = view.series_color(focused_idx, cx);
             let (x_min, x_max) = view.data_x_bounds();
             let x_is_time = view.x_is_time();
             (s, label, color, x_min, x_max, x_is_time)
@@ -2633,20 +2635,22 @@ impl DataGridPanel {
         let points_count = self.result.rows.len();
 
         // Value color per stat:
-        //   min, max, avg  → CHART_ACCENT_CYAN  (#95E6CB)
-        //   p99            → CHART_ACCENT_PRIMARY (#FFB454 / theme primary)
+        //   min, max, avg  → theme.cyan   (≈ #95E6CB on Dark/Mirage, #4CBF99 on Light)
+        //   p99            → theme.primary (≈ #FFB454 on Dark, varies per theme)
         //   others         → theme.foreground
+        let cyan_color = theme.cyan;
+        let primary_color = theme.primary;
         let cyan_val = |v: f64| -> gpui::AnyElement {
             div()
                 .text_size(px(11.0))
-                .text_color(CHART_ACCENT_CYAN)
+                .text_color(cyan_color)
                 .child(SharedString::from(format_y_value(v)))
                 .into_any_element()
         };
         let primary_val = |v: f64| -> gpui::AnyElement {
             div()
                 .text_size(px(11.0))
-                .text_color(CHART_ACCENT_PRIMARY)
+                .text_color(primary_color)
                 .child(SharedString::from(format_y_value(v)))
                 .into_any_element()
         };


### PR DESCRIPTION
Part of #115 — **PR2 of 3** of making charts theme-responsive. Builds on the `ChartColors` struct from #116.

## What this PR does

Wires the chart engine to the active theme so series colors and canvas chrome derive from `cx.theme()` and `theme.chart_1..5` instead of dark-only hardcoded literals.

### Series palette (render-time)
- Removed the static `CHART_PALETTE`. `RenderModel` now stores `palette_slots: Vec<u8>` (slot indices); the paint closure resolves `slot % 5 → theme.chart_N` each frame.
- Accessor signatures: `series_color(idx) → series_color(idx, cx)`; `palette_colors() → resolved_palette(cx)`. The two call-sites in `data_grid_panel/render.rs` (legend, stats dock) already hold `cx`.

### Canvas chrome via `cx.theme()`

| Element | Was | Now |
|---|---|---|
| Gridlines | `hsla(0,0,0.5,0.18)` | `theme.border` |
| Crosshair | `hsla(0.097,1,0.666,0.7)` | `theme.primary` @ alpha 0.7 |
| Hover-dot bg | `hsla(0.56,0.17,0.07,1)` | `theme.background` |
| Tick labels | `hsla(0,0,0.55,1)` | `theme.muted_foreground` |
| Readout overlay (bg/border/text) | dark literals | `ChartColors.{panel_bg, panel_border, value_fg, label_fg}` |

OOB neutral fallback `hsla(0.6,0.6,0.5,1)` left in place (safety path).

### Accent consts removed
- `CHART_ACCENT_CYAN` and `CHART_ACCENT_PRIMARY` deleted from `engine.rs`; the render.rs Stats-dock and degraded/picker call-sites migrated to `cx.theme().cyan` / `cx.theme().primary` in this PR (compile-time forcing function, same pattern as `tokens::BannerColors` hard-removal in #111 Phase 1).

## Behavior (intentional, per #5698)

- **Dark series palette**: byte-identical (`theme.chart_1..5` Dark = `#59C2FF/AAD94C/FFB454/F07178/D2A6FF` = the old `CHART_PALETTE` exactly).
- **Dark chrome**: derives from theme tokens. Most are very close to the old literals; **three roles are close-but-not-byte-identical** and worth a visual sanity-check on Dark: gridlines (`theme.border` vs old `0.5/0.18`), tick labels (`theme.muted_foreground` ≈ L40% vs old L55% — labels may look slightly dimmer), hover-dot bg (`theme.background` vs old dark-teal). None are regressions; all are the design's documented divergences for theme-token consumption. If any feels off, easy to revert that specific role to a literal or use a brighter token.
- **Mirage and Light**: intentionally theme-responsive — Mirage now uses theme-appropriate `info/success/warning/error/lavender` for series; Light gets the correct Light palette (was previously broken, using the Dark palette).

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace` — pass
- `cargo nextest run --workspace --no-fail-fast` — **2340 passed, 0 failed**
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo test --doc --workspace` — pass
- `cargo build -p dbflux --no-default-features --features sqlite,…,lua,aws` — pass (mcp gate)
- `dbflux_components` still domain-free; grep `CHART_PALETTE|CHART_ACCENT_*` → zero
- Visual QA on Dark/Mirage/Light is a human acceptance step (not blocked here).

## Size

~225 changed lines (3 files; net −25 because the removed consts were heavier than the new code). No `size:exception`.

## Remaining

PR3: element factories (`point_inspector_element`, `axis_bar_element`, `legend_element`) consume `ChartColors`; remove the 23 chart `// guardrail-allow` lines in `data_grid_panel/render.rs`; tighten the `/chart/` guardrail exemption to `engine.rs` only.