### PR TITLE
feat(query): time-range macros for InfluxQL and Flux (#119)

### DIFF
--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -111,9 +111,10 @@ pub use query::{
     SemanticRequest, SemanticRequestKind, SortDirection, SqlLanguageService, SqlMutationGenerator,
     TSqlLanguageService, TableBrowseRequest, TableCountRequest, TableRef, TextPosition,
     TextPositionRange, TextRange, ValidationResult, classify_query_for_governance,
-    classify_query_for_language, classify_sql_execution, detect_dangerous_mongo,
-    detect_dangerous_query, detect_dangerous_redis, detect_dangerous_sql, is_safe_read_query,
-    parse_semantic_filter_json, render_semantic_filter_sql, strip_leading_comments,
+    classify_query_for_language, classify_sql_execution, contains_time_macros,
+    detect_dangerous_mongo, detect_dangerous_query, detect_dangerous_redis, detect_dangerous_sql,
+    is_safe_read_query, parse_semantic_filter_json, render_semantic_filter_sql,
+    strip_leading_comments, substitute_time_macros,
 };
 
 pub use schema::node_id as schema_node_id;

--- a/crates/dbflux_core/src/query/mod.rs
+++ b/crates/dbflux_core/src/query/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod language_service;
 pub(crate) mod safety;
 pub(crate) mod semantic;
 pub(crate) mod table_browser;
+pub(crate) mod time_macros;
 pub(crate) mod types;
 
 pub use generator::{
@@ -27,6 +28,7 @@ pub use table_browser::{
     ExplainRequest, OrderByColumn, Pagination, SortDirection, TableBrowseRequest,
     TableCountRequest, TableRef,
 };
+pub use time_macros::{contains_time_macros, substitute_time_macros};
 pub use types::{
     ColumnKind, ColumnMeta, QueryHandle, QueryRequest, QueryResult, QueryResultShape,
     ResolvedWindow, Row,

--- a/crates/dbflux_core/src/query/time_macros.rs
+++ b/crates/dbflux_core/src/query/time_macros.rs
@@ -1,0 +1,385 @@
+//! Pure helper for query time-range macro substitution.
+//!
+//! Recognizes Grafana-compatible token names and replaces them with
+//! RFC3339-formatted time literals derived from a bound window.
+//!
+//! Supported tokens:
+//! - InfluxQL: `$timeFilter`, `$__from`, `$__to`
+//! - Flux: `v.timeRangeStart`, `v.timeRangeStop`
+//!
+//! Substitution is language-specific: only `InfluxQuery` and `Flux` documents
+//! receive token expansion; all other languages pass through unchanged.
+//!
+//! # Known limitation
+//!
+//! Matching uses naïve substring search (`str::contains` / `str::replace`).
+//! For Flux, `v.timeRangeStart` and `v.timeRangeStop` will incorrectly match
+//! Flux variable names that merely start with those strings (e.g.
+//! `v.timeRangeStartCustom`). Proper tokenisation is deferred to a future
+//! version (REQ-9).
+
+use crate::QueryLanguage;
+use chrono::{DateTime, Utc};
+
+// InfluxQL tokens (Grafana-aligned naming).
+const INFLUXQL_TOKEN_TIME_FILTER: &str = "$timeFilter";
+const TOKEN_FROM: &str = "$__from";
+const TOKEN_TO: &str = "$__to";
+
+// Flux tokens (Grafana variable-namespace convention).
+const FLUX_TOKEN_RANGE_START: &str = "v.timeRangeStart";
+const FLUX_TOKEN_RANGE_STOP: &str = "v.timeRangeStop";
+
+/// Returns `true` when the query string contains at least one recognized
+/// time-range macro token.
+///
+/// Recognized tokens:
+/// - InfluxQL: `$timeFilter`, `$__from`, `$__to`
+/// - Flux: `v.timeRangeStart`, `v.timeRangeStop`
+///
+/// Matching is exact and case-sensitive.
+///
+/// # Example
+///
+/// ```
+/// use dbflux_core::contains_time_macros;
+///
+/// assert!(contains_time_macros("SELECT * FROM cpu WHERE $timeFilter"));
+/// assert!(contains_time_macros("from(bucket: \"x\") |> range(start: v.timeRangeStart)"));
+/// assert!(!contains_time_macros("SELECT * FROM cpu WHERE time > now() - 1h"));
+/// ```
+pub fn contains_time_macros(query: &str) -> bool {
+    query.contains(INFLUXQL_TOKEN_TIME_FILTER)
+        || query.contains(TOKEN_FROM)
+        || query.contains(TOKEN_TO)
+        || query.contains(FLUX_TOKEN_RANGE_START)
+        || query.contains(FLUX_TOKEN_RANGE_STOP)
+}
+
+/// Replaces all occurrences of recognized time-range macro tokens with their
+/// language-specific expansions.
+///
+/// When `window` is `None` the query is returned unchanged. When `window` is
+/// `Some((start_ms, end_ms))`, both epoch-millisecond timestamps are converted
+/// to RFC3339 second-precision UTC strings (`YYYY-MM-DDTHH:MM:SSZ`) and used
+/// as substitution values.
+///
+/// Token mapping by language:
+/// - `InfluxQuery`: `$timeFilter` → `time >= 'start' AND time <= 'end'`,
+///   `$__from` → `'start'`, `$__to` → `'end'`
+/// - `Flux`: `v.timeRangeStart` → `'start'`, `v.timeRangeStop` → `'end'`
+/// - All other languages: pass through unchanged regardless of window presence
+///
+/// # Example
+///
+/// ```
+/// use dbflux_core::{substitute_time_macros, QueryLanguage};
+///
+/// let q = "SELECT * FROM cpu WHERE $timeFilter GROUP BY time(1m)";
+/// let result = substitute_time_macros(q, Some((1_710_000_000_000, 1_710_003_600_000)), QueryLanguage::InfluxQuery);
+/// assert!(result.contains("time >=") && result.contains("time <="));
+/// ```
+pub fn substitute_time_macros(
+    query: &str,
+    window: Option<(i64, i64)>,
+    lang: QueryLanguage,
+) -> String {
+    let Some((start_ms, end_ms)) = window else {
+        // Diagnostic: macros only resolve when a CollectionWindow is bound on
+        // the execution context. A macro-bearing query with no window will be
+        // sent verbatim to the driver and almost certainly parse-error or
+        // silently use a server-side default. Surface this state early so the
+        // root cause is not buried in driver errors.
+        if contains_time_macros(query) {
+            log::warn!(
+                "[time_macros] query contains time macros but no window is bound; \
+                 macros will pass through unsubstituted (likely a stale exec_ctx or \
+                 missing time-range panel)"
+            );
+        }
+        return query.to_string();
+    };
+
+    let start = rfc3339(start_ms);
+    let end = rfc3339(end_ms);
+
+    match lang {
+        QueryLanguage::InfluxQuery => query
+            .replace(
+                INFLUXQL_TOKEN_TIME_FILTER,
+                &format!("time >= '{start}' AND time <= '{end}'"),
+            )
+            .replace(TOKEN_FROM, &format!("'{start}'"))
+            .replace(TOKEN_TO, &format!("'{end}'")),
+
+        QueryLanguage::Flux => query
+            .replace(FLUX_TOKEN_RANGE_START, &format!("'{start}'"))
+            .replace(FLUX_TOKEN_RANGE_STOP, &format!("'{end}'")),
+
+        _ => query.to_string(),
+    }
+}
+
+/// Format an epoch-millisecond timestamp as RFC3339 second-precision UTC.
+///
+/// Returns the Unix epoch (`1970-01-01T00:00:00Z`) for out-of-range values.
+fn rfc3339(ms: i64) -> String {
+    DateTime::<Utc>::from_timestamp_millis(ms)
+        .unwrap_or_default()
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- contains_time_macros ---
+
+    #[test]
+    fn contains_returns_true_for_influxql_time_filter_token() {
+        // Grafana-aligned single-underscore token for InfluxQL.
+        assert!(contains_time_macros("SELECT * FROM cpu WHERE $timeFilter"));
+    }
+
+    #[test]
+    fn contains_returns_false_for_old_double_underscore_time_filter() {
+        // The old `$__timeFilter` token is no longer recognized; it passes through.
+        assert!(!contains_time_macros("$__timeFilter"));
+    }
+
+    #[test]
+    fn contains_returns_true_for_from_token() {
+        assert!(contains_time_macros(
+            "SELECT * FROM cpu WHERE time >= $__from"
+        ));
+    }
+
+    #[test]
+    fn contains_returns_true_for_to_token() {
+        assert!(contains_time_macros(
+            "SELECT * FROM cpu WHERE time <= $__to"
+        ));
+    }
+
+    #[test]
+    fn contains_returns_true_for_flux_range_start_token() {
+        assert!(contains_time_macros(
+            "from(bucket: \"x\") |> range(start: v.timeRangeStart)"
+        ));
+    }
+
+    #[test]
+    fn contains_returns_true_for_flux_range_stop_token() {
+        assert!(contains_time_macros(
+            "from(bucket: \"x\") |> range(start: -6h, stop: v.timeRangeStop)"
+        ));
+    }
+
+    #[test]
+    fn contains_returns_false_for_unrelated_text() {
+        assert!(!contains_time_macros(
+            "SELECT * FROM cpu WHERE time > now() - 1h"
+        ));
+    }
+
+    #[test]
+    fn contains_returns_false_for_mixed_case_token() {
+        // Matching is case-sensitive per REQ-1.
+        assert!(!contains_time_macros("$TimeFilter"));
+        assert!(!contains_time_macros("V.TimeRangeStart"));
+    }
+
+    #[test]
+    fn contains_returns_true_when_multiple_tokens_present() {
+        let q = "SELECT * FROM cpu WHERE time >= $__from AND time <= $__to";
+        assert!(contains_time_macros(q));
+    }
+
+    // --- substring boundary: v.timeRangeStart must not match longer names ---
+    //
+    // Known limitation (REQ-9): naïve str::contains will match
+    // `v.timeRangeStartCustom` because it contains `v.timeRangeStart`. This
+    // test documents the current behaviour (the macro guard fires) so the
+    // regression is visible if tokenisation is added later.
+    #[test]
+    fn contains_flux_range_start_fires_for_extended_name_known_limitation() {
+        // This is intentionally documenting the limitation: the guard WILL fire.
+        assert!(contains_time_macros("v.timeRangeStartButNot"));
+    }
+
+    // --- substitute_time_macros: no-window passthrough ---
+
+    #[test]
+    fn no_window_returns_query_unchanged_for_influxql() {
+        let q = "SELECT * FROM cpu WHERE $timeFilter";
+        assert_eq!(
+            substitute_time_macros(q, None, QueryLanguage::InfluxQuery),
+            q
+        );
+    }
+
+    #[test]
+    fn no_window_returns_query_unchanged_for_flux() {
+        let q = "from(bucket: \"x\") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)";
+        assert_eq!(substitute_time_macros(q, None, QueryLanguage::Flux), q);
+    }
+
+    #[test]
+    fn no_window_returns_query_unchanged_for_sql() {
+        let q = "SELECT $__from FROM table";
+        assert_eq!(substitute_time_macros(q, None, QueryLanguage::Sql), q);
+    }
+
+    // --- InfluxQL substitutions ---
+
+    #[test]
+    fn influxql_time_filter_expands_to_time_range_predicate() {
+        let q = "SELECT mean(usage_user) FROM cpu WHERE $timeFilter GROUP BY time(1m)";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::InfluxQuery);
+        assert!(
+            result.contains("time >= '2024-03-09T16:00:00Z' AND time <= '2024-03-09T17:00:00Z'"),
+            "got: {result}"
+        );
+    }
+
+    #[test]
+    fn influxql_from_expands_to_quoted_rfc3339() {
+        let q = "SELECT * FROM cpu WHERE time >= $__from";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::InfluxQuery);
+        assert!(
+            result.contains("time >= '2024-03-09T16:00:00Z'"),
+            "got: {result}"
+        );
+        // $__to not present — must not be injected
+        assert!(!result.contains("$__to"), "got: {result}");
+    }
+
+    #[test]
+    fn influxql_to_expands_to_quoted_rfc3339() {
+        let q = "SELECT * FROM cpu WHERE time <= $__to";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::InfluxQuery);
+        assert!(
+            result.contains("time <= '2024-03-09T17:00:00Z'"),
+            "got: {result}"
+        );
+    }
+
+    #[test]
+    fn influxql_multiple_occurrences_of_same_token_all_replaced() {
+        let q = "SELECT * FROM cpu WHERE $__from > $__from";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::InfluxQuery);
+        // No raw $__from must remain.
+        assert!(!result.contains("$__from"), "got: {result}");
+        assert_eq!(
+            result.matches("2024-03-09T16:00:00Z").count(),
+            2,
+            "both occurrences must be replaced, got: {result}"
+        );
+    }
+
+    // --- Flux substitutions ---
+
+    #[test]
+    fn flux_range_start_expands_to_quoted_rfc3339() {
+        let q = "from(bucket: \"x\") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::Flux);
+        assert!(
+            result.contains("start: '2024-03-09T16:00:00Z'"),
+            "got: {result}"
+        );
+        assert!(
+            result.contains("stop: '2024-03-09T17:00:00Z'"),
+            "got: {result}"
+        );
+        // No raw tokens must remain.
+        assert!(!result.contains("v.timeRangeStart"), "got: {result}");
+        assert!(!result.contains("v.timeRangeStop"), "got: {result}");
+    }
+
+    #[test]
+    fn flux_range_stop_only_expands_to_quoted_rfc3339() {
+        let q = "from(bucket: \"x\") |> range(start: -6h, stop: v.timeRangeStop)";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::Flux);
+        assert!(
+            result.contains("stop: '2024-03-09T17:00:00Z'"),
+            "got: {result}"
+        );
+        // The literal `-6h` must be preserved.
+        assert!(result.contains("start: -6h"), "got: {result}");
+    }
+
+    #[test]
+    fn flux_multiple_occurrences_of_range_start_all_replaced() {
+        let q = "from(bucket: \"x\") |> range(start: v.timeRangeStart) |> filter(fn: (r) => r._time >= v.timeRangeStart)";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::Flux);
+        assert!(!result.contains("v.timeRangeStart"), "got: {result}");
+        assert_eq!(
+            result.matches("2024-03-09T16:00:00Z").count(),
+            2,
+            "both occurrences must be replaced, got: {result}"
+        );
+    }
+
+    #[test]
+    fn flux_old_double_underscore_tokens_pass_through_unchanged() {
+        // $__from / $__to are InfluxQL-only tokens. In Flux context they must
+        // NOT be substituted — the user must use v.timeRangeStart/Stop instead.
+        let q = "from(bucket: \"x\") |> range(start: $__from, stop: $__to)";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::Flux);
+        // Tokens remain verbatim — no expansion in Flux.
+        assert_eq!(result, q, "Flux must not expand $__from/$__to");
+    }
+
+    // --- Non-InfluxDB languages pass through ---
+
+    #[test]
+    fn sql_language_passes_through_unchanged() {
+        let q = "SELECT $__from FROM table WHERE id = $__to";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::Sql);
+        assert_eq!(result, q);
+    }
+
+    #[test]
+    fn mongo_query_language_passes_through_unchanged() {
+        let q = "{ \"$__from\": 1 }";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::MongoQuery);
+        assert_eq!(result, q);
+    }
+
+    #[test]
+    fn redis_commands_language_passes_through_unchanged() {
+        let q = "GET $__from";
+        let window = Some((1_710_000_000_000_i64, 1_710_003_600_000_i64));
+        let result = substitute_time_macros(q, window, QueryLanguage::RedisCommands);
+        assert_eq!(result, q);
+    }
+
+    // --- RFC3339 determinism ---
+
+    #[test]
+    fn rfc3339_fixed_epoch_produces_expected_string() {
+        // 1_710_000_000_000 ms = 2024-03-09T16:00:00Z
+        assert_eq!(rfc3339(1_710_000_000_000), "2024-03-09T16:00:00Z");
+    }
+
+    #[test]
+    fn rfc3339_second_epoch_ms_also_deterministic() {
+        // 1_710_003_600_000 ms = 2024-03-09T17:00:00Z (1 hour later)
+        assert_eq!(rfc3339(1_710_003_600_000), "2024-03-09T17:00:00Z");
+    }
+}

