### PR TITLE
feat(chart): make factories + render overlays theme-responsive (#115 PR3)

### DIFF
--- a/crates/dbflux_components/src/chart/axis_bar.rs
+++ b/crates/dbflux_components/src/chart/axis_bar.rs
@@ -21,6 +21,7 @@ use gpui::{
 };
 
 use crate::chart::spec::{AggKind, BindingSpec};
+use crate::semantic::ChartColors;
 use dbflux_core::{ColumnKind, ColumnMeta};
 
 /// Identifies which AxisBar pill is currently open (showing its picker).
@@ -61,6 +62,7 @@ pub fn axis_bar_element<FPill, FX, FY, FGroup, FAgg>(
     bindings: &BindingSpec,
     columns: &[ColumnMeta],
     open_pill: Option<AxisPill>,
+    colors: &ChartColors,
     on_pill_click: FPill,
     on_x_select: FX,
     on_y_toggle: FY,
@@ -122,7 +124,7 @@ where
     // X pill
     let x_pill = {
         let handler = on_pill_click.clone();
-        pill_element("axis-pill-x", "X", x_label, x_open, move |w, cx| {
+        pill_element("axis-pill-x", "X", x_label, x_open, colors, move |w, cx| {
             handler(AxisPill::X, w, cx)
         })
     };
@@ -146,6 +148,7 @@ where
                 "axis-picker-x",
                 x_candidates,
                 Some(bindings.x),
+                colors,
                 move |col_idx, w, cx| on_x_select(col_idx, w, cx),
             )
             .into_any_element(),
@@ -157,7 +160,7 @@ where
     // Y pill
     let y_pill = {
         let handler = on_pill_click.clone();
-        pill_element("axis-pill-y", "Y", y_label, y_open, move |w, cx| {
+        pill_element("axis-pill-y", "Y", y_label, y_open, colors, move |w, cx| {
             handler(AxisPill::Y, w, cx)
         })
     };
@@ -178,6 +181,7 @@ where
             y_picker_element(
                 "axis-picker-y",
                 y_candidates,
+                colors,
                 move |col_idx, checked, w, cx| {
                     on_y_toggle(col_idx, checked, w, cx);
                 },
@@ -196,6 +200,7 @@ where
             "Group",
             group_label,
             group_open,
+            colors,
             move |w, cx| handler(AxisPill::Group, w, cx),
         )
     };
@@ -220,6 +225,7 @@ where
                 "axis-picker-group",
                 group_candidates,
                 current,
+                colors,
                 move |sel, w, cx| on_group_select(sel, w, cx),
             )
             .into_any_element(),
@@ -231,9 +237,14 @@ where
     // Agg pill
     let agg_pill = {
         let handler = on_pill_click.clone();
-        pill_element("axis-pill-agg", "Agg", agg_label, agg_open, move |w, cx| {
-            handler(AxisPill::Agg, w, cx)
-        })
+        pill_element(
+            "axis-pill-agg",
+            "Agg",
+            agg_label,
+            agg_open,
+            colors,
+            move |w, cx| handler(AxisPill::Agg, w, cx),
+        )
     };
 
     // Agg picker (enum dropdown)
@@ -248,9 +259,15 @@ where
         let current = bindings.aggregation;
 
         Some(
-            agg_picker_element("axis-picker-agg", agg_kinds, current, move |kind, w, cx| {
-                on_agg_select(kind, w, cx);
-            })
+            agg_picker_element(
+                "axis-picker-agg",
+                agg_kinds,
+                current,
+                colors,
+                move |kind, w, cx| {
+                    on_agg_select(kind, w, cx);
+                },
+            )
             .into_any_element(),
         )
     } else {
@@ -284,9 +301,25 @@ fn pill_element(
     role: &'static str,
     value: SharedString,
     active: bool,
+    colors: &ChartColors,
     on_click: impl Fn(&mut Window, &mut App) + Send + Sync + 'static,
 ) -> impl IntoElement {
-    let border_alpha = if active { 0.6_f32 } else { 0.18 };
+    // Active pills get a more opaque border; inactive use the standard pill_border.
+    // Expressed as an alpha override on the pill_border hue/sat/lum so the
+    // on-Light theme border color still follows the role.
+    let border_color = if active {
+        gpui::Hsla {
+            a: 0.6,
+            ..colors.pill_border
+        }
+    } else {
+        colors.pill_border
+    };
+    let bg_color = if active {
+        colors.pill_bg
+    } else {
+        colors.hover_bg
+    };
 
     div()
         .id(id.into())
@@ -298,10 +331,10 @@ fn pill_element(
         .py(px(2.0))
         .rounded(px(4.0))
         .border_1()
-        .border_color(gpui::hsla(0.0, 0.0, 1.0, border_alpha))
-        .bg(gpui::hsla(0.0, 0.0, 1.0, if active { 0.08 } else { 0.04 }))
+        .border_color(border_color)
+        .bg(bg_color)
         .cursor_pointer()
-        .hover(|s| s.bg(gpui::hsla(0.0, 0.0, 1.0, 0.10)))
+        .hover(|s| s.bg(colors.hover_bg))
         .on_mouse_down(MouseButton::Left, move |_, window, cx| {
             on_click(window, cx);
         })
@@ -309,13 +342,13 @@ fn pill_element(
             div()
                 .text_size(px(10.0))
                 .font_weight(gpui::FontWeight::SEMIBOLD)
-                .text_color(gpui::hsla(0.0, 0.0, 0.5, 1.0))
+                .text_color(colors.label_fg)
                 .child(SharedString::from(role)),
         )
         .child(
             div()
                 .text_size(px(11.0))
-                .text_color(gpui::hsla(0.0, 0.0, 0.9, 1.0))
+                .text_color(colors.value_fg)
                 .child(value),
         )
 }
@@ -351,6 +384,7 @@ fn column_picker_element<F>(
     id: impl Into<ElementId>,
     candidates: Vec<(usize, SharedString)>,
     selected: Option<usize>,
+    colors: &ChartColors,
     on_select: F,
 ) -> impl IntoElement
 where
@@ -361,6 +395,8 @@ where
         .map(|(col_idx, label)| {
             let is_selected = selected == Some(col_idx);
             let handler = on_select.clone();
+            let hover_bg = colors.hover_bg;
+            let value_fg = colors.value_fg;
 
             div()
                 .id(ElementId::Name(format!("col-pick-{}", col_idx).into()))
@@ -371,28 +407,24 @@ where
                 .px(px(8.0))
                 .py(px(3.0))
                 .cursor_pointer()
-                .hover(|s| s.bg(gpui::hsla(0.0, 0.0, 1.0, 0.06)))
+                .hover(move |s| s.bg(hover_bg))
                 .when(is_selected, |d| d.font_weight(gpui::FontWeight::MEDIUM))
                 .on_mouse_down(MouseButton::Left, move |_, window, cx| {
                     handler(col_idx, window, cx);
                 })
-                .child(
-                    div()
-                        .text_size(px(11.0))
-                        .text_color(gpui::hsla(0.0, 0.0, 0.9, 1.0))
-                        .child(label),
-                )
+                .child(div().text_size(px(11.0)).text_color(value_fg).child(label))
                 .into_any_element()
         })
         .collect();
 
-    picker_container(id, rows)
+    picker_container(id, rows, colors)
 }
 
 /// A multi-select Y-column picker with one checkbox row per candidate.
 fn y_picker_element<F>(
     id: impl Into<ElementId>,
     candidates: Vec<(usize, SharedString, bool)>,
+    colors: &ChartColors,
     on_toggle: F,
 ) -> impl IntoElement
 where
@@ -402,6 +434,10 @@ where
         .into_iter()
         .map(|(col_idx, label, checked)| {
             let handler = on_toggle.clone();
+            let hover_bg = colors.hover_bg;
+            let pill_border = colors.pill_border;
+            let checkbox_checked = colors.checkbox_checked;
+            let value_fg = colors.value_fg;
 
             div()
                 .id(ElementId::Name(format!("y-pick-{}", col_idx).into()))
@@ -412,7 +448,7 @@ where
                 .px(px(8.0))
                 .py(px(3.0))
                 .cursor_pointer()
-                .hover(|s| s.bg(gpui::hsla(0.0, 0.0, 1.0, 0.06)))
+                .hover(move |s| s.bg(hover_bg))
                 .on_mouse_down(MouseButton::Left, move |_, window, cx| {
                     handler(col_idx, !checked, window, cx);
                 })
@@ -423,24 +459,19 @@ where
                         .h(px(10.0))
                         .rounded(px(2.0))
                         .border_1()
-                        .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.3))
+                        .border_color(pill_border)
                         .bg(if checked {
-                            gpui::hsla(0.55, 0.7, 0.5, 1.0)
+                            checkbox_checked
                         } else {
-                            gpui::hsla(0.0, 0.0, 0.0, 0.0)
+                            gpui::transparent_black()
                         }),
                 )
-                .child(
-                    div()
-                        .text_size(px(11.0))
-                        .text_color(gpui::hsla(0.0, 0.0, 0.9, 1.0))
-                        .child(label),
-                )
+                .child(div().text_size(px(11.0)).text_color(value_fg).child(label))
                 .into_any_element()
         })
         .collect();
 
