### PR TITLE
refactor: move TSqlLanguageService from dbflux_core to dbflux_driver_mssql

### DIFF
--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -113,7 +113,7 @@ pub use query::{
     ReadTemplateOperation, ReadTemplateRequest, ResolvedWindow, Row, SemanticFieldRef,
     SemanticFilter, SemanticPlan, SemanticPlanKind, SemanticPlanner, SemanticPredicate,
     SemanticRequest, SemanticRequestKind, SortDirection, SqlLanguageService, SqlMutationGenerator,
-    TSqlLanguageService, TableBrowseRequest, TableCountRequest, TableRef, TextPosition,
+    TableBrowseRequest, TableCountRequest, TableRef, TextPosition,
     TextPositionRange, TextRange, ValidationResult, classify_query_for_governance,
     classify_query_for_language, classify_sql_execution, contains_time_macros,
     detect_dangerous_mongo, detect_dangerous_query, detect_dangerous_redis, detect_dangerous_sql,

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -113,12 +113,11 @@ pub use query::{
     ReadTemplateOperation, ReadTemplateRequest, ResolvedWindow, Row, SemanticFieldRef,
     SemanticFilter, SemanticPlan, SemanticPlanKind, SemanticPlanner, SemanticPredicate,
     SemanticRequest, SemanticRequestKind, SortDirection, SqlLanguageService, SqlMutationGenerator,
-    TableBrowseRequest, TableCountRequest, TableRef, TextPosition,
-    TextPositionRange, TextRange, ValidationResult, classify_query_for_governance,
-    classify_query_for_language, classify_sql_execution, contains_time_macros,
-    detect_dangerous_mongo, detect_dangerous_query, detect_dangerous_redis, detect_dangerous_sql,
-    is_safe_read_query, parse_semantic_filter_json, render_semantic_filter_sql,
-    strip_leading_comments, substitute_time_macros,
+    TableBrowseRequest, TableCountRequest, TableRef, TextPosition, TextPositionRange, TextRange,
+    ValidationResult, classify_query_for_governance, classify_query_for_language,
+    classify_sql_execution, contains_time_macros, detect_dangerous_mongo, detect_dangerous_query,
+    detect_dangerous_redis, detect_dangerous_sql, is_safe_read_query, parse_semantic_filter_json,
+    render_semantic_filter_sql, strip_leading_comments, substitute_time_macros,
 };
 
 pub use schema::node_id as schema_node_id;

--- a/crates/dbflux_core/src/query/language_service.rs
+++ b/crates/dbflux_core/src/query/language_service.rs
@@ -323,33 +323,6 @@ impl LanguageService for SqlLanguageService {
     }
 }
 
