### PR TITLE
fix(ui): unify confirm modals on ModalShell to stop button overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+* **Modal sizing & button overflow** — three confirm dialogs (Run entire
+  script, Dangerous query, sidebar Delete/Drop) now use the shared
+  `ModalShell` primitive with consistent widths and a dedicated footer
+  button row. Buttons no longer overflow into the body, and the
+  Drop Database / Delete confirms no longer render at half the size of
+  the other confirm modals.
+
 ## [0.6.0-dev.8] - 2026-05-23
 
 ### Added

--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -2,9 +2,10 @@ use super::*;
 use crate::keymap::ContextId;
 use crate::platform;
 use crate::ui::components::modal_frame::ModalFrame;
-use crate::ui::tokens::FontSizes;
 use dbflux_components::composites::{PanelHeaderVariant, panel_header_collapsible_variant};
-use dbflux_components::primitives::{Chord, Icon, Text, overlay_bg};
+use dbflux_components::controls::Button;
+use dbflux_components::modals::shell::{ModalShell, ModalVariant};
+use dbflux_components::primitives::{Chord, Icon, Text};
 use dbflux_components::typography::Body;
 use gpui_component::IconName;
 
@@ -877,9 +878,20 @@ impl Render for Workspace {
             .when_some(
                 self.sidebar.read(cx).delete_modal_state(),
                 |el, modal_state| {
-                    let theme = cx.theme();
+                    // Capture sidebar clones for each callback before building the footer.
                     let sidebar_confirm = self.sidebar.clone();
                     let sidebar_cancel = self.sidebar.clone();
+                    let sidebar_close = self.sidebar.clone();
+
+                    let title = if modal_state.multi_count.is_some() {
+                        "Delete"
+                    } else if modal_state.is_ddl {
+                        "Drop"
+                    } else if modal_state.is_folder {
+                        "Delete folder"
+                    } else {
+                        "Delete connection"
+                    };
 
                     let message = if let Some(count) = modal_state.multi_count {
                         format!("Delete {count} selected items?")
@@ -893,118 +905,44 @@ impl Render for Workspace {
                     };
 
                     let confirm_label = if modal_state.is_ddl { "Drop" } else { "Delete" };
-                    let btn_hover = theme.muted;
+                    let variant = if modal_state.is_ddl {
+                        ModalVariant::Danger
+                    } else {
+                        ModalVariant::Default
+                    };
+
+                    let body = Text::body(message).into_any_element();
+
+                    let footer = div()
+                        .flex()
+                        .gap(Spacing::SM)
+                        .child(
+                            Button::new("delete-cancel", "Cancel").on_click(move |_, _, cx| {
+                                sidebar_cancel.update(cx, |this, cx| {
+                                    this.cancel_modal_delete(cx);
+                                });
+                            }),
+                        )
+                        .child(
+                            Button::new("delete-confirm", confirm_label)
+                                .when(modal_state.is_ddl, |b| b.danger())
+                                .on_click(move |_, _, cx| {
+                                    sidebar_confirm.update(cx, |this, cx| {
+                                        this.confirm_modal_delete(cx);
+                                    });
+                                }),
+                        )
+                        .into_any_element();
 
                     el.child(
-                        div()
-                            .id("delete-modal-overlay")
-                            .absolute()
-                            .inset_0()
-                            .bg(overlay_bg(theme))
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                                cx.stop_propagation();
-                            })
-                            .child(
-                                div()
-                                    .bg(theme.sidebar)
-                                    .border_1()
-                                    .border_color(if modal_state.is_ddl {
-                                        theme.danger
-                                    } else {
-                                        theme.border
-                                    })
-                                    .rounded(Radii::MD)
-                                    .p(Spacing::MD)
-                                    .min_w(px(250.0))
-                                    .flex()
-                                    .flex_col()
-                                    .gap(Spacing::MD)
-                                    .child(
-                                        div()
-                                            .flex()
-                                            .items_center()
-                                            .gap_2()
-                                            .child(
-                                                svg()
-                                                    .path(if modal_state.is_ddl {
-                                                        AppIcon::Delete.path()
-                                                    } else {
-                                                        AppIcon::TriangleAlert.path()
-                                                    })
-                                                    .size_5()
-                                                    .text_color(if modal_state.is_ddl {
-                                                        theme.danger
-                                                    } else {
-                                                        theme.warning
-                                                    }),
-                                            )
-                                            .child(Text::body(message)),
-                                    )
-                                    .child(
-                                        div()
-                                            .flex()
-                                            .justify_end()
-                                            .gap(Spacing::SM)
-                                            .child(
-                                                div()
-                                                    .id("delete-cancel")
-                                                    .flex()
-                                                    .items_center()
-                                                    .gap_1()
-                                                    .px(Spacing::SM)
-                                                    .py(Spacing::XS)
-                                                    .rounded(Radii::SM)
-                                                    .cursor_pointer()
-                                                    .text_size(FontSizes::SM)
-                                                    .bg(theme.secondary)
-                                                    .hover(move |d| d.bg(btn_hover))
-                                                    .on_click(move |_, _, cx| {
-                                                        sidebar_cancel.update(cx, |this, cx| {
-                                                            this.cancel_modal_delete(cx);
-                                                        });
-                                                    })
-                                                    .child(
-                                                        Icon::new(AppIcon::X)
-                                                            .size(px(16.0))
-                                                            .muted(),
-                                                    )
-                                                    .child(
-                                                        Text::caption("Cancel").muted_foreground(),
-                                                    ),
-                                            )
-                                            .child(
-                                                div()
-                                                    .id("delete-confirm")
-                                                    .flex()
-                                                    .items_center()
-                                                    .gap_1()
-                                                    .px(Spacing::SM)
-                                                    .py(Spacing::XS)
-                                                    .rounded(Radii::SM)
-                                                    .cursor_pointer()
-                                                    .text_size(FontSizes::SM)
-                                                    .bg(theme.danger)
-                                                    .hover(|d| d.opacity(0.9))
-                                                    .on_click(move |_, _, cx| {
-                                                        sidebar_confirm.update(cx, |this, cx| {
-                                                            this.confirm_modal_delete(cx);
-                                                        });
-                                                    })
-                                                    .child(
-                                                        Icon::new(AppIcon::Delete)
-                                                            .size(px(16.0))
-                                                            .color(theme.background),
-                                                    )
-                                                    .child(
-                                                        Text::caption(confirm_label)
-                                                            .color(theme.background),
-                                                    ),
-                                            ),
-                                    ),
-                            ),
+                        ModalShell::new(title, body, footer)
+                            .width(px(360.0))
+                            .variant(variant)
+                            .on_close(move |_, cx| {
+                                sidebar_close.update(cx, |this, cx| {
+                                    this.cancel_modal_delete(cx);
+                                });
+                            }),
                     )
                 },
             )

