### PR TITLE
fix(chart): wire Stats rail toggle in ChartDocument + responsive toolbar

### DIFF
--- a/crates/dbflux_ui_document/src/chart/shell.rs
+++ b/crates/dbflux_ui_document/src/chart/shell.rs
@@ -6,7 +6,7 @@
 //! legend, rail, hidden-series management) without duplicating state.
 
 /// Active tab in the chart Configure/Stats/Metric rail.
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ChartRailTab {
     #[default]
     Configure,

--- a/crates/dbflux_ui_document/src/chart/toolbar.rs
+++ b/crates/dbflux_ui_document/src/chart/toolbar.rs
@@ -268,13 +268,23 @@ pub fn render_chart_toolbar(
             on_save(window, cx);
         });
 
+    // Responsive layout: a single `flex_wrap` row that wraps onto multiple
+    // lines when the viewport gets narrower. Per the project pattern
+    // (`result_panel/mod.rs`), `flex_wrap` is incompatible with positional
+    // spacers, so no `flex_1` divider is inserted — items flow left-to-right
+    // and wrap naturally. `w_full` forces the row to its parent's width so
+    // overflow can be detected. `min_h` (instead of fixed `h`) lets the row
+    // grow vertically when items wrap.
     div()
         .flex()
         .flex_row()
+        .flex_wrap()
         .items_center()
-        .h(px(34.0))
+        .w_full()
+        .min_h(px(34.0))
         .px(Spacing::SM)
-        .gap(px(4.0))
+        .gap_x(px(4.0))
+        .gap_y(px(2.0))
         .border_b_1()
         .border_color(theme.border)
         .bg(theme.tab_bar)
@@ -296,8 +306,6 @@ pub fn render_chart_toolbar(
                         .child(window_label),
                 ),
         )
-        // Spacer
-        .child(div().flex_1())
         // Points · resolution
         .child(
             div()

--- a/crates/dbflux_ui_document/src/chart_document/mod.rs
+++ b/crates/dbflux_ui_document/src/chart_document/mod.rs
@@ -1051,6 +1051,30 @@ impl ChartHost for ChartDocument {
     }
 }
 