-/// Language service for T-SQL (Microsoft SQL Server).
-///
-/// Behaves like `SqlLanguageService` for dangerous-query detection (the
-/// destructive keywords DROP/TRUNCATE/DELETE are spelled identically), but
-/// skips the live parse diagnostics entirely. The shared `tree-sitter-sequel`
-/// grammar follows generic ANSI SQL and flags T-SQL-only constructs as
-/// errors — `SELECT TOP n`, `OUTPUT INSERTED.*`, `MERGE`, `CROSS APPLY /
-/// OUTER APPLY`, table hints like `WITH (NOLOCK)`, `OFFSET … ROWS FETCH
-/// NEXT … ROWS ONLY`, etc. The server is the source of truth for syntax
-/// validity; surfacing parser false-positives in the editor only adds
-/// noise.
-pub struct TSqlLanguageService;
-
-impl LanguageService for TSqlLanguageService {
-    fn validate(&self, _query: &str) -> ValidationResult {
-        ValidationResult::Valid
-    }
-
-    fn detect_dangerous(&self, query: &str) -> Option<DangerousQueryKind> {
-        detect_dangerous_sql(query)
-    }
-
-    fn editor_diagnostics(&self, _query: &str) -> Vec<EditorDiagnostic> {
-        Vec::new()
-    }
-}
-
 /// Produce editor diagnostics for SQL using tree-sitter error nodes.
 fn sql_editor_diagnostics(query: &str) -> Vec<EditorDiagnostic> {
     if query.trim().is_empty() {

--- a/crates/dbflux_core/src/query/mod.rs
+++ b/crates/dbflux_core/src/query/mod.rs
@@ -13,8 +13,8 @@ pub use generator::{
 };
 pub use language_service::{
     DangerousQueryKind, Diagnostic, DiagnosticSeverity, EditorDiagnostic, LanguageService,
-    SqlLanguageService, TSqlLanguageService, TextPosition, TextPositionRange, TextRange,
-    ValidationResult, classify_query_for_language, detect_dangerous_mongo, detect_dangerous_query,
+    SqlLanguageService, TextPosition, TextPositionRange, TextRange, ValidationResult,
+    classify_query_for_language, detect_dangerous_mongo, detect_dangerous_query,
     detect_dangerous_redis, detect_dangerous_sql, strip_leading_comments,
 };
 pub use safety::{classify_query_for_governance, classify_sql_execution, is_safe_read_query};

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1391,7 +1391,7 @@ impl Connection for MssqlConnection {
         // WITH (NOLOCK), OFFSET ROWS FETCH NEXT, etc.). Returning the
         // T-SQL-aware service suppresses the noisy parse diagnostics
         // while keeping dangerous-query detection.
-        &dbflux_core::TSqlLanguageService
+        &crate::TSqlLanguageService
     }
 
     fn ping(&self) -> Result<(), DbError> {

--- a/crates/dbflux_driver_mssql/src/language_service.rs
+++ b/crates/dbflux_driver_mssql/src/language_service.rs
@@ -51,12 +51,11 @@ mod tests {
     fn editor_diagnostics_returns_empty() {
         let svc = TSqlLanguageService;
 
-        assert!(svc
-            .editor_diagnostics("SELECT TOP 1 id FROM dbo.users WITH (NOLOCK)")
-            .is_empty());
-        assert!(svc
-            .editor_diagnostics("EXEC sp_helpdb 'master'")
-            .is_empty());
+        assert!(
+            svc.editor_diagnostics("SELECT TOP 1 id FROM dbo.users WITH (NOLOCK)")
+                .is_empty()
+        );
+        assert!(svc.editor_diagnostics("EXEC sp_helpdb 'master'").is_empty());
         assert!(svc.editor_diagnostics("").is_empty());
     }
 

--- a/crates/dbflux_driver_mssql/src/language_service.rs
+++ b/crates/dbflux_driver_mssql/src/language_service.rs
@@ -1,0 +1,73 @@
+use dbflux_core::{
+    DangerousQueryKind, EditorDiagnostic, LanguageService, ValidationResult, detect_dangerous_sql,
+};
+
+/// Language service for T-SQL (Microsoft SQL Server).
+///
+/// Behaves like the generic `SqlLanguageService` for dangerous-query detection
+/// (the destructive keywords DROP/TRUNCATE/DELETE are spelled identically), but
+/// suppresses live parse diagnostics entirely. The bundled `tree-sitter-sequel`
+/// grammar follows generic ANSI SQL and flags T-SQL-only constructs as errors —
+/// `SELECT TOP n`, `OUTPUT INSERTED.*`, `MERGE`, `CROSS APPLY / OUTER APPLY`,
+/// table hints like `WITH (NOLOCK)`, `OFFSET … ROWS FETCH NEXT … ROWS ONLY`,
+/// etc. The server is the source of truth for syntax validity; surfacing parser
+/// false-positives in the editor only adds noise.
+pub struct TSqlLanguageService;
+
+impl LanguageService for TSqlLanguageService {
+    fn validate(&self, _query: &str) -> ValidationResult {
+        ValidationResult::Valid
+    }
+
+    fn detect_dangerous(&self, query: &str) -> Option<DangerousQueryKind> {
+        detect_dangerous_sql(query)
+    }
+
+    fn editor_diagnostics(&self, _query: &str) -> Vec<EditorDiagnostic> {
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_returns_valid_for_any_input() {
+        let svc = TSqlLanguageService;
+
+        assert!(matches!(
+            svc.validate("SELECT TOP 10 * FROM sys.tables"),
+            ValidationResult::Valid
+        ));
+        assert!(matches!(svc.validate(""), ValidationResult::Valid));
+        assert!(matches!(
+            svc.validate("SELECT FROM WHERE"),
+            ValidationResult::Valid
+        ));
+    }
+
+    #[test]
+    fn editor_diagnostics_returns_empty() {
+        let svc = TSqlLanguageService;
+
+        assert!(svc
+            .editor_diagnostics("SELECT TOP 1 id FROM dbo.users WITH (NOLOCK)")
+            .is_empty());
+        assert!(svc
+            .editor_diagnostics("EXEC sp_helpdb 'master'")
+            .is_empty());
+        assert!(svc.editor_diagnostics("").is_empty());
+    }
+
+    #[test]
+    fn detect_dangerous_drops_table() {
+        let svc = TSqlLanguageService;
+
+        assert_eq!(
+            svc.detect_dangerous("DROP TABLE dbo.orders"),
+            Some(DangerousQueryKind::Drop)
+        );
+        assert_eq!(svc.detect_dangerous("SELECT * FROM dbo.orders"), None);
+    }
+}

--- a/crates/dbflux_driver_mssql/src/lib.rs
+++ b/crates/dbflux_driver_mssql/src/lib.rs
@@ -10,5 +10,7 @@
 )]
 
 pub mod driver;
+pub mod language_service;
 
 pub use driver::{METADATA, MssqlDriver};
+pub use language_service::TSqlLanguageService;


### PR DESCRIPTION
## Summary

Moves `TSqlLanguageService` out of `dbflux_core` and into `dbflux_driver_mssql`, removing the last dialect-specific `LanguageService` implementation from core. Mirrors the pattern already established for `MongoLanguageService` and (post #128) `MySqlLanguageService`.

Per the architecture rule in `CLAUDE.md`: core exposes seams (`LanguageService` trait, generic `SqlLanguageService`, shared `detect_dangerous_sql` / `should_skip_sql_parse_diagnostics` helpers); driver-specific dialect knowledge lives with the driver.

## Changes

- **New**: `crates/dbflux_driver_mssql/src/language_service.rs` — `TSqlLanguageService` with 3 unit tests (validate-always-valid, editor_diagnostics-empty for representative T-SQL constructs, detect_dangerous still fires on `DROP TABLE`).
- **Wiring**: `crates/dbflux_driver_mssql/src/lib.rs` adds `pub mod language_service;` + `pub use language_service::TSqlLanguageService;`.
- **Switch**: `crates/dbflux_driver_mssql/src/driver.rs:1394` returns `&crate::TSqlLanguageService` instead of `&dbflux_core::TSqlLanguageService`.
- **Remove**: `TSqlLanguageService` struct/impl from `crates/dbflux_core/src/query/language_service.rs`; re-exports in `crates/dbflux_core/src/query/mod.rs` and `crates/dbflux_core/src/lib.rs`.

No behavioral change for MSSQL users. No `Cargo.toml` changes (mssql driver already depends on `dbflux_core`).

## Test plan

- [x] `cargo nextest run --workspace` — 2471/2471 pass
- [x] `cargo test --doc --workspace` — 0 failures
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `rg "TSqlLanguageService" crates/dbflux_core` — zero matches
- [x] New driver-side tests pass: `validate_returns_valid_for_any_input`, `editor_diagnostics_returns_empty`, `detect_dangerous_drops_table`

Closes #129