--- a/crates/dbflux_ui_document/src/code/render.rs
+++ b/crates/dbflux_ui_document/src/code/render.rs
@@ -3,9 +3,9 @@ use crate::chrome::{ToolbarButton, ToolbarButtonVariant, compact_top_bar};
 use dbflux_components::composites::split_toolbar_action;
 use dbflux_components::controls::Button;
 use dbflux_components::helpers::text_color_for_active;
+use dbflux_components::modals::shell::{ModalShell, ModalVariant};
 use dbflux_components::primitives::{
-    Badge, BadgeVariant, BannerBlock, BannerVariant, Icon, Text, focus_frame, overlay_bg,
-    surface_panel,
+    Badge, BadgeVariant, BannerBlock, BannerVariant, Icon, Text, focus_frame,
 };
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
 use gpui_component::scroll::ScrollableElement;
@@ -605,9 +605,10 @@ impl CodeDocument {
     }
 
     fn render_script_confirm_modal(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = cx.theme();
-        let entity = cx.entity().clone();
+        // Capture entity clones for each callback before building the footer.
         let entity_cancel = cx.entity().clone();
+        let entity_run = cx.entity().clone();
+        let entity_close = cx.entity().clone();
 
         let statement_count = self
             .pending_script_confirm
@@ -619,66 +620,46 @@ impl CodeDocument {
             statement_count
         );
 
-        div()
-            .id("script-confirm-modal-overlay")
-            .absolute()
-            .inset_0()
-            .bg(overlay_bg(theme))
+        let body = Text::caption(message).into_any_element();
+
+        let footer = div()
             .flex()
-            .items_center()
-            .justify_center()
-            .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                cx.stop_propagation();
-            })
+            .gap(Spacing::SM)
             .child(
-                surface_panel(cx)
-                    .rounded(Radii::MD)
-                    .min_w(px(350.0))
-                    .max_w(px(500.0))
-                    .flex()
-                    .flex_col()
-                    .gap(Spacing::MD)
-                    .p(Spacing::MD)
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap_2()
-                            .child(Icon::new(AppIcon::TriangleAlert).size(px(20.0)).warning())
-                            .child(Text::heading("Run entire script")),
-                    )
-                    .child(Text::caption(message))
-                    .child(
-                        div().flex().justify_end().items_center().child(
-                            div()
-                                .flex()
-                                .gap(Spacing::SM)
-                                .child(Button::new("script-confirm-cancel-btn", "Cancel").on_click(
-                                    move |_, _, cx| {
-                                        entity_cancel.update(cx, |doc, cx| {
-                                            doc.cancel_script_query(cx);
-                                        });
-                                    },
-                                ))
-                                .child(
-                                    Button::new("script-confirm-run-btn", "Run Script").on_click(
-                                        move |_, window, cx| {
-                                            entity.update(cx, |doc, cx| {
-                                                doc.confirm_script_query(window, cx);
-                                            });
-                                        },
-                                    ),
-                                ),
-                        ),
-                    ),
+                Button::new("script-confirm-cancel-btn", "Cancel").on_click(move |_, _, cx| {
+                    entity_cancel.update(cx, |doc, cx| {
+                        doc.cancel_script_query(cx);
+                    });
+                }),
             )