--- a/crates/dbflux_driver_influxdb/README.md
+++ b/crates/dbflux_driver_influxdb/README.md
@@ -11,7 +11,51 @@ InfluxDB driver for DBFlux.
 - **Optional default bucket** — the connection profile's bucket (v2) or database (v1) field is optional. A v2 API token gives access to all buckets in the organisation; a v1 user gives access to all databases on the server. Leaving the field blank lets the user select a bucket per-query from the source-context dropdown in the editor. Setting it pre-selects that bucket without restricting access to others.
 - **Per-query bucket routing** — the bucket used for each InfluxQL query comes from the source-context dropdown selection, not the connection profile. For Flux queries the bucket is embedded in the query text itself (`from(bucket: "...")`).
 - **Bucket-free ping** — the connection liveness check does not require a bucket: v1 uses `SHOW DATABASES` against the internal database; v2 fetches `/api/v2/buckets?limit=1`.
-- **Automatic time-window injection** — when a time range is set via the source context panel and the query does not already contain a time predicate (`time >=` etc. for InfluxQL, `|> range(` for Flux), the driver injects the bounds automatically.
+- **Time range macros** — InfluxQL and Flux queries support Grafana-compatible macro tokens that are substituted with the bound time-range window before the query is sent to the driver:
+
+  | Token | Language | Expansion |
+  |---|---|---|
+  | `$timeFilter` | InfluxQL | `time >= 'RFC3339_start' AND time <= 'RFC3339_end'` |
+  | `$__from` | InfluxQL | `'RFC3339_start'` |
+  | `$__to` | InfluxQL | `'RFC3339_end'` |
+  | `v.timeRangeStart` | Flux | `'RFC3339_start'` |
+  | `v.timeRangeStop` | Flux | `'RFC3339_end'` |
+
+  These tokens match Grafana's variable conventions (`$timeFilter` for InfluxQL, `v.timeRangeStart`/`v.timeRangeStop` for Flux). Users familiar with Grafana should find the syntax intuitive.
+
+  RFC3339 format: `YYYY-MM-DDTHH:MM:SSZ` (UTC, second precision, Z suffix).
+
+  **InfluxQL example** — using `$timeFilter`:
+
+  ```influxql
+  -- Typed:
+  SELECT mean(usage_user) FROM cpu WHERE $timeFilter GROUP BY time(1m)
+
+  -- Executed (window = 2026-05-20T00:00:00Z to 2026-05-22T23:59:00Z):
+  SELECT mean(usage_user) FROM cpu WHERE time >= '2026-05-20T00:00:00Z' AND time <= '2026-05-22T23:59:00Z' GROUP BY time(1m)
+  ```
+
+  **Flux example** — using `v.timeRangeStart` / `v.timeRangeStop`:
+
+  ```flux
+  -- Typed:
+  from(bucket: "telegraf")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> filter(fn: (r) => r._measurement == "cpu")
+
+  -- Executed (same window):
+  from(bucket: "telegraf")
+    |> range(start: '2026-05-20T00:00:00Z', stop: '2026-05-22T23:59:00Z')
+    |> filter(fn: (r) => r._measurement == "cpu")
+  ```
+
+  **Macros require a bound window** — if the query contains macro tokens but no time-range window is set (i.e., the source-context panel has no selection), the macros pass through to the driver unsubstituted. InfluxDB will return a parse error since `$timeFilter` etc. are not valid InfluxQL/Flux syntax.
+
+  **Macros suppress inject-when-absent** — when a query contains any of the recognized macro tokens, the automatic time-window injection (see below) is suppressed. The macro substitution is treated as the user's authoritative time bound.
+
+  **v1 known limitation (naïve substring substitution)** — macro tokens inside quoted string literals or comments are also substituted. There is no escape syntax in v1. For Flux, a variable whose name merely starts with `v.timeRangeStart` or `v.timeRangeStop` (e.g. `v.timeRangeStartCustom`) will also be substituted. Proper tokenisation is planned for a future version.
+
+- **Automatic time-window injection** — when a time range is set via the source context panel and the query does not already contain a time predicate (`time >=` etc. for InfluxQL, `|> range(` for Flux), the driver injects the bounds automatically. This behavior is suppressed when the query contains explicit time-range macro tokens.
 - **Structured error messages** — server-side errors are parsed from the JSON `{"error": "..."}` field instead of being displayed as raw HTTP status codes.
 - **CSV and JSON export** — query results can be exported through the standard DBFlux export pipeline.
 - **Audit emission** — all queries are tracked through the standard DBFlux audit sink. The `bucket_or_database` metadata field records the actual bucket used for each query, not the profile default.