+/// Returns `true` when `ChartDocument` should render the Stats rail.
+///
+/// The render branch in `render_chart_content` delegates to this predicate so
+/// tests can pin the gating logic without a GPUI runtime.
+fn should_render_stats_rail(rail_open: bool, rail_tab: crate::chart::ChartRailTab) -> bool {
+    rail_open && rail_tab == crate::chart::ChartRailTab::Stats
+}
+
+/// Returns the new `(open, tab)` state after the Stats toolbar button is clicked.
+///
+/// Toggling while already open on the Stats tab closes the rail. Clicking Stats
+/// from any other state (closed, or open on a different tab) opens the rail and
+/// switches to the Stats tab.
+fn toggle_stats_rail(
+    open: bool,
+    tab: crate::chart::ChartRailTab,
+) -> (bool, crate::chart::ChartRailTab) {
+    if open && tab == crate::chart::ChartRailTab::Stats {
+        (false, tab)
+    } else {
+        (true, crate::chart::ChartRailTab::Stats)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1512,6 +1536,86 @@ mod tests {
         assert!(
             title.contains("Invocations"),
             "title must include metric name: got {title:?}"
+        );
+    }
+
+    // ---- stats rail helpers ----
+
+    /// T-SR-01: `should_render_stats_rail` returns true when rail is open on Stats tab.
+    #[test]
+    fn should_render_stats_rail_when_open_and_stats() {
+        assert!(
+            super::should_render_stats_rail(true, crate::chart::ChartRailTab::Stats),
+            "rail must render when open and tab is Stats"
+        );
+    }
+
+    /// T-SR-02: `should_render_stats_rail` returns false when rail is closed.
+    #[test]
+    fn should_not_render_when_closed() {
+        assert!(
+            !super::should_render_stats_rail(false, crate::chart::ChartRailTab::Stats),
+            "rail must not render when closed"
+        );
+    }
+
+    /// T-SR-03: `should_render_stats_rail` returns false when a different tab is active.
+    #[test]
+    fn should_not_render_when_other_tab() {
+        assert!(
+            !super::should_render_stats_rail(true, crate::chart::ChartRailTab::Metric),
+            "rail must not render when tab is not Stats"
+        );
+    }
+
+    /// T-SR-04: toggling from closed state opens the rail on Stats tab.
+    #[test]
+    fn toggle_from_closed_opens_stats() {
+        let (open, tab) = super::toggle_stats_rail(false, crate::chart::ChartRailTab::Configure);
+        assert!(open, "toggle from closed must open the rail");
+        assert_eq!(
+            tab,
+            crate::chart::ChartRailTab::Stats,
+            "toggle from closed must set tab to Stats"
+        );
+    }
+
+    /// T-SR-05: toggling while open on Stats tab closes the rail.
+    #[test]
+    fn toggle_while_open_on_stats_closes() {
+        let (open, tab) = super::toggle_stats_rail(true, crate::chart::ChartRailTab::Stats);
+        assert!(!open, "toggle while open on Stats must close the rail");
+        assert_eq!(
+            tab,
+            crate::chart::ChartRailTab::Stats,
+            "closed toggle must preserve Stats tab identity"
+        );
+    }
+
+    /// T-SR-06: toggling while rail is open on Metric tab switches to Stats without closing.
+    #[test]
+    fn toggle_while_open_on_metric_switches_to_stats() {
+        let (open, tab) = super::toggle_stats_rail(true, crate::chart::ChartRailTab::Metric);
+        assert!(open, "switching from Metric to Stats must keep rail open");
+        assert_eq!(
+            tab,
+            crate::chart::ChartRailTab::Stats,
+            "switching from Metric must set tab to Stats"
+        );
+    }
+
+    /// T-SR-07: toggling while rail is open on Configure tab switches to Stats without closing.
+    #[test]
+    fn toggle_while_open_on_configure_switches_to_stats() {
+        let (open, tab) = super::toggle_stats_rail(true, crate::chart::ChartRailTab::Configure);
+        assert!(
+            open,
+            "switching from Configure to Stats must keep rail open"
+        );
+        assert_eq!(
+            tab,
+            crate::chart::ChartRailTab::Stats,
+            "switching from Configure must set tab to Stats"
         );
     }
 

--- a/crates/dbflux_ui_document/src/chart_document/render.rs
+++ b/crates/dbflux_ui_document/src/chart_document/render.rs
@@ -28,7 +28,8 @@ use dbflux_components::common::time_range::state::TimeRange;
 use dbflux_components::common::time_range::view::{TimeRangeChanged, TimeRangePanel};
 use dbflux_components::controls::DropdownSelectionChanged;
 use dbflux_components::controls::Input;
-use dbflux_components::primitives::Text;
+use dbflux_components::icons::AppIcon;
+use dbflux_components::primitives::{Icon, Text};
 use dbflux_components::result_panel::ResultPanel;
 use dbflux_components::semantic::ChartColors;
 use dbflux_components::tokens::{FontSizes, Heights, Radii, Spacing};
@@ -611,35 +612,21 @@ impl ChartDocument {
             (cv, fi)
         };
 
-        let Some(chart_view) = chart_view_opt else {
-            let placeholder = div()
+        let placeholder = |msg: &'static str| -> AnyElement {
+            div()
                 .p_2()
                 .text_size(FontSizes::XS)
                 .text_color(theme.muted_foreground)
-                .child("Rebuilding chart…")
-                .into_any_element();
-            return Some(
-                div()
-                    .absolute()
-                    .top_0()
-                    .right_0()
-                    .bottom_0()
-                    .w(px(320.0))
-                    .flex()
-                    .flex_col()
-                    .border_l_1()
-                    .border_color(theme.border)
-                    .bg(theme.popover)
-                    .occlude()
-                    .child(
-                        div()
-                            .flex_grow()
-                            .min_h_0()
-                            .overflow_hidden()
-                            .child(placeholder),
-                    )
-                    .into_any_element(),
-            );
+                .child(msg)
+                .into_any_element()
+        };
+
+        let Some(chart_view) = chart_view_opt else {
+            return Some(self.wrap_stats_rail_chrome(
+                placeholder("Rebuilding chart…"),
+                theme,
+                &chart_colors,
+            ));
         };
 
         // Scope 2: read chart_view entity to capture all primitive values before
@@ -656,34 +643,11 @@ impl ChartDocument {
         };
 
         let Some(stats) = stats_opt else {
-            let placeholder = div()
-                .p_2()
-                .text_size(FontSizes::XS)
-                .text_color(theme.muted_foreground)
-                .child("No stats available for this series.")
-                .into_any_element();
-            return Some(
-                div()
-                    .absolute()
-                    .top_0()
-                    .right_0()
-                    .bottom_0()
-                    .w(px(320.0))
-                    .flex()
-                    .flex_col()
-                    .border_l_1()
-                    .border_color(theme.border)
-                    .bg(theme.popover)
-                    .occlude()
-                    .child(
-                        div()
-                            .flex_grow()
-                            .min_h_0()
-                            .overflow_hidden()
-                            .child(placeholder),
-                    )
-                    .into_any_element(),
-            );
+            return Some(self.wrap_stats_rail_chrome(
+                placeholder("No stats available for this series."),
+                theme,
+                &chart_colors,
+            ));
         };
 
         let start_label = format_x_value(x_min, x_is_time);
@@ -806,21 +770,71 @@ impl ChartDocument {
             ))
             .into_any_element();
 
-        Some(
-            div()
-                .absolute()
-                .top_0()
-                .right_0()
-                .bottom_0()
-                .w(px(320.0))
-                .flex()
-                .flex_col()
-                .border_l_1()
-                .border_color(theme.border)
-                .bg(theme.popover)
-                .occlude()
-                .child(div().flex_grow().min_h_0().overflow_hidden().child(body))
-                .into_any_element(),
-        )
+        Some(self.wrap_stats_rail_chrome(body, theme, &chart_colors))
+    }
+
+    /// Wraps a stats rail body in the absolute-right 320 px chrome, prefixed by
+    /// a header bar containing the "STATS" title and a close button that
+    /// dismisses the rail by setting `chart_rail_open = false` on the shell.
+    fn wrap_stats_rail_chrome(
+        &self,
+        body: AnyElement,
+        theme: &gpui_component::theme::Theme,
+        chart_colors: &ChartColors,
+    ) -> AnyElement {
+        let shell_for_close = self.chart_shell.clone();
+        let muted_fg = chart_colors.muted_fg;
+
+        let header = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_between()
+            .px(px(14.0))
+            .py(Spacing::SM)
+            .border_b_1()
+            .border_color(theme.border)
+            .child(
+                div()
+                    .text_size(px(10.0))
+                    .text_color(muted_fg)
+                    .font_weight(FontWeight::BOLD)
+                    .child("STATS"),
+            )
+            .child(
+                div()
+                    .id("chart-doc-stats-rail-close")
+                    .w(px(20.0))
+                    .h(px(20.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(Radii::SM)
+                    .cursor_pointer()
+                    .hover(|h| h.bg(theme.muted))
+                    .on_mouse_down(MouseButton::Left, move |_, _window, cx| {
+                        shell_for_close.update(cx, |s, cx| {
+                            s.chart_rail_open = false;
+                            cx.notify();
+                        });
+                    })
+                    .child(Icon::new(AppIcon::X).size(px(11.0)).color(muted_fg)),
+            );
+
+        div()
+            .absolute()
+            .top_0()
+            .right_0()
+            .bottom_0()
+            .w(px(320.0))
+            .flex()
+            .flex_col()
+            .border_l_1()
+            .border_color(theme.border)
+            .bg(theme.popover)
+            .occlude()
+            .child(header)
+            .child(div().flex_grow().min_h_0().overflow_hidden().child(body))
+            .into_any_element()
     }
 }

--- a/crates/dbflux_ui_document/src/chart_document/render.rs
+++ b/crates/dbflux_ui_document/src/chart_document/render.rs
@@ -17,11 +17,13 @@
 //! The chart content area is rendered by `render_chart_content`, called from
 //! the `ViewHandle::render` closure built by `into_view_handle`.
 
-use super::{ChartDocument, ExecState};
+use super::{ChartDocument, ExecState, should_render_stats_rail, toggle_stats_rail};
 use crate::chart::ChartRailTab;
 use crate::chart::metric_picker_render::MetricPickerView;
 use crate::chart::toolbar::{ChartToolbarContext, ChartToolbarHandlers, render_chart_toolbar};
-use dbflux_components::chart::{ChartDetection, axis_bar_element};
+use dbflux_components::chart::{
+    ChartDetection, ChartView, axis_bar_element, format_span, format_x_value, format_y_value,
+};
 use dbflux_components::common::time_range::state::TimeRange;
 use dbflux_components::common::time_range::view::{TimeRangeChanged, TimeRangePanel};
 use dbflux_components::controls::DropdownSelectionChanged;
@@ -29,13 +31,53 @@ use dbflux_components::controls::Input;
 use dbflux_components::primitives::Text;
 use dbflux_components::result_panel::ResultPanel;
 use dbflux_components::semantic::ChartColors;
-use dbflux_components::tokens::{Heights, Radii, Spacing};
+use dbflux_components::tokens::{FontSizes, Heights, Radii, Spacing};
 use dbflux_ui_base::toast::{PendingToast, flush_pending_toast, now_hms};
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::button::{Button, ButtonVariant, ButtonVariants};
 use gpui_component::{ActiveTheme, Disableable, Sizable};
 use std::sync::Arc;
+
+// Mirrors DataGridPanel::dock_* — flagged for future shared module.
+
+fn dock_section(
+    content: impl IntoElement,
+    theme: &gpui_component::theme::Theme,
+) -> impl IntoElement {
+    div()
+        .px(px(14.0))
+        .py(Spacing::MD)
+        .border_b_1()
+        .border_color(theme.border)
+        .child(content)
+}
+
+fn dock_header(label: &str, chart_colors: &ChartColors) -> impl IntoElement {
+    div()
+        .text_size(px(10.0))
+        .text_color(chart_colors.muted_fg)
+        .font_weight(FontWeight::BOLD)
+        .mb(Spacing::XXS)
+        .child(SharedString::from(label.to_uppercase()))
+}
+
+fn dock_kv_row(k: &str, v: impl IntoElement, chart_colors: &ChartColors) -> impl IntoElement {
+    div()
+        .flex()
+        .items_start()
+        .gap(Spacing::SM)
+        .py(px(2.0))
+        .child(
+            div()
+                .w(px(96.0))
+                .flex_shrink_0()
+                .text_size(px(10.0))
+                .text_color(chart_colors.muted_fg)
+                .child(SharedString::from(k.to_string())),
+        )
+        .child(div().flex_1().text_size(px(11.0)).child(v))
+}
 
 impl Render for ChartDocument {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
@@ -298,12 +340,8 @@ impl ChartDocument {
                 }),
                 on_toggle_stats_rail: Arc::new(move |_window, cx| {
                     shell_for_stats.update(cx, |s, cx| {
-                        if s.chart_rail_open && s.chart_rail_tab == ChartRailTab::Stats {
-                            s.chart_rail_open = false;
-                        } else {
-                            s.chart_rail_open = true;
-                            s.chart_rail_tab = ChartRailTab::Stats;
-                        }
+                        (s.chart_rail_open, s.chart_rail_tab) =
+                            toggle_stats_rail(s.chart_rail_open, s.chart_rail_tab);
                         cx.notify();
                     });
                 }),
@@ -521,6 +559,20 @@ impl ChartDocument {
             }
         };
 