+            .child(
+                Button::new("script-confirm-run-btn", "Run Script").on_click(
+                    move |_, window, cx| {
+                        entity_run.update(cx, |doc, cx| {
+                            doc.confirm_script_query(window, cx);
+                        });
+                    },
+                ),
+            )
+            .into_any_element();
+
+        ModalShell::new("Run entire script", body, footer)
+            .width(px(460.0))
+            .on_close(move |_, cx| {
+                entity_close.update(cx, |doc, cx| {
+                    doc.cancel_script_query(cx);
+                });
+            })
     }
 
     fn render_dangerous_query_modal(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
-        let entity = cx.entity().clone();
+
+        // Capture entity clones for each callback before building the footer.
+        let entity_run = cx.entity().clone();
         let entity_cancel = cx.entity().clone();
         let entity_suppress = cx.entity().clone();
+        let entity_close = cx.entity().clone();
 
         let (title, message) = self
             .pending_dangerous_query
@@ -704,81 +685,63 @@ impl CodeDocument {
             })
             .unwrap_or(("Warning", "This query may be dangerous."));
 
-        div()
-            .id("dangerous-query-modal-overlay")
-            .absolute()
-            .inset_0()
-            .bg(overlay_bg(theme))
+        let body = Text::caption(message).into_any_element();
+
+        let dont_ask_chip = div()
+            .id("dont-ask-again-btn")
             .flex()
             .items_center()
-            .justify_center()
-            .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                cx.stop_propagation();
+            .gap_1()
+            .px(Spacing::SM)
+            .py(Spacing::XS)
+            .rounded(Radii::SM)
+            .cursor_pointer()
+            .hover(|d| d.bg(theme.secondary))
+            .on_click(move |_, window, cx| {
+                entity_suppress.update(cx, |doc, cx| {
+                    doc.confirm_dangerous_query(true, window, cx);
+                });
             })
+            .child(Text::caption("Don't ask again"));
+
+        let cancel_btn = Button::new("dangerous-cancel-btn", "Cancel").on_click(move |_, _, cx| {
+            entity_cancel.update(cx, |doc, cx| {
+                doc.cancel_dangerous_query(cx);
+            });
+        });
+
+        let run_anyway_btn = Button::new("dangerous-confirm-btn", "Run Anyway")
+            .danger()
+            .on_click(move |_, window, cx| {
+                entity_run.update(cx, |doc, cx| {
+                    doc.confirm_dangerous_query(false, window, cx);
+                });
+            });
+
+        // Footer: "Don't ask again" left-aligned, Cancel + Run Anyway right-aligned.
+        // The flex_1 spacer pushes the buttons to the right within the single footer AnyElement.
+        let footer = div()
+            .flex()
+            .items_center()
+            .child(dont_ask_chip)
+            .child(div().flex_1())
             .child(
-                surface_panel(cx)
-                    .rounded(Radii::MD)
-                    .min_w(px(350.0))
-                    .max_w(px(500.0))
+                div()
                     .flex()
-                    .flex_col()
-                    .gap(Spacing::MD)
-                    .p(Spacing::MD)
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap_2()
-                            .child(Icon::new(AppIcon::TriangleAlert).size(px(20.0)).warning())
-                            .child(Text::heading(title)),
-                    )
-                    .child(Text::caption(message))
-                    .child(
-                        div()
-                            .flex()
-                            .justify_between()
-                            .items_center()
-                            .child(
-                                div()
-                                    .id("dont-ask-again-btn")
-                                    .flex()
-                                    .items_center()
-                                    .gap_1()
-                                    .px(Spacing::SM)
-                                    .py(Spacing::XS)
-                                    .rounded(Radii::SM)
-                                    .cursor_pointer()
-                                    .hover(|d| d.bg(theme.secondary))
-                                    .on_click(move |_, window, cx| {
-                                        entity_suppress.update(cx, |doc, cx| {
-                                            doc.confirm_dangerous_query(true, window, cx);
-                                        });
-                                    })
-                                    .child(Text::caption("Don't ask again")),
-                            )
-                            .child(
-                                div()
-                                    .flex()
-                                    .gap(Spacing::SM)
-                                    .child(Button::new("dangerous-cancel-btn", "Cancel").on_click(
-                                        move |_, _, cx| {
-                                            entity_cancel.update(cx, |doc, cx| {
-                                                doc.cancel_dangerous_query(cx);
-                                            });
-                                        },
-                                    ))
-                                    .child(
-                                        Button::new("dangerous-confirm-btn", "Run Anyway")
-                                            .danger()
-                                            .on_click(move |_, window, cx| {
-                                                entity.update(cx, |doc, cx| {
-                                                    doc.confirm_dangerous_query(false, window, cx);
-                                                });
-                                            }),
-                                    ),
-                            ),
-                    ),
+                    .gap(Spacing::SM)
+                    .child(cancel_btn)
+                    .child(run_anyway_btn),
             )