--- a/crates/dbflux_driver_influxdb/src/connection.rs
+++ b/crates/dbflux_driver_influxdb/src/connection.rs
@@ -11,7 +11,7 @@ use dbflux_core::{
     CollectionBrowseRequest, CollectionCountRequest, Connection, DatabaseInfo, DbError, DbKind,
     DefaultSqlDialect, DriverMetadata, InfluxVersion, MeasurementInfo, QueryLanguage, QueryRequest,
     QueryResult, ResolvedWindow, SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot,
-    SourceContextSpec, SourceQueryMode, TimeSeriesSchema,
+    SourceContextSpec, SourceQueryMode, TimeSeriesSchema, contains_time_macros,
 };
 
 use crate::error_formatter::InfluxErrorFormatter;
@@ -369,29 +369,38 @@ impl Connection for InfluxConnection {
         let resolved_window: Option<ResolvedWindow>;
         let final_query: String;
 
-        match language {
-            QueryLanguage::Flux => {
-                let had_range = flux_has_range_call(&req.sql);
-                final_query = inject_flux_window(&req.sql, &window);
-                injected_window = !had_range
-                    && (window.start_rfc3339.is_some() || window.end_rfc3339.is_some())
-                    && flux_has_range_call(&final_query);
-                resolved_window = if injected_window {
-                    window_to_resolved(&window, language.clone())
-                } else {
-                    None
-                };
-            }
-            _ => {
-                let had_predicate = influxql_has_time_predicate(&req.sql);
-                final_query = inject_influxql_window(&req.sql, &window);
-                injected_window = !had_predicate
-                    && (window.start_rfc3339.is_some() || window.end_rfc3339.is_some());
-                resolved_window = if injected_window {
-                    window_to_resolved(&window, language.clone())
-                } else {
-                    None
-                };
+        // When the query already contains explicit time-range macros (substituted upstream by
+        // `substitute_time_macros`), the user has declared their own time bounds. Skip the
+        // inject-when-absent logic entirely so the macro-derived predicates win (REQ-5).
+        if contains_time_macros(&req.sql) {
+            final_query = req.sql.clone();
+            injected_window = false;
+            resolved_window = None;
+        } else {
+            match language {
+                QueryLanguage::Flux => {
+                    let had_range = flux_has_range_call(&req.sql);
+                    final_query = inject_flux_window(&req.sql, &window);
+                    injected_window = !had_range
+                        && (window.start_rfc3339.is_some() || window.end_rfc3339.is_some())
+                        && flux_has_range_call(&final_query);
+                    resolved_window = if injected_window {
+                        window_to_resolved(&window, language.clone())
+                    } else {
+                        None
+                    };
+                }
+                _ => {
+                    let had_predicate = influxql_has_time_predicate(&req.sql);
+                    final_query = inject_influxql_window(&req.sql, &window);
+                    injected_window = !had_predicate
+                        && (window.start_rfc3339.is_some() || window.end_rfc3339.is_some());
+                    resolved_window = if injected_window {
+                        window_to_resolved(&window, language.clone())
+                    } else {
+                        None
+                    };
+                }
             }
         }
 
@@ -1227,6 +1236,76 @@ mod tests {
             InfluxVersion::V2,
         )
         .expect("stub HTTP client build")
+    }
+
+    // Guard logic tests (REQ-5) — verify the macro guard decision path.
+    //
+    // The guard branches on `contains_time_macros(&req.sql)`. These tests confirm that
+    // the function correctly identifies which queries should skip injection and which
+    // should proceed through the normal inject-when-absent path. They do not call
+    // `execute()` (which requires an HTTP connection) but validate the predicate that
+    // drives the guard decision.
+
+    /// Queries with explicit macros trigger the guard (injection skipped).
+    #[test]
+    fn guard_macros_present_triggers_skip_injection() {
+        // After substitution by the UI layer, the macro token is replaced. However,
+        // if macros somehow reach the driver unsubstituted (e.g., no window), the guard
+        // ensures injection is not attempted on a syntactically invalid query.
+        assert!(
+            dbflux_core::contains_time_macros(
+                "SELECT mean(usage_user) FROM cpu WHERE $timeFilter GROUP BY time(1m)"
+            ),
+            "$timeFilter macro must be detected"
+        );
+        assert!(
+            dbflux_core::contains_time_macros("SELECT * FROM cpu WHERE time >= $__from"),
+            "$__from macro must be detected"
+        );
+        assert!(
+            dbflux_core::contains_time_macros("SELECT * FROM cpu WHERE time <= $__to"),
+            "$__to macro must be detected"
+        );
+        assert!(
+            dbflux_core::contains_time_macros(
+                "from(bucket: \"x\") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)"
+            ),
+            "Flux v.timeRangeStart/Stop macros must be detected"
+        );
+    }
+
+    /// Macro-free queries do not trigger the guard (injection proceeds normally).
+    #[test]
+    fn guard_macro_free_query_does_not_trigger_skip() {
+        assert!(
+            !dbflux_core::contains_time_macros("SELECT * FROM cpu"),
+            "plain InfluxQL must not be flagged as macro-bearing"
+        );
+        assert!(
+            !dbflux_core::contains_time_macros("SELECT * FROM cpu WHERE time > now() - 1h"),
+            "query with native time predicate must not be flagged"
+        );
+    }
+
+    /// After macro substitution the resulting query contains no raw macro tokens,
+    /// so the guard lets injection proceed normally (existing predicate check still stops it).
+    #[test]
+    fn guard_does_not_fire_on_substituted_query() {
+        let substituted = "SELECT mean(usage_user) FROM cpu WHERE time >= '2024-03-09T16:00:00Z' AND time <= '2024-03-09T17:00:00Z' GROUP BY time(1m)";
+
+        // The substituted form contains `time >=`, so the existing inject logic also
+        // skips injection (influxql_has_time_predicate returns true). Confirm neither
+        // guard path is triggered unexpectedly.
+        assert!(
+            !dbflux_core::contains_time_macros(substituted),
+            "substituted query must not be flagged as macro-bearing"
+        );
+
+        // Confirm injection logic would also skip it via the existing predicate check.
+        assert!(
+            crate::injection::influxql_has_time_predicate(substituted),
+            "substituted query must have a time predicate detected"
+        );
     }
 
     // C.8.4 — escape_influxql_ident wraps plain names and escapes embedded quotes

--- a/crates/dbflux_ui_document/src/chart_document/mod.rs
+++ b/crates/dbflux_ui_document/src/chart_document/mod.rs
@@ -482,6 +482,19 @@ impl ChartDocument {
             }
         };
 
+        // Apply time-range macro substitution before dispatch. ChartDocument
+        // does not flow through `query_request_for_execution` in code/mod.rs,
+        // so we substitute here using the connection's declared QueryLanguage
+        // and the same window that drove the data-source plan. Without this,
+        // queries containing `$timeFilter` / `$__from` / `$__to` (InfluxQL) or
+        // `v.timeRangeStart` / `v.timeRangeStop` (Flux) would reach the driver
+        // unsubstituted and fail to parse.
+        let mut request = request;
+        let macro_window = self.pending_time_window;
+        let query_language = conn.metadata().query_language.clone();
+        request.sql =
+            dbflux_core::substitute_time_macros(&request.sql, macro_window, query_language);
+
         let (task_id, cancel_token) =
             self.runner
                 .start_primary(dbflux_core::TaskKind::Query, "Chart query", cx);

--- a/crates/dbflux_ui_document/src/code/context_bar.rs
+++ b/crates/dbflux_ui_document/src/code/context_bar.rs
@@ -306,7 +306,12 @@ impl CodeDocument {
             .as_ref()
             .is_some_and(|spec| !spec.start_label.is_empty() && !spec.end_label.is_empty());
 
-        if !wants_panel {
+        // Only tear down when the spec is resolved AND explicitly does not want
+        // a panel. A transient `source_spec = None` (e.g. mid-schema-reload on
+        // an AppStateChanged) would otherwise destroy the panel and force a
+        // re-seed of the default preset on the next render — clobbering any
+        // custom window the user just applied via the chart toolbar.
+        if !wants_panel && source_spec.is_some() {
             self.source_time_range_panel = None;
             self._source_time_range_sub = None;
         }

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -547,7 +547,12 @@ impl CodeDocument {
         cx.emit(DocumentEvent::ExecutionStarted);
         cx.notify();
 
-        let request = query_request_for_execution(query.clone(), active_database, &self.exec_ctx);
+        let request = query_request_for_execution(
+            query.clone(),
+            active_database,
+            &self.exec_ctx,
+            self.query_language.clone(),
+        );
 
         // Capture audit_service, task_target, and started_at before spawning so we can emit
         // audit events even if the document is closed before the deferred task runs.
@@ -1801,7 +1806,7 @@ impl CodeDocument {
 mod tests {
     use super::query_request_for_execution;
     use crate::code::build_source_window_context;
-    use dbflux_core::{ExecutionContext, ExecutionSourceContext};
+    use dbflux_core::{ExecutionContext, ExecutionSourceContext, QueryLanguage};
     use uuid::Uuid;
 
     #[test]
@@ -1822,8 +1827,13 @@ mod tests {
             ),
         };
 
-        let request =
-            query_request_for_execution("fields @message".into(), Some("logs".into()), &exec_ctx);
+        // "fields @message" contains no macros; CloudWatchLogsInsightsQl passes through unchanged.
+        let request = query_request_for_execution(
+            "fields @message".into(),
+            Some("logs".into()),
+            &exec_ctx,
+            QueryLanguage::CloudWatchLogsInsightsQl,
+        );
 
         assert_eq!(request.database.as_deref(), Some("logs"));
 
@@ -1887,6 +1897,148 @@ mod tests {
             )
             .unwrap_err(),
             "Start time must be earlier than end time"
+        );
+    }
+
+    /// REQ-4: macro substitution fires when source is CollectionWindow + InfluxQL.
+    #[test]
+    fn influxql_macro_substituted_when_collection_window() {
+        let exec_ctx = ExecutionContext {
+            connection_id: None,
+            database: None,
+            schema: None,
+            container: None,
+            source: Some(
+                build_source_window_context(
+                    None,
+                    &["cpu".to_string()],
+                    Some(1_710_000_000_000),
+                    Some(1_710_003_600_000),
+                )
+                .expect("valid source"),
+            ),
+        };
+
+        let request = query_request_for_execution(
+            "SELECT mean(usage_user) FROM cpu WHERE $timeFilter GROUP BY time(1m)".into(),
+            None,
+            &exec_ctx,
+            QueryLanguage::InfluxQuery,
+        );
+
+        assert!(
+            request.sql.contains("time >="),
+            "time >= expected in: {}",
+            request.sql
+        );
+        assert!(
+            request.sql.contains("time <="),
+            "time <= expected in: {}",
+            request.sql
+        );
+        assert!(
+            !request.sql.contains("$timeFilter"),
+            "macro must be replaced, got: {}",
+            request.sql
+        );
+    }
+
+    /// REQ-4: Flux macro substitution fires when source is CollectionWindow + Flux.
+    #[test]
+    fn flux_macro_substituted_when_collection_window() {
+        let exec_ctx = ExecutionContext {
+            connection_id: None,
+            database: None,
+            schema: None,
+            container: None,
+            source: Some(
+                build_source_window_context(
+                    None,
+                    &["telegraf".to_string()],
+                    Some(1_710_000_000_000),
+                    Some(1_710_003_600_000),
+                )
+                .expect("valid source"),
+            ),
+        };
+
+        let request = query_request_for_execution(
+            "from(bucket: \"telegraf\") |> range(start: v.timeRangeStart, stop: v.timeRangeStop)"
+                .into(),
+            None,
+            &exec_ctx,
+            QueryLanguage::Flux,
+        );
+
+        assert!(
+            !request.sql.contains("v.timeRangeStart"),
+            "v.timeRangeStart macro must be replaced, got: {}",
+            request.sql
+        );
+        assert!(
+            !request.sql.contains("v.timeRangeStop"),
+            "v.timeRangeStop macro must be replaced, got: {}",
+            request.sql
+        );
+        assert!(
+            request.sql.contains("'2024-03-09T16:00:00Z'"),
+            "start RFC3339 expected in: {}",
+            request.sql
+        );
+        assert!(
+            request.sql.contains("'2024-03-09T17:00:00Z'"),
+            "stop RFC3339 expected in: {}",
+            request.sql
+        );
+    }
+
+    /// REQ-6: macros are NOT substituted when no window is bound (source is None).
+    #[test]
+    fn macro_passthrough_when_no_window() {
+        let exec_ctx = ExecutionContext {
+            connection_id: None,
+            database: None,
+            schema: None,
+            container: None,
+            source: None,
+        };
+
+        let query = "SELECT * FROM cpu WHERE time >= $__from";
+        let request =
+            query_request_for_execution(query.into(), None, &exec_ctx, QueryLanguage::InfluxQuery);
+
+        assert_eq!(
+            request.sql, query,
+            "query must pass through unchanged when no window"
+        );
+    }
+
+    /// REQ-4: non-InfluxDB language passes through even with a CollectionWindow present.
+    #[test]
+    fn macro_passthrough_for_non_influx_language() {
+        let exec_ctx = ExecutionContext {
+            connection_id: None,
+            database: None,
+            schema: None,
+            container: None,
+            source: Some(
+                build_source_window_context(
+                    Some("sql".to_string()),
+                    &[],
+                    Some(1_710_000_000_000),
+                    Some(1_710_003_600_000),
+                )
+                .expect("valid source"),
+            ),
+        };
+
+        let query = "SELECT $__from FROM table";
+        let request =
+            query_request_for_execution(query.into(), None, &exec_ctx, QueryLanguage::Sql);
+
+        assert_eq!(
+            request.sql, query,
+            "SQL language must pass through unchanged"
         );
     }
 }

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -186,8 +186,18 @@ fn query_request_for_execution(
     query: String,
     active_database: Option<String>,
     exec_ctx: &ExecutionContext,
+    query_language: QueryLanguage,
 ) -> QueryRequest {
-    QueryRequest::new(query)
+    let window = match &exec_ctx.source {
+        Some(ExecutionSourceContext::CollectionWindow {
+            start_ms, end_ms, ..
+        }) => Some((*start_ms, *end_ms)),
+        _ => None,
+    };
+
+    let sql = dbflux_core::substitute_time_macros(&query, window, query_language);
+
+    QueryRequest::new(sql)
         .with_database(active_database)
         .with_execution_context(Some(exec_ctx.clone()))
 }

--- a/crates/dbflux_ui_document/src/code/render.rs
+++ b/crates/dbflux_ui_document/src/code/render.rs
@@ -832,10 +832,14 @@ impl Render for CodeDocument {
                     });
                 }
 
