### PR TITLE
feat(sidebar): collapse single-database wrapper level (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+* **Sidebar collapses single-database wrapper** — Connections whose driver
+  exposes exactly one database (CloudWatch's `logs`, DynamoDB's default
+  region, single-file SQLite, etc.) no longer render the redundant database
+  level. Child nodes (Collections, Metrics, Tables) attach directly under the
+  connection node. Multi-database drivers (Postgres, MySQL, MongoDB) are
+  unaffected — the wrapper still discriminates between databases (#131).
+
 ### Added
 
 * **Metric picker rail tab for chart documents** — CloudWatch metric charts now

--- a/crates/dbflux_ui_sidebar/src/tree_builder.rs
+++ b/crates/dbflux_ui_sidebar/src/tree_builder.rs
@@ -287,6 +287,13 @@ impl Sidebar {
                     );
                 }
             } else if !schema.databases().is_empty() {
+                // See `should_collapse_database_wrapper`: when the connection
+                // exposes a single trivial database (CloudWatch, DynamoDB,
+                // single-DB SQL, etc.) the wrapper adds no information vs the
+                // connection root. Children (Collections, Metrics, Tables)
+                // already embed `database` in their node IDs so routing is
+                // unaffected by the missing intermediate.
+                let collapse_single_db = should_collapse_database_wrapper(schema.databases());
                 for db in schema.databases() {
                     let is_pending = state.is_operation_pending(profile_id, Some(&db.name));
                     let is_active_db = connected.active_database.as_deref() == Some(&db.name);
@@ -426,31 +433,35 @@ impl Sidebar {
                         Vec::new()
                     };
 
-                    let db_label = if is_pending {
-                        format!("{} (loading...)", db.name)
+                    if collapse_single_db {
+                        profile_children.extend(db_children);
                     } else {
-                        db.name.clone()
-                    };
+                        let db_label = if is_pending {
+                            format!("{} (loading...)", db.name)
+                        } else {
+                            db.name.clone()
+                        };
 
-                    let has_per_db_conn = connected.database_connections.contains_key(&db.name);
-                    let is_expanded = if uses_lazy_loading {
-                        is_active_db
-                    } else {
-                        db.is_current || has_per_db_conn
-                    };
+                        let has_per_db_conn = connected.database_connections.contains_key(&db.name);
+                        let is_expanded = if uses_lazy_loading {
+                            is_active_db
+                        } else {
+                            db.is_current || has_per_db_conn
+                        };
 
-                    profile_children.push(
-                        TreeItem::new(
-                            SchemaNodeId::Database {
-                                profile_id,
-                                name: db.name.clone(),
-                            }
-                            .to_string(),
-                            db_label,
-                        )
-                        .expanded(is_expanded)
-                        .children(db_children),
-                    );
+                        profile_children.push(
+                            TreeItem::new(
+                                SchemaNodeId::Database {
+                                    profile_id,
+                                    name: db.name.clone(),
+                                }
+                                .to_string(),
+                                db_label,
+                            )
+                            .expanded(is_expanded)
+                            .children(db_children),
+                        );
+                    }
                 }
             } else {
                 // No databases defined - use active_database or first schema as fallback
@@ -1702,6 +1713,21 @@ impl Sidebar {
     }
 }
 
+/// Return `true` when the sidebar should hide the database wrapper level for
+/// a connection.
+///
+/// The wrapper exists to disambiguate multiple databases under one connection.
+/// When a driver exposes a single trivial database (CloudWatch's `logs`,
+/// DynamoDB's default region, a SQLite file, etc.) the wrapper carries no
+/// information beyond what the connection node already shows, so children are
+/// rendered directly under the connection.
+///
+/// Multi-database drivers (Postgres, MySQL, MongoDB) are unaffected: with two
+/// or more databases the wrapper still discriminates between them.
+fn should_collapse_database_wrapper(databases: &[dbflux_core::DatabaseInfo]) -> bool {
+    databases.len() == 1
+}
+
 fn build_collection_field_items(
     profile_id: Uuid,
     collection_name: &str,
@@ -2295,5 +2321,44 @@ mod tests {
                 _ => panic!("expected CustomType variant"),
             }
         }
+    }
+
+    #[test]
+    fn collapse_wrapper_when_single_database() {
+        let dbs = vec![dbflux_core::DatabaseInfo {
+            name: "logs".to_string(),
+            is_current: true,
+        }];
+        assert!(
+            super::should_collapse_database_wrapper(&dbs),
+            "single database must collapse (CloudWatch/DynamoDB/SQLite case)"
+        );
+    }
+
+    #[test]
+    fn keep_wrapper_when_multiple_databases() {
+        let dbs = vec![
+            dbflux_core::DatabaseInfo {
+                name: "postgres".to_string(),
+                is_current: true,
+            },
+            dbflux_core::DatabaseInfo {
+                name: "app_prod".to_string(),
+                is_current: false,
+            },
+        ];
+        assert!(
+            !super::should_collapse_database_wrapper(&dbs),
+            "multiple databases must remain visible to discriminate them"
+        );
+    }
+
+    #[test]
+    fn keep_wrapper_when_zero_databases() {
+        let dbs: Vec<dbflux_core::DatabaseInfo> = vec![];
+        assert!(
+            !super::should_collapse_database_wrapper(&dbs),
+            "zero databases must not trigger collapse path (falls through to fallback branch)"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Collapses the redundant database-wrapper level in the sidebar tree when a connection exposes exactly one database. Children attach directly under the connection node.

Before / after for a CloudWatch connection:

```
Before                            After
──────────────────────────        ──────────────────────────
CloudWatch                     CloudWatch 
└── logs                          ├── Collections (226)
    ├── Collections (226)         └── Metrics
    └── Metrics
```

## What does this resolve?

- Resolves #131

## How was this solved?

The decision lives in a small predicate `should_collapse_database_wrapper(&[DatabaseInfo]) -> bool` (currently `databases.len() == 1`). The tree-building dispatcher in `tree_builder.rs::build_profile_item_with_errors` checks the predicate once per connection and, when collapsing, appends each database's children directly to `profile_children` instead of wrapping them in a `SchemaNodeId::Database` `TreeItem`.

Routing is unaffected because child node IDs (`CollectionsFolder`, `MetricsFolder`, `Table`, etc.) already embed the `database` field — the wrapper only ever contributed a visual node, not a routing key.

Drivers affected by the collapse: **CloudWatch** (`logs` wrapper), **DynamoDB** (default region wrapper), **SQLite** (single-file), and any other driver that returns exactly one `DatabaseInfo`. Multi-database drivers (Postgres, MySQL, MongoDB) keep the wrapper since it discriminates between databases. Redis was already exempt because its key-value schema bypasses the `databases()` accessor.

## Validation

- `cargo nextest run --workspace` — **2459 / 2459 passed** (3 new tests for the predicate)
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Test additions in `dbflux_ui_sidebar::tree_builder::tests`:
  - `collapse_wrapper_when_single_database`
  - `keep_wrapper_when_multiple_databases`
  - `keep_wrapper_when_zero_databases`
- Manual scenarios:
  - CloudWatch connection: `logs` wrapper gone; `Collections (N)` and `Metrics` sit directly under the connection.
  - Postgres connection with `postgres` + `app_prod`: both databases still appear under the connection node.
  - Clicking into a collection / metric still opens the correct document (routing preserved).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [x] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels

## Labels to apply

- `ui:feature`