-    picker_container(id, rows)
+    picker_container(id, rows, colors)
 }
 
 /// A single-select picker for group-by column (includes a "none" option).
@@ -448,6 +479,7 @@ fn group_picker_element<F>(
     id: impl Into<ElementId>,
     candidates: Vec<(Option<usize>, SharedString)>,
     selected: Option<usize>,
+    colors: &ChartColors,
     on_select: F,
 ) -> impl IntoElement
 where
@@ -458,6 +490,8 @@ where
         .map(|(col_idx_opt, label)| {
             let is_selected = col_idx_opt == selected;
             let handler = on_select.clone();
+            let hover_bg = colors.hover_bg;
+            let value_fg = colors.value_fg;
 
             div()
                 .id(ElementId::Name(
@@ -476,22 +510,17 @@ where
                 .px(px(8.0))
                 .py(px(3.0))
                 .cursor_pointer()
-                .hover(|s| s.bg(gpui::hsla(0.0, 0.0, 1.0, 0.06)))
+                .hover(move |s| s.bg(hover_bg))
                 .when(is_selected, |d| d.font_weight(gpui::FontWeight::MEDIUM))
                 .on_mouse_down(MouseButton::Left, move |_, window, cx| {
                     handler(col_idx_opt, window, cx);
                 })
-                .child(
-                    div()
-                        .text_size(px(11.0))
-                        .text_color(gpui::hsla(0.0, 0.0, 0.9, 1.0))
-                        .child(label),
-                )
+                .child(div().text_size(px(11.0)).text_color(value_fg).child(label))
                 .into_any_element()
         })
         .collect();
 
-    picker_container(id, rows)
+    picker_container(id, rows, colors)
 }
 
 /// A single-select picker for `AggKind`.
@@ -499,6 +528,7 @@ fn agg_picker_element<F>(
     id: impl Into<ElementId>,
     agg_kinds: Vec<(AggKind, SharedString)>,
     current: AggKind,
+    colors: &ChartColors,
     on_select: F,
 ) -> impl IntoElement
 where
@@ -509,6 +539,8 @@ where
         .map(|(kind, label)| {
             let is_selected = kind == current;
             let handler = on_select.clone();
+            let hover_bg = colors.hover_bg;
+            let value_fg = colors.value_fg;
 
             div()
                 .id(ElementId::Name(format!("agg-pick-{:?}", kind).into()))
@@ -519,34 +551,33 @@ where
                 .px(px(8.0))
                 .py(px(3.0))
                 .cursor_pointer()
-                .hover(|s| s.bg(gpui::hsla(0.0, 0.0, 1.0, 0.06)))
+                .hover(move |s| s.bg(hover_bg))
                 .when(is_selected, |d| d.font_weight(gpui::FontWeight::MEDIUM))
                 .on_mouse_down(MouseButton::Left, move |_, window, cx| {
                     handler(kind, window, cx);
                 })
-                .child(
-                    div()
-                        .text_size(px(11.0))
-                        .text_color(gpui::hsla(0.0, 0.0, 0.9, 1.0))
-                        .child(label),
-                )
+                .child(div().text_size(px(11.0)).text_color(value_fg).child(label))
                 .into_any_element()
         })
         .collect();
 
-    picker_container(id, rows)
+    picker_container(id, rows, colors)
 }
 
 /// Shared container styling for picker dropdowns.
-fn picker_container(id: impl Into<ElementId>, rows: Vec<AnyElement>) -> impl IntoElement {
+fn picker_container(
+    id: impl Into<ElementId>,
+    rows: Vec<AnyElement>,
+    colors: &ChartColors,
+) -> impl IntoElement {
     div()
         .id(id.into())
         .flex()
         .flex_col()
         .min_w(px(140.0))
-        .bg(gpui::hsla(0.0, 0.0, 0.12, 1.0))
+        .bg(colors.panel_bg)
         .border_1()
-        .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.12))
+        .border_color(colors.pill_border)
         .rounded(px(4.0))
         .shadow_lg()
         .py(px(2.0))