-                // Seed the initial window for the default preset. The panel
-                // cannot emit during its constructor because the subscription
-                // above is not registered until after `cx.new` returns.
-                panel.update(cx, |panel, cx| panel.emit_initial(cx));
+                // Seed the initial window for the default preset only when no
+                // user-selected window already exists. On panel *recreation*
+                // (e.g. after a transient teardown / connection reload) the
+                // existing exec_ctx.source carries the user's current selection
+                // and must not be overwritten by Last-24h.
+                if self.exec_ctx.source.is_none() {
+                    panel.update(cx, |panel, cx| panel.emit_initial(cx));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Adds opt-in time-range macro substitution so user-written InfluxDB queries honor the UI time range. Tokens follow Grafana conventions and ship for InfluxQL and Flux only in v1.

## What does this resolve?

- Resolves #119

## How was this solved?

**Helper layer** (`dbflux_core::substitute_time_macros`): pure function that expands Grafana-aligned tokens against an `(start_ms, end_ms)` window. Per-language expansion table:

| Language | Token | Expansion |
|----------|-------|-----------|
| InfluxQL | `$timeFilter` | `time >= 'rfc3339_start' AND time <= 'rfc3339_end'` |
| InfluxQL | `$__from` / `$__to` | `'rfc3339'` (quoted) |
| Flux | `v.timeRangeStart` / `v.timeRangeStop` | `'rfc3339'` (quoted) |
| All other languages | any | pass-through |

**Two chokepoints** because chart documents bypass the editor execution path:
1. `code/mod.rs::query_request_for_execution` — main editor + result tabs.
2. `chart_document/mod.rs::request_reexecute` — first-class chart documents opened via "Chart this query".

Both read `QueryLanguage` from the connection's `DriverMetadata` and `(start_ms, end_ms)` from `ExecutionSourceContext::CollectionWindow` (or `pending_time_window` in ChartDocument).

**InfluxDB driver guard** (`injection.rs`): when `contains_time_macros(query)` is true, the existing inject-when-absent path is skipped. Macros take precedence without double-injection. Queries without macros keep today's behavior byte-for-byte.

**Pre-existing bug fixes surfaced by macros**:
- `code/context_bar.rs::sync_source_controls` no longer destroys the panel when `source_spec` is transiently `None` (e.g. mid-`AppStateChanged`). Previously a destroyed panel was recreated and re-seeded with `Last24h`, clobbering the user's custom window.
- `code/render.rs::emit_initial` only fires when `exec_ctx.source` is `None`. On panel recreation the existing user window is preserved.
- `time_macros::substitute_time_macros` logs a `log::warn!` when macros reach substitution with no bound window, so future regressions surface early instead of as opaque driver parse errors.

**Tradeoffs**:
- Substitution is naive substring `str::replace`. Tokens inside string literals or comments are still substituted. For Flux, `v.timeRangeStart` matches `v.timeRangeStartCustom` (variable-name prefix). Both are accepted v1 limitations and documented in the driver README.
- SQL drivers (Postgres, MySQL, SQLite, MSSQL), MongoDB, Redis, DynamoDB, CloudWatch — out of scope for v1. SQL drivers don't even surface the time-range UI today (no `SourceContextSpec`). Tracked for a follow-up.
- The `$__timeFilter` no-op for Flux is deliberately dropped (Flux uses `range(start:..., stop:...)`, not predicates).

## Validation

- `cargo nextest run --workspace` — 2378/2378 passed, 154 skipped
- `cargo test --doc --workspace` — passes (2 doctests)
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Test additions:
  - 22 unit tests in `dbflux_core::query::time_macros` covering token detection, per-language expansion, no-window passthrough, Grafana token specificity, and the known `v.timeRangeStart*` substring limitation
  - 3 integration tests in `code/execution.rs` for the chokepoint
  - 3 guard tests in `influxdb/connection.rs` confirming inject is skipped when macros are present
- Manual scenarios:
  - InfluxQL with `$timeFilter`: preset change + custom range Apply both update the chart with the new window.
  - Flux with `v.timeRangeStart`/`v.timeRangeStop`: same.
  - "Chart this query" from a code result opens a `ChartDocument` and substitutes the seed `Last 24h` window on first run; picker changes re-execute correctly.
  - Queries without macros behave as before (inject-when-absent still fires when no predicate is present).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [x] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

- `query:feature` (new macro syntax)
- `driver:influxdb` (driver-specific guard + docs)
- `ui:feature` (panel teardown / emit_initial fixes)
- `size:exception` (~520 LOC gross — driven by test verbosity; net is ~270)