+            .into_any_element();
+
+        ModalShell::new(title, body, footer)
+            .width(px(460.0))
+            .variant(ModalVariant::Danger)
+            .on_close(move |_, cx| {
+                entity_close.update(cx, |doc, cx| {
+                    doc.cancel_dangerous_query(cx);
+                });
+            })
     }
 }
 


### PR DESCRIPTION
## Summary

Three confirm dialogs in the app — *Run entire script*, *Dangerous query*, and the sidebar *Delete/Drop* prompt — each rolled their own modal container with ad-hoc widths and no dedicated footer row. Buttons rendered as siblings of the body text could overflow the frame when the body wrapped (the symptom shown in issue #127), and the sidebar confirm came out at roughly half the width of the others, making confirms feel inconsistent across the app.

This PR ports all three to the existing `ModalShell` primitive that the other confirm modals (drop table, delete connection, unsaved changes, active query) already use.

## What does this resolve?

- Resolves #127

## How was this solved?

`ModalShell` provides a stateless `RenderOnce` frame with three distinct zones: header (toolbar height), body (padded, scrollable, min-height), and a dedicated footer (`border_t_1`, right-aligned). Adopting it gives the three ported call-sites consistent widths and a real button row that body text cannot crowd.

Per-modal choices:

| Modal | Width | Variant | Notes |
|---|---|---|---|
| Run entire script | 460 px | Default | Footer: `Cancel`, `Run Script` |
| Dangerous query | 460 px | Danger | Footer: `Don't ask again` chip + `flex_1` spacer + `Cancel` + `Run Anyway` |
| Sidebar Delete/Drop | 360 px | Danger when destructive DDL, Default otherwise | Footer: `Cancel` + destructive action button |

All existing callbacks, keyboard shortcuts, and the "Don't ask again" persistence are preserved verbatim. The only behavioral additions are `ModalShell`'s click-outside dismiss and X button, both wired to the existing Cancel handler — they cancel the action, never confirm it.

Net diff: +147 / −237 lines across two files. The change is a simplification — removing duplicated container scaffolding in favor of the shared primitive.

## Validation

Build gates (run inside the worktree):

```
cargo check --workspace                       # OK
cargo clippy --workspace -- -D warnings       # OK
cargo fmt --all -- --check                    # OK
cargo nextest run --workspace                 # 2388 passed, 0 failed
```

> Pre-existing clippy lints in `crates/dbflux_ui_base/src/sso_wizard.rs` (unused imports + unused mut) are unrelated to this change and were not touched.

### Manual visual checks expected on Linux/Wayland

The change is pure GPUI render layout, so there is no automated coverage of the visual output. A reviewer should walk through these before merge:

- [ ] Run-Script: open a multi-statement script, no selection, trigger Run Entire Script. Long message wraps; buttons sit in the footer, inside the frame.
- [ ] Dangerous-Query: trigger a destructive query (e.g. `DELETE FROM ... ` without `WHERE`). Danger top-border visible; "Don't ask again" stays left-aligned; persistence toggles correctly.
- [ ] Sidebar DDL path: right-click a database / table → Drop. 360 px frame, danger variant, red destructive button.
- [ ] Sidebar non-DDL path: delete a connection or folder. 360 px frame, default variant, neutral confirm button.
- [ ] Keyboard: Enter triggers confirm, Esc triggers cancel on all three.
- [ ] Click-outside / X button: dismiss as Cancel on all three (new behavior, acceptable per design).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests (workspace build + nextest sanity; no new tests — GPUI render layout)
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland

## Checklist

- [x] I verified the change against the affected user flow(s) (build + structural review; manual visual review pending in PR)
- [x] I added or updated tests when needed (N/A — pure GPUI render layout; strict TDD exception declared)
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I applied the appropriate labels (see CONTRIBUTING.md#label-guide)

## Labels to apply

- `ui:bug`
- `platform:linux` (visually verified here; macOS/Windows pending)