--- a/crates/dbflux_components/src/chart/legend.rs
+++ b/crates/dbflux_components/src/chart/legend.rs
@@ -10,6 +10,7 @@ use gpui::{AnyElement, Hsla, IntoElement, SharedString, div};
 
 use crate::chart::spec::SeriesSpec;
 use crate::chart::stats::SeriesStats;
+use crate::semantic::ChartColors;
 
 /// Build the legend element for a chart.
 ///
@@ -19,6 +20,7 @@ use crate::chart::stats::SeriesStats;
 /// - `stats`: per-series statistics (parallel to `series`); may be `None` for empty series.
 /// - `hidden`: set of hidden series indices; chips for hidden indices are rendered at 40% opacity.
 /// - `focused_series_idx`: currently focused series (chip highlighted with a border).
+/// - `colors`: semantic chart colors for the active theme.
 /// - `on_toggle_hidden`: called with the series index when the chip is clicked.
 pub fn legend_element<F>(
     series: &[SeriesSpec],
@@ -26,6 +28,7 @@ pub fn legend_element<F>(
     stats: &[Option<SeriesStats>],
     hidden: &HashSet<usize>,
     focused_series_idx: usize,
+    colors: &ChartColors,
     on_toggle_hidden: Option<F>,
 ) -> impl IntoElement
 where
@@ -42,7 +45,7 @@ where
             let color = palette
                 .get(s.color_slot as usize % palette.len().max(1))
                 .copied()
-                .unwrap_or(gpui::hsla(0.6, 0.6, 0.5, 1.0));
+                .unwrap_or(gpui::hsla(0.6, 0.6, 0.5, 1.0)); // guardrail-allow: OOB palette slot neutral fallback, no semantic token for this case
 
             let label: SharedString = s.label.clone().into();
             let is_focused = i == focused_series_idx;
@@ -73,11 +76,7 @@ where
                 .child(div().child(label));
 
             if let Some(stat) = stat_str {
-                chip = chip.child(
-                    div()
-                        .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0))
-                        .child(stat),
-                );
+                chip = chip.child(div().text_color(colors.label_fg).child(stat));
             }
 
             if let Some(ref handler) = on_toggle_hidden {
@@ -104,14 +103,14 @@ where
         .px(gpui::px(12.0))
         .py(gpui::px(4.0))
         .border_t_1()
-        .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.06))
+        .border_color(colors.pill_border)
         .children(chips)
         .child(
             div()
                 .flex_1()
                 .flex()
                 .justify_end()
-                .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0))
+                .text_color(colors.muted_fg)
                 .text_size(gpui::px(10.0))
                 .child(counter),
         )

--- a/crates/dbflux_components/src/chart/point_inspector.rs
+++ b/crates/dbflux_components/src/chart/point_inspector.rs
@@ -8,6 +8,7 @@
 use gpui::prelude::*;
 use gpui::{AnyElement, div, px};
 
+use crate::semantic::ChartColors;
 use crate::tokens::FontSizes;
 
 // ---------------------------------------------------------------------------
@@ -53,6 +54,7 @@ pub struct SourceRowRef {
 /// * `hovered_y` — formatted Y value.
 /// * `delta_prev` — optional formatted delta vs the previous decimated sample.
 /// * `delta_avg` — optional formatted delta vs the window average.
+/// * `colors` — semantic chart colors for the active theme.
 #[allow(clippy::too_many_arguments)]
 pub fn point_inspector_element(
     source: SourceRowRef,
@@ -62,6 +64,7 @@ pub fn point_inspector_element(
     hovered_y: &str,
     delta_prev: Option<&str>,
     delta_avg: Option<&str>,
+    colors: &ChartColors,
 ) -> AnyElement {
     let show_in_tree_source = source;
 
@@ -71,8 +74,8 @@ pub fn point_inspector_element(
         .flex()
         .flex_col()
         .border_l_1()
-        .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.08))
-        .bg(gpui::hsla(0.0, 0.0, 0.08, 1.0))
+        .border_color(colors.panel_border)
+        .bg(colors.panel_bg)
         .overflow_hidden()
         // Header: series name
         .child(
@@ -80,14 +83,14 @@ pub fn point_inspector_element(
                 .px(px(12.0))
                 .py(px(8.0))
                 .border_b_1()
-                .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.06))
+                .border_color(colors.pill_bg)
                 .flex()
                 .items_center()
                 .gap(px(6.0))
                 .child(
                     div()
                         .text_size(FontSizes::XS)
-                        .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0))
+                        .text_color(colors.label_fg)
                         .font_weight(gpui::FontWeight::SEMIBOLD)
                         .child("SERIES"),
                 )
@@ -95,7 +98,7 @@ pub fn point_inspector_element(
                     div()
                         .flex_1()
                         .text_size(FontSizes::SM)
-                        .text_color(gpui::hsla(0.0, 0.0, 0.90, 1.0))
+                        .text_color(colors.value_fg)
                         .font_weight(gpui::FontWeight::SEMIBOLD)
                         .child(series_name.to_string()),
                 ),
@@ -107,10 +110,11 @@ pub fn point_inspector_element(
                 .flex()
                 .flex_col()
                 .gap(px(4.0))
-                .child(kv_row("Time", hovered_x))
-                .child(kv_row("Value", hovered_y))
-                .when_some(delta_prev, |d, v| d.child(kv_row("Δ prev", v)))
-                .when_some(delta_avg, |d, v| d.child(kv_row("Δ avg", v))),
+                .child(kv_row("Time", hovered_x, colors))
+                .child(kv_row("Value", hovered_y, colors))
+                .when_some(delta_prev, |d, v| d.child(kv_row("Δ prev", v, colors)))
+                .when_some(delta_avg, |d, v| d.child(kv_row("Δ avg", v, colors))),
+            colors,
         ))
         // Source doc section: pretty-print the row fields
         .child(inspector_section(
@@ -130,7 +134,7 @@ pub fn point_inspector_element(
                                 .flex_shrink_0()
                                 .w(px(80.0))
                                 .text_size(FontSizes::XS)
-                                .text_color(gpui::hsla(0.0, 0.0, 0.50, 1.0))
+                                .text_color(colors.muted_fg)
                                 .overflow_hidden()
                                 .child(key.clone()),
                         )
@@ -138,11 +142,12 @@ pub fn point_inspector_element(
                             div()
                                 .flex_1()
                                 .text_size(FontSizes::XS)
-                                .text_color(gpui::hsla(0.0, 0.0, 0.85, 1.0))
+                                .text_color(colors.value_fg)
                                 .overflow_hidden()
                                 .child(val.clone()),
                         )
                 })),
+            colors,
         ))
         // Quick actions row
         .child(
@@ -150,14 +155,14 @@ pub fn point_inspector_element(
                 .px(px(12.0))
                 .py(px(10.0))
                 .border_t_1()
-                .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.06))
+                .border_color(colors.pill_bg)
                 .flex()
                 .flex_col()
                 .gap(px(6.0))
                 .child(
                     div()
                         .text_size(FontSizes::XS)
-                        .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0))
+                        .text_color(colors.muted_fg)
                         .font_weight(gpui::FontWeight::SEMIBOLD)
                         .child("QUICK ACTIONS"),
                 )
@@ -176,11 +181,16 @@ pub fn point_inspector_element(
                             "Show in tree",
                             false,
                             show_in_tree_source.row_idx,
+                            colors,
                         ))
                         // "Annotate" — stub, coming soon.
-                        .child(action_button_disabled("Annotate", "Coming soon"))
+                        .child(action_button_disabled("Annotate", "Coming soon", colors))
                         // "Copy as query" — stub.
-                        .child(action_button_disabled("Copy as query", "Coming soon")),
+                        .child(action_button_disabled(
+                            "Copy as query",
+                            "Coming soon",
+                            colors,
+                        )),
                 ),
         )
         .into_any_element()
@@ -190,26 +200,30 @@ pub fn point_inspector_element(
 // Layout helpers (private)
 // ---------------------------------------------------------------------------
 
-fn inspector_section(label: &'static str, content: impl IntoElement) -> impl IntoElement {
+fn inspector_section(
+    label: &'static str,
+    content: impl IntoElement,
+    colors: &ChartColors,
+) -> impl IntoElement {
     div()
         .px(px(12.0))
         .py(px(8.0))
         .border_b_1()
-        .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.06))
+        .border_color(colors.pill_bg)
         .flex()
         .flex_col()
         .gap(px(6.0))
         .child(
             div()
                 .text_size(FontSizes::XS)
-                .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0))
+                .text_color(colors.muted_fg)
                 .font_weight(gpui::FontWeight::SEMIBOLD)
                 .child(label),
         )
         .child(content)
 }
 
-fn kv_row(key: &'static str, value: &str) -> impl IntoElement {
+fn kv_row(key: &'static str, value: &str, colors: &ChartColors) -> impl IntoElement {
     div()
         .flex()
         .items_center()
@@ -219,14 +233,14 @@ fn kv_row(key: &'static str, value: &str) -> impl IntoElement {
                 .w(px(60.0))
                 .flex_shrink_0()
                 .text_size(FontSizes::XS)
-                .text_color(gpui::hsla(0.0, 0.0, 0.50, 1.0))
+                .text_color(colors.muted_fg)
                 .child(key),
         )
         .child(
             div()
                 .flex_1()
                 .text_size(FontSizes::XS)
-                .text_color(gpui::hsla(0.0, 0.0, 0.90, 1.0))
+                .text_color(colors.value_fg)
                 .font_weight(gpui::FontWeight::SEMIBOLD)
                 .child(value.to_string()),
         )
@@ -236,7 +250,12 @@ fn kv_row(key: &'static str, value: &str) -> impl IntoElement {
 /// `SourceRowRef.row_idx` encoded in the element ID so the host can read it
 /// from the DOM event. The actual scroll is wired by the host — the inspector
 /// does not own the target entity.
-fn action_button(label: &'static str, _disabled: bool, row_idx: usize) -> impl IntoElement {
+fn action_button(
+    label: &'static str,
+    _disabled: bool,
+    row_idx: usize,
+    colors: &ChartColors,
+) -> impl IntoElement {
     div()
         .id(gpui::ElementId::Name(
             format!(
@@ -250,27 +269,31 @@ fn action_button(label: &'static str, _disabled: bool, row_idx: usize) -> impl I
         .py(px(3.0))
         .rounded(px(4.0))
         .border_1()
-        .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.12))
-        .bg(gpui::hsla(0.0, 0.0, 0.13, 1.0))
+        .border_color(colors.pill_border)
+        .bg(colors.pill_bg)
         .cursor_pointer()
         .text_size(FontSizes::XS)
-        .text_color(gpui::hsla(0.0, 0.0, 0.85, 1.0))
-        .hover(|d| d.bg(gpui::hsla(0.0, 0.0, 0.18, 1.0)))
+        .text_color(colors.value_fg)
+        .hover(|d| d.bg(colors.hover_bg))
         .child(label)
 }
 
 /// Disabled action button with a tooltip hint.
-fn action_button_disabled(label: &'static str, _tooltip: &'static str) -> impl IntoElement {
+fn action_button_disabled(
+    label: &'static str,
+    _tooltip: &'static str,
+    colors: &ChartColors,
+) -> impl IntoElement {
     div()
         .px(px(8.0))
         .py(px(3.0))
         .rounded(px(4.0))
         .border_1()
-        .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.06))
-        .bg(gpui::hsla(0.0, 0.0, 0.09, 1.0))
+        .border_color(colors.pill_bg)
+        .bg(colors.panel_bg)
         .cursor_default()
         .text_size(FontSizes::XS)
-        .text_color(gpui::hsla(0.0, 0.0, 0.35, 1.0))
+        .text_color(colors.muted_fg)
         .child(label)
 }
 

--- a/crates/dbflux_components/src/style_guardrails.rs
+++ b/crates/dbflux_components/src/style_guardrails.rs
@@ -18,17 +18,32 @@ mod style_guardrails {
 
     const SRC_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src");
 
-    /// Fragments that, when found in a file's path, exempt it from all checks.
-    /// These are canonical token/semantic/theme definition files where bare
-    /// literals and color constructors are legitimately defined.
+    /// Fragments that, when found in a file's path, exempt it from ALL checks
+    /// (both spacing and color). These are canonical token/semantic/theme
+    /// definition files where bare literals and color constructors are
+    /// legitimately defined.
     const FILE_EXEMPT_FRAGMENTS: &[&str] = &[
         "tokens.rs",
         "semantic.rs",
         "density.rs",
-        "/chart/",
         "theme.rs",
         "style_guardrails.rs",
     ];
+
+    /// Fragments that exempt a file from the color check only.
+    /// Chart factory files (`axis_bar`, `point_inspector`, `legend`) use raw
+    /// spacing tokens (px values) that pre-date the token system and are
+    /// exempt from the spacing check via `FILE_EXEMPT_CHART_SPACING_FRAGMENTS`.
+    /// They route all colour roles through `ChartColors` so they pass the
+    /// colour check — but engine.rs retains canvas paint literals and stays
+    /// fully exempt.
+    const FILE_EXEMPT_COLOR_FRAGMENTS: &[&str] = &["/chart/engine.rs"];
+
+    /// Fragments that exempt a file from the spacing check only.
+    /// Chart files use raw px() spacing values that were exempt under the old
+    /// `/chart/` blanket exemption. They now route colors through `ChartColors`
+    /// but their spacing literals remain and are exempt from the spacing check.
+    const FILE_EXEMPT_SPACING_FRAGMENTS: &[&str] = &["/chart/"];
 
     /// Spacing/size literal patterns that are forbidden in component code.
     ///
@@ -65,10 +80,11 @@ mod style_guardrails {
         }
     }
 
-    fn is_file_exempt(path: &Path) -> bool {
+    fn is_file_exempt(path: &Path, extra_exempt: &[&str]) -> bool {
         let path_str = path.to_string_lossy();
         FILE_EXEMPT_FRAGMENTS
             .iter()
+            .chain(extra_exempt.iter())
             .any(|fragment| path_str.contains(fragment))
     }
 
@@ -76,7 +92,7 @@ mod style_guardrails {
         line.contains("// guardrail-allow") || line.contains("px(0.)") || line.contains("px(0.0)")
     }
 
-    fn check_violations(forbidden_patterns: &[&str]) -> Vec<String> {
+    fn check_violations(forbidden_patterns: &[&str], extra_exempt: &[&str]) -> Vec<String> {
         let src_root = PathBuf::from(SRC_DIR);
         let mut files = Vec::new();
         collect_rust_files(&src_root, &mut files);
@@ -84,7 +100,7 @@ mod style_guardrails {
         let mut violations = Vec::new();
 
         for file in &files {
-            if is_file_exempt(file) {
+            if is_file_exempt(file, extra_exempt) {
                 continue;
             }
 
@@ -117,7 +133,8 @@ mod style_guardrails {
 
     #[test]
     fn no_bare_spacing_literals_in_component_code() {
-        let violations = check_violations(FORBIDDEN_SPACING_PATTERNS);
+        let violations =
+            check_violations(FORBIDDEN_SPACING_PATTERNS, FILE_EXEMPT_SPACING_FRAGMENTS);
 
         assert!(
             violations.is_empty(),
@@ -128,7 +145,7 @@ mod style_guardrails {
 
     #[test]
     fn no_raw_color_constructors_in_component_code() {
-        let violations = check_violations(FORBIDDEN_COLOR_PATTERNS);
+        let violations = check_violations(FORBIDDEN_COLOR_PATTERNS, FILE_EXEMPT_COLOR_FRAGMENTS);
 
         assert!(
             violations.is_empty(),

--- a/crates/dbflux_ui_document/src/chart_document/render.rs
+++ b/crates/dbflux_ui_document/src/chart_document/render.rs
@@ -27,6 +27,7 @@ use dbflux_components::controls::DropdownSelectionChanged;
 use dbflux_components::controls::Input;
 use dbflux_components::primitives::Text;
 use dbflux_components::result_panel::ResultPanel;
+use dbflux_components::semantic::ChartColors;
 use dbflux_components::tokens::{Heights, Radii, Spacing};
 use dbflux_ui_base::toast::{PendingToast, flush_pending_toast, now_hms};
 use gpui::prelude::*;
@@ -326,10 +327,13 @@ impl ChartDocument {
         let chart_shell_for_group = self.chart_shell.clone();
         let chart_shell_for_agg = self.chart_shell.clone();
 
+        let chart_colors = ChartColors::for_current(cx);
+
         let axis_bar = axis_bar_element(
             &bindings,
             &columns,
             open_pill,
+            &chart_colors,
             move |pill, _window, cx| {
                 chart_shell_for_pill.update(cx, |s, cx| s.toggle_axis_pill(pill, cx));
             },

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -15,6 +15,7 @@ use dbflux_components::components::data_table::SortState as TableSortState;
 use dbflux_components::controls::{Checkbox, Input, InputState};
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{BannerBlock, BannerVariant, Icon, Text, surface_raised};
+use dbflux_components::semantic::ChartColors;
 use dbflux_components::tokens::{FontSizes, Heights, Radii, Spacing};
 use dbflux_core::{ColumnKind, Pagination, QueryResultShape, SortDirection, Value};
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
@@ -1362,10 +1363,13 @@ impl DataGridPanel {
         let shell_for_group = self.chart_shell.clone();
         let shell_for_agg = self.chart_shell.clone();
 
+        let chart_colors = ChartColors::for_current(cx);
+
         let axis_row = dbflux_components::chart::axis_bar_element(
             &bindings,
             &columns,
             open_pill,
+            &chart_colors,
             move |pill, _window, cx| {
                 if let Some(shell) = &shell_for_pill {
                     shell.update(cx, |s, cx| s.toggle_axis_pill(pill, cx));
@@ -1640,6 +1644,8 @@ impl DataGridPanel {
             })
             .unwrap_or_default();
 
+        let chart_colors = ChartColors::for_current(cx);
+
         div()
             .h_full()
             .flex_shrink_0()
@@ -1651,6 +1657,7 @@ impl DataGridPanel {
                 &hovered_y,
                 None,
                 None,
+                &chart_colors,
             ))
             // Overlay listener: catch mousedown events bubbling up from the
             // "Show in tree" button and scroll the table to the source row.
@@ -1701,12 +1708,15 @@ impl DataGridPanel {
             });
         };
 
+        let chart_colors = ChartColors::for_current(cx);
+
         legend_element(
             &series,
             &palette,
             &stats,
             &hidden,
             focused_idx,
+            &chart_colors,
             Some(on_toggle),
         )
         .into_any_element()
@@ -1789,6 +1799,8 @@ impl DataGridPanel {
     /// When the picker overlay is open, `render_chart_picker_overlay` is shown below
     /// the card.
     fn render_chart_degraded(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
+        let chart_colors = ChartColors::for_current(cx);
+
         let (detection, picker_open) = self
             .chart_shell
             .as_ref()
@@ -1849,8 +1861,8 @@ impl DataGridPanel {
                     .py(px(2.0))
                     .rounded(Radii::SM)
                     .text_size(px(10.0))
-                    .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0)) // guardrail-allow: chart degraded-card inline color
-                    .bg(gpui::hsla(0.0, 0.0, 0.5, 0.1)) // guardrail-allow: chart degraded-card inline color
+                    .text_color(chart_colors.label_fg)
+                    .bg(chart_colors.hover_bg)
                     .child(chip_label)
                     .into_any_element()
             })
@@ -1862,8 +1874,8 @@ impl DataGridPanel {
             .p(Spacing::XL)
             .rounded(Radii::LG)
             .border_1()
-            .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.1)) // guardrail-allow: chart degraded-card inline color
-            .bg(gpui::hsla(0.0, 0.0, 0.12, 1.0)) // guardrail-allow: chart degraded-card inline color
+            .border_color(chart_colors.panel_border)
+            .bg(chart_colors.panel_bg)
             .flex()
             .flex_col()
             .gap(Spacing::MD)
@@ -1876,7 +1888,10 @@ impl DataGridPanel {
                     .child(
                         Icon::new(AppIcon::CircleAlert)
                             .size(px(20.0))
-                            .color(gpui::hsla(0.097, 1.0, 0.666, 0.8)), // guardrail-allow: chart degraded-card accent color
+                            .color(gpui::Hsla {
+                                a: 0.8,
+                                ..cx.theme().primary
+                            }),
                     )
                     .child(
                         div()
@@ -1889,7 +1904,7 @@ impl DataGridPanel {
             .child(
                 div()
                     .text_size(FontSizes::SM)
-                    .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0)) // guardrail-allow: chart degraded-card inline color
+                    .text_color(chart_colors.label_fg)
                     .child(SharedString::from(body)),
             )
             // Shape preview
@@ -1901,7 +1916,7 @@ impl DataGridPanel {
                     .child(
                         div()
                             .text_size(px(10.0))
-                            .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0)) // guardrail-allow: chart degraded-card inline color
+                            .text_color(chart_colors.muted_fg)
                             .child(shape_label),
                     )
                     .child(
@@ -1928,9 +1943,9 @@ impl DataGridPanel {
                             .text_size(FontSizes::SM)
                             .cursor_pointer()
                             .border_1()
-                            .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.15)) // guardrail-allow: chart degraded-card ghost button color
-                            .text_color(gpui::hsla(0.0, 0.0, 0.55, 1.0)) // guardrail-allow: chart degraded-card ghost button color
-                            .hover(|d| d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.1))) // guardrail-allow: chart degraded-card ghost button hover
+                            .border_color(chart_colors.pill_border)
+                            .text_color(chart_colors.label_fg)
+                            .hover(|d| d.bg(chart_colors.hover_bg))
                             .on_mouse_down(
                                 MouseButton::Left,
                                 cx.listener(|this, _, _, cx| {
@@ -1996,6 +2011,7 @@ impl DataGridPanel {
     /// Extracted from the old inline degraded view so the card action button can toggle it.
     fn render_chart_picker_overlay(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
         let primary = cx.theme().primary;
+        let chart_colors = ChartColors::for_current(cx);
 
         let y_candidates: Vec<(usize, String)> = self
             .result
@@ -2048,8 +2064,8 @@ impl DataGridPanel {
             .p(px(20.0))
             .rounded(Radii::LG)
             .border_1()
-            .border_color(gpui::hsla(0.0, 0.0, 1.0, 0.08)) // guardrail-allow: chart picker overlay card color
-            .bg(gpui::hsla(0.0, 0.0, 0.10, 1.0)) // guardrail-allow: chart picker overlay card color
+            .border_color(chart_colors.panel_border)
+            .bg(chart_colors.panel_bg)
             .flex()
             .flex_col()
             .gap(Spacing::MD);
@@ -2078,9 +2094,9 @@ impl DataGridPanel {
                                     .rounded(Radii::SM)
                                     .cursor_pointer()
                                     .text_size(FontSizes::SM)
-                                    .when(is_selected, |d| d.bg(gpui::hsla(0.6, 0.7, 0.55, 0.2))) // guardrail-allow: chart picker axis-col selected color
+                                    .when(is_selected, |d| d.bg(gpui::Hsla { a: 0.2, ..primary }))
                                     .when(!is_selected, |d| {
-                                        d.hover(|d| d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.1))) // guardrail-allow: chart picker axis-col hover color
+                                        d.hover(|d| d.bg(chart_colors.hover_bg))
                                     })
                                     .on_mouse_down(
                                         MouseButton::Left,
@@ -2191,8 +2207,14 @@ impl DataGridPanel {
                     )
             })
             .when(!any_y_checked, |d| {
-                d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.3)) // guardrail-allow: chart picker apply-btn disabled bg
-                    .text_color(gpui::hsla(0.0, 0.0, 0.5, 0.7)) // guardrail-allow: chart picker apply-btn disabled fg
+                d.bg(gpui::Hsla {
+                    a: 0.3,
+                    ..chart_colors.muted_fg
+                })
+                .text_color(gpui::Hsla {
+                    a: 0.7,
+                    ..chart_colors.muted_fg
+                })
             })
             .child("Apply");
 
@@ -2240,10 +2262,10 @@ impl DataGridPanel {
 
     /// Section header label for the right dock panels.
     /// Renders uppercase tracked muted 10px text, optionally prefixed by an icon.
-    fn dock_header(label: &str) -> impl IntoElement {
+    fn dock_header(label: &str, chart_colors: &ChartColors) -> impl IntoElement {
         div()
             .text_size(px(10.0))
-            .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0)) // guardrail-allow: chart rail dock header inline color
+            .text_color(chart_colors.muted_fg)
             .font_weight(gpui::FontWeight::BOLD)
             .mb(Spacing::XXS)
             .child(SharedString::from(label.to_uppercase()))
@@ -2251,7 +2273,7 @@ impl DataGridPanel {
 
     /// Key/value row for the right dock panels.
     /// `k` is shown muted at 10px, `v` is the value element at 11px.
-    fn dock_kv_row(k: &str, v: impl IntoElement) -> impl IntoElement {
+    fn dock_kv_row(k: &str, v: impl IntoElement, chart_colors: &ChartColors) -> impl IntoElement {
         div()
             .flex()
             .items_start()
@@ -2262,7 +2284,7 @@ impl DataGridPanel {
                     .w(px(96.0))
                     .flex_shrink_0()
                     .text_size(px(10.0))
-                    .text_color(gpui::hsla(0.0, 0.0, 0.45, 1.0)) // guardrail-allow: chart rail dock kv-row inline color
+                    .text_color(chart_colors.muted_fg)
                     .child(SharedString::from(k.to_string())),
             )
             .child(div().flex_1().text_size(px(11.0)).child(v))
@@ -2281,6 +2303,7 @@ impl DataGridPanel {
     ) -> impl IntoElement {
         use dbflux_core::ColumnKind;
 
+        let chart_colors = ChartColors::for_current(cx);
         let columns = &self.result.columns;
         let (num_numeric, num_ts) = count_columns_for_why(columns);
 
@@ -2368,7 +2391,7 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Self::dock_header("Why this panel"))
+                    .child(Self::dock_header("Why this panel", &chart_colors))
                     .child(
                         div()
                             .text_size(px(11.0))
@@ -2383,7 +2406,7 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Self::dock_header("Time column"))
+                    .child(Self::dock_header("Time column", &chart_colors))
                     .children(x_candidates.iter().enumerate().map(
                         |(cand_idx, (col_idx, col_name))| {
                             let col_idx = *col_idx;
@@ -2397,8 +2420,11 @@ impl DataGridPanel {
                                 .cursor_pointer()
                                 .text_size(px(11.0))
                                 .when(is_selected, |d| {
-                                    d.bg(gpui::hsla(0.6, 0.7, 0.55, 0.18)) // guardrail-allow: chart rail axis-col selected color
-                                        .text_color(theme.foreground)
+                                    d.bg(gpui::Hsla {
+                                        a: 0.18,
+                                        ..cx.theme().primary
+                                    })
+                                    .text_color(theme.foreground)
                                 })
                                 .when(!is_selected, |d| {
                                     d.text_color(theme.muted_foreground)
@@ -2426,7 +2452,7 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XXS)
-                    .child(Self::dock_header("Series"))
+                    .child(Self::dock_header("Series", &chart_colors))
                     .children(y_candidates.iter().enumerate().map(
                         |(cand_idx, (col_idx, col_name))| {
                             let col_idx = *col_idx;
@@ -2489,13 +2515,14 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(Self::dock_header("Axis & Stacking"))
+                    .child(Self::dock_header("Axis & Stacking", &chart_colors))
                     .child(Self::dock_kv_row(
                         "y-axis",
                         div()
                             .text_size(px(11.0))
                             .text_color(theme.foreground)
                             .child("linear · 0 → auto"),
+                        &chart_colors,
                     ))
                     .child(Self::dock_kv_row(
                         "stack",
@@ -2503,6 +2530,7 @@ impl DataGridPanel {
                             .text_size(px(11.0))
                             .text_color(theme.muted_foreground)
                             .child("off (v0.6.0)"),
+                        &chart_colors,
                     ))
                     .child(Self::dock_kv_row(
                         "interpolation",
@@ -2510,6 +2538,7 @@ impl DataGridPanel {
                             .text_size(px(11.0))
                             .text_color(theme.foreground)
                             .child("linear"),
+                        &chart_colors,
                     )),
                 theme,
             ))
@@ -2554,10 +2583,11 @@ impl DataGridPanel {
                             .rounded(Radii::SM)
                             .text_size(FontSizes::XS)
                             .when(any_y_checked, |d| {
+                                let primary = cx.theme().primary;
                                 d.cursor_pointer()
-                                    .bg(gpui::hsla(0.6, 0.7, 0.55, 1.0)) // guardrail-allow: chart rail apply-btn active color
+                                    .bg(primary)
                                     .text_color(gpui::white())
-                                    .hover(|d| d.bg(gpui::hsla(0.6, 0.7, 0.50, 1.0))) // guardrail-allow: chart rail apply-btn hover color
+                                    .hover(move |d| d.bg(primary))
                                     .on_mouse_down(
                                         gpui::MouseButton::Left,
                                         cx.listener(|this, _, _, cx| {
@@ -2566,8 +2596,14 @@ impl DataGridPanel {
                                     )
                             })
                             .when(!any_y_checked, |d| {
-                                d.bg(gpui::hsla(0.0, 0.0, 0.5, 0.3)) // guardrail-allow: chart rail apply-btn disabled color
-                                    .text_color(gpui::hsla(0.0, 0.0, 0.5, 0.7)) // guardrail-allow: chart rail apply-btn disabled color
+                                d.bg(gpui::Hsla {
+                                    a: 0.3,
+                                    ..chart_colors.muted_fg
+                                })
+                                .text_color(gpui::Hsla {
+                                    a: 0.7,
+                                    ..chart_colors.muted_fg
+                                })
                             })
                             .child("Apply"),
                     ),
@@ -2581,6 +2617,8 @@ impl DataGridPanel {
         theme: &gpui_component::theme::Theme,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
+        let chart_colors = ChartColors::for_current(cx);
+
         // Read focus from the live ChartView so hover-driven focus changes
         // (which only mutate the chart entity's state) update the Stats tab
         // on the next render. Falling back to the shell's cached index when
@@ -2706,14 +2744,18 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(Self::dock_header("Stats"))
-                    .child(Self::dock_kv_row("min", cyan_val(stats.min)))
-                    .child(Self::dock_kv_row("max", cyan_val(stats.max)))
-                    .child(Self::dock_kv_row("avg", cyan_val(stats.avg)))
-                    .child(Self::dock_kv_row("p50", fg_val(stats.p50)))
-                    .child(Self::dock_kv_row("p95", fg_val(stats.p95)))
-                    .child(Self::dock_kv_row("p99", primary_val(stats.p99)))
-                    .child(Self::dock_kv_row("last", fg_val(stats.last))),
+                    .child(Self::dock_header("Stats", &chart_colors))
+                    .child(Self::dock_kv_row("min", cyan_val(stats.min), &chart_colors))
+                    .child(Self::dock_kv_row("max", cyan_val(stats.max), &chart_colors))
+                    .child(Self::dock_kv_row("avg", cyan_val(stats.avg), &chart_colors))
+                    .child(Self::dock_kv_row("p50", fg_val(stats.p50), &chart_colors))
+                    .child(Self::dock_kv_row("p95", fg_val(stats.p95), &chart_colors))
+                    .child(Self::dock_kv_row(
+                        "p99",
+                        primary_val(stats.p99),
+                        &chart_colors,
+                    ))
+                    .child(Self::dock_kv_row("last", fg_val(stats.last), &chart_colors)),
                 theme,
             ))
             // WINDOW section
@@ -2722,13 +2764,22 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(Self::dock_header("Window"))
-                    .child(Self::dock_kv_row("start", str_val(start_label)))
-                    .child(Self::dock_kv_row("end", str_val(end_label)))
-                    .child(Self::dock_kv_row("span", str_val(span_label)))
+                    .child(Self::dock_header("Window", &chart_colors))
+                    .child(Self::dock_kv_row(
+                        "start",
+                        str_val(start_label),
+                        &chart_colors,
+                    ))
+                    .child(Self::dock_kv_row("end", str_val(end_label), &chart_colors))
+                    .child(Self::dock_kv_row(
+                        "span",
+                        str_val(span_label),
+                        &chart_colors,
+                    ))
                     .child(Self::dock_kv_row(
                         "points",
                         str_val(format!("{}", points_count)),
+                        &chart_colors,
                     )),
                 theme,
             ))
@@ -2739,11 +2790,15 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(Self::dock_header("Source"))
-                    .child(Self::dock_kv_row("measurement", unavail_val()))
-                    .child(Self::dock_kv_row("field", unavail_val()))
-                    .child(Self::dock_kv_row("host", unavail_val()))
-                    .child(Self::dock_kv_row("region", unavail_val())),
+                    .child(Self::dock_header("Source", &chart_colors))
+                    .child(Self::dock_kv_row(
+                        "measurement",
+                        unavail_val(),
+                        &chart_colors,
+                    ))
+                    .child(Self::dock_kv_row("field", unavail_val(), &chart_colors))
+                    .child(Self::dock_kv_row("host", unavail_val(), &chart_colors))
+                    .child(Self::dock_kv_row("region", unavail_val(), &chart_colors)),
                 theme,
             ))
             .into_any_element()


### PR DESCRIPTION
Closes #115

Part of #115 — **PR3 of 3 (final)** of the chart-theme-colors epic. Completes the work started in #116 (ChartColors struct) and #117 (engine canvas + palette). Charts now respond fully to the active theme (Dark / Mirage / Light) at every rendering surface.

## What this PR does

Routes the remaining hardcoded `hsla(...)` literals in the chart element factories and the chart-overlay sections of the data-grid renderer through `semantic::ChartColors` (and `cx.theme()` where appropriate), then tightens the guardrail so those files stay clean going forward.

### Element factories migrated
- **`point_inspector_element`** (`crates/dbflux_components/src/chart/point_inspector.rs`) — gains `colors: &ChartColors`; ~20 hsla literals replaced.
- **`axis_bar_element`** (`crates/dbflux_components/src/chart/axis_bar.rs`) — gains `colors: &ChartColors`; ~18 hsla literals replaced. The checkbox-checked sentinel routes through `colors.checkbox_checked`; unchecked uses `transparent_black()`.
- **`legend_element`** (`crates/dbflux_components/src/chart/legend.rs`) — gains `colors: &ChartColors`; the 3 chrome hsla literals route through ChartColors. The OOB palette-slot neutral fallback at `legend.rs:48` is preserved with `// guardrail-allow` (no semantic token applies to that case).

### Call sites updated
- **`crates/dbflux_ui_document/src/data_grid_panel/render.rs`** — binds `let chart_colors = ChartColors::for_current(cx)` and passes `&chart_colors` to all three factory call sites. 23 inline `hsla(...)` literals in chart-overlay/degraded-card/picker functions migrated to ChartColors / `cx.theme()`. All 23 `// guardrail-allow: chart ...` suffixes removed (count drops 32 → 9).
- **`crates/dbflux_ui_document/src/chart_document/render.rs`** — passes `&ChartColors::for_current(cx)` to `axis_bar_element`.

### Guardrail tightened
- **`crates/dbflux_components/src/style_guardrails.rs`** — the prior blanket `"/chart/"` entry in `FILE_EXEMPT_FRAGMENTS` was split into two narrower exemption lists:
  - `FILE_EXEMPT_COLOR_FRAGMENTS = ["/chart/engine.rs"]` — only `engine.rs` retains the color exemption (canvas paint literals legitimately live there).
  - `FILE_EXEMPT_SPACING_FRAGMENTS = ["/chart/"]` — chart geometry math (raw `px(...)` values like `px(140.0)`, `px(11.0)`, `px(320.0)`) stays exempt because chart-spacing tokenization is out of scope for this epic and would balloon the diff.
  
  This intentionally un-arms color checks on `axis_bar.rs` / `point_inspector.rs` / `legend.rs` so they now sit under the guardrail.

## Behavior

- **Dark**: byte-identical where the design specifies; the same three close-but-not-equal divergences already documented in PR2 (gridlines via `theme.border`, tick labels via `theme.muted_foreground`, hover-dot bg via `theme.background`) remain.
- **Mirage**: intentional drift — chrome now uses the theme-driven ChartColors palette.
- **Light**: fixed — was rendering the dark series palette over a light canvas; now uses the Ayu Light role mapping per design table.

This is the most visible PR of the epic in Light/Mirage. The Dark behavior is the QA control: any unexpected Dark drift outside the three documented divergences would be a regression.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo check --workspace` — pass
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo nextest run --workspace --no-fail-fast` — **2340 passed, 0 failed**, 154 skipped (= PR2 baseline; no test count change)
- `cargo test --doc --workspace` — pass
- `cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,lua,aws` — pass (mcp-off gate)
- `grep -c "guardrail-allow" crates/dbflux_ui_document/src/data_grid_panel/render.rs` — **9** (was 32, 23 removed as required)
- `grep "gpui::hsla\|hsla(" crates/dbflux_components/src/chart/{point_inspector,axis_bar,legend}.rs` — only the documented OOB neutral fallback in `legend.rs:48`
- `grep '"/chart/' crates/dbflux_components/src/style_guardrails.rs` — split into the two narrower arrays above

## Size

`size:exception`. ~421 changed lines (275 insertions / 146 deletions across 6 files). The overrun versus the original ~150–200 estimate comes from multi-line struct-update wraps for `ChartColors` field references (e.g. `gpui::Hsla { a: 0.6, ..colors.pill_border }` preserving alpha overrides) and the additional `chart_colors` rebinding lines inside large render functions. Splitting further would have to break apart logically-grouped overlay functions; the alternative is the single behavior-preserving migration here.

## Visual QA

Human-gate. Please verify on Dark / Mirage / Light:
- Series colors look correct (Dark: byte-identical to before the epic; Light: no longer dark colors on light bg; Mirage: theme palette).
- Point-inspector / axis bar / legend chrome renders correctly in all three themes.
- The "chart degraded" placeholder card and the column picker overlay render correctly.
- Dark divergences flagged in PR2 (gridlines, tick labels, hover-dot bg) still acceptable.

## Epic #115 status

This closes the structural work on #115. Charts are now fully theme-responsive. Any remaining tuning (e.g. label brightness in Dark) can be a follow-up.