+        // -- Stats rail (absolute overlay, right edge) --
+        // Rendered when the Stats tab is active and the shell's rail is open.
+        let stats_rail: Option<AnyElement> = {
+            let (rail_open, rail_tab) = {
+                let shell = self.chart_shell.read(cx);
+                (shell.chart_rail_open, shell.chart_rail_tab)
+            };
+            if should_render_stats_rail(rail_open, rail_tab) {
+                self.render_stats_rail(&theme, cx)
+            } else {
+                None
+            }
+        };
+
         div()
             .flex()
             .flex_col()
@@ -531,6 +583,244 @@ impl ChartDocument {
             .child(axis_row)
             .child(div().flex_1().min_h_0().child(chart_area))
             .when_some(metric_rail, |el, rail| el.child(rail))
+            .when_some(stats_rail, |el, rail| el.child(rail))
             .into_any_element()
+    }
+
+    /// Render the 320 px Stats rail for the right-edge overlay.
+    ///
+    /// Returns `None` when the chart view is still being built or when no stats
+    /// are available for the focused series. Mirrors the layout produced by
+    /// `DataGridPanel::render_rail_stats_tab` with snapshot-style borrows to
+    /// satisfy GPUI's single-context borrow rules.
+    fn render_stats_rail(
+        &self,
+        theme: &gpui_component::theme::Theme,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        let chart_colors = ChartColors::for_current(cx);
+
+        // Scope 1: read chart_shell to capture chart_view and focused_idx.
+        let (chart_view_opt, focused_idx) = {
+            let shell = self.chart_shell.read(cx);
+            let cv = shell.chart_view().cloned();
+            let fi = cv
+                .as_ref()
+                .map(|cv| cv.read(cx).focused_series_idx())
+                .unwrap_or(shell.chart_focused_series_idx);
+            (cv, fi)
+        };
+
+        let Some(chart_view) = chart_view_opt else {
+            let placeholder = div()
+                .p_2()
+                .text_size(FontSizes::XS)
+                .text_color(theme.muted_foreground)
+                .child("Rebuilding chart…")
+                .into_any_element();
+            return Some(
+                div()
+                    .absolute()
+                    .top_0()
+                    .right_0()
+                    .bottom_0()
+                    .w(px(320.0))
+                    .flex()
+                    .flex_col()
+                    .border_l_1()
+                    .border_color(theme.border)
+                    .bg(theme.popover)
+                    .occlude()
+                    .child(
+                        div()
+                            .flex_grow()
+                            .min_h_0()
+                            .overflow_hidden()
+                            .child(placeholder),
+                    )
+                    .into_any_element(),
+            );
+        };
+
+        // Scope 2: read chart_view entity to capture all primitive values before
+        // building the element tree. Borrows must be dropped before constructing
+        // elements — mirrors DataGridPanel::render_rail_stats_tab exactly.
+        let (stats_opt, label, color, x_min, x_max, x_is_time) = {
+            let view = chart_view.read(cx);
+            let stats = view.series_stats().get(focused_idx).copied().flatten();
+            let label = view.series_label(focused_idx).to_string();
+            let color = view.series_color(focused_idx, cx);
+            let (x_min, x_max) = view.data_x_bounds();
+            let x_is_time = view.x_is_time();
+            (stats, label, color, x_min, x_max, x_is_time)
+        };
+
+        let Some(stats) = stats_opt else {
+            let placeholder = div()
+                .p_2()
+                .text_size(FontSizes::XS)
+                .text_color(theme.muted_foreground)
+                .child("No stats available for this series.")
+                .into_any_element();
+            return Some(
+                div()
+                    .absolute()
+                    .top_0()
+                    .right_0()
+                    .bottom_0()
+                    .w(px(320.0))
+                    .flex()
+                    .flex_col()
+                    .border_l_1()
+                    .border_color(theme.border)
+                    .bg(theme.popover)
+                    .occlude()
+                    .child(
+                        div()
+                            .flex_grow()
+                            .min_h_0()
+                            .overflow_hidden()
+                            .child(placeholder),
+                    )
+                    .into_any_element(),
+            );
+        };
+
+        let start_label = format_x_value(x_min, x_is_time);
+        let end_label = format_x_value(x_max, x_is_time);
+        let span_label = format_span(x_max - x_min);
+        let points_count = self
+            .last_result
+            .as_ref()
+            .map(|r| r.row_count())
+            .unwrap_or(0);
+
+        let cyan_color = theme.cyan;
+        let primary_color = theme.primary;
+
+        let cyan_val = |v: f64| -> AnyElement {
+            div()
+                .text_size(px(11.0))
+                .text_color(cyan_color)
+                .child(SharedString::from(format_y_value(v)))
+                .into_any_element()
+        };
+        let primary_val = |v: f64| -> AnyElement {
+            div()
+                .text_size(px(11.0))
+                .text_color(primary_color)
+                .child(SharedString::from(format_y_value(v)))
+                .into_any_element()
+        };
+        let fg_val = |v: f64| -> AnyElement {
+            div()
+                .text_size(px(11.0))
+                .text_color(theme.foreground)
+                .child(SharedString::from(format_y_value(v)))
+                .into_any_element()
+        };
+        let str_val = |s: String| -> AnyElement {
+            div()
+                .text_size(px(11.0))
+                .text_color(theme.foreground)
+                .child(SharedString::from(s))
+                .into_any_element()
+        };
+        let unavail_val = || -> AnyElement {
+            div()
+                .text_size(px(11.0))
+                .text_color(theme.muted_foreground)
+                .italic()
+                .child("unavailable")
+                .into_any_element()
+        };
+
+        let body = div()
+            .id("chart-doc-rail-stats-scroll")
+            .size_full()
+            .flex()
+            .flex_col()
+            .overflow_y_scroll()
+            // SERIES header
+            .child(dock_section(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap(Spacing::SM)
+                    .child(div().w(px(10.0)).h(px(10.0)).rounded_sm().bg(color))
+                    .child(
+                        div()
+                            .text_size(FontSizes::XS)
+                            .font_weight(FontWeight::BOLD)
+                            .text_color(theme.foreground)
+                            .child(SharedString::from(label)),
+                    ),
+                theme,
+            ))
+            // STATS section
+            .child(dock_section(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(2.0))
+                    .child(dock_header("Stats", &chart_colors))
+                    .child(dock_kv_row("min", cyan_val(stats.min), &chart_colors))
+                    .child(dock_kv_row("max", cyan_val(stats.max), &chart_colors))
+                    .child(dock_kv_row("avg", cyan_val(stats.avg), &chart_colors))
+                    .child(dock_kv_row("p50", fg_val(stats.p50), &chart_colors))
+                    .child(dock_kv_row("p95", fg_val(stats.p95), &chart_colors))
+                    .child(dock_kv_row("p99", primary_val(stats.p99), &chart_colors))
+                    .child(dock_kv_row("last", fg_val(stats.last), &chart_colors)),
+                theme,
+            ))
+            // WINDOW section
+            .child(dock_section(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(2.0))
+                    .child(dock_header("Window", &chart_colors))
+                    .child(dock_kv_row("start", str_val(start_label), &chart_colors))
+                    .child(dock_kv_row("end", str_val(end_label), &chart_colors))
+                    .child(dock_kv_row("span", str_val(span_label), &chart_colors))
+                    .child(dock_kv_row(
+                        "points",
+                        str_val(format!("{}", points_count)),
+                        &chart_colors,
+                    )),
+                theme,
+            ))
+            // SOURCE section — placeholder until drivers populate QueryResult.metadata
+            .child(dock_section(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(2.0))
+                    .child(dock_header("Source", &chart_colors))
+                    .child(dock_kv_row("measurement", unavail_val(), &chart_colors))
+                    .child(dock_kv_row("field", unavail_val(), &chart_colors))
+                    .child(dock_kv_row("host", unavail_val(), &chart_colors))
+                    .child(dock_kv_row("region", unavail_val(), &chart_colors)),
+                theme,
+            ))
+            .into_any_element();
+
+        Some(
+            div()
+                .absolute()
+                .top_0()
+                .right_0()
+                .bottom_0()
+                .w(px(320.0))
+                .flex()
+                .flex_col()
+                .border_l_1()
+                .border_color(theme.border)
+                .bg(theme.popover)
+                .occlude()
+                .child(div().flex_grow().min_h_0().overflow_hidden().child(body))
+                .into_any_element(),
+        )
     }
 }


