### PR TITLE
refactor(query): move Mongo and Redis dangerous detection

### DIFF
--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -115,9 +115,9 @@ pub use query::{
     SemanticRequest, SemanticRequestKind, SortDirection, SqlLanguageService, SqlMutationGenerator,
     TableBrowseRequest, TableCountRequest, TableRef, TextPosition, TextPositionRange, TextRange,
     ValidationResult, classify_query_for_governance, classify_query_for_language,
-    classify_sql_execution, contains_time_macros, detect_dangerous_mongo, detect_dangerous_query,
-    detect_dangerous_redis, detect_dangerous_sql, is_safe_read_query, parse_semantic_filter_json,
-    render_semantic_filter_sql, strip_leading_comments, substitute_time_macros,
+    classify_sql_execution, contains_time_macros, detect_dangerous_query, detect_dangerous_sql,
+    is_safe_read_query, parse_semantic_filter_json, render_semantic_filter_sql,
+    strip_leading_comments, substitute_time_macros,
 };
 
 pub use schema::node_id as schema_node_id;

--- a/crates/dbflux_core/src/query/language_service.rs
+++ b/crates/dbflux_core/src/query/language_service.rs
@@ -105,9 +105,8 @@ impl From<&str> for Diagnostic {
 
 /// Categories of potentially dangerous queries that require user confirmation.
 ///
-/// Each variant maps to a destructive pattern detected by heuristic analysis.
-/// Both SQL and document-database patterns are represented here so the core
-/// owns the full definition and the UI never needs to know query syntax.
+/// Each variant maps to a destructive pattern detected by driver-local or
+/// shared heuristic analysis.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DangerousQueryKind {
     // SQL patterns
@@ -185,8 +184,26 @@ fn classify_mongo_query(query: &str) -> ExecutionClassification {
         return ExecutionClassification::Metadata;
     }
 
-    if let Some(kind) = detect_dangerous_mongo(query) {
-        return classification_from_dangerous_kind(kind);
+    if normalized.contains(".dropdatabase(") {
+        return ExecutionClassification::Destructive;
+    }
+
+    if normalized.contains(".drop(") && !normalized.contains(".dropdatabase(") {
+        return ExecutionClassification::Destructive;
+    }
+
+    if let Some(pos) = normalized.find(".deletemany(") {
+        let after_paren = &normalized[pos + 12..];
+        if is_empty_filter(after_paren) {
+            return ExecutionClassification::Write;
+        }
+    }
+
+    if let Some(pos) = normalized.find(".updatemany(") {
+        let after_paren = &normalized[pos + 12..];
+        if is_empty_filter(after_paren) {
+            return ExecutionClassification::Write;
+        }
     }
 
     if normalized.contains(".find(") || normalized.contains(".aggregate(") {
@@ -222,13 +239,18 @@ fn classify_redis_query(query: &str) -> ExecutionClassification {
         return ExecutionClassification::Metadata;
     }
 
-    if let Some(kind) = detect_dangerous_redis(query) {
-        return classification_from_dangerous_kind(kind);
-    }
-
     let Some(command) = normalized.split_whitespace().next() else {
         return ExecutionClassification::Metadata;
     };
+
+    match command {
+        "flushall" | "flushdb" => return ExecutionClassification::Destructive,
+        "del" if normalized.split_whitespace().skip(1).count() > 1 => {
+            return ExecutionClassification::Write;
+        }
+        "keys" => return ExecutionClassification::Read,
+        _ => {}
+    }
 
     match command {
         "info" | "dbsize" | "type" | "ttl" | "pttl" | "exists" | "llen" | "hget" | "hmget"
@@ -238,25 +260,6 @@ fn classify_redis_query(query: &str) -> ExecutionClassification {
         "command" | "help" => ExecutionClassification::Metadata,
         "config" | "acl" | "script" | "module" => ExecutionClassification::Admin,
         _ => ExecutionClassification::Write,
-    }
-}
-
-fn classification_from_dangerous_kind(kind: DangerousQueryKind) -> ExecutionClassification {
-    match kind {
-        DangerousQueryKind::Drop
-        | DangerousQueryKind::Truncate
-        | DangerousQueryKind::MongoDropCollection
-        | DangerousQueryKind::MongoDropDatabase
-        | DangerousQueryKind::RedisFlushAll
-        | DangerousQueryKind::RedisFlushDb => ExecutionClassification::Destructive,
-        DangerousQueryKind::DeleteNoWhere
-        | DangerousQueryKind::UpdateNoWhere
-        | DangerousQueryKind::MongoDeleteMany
-        | DangerousQueryKind::MongoUpdateMany
-        | DangerousQueryKind::RedisMultiDelete => ExecutionClassification::Write,
-        DangerousQueryKind::Alter => ExecutionClassification::Admin,
-        DangerousQueryKind::Script => ExecutionClassification::Write,
-        DangerousQueryKind::RedisKeysPattern => ExecutionClassification::Read,
     }
 }
 
@@ -487,76 +490,8 @@ pub fn detect_dangerous_sql(query: &str) -> Option<DangerousQueryKind> {
     detect_dangerous_single(statements[0])
 }
 
-/// Detect dangerous MongoDB shell commands using heuristic pattern matching.
-pub fn detect_dangerous_mongo(query: &str) -> Option<DangerousQueryKind> {
-    let normalized = query.trim().to_lowercase();
-
-    if normalized.contains(".dropdatabase(") {
-        return Some(DangerousQueryKind::MongoDropDatabase);
-    }
-
-    if normalized.contains(".drop(") && !normalized.contains(".dropdatabase(") {
-        return Some(DangerousQueryKind::MongoDropCollection);
-    }
-
-    if let Some(pos) = normalized.find(".deletemany(") {
-        let after_paren = &normalized[pos + 12..];
-        if is_empty_filter(after_paren) {
-            return Some(DangerousQueryKind::MongoDeleteMany);
-        }
-    }
-
-    if let Some(pos) = normalized.find(".updatemany(") {
-        let after_paren = &normalized[pos + 12..];
-        if is_empty_filter(after_paren) {
-            return Some(DangerousQueryKind::MongoUpdateMany);
-        }
-    }
-
-    None
-}
-
-/// Detect dangerous Redis commands using keyword matching.
-pub fn detect_dangerous_redis(query: &str) -> Option<DangerousQueryKind> {
-    let normalized = query.trim().to_lowercase();
-
-    let first_word = normalized.split_whitespace().next().unwrap_or("");
-
-    if first_word == "flushall" {
-        return Some(DangerousQueryKind::RedisFlushAll);
-    }
-
-    if first_word == "flushdb" {
-        return Some(DangerousQueryKind::RedisFlushDb);
-    }
-
-    if first_word == "del" {
-        let args: Vec<&str> = normalized.split_whitespace().skip(1).collect();
-        if args.len() > 1 {
-            return Some(DangerousQueryKind::RedisMultiDelete);
-        }
-    }
-
-    if first_word == "keys" {
-        return Some(DangerousQueryKind::RedisKeysPattern);
-    }
-
-    None
-}
-
-/// Unified entry point: auto-detects language and checks for dangerous patterns.
-///
-/// Detects MongoDB shell syntax (`db.`) vs SQL automatically.
+/// Unified entry point for shared SQL dangerous-query checks.
 pub fn detect_dangerous_query(query: &str) -> Option<DangerousQueryKind> {
-    let clean = strip_leading_comments(query);
-    if clean.is_empty() {
-        return None;
-    }
-
-    if clean.trim().starts_with("db.") {
-        return detect_dangerous_mongo(clean);
-    }
-
     detect_dangerous_sql(query)
 }
 
@@ -1087,116 +1022,10 @@ mod tests {
         assert!(!DangerousQueryKind::MongoUpdateMany.message().is_empty());
         assert!(!DangerousQueryKind::MongoDropCollection.message().is_empty());
         assert!(!DangerousQueryKind::MongoDropDatabase.message().is_empty());
-    }
-
-    // ==================== MongoDB tests ====================
-
-    #[test]
-    fn mongo_delete_many_empty_filter_is_dangerous() {
-        assert_eq!(
-            detect_dangerous_query("db.users.deleteMany({})"),
-            Some(DangerousQueryKind::MongoDeleteMany)
-        );
-    }
-
-    #[test]
-    fn mongo_delete_many_no_args_is_dangerous() {
-        assert_eq!(
-            detect_dangerous_query("db.users.deleteMany()"),
-            Some(DangerousQueryKind::MongoDeleteMany)
-        );
-    }
-
-    #[test]
-    fn mongo_delete_many_with_filter_is_safe() {
-        assert_eq!(
-            detect_dangerous_query(r#"db.users.deleteMany({"archived": true})"#),
-            None
-        );
-    }
-
-    #[test]
-    fn mongo_update_many_empty_filter_is_dangerous() {
-        assert_eq!(
-            detect_dangerous_query(r#"db.users.updateMany({}, {"$set": {"active": false}})"#),
-            Some(DangerousQueryKind::MongoUpdateMany)
-        );
-    }
-
-    #[test]
-    fn mongo_update_many_with_filter_is_safe() {
-        assert_eq!(
-            detect_dangerous_query(
-                r#"db.users.updateMany({"status": "old"}, {"$set": {"archived": true}})"#
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn mongo_drop_collection_is_dangerous() {
-        assert_eq!(
-            detect_dangerous_query("db.temp_collection.drop()"),
-            Some(DangerousQueryKind::MongoDropCollection)
-        );
-    }
-
-    #[test]
-    fn mongo_drop_database_is_dangerous() {
-        assert_eq!(
-            detect_dangerous_query("db.dropDatabase()"),
-            Some(DangerousQueryKind::MongoDropDatabase)
-        );
-    }
-
-    #[test]
-    fn mongo_find_is_safe() {
-        assert_eq!(detect_dangerous_query("db.users.find()"), None);
-        assert_eq!(detect_dangerous_query("db.users.find({})"), None);
-        assert_eq!(
-            detect_dangerous_query(r#"db.users.find({"name": "John"})"#),
-            None
-        );
-    }
-
-    #[test]
-    fn mongo_delete_one_is_safe() {
-        assert_eq!(
-            detect_dangerous_query(r#"db.users.deleteOne({"_id": "123"})"#),
-            None
-        );
-    }
-
-    #[test]
-    fn mongo_insert_is_safe() {
-        assert_eq!(
-            detect_dangerous_query(r#"db.users.insertOne({"name": "Alice"})"#),
-            None
-        );
-        assert_eq!(
-            detect_dangerous_query(r#"db.users.insertMany([{"name": "A"}, {"name": "B"}])"#),
-            None
-        );
-    }
-
-    #[test]
-    fn mongo_aggregate_is_safe() {
-        assert_eq!(
-            detect_dangerous_query(r#"db.orders.aggregate([{"$match": {"status": "active"}}])"#),
-            None
-        );
-    }
-
-    #[test]
-    fn mongo_case_insensitive() {
-        assert_eq!(
-            detect_dangerous_query("db.users.DELETEMANY({})"),
-            Some(DangerousQueryKind::MongoDeleteMany)
-        );
-        assert_eq!(
-            detect_dangerous_query("db.users.DeleteMany({})"),
-            Some(DangerousQueryKind::MongoDeleteMany)
-        );
+        assert!(!DangerousQueryKind::RedisFlushAll.message().is_empty());
+        assert!(!DangerousQueryKind::RedisFlushDb.message().is_empty());
+        assert!(!DangerousQueryKind::RedisMultiDelete.message().is_empty());
+        assert!(!DangerousQueryKind::RedisKeysPattern.message().is_empty());
     }
 
     #[test]
@@ -1276,83 +1105,6 @@ END $$;"#;
         // A lone `$` is not a closed dollar-quoted block, so real errors still surface.
         let diags = sql_editor_diagnostics("SELEC $ FROM users");
         assert!(!diags.is_empty());
-    }
-
-    // ==================== Redis tests ====================
-
-    #[test]
-    fn redis_flushall_is_dangerous() {
-        assert_eq!(
-            detect_dangerous_redis("FLUSHALL"),
-            Some(DangerousQueryKind::RedisFlushAll)
-        );
-        assert_eq!(
-            detect_dangerous_redis("flushall"),
-            Some(DangerousQueryKind::RedisFlushAll)
-        );
-        assert_eq!(
-            detect_dangerous_redis("FLUSHALL ASYNC"),
-            Some(DangerousQueryKind::RedisFlushAll)
-        );
-    }
-
-    #[test]
-    fn redis_flushdb_is_dangerous() {
-        assert_eq!(
-            detect_dangerous_redis("FLUSHDB"),
-            Some(DangerousQueryKind::RedisFlushDb)
-        );
-        assert_eq!(
-            detect_dangerous_redis("flushdb ASYNC"),
-            Some(DangerousQueryKind::RedisFlushDb)
-        );
-    }
-
-    #[test]
-    fn redis_del_multi_key_is_dangerous() {
-        assert_eq!(
-            detect_dangerous_redis("DEL key1 key2"),
-            Some(DangerousQueryKind::RedisMultiDelete)
-        );
-        assert_eq!(
-            detect_dangerous_redis("del a b c"),
-            Some(DangerousQueryKind::RedisMultiDelete)
-        );
-    }
-
-    #[test]
-    fn redis_del_single_key_is_safe() {
-        assert_eq!(detect_dangerous_redis("DEL mykey"), None);
-    }
-
-    #[test]
-    fn redis_keys_is_dangerous() {
-        assert_eq!(
-            detect_dangerous_redis("KEYS *"),
-            Some(DangerousQueryKind::RedisKeysPattern)
-        );
-        assert_eq!(
-            detect_dangerous_redis("keys user:*"),
-            Some(DangerousQueryKind::RedisKeysPattern)
-        );
-    }
-
-    #[test]
-    fn redis_get_is_safe() {
-        assert_eq!(detect_dangerous_redis("GET mykey"), None);
-    }
-
-    #[test]
-    fn redis_set_is_safe() {
-        assert_eq!(detect_dangerous_redis("SET mykey myvalue"), None);
-    }
-
-    #[test]
-    fn redis_kind_messages_are_non_empty() {
-        assert!(!DangerousQueryKind::RedisFlushAll.message().is_empty());
-        assert!(!DangerousQueryKind::RedisFlushDb.message().is_empty());
-        assert!(!DangerousQueryKind::RedisMultiDelete.message().is_empty());
-        assert!(!DangerousQueryKind::RedisKeysPattern.message().is_empty());
     }
 
     #[test]

--- a/crates/dbflux_core/src/query/mod.rs
+++ b/crates/dbflux_core/src/query/mod.rs
@@ -14,8 +14,8 @@ pub use generator::{
 pub use language_service::{
     DangerousQueryKind, Diagnostic, DiagnosticSeverity, EditorDiagnostic, LanguageService,
     SqlLanguageService, TextPosition, TextPositionRange, TextRange, ValidationResult,
-    classify_query_for_language, detect_dangerous_mongo, detect_dangerous_query,
-    detect_dangerous_redis, detect_dangerous_sql, strip_leading_comments,
+    classify_query_for_language, detect_dangerous_query, detect_dangerous_sql,
+    strip_leading_comments,
 };
 pub use safety::{classify_query_for_governance, classify_sql_execution, is_safe_read_query};
 pub use semantic::{

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -11,22 +11,22 @@ use std::sync::Arc;
 
 use bson::{Bson, Document, doc};
 use dbflux_core::secrecy::{ExposeSecret, SecretString};
+
+use crate::language_service::MongoLanguageService;
 use dbflux_core::{
     CollectionBrowseRequest, CollectionCountRequest, CollectionIndexInfo, ColumnKind, ColumnMeta,
     Connection, ConnectionErrorFormatter, ConnectionExt, ConnectionProfile, CrudResult,
-    DangerousQueryKind, DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError, DbKind,
-    DbSchemaInfo, DdlCapabilities, DeploymentClass, DescribeRequest, Diagnostic,
-    DiagnosticSeverity, DocumentConnection, DocumentDelete, DocumentInsert, DocumentSchema,
-    DocumentUpdate, DriverCapabilities, DriverFormDef, DriverLimits, DriverMetadata,
-    EditorDiagnostic, FieldInfo, FormFieldDef, FormFieldKind, FormSection, FormTab, FormValues,
-    FormattedError, Icon, IndexData, IndexDirection, KeyValueConnection, LanguageService,
-    MONGODB_FORM, MutationCapabilities, OrderByColumn, PaginationStyle, PlaceholderStyle,
-    QueryCancelHandle, QueryCapabilities, QueryErrorFormatter, QueryGenerator, QueryHandle,
-    QueryLanguage, QueryRequest, QueryResult, RelationalConnection, Row, SchemaDropTarget,
-    SchemaLoadingStrategy, SchemaObjectKind, SchemaSnapshot, SemanticFieldRef, SemanticFilter,
-    SemanticPlan, SemanticPlanKind, SemanticRequest, SqlDialect, SshTunnelConfig, TableInfo,
-    TextPosition, TextPositionRange, TransactionCapabilities, ValidationResult, Value, ViewInfo,
-    WhereOperator, detect_dangerous_mongo, sanitize_uri,
+    DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DbSchemaInfo,
+    DdlCapabilities, DeploymentClass, DescribeRequest, DocumentConnection, DocumentDelete,
+    DocumentInsert, DocumentSchema, DocumentUpdate, DriverCapabilities, DriverFormDef,
+    DriverLimits, DriverMetadata, FieldInfo, FormFieldDef, FormFieldKind, FormSection, FormTab,
+    FormValues, FormattedError, Icon, IndexData, IndexDirection, KeyValueConnection,
+    LanguageService, MONGODB_FORM, MutationCapabilities, OrderByColumn, PaginationStyle,
+    PlaceholderStyle, QueryCancelHandle, QueryCapabilities, QueryErrorFormatter, QueryGenerator,
+    QueryHandle, QueryLanguage, QueryRequest, QueryResult, RelationalConnection, Row,
+    SchemaDropTarget, SchemaLoadingStrategy, SchemaObjectKind, SchemaSnapshot, SemanticFieldRef,
+    SemanticFilter, SemanticPlan, SemanticPlanKind, SemanticRequest, SqlDialect, SshTunnelConfig,
+    TableInfo, TransactionCapabilities, Value, ViewInfo, WhereOperator, sanitize_uri,
 };
 use dbflux_ssh::SshTunnel;
 use mongodb::sync::{Client, Database};
@@ -2356,115 +2356,6 @@ impl ConnectionExt for MongoConnection {
     fn as_keyvalue(&self) -> Option<&dyn KeyValueConnection> {
         None
     }
-}
-
-/// MongoDB language service that validates shell syntax and detects dangerous operations.
-struct MongoLanguageService;
-
-impl LanguageService for MongoLanguageService {
-    fn validate(&self, query: &str) -> ValidationResult {
-        let trimmed = query.trim();
-        if trimmed.is_empty() {
-            return ValidationResult::Valid;
-        }
-
-        let lower = trimmed.to_lowercase();
-        if lower.starts_with("select ")
-            || lower.starts_with("insert into")
-            || lower.starts_with("update ")
-            || lower.starts_with("delete from")
-        {
-            return ValidationResult::WrongLanguage {
-                expected: QueryLanguage::MongoQuery,
-                message: "SQL syntax not supported for MongoDB. Use db.collection.method() or db.method() syntax."
-                    .to_string(),
-            };
-        }
-
-        match crate::query_parser::validate_query(query) {
-            Ok(_) => ValidationResult::Valid,
-            Err(e) => ValidationResult::SyntaxError(
-                Diagnostic::error(format!("Invalid MongoDB query: {}", e))
-                    .with_hint("Use db.collection.method() or db.method() syntax"),
-            ),
-        }
-    }
-
-    fn detect_dangerous(&self, query: &str) -> Option<DangerousQueryKind> {
-        detect_dangerous_mongo(query)
-    }
-
-    fn editor_diagnostics(&self, query: &str) -> Vec<EditorDiagnostic> {
-        let trimmed = query.trim();
-
-        if trimmed.is_empty() {
-            return vec![];
-        }
-
-        let lower = trimmed.to_lowercase();
-        if lower.starts_with("select ")
-            || lower.starts_with("insert into")
-            || lower.starts_with("update ")
-            || lower.starts_with("delete from")
-        {
-            return vec![EditorDiagnostic {
-                severity: DiagnosticSeverity::Error,
-                message: "SQL syntax not supported for MongoDB. Use db.collection.method() or db.method() syntax."
-                    .to_string(),
-                range: full_first_line_range(query),
-            }];
-        }
-
-        let errors = crate::query_parser::validate_query_positional(query);
-        errors
-            .into_iter()
-            .map(|err| {
-                let range = byte_offset_to_range(query, err.offset, err.len);
-                EditorDiagnostic {
-                    severity: DiagnosticSeverity::Error,
-                    message: err.message,
-                    range,
-                }
-            })
-            .collect()
-    }
-}
-
-fn byte_offset_to_range(source: &str, offset: usize, len: usize) -> TextPositionRange {
-    let clamped_offset = offset.min(source.len());
-    let clamped_end = (offset + len.max(1))
-        .min(source.len())
-        .max(clamped_offset + 1);
-
-    let start = byte_offset_to_position(source, clamped_offset);
-    let end = byte_offset_to_position(source, clamped_end);
-
-    if start == end {
-        let end_col = start.column + 1;
-        return TextPositionRange::new(start, TextPosition::new(start.line, end_col));
-    }
-
-    TextPositionRange::new(start, end)
-}
-
-fn byte_offset_to_position(source: &str, offset: usize) -> TextPosition {
-    let before = &source[..offset.min(source.len())];
-    let line = before.matches('\n').count() as u32;
-    let last_newline = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
-    let column = before[last_newline..].chars().count() as u32;
-    TextPosition::new(line, column)
-}
-
-fn full_first_line_range(query: &str) -> TextPositionRange {
-    let first_line_len = query
-        .lines()
-        .next()
-        .map(|line| line.chars().count())
-        .unwrap_or(1) as u32;
-
-    let end_col = first_line_len.max(1);
-
-    TextPositionRange::new(TextPosition::new(0, 0), TextPosition::new(0, end_col))
 }
 
 /// Stub dialect for MongoDB. SQL generation is not used for document databases.

--- a/crates/dbflux_driver_mongodb/src/language_service.rs
+++ b/crates/dbflux_driver_mongodb/src/language_service.rs
@@ -1,5 +1,6 @@
 use dbflux_core::{
-    DangerousQueryKind, LanguageService, QueryLanguage, ValidationResult, detect_dangerous_mongo,
+    DangerousQueryKind, DiagnosticSeverity, EditorDiagnostic, LanguageService, QueryLanguage,
+    TextPosition, TextPositionRange, ValidationResult,
 };
 
 /// MongoDB language service with lightweight syntax/language checks.
@@ -25,10 +26,242 @@ impl LanguageService for MongoLanguageService {
             };
         }
 
-        ValidationResult::Valid
+        match crate::query_parser::validate_query(query) {
+            Ok(_) => ValidationResult::Valid,
+            Err(error) => ValidationResult::SyntaxError(
+                dbflux_core::Diagnostic::error(format!("Invalid MongoDB query: {}", error))
+                    .with_hint("Use db.collection.method() or db.method() syntax"),
+            ),
+        }
     }
 
     fn detect_dangerous(&self, query: &str) -> Option<DangerousQueryKind> {
         detect_dangerous_mongo(query)
+    }
+
+    fn editor_diagnostics(&self, query: &str) -> Vec<EditorDiagnostic> {
+        let trimmed = query.trim();
+
+        if trimmed.is_empty() {
+            return vec![];
+        }
+
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.starts_with("select ")
+            || lower.starts_with("insert into")
+            || lower.starts_with("update ")
+            || lower.starts_with("delete from")
+        {
+            return vec![EditorDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                message: "SQL syntax not supported for MongoDB. Use db.collection.method() or db.method() syntax."
+                    .to_string(),
+                range: full_first_line_range(query),
+            }];
+        }
+
+        crate::query_parser::validate_query_positional(query)
+            .into_iter()
+            .map(|error| EditorDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                message: error.message,
+                range: byte_offset_to_range(query, error.offset, error.len),
+            })
+            .collect()
+    }
+}
+
+/// Detect dangerous MongoDB shell commands using heuristic pattern matching.
+pub(crate) fn detect_dangerous_mongo(query: &str) -> Option<DangerousQueryKind> {
+    let normalized = query.trim().to_lowercase();
+
+    if normalized.contains(".dropdatabase(") {
+        return Some(DangerousQueryKind::MongoDropDatabase);
+    }
+
+    if normalized.contains(".drop(") && !normalized.contains(".dropdatabase(") {
+        return Some(DangerousQueryKind::MongoDropCollection);
+    }
+
+    if let Some(pos) = normalized.find(".deletemany(") {
+        let after_paren = &normalized[pos + 12..];
+        if is_empty_filter(after_paren) {
+            return Some(DangerousQueryKind::MongoDeleteMany);
+        }
+    }
+
+    if let Some(pos) = normalized.find(".updatemany(") {
+        let after_paren = &normalized[pos + 12..];
+        if is_empty_filter(after_paren) {
+            return Some(DangerousQueryKind::MongoUpdateMany);
+        }
+    }
+
+    None
+}
+
+fn is_empty_filter(args_start: &str) -> bool {
+    let trimmed = args_start.trim();
+
+    if trimmed.starts_with(')') {
+        return true;
+    }
+
+    if trimmed.starts_with("{}") {
+        return true;
+    }
+
+    if let Some(brace_end) = trimmed.find('}') {
+        let inside = &trimmed[1..brace_end];
+        if inside.trim().is_empty() {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn byte_offset_to_range(source: &str, offset: usize, len: usize) -> TextPositionRange {
+    let clamped_offset = offset.min(source.len());
+    let clamped_end = (offset + len.max(1))
+        .min(source.len())
+        .max(clamped_offset + 1);
+
+    let start = byte_offset_to_position(source, clamped_offset);
+    let end = byte_offset_to_position(source, clamped_end);
+
+    if start == end {
+        return TextPositionRange::new(start, TextPosition::new(start.line, start.column + 1));
+    }
+
+    TextPositionRange::new(start, end)
+}
+
+fn byte_offset_to_position(source: &str, offset: usize) -> TextPosition {
+    let before = &source[..offset.min(source.len())];
+    let line = before.matches('\n').count() as u32;
+    let last_newline = before.rfind('\n').map(|index| index + 1).unwrap_or(0);
+    let column = before[last_newline..].chars().count() as u32;
+    TextPosition::new(line, column)
+}
+
+fn full_first_line_range(query: &str) -> TextPositionRange {
+    let first_line_len = query
+        .lines()
+        .next()
+        .map(|line| line.chars().count())
+        .unwrap_or(1) as u32;
+
+    TextPositionRange::new(
+        TextPosition::new(0, 0),
+        TextPosition::new(0, first_line_len.max(1)),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mongo_delete_many_empty_filter_is_dangerous() {
+        assert_eq!(
+            MongoLanguageService.detect_dangerous("db.users.deleteMany({})"),
+            Some(DangerousQueryKind::MongoDeleteMany)
+        );
+    }
+
+    #[test]
+    fn mongo_delete_many_no_args_is_dangerous() {
+        assert_eq!(
+            MongoLanguageService.detect_dangerous("db.users.deleteMany()"),
+            Some(DangerousQueryKind::MongoDeleteMany)
+        );
+    }
+
+    #[test]
+    fn mongo_delete_many_with_filter_is_safe() {
+        assert_eq!(
+            MongoLanguageService.detect_dangerous(r#"db.users.deleteMany({"archived": true})"#),
+            None
+        );
+    }
+
+    #[test]
+    fn mongo_update_many_empty_filter_is_dangerous() {
+        assert_eq!(
+            MongoLanguageService
+                .detect_dangerous(r#"db.users.updateMany({}, {"$set": {"active": false}})"#),
+            Some(DangerousQueryKind::MongoUpdateMany)
+        );
+    }
+
+    #[test]
+    fn mongo_update_many_with_filter_is_safe() {
+        assert_eq!(
+            MongoLanguageService.detect_dangerous(
+                r#"db.users.updateMany({"active": true}, {"$set": {"active": false}})"#,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn mongo_drop_collection_is_dangerous() {
+        assert_eq!(
+            MongoLanguageService.detect_dangerous("db.temp_collection.drop()"),
+            Some(DangerousQueryKind::MongoDropCollection)
+        );
+    }
+
+    #[test]
+    fn mongo_drop_database_is_dangerous() {
+        assert_eq!(
+            MongoLanguageService.detect_dangerous("db.dropDatabase()"),
+            Some(DangerousQueryKind::MongoDropDatabase)
+        );
+    }
+
+    #[test]
+    fn mongo_safe_queries_are_safe() {
+        assert_eq!(
+            MongoLanguageService.detect_dangerous("db.users.find()"),
+            None
+        );
+        assert_eq!(
+            MongoLanguageService.detect_dangerous(r#"db.users.find({"name": "John"})"#),
+            None
+        );
+        assert_eq!(
+            MongoLanguageService.detect_dangerous(r#"db.users.deleteOne({"_id": "123"})"#),
+            None
+        );
+        assert_eq!(
+            MongoLanguageService.detect_dangerous(r#"db.users.insertOne({"name": "Alice"})"#),
+            None
+        );
+        assert_eq!(
+            MongoLanguageService
+                .detect_dangerous(r#"db.orders.aggregate([{"$match": {"status": "active"}}])"#),
+            None
+        );
+    }
+
+    #[test]
+    fn mongo_detection_is_case_insensitive() {
+        assert_eq!(
+            MongoLanguageService.detect_dangerous("db.users.DELETEMANY({})"),
+            Some(DangerousQueryKind::MongoDeleteMany)
+        );
+        assert_eq!(
+            MongoLanguageService.detect_dangerous("db.users.DeleteMany({})"),
+            Some(DangerousQueryKind::MongoDeleteMany)
+        );
+    }
+
+    #[test]
+    fn mongo_editor_diagnostics_flag_wrong_language() {
+        let diagnostics = MongoLanguageService.editor_diagnostics("SELECT * FROM users");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, DiagnosticSeverity::Error);
     }
 }

--- a/crates/dbflux_driver_redis/src/driver.rs
+++ b/crates/dbflux_driver_redis/src/driver.rs
@@ -6,14 +6,16 @@ use std::time::Instant;
 use std::sync::Arc;
 
 use dbflux_core::secrecy::{ExposeSecret, SecretString};
+
+use crate::language_service::RedisLanguageService;
 use dbflux_core::{
     ColumnKind, ColumnMeta, Connection, ConnectionErrorFormatter, ConnectionExt, ConnectionProfile,
     DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DbSchemaInfo,
-    DdlCapabilities, DefaultSqlDialect, DeploymentClass, Diagnostic, DiagnosticSeverity,
-    DocumentConnection, DriverCapabilities, DriverFormDef, DriverLimits, DriverMetadata,
-    EditorDiagnostic, FormFieldDef, FormFieldKind, FormSection, FormTab, FormValues,
-    FormattedError, HashDeleteRequest, HashSetRequest, Icon, KeyBulkGetRequest, KeyDeleteRequest,
-    KeyEntry, KeyExistsRequest, KeyExpireRequest, KeyGetRequest, KeyGetResult, KeyPersistRequest,
+    DdlCapabilities, DefaultSqlDialect, DeploymentClass, DiagnosticSeverity, DocumentConnection,
+    DriverCapabilities, DriverFormDef, DriverLimits, DriverMetadata, EditorDiagnostic,
+    FormFieldDef, FormFieldKind, FormSection, FormTab, FormValues, FormattedError,
+    HashDeleteRequest, HashSetRequest, Icon, KeyBulkGetRequest, KeyDeleteRequest, KeyEntry,
+    KeyExistsRequest, KeyExpireRequest, KeyGetRequest, KeyGetResult, KeyPersistRequest,
     KeyRenameRequest, KeyScanPage, KeyScanRequest, KeySetRequest, KeySpaceInfo, KeyTtlRequest,
     KeyType, KeyTypeRequest, KeyValueApi, KeyValueConnection, KeyValueSchema, LanguageService,
     ListEnd, ListPushRequest, ListRemoveRequest, ListSetRequest, MutationCapabilities,
@@ -22,7 +24,7 @@ use dbflux_core::{
     SchemaDropTarget, SchemaLoadingStrategy, SchemaSnapshot, SemanticPlan, SemanticRequest,
     SetAddRequest, SetCondition, SetRemoveRequest, SqlDialect, SshTunnelConfig, StreamAddRequest,
     StreamDeleteRequest, StreamEntryId, TextPosition, TextPositionRange, TransactionCapabilities,
-    ValidationResult, Value, ValueRepr, ZSetAddRequest, ZSetRemoveRequest, sanitize_uri,
+    Value, ValueRepr, ZSetAddRequest, ZSetRemoveRequest, sanitize_uri,
 };
 use dbflux_ssh::SshTunnel;
 
@@ -2201,7 +2203,7 @@ fn split_command(input: &str) -> Result<Vec<String>, DbError> {
     Ok(items)
 }
 
-fn parse_command(input: &str) -> Result<Vec<String>, DbError> {
+pub(crate) fn parse_command(input: &str) -> Result<Vec<String>, DbError> {
     let cleaned = input
         .lines()
         .filter(|line| {
@@ -2218,74 +2220,6 @@ fn parse_command(input: &str) -> Result<Vec<String>, DbError> {
 
     let cleaned = cleaned.trim_end_matches(';').trim();
     split_command(cleaned)
-}
-
-struct RedisLanguageService;
-
-impl LanguageService for RedisLanguageService {
-    fn validate(&self, query: &str) -> ValidationResult {
-        let trimmed = query.trim();
-        if trimmed.is_empty() {
-            return ValidationResult::Valid;
-        }
-
-        let lower = trimmed.to_lowercase();
-        if lower.starts_with("select ")
-            || lower.starts_with("insert ")
-            || lower.starts_with("update ")
-            || lower.starts_with("delete ")
-        {
-            return ValidationResult::WrongLanguage {
-                expected: QueryLanguage::RedisCommands,
-                message:
-                    "SQL syntax not supported for Redis. Use Redis command syntax (e.g. GET key)."
-                        .to_string(),
-            };
-        }
-
-        match parse_command(query) {
-            Ok(_) => ValidationResult::Valid,
-            Err(e) => ValidationResult::SyntaxError(
-                Diagnostic::error(format!("Invalid Redis command: {}", e))
-                    .with_hint("Use Redis command syntax, for example: SET mykey myvalue"),
-            ),
-        }
-    }
-
-    fn detect_dangerous(&self, query: &str) -> Option<dbflux_core::DangerousQueryKind> {
-        dbflux_core::detect_dangerous_redis(query)
-    }
-
-    fn editor_diagnostics(&self, query: &str) -> Vec<EditorDiagnostic> {
-        let trimmed = query.trim();
-        if trimmed.is_empty() {
-            return vec![];
-        }
-
-        let lower = trimmed.to_lowercase();
-        if lower.starts_with("select ")
-            || lower.starts_with("insert ")
-            || lower.starts_with("update ")
-            || lower.starts_with("delete ")
-        {
-            return vec![EditorDiagnostic {
-                severity: DiagnosticSeverity::Error,
-                message:
-                    "SQL syntax not supported for Redis. Use Redis command syntax (e.g. GET key)."
-                        .to_string(),
-                range: redis_first_line_range(query),
-            }];
-        }
-
-        match parse_command(query) {
-            Ok(tokens) => check_redis_arity(&tokens, query),
-            Err(e) => vec![EditorDiagnostic {
-                severity: DiagnosticSeverity::Error,
-                message: format!("Invalid Redis command: {}", e),
-                range: redis_first_line_range(query),
-            }],
-        }
-    }
 }
 
 /// Arity rule for a Redis command.
@@ -2373,7 +2307,7 @@ fn command_arity(command: &str) -> Option<Arity> {
 
 /// Check argument count for a parsed Redis command, returning diagnostics if
 /// the arity is wrong.
-fn check_redis_arity(tokens: &[String], query: &str) -> Vec<EditorDiagnostic> {
+pub(crate) fn check_redis_arity(tokens: &[String], query: &str) -> Vec<EditorDiagnostic> {
     if tokens.is_empty() {
         return vec![];
     }
@@ -2443,7 +2377,7 @@ fn check_pairing(command: &str, arg_count: usize) -> Option<String> {
     }
 }
 
-fn redis_first_line_range(query: &str) -> TextPositionRange {
+pub(crate) fn redis_first_line_range(query: &str) -> TextPositionRange {
     let first_line_len = query
         .lines()
         .next()

--- a/crates/dbflux_driver_redis/src/language_service.rs
+++ b/crates/dbflux_driver_redis/src/language_service.rs
@@ -1,14 +1,179 @@
-use dbflux_core::{DangerousQueryKind, LanguageService, ValidationResult, detect_dangerous_redis};
+use dbflux_core::{
+    DangerousQueryKind, DiagnosticSeverity, EditorDiagnostic, LanguageService, QueryLanguage,
+    ValidationResult,
+};
 
 /// Redis language service with lightweight syntax/language checks.
 pub struct RedisLanguageService;
 
 impl LanguageService for RedisLanguageService {
-    fn validate(&self, _query: &str) -> ValidationResult {
-        ValidationResult::Valid
+    fn validate(&self, query: &str) -> ValidationResult {
+        let trimmed = query.trim();
+        if trimmed.is_empty() {
+            return ValidationResult::Valid;
+        }
+
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.starts_with("select ")
+            || lower.starts_with("insert ")
+            || lower.starts_with("update ")
+            || lower.starts_with("delete ")
+        {
+            return ValidationResult::WrongLanguage {
+                expected: QueryLanguage::RedisCommands,
+                message:
+                    "SQL syntax not supported for Redis. Use Redis command syntax (e.g. GET key)."
+                        .to_string(),
+            };
+        }
+
+        match crate::driver::parse_command(query) {
+            Ok(_) => ValidationResult::Valid,
+            Err(error) => ValidationResult::SyntaxError(
+                dbflux_core::Diagnostic::error(format!("Invalid Redis command: {}", error))
+                    .with_hint("Use Redis command syntax, for example: SET mykey myvalue"),
+            ),
+        }
     }
 
     fn detect_dangerous(&self, query: &str) -> Option<DangerousQueryKind> {
         detect_dangerous_redis(query)
+    }
+
+    fn editor_diagnostics(&self, query: &str) -> Vec<EditorDiagnostic> {
+        let trimmed = query.trim();
+        if trimmed.is_empty() {
+            return vec![];
+        }
+
+        let lower = trimmed.to_ascii_lowercase();
+        if lower.starts_with("select ")
+            || lower.starts_with("insert ")
+            || lower.starts_with("update ")
+            || lower.starts_with("delete ")
+        {
+            return vec![EditorDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                message:
+                    "SQL syntax not supported for Redis. Use Redis command syntax (e.g. GET key)."
+                        .to_string(),
+                range: crate::driver::redis_first_line_range(query),
+            }];
+        }
+
+        match crate::driver::parse_command(query) {
+            Ok(tokens) => crate::driver::check_redis_arity(&tokens, query),
+            Err(error) => vec![EditorDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                message: format!("Invalid Redis command: {}", error),
+                range: crate::driver::redis_first_line_range(query),
+            }],
+        }
+    }
+}
+
+/// Detect dangerous Redis commands using keyword matching.
+pub(crate) fn detect_dangerous_redis(query: &str) -> Option<DangerousQueryKind> {
+    let normalized = query.trim().to_lowercase();
+
+    let first_word = normalized.split_whitespace().next().unwrap_or("");
+
+    if first_word == "flushall" {
+        return Some(DangerousQueryKind::RedisFlushAll);
+    }
+
+    if first_word == "flushdb" {
+        return Some(DangerousQueryKind::RedisFlushDb);
+    }
+
+    if first_word == "del" {
+        let args: Vec<&str> = normalized.split_whitespace().skip(1).collect();
+        if args.len() > 1 {
+            return Some(DangerousQueryKind::RedisMultiDelete);
+        }
+    }
+
+    if first_word == "keys" {
+        return Some(DangerousQueryKind::RedisKeysPattern);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redis_flushall_is_dangerous() {
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("FLUSHALL"),
+            Some(DangerousQueryKind::RedisFlushAll)
+        );
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("flushall"),
+            Some(DangerousQueryKind::RedisFlushAll)
+        );
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("FLUSHALL ASYNC"),
+            Some(DangerousQueryKind::RedisFlushAll)
+        );
+    }
+
+    #[test]
+    fn redis_flushdb_is_dangerous() {
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("FLUSHDB"),
+            Some(DangerousQueryKind::RedisFlushDb)
+        );
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("flushdb ASYNC"),
+            Some(DangerousQueryKind::RedisFlushDb)
+        );
+    }
+
+    #[test]
+    fn redis_del_multi_key_is_dangerous() {
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("DEL key1 key2"),
+            Some(DangerousQueryKind::RedisMultiDelete)
+        );
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("del a b c"),
+            Some(DangerousQueryKind::RedisMultiDelete)
+        );
+    }
+
+    #[test]
+    fn redis_del_single_key_is_safe() {
+        assert_eq!(RedisLanguageService.detect_dangerous("DEL mykey"), None);
+    }
+
+    #[test]
+    fn redis_keys_is_dangerous() {
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("KEYS *"),
+            Some(DangerousQueryKind::RedisKeysPattern)
+        );
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("keys user:*"),
+            Some(DangerousQueryKind::RedisKeysPattern)
+        );
+    }
+
+    #[test]
+    fn redis_safe_reads_and_writes_are_safe() {
+        assert_eq!(RedisLanguageService.detect_dangerous("GET mykey"), None);
+        assert_eq!(
+            RedisLanguageService.detect_dangerous("SET mykey myvalue"),
+            None
+        );
+    }
+
+    #[test]
+    fn redis_editor_diagnostics_flag_wrong_language() {
+        let diagnostics = RedisLanguageService.editor_diagnostics("SELECT * FROM users");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, DiagnosticSeverity::Error);
     }
 }

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -252,7 +252,20 @@ impl CodeDocument {
             return;
         }
 
-        if let Some(kind) = detect_dangerous_query(&query) {
+        let dangerous_kind = self.connection_id.and_then(|conn_id| {
+            self.app_state
+                .read(cx)
+                .connections()
+                .get(&conn_id)
+                .and_then(|connected| {
+                    connected
+                        .connection
+                        .language_service()
+                        .detect_dangerous(&query)
+                })
+        });
+
+        if let Some(kind) = dangerous_kind {
             let is_suppressed = self
                 .app_state
                 .read(cx)

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -29,7 +29,7 @@ use dbflux_core::{
     DriftOutcome, DriverCapabilities, EditorDiagnostic as CoreEditorDiagnostic, ExecutionContext,
     ExecutionSourceContext, HistoryEntry, OutputReceiver, QueryLanguage, QueryRequest, QueryResult,
     RefreshPolicy, SchemaDriftDetected, SchemaLoadingStrategy, TaskTarget, ValidationResult,
-    check_schema_drift, detect_dangerous_query,
+    check_schema_drift,
 };
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
 use dbflux_ui_base::{AppStateChanged, AppStateEntity};


### PR DESCRIPTION
Closes #139

## Type
- [ ] Feature
- [ ] Fix
- [x] Refactor
- [ ] Docs
- [ ] Test
- [ ] Build/CI

## Summary
- Moves MongoDB and Redis dangerous-query detection out of `dbflux_core` into their driver language services.
- Routes query execution dangerous checks through the active connection's `LanguageService`.
- Keeps shared `DangerousQueryKind` and SQL detection in core while removing Mongo/Redis helper exports and core tests.

## Changes
| File | Change |
|------|--------|
| `crates/dbflux_driver_mongodb/src/language_service.rs` | Owns Mongo dangerous detection helpers and unit tests |
| `crates/dbflux_driver_redis/src/language_service.rs` | Owns Redis dangerous detection helpers and unit tests |
| `crates/dbflux_driver_mongodb/src/driver.rs` | Uses driver-local Mongo dangerous detection |
| `crates/dbflux_driver_redis/src/driver.rs` | Uses driver-local Redis dangerous detection |
| `crates/dbflux_core/src/query/language_service.rs` | Removes Mongo/Redis dangerous helper ownership and keeps SQL/core classification behavior |
| `crates/dbflux_core/src/query/mod.rs` | Stops re-exporting Mongo/Redis dangerous helpers |
| `crates/dbflux_core/src/lib.rs` | Stops re-exporting Mongo/Redis dangerous helpers |
| `crates/dbflux_ui_document/src/code/execution.rs` | Checks dangerous queries through the active connection language service |
| `crates/dbflux_ui_document/src/code/mod.rs` | Removes core `detect_dangerous_query` import |

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo test -p dbflux_driver_mongodb mongo_ -- --nocapture`
- [x] `cargo test -p dbflux_driver_redis redis_ -- --nocapture`
- [x] `cargo test -p dbflux_core language_classification_escalates_ambiguous_queries -- --nocapture`
- [x] `cargo check --workspace`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Ran relevant checks
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
