### PR TITLE
fix(ux): batch of connection and sidebar UX fixes

### DIFF
--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -2262,10 +2262,23 @@ impl AppState {
             .map(|task| task.id)
             .collect();
 
-        connect_task_ids
+        let cancelled = connect_task_ids
             .into_iter()
             .filter(|task_id| self.facade.tasks.cancel(*task_id))
-            .count()
+            .count();
+
+        // Clear the profile-level pending-operation entry so the sidebar can
+        // reflect the cancelled state and the user can retry without waiting
+        // for the (potentially long-running) async connect task to unwind.
+        // `finish_pending_operation` is a HashSet remove, so the eventual
+        // duplicate call from the async task's own cancellation path is a no-op.
+        if cancelled > 0 {
+            self.facade
+                .connections
+                .finish_pending_operation(profile_id, None);
+        }
+
+        cancelled
     }
 
     pub fn connections_mut(&mut self) -> &mut HashMap<Uuid, ConnectedProfile> {

--- a/crates/dbflux_components/src/components/data_table/table.rs
+++ b/crates/dbflux_components/src/components/data_table/table.rs
@@ -108,7 +108,11 @@ pub fn init(cx: &mut App) {
         // Ctrl elsewhere. Use it for the system-standard commands so macOS
         // gets the expected Cmd shortcut without binding the literal Ctrl
         // chord too (which would shadow editor interrupt semantics on Mac).
-        KeyBinding::new("secondary-a", SelectAll, Some(CONTEXT)),
+        //
+        // Scope this to "table without an active Input" so that ctrl-a /
+        // cmd-a inside an inline cell editor (or any other Input nested in
+        // the table) selects the input's text instead of all rows.
+        KeyBinding::new("secondary-a", SelectAll, Some("Results && !Input")),
         KeyBinding::new("escape", ClearSelection, Some(CONTEXT)),
         // Copy
         KeyBinding::new("secondary-c", Copy, Some(CONTEXT)),

--- a/crates/dbflux_ui/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions.rs
@@ -130,14 +130,21 @@ impl Workspace {
     pub(super) fn open_settings(&self, cx: &mut Context<Self>) {
         let app_state = self.app_state.clone();
 
-        // Check if settings window is already open - if so, focus it
+        // If a settings window is already open, focus it and return. If the
+        // stored handle is stale (window was closed without us being notified),
+        // clear it and fall through to open a fresh window.
         if let Some(handle) = app_state.read(cx).settings_window {
-            if let Err(e) = handle.update(cx, |_root, window, _cx| {
+            match handle.update(cx, |_root, window, _cx| {
                 window.activate_window();
             }) {
-                log::warn!("Failed to activate existing settings window: {:?}", e);
+                Ok(_) => return,
+                Err(e) => {
+                    log::warn!("Stale settings window handle, reopening: {:?}", e);
+                    app_state.update(cx, |state, _| {
+                        state.settings_window = None;
+                    });
+                }
             }
-            return;
         }
 
         let workspace = cx.entity().clone();
@@ -155,7 +162,15 @@ impl Workspace {
         };
         platform::apply_window_options(&mut options, 800.0, 600.0);
 
+        let app_state_for_close = app_state.clone();
         if let Ok(handle) = cx.open_window(options, |window, cx| {
+            window.on_window_should_close(cx, move |_window, cx| {
+                app_state_for_close.update(cx, |state, _| {
+                    state.settings_window = None;
+                });
+                true
+            });
+
             let settings = cx.new(|cx| SettingsWindow::new(app_state.clone(), window, cx));
 
             cx.subscribe(

--- a/crates/dbflux_ui/src/ui/views/workspace/inspector.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/inspector.rs
@@ -3,7 +3,10 @@
 //! `WorkspaceInspector` is a persistent right-edge panel that renders arbitrary
 //! `AnyView` content supplied by the event chain originating from
 //! `DataGridPanel::open_row_inspector`.  The workspace owns this entity for
-//! its entire lifetime; the inspector stays open across tab switches.
+//! its entire lifetime; per-tab visibility is driven by `OpenInspector` /
+//! `CloseInspector` events the active document emits on `set_active_tab`,
+//! so the rail follows the active tab instead of bleeding stale content
+//! across tab switches.
 //!
 //! # Resize
 //!
@@ -104,6 +107,23 @@ impl WorkspaceInspector {
         self.content = Some(content);
         self.title = title;
         self.is_open = true;
+        cx.notify();
+    }
+
+    /// Hide the rail without forgetting its content or emitting `Closed`.
+    ///
+    /// Used by per-tab visibility: when the user switches to a tab that has
+    /// no inspector, the rail collapses but the previously-active tab's
+    /// `inspector_row` state is left intact so the rail reappears on
+    /// switch-back. Explicit user dismissal goes through `close` instead.
+    pub fn hide(&mut self, cx: &mut Context<Self>) {
+        if !self.is_open {
+            return;
+        }
+        self.is_open = false;
+        self.is_resizing = false;
+        self.resize_start_x = None;
+        self.resize_start_width = None;
         cx.notify();
     }
 

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -902,6 +902,17 @@ impl Workspace {
                     this.persist_inspector_width(*px_width, cx);
                 }
                 inspector::WorkspaceInspectorEvent::Closed => {
+                    // Propagate explicit user dismissal to the active document
+                    // so it forgets its inspector state and does not re-open
+                    // the rail on the next tab activation or refresh.
+                    let active_id = this.tab_manager.read(cx).active_id();
+                    if let Some(id) = active_id {
+                        this.tab_manager.update(cx, |mgr, cx| {
+                            if let Some(tab) = mgr.document(id) {
+                                tab.mark_inspector_closed(cx);
+                            }
+                        });
+                    }
                     cx.notify();
                 }
             },
@@ -927,6 +938,11 @@ impl Workspace {
                     TabManagerEvent::OpenInspector { title, content } => {
                         this.workspace_inspector.update(cx, |insp, cx| {
                             insp.open_with(content.clone(), title.clone(), cx);
+                        });
+                    }
+                    TabManagerEvent::CloseInspector => {
+                        this.workspace_inspector.update(cx, |insp, cx| {
+                            insp.hide(cx);
                         });
                     }
                     TabManagerEvent::Activated(new_id) => {

--- a/crates/dbflux_ui_base/src/app_state_entity.rs
+++ b/crates/dbflux_ui_base/src/app_state_entity.rs
@@ -53,6 +53,17 @@ pub struct AppStateEntity {
 
     /// Saved-chart manager — load once at startup, mutated via `upsert`/`remove`.
     pub saved_charts: SavedChartManager,
+
+    /// Set by the Connection Manager after editing a profile that is currently
+    /// connected. The sidebar consumes this on the next `AppStateChanged` to
+    /// surface a "Reconnect now / Later" prompt — the edit itself is already
+    /// persisted regardless of the user's choice.
+    pub pending_edit_reconnect_prompt: Option<Uuid>,
+
+    /// Set by the reconnect prompt action when the user chooses to reconnect.
+    /// Picked up by the sidebar on `AppStateChanged` to drive
+    /// disconnect + connect for that profile.
+    pub pending_reconnect_request: Option<Uuid>,
 }
 
 impl AppStateEntity {
@@ -62,6 +73,8 @@ impl AppStateEntity {
             inner: AppState::new(),
             settings_window: None,
             saved_charts: SavedChartManager::load(),
+            pending_edit_reconnect_prompt: None,
+            pending_reconnect_request: None,
         }
     }
 
@@ -71,6 +84,8 @@ impl AppStateEntity {
             inner: AppState::new_with_storage_runtime(storage_runtime),
             settings_window: None,
             saved_charts: SavedChartManager::load(),
+            pending_edit_reconnect_prompt: None,
+            pending_reconnect_request: None,
         }
     }
 }

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -1288,6 +1288,9 @@ impl CodeDocument {
                         content: content.clone(),
                     });
                 }
+                DataGridEvent::CloseInspector => {
+                    cx.emit(DocumentEvent::CloseInspector);
+                }
                 DataGridEvent::ChartThisQuery { .. } => {
                     // CodeDocument result tabs use QueryResult sources created without an
                     // original_query, so can_chart_from_context_menu is always false for them.

--- a/crates/dbflux_ui_document/src/data_document/mod.rs
+++ b/crates/dbflux_ui_document/src/data_document/mod.rs
@@ -143,6 +143,9 @@ impl DataDocument {
                     content: content.clone(),
                 });
             }
+            DataGridEvent::CloseInspector => {
+                cx.emit(DocumentEvent::CloseInspector);
+            }
             DataGridEvent::ChartThisQuery {
                 query,
                 connection_id,
@@ -201,7 +204,15 @@ impl DataDocument {
 
     pub fn set_active_tab(&mut self, active: bool, cx: &mut Context<Self>) {
         self.data_grid
-            .update(cx, |grid, _cx| grid.set_active_tab(active));
+            .update(cx, |grid, cx| grid.set_active_tab(active, cx));
+    }
+
+    /// Drop the cached row-inspector state in response to the user dismissing
+    /// the workspace inspector rail. Called from the `PaneHandle` closure
+    /// installed in `into_pane`.
+    pub fn mark_inspector_closed(&mut self, cx: &mut Context<Self>) {
+        self.data_grid
+            .update(cx, |grid, cx| grid.clear_inspector_state(cx));
     }
 
     pub fn refresh_policy(&self, cx: &App) -> RefreshPolicy {

--- a/crates/dbflux_ui_document/src/data_document/pane.rs
+++ b/crates/dbflux_ui_document/src/data_document/pane.rs
@@ -23,7 +23,7 @@ impl DataDocument {
     pub fn into_pane(entity: Entity<Self>, cx: &App) -> PaneHandle {
         let id = entity.read(cx).id();
 
-        PaneHandle::new_chart(
+        let mut handle = PaneHandle::new_chart(
             id,
             DocumentKind::Data,
             // render
@@ -138,6 +138,15 @@ impl DataDocument {
                     cx.subscribe(&e, move |_, ev: &DocumentEvent, cx| cb(ev, cx))
                 })
             },
-        )
+        );
+
+        handle.mark_inspector_closed = Some({
+            let e = entity.clone();
+            Box::new(move |cx| {
+                e.update(cx, |d, cx| d.mark_inspector_closed(cx));
+            })
+        });
+
+        handle
     }
 }

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu.rs
@@ -2349,6 +2349,16 @@ impl DataGridPanel {
         let state = table_state.read(cx);
         let model = state.model();
 
+        // The remembered row may now be out of bounds after a refresh shrinks
+        // the result. Drop the cached state and hide the rail rather than
+        // showing a phantom row of nulls.
+        if row >= model.row_count() {
+            self.inspector_row = None;
+            self.row_inspector_content = None;
+            cx.emit(DataGridEvent::CloseInspector);
+            return;
+        }
+
         let pk_cols: std::collections::HashSet<usize> =
             state.pk_columns().iter().copied().collect();
         let fk_cols = state.fk_columns().clone();
@@ -2414,6 +2424,10 @@ impl DataGridPanel {
 
         // Fire FK resolution against the (possibly reused) content entity.
         self.fire_fk_resolution(fk_references, content.clone(), cx);
+
+        // Remember the active coordinates so refresh / tab activation /
+        // selection navigation can rebuild the snapshot from fresh data.
+        self.inspector_row = Some((row, col));
 
         // Tell the workspace to mount/replace the inspector rail.
         let title = SharedString::from(row_label);

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -149,6 +149,9 @@ pub enum DataGridEvent {
         title: SharedString,
         content: AnyView,
     },
+    /// Request to hide the workspace inspector rail without losing the
+    /// panel's cached inspector state (e.g. when switching to another tab).
+    CloseInspector,
     /// User requested "Chart this query" from the context menu.
     ChartThisQuery {
         query: String,
@@ -395,6 +398,14 @@ pub struct DataGridPanel {
 
     // Row inspector content entity (workspace owns the chrome/lifecycle).
     row_inspector_content: Option<Entity<row_inspector::RowInspectorContent>>,
+
+    /// Last `(row, col)` opened in the row inspector. `Some` means the inspector
+    /// is logically "on" for this panel — it should reappear when the panel's
+    /// tab is re-activated, follow the user's cursor on `SelectionChanged`, and
+    /// re-snapshot itself after a refresh. Cleared when the user dismisses the
+    /// rail explicitly (via [`DataGridPanel::clear_inspector_state`]) or when
+    /// the stored row falls outside the new result.
+    inspector_row: Option<(usize, usize)>,
 
     export_menu_open: bool,
 
@@ -828,6 +839,7 @@ impl DataGridPanel {
             document_preview_modal,
             pending_document_preview: None,
             row_inspector_content: None,
+            inspector_row: None,
             export_menu_open: false,
             toolbar_in_chrome_row: false,
             chart_shell: None,
@@ -1212,8 +1224,29 @@ impl DataGridPanel {
             && self.chart_source_time_range_panel.is_some()
     }
 
-    pub fn set_active_tab(&mut self, active: bool) {
+    pub fn set_active_tab(&mut self, active: bool, cx: &mut Context<Self>) {
         self.is_active_tab = active;
+
+        if active {
+            // Re-mount the inspector rail with a fresh snapshot of the
+            // remembered row so it follows the active tab without rendering
+            // stale data from a previous result set.
+            if let Some((row, col)) = self.inspector_row {
+                self.open_row_inspector(row, col, cx);
+            }
+        } else if self.inspector_row.is_some() {
+            // Hide the rail (without dropping our cached state) so the next
+            // active tab can take it over.
+            cx.emit(DataGridEvent::CloseInspector);
+        }
+    }
+
+    /// Called by the workspace when the user dismisses the inspector rail
+    /// explicitly (× button or ESC fallback). Drops the cached coordinates so
+    /// the rail does not re-open on tab activation or refresh.
+    pub fn clear_inspector_state(&mut self, _cx: &mut Context<Self>) {
+        self.inspector_row = None;
+        self.row_inspector_content = None;
     }
 
     pub fn refresh_policy(&self) -> RefreshPolicy {
@@ -1348,6 +1381,13 @@ impl DataGridPanel {
         self.result = result;
         self.rebuild_table(None, cx);
         self.state = GridState::Ready;
+
+        // Re-snapshot the row inspector against the fresh data so the rail
+        // keeps following the same row position across refreshes.
+        if let Some((row, col)) = self.inspector_row {
+            self.open_row_inspector(row, col, cx);
+        }
+
         cx.notify();
     }
 
@@ -1498,7 +1538,16 @@ impl DataGridPanel {
                     DataTableEvent::Focused => {
                         cx.emit(DataGridEvent::Focused);
                     }
-                    DataTableEvent::SelectionChanged(_) => {}
+                    DataTableEvent::SelectionChanged(selection) => {
+                        // When the row inspector is active, follow the user's
+                        // cursor so click / arrow-key navigation updates the
+                        // rail in place.
+                        if this.inspector_row.is_some()
+                            && let Some(active) = selection.active
+                        {
+                            this.open_row_inspector(active.row, active.col, cx);
+                        }
+                    }
                     DataTableEvent::SaveRowRequested(row_idx) => {
                         this.handle_save_row(*row_idx, cx);
                     }

--- a/crates/dbflux_ui_document/src/data_grid_panel/row_inspector.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/row_inspector.rs
@@ -111,14 +111,17 @@ fn render_row_entry(
         .py(Spacing::XS)
         .border_b_1()
         .border_color(theme.border.opacity(0.5))
-        // Column name (left)
+        // Column name (left). flex_1 + flex_basis(140) makes the name column
+        // share extra horizontal space with the value column as the inspector
+        // rail is resized, instead of staying frozen at a fixed 120px.
         .child(
             div()
                 .flex()
-                .flex_shrink_0()
                 .items_center()
                 .gap_1()
-                .w(px(120.0))
+                .flex_1()
+                .flex_basis(px(140.0))
+                .min_w(px(80.0))
                 .overflow_hidden()
                 .when(cell.is_primary_key, |d| {
                     d.child(
@@ -136,16 +139,22 @@ fn render_row_entry(
                 })
                 .child(
                     div()
+                        .min_w_0()
                         .overflow_hidden()
+                        .whitespace_nowrap()
                         .text_ellipsis()
                         .child(Text::caption(cell.name.clone()).color(theme.muted_foreground)),
                 ),
         )
-        // Value (right)
+        // Value (right). Slightly larger flex_basis so the value gets more
+        // initial room than the name, but both grow together on rail resize.
         .child(
             div()
                 .flex_1()
+                .flex_basis(px(220.0))
+                .min_w(px(60.0))
                 .overflow_hidden()
+                .whitespace_nowrap()
                 .text_ellipsis()
                 .when(is_null, |d| d.italic())
                 .child(Text::caption(value_text).color(if is_null {
@@ -355,9 +364,22 @@ fn render_meta_row(
         .flex()
         .items_center()
         .justify_between()
-        .gap(Spacing::XS)
-        .child(Text::caption(label.to_string()).color(theme.muted_foreground))
-        .child(Text::caption(value.to_string()).color(theme.foreground))
+        .gap(Spacing::SM)
+        .child(
+            div()
+                .flex_shrink_0()
+                .child(Text::caption(label.to_string()).color(theme.muted_foreground)),
+        )
+        .child(
+            div()
+                .flex_1()
+                .min_w_0()
+                .overflow_hidden()
+                .whitespace_nowrap()
+                .text_ellipsis()
+                .text_right()
+                .child(Text::caption(value.to_string()).color(theme.foreground)),
+        )
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/dbflux_ui_document/src/handle.rs
+++ b/crates/dbflux_ui_document/src/handle.rs
@@ -21,6 +21,10 @@ pub enum DocumentEvent {
         title: gpui::SharedString,
         content: gpui::AnyView,
     },
+    /// Request to hide the workspace inspector rail without losing the
+    /// document's cached inspector state (e.g. when switching away from a
+    /// tab whose inspector should reappear on return).
+    CloseInspector,
     /// User requested "Chart this query" from a data document's context menu.
     ChartThisQuery {
         query: String,

--- a/crates/dbflux_ui_document/src/pane.rs
+++ b/crates/dbflux_ui_document/src/pane.rs
@@ -96,6 +96,11 @@ pub struct PaneHandle {
 
     /// Returns a session snapshot for code documents (used by session manifest).
     pub session_tab_snapshot: Option<Box<dyn Fn(&App) -> Option<CodeSessionTabSnapshot>>>,
+
+    /// Tells the document that the workspace inspector was dismissed by the
+    /// user (× button or ESC). Documents that own inspector state clear it
+    /// here so the rail stays closed on subsequent tab activations.
+    pub mark_inspector_closed: Option<Box<dyn Fn(&mut App)>>,
 }
 
 impl PaneHandle {
@@ -146,6 +151,7 @@ impl PaneHandle {
             matches_event_stream: None,
             is_file_backed_empty: None,
             session_tab_snapshot: None,
+            mark_inspector_closed: None,
         }
     }
 

--- a/crates/dbflux_ui_document/src/tab_manager.rs
+++ b/crates/dbflux_ui_document/src/tab_manager.rs
@@ -159,6 +159,19 @@ impl Tab {
         }
     }
 
+    /// Tells the document that the workspace inspector rail was dismissed,
+    /// so it can drop any cached inspector state. No-op for documents that do
+    /// not own an inspector.
+    pub fn mark_inspector_closed(&self, cx: &mut App) {
+        match self {
+            Tab::Pane(p) => {
+                if let Some(f) = p.mark_inspector_closed.as_ref() {
+                    f(cx);
+                }
+            }
+        }
+    }
+
     /// Returns a session snapshot for this tab if it is a code document with
     /// a persistent backing (file-backed or scratch). Returns `None` for all
     /// other document types and for ephemeral tabs with no backing path.
@@ -227,6 +240,9 @@ impl TabManager {
                         title: title.clone(),
                         content: content.clone(),
                     });
+                }
+                DocumentEvent::CloseInspector => {
+                    cx.emit(TabManagerEvent::CloseInspector);
                 }
                 DocumentEvent::ChartThisQuery {
                     query,
@@ -600,6 +616,9 @@ pub enum TabManagerEvent {
         title: gpui::SharedString,
         content: gpui::AnyView,
     },
+    /// Request to hide the workspace inspector rail without forgetting the
+    /// document's cached inspector state.
+    CloseInspector,
     /// User requested "Chart this query" from a data document's context menu.
     ChartThisQuery {
         query: String,

--- a/crates/dbflux_ui_sidebar/src/lib.rs
+++ b/crates/dbflux_ui_sidebar/src/lib.rs
@@ -776,7 +776,22 @@ impl Sidebar {
 
         let app_state_subscription = cx.subscribe(
             &app_state,
-            |this, _app_state, _event: &AppStateChanged, cx| {
+            |this, app_state, _event: &AppStateChanged, cx| {
+                // Consume cross-window prompts deposited by the Connection
+                // Manager and the toast action callbacks before refreshing,
+                // so the resulting UI updates are batched into this tick.
+                let edit_prompt_profile =
+                    app_state.update(cx, |state, _| state.pending_edit_reconnect_prompt.take());
+                if let Some(profile_id) = edit_prompt_profile {
+                    this.show_edit_reconnect_toast(profile_id, &app_state, cx);
+                }
+
+                let reconnect_profile =
+                    app_state.update(cx, |state, _| state.pending_reconnect_request.take());
+                if let Some(profile_id) = reconnect_profile {
+                    this.reconnect_profile_after_edit(profile_id, cx);
+                }
+
                 this.refresh_tree(cx);
                 this.refresh_scripts_tree(cx);
             },
@@ -1005,6 +1020,41 @@ impl Sidebar {
         cx.notify();
     }
 
+    fn show_edit_reconnect_toast(
+        &mut self,
+        profile_id: Uuid,
+        app_state: &Entity<AppStateEntity>,
+        cx: &mut Context<Self>,
+    ) {
+        let profile_name = app_state
+            .read(cx)
+            .profiles()
+            .iter()
+            .find(|profile| profile.id == profile_id)
+            .map(|profile| profile.name.clone())
+            .unwrap_or_else(|| "connection".to_string());
+
+        let app_state_for_action = app_state.clone();
+        let reconnect_action =
+            dbflux_ui_base::toast::ToastAction::new("edit-reconnect-now", "Reconnect now")
+                .primary()
+                .on_click(move |cx| {
+                    app_state_for_action.update(cx, |state, cx| {
+                        state.pending_reconnect_request = Some(profile_id);
+                        cx.emit(AppStateChanged);
+                    });
+                });
+
+        let later_action = dbflux_ui_base::toast::ToastAction::new("edit-reconnect-later", "Later");
+
+        dbflux_ui_base::toast::Toast::info(format!("'{}' updated", profile_name))
+            .body("Reconnect to apply the changes to the live session.")
+            .meta_right(dbflux_ui_base::toast::now_hms())
+            .action(reconnect_action)
+            .action(later_action)
+            .push(cx);
+    }
+
     fn active_tree_state(&self) -> &Entity<TreeState> {
         match self.active_tab {
             SidebarTab::Connections => &self.tree_state,
@@ -1181,6 +1231,22 @@ impl Sidebar {
 
         // Ctrl/Cmd+Click: toggle item in active tab multi-selection.
         if with_ctrl && click_count == 1 {
+            // If the user has only a keyboard cursor (no prior multi-selection),
+            // seed the cursor item into the selection so ctrl+click extends from
+            // the visually focused item instead of replacing it.
+            if !self.has_multi_selection() {
+                let cursor_id = self
+                    .active_tree_state()
+                    .read(cx)
+                    .selected_entry()
+                    .map(|entry| entry.item().id.to_string());
+                if let Some(cursor_id) = cursor_id {
+                    if cursor_id != item_id {
+                        self.toggle_selection(&cursor_id, cx);
+                    }
+                }
+            }
+
             self.toggle_selection(item_id, cx);
 
             if let Some(idx) = self.find_item_index(item_id, cx) {

--- a/crates/dbflux_ui_sidebar/src/lib.rs
+++ b/crates/dbflux_ui_sidebar/src/lib.rs
@@ -1240,10 +1240,10 @@ impl Sidebar {
                     .read(cx)
                     .selected_entry()
                     .map(|entry| entry.item().id.to_string());
-                if let Some(cursor_id) = cursor_id {
-                    if cursor_id != item_id {
-                        self.toggle_selection(&cursor_id, cx);
-                    }
+                if let Some(cursor_id) = cursor_id
+                    && cursor_id != item_id
+                {
+                    self.toggle_selection(&cursor_id, cx);
                 }
             }
 

--- a/crates/dbflux_ui_sidebar/src/operations.rs
+++ b/crates/dbflux_ui_sidebar/src/operations.rs
@@ -2529,6 +2529,66 @@ impl Sidebar {
         self.connect_to_profile_inner(profile_id, None, false, cx);
     }
 
+    /// Disconnect a live session and reconnect once the connection has fully
+    /// cleared. Used by the "Reconnect now" prompt that fires after the user
+    /// edits a profile that is currently connected — the new settings only take
+    /// effect on a fresh connect, but the pending-operation map blocks a
+    /// back-to-back call, so we wait for the disconnect to drain first.
+    pub fn reconnect_profile_after_edit(&mut self, profile_id: Uuid, cx: &mut Context<Self>) {
+        if !self
+            .app_state
+            .read(cx)
+            .connections()
+            .contains_key(&profile_id)
+        {
+            // Not connected — just connect.
+            self.connect_to_profile(profile_id, cx);
+            return;
+        }
+
+        self.disconnect_profile(profile_id, cx);
+
+        let app_state = self.app_state.clone();
+        let sidebar = cx.entity().clone();
+
+        cx.spawn(async move |_this, cx| {
+            // Poll until the connection has been removed from the live map
+            // (capped at ~5s to avoid hanging if the disconnect stalls).
+            for _ in 0..50 {
+                cx.background_executor()
+                    .timer(std::time::Duration::from_millis(100))
+                    .await;
+
+                let cleared = cx
+                    .update(|cx| {
+                        let still_connected =
+                            app_state.read(cx).connections().contains_key(&profile_id);
+                        let still_pending =
+                            app_state.read(cx).is_operation_pending(profile_id, None);
+                        !still_connected && !still_pending
+                    })
+                    .unwrap_or(false);
+
+                if cleared {
+                    break;
+                }
+            }
+
+            if let Err(error) = cx.update(|cx| {
+                sidebar.update(cx, |sidebar, cx| {
+                    sidebar.connect_to_profile(profile_id, cx);
+                });
+            }) {
+                log::warn!(
+                    "Failed to trigger reconnect after edit for profile {}: {:?}",
+                    profile_id,
+                    error
+                );
+            }
+        })
+        .detach();
+    }
+
     /// Retry a connection with an explicit SSH passphrase supplied by the user via the modal.
     ///
     /// If this attempt also fails with a passphrase error, the modal will reopen showing

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -554,6 +554,15 @@ impl ConnectionManagerWindow {
 
             if is_edit {
                 state.update_profile(profile);
+
+                // If the edited profile is currently connected, surface a
+                // reconnect prompt — the sidebar consumes this flag on the
+                // next AppStateChanged and shows a toast with the choice.
+                // The profile change itself is already persisted; only the
+                // live session needs the explicit reconnect to pick it up.
+                if state.connections().contains_key(&saved_profile_id) {
+                    state.pending_edit_reconnect_prompt = Some(saved_profile_id);
+                }
             } else {
                 state.add_profile_in_folder(profile, self.target_folder_id);
             }


### PR DESCRIPTION
## Summary

UX bug fixes bundled into one PR.

### Bug 1 — Cancelled connection stuck in `(connecting...)`
`cancel_running_connect_tasks_for_profile` cancelled the task token but never cleared the profile-level pending-operation entry, so the sidebar kept showing `(connecting...)` and `is_operation_pending` blocked any retry — the only workaround was restarting the app. The async connect task only clears the entry once `params.execute()` returns, which can hang on a slow TCP dial.

Fix: clear the pending-operation entry inside `cancel_running_connect_tasks_for_profile`. The async task's own cancellation path still runs, but `finish_pending_operation` is a `HashSet::remove` so the second call is a no-op.

### Bug 2 — Editing an open connection had no refresh prompt
`save_profile` persisted the edit and closed the window without consulting `state.connections()`, so the live session silently kept running with stale config.

Fix: on save-while-connected, set `pending_edit_reconnect_prompt` on `AppStateEntity`. The sidebar consumes it via the existing `AppStateChanged` subscription and shows a toast with two actions:
- **Reconnect now** — sets `pending_reconnect_request`; the sidebar runs `reconnect_profile_after_edit`, which disconnects, waits for the pending-operation map to drain (capped at ~5s), then reconnects.
- **Later** — the edit stays persisted; the live session is untouched.

### Bug 3 — Multiple Settings windows
`app_state.settings_window` was never cleared on close, so after closing Settings the first reopen attempt hit a stale `WindowHandle`, logged a warning, and `return`ed without opening anything — the user had to click Settings twice.

Fix: register `on_window_should_close` to null the handle when the window is closing, and fall through to opening a fresh window when the focus attempt fails on a stale handle.

### Bug 4 — Ctrl+click ignored the keyboard cursor
The sidebar tracks two independent states: the keyboard cursor (`selected_index`, orange outline from arrow-key nav) and the multi-selection set. Ctrl+click only toggled the clicked item into `multi_selection`, so the visually focused item was never included.

Fix: when `multi_selection` is empty on ctrl+click, seed it with the current keyboard cursor before toggling the clicked item. Shift+click already had equivalent fallback through `select_range_to_item`.

### Bug 5 — Row inspector did not follow the active tab or selection
The workspace inspector rail was a singleton with no per-tab state, so switching tabs left a previously-active table's inspector rendered against the new tab's chrome. Refreshes did not re-snapshot the row, and keyboard / mouse row navigation was a no-op for the inspector.

Fix:
- `DataGridPanel` now remembers `(row, col)` when the inspector opens. `set_active_tab(false)` emits `CloseInspector` to hide the rail without forgetting the cached coords; `set_active_tab(true)` and `set_result` re-snapshot the row against the live data so the rail follows the same position across refreshes. `SelectionChanged` is wired to re-snapshot on click and arrow-key navigation. Rows that fall out of bounds after a refresh close the rail cleanly instead of rendering a phantom row of nulls.
- `WorkspaceInspector` gains `hide()`, called on `TabManagerEvent::CloseInspector`. Explicit dismissal (× / ESC) still routes through `close()` and now propagates to the active document's `mark_inspector_closed` closure so the cached coords are dropped and the rail stays closed on return.
- `DocumentEvent` / `TabManagerEvent` / `DataGridEvent` each gain a `CloseInspector` variant; `DataDocument` and `CodeDocument`'s result tabs forward it. `PaneHandle` exposes an optional `mark_inspector_closed` hook that `DataDocument` wires.

### Bug 6 — Ctrl-A / Cmd-A inside an inline cell editor selected rows
`DataTable`'s `SelectAll` was bound on `secondary-a` in the `Results` context. When the user opened the inline cell editor, the input nested inside the table inherited both `Input` and `Results` contexts; the table's binding won and selected all rows instead of the cell text.

Fix: scope the table binding to `Results && !Input` so the nested input's own `SelectAll` (from `gpui-component`) takes precedence whenever an `Input` is in the focus chain.

### Bug 7 — Row inspector column names wrapped and ignored rail resize
The inspector body capped the column-name column at a fixed 120px and let the text wrap. Long names broke onto a second line, and widening the rail only widened the value column.

Fix: replace the fixed width with a flex layout — name and value cells each have a `flex_basis` (140 / 220) and `flex_1`, so they share extra horizontal space as the rail is resized. Names truncate with ellipsis (`whitespace_nowrap` + `text_ellipsis` on a `min_w_0` child) instead of wrapping. The COLUMN metadata section's value column gets the same treatment with right-aligned truncation.

### Related — feature request tracked separately
The "build joins / complex queries from the UI" feature requested in the same chat was opened as #146 instead of being implemented here.

## Test plan
- [ ] Cancel a connection mid-attempt and confirm the sidebar exits `(connecting...)` immediately and a retry is possible.
- [ ] Edit a connected profile, choose **Later**: edit persists, live session unchanged.
- [ ] Edit a connected profile, choose **Reconnect now**: session disconnects and reconnects with the new settings.
- [ ] Open Settings, close it, open it again with a single click.
- [ ] Arrow-key to a sidebar item, ctrl+click a different item: both end up selected.
- [ ] Open the row inspector on table A, switch to table B (inspector hides), switch back (inspector reappears with the same row).
- [ ] Open the inspector, refresh the query: rail stays on the same row index against the fresh data; rail closes cleanly if the result no longer has that row.
- [ ] Open the inspector, click on different rows and use arrow keys: rail updates in place.
- [ ] Close the inspector explicitly (×): it stays closed across tab switches and refreshes until re-opened.
- [ ] Start editing a cell, press Ctrl-A / Cmd-A: the cell text is selected, not the table rows.
- [ ] Open the inspector on a table with long column names: names truncate with ellipsis instead of wrapping; drag the rail wider and the name column grows along with the value column.