### PR TITLE
refactor(ui): centralize TimeRangePanel custom-picker + fix chart apply race

### DIFF
--- a/crates/dbflux_components/src/common/time_range/mod.rs
+++ b/crates/dbflux_components/src/common/time_range/mod.rs
@@ -5,4 +5,4 @@ pub use state::{
     TimeRange, TimestampDisplayMode, format_timestamp_ms, timestamp_from_date_time,
     validate_custom_range_parts,
 };
-pub use view::{TimeRangeChanged, TimeRangePanel};
+pub use view::{CustomPickerSlots, TimeRangeChanged, TimeRangePanel};

--- a/crates/dbflux_components/src/common/time_range/view.rs
+++ b/crates/dbflux_components/src/common/time_range/view.rs
@@ -10,10 +10,12 @@
 //! still reference them in `FilterBarItem` lists for keyboard navigation.
 
 use crate::controls::{Dropdown, DropdownItem, DropdownSelectionChanged};
+use crate::primitives::Text;
 use gpui::prelude::*;
 use gpui::{App, Entity, EventEmitter, Subscription, Window};
+use gpui_component::Sizable;
 use gpui_component::calendar::Date;
-use gpui_component::date_picker::{DatePickerEvent, DatePickerState};
+use gpui_component::date_picker::{DatePicker, DatePickerEvent, DatePickerState};
 
 use super::state::{TimeRange, TimestampDisplayMode, validate_custom_range_parts};
 
@@ -351,13 +353,73 @@ impl TimeRangePanel {
 
         Ok((start_ms, end_ms))
     }
+
+    /// Render the shared custom date+time picker row used by chart and code hosts
+    /// when the user has selected the Custom preset.
+    ///
+    /// Returns a flex row containing: the date-range picker at `date_picker_width`,
+    /// a "from" label, start-hour dropdown, start-minute dropdown, a "to" label,
+    /// end-hour dropdown, and end-minute dropdown.
+    ///
+    /// Does NOT include an Apply button — each host owns its own Apply because the
+    /// component type, disabled visuals, and side-effect chain differ between hosts.
+    ///
+    /// Does NOT include outer chrome (border, background, padding) — callers are
+    /// responsible for wrapping with their own container styling.
+    ///
+    /// `date_picker_width` is parameterized because chart uses `px(260)` and code
+    /// uses `px(320)`. Standardizing is a visible change and out of scope for this
+    /// refactor. The `_cx` parameter is reserved for future theme-aware tweaks.
+    pub fn render_custom_picker_row(
+        &self,
+        date_picker_width: gpui::Pixels,
+        _cx: &gpui::App,
+    ) -> impl gpui::IntoElement {
+        use gpui::{div, px};
+
+        div()
+            .flex()
+            .items_center()
+            .gap_1()
+            .child(
+                div().w(date_picker_width).child(
+                    DatePicker::new(&self.custom_date_range_picker)
+                        .small()
+                        .placeholder("Select date range")
+                        .number_of_months(2),
+                ),
+            )
+            .child(Text::caption("from"))
+            .child(
+                div()
+                    .w(px(72.0))
+                    .child(self.custom_start_hour_dropdown.clone()),
+            )
+            .child(
+                div()
+                    .w(px(72.0))
+                    .child(self.custom_start_minute_dropdown.clone()),
+            )
+            .child(Text::caption("to"))
+            .child(
+                div()
+                    .w(px(72.0))
+                    .child(self.custom_end_hour_dropdown.clone()),
+            )
+            .child(
+                div()
+                    .w(px(72.0))
+                    .child(self.custom_end_minute_dropdown.clone()),
+            )
+    }
 }
 
 impl EventEmitter<TimeRangeChanged> for TimeRangePanel {}
 
 #[cfg(test)]
 mod tests {
-    use super::{TimeRange, TimeRangePanel};
+    use super::{TimeRange, TimeRangeChanged, TimeRangePanel};
+    use gpui::prelude::*;
 
     #[test]
     fn preset_index_maps_to_correct_range_variant() {
@@ -474,5 +536,176 @@ mod tests {
                 "index {index} must not be Custom"
             );
         }
+    }
+
+    // ── render_custom_picker_row TDD tests ────────────────────────────────────
+    //
+    // These tests verify the render helper contract:
+    //   - Returns an element that converts to `AnyElement` without panicking.
+    //   - Does not emit `TimeRangeChanged` or mutate panel state.
+    //   - Sub-entity handles are stable across repeated calls.
+    //
+    // The helper requires a constructed `TimeRangePanel`, which in turn requires
+    // a `&mut Window`. We use `#[gpui::test]` with `cx.add_window_view` and a
+    // minimal `Render` harness, since `TimeRangePanel` does not implement `Render`.
+
+    /// Minimal window harness so tests can open a window in dbflux_components
+    /// without importing dbflux_ui's `Root` type.
+    struct PanelHarness {
+        #[allow(dead_code)]
+        panel: gpui::Entity<TimeRangePanel>,
+    }
+
+    impl gpui::Render for PanelHarness {
+        fn render(
+            &mut self,
+            _window: &mut gpui::Window,
+            _cx: &mut gpui::Context<Self>,
+        ) -> impl gpui::IntoElement {
+            gpui::div()
+        }
+    }
+
+    /// Smoke test: `render_custom_picker_row` returns an element that can be
+    /// converted to `AnyElement` without panicking.
+    ///
+    /// Satisfies REQ-1, SCEN-7.
+    #[gpui::test]
+    fn render_custom_picker_row_returns_element(cx: &mut gpui::TestAppContext) {
+        use gpui::px;
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        let panel_ref: Rc<RefCell<Option<gpui::Entity<TimeRangePanel>>>> =
+            Rc::new(RefCell::new(None));
+
+        let (_, window) = cx.add_window_view({
+            let panel_ref = panel_ref.clone();
+            move |window, cx| {
+                let panel = cx.new(|cx| TimeRangePanel::new("Select range", None, window, cx));
+                panel_ref.replace(Some(panel.clone()));
+                PanelHarness { panel }
+            }
+        });
+
+        let panel = panel_ref.borrow().clone().expect("panel must be created");
+
+        window.update(|_, app| {
+            let element = panel.read(app).render_custom_picker_row(px(260.0), app);
+            // Converting to AnyElement must not panic — pins that the method exists
+            // and its return type implements IntoElement.
+            let _ = element.into_any_element();
+        });
+    }
+
+    /// `render_custom_picker_row` must not emit `TimeRangeChanged` and must not
+    /// mutate `selected_time_range`.
+    ///
+    /// Satisfies REQ-5 (event contract), SCEN-7.
+    #[gpui::test]
+    fn render_custom_picker_row_is_render_only(cx: &mut gpui::TestAppContext) {
+        use gpui::px;
+        use std::cell::{Cell, RefCell};
+        use std::rc::Rc;
+
+        let panel_ref: Rc<RefCell<Option<gpui::Entity<TimeRangePanel>>>> =
+            Rc::new(RefCell::new(None));
+        let event_count = Rc::new(Cell::new(0u32));
+
+        let (_, window) = cx.add_window_view({
+            let panel_ref = panel_ref.clone();
+            let event_count = event_count.clone();
+            move |window, cx| {
+                let panel = cx.new(|cx| TimeRangePanel::new("Select range", None, window, cx));
+                panel_ref.replace(Some(panel.clone()));
+
+                // Subscribe to TimeRangeChanged before the helper is called.
+                let _sub = cx.subscribe(&panel, {
+                    let event_count = event_count.clone();
+                    move |_this, _, _event: &TimeRangeChanged, _cx| {
+                        event_count.set(event_count.get() + 1);
+                    }
+                });
+
+                PanelHarness { panel }
+            }
+        });
+
+        let panel = panel_ref.borrow().clone().expect("panel must be created");
+
+        window.update(|_, app| {
+            let selected_before = panel.read(app).selected_time_range;
+            let element = panel.read(app).render_custom_picker_row(px(260.0), app);
+            let _ = element.into_any_element();
+            let selected_after = panel.read(app).selected_time_range;
+
+            assert_eq!(
+                selected_before, selected_after,
+                "render_custom_picker_row must not mutate selected_time_range"
+            );
+        });
+
+        // No events should have been emitted during the helper call.
+        assert_eq!(
+            event_count.get(),
+            0,
+            "render_custom_picker_row must not emit TimeRangeChanged"
+        );
+    }
+
+    /// Sub-entity handles are stable across two consecutive calls to the helper.
+    ///
+    /// Satisfies REQ-4.
+    #[gpui::test]
+    fn render_custom_picker_row_does_not_mutate_sub_entities(cx: &mut gpui::TestAppContext) {
+        use gpui::px;
+        use std::cell::RefCell;
+        use std::rc::Rc;
+
+        let panel_ref: Rc<RefCell<Option<gpui::Entity<TimeRangePanel>>>> =
+            Rc::new(RefCell::new(None));
+
+        let (_, window) = cx.add_window_view({
+            let panel_ref = panel_ref.clone();
+            move |window, cx| {
+                let panel = cx.new(|cx| TimeRangePanel::new("Select range", None, window, cx));
+                panel_ref.replace(Some(panel.clone()));
+                PanelHarness { panel }
+            }
+        });
+
+        let panel = panel_ref.borrow().clone().expect("panel must be created");
+
+        window.update(|_, app| {
+            // Capture entity IDs before calling the helper.
+            let (picker_id, sh_id, sm_id, eh_id, em_id) = {
+                let p = panel.read(app);
+                (
+                    p.custom_date_range_picker.entity_id(),
+                    p.custom_start_hour_dropdown.entity_id(),
+                    p.custom_start_minute_dropdown.entity_id(),
+                    p.custom_end_hour_dropdown.entity_id(),
+                    p.custom_end_minute_dropdown.entity_id(),
+                )
+            };
+
+            // Call the helper twice with different widths.
+            let _ = panel
+                .read(app)
+                .render_custom_picker_row(px(260.0), app)
+                .into_any_element();
+            let _ = panel
+                .read(app)
+                .render_custom_picker_row(px(320.0), app)
+                .into_any_element();
+
+            // Sub-entity handles must be unchanged (cloned, not replaced).
+            let p = panel.read(app);
+            assert_eq!(p.custom_date_range_picker.entity_id(), picker_id);
+            assert_eq!(p.custom_start_hour_dropdown.entity_id(), sh_id);
+            assert_eq!(p.custom_start_minute_dropdown.entity_id(), sm_id);
+            assert_eq!(p.custom_end_hour_dropdown.entity_id(), eh_id);
+            assert_eq!(p.custom_end_minute_dropdown.entity_id(), em_id);
+        });
     }
 }

--- a/crates/dbflux_components/src/common/time_range/view.rs
+++ b/crates/dbflux_components/src/common/time_range/view.rs
@@ -354,6 +354,57 @@ impl TimeRangePanel {
         Ok((start_ms, end_ms))
     }
 
+    /// Returns the individual sub-elements of the custom picker row as a struct.
+    ///
+    /// Each element is pre-sized (date picker at `date_picker_width`, time
+    /// dropdowns at `px(72)`) but NOT wrapped with outer chrome (ring borders,
+    /// background, padding) — callers compose them into a row with whatever
+    /// decoration they need.
+    ///
+    /// Use this when per-slot decoration is required (e.g. audit's keyboard-focus
+    /// ring guards that wrap each individual control). Use `render_custom_picker_row`
+    /// when the standard gap-1 flex row layout suffices.
+    ///
+    /// Both APIs render the same underlying sub-entities: `render_custom_picker_row`
+    /// calls this method internally and assembles the result into the standard row.
+    pub fn custom_picker_slots(
+        &self,
+        date_picker_width: gpui::Pixels,
+        _cx: &gpui::App,
+    ) -> CustomPickerSlots {
+        use gpui::{div, px};
+
+        CustomPickerSlots {
+            date_picker: div()
+                .w(date_picker_width)
+                .child(
+                    DatePicker::new(&self.custom_date_range_picker)
+                        .small()
+                        .placeholder("Select date range")
+                        .number_of_months(2),
+                )
+                .into_any_element(),
+            from_label: Text::caption("from").into_any_element(),
+            start_hour: div()
+                .w(px(72.0))
+                .child(self.custom_start_hour_dropdown.clone())
+                .into_any_element(),
+            start_minute: div()
+                .w(px(72.0))
+                .child(self.custom_start_minute_dropdown.clone())
+                .into_any_element(),
+            to_label: Text::caption("to").into_any_element(),
+            end_hour: div()
+                .w(px(72.0))
+                .child(self.custom_end_hour_dropdown.clone())
+                .into_any_element(),
+            end_minute: div()
+                .w(px(72.0))
+                .child(self.custom_end_minute_dropdown.clone())
+                .into_any_element(),
+        }
+    }
+
     /// Render the shared custom date+time picker row used by chart and code hosts
     /// when the user has selected the Custom preset.
     ///
@@ -370,48 +421,52 @@ impl TimeRangePanel {
     /// `date_picker_width` is parameterized because chart uses `px(260)` and code
     /// uses `px(320)`. Standardizing is a visible change and out of scope for this
     /// refactor. The `_cx` parameter is reserved for future theme-aware tweaks.
+    ///
+    /// Internally delegates to `custom_picker_slots` so both APIs render the same
+    /// sub-elements with guaranteed structural parity.
     pub fn render_custom_picker_row(
         &self,
         date_picker_width: gpui::Pixels,
-        _cx: &gpui::App,
+        cx: &gpui::App,
     ) -> impl gpui::IntoElement {
-        use gpui::{div, px};
+        use gpui::div;
+
+        let slots = self.custom_picker_slots(date_picker_width, cx);
 
         div()
             .flex()
             .items_center()
             .gap_1()
-            .child(
-                div().w(date_picker_width).child(
-                    DatePicker::new(&self.custom_date_range_picker)
-                        .small()
-                        .placeholder("Select date range")
-                        .number_of_months(2),
-                ),
-            )
-            .child(Text::caption("from"))
-            .child(
-                div()
-                    .w(px(72.0))
-                    .child(self.custom_start_hour_dropdown.clone()),
-            )
-            .child(
-                div()
-                    .w(px(72.0))
-                    .child(self.custom_start_minute_dropdown.clone()),
-            )
-            .child(Text::caption("to"))
-            .child(
-                div()
-                    .w(px(72.0))
-                    .child(self.custom_end_hour_dropdown.clone()),
-            )
-            .child(
-                div()
-                    .w(px(72.0))
-                    .child(self.custom_end_minute_dropdown.clone()),
-            )
+            .child(slots.date_picker)
+            .child(slots.from_label)
+            .child(slots.start_hour)
+            .child(slots.start_minute)
+            .child(slots.to_label)
+            .child(slots.end_hour)
+            .child(slots.end_minute)
     }
+}
+
+/// Individual picker elements returned by [`TimeRangePanel::custom_picker_slots`].
+///
+/// Hosts that need per-slot decoration (e.g. audit's keyboard-focus ring guards)
+/// receive each element separately and compose them into a row. All elements
+/// are pre-sized but carry no outer chrome.
+pub struct CustomPickerSlots {
+    /// Date-range picker at the caller-specified width.
+    pub date_picker: gpui::AnyElement,
+    /// The "from" label between the date picker and start-time dropdowns.
+    pub from_label: gpui::AnyElement,
+    /// Start-hour dropdown at `px(72)`.
+    pub start_hour: gpui::AnyElement,
+    /// Start-minute dropdown at `px(72)`.
+    pub start_minute: gpui::AnyElement,
+    /// The "to" label between start and end dropdowns.
+    pub to_label: gpui::AnyElement,
+    /// End-hour dropdown at `px(72)`.
+    pub end_hour: gpui::AnyElement,
+    /// End-minute dropdown at `px(72)`.
+    pub end_minute: gpui::AnyElement,
 }
 
 impl EventEmitter<TimeRangeChanged> for TimeRangePanel {}

--- a/crates/dbflux_ui_document/src/audit/render.rs
+++ b/crates/dbflux_ui_document/src/audit/render.rs
@@ -313,63 +313,53 @@ impl AuditDocument {
                 this.apply_custom_time_range(cx);
             }));
 
+        // Obtain individual picker elements from the shared panel so the audit
+        // render and other hosts stay structurally aligned.  Ring-guard wrappers
+        // are applied per-slot here to preserve the keyboard-focus indicators
+        // that audit requires for its FilterBar navigation.
+        let slots = self
+            .time_range_panel
+            .read(cx)
+            .custom_picker_slots(px(260.0), cx);
+
+        let ring_start = self.slot_has_ring(ToolbarSlot::CustomStart);
+        let ring_end = self.slot_has_ring(ToolbarSlot::CustomEnd);
+
         let custom_time_controls = div()
             .flex()
             .items_center()
             .gap_1()
             .child(
                 div()
-                    .w(px(260.0))
                     .rounded(Radii::SM)
-                    .when(self.slot_has_ring(ToolbarSlot::CustomStart), |d| {
-                        d.border_1().border_color(theme.ring)
-                    })
-                    .child(
-                        gpui_component::date_picker::DatePicker::new(
-                            &self.custom_date_range_picker,
-                        )
-                        .small()
-                        .placeholder("Select date range")
-                        .number_of_months(2),
-                    ),
+                    .when(ring_start, |d| d.border_1().border_color(theme.ring))
+                    .child(slots.date_picker),
             )
-            .child(Text::caption("from"))
+            .child(slots.from_label)
             .child(
                 div()
-                    .w(px(72.0))
                     .rounded(Radii::SM)
-                    .when(self.slot_has_ring(ToolbarSlot::CustomStart), |d| {
-                        d.border_1().border_color(theme.ring)
-                    })
-                    .child(self.custom_start_hour_dropdown.clone()),
+                    .when(ring_start, |d| d.border_1().border_color(theme.ring))
+                    .child(slots.start_hour),
             )
             .child(
                 div()
-                    .w(px(72.0))
                     .rounded(Radii::SM)
-                    .when(self.slot_has_ring(ToolbarSlot::CustomStart), |d| {
-                        d.border_1().border_color(theme.ring)
-                    })
-                    .child(self.custom_start_minute_dropdown.clone()),
+                    .when(ring_start, |d| d.border_1().border_color(theme.ring))
+                    .child(slots.start_minute),
             )
-            .child(Text::caption("to"))
+            .child(slots.to_label)
             .child(
                 div()
-                    .w(px(72.0))
                     .rounded(Radii::SM)
-                    .when(self.slot_has_ring(ToolbarSlot::CustomEnd), |d| {
-                        d.border_1().border_color(theme.ring)
-                    })
-                    .child(self.custom_end_hour_dropdown.clone()),
+                    .when(ring_end, |d| d.border_1().border_color(theme.ring))
+                    .child(slots.end_hour),
             )
             .child(
                 div()
-                    .w(px(72.0))
                     .rounded(Radii::SM)
-                    .when(self.slot_has_ring(ToolbarSlot::CustomEnd), |d| {
-                        d.border_1().border_color(theme.ring)
-                    })
-                    .child(self.custom_end_minute_dropdown.clone()),
+                    .when(ring_end, |d| d.border_1().border_color(theme.ring))
+                    .child(slots.end_minute),
             )
             .child(custom_apply_button);
 

--- a/crates/dbflux_ui_document/src/chart_document/mod.rs
+++ b/crates/dbflux_ui_document/src/chart_document/mod.rs
@@ -578,18 +578,26 @@ impl ChartDocument {
     /// Apply the custom date/time picker values and trigger a chart re-execution.
     ///
     /// Called by the Apply button in the custom picker row. Delegates to the
-    /// panel's `apply_custom_range`, which validates the inputs, emits
-    /// `TimeRangeChanged` (handled by `on_time_range_changed`), and notifies.
-    /// On validation failure a toast is shown.
+    /// panel's `apply_custom_range`, which validates the inputs and emits
+    /// `TimeRangeChanged`. The flags are set here synchronously from the
+    /// returned `(start_ms, end_ms)` bounds rather than waiting for the
+    /// deferred subscription delivery, which eliminates a render-timing race
+    /// where the re-execution flag could be missed.
     pub(super) fn apply_custom_range(&mut self, cx: &mut Context<Self>) {
         let Some(panel) = self.time_range_panel.clone() else {
             return;
         };
 
         match panel.update(cx, |p, cx| p.apply_custom_range(cx)) {
-            Ok(_) => {
-                // `TimeRangeChanged` is emitted by the panel; `on_time_range_changed`
-                // handles the window stash and re-execution scheduling.
+            Ok((start_ms, end_ms)) => {
+                // Drive re-execution synchronously from the validated bounds rather
+                // than waiting for the deferred TimeRangeChanged subscription to
+                // mutate state. The subscription still fires (and mirrors
+                // selected_time_range), but the chart re-run is no longer gated
+                // on its delivery timing.
+                self.pending_time_window = Some((start_ms, end_ms));
+                self.pending_chart_reexecute = true;
+                cx.notify();
             }
             Err(error) => {
                 self.pending_toast = Some(PendingToast {
@@ -913,6 +921,49 @@ mod tests {
         assert!(
             !result_both_none.pending_chart_reexecute,
             "must not reexecute when both are None"
+        );
+    }
+
+    // ---- apply_custom_range synchronous flag-set ----
+
+    /// Simulated outcome of the Ok branch in `apply_custom_range`.
+    struct ApplyCustomRangeOutcome {
+        pending_chart_reexecute: bool,
+        pending_time_window: Option<(i64, i64)>,
+    }
+
+    /// Exercise the `apply_custom_range` Ok-branch logic without a GPUI runtime
+    /// by replicating the synchronous flag-set directly.
+    ///
+    /// T-CR-07: Apply sets both flags in the same call as validation, removing
+    /// the timing dependency on `TimeRangeChanged` subscription delivery.
+    fn simulate_apply_custom_range_ok(start_ms: i64, end_ms: i64) -> ApplyCustomRangeOutcome {
+        // This replicates the Ok branch added in Piece A: the bounds returned
+        // by `panel.apply_custom_range` are used to set state synchronously.
+        let pending_time_window = Some((start_ms, end_ms));
+        let pending_chart_reexecute = true;
+
+        ApplyCustomRangeOutcome {
+            pending_chart_reexecute,
+            pending_time_window,
+        }
+    }
+
+    /// `apply_custom_range` Ok branch sets `pending_chart_reexecute` and stashes
+    /// the exact bounds returned by the panel — no subscription needed.
+    ///
+    /// T-CR-07: synchronous flag-set test.
+    #[test]
+    fn apply_custom_range_ok_sets_flags_synchronously() {
+        let outcome = simulate_apply_custom_range_ok(1_000, 2_000);
+        assert!(
+            outcome.pending_chart_reexecute,
+            "pending_chart_reexecute must be true immediately after Ok"
+        );
+        assert_eq!(
+            outcome.pending_time_window,
+            Some((1_000, 2_000)),
+            "pending_time_window must hold the exact validated bounds"
         );
     }
 

--- a/crates/dbflux_ui_document/src/chart_document/render.rs
+++ b/crates/dbflux_ui_document/src/chart_document/render.rs
@@ -33,7 +33,6 @@ use dbflux_ui_base::toast::{PendingToast, flush_pending_toast, now_hms};
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::button::{Button, ButtonVariant, ButtonVariants};
-use gpui_component::date_picker::DatePicker;
 use gpui_component::{ActiveTheme, Disableable, Sizable};
 use std::sync::Arc;
 
@@ -392,11 +391,10 @@ impl ChartDocument {
         let custom_picker_row: Option<AnyElement> =
             if self.selected_time_range == Some(TimeRange::Custom) {
                 if let Some(panel_entity) = &self.time_range_panel {
-                    // Read can_apply before borrowing the panel's internals so
-                    // we don't hold two simultaneous borrows through cx.
+                    // Read can_apply (and weak_self for the Apply click closure)
+                    // before the helper call so there are no concurrent borrows.
                     let can_apply = panel_entity.read(cx).can_apply_custom_range(cx);
                     let weak_self = cx.weak_entity();
-                    let panel = panel_entity.read(cx);
 
                     let apply_btn = div()
                         .id("chart-custom-time-apply")
@@ -422,6 +420,9 @@ impl ChartDocument {
                         .when(!can_apply, |d| d.opacity(0.45))
                         .child(Text::caption("Apply"));
 
+                    // Outer band: full-width chrome (border, bg, padding) plus
+                    // flex_wrap so the picker row + Apply can wrap on narrow
+                    // viewports. The picker row itself is one opaque unit.
                     let row = div()
                         .flex()
                         .flex_row()
@@ -434,34 +435,9 @@ impl ChartDocument {
                         .border_color(theme.border)
                         .bg(theme.tab_bar)
                         .child(
-                            div().w(px(260.0)).child(
-                                DatePicker::new(&panel.custom_date_range_picker)
-                                    .small()
-                                    .placeholder("Select date range")
-                                    .number_of_months(2),
-                            ),
-                        )
-                        .child(Text::caption("from"))
-                        .child(
-                            div()
-                                .w(px(72.0))
-                                .child(panel.custom_start_hour_dropdown.clone()),
-                        )
-                        .child(
-                            div()
-                                .w(px(72.0))
-                                .child(panel.custom_start_minute_dropdown.clone()),
-                        )
-                        .child(Text::caption("to"))
-                        .child(
-                            div()
-                                .w(px(72.0))
-                                .child(panel.custom_end_hour_dropdown.clone()),
-                        )
-                        .child(
-                            div()
-                                .w(px(72.0))
-                                .child(panel.custom_end_minute_dropdown.clone()),
+                            panel_entity
+                                .read(cx)
+                                .render_custom_picker_row(px(260.0), cx),
                         )
                         .child(apply_btn);
 

--- a/crates/dbflux_ui_document/src/code/context_bar.rs
+++ b/crates/dbflux_ui_document/src/code/context_bar.rs
@@ -1207,24 +1207,15 @@ impl CodeDocument {
         // is, the picker + hour/minute dropdowns + Apply button are rendered
         // on a dedicated second row so they don't overflow the bar width.
         // Hidden in Chart mode (chart toolbar covers the range selection).
+        // Tuple shrunk to (panel_entity, can_apply) — the helper owns the
+        // individual sub-entity references via render_custom_picker_row.
         let custom_range_info = (!is_chart_mode)
             .then_some(())
             .and(self.source_time_range_panel.as_ref())
             .and_then(|p| {
                 let panel = p.read(cx);
                 let is_custom = panel.selected_time_range == Some(TimeRange::Custom);
-
-                is_custom.then(|| {
-                    (
-                        p.clone(),
-                        panel.custom_date_range_picker.clone(),
-                        panel.custom_start_hour_dropdown.clone(),
-                        panel.custom_start_minute_dropdown.clone(),
-                        panel.custom_end_hour_dropdown.clone(),
-                        panel.custom_end_minute_dropdown.clone(),
-                        panel.can_apply_custom_range(cx),
-                    )
-                })
+                is_custom.then(|| (p.clone(), panel.can_apply_custom_range(cx)))
             });
 
         // Build the primary (always-visible) controls row.
@@ -1434,57 +1425,31 @@ impl CodeDocument {
             // Custom date-range second row — only visible when Custom is active.
             // This avoids overflowing the single-line bar with the date picker,
             // four time dropdowns, and Apply button all pushed onto one row.
-            .when_some(
-                custom_range_info,
-                |el,
-                 (
-                    panel,
-                    date_picker,
-                    start_hour,
-                    start_minute,
-                    end_hour,
-                    end_minute,
-                    can_apply,
-                )| {
-                    el.child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap(Spacing::SM)
-                            .pt(Spacing::XS)
-                            .child(
-                                div().w(px(320.0)).child(control_shell(
-                                    DatePicker::new(&date_picker)
-                                        .small()
-                                        .placeholder("Select date range")
-                                        .number_of_months(2),
-                                    cx,
-                                )),
-                            )
-                            .child(Text::caption("from"))
-                            .child(div().w(px(72.0)).child(control_shell(start_hour, cx)))
-                            .child(div().w(px(72.0)).child(control_shell(start_minute, cx)))
-                            .child(Text::caption("to"))
-                            .child(div().w(px(72.0)).child(control_shell(end_hour, cx)))
-                            .child(div().w(px(72.0)).child(control_shell(end_minute, cx)))
-                            .child(
-                                Button::new("ctx-time-range-apply", "Apply")
-                                    .small()
-                                    .disabled(!can_apply)
-                                    .on_click(cx.listener(move |this, _, _, cx| {
-                                        panel.update(cx, |p, cx| {
-                                            // Ignore the returned bounds — the panel emits
-                                            // TimeRangeChanged which is the authoritative signal.
-                                            let _ = p.apply_custom_range(cx);
-                                        });
-                                        this.sync_source_exec_context(cx);
-                                        cx.emit(DocumentEvent::MetaChanged);
-                                        cx.notify();
-                                    })),
-                            ),
-                    )
-                },
-            )
+            .when_some(custom_range_info, |el, (panel, can_apply)| {
+                el.child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_1()
+                        .pt(Spacing::XS)
+                        .child(panel.read(cx).render_custom_picker_row(px(320.0), cx))
+                        .child(
+                            Button::new("ctx-time-range-apply", "Apply")
+                                .small()
+                                .disabled(!can_apply)
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    panel.update(cx, |p, cx| {
+                                        // Ignore the returned bounds — the panel emits
+                                        // TimeRangeChanged which is the authoritative signal.
+                                        let _ = p.apply_custom_range(cx);
+                                    });
+                                    this.sync_source_exec_context(cx);
+                                    cx.emit(DocumentEvent::MetaChanged);
+                                    cx.notify();
+                                })),
+                        ),
+                )
+            })
             .into_any_element()
     }
 }

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -37,7 +37,6 @@ use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::ActiveTheme;
 use gpui_component::Sizable;
-use gpui_component::date_picker::DatePicker;
 use gpui_component::highlighter::{
     Diagnostic as InputDiagnostic, DiagnosticSeverity as InputDiagnosticSeverity,
 };

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -1336,6 +1336,57 @@ impl DataGridPanel {
 
         let toolbar_row = render_chart_toolbar(ctx, handlers, cx);
 
+        // Custom date/time picker row — rendered between the chart toolbar and
+        // the AxisBar when the user has selected "Custom…" in the time-range
+        // preset dropdown. Allows adjusting the custom time window without
+        // leaving the CodeDocument's result chart view.
+        //
+        // The Apply button calls `panel.apply_custom_range`; the parent
+        // CodeDocument's `TimeRangeChanged` subscription handles re-execution.
+        let custom_picker_row: Option<AnyElement> = self
+            .chart_source_time_range_panel
+            .as_ref()
+            .and_then(|panel_entity| {
+                use dbflux_components::common::time_range::state::TimeRange;
+                use dbflux_components::controls::Button;
+
+                let panel = panel_entity.read(cx);
+                if panel.selected_time_range != Some(TimeRange::Custom) {
+                    return None;
+                }
+
+                let can_apply = panel.can_apply_custom_range(cx);
+                let picker_row = panel.render_custom_picker_row(px(320.0), cx);
+                let panel_clone = panel_entity.clone();
+
+                let row = div()
+                    .flex()
+                    .items_center()
+                    .gap_1()
+                    .pt(Spacing::XS)
+                    .px(Spacing::SM)
+                    .py(Spacing::XS)
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .bg(theme.tab_bar)
+                    .child(picker_row)
+                    .child(
+                        Button::new("data-grid-chart-time-range-apply", "Apply")
+                            .small()
+                            .disabled(!can_apply)
+                            .on_click(move |_, _, cx| {
+                                panel_clone.update(cx, |p, cx| {
+                                    // The returned bounds are intentionally discarded:
+                                    // the parent CodeDocument's TimeRangeChanged
+                                    // subscription drives re-execution.
+                                    let _ = p.apply_custom_range(cx);
+                                });
+                            }),
+                    );
+
+                Some(row.into_any_element())
+            });
+
         // AxisBar row: shown below the main toolbar when a chart view is live.
         // Reads bindings and open-pill state from the shell.
         let (bindings, open_pill, columns) = self
@@ -1425,6 +1476,7 @@ impl DataGridPanel {
             .border_b_1()
             .border_color(theme.border)
             .child(toolbar_row)
+            .when_some(custom_picker_row, |el, row| el.child(row))
             .child(
                 div()
                     .flex()


### PR DESCRIPTION
## Summary

Centralizes the `TimeRangePanel` custom date/time picker rendering so every host (audit, chart, code, data-grid chart toolbar) uses the same component. Also fixes two defects surfaced during manual verification: a deferred-subscription race in `ChartDocument`'s Apply path, and a missing custom picker row in the data-grid chart toolbar.

## What does this resolve?

- Resolves #100
- Surfaces follow-up scope tracked in #119 (UI time range vs user-written queries) and #120 (chart axis label clipping)

## How was this solved?

Two layers:

1. **Centralization (refactor commit `ed50cf59`)** — adds `render_custom_picker_row(date_picker_width, cx)` to `TimeRangePanel`. Chart and code adopt it, replacing ~80 lines of duplicated layout with helper calls. The helper stays domain-free (`gpui`, `gpui_component`, `dbflux_components` only).

2. **Unification + bugfixes (`91a7c2ba`)**:
   - Adds `CustomPickerSlots` + `custom_picker_slots()` API on `TimeRangePanel`. Hosts that need per-slot decoration (audit's keyboard-focus ring guards) compose the row themselves while sharing the same sub-element rendering. `render_custom_picker_row` now delegates to `custom_picker_slots` internally — single source of truth.
   - **Audit migrated** to `custom_picker_slots`. Removes the last hand-rolled custom picker row in the app; preserves the existing `FilterBarItem` keyboard nav and ring guards.
   - **Data-grid chart toolbar** (`data_grid_panel::render_chart_toolbar`) now renders the custom picker row below the toolbar when the host's `TimeRangePanel` has `selected_time_range == Custom`. Fixes the missing picker in CodeDocument's Result→Chart sub-tab.
   - **ChartDocument Apply race fix**: `apply_custom_range` now sets `pending_time_window` and `pending_chart_reexecute` synchronously from the validated `(start_ms, end_ms)` returned by the panel, instead of waiting for the deferred `TimeRangeChanged` subscription. The subscription still fires (mirrors `selected_time_range`) but the chart re-run is no longer gated on its delivery timing.

Tradeoffs:
- Date picker width is parameterized (`px(260)` for audit + chart, `px(320)` for code). Standardizing would be a visible change and is out of scope.
- CodeDocument's gap normalizes from `Spacing::SM` to `gap_1()` (~4 px tighter) and drops `control_shell` around the picker controls. Accepted in the design phase.
- Apply button style stays host-specific (`ToolbarButton` in audit, hand-rolled `div` in chart, stock `Button` in code + data-grid chart toolbar). Normalizing is a follow-up.

## Validation

- `cargo nextest run --workspace` — 2345/2345 passed, 154 skipped
- `cargo test --doc --workspace` — passes
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- New unit tests:
  - `render_custom_picker_row_returns_element`, `render_custom_picker_row_is_render_only`, `render_custom_picker_row_does_not_mutate_sub_entities` (component layer)
  - `apply_custom_range_ok_sets_flags_synchronously` (chart document — covers the race fix)
- Manual scenarios:
  - Audit document: custom picker row + ring guards + keyboard nav unchanged.
  - ChartDocument: pick "Custom…" → picker appears, click Apply → chart re-executes with new window.
  - CodeDocument context bar: pick "Custom…" → picker row appears below the bar with same controls as before.
  - CodeDocument Result→Chart sub-tab: pick "Custom…" → picker row now appears (previously missing).

Known limitation: when the user-written query has its own `WHERE time …` clause, the result still reflects the query's clause rather than the UI window. Tracked in #119 — out of scope here.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [x] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

- `ui:feature` (component centralization + new picker row in data-grid chart toolbar)
- `ui:bug` (ChartDocument Apply race)
- `chart:bug` (chart Apply / missing picker row in chart sub-tab)