### PR DESCRIPTION
## Summary

- Wire the chart toolbar **Stats** button to the `ChartShell` rail in `ChartDocument` (issue #133): the button toggled state correctly but had no render branch, so nothing appeared.
- Add an in-rail **close button** (X) at the top of the stats rail so users can dismiss it without going back to the toolbar.
- Make the shared chart toolbar **responsive** so trailing controls wrap onto a second line on narrow viewports instead of getting clipped.

## What does this resolve?

- Resolves #133

## How was this solved?

**1. Stats rail render branch (`ca9a3d10`)**
Root cause: `ChartDocument::render_chart_content` had a `ChartRailTab::Metric` render branch but no parallel branch for `ChartRailTab::Stats`. The toggle closure updated `chart_rail_open` and `chart_rail_tab` on the shell and called `cx.notify()`, but the element tree never produced a stats rail child, so the rail was invisible. `DataGridPanel::render_rail_stats_tab` already worked — the same fix was missing on `ChartDocument`.

Added under strict TDD:
- Two pure helpers in `chart_document/mod.rs`: `should_render_stats_rail(rail_open, rail_tab)` (gating predicate) and `toggle_stats_rail(rail_open, rail_tab) -> (bool, ChartRailTab)` (toggle state machine). Seven red-first unit tests cover the helper truth tables and toggle transitions (closed → open Stats, open Stats → closed, open Metric → switch to Stats).
- Private `render_stats_rail` method building the rail body (SERIES / STATS / WINDOW / SOURCE sections) mirroring `DataGridPanel::render_rail_stats_tab`. `SeriesStats` come from `chart_shell.read(cx).chart_view()`; point count comes from `self.last_result.row_count()`. Placeholder elements when the chart view is rebuilding or no stats are available.
- `dock_section` / `dock_header` / `dock_kv_row` inlined as private free functions in the same module (the originals are private on `DataGridPanel::impl`; duplication is flagged for a future shared module).
- Stats branch in `render_chart_content` parallel to the existing Metric branch, using the gating helper.

**2. Close button (`d7a5f5f1`)**
Manual smoke-test surfaced a UX gap: once open, the rail had no in-rail close affordance. Added a header bar with `STATS` title + X icon button that sets `chart_rail_open = false` on the shell. Refactored `render_stats_rail` to build the absolute-right chrome once via `wrap_stats_rail_chrome`, eliminating triplication across the rebuilding / no-stats / full-body branches.

**3. Responsive toolbar (`adc5b4f2`)**
Opportunistic fix: the shared `render_chart_toolbar` was a single non-wrapping flex row with a `flex_1` spacer. On narrow viewports trailing controls (TYPE chips, Stats/PNG/Save) were pushed off-screen. Switched to the codebase responsive pattern (matches `result_panel/mod.rs` chrome): `flex_wrap` + `w_full` + `gap_x`/`gap_y`, removing the positional spacer (incompatible with `flex_wrap` per the documented pattern). `h(34px)` → `min_h(34px)` lets the row grow when items wrap. This also benefits `DataGridPanel` since the toolbar is shared.

Trade-off: actions are no longer right-aligned on wide viewports — items flow left-to-right. Preserving right-alignment with wrap behavior would require splitting into multi-row groups, deferred as future work.

## Validation

- `cargo nextest run --workspace` — 2466 passed, 154 skipped
- `cargo test --doc --workspace` — clean
- `cargo clippy --workspace -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- 7 new unit tests in `chart_document/mod.rs` (red → green TDD evidence captured in the SDD apply-progress artifact)
- Manual smoke-test on Linux/Wayland (this dev environment): query-result chart, CloudWatch metric chart, saved chart — Stats button opens rail, click again closes, switch to Metric tab works, X close button works, toolbar wraps correctly on narrow window widths.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated \`CHANGELOG.md\` under \`## [Unreleased]\` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Follow-ups (out of scope)

- `DataGridPanel`'s chart stats rail has the same missing close-button UX gap; a future change can share a single `chart-stats-rail-chrome` helper.
- `dock_section` / `dock_header` / `dock_kv_row` duplicated between `ChartDocument` and `DataGridPanel` — candidate for a shared module.
- `render_chart_content` is pre-existing oversized (~330 LOC); not introduced by this PR, but a future refactor could extract the chart area and rail blocks.
- Responsive toolbar loses right-alignment for action buttons on wide viewports; multi-row layout would preserve it.