### PR TITLE
feat(aws): reflect AWS profiles live from ~/.aws as source of truth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,6 +2490,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2483,6 +2483,7 @@ dependencies = [
  "chrono",
  "dbflux_core",
  "dirs 5.0.1",
+ "filetime",
  "futures-lite 2.6.1",
  "log",
  "secrecy",

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -1989,6 +1989,17 @@ impl AppState {
         profiles
     }
 
+    /// Returns only profiles stored in the SQLite database.
+    ///
+    /// Reflected AWS profiles (from `~/.aws/config`) are NOT included.
+    /// All callers that resolve auth identity at connect time, dropdown
+    /// fetch time, or SSO login time MUST use `list_auth_profiles()` instead
+    /// so that reflected profiles participate in resolution.
+    ///
+    /// This method is retained only for callers that genuinely need the raw
+    /// stored slice: migration code, config loaders that write back to storage,
+    /// and MCP state that lists persisted profiles only.
+    #[deprecated(note = "use list_auth_profiles(); stored-only view hides reflected AWS profiles")]
     pub fn auth_profiles(&self) -> &[dbflux_core::AuthProfile] {
         &self.facade.auth_profiles.items
     }
@@ -3758,6 +3769,7 @@ mod tests {
             fields: HashMap::new(),
             enabled: true,
             read_only: true,
+            dangling_origin: None,
         }
     }
 
@@ -3769,6 +3781,9 @@ mod tests {
         let mut state =
             test_state_with_profiles_and_auth_profiles(HashMap::new(), Vec::new(), Vec::new());
 
+        // Replace the registry with a clean one so real AWS providers that read
+        // from the test machine's ~/.aws/config do not pollute the result.
+        state.auth_provider_registry = AuthProviderRegistry::new();
         state
             .auth_provider_registry
             .register(Arc::new(ReflectingTestAuthProvider::new(
@@ -3800,6 +3815,7 @@ mod tests {
             fields: HashMap::new(),
             enabled: true,
             read_only: false,
+            dangling_origin: None,
         };
         let reflected_sso = make_reflected_sso_profile("staging");
 
@@ -3809,6 +3825,9 @@ mod tests {
             vec![stored_non_aws.clone()],
         );
 
+        // Replace the registry with a clean one so real AWS providers that read
+        // from the test machine's ~/.aws/config do not pollute the result.
+        state.auth_provider_registry = AuthProviderRegistry::new();
         state
             .auth_provider_registry
             .register(Arc::new(ReflectingTestAuthProvider::new(
@@ -3840,6 +3859,7 @@ mod tests {
             fields: HashMap::new(),
             enabled: true,
             read_only: false,
+            dangling_origin: None,
         };
 
         let reflected_sso = make_reflected_sso_profile("current-sso");

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -2889,6 +2889,31 @@ impl AppState {
         self.auth_provider_registry.get(provider_id)
     }
 
+    /// Provider ids that exist only to be referenced by another provider's
+    /// `AuthProfileRef` field (e.g. an SSO-session block referenced by an SSO
+    /// profile). Profiles from these providers are building blocks, not
+    /// standalone connection credentials, so a connection's Auth Profile picker
+    /// must exclude them. Derived from the form definitions so the UI stays
+    /// agnostic to concrete provider ids.
+    pub fn reference_only_auth_provider_ids(&self) -> HashSet<String> {
+        use dbflux_core::FormFieldKind;
+
+        let mut ids = HashSet::new();
+        for provider in self.auth_provider_registry.providers() {
+            let form = provider.form_def();
+            for tab in &form.tabs {
+                for section in &tab.sections {
+                    for field in &section.fields {
+                        if let FormFieldKind::AuthProfileRef { provider_id } = &field.kind {
+                            ids.insert(provider_id.clone());
+                        }
+                    }
+                }
+            }
+        }
+        ids
+    }
+
     pub fn resolve_profile_hooks(&self, profile: &ConnectionProfile) -> ConnectionHooks {
         ConnectionHooks::resolve_from_bindings(profile, &self.hook_definitions)
     }

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -272,6 +272,11 @@ impl AppState {
             log::warn!("Failed to bootstrap MCP runtime from persistence: {}", e);
         }
 
+        #[cfg(feature = "aws")]
+        if let Err(e) = state.bootstrap_aws_config_reflect_migration() {
+            log::warn!("aws_config_reflect_migration failed (non-fatal): {}", e);
+        }
+
         if let Err(e) = state.bootstrap_audit_settings() {
             log::warn!("Failed to bootstrap audit settings: {}", e);
             let now_ms = dbflux_core::chrono::Utc::now().timestamp_millis();
@@ -483,6 +488,92 @@ impl AppState {
                 "Failed to record audit bootstrap success event: {}",
                 rec_err
             );
+        }
+
+        Ok(())
+    }
+
+    /// Runs the one-time AWS config reflection migration at startup.
+    ///
+    /// Reads the live AWS config files once, passes the section name sets to the
+    /// migration, and logs any dangling profiles as non-blocking warnings. This
+    /// method is only compiled when the `aws` feature is enabled because it
+    /// depends on `CachedAwsConfig` from `dbflux_aws`.
+    ///
+    /// Failure is non-fatal: the caller logs the error and continues startup.
+    #[cfg(feature = "aws")]
+    fn bootstrap_aws_config_reflect_migration(&self) -> Result<(), String> {
+        use std::collections::HashSet;
+
+        use dbflux_aws::CachedAwsConfig;
+
+        use crate::aws_config_reflect_migration::run_aws_config_reflect_migration;
+
+        // Obtain section names from the AWS config files.
+        // CachedAwsConfig::new() initializes the cache; errors are non-fatal
+        // (an empty config means zero stored AWS rows match → no rebinds).
+        let mut aws_config = CachedAwsConfig::new();
+
+        // All profile section names from ~/.aws/config (SSO and non-SSO).
+        let config_section_names: HashSet<String> = aws_config
+            .profiles()
+            .iter()
+            .map(|p| p.name.clone())
+            .collect();
+
+        // Section names from ~/.aws/credentials (bare [NAME] headers).
+        let credentials_names: HashSet<String> =
+            aws_config.credentials_names().iter().cloned().collect();
+
+        // Union of both: any name present in either file is a match candidate.
+        let all_config_names: HashSet<String> = config_section_names
+            .union(&credentials_names)
+            .cloned()
+            .collect();
+
+        // We do not have access to the real keyring in this context without
+        // loading a full SecretManager. Use a best-effort probe: the stored
+        // auth profile's `provider_id == "aws-static-credentials"` is a
+        // sufficient signal for the dangling-origin classification. The keyring
+        // predicate is used only to choose between "keyring-only" and
+        // "file-gone" for static profiles; we pass a conservative closure that
+        // returns `true` for all static-credentials profiles so they are
+        // classified as "keyring-only" (the safer choice: preserves the keyring
+        // entry and keeps the stored row).
+        //
+        // The actual keyring secret is never read or deleted by this migration.
+        let static_provider = "aws-static-credentials";
+        let auth_repo = self.storage_runtime.auth_profiles();
+        let static_ids: std::collections::HashSet<String> = auth_repo
+            .all()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|r| r.provider_id == static_provider)
+            .map(|r| r.id)
+            .collect();
+
+        let summary = run_aws_config_reflect_migration(
+            &self.storage_runtime,
+            &all_config_names,
+            &credentials_names,
+            move |id: &str| static_ids.contains(id),
+        )
+        .map_err(|e| e.to_string())?;
+
+        for dangling in &summary.dangling {
+            if let crate::aws_config_reflect_migration::ProfileMigrationOutcome::Dangling {
+                id,
+                origin,
+            } = dangling
+            {
+                log::warn!(
+                    "AWS config reflect migration: profile {} is dangling \
+                     (origin={}). The connection will fail at connect time until \
+                     the credential source is restored.",
+                    id,
+                    origin.as_str()
+                );
+            }
         }
 
         Ok(())

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -1871,6 +1871,33 @@ impl AppState {
         }
     }
 
+    /// Returns all auth profiles visible to the application: stored non-AWS profiles
+    /// unioned with AWS profiles reflected live from `~/.aws/config` and
+    /// `~/.aws/credentials`.
+    ///
+    /// This is the single read seam for auth profiles. All callers must use this
+    /// method instead of reading `facade.auth_profiles.items` directly, so that
+    /// reflected AWS profiles are always included.
+    pub fn list_auth_profiles(&self) -> Vec<dbflux_core::AuthProfile> {
+        const AWS_REFLECTED_PROVIDER_IDS: &[&str] =
+            &["aws-sso", "aws-sso-session", "aws-shared-credentials"];
+
+        let mut profiles: Vec<dbflux_core::AuthProfile> = self
+            .facade
+            .auth_profiles
+            .items
+            .iter()
+            .filter(|p| !AWS_REFLECTED_PROVIDER_IDS.contains(&p.provider_id.as_str()))
+            .cloned()
+            .collect();
+
+        for provider in self.auth_provider_registry.providers() {
+            profiles.extend(provider.reflect_profiles());
+        }
+
+        profiles
+    }
+
     pub fn auth_profiles(&self) -> &[dbflux_core::AuthProfile] {
         &self.facade.auth_profiles.items
     }
@@ -2809,12 +2836,9 @@ impl AppState {
             .or(profile.auth_profile_id);
 
         let selected_auth_profile = selected_auth_profile_id.and_then(|auth_id| {
-            self.facade
-                .auth_profiles
-                .items
-                .iter()
+            self.list_auth_profiles()
+                .into_iter()
                 .find(|p| p.id == auth_id && p.enabled)
-                .cloned()
         });
 
         let auth_profile =
@@ -2868,7 +2892,7 @@ impl AppState {
                 })?;
 
             let profile_registry_snapshot: Vec<dbflux_core::auth::AuthProfile> =
-                self.facade.auth_profiles.items.clone();
+                self.list_auth_profiles();
             let expanded = dbflux_core::auth::expand_auth_profile_refs(
                 &profile,
                 provider.form_def(),
@@ -2960,7 +2984,7 @@ impl AppState {
             return None;
         }
 
-        if let Some(profile) = self.facade.auth_profiles.items.iter().find(|auth_profile| {
+        if let Some(profile) = self.list_auth_profiles().into_iter().find(|auth_profile| {
             auth_profile.enabled
                 && auth_profile
                     .fields
@@ -2971,7 +2995,7 @@ impl AppState {
                     .get(&auth_profile.provider_id)
                     .is_some_and(|provider| provider.capabilities().login.supported)
         }) {
-            return Some(profile.clone());
+            return Some(profile);
         }
 
         self.auth_provider_registry
@@ -3569,6 +3593,191 @@ mod tests {
 
     /// D.2.1 — With the influxdb feature enabled, the builtin driver registry must contain
     /// a driver whose `driver_key()` is `"builtin:influxdb"`.
+    // --- T-3.6: list_auth_profiles() union seam ---
+
+    struct ReflectingTestAuthProvider {
+        provider_id: String,
+        reflected: Vec<AuthProfile>,
+    }
+
+    impl ReflectingTestAuthProvider {
+        fn new(provider_id: impl Into<String>, reflected: Vec<AuthProfile>) -> Self {
+            Self {
+                provider_id: provider_id.into(),
+                reflected,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl DynAuthProvider for ReflectingTestAuthProvider {
+        fn provider_id(&self) -> &str {
+            &self.provider_id
+        }
+
+        fn display_name(&self) -> &str {
+            "Reflecting Test Provider"
+        }
+
+        fn form_def(&self) -> &AuthFormDef {
+            static FORM: std::sync::OnceLock<AuthFormDef> = std::sync::OnceLock::new();
+            FORM.get_or_init(|| AuthFormDef { tabs: vec![] })
+        }
+
+        async fn validate_session(
+            &self,
+            _profile: &AuthProfile,
+        ) -> Result<AuthSessionState, DbError> {
+            Ok(AuthSessionState::LoginRequired)
+        }
+
+        async fn login(
+            &self,
+            profile: &AuthProfile,
+            url_callback: UrlCallback,
+        ) -> Result<AuthSession, DbError> {
+            url_callback(None);
+            Ok(AuthSession {
+                provider_id: self.provider_id.clone(),
+                profile_id: profile.id,
+                expires_at: None,
+                data: None,
+            })
+        }
+
+        async fn resolve_credentials(
+            &self,
+            _profile: &AuthProfile,
+        ) -> Result<ResolvedCredentials, DbError> {
+            Ok(ResolvedCredentials::default())
+        }
+
+        fn reflect_profiles(&self) -> Vec<AuthProfile> {
+            self.reflected.clone()
+        }
+    }
+
+    fn make_reflected_sso_profile(name: &str) -> AuthProfile {
+        use dbflux_core::auth::aws_profile_uuid;
+        let id = aws_profile_uuid("aws-sso", name);
+        AuthProfile {
+            id,
+            name: name.to_string(),
+            provider_id: "aws-sso".to_string(),
+            fields: HashMap::new(),
+            enabled: true,
+            read_only: true,
+        }
+    }
+
+    #[test]
+    fn list_auth_profiles_returns_reflected_aws_profiles_when_store_is_empty() {
+        let reflected_a = make_reflected_sso_profile("dev");
+        let reflected_b = make_reflected_sso_profile("prod");
+
+        let mut state =
+            test_state_with_profiles_and_auth_profiles(HashMap::new(), Vec::new(), Vec::new());
+
+        state
+            .auth_provider_registry
+            .register(Arc::new(ReflectingTestAuthProvider::new(
+                "aws-sso",
+                vec![reflected_a.clone(), reflected_b.clone()],
+            )));
+
+        let result = state.list_auth_profiles();
+
+        assert_eq!(result.len(), 2, "expected exactly two reflected profiles");
+        assert!(
+            result
+                .iter()
+                .any(|p| p.id == reflected_a.id && p.name == "dev")
+        );
+        assert!(
+            result
+                .iter()
+                .any(|p| p.id == reflected_b.id && p.name == "prod")
+        );
+    }
+
+    #[test]
+    fn list_auth_profiles_includes_stored_non_aws_profile_alongside_reflected() {
+        let stored_non_aws = AuthProfile {
+            id: Uuid::new_v4(),
+            name: "OIDC Provider".to_string(),
+            provider_id: "custom-oidc".to_string(),
+            fields: HashMap::new(),
+            enabled: true,
+            read_only: false,
+        };
+        let reflected_sso = make_reflected_sso_profile("staging");
+
+        let mut state = test_state_with_profiles_and_auth_profiles(
+            HashMap::new(),
+            Vec::new(),
+            vec![stored_non_aws.clone()],
+        );
+
+        state
+            .auth_provider_registry
+            .register(Arc::new(ReflectingTestAuthProvider::new(
+                "aws-sso",
+                vec![reflected_sso.clone()],
+            )));
+
+        let result = state.list_auth_profiles();
+
+        assert_eq!(result.len(), 2);
+        assert!(
+            result.iter().any(|p| p.id == stored_non_aws.id),
+            "stored non-AWS profile must appear in union"
+        );
+        assert!(
+            result.iter().any(|p| p.id == reflected_sso.id),
+            "reflected AWS profile must appear in union"
+        );
+    }
+
+    #[test]
+    fn list_auth_profiles_excludes_stored_aws_rows_in_favour_of_reflection() {
+        // A stored aws-sso row — this should be excluded from the union
+        // because aws-sso is a reflected provider-id.
+        let stored_aws_row = AuthProfile {
+            id: Uuid::new_v4(),
+            name: "legacy-sso".to_string(),
+            provider_id: "aws-sso".to_string(),
+            fields: HashMap::new(),
+            enabled: true,
+            read_only: false,
+        };
+
+        let reflected_sso = make_reflected_sso_profile("current-sso");
+
+        let mut state = test_state_with_profiles_and_auth_profiles(
+            HashMap::new(),
+            Vec::new(),
+            vec![stored_aws_row.clone()],
+        );
+
+        state
+            .auth_provider_registry
+            .register(Arc::new(ReflectingTestAuthProvider::new(
+                "aws-sso",
+                vec![reflected_sso.clone()],
+            )));
+
+        let result = state.list_auth_profiles();
+
+        assert!(
+            result.iter().all(|p| p.id != stored_aws_row.id),
+            "stored aws-sso row must NOT appear in union (reflection supersedes stored)"
+        );
+        assert!(
+            result.iter().any(|p| p.id == reflected_sso.id),
+            "reflected profile must appear in union"
+        );
+    }
+
     #[test]
     #[cfg(feature = "influxdb")]
     fn influxdb_registration_present_when_feature_enabled() {

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -219,8 +219,6 @@ impl AppState {
             auth_provider_registry.register(Arc::new(dbflux_aws::AwsSsoAuthProvider::new()));
             auth_provider_registry
                 .register(Arc::new(dbflux_aws::AwsSharedCredentialsAuthProvider::new()));
-            auth_provider_registry
-                .register(Arc::new(dbflux_aws::AwsStaticCredentialsAuthProvider::new()));
         }
 
         if !services.is_empty() {

--- a/crates/dbflux_app/src/aws_config_reflect_migration.rs
+++ b/crates/dbflux_app/src/aws_config_reflect_migration.rs
@@ -54,7 +54,7 @@
 //! The `sys_app_meta` key `aws_config_reflect_migrated` acts as a guard. Once
 //! set, subsequent calls to `run_aws_config_reflect_migration` are no-ops.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use log::{info, warn};
 
@@ -162,74 +162,85 @@ pub fn run_aws_config_reflect_migration(
         .filter(|row| AWS_PROVIDER_IDS.contains(&row.provider_id.as_str()))
         .collect();
 
-    // Collect all names (case-insensitive lookup).
-    let all_names_lower: HashSet<String> = all_config_names
+    // Case-insensitive lookup from a section name to its canonical (file-cased)
+    // form. Reflection derives the profile UUID from the file section name, so
+    // rebinding to the canonical casing keeps connection bindings resolvable.
+    let canonical_by_lower: HashMap<String, String> = all_config_names
         .iter()
         .chain(credentials_names.iter())
-        .map(|n| n.to_lowercase())
+        .map(|n| (n.to_lowercase(), n.clone()))
         .collect();
 
     let mut summary = MigrationSummary::default();
 
     for row in aws_rows {
-        let name_lower = row.name.to_lowercase();
-        let matched = all_names_lower.contains(&name_lower);
+        // The real AWS section name lives in the `profile_name` field. The
+        // display `name` may be decorated (the old import flow prefixed it with
+        // "AWS "), so matching or deriving the UUID from it would mark every
+        // imported profile dangling and leave its connections unbound.
+        let stored_fields = auth_repo.get_fields(&row.id).unwrap_or_default();
+        let aws_name = stored_fields
+            .get("profile_name")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| row.name.trim().to_string());
 
-        if matched {
-            // Determine the canonical name (preserve original casing from first
-            // matching source — we use the stored name since it was the original).
-            let new_provider_id = reflected_provider_id(&row.provider_id);
-            let new_id = aws_profile_uuid(new_provider_id, &row.name);
-            let new_id_str = new_id.to_string();
+        match canonical_by_lower.get(&aws_name.to_lowercase()) {
+            Some(canonical_name) => {
+                let new_provider_id = reflected_provider_id(&row.provider_id);
+                let new_id = aws_profile_uuid(new_provider_id, canonical_name);
+                let new_id_str = new_id.to_string();
 
-            // Perform transactional rebind: update all connection rows that
-            // reference the old UUID, then delete the stored auth-profile row.
-            let connections_rebound = rebind_and_delete(runtime, &row.id, &new_id_str)?;
+                // Perform transactional rebind: update all connection rows that
+                // reference the old UUID, then delete the stored auth-profile row.
+                let connections_rebound = rebind_and_delete(runtime, &row.id, &new_id_str)?;
 
-            // Log orphaned keyring entry notice (do NOT delete it).
-            if keyring_has_secret_fn(&row.id) {
+                // Log orphaned keyring entry notice (do NOT delete it).
+                if keyring_has_secret_fn(&row.id) {
+                    info!(
+                        "aws_config_reflect_migration: profile '{}' (id={}) rebound to {}; \
+                         a keyring secret for the old ID is now orphaned and can be cleaned up \
+                         via a future consent-gated action",
+                        aws_name, row.id, new_id_str
+                    );
+                }
+
                 info!(
-                    "aws_config_reflect_migration: profile '{}' (id={}) rebound to {}; \
-                     a keyring secret for the old ID is now orphaned and can be cleaned up \
-                     via a future consent-gated action",
-                    row.name, row.id, new_id_str
+                    "aws_config_reflect_migration: rebound '{}' {} -> {} ({} connections)",
+                    aws_name, row.id, new_id_str, connections_rebound
                 );
+
+                summary.rebound.push(ProfileMigrationOutcome::Rebound {
+                    old_id: row.id,
+                    new_id: new_id_str,
+                    connections_rebound,
+                });
             }
+            None => {
+                // Not found in config files — determine dangling origin.
+                let is_static = row.provider_id == "aws-static-credentials";
+                let has_secret = keyring_has_secret_fn(&row.id);
 
-            info!(
-                "aws_config_reflect_migration: rebound '{}' {} -> {} ({} connections)",
-                row.name, row.id, new_id_str, connections_rebound
-            );
+                let origin = if is_static && has_secret {
+                    DanglingOrigin::KeyringOnly
+                } else {
+                    DanglingOrigin::FileGone
+                };
 
-            summary.rebound.push(ProfileMigrationOutcome::Rebound {
-                old_id: row.id,
-                new_id: new_id_str,
-                connections_rebound,
-            });
-        } else {
-            // Not found in config files — determine dangling origin.
-            let is_static = row.provider_id == "aws-static-credentials";
-            let has_secret = keyring_has_secret_fn(&row.id);
+                warn!(
+                    "aws_config_reflect_migration: profile '{}' (id={}) not found in AWS config \
+                     files — marked dangling (origin={})",
+                    aws_name,
+                    row.id,
+                    origin.as_str()
+                );
 
-            let origin = if is_static && has_secret {
-                DanglingOrigin::KeyringOnly
-            } else {
-                DanglingOrigin::FileGone
-            };
+                auth_repo.set_dangling_origin(&row.id, origin.as_str())?;
 
-            warn!(
-                "aws_config_reflect_migration: profile '{}' (id={}) not found in AWS config \
-                 files — marked dangling (origin={})",
-                row.name,
-                row.id,
-                origin.as_str()
-            );
-
-            auth_repo.set_dangling_origin(&row.id, origin.as_str())?;
-
-            summary
-                .dangling
-                .push(ProfileMigrationOutcome::Dangling { id: row.id, origin });
+                summary
+                    .dangling
+                    .push(ProfileMigrationOutcome::Dangling { id: row.id, origin });
+            }
         }
     }
 
@@ -549,6 +560,55 @@ mod tests {
         assert_eq!(
             conn2.auth_profile_id.as_deref(),
             Some(expected_new_id.as_str())
+        );
+    }
+
+    // Regression: the display name is decorated (e.g. an "AWS " prefix from the
+    // old import flow) while the real section name lives in the `profile_name`
+    // field. Matching and UUID derivation must use the field, otherwise the
+    // profile is wrongly marked dangling and its connections lose their binding.
+    #[test]
+    fn decorated_display_name_matches_via_profile_name_field() {
+        let runtime = open_runtime();
+        let old_id = Uuid::new_v4().to_string();
+        insert_auth_profile(&runtime, &old_id, "AWS dev-sso", "aws-sso");
+
+        let mut fields = HashMap::new();
+        fields.insert("profile_name".to_string(), "dev-sso".to_string());
+        runtime
+            .auth_profiles()
+            .set_fields(&old_id, &fields)
+            .expect("set profile_name field");
+
+        let conn_id = Uuid::new_v4().to_string();
+        insert_connection(&runtime, &conn_id, &old_id);
+
+        let expected_new_id = aws_profile_uuid("aws-sso", "dev-sso").to_string();
+
+        let result = run_aws_config_reflect_migration(
+            &runtime,
+            &names(&["dev-sso"]),
+            &names(&[]),
+            no_keyring,
+        )
+        .expect("migration");
+
+        assert_eq!(
+            result.rebound.len(),
+            1,
+            "profile must rebind via its profile_name field, not the display name"
+        );
+        assert_eq!(result.dangling.len(), 0, "must not be marked dangling");
+
+        let conn = runtime
+            .connection_profiles()
+            .get(&conn_id)
+            .expect("get")
+            .expect("exists");
+        assert_eq!(
+            conn.auth_profile_id.as_deref(),
+            Some(expected_new_id.as_str()),
+            "connection must rebind to the reflected deterministic UUID"
         );
     }
 

--- a/crates/dbflux_app/src/aws_config_reflect_migration.rs
+++ b/crates/dbflux_app/src/aws_config_reflect_migration.rs
@@ -1,0 +1,892 @@
+//! One-time migration: rebind stored AWS auth-profile rows to deterministic UUIDs.
+//!
+//! ## What this migration does
+//!
+//! Before `aws-config-reflect`, DBFlux stored AWS auth profiles as opaque rows
+//! in `cfg_auth_profiles` with random UUIDs. After the change, AWS profiles are
+//! reflected live from `~/.aws/config` and `~/.aws/credentials`, with identity
+//! determined by `UUIDv5(AWS_AUTH_NAMESPACE, provider_id + ":" + name)`.
+//!
+//! This migration bridges the gap for existing installations:
+//!
+//! 1. For each stored AWS auth-profile row, look for a matching section name in
+//!    the AWS config files.
+//! 2. If found: compute the deterministic UUID, rebind every
+//!    `cfg_connection_profiles.auth_profile_id` that referenced the old random
+//!    UUID, then delete the now-redundant stored row — all in one transaction.
+//! 3. If not found: mark the stored row as dangling (no rebind, row kept),
+//!    surface a warning.
+//!
+//! ## Provider-id mapping
+//!
+//! Stored rows that carried `provider_id = "aws-static-credentials"` are
+//! considered candidates for the reflected `aws-shared-credentials` provider,
+//! because that provider replaced the old static-credentials concept. Their new
+//! deterministic UUID is computed with `provider_id = "aws-shared-credentials"`.
+//!
+//! | Stored provider_id          | Reflected provider_id       |
+//! |-----------------------------|------------------------------|
+//! | `aws-sso`                   | `aws-sso`                    |
+//! | `aws-sso-session`           | `aws-sso-session`            |
+//! | `aws-shared-credentials`    | `aws-shared-credentials`     |
+//! | `aws-static-credentials`    | `aws-shared-credentials`     |
+//!
+//! ## Keyring secret handling
+//!
+//! Keyring secrets are **never deleted** by this migration. After a successful
+//! rebind, the old keyring entry becomes orphaned (the reflected provider reads
+//! credentials from `~/.aws/credentials` directly). The orphaned entry is logged
+//! at info level. A consent-gated cleanup is future work and is NOT part of this
+//! migration.
+//!
+//! ## Dangling profiles
+//!
+//! - **keyring-only**: a stored `aws-static-credentials` row has a keyring
+//!   secret but no matching section in either config file. The row is marked
+//!   `dangling_origin = "keyring-only"`. Secret untouched. Row kept. Connection
+//!   bindings unchanged.
+//! - **file-gone**: any stored AWS row (non-static provider) whose name does not
+//!   appear in the config files. Marked `dangling_origin = "file-gone"`. Row
+//!   kept. Connection bindings unchanged.
+//!
+//! ## Idempotency
+//!
+//! The `sys_app_meta` key `aws_config_reflect_migrated` acts as a guard. Once
+//! set, subsequent calls to `run_aws_config_reflect_migration` are no-ops.
+
+use std::collections::HashSet;
+
+use log::{info, warn};
+
+use dbflux_core::auth::aws_profile_uuid;
+use dbflux_storage::bootstrap::StorageRuntime;
+use dbflux_storage::error::StorageError;
+
+/// Name of the idempotency marker stored in `sys_app_meta`.
+pub const MIGRATION_MARKER_KEY: &str = "aws_config_reflect_migrated";
+
+/// Provider IDs that are considered AWS-owned and are candidates for migration.
+const AWS_PROVIDER_IDS: &[&str] = &[
+    "aws-sso",
+    "aws-sso-session",
+    "aws-shared-credentials",
+    "aws-static-credentials",
+];
+
+/// Maps a stored provider_id to the reflected provider_id used to compute the
+/// deterministic UUID. The old `aws-static-credentials` concept was folded into
+/// `aws-shared-credentials` when DBFlux stopped owning AWS secrets.
+fn reflected_provider_id(stored_provider_id: &str) -> &str {
+    match stored_provider_id {
+        "aws-static-credentials" => "aws-shared-credentials",
+        other => other,
+    }
+}
+
+/// Outcome for a single stored AWS auth-profile row during migration.
+#[derive(Debug, PartialEq)]
+pub enum ProfileMigrationOutcome {
+    /// The profile was matched in the config files, rebind was committed, and
+    /// the stored row was deleted.
+    Rebound {
+        old_id: String,
+        new_id: String,
+        connections_rebound: usize,
+    },
+    /// The profile name was not found in the config files. The row is kept and
+    /// marked dangling. The `origin` field describes why it is dangling.
+    Dangling { id: String, origin: DanglingOrigin },
+}
+
+/// Describes why a profile is dangling.
+#[derive(Debug, PartialEq)]
+pub enum DanglingOrigin {
+    /// The profile had a keyring secret but no matching file entry exists.
+    KeyringOnly,
+    /// The profile name no longer appears in the config files.
+    FileGone,
+}
+
+impl DanglingOrigin {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DanglingOrigin::KeyringOnly => "keyring-only",
+            DanglingOrigin::FileGone => "file-gone",
+        }
+    }
+}
+
+/// Summary of the entire migration run.
+#[derive(Debug, Default)]
+pub struct MigrationSummary {
+    pub rebound: Vec<ProfileMigrationOutcome>,
+    pub dangling: Vec<ProfileMigrationOutcome>,
+}
+
+/// Runs the one-time AWS config reflection migration.
+///
+/// Returns a summary of what was done. If the idempotency marker is already set,
+/// returns an empty summary immediately.
+///
+/// # Parameters
+///
+/// - `runtime`: open storage runtime with migration 010 applied.
+/// - `config_section_names`: section names present in `~/.aws/config`
+///   (non-SSO: from `shared_profile_names()`; SSO: from `config_profile_names()`).
+///   For a full match, pass ALL profile names from both files unioned.
+/// - `credentials_names`: section names from `~/.aws/credentials` (bare `[NAME]`).
+///   These are used to determine if a static-credentials profile is dangling.
+/// - `keyring_has_secret_fn`: predicate that returns `true` when the DBFlux
+///   keyring holds a secret for the given auth-profile ID. Used to distinguish
+///   `keyring-only` from `file-gone` dangling profiles.
+pub fn run_aws_config_reflect_migration(
+    runtime: &StorageRuntime,
+    all_config_names: &HashSet<String>,
+    credentials_names: &HashSet<String>,
+    keyring_has_secret_fn: impl Fn(&str) -> bool,
+) -> Result<MigrationSummary, StorageError> {
+    let meta_repo = runtime.app_meta();
+
+    // Check and set the idempotency marker.
+    if meta_repo.is_flag_set(MIGRATION_MARKER_KEY)? {
+        info!("aws_config_reflect_migration: marker already set — skipping");
+        return Ok(MigrationSummary::default());
+    }
+
+    let auth_repo = runtime.auth_profiles();
+    let stored_rows = auth_repo.all()?;
+
+    // Only consider rows for AWS provider IDs.
+    let aws_rows: Vec<_> = stored_rows
+        .into_iter()
+        .filter(|row| AWS_PROVIDER_IDS.contains(&row.provider_id.as_str()))
+        .collect();
+
+    // Collect all names (case-insensitive lookup).
+    let all_names_lower: HashSet<String> = all_config_names
+        .iter()
+        .chain(credentials_names.iter())
+        .map(|n| n.to_lowercase())
+        .collect();
+
+    let mut summary = MigrationSummary::default();
+
+    for row in aws_rows {
+        let name_lower = row.name.to_lowercase();
+        let matched = all_names_lower.contains(&name_lower);
+
+        if matched {
+            // Determine the canonical name (preserve original casing from first
+            // matching source — we use the stored name since it was the original).
+            let new_provider_id = reflected_provider_id(&row.provider_id);
+            let new_id = aws_profile_uuid(new_provider_id, &row.name);
+            let new_id_str = new_id.to_string();
+
+            // Perform transactional rebind: update all connection rows that
+            // reference the old UUID, then delete the stored auth-profile row.
+            let connections_rebound = rebind_and_delete(runtime, &row.id, &new_id_str)?;
+
+            // Log orphaned keyring entry notice (do NOT delete it).
+            if keyring_has_secret_fn(&row.id) {
+                info!(
+                    "aws_config_reflect_migration: profile '{}' (id={}) rebound to {}; \
+                     a keyring secret for the old ID is now orphaned and can be cleaned up \
+                     via a future consent-gated action",
+                    row.name, row.id, new_id_str
+                );
+            }
+
+            info!(
+                "aws_config_reflect_migration: rebound '{}' {} -> {} ({} connections)",
+                row.name, row.id, new_id_str, connections_rebound
+            );
+
+            summary.rebound.push(ProfileMigrationOutcome::Rebound {
+                old_id: row.id,
+                new_id: new_id_str,
+                connections_rebound,
+            });
+        } else {
+            // Not found in config files — determine dangling origin.
+            let is_static = row.provider_id == "aws-static-credentials";
+            let has_secret = keyring_has_secret_fn(&row.id);
+
+            let origin = if is_static && has_secret {
+                DanglingOrigin::KeyringOnly
+            } else {
+                DanglingOrigin::FileGone
+            };
+
+            warn!(
+                "aws_config_reflect_migration: profile '{}' (id={}) not found in AWS config \
+                 files — marked dangling (origin={})",
+                row.name,
+                row.id,
+                origin.as_str()
+            );
+
+            auth_repo.set_dangling_origin(&row.id, origin.as_str())?;
+
+            summary
+                .dangling
+                .push(ProfileMigrationOutcome::Dangling { id: row.id, origin });
+        }
+    }
+
+    // Set the idempotency marker.
+    meta_repo.set_flag(MIGRATION_MARKER_KEY)?;
+
+    info!(
+        "aws_config_reflect_migration: done — {} rebound, {} dangling",
+        summary.rebound.len(),
+        summary.dangling.len()
+    );
+
+    Ok(summary)
+}
+
+/// Rebinds all `cfg_connection_profiles.auth_profile_id` rows that reference
+/// `old_id` to `new_id`, then deletes the `cfg_auth_profiles` row for `old_id`.
+///
+/// All SQL operations are wrapped in a single transaction. If verification fails
+/// (rebound count != referencing count before commit), the transaction is rolled
+/// back and an error is returned.
+///
+/// Foreign key enforcement is temporarily disabled for this connection because
+/// the new `auth_profile_id` values are deterministic UUIDs for virtual/reflected
+/// profiles — they do not have rows in `cfg_auth_profiles`. FK enforcement is
+/// restored after the commit (or rollback). This is safe because:
+/// - The SQLite pragma applies only to this connection.
+/// - The operation is atomic: either all rebinds + the delete commit, or nothing.
+fn rebind_and_delete(
+    runtime: &StorageRuntime,
+    old_id: &str,
+    new_id: &str,
+) -> Result<usize, StorageError> {
+    // Use a fresh raw connection for the transaction to avoid shared-connection
+    // contention with repository-level connections.
+    let conn = runtime.open_dbflux_db()?;
+
+    // Disable FK enforcement before the transaction (SQLite requires this to be
+    // done outside any active transaction).
+    conn.pragma_update(None, "foreign_keys", "OFF")
+        .map_err(|source| StorageError::Sqlite {
+            path: "dbflux.db".into(),
+            source,
+        })?;
+
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|source| StorageError::Sqlite {
+            path: "dbflux.db".into(),
+            source,
+        })?;
+
+    // Count connections referencing the old auth-profile ID.
+    let referencing_count: usize = tx
+        .query_row(
+            "SELECT COUNT(*) FROM cfg_connection_profiles WHERE auth_profile_id = ?1",
+            [old_id],
+            |row| row.get::<_, i64>(0),
+        )
+        .map(|n| n as usize)
+        .map_err(|source| StorageError::Sqlite {
+            path: "dbflux.db".into(),
+            source,
+        })?;
+
+    // Rebind connection profiles.
+    let rebound = tx
+        .execute(
+            "UPDATE cfg_connection_profiles SET auth_profile_id = ?2 WHERE auth_profile_id = ?1",
+            [old_id, new_id],
+        )
+        .map_err(|source| StorageError::Sqlite {
+            path: "dbflux.db".into(),
+            source,
+        })?;
+
+    // Verify: rebound count must match referencing count before commit.
+    if rebound != referencing_count {
+        tx.rollback().ok();
+        return Err(StorageError::Migration {
+            kind: "aws_config_reflect_migration".to_string(),
+            details: format!(
+                "rebind count mismatch for old_id={}: expected {}, got {}",
+                old_id, referencing_count, rebound
+            ),
+        });
+    }
+
+    // Also rebind access_params rows that reference the profile via the
+    // `auth_profile_id` param (for Managed access kind). These are string
+    // params in cfg_connection_profile_access_params; we update by value.
+    tx.execute(
+        "UPDATE cfg_connection_profile_access_params \
+         SET param_value = ?2 \
+         WHERE param_key = 'auth_profile_id' AND param_value = ?1",
+        [old_id, new_id],
+    )
+    .map_err(|source| StorageError::Sqlite {
+        path: "dbflux.db".into(),
+        source,
+    })?;
+
+    // Delete the now-redundant stored auth-profile row.
+    // Child fields in cfg_auth_profile_fields are deleted automatically via
+    // the ON DELETE CASCADE foreign key defined in migration 001.
+    tx.execute("DELETE FROM cfg_auth_profiles WHERE id = ?1", [old_id])
+        .map_err(|source| StorageError::Sqlite {
+            path: "dbflux.db".into(),
+            source,
+        })?;
+
+    tx.commit().map_err(|source| StorageError::Sqlite {
+        path: "dbflux.db".into(),
+        source,
+    })?;
+
+    // Re-enable FK enforcement after the transaction completes.
+    // Failure here is non-fatal for the migration itself (the connection will
+    // be dropped after this function returns), but log it for visibility.
+    if let Err(e) = conn.pragma_update(None, "foreign_keys", "ON") {
+        log::warn!(
+            "aws_config_reflect_migration: failed to re-enable foreign_keys after rebind: {}",
+            e
+        );
+    }
+
+    Ok(rebound)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    use dbflux_storage::bootstrap::StorageRuntime;
+    use dbflux_storage::repositories::auth_profiles::AuthProfileDto;
+    use dbflux_storage::repositories::connection_profiles::ConnectionProfileDto;
+    use uuid::Uuid;
+
+    fn open_runtime() -> StorageRuntime {
+        StorageRuntime::in_memory().expect("in-memory runtime")
+    }
+
+    fn insert_auth_profile(runtime: &StorageRuntime, id: &str, name: &str, provider_id: &str) {
+        let repo = runtime.auth_profiles();
+        repo.insert(&AuthProfileDto {
+            id: id.to_string(),
+            name: name.to_string(),
+            provider_id: provider_id.to_string(),
+            enabled: true,
+            created_at: String::new(),
+            updated_at: String::new(),
+            dangling_origin: None,
+        })
+        .expect("insert auth profile");
+    }
+
+    fn insert_connection(runtime: &StorageRuntime, conn_id: &str, auth_profile_id: &str) {
+        let repo = runtime.connection_profiles();
+        repo.insert(&ConnectionProfileDto {
+            id: conn_id.to_string(),
+            name: format!("connection-{}", conn_id),
+            driver_id: Some("postgres".to_string()),
+            description: None,
+            favorite: false,
+            color: None,
+            icon: None,
+            save_password: false,
+            kind: Some("Postgres".to_string()),
+            access_kind: Some("direct".to_string()),
+            access_provider: None,
+            auth_profile_id: Some(auth_profile_id.to_string()),
+            proxy_profile_id: None,
+            ssh_tunnel_profile_id: None,
+            created_at: String::new(),
+            updated_at: String::new(),
+        })
+        .expect("insert connection");
+    }
+
+    fn no_keyring(_id: &str) -> bool {
+        false
+    }
+
+    fn has_keyring(target_id: &str) -> impl Fn(&str) -> bool + '_ {
+        move |id: &str| id == target_id
+    }
+
+    fn names(items: &[&str]) -> HashSet<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    // T-4.1: marker absent → runs; marker present → no-op.
+    #[test]
+    fn marker_absent_migration_runs() {
+        let runtime = open_runtime();
+        insert_auth_profile(&runtime, "old-id-1", "dev", "aws-sso");
+
+        let result =
+            run_aws_config_reflect_migration(&runtime, &names(&["dev"]), &names(&[]), no_keyring)
+                .expect("migration");
+
+        // Should have rebound or processed the profile.
+        assert_eq!(result.rebound.len() + result.dangling.len(), 1);
+
+        // Marker must be set now.
+        let meta = runtime.app_meta();
+        assert!(
+            meta.is_flag_set(MIGRATION_MARKER_KEY).expect("query"),
+            "migration marker must be set after run"
+        );
+    }
+
+    #[test]
+    fn marker_present_migration_is_no_op() {
+        let runtime = open_runtime();
+        // Pre-set the marker.
+        runtime
+            .app_meta()
+            .set_flag(MIGRATION_MARKER_KEY)
+            .expect("set flag");
+
+        insert_auth_profile(&runtime, "old-id-2", "prod", "aws-sso");
+
+        let result =
+            run_aws_config_reflect_migration(&runtime, &names(&["prod"]), &names(&[]), no_keyring)
+                .expect("migration");
+
+        // No-op: nothing touched.
+        assert_eq!(result.rebound.len(), 0, "no rebind on second run");
+        assert_eq!(result.dangling.len(), 0, "no dangling on second run");
+
+        // The stored profile must still exist.
+        let auth_repo = runtime.auth_profiles();
+        let all = auth_repo.all().expect("list");
+        assert_eq!(all.len(), 1, "stored row must be untouched");
+    }
+
+    // T-4.2: empty rows → no-op, marker set.
+    #[test]
+    fn empty_aws_rows_is_noop() {
+        let runtime = open_runtime();
+
+        let result =
+            run_aws_config_reflect_migration(&runtime, &names(&[]), &names(&[]), no_keyring)
+                .expect("migration");
+
+        assert_eq!(result.rebound.len(), 0);
+        assert_eq!(result.dangling.len(), 0);
+
+        let meta = runtime.app_meta();
+        assert!(meta.is_flag_set(MIGRATION_MARKER_KEY).expect("flag"));
+    }
+
+    // T-4.2: matched SSO row → rebind + delete stored row.
+    #[test]
+    fn matched_sso_row_is_rebound_and_deleted() {
+        let runtime = open_runtime();
+        let old_id = Uuid::new_v4().to_string();
+        insert_auth_profile(&runtime, &old_id, "prod-sso", "aws-sso");
+
+        // Two connections reference the old UUID.
+        let conn1_id = Uuid::new_v4().to_string();
+        let conn2_id = Uuid::new_v4().to_string();
+        insert_connection(&runtime, &conn1_id, &old_id);
+        insert_connection(&runtime, &conn2_id, &old_id);
+
+        let expected_new_id = aws_profile_uuid("aws-sso", "prod-sso").to_string();
+
+        let result = run_aws_config_reflect_migration(
+            &runtime,
+            &names(&["prod-sso"]),
+            &names(&[]),
+            no_keyring,
+        )
+        .expect("migration");
+
+        assert_eq!(result.rebound.len(), 1, "one profile should be rebound");
+        assert_eq!(result.dangling.len(), 0);
+
+        let outcome = &result.rebound[0];
+        match outcome {
+            ProfileMigrationOutcome::Rebound {
+                old_id: oid,
+                new_id: nid,
+                connections_rebound,
+            } => {
+                assert_eq!(oid, &old_id);
+                assert_eq!(nid, &expected_new_id);
+                assert_eq!(*connections_rebound, 2);
+            }
+            other => panic!("expected Rebound, got {:?}", other),
+        }
+
+        // Stored auth-profile row must be deleted.
+        let auth_repo = runtime.auth_profiles();
+        let all = auth_repo.all().expect("list");
+        assert!(
+            all.iter().all(|p| p.id != old_id),
+            "old stored row must be deleted after rebind"
+        );
+
+        // Connections must now reference the new deterministic UUID.
+        let conn_repo = runtime.connection_profiles();
+        let conn1 = conn_repo.get(&conn1_id).expect("get").expect("exists");
+        assert_eq!(
+            conn1.auth_profile_id.as_deref(),
+            Some(expected_new_id.as_str())
+        );
+
+        let conn2 = conn_repo.get(&conn2_id).expect("get").expect("exists");
+        assert_eq!(
+            conn2.auth_profile_id.as_deref(),
+            Some(expected_new_id.as_str())
+        );
+    }
+
+    // T-4.2: unmatched SSO row → dangling, connection UUID unchanged.
+    #[test]
+    fn unmatched_sso_row_marked_dangling() {
+        let runtime = open_runtime();
+        let old_id = Uuid::new_v4().to_string();
+        insert_auth_profile(&runtime, &old_id, "old-env", "aws-sso");
+
+        let conn_id = Uuid::new_v4().to_string();
+        insert_connection(&runtime, &conn_id, &old_id);
+
+        let result = run_aws_config_reflect_migration(
+            &runtime,
+            &names(&[]), // no matching section
+            &names(&[]),
+            no_keyring,
+        )
+        .expect("migration");
+
+        assert_eq!(result.rebound.len(), 0);
+        assert_eq!(result.dangling.len(), 1, "one profile should be dangling");
+
+        // Stored row must still exist.
+        let auth_repo = runtime.auth_profiles();
+        let dto = auth_repo
+            .get(&old_id)
+            .expect("get")
+            .expect("row must exist");
+        assert_eq!(dto.dangling_origin.as_deref(), Some("file-gone"));
+
+        // Connection must still reference the old UUID.
+        let conn_repo = runtime.connection_profiles();
+        let conn = conn_repo.get(&conn_id).expect("get").expect("exists");
+        assert_eq!(conn.auth_profile_id.as_deref(), Some(old_id.as_str()));
+    }
+
+    // T-4.2: idempotency — second run is a no-op.
+    #[test]
+    fn second_run_is_noop() {
+        let runtime = open_runtime();
+        insert_auth_profile(&runtime, &Uuid::new_v4().to_string(), "dev", "aws-sso");
+
+        run_aws_config_reflect_migration(&runtime, &names(&["dev"]), &names(&[]), no_keyring)
+            .expect("first run");
+
+        // After the first run the stored row is deleted and the marker is set.
+        // A second run should be a no-op.
+        let result2 =
+            run_aws_config_reflect_migration(&runtime, &names(&["dev"]), &names(&[]), no_keyring)
+                .expect("second run");
+
+        assert_eq!(result2.rebound.len(), 0, "second run must not rebind");
+        assert_eq!(
+            result2.dangling.len(),
+            0,
+            "second run must not mark dangling"
+        );
+    }
+
+    // T-4.3: aws-static-credentials row → rebind to aws-shared-credentials UUID.
+    #[test]
+    fn static_credentials_row_rebinds_to_shared_credentials_uuid() {
+        let runtime = open_runtime();
+        let old_id = Uuid::new_v4().to_string();
+        insert_auth_profile(&runtime, &old_id, "deploy", "aws-static-credentials");
+
+        let conn_id = Uuid::new_v4().to_string();
+        insert_connection(&runtime, &conn_id, &old_id);
+
+        // The credentials file has a matching entry.
+        let expected_new_id = aws_profile_uuid("aws-shared-credentials", "deploy").to_string();
+
+        let result = run_aws_config_reflect_migration(
+            &runtime,
+            &names(&[]),
+            &names(&["deploy"]), // found in credentials file
+            no_keyring,
+        )
+        .expect("migration");
+
+        assert_eq!(result.rebound.len(), 1);
+
+        let outcome = &result.rebound[0];
+        match outcome {
+            ProfileMigrationOutcome::Rebound { new_id, .. } => {
+                assert_eq!(
+                    new_id, &expected_new_id,
+                    "static-credentials must rebind to aws-shared-credentials UUID"
+                );
+            }
+            other => panic!("expected Rebound, got {:?}", other),
+        }
+
+        // Connection must reference the new UUID.
+        let conn_repo = runtime.connection_profiles();
+        let conn = conn_repo.get(&conn_id).expect("get").expect("exists");
+        assert_eq!(
+            conn.auth_profile_id.as_deref(),
+            Some(expected_new_id.as_str())
+        );
+    }
+
+    // T-4.4: matched static profile → keyring preserved (not deleted), orphan logged.
+    // We verify the test keyring predicate is called and the profile IS rebound.
+    #[test]
+    fn matched_static_profile_keyring_preserved() {
+        let runtime = open_runtime();
+        let old_id = Uuid::new_v4().to_string();
+        insert_auth_profile(&runtime, &old_id, "ci-user", "aws-static-credentials");
+
+        let old_id_clone = old_id.clone();
+        let mut keyring_checked = false;
+        // We can't capture and mutate in the Fn closure easily, so we use an Arc<Mutex>.
+        let checked = Arc::new(std::sync::Mutex::new(false));
+        let checked_clone = checked.clone();
+
+        let result = run_aws_config_reflect_migration(
+            &runtime,
+            &names(&[]),
+            &names(&["ci-user"]), // matched in credentials file
+            move |id: &str| {
+                if id == old_id_clone {
+                    *checked_clone.lock().unwrap() = true;
+                    true // has keyring secret
+                } else {
+                    false
+                }
+            },
+        )
+        .expect("migration");
+
+        // Profile was matched and rebound.
+        assert_eq!(result.rebound.len(), 1, "profile must be rebound");
+        // The keyring predicate was called for the profile's old ID.
+        assert!(
+            *checked.lock().unwrap(),
+            "keyring predicate must be called for matched profile"
+        );
+
+        // Stored row deleted after rebind.
+        let auth_repo = runtime.auth_profiles();
+        assert!(
+            auth_repo.get(&old_id).expect("get").is_none(),
+            "matched profile's stored row must be deleted"
+        );
+        // (Actual keyring deletion is NOT performed — no assertion for deletion
+        //  needed since we never delete. If the test keyring has the entry, it
+        //  must still have it — but we are not simulating a real keyring here.)
+    }
+
+    // T-4.5: dangling keyring-only static profile → secret NOT deleted, row kept.
+    #[test]
+    fn dangling_keyring_only_static_profile_preserved() {
+        let runtime = open_runtime();
+        let old_id = Uuid::new_v4().to_string();
+        insert_auth_profile(&runtime, &old_id, "legacy-key", "aws-static-credentials");
+
+        let conn_id = Uuid::new_v4().to_string();
+        insert_connection(&runtime, &conn_id, &old_id);
+
+        let result = run_aws_config_reflect_migration(
+            &runtime,
+            &names(&[]),          // not in config
+            &names(&[]),          // not in credentials
+            has_keyring(&old_id), // has keyring secret
+        )
+        .expect("migration");
+
+        assert_eq!(result.dangling.len(), 1);
+        match &result.dangling[0] {
+            ProfileMigrationOutcome::Dangling { id, origin } => {
+                assert_eq!(id, &old_id);
+                assert_eq!(*origin, DanglingOrigin::KeyringOnly);
+            }
+            other => panic!("expected Dangling, got {:?}", other),
+        }
+
+        // Row must be kept.
+        let auth_repo = runtime.auth_profiles();
+        let dto = auth_repo.get(&old_id).expect("get").expect("must exist");
+        assert_eq!(
+            dto.dangling_origin.as_deref(),
+            Some("keyring-only"),
+            "dangling_origin must be 'keyring-only'"
+        );
+
+        // Connection must retain old UUID.
+        let conn_repo = runtime.connection_profiles();
+        let conn = conn_repo.get(&conn_id).expect("get").expect("exists");
+        assert_eq!(
+            conn.auth_profile_id.as_deref(),
+            Some(old_id.as_str()),
+            "connection must keep old UUID for dangling profile"
+        );
+    }
+
+    // T-4.6: dangling non-static profile (SSO name no longer in file).
+    #[test]
+    fn dangling_non_static_sso_profile_preserved() {
+        let runtime = open_runtime();
+        let old_id = Uuid::new_v4().to_string();
+        insert_auth_profile(&runtime, &old_id, "old-env", "aws-sso-session");
+
+        let conn_id = Uuid::new_v4().to_string();
+        insert_connection(&runtime, &conn_id, &old_id);
+
+        let result = run_aws_config_reflect_migration(
+            &runtime,
+            &names(&[]), // not in config (deleted from ~/.aws/config)
+            &names(&[]),
+            no_keyring,
+        )
+        .expect("migration");
+
+        assert_eq!(result.dangling.len(), 1);
+        match &result.dangling[0] {
+            ProfileMigrationOutcome::Dangling { id, origin } => {
+                assert_eq!(id, &old_id);
+                assert_eq!(*origin, DanglingOrigin::FileGone);
+            }
+            other => panic!("expected Dangling, got {:?}", other),
+        }
+
+        // Row kept, marked file-gone.
+        let auth_repo = runtime.auth_profiles();
+        let dto = auth_repo.get(&old_id).expect("get").expect("must exist");
+        assert_eq!(dto.dangling_origin.as_deref(), Some("file-gone"));
+
+        // Connection UUID unchanged.
+        let conn_repo = runtime.connection_profiles();
+        let conn = conn_repo.get(&conn_id).expect("get").expect("exists");
+        assert_eq!(conn.auth_profile_id.as_deref(), Some(old_id.as_str()));
+    }
+
+    // Integration test: all four outcome types in one run.
+    #[test]
+    fn integration_all_four_outcome_types() {
+        let runtime = open_runtime();
+
+        // 1. Matched SSO profile → will be rebound.
+        let matched_sso_id = Uuid::new_v4().to_string();
+        insert_auth_profile(&runtime, &matched_sso_id, "dev", "aws-sso");
+        let conn_sso_id = Uuid::new_v4().to_string();
+        insert_connection(&runtime, &conn_sso_id, &matched_sso_id);
+
+        // 2. Matched credentials-file profile → rebound (aws-static → aws-shared).
+        let matched_cred_id = Uuid::new_v4().to_string();
+        insert_auth_profile(
+            &runtime,
+            &matched_cred_id,
+            "ci-deploy",
+            "aws-static-credentials",
+        );
+
+        // 3. Dangling keyring-only static profile.
+        let dangling_keyring_id = Uuid::new_v4().to_string();
+        insert_auth_profile(
+            &runtime,
+            &dangling_keyring_id,
+            "legacy-secret",
+            "aws-static-credentials",
+        );
+
+        // 4. Dangling non-static SSO-session profile.
+        let dangling_sso_session_id = Uuid::new_v4().to_string();
+        insert_auth_profile(
+            &runtime,
+            &dangling_sso_session_id,
+            "gone-session",
+            "aws-sso-session",
+        );
+
+        let dangling_keyring_clone = dangling_keyring_id.clone();
+
+        let result = run_aws_config_reflect_migration(
+            &runtime,
+            &names(&["dev"]),       // only "dev" found in config
+            &names(&["ci-deploy"]), // "ci-deploy" found in credentials
+            move |id: &str| id == dangling_keyring_clone, // only "legacy-secret" has a keyring secret
+        )
+        .expect("migration");
+
+        // Two profiles should be rebound.
+        assert_eq!(result.rebound.len(), 2, "two profiles must be rebound");
+
+        // Two profiles should be dangling.
+        assert_eq!(result.dangling.len(), 2, "two profiles must be dangling");
+
+        // Verify dangling origins.
+        let keyring_only = result.dangling.iter().find(|d| match d {
+            ProfileMigrationOutcome::Dangling { id, .. } => id == &dangling_keyring_id,
+            _ => false,
+        });
+        assert!(
+            keyring_only.is_some(),
+            "dangling_keyring_id must appear in dangling list"
+        );
+        match keyring_only.unwrap() {
+            ProfileMigrationOutcome::Dangling { origin, .. } => {
+                assert_eq!(*origin, DanglingOrigin::KeyringOnly);
+            }
+            _ => unreachable!(),
+        }
+
+        let file_gone = result.dangling.iter().find(|d| match d {
+            ProfileMigrationOutcome::Dangling { id, .. } => id == &dangling_sso_session_id,
+            _ => false,
+        });
+        assert!(
+            file_gone.is_some(),
+            "dangling_sso_session_id must appear in dangling list"
+        );
+        match file_gone.unwrap() {
+            ProfileMigrationOutcome::Dangling { origin, .. } => {
+                assert_eq!(*origin, DanglingOrigin::FileGone);
+            }
+            _ => unreachable!(),
+        }
+
+        // Marker must be set.
+        assert!(
+            runtime
+                .app_meta()
+                .is_flag_set(MIGRATION_MARKER_KEY)
+                .expect("flag"),
+            "migration marker must be set after run"
+        );
+
+        // SSO connection must be rebound to deterministic UUID.
+        let expected_sso_id = aws_profile_uuid("aws-sso", "dev").to_string();
+        let conn_repo = runtime.connection_profiles();
+        let sso_conn = conn_repo.get(&conn_sso_id).expect("get").expect("exists");
+        assert_eq!(
+            sso_conn.auth_profile_id.as_deref(),
+            Some(expected_sso_id.as_str()),
+            "SSO connection must reference deterministic UUID"
+        );
+    }
+}

--- a/crates/dbflux_app/src/aws_config_reflect_migration.rs
+++ b/crates/dbflux_app/src/aws_config_reflect_migration.rs
@@ -662,8 +662,7 @@ mod tests {
         insert_auth_profile(&runtime, &old_id, "ci-user", "aws-static-credentials");
 
         let old_id_clone = old_id.clone();
-        let mut keyring_checked = false;
-        // We can't capture and mutate in the Fn closure easily, so we use an Arc<Mutex>.
+        // The Fn closure can't capture-and-mutate a local, so track the probe via Arc<Mutex>.
         let checked = Arc::new(std::sync::Mutex::new(false));
         let checked_clone = checked.clone();
 

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -756,6 +756,7 @@ pub fn save_auth_profiles(
             enabled: profile.enabled,
             created_at: String::new(),
             updated_at: String::new(),
+            dangling_origin: None,
         };
 
         if existing_ids.contains(&dto.id) {

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -1518,6 +1518,7 @@ fn load_auth_profiles(
                     fields,
                     enabled: dto.enabled,
                     read_only: false,
+                    dangling_origin: dto.dangling_origin,
                 })
             })
             .collect()

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -1516,6 +1516,7 @@ fn load_auth_profiles(
                     provider_id: dto.provider_id,
                     fields,
                     enabled: dto.enabled,
+                    read_only: false,
                 })
             })
             .collect()

--- a/crates/dbflux_app/src/lib.rs
+++ b/crates/dbflux_app/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod access_manager;
 pub mod app_state;
 pub mod auth_provider_registry;
+pub mod aws_config_reflect_migration;
 pub mod config_loader;
 pub mod history_manager_sqlite;
 pub mod hook_executor;

--- a/crates/dbflux_aws/Cargo.toml
+++ b/crates/dbflux_aws/Cargo.toml
@@ -35,3 +35,4 @@ futures-lite = "2"
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
 tempfile = "3"
+filetime = "0.2"

--- a/crates/dbflux_aws/Cargo.toml
+++ b/crates/dbflux_aws/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "5"
 sha1 = "0.10"
+sha2 = "0.10"
 futures-lite = "2"
 
 [dev-dependencies]

--- a/crates/dbflux_aws/src/accounts.rs
+++ b/crates/dbflux_aws/src/accounts.rs
@@ -177,28 +177,13 @@ fn load_valid_access_token(profile_name: &str, sso_start_url: &str) -> Result<St
     let target_start_url = normalize_start_url(sso_start_url);
     let cache_path = sso_cache_path(sso_start_url);
 
-    if cache_path.exists() {
-        let cache_entry = load_cache_entry(&cache_path)?;
-
-        if !start_url_matches(&cache_entry.start_url, target_start_url.as_str()) {
-            return Err(DbError::ValueResolutionFailed(format!(
-                "Login required: AWS SSO cache '{}' does not match start URL '{}'; run 'aws sso login --profile {}'",
-                cache_path.display(),
-                sso_start_url,
-                profile_name
-            )));
-        }
-
-        if Utc::now() < cache_entry.expires_at {
-            return Ok(cache_entry.access_token);
-        }
-
-        return Err(DbError::ValueResolutionFailed(format!(
-            "Login required: AWS SSO session expired for profile '{}'; run 'aws sso login --profile {}'",
-            profile_name, profile_name
-        )));
-    }
-
+    // Do not trust the hash-named file. AWS CLI v2 keys the cache by
+    // `sha1(session_name)` when the profile uses an `sso_session` block, and
+    // even for direct-URL logins it keys by the exact URL form (trailing slash
+    // included), while `sso_cache_path` normalizes the slash away. A stale,
+    // expired file can therefore sit at the hashed path while the fresh token
+    // lives under a different filename. Always scan the directory and pick the
+    // newest non-expired entry whose `startUrl` matches.
     let cache_dir = cache_path.parent().map(Path::to_path_buf).ok_or_else(|| {
         DbError::ValueResolutionFailed(format!(
             "Login required: invalid AWS SSO cache path '{}'; run 'aws sso login --profile {}'",
@@ -207,7 +192,23 @@ fn load_valid_access_token(profile_name: &str, sso_start_url: &str) -> Result<St
         ))
     })?;
 
-    let cache_entries = std::fs::read_dir(&cache_dir).map_err(|err| {
+    select_freshest_access_token(&cache_dir, target_start_url.as_str(), profile_name)
+}
+
+/// Scans every `.json` file in `cache_dir`, keeps the entries whose `startUrl`
+/// matches `target_start_url`, and returns the access token of the most
+/// recently expiring non-expired one.
+///
+/// This deliberately ignores the hash-derived filename: AWS CLI v2 keys the
+/// file by `sha1(session_name)` for `sso_session` profiles and by the exact
+/// URL form for direct-URL logins, so a stale expired file can shadow the
+/// fresh token at the path `sso_cache_path` would compute.
+fn select_freshest_access_token(
+    cache_dir: &Path,
+    target_start_url: &str,
+    profile_name: &str,
+) -> Result<String, DbError> {
+    let cache_entries = std::fs::read_dir(cache_dir).map_err(|err| {
         DbError::ValueResolutionFailed(format!(
             "Login required: failed to read AWS SSO cache directory '{}': {}. Run 'aws sso login --profile {}'",
             cache_dir.display(),
@@ -237,7 +238,7 @@ fn load_valid_access_token(profile_name: &str, sso_start_url: &str) -> Result<St
             continue;
         };
 
-        if !start_url_matches(&cache_entry.start_url, target_start_url.as_str()) {
+        if !start_url_matches(&cache_entry.start_url, target_start_url) {
             continue;
         }
 
@@ -279,71 +280,6 @@ struct CacheEntry {
     start_url: String,
     access_token: String,
     expires_at: DateTime<Utc>,
-}
-
-fn load_cache_entry(path: &Path) -> Result<CacheEntry, DbError> {
-    let contents = std::fs::read_to_string(path).map_err(|err| {
-        DbError::ValueResolutionFailed(format!(
-            "failed to read AWS SSO cache '{}': {}",
-            path.display(),
-            err
-        ))
-    })?;
-
-    let parsed: serde_json::Value = serde_json::from_str(&contents).map_err(|err| {
-        DbError::ValueResolutionFailed(format!(
-            "invalid AWS SSO cache '{}': {}",
-            path.display(),
-            err
-        ))
-    })?;
-
-    let start_url = parsed
-        .get("startUrl")
-        .and_then(|value| value.as_str())
-        .map(ToString::to_string)
-        .filter(|value| !value.trim().is_empty())
-        .ok_or_else(|| {
-            DbError::ValueResolutionFailed(format!(
-                "AWS SSO cache '{}' missing startUrl",
-                path.display()
-            ))
-        })?;
-
-    let access_token = parsed
-        .get("accessToken")
-        .and_then(|value| value.as_str())
-        .map(ToString::to_string)
-        .filter(|value| !value.is_empty())
-        .ok_or_else(|| {
-            DbError::ValueResolutionFailed(format!(
-                "AWS SSO cache '{}' missing access token",
-                path.display()
-            ))
-        })?;
-
-    let expires_at_str = parsed
-        .get("expiresAt")
-        .and_then(|value| value.as_str())
-        .ok_or_else(|| {
-            DbError::ValueResolutionFailed(format!(
-                "AWS SSO cache '{}' missing expiry",
-                path.display()
-            ))
-        })?;
-
-    let expires_at = parse_sso_expiry(expires_at_str).ok_or_else(|| {
-        DbError::ValueResolutionFailed(format!(
-            "AWS SSO cache '{}' has invalid expiry",
-            path.display()
-        ))
-    })?;
-
-    Ok(CacheEntry {
-        start_url,
-        access_token,
-        expires_at,
-    })
 }
 
 fn load_cache_entry_for_scan(path: &Path) -> Option<CacheEntry> {
@@ -463,4 +399,97 @@ where
         })?;
 
     runtime.block_on(future)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    fn write_cache_file(dir: &Path, name: &str, start_url: &str, token: &str, expires_at: &str) {
+        let contents = format!(
+            r#"{{"startUrl":"{start_url}","accessToken":"{token}","expiresAt":"{expires_at}"}}"#
+        );
+        fs::write(dir.join(format!("{name}.json")), contents).unwrap();
+    }
+
+    const START_URL: &str = "https://example.awsapps.com/start/";
+    const PROFILE_NAME: &str = "example-profile";
+
+    #[test]
+    fn picks_fresh_token_over_stale_file_with_different_filename() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Stale file under the URL-hashed name (what `sso_cache_path` would
+        // compute, with the slash normalized away): matching start URL but
+        // already expired.
+        write_cache_file(
+            dir.path(),
+            "stale-hashed",
+            "https://example.awsapps.com/start",
+            "stale-token",
+            "2020-01-01T00:00:00Z",
+        );
+
+        // Fresh token under a different filename (e.g. session-keyed or the
+        // trailing-slash URL form), with a far-future expiry.
+        write_cache_file(
+            dir.path(),
+            "fresh-other",
+            START_URL,
+            "fresh-token",
+            "2999-01-01T00:00:00Z",
+        );
+
+        let token =
+            select_freshest_access_token(dir.path(), &normalize_start_url(START_URL), PROFILE_NAME)
+                .expect("fresh token should be selected despite the stale hashed file");
+
+        assert_eq!(token, "fresh-token");
+    }
+
+    #[test]
+    fn reports_session_expired_when_all_matching_entries_expired() {
+        let dir = tempfile::tempdir().unwrap();
+
+        write_cache_file(
+            dir.path(),
+            "anyhash",
+            "https://example.awsapps.com/start",
+            "stale-token",
+            "2020-01-01T00:00:00Z",
+        );
+
+        let result =
+            select_freshest_access_token(dir.path(), &normalize_start_url(START_URL), PROFILE_NAME);
+
+        let err = result.expect_err("expired-only cache must not return a token");
+        assert!(
+            err.to_string().contains("session expired"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn reports_login_required_when_no_entry_matches_start_url() {
+        let dir = tempfile::tempdir().unwrap();
+
+        write_cache_file(
+            dir.path(),
+            "other",
+            "https://other.awsapps.com/start",
+            "other-token",
+            "2999-01-01T00:00:00Z",
+        );
+
+        let result =
+            select_freshest_access_token(dir.path(), &normalize_start_url(START_URL), PROFILE_NAME);
+
+        let err = result.expect_err("no matching start URL must not return a token");
+        assert!(
+            err.to_string().contains("Login required"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -63,24 +63,14 @@ pub fn ensure_aws_profile_configured(config: &SsoProfileConfig) -> Result<(), Db
     }
 
     let config_path = aws_config_path();
-    let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
 
     let profile_header = format!("[profile {}]", config.profile_name);
     let new_block = build_sso_profile_block(config);
 
-    let updated = replace_or_append_profile_block(&existing, &profile_header, &new_block);
-
-    // Ensure the directory exists before writing.
-    if let Some(parent) = config_path.parent() {
-        std::fs::create_dir_all(parent).map_err(|err| {
-            DbError::ValueResolutionFailed(format!(
-                "Could not create AWS config directory: {}",
-                err
-            ))
-        })?;
-    }
-
-    std::fs::write(&config_path, updated).map_err(|err| {
+    crate::config::update_aws_config_atomic(&config_path, |existing| {
+        replace_or_append_profile_block(existing, &profile_header, &new_block)
+    })
+    .map_err(|err| {
         DbError::ValueResolutionFailed(format!("Could not write ~/.aws/config: {}", err))
     })
 }
@@ -113,7 +103,6 @@ fn ensure_aws_profile_configured_with_session(
     }
 
     let config_path = aws_config_path();
-    let existing = std::fs::read_to_string(&config_path).unwrap_or_default();
 
     let profile_header = format!("[profile {}]", profile_name);
     let profile_block = build_sso_session_profile_block(
@@ -123,22 +112,16 @@ fn ensure_aws_profile_configured_with_session(
         sso_account_id,
         sso_role_name,
     );
-    let after_profile = replace_or_append_profile_block(&existing, &profile_header, &profile_block);
 
     let session_header = format!("[sso-session {}]", session_name);
     let session_block = build_sso_session_block(session_name, sso_start_url, sso_region);
-    let updated = replace_or_append_profile_block(&after_profile, &session_header, &session_block);
 
-    if let Some(parent) = config_path.parent() {
-        std::fs::create_dir_all(parent).map_err(|err| {
-            DbError::ValueResolutionFailed(format!(
-                "Could not create AWS config directory: {}",
-                err
-            ))
-        })?;
-    }
-
-    std::fs::write(&config_path, updated).map_err(|err| {
+    crate::config::update_aws_config_atomic(&config_path, |existing| {
+        let after_profile =
+            replace_or_append_profile_block(existing, &profile_header, &profile_block);
+        replace_or_append_profile_block(&after_profile, &session_header, &session_block)
+    })
+    .map_err(|err| {
         DbError::ValueResolutionFailed(format!("Could not write ~/.aws/config: {}", err))
     })
 }

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -461,9 +461,7 @@ impl AwsSsoSessionAuthProvider {
             .filter(|p| p.is_sso_session)
             .filter_map(|p| {
                 if p.name.is_empty() {
-                    log::warn!(
-                        "aws-config-reflect: skipping sso-session profile with empty name"
-                    );
+                    log::warn!("aws-config-reflect: skipping sso-session profile with empty name");
                     return None;
                 }
 
@@ -883,8 +881,8 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
             .get("sso_start_url")
             .map(String::as_str)
             .unwrap_or("");
-        let sso_start_url = resolve_sso_start_url(&profile_name, raw_sso_start_url)
-            .ok_or_else(|| {
+        let sso_start_url =
+            resolve_sso_start_url(&profile_name, raw_sso_start_url).ok_or_else(|| {
                 DbError::InvalidProfile(format!(
                     "AWS SSO profile '{}' has no sso_start_url (check ~/.aws/config)",
                     profile_name
@@ -919,6 +917,10 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
 
     fn abort_login(&self, profile: &AuthProfile) -> bool {
         abort_sso_login(profile.id)
+    }
+
+    fn reflect_profiles(&self) -> Vec<AuthProfile> {
+        AwsSsoAuthProvider::reflect_profiles(self)
     }
 
     fn detect_importable_profiles(&self) -> Vec<ImportableProfile> {
@@ -1170,6 +1172,9 @@ impl dbflux_core::auth::DynAuthProvider for AwsSharedCredentialsAuthProvider {
         Ok(())
     }
 
+    fn reflect_profiles(&self) -> Vec<AuthProfile> {
+        AwsSharedCredentialsAuthProvider::reflect_profiles(self)
+    }
 }
 
 #[async_trait::async_trait]
@@ -1251,6 +1256,10 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoSessionAuthProvider {
                 }
             })
             .collect()
+    }
+
+    fn reflect_profiles(&self) -> Vec<AuthProfile> {
+        AwsSsoSessionAuthProvider::reflect_profiles(self)
     }
 }
 
@@ -2140,7 +2149,10 @@ sso_region = us-east-1
         assert!(p.enabled);
 
         let expected_id = dbflux_core::auth::aws_profile_uuid("aws-sso", "dev-sso");
-        assert_eq!(p.id, expected_id, "id must equal aws_profile_uuid(aws-sso, name)");
+        assert_eq!(
+            p.id, expected_id,
+            "id must equal aws_profile_uuid(aws-sso, name)"
+        );
 
         assert_eq!(
             p.fields.get("sso_start_url").map(String::as_str),
@@ -2184,7 +2196,10 @@ sso_region = us-east-1
         let profiles = provider.reflect_profiles();
 
         // Only one SSO profile (the sso-session is handled by AwsSsoSessionAuthProvider).
-        let sso = profiles.iter().find(|p| p.name == "my-sso").expect("my-sso must be reflected");
+        let sso = profiles
+            .iter()
+            .find(|p| p.name == "my-sso")
+            .expect("my-sso must be reflected");
 
         assert_eq!(sso.provider_id, "aws-sso");
         assert_eq!(
@@ -2217,7 +2232,10 @@ sso_region = us-east-1
         };
 
         let profiles = provider.reflect_profiles();
-        assert!(profiles.is_empty(), "missing config must yield empty list, no panic");
+        assert!(
+            profiles.is_empty(),
+            "missing config must yield empty list, no panic"
+        );
     }
 
     #[test]
@@ -2300,8 +2318,14 @@ sso_region = us-east-1
         let sso_profiles = sso_provider.reflect_profiles();
         let session_profiles = session_provider.reflect_profiles();
 
-        let sso_p = sso_profiles.iter().find(|p| p.name == "shared").expect("sso shared");
-        let session_p = session_profiles.iter().find(|p| p.name == "shared").expect("session shared");
+        let sso_p = sso_profiles
+            .iter()
+            .find(|p| p.name == "shared")
+            .expect("sso shared");
+        let session_p = session_profiles
+            .iter()
+            .find(|p| p.name == "shared")
+            .expect("session shared");
 
         assert_ne!(
             sso_p.id, session_p.id,
@@ -2347,7 +2371,10 @@ sso_region = us-east-1
         let provider = shared_provider_with_files(config, credentials);
         let profiles = provider.reflect_profiles();
 
-        let ci = profiles.iter().find(|p| p.name == "ci-user").expect("ci-user must be reflected");
+        let ci = profiles
+            .iter()
+            .find(|p| p.name == "ci-user")
+            .expect("ci-user must be reflected");
         assert_eq!(ci.provider_id, "aws-shared-credentials");
         assert!(ci.read_only);
 
@@ -2362,7 +2389,10 @@ sso_region = us-east-1
         let provider = shared_provider_with_files(config, credentials);
         let profiles = provider.reflect_profiles();
 
-        let ci = profiles.iter().find(|p| p.name == "ci-user").expect("ci-user");
+        let ci = profiles
+            .iter()
+            .find(|p| p.name == "ci-user")
+            .expect("ci-user");
         assert_eq!(
             ci.fields.get("region").map(String::as_str),
             Some("us-west-2"),
@@ -2376,7 +2406,10 @@ sso_region = us-east-1
         let provider = shared_provider_with_files("", credentials);
         let profiles = provider.reflect_profiles();
 
-        let p = profiles.iter().find(|p| p.name == "my-profile").expect("my-profile");
+        let p = profiles
+            .iter()
+            .find(|p| p.name == "my-profile")
+            .expect("my-profile");
         assert!(
             p.fields.get("region").is_none(),
             "absent region must not appear in fields"

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -80,12 +80,24 @@ pub fn start_sso_login_blocking(profile_name: &str) -> Result<SsoLoginHandle, Db
     use std::process::{Command, Stdio};
 
     log::debug!(
-        "Spawning 'aws sso login --no-browser --profile {}'",
+        "Spawning 'aws sso login --no-browser --use-device-code --profile {}'",
         profile_name
     );
 
+    // `--use-device-code` forces the device-authorization grant instead of the
+    // modern PKCE/loopback default. It yields a short verification URL with the
+    // code autofilled (`...#/device?user_code=XXXX-YYYY`) — far cleaner to show
+    // and copy than the long `/authorize?...&redirect_uri=127.0.0.1...` URL, and
+    // it needs no local loopback listener (works on headless/remote setups).
     let mut child = Command::new("aws")
-        .args(["sso", "login", "--no-browser", "--profile", profile_name])
+        .args([
+            "sso",
+            "login",
+            "--no-browser",
+            "--use-device-code",
+            "--profile",
+            profile_name,
+        ])
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -39,93 +39,6 @@ const SSO_LOGIN_TIMEOUT: Duration = Duration::from_secs(300);
 /// The `verification_url` is extracted from `aws sso login` stdout and is
 /// ready to be surfaced in the UI. The login is not yet complete — the caller
 /// must still wait (poll the SSO cache) for the session to appear.
-/// All SSO fields needed to write a complete `[profile X]` block in `~/.aws/config`.
-pub struct SsoProfileConfig {
-    pub profile_name: String,
-    pub region: String,
-    pub sso_start_url: String,
-    pub sso_account_id: String,
-    pub sso_role_name: String,
-}
-
-/// Writes (or updates) a `[profile <name>]` block in `~/.aws/config` with
-/// all SSO fields so that `aws sso login --profile <name>` runs non-interactively.
-///
-/// Only writes fields that are non-empty. Existing lines for the profile are
-/// replaced; unrelated parts of the file are left untouched.
-pub fn ensure_aws_profile_configured(config: &SsoProfileConfig) -> Result<(), DbError> {
-    // Skip if we don't have the minimum required fields to make the profile useful.
-    if config.sso_start_url.trim().is_empty()
-        || config.sso_account_id.trim().is_empty()
-        || config.sso_role_name.trim().is_empty()
-    {
-        return Ok(());
-    }
-
-    let config_path = aws_config_path();
-
-    let profile_header = format!("[profile {}]", config.profile_name);
-    let new_block = build_sso_profile_block(config);
-
-    crate::config::update_aws_config_atomic(&config_path, |existing| {
-        replace_or_append_profile_block(existing, &profile_header, &new_block)
-    })
-    .map_err(|err| {
-        DbError::ValueResolutionFailed(format!("Could not write ~/.aws/config: {}", err))
-    })
-}
-
-/// Writes both a session-form `[profile NAME]` block (with `sso_session =`
-/// indirection) and the referenced `[sso-session SESSION]` block to
-/// `~/.aws/config`. Both blocks are fully rewritten so any stale keys (e.g.
-/// a stray `sso_region =` inside the profile block) are cleaned up.
-fn ensure_aws_profile_configured_with_session(
-    profile_name: &str,
-    session_name: &str,
-    region: &str,
-    sso_account_id: &str,
-    sso_role_name: &str,
-    sso_start_url: &str,
-    sso_region: &str,
-) -> Result<(), DbError> {
-    // Account ID and Role Name are optional here: writing the session-form
-    // profile block is what sanitizes a malformed `[profile X]` (e.g. a
-    // stray `sso_region` line that AWS SDK rejects). We want that
-    // sanitation to happen as soon as the user has picked an `sso-session`
-    // ref, even before they've filled in account/role — otherwise the SDK
-    // can't load the config to call `list_sso_accounts` and populate the
-    // dropdowns in the first place.
-    if profile_name.trim().is_empty()
-        || session_name.trim().is_empty()
-        || sso_start_url.trim().is_empty()
-    {
-        return Ok(());
-    }
-
-    let config_path = aws_config_path();
-
-    let profile_header = format!("[profile {}]", profile_name);
-    let profile_block = build_sso_session_profile_block(
-        profile_name,
-        session_name,
-        region,
-        sso_account_id,
-        sso_role_name,
-    );
-
-    let session_header = format!("[sso-session {}]", session_name);
-    let session_block = build_sso_session_block(session_name, sso_start_url, sso_region);
-
-    crate::config::update_aws_config_atomic(&config_path, |existing| {
-        let after_profile =
-            replace_or_append_profile_block(existing, &profile_header, &profile_block);
-        replace_or_append_profile_block(&after_profile, &session_header, &session_block)
-    })
-    .map_err(|err| {
-        DbError::ValueResolutionFailed(format!("Could not write ~/.aws/config: {}", err))
-    })
-}
-
 fn aws_config_path() -> std::path::PathBuf {
     // AWS_CONFIG_FILE env var overrides the default location.
     if let Ok(path) = std::env::var("AWS_CONFIG_FILE") {
@@ -135,133 +48,6 @@ fn aws_config_path() -> std::path::PathBuf {
         .unwrap_or_else(|| std::path::PathBuf::from("~"))
         .join(".aws")
         .join("config")
-}
-
-fn build_sso_profile_block(config: &SsoProfileConfig) -> String {
-    let mut lines = vec![
-        format!("[profile {}]", config.profile_name),
-        format!("sso_start_url = {}", config.sso_start_url),
-        format!("sso_region = {}", config.region),
-        format!("sso_account_id = {}", config.sso_account_id),
-        format!("sso_role_name = {}", config.sso_role_name),
-    ];
-
-    if !config.region.is_empty() {
-        lines.push(format!("region = {}", config.region));
-    }
-
-    lines.push("output = json".to_string());
-    lines.push(String::new()); // trailing newline after block
-
-    lines.join("\n")
-}
-
-/// Builds a session-form `[profile X]` block that references an
-/// `[sso-session NAME]` block via `sso_session = NAME`. Used when the
-/// DBFlux profile declares an `sso_session_ref` so the written block
-/// matches the AWS SDK's expected indirection form and does not duplicate
-/// SSO config keys that must live under the session.
-fn build_sso_session_profile_block(
-    profile_name: &str,
-    session_name: &str,
-    region: &str,
-    sso_account_id: &str,
-    sso_role_name: &str,
-) -> String {
-    let mut lines = vec![
-        format!("[profile {}]", profile_name),
-        format!("sso_session = {}", session_name),
-    ];
-
-    // Account ID and Role Name are optional in the on-disk block: the AWS
-    // SDK accepts profiles with only `sso_session = X` (no credentials can
-    // be generated, but the profile parses cleanly and the SSO token cache
-    // works, so `list_sso_accounts` / `list_sso_account_roles` can be
-    // called to populate the DBFlux dropdowns).
-    if !sso_account_id.trim().is_empty() {
-        lines.push(format!("sso_account_id = {}", sso_account_id));
-    }
-    if !sso_role_name.trim().is_empty() {
-        lines.push(format!("sso_role_name = {}", sso_role_name));
-    }
-
-    if !region.is_empty() {
-        lines.push(format!("region = {}", region));
-    }
-
-    lines.push("output = json".to_string());
-    lines.push(String::new());
-
-    lines.join("\n")
-}
-
-/// Builds an `[sso-session NAME]` block.
-fn build_sso_session_block(session_name: &str, sso_start_url: &str, sso_region: &str) -> String {
-    let mut lines = vec![
-        format!("[sso-session {}]", session_name),
-        format!("sso_start_url = {}", sso_start_url),
-    ];
-
-    if !sso_region.is_empty() {
-        lines.push(format!("sso_region = {}", sso_region));
-    }
-
-    // Default scopes — AWS CLI requires this for the session form.
-    lines.push("sso_registration_scopes = sso:account:access".to_string());
-    lines.push(String::new());
-
-    lines.join("\n")
-}
-
-/// Replaces an existing `[profile X]` block in the INI content with
-/// `new_block`, or appends it if the profile does not exist yet.
-///
-/// A profile block spans from its header line until the next `[` section
-/// header (or end of file).
-fn replace_or_append_profile_block(content: &str, header: &str, new_block: &str) -> String {
-    let mut result = String::with_capacity(content.len() + new_block.len());
-    let mut inside_target = false;
-    let mut replaced = false;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        if trimmed == header {
-            // Start of the target profile — emit the new block instead.
-            result.push_str(new_block);
-            inside_target = true;
-            replaced = true;
-            continue;
-        }
-
-        if inside_target {
-            // Skip lines belonging to the old profile block.
-            if trimmed.starts_with('[') {
-                // Next section starts — stop skipping and emit this line.
-                inside_target = false;
-                result.push_str(line);
-                result.push('\n');
-            }
-            // else: still inside old block, discard.
-            continue;
-        }
-
-        result.push_str(line);
-        result.push('\n');
-    }
-
-    if !replaced {
-        // Profile didn't exist — append with a blank line separator.
-        if !result.ends_with("\n\n") {
-            if !result.ends_with('\n') {
-                result.push('\n');
-            }
-            result.push('\n');
-        }
-        result.push_str(new_block);
-    }
-
-    result
 }
 
 pub struct SsoLoginHandle {
@@ -799,20 +585,6 @@ impl Default for AwsSharedCredentialsAuthProvider {
     }
 }
 
-pub struct AwsStaticCredentialsAuthProvider;
-
-impl AwsStaticCredentialsAuthProvider {
-    pub fn new() -> Self {
-        Self
-    }
-}
-
-impl Default for AwsStaticCredentialsAuthProvider {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 fn required_text_field(id: &str, label: &str, placeholder: &str) -> FormFieldDef {
     FormFieldDef {
         id: id.to_string(),
@@ -820,21 +592,6 @@ fn required_text_field(id: &str, label: &str, placeholder: &str) -> FormFieldDef
         kind: FormFieldKind::Text,
         placeholder: placeholder.to_string(),
         required: true,
-        default_value: String::new(),
-        enabled_when_checked: None,
-        enabled_when_unchecked: None,
-        disabled_when_field_set: None,
-        help: None,
-    }
-}
-
-fn password_field(id: &str, label: &str, placeholder: &str, required: bool) -> FormFieldDef {
-    FormFieldDef {
-        id: id.to_string(),
-        label: label.to_string(),
-        kind: FormFieldKind::Password,
-        placeholder: placeholder.to_string(),
-        required,
         default_value: String::new(),
         enabled_when_checked: None,
         enabled_when_unchecked: None,
@@ -976,24 +733,6 @@ fn build_aws_sso_session_form() -> AuthFormDef {
     }
 }
 
-fn build_aws_static_credentials_form() -> AuthFormDef {
-    AuthFormDef {
-        tabs: vec![FormTab {
-            id: "main".to_string(),
-            label: "Main".to_string(),
-            sections: vec![FormSection {
-                title: "AWS Static Credentials".to_string(),
-                fields: vec![
-                    required_text_field("access_key_id", "Access Key ID", "AKIAIOSFODNN7EXAMPLE"),
-                    password_field("secret_access_key", "Secret Access Key", "", true),
-                    password_field("session_token", "Session Token", "", false),
-                    required_text_field("region", "Region", "us-east-1"),
-                ],
-            }],
-        }],
-    }
-}
-
 fn non_expiring_login(
     profile: &AuthProfile,
     provider_id: &str,
@@ -1035,106 +774,6 @@ fn effective_aws_profile_name(profile: &AuthProfile) -> Option<&str> {
     }
 
     None
-}
-
-fn sso_profile_config_from_auth_profile(profile: &AuthProfile) -> Option<SsoProfileConfig> {
-    if profile.provider_id != "aws-sso" {
-        return None;
-    }
-
-    let profile_name = effective_aws_profile_name(profile)?.to_string();
-    let region = profile.fields.get("region")?.trim().to_string();
-    let sso_start_url = profile.fields.get("sso_start_url")?.trim().to_string();
-    let sso_account_id = profile.fields.get("sso_account_id")?.trim().to_string();
-    let sso_role_name = profile.fields.get("sso_role_name")?.trim().to_string();
-
-    if region.is_empty()
-        || sso_start_url.is_empty()
-        || sso_account_id.is_empty()
-        || sso_role_name.is_empty()
-    {
-        return None;
-    }
-
-    Some(SsoProfileConfig {
-        profile_name,
-        region,
-        sso_start_url,
-        sso_account_id,
-        sso_role_name,
-    })
-}
-
-fn ensure_sso_profile_configured_from_auth_profile(profile: &AuthProfile) {
-    // When the DBFlux profile references an `aws-sso-session` (expanded via
-    // `expand_auth_profile_refs`, which stashes the session name under
-    // `sso_session_ref_name`), write the session-form block. This sanitizes
-    // any stray `sso_region` lines inside the user's existing flat profile
-    // block, which AWS SDK rejects when `sso_session = X` is also present.
-    let profile_name = effective_aws_profile_name(profile).map(ToOwned::to_owned);
-    let session_name = profile
-        .fields
-        .get("sso_session_ref_name")
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty());
-
-    if let (Some(profile_name), Some(session_name)) = (profile_name.as_ref(), session_name.as_ref())
-    {
-        let region = profile
-            .fields
-            .get("region")
-            .map(String::as_str)
-            .unwrap_or("");
-        let sso_account_id = profile
-            .fields
-            .get("sso_account_id")
-            .map(String::as_str)
-            .unwrap_or("");
-        let sso_role_name = profile
-            .fields
-            .get("sso_role_name")
-            .map(String::as_str)
-            .unwrap_or("");
-        let sso_start_url = profile
-            .fields
-            .get("sso_start_url")
-            .map(String::as_str)
-            .unwrap_or("");
-        let sso_region = profile
-            .fields
-            .get("sso_region")
-            .map(String::as_str)
-            .unwrap_or(region);
-
-        if let Err(err) = ensure_aws_profile_configured_with_session(
-            profile_name,
-            session_name,
-            region,
-            sso_account_id,
-            sso_role_name,
-            sso_start_url,
-            sso_region,
-        ) {
-            log::warn!(
-                "Failed to sync AWS SSO session-form profile '{}' into ~/.aws/config: {}",
-                profile_name,
-                err
-            );
-        }
-        return;
-    }
-
-    let Some(config) = sso_profile_config_from_auth_profile(profile) else {
-        return;
-    };
-
-    if let Err(err) = ensure_aws_profile_configured(&config) {
-        log::warn!(
-            "Failed to sync AWS SSO profile '{}' into ~/.aws/config: {}",
-            config.profile_name,
-            err
-        );
-    }
 }
 
 fn profile_name_and_region(profile: &AuthProfile) -> (Option<&str>, &str) {
@@ -1186,80 +825,6 @@ fn build_aws_value_providers_blocking(
 /// Builds an `SdkConfig` from explicit static credentials stored in the
 /// auth profile's `fields` map, bypassing the default credential chain.
 ///
-/// Reads `access_key_id`, `secret_access_key`, `session_token`, and `region`
-/// from `profile.fields`. Returns an error if `access_key_id` or
-/// `secret_access_key` is absent or empty.
-fn build_static_sdk_config_blocking(
-    profile: &AuthProfile,
-) -> Result<aws_config::SdkConfig, DbError> {
-    let access_key_id = profile
-        .fields
-        .get("access_key_id")
-        .map(String::as_str)
-        .unwrap_or("");
-    if access_key_id.is_empty() {
-        return Err(DbError::ValueResolutionFailed(
-            "Missing required field 'access_key_id' for static AWS credentials".to_string(),
-        ));
-    }
-
-    let secret_access_key = profile
-        .fields
-        .get("secret_access_key")
-        .map(String::as_str)
-        .unwrap_or("");
-    if secret_access_key.is_empty() {
-        return Err(DbError::ValueResolutionFailed(
-            "Missing required field 'secret_access_key' for static AWS credentials".to_string(),
-        ));
-    }
-
-    let session_token = profile
-        .fields
-        .get("session_token")
-        .map(String::as_str)
-        .filter(|s| !s.is_empty())
-        .map(String::from);
-
-    let region = profile
-        .fields
-        .get("region")
-        .cloned()
-        .unwrap_or_else(|| "us-east-1".to_string());
-
-    let access_key_id = access_key_id.to_string();
-    let secret_access_key = secret_access_key.to_string();
-
-    let creds = aws_sdk_sts::config::Credentials::new(
-        access_key_id,
-        secret_access_key,
-        session_token,
-        None,
-        "dbflux-static",
-    );
-
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(2)
-        .enable_all()
-        .build()
-        .map_err(|err| {
-            DbError::ValueResolutionFailed(format!(
-                "Failed to create Tokio runtime for static AWS provider init: {}",
-                err
-            ))
-        })?;
-
-    runtime.block_on(async move {
-        let sdk_config = aws_config::defaults(aws_config::BehaviorVersion::latest())
-            .credentials_provider(creds)
-            .region(aws_config::Region::new(region))
-            .load()
-            .await;
-
-        Ok(sdk_config)
-    })
-}
-
 #[async_trait::async_trait]
 impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
     fn provider_id(&self) -> &'static str {
@@ -1287,8 +852,6 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
     }
 
     async fn validate_session(&self, profile: &AuthProfile) -> Result<AuthSessionState, DbError> {
-        ensure_sso_profile_configured_from_auth_profile(profile);
-
         let profile_name = effective_aws_profile_name(profile).unwrap_or("");
         let sso_start_url = profile
             .fields
@@ -1315,7 +878,6 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
         let profile_name = effective_aws_profile_name(profile)
             .map(ToOwned::to_owned)
             .unwrap_or_default();
-        let region = profile.fields.get("region").cloned().unwrap_or_default();
         let raw_sso_start_url = profile
             .fields
             .get("sso_start_url")
@@ -1324,63 +886,13 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
         let sso_start_url = resolve_sso_start_url(&profile_name, raw_sso_start_url)
             .ok_or_else(|| {
                 DbError::InvalidProfile(format!(
-                    "AWS SSO profile '{}' has no sso_start_url (not set in DBFlux profile, not in ~/.aws/config directly or via sso_session)",
+                    "AWS SSO profile '{}' has no sso_start_url (check ~/.aws/config)",
                     profile_name
                 ))
             })?;
-        let sso_account_id = profile
-            .fields
-            .get("sso_account_id")
-            .cloned()
-            .unwrap_or_default();
-        let sso_role_name = profile
-            .fields
-            .get("sso_role_name")
-            .cloned()
-            .unwrap_or_default();
 
-        // If the DBFlux profile references an `aws-sso-session` profile,
-        // write the session-form profile block (`sso_session = NAME`)
-        // alongside the `[sso-session NAME]` block. Otherwise write the
-        // flat profile block as before. The expansion step stored the
-        // referenced session's name under `sso_session_ref_name`.
-        let session_name = profile
-            .fields
-            .get("sso_session_ref_name")
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
-
-        if let Some(session_name) = session_name.as_ref() {
-            let sso_region = profile
-                .fields
-                .get("sso_region")
-                .cloned()
-                .unwrap_or_else(|| region.clone());
-
-            if let Err(err) = ensure_aws_profile_configured_with_session(
-                &profile_name,
-                session_name,
-                &region,
-                &sso_account_id,
-                &sso_role_name,
-                &sso_start_url,
-                &sso_region,
-            ) {
-                log::warn!("Could not write AWS session-form profile config: {}", err);
-            }
-        } else {
-            let sso_config = SsoProfileConfig {
-                profile_name: profile_name.clone(),
-                region: region.clone(),
-                sso_start_url: sso_start_url.clone(),
-                sso_account_id: sso_account_id.clone(),
-                sso_role_name: sso_role_name.clone(),
-            };
-            if let Err(err) = ensure_aws_profile_configured(&sso_config) {
-                log::warn!("Could not write AWS profile config: {}", err);
-            }
-        }
-
+        // The profile section already exists in ~/.aws/config (it was reflected
+        // from the file). No write-back to the config file is needed here.
         sso_login_with_url(profile, &profile_name, &sso_start_url, url_callback).await
     }
 
@@ -1452,40 +964,6 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
             .collect()
     }
 
-    fn after_profile_saved(&self, profile: &AuthProfile) {
-        let Some(profile_name) = profile.fields.get("profile_name") else {
-            return;
-        };
-        let Some(sso_start_url) = profile.fields.get("sso_start_url") else {
-            return;
-        };
-        let Some(region) = profile.fields.get("region") else {
-            return;
-        };
-        let Some(sso_account_id) = profile.fields.get("sso_account_id") else {
-            return;
-        };
-        let Some(sso_role_name) = profile.fields.get("sso_role_name") else {
-            return;
-        };
-
-        let profile_info = crate::config::AwsProfileInfo {
-            name: profile_name.clone(),
-            region: Some(region.clone()),
-            is_sso: true,
-            sso_start_url: Some(sso_start_url.clone()),
-            sso_region: Some(region.clone()),
-            sso_account_id: Some(sso_account_id.clone()),
-            sso_role_name: Some(sso_role_name.clone()),
-            sso_session: None,
-            is_sso_session: false,
-        };
-
-        if let Err(err) = crate::config::write_profile_to_aws_config(&profile_info) {
-            log::warn!("Failed to write AWS SSO profile to config: {}", err);
-        }
-    }
-
     /// Fetches runtime options for `sso_account_id` and `sso_role_name`
     /// `DynamicSelect` fields.
     ///
@@ -1500,12 +978,6 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
         profile: &AuthProfile,
         request: FetchOptionsRequest,
     ) -> Result<FetchOptionsResponse, FetchOptionsError> {
-        // Sync `~/.aws/config` with the current profile state before any AWS
-        // SDK call. Without this, a stale or malformed `[profile X]` block
-        // (e.g. one with a stray `sso_region` line that the SDK rejects)
-        // makes every dynamic-options fetch fail.
-        ensure_sso_profile_configured_from_auth_profile(profile);
-
         let profile_name = effective_aws_profile_name(profile)
             .unwrap_or("")
             .to_string();
@@ -1698,98 +1170,6 @@ impl dbflux_core::auth::DynAuthProvider for AwsSharedCredentialsAuthProvider {
         Ok(())
     }
 
-    fn after_profile_saved(&self, profile: &AuthProfile) {
-        let Some(profile_name) = profile.fields.get("profile_name") else {
-            return;
-        };
-        let Some(region) = profile.fields.get("region") else {
-            return;
-        };
-
-        let profile_info = crate::config::AwsProfileInfo {
-            name: profile_name.clone(),
-            region: Some(region.clone()),
-            is_sso: false,
-            sso_start_url: None,
-            sso_region: None,
-            sso_account_id: None,
-            sso_role_name: None,
-            sso_session: None,
-            is_sso_session: false,
-        };
-
-        if let Err(err) = crate::config::write_profile_to_aws_config(&profile_info) {
-            log::warn!(
-                "Failed to write AWS shared credentials profile to config: {}",
-                err
-            );
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl dbflux_core::auth::DynAuthProvider for AwsStaticCredentialsAuthProvider {
-    fn provider_id(&self) -> &'static str {
-        "aws-static-credentials"
-    }
-
-    fn display_name(&self) -> &'static str {
-        "AWS Static Credentials"
-    }
-
-    fn form_def(&self) -> &'static AuthFormDef {
-        static FORM: OnceLock<AuthFormDef> = OnceLock::new();
-        FORM.get_or_init(build_aws_static_credentials_form)
-    }
-
-    fn capabilities(&self) -> &AuthProviderCapabilities {
-        static CAPABILITIES: AuthProviderCapabilities = AuthProviderCapabilities {
-            login: AuthProviderLoginCapabilities {
-                supported: false,
-                verification_url_progress: false,
-            },
-        };
-
-        &CAPABILITIES
-    }
-
-    async fn validate_session(&self, _profile: &AuthProfile) -> Result<AuthSessionState, DbError> {
-        Ok(AuthSessionState::Valid { expires_at: None })
-    }
-
-    async fn login(
-        &self,
-        profile: &AuthProfile,
-        url_callback: UrlCallback,
-    ) -> Result<AuthSession, DbError> {
-        Ok(non_expiring_login(
-            profile,
-            self.provider_id(),
-            url_callback,
-        ))
-    }
-
-    async fn resolve_credentials(
-        &self,
-        profile: &AuthProfile,
-    ) -> Result<ResolvedCredentials, DbError> {
-        resolve_aws_credentials(profile).await
-    }
-
-    fn register_value_providers(
-        &self,
-        profile: &AuthProfile,
-        _session: Option<&AuthSession>,
-        resolver: &mut dbflux_core::values::CompositeValueResolver,
-    ) -> Result<(), DbError> {
-        let sdk_config = build_static_sdk_config_blocking(profile)?;
-
-        resolver
-            .register_secret_provider(Arc::new(AwsSecretsManagerProvider::new(sdk_config.clone())));
-        resolver.register_parameter_provider(Arc::new(AwsSsmParameterProvider::new(sdk_config)));
-
-        Ok(())
-    }
 }
 
 #[async_trait::async_trait]
@@ -1979,8 +1359,6 @@ pub(crate) fn validate_sso_session(sso_start_url: &str) -> Result<AuthSessionSta
 /// is safe to call from async contexts without an active Tokio reactor
 /// (e.g. the GPUI background executor).
 async fn resolve_aws_credentials(profile: &AuthProfile) -> Result<ResolvedCredentials, DbError> {
-    ensure_sso_profile_configured_from_auth_profile(profile);
-
     let profile_name = effective_aws_profile_name(profile).map(ToOwned::to_owned);
     let region = profile
         .fields
@@ -2377,22 +1755,15 @@ impl std::future::Future for SleepFuture {
 /// Safe to call from a plain OS thread with no async runtime. Used by the
 /// Settings UI login button which runs on the GPUI background executor
 /// (which has no Tokio reactor).
+/// Performs a blocking SSO login for the given profile.
+///
+/// The profile section must already exist in `~/.aws/config` (it is reflected
+/// from the file). No write to `~/.aws/config` is performed here.
 pub fn login_sso_blocking(
     profile_id: uuid::Uuid,
     profile_name: &str,
     sso_start_url: &str,
-    sso_region: &str,
-    sso_account_id: &str,
-    sso_role_name: &str,
 ) -> Result<AuthSession, DbError> {
-    ensure_aws_profile_configured(&SsoProfileConfig {
-        profile_name: profile_name.to_string(),
-        region: sso_region.to_string(),
-        sso_start_url: sso_start_url.to_string(),
-        sso_account_id: sso_account_id.to_string(),
-        sso_role_name: sso_role_name.to_string(),
-    })?;
-
     let handle = start_sso_login_blocking(profile_name)?;
     log::debug!(
         "AWS SSO login started for profile '{}', verification URL: {:?}",
@@ -2543,57 +1914,6 @@ mod tests {
     }
 
     #[test]
-    fn sso_profile_config_can_be_derived_from_auth_profile_fields() {
-        let profile = AuthProfile::new(
-            "Aws example",
-            "aws-sso",
-            [
-                ("profile_name".to_string(), "example".to_string()),
-                ("region".to_string(), "us-east-1".to_string()),
-                (
-                    "sso_start_url".to_string(),
-                    "https://example.awsapps.com/start".to_string(),
-                ),
-                ("sso_account_id".to_string(), "123456789012".to_string()),
-                (
-                    "sso_role_name".to_string(),
-                    "AdministratorAccess".to_string(),
-                ),
-            ]
-            .into_iter()
-            .collect(),
-        );
-
-        let config = sso_profile_config_from_auth_profile(&profile).expect("sso profile config");
-
-        assert_eq!(config.profile_name, "example");
-        assert_eq!(config.region, "us-east-1");
-        assert_eq!(config.sso_account_id, "123456789012");
-        assert_eq!(config.sso_role_name, "AdministratorAccess");
-    }
-
-    #[test]
-    fn static_credentials_do_not_fall_back_to_auth_profile_name() {
-        let mut fields = std::collections::HashMap::new();
-        fields.insert(
-            "access_key_id".to_string(),
-            "AKIAIOSFODNN7EXAMPLE".to_string(),
-        );
-        fields.insert(
-            "secret_access_key".to_string(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
-        );
-        fields.insert("region".to_string(), "us-east-1".to_string());
-
-        let profile = AuthProfile::new("static-creds", "aws-static-credentials", fields);
-
-        let (profile_name, region) = profile_name_and_region(&profile);
-
-        assert_eq!(profile_name, None);
-        assert_eq!(region, "us-east-1");
-    }
-
-    #[test]
     fn aws_sso_capabilities_advertise_interactive_login() {
         let provider = AwsSsoAuthProvider::new();
 
@@ -2610,7 +1930,7 @@ mod tests {
     }
 
     #[test]
-    fn non_interactive_aws_providers_keep_login_disabled() {
+    fn shared_credentials_provider_keeps_login_disabled() {
         let shared = AwsSharedCredentialsAuthProvider::new();
         let shared_capabilities =
             <AwsSharedCredentialsAuthProvider as dbflux_core::auth::DynAuthProvider>::capabilities(
@@ -2618,14 +1938,6 @@ mod tests {
             );
         assert!(!shared_capabilities.login.supported);
         assert!(!shared_capabilities.login.verification_url_progress);
-
-        let static_provider = AwsStaticCredentialsAuthProvider::new();
-        let static_capabilities =
-            <AwsStaticCredentialsAuthProvider as dbflux_core::auth::DynAuthProvider>::capabilities(
-                &static_provider,
-            );
-        assert!(!static_capabilities.login.supported);
-        assert!(!static_capabilities.login.verification_url_progress);
     }
 
     #[test]
@@ -2681,241 +1993,6 @@ mod tests {
 
     fn field_def_by_id<'a>(fields: &'a [FormFieldDef], id: &str) -> Option<&'a FormFieldDef> {
         fields.iter().find(|f| f.id == id)
-    }
-
-    #[test]
-    fn static_credentials_form_has_all_fields() {
-        let form = build_aws_static_credentials_form();
-
-        let fields = &form.tabs[0].sections[0].fields;
-
-        let access_key =
-            field_def_by_id(fields, "access_key_id").expect("access_key_id field missing");
-        assert_eq!(access_key.kind, FormFieldKind::Text);
-        assert!(access_key.required);
-
-        let secret_key =
-            field_def_by_id(fields, "secret_access_key").expect("secret_access_key field missing");
-        assert_eq!(secret_key.kind, FormFieldKind::Password);
-        assert!(secret_key.required);
-
-        let session_token =
-            field_def_by_id(fields, "session_token").expect("session_token field missing");
-        assert_eq!(session_token.kind, FormFieldKind::Password);
-        assert!(!session_token.required);
-
-        let region = field_def_by_id(fields, "region").expect("region field missing");
-        assert_eq!(region.kind, FormFieldKind::Text);
-        assert!(region.required);
-    }
-
-    #[test]
-    fn static_credentials_missing_access_key_returns_error() {
-        let mut fields = std::collections::HashMap::new();
-        fields.insert(
-            "secret_access_key".to_string(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
-        );
-        fields.insert("region".to_string(), "us-east-1".to_string());
-
-        let profile = AuthProfile::new("test-static", "aws-static-credentials", fields);
-
-        let result = build_static_sdk_config_blocking(&profile);
-        assert!(result.is_err());
-
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("access_key_id"),
-            "Error should mention access_key_id, got: {}",
-            err_msg
-        );
-    }
-
-    #[test]
-    fn static_credentials_missing_secret_key_returns_error() {
-        let mut fields = std::collections::HashMap::new();
-        fields.insert(
-            "access_key_id".to_string(),
-            "AKIAIOSFODNN7EXAMPLE".to_string(),
-        );
-        fields.insert("region".to_string(), "us-east-1".to_string());
-
-        let profile = AuthProfile::new("test-static", "aws-static-credentials", fields);
-
-        let result = build_static_sdk_config_blocking(&profile);
-        assert!(result.is_err());
-
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("secret_access_key"),
-            "Error should mention secret_access_key, got: {}",
-            err_msg
-        );
-    }
-
-    #[test]
-    fn static_credentials_empty_session_token_succeeds() {
-        let mut fields = std::collections::HashMap::new();
-        fields.insert(
-            "access_key_id".to_string(),
-            "AKIAIOSFODNN7EXAMPLE".to_string(),
-        );
-        fields.insert(
-            "secret_access_key".to_string(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
-        );
-        fields.insert("session_token".to_string(), String::new());
-        fields.insert("region".to_string(), "us-east-1".to_string());
-
-        let profile = AuthProfile::new("test-static", "aws-static-credentials", fields);
-
-        let result = build_static_sdk_config_blocking(&profile);
-
-        // The SdkConfig load attempts a network call to STS regional endpoints,
-        // which may fail in CI without real AWS credentials. The important
-        // assertion is that the function passes validation — it must NOT return
-        // a "missing required field" error for access_key_id, secret_access_key,
-        // or session_token (since the latter is optional and was provided as empty).
-        match result {
-            Ok(_) => {}
-            Err(err) => {
-                let msg = err.to_string();
-                let forbidden_fields = ["access_key_id", "secret_access_key", "session_token"];
-                for field in &forbidden_fields {
-                    assert!(
-                        !msg.contains(field),
-                        "Should not fail on field '{}', got error: {}",
-                        field,
-                        msg
-                    );
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn static_credentials_missing_session_token_succeeds() {
-        let mut fields = std::collections::HashMap::new();
-        fields.insert(
-            "access_key_id".to_string(),
-            "AKIAIOSFODNN7EXAMPLE".to_string(),
-        );
-        fields.insert(
-            "secret_access_key".to_string(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
-        );
-        fields.insert("region".to_string(), "us-east-1".to_string());
-        // Deliberately NOT inserting "session_token" at all.
-
-        let profile = AuthProfile::new("test-static-no-token", "aws-static-credentials", fields);
-
-        let result = build_static_sdk_config_blocking(&profile);
-
-        // Same as the empty-session-token test — we just need to verify the
-        // function does not error on missing session_token (it's optional).
-        // Network failures from fake credentials are acceptable.
-        match result {
-            Ok(_) => {}
-            Err(err) => {
-                let msg = err.to_string();
-                assert!(
-                    !msg.contains("access_key_id"),
-                    "Should not fail on access_key_id, got: {}",
-                    msg
-                );
-                assert!(
-                    !msg.contains("secret_access_key"),
-                    "Should not fail on secret_access_key, got: {}",
-                    msg
-                );
-                assert!(
-                    !msg.contains("session_token"),
-                    "session_token is optional, got error mentioning it: {}",
-                    msg
-                );
-            }
-        }
-    }
-
-    /// Verifies that `register_value_providers()` exercises the full code path
-    /// through `build_static_sdk_config_blocking` with present-but-fake
-    /// credentials. The AWS SDK will reject the fake credentials at runtime,
-    /// but the test proves the function does not fail on missing-field
-    /// validation and that the error (if any) propagates correctly.
-    ///
-    /// The happy path (real AWS credentials resolving to a working SdkConfig
-    /// and providers being registered) requires integration testing with live
-    /// AWS credentials and is not covered here.
-    #[test]
-    fn static_credentials_register_value_providers_with_fake_credentials() {
-        let mut fields = std::collections::HashMap::new();
-        fields.insert(
-            "access_key_id".to_string(),
-            "AKIAIOSFODNN7EXAMPLE".to_string(),
-        );
-        fields.insert(
-            "secret_access_key".to_string(),
-            "wJalrXUtnFEMI/K7MDENG/bPxRfiCY".to_string(),
-        );
-        fields.insert("region".to_string(), "us-east-1".to_string());
-
-        let profile = AuthProfile::new("test-register", "aws-static-credentials", fields);
-
-        let provider = AwsStaticCredentialsAuthProvider::new();
-        let cache = Arc::new(dbflux_core::values::ValueCache::new(
-            std::time::Duration::from_secs(60),
-        ));
-        let mut resolver = dbflux_core::values::CompositeValueResolver::new(cache);
-
-        let result = dbflux_core::auth::DynAuthProvider::register_value_providers(
-            &provider,
-            &profile,
-            None,
-            &mut resolver,
-        );
-
-        // With fake credentials, the SdkConfig load may or may not succeed
-        // depending on the environment. The critical assertion is that if it
-        // fails, the error is NOT about missing required fields — proving the
-        // validation passed and the error came from the AWS SDK layer.
-        match result {
-            Ok(()) => {
-                // SdkConfig loaded successfully — verify providers were registered.
-                let secret_providers = resolver.available_secret_providers();
-                let param_providers = resolver.available_parameter_providers();
-
-                assert!(
-                    secret_providers
-                        .iter()
-                        .any(|(id, _)| *id == "aws-secrets-manager"),
-                    "Expected aws-secrets-manager provider to be registered, found: {:?}",
-                    secret_providers
-                );
-                assert!(
-                    param_providers.iter().any(|(id, _)| *id == "aws-ssm"),
-                    "Expected aws-ssm provider to be registered, found: {:?}",
-                    param_providers
-                );
-            }
-            Err(err) => {
-                let msg = err.to_string();
-                assert!(
-                    !msg.contains("access_key_id"),
-                    "Should not fail on access_key_id validation, got: {}",
-                    msg
-                );
-                assert!(
-                    !msg.contains("secret_access_key"),
-                    "Should not fail on secret_access_key validation, got: {}",
-                    msg
-                );
-                assert!(
-                    !msg.contains("session_token"),
-                    "session_token is optional, got: {}",
-                    msg
-                );
-            }
-        }
     }
 
     // -------------------------------------------------------------------------

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -382,6 +382,16 @@ impl AwsSsoAuthProvider {
                     fields.insert("sso_session".to_string(), session_name.clone());
 
                     if let Some(session) = session_map.get(&session_name.to_lowercase()) {
+                        // Expose the referenced session's deterministic UUID
+                        // under the form's `sso_session_ref` field so the
+                        // Settings dropdown pre-selects it on load. The value
+                        // must match the id minted by the sso-session provider,
+                        // so derive it from the section's canonical header name.
+                        fields.insert(
+                            "sso_session_ref".to_string(),
+                            aws_profile_uuid("aws-sso-session", &session.name).to_string(),
+                        );
+
                         if let Some(ref url) = session.sso_start_url {
                             fields.insert("sso_start_url".to_string(), url.clone());
                         }
@@ -1007,8 +1017,17 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
     /// Returns `Conflict { file: Config }` without writing if the section was
     /// modified externally between `open_edit_snapshot` and this call.
     ///
-    /// Fields written: `sso_start_url`, `sso_account_id`, `sso_region`,
-    /// `sso_role_name`, `sso_session`, `region`, `output`.
+    /// When the profile references an `[sso-session NAME]` block (the
+    /// `sso_session_ref` form field is set, surfaced here as
+    /// `sso_session_ref_name` after ref expansion), the written section uses
+    /// the `sso_session = NAME` indirection and omits `sso_start_url` /
+    /// `sso_region`, which belong to the session block. Otherwise those keys
+    /// are written inline.
+    ///
+    /// Fields written (inline form): `sso_start_url`, `sso_account_id`,
+    /// `sso_region`, `sso_role_name`, `region`, `output`.
+    /// Fields written (session-ref form): `sso_session`, `sso_account_id`,
+    /// `sso_role_name`, `region`, `output`.
     fn save_edit(
         &self,
         name: &str,
@@ -1020,18 +1039,39 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
             cache.config_path().to_path_buf()
         };
 
-        let config_fields: Vec<(String, String)> = [
-            "sso_start_url",
-            "sso_account_id",
-            "sso_region",
-            "sso_role_name",
-            "sso_session",
-            "region",
-            "output",
-        ]
-        .iter()
-        .filter_map(|&key| fields.get(key).map(|v| (key.to_string(), v.clone())))
-        .collect();
+        let session_ref_name = fields
+            .get("sso_session_ref_name")
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty());
+
+        // `sso_session` and inline `sso_start_url` / `sso_region` are mutually
+        // exclusive in a `[profile]` block: when a session is referenced the
+        // URL/region live in the `[sso-session]` block, and the AWS SDK rejects
+        // a profile that carries both. Because the block writer merges (keeps
+        // unmanaged on-disk keys), the opposite key must be removed explicitly.
+        let (config_fields, remove_keys): (Vec<(String, String)>, &[&str]) =
+            if let Some(session_name) = session_ref_name {
+                let mut collected = vec![("sso_session".to_string(), session_name.to_string())];
+                collected.extend(
+                    ["sso_account_id", "sso_role_name", "region", "output"]
+                        .iter()
+                        .filter_map(|&key| fields.get(key).map(|v| (key.to_string(), v.clone()))),
+                );
+                (collected, &["sso_start_url", "sso_region"])
+            } else {
+                let collected = [
+                    "sso_start_url",
+                    "sso_account_id",
+                    "sso_region",
+                    "sso_role_name",
+                    "region",
+                    "output",
+                ]
+                .iter()
+                .filter_map(|&key| fields.get(key).map(|v| (key.to_string(), v.clone())))
+                .collect();
+                (collected, &["sso_session"])
+            };
 
         let snapshot_hash = snapshot.config_section.as_ref().map(|h| h.0);
 
@@ -1057,7 +1097,7 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
                 .iter()
                 .map(|(k, v)| (k.as_str(), v.as_str()))
                 .collect();
-            crate::config::replace_or_append_profile_block(existing, name, &borrowed)
+            crate::config::replace_or_append_profile_block(existing, name, &borrowed, remove_keys)
         });
 
         if result.is_err() {
@@ -1489,7 +1529,7 @@ impl dbflux_core::auth::DynAuthProvider for AwsSharedCredentialsAuthProvider {
                     .iter()
                     .map(|(k, v)| (k.as_str(), v.as_str()))
                     .collect();
-                crate::config::replace_or_append_profile_block(existing, name, &borrowed)
+                crate::config::replace_or_append_profile_block(existing, name, &borrowed, &[])
             });
 
             if result.is_err() || conflict_detected.get() {
@@ -3288,6 +3328,49 @@ sso_region = us-east-1
             other_hash_before.map(|h| h.0),
             other_hash_after.map(|h| h.0),
             "other section must be byte-identical after surgical write"
+        );
+    }
+
+    /// A profile referencing a session writes `sso_session = NAME` and keeps
+    /// `sso_start_url` / `sso_region` out of the profile block (they belong to
+    /// the session block). The session name arrives via `sso_session_ref_name`,
+    /// stashed by ref expansion before save_edit is called.
+    #[test]
+    fn sso_save_edit_session_ref_persists_indirection_not_inline_url() {
+        // Pre-existing inline sso_start_url / sso_region must be removed when a
+        // session is referenced (the block writer merges, so omission alone
+        // would leave the invalid both-present combo the AWS SDK rejects).
+        let config = "[profile dev-sso]\nsso_start_url = https://stale.awsapps.com/start\nsso_region = us-west-2\nsso_account_id = 111111111111\n";
+        let (provider, config_path, _creds, _dir) = sso_provider_with_config_and_creds(config, "");
+
+        let snapshot = provider.open_edit_snapshot("dev-sso");
+
+        let mut fields = HashMap::new();
+        fields.insert("sso_session_ref_name".to_string(), "my-org".to_string());
+        // A folded URL is present on the form but must NOT be written inline.
+        fields.insert(
+            "sso_start_url".to_string(),
+            "https://example.awsapps.com/start".to_string(),
+        );
+        fields.insert("sso_account_id".to_string(), "222222222222".to_string());
+
+        let outcome = provider.save_edit("dev-sso", &fields, &snapshot);
+        assert!(matches!(outcome, AuthSaveOutcome::Saved));
+
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        let section = crate::config::parse_aws_config_str(&after)
+            .into_iter()
+            .find(|p| p.name == "dev-sso")
+            .expect("dev-sso section must exist");
+
+        assert_eq!(
+            section.sso_session.as_deref(),
+            Some("my-org"),
+            "sso_session indirection must be persisted"
+        );
+        assert!(
+            !after.contains("sso_start_url"),
+            "sso_start_url must not be written inline when a session is referenced"
         );
     }
 

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -20,7 +20,7 @@ use dbflux_core::DbError;
 use dbflux_core::auth::{
     AuthFormDef, AuthProfile, AuthProviderCapabilities, AuthProviderLoginCapabilities, AuthSession,
     AuthSessionState, FetchOptionsError, FetchOptionsRequest, FetchOptionsResponse,
-    ImportableProfile, ResolvedCredentials, UrlCallback,
+    ImportableProfile, ResolvedCredentials, UrlCallback, aws_profile_uuid,
 };
 use dbflux_core::{
     FormFieldDef, FormFieldKind, FormSection, FormTab, RefreshTrigger, SelectOption,
@@ -538,6 +538,99 @@ impl AwsSsoAuthProvider {
         let mut cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
         cache.profiles().to_vec()
     }
+
+    /// Reflects all `[profile NAME]` SSO sections from `~/.aws/config` into
+    /// `AuthProfile` records.
+    ///
+    /// Each reflected profile has:
+    /// - `provider_id = "aws-sso"`
+    /// - `id = aws_profile_uuid("aws-sso", name)`
+    /// - `read_only = true`
+    /// - `fields` populated from the parsed config section; `sso_session`
+    ///   indirection is folded in from the referenced `[sso-session]` block.
+    ///
+    /// Malformed sections (empty name, required fields absent) are skipped
+    /// with a log warning. Missing or empty config returns an empty vec.
+    pub fn reflect_profiles(&self) -> Vec<AuthProfile> {
+        let profiles = {
+            let mut cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
+            cache.profiles().to_vec()
+        };
+
+        // Build a lookup for [sso-session NAME] blocks so we can fold them
+        // into profiles that use the sso_session = NAME indirection.
+        let session_lookup: HashMap<String, &crate::config::AwsProfileInfo> = profiles
+            .iter()
+            .filter(|p| p.is_sso_session)
+            .map(|p| (p.name.to_lowercase(), p))
+            .collect::<HashMap<_, _>>();
+        // Work around the lifetime issue: collect session data into owned vecs.
+        let session_map: HashMap<String, crate::config::AwsProfileInfo> = profiles
+            .iter()
+            .filter(|p| p.is_sso_session)
+            .map(|p| (p.name.to_lowercase(), p.clone()))
+            .collect();
+        drop(session_lookup); // was only used to build session_map
+
+        profiles
+            .iter()
+            .filter(|p| p.is_sso && !p.is_sso_session)
+            .filter_map(|p| {
+                if p.name.is_empty() {
+                    log::warn!("aws-config-reflect: skipping SSO profile with empty name");
+                    return None;
+                }
+
+                let mut fields = HashMap::new();
+                fields.insert("profile_name".to_string(), p.name.clone());
+
+                if let Some(ref region) = p.region {
+                    fields.insert("region".to_string(), region.clone());
+                }
+
+                // Fold sso_session indirection: if the profile references a
+                // [sso-session NAME] block, merge start_url and sso_region
+                // from the session into the profile's fields.
+                if let Some(ref session_name) = p.sso_session {
+                    fields.insert("sso_session".to_string(), session_name.clone());
+
+                    if let Some(session) = session_map.get(&session_name.to_lowercase()) {
+                        if let Some(ref url) = session.sso_start_url {
+                            fields.insert("sso_start_url".to_string(), url.clone());
+                        }
+                        if let Some(ref sso_region) = session.sso_region {
+                            fields.insert("sso_region".to_string(), sso_region.clone());
+                        }
+                    }
+                } else {
+                    if let Some(ref url) = p.sso_start_url {
+                        fields.insert("sso_start_url".to_string(), url.clone());
+                    }
+                    if let Some(ref sso_region) = p.sso_region {
+                        fields.insert("sso_region".to_string(), sso_region.clone());
+                    }
+                }
+
+                if let Some(ref account_id) = p.sso_account_id {
+                    fields.insert("sso_account_id".to_string(), account_id.clone());
+                }
+                if let Some(ref role_name) = p.sso_role_name {
+                    fields.insert("sso_role_name".to_string(), role_name.clone());
+                }
+
+                let id = aws_profile_uuid("aws-sso", &p.name);
+
+                Some(AuthProfile {
+                    id,
+                    name: p.name.clone(),
+                    provider_id: "aws-sso".to_string(),
+                    fields,
+                    enabled: true,
+                    read_only: true,
+                })
+            })
+            .collect()
+    }
 }
 
 impl Default for AwsSsoAuthProvider {
@@ -562,6 +655,55 @@ impl AwsSsoSessionAuthProvider {
             config_cache: Mutex::new(CachedAwsConfig::new()),
         }
     }
+
+    /// Reflects all `[sso-session NAME]` sections from `~/.aws/config` into
+    /// `AuthProfile` records.
+    ///
+    /// Each reflected profile has:
+    /// - `provider_id = "aws-sso-session"`
+    /// - `id = aws_profile_uuid("aws-sso-session", name)` — distinct from
+    ///   the same name under `aws-sso` (S17, provider-id scoping)
+    /// - `read_only = true`
+    ///
+    /// Malformed sections (empty name) are skipped with a log warning.
+    pub fn reflect_profiles(&self) -> Vec<AuthProfile> {
+        let mut cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
+        let profiles = cache.profiles().to_vec();
+
+        profiles
+            .iter()
+            .filter(|p| p.is_sso_session)
+            .filter_map(|p| {
+                if p.name.is_empty() {
+                    log::warn!(
+                        "aws-config-reflect: skipping sso-session profile with empty name"
+                    );
+                    return None;
+                }
+
+                let mut fields = HashMap::new();
+                fields.insert("profile_name".to_string(), p.name.clone());
+
+                if let Some(ref url) = p.sso_start_url {
+                    fields.insert("sso_start_url".to_string(), url.clone());
+                }
+                if let Some(ref sso_region) = p.sso_region {
+                    fields.insert("sso_region".to_string(), sso_region.clone());
+                }
+
+                let id = aws_profile_uuid("aws-sso-session", &p.name);
+
+                Some(AuthProfile {
+                    id,
+                    name: p.name.clone(),
+                    provider_id: "aws-sso-session".to_string(),
+                    fields,
+                    enabled: true,
+                    read_only: true,
+                })
+            })
+            .collect()
+    }
 }
 
 impl Default for AwsSsoSessionAuthProvider {
@@ -570,11 +712,84 @@ impl Default for AwsSsoSessionAuthProvider {
     }
 }
 
-pub struct AwsSharedCredentialsAuthProvider;
+pub struct AwsSharedCredentialsAuthProvider {
+    config_cache: Mutex<CachedAwsConfig>,
+}
 
 impl AwsSharedCredentialsAuthProvider {
     pub fn new() -> Self {
-        Self
+        Self {
+            config_cache: Mutex::new(CachedAwsConfig::new()),
+        }
+    }
+
+    /// Reflects all non-SSO profile names from `~/.aws/config` and
+    /// `~/.aws/credentials` into `AuthProfile` records.
+    ///
+    /// Uses `shared_profile_names()` which unions the non-SSO config sections
+    /// with the credentials-file section names (deduped, case-preserving).
+    ///
+    /// Reflected fields contain `profile_name` and optionally `region` from
+    /// the config file. Key material (`aws_access_key_id`,
+    /// `aws_secret_access_key`) is NEVER included — the AWS SDK reads those
+    /// directly from `~/.aws/credentials` at connect time.
+    pub fn reflect_profiles(&self) -> Vec<AuthProfile> {
+        let mut cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
+        let names = cache.shared_profile_names();
+
+        // Build a region lookup from the config profiles (names only; no keys).
+        let config_profiles = cache.profiles().to_vec();
+        let region_lookup: HashMap<String, String> = config_profiles
+            .iter()
+            .filter(|p| !p.is_sso && !p.is_sso_session)
+            .filter_map(|p| {
+                p.region
+                    .as_ref()
+                    .map(|r| (p.name.to_lowercase(), r.clone()))
+            })
+            .collect();
+
+        names
+            .into_iter()
+            .filter_map(|name| {
+                if name.is_empty() {
+                    log::warn!(
+                        "aws-config-reflect: skipping shared-credentials profile with empty name"
+                    );
+                    return None;
+                }
+
+                let mut fields = HashMap::new();
+                fields.insert("profile_name".to_string(), name.clone());
+
+                if let Some(region) = region_lookup.get(&name.to_lowercase()) {
+                    fields.insert("region".to_string(), region.clone());
+                }
+
+                // Security invariant: no key material in reflected fields.
+                // aws_access_key_id and aws_secret_access_key are intentionally
+                // absent — the AWS SDK reads them from ~/.aws/credentials.
+                debug_assert!(
+                    !fields.contains_key("aws_access_key_id"),
+                    "aws-config-reflect: key material must never appear in reflected fields"
+                );
+                debug_assert!(
+                    !fields.contains_key("aws_secret_access_key"),
+                    "aws-config-reflect: key material must never appear in reflected fields"
+                );
+
+                let id = aws_profile_uuid("aws-shared-credentials", &name);
+
+                Some(AuthProfile {
+                    id,
+                    name: name.clone(),
+                    provider_id: "aws-shared-credentials".to_string(),
+                    fields,
+                    enabled: true,
+                    read_only: true,
+                })
+            })
+            .collect()
     }
 }
 
@@ -2722,6 +2937,7 @@ mod tests {
             provider_id: "aws-sso".to_string(),
             fields,
             enabled: true,
+            read_only: false,
         }
     }
 
@@ -2790,6 +3006,332 @@ mod tests {
             "expected Permanent error for unknown field, got {:?}",
             result
         );
+    }
+
+    // --- T-3.1: AwsSsoAuthProvider::reflect_profiles() ---
+
+    /// Helper: creates a `CachedAwsConfig` backed by a temp config file, wrapped
+    /// in an `AwsSsoAuthProvider`.
+    fn sso_provider_with_config(config_content: &str) -> AwsSsoAuthProvider {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config_content).unwrap();
+        std::fs::write(&creds_path, "").unwrap();
+        let cache = crate::config::CachedAwsConfig::new_with_paths(config_path, creds_path);
+        // Leak the tempdir so the files remain for the test's duration.
+        std::mem::forget(dir);
+        AwsSsoAuthProvider {
+            config_cache: Mutex::new(cache),
+        }
+    }
+
+    /// Helper: creates a provider with both a config and a credentials file.
+    fn sso_provider_with_config_keep_dir(
+        config_content: &str,
+    ) -> (AwsSsoAuthProvider, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config_content).unwrap();
+        std::fs::write(&creds_path, "").unwrap();
+        let cache = crate::config::CachedAwsConfig::new_with_paths(config_path, creds_path);
+        let provider = AwsSsoAuthProvider {
+            config_cache: Mutex::new(cache),
+        };
+        (provider, dir)
+    }
+
+    #[test]
+    fn sso_reflect_produces_auth_profile_with_correct_provider_and_uuid() {
+        let config = r#"
+[profile dev-sso]
+sso_start_url = https://example.awsapps.com/start
+sso_account_id = 123456789012
+sso_role_name = DevAccess
+sso_region = us-east-1
+"#;
+        let provider = sso_provider_with_config(config);
+        let profiles = provider.reflect_profiles();
+
+        assert_eq!(profiles.len(), 1, "expected one reflected SSO profile");
+        let p = &profiles[0];
+
+        assert_eq!(p.provider_id, "aws-sso");
+        assert_eq!(p.name, "dev-sso");
+        assert!(p.read_only, "reflected profile must be read-only");
+        assert!(p.enabled);
+
+        let expected_id = dbflux_core::auth::aws_profile_uuid("aws-sso", "dev-sso");
+        assert_eq!(p.id, expected_id, "id must equal aws_profile_uuid(aws-sso, name)");
+
+        assert_eq!(
+            p.fields.get("sso_start_url").map(String::as_str),
+            Some("https://example.awsapps.com/start")
+        );
+        assert_eq!(
+            p.fields.get("sso_account_id").map(String::as_str),
+            Some("123456789012")
+        );
+        assert_eq!(
+            p.fields.get("sso_role_name").map(String::as_str),
+            Some("DevAccess")
+        );
+        assert_eq!(
+            p.fields.get("profile_name").map(String::as_str),
+            Some("dev-sso")
+        );
+
+        // No secret fields.
+        assert!(
+            !p.fields.contains_key("aws_access_key_id"),
+            "aws_access_key_id must not appear in reflected fields"
+        );
+        assert!(
+            !p.fields.contains_key("aws_secret_access_key"),
+            "aws_secret_access_key must not appear in reflected fields"
+        );
+    }
+
+    #[test]
+    fn sso_reflect_folds_sso_session_indirection() {
+        let config = r#"
+[profile my-sso]
+sso_session = my-org
+
+[sso-session my-org]
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+"#;
+        let provider = sso_provider_with_config(config);
+        let profiles = provider.reflect_profiles();
+
+        // Only one SSO profile (the sso-session is handled by AwsSsoSessionAuthProvider).
+        let sso = profiles.iter().find(|p| p.name == "my-sso").expect("my-sso must be reflected");
+
+        assert_eq!(sso.provider_id, "aws-sso");
+        assert_eq!(
+            sso.fields.get("sso_start_url").map(String::as_str),
+            Some("https://example.awsapps.com/start"),
+            "sso_start_url must be folded from the sso-session block"
+        );
+        assert_eq!(
+            sso.fields.get("sso_region").map(String::as_str),
+            Some("us-east-1"),
+            "sso_region must be folded from the sso-session block"
+        );
+        assert_eq!(
+            sso.fields.get("sso_session").map(String::as_str),
+            Some("my-org"),
+            "sso_session reference name must be preserved in fields"
+        );
+    }
+
+    #[test]
+    fn sso_reflect_returns_empty_when_config_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        // config_path intentionally does not exist.
+        let config_path = dir.path().join("nonexistent_config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&creds_path, "").unwrap();
+        let cache = crate::config::CachedAwsConfig::new_with_paths(config_path, creds_path);
+        let provider = AwsSsoAuthProvider {
+            config_cache: Mutex::new(cache),
+        };
+
+        let profiles = provider.reflect_profiles();
+        assert!(profiles.is_empty(), "missing config must yield empty list, no panic");
+    }
+
+    #[test]
+    fn sso_reflect_skips_non_sso_sections_but_reflects_sso_ones() {
+        let config = r#"
+[profile ci-user]
+region = us-west-2
+
+[profile dev-sso]
+sso_start_url = https://example.awsapps.com/start
+sso_account_id = 123456789012
+sso_role_name = DevAccess
+sso_region = us-east-1
+"#;
+        let provider = sso_provider_with_config(config);
+        let profiles = provider.reflect_profiles();
+
+        // Only SSO profiles; ci-user is shared-credentials, not SSO.
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].name, "dev-sso");
+    }
+
+    // --- T-3.2: AwsSsoSessionAuthProvider::reflect_profiles() ---
+
+    fn sso_session_provider_with_config(config_content: &str) -> AwsSsoSessionAuthProvider {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config_content).unwrap();
+        std::fs::write(&creds_path, "").unwrap();
+        let cache = crate::config::CachedAwsConfig::new_with_paths(config_path, creds_path);
+        std::mem::forget(dir);
+        AwsSsoSessionAuthProvider {
+            config_cache: Mutex::new(cache),
+        }
+    }
+
+    #[test]
+    fn sso_session_reflect_produces_correct_provider_and_uuid() {
+        let config = r#"
+[sso-session my-org]
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+"#;
+        let provider = sso_session_provider_with_config(config);
+        let profiles = provider.reflect_profiles();
+
+        assert_eq!(profiles.len(), 1);
+        let p = &profiles[0];
+
+        assert_eq!(p.provider_id, "aws-sso-session");
+        assert_eq!(p.name, "my-org");
+        assert!(p.read_only);
+
+        let expected_id = dbflux_core::auth::aws_profile_uuid("aws-sso-session", "my-org");
+        assert_eq!(p.id, expected_id);
+
+        assert_eq!(
+            p.fields.get("sso_start_url").map(String::as_str),
+            Some("https://example.awsapps.com/start")
+        );
+    }
+
+    #[test]
+    fn sso_session_uuid_differs_from_sso_same_name() {
+        let config = r#"
+[profile shared]
+sso_start_url = https://example.awsapps.com/start
+sso_account_id = 111122223333
+sso_role_name = Admin
+sso_region = us-east-1
+
+[sso-session shared]
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+"#;
+        let sso_provider = sso_provider_with_config(config);
+        let session_provider = sso_session_provider_with_config(config);
+
+        let sso_profiles = sso_provider.reflect_profiles();
+        let session_profiles = session_provider.reflect_profiles();
+
+        let sso_p = sso_profiles.iter().find(|p| p.name == "shared").expect("sso shared");
+        let session_p = session_profiles.iter().find(|p| p.name == "shared").expect("session shared");
+
+        assert_ne!(
+            sso_p.id, session_p.id,
+            "same name under aws-sso vs aws-sso-session must have distinct UUIDs"
+        );
+    }
+
+    #[test]
+    fn sso_session_reflect_returns_empty_when_config_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("nonexistent");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&creds_path, "").unwrap();
+        let cache = crate::config::CachedAwsConfig::new_with_paths(config_path, creds_path);
+        let provider = AwsSsoSessionAuthProvider {
+            config_cache: Mutex::new(cache),
+        };
+        assert!(provider.reflect_profiles().is_empty());
+    }
+
+    // --- T-3.3: AwsSharedCredentialsAuthProvider::reflect_profiles() ---
+
+    fn shared_provider_with_files(
+        config_content: &str,
+        credentials_content: &str,
+    ) -> AwsSharedCredentialsAuthProvider {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config_content).unwrap();
+        std::fs::write(&creds_path, credentials_content).unwrap();
+        let cache = crate::config::CachedAwsConfig::new_with_paths(config_path, creds_path);
+        std::mem::forget(dir);
+        AwsSharedCredentialsAuthProvider {
+            config_cache: Mutex::new(cache),
+        }
+    }
+
+    #[test]
+    fn shared_reflect_includes_credentials_file_profiles() {
+        let credentials = "[ci-user]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCY\n";
+        let config = "";
+        let provider = shared_provider_with_files(config, credentials);
+        let profiles = provider.reflect_profiles();
+
+        let ci = profiles.iter().find(|p| p.name == "ci-user").expect("ci-user must be reflected");
+        assert_eq!(ci.provider_id, "aws-shared-credentials");
+        assert!(ci.read_only);
+
+        let expected_id = dbflux_core::auth::aws_profile_uuid("aws-shared-credentials", "ci-user");
+        assert_eq!(ci.id, expected_id);
+    }
+
+    #[test]
+    fn shared_reflect_reflects_region_from_config_when_present() {
+        let config = "[profile ci-user]\nregion = us-west-2\n";
+        let credentials = "[ci-user]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI\n";
+        let provider = shared_provider_with_files(config, credentials);
+        let profiles = provider.reflect_profiles();
+
+        let ci = profiles.iter().find(|p| p.name == "ci-user").expect("ci-user");
+        assert_eq!(
+            ci.fields.get("region").map(String::as_str),
+            Some("us-west-2"),
+            "region from config must be reflected"
+        );
+    }
+
+    #[test]
+    fn shared_reflect_no_region_does_not_error() {
+        let credentials = "[my-profile]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI\n";
+        let provider = shared_provider_with_files("", credentials);
+        let profiles = provider.reflect_profiles();
+
+        let p = profiles.iter().find(|p| p.name == "my-profile").expect("my-profile");
+        assert!(
+            p.fields.get("region").is_none(),
+            "absent region must not appear in fields"
+        );
+    }
+
+    /// Security assertion: reflected shared-credentials profiles must never
+    /// contain key material (ADR-7 invariant).
+    #[test]
+    fn shared_reflect_never_includes_key_material() {
+        let credentials = "[prod]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCY\n";
+        let provider = shared_provider_with_files("", credentials);
+        let profiles = provider.reflect_profiles();
+
+        for profile in &profiles {
+            let keys_present = profile.fields.contains_key("aws_access_key_id")
+                || profile.fields.contains_key("aws_secret_access_key");
+            assert!(
+                !keys_present,
+                "profile '{}' must not contain key material in reflected fields",
+                profile.name
+            );
+
+            // Also assert no AKIA-pattern value appears anywhere in the fields.
+            for (key, value) in &profile.fields {
+                assert!(
+                    !value.starts_with("AKIA"),
+                    "field '{}' contains an AKIA-pattern value, which is forbidden in reflected fields",
+                    key
+                );
+            }
+        }
     }
 
     /// When `sso_account_id` dependency is missing, `sso_role_name` fetch

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -2080,10 +2080,6 @@ mod tests {
         }
     }
 
-    fn field_def_by_id<'a>(fields: &'a [FormFieldDef], id: &str) -> Option<&'a FormFieldDef> {
-        fields.iter().find(|f| f.id == id)
-    }
-
     // -------------------------------------------------------------------------
     // T16: fetch_dynamic_options unit tests (no live AWS calls)
     // -------------------------------------------------------------------------

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -413,6 +413,7 @@ impl AwsSsoAuthProvider {
                     fields,
                     enabled: true,
                     read_only: true,
+                    dangling_origin: None,
                 })
             })
             .collect()
@@ -484,6 +485,7 @@ impl AwsSsoSessionAuthProvider {
                     fields,
                     enabled: true,
                     read_only: true,
+                    dangling_origin: None,
                 })
             })
             .collect()
@@ -571,6 +573,7 @@ impl AwsSharedCredentialsAuthProvider {
                     fields,
                     enabled: true,
                     read_only: true,
+                    dangling_origin: None,
                 })
             })
             .collect()
@@ -923,6 +926,48 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
         AwsSsoAuthProvider::reflect_profiles(self)
     }
 
+    fn write_new_profile_to_config(&self, profile: &AuthProfile) -> Option<Result<(), String>> {
+        let name = profile.name.trim().to_string();
+        let sso_start_url = profile
+            .fields
+            .get("sso_start_url")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        let sso_region = profile
+            .fields
+            .get("sso_region")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        let sso_account_id = profile
+            .fields
+            .get("sso_account_id")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        let sso_role_name = profile
+            .fields
+            .get("sso_role_name")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        let region = profile
+            .fields
+            .get("region")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+
+        Some(
+            crate::config::append_aws_sso_profile(
+                &name,
+                &sso_start_url,
+                &sso_region,
+                &sso_account_id,
+                &sso_role_name,
+                &region,
+            )
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        )
+    }
+
     fn detect_importable_profiles(&self) -> Vec<ImportableProfile> {
         let mut cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -1175,6 +1220,21 @@ impl dbflux_core::auth::DynAuthProvider for AwsSharedCredentialsAuthProvider {
     fn reflect_profiles(&self) -> Vec<AuthProfile> {
         AwsSharedCredentialsAuthProvider::reflect_profiles(self)
     }
+
+    fn write_new_profile_to_config(&self, profile: &AuthProfile) -> Option<Result<(), String>> {
+        let name = profile.name.trim().to_string();
+        let region = profile
+            .fields
+            .get("region")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+
+        Some(
+            crate::config::append_aws_shared_credentials_profile(&name, &region)
+                .map(|_| ())
+                .map_err(|e| e.to_string()),
+        )
+    }
 }
 
 #[async_trait::async_trait]
@@ -1260,6 +1320,26 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoSessionAuthProvider {
 
     fn reflect_profiles(&self) -> Vec<AuthProfile> {
         AwsSsoSessionAuthProvider::reflect_profiles(self)
+    }
+
+    fn write_new_profile_to_config(&self, profile: &AuthProfile) -> Option<Result<(), String>> {
+        let name = profile.name.trim().to_string();
+        let sso_start_url = profile
+            .fields
+            .get("sso_start_url")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        let sso_region = profile
+            .fields
+            .get("sso_region")
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+
+        Some(
+            crate::config::append_aws_sso_session_profile(&name, &sso_start_url, &sso_region)
+                .map(|_| ())
+                .map_err(|e| e.to_string()),
+        )
     }
 }
 
@@ -2024,6 +2104,7 @@ mod tests {
             fields,
             enabled: true,
             read_only: false,
+            dangling_origin: None,
         }
     }
 
@@ -2110,22 +2191,6 @@ mod tests {
         AwsSsoAuthProvider {
             config_cache: Mutex::new(cache),
         }
-    }
-
-    /// Helper: creates a provider with both a config and a credentials file.
-    fn sso_provider_with_config_keep_dir(
-        config_content: &str,
-    ) -> (AwsSsoAuthProvider, tempfile::TempDir) {
-        let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("config");
-        let creds_path = dir.path().join("credentials");
-        std::fs::write(&config_path, config_content).unwrap();
-        std::fs::write(&creds_path, "").unwrap();
-        let cache = crate::config::CachedAwsConfig::new_with_paths(config_path, creds_path);
-        let provider = AwsSsoAuthProvider {
-            config_cache: Mutex::new(cache),
-        };
-        (provider, dir)
     }
 
     #[test]
@@ -2442,6 +2507,169 @@ sso_region = us-east-1
                 );
             }
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // S3–S5: write-back prohibition — config file must not be modified
+    // -------------------------------------------------------------------------
+
+    /// S3: `reflect_profiles()` must not write to `~/.aws/config`.
+    ///
+    /// Verified by checking that the config file mtime is unchanged after
+    /// reflect_profiles() completes. Uses a temp file as the config source so
+    /// the real user config is never touched.
+    #[test]
+    fn reflect_profiles_does_not_write_to_config() {
+        let config = r#"
+[profile dev-sso]
+sso_start_url = https://example.awsapps.com/start
+sso_account_id = 123456789012
+sso_role_name = DevAccess
+sso_region = us-east-1
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config).unwrap();
+        std::fs::write(&creds_path, "").unwrap();
+
+        let mtime_before = std::fs::metadata(&config_path).unwrap().modified().unwrap();
+        let hash_before = std::fs::read(&config_path).unwrap();
+
+        let cache =
+            crate::config::CachedAwsConfig::new_with_paths(config_path.clone(), creds_path.clone());
+        let provider = AwsSsoAuthProvider {
+            config_cache: Mutex::new(cache),
+        };
+        let _ = provider.reflect_profiles();
+
+        let mtime_after = std::fs::metadata(&config_path).unwrap().modified().unwrap();
+        let hash_after = std::fs::read(&config_path).unwrap();
+
+        assert_eq!(
+            mtime_before, mtime_after,
+            "reflect_profiles() must not modify ~/.aws/config (mtime changed)"
+        );
+        assert_eq!(
+            hash_before, hash_after,
+            "reflect_profiles() must not modify ~/.aws/config (content changed)"
+        );
+    }
+
+    /// S4: `fetch_dynamic_options()` must not write to `~/.aws/config`.
+    ///
+    /// Uses an unknown field id (returns Permanent immediately without network
+    /// calls) while asserting the config file is untouched.
+    #[test]
+    fn fetch_dynamic_options_does_not_write_to_config() {
+        let config = r#"
+[profile dev-sso]
+sso_start_url = https://example.awsapps.com/start
+sso_account_id = 123456789012
+sso_role_name = DevAccess
+sso_region = us-east-1
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config).unwrap();
+        std::fs::write(&creds_path, "").unwrap();
+
+        let mtime_before = std::fs::metadata(&config_path).unwrap().modified().unwrap();
+        let hash_before = std::fs::read(&config_path).unwrap();
+
+        let cache =
+            crate::config::CachedAwsConfig::new_with_paths(config_path.clone(), creds_path.clone());
+        let provider = AwsSsoAuthProvider {
+            config_cache: Mutex::new(cache),
+        };
+
+        let profile = make_sso_profile();
+        let request = FetchOptionsRequest {
+            field_id: "unknown_field".to_string(),
+            dependencies: std::collections::HashMap::new(),
+            session: None,
+        };
+        let _result = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(provider.fetch_dynamic_options(&profile, request));
+
+        let mtime_after = std::fs::metadata(&config_path).unwrap().modified().unwrap();
+        let hash_after = std::fs::read(&config_path).unwrap();
+
+        assert_eq!(
+            mtime_before, mtime_after,
+            "fetch_dynamic_options() must not modify ~/.aws/config (mtime changed)"
+        );
+        assert_eq!(
+            hash_before, hash_after,
+            "fetch_dynamic_options() must not modify ~/.aws/config (content changed)"
+        );
+    }
+
+    /// S5: `login()` must not write to `~/.aws/config`.
+    ///
+    /// Uses a profile without `sso_start_url` to trigger an early error before
+    /// any network calls, while asserting the config file is untouched.
+    #[test]
+    fn login_does_not_write_to_config() {
+        let config = r#"
+[profile dev-sso]
+sso_account_id = 123456789012
+sso_role_name = DevAccess
+sso_region = us-east-1
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config).unwrap();
+        std::fs::write(&creds_path, "").unwrap();
+
+        let mtime_before = std::fs::metadata(&config_path).unwrap().modified().unwrap();
+        let hash_before = std::fs::read(&config_path).unwrap();
+
+        let cache =
+            crate::config::CachedAwsConfig::new_with_paths(config_path.clone(), creds_path.clone());
+        let provider = AwsSsoAuthProvider {
+            config_cache: Mutex::new(cache),
+        };
+
+        // Use a profile with no sso_start_url so login() errors before network
+        // calls. The profile name ("dev-sso") matches a section in the config
+        // but the provider still must not write back.
+        let mut fields = std::collections::HashMap::new();
+        fields.insert("profile_name".to_string(), "dev-sso".to_string());
+        let profile = AuthProfile {
+            id: uuid::Uuid::new_v4(),
+            name: "dev-sso".to_string(),
+            provider_id: "aws-sso".to_string(),
+            fields,
+            enabled: true,
+            read_only: true,
+            dangling_origin: None,
+        };
+
+        let _result = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(provider.login(&profile, Box::new(|_url: Option<String>| {})));
+
+        let mtime_after = std::fs::metadata(&config_path).unwrap().modified().unwrap();
+        let hash_after = std::fs::read(&config_path).unwrap();
+
+        assert_eq!(
+            mtime_before, mtime_after,
+            "login() must not modify ~/.aws/config (mtime changed)"
+        );
+        assert_eq!(
+            hash_before, hash_after,
+            "login() must not modify ~/.aws/config (content changed)"
+        );
     }
 
     /// When `sso_account_id` dependency is missing, `sso_role_name` fetch

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -413,7 +413,8 @@ impl AwsSsoAuthProvider {
                     provider_id: "aws-sso".to_string(),
                     fields,
                     enabled: true,
-                    read_only: true,
+                    // Reflected non-dangling profiles are editable (design §13).
+                    read_only: false,
                     dangling_origin: None,
                 })
             })
@@ -485,7 +486,8 @@ impl AwsSsoSessionAuthProvider {
                     provider_id: "aws-sso-session".to_string(),
                     fields,
                     enabled: true,
-                    read_only: true,
+                    // Reflected non-dangling profiles are editable (design §13).
+                    read_only: false,
                     dangling_origin: None,
                 })
             })
@@ -573,7 +575,8 @@ impl AwsSharedCredentialsAuthProvider {
                     provider_id: "aws-shared-credentials".to_string(),
                     fields,
                     enabled: true,
-                    read_only: true,
+                    // Reflected non-dangling profiles are editable (design §13).
+                    read_only: false,
                     dangling_origin: None,
                 })
             })
@@ -689,13 +692,66 @@ fn build_aws_shared_credentials_form() -> AuthFormDef {
         tabs: vec![FormTab {
             id: "main".to_string(),
             label: "Main".to_string(),
-            sections: vec![FormSection {
-                title: "AWS Shared Credentials".to_string(),
-                fields: vec![
-                    required_text_field("profile_name", "AWS Profile Name", "default"),
-                    required_text_field("region", "Region", "us-east-1"),
-                ],
-            }],
+            sections: vec![
+                FormSection {
+                    title: "AWS Shared Credentials".to_string(),
+                    fields: vec![
+                        required_text_field("profile_name", "AWS Profile Name", "default"),
+                        required_text_field("region", "Region", "us-east-1"),
+                        FormFieldDef {
+                            id: "aws_access_key_id".to_string(),
+                            label: "Access Key ID".to_string(),
+                            kind: FormFieldKind::Text,
+                            placeholder: "AKIAIOSFODNN7EXAMPLE".to_string(),
+                            required: false,
+                            default_value: String::new(),
+                            enabled_when_checked: None,
+                            enabled_when_unchecked: None,
+                            disabled_when_field_set: None,
+                            help: Some(
+                                "Written to the [name] section in ~/.aws/credentials.".to_string(),
+                            ),
+                        },
+                    ],
+                },
+                FormSection {
+                    title: "Credentials (write-only)".to_string(),
+                    fields: vec![
+                        FormFieldDef {
+                            id: "aws_secret_access_key".to_string(),
+                            label: "Secret Access Key".to_string(),
+                            kind: FormFieldKind::WriteOnly,
+                            placeholder: "Leave blank to keep current".to_string(),
+                            required: false,
+                            default_value: String::new(),
+                            enabled_when_checked: None,
+                            enabled_when_unchecked: None,
+                            disabled_when_field_set: None,
+                            help: Some(
+                                "Write-only. Leave blank to preserve the existing value in \
+                                 ~/.aws/credentials. Enter a value to overwrite it."
+                                    .to_string(),
+                            ),
+                        },
+                        FormFieldDef {
+                            id: "aws_session_token".to_string(),
+                            label: "Session Token".to_string(),
+                            kind: FormFieldKind::WriteOnly,
+                            placeholder: "Leave blank to keep current".to_string(),
+                            required: false,
+                            default_value: String::new(),
+                            enabled_when_checked: None,
+                            enabled_when_unchecked: None,
+                            disabled_when_field_set: None,
+                            help: Some(
+                                "Optional. Write-only. Leave blank to preserve the existing \
+                                 value in ~/.aws/credentials."
+                                    .to_string(),
+                            ),
+                        },
+                    ],
+                },
+            ],
         }],
     }
 }
@@ -2537,7 +2593,11 @@ sso_region = us-east-1
 
         assert_eq!(p.provider_id, "aws-sso");
         assert_eq!(p.name, "dev-sso");
-        assert!(p.read_only, "reflected profile must be read-only");
+        // Non-dangling reflected profiles are editable (design §13); read_only = false.
+        assert!(
+            !p.read_only,
+            "non-dangling reflected profile must be editable (read_only = false)"
+        );
         assert!(p.enabled);
 
         let expected_id = dbflux_core::auth::aws_profile_uuid("aws-sso", "dev-sso");
@@ -2680,7 +2740,8 @@ sso_region = us-east-1
 
         assert_eq!(p.provider_id, "aws-sso-session");
         assert_eq!(p.name, "my-org");
-        assert!(p.read_only);
+        // Non-dangling reflected profiles are editable (design §13); read_only = false.
+        assert!(!p.read_only);
 
         let expected_id = dbflux_core::auth::aws_profile_uuid("aws-sso-session", "my-org");
         assert_eq!(p.id, expected_id);
@@ -2768,7 +2829,8 @@ sso_region = us-east-1
             .find(|p| p.name == "ci-user")
             .expect("ci-user must be reflected");
         assert_eq!(ci.provider_id, "aws-shared-credentials");
-        assert!(ci.read_only);
+        // Non-dangling reflected profiles are editable (design §13); read_only = false.
+        assert!(!ci.read_only);
 
         let expected_id = dbflux_core::auth::aws_profile_uuid("aws-shared-credentials", "ci-user");
         assert_eq!(ci.id, expected_id);
@@ -3495,5 +3557,109 @@ sso_region = us-east-1
             snapshot.credentials_section.is_some(),
             "credentials_section hash must be Some when [ci] exists"
         );
+    }
+
+    // ── E5: Workspace-level security audit ────────────────────────────────────
+
+    /// E5.1: `AuthSaveOutcome` debug representation contains no secret material
+    /// after a credentials write. (Cross-crate security regression guard.)
+    #[test]
+    fn e5_auth_save_outcome_debug_never_exposes_secret() {
+        let creds = "[myprofile]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n";
+        let (provider, _config_path, _creds_path, _dir) = shared_provider_with_paths("", creds);
+
+        let snapshot = provider.open_edit_snapshot("myprofile");
+        let mut fields = HashMap::new();
+        // Use a distinct value so we can check it is not present in the outcome.
+        fields.insert(
+            "aws_secret_access_key".to_string(),
+            "A1B2C3D4E5F6EXAMPLEKEY".to_string(),
+        );
+
+        let outcome = provider.save_edit("myprofile", &fields, &snapshot);
+        let debug_repr = format!("{outcome:?}");
+
+        let secret_patterns = [
+            "A1B2C3D4E5F6",
+            "wJalrXUtnFEMI",
+            "aws_secret_access_key",
+            "AKIA",
+        ];
+        for pattern in &secret_patterns {
+            assert!(
+                !debug_repr.contains(pattern),
+                "AuthSaveOutcome debug must not contain '{pattern}': got {debug_repr}"
+            );
+        }
+    }
+
+    /// E5.2: Surgical write to `~/.aws/config` leaves non-target sections
+    /// byte-identical. Also verified in WU-E3 tests; re-stated here as a
+    /// workspace-level regression anchor.
+    #[test]
+    fn e5_surgical_write_config_leaves_other_sections_byte_identical() {
+        let config = "[profile dev]\nsso_start_url = https://before.example.com/start\n\
+                      sso_region = us-east-1\n\
+                      sso_account_id = 111111111111\n\
+                      [profile staging]\nregion = eu-west-1\n";
+        let provider = sso_provider_with_config(config);
+
+        let snapshot = provider.open_edit_snapshot("dev");
+
+        // Record the staging section hash before the write using the public hash helper.
+        let staging_hash_before = crate::config::hash_config_section(config, "staging");
+
+        let mut fields = HashMap::new();
+        fields.insert("sso_account_id".to_string(), "999999999999".to_string());
+
+        let outcome = provider.save_edit("dev", &fields, &snapshot);
+        assert!(
+            matches!(outcome, AuthSaveOutcome::Saved),
+            "save should succeed; got {outcome:?}"
+        );
+
+        // Re-read the config to get the post-write content and check staging.
+        let config_path = provider
+            .config_cache
+            .lock()
+            .unwrap()
+            .config_path()
+            .to_path_buf();
+        let after = std::fs::read_to_string(&config_path).unwrap();
+
+        let staging_hash_after = crate::config::hash_config_section(&after, "staging");
+
+        assert_eq!(
+            staging_hash_before.map(|h| h.0),
+            staging_hash_after.map(|h| h.0),
+            "[profile staging] section hash must be identical after editing [profile dev]"
+        );
+    }
+
+    /// E5.3: Names-only enumeration never returns values that resemble AWS
+    /// access keys, even when the credentials file contains them.
+    #[test]
+    fn e5_names_only_enumeration_contains_no_key_material() {
+        let creds = "[ci-user]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n\
+                     aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n\
+                     [staging]\naws_access_key_id = AKIAI44QH8DHBEXAMPLE\n";
+
+        let names = crate::config::parse_aws_credentials_str(creds);
+
+        for name in &names {
+            assert!(
+                !name.starts_with("AKIA"),
+                "enumerated name '{name}' looks like an access key; key material must not be returned"
+            );
+            assert!(
+                !name.contains("secret") && !name.contains("wJalrX"),
+                "enumerated name '{name}' contains secret material"
+            );
+        }
+
+        // Exactly the two profile names must be returned.
+        assert_eq!(names.len(), 2);
+        assert!(names.contains(&"ci-user".to_string()));
+        assert!(names.contains(&"staging".to_string()));
     }
 }

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -18,9 +18,10 @@ use aws_sdk_sts::config::ProvideCredentials;
 
 use dbflux_core::DbError;
 use dbflux_core::auth::{
-    AuthFormDef, AuthProfile, AuthProviderCapabilities, AuthProviderLoginCapabilities, AuthSession,
-    AuthSessionState, FetchOptionsError, FetchOptionsRequest, FetchOptionsResponse,
-    ImportableProfile, ResolvedCredentials, UrlCallback, aws_profile_uuid,
+    AuthFormDef, AuthProfile, AuthProviderCapabilities, AuthProviderLoginCapabilities,
+    AuthSaveOutcome, AuthSession, AuthSessionState, AwsEditFile, AwsEditSnapshot,
+    FetchOptionsError, FetchOptionsRequest, FetchOptionsResponse, ImportableProfile,
+    ResolvedCredentials, UrlCallback, aws_profile_uuid,
 };
 use dbflux_core::{
     FormFieldDef, FormFieldKind, FormSection, FormTab, RefreshTrigger, SelectOption,
@@ -922,6 +923,102 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoAuthProvider {
         abort_sso_login(profile.id)
     }
 
+    /// Captures a SHA-256 snapshot of the `[profile NAME]` section in
+    /// `~/.aws/config` at the moment the edit form opens.
+    ///
+    /// The config section is the only writable target for `aws-sso` profiles.
+    /// Returns `config_section = None` when the section is absent (new profile).
+    fn open_edit_snapshot(&self, name: &str) -> AwsEditSnapshot {
+        let config_path = {
+            let cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
+            cache.config_path().to_path_buf()
+        };
+
+        let config_section = std::fs::read_to_string(&config_path)
+            .ok()
+            .and_then(|contents| crate::config::hash_config_section(&contents, name));
+
+        AwsEditSnapshot {
+            config_section,
+            credentials_section: None,
+        }
+    }
+
+    /// Writes the edited SSO profile fields to `~/.aws/config` atomically.
+    ///
+    /// Performs an optimistic-concurrency check under the file lock: re-hashes
+    /// the `[profile NAME]` section from disk and compares against `snapshot`.
+    /// Returns `Conflict { file: Config }` without writing if the section was
+    /// modified externally between `open_edit_snapshot` and this call.
+    ///
+    /// Fields written: `sso_start_url`, `sso_account_id`, `sso_region`,
+    /// `sso_role_name`, `sso_session`, `region`, `output`.
+    fn save_edit(
+        &self,
+        name: &str,
+        fields: &HashMap<String, String>,
+        snapshot: &AwsEditSnapshot,
+    ) -> AuthSaveOutcome {
+        let config_path = {
+            let cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
+            cache.config_path().to_path_buf()
+        };
+
+        let config_fields: Vec<(String, String)> = [
+            "sso_start_url",
+            "sso_account_id",
+            "sso_region",
+            "sso_role_name",
+            "sso_session",
+            "region",
+            "output",
+        ]
+        .iter()
+        .filter_map(|&key| fields.get(key).map(|v| (key.to_string(), v.clone())))
+        .collect();
+
+        let snapshot_hash = snapshot.config_section.as_ref().map(|h| h.0);
+
+        // Use a Cell to signal conflict from within the atomic transform.
+        // The transform is FnOnce, so we capture by reference via a local flag.
+        let conflict_detected = std::cell::Cell::new(false);
+
+        let result = crate::config::update_aws_config_atomic(&config_path, |existing| {
+            let current_hash = crate::config::hash_config_section(existing, name).map(|h| h.0);
+
+            let hashes_match = match (snapshot_hash, current_hash) {
+                (Some(snap), Some(current)) => snap == current,
+                (None, None) => true,
+                _ => false,
+            };
+
+            if !hashes_match {
+                conflict_detected.set(true);
+                return existing.to_string();
+            }
+
+            let borrowed: Vec<(&str, &str)> = config_fields
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            crate::config::replace_or_append_profile_block(existing, name, &borrowed)
+        });
+
+        if result.is_err() {
+            return AuthSaveOutcome::Conflict {
+                file: AwsEditFile::Config,
+            };
+        }
+
+        if conflict_detected.get() {
+            return AuthSaveOutcome::Conflict {
+                file: AwsEditFile::Config,
+            };
+        }
+
+        AuthSaveOutcome::Saved
+    }
+
     fn reflect_profiles(&self) -> Vec<AuthProfile> {
         AwsSsoAuthProvider::reflect_profiles(self)
     }
@@ -1235,6 +1332,166 @@ impl dbflux_core::auth::DynAuthProvider for AwsSharedCredentialsAuthProvider {
                 .map_err(|e| e.to_string()),
         )
     }
+
+    /// Captures section-hash snapshots for both `~/.aws/config` (`[profile NAME]`)
+    /// and `~/.aws/credentials` (`[NAME]`) at the moment the edit form opens.
+    ///
+    /// Either hash may be `None` when the corresponding section is absent.
+    fn open_edit_snapshot(&self, name: &str) -> AwsEditSnapshot {
+        let (config_path, credentials_path) = {
+            let cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
+            (
+                cache.config_path().to_path_buf(),
+                cache.credentials_path().to_path_buf(),
+            )
+        };
+
+        let config_section = std::fs::read_to_string(&config_path)
+            .ok()
+            .and_then(|contents| crate::config::hash_config_section(&contents, name));
+
+        let credentials_section = std::fs::read_to_string(&credentials_path)
+            .ok()
+            .and_then(|contents| crate::config::hash_credentials_section(&contents, name));
+
+        AwsEditSnapshot {
+            config_section,
+            credentials_section,
+        }
+    }
+
+    /// Writes edited shared-credentials profile fields atomically to both
+    /// `~/.aws/config` and `~/.aws/credentials` as needed.
+    ///
+    /// Config fields (`region`, `output`) go to `[profile NAME]` in
+    /// `~/.aws/config`. Credentials fields (`aws_access_key_id`,
+    /// `aws_secret_access_key`, `aws_session_token`) go to `[NAME]` in
+    /// `~/.aws/credentials`.
+    ///
+    /// Write order: config first, credentials second (ADR-11). Each write has
+    /// its own conflict check under the shared lock. If config writes but
+    /// credentials conflicts, returns `PartialSaved { written: Config,
+    /// conflicted: Credentials }`.
+    ///
+    /// Secret fields: `aws_secret_access_key` and `aws_session_token` transit
+    /// only transiently inside the write transform and are never persisted to
+    /// DBFlux storage or logs.
+    fn save_edit(
+        &self,
+        name: &str,
+        fields: &HashMap<String, String>,
+        snapshot: &AwsEditSnapshot,
+    ) -> AuthSaveOutcome {
+        let (config_path, credentials_path) = {
+            let cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
+            (
+                cache.config_path().to_path_buf(),
+                cache.credentials_path().to_path_buf(),
+            )
+        };
+
+        // Config-side fields (non-secret).
+        let config_fields: Vec<(String, String)> = ["region", "output"]
+            .iter()
+            .filter_map(|&key| fields.get(key).map(|v| (key.to_string(), v.clone())))
+            .collect();
+
+        // Credentials-side fields (includes write-only secrets).
+        let creds_fields: Vec<(String, String)> = [
+            "aws_access_key_id",
+            "aws_secret_access_key",
+            "aws_session_token",
+        ]
+        .iter()
+        .filter_map(|&key| fields.get(key).map(|v| (key.to_string(), v.clone())))
+        .collect();
+
+        let has_config_fields = !config_fields.is_empty();
+        let has_creds_fields = !creds_fields.is_empty();
+
+        // Write config section first (when there are config-side fields to write).
+        let config_written = if has_config_fields {
+            let snapshot_hash = snapshot.config_section.as_ref().map(|h| h.0);
+            let conflict_detected = std::cell::Cell::new(false);
+
+            let config_fields_borrowed = config_fields.clone();
+            let result = crate::config::update_aws_config_atomic(&config_path, |existing| {
+                let current_hash = crate::config::hash_config_section(existing, name).map(|h| h.0);
+
+                let hashes_match = match (snapshot_hash, current_hash) {
+                    (Some(snap), Some(current)) => snap == current,
+                    (None, None) => true,
+                    _ => false,
+                };
+
+                if !hashes_match {
+                    conflict_detected.set(true);
+                    return existing.to_string();
+                }
+
+                let borrowed: Vec<(&str, &str)> = config_fields_borrowed
+                    .iter()
+                    .map(|(k, v)| (k.as_str(), v.as_str()))
+                    .collect();
+                crate::config::replace_or_append_profile_block(existing, name, &borrowed)
+            });
+
+            if result.is_err() || conflict_detected.get() {
+                return AuthSaveOutcome::Conflict {
+                    file: AwsEditFile::Config,
+                };
+            }
+
+            true
+        } else {
+            false
+        };
+
+        // Write credentials section second (when there are credentials-side fields).
+        if has_creds_fields {
+            let snapshot_hash = snapshot.credentials_section.as_ref().map(|h| h.0);
+            let conflict_detected = std::cell::Cell::new(false);
+
+            let creds_fields_borrowed = creds_fields.clone();
+            let result =
+                crate::config::update_aws_credentials_atomic(&credentials_path, |existing| {
+                    let current_hash =
+                        crate::config::hash_credentials_section(existing, name).map(|h| h.0);
+
+                    let hashes_match = match (snapshot_hash, current_hash) {
+                        (Some(snap), Some(current)) => snap == current,
+                        (None, None) => true,
+                        _ => false,
+                    };
+
+                    if !hashes_match {
+                        conflict_detected.set(true);
+                        return existing.to_string();
+                    }
+
+                    let borrowed: Vec<(&str, &str)> = creds_fields_borrowed
+                        .iter()
+                        .map(|(k, v)| (k.as_str(), v.as_str()))
+                        .collect();
+                    crate::config::replace_or_append_credentials_block(existing, name, &borrowed)
+                });
+
+            if result.is_err() || conflict_detected.get() {
+                return if config_written {
+                    AuthSaveOutcome::PartialSaved {
+                        written: AwsEditFile::Config,
+                        conflicted: AwsEditFile::Credentials,
+                    }
+                } else {
+                    AuthSaveOutcome::Conflict {
+                        file: AwsEditFile::Credentials,
+                    }
+                };
+            }
+        }
+
+        AuthSaveOutcome::Saved
+    }
 }
 
 #[async_trait::async_trait]
@@ -1340,6 +1597,80 @@ impl dbflux_core::auth::DynAuthProvider for AwsSsoSessionAuthProvider {
                 .map(|_| ())
                 .map_err(|e| e.to_string()),
         )
+    }
+
+    /// Captures a SHA-256 snapshot of the `[sso-session NAME]` section in
+    /// `~/.aws/config` at the moment the edit form opens.
+    fn open_edit_snapshot(&self, name: &str) -> AwsEditSnapshot {
+        let config_path = {
+            let cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
+            cache.config_path().to_path_buf()
+        };
+
+        let config_section = std::fs::read_to_string(&config_path)
+            .ok()
+            .and_then(|contents| crate::config::hash_sso_session_section(&contents, name));
+
+        AwsEditSnapshot {
+            config_section,
+            credentials_section: None,
+        }
+    }
+
+    /// Writes the edited sso-session fields to the `[sso-session NAME]` section
+    /// in `~/.aws/config` atomically.
+    ///
+    /// Fields written: `sso_start_url`, `sso_region`, `sso_registration_scopes`.
+    fn save_edit(
+        &self,
+        name: &str,
+        fields: &HashMap<String, String>,
+        snapshot: &AwsEditSnapshot,
+    ) -> AuthSaveOutcome {
+        let config_path = {
+            let cache = self.config_cache.lock().unwrap_or_else(|e| e.into_inner());
+            cache.config_path().to_path_buf()
+        };
+
+        let session_fields: Vec<(String, String)> =
+            ["sso_start_url", "sso_region", "sso_registration_scopes"]
+                .iter()
+                .filter_map(|&key| fields.get(key).map(|v| (key.to_string(), v.clone())))
+                .collect();
+
+        let snapshot_hash = snapshot.config_section.as_ref().map(|h| h.0);
+        let conflict_detected = std::cell::Cell::new(false);
+
+        let result = crate::config::update_aws_config_atomic(&config_path, |existing| {
+            let current_hash = crate::config::hash_sso_session_section(existing, name).map(|h| h.0);
+
+            let hashes_match = match (snapshot_hash, current_hash) {
+                (Some(snap), Some(current)) => snap == current,
+                (None, None) => true,
+                _ => false,
+            };
+
+            if !hashes_match {
+                conflict_detected.set(true);
+                return existing.to_string();
+            }
+
+            // Build a replacement `[sso-session NAME]` block using the
+            // sso-session-specific block builder.
+            let borrowed: Vec<(&str, &str)> = session_fields
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            crate::config::replace_or_append_sso_session_block(existing, name, &borrowed)
+        });
+
+        if result.is_err() || conflict_detected.get() {
+            return AuthSaveOutcome::Conflict {
+                file: AwsEditFile::Config,
+            };
+        }
+
+        AuthSaveOutcome::Saved
     }
 }
 
@@ -2691,6 +3022,478 @@ sso_region = us-east-1
             matches!(result, Err(FetchOptionsError::Permanent(_))),
             "expected Permanent error when sso_account_id is absent, got {:?}",
             result
+        );
+    }
+
+    // =========================================================================
+    // WU-E3: open_edit_snapshot + save_edit per-provider tests
+    // =========================================================================
+
+    // Helper: creates an AwsSsoAuthProvider backed by a temp config file.
+    fn sso_provider_with_config_and_creds(
+        config_content: &str,
+        creds_content: &str,
+    ) -> (
+        AwsSsoAuthProvider,
+        std::path::PathBuf,
+        std::path::PathBuf,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config_content).unwrap();
+        std::fs::write(&creds_path, creds_content).unwrap();
+        let cache =
+            crate::config::CachedAwsConfig::new_with_paths(config_path.clone(), creds_path.clone());
+        let provider = AwsSsoAuthProvider {
+            config_cache: Mutex::new(cache),
+        };
+        (provider, config_path, creds_path, dir)
+    }
+
+    // Helper: creates an AwsSharedCredentialsAuthProvider backed by temp files.
+    fn shared_provider_with_paths(
+        config_content: &str,
+        creds_content: &str,
+    ) -> (
+        AwsSharedCredentialsAuthProvider,
+        std::path::PathBuf,
+        std::path::PathBuf,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config_content).unwrap();
+        std::fs::write(&creds_path, creds_content).unwrap();
+        let cache =
+            crate::config::CachedAwsConfig::new_with_paths(config_path.clone(), creds_path.clone());
+        let provider = AwsSharedCredentialsAuthProvider {
+            config_cache: Mutex::new(cache),
+        };
+        (provider, config_path, creds_path, dir)
+    }
+
+    // Helper: creates an AwsSsoSessionAuthProvider backed by a temp config file.
+    fn sso_session_provider_with_config_path(
+        config_content: &str,
+    ) -> (
+        AwsSsoSessionAuthProvider,
+        std::path::PathBuf,
+        std::path::PathBuf,
+        tempfile::TempDir,
+    ) {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&config_path, config_content).unwrap();
+        std::fs::write(&creds_path, "").unwrap();
+        let cache =
+            crate::config::CachedAwsConfig::new_with_paths(config_path.clone(), creds_path.clone());
+        let provider = AwsSsoSessionAuthProvider {
+            config_cache: Mutex::new(cache),
+        };
+        (provider, config_path, creds_path, dir)
+    }
+
+    // ── E3.3 (aws-sso): optimistic concurrency ────────────────────────────────
+
+    /// S28: no external change between snapshot and save → `Saved`.
+    #[test]
+    fn sso_save_edit_no_external_change_returns_saved() {
+        let config = "[profile dev-sso]\nsso_start_url = https://example.awsapps.com/start\nsso_account_id = 111111111111\n";
+        let (provider, _config, _creds, _dir) = sso_provider_with_config_and_creds(config, "");
+
+        let snapshot = provider.open_edit_snapshot("dev-sso");
+        assert!(
+            snapshot.config_section.is_some(),
+            "open_edit_snapshot must capture a hash for an existing section"
+        );
+
+        let mut fields = HashMap::new();
+        fields.insert("sso_account_id".to_string(), "999999999999".to_string());
+
+        let outcome = provider.save_edit("dev-sso", &fields, &snapshot);
+        assert!(
+            matches!(outcome, AuthSaveOutcome::Saved),
+            "expected Saved when no external change, got {:?}",
+            outcome
+        );
+    }
+
+    /// S29: same section changed on disk between snapshot and save → `Conflict`.
+    #[test]
+    fn sso_save_edit_same_section_changed_externally_returns_conflict() {
+        let config = "[profile dev-sso]\nsso_start_url = https://example.awsapps.com/start\nsso_account_id = 111111111111\n";
+        let (provider, config_path, _creds, _dir) = sso_provider_with_config_and_creds(config, "");
+
+        // Take snapshot before external change.
+        let snapshot = provider.open_edit_snapshot("dev-sso");
+
+        // Simulate external edit of the same section.
+        std::fs::write(
+            &config_path,
+            "[profile dev-sso]\nsso_start_url = https://example.awsapps.com/start\nsso_account_id = 222222222222\n",
+        )
+        .unwrap();
+
+        let mut fields = HashMap::new();
+        fields.insert("sso_account_id".to_string(), "999999999999".to_string());
+
+        let outcome = provider.save_edit("dev-sso", &fields, &snapshot);
+        assert!(
+            matches!(
+                outcome,
+                AuthSaveOutcome::Conflict {
+                    file: AwsEditFile::Config
+                }
+            ),
+            "expected Conflict(Config) when same section changed externally, got {:?}",
+            outcome
+        );
+
+        // File must be unchanged (nothing written on conflict).
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            after.contains("222222222222"),
+            "file must retain external change, not the user's edit"
+        );
+        assert!(
+            !after.contains("999999999999"),
+            "user's conflicted edit must not appear in file"
+        );
+    }
+
+    /// S30: a DIFFERENT section changed externally → save succeeds.
+    #[test]
+    fn sso_save_edit_different_section_changed_does_not_conflict() {
+        let config = "[profile dev-sso]\nsso_account_id = 111111111111\n\n[profile staging]\nsso_account_id = 555555555555\n";
+        let (provider, config_path, _creds, _dir) = sso_provider_with_config_and_creds(config, "");
+
+        let snapshot = provider.open_edit_snapshot("dev-sso");
+
+        // External change to a DIFFERENT section.
+        std::fs::write(
+            &config_path,
+            "[profile dev-sso]\nsso_account_id = 111111111111\n\n[profile staging]\nsso_account_id = 999999999999\n",
+        )
+        .unwrap();
+
+        let mut fields = HashMap::new();
+        fields.insert("sso_account_id".to_string(), "777777777777".to_string());
+
+        let outcome = provider.save_edit("dev-sso", &fields, &snapshot);
+        assert!(
+            matches!(outcome, AuthSaveOutcome::Saved),
+            "expected Saved when only a different section changed, got {:?}",
+            outcome
+        );
+
+        // Both sections must be present: dev-sso updated, staging preserved.
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            after.contains("777777777777"),
+            "dev-sso edit must be applied"
+        );
+        assert!(
+            after.contains("999999999999"),
+            "staging external change must be preserved"
+        );
+    }
+
+    /// Surgical write: other sections in the config file are byte-identical after save.
+    #[test]
+    fn sso_save_edit_is_surgical_other_sections_unchanged() {
+        let config = "[profile other]\nregion = eu-west-1\n\n[profile dev-sso]\nsso_account_id = 111111111111\n";
+        let (provider, config_path, _creds, _dir) = sso_provider_with_config_and_creds(config, "");
+
+        let snapshot = provider.open_edit_snapshot("dev-sso");
+        let other_hash_before = crate::config::hash_config_section(
+            &std::fs::read_to_string(&config_path).unwrap(),
+            "other",
+        );
+
+        let mut fields = HashMap::new();
+        fields.insert("sso_account_id".to_string(), "999999999999".to_string());
+        let outcome = provider.save_edit("dev-sso", &fields, &snapshot);
+        assert!(matches!(outcome, AuthSaveOutcome::Saved));
+
+        let after = std::fs::read_to_string(&config_path).unwrap();
+        let other_hash_after = crate::config::hash_config_section(&after, "other");
+
+        assert_eq!(
+            other_hash_before.map(|h| h.0),
+            other_hash_after.map(|h| h.0),
+            "other section must be byte-identical after surgical write"
+        );
+    }
+
+    // ── E3.4 (aws-shared-credentials): credentials merge semantics ────────────
+
+    /// Blank secret field preserves existing on-disk value (S27).
+    #[test]
+    fn shared_save_edit_blank_secret_preserves_existing() {
+        let config = "[profile ci]\nregion = us-east-1\n";
+        // Using AWS-doc-compliant dummy values (not real credentials).
+        let creds = "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n";
+        let (provider, _config_path, creds_path, _dir) = shared_provider_with_paths(config, creds);
+
+        let snapshot = provider.open_edit_snapshot("ci");
+
+        // Leave secret blank; only update access_key_id.
+        let mut fields = HashMap::new();
+        fields.insert(
+            "aws_access_key_id".to_string(),
+            "AKIAI44QH8DHBEXAMPLE".to_string(),
+        );
+        // aws_secret_access_key intentionally absent from fields → blank = preserve.
+
+        let outcome = provider.save_edit("ci", &fields, &snapshot);
+        assert!(
+            matches!(outcome, AuthSaveOutcome::Saved),
+            "expected Saved, got {:?}",
+            outcome
+        );
+
+        let after = std::fs::read_to_string(&creds_path).unwrap();
+        assert!(
+            after.contains("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+            "existing secret must be preserved when the field is omitted from edited_fields"
+        );
+        assert!(
+            after.contains("AKIAI44QH8DHBEXAMPLE"),
+            "access key id must be updated"
+        );
+    }
+
+    /// Non-blank secret field overwrites the on-disk value (S26).
+    #[test]
+    fn shared_save_edit_non_blank_secret_overwrites() {
+        let config = "";
+        let creds = "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n";
+        let (provider, _config_path, creds_path, _dir) = shared_provider_with_paths(config, creds);
+
+        let snapshot = provider.open_edit_snapshot("ci");
+
+        let mut fields = HashMap::new();
+        fields.insert(
+            "aws_secret_access_key".to_string(),
+            "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY".to_string(),
+        );
+
+        let outcome = provider.save_edit("ci", &fields, &snapshot);
+        assert!(
+            matches!(outcome, AuthSaveOutcome::Saved),
+            "expected Saved, got {:?}",
+            outcome
+        );
+
+        let after = std::fs::read_to_string(&creds_path).unwrap();
+        assert!(
+            after.contains("je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY"),
+            "new secret must be written"
+        );
+        assert!(
+            !after.contains("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+            "old secret must be replaced"
+        );
+    }
+
+    /// The `AuthSaveOutcome` returned never exposes the secret value.
+    #[test]
+    fn shared_save_edit_outcome_contains_no_secret() {
+        let config = "";
+        let creds = "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n";
+        let (provider, _config_path, _creds_path, _dir) = shared_provider_with_paths(config, creds);
+
+        let snapshot = provider.open_edit_snapshot("ci");
+        let mut fields = HashMap::new();
+        fields.insert(
+            "aws_secret_access_key".to_string(),
+            "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY".to_string(),
+        );
+
+        let outcome = provider.save_edit("ci", &fields, &snapshot);
+
+        // The outcome is a unit-like enum — no variant carries a value payload.
+        // Assert no secret appears in the debug representation.
+        let debug_repr = format!("{:?}", outcome);
+        assert!(
+            !debug_repr.contains("je7MtGbClwBF"),
+            "AuthSaveOutcome debug must not expose the secret value"
+        );
+        assert!(
+            !debug_repr.contains("wJalrXUtnFEMI"),
+            "AuthSaveOutcome debug must not expose the old secret value"
+        );
+    }
+
+    // ── PartialSaved path ─────────────────────────────────────────────────────
+
+    /// When config writes but credentials section conflicts, returns PartialSaved.
+    #[test]
+    fn shared_save_edit_partial_saved_when_credentials_conflict() {
+        let config = "[profile ci]\nregion = us-east-1\n";
+        let creds = "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n";
+        let (provider, _config_path, creds_path, _dir) = shared_provider_with_paths(config, creds);
+
+        // Take snapshot BEFORE external change to credentials.
+        let snapshot = provider.open_edit_snapshot("ci");
+
+        // Simulate external edit of the credentials section only.
+        std::fs::write(
+            &creds_path,
+            "[ci]\naws_access_key_id = AKIAI44QH8DHBEXAMPLE\n",
+        )
+        .unwrap();
+
+        // Edit both config (region) and credentials (access key id).
+        let mut fields = HashMap::new();
+        fields.insert("region".to_string(), "eu-west-1".to_string());
+        fields.insert(
+            "aws_access_key_id".to_string(),
+            "AKIAZZZZZZZZZEXAMPLE".to_string(),
+        );
+
+        let outcome = provider.save_edit("ci", &fields, &snapshot);
+        assert!(
+            matches!(
+                outcome,
+                AuthSaveOutcome::PartialSaved {
+                    written: AwsEditFile::Config,
+                    conflicted: AwsEditFile::Credentials,
+                }
+            ),
+            "expected PartialSaved(Config written, Credentials conflicted), got {:?}",
+            outcome
+        );
+    }
+
+    // ── Surgical write: credentials file ─────────────────────────────────────
+
+    /// Other sections in ~/.aws/credentials are byte-identical after save (S31).
+    #[test]
+    fn shared_save_edit_credentials_surgical_other_sections_unchanged() {
+        let config = "";
+        let creds = "[prod]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n\n[ci]\naws_access_key_id = AKIAI44QH8DHBEXAMPLE\n";
+        let (provider, _config_path, creds_path, _dir) = shared_provider_with_paths(config, creds);
+
+        let snapshot = provider.open_edit_snapshot("ci");
+        let prod_hash_before = crate::config::hash_credentials_section(
+            &std::fs::read_to_string(&creds_path).unwrap(),
+            "prod",
+        );
+
+        let mut fields = HashMap::new();
+        fields.insert(
+            "aws_access_key_id".to_string(),
+            "AKIAZZZZZZZZZEXAMPLE".to_string(),
+        );
+        let outcome = provider.save_edit("ci", &fields, &snapshot);
+        assert!(matches!(outcome, AuthSaveOutcome::Saved));
+
+        let after = std::fs::read_to_string(&creds_path).unwrap();
+        let prod_hash_after = crate::config::hash_credentials_section(&after, "prod");
+
+        assert_eq!(
+            prod_hash_before.map(|h| h.0),
+            prod_hash_after.map(|h| h.0),
+            "prod section must be byte-identical after surgical credentials write"
+        );
+    }
+
+    // ── E3.3 (aws-sso-session): optimistic concurrency ───────────────────────
+
+    /// sso-session provider: no external change → Saved.
+    #[test]
+    fn sso_session_save_edit_no_external_change_returns_saved() {
+        let config = "[sso-session my-org]\nsso_start_url = https://example.awsapps.com/start\nsso_region = us-east-1\n";
+        let (provider, _config_path, _creds_path, _dir) =
+            sso_session_provider_with_config_path(config);
+
+        let snapshot = provider.open_edit_snapshot("my-org");
+        assert!(
+            snapshot.config_section.is_some(),
+            "snapshot must capture existing sso-session section hash"
+        );
+
+        let mut fields = HashMap::new();
+        fields.insert("sso_region".to_string(), "eu-west-1".to_string());
+
+        let outcome = provider.save_edit("my-org", &fields, &snapshot);
+        assert!(
+            matches!(outcome, AuthSaveOutcome::Saved),
+            "expected Saved when no external change, got {:?}",
+            outcome
+        );
+    }
+
+    /// sso-session provider: same section changed externally → Conflict.
+    #[test]
+    fn sso_session_save_edit_same_section_changed_returns_conflict() {
+        let config = "[sso-session my-org]\nsso_start_url = https://example.awsapps.com/start\nsso_region = us-east-1\n";
+        let (provider, config_path, _creds_path, _dir) =
+            sso_session_provider_with_config_path(config);
+
+        let snapshot = provider.open_edit_snapshot("my-org");
+
+        // External change to the same section.
+        std::fs::write(
+            &config_path,
+            "[sso-session my-org]\nsso_start_url = https://example.awsapps.com/start\nsso_region = ap-southeast-1\n",
+        )
+        .unwrap();
+
+        let mut fields = HashMap::new();
+        fields.insert("sso_region".to_string(), "eu-west-1".to_string());
+
+        let outcome = provider.save_edit("my-org", &fields, &snapshot);
+        assert!(
+            matches!(
+                outcome,
+                AuthSaveOutcome::Conflict {
+                    file: AwsEditFile::Config
+                }
+            ),
+            "expected Conflict(Config) when sso-session section changed, got {:?}",
+            outcome
+        );
+    }
+
+    // ── open_edit_snapshot for absent sections ────────────────────────────────
+
+    /// open_edit_snapshot returns None hashes when the section doesn't exist yet.
+    #[test]
+    fn open_edit_snapshot_absent_section_returns_none_hashes() {
+        let (provider, _config, _creds, _dir) = sso_provider_with_config_and_creds("", "");
+
+        let snapshot = provider.open_edit_snapshot("nonexistent");
+        assert!(
+            snapshot.config_section.is_none(),
+            "absent config section must produce None hash in snapshot"
+        );
+        assert!(
+            snapshot.credentials_section.is_none(),
+            "absent credentials section must produce None hash in snapshot"
+        );
+    }
+
+    /// shared-credentials: open_edit_snapshot captures both config and credentials hashes.
+    #[test]
+    fn shared_open_edit_snapshot_captures_both_file_hashes() {
+        let config = "[profile ci]\nregion = us-east-1\n";
+        let creds = "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n";
+        let (provider, _config_path, _creds_path, _dir) = shared_provider_with_paths(config, creds);
+
+        let snapshot = provider.open_edit_snapshot("ci");
+        assert!(
+            snapshot.config_section.is_some(),
+            "config_section hash must be Some when [profile ci] exists"
+        );
+        assert!(
+            snapshot.credentials_section.is_some(),
+            "credentials_section hash must be Some when [ci] exists"
         );
     }
 }

--- a/crates/dbflux_aws/src/config.rs
+++ b/crates/dbflux_aws/src/config.rs
@@ -373,11 +373,6 @@ fn flush_section(
     });
 }
 
-pub fn write_profile_to_aws_config(profile: &AwsProfileInfo) -> Result<(), io::Error> {
-    let path = config_file_path();
-    write_profile_to_path(profile, &path)
-}
-
 pub fn restore_aws_config_backup() -> Result<(), io::Error> {
     let path = config_file_path();
     restore_backup_for_path(&path)
@@ -424,125 +419,6 @@ pub(crate) fn update_aws_config_atomic(
     }
 
     write_atomic_with_backup(path, &updated)
-}
-
-fn write_profile_to_path(
-    profile: &AwsProfileInfo,
-    path: &std::path::Path,
-) -> Result<(), io::Error> {
-    update_aws_config_atomic(path, |existing| upsert_profile_section(existing, profile))
-}
-
-fn profile_section_header(name: &str) -> String {
-    if name.eq_ignore_ascii_case("default") {
-        "[default]".to_string()
-    } else {
-        format!("[profile {}]", name)
-    }
-}
-
-fn profile_entries(profile: &AwsProfileInfo) -> Vec<(String, String)> {
-    let mut entries = Vec::new();
-
-    if profile.is_sso {
-        if let Some(value) = profile.sso_start_url.as_ref()
-            && !value.trim().is_empty()
-        {
-            entries.push(("sso_start_url".to_string(), value.clone()));
-        }
-
-        if let Some(value) = profile.sso_region.as_ref()
-            && !value.trim().is_empty()
-        {
-            entries.push(("sso_region".to_string(), value.clone()));
-        }
-
-        if let Some(value) = profile.sso_account_id.as_ref()
-            && !value.trim().is_empty()
-        {
-            entries.push(("sso_account_id".to_string(), value.clone()));
-        }
-
-        if let Some(value) = profile.sso_role_name.as_ref()
-            && !value.trim().is_empty()
-        {
-            entries.push(("sso_role_name".to_string(), value.clone()));
-        }
-    }
-
-    if let Some(value) = profile.region.as_ref()
-        && !value.trim().is_empty()
-    {
-        entries.push(("region".to_string(), value.clone()));
-    }
-
-    entries
-}
-
-fn find_section_bounds(lines: &[String], section_header: &str) -> Option<(usize, usize)> {
-    let start = lines
-        .iter()
-        .position(|line| line.trim().eq_ignore_ascii_case(section_header))?;
-
-    let mut end = lines.len();
-    for (index, line) in lines.iter().enumerate().skip(start + 1) {
-        let trimmed = line.trim();
-        if trimmed.starts_with('[') && trimmed.ends_with(']') {
-            end = index;
-            break;
-        }
-    }
-
-    Some((start, end))
-}
-
-fn upsert_profile_section(contents: &str, profile: &AwsProfileInfo) -> String {
-    let section_header = profile_section_header(&profile.name);
-    let entries = profile_entries(profile);
-
-    let mut lines = contents
-        .lines()
-        .map(|line| line.to_string())
-        .collect::<Vec<_>>();
-
-    if let Some((start, end)) = find_section_bounds(&lines, &section_header) {
-        let mut seen = HashMap::<String, bool>::new();
-        for (key, _) in &entries {
-            seen.insert(key.clone(), false);
-        }
-
-        for line in lines.iter_mut().take(end).skip(start + 1) {
-            if let Some((key, _)) = parse_key_value(line.trim())
-                && let Some((_, value)) = entries.iter().find(|(entry_key, _)| *entry_key == key)
-            {
-                *line = format!("{} = {}", key, value);
-                seen.insert(key, true);
-            }
-        }
-
-        let mut insert_index = end;
-        for (key, value) in &entries {
-            if !seen.get(key).copied().unwrap_or(false) {
-                lines.insert(insert_index, format!("{} = {}", key, value));
-                insert_index += 1;
-            }
-        }
-    } else {
-        if !lines.is_empty() && !lines.last().is_some_and(|line| line.trim().is_empty()) {
-            lines.push(String::new());
-        }
-
-        lines.push(section_header);
-        for (key, value) in entries {
-            lines.push(format!("{} = {}", key, value));
-        }
-    }
-
-    let mut updated = lines.join("\n");
-    if !updated.ends_with('\n') {
-        updated.push('\n');
-    }
-    updated
 }
 
 fn write_atomic_with_backup(path: &std::path::Path, content: &str) -> Result<(), io::Error> {
@@ -701,6 +577,53 @@ pub fn append_aws_shared_credentials_profile(
     writeln!(block, "region = {region}").ok();
 
     append_config_block_if_absent(&path, name, &block)
+}
+
+/// Appends a new `[sso-session <name>]` block to `~/.aws/config`.
+///
+/// Creates the `~/.aws/` directory and the config file if they do not exist.
+/// If a section with the given name already exists, the file is left unchanged
+/// and the function returns `Ok(false)`. On a successful write it returns
+/// `Ok(true)`.
+pub fn append_aws_sso_session_profile(
+    name: &str,
+    sso_start_url: &str,
+    sso_region: &str,
+) -> Result<bool, std::io::Error> {
+    let path = config_file_path();
+
+    let mut block = String::new();
+    writeln!(block).ok();
+    writeln!(block, "[sso-session {name}]").ok();
+    writeln!(block, "sso_start_url = {sso_start_url}").ok();
+    writeln!(block, "sso_region = {sso_region}").ok();
+
+    // Use a unique sentinel for sso-session headers (not [default] or [profile X]).
+    // Since `append_config_block_if_absent` checks for [profile X] / [default],
+    // and sso-session sections use [sso-session X], we call `update_aws_config_atomic`
+    // directly with a sso-session-aware existence check.
+    let mut appended = false;
+    let sso_header = format!("[sso-session {name}]");
+
+    update_aws_config_atomic(&path, |existing| {
+        let already_exists = existing
+            .lines()
+            .any(|line| line.trim().eq_ignore_ascii_case(&sso_header));
+
+        if already_exists {
+            return existing.to_string();
+        }
+
+        appended = true;
+        let mut content = existing.to_string();
+        if !content.is_empty() && !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push_str(&block);
+        content
+    })?;
+
+    Ok(appended)
 }
 
 /// Reads the config file content, returning an empty string if the file does
@@ -996,7 +919,7 @@ output=json
         }
         std::fs::write(path.as_ref(), &seed).expect("seed");
 
-        // Many threads, each upserting its own distinct profile at the same
+        // Many threads, each appending its own distinct profile at the same
         // time. Before the lock + atomic rename, interleaved read-modify-write
         // cycles over a non-atomic write could read a half-written file and
         // persist the truncation, dropping unrelated sections.
@@ -1004,18 +927,9 @@ output=json
         for index in 0..16 {
             let path = Arc::clone(&path);
             handles.push(thread::spawn(move || {
-                let profile = AwsProfileInfo {
-                    name: format!("worker-{index}"),
-                    region: Some("eu-west-1".to_string()),
-                    is_sso: false,
-                    sso_start_url: None,
-                    sso_region: None,
-                    sso_account_id: None,
-                    sso_role_name: None,
-                    sso_session: None,
-                    is_sso_session: false,
-                };
-                write_profile_to_path(&profile, path.as_ref()).expect("write");
+                let name = format!("worker-{index}");
+                let block = format!("\n[profile {name}]\nregion = eu-west-1\n");
+                append_config_block_if_absent(path.as_ref(), &name, &block).expect("write");
             }));
         }
 

--- a/crates/dbflux_aws/src/config.rs
+++ b/crates/dbflux_aws/src/config.rs
@@ -964,6 +964,7 @@ pub(crate) fn replace_or_append_profile_block(
     contents: &str,
     name: &str,
     fields: &[(&str, &str)],
+    remove_keys: &[&str],
 ) -> String {
     let header = if name.eq_ignore_ascii_case("default") {
         "[default]".to_string()
@@ -972,7 +973,7 @@ pub(crate) fn replace_or_append_profile_block(
     };
 
     let header_lower = header.to_lowercase();
-    let new_block = build_profile_block(&header, contents, fields);
+    let new_block = build_profile_block(&header, contents, fields, remove_keys);
 
     let Some(raw) = section_raw_bytes(contents, &header) else {
         // Section absent — append at EOF.
@@ -1006,7 +1007,7 @@ pub(crate) fn replace_or_append_sso_session_block(
 ) -> String {
     let header = format!("[sso-session {name}]");
     let header_lower = header.to_lowercase();
-    let new_block = build_profile_block(&header, contents, fields);
+    let new_block = build_profile_block(&header, contents, fields, &[]);
 
     let Some(raw) = section_raw_bytes(contents, &header) else {
         let mut result = contents.to_string();
@@ -1029,7 +1030,21 @@ pub(crate) fn replace_or_append_sso_session_block(
 }
 
 /// Builds the replacement `[profile NAME]` section block for `~/.aws/config`.
-fn build_profile_block(header: &str, contents: &str, fields: &[(&str, &str)]) -> String {
+///
+/// Existing on-disk keys not present in `fields` are preserved (merge
+/// semantics), so unmanaged keys survive a save. Keys listed in `remove_keys`
+/// are dropped from the section entirely — used to enforce mutually exclusive
+/// AWS keys (e.g. a session-backed profile must not also carry an inline
+/// `sso_start_url`).
+fn build_profile_block(
+    header: &str,
+    contents: &str,
+    fields: &[(&str, &str)],
+    remove_keys: &[&str],
+) -> String {
+    let remove: std::collections::HashSet<String> =
+        remove_keys.iter().map(|k| k.to_lowercase()).collect();
+
     // Collect existing keys from the current on-disk section, in order.
     let mut existing_keys: Vec<(String, String)> = Vec::new();
     if let Some(raw) = section_raw_bytes(contents, header) {
@@ -1052,6 +1067,10 @@ fn build_profile_block(header: &str, contents: &str, fields: &[(&str, &str)]) ->
 
     let mut emitted_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
     for (key, existing_val) in &existing_keys {
+        if remove.contains(key) {
+            continue;
+        }
+
         let value = overrides
             .get(key)
             .map(String::as_str)
@@ -1062,6 +1081,9 @@ fn build_profile_block(header: &str, contents: &str, fields: &[(&str, &str)]) ->
 
     for (key, value) in fields {
         let key_lower = key.to_lowercase();
+        if remove.contains(&key_lower) {
+            continue;
+        }
         if !emitted_keys.contains(&key_lower) && !value.is_empty() {
             writeln!(block, "{key_lower} = {value}").ok();
         }
@@ -1980,6 +2002,7 @@ output=json
                 existing,
                 "b",
                 &[("region", "us-west-2"), ("output", "text")],
+                &[],
             )
         })
         .expect("config write");

--- a/crates/dbflux_aws/src/config.rs
+++ b/crates/dbflux_aws/src/config.rs
@@ -9,6 +9,7 @@ use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
 use std::time::SystemTime;
 
 #[derive(Debug, Clone)]
@@ -37,10 +38,33 @@ enum SectionKind {
     SsoSession(String),
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CachedAwsConfig {
+    config_path: PathBuf,
+    credentials_path: PathBuf,
+
     profiles: Vec<AwsProfileInfo>,
     last_modified: Option<SystemTime>,
+
+    /// Section names extracted from `~/.aws/credentials`.
+    ///
+    /// This cache is guarded independently from the config-file cache. A
+    /// change to either file triggers re-read of only that file.
+    credentials_names: Vec<String>,
+    credentials_last_modified: Option<SystemTime>,
+}
+
+impl Default for CachedAwsConfig {
+    fn default() -> Self {
+        Self {
+            config_path: config_file_path(),
+            credentials_path: credentials_file_path(),
+            profiles: Vec::new(),
+            last_modified: None,
+            credentials_names: Vec::new(),
+            credentials_last_modified: None,
+        }
+    }
 }
 
 impl CachedAwsConfig {
@@ -48,11 +72,26 @@ impl CachedAwsConfig {
         Self::default()
     }
 
+    /// Creates a `CachedAwsConfig` with explicit file paths.
+    ///
+    /// Used in tests to point the cache at temporary files instead of the
+    /// real `~/.aws/config` and `~/.aws/credentials`.
+    pub fn new_with_paths(config_path: PathBuf, credentials_path: PathBuf) -> Self {
+        Self {
+            config_path,
+            credentials_path,
+            profiles: Vec::new(),
+            last_modified: None,
+            credentials_names: Vec::new(),
+            credentials_last_modified: None,
+        }
+    }
+
     /// Returns cached profiles if the config file hasn't changed since last
     /// parse. Re-parses from disk when the file's mtime differs or on first
     /// call.
     pub fn profiles(&mut self) -> &[AwsProfileInfo] {
-        let path = config_file_path();
+        let path = self.config_path.clone();
         let current_mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
 
         let needs_refresh = match (&self.last_modified, &current_mtime) {
@@ -81,6 +120,78 @@ impl CachedAwsConfig {
 
         &self.profiles
     }
+
+    /// Returns the section names present in `~/.aws/credentials`.
+    ///
+    /// The cache is guarded independently from `profiles()`: a change to the
+    /// credentials file triggers a re-read of only that file; the config cache
+    /// is unaffected.
+    ///
+    /// Returns an empty slice when the file is missing or unreadable (R8.7
+    /// equivalent for the credentials file). The caller is responsible for
+    /// warning the user if an unreadable credentials file is unexpected.
+    pub fn credentials_names(&mut self) -> &[String] {
+        let path = self.credentials_path.clone();
+        let current_mtime = std::fs::metadata(&path).and_then(|m| m.modified()).ok();
+
+        let needs_refresh = match (&self.credentials_last_modified, &current_mtime) {
+            (Some(cached), Some(current)) => cached != current,
+            (None, Some(_)) => true,
+            (_, None) => {
+                self.credentials_names.clear();
+                self.credentials_last_modified = None;
+                return &self.credentials_names;
+            }
+        };
+
+        if needs_refresh {
+            match std::fs::read_to_string(&path) {
+                Ok(contents) => {
+                    self.credentials_names = parse_aws_credentials_str(&contents);
+                    self.credentials_last_modified = current_mtime;
+                }
+                Err(err) => {
+                    log::warn!(
+                        "Failed to read AWS credentials at {}: {}",
+                        path.display(),
+                        err
+                    );
+                    self.credentials_names.clear();
+                    self.credentials_last_modified = None;
+                }
+            }
+        }
+
+        &self.credentials_names
+    }
+
+    /// Returns the union of non-SSO config profile names and credentials-file
+    /// section names, deduplicated (first-seen name wins, case-preserving).
+    ///
+    /// This is the complete set of names that `AwsSharedCredentialsAuthProvider`
+    /// should reflect: a non-SSO section in `~/.aws/config` OR a section in
+    /// `~/.aws/credentials` (or both) produces exactly one reflected profile.
+    pub fn shared_profile_names(&mut self) -> Vec<String> {
+        let config_names: Vec<String> = self
+            .profiles()
+            .iter()
+            .filter(|p| !p.is_sso && !p.is_sso_session)
+            .map(|p| p.name.clone())
+            .collect();
+
+        let creds_names = self.credentials_names().to_vec();
+
+        let mut seen = std::collections::HashSet::new();
+        let mut result = Vec::new();
+
+        for name in config_names.into_iter().chain(creds_names) {
+            if seen.insert(name.clone()) {
+                result.push(name);
+            }
+        }
+
+        result
+    }
 }
 
 /// Returns the platform path to `~/.aws/config`.
@@ -89,6 +200,66 @@ pub fn config_file_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("~"))
         .join(".aws")
         .join("config")
+}
+
+/// Returns the platform path to `~/.aws/credentials`.
+///
+/// Respects the `AWS_SHARED_CREDENTIALS_FILE` environment variable, which the
+/// AWS CLI and SDK honour as an override for the credentials file location.
+/// Mirrors the behaviour of `config_file_path`.
+pub fn credentials_file_path() -> PathBuf {
+    if let Ok(override_path) = std::env::var("AWS_SHARED_CREDENTIALS_FILE")
+        && !override_path.is_empty()
+    {
+        return PathBuf::from(override_path);
+    }
+
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("~"))
+        .join(".aws")
+        .join("credentials")
+}
+
+/// Parses the contents of `~/.aws/credentials` and returns the list of
+/// section names found in the file.
+///
+/// ## Names-only contract (security invariant — ADR-7)
+///
+/// This function returns **section names only**. It intentionally discards
+/// every key/value pair, including `aws_access_key_id` and
+/// `aws_secret_access_key`. Callers can determine which credentials-file
+/// profiles exist without ever loading secret material into DBFlux memory.
+/// The AWS SDK reads the actual key values from the file at connect time.
+///
+/// Credentials files use bare `[NAME]` section headers (no `profile ` prefix
+/// and no `sso-session` headers). Headers using those prefixes are treated as
+/// literal profile names (mirroring the AWS CLI's credentials-file grammar).
+pub fn parse_aws_credentials_str(contents: &str) -> Vec<String> {
+    let mut names = Vec::new();
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+
+        // Skip blank lines and comment lines (# and ; are both comment markers
+        // in credentials files).
+        if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with(';') {
+            continue;
+        }
+
+        // Section header: extract the name and record it.  Key/value lines are
+        // intentionally ignored — this is the names-only security boundary.
+        if trimmed.starts_with('[') && trimmed.ends_with(']') {
+            let name = trimmed[1..trimmed.len() - 1].trim().to_string();
+            if !name.is_empty() {
+                names.push(name);
+            }
+            continue;
+        }
+
+        // Key/value lines and any other content: intentionally discarded.
+    }
+
+    names
 }
 
 /// Parses an AWS config file's contents into profile info entries.
@@ -212,18 +383,54 @@ pub fn restore_aws_config_backup() -> Result<(), io::Error> {
     restore_backup_for_path(&path)
 }
 
-fn write_profile_to_path(
-    profile: &AwsProfileInfo,
+/// Process-wide lock serializing every read-modify-write of `~/.aws/config`.
+///
+/// DBFlux mutates the config from several concurrent contexts: dropdown
+/// population fetches account and role options on separate threads, the SSO
+/// login flow writes the profile/session blocks, and profile import writes
+/// each imported profile. Without serialization two threads can each read the
+/// file, mutate their own copy, and write it back — and when the underlying
+/// write is not atomic, a reader can even observe a half-written file and
+/// persist that truncation. That race silently deleted unrelated profiles from
+/// the user's `~/.aws/config`. Every writer now funnels through this lock plus
+/// an atomic temp-file rename, so the file is never read or written partially.
+static AWS_CONFIG_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn aws_config_lock() -> &'static Mutex<()> {
+    AWS_CONFIG_LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// Reads `~/.aws/config`, applies `transform`, and writes the result back
+/// atomically with a backup — all under the process-wide config lock.
+///
+/// The read, the transform, and the write happen inside a single critical
+/// section so concurrent callers cannot interleave their read-modify-write
+/// cycles. When the transform leaves the content unchanged no write (and no
+/// backup) is performed, so idempotent re-syncs (e.g. repeated dropdown polls)
+/// do not churn the file.
+pub(crate) fn update_aws_config_atomic(
     path: &std::path::Path,
+    transform: impl FnOnce(&str) -> String,
 ) -> Result<(), io::Error> {
+    let _guard = aws_config_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+
     let existing = read_config_or_default(path)?;
-    let updated = upsert_profile_section(&existing, profile);
+    let updated = transform(&existing);
 
     if existing == updated {
         return Ok(());
     }
 
     write_atomic_with_backup(path, &updated)
+}
+
+fn write_profile_to_path(
+    profile: &AwsProfileInfo,
+    path: &std::path::Path,
+) -> Result<(), io::Error> {
+    update_aws_config_atomic(path, |existing| upsert_profile_section(existing, profile))
 }
 
 fn profile_section_header(name: &str) -> String {
@@ -445,11 +652,6 @@ pub fn append_aws_sso_profile(
     region: &str,
 ) -> Result<bool, std::io::Error> {
     let path = config_file_path();
-    let existing = read_config_or_default(&path)?;
-
-    if profile_section_exists(&existing, name) {
-        return Ok(false);
-    }
 
     let mut block = String::new();
     writeln!(block).ok();
@@ -467,7 +669,7 @@ pub fn append_aws_sso_profile(
     writeln!(block, "sso_role_name = {sso_role_name}").ok();
     writeln!(block, "region = {region}").ok();
 
-    write_config_block(&path, &existing, &block)
+    append_config_block_if_absent(&path, name, &block)
 }
 
 /// Appends a new shared-credentials profile block to `~/.aws/config`.
@@ -485,11 +687,6 @@ pub fn append_aws_shared_credentials_profile(
     region: &str,
 ) -> Result<bool, std::io::Error> {
     let path = config_file_path();
-    let existing = read_config_or_default(&path)?;
-
-    if profile_section_exists(&existing, name) {
-        return Ok(false);
-    }
 
     let mut block = String::new();
     writeln!(block).ok();
@@ -503,7 +700,7 @@ pub fn append_aws_shared_credentials_profile(
     writeln!(block, "{header}").ok();
     writeln!(block, "region = {region}").ok();
 
-    write_config_block(&path, &existing, &block)
+    append_config_block_if_absent(&path, name, &block)
 }
 
 /// Reads the config file content, returning an empty string if the file does
@@ -532,29 +729,37 @@ fn profile_section_exists(contents: &str, name: &str) -> bool {
         .any(|line| line.trim().eq_ignore_ascii_case(&needle))
 }
 
-/// Ensures the `~/.aws/` directory exists, then appends `block` to the config
-/// file (creating it if necessary). Returns `Ok(true)` on success.
-fn write_config_block(
+/// Appends `block` to the config file unless a `[profile <name>]` (or
+/// `[default]`) section already exists, in which case the file is left
+/// untouched. Returns `Ok(true)` when the block was appended, `Ok(false)`
+/// when an existing section made the write a no-op.
+///
+/// The existence check, the append, and the disk write all happen inside the
+/// process-wide lock and the atomic-rename writer, so a concurrent reader can
+/// never observe a partially written file.
+fn append_config_block_if_absent(
     path: &std::path::Path,
-    existing: &str,
+    name: &str,
     block: &str,
 ) -> Result<bool, std::io::Error> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
+    let mut appended = false;
 
-    let mut content = existing.to_string();
+    update_aws_config_atomic(path, |existing| {
+        if profile_section_exists(existing, name) {
+            return existing.to_string();
+        }
 
-    // Ensure the existing content ends with a newline before appending.
-    if !content.is_empty() && !content.ends_with('\n') {
-        content.push('\n');
-    }
+        appended = true;
 
-    content.push_str(block);
+        let mut content = existing.to_string();
+        if !content.is_empty() && !content.ends_with('\n') {
+            content.push('\n');
+        }
+        content.push_str(block);
+        content
+    })?;
 
-    fs::write(path, &content)?;
-
-    Ok(true)
+    Ok(appended)
 }
 
 #[cfg(test)]
@@ -731,8 +936,6 @@ output=json
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("config");
 
-        // Override write target via the helper (we call write_config_block directly).
-        let existing = "";
         let mut block = String::new();
         block.push('\n');
         block.push_str("[profile new-sso]\n");
@@ -742,7 +945,7 @@ output=json
         block.push_str("sso_role_name = AdminAccess\n");
         block.push_str("region = us-east-1\n");
 
-        let written = write_config_block(&path, existing, &block).expect("write");
+        let written = append_config_block_if_absent(&path, "new-sso", &block).expect("write");
         assert!(written);
 
         let content = std::fs::read_to_string(&path).expect("read");
@@ -765,13 +968,279 @@ output=json
         let path = dir.path().join("config");
         std::fs::write(&path, "[default]\nregion = us-east-1").expect("seed");
 
-        let existing = std::fs::read_to_string(&path).expect("read existing");
         let block = "\n[profile staging]\nregion = eu-west-1\n";
 
-        write_config_block(&path, &existing, block).expect("write");
+        append_config_block_if_absent(&path, "staging", block).expect("write");
 
         let content = std::fs::read_to_string(&path).expect("read result");
-        // The existing content had no trailing newline; write_config_block must add one.
+        // The existing content had no trailing newline; the appender must add one.
         assert!(content.contains("[default]\nregion = us-east-1\n\n[profile staging]"));
+    }
+
+    #[test]
+    fn concurrent_writes_preserve_unrelated_sections() {
+        use std::sync::Arc;
+        use std::thread;
+
+        // Seed the file with several pre-existing profiles that none of the
+        // concurrent writers touch. The atomic + locked writer must keep every
+        // one of them intact.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = Arc::new(dir.path().join("config"));
+
+        let mut seed = String::new();
+        for index in 0..8 {
+            seed.push_str(&format!(
+                "[profile existing-{index}]\nregion = us-east-1\n\n"
+            ));
+        }
+        std::fs::write(path.as_ref(), &seed).expect("seed");
+
+        // Many threads, each upserting its own distinct profile at the same
+        // time. Before the lock + atomic rename, interleaved read-modify-write
+        // cycles over a non-atomic write could read a half-written file and
+        // persist the truncation, dropping unrelated sections.
+        let mut handles = Vec::new();
+        for index in 0..16 {
+            let path = Arc::clone(&path);
+            handles.push(thread::spawn(move || {
+                let profile = AwsProfileInfo {
+                    name: format!("worker-{index}"),
+                    region: Some("eu-west-1".to_string()),
+                    is_sso: false,
+                    sso_start_url: None,
+                    sso_region: None,
+                    sso_account_id: None,
+                    sso_role_name: None,
+                    sso_session: None,
+                    is_sso_session: false,
+                };
+                write_profile_to_path(&profile, path.as_ref()).expect("write");
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("thread join");
+        }
+
+        let final_contents = std::fs::read_to_string(path.as_ref()).expect("read result");
+
+        for index in 0..8 {
+            assert!(
+                profile_section_exists(&final_contents, &format!("existing-{index}")),
+                "pre-existing profile existing-{index} must survive concurrent writes"
+            );
+        }
+        for index in 0..16 {
+            assert!(
+                profile_section_exists(&final_contents, &format!("worker-{index}")),
+                "concurrently written profile worker-{index} must be present"
+            );
+        }
+    }
+
+    // T-2.1 — credentials_file_path tests
+
+    #[test]
+    fn credentials_file_path_ends_with_aws_credentials() {
+        let path = credentials_file_path();
+        assert!(
+            path.ends_with(".aws/credentials"),
+            "expected path ending in .aws/credentials, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn credentials_file_path_override_via_env() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let custom = dir.path().join("my-credentials");
+
+        // Safety: test-only env mutation is acceptable here; tests run in a
+        // single-threaded test harness per process.
+        unsafe {
+            std::env::set_var("AWS_SHARED_CREDENTIALS_FILE", custom.to_str().unwrap());
+        }
+        let path = credentials_file_path();
+        unsafe {
+            std::env::remove_var("AWS_SHARED_CREDENTIALS_FILE");
+        }
+
+        assert_eq!(path, custom);
+    }
+
+    // T-2.2 — parse_aws_credentials_str tests
+
+    #[test]
+    fn parse_credentials_empty_input_returns_empty() {
+        let names = parse_aws_credentials_str("");
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn parse_credentials_extracts_section_names_only() {
+        let input = "[default]\n\
+                     aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n\
+                     aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n\
+                     \n\
+                     [prod]\n\
+                     aws_access_key_id = AKIAI44QH8DHBEXAMPLE\n\
+                     aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY\n";
+
+        let names = parse_aws_credentials_str(input);
+
+        assert_eq!(names, vec!["default", "prod"]);
+    }
+
+    #[test]
+    fn parse_credentials_comments_and_blank_lines_produce_no_names() {
+        let input = "# This is a comment\n\
+                     \n\
+                     ; semicolon comment\n\
+                     [staging]\n\
+                     region = eu-west-1\n";
+
+        let names = parse_aws_credentials_str(input);
+
+        assert_eq!(names, vec!["staging"]);
+    }
+
+    #[test]
+    fn parse_credentials_bare_headers_no_profile_prefix() {
+        // Credentials file uses bare [NAME] not [profile NAME].
+        let input = "[my-profile]\n\
+                     aws_access_key_id = AKIAIOSFODNN7EXAMPLE\n\
+                     \n\
+                     [another]\n\
+                     aws_access_key_id = AKIAI44QH8DHBEXAMPLE\n";
+
+        let names = parse_aws_credentials_str(input);
+
+        assert_eq!(names, vec!["my-profile", "another"]);
+    }
+
+    /// MANDATORY security assertion (ADR-7): the parser must NEVER return key
+    /// material — not access key IDs, not secret access keys. The returned
+    /// `Vec<String>` contains section names only; any substring that looks like
+    /// an AWS access key or secret must be absent.
+    #[test]
+    fn parse_credentials_never_returns_key_material() {
+        // Uses AWS documentation example values (never real credentials).
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+        let input = format!(
+            "[default]\n\
+             aws_access_key_id = {access_key}\n\
+             aws_secret_access_key = {secret_key}\n\
+             \n\
+             [dev]\n\
+             aws_access_key_id = AKIAI44QH8DHBEXAMPLE\n\
+             aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY\n"
+        );
+
+        let names = parse_aws_credentials_str(&input);
+
+        // Section names must be extracted.
+        assert_eq!(names, vec!["default", "dev"]);
+
+        // No returned string may start with the AWS access-key-ID prefix "AKIA".
+        for name in &names {
+            assert!(
+                !name.starts_with("AKIA"),
+                "returned name must not start with AKIA (access key pattern): {name}"
+            );
+        }
+
+        // More direct: assert the exact known secret values do not appear anywhere
+        // in the returned vec.
+        let all_returned = names.join(" ");
+        assert!(
+            !all_returned.contains(access_key),
+            "access key must not appear in returned names"
+        );
+        assert!(
+            !all_returned.contains(secret_key),
+            "secret key must not appear in returned names"
+        );
+    }
+
+    // T-2.3 — CachedAwsConfig credentials extension tests
+
+    #[test]
+    fn credentials_names_returns_empty_when_file_absent() {
+        let mut cache = CachedAwsConfig::new();
+        // credentials_file_path() may not exist on test machines; must not panic.
+        let names = cache.credentials_names();
+        // We cannot assert the exact content since the real file might exist on
+        // the developer's machine, but the call must not panic.
+        let _ = names;
+    }
+
+    #[test]
+    fn credentials_cache_invalidates_when_mtime_advances() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let creds_path = dir.path().join("credentials");
+
+        std::fs::write(&creds_path, "[profile-a]\nregion = us-east-1\n").expect("seed");
+
+        let mut cache = CachedAwsConfig::new_with_paths(config_file_path(), creds_path.clone());
+
+        let first = cache.credentials_names().to_vec();
+        assert_eq!(first, vec!["profile-a"]);
+
+        // Advance mtime by writing new content.
+        std::fs::write(
+            &creds_path,
+            "[profile-a]\nregion = us-east-1\n\n[profile-b]\n",
+        )
+        .expect("update");
+        // Force a detectable mtime change by setting it explicitly.
+        let new_time = std::time::SystemTime::now() + std::time::Duration::from_secs(2);
+        filetime::set_file_mtime(&creds_path, filetime::FileTime::from_system_time(new_time))
+            .expect("set mtime");
+
+        let second = cache.credentials_names().to_vec();
+        assert_eq!(second, vec!["profile-a", "profile-b"]);
+    }
+
+    #[test]
+    fn shared_profile_names_union_dedup() {
+        // config file with two non-SSO profiles (one shared with credentials)
+        let config_content =
+            "[profile shared]\nregion = eu-west-1\n\n[profile config-only]\nregion = us-east-1\n";
+        // credentials file with one profile that overlaps and one unique one
+        let creds_content = "[shared]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n\n[creds-only]\n";
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("config");
+        let creds_path = dir.path().join("credentials");
+
+        std::fs::write(&config_path, config_content).expect("write config");
+        std::fs::write(&creds_path, creds_content).expect("write credentials");
+
+        let mut cache = CachedAwsConfig::new_with_paths(config_path, creds_path);
+
+        let mut names = cache.shared_profile_names();
+        names.sort();
+
+        // "shared" appears in both files but must appear only once.
+        assert!(names.contains(&"config-only".to_string()));
+        assert!(names.contains(&"creds-only".to_string()));
+        assert!(names.contains(&"shared".to_string()));
+        let shared_count = names.iter().filter(|n| n.as_str() == "shared").count();
+        assert_eq!(shared_count, 1, "shared name must appear exactly once");
+    }
+
+    #[test]
+    fn unreadable_credentials_file_does_not_panic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+
+        let mut cache = CachedAwsConfig::new_with_paths(config_file_path(), missing);
+
+        // Must not panic; must return empty.
+        let names = cache.credentials_names();
+        assert!(names.is_empty());
     }
 }

--- a/crates/dbflux_aws/src/config.rs
+++ b/crates/dbflux_aws/src/config.rs
@@ -75,6 +75,16 @@ impl CachedAwsConfig {
         Self::default()
     }
 
+    /// Returns the path to the AWS config file used by this cache instance.
+    pub fn config_path(&self) -> &std::path::Path {
+        &self.config_path
+    }
+
+    /// Returns the path to the AWS credentials file used by this cache instance.
+    pub fn credentials_path(&self) -> &std::path::Path {
+        &self.credentials_path
+    }
+
     /// Creates a `CachedAwsConfig` with explicit file paths.
     ///
     /// Used in tests to point the cache at temporary files instead of the
@@ -703,8 +713,6 @@ fn append_config_block_if_absent(
 /// Used internally to extract the raw bytes for section hashing
 /// (`hash_config_section`, `hash_credentials_section`) and for conflict
 /// detection inside the atomic write transforms.
-// WU-E3 (auth.rs) will add the production call sites; allowed until then.
-#[allow(dead_code)]
 fn section_raw_bytes<'a>(contents: &'a str, header: &str) -> Option<&'a str> {
     let header_lower = header.to_lowercase();
 
@@ -776,7 +784,6 @@ fn section_raw_bytes<'a>(contents: &'a str, header: &str) -> Option<&'a str> {
 ///
 /// The hash is over raw bytes — whitespace, comments, and value order are all
 /// captured — so any byte-level change produces a different hash.
-#[allow(dead_code)]
 pub(crate) fn hash_config_section(contents: &str, profile_name: &str) -> Option<AwsSectionHash> {
     let header = if profile_name.eq_ignore_ascii_case("default") {
         "[default]".to_string()
@@ -789,13 +796,25 @@ pub(crate) fn hash_config_section(contents: &str, profile_name: &str) -> Option<
     Some(AwsSectionHash(digest.into()))
 }
 
+/// Returns the SHA-256 hash of the raw bytes of an `[sso-session NAME]` section
+/// in a config-file string.
+///
+/// Uses the `[sso-session NAME]` header form, which differs from the
+/// `[profile NAME]` form used by `hash_config_section`. Returns `None` when
+/// the section is absent from `contents`.
+pub(crate) fn hash_sso_session_section(contents: &str, name: &str) -> Option<AwsSectionHash> {
+    let header = format!("[sso-session {name}]");
+    let raw = section_raw_bytes(contents, &header)?;
+    let digest = Sha256::digest(raw.as_bytes());
+    Some(AwsSectionHash(digest.into()))
+}
+
 /// Returns the SHA-256 hash of the raw bytes of the named section in a
 /// credentials-file string.
 ///
 /// The section is identified by its bare `[NAME]` header (credentials files
 /// do not use the `profile ` prefix). Returns `None` when the section is
 /// absent from `contents`.
-#[allow(dead_code)]
 pub(crate) fn hash_credentials_section(contents: &str, name: &str) -> Option<AwsSectionHash> {
     let header = format!("[{name}]");
     let raw = section_raw_bytes(contents, &header)?;
@@ -818,7 +837,6 @@ pub(crate) fn hash_credentials_section(contents: &str, name: &str) -> Option<Aws
 /// original file's permissions on the temp file and backup file (security
 /// requirement). If the original file does not yet exist the temp file is
 /// written with the same permissions as the new file (0600 on Unix).
-#[allow(dead_code)]
 pub(crate) fn update_aws_credentials_atomic(
     path: &Path,
     transform: impl FnOnce(&str) -> String,
@@ -842,7 +860,6 @@ pub(crate) fn update_aws_credentials_atomic(
 /// credentials files written on Unix are never world-readable.
 ///
 /// On non-Unix platforms the behaviour is identical to `write_atomic_with_backup`.
-#[allow(dead_code)]
 fn write_atomic_with_backup_perms(path: &Path, content: &str) -> Result<(), io::Error> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -893,7 +910,6 @@ fn write_atomic_with_backup_perms(path: &Path, content: &str) -> Result<(), io::
 /// `fields` lists the key/value pairs to write into the section. Keys not
 /// listed in `fields` that are present in the existing section are preserved
 /// (merge-write semantics: only explicitly passed keys are changed).
-#[allow(dead_code)]
 pub(crate) fn replace_or_append_credentials_block(
     contents: &str,
     name: &str,
@@ -932,7 +948,6 @@ pub(crate) fn replace_or_append_credentials_block(
 
 /// Locates the byte offset of the first line in `contents` whose lowercased
 /// trim equals `header_lower`.
-#[allow(dead_code)]
 fn find_section_start(contents: &str, header_lower: &str) -> usize {
     let mut offset = 0;
     for line in contents.lines() {
@@ -960,7 +975,6 @@ fn find_section_start(contents: &str, header_lower: &str) -> usize {
 /// `fields` lists the key/value pairs to write into the section. Keys not
 /// listed in `fields` that are present in the existing section are preserved
 /// (merge-write semantics).
-#[allow(dead_code)]
 pub(crate) fn replace_or_append_profile_block(
     contents: &str,
     name: &str,
@@ -996,8 +1010,40 @@ pub(crate) fn replace_or_append_profile_block(
     result
 }
 
+/// Replaces or appends an `[sso-session NAME]` section block in a config-file string.
+///
+/// Analogous to `replace_or_append_profile_block` but uses the `[sso-session NAME]`
+/// header form required for sso-session sections in `~/.aws/config`.
+pub(crate) fn replace_or_append_sso_session_block(
+    contents: &str,
+    name: &str,
+    fields: &[(&str, &str)],
+) -> String {
+    let header = format!("[sso-session {name}]");
+    let header_lower = header.to_lowercase();
+    let new_block = build_profile_block(&header, contents, fields);
+
+    let Some(raw) = section_raw_bytes(contents, &header) else {
+        let mut result = contents.to_string();
+        if !result.is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push('\n');
+        result.push_str(&new_block);
+        return result;
+    };
+
+    let start = find_section_start(contents, &header_lower);
+    let end = start + raw.len();
+
+    let mut result = String::with_capacity(contents.len());
+    result.push_str(&contents[..start]);
+    result.push_str(&new_block);
+    result.push_str(&contents[end..]);
+    result
+}
+
 /// Builds the replacement `[profile NAME]` section block for `~/.aws/config`.
-#[allow(dead_code)]
 fn build_profile_block(header: &str, contents: &str, fields: &[(&str, &str)]) -> String {
     // Collect existing keys from the current on-disk section, in order.
     let mut existing_keys: Vec<(String, String)> = Vec::new();
@@ -1045,7 +1091,6 @@ fn build_profile_block(header: &str, contents: &str, fields: &[(&str, &str)]) ->
 /// applies the caller-provided `fields` as overrides, and emits the merged
 /// section. Keys provided with an empty string value are omitted (kept as-is
 /// from the existing section — blank = preserve).
-#[allow(dead_code)]
 fn build_credentials_block(
     header: &str,
     contents: &str,

--- a/crates/dbflux_aws/src/config.rs
+++ b/crates/dbflux_aws/src/config.rs
@@ -431,26 +431,7 @@ pub(crate) fn update_aws_config_atomic(
         return Ok(());
     }
 
-    write_atomic_with_backup(path, &updated)
-}
-
-fn write_atomic_with_backup(path: &std::path::Path, content: &str) -> Result<(), io::Error> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-
-    let backup_path = create_backup_for_path(path)?;
-    let temp_path = path.with_extension("tmp");
-
-    fs::write(&temp_path, content)?;
-
-    if let Err(error) = fs::rename(&temp_path, path) {
-        let _ = fs::remove_file(&temp_path);
-        let _ = fs::copy(&backup_path, path);
-        return Err(error);
-    }
-
-    Ok(())
+    write_atomic_with_backup_perms(path, &updated)
 }
 
 fn create_backup_for_path(path: &std::path::Path) -> Result<PathBuf, io::Error> {
@@ -855,11 +836,15 @@ pub(crate) fn update_aws_credentials_atomic(
     write_atomic_with_backup_perms(path, &updated)
 }
 
-/// Like `write_atomic_with_backup` but additionally sets the temp file's
-/// permissions to match the original file (or 0600 when the file is new), so
-/// credentials files written on Unix are never world-readable.
+/// Atomically writes `content` to `path` via a temp-file-then-rename sequence,
+/// creating a backup first so a rename failure can restore the original.
 ///
-/// On non-Unix platforms the behaviour is identical to `write_atomic_with_backup`.
+/// On Unix the temp file and backup file are restricted to at most the mode of
+/// the original file (or 0600 when the file is new), ensuring that neither
+/// `~/.aws/config` nor `~/.aws/credentials` is ever world-readable during the
+/// write window.
+///
+/// Used by both `update_aws_config_atomic` and `update_aws_credentials_atomic`.
 fn write_atomic_with_backup_perms(path: &Path, content: &str) -> Result<(), io::Error> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -2119,6 +2104,96 @@ output=json
             0,
             "final credentials file must not be group/other readable; mode = {:o}",
             final_mode
+        );
+    }
+
+    // ── Fix 1 — config file perm test ──────────────────────────────────────────
+
+    /// Verifies that `update_aws_config_atomic` (which now uses the unified
+    /// `write_atomic_with_backup_perms`) does not leave the config temp or
+    /// final file group/other readable when the source file is mode 0600.
+    ///
+    /// `~/.aws/config` contains `sso_start_url`, account IDs, and role names,
+    /// so it must receive the same umask-independent permission treatment as
+    /// `~/.aws/credentials`.
+    #[cfg(unix)]
+    #[test]
+    fn config_write_temp_and_final_are_not_world_readable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config");
+
+        // Seed with 0600 — a conservative mode a user might set on ~/.aws/config.
+        std::fs::write(
+            &path,
+            "[profile ci]\nsso_start_url = https://example.awsapps.com/start\n",
+        )
+        .expect("seed");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("set 0600");
+
+        // Perform a round-trip write via the config atomic writer.
+        update_aws_config_atomic(&path, |existing| {
+            existing.replace(
+                "https://example.awsapps.com/start",
+                "https://ci.awsapps.com/start",
+            )
+        })
+        .expect("write");
+
+        // The final file must be at most 0600 (no group/other bits).
+        let final_mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+
+        assert_eq!(
+            final_mode & 0o077,
+            0,
+            "final config file must not be group/other readable; mode = {:o}",
+            final_mode
+        );
+    }
+
+    // ── Fix 2 — rename-failure restore test ────────────────────────────────────
+
+    /// Verifies that when the atomic rename fails, `write_atomic_with_backup_perms`
+    /// restores the original file content from the backup.
+    ///
+    /// Rename failure is injected by creating a *directory* at the temp-file path
+    /// before the write is attempted. On Linux (and macOS) `fs::rename` fails with
+    /// `EISDIR` when the destination is a directory, triggering the restore branch.
+    ///
+    /// The test verifies:
+    /// 1. The function returns an `Err`.
+    /// 2. The original file still contains the original content after the error.
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_rename_failure_preserves_original_content() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("config");
+        let temp_path = path.with_extension("tmp");
+
+        let original = "[profile dev]\nregion = us-east-1\n";
+        std::fs::write(&path, original).expect("seed");
+
+        // Block the rename by occupying the temp path with a directory.
+        std::fs::create_dir_all(&temp_path).expect("create blocking dir");
+
+        let result = write_atomic_with_backup_perms(&path, "[profile dev]\nregion = us-west-2\n");
+
+        // The call must fail (rename is impossible with a directory in the way).
+        assert!(
+            result.is_err(),
+            "expected Err when rename destination is a directory"
+        );
+
+        // The original file must still contain the original content.
+        let actual = std::fs::read_to_string(&path).expect("read after failure");
+        assert_eq!(
+            actual, original,
+            "original content must be intact after rename failure"
         );
     }
 }

--- a/crates/dbflux_aws/src/config.rs
+++ b/crates/dbflux_aws/src/config.rs
@@ -8,9 +8,12 @@ use std::collections::HashMap;
 use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::SystemTime;
+
+use dbflux_core::auth::AwsSectionHash;
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone)]
 pub struct AwsProfileInfo {
@@ -685,6 +688,418 @@ fn append_config_block_if_absent(
     Ok(appended)
 }
 
+// ── Section-hash helpers ──────────────────────────────────────────────────────
+
+/// Returns a slice of `contents` from the line matching `header` through the
+/// line before the next `[` header or EOF.
+///
+/// The `header` argument must include the brackets, e.g.
+/// `"[profile dev]"` for a config section or `"[ci]"` for a credentials
+/// section. The comparison is exact (byte-level), so the caller is
+/// responsible for providing the correctly-formed header string.
+///
+/// Returns `None` when no line in `contents` matches `header`.
+///
+/// Used internally to extract the raw bytes for section hashing
+/// (`hash_config_section`, `hash_credentials_section`) and for conflict
+/// detection inside the atomic write transforms.
+// WU-E3 (auth.rs) will add the production call sites; allowed until then.
+#[allow(dead_code)]
+fn section_raw_bytes<'a>(contents: &'a str, header: &str) -> Option<&'a str> {
+    let header_lower = header.to_lowercase();
+
+    // Find the byte offset where the matching header line starts.
+    let mut header_start: Option<usize> = None;
+    let mut current_offset = 0;
+
+    for line in contents.lines() {
+        if line.trim().to_lowercase() == header_lower {
+            header_start = Some(current_offset);
+            break;
+        }
+        // Advance past the line + newline. `str::lines()` strips the
+        // line terminator, so we need to account for it manually. Both
+        // `\n` and `\r\n` are handled: the slice includes the terminator.
+        current_offset += line.len();
+        if contents[current_offset..].starts_with("\r\n") {
+            current_offset += 2;
+        } else if contents[current_offset..].starts_with('\n') {
+            current_offset += 1;
+        }
+    }
+
+    let start = header_start?;
+
+    // Find the byte offset where the section ends: the start of the next
+    // `[` header line (after the matched section), or EOF.
+    let rest = &contents[start..];
+    let mut section_end = rest.len();
+    let mut at_header = false;
+
+    let mut offset = 0;
+    for line in rest.lines() {
+        // The first line is the matched header itself; skip it.
+        if !at_header {
+            at_header = true;
+            offset += line.len();
+            if rest[offset..].starts_with("\r\n") {
+                offset += 2;
+            } else if rest[offset..].starts_with('\n') {
+                offset += 1;
+            }
+            continue;
+        }
+
+        // Any subsequent line that starts with `[` marks the next section.
+        if line.trim_start().starts_with('[') {
+            section_end = offset;
+            break;
+        }
+
+        offset += line.len();
+        if rest[offset..].starts_with("\r\n") {
+            offset += 2;
+        } else if rest[offset..].starts_with('\n') {
+            offset += 1;
+        }
+    }
+
+    Some(&rest[..section_end])
+}
+
+/// Returns the SHA-256 hash of the raw bytes of the named profile section in
+/// a config-file string.
+///
+/// The section is identified by its `[profile NAME]` header (or `[default]`
+/// for the default profile). Uses `section_raw_bytes` internally; returns
+/// `None` when the section is absent from `contents`.
+///
+/// The hash is over raw bytes — whitespace, comments, and value order are all
+/// captured — so any byte-level change produces a different hash.
+#[allow(dead_code)]
+pub(crate) fn hash_config_section(contents: &str, profile_name: &str) -> Option<AwsSectionHash> {
+    let header = if profile_name.eq_ignore_ascii_case("default") {
+        "[default]".to_string()
+    } else {
+        format!("[profile {profile_name}]")
+    };
+
+    let raw = section_raw_bytes(contents, &header)?;
+    let digest = Sha256::digest(raw.as_bytes());
+    Some(AwsSectionHash(digest.into()))
+}
+
+/// Returns the SHA-256 hash of the raw bytes of the named section in a
+/// credentials-file string.
+///
+/// The section is identified by its bare `[NAME]` header (credentials files
+/// do not use the `profile ` prefix). Returns `None` when the section is
+/// absent from `contents`.
+#[allow(dead_code)]
+pub(crate) fn hash_credentials_section(contents: &str, name: &str) -> Option<AwsSectionHash> {
+    let header = format!("[{name}]");
+    let raw = section_raw_bytes(contents, &header)?;
+    let digest = Sha256::digest(raw.as_bytes());
+    Some(AwsSectionHash(digest.into()))
+}
+
+// ── Credentials atomic writer ─────────────────────────────────────────────────
+
+/// Reads `~/.aws/credentials`, applies `transform`, and writes the result back
+/// atomically with a backup — all under the SAME process-wide lock as
+/// `update_aws_config_atomic` (spec R9.2.1, design section 12).
+///
+/// Using a single shared lock for both files serializes all config+credentials
+/// writes so there is no cross-file interleave (ADR-11). The implementation is
+/// a thin sibling of `update_aws_config_atomic`; the locking and atomic-rename
+/// logic is NOT forked.
+///
+/// Credentials files typically have mode 0600. The writer preserves the
+/// original file's permissions on the temp file and backup file (security
+/// requirement). If the original file does not yet exist the temp file is
+/// written with the same permissions as the new file (0600 on Unix).
+#[allow(dead_code)]
+pub(crate) fn update_aws_credentials_atomic(
+    path: &Path,
+    transform: impl FnOnce(&str) -> String,
+) -> Result<(), io::Error> {
+    let _guard = aws_config_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
+
+    let existing = read_config_or_default(path)?;
+    let updated = transform(&existing);
+
+    if existing == updated {
+        return Ok(());
+    }
+
+    write_atomic_with_backup_perms(path, &updated)
+}
+
+/// Like `write_atomic_with_backup` but additionally sets the temp file's
+/// permissions to match the original file (or 0600 when the file is new), so
+/// credentials files written on Unix are never world-readable.
+///
+/// On non-Unix platforms the behaviour is identical to `write_atomic_with_backup`.
+#[allow(dead_code)]
+fn write_atomic_with_backup_perms(path: &Path, content: &str) -> Result<(), io::Error> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let backup_path = create_backup_for_path(path)?;
+    let temp_path = path.with_extension("tmp");
+
+    // Write the temp file first, then restrict its permissions to match the
+    // original (or enforce 0600 for credentials on first create).
+    fs::write(&temp_path, content)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Try to read the original file's permissions; fall back to 0600.
+        let mode = fs::metadata(path)
+            .map(|m| m.permissions().mode())
+            .unwrap_or(0o600);
+
+        // Restrict to at most the original mode — never widen.
+        let effective_mode = mode & 0o600;
+        fs::set_permissions(&temp_path, fs::Permissions::from_mode(effective_mode))?;
+
+        // Also restrict the backup file to the same mode.
+        if backup_path.exists() {
+            fs::set_permissions(&backup_path, fs::Permissions::from_mode(effective_mode))?;
+        }
+    }
+
+    if let Err(error) = fs::rename(&temp_path, path) {
+        let _ = fs::remove_file(&temp_path);
+        let _ = fs::copy(&backup_path, path);
+        return Err(error);
+    }
+
+    Ok(())
+}
+
+/// Replaces or appends a `[NAME]` section block in a credentials-file string.
+///
+/// The `[NAME]` header uses the bare form (no `profile ` prefix) as required
+/// by the credentials-file grammar. When a section with this name already
+/// exists, it is replaced in-place; all other sections remain byte-identical.
+/// When the section is absent, it is appended at the end of the string.
+///
+/// `fields` lists the key/value pairs to write into the section. Keys not
+/// listed in `fields` that are present in the existing section are preserved
+/// (merge-write semantics: only explicitly passed keys are changed).
+#[allow(dead_code)]
+pub(crate) fn replace_or_append_credentials_block(
+    contents: &str,
+    name: &str,
+    fields: &[(&str, &str)],
+) -> String {
+    let header = format!("[{name}]");
+    let header_lower = header.to_lowercase();
+
+    // Build the new section block from the existing section's keys merged
+    // with the provided fields. Keys not provided by the caller are
+    // kept verbatim from the existing section.
+    let new_block = build_credentials_block(&header, contents, name, fields);
+
+    // Find the extent of the existing section, if present.
+    let Some(raw) = section_raw_bytes(contents, &header) else {
+        // Section absent — append at EOF.
+        let mut result = contents.to_string();
+        if !result.is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push('\n');
+        result.push_str(&new_block);
+        return result;
+    };
+
+    // The section exists; find its start offset in `contents`.
+    let start = find_section_start(contents, &header_lower);
+    let end = start + raw.len();
+
+    let mut result = String::with_capacity(contents.len());
+    result.push_str(&contents[..start]);
+    result.push_str(&new_block);
+    result.push_str(&contents[end..]);
+    result
+}
+
+/// Locates the byte offset of the first line in `contents` whose lowercased
+/// trim equals `header_lower`.
+#[allow(dead_code)]
+fn find_section_start(contents: &str, header_lower: &str) -> usize {
+    let mut offset = 0;
+    for line in contents.lines() {
+        if line.trim().to_lowercase() == header_lower {
+            return offset;
+        }
+        offset += line.len();
+        if contents[offset..].starts_with("\r\n") {
+            offset += 2;
+        } else if contents[offset..].starts_with('\n') {
+            offset += 1;
+        }
+    }
+    0
+}
+
+/// Replaces or appends a `[profile NAME]` section block in a config-file string.
+///
+/// The header uses the `[profile NAME]` form (or `[default]` when
+/// `name == "default"`), as required by the `~/.aws/config` grammar. When a
+/// matching section already exists, it is replaced in-place; all other
+/// sections remain byte-identical. When the section is absent, it is
+/// appended at the end of the string.
+///
+/// `fields` lists the key/value pairs to write into the section. Keys not
+/// listed in `fields` that are present in the existing section are preserved
+/// (merge-write semantics).
+#[allow(dead_code)]
+pub(crate) fn replace_or_append_profile_block(
+    contents: &str,
+    name: &str,
+    fields: &[(&str, &str)],
+) -> String {
+    let header = if name.eq_ignore_ascii_case("default") {
+        "[default]".to_string()
+    } else {
+        format!("[profile {name}]")
+    };
+
+    let header_lower = header.to_lowercase();
+    let new_block = build_profile_block(&header, contents, fields);
+
+    let Some(raw) = section_raw_bytes(contents, &header) else {
+        // Section absent — append at EOF.
+        let mut result = contents.to_string();
+        if !result.is_empty() && !result.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push('\n');
+        result.push_str(&new_block);
+        return result;
+    };
+
+    let start = find_section_start(contents, &header_lower);
+    let end = start + raw.len();
+
+    let mut result = String::with_capacity(contents.len());
+    result.push_str(&contents[..start]);
+    result.push_str(&new_block);
+    result.push_str(&contents[end..]);
+    result
+}
+
+/// Builds the replacement `[profile NAME]` section block for `~/.aws/config`.
+#[allow(dead_code)]
+fn build_profile_block(header: &str, contents: &str, fields: &[(&str, &str)]) -> String {
+    // Collect existing keys from the current on-disk section, in order.
+    let mut existing_keys: Vec<(String, String)> = Vec::new();
+    if let Some(raw) = section_raw_bytes(contents, header) {
+        for line in raw.lines().skip(1) {
+            if let Some((k, v)) = parse_key_value(line) {
+                existing_keys.push((k, v));
+            }
+        }
+    }
+
+    let overrides: HashMap<String, String> = fields
+        .iter()
+        .filter(|(_, v)| !v.is_empty())
+        .map(|(k, v)| (k.to_lowercase(), v.to_string()))
+        .collect();
+
+    let mut block = String::new();
+    block.push_str(header);
+    block.push('\n');
+
+    let mut emitted_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (key, existing_val) in &existing_keys {
+        let value = overrides
+            .get(key)
+            .map(String::as_str)
+            .unwrap_or(existing_val);
+        writeln!(block, "{key} = {value}").ok();
+        emitted_keys.insert(key.clone());
+    }
+
+    for (key, value) in fields {
+        let key_lower = key.to_lowercase();
+        if !emitted_keys.contains(&key_lower) && !value.is_empty() {
+            writeln!(block, "{key_lower} = {value}").ok();
+        }
+    }
+
+    block
+}
+
+/// Builds the replacement `[NAME]` section block.
+///
+/// Reads existing key/value lines from the current section (if present),
+/// applies the caller-provided `fields` as overrides, and emits the merged
+/// section. Keys provided with an empty string value are omitted (kept as-is
+/// from the existing section — blank = preserve).
+#[allow(dead_code)]
+fn build_credentials_block(
+    header: &str,
+    contents: &str,
+    name: &str,
+    fields: &[(&str, &str)],
+) -> String {
+    // Collect existing keys from the current on-disk section, in order.
+    let mut existing_keys: Vec<(String, String)> = Vec::new();
+    if let Some(raw) = section_raw_bytes(contents, header) {
+        for line in raw.lines().skip(1) {
+            // Skip the header line itself.
+            if let Some((k, v)) = parse_key_value(line) {
+                existing_keys.push((k, v));
+            }
+        }
+    }
+
+    // Build a lookup map from the caller-provided overrides (non-blank only).
+    let overrides: HashMap<String, String> = fields
+        .iter()
+        .filter(|(_, v)| !v.is_empty())
+        .map(|(k, v)| (k.to_lowercase(), v.to_string()))
+        .collect();
+
+    let mut block = String::new();
+    block.push_str(header);
+    block.push('\n');
+
+    // Emit existing keys, overriding where a new value was provided.
+    let mut emitted_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (key, existing_val) in &existing_keys {
+        let value = overrides
+            .get(key)
+            .map(String::as_str)
+            .unwrap_or(existing_val);
+        writeln!(block, "{key} = {value}").ok();
+        emitted_keys.insert(key.clone());
+    }
+
+    // Emit new keys that were not already in the existing section.
+    for (key, value) in fields {
+        let key_lower = key.to_lowercase();
+        if !emitted_keys.contains(&key_lower) && !value.is_empty() {
+            writeln!(block, "{key_lower} = {value}").ok();
+        }
+    }
+
+    // Preserve the name prefix (unused here but kept for symmetry with
+    // replace_or_append_profile_block).
+    let _ = name;
+
+    block
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1156,5 +1571,509 @@ output=json
         // Must not panic; must return empty.
         let names = cache.credentials_names();
         assert!(names.is_empty());
+    }
+
+    // ── E2.1 — section_raw_bytes tests ──────────────────────────────────────
+
+    #[test]
+    fn section_raw_bytes_config_profile_exact_slice() {
+        let contents = "[profile a]\nregion = us-east-1\n\n[profile b]\noutput = json\n";
+
+        let raw = section_raw_bytes(contents, "[profile a]").unwrap();
+
+        assert!(raw.contains("[profile a]"));
+        assert!(raw.contains("region = us-east-1"));
+        // Must NOT bleed into the next section.
+        assert!(!raw.contains("[profile b]"));
+        assert!(!raw.contains("output = json"));
+    }
+
+    #[test]
+    fn section_raw_bytes_credentials_bare_header() {
+        let contents = "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n\n[prod]\naws_access_key_id = AKIAI44QH8DHBEXAMPLE\n";
+
+        let raw = section_raw_bytes(contents, "[ci]").unwrap();
+
+        assert!(raw.contains("[ci]"));
+        assert!(raw.contains("aws_access_key_id = AKIAIOSFODNN7EXAMPLE"));
+        assert!(!raw.contains("[prod]"));
+    }
+
+    #[test]
+    fn section_raw_bytes_returns_none_when_section_absent() {
+        let contents = "[profile a]\nregion = us-east-1\n";
+
+        let result = section_raw_bytes(contents, "[profile missing]");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn section_raw_bytes_last_section_no_trailing_newline() {
+        // The last section runs to EOF with no trailing newline.
+        let contents = "[profile a]\nregion = us-east-1\n\n[profile b]\noutput = json";
+
+        let raw = section_raw_bytes(contents, "[profile b]").unwrap();
+
+        assert!(raw.contains("[profile b]"));
+        assert!(raw.contains("output = json"));
+        // Should not be empty and should end at EOF without extra content.
+        assert!(!raw.is_empty());
+    }
+
+    #[test]
+    fn section_raw_bytes_three_section_config_correct_bounds() {
+        let contents =
+            "[profile a]\nkey = val-a\n\n[profile b]\nkey = val-b\n\n[profile c]\nkey = val-c\n";
+
+        let raw_a = section_raw_bytes(contents, "[profile a]").unwrap();
+        let raw_b = section_raw_bytes(contents, "[profile b]").unwrap();
+        let raw_c = section_raw_bytes(contents, "[profile c]").unwrap();
+
+        assert!(raw_a.contains("val-a") && !raw_a.contains("val-b") && !raw_a.contains("val-c"));
+        assert!(raw_b.contains("val-b") && !raw_b.contains("val-a") && !raw_b.contains("val-c"));
+        assert!(raw_c.contains("val-c") && !raw_c.contains("val-a") && !raw_c.contains("val-b"));
+    }
+
+    // ── E2.2 — hash_config_section and hash_credentials_section tests ────────
+
+    #[test]
+    fn hash_config_section_identical_bytes_same_hash() {
+        let contents = "[profile dev]\nsso_start_url = https://example.awsapps.com/start\nregion = us-east-1\n";
+
+        let h1 = hash_config_section(contents, "dev").unwrap();
+        let h2 = hash_config_section(contents, "dev").unwrap();
+
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn hash_config_section_one_byte_change_produces_different_hash() {
+        let contents_a = "[profile dev]\nsso_start_url = https://example.awsapps.com/start\nregion = us-east-1\n";
+        let contents_b = "[profile dev]\nsso_start_url = https://example.awsapps.com/start\nregion = us-east-2\n";
+
+        let ha = hash_config_section(contents_a, "dev").unwrap();
+        let hb = hash_config_section(contents_b, "dev").unwrap();
+
+        assert_ne!(ha, hb);
+    }
+
+    #[test]
+    fn hash_config_section_different_section_does_not_affect_hash() {
+        let contents_before =
+            "[profile a]\nregion = us-east-1\n\n[profile b]\nregion = eu-west-1\n";
+        let contents_after = "[profile a]\nregion = us-east-1\n\n[profile b]\nregion = us-west-2\n";
+
+        let ha_before = hash_config_section(contents_before, "a").unwrap();
+        let ha_after = hash_config_section(contents_after, "a").unwrap();
+
+        // Changing [profile b] must not affect [profile a]'s hash.
+        assert_eq!(ha_before, ha_after);
+    }
+
+    #[test]
+    fn hash_config_section_uses_profile_header_form() {
+        // hash_config_section uses [profile NAME] header.
+        let config_contents = "[profile dev]\nregion = us-east-1\n";
+
+        let hash = hash_config_section(config_contents, "dev");
+        assert!(hash.is_some(), "should find [profile dev] section");
+
+        // A bare [dev] header in a config file must NOT match.
+        let bare_contents = "[dev]\nregion = us-east-1\n";
+        let hash_bare = hash_config_section(bare_contents, "dev");
+        assert!(
+            hash_bare.is_none(),
+            "[profile dev] should not match bare [dev]"
+        );
+    }
+
+    #[test]
+    fn hash_credentials_section_uses_bare_header_form() {
+        let creds_contents = "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n";
+
+        let hash = hash_credentials_section(creds_contents, "ci");
+        assert!(hash.is_some(), "should find [ci] section");
+
+        // A [profile ci] form in a credentials file must NOT match.
+        let profile_contents = "[profile ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n";
+        let hash_profile = hash_credentials_section(profile_contents, "ci");
+        assert!(
+            hash_profile.is_none(),
+            "hash_credentials_section should not match [profile ci]"
+        );
+    }
+
+    /// MANDATORY security test (E2.2): the AwsSectionHash digest must not
+    /// contain any substring from the credential values in the hashed section.
+    /// The hash is a one-way SHA-256 digest; the secret bytes never appear in
+    /// the returned value, even in hex form.
+    #[test]
+    fn hash_credentials_section_digest_contains_no_secret_substrings() {
+        let access_key = "AKIAIOSFODNN7EXAMPLE";
+        let secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+        let contents = format!(
+            "[ci]\naws_access_key_id = {access_key}\naws_secret_access_key = {secret_key}\n"
+        );
+
+        let hash = hash_credentials_section(&contents, "ci").unwrap();
+        let hex_repr = format!("{hash:?}");
+
+        // The digest representation must not contain the access key ID or the
+        // secret access key value.
+        assert!(
+            !hex_repr.contains(access_key),
+            "hash debug repr must not contain the access key ID"
+        );
+        assert!(
+            !hex_repr.contains(secret_key),
+            "hash debug repr must not contain the secret access key"
+        );
+        // Additional guard: the raw bytes (as u8 slice) must not encode a
+        // known text value — this is trivially true for SHA-256 but documented
+        // as a deliberate security assertion.
+        let text_from_bytes = String::from_utf8_lossy(&hash.0);
+        assert!(!text_from_bytes.contains(access_key));
+        assert!(!text_from_bytes.contains(secret_key));
+    }
+
+    // ── E2.5 — update_aws_credentials_atomic tests ─────────────────────────
+
+    #[test]
+    fn credentials_atomic_write_applies_transform() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("credentials");
+
+        std::fs::write(&path, "[ci]\naws_access_key_id = OLD\n").expect("seed");
+
+        update_aws_credentials_atomic(&path, |existing| existing.replace("OLD", "NEW"))
+            .expect("write");
+
+        let content = std::fs::read_to_string(&path).expect("read");
+        assert!(content.contains("aws_access_key_id = NEW"));
+        assert!(!content.contains("aws_access_key_id = OLD"));
+    }
+
+    #[test]
+    fn credentials_atomic_write_no_change_does_not_update_mtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("credentials");
+        let content = "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n";
+
+        std::fs::write(&path, content).expect("seed");
+
+        let mtime_before = std::fs::metadata(&path)
+            .and_then(|m| m.modified())
+            .expect("mtime before");
+
+        // Transform returns the original string — no change.
+        update_aws_credentials_atomic(&path, |existing| existing.to_string()).expect("write");
+
+        let mtime_after = std::fs::metadata(&path)
+            .and_then(|m| m.modified())
+            .expect("mtime after");
+
+        assert_eq!(
+            mtime_before, mtime_after,
+            "mtime must not change when content is identical"
+        );
+    }
+
+    #[test]
+    fn credentials_atomic_write_uses_same_lock_as_config_write() {
+        // Two threads: one writes to a temp config path under the shared lock,
+        // the other writes to a credentials path. They must not deadlock and
+        // both writes must land.
+        use std::sync::Arc;
+        use std::thread;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = Arc::new(dir.path().join("config"));
+        let creds_path = Arc::new(dir.path().join("credentials"));
+
+        std::fs::write(config_path.as_ref(), "[profile a]\nregion = us-east-1\n")
+            .expect("seed config");
+        std::fs::write(
+            creds_path.as_ref(),
+            "[a]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n",
+        )
+        .expect("seed creds");
+
+        let cp = Arc::clone(&config_path);
+        let creds = Arc::clone(&creds_path);
+
+        let h1 = thread::spawn(move || {
+            update_aws_config_atomic(&cp, |existing| existing.replace("us-east-1", "us-west-2"))
+                .expect("config write");
+        });
+
+        let h2 = thread::spawn(move || {
+            update_aws_credentials_atomic(&creds, |existing| {
+                existing.replace("AKIAIOSFODNN7EXAMPLE", "AKIAI44QH8DHBEXAMPLE")
+            })
+            .expect("creds write");
+        });
+
+        h1.join().expect("thread 1");
+        h2.join().expect("thread 2");
+
+        let config_content = std::fs::read_to_string(config_path.as_ref()).expect("read config");
+        let creds_content = std::fs::read_to_string(creds_path.as_ref()).expect("read creds");
+
+        assert!(
+            config_content.contains("us-west-2"),
+            "config write must land"
+        );
+        assert!(
+            creds_content.contains("AKIAI44QH8DHBEXAMPLE"),
+            "creds write must land"
+        );
+    }
+
+    // ── E2.6 — replace_or_append_credentials_block tests ───────────────────
+
+    #[test]
+    fn replace_credentials_block_uses_bare_header() {
+        let contents = "[ci]\naws_access_key_id = OLD\n";
+        let result =
+            replace_or_append_credentials_block(contents, "ci", &[("aws_access_key_id", "NEW")]);
+
+        // Bare [ci] header must be present; no [profile ci].
+        assert!(result.contains("[ci]"), "must use bare [ci] header");
+        assert!(
+            !result.contains("[profile ci]"),
+            "must NOT use [profile ci]"
+        );
+        assert!(result.contains("aws_access_key_id = NEW"));
+    }
+
+    #[test]
+    fn replace_credentials_block_other_sections_byte_identical() {
+        let contents = "[prod]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\nregion = us-east-1\n\n[ci]\naws_access_key_id = AKIAI44QH8DHBEXAMPLE\n\n[dev]\nregion = eu-west-1\n";
+
+        let result = replace_or_append_credentials_block(
+            contents,
+            "ci",
+            &[("aws_access_key_id", "AKIANEWVALUE7EXAMPLE")],
+        );
+
+        // [prod] and [dev] must be byte-identical.
+        let prod_before = section_raw_bytes(contents, "[prod]").unwrap();
+        let prod_after = section_raw_bytes(&result, "[prod]").unwrap();
+        assert_eq!(prod_before, prod_after, "[prod] must be byte-identical");
+
+        let dev_before = section_raw_bytes(contents, "[dev]").unwrap();
+        let dev_after = section_raw_bytes(&result, "[dev]").unwrap();
+        assert_eq!(dev_before, dev_after, "[dev] must be byte-identical");
+
+        // [ci] must be updated.
+        assert!(result.contains("aws_access_key_id = AKIANEWVALUE7EXAMPLE"));
+    }
+
+    #[test]
+    fn replace_credentials_block_appends_when_section_absent() {
+        let contents = "[prod]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n";
+
+        let result = replace_or_append_credentials_block(
+            contents,
+            "new-profile",
+            &[("aws_access_key_id", "AKIANEWVALUE7EXAMPLE")],
+        );
+
+        assert!(result.contains("[new-profile]"));
+        assert!(result.contains("aws_access_key_id = AKIANEWVALUE7EXAMPLE"));
+        // Original section must still be present.
+        assert!(result.contains("[prod]"));
+    }
+
+    // ── E2.3 / E2.8 — blank-preserves / non-blank-overwrites ────────────────
+
+    #[test]
+    fn credentials_merge_blank_preserves_existing_key() {
+        // A blank value in `fields` means "keep the existing on-disk value".
+        let contents = "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n";
+
+        let result = replace_or_append_credentials_block(
+            contents,
+            "ci",
+            &[
+                ("aws_access_key_id", "AKIANEWVALUE7EXAMPLE"),
+                ("aws_secret_access_key", ""), // blank — preserve existing
+            ],
+        );
+
+        assert!(result.contains("aws_access_key_id = AKIANEWVALUE7EXAMPLE"));
+        // The existing secret must be preserved because the caller passed blank.
+        assert!(
+            result.contains("aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        );
+    }
+
+    #[test]
+    fn credentials_merge_non_blank_overwrites_existing_key() {
+        let contents =
+            "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = OLD_SECRET\n";
+
+        let result = replace_or_append_credentials_block(
+            contents,
+            "ci",
+            &[
+                ("aws_access_key_id", "AKIANEWVALUE7EXAMPLE"),
+                ("aws_secret_access_key", "NEW_SECRET"),
+            ],
+        );
+
+        assert!(result.contains("aws_secret_access_key = NEW_SECRET"));
+        assert!(!result.contains("OLD_SECRET"));
+    }
+
+    // ── E2.9 — MANDATORY surgical-write regression test (both files) ─────────
+
+    #[test]
+    fn surgical_write_config_leaves_other_sections_byte_identical() {
+        let contents = "\
+[profile a]\nregion = us-east-1\noutput = json\n\n\
+[profile b]\nregion = eu-west-1\noutput = text\n\n\
+[profile c]\nregion = ap-southeast-1\noutput = json\n";
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("config");
+        std::fs::write(&config_path, contents).expect("seed");
+
+        // Hash sections a and c BEFORE the write.
+        let ha_before = hash_config_section(contents, "a").unwrap();
+        let hc_before = hash_config_section(contents, "c").unwrap();
+
+        // Write to [profile b] only.
+        update_aws_config_atomic(&config_path, |existing| {
+            replace_or_append_profile_block(
+                existing,
+                "b",
+                &[("region", "us-west-2"), ("output", "text")],
+            )
+        })
+        .expect("config write");
+
+        let after = std::fs::read_to_string(&config_path).expect("read after");
+
+        let ha_after = hash_config_section(&after, "a").unwrap();
+        let hc_after = hash_config_section(&after, "c").unwrap();
+
+        assert_eq!(
+            ha_before, ha_after,
+            "[profile a] must be byte-identical after write to [profile b]"
+        );
+        assert_eq!(
+            hc_before, hc_after,
+            "[profile c] must be byte-identical after write to [profile b]"
+        );
+    }
+
+    #[test]
+    fn surgical_write_credentials_leaves_other_sections_byte_identical() {
+        let contents = "\
+[staging]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\naws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n\n\
+[ci]\naws_access_key_id = AKIAI44QH8DHBEXAMPLE\naws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY\n\n\
+[prod]\naws_access_key_id = AKIAJ4JHDL3GEXAMPLE\naws_secret_access_key = 9drTJvcXLB89EXAMPLEKEY\n";
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let creds_path = dir.path().join("credentials");
+        std::fs::write(&creds_path, contents).expect("seed");
+
+        // Hash [staging] and [prod] BEFORE the write.
+        let h_staging_before = hash_credentials_section(contents, "staging").unwrap();
+        let h_prod_before = hash_credentials_section(contents, "prod").unwrap();
+
+        // Write to [ci] only.
+        update_aws_credentials_atomic(&creds_path, |existing| {
+            replace_or_append_credentials_block(
+                existing,
+                "ci",
+                &[
+                    ("aws_access_key_id", "AKIANEWVALUE7EXAMPLE"),
+                    ("aws_secret_access_key", "NEW_SECRET_VALUE"),
+                ],
+            )
+        })
+        .expect("creds write");
+
+        let after = std::fs::read_to_string(&creds_path).expect("read after");
+
+        let h_staging_after = hash_credentials_section(&after, "staging").unwrap();
+        let h_prod_after = hash_credentials_section(&after, "prod").unwrap();
+
+        assert_eq!(
+            h_staging_before, h_staging_after,
+            "[staging] must be byte-identical after write to [ci]"
+        );
+        assert_eq!(
+            h_prod_before, h_prod_after,
+            "[prod] must be byte-identical after write to [ci]"
+        );
+    }
+
+    // ── E2.10 — SECURITY: no secret logging; parse_aws_credentials_str unchanged ─
+
+    /// Verifies that `update_aws_credentials_atomic` does not return any
+    /// secret value — the only thing that crosses back is the `Result<(), _>`
+    /// return. The secret stays inside the transform closure and is dropped
+    /// when the closure returns.
+    #[test]
+    fn credentials_write_return_type_cannot_carry_secrets() {
+        // This is a compile-time structural assertion: the return type of
+        // `update_aws_credentials_atomic` is `Result<(), io::Error>`, which
+        // has no `String` or `&str` payload. We call it and assert Ok(()).
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("credentials");
+
+        let secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+
+        std::fs::write(&path, format!("[ci]\naws_secret_access_key = {secret}\n")).expect("seed");
+
+        // The return value is () — it cannot carry any string, let alone the secret.
+        let result = update_aws_credentials_atomic(&path, |existing| existing.to_string());
+        assert!(result.is_ok());
+
+        // parse_aws_credentials_str called on the same file still returns names only.
+        let content = std::fs::read_to_string(&path).expect("read");
+        let names = parse_aws_credentials_str(&content);
+        assert_eq!(names, vec!["ci"]);
+        for name in &names {
+            assert!(!name.contains(secret), "parse must not return secret value");
+        }
+    }
+
+    /// MANDATORY file-permission test (Unix only): credentials temp and backup
+    /// files must not be group- or other-readable when the original is 0600.
+    #[cfg(unix)]
+    #[test]
+    fn credentials_write_temp_and_backup_are_not_world_readable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("credentials");
+
+        // Seed with 0600 permissions (typical for ~/.aws/credentials).
+        std::fs::write(&path, "[ci]\naws_access_key_id = AKIAIOSFODNN7EXAMPLE\n").expect("seed");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("set 0600");
+
+        // Perform a write — this creates the temp file and the backup.
+        update_aws_credentials_atomic(&path, |existing| {
+            existing.replace("AKIAIOSFODNN7EXAMPLE", "AKIAI44QH8DHBEXAMPLE")
+        })
+        .expect("write");
+
+        // The final written file must be at most 0600 (not group/other readable).
+        let final_mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            final_mode & 0o077,
+            0,
+            "final credentials file must not be group/other readable; mode = {:o}",
+            final_mode
+        );
     }
 }

--- a/crates/dbflux_aws/src/lib.rs
+++ b/crates/dbflux_aws/src/lib.rs
@@ -10,7 +10,7 @@ pub use accounts::{
 };
 pub use auth::{
     AwsSharedCredentialsAuthProvider, AwsSsoAuthProvider, AwsSsoSessionAuthProvider,
-    AwsStaticCredentialsAuthProvider, SsoLoginHandle, abort_sso_login, login_sso_blocking,
+    SsoLoginHandle, abort_sso_login, login_sso_blocking,
     start_sso_login_blocking, wait_for_sso_session_blocking,
 };
 pub use config::{

--- a/crates/dbflux_aws/src/lib.rs
+++ b/crates/dbflux_aws/src/lib.rs
@@ -15,7 +15,7 @@ pub use auth::{
 };
 pub use config::{
     AwsProfileInfo, CachedAwsConfig, append_aws_shared_credentials_profile, append_aws_sso_profile,
-    restore_aws_config_backup, write_profile_to_aws_config,
+    append_aws_sso_session_profile, restore_aws_config_backup,
 };
 pub use parameters::AwsSsmParameterProvider;
 pub use secrets::AwsSecretsManagerProvider;

--- a/crates/dbflux_aws/src/lib.rs
+++ b/crates/dbflux_aws/src/lib.rs
@@ -10,8 +10,8 @@ pub use accounts::{
 };
 pub use auth::{
     AwsSharedCredentialsAuthProvider, AwsSsoAuthProvider, AwsSsoSessionAuthProvider,
-    SsoLoginHandle, abort_sso_login, login_sso_blocking,
-    start_sso_login_blocking, wait_for_sso_session_blocking,
+    SsoLoginHandle, abort_sso_login, login_sso_blocking, start_sso_login_blocking,
+    wait_for_sso_session_blocking,
 };
 pub use config::{
     AwsProfileInfo, CachedAwsConfig, append_aws_shared_credentials_profile, append_aws_sso_profile,

--- a/crates/dbflux_components/src/components/form_renderer.rs
+++ b/crates/dbflux_components/src/components/form_renderer.rs
@@ -77,7 +77,8 @@ pub fn create_inputs<T>(
                     _ => {
                         let placeholder = field.placeholder.clone();
                         let value = initial_value;
-                        let masked = field.kind == FormFieldKind::Password;
+                        let masked = field.kind == FormFieldKind::Password
+                            || field.kind == FormFieldKind::WriteOnly;
 
                         let input = cx.new(|cx| {
                             let mut input = InputState::new(window, cx).placeholder(placeholder);

--- a/crates/dbflux_components/src/controls/dropdown.rs
+++ b/crates/dbflux_components/src/controls/dropdown.rs
@@ -661,7 +661,7 @@ impl Render for Dropdown {
         let variant = self.trigger_variant();
         let trigger = self.render_trigger(label, disabled, cx);
 
-        let container = div()
+        div()
             .id(self.id.clone())
             .debug_selector({
                 let id = self.id.to_string();
@@ -670,9 +670,7 @@ impl Render for Dropdown {
             .w_full()
             .when(variant == DropdownTriggerVariant::Compact, |el| el.h_full())
             .child(trigger)
-            .child(self.render_menu(cx));
-
-        container
+            .child(self.render_menu(cx))
     }
 }
 

--- a/crates/dbflux_components/src/controls/dropdown.rs
+++ b/crates/dbflux_components/src/controls/dropdown.rs
@@ -440,6 +440,7 @@ impl Dropdown {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        cx.stop_propagation();
         self.toggle_open(cx);
     }
 
@@ -526,6 +527,7 @@ impl Dropdown {
             .on_scroll_wheel(cx.listener(Self::handle_menu_scroll_wheel))
             .shadow_lg()
             .occlude()
+            .on_mouse_down_out(cx.listener(Self::handle_mouse_down_out))
             .children(items);
 
         deferred(
@@ -619,7 +621,12 @@ impl Dropdown {
             }
         }
 
-        if !disabled {
+        // Only the closed trigger toggles open. While open, dismissal is owned
+        // by the menu's on_mouse_down_out: a click on the trigger lands outside
+        // the (deferred, snap-positioned) menu and closes it. Keeping on_click
+        // here while open would re-toggle (down dismisses, up reopens),
+        // producing the open/close flicker that surfaced after window resize.
+        if !disabled && !self.open {
             trigger = trigger.on_click(cx.listener(Self::handle_trigger_click));
         }
 
@@ -654,7 +661,7 @@ impl Render for Dropdown {
         let variant = self.trigger_variant();
         let trigger = self.render_trigger(label, disabled, cx);
 
-        let mut container = div()
+        let container = div()
             .id(self.id.clone())
             .debug_selector({
                 let id = self.id.to_string();
@@ -664,10 +671,6 @@ impl Render for Dropdown {
             .when(variant == DropdownTriggerVariant::Compact, |el| el.h_full())
             .child(trigger)
             .child(self.render_menu(cx));
-
-        if self.open {
-            container = container.on_mouse_down_out(cx.listener(Self::handle_mouse_down_out));
-        }
 
         container
     }

--- a/crates/dbflux_core/Cargo.toml
+++ b/crates/dbflux_core/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 thiserror = "2"
 dirs = "5"
 log = "0.4"

--- a/crates/dbflux_core/src/auth/edit.rs
+++ b/crates/dbflux_core/src/auth/edit.rs
@@ -1,16 +1,16 @@
-/// Edit-session types for AWS profile write-back.
-///
-/// These types are part of the optimistic-concurrency contract between the
-/// Settings UI and the AWS write-back layer (spec R9.3, design section 11).
-/// They live in `dbflux_core` so both `dbflux_aws` (write seam) and
-/// `dbflux_ui_windows` (Settings UI) share the same types without creating
-/// a direct dependency between those crates.
-///
-/// # Security invariant
-///
-/// `AwsSectionHash` carries only a SHA-256 digest — never raw section bytes
-/// or secret values. `AuthSaveOutcome` carries only file identifiers, never
-/// key material. No `Debug` or `Display` impl on these types prints secrets.
+//! Edit-session types for AWS profile write-back.
+//!
+//! These types are part of the optimistic-concurrency contract between the
+//! Settings UI and the AWS write-back layer (spec R9.3, design section 11).
+//! They live in `dbflux_core` so both `dbflux_aws` (write seam) and
+//! `dbflux_ui_windows` (Settings UI) share the same types without creating
+//! a direct dependency between those crates.
+//!
+//! # Security invariant
+//!
+//! `AwsSectionHash` carries only a SHA-256 digest — never raw section bytes
+//! or secret values. `AuthSaveOutcome` carries only file identifiers, never
+//! key material. No `Debug` or `Display` impl on these types prints secrets.
 
 /// Identifies which AWS credential file a write targets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -193,7 +193,11 @@ mod tests {
             written: AwsEditFile::Config,
             conflicted: AwsEditFile::Credentials,
         };
-        let AuthSaveOutcome::PartialSaved { written, conflicted } = outcome else {
+        let AuthSaveOutcome::PartialSaved {
+            written,
+            conflicted,
+        } = outcome
+        else {
             panic!("expected PartialSaved variant");
         };
         assert_eq!(written, AwsEditFile::Config);
@@ -217,7 +221,10 @@ mod tests {
 
         for outcome in &outcomes {
             let repr = format!("{outcome:?}");
-            assert!(!repr.contains("AKIA"), "outcome debug must not contain AKIA");
+            assert!(
+                !repr.contains("AKIA"),
+                "outcome debug must not contain AKIA"
+            );
             assert!(
                 !repr.contains("aws_secret_access_key"),
                 "outcome debug must not contain secret key name"

--- a/crates/dbflux_core/src/auth/edit.rs
+++ b/crates/dbflux_core/src/auth/edit.rs
@@ -1,0 +1,227 @@
+/// Edit-session types for AWS profile write-back.
+///
+/// These types are part of the optimistic-concurrency contract between the
+/// Settings UI and the AWS write-back layer (spec R9.3, design section 11).
+/// They live in `dbflux_core` so both `dbflux_aws` (write seam) and
+/// `dbflux_ui_windows` (Settings UI) share the same types without creating
+/// a direct dependency between those crates.
+///
+/// # Security invariant
+///
+/// `AwsSectionHash` carries only a SHA-256 digest — never raw section bytes
+/// or secret values. `AuthSaveOutcome` carries only file identifiers, never
+/// key material. No `Debug` or `Display` impl on these types prints secrets.
+
+/// Identifies which AWS credential file a write targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AwsEditFile {
+    /// `~/.aws/config`
+    Config,
+    /// `~/.aws/credentials`
+    Credentials,
+}
+
+/// Opaque SHA-256 digest over the raw bytes of one section in an AWS file.
+///
+/// Computed backend-side at edit-open time and re-checked inside the atomic
+/// write transform before any bytes are written (spec R9.3.1–R9.3.5).
+///
+/// The inner `[u8; 32]` is the only thing that crosses the seam; section
+/// contents and secrets are never included.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct AwsSectionHash(pub [u8; 32]);
+
+impl std::fmt::Debug for AwsSectionHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Print as a hex string to keep the Debug representation legible and
+        // unambiguous. The bytes are a SHA-256 digest — there is no secret
+        // material here — but a hex rendering is cleaner than a byte array.
+        write!(f, "AwsSectionHash(")?;
+        for byte in &self.0 {
+            write!(f, "{byte:02x}")?;
+        }
+        write!(f, ")")
+    }
+}
+
+/// Snapshot token captured at edit-open time (spec R9.3.1).
+///
+/// Holds the per-section SHA-256 hashes needed for optimistic-concurrency
+/// conflict detection. Passed back by the UI to the write seam at save time.
+///
+/// Fields are `None` when the provider does not write to that file (e.g. an
+/// SSO-only profile has no credentials section).
+///
+/// # Security invariant
+///
+/// This struct carries no secret material. A `Debug` print is safe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AwsEditSnapshot {
+    /// Hash of the `[profile NAME]` (or `[sso-session NAME]`) block in
+    /// `~/.aws/config`, captured when the edit form was opened.
+    ///
+    /// `None` when the provider does not write to `~/.aws/config` or when
+    /// the section did not exist on disk at snapshot time.
+    pub config_section: Option<AwsSectionHash>,
+
+    /// Hash of the bare `[NAME]` block in `~/.aws/credentials`, captured when
+    /// the edit form was opened.
+    ///
+    /// `None` when the provider does not write to `~/.aws/credentials` or
+    /// when the credentials section did not exist on disk at snapshot time.
+    pub credentials_section: Option<AwsSectionHash>,
+}
+
+/// Result returned by the edit-save seam after an attempted write (spec R9.3.4,
+/// R9.3.5, design section 11).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthSaveOutcome {
+    /// All targeted file sections were written successfully.
+    Saved,
+
+    /// The targeted section in `file` was modified on disk between edit-open
+    /// and save. No bytes were written for that file. The UI should offer a
+    /// Reload action (spec R9.3.6).
+    Conflict {
+        /// Which file's section hash did not match the snapshot.
+        file: AwsEditFile,
+    },
+
+    /// An edit spanning both files where one succeeded and the other
+    /// conflicted. The files are independent; the successful write is NOT
+    /// rolled back. The UI should surface which file was written and which
+    /// needs reload (spec S35).
+    PartialSaved {
+        /// The file whose section was successfully written.
+        written: AwsEditFile,
+        /// The file whose section hash did not match the snapshot; not written.
+        conflicted: AwsEditFile,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // E1.1 — Test-first: types compile and have the expected shapes.
+
+    #[test]
+    fn aws_section_hash_is_32_bytes() {
+        let hash = AwsSectionHash([0u8; 32]);
+        assert_eq!(hash.0.len(), 32);
+    }
+
+    #[test]
+    fn aws_section_hash_derives_eq() {
+        let a = AwsSectionHash([1u8; 32]);
+        let b = AwsSectionHash([1u8; 32]);
+        let c = AwsSectionHash([2u8; 32]);
+
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn aws_section_hash_debug_does_not_contain_secret_material() {
+        // The debug representation must be a hex digest string only — no
+        // raw bytes that could coincide with secret material, no "secret",
+        // no key-material keywords.
+        let hash = AwsSectionHash([0xABu8; 32]);
+        let repr = format!("{hash:?}");
+
+        // Should look like: AwsSectionHash(abababab...)
+        assert!(repr.starts_with("AwsSectionHash("));
+        assert!(!repr.contains("secret"));
+        assert!(!repr.contains("key"));
+    }
+
+    #[test]
+    fn aws_edit_file_variants_are_distinct() {
+        assert_ne!(AwsEditFile::Config, AwsEditFile::Credentials);
+        // Both variants must derive Debug and Copy without issues.
+        let _config = AwsEditFile::Config;
+        let _creds = AwsEditFile::Credentials;
+        let copy = _config;
+        assert_eq!(copy, AwsEditFile::Config);
+    }
+
+    #[test]
+    fn aws_edit_snapshot_carries_two_optional_hashes() {
+        let snapshot = AwsEditSnapshot {
+            config_section: Some(AwsSectionHash([1u8; 32])),
+            credentials_section: None,
+        };
+
+        assert!(snapshot.config_section.is_some());
+        assert!(snapshot.credentials_section.is_none());
+    }
+
+    #[test]
+    fn aws_edit_snapshot_with_both_sections() {
+        let snapshot = AwsEditSnapshot {
+            config_section: Some(AwsSectionHash([1u8; 32])),
+            credentials_section: Some(AwsSectionHash([2u8; 32])),
+        };
+
+        assert_eq!(snapshot.config_section, Some(AwsSectionHash([1u8; 32])));
+        assert_eq!(
+            snapshot.credentials_section,
+            Some(AwsSectionHash([2u8; 32]))
+        );
+    }
+
+    #[test]
+    fn auth_save_outcome_saved_variant() {
+        let outcome = AuthSaveOutcome::Saved;
+        assert_eq!(outcome, AuthSaveOutcome::Saved);
+    }
+
+    #[test]
+    fn auth_save_outcome_conflict_variant_carries_file() {
+        let outcome = AuthSaveOutcome::Conflict {
+            file: AwsEditFile::Config,
+        };
+        let AuthSaveOutcome::Conflict { file } = outcome else {
+            panic!("expected Conflict variant");
+        };
+        assert_eq!(file, AwsEditFile::Config);
+    }
+
+    #[test]
+    fn auth_save_outcome_partial_saved_variant() {
+        let outcome = AuthSaveOutcome::PartialSaved {
+            written: AwsEditFile::Config,
+            conflicted: AwsEditFile::Credentials,
+        };
+        let AuthSaveOutcome::PartialSaved { written, conflicted } = outcome else {
+            panic!("expected PartialSaved variant");
+        };
+        assert_eq!(written, AwsEditFile::Config);
+        assert_eq!(conflicted, AwsEditFile::Credentials);
+    }
+
+    #[test]
+    fn auth_save_outcome_debug_repr_contains_no_secret_material() {
+        // Regression guard: none of the outcome variants should contain secret
+        // patterns. This is trivially true now but documents the invariant.
+        let outcomes = [
+            AuthSaveOutcome::Saved,
+            AuthSaveOutcome::Conflict {
+                file: AwsEditFile::Config,
+            },
+            AuthSaveOutcome::PartialSaved {
+                written: AwsEditFile::Config,
+                conflicted: AwsEditFile::Credentials,
+            },
+        ];
+
+        for outcome in &outcomes {
+            let repr = format!("{outcome:?}");
+            assert!(!repr.contains("AKIA"), "outcome debug must not contain AKIA");
+            assert!(
+                !repr.contains("aws_secret_access_key"),
+                "outcome debug must not contain secret key name"
+            );
+        }
+    }
+}

--- a/crates/dbflux_core/src/auth/identity.rs
+++ b/crates/dbflux_core/src/auth/identity.rs
@@ -1,0 +1,89 @@
+use uuid::Uuid;
+
+/// Namespace UUID for all DBFlux-derived AWS auth profile identities.
+///
+/// Every AWS profile UUID in DBFlux is derived as `UUIDv5(AWS_AUTH_NAMESPACE,
+/// provider_id + ":" + profile_name)`. This constant is **frozen**: changing it
+/// after the first release would silently orphan every stored
+/// `ConnectionProfile.auth_profile_id` that references an AWS profile, breaking
+/// all existing connections. Do not change this value.
+pub const AWS_AUTH_NAMESPACE: Uuid = Uuid::from_u128(0x5fab674f_2a8b_4668_9b06_9d0e1ad74f7a);
+
+/// Derive a deterministic, stable UUID for an AWS auth profile.
+///
+/// Identity is `UUIDv5(AWS_AUTH_NAMESPACE, "{provider_id}:{name}")`.
+///
+/// ## Stability guarantees
+///
+/// - Same `provider_id` + `name` always yields the same UUID across process
+///   restarts, machines, and DBFlux versions (as long as `AWS_AUTH_NAMESPACE`
+///   remains frozen).
+/// - Different `provider_id` values for the same `name` produce different UUIDs,
+///   preventing collisions between `aws-sso`, `aws-sso-session`, and
+///   `aws-shared-credentials` providers.
+/// - Name comparison is case-sensitive: `"Prod"` and `"prod"` produce different
+///   UUIDs, matching the AWS CLI's own case-sensitive profile naming.
+pub fn aws_profile_uuid(provider_id: &str, name: &str) -> Uuid {
+    Uuid::new_v5(
+        &AWS_AUTH_NAMESPACE,
+        format!("{provider_id}:{name}").as_bytes(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // T-1.3a: Determinism — identical inputs always produce the same UUID.
+    #[test]
+    fn aws_profile_uuid_is_deterministic() {
+        let first = aws_profile_uuid("aws-sso", "dev");
+        let second = aws_profile_uuid("aws-sso", "dev");
+
+        assert_eq!(first, second);
+    }
+
+    // T-1.3b: Provider-id scoping — same profile name under different providers
+    // must produce distinct UUIDs (spec R2.2, S17).
+    #[test]
+    fn aws_profile_uuid_scoped_by_provider_id() {
+        let sso = aws_profile_uuid("aws-sso", "shared");
+        let sso_session = aws_profile_uuid("aws-sso-session", "shared");
+        let shared_creds = aws_profile_uuid("aws-shared-credentials", "shared");
+
+        assert_ne!(sso, sso_session);
+        assert_ne!(sso, shared_creds);
+        assert_ne!(sso_session, shared_creds);
+    }
+
+    // T-1.3c: Name case sensitivity — "Foo" and "foo" must produce distinct UUIDs
+    // (spec R2.3).
+    #[test]
+    fn aws_profile_uuid_is_case_sensitive() {
+        let upper = aws_profile_uuid("aws-sso", "Foo");
+        let lower = aws_profile_uuid("aws-sso", "foo");
+
+        assert_ne!(upper, lower);
+    }
+
+    // T-1.3d: Stability regression fixture — hard-coded expected UUID for a known
+    // (provider_id, name) pair. If AWS_AUTH_NAMESPACE is ever accidentally changed,
+    // or the derivation algorithm drifts, this test catches it immediately.
+    //
+    // Expected value computed from:
+    //   Uuid::new_v5(&Uuid::from_u128(0x5fab674f_2a8b_4668_9b06_9d0e1ad74f7a),
+    //                b"aws-sso:prod")
+    // = e18201b8-45ff-5b27-a2ad-224a8e25728e
+    #[test]
+    fn aws_profile_uuid_regression_fixture() {
+        let result = aws_profile_uuid("aws-sso", "prod");
+        let expected: Uuid = "e18201b8-45ff-5b27-a2ad-224a8e25728e"
+            .parse()
+            .expect("hard-coded UUID must be valid");
+
+        assert_eq!(
+            result, expected,
+            "UUID derivation changed — AWS_AUTH_NAMESPACE or algorithm may have been modified"
+        );
+    }
+}

--- a/crates/dbflux_core/src/auth/mod.rs
+++ b/crates/dbflux_core/src/auth/mod.rs
@@ -161,6 +161,15 @@ pub trait DynAuthProvider: Send + Sync {
     /// The default is a no-op.
     fn after_profile_saved(&self, _profile: &AuthProfile) {}
 
+    /// Synthesize virtual `AuthProfile` records by reading external config files
+    /// (e.g., `~/.aws/config` and `~/.aws/credentials`) without storing anything.
+    ///
+    /// Returned profiles carry `read_only = true`. The default returns an empty list;
+    /// AWS providers override this to enumerate their respective profile types.
+    fn reflect_profiles(&self) -> Vec<AuthProfile> {
+        vec![]
+    }
+
     /// Abort any in-flight login for `profile` if the provider tracks one.
     ///
     /// Returns `true` if an in-flight login was found and signalled to stop.

--- a/crates/dbflux_core/src/auth/mod.rs
+++ b/crates/dbflux_core/src/auth/mod.rs
@@ -1,3 +1,4 @@
+mod edit;
 mod identity;
 mod refs;
 mod types;
@@ -12,6 +13,7 @@ use crate::DbError;
 use crate::driver::form::DriverFormDef;
 use crate::values::CompositeValueResolver;
 
+pub use edit::{AuthSaveOutcome, AwsEditFile, AwsEditSnapshot, AwsSectionHash};
 pub use identity::{AWS_AUTH_NAMESPACE, aws_profile_uuid};
 pub use refs::{AuthProfileLookup, expand_auth_profile_refs};
 pub use types::*;
@@ -192,6 +194,40 @@ pub trait DynAuthProvider: Send + Sync {
         false
     }
 
+    /// Capture a section-hash snapshot at the moment the edit form opens.
+    ///
+    /// The returned `AwsEditSnapshot` is an opaque token: it holds the
+    /// SHA-256 digest(s) of the on-disk section byte slice(s) so the write
+    /// seam can detect external edits before committing (spec R9.3.1).
+    ///
+    /// The default implementation returns an empty snapshot (both hashes
+    /// `None`), which means the provider does not support file-backed editing.
+    /// AWS providers override this to capture real section hashes.
+    fn open_edit_snapshot(&self, _name: &str) -> AwsEditSnapshot {
+        AwsEditSnapshot {
+            config_section: None,
+            credentials_section: None,
+        }
+    }
+
+    /// Persist the user's edited fields to the provider's backing file(s).
+    ///
+    /// Compares the current on-disk section hash(es) against `snapshot` under
+    /// the file lock. Returns `Conflict` or `PartialSaved` when a concurrent
+    /// external change is detected (spec R9.3.4, R9.3.5).
+    ///
+    /// The default implementation returns `AuthSaveOutcome::Saved` without
+    /// writing anything — safe no-op for non-file-backed providers. AWS
+    /// providers override this with a real atomic write-back.
+    fn save_edit(
+        &self,
+        _name: &str,
+        _fields: &HashMap<String, String>,
+        _snapshot: &AwsEditSnapshot,
+    ) -> AuthSaveOutcome {
+        AuthSaveOutcome::Saved
+    }
+
     /// Fetch the available options for a `DynamicSelect` field declared in this
     /// provider's `form_def()`.
     ///
@@ -340,6 +376,19 @@ impl DynAuthProvider for SharedDynAuthProvider {
     ) -> Result<FetchOptionsResponse, FetchOptionsError> {
         self.provider.fetch_dynamic_options(profile, request).await
     }
+
+    fn open_edit_snapshot(&self, name: &str) -> AwsEditSnapshot {
+        self.provider.open_edit_snapshot(name)
+    }
+
+    fn save_edit(
+        &self,
+        name: &str,
+        fields: &HashMap<String, String>,
+        snapshot: &AwsEditSnapshot,
+    ) -> AuthSaveOutcome {
+        self.provider.save_edit(name, fields, snapshot)
+    }
 }
 
 #[async_trait::async_trait]
@@ -411,6 +460,19 @@ impl DynAuthProvider for std::sync::Arc<dyn DynAuthProvider> {
         request: FetchOptionsRequest,
     ) -> Result<FetchOptionsResponse, FetchOptionsError> {
         self.as_ref().fetch_dynamic_options(profile, request).await
+    }
+
+    fn open_edit_snapshot(&self, name: &str) -> AwsEditSnapshot {
+        self.as_ref().open_edit_snapshot(name)
+    }
+
+    fn save_edit(
+        &self,
+        name: &str,
+        fields: &HashMap<String, String>,
+        snapshot: &AwsEditSnapshot,
+    ) -> AuthSaveOutcome {
+        self.as_ref().save_edit(name, fields, snapshot)
     }
 }
 

--- a/crates/dbflux_core/src/auth/mod.rs
+++ b/crates/dbflux_core/src/auth/mod.rs
@@ -1,3 +1,4 @@
+mod identity;
 mod refs;
 mod types;
 
@@ -11,6 +12,7 @@ use crate::DbError;
 use crate::driver::form::DriverFormDef;
 use crate::values::CompositeValueResolver;
 
+pub use identity::{AWS_AUTH_NAMESPACE, aws_profile_uuid};
 pub use refs::{AuthProfileLookup, expand_auth_profile_refs};
 pub use types::*;
 

--- a/crates/dbflux_core/src/auth/mod.rs
+++ b/crates/dbflux_core/src/auth/mod.rs
@@ -170,6 +170,20 @@ pub trait DynAuthProvider: Send + Sync {
         vec![]
     }
 
+    /// Write a newly created profile to an external config file instead of
+    /// DBFlux's SQLite store.
+    ///
+    /// Returns `Some(Ok(()))` on a successful file write. Returns `Some(Err(msg))`
+    /// when the write failed. Returns `None` for providers that store profiles
+    /// normally in DBFlux (the UI then falls back to `add_auth_profile`).
+    ///
+    /// Only AWS file-backed providers override this. The Settings UI calls this
+    /// before `add_auth_profile` so it can skip SQLite storage for file-backed
+    /// providers and let reflection pick up the new profile on the next read.
+    fn write_new_profile_to_config(&self, _profile: &AuthProfile) -> Option<Result<(), String>> {
+        None
+    }
+
     /// Abort any in-flight login for `profile` if the provider tracks one.
     ///
     /// Returns `true` if an in-flight login was found and signalled to stop.
@@ -311,6 +325,10 @@ impl DynAuthProvider for SharedDynAuthProvider {
         self.provider.after_profile_saved(profile);
     }
 
+    fn write_new_profile_to_config(&self, profile: &AuthProfile) -> Option<Result<(), String>> {
+        self.provider.write_new_profile_to_config(profile)
+    }
+
     fn abort_login(&self, profile: &AuthProfile) -> bool {
         self.provider.abort_login(profile)
     }
@@ -377,6 +395,10 @@ impl DynAuthProvider for std::sync::Arc<dyn DynAuthProvider> {
 
     fn after_profile_saved(&self, profile: &AuthProfile) {
         self.as_ref().after_profile_saved(profile);
+    }
+
+    fn write_new_profile_to_config(&self, profile: &AuthProfile) -> Option<Result<(), String>> {
+        self.as_ref().write_new_profile_to_config(profile)
     }
 
     fn abort_login(&self, profile: &AuthProfile) -> bool {

--- a/crates/dbflux_core/src/auth/types.rs
+++ b/crates/dbflux_core/src/auth/types.rs
@@ -23,6 +23,11 @@ pub struct AuthProviderLoginCapabilities {
 /// `AuthProfile` uses a custom `Deserialize` impl to handle migration from
 /// the legacy `"config"` format (see impl below). `Serialize` is derived
 /// normally and always writes the new `"fields"` format.
+///
+/// `read_only` is `true` for profiles that are reflected live from AWS config
+/// files and must not be edited in DBFlux. Stored profiles always have
+/// `read_only = false`. This field is never persisted to SQLite; reflected
+/// profiles are never serialized.
 #[derive(Debug, Clone, Serialize)]
 pub struct AuthProfile {
     pub id: Uuid,
@@ -30,6 +35,11 @@ pub struct AuthProfile {
     pub provider_id: String,
     pub fields: HashMap<String, String>,
     pub enabled: bool,
+    /// Whether this profile is a live reflection and must not be edited in DBFlux.
+    ///
+    /// Defaults to `false` for stored profiles. `true` for AWS reflected profiles.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub read_only: bool,
 }
 
 /// Provider ID rewrites for old `config.type` values.
@@ -122,12 +132,18 @@ impl<'de> Deserialize<'de> for AuthProfile {
             (HashMap::new(), provider_id)
         };
 
+        let read_only = obj
+            .get("read_only")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
         Ok(AuthProfile {
             id,
             name,
             provider_id,
             fields,
             enabled,
+            read_only,
         })
     }
 }
@@ -144,6 +160,7 @@ impl AuthProfile {
             provider_id: provider_id.into(),
             fields,
             enabled: true,
+            read_only: false,
         }
     }
 
@@ -322,6 +339,7 @@ mod tests {
             provider_id: "aws-sso".to_string(),
             fields: fields.clone(),
             enabled: true,
+            read_only: false,
         };
 
         let serialized = serde_json::to_value(&original).unwrap();

--- a/crates/dbflux_core/src/auth/types.rs
+++ b/crates/dbflux_core/src/auth/types.rs
@@ -40,6 +40,19 @@ pub struct AuthProfile {
     /// Defaults to `false` for stored profiles. `true` for AWS reflected profiles.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub read_only: bool,
+    /// Why this stored profile is dangling, if it is.
+    ///
+    /// Set by the one-time migration when a stored AWS profile can no longer be
+    /// matched to a file section. Known values:
+    /// - `"keyring-only"`: the credentials live only in the DBFlux keyring with no
+    ///   matching `~/.aws/credentials` entry.
+    /// - `"file-gone"`: the profile section disappeared from `~/.aws/config`.
+    ///
+    /// `None` for healthy stored profiles and for all reflected (virtual) profiles.
+    /// This field is never persisted by serialization; it is populated at load time
+    /// from the `dangling_origin` column in `cfg_auth_profiles`.
+    #[serde(skip)]
+    pub dangling_origin: Option<String>,
 }
 
 /// Provider ID rewrites for old `config.type` values.
@@ -144,6 +157,7 @@ impl<'de> Deserialize<'de> for AuthProfile {
             fields,
             enabled,
             read_only,
+            dangling_origin: None,
         })
     }
 }
@@ -161,6 +175,7 @@ impl AuthProfile {
             fields,
             enabled: true,
             read_only: false,
+            dangling_origin: None,
         }
     }
 
@@ -340,6 +355,7 @@ mod tests {
             fields: fields.clone(),
             enabled: true,
             read_only: false,
+            dangling_origin: None,
         };
 
         let serialized = serde_json::to_value(&original).unwrap();

--- a/crates/dbflux_core/src/driver/form.rs
+++ b/crates/dbflux_core/src/driver/form.rs
@@ -41,6 +41,19 @@ pub enum RefreshTrigger {
 pub enum FormFieldKind {
     Text,
     Password,
+    /// A write-only secret input.
+    ///
+    /// The field is rendered as a masked, always-empty input. The placeholder
+    /// signals write-only semantics (e.g. "Leave blank to keep current"). When
+    /// the user saves without entering a value, the provider receives an empty
+    /// string; it MUST interpret blank as "preserve the existing on-disk value"
+    /// (spec R9.4.2). A non-blank value is written to disk and then discarded
+    /// from memory — it is never stored in DBFlux SQLite, keyring, or logs
+    /// (spec R9.4.4, R9.6).
+    ///
+    /// Use this instead of `Password` for credentials that live exclusively on
+    /// disk and must never be pre-filled or round-tripped through the UI.
+    WriteOnly,
     Number,
     FilePath,
     Checkbox,

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -23,9 +23,9 @@ pub use access::{AccessHandle, AccessKind, AccessManager};
 pub use document_id::DocumentId;
 
 pub use auth::{
-    AuthFormDef, AuthProfile, AuthProfileSummary, AuthProvider, AuthSession, AuthSessionState,
-    DynAuthProvider, FetchOptionsError, FetchOptionsRequest, FetchOptionsResponse,
-    ImportableProfile, ResolvedCredentials,
+    AuthFormDef, AuthProfile, AuthProfileSummary, AuthProvider, AuthSaveOutcome, AuthSession,
+    AuthSessionState, AwsEditFile, AwsEditSnapshot, DynAuthProvider, FetchOptionsError,
+    FetchOptionsRequest, FetchOptionsResponse, ImportableProfile, ResolvedCredentials,
 };
 
 pub use config::{

--- a/crates/dbflux_ipc/src/auth_provider_client.rs
+++ b/crates/dbflux_ipc/src/auth_provider_client.rs
@@ -319,13 +319,18 @@ pub fn build_fetch_dependencies(
         })
         .unwrap_or_default();
 
-    // Collect a set of field ids that have Password kind.
+    // Collect a set of field ids that have Password or WriteOnly kind.
+    // Both carry secret values and are filtered from dependency maps sent to
+    // external RPC providers unless the provider opts in via
+    // `secret_dependency_opt_in`.
     let password_field_ids: std::collections::HashSet<&str> = form_def
         .tabs
         .iter()
         .flat_map(|tab| tab.sections.iter())
         .flat_map(|section| section.fields.iter())
-        .filter(|field| field.kind == FormFieldKind::Password)
+        .filter(|field| {
+            field.kind == FormFieldKind::Password || field.kind == FormFieldKind::WriteOnly
+        })
         .map(|field| field.id.as_str())
         .collect();
 

--- a/crates/dbflux_mcp_server/src/state.rs
+++ b/crates/dbflux_mcp_server/src/state.rs
@@ -278,6 +278,7 @@ fn load_auth_profiles(runtime: &StorageRuntime) -> Result<Vec<dbflux_core::AuthP
                 provider_id: dto.provider_id,
                 fields,
                 enabled: dto.enabled,
+                read_only: false,
             })
         })
         .collect()

--- a/crates/dbflux_mcp_server/src/state.rs
+++ b/crates/dbflux_mcp_server/src/state.rs
@@ -279,6 +279,7 @@ fn load_auth_profiles(runtime: &StorageRuntime) -> Result<Vec<dbflux_core::AuthP
                 fields,
                 enabled: dto.enabled,
                 read_only: false,
+                dangling_origin: dto.dangling_origin,
             })
         })
         .collect()

--- a/crates/dbflux_mcp_server/src/state.rs
+++ b/crates/dbflux_mcp_server/src/state.rs
@@ -844,12 +844,9 @@ fn build_auth_provider_registry(
             as Arc<dyn DynAuthProvider>;
         registry.insert(shared.provider_id().to_string(), shared);
 
-        let static_credentials = Arc::new(dbflux_aws::AwsStaticCredentialsAuthProvider::new())
-            as Arc<dyn DynAuthProvider>;
-        registry.insert(
-            static_credentials.provider_id().to_string(),
-            static_credentials,
-        );
+        // aws-static-credentials provider removed (ADR-7): DBFlux no longer
+        // stores AWS long-lived secrets. Shared-credentials profiles are
+        // reflected from ~/.aws/credentials via AwsSharedCredentialsAuthProvider.
     }
 
     load_external_auth_providers(&mut registry, services);

--- a/crates/dbflux_storage/src/bootstrap.rs
+++ b/crates/dbflux_storage/src/bootstrap.rs
@@ -8,6 +8,7 @@ use crate::artifacts::ArtifactStore;
 use crate::error::StorageError;
 use crate::migrations::MigrationRegistry;
 use crate::paths;
+use crate::repositories::app_meta::AppMetaRepository;
 use crate::repositories::audit::AuditRepository;
 use crate::repositories::audit_settings::AuditSettingsRepository;
 use crate::repositories::auth_profiles::AuthProfileRepository;
@@ -136,6 +137,11 @@ impl StorageRuntime {
     // All repositories now use the single unified database connection.
     // Config-domain and state-domain tables coexist in the same database
     // with domain-prefixed names (cfg_*, st_*).
+
+    /// Creates an app metadata repository for one-time migration flags.
+    pub fn app_meta(&self) -> AppMetaRepository {
+        AppMetaRepository::new(self.dbflux_db())
+    }
 
     /// Creates a connection profile repository.
     pub fn connection_profiles(&self) -> ConnectionProfileRepository {

--- a/crates/dbflux_storage/src/bootstrap.rs
+++ b/crates/dbflux_storage/src/bootstrap.rs
@@ -57,8 +57,16 @@ impl StorageRuntime {
     pub fn for_path(dbflux_db_path: PathBuf) -> Result<Self, StorageError> {
         // Open and validate dbflux.db - apply migrations if needed
         let dbflux_conn = crate::sqlite::open_database(&dbflux_db_path)?;
+
+        // Run migrations with foreign-key enforcement disabled so table-rebuild
+        // migrations (drop + recreate to change constraints) do not cascade-delete
+        // child rows when the parent table is dropped. Enforcement is restored for
+        // normal runtime use immediately afterwards.
+        crate::sqlite::set_foreign_keys(&dbflux_conn, false)?;
         let registry = MigrationRegistry::new();
         registry.run_all(&dbflux_conn)?;
+        crate::sqlite::set_foreign_keys(&dbflux_conn, true)?;
+
         info!("Unified database ready at {}", dbflux_db_path.display());
 
         // Initialize the artifact store using the parent directory of dbflux.db as data root.

--- a/crates/dbflux_storage/src/lib.rs
+++ b/crates/dbflux_storage/src/lib.rs
@@ -10,6 +10,7 @@ pub mod sqlite_tree_store;
 
 pub use artifacts::ArtifactStore;
 pub use bootstrap::{OwnedConnection, StorageRuntime};
+pub use repositories::app_meta::AppMetaRepository;
 pub use repositories::audit::{
     AppendAuditEvent, AppendAuditEventExtended, AuditAggregateParams, AuditEventDto,
     AuditGroupColumn, AuditQueryFilter, AuditRepository,

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -141,6 +141,7 @@ impl MigrationRegistry {
         registry.register(mod_008_general_settings_style::MigrationImpl);
         registry.register(mod_009_mssql_instance::MigrationImpl);
         registry.register(mod_010_aws_reflect_migration_flag::MigrationImpl);
+        registry.register(mod_011_connection_drop_auth_profile_fk::MigrationImpl);
         registry
     }
 
@@ -289,6 +290,7 @@ mod mod_007_session_exec_ctx_json;
 mod mod_008_general_settings_style;
 mod mod_009_mssql_instance;
 mod mod_010_aws_reflect_migration_flag;
+mod mod_011_connection_drop_auth_profile_fk;
 
 pub use mod_001_initial::MigrationImpl;
 pub use mod_002_audit_extended::MigrationImpl as MigrationImplAuditExtended;

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -140,6 +140,7 @@ impl MigrationRegistry {
         registry.register(mod_007_session_exec_ctx_json::MigrationImpl);
         registry.register(mod_008_general_settings_style::MigrationImpl);
         registry.register(mod_009_mssql_instance::MigrationImpl);
+        registry.register(mod_010_aws_reflect_migration_flag::MigrationImpl);
         registry
     }
 
@@ -287,6 +288,7 @@ mod mod_006_rpc_service_api_contract;
 mod mod_007_session_exec_ctx_json;
 mod mod_008_general_settings_style;
 mod mod_009_mssql_instance;
+mod mod_010_aws_reflect_migration_flag;
 
 pub use mod_001_initial::MigrationImpl;
 pub use mod_002_audit_extended::MigrationImpl as MigrationImplAuditExtended;
@@ -296,6 +298,7 @@ pub use mod_005_rpc_service_kind::MigrationImpl as MigrationImplRpcServiceKind;
 pub use mod_006_rpc_service_api_contract::MigrationImpl as MigrationImplRpcServiceApiContract;
 pub use mod_007_session_exec_ctx_json::MigrationImpl as MigrationImplSessionExecCtxJson;
 pub use mod_008_general_settings_style::MigrationImpl as MigrationImplGeneralSettingsStyle;
+pub use mod_010_aws_reflect_migration_flag::MigrationImpl as MigrationImplAwsReflectMigrationFlag;
 
 // ---------------------------------------------------------------------------
 // Database verification utilities
@@ -498,6 +501,14 @@ mod tests {
 
         // System domain tables
         assert!(tables.contains("sys_migrations"), "missing sys_migrations");
+        assert!(tables.contains("sys_app_meta"), "missing sys_app_meta");
+
+        // Migration 010: dangling_origin column on cfg_auth_profiles
+        let auth_columns = column_names(&conn, "cfg_auth_profiles");
+        assert!(
+            auth_columns.contains("dangling_origin"),
+            "cfg_auth_profiles missing dangling_origin column"
+        );
 
         drop(conn);
         let _ = std::fs::remove_dir_all(temp_dir);

--- a/crates/dbflux_storage/src/migrations/mod_010_aws_reflect_migration_flag.rs
+++ b/crates/dbflux_storage/src/migrations/mod_010_aws_reflect_migration_flag.rs
@@ -1,0 +1,79 @@
+//! Migration 010: Add `sys_app_meta` table and `dangling_origin` column to
+//! `cfg_auth_profiles`.
+//!
+//! ## `sys_app_meta`
+//!
+//! A general-purpose key-value table for one-time migration flags and other
+//! app-level metadata that does not belong in user-facing config tables.
+//!
+//! The one-time AWS config reflection migration uses the key
+//! `aws_config_reflect_migrated` with value `1` to prevent re-execution.
+//!
+//! ## `cfg_auth_profiles.dangling_origin`
+//!
+//! Optional text column. When set, the profile is considered dangling — the
+//! stored row exists but the backing credential source is gone. Possible values:
+//! - `keyring-only`: the profile had a secret stored in the DBFlux keyring but
+//!   no matching section exists in `~/.aws/config` or `~/.aws/credentials`.
+//! - `file-gone`: the profile name no longer appears in the AWS config file.
+
+use rusqlite::Transaction;
+
+use crate::migrations::{Migration, MigrationError};
+
+pub struct MigrationImpl;
+
+impl Migration for MigrationImpl {
+    fn name(&self) -> &str {
+        "010_aws_reflect_migration_flag"
+    }
+
+    fn run(&self, tx: &Transaction) -> Result<(), MigrationError> {
+        let map_err = |source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        };
+
+        // Create sys_app_meta table if it does not exist.
+        tx.execute_batch(
+            "CREATE TABLE IF NOT EXISTS sys_app_meta (
+                key   TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );",
+        )
+        .map_err(map_err)?;
+
+        // Add dangling_origin column to cfg_auth_profiles if the table exists
+        // and the column is absent. The table may be absent in partial test
+        // databases that simulate an intermediate migration state.
+        let table_exists: bool = tx
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='table' AND name='cfg_auth_profiles'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .map_err(map_err)?;
+
+        if table_exists {
+            let column_exists: bool = tx
+                .query_row(
+                    "SELECT COUNT(*) FROM pragma_table_info('cfg_auth_profiles') \
+                     WHERE name = 'dangling_origin'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map(|n| n > 0)
+                .map_err(map_err)?;
+
+            if !column_exists {
+                tx.execute_batch("ALTER TABLE cfg_auth_profiles ADD COLUMN dangling_origin TEXT;")
+                    .map_err(map_err)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/dbflux_storage/src/migrations/mod_011_connection_drop_auth_profile_fk.rs
+++ b/crates/dbflux_storage/src/migrations/mod_011_connection_drop_auth_profile_fk.rs
@@ -1,0 +1,219 @@
+//! Migration 011: Drop the `auth_profile_id` foreign key on
+//! `cfg_connection_profiles`.
+//!
+//! AWS auth profiles are now reflected live from `~/.aws/config` rather than
+//! stored in `cfg_auth_profiles`. A connection bound to a reflected profile
+//! therefore holds an `auth_profile_id` that has no row in `cfg_auth_profiles`.
+//! With foreign-key enforcement ON, saving such a connection violated the
+//! `auth_profile_id -> cfg_auth_profiles(id)` constraint, so the binding never
+//! persisted and appeared "deassigned" after a restart.
+//!
+//! SQLite cannot drop a single constraint in place, so the table is rebuilt
+//! without that foreign key. The `proxy_profile_id` and `ssh_tunnel_profile_id`
+//! foreign keys are kept — those profiles are still stored. The rebuild relies
+//! on the caller running migrations with `PRAGMA foreign_keys = OFF` (see
+//! `StorageRuntime::for_path`), otherwise dropping the parent table would
+//! cascade-delete every connection's child rows.
+
+use rusqlite::Transaction;
+
+use crate::migrations::{Migration, MigrationError};
+
+pub struct MigrationImpl;
+
+impl Migration for MigrationImpl {
+    fn name(&self) -> &str {
+        "011_connection_drop_auth_profile_fk"
+    }
+
+    fn run(&self, tx: &Transaction) -> Result<(), MigrationError> {
+        let map_err = |source| MigrationError::Sqlite {
+            path: std::path::PathBuf::from("<unknown>"),
+            source,
+        };
+
+        let table_exists: bool = tx
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master \
+                 WHERE type='table' AND name='cfg_connection_profiles'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .map_err(map_err)?;
+
+        if !table_exists {
+            return Ok(());
+        }
+
+        // Idempotency: skip if the auth_profile_id foreign key is already gone.
+        let auth_fk_exists: bool = tx
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_foreign_key_list('cfg_connection_profiles') \
+                 WHERE \"table\" = 'cfg_auth_profiles'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .map_err(map_err)?;
+
+        if !auth_fk_exists {
+            return Ok(());
+        }
+
+        // Rebuild without the auth_profile_id foreign key. Columns are listed
+        // explicitly so the copy is independent of physical column order.
+        tx.execute_batch(
+            "CREATE TABLE cfg_connection_profiles_new (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                driver_id TEXT,
+                description TEXT,
+                kind TEXT,
+                save_password INTEGER NOT NULL DEFAULT 0,
+                access_kind TEXT,
+                access_provider TEXT,
+                favorite INTEGER DEFAULT 0,
+                color TEXT,
+                icon TEXT,
+                auth_profile_id TEXT,
+                proxy_profile_id TEXT,
+                ssh_tunnel_profile_id TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY (proxy_profile_id) REFERENCES cfg_proxy_profiles(id) ON DELETE SET NULL,
+                FOREIGN KEY (ssh_tunnel_profile_id) REFERENCES cfg_ssh_tunnel_profiles(id) ON DELETE SET NULL
+            );
+
+            INSERT INTO cfg_connection_profiles_new (
+                id, name, driver_id, description, kind, save_password, access_kind,
+                access_provider, favorite, color, icon, auth_profile_id,
+                proxy_profile_id, ssh_tunnel_profile_id, created_at, updated_at
+            )
+            SELECT
+                id, name, driver_id, description, kind, save_password, access_kind,
+                access_provider, favorite, color, icon, auth_profile_id,
+                proxy_profile_id, ssh_tunnel_profile_id, created_at, updated_at
+            FROM cfg_connection_profiles;
+
+            DROP TABLE cfg_connection_profiles;
+
+            ALTER TABLE cfg_connection_profiles_new RENAME TO cfg_connection_profiles;",
+        )
+        .map_err(map_err)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    fn fk_target_tables(conn: &Connection) -> Vec<String> {
+        let mut stmt = conn
+            .prepare("SELECT \"table\" FROM pragma_foreign_key_list('cfg_connection_profiles')")
+            .unwrap();
+        stmt.query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect()
+    }
+
+    fn seed_old_schema(conn: &Connection) {
+        // A fresh in-memory connection has foreign_keys OFF by default, matching
+        // how migrations run (StorageRuntime::for_path disables enforcement).
+        conn.execute_batch(
+            "CREATE TABLE cfg_proxy_profiles (id TEXT PRIMARY KEY);
+             CREATE TABLE cfg_ssh_tunnel_profiles (id TEXT PRIMARY KEY);
+             CREATE TABLE cfg_auth_profiles (id TEXT PRIMARY KEY);
+             CREATE TABLE cfg_connection_profiles (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                driver_id TEXT,
+                description TEXT,
+                kind TEXT,
+                save_password INTEGER NOT NULL DEFAULT 0,
+                access_kind TEXT,
+                access_provider TEXT,
+                favorite INTEGER DEFAULT 0,
+                color TEXT,
+                icon TEXT,
+                auth_profile_id TEXT,
+                proxy_profile_id TEXT,
+                ssh_tunnel_profile_id TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                FOREIGN KEY (auth_profile_id) REFERENCES cfg_auth_profiles(id) ON DELETE SET NULL,
+                FOREIGN KEY (proxy_profile_id) REFERENCES cfg_proxy_profiles(id) ON DELETE SET NULL,
+                FOREIGN KEY (ssh_tunnel_profile_id) REFERENCES cfg_ssh_tunnel_profiles(id) ON DELETE SET NULL
+             );",
+        )
+        .unwrap();
+    }
+
+    fn apply(conn: &Connection) {
+        let tx = conn.unchecked_transaction().unwrap();
+        MigrationImpl.run(&tx).unwrap();
+        tx.commit().unwrap();
+    }
+
+    #[test]
+    fn drops_auth_fk_keeps_others_and_preserves_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Migrations run with enforcement OFF (see StorageRuntime::for_path).
+        conn.pragma_update(None, "foreign_keys", "OFF").unwrap();
+        seed_old_schema(&conn);
+
+        // Connection bound to a reflected auth profile id absent from cfg_auth_profiles.
+        conn.execute(
+            "INSERT INTO cfg_connection_profiles (id, name, auth_profile_id) \
+             VALUES ('c1', 'conn', 'reflected-uuid')",
+            [],
+        )
+        .unwrap();
+
+        assert!(fk_target_tables(&conn).contains(&"cfg_auth_profiles".to_string()));
+
+        apply(&conn);
+
+        let fks = fk_target_tables(&conn);
+        assert!(
+            !fks.contains(&"cfg_auth_profiles".to_string()),
+            "auth_profile_id FK must be dropped"
+        );
+        assert!(fks.contains(&"cfg_proxy_profiles".to_string()), "proxy FK kept");
+        assert!(
+            fks.contains(&"cfg_ssh_tunnel_profiles".to_string()),
+            "ssh FK kept"
+        );
+
+        let auth: Option<String> = conn
+            .query_row(
+                "SELECT auth_profile_id FROM cfg_connection_profiles WHERE id='c1'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            auth.as_deref(),
+            Some("reflected-uuid"),
+            "reflected binding must survive the rebuild"
+        );
+    }
+
+    #[test]
+    fn second_run_is_noop() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Migrations run with enforcement OFF (see StorageRuntime::for_path).
+        conn.pragma_update(None, "foreign_keys", "OFF").unwrap();
+        seed_old_schema(&conn);
+
+        apply(&conn);
+        // Already dropped — must not error or re-rebuild.
+        apply(&conn);
+
+        assert!(!fk_target_tables(&conn).contains(&"cfg_auth_profiles".to_string()));
+    }
+}

--- a/crates/dbflux_storage/src/migrations/mod_011_connection_drop_auth_profile_fk.rs
+++ b/crates/dbflux_storage/src/migrations/mod_011_connection_drop_auth_profile_fk.rs
@@ -183,7 +183,10 @@ mod tests {
             !fks.contains(&"cfg_auth_profiles".to_string()),
             "auth_profile_id FK must be dropped"
         );
-        assert!(fks.contains(&"cfg_proxy_profiles".to_string()), "proxy FK kept");
+        assert!(
+            fks.contains(&"cfg_proxy_profiles".to_string()),
+            "proxy FK kept"
+        );
         assert!(
             fks.contains(&"cfg_ssh_tunnel_profiles".to_string()),
             "ssh FK kept"

--- a/crates/dbflux_storage/src/repositories/app_meta.rs
+++ b/crates/dbflux_storage/src/repositories/app_meta.rs
@@ -1,0 +1,154 @@
+//! Repository for the `sys_app_meta` key-value table.
+//!
+//! `sys_app_meta` stores one-time migration flags and other app-level metadata
+//! that does not belong in user-facing config tables. Keys are plain strings;
+//! values are stored as `TEXT`.
+//!
+//! The AWS config reflection migration uses the key
+//! `aws_config_reflect_migrated` with value `"1"` as its idempotency guard.
+
+use rusqlite::Connection;
+
+use crate::bootstrap::OwnedConnection;
+use crate::error::StorageError;
+
+const META_PATH: &str = "dbflux.db";
+
+/// Repository for `sys_app_meta` key-value metadata.
+pub struct AppMetaRepository {
+    conn: OwnedConnection,
+}
+
+impl AppMetaRepository {
+    /// Creates a new repository instance.
+    pub fn new(conn: OwnedConnection) -> Self {
+        Self { conn }
+    }
+
+    fn conn(&self) -> &Connection {
+        &self.conn
+    }
+
+    /// Returns the value associated with `key`, or `None` if the key is absent.
+    pub fn get(&self, key: &str) -> Result<Option<String>, StorageError> {
+        let result = self.conn().query_row(
+            "SELECT value FROM sys_app_meta WHERE key = ?1",
+            [key],
+            |row| row.get::<_, String>(0),
+        );
+
+        match result {
+            Ok(value) => Ok(Some(value)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(source) => Err(StorageError::Sqlite {
+                path: META_PATH.into(),
+                source,
+            }),
+        }
+    }
+
+    /// Returns `true` when `key` is present with the value `"1"`.
+    ///
+    /// This is the canonical check for boolean one-time migration flags.
+    pub fn is_flag_set(&self, key: &str) -> Result<bool, StorageError> {
+        Ok(self.get(key)?.as_deref() == Some("1"))
+    }
+
+    /// Inserts or updates `key` to `value`.
+    pub fn set(&self, key: &str, value: &str) -> Result<(), StorageError> {
+        self.conn()
+            .execute(
+                "INSERT INTO sys_app_meta (key, value, updated_at) \
+                 VALUES (?1, ?2, datetime('now')) \
+                 ON CONFLICT(key) DO UPDATE SET \
+                     value = excluded.value, \
+                     updated_at = excluded.updated_at",
+                [key, value],
+            )
+            .map_err(|source| StorageError::Sqlite {
+                path: META_PATH.into(),
+                source,
+            })?;
+
+        Ok(())
+    }
+
+    /// Sets `key` to `"1"`, recording a boolean flag as present.
+    pub fn set_flag(&self, key: &str) -> Result<(), StorageError> {
+        self.set(key, "1")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migrations::MigrationRegistry;
+    use crate::sqlite::open_database;
+    use std::sync::Arc;
+
+    fn temp_path(label: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("dbflux_meta_{}_{}", label, std::process::id()))
+    }
+
+    fn open_repo(label: &str) -> AppMetaRepository {
+        let path = temp_path(label);
+        let _ = std::fs::remove_file(&path);
+        let conn = open_database(&path).expect("open");
+        MigrationRegistry::new().run_all(&conn).expect("migrations");
+        #[allow(clippy::arc_with_non_send_sync)]
+        AppMetaRepository::new(Arc::new(conn))
+    }
+
+    // T-4.1: absent marker → migration should run; present marker → skip.
+    #[test]
+    fn flag_absent_initially() {
+        let repo = open_repo("flag_absent");
+        assert!(
+            !repo
+                .is_flag_set("aws_config_reflect_migrated")
+                .expect("query"),
+            "flag must be absent on a fresh database"
+        );
+    }
+
+    #[test]
+    fn set_flag_makes_it_present() {
+        let repo = open_repo("flag_set");
+        repo.set_flag("aws_config_reflect_migrated").expect("set");
+        assert!(
+            repo.is_flag_set("aws_config_reflect_migrated")
+                .expect("query"),
+            "flag must be present after set_flag"
+        );
+    }
+
+    #[test]
+    fn set_flag_is_idempotent() {
+        let repo = open_repo("flag_idempotent");
+        repo.set_flag("aws_config_reflect_migrated")
+            .expect("first set");
+        repo.set_flag("aws_config_reflect_migrated")
+            .expect("second set (idempotent)");
+        assert!(
+            repo.is_flag_set("aws_config_reflect_migrated")
+                .expect("query"),
+            "flag must still be present after double set"
+        );
+    }
+
+    #[test]
+    fn get_returns_none_for_unknown_key() {
+        let repo = open_repo("flag_unknown");
+        assert_eq!(repo.get("nonexistent_key").expect("query"), None);
+    }
+
+    #[test]
+    fn set_and_get_arbitrary_value() {
+        let repo = open_repo("flag_arbitrary");
+        repo.set("some_key", "hello").expect("set");
+        assert_eq!(
+            repo.get("some_key").expect("query"),
+            Some("hello".to_string())
+        );
+    }
+}

--- a/crates/dbflux_storage/src/repositories/auth_profiles.rs
+++ b/crates/dbflux_storage/src/repositories/auth_profiles.rs
@@ -81,7 +81,7 @@ impl AuthProfileRepository {
             .conn()
             .prepare(
                 r#"
-                SELECT id, name, provider_id, enabled, created_at, updated_at
+                SELECT id, name, provider_id, enabled, created_at, updated_at, dangling_origin
                 FROM cfg_auth_profiles
                 ORDER BY name ASC
                 "#,
@@ -100,6 +100,7 @@ impl AuthProfileRepository {
                     enabled: row.get::<_, i32>(3)? != 0,
                     created_at: row.get(4)?,
                     updated_at: row.get(5)?,
+                    dangling_origin: row.get(6)?,
                 })
             })
             .map_err(|source| StorageError::Sqlite {
@@ -132,7 +133,7 @@ impl AuthProfileRepository {
             .conn()
             .prepare(
                 r#"
-                SELECT id, name, provider_id, enabled, created_at, updated_at
+                SELECT id, name, provider_id, enabled, created_at, updated_at, dangling_origin
                 FROM cfg_auth_profiles
                 WHERE id = ?1
                 "#,
@@ -150,6 +151,7 @@ impl AuthProfileRepository {
                 enabled: row.get::<_, i32>(3)? != 0,
                 created_at: row.get(4)?,
                 updated_at: row.get(5)?,
+                dangling_origin: row.get(6)?,
             })
         });
 
@@ -221,6 +223,7 @@ impl AuthProfileRepository {
                     name = ?2,
                     provider_id = ?3,
                     enabled = ?4,
+                    dangling_origin = ?5,
                     updated_at = datetime('now')
                 WHERE id = ?1
                 "#,
@@ -229,6 +232,7 @@ impl AuthProfileRepository {
                     profile.name,
                     profile.provider_id,
                     profile.enabled as i32,
+                    profile.dangling_origin,
                 ],
             )
             .map_err(|source| StorageError::Sqlite {
@@ -251,6 +255,25 @@ impl AuthProfileRepository {
         Ok(())
     }
 
+    /// Marks a stored auth profile as dangling by setting its `dangling_origin`.
+    ///
+    /// This is a targeted update that leaves all other fields intact.
+    pub fn set_dangling_origin(&self, id: &str, origin: &str) -> Result<(), StorageError> {
+        self.conn()
+            .execute(
+                "UPDATE cfg_auth_profiles \
+                 SET dangling_origin = ?2, updated_at = datetime('now') \
+                 WHERE id = ?1",
+                rusqlite::params![id, origin],
+            )
+            .map_err(|source| StorageError::Sqlite {
+                path: "dbflux.db".into(),
+                source,
+            })?;
+
+        Ok(())
+    }
+
     /// Inserts a new auth profile from the core AuthProfile type.
     pub fn insert_auth_profile(
         &self,
@@ -263,6 +286,7 @@ impl AuthProfileRepository {
             enabled: profile.enabled,
             created_at: String::new(),
             updated_at: String::new(),
+            dangling_origin: None,
         };
 
         // Insert the profile
@@ -313,6 +337,10 @@ impl AuthProfileRepository {
 /// DTO for auth profile storage.
 /// Note: fields are stored in auth_profile_fields child table.
 /// The fields_json column was dropped in migration v10.
+///
+/// `dangling_origin` is `None` for healthy profiles. When set, the profile is
+/// dangling — the stored row exists but the backing credential source is gone.
+/// See migration 010 for the allowed values (`"keyring-only"`, `"file-gone"`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthProfileDto {
     pub id: String,
@@ -321,10 +349,12 @@ pub struct AuthProfileDto {
     pub enabled: bool,
     pub created_at: String,
     pub updated_at: String,
+    /// When present, marks the profile as dangling; see migration 010 docs.
+    pub dangling_origin: Option<String>,
 }
 
 impl AuthProfileDto {
-    /// Creates a new DTO.
+    /// Creates a new DTO without a dangling origin (healthy profile).
     pub fn new(id: Uuid, name: String, provider_id: String) -> Self {
         Self {
             id: id.to_string(),
@@ -333,6 +363,7 @@ impl AuthProfileDto {
             enabled: true,
             created_at: String::new(),
             updated_at: String::new(),
+            dangling_origin: None,
         }
     }
 }

--- a/crates/dbflux_storage/src/repositories/mod.rs
+++ b/crates/dbflux_storage/src/repositories/mod.rs
@@ -3,6 +3,7 @@
 //! Each repository provides CRUD operations for a specific config domain.
 //! Config repositories operate on `dbflux.db`.
 
+pub mod app_meta;
 pub mod audit;
 pub mod audit_settings;
 pub mod saved_filters;

--- a/crates/dbflux_storage/src/sqlite.rs
+++ b/crates/dbflux_storage/src/sqlite.rs
@@ -44,6 +44,20 @@ fn apply_default_pragmas(conn: &Connection, path: &Path) -> Result<(), StorageEr
     Ok(())
 }
 
+/// Toggles foreign-key enforcement on `conn`.
+///
+/// Must be called OUTSIDE any open transaction — `PRAGMA foreign_keys` is a
+/// no-op while a transaction is active. Migrations that rebuild a table (drop +
+/// recreate to change constraints) require enforcement OFF, otherwise dropping
+/// a referenced parent triggers cascading deletes on its child rows.
+pub fn set_foreign_keys(conn: &Connection, enabled: bool) -> Result<(), StorageError> {
+    conn.pragma_update(None, "foreign_keys", if enabled { "ON" } else { "OFF" })
+        .map_err(|source| StorageError::Sqlite {
+            path: std::path::PathBuf::from("<dbflux>"),
+            source,
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/dbflux_ui_base/src/sso_wizard.rs
+++ b/crates/dbflux_ui_base/src/sso_wizard.rs
@@ -184,11 +184,7 @@ impl SsoWizard {
 
         let this = cx.entity().clone();
         let task = cx.background_executor().spawn(async move {
-            let _ = login_sso_blocking(
-                Uuid::nil(),
-                &profile_name,
-                &start_url,
-            );
+            let _ = login_sso_blocking(Uuid::nil(), &profile_name, &start_url);
             list_sso_accounts_blocking(&profile_name, &region, &start_url)
         });
 

--- a/crates/dbflux_ui_base/src/sso_wizard.rs
+++ b/crates/dbflux_ui_base/src/sso_wizard.rs
@@ -149,6 +149,7 @@ impl SsoWizard {
                 fields,
                 enabled: true,
                 read_only: false,
+                dangling_origin: None,
             });
             cx.emit(AuthProfileCreated { profile_id });
             cx.emit(AppStateChanged);

--- a/crates/dbflux_ui_base/src/sso_wizard.rs
+++ b/crates/dbflux_ui_base/src/sso_wizard.rs
@@ -148,6 +148,7 @@ impl SsoWizard {
                 provider_id: "aws-sso".to_string(),
                 fields,
                 enabled: true,
+                read_only: false,
             });
             cx.emit(AuthProfileCreated { profile_id });
             cx.emit(AppStateChanged);

--- a/crates/dbflux_ui_base/src/sso_wizard.rs
+++ b/crates/dbflux_ui_base/src/sso_wizard.rs
@@ -170,8 +170,6 @@ impl SsoWizard {
         let profile_name = self.input_profile_name.read(cx).value().trim().to_string();
         let start_url = self.input_start_url.read(cx).value().trim().to_string();
         let region = self.input_region.read(cx).value().trim().to_string();
-        let account_id = self.input_account_id.read(cx).value().trim().to_string();
-        let role_name = self.input_role_name.read(cx).value().trim().to_string();
 
         if profile_name.is_empty() || start_url.is_empty() || region.is_empty() {
             self.status =
@@ -190,9 +188,6 @@ impl SsoWizard {
                 Uuid::nil(),
                 &profile_name,
                 &start_url,
-                &region,
-                &account_id,
-                &role_name,
             );
             list_sso_accounts_blocking(&profile_name, &region, &start_url)
         });

--- a/crates/dbflux_ui_sidebar/src/operations.rs
+++ b/crates/dbflux_ui_sidebar/src/operations.rs
@@ -3135,11 +3135,11 @@ impl Sidebar {
             hook_context,
         ) = match self.app_state.update(cx, |state, _cx| {
             if state.is_operation_pending(profile_id, None) {
-                return Err("Connection already pending".to_string());
+                return Err(("Connection already pending".to_string(), false));
             }
 
             if !state.start_pending_operation(profile_id, None) {
-                return Err("Operation started by another thread".to_string());
+                return Err(("Operation started by another thread".to_string(), false));
             }
 
             let cancel = CancelToken::new();
@@ -3162,13 +3162,26 @@ impl Sidebar {
                 }
                 Err(error) => {
                     state.finish_pending_operation(profile_id, None);
-                    Err(error)
+                    Err((error, true))
                 }
             }
         }) {
             Ok(values) => values,
-            Err(e) => {
-                log::info!("Pipeline connect skipped: {}", e);
+            Err((message, is_user_error)) => {
+                // Benign concurrency skips (already pending / raced start) stay
+                // info-only. A real preparation failure is actionable (e.g. a
+                // missing auth profile) and must reach the user, not just logs.
+                if is_user_error {
+                    log::warn!("Pipeline connect failed: {}", message);
+                    self.pending_toast = Some(PendingToast {
+                        message,
+                        is_error: true,
+                    });
+                    self.refresh_tree(cx);
+                    cx.notify();
+                } else {
+                    log::info!("Pipeline connect skipped: {}", message);
+                }
                 return;
             }
         };

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -183,6 +183,48 @@ impl ConnectionManagerWindow {
             }
         }
 
+        // T-5.4: Dangling-reference guard. When a bound auth-profile UUID no
+        // longer resolves to any entry in the current reflected+stored union,
+        // block the connect with a user-facing message. When the stored profile
+        // is present but marked dangling, tailor the message to the origin.
+        if let Some(auth_profile_id) = self.selected_auth_profile_id {
+            let bound_profile = self
+                .app_state
+                .read(cx)
+                .list_auth_profiles()
+                .into_iter()
+                .find(|profile| profile.id == auth_profile_id);
+
+            match bound_profile {
+                None => {
+                    self.validation_errors.push(format!(
+                        "AWS profile '{}' not found in ~/.aws/config — please restore or \
+                         recreate the profile in ~/.aws/config before connecting.",
+                        auth_profile_id
+                    ));
+                }
+
+                Some(profile) if profile.dangling_origin.as_deref() == Some("keyring-only") => {
+                    self.validation_errors.push(format!(
+                        "Auth profile '{}' is only in the DBFlux keyring and no longer has a \
+                         corresponding entry in ~/.aws/config or ~/.aws/credentials. \
+                         Add the credentials to ~/.aws/credentials to connect with this profile.",
+                        profile.name
+                    ));
+                }
+
+                Some(profile) if profile.dangling_origin.is_some() => {
+                    self.validation_errors.push(format!(
+                        "Auth profile '{}' could not be found in ~/.aws/config. \
+                         Please recreate the profile or update the connection binding.",
+                        profile.name
+                    ));
+                }
+
+                _ => {}
+            }
+        }
+
         let uses_dynamic_auth_sources = self.collect_value_refs(cx).values().any(|value_ref| {
             matches!(
                 value_ref,
@@ -199,14 +241,14 @@ impl ConnectionManagerWindow {
                 return self.validation_errors.is_empty();
             };
 
-            let selected_profile = self
+            let bound_profile = self
                 .app_state
                 .read(cx)
-                .auth_profiles()
-                .iter()
+                .list_auth_profiles()
+                .into_iter()
                 .find(|profile| profile.id == auth_profile_id);
 
-            if let Some(profile) = selected_profile {
+            if let Some(profile) = bound_profile {
                 if self
                     .app_state
                     .read(cx)
@@ -219,10 +261,8 @@ impl ConnectionManagerWindow {
                     ));
                 }
             } else {
-                self.validation_errors.push(
-                    "Selected Auth Profile no longer exists. Re-select it in Access tab."
-                        .to_string(),
-                );
+                // Already reported above in the dangling-reference guard; no
+                // duplicate message needed.
             }
         }
 
@@ -739,7 +779,8 @@ impl ConnectionManagerWindow {
                         Err(error) => {
                             info!("Test connection failed: {}", error);
                             this.test_status = TestStatus::Failed;
-                            this.test_error = Some(error);
+                            this.test_error =
+                                Some(normalize_aws_credentials_error(&profile_name, &error));
                             this.test_result = None;
                         }
                     }
@@ -753,5 +794,81 @@ impl ConnectionManagerWindow {
             }
         })
         .detach();
+    }
+}
+
+/// Detect AWS SDK credential-resolution failures and replace them with a
+/// user-facing message that directs to `~/.aws/credentials`.
+///
+/// AWS SDK error strings for missing credentials typically contain phrases
+/// like "no credentials" or "CredentialsNotLoaded". We normalise these so the
+/// user sees a clear, actionable message and is never prompted to enter a
+/// secret access key directly into DBFlux.
+fn normalize_aws_credentials_error(profile_name: &str, error: &str) -> String {
+    let lower = error.to_ascii_lowercase();
+
+    let is_missing_credentials = lower.contains("no credentials")
+        || lower.contains("credentials not found")
+        || lower.contains("credentialsnotloaded")
+        || lower.contains("no credential providers")
+        || lower.contains("no credentials in chain");
+
+    if is_missing_credentials {
+        return format!(
+            "AWS credentials for profile '{}' could not be resolved. \
+             Add the credentials to ~/.aws/credentials (or use environment \
+             variables / IAM role) and retry. \
+             DBFlux does not store AWS access keys — credentials are read \
+             directly by the AWS SDK.",
+            profile_name
+        );
+    }
+
+    error.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[::core::prelude::v1::test]
+    fn normalize_aws_credentials_error_rewrites_no_credentials() {
+        let result = normalize_aws_credentials_error("my-profile", "no credentials provided");
+        assert!(
+            result.contains("~/.aws/credentials"),
+            "error should direct user to ~/.aws/credentials"
+        );
+        assert!(!result.contains("secret"), "error must not mention secrets");
+        assert!(
+            result.contains("my-profile"),
+            "error should name the profile"
+        );
+    }
+
+    #[::core::prelude::v1::test]
+    fn normalize_aws_credentials_error_rewrites_credentials_not_found() {
+        let result =
+            normalize_aws_credentials_error("ci-user", "Credentials not found for profile");
+        assert!(result.contains("~/.aws/credentials"));
+        assert!(result.contains("ci-user"));
+    }
+
+    #[::core::prelude::v1::test]
+    fn normalize_aws_credentials_error_rewrites_no_credentials_in_chain() {
+        let result = normalize_aws_credentials_error("prod", "no credentials in chain");
+        assert!(result.contains("~/.aws/credentials"));
+    }
+
+    #[::core::prelude::v1::test]
+    fn normalize_aws_credentials_error_preserves_unrelated_errors() {
+        let original = "connection refused: 127.0.0.1:5432";
+        let result = normalize_aws_credentials_error("pg-local", original);
+        assert_eq!(result, original);
+    }
+
+    #[::core::prelude::v1::test]
+    fn normalize_aws_credentials_error_is_case_insensitive() {
+        let result = normalize_aws_credentials_error("dev", "NO CREDENTIALS");
+        assert!(result.contains("~/.aws/credentials"));
     }
 }

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -846,13 +846,15 @@ impl ConnectionManagerWindow {
 
         instance.conn_mcp_enabled = profile.mcp_governance.as_ref().is_some_and(|g| g.enabled);
 
-        let first_binding = profile
-            .mcp_governance
-            .as_ref()
-            .and_then(|governance| governance.policy_bindings.first().cloned());
-
         #[cfg(feature = "mcp")]
-        instance.load_mcp_dropdowns(first_binding.as_ref(), window, cx);
+        {
+            let first_binding = profile
+                .mcp_governance
+                .as_ref()
+                .and_then(|governance| governance.policy_bindings.first().cloned());
+
+            instance.load_mcp_dropdowns(first_binding.as_ref(), window, cx);
+        }
 
         instance.selected_proxy_id = profile.proxy_profile_id;
         instance.selected_auth_profile_id = profile.auth_profile_id;

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -1033,7 +1033,8 @@ impl ConnectionManagerWindow {
         for field in fields {
             let placeholder = &field.placeholder;
             let default_value = &field.default_value;
-            let is_masked = field.kind == FormFieldKind::Password;
+            let is_masked =
+                field.kind == FormFieldKind::Password || field.kind == FormFieldKind::WriteOnly;
             let field_id = field.id.clone();
 
             let input = cx.new(|cx| {

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -2173,6 +2173,11 @@ impl ConnectionManagerWindow {
     fn populate_auth_profile_dropdown(&mut self, cx: &mut Context<Self>) {
         let profiles = self.app_state.read(cx).list_auth_profiles();
 
+        // Exclude reference-only providers (e.g. SSO-session blocks): they are
+        // building blocks referenced by other profiles, not selectable as a
+        // connection's own auth profile.
+        let reference_only = self.app_state.read(cx).reference_only_auth_provider_ids();
+
         let mut auth_items = vec![dbflux_components::controls::DropdownItem::with_value(
             "None", "",
         )];
@@ -2186,6 +2191,9 @@ impl ConnectionManagerWindow {
 
         for profile in &profiles {
             if !profile.enabled {
+                continue;
+            }
+            if reference_only.contains(&profile.provider_id) {
                 continue;
             }
             let session_status = match self.auth_profile_session_states.get(&profile.id) {

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -684,7 +684,7 @@ impl ConnectionManagerWindow {
             pending_wizard_auth_profile_selection: false,
             known_auth_profile_ids: app_state
                 .read(cx)
-                .auth_profiles()
+                .list_auth_profiles()
                 .iter()
                 .map(|profile| profile.id)
                 .collect(),
@@ -2170,7 +2170,7 @@ impl ConnectionManagerWindow {
 
     /// Populate the auth profile dropdown from the current list of saved profiles.
     fn populate_auth_profile_dropdown(&mut self, cx: &mut Context<Self>) {
-        let profiles = self.app_state.read(cx).auth_profiles().to_vec();
+        let profiles = self.app_state.read(cx).list_auth_profiles();
 
         let mut auth_items = vec![dbflux_components::controls::DropdownItem::with_value(
             "None", "",
@@ -2220,28 +2220,47 @@ impl ConnectionManagerWindow {
             "__new_auth_profile__",
         ));
 
-        let selected_index = self
+        // If the bound auth-profile UUID is not in the current reflected list,
+        // add a "(profile not found)" placeholder entry so the dropdown shows
+        // something instead of falling back silently to "None".
+        let auth_selected_index = self
             .selected_auth_profile_id
             .and_then(|id| {
-                self.auth_profile_uuids
-                    .iter()
-                    .position(|uid| *uid == id)
-                    .map(|pos| pos + 1)
+                let pos = self.auth_profile_uuids.iter().position(|uid| *uid == id);
+                pos.map(|p| p + 1).or_else(|| {
+                    // Bound profile is not reflected — insert a dangling sentinel.
+                    let dangling_label = format!("(profile not found) [{}]", id);
+                    auth_items.push(dbflux_components::controls::DropdownItem::with_value(
+                        dangling_label,
+                        id.to_string(),
+                    ));
+                    self.auth_profile_uuids.push(id);
+                    Some(self.auth_profile_uuids.len())
+                })
             })
             .unwrap_or(0);
 
         self.auth_profile_dropdown.update(cx, |dropdown, cx| {
             dropdown.set_items(auth_items, cx);
-            dropdown.set_selected_index(Some(selected_index), cx);
+            dropdown.set_selected_index(Some(auth_selected_index), cx);
         });
 
         let ssm_selected_index = self
             .selected_ssm_auth_profile_id
             .and_then(|id| {
-                self.ssm_auth_profile_uuids
+                let pos = self
+                    .ssm_auth_profile_uuids
                     .iter()
-                    .position(|uid| *uid == id)
-                    .map(|pos| pos + 1)
+                    .position(|uid| *uid == id);
+                pos.map(|p| p + 1).or_else(|| {
+                    let dangling_label = format!("(profile not found) [{}]", id);
+                    ssm_items.push(dbflux_components::controls::DropdownItem::with_value(
+                        dangling_label,
+                        id.to_string(),
+                    ));
+                    self.ssm_auth_profile_uuids.push(id);
+                    Some(self.ssm_auth_profile_uuids.len())
+                })
             })
             .unwrap_or(0);
 
@@ -2256,20 +2275,18 @@ impl ConnectionManagerWindow {
 
         self.app_state
             .read(cx)
-            .auth_profiles()
-            .iter()
+            .list_auth_profiles()
+            .into_iter()
             .find(|profile| profile.id == selected_id && profile.enabled)
-            .cloned()
     }
 
     fn refresh_auth_profile_sessions(&mut self, cx: &mut Context<Self>) {
         let profiles = self
             .app_state
             .read(cx)
-            .auth_profiles()
-            .iter()
+            .list_auth_profiles()
+            .into_iter()
             .filter(|profile| profile.enabled)
-            .cloned()
             .collect::<Vec<_>>();
 
         let this = cx.entity().clone();
@@ -2316,7 +2333,7 @@ impl ConnectionManagerWindow {
         self.known_auth_profile_ids = self
             .app_state
             .read(cx)
-            .auth_profiles()
+            .list_auth_profiles()
             .iter()
             .map(|profile| profile.id)
             .collect();
@@ -2347,7 +2364,7 @@ impl ConnectionManagerWindow {
     }
 
     fn handle_app_state_changed(&mut self, cx: &mut Context<Self>) {
-        let current_profiles = self.app_state.read(cx).auth_profiles().to_vec();
+        let current_profiles = self.app_state.read(cx).list_auth_profiles();
         let current_ids = current_profiles
             .iter()
             .map(|profile| profile.id)
@@ -2565,10 +2582,9 @@ impl ConnectionManagerWindow {
         let selected_profile = self
             .app_state
             .read(cx)
-            .auth_profiles()
-            .iter()
-            .find(|profile| profile.id == auth_profile_id)
-            .cloned();
+            .list_auth_profiles()
+            .into_iter()
+            .find(|profile| profile.id == auth_profile_id);
 
         let Some(profile) = selected_profile else {
             return;

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -509,7 +509,12 @@ impl ConnectionManagerWindow {
         let focused = show_focus && field_focus == Some(self.form_focus);
 
         match &field_def.kind {
-            FormFieldKind::Text | FormFieldKind::Password | FormFieldKind::Number => {
+            // WriteOnly fields behave identically to Password in connection forms:
+            // the input is masked and starts empty.
+            FormFieldKind::Text
+            | FormFieldKind::Password
+            | FormFieldKind::WriteOnly
+            | FormFieldKind::Number => {
                 let Some(input_state) = self.input_state_for_field(&field_def.id) else {
                     return div().into_any_element();
                 };

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -12,8 +12,7 @@ use dbflux_components::primitives::focus_frame;
 use dbflux_components::primitives::{Icon as FluxIcon, Label, Text};
 use dbflux_components::tokens::{Heights, Radii, Spacing};
 use dbflux_core::{
-    AccessKind, AuthProfile, FetchOptionsError, FetchOptionsRequest, FormFieldKind,
-    ImportableProfile, RefreshTrigger,
+    AccessKind, AuthProfile, FetchOptionsError, FetchOptionsRequest, FormFieldKind, RefreshTrigger,
 };
 use dbflux_ui_base::keymap::key_chord_from_gpui;
 use dbflux_ui_base::{AppStateChanged, AppStateEntity};
@@ -47,6 +46,14 @@ pub(super) struct AuthProfilesSection {
     profile_enabled: bool,
     pending_delete_profile_id: Option<Uuid>,
     pending_sync_from_app_state: bool,
+
+    /// Whether the currently-displayed profile is read-only (i.e. reflected
+    /// from an external config such as `~/.aws/config`). When `true` the form
+    /// is rendered in mirror mode: no editable inputs, no Save/Delete buttons.
+    profile_is_read_only: bool,
+    /// Why the currently-displayed profile is dangling, if it is.
+    /// Known values: `"keyring-only"`, `"file-gone"`. `None` for healthy profiles.
+    profile_dangling_origin: Option<String>,
 
     input_name: Entity<InputState>,
     form_inputs: HashMap<String, Entity<InputState>>,
@@ -177,6 +184,7 @@ fn build_auth_profile_from_form(
         fields,
         enabled,
         read_only: false,
+        dangling_origin: None,
     })
 }
 
@@ -245,7 +253,11 @@ impl AuthProfilesSection {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let selected_profile_id = app_state.read(cx).auth_profiles().first().map(|p| p.id);
+        let selected_profile_id = app_state
+            .read(cx)
+            .list_auth_profiles()
+            .first()
+            .map(|p| p.id);
         let selected_provider_id = app_state
             .read(cx)
             .auth_provider_registry()
@@ -309,6 +321,8 @@ impl AuthProfilesSection {
             profile_enabled: true,
             pending_delete_profile_id: None,
             pending_sync_from_app_state: false,
+            profile_is_read_only: false,
+            profile_dangling_origin: None,
             input_name,
             form_inputs: HashMap::new(),
             provider_field_order: Vec::new(),
@@ -641,6 +655,7 @@ impl AuthProfilesSection {
             fields: fields_snap,
             enabled: self.profile_enabled,
             read_only: false,
+            dangling_origin: None,
         };
 
         // Expand AuthProfileRef fields so the provider sees the same flat
@@ -648,7 +663,7 @@ impl AuthProfilesSection {
         // with an `sso_session_ref` gets `sso_start_url`/`sso_region` merged
         // in from the referenced session profile).
         let profile_registry_snapshot: Vec<AuthProfile> =
-            self.app_state.read(cx).auth_profiles().to_vec();
+            self.app_state.read(cx).list_auth_profiles();
         let profile_snapshot = dbflux_core::auth::expand_auth_profile_refs(
             &raw_snapshot,
             provider.form_def(),
@@ -854,6 +869,10 @@ impl AuthProfilesSection {
             "— None —".to_string(),
             String::new(),
         )];
+        // Stored-only access is intentional: ref-type dropdowns list only
+        // profiles that exist in storage (reflected profiles cannot be
+        // referenced across profiles since they have no writable UUID).
+        #[allow(deprecated)]
         let referenced_profiles: Vec<(String, String)> = self
             .app_state
             .read(cx)
@@ -923,7 +942,7 @@ impl AuthProfilesSection {
         // in the dropdown without requiring a section reload.
         self.provider_entries_cache = self.provider_entries(cx);
 
-        let profiles = self.app_state.read(cx).auth_profiles().to_vec();
+        let profiles = self.app_state.read(cx).list_auth_profiles();
 
         if profiles.is_empty() {
             self.selected_profile_id = None;
@@ -946,7 +965,7 @@ impl AuthProfilesSection {
     fn profile_ids(&self, cx: &App) -> Vec<Uuid> {
         self.app_state
             .read(cx)
-            .auth_profiles()
+            .list_auth_profiles()
             .iter()
             .map(|profile| profile.id)
             .collect()
@@ -1088,17 +1107,26 @@ impl AuthProfilesSection {
         let profile = self
             .app_state
             .read(cx)
-            .auth_profiles()
-            .iter()
-            .find(|profile| profile.id == profile_id)
-            .cloned();
+            .list_auth_profiles()
+            .into_iter()
+            .find(|profile| profile.id == profile_id);
 
         let Some(profile) = profile else {
             return;
         };
 
         self.selected_profile_id = Some(profile.id);
-        self.editing_profile_id = Some(profile.id);
+        self.profile_is_read_only = profile.read_only;
+        self.profile_dangling_origin = profile.dangling_origin.clone();
+
+        // Read-only profiles (reflected from external config) are never
+        // set as editing targets — no SQLite writes occur for them.
+        self.editing_profile_id = if profile.read_only {
+            None
+        } else {
+            Some(profile.id)
+        };
+
         self.profile_enabled = profile.enabled;
         self.selected_provider_id = Some(profile.provider_id.clone());
 
@@ -1128,12 +1156,20 @@ impl AuthProfilesSection {
 
     fn begin_create_profile(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.selected_profile_id = None;
+        self.profile_is_read_only = false;
+        self.profile_dangling_origin = None;
         self.clear_form(window, cx);
         self.enter_form(window, cx);
         cx.notify();
     }
 
     fn save_profile(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        // Read-only profiles are reflected from external config; they cannot
+        // be saved through this path.
+        if self.profile_is_read_only {
+            return;
+        }
+
         let name = self.input_name.read(cx).value().trim().to_string();
         if name.is_empty() {
             return;
@@ -1157,7 +1193,51 @@ impl AuthProfilesSection {
             fields,
             enabled: self.profile_enabled,
             read_only: false,
+            dangling_origin: None,
         };
+
+        // For file-backed providers (e.g. AWS), write to the external config
+        // file instead of DBFlux's SQLite store. The provider returns
+        // `Some(result)` when it handles the write. Reflection will surface
+        // the new profile on the next `list_auth_profiles()` call.
+        let is_new = self.editing_profile_id.is_none();
+        if is_new
+            && let Some(provider) = self
+                .app_state
+                .read(cx)
+                .auth_provider_by_id(&profile.provider_id)
+        {
+            match provider.write_new_profile_to_config(&profile) {
+                Some(Ok(())) => {
+                    // File-backed create succeeded. Signal a refresh so
+                    // the reflection pass picks up the new entry.
+                    self.app_state.update(cx, |_, cx| {
+                        cx.emit(AppStateChanged);
+                    });
+
+                    self.selected_profile_id = None;
+                    self.profile_is_read_only = false;
+                    self.profile_dangling_origin = None;
+
+                    self.provider_login_status =
+                        Some(("Profile written to ~/.aws/config.".to_string(), true));
+                    cx.notify();
+                    return;
+                }
+
+                Some(Err(msg)) => {
+                    self.provider_login_status =
+                        Some((format!("Failed to write profile to config: {}", msg), false));
+                    cx.notify();
+                    return;
+                }
+
+                None => {
+                    // Provider does not do file-backed writes; fall through
+                    // to the standard SQLite path below.
+                }
+            }
+        }
 
         let is_edit = self.editing_profile_id.is_some();
         self.app_state.update(cx, |state, cx| {
@@ -1211,7 +1291,7 @@ impl AuthProfilesSection {
         // Expand AuthProfileRef fields so the provider's login() sees a flat
         // field map (e.g. `sso_start_url` filled from the referenced session).
         let profile_registry_snapshot: Vec<AuthProfile> =
-            self.app_state.read(cx).auth_profiles().to_vec();
+            self.app_state.read(cx).list_auth_profiles();
         let profile = dbflux_core::auth::expand_auth_profile_refs(
             &raw_profile,
             provider.form_def(),
@@ -1368,6 +1448,9 @@ impl AuthProfilesSection {
                 state.update_profile(profile);
             }
 
+            // Stored-only access is intentional: `remove_auth_profile` operates
+            // on the stored list by index; reflected profiles are not removable.
+            #[allow(deprecated)]
             if let Some(index) = state
                 .auth_profiles()
                 .iter()
@@ -1380,12 +1463,16 @@ impl AuthProfilesSection {
         });
 
         self.editing_profile_id = None;
-        self.selected_profile_id = self
+        // Stored-only access is intentional: after deletion the sidebar re-selects
+        // the first stored profile (reflected profiles are not user-managed).
+        #[allow(deprecated)]
+        let first_stored_id = self
             .app_state
             .read(cx)
             .auth_profiles()
             .first()
             .map(|profile| profile.id);
+        self.selected_profile_id = first_stored_id;
 
         if let Some(selected_id) = self.selected_profile_id {
             self.load_profile_into_form(selected_id, window, cx);
@@ -1417,195 +1504,6 @@ impl AuthProfilesSection {
                     )
             })
             .count()
-    }
-
-    fn imported_profile_keys(profiles: &[AuthProfile]) -> HashSet<String> {
-        profiles
-            .iter()
-            .map(|profile| {
-                let name = profile
-                    .fields
-                    .get("profile_name")
-                    .cloned()
-                    .unwrap_or_else(|| profile.name.clone());
-                format!("{}::{}", profile.provider_id, name)
-            })
-            .collect()
-    }
-
-    fn detected_unimported_profiles(&self, cx: &App) -> Vec<ImportableProfile> {
-        let state = self.app_state.read(cx);
-        let imported = Self::imported_profile_keys(state.auth_profiles());
-
-        state
-            .auth_provider_registry()
-            .providers()
-            .flat_map(|provider| provider.detect_importable_profiles())
-            .filter(|profile| {
-                let name = profile
-                    .fields
-                    .get("profile_name")
-                    .cloned()
-                    .unwrap_or_else(|| profile.display_name.clone());
-                let key = format!("{}::{}", profile.provider_id, name);
-                !imported.contains(&key)
-            })
-            .collect()
-    }
-
-    fn import_detected_profiles(&mut self, cx: &mut Context<Self>) {
-        let mut detected = self.detected_unimported_profiles(cx);
-        if detected.is_empty() {
-            return;
-        }
-
-        // Order: import providers that other profiles can reference first
-        // (e.g. `aws-sso-session` before `aws-sso`) so the post-import
-        // wire-up pass can resolve `sso_session_ref` to a known UUID.
-        detected.sort_by_key(|profile| match profile.provider_id.as_str() {
-            "aws-sso-session" => 0_u8,
-            _ => 1,
-        });
-
-        let imported_count = self.app_state.update(cx, |state, cx| {
-            let mut existing = Self::imported_profile_keys(state.auth_profiles());
-            let mut imported_count = 0;
-
-            for profile in detected {
-                let key_name = profile
-                    .fields
-                    .get("profile_name")
-                    .cloned()
-                    .unwrap_or_else(|| profile.display_name.clone());
-                let key = format!("{}::{}", profile.provider_id, key_name);
-                if existing.contains(&key) {
-                    continue;
-                }
-
-                state.add_auth_profile(AuthProfile {
-                    id: Uuid::new_v4(),
-                    name: profile.display_name,
-                    provider_id: profile.provider_id,
-                    fields: profile.fields,
-                    enabled: true,
-                    read_only: false,
-                });
-
-                existing.insert(key);
-                imported_count += 1;
-            }
-
-            // Wire `sso_session_ref` on `aws-sso` profiles whose `fields`
-            // carry the transient `sso_session` name (from `~/.aws/config`'s
-            // `[profile X] sso_session = NAME`). Match by AuthProfile.name
-            // against existing `aws-sso-session` profiles. The session map
-            // is rebuilt from the registry to include sessions imported in
-            // this same pass.
-            let session_id_by_name: HashMap<String, Uuid> = state
-                .auth_profiles()
-                .iter()
-                .filter(|p| p.provider_id == "aws-sso-session" && p.enabled)
-                .map(|p| (p.name.clone(), p.id))
-                .collect();
-
-            let sso_updates: Vec<AuthProfile> = state
-                .auth_profiles()
-                .iter()
-                .filter(|p| p.provider_id == "aws-sso")
-                .filter_map(|p| {
-                    let session_name = p
-                        .fields
-                        .get("sso_session")
-                        .map(String::as_str)
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty())?;
-
-                    let session_id = session_id_by_name.get(session_name).copied()?;
-
-                    let mut updated = p.clone();
-                    updated.fields.remove("sso_session");
-                    updated
-                        .fields
-                        .insert("sso_session_ref".to_string(), session_id.to_string());
-                    Some(updated)
-                })
-                .collect();
-
-            for profile in sso_updates {
-                state.update_auth_profile(profile);
-            }
-
-            if imported_count > 0 {
-                cx.emit(AppStateChanged);
-            }
-
-            imported_count
-        });
-
-        if imported_count > 0 {
-            cx.notify();
-        }
-    }
-
-    fn render_import_banner(
-        &self,
-        detected_profiles: &[ImportableProfile],
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        let theme = cx.theme();
-        let names_preview = detected_profiles
-            .iter()
-            .take(3)
-            .map(|profile| profile.display_name.as_str())
-            .collect::<Vec<_>>()
-            .join(", ");
-
-        div()
-            .m_4()
-            .p_3()
-            .rounded(Spacing::SM)
-            .border_1()
-            .border_color(theme.primary)
-            .bg(theme.secondary)
-            .flex()
-            .items_center()
-            .justify_between()
-            .gap_3()
-            .child(
-                div()
-                    .flex()
-                    .items_start()
-                    .gap_2()
-                    .child(
-                        FluxIcon::new(AppIcon::Info)
-                            .size(Heights::ICON_SM)
-                            .color(theme.primary),
-                    )
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap_1()
-                            .child(Label::new(format!(
-                                "Detected {} importable profile{}",
-                                detected_profiles.len(),
-                                if detected_profiles.len() == 1 {
-                                    ""
-                                } else {
-                                    "s"
-                                }
-                            )))
-                            .child(Text::caption(names_preview)),
-                    ),
-            )
-            .child(
-                Button::new("import-detected-auth-profiles", "Import")
-                    .small()
-                    .primary()
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.import_detected_profiles(cx);
-                    })),
-            )
     }
 
     fn render_input_row(
@@ -1702,12 +1600,18 @@ impl AuthProfilesSection {
     /// surface the referenced field's value in disabled inputs.
     fn resolve_ref_profile(&self, trigger_value: &str, cx: &App) -> Option<AuthProfile> {
         let target_id = Uuid::parse_str(trigger_value.trim()).ok()?;
-        self.app_state
+        // Stored-only access is intentional: ref-profile resolution in the form
+        // editor resolves display hints for profiles that were explicitly linked
+        // in the stored form data; reflected profiles cannot be referenced here.
+        #[allow(deprecated)]
+        let result = self
+            .app_state
             .read(cx)
             .auth_profiles()
             .iter()
             .find(|profile| profile.id == target_id)
-            .cloned()
+            .cloned();
+        result
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1904,11 +1808,116 @@ impl AuthProfilesSection {
             )
     }
 
-    fn render_editor_panel(
-        &mut self,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    /// Renders a read-only info panel for profiles that are reflected from an
+    /// external config (e.g. `~/.aws/config`). No editable inputs are shown;
+    /// all field values are displayed as plain text. A dangling-profile banner
+    /// is shown when `profile_dangling_origin` is set.
+    fn render_read_only_mirror(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme().clone();
+
+        let profile_name = self.input_name.read(cx).value().to_string();
+
+        let provider_label = self
+            .selected_provider_id
+            .as_deref()
+            .and_then(|id| self.app_state.read(cx).auth_provider_by_id(id))
+            .map(|provider| provider.display_name().to_string())
+            .or_else(|| self.selected_provider_id.clone())
+            .unwrap_or_default();
+
+        let field_rows: Vec<(String, String)> = self
+            .provider_field_order
+            .iter()
+            .filter_map(|field_id| {
+                let value = self.form_inputs.get(field_id)?.read(cx).value().to_string();
+
+                if value.is_empty() {
+                    return None;
+                }
+
+                Some((field_id.replace('_', " "), value))
+            })
+            .collect();
+
+        let dangling_origin = self.profile_dangling_origin.clone();
+
+        layout::sticky_form_shell(
+            div()
+                .child(Label::new(profile_name))
+                .child(Text::muted(provider_label)),
+            div()
+                .flex()
+                .flex_col()
+                .gap_3()
+                .when_some(dangling_origin, |content, origin| {
+                    let (banner_text, hint_text) = if origin == "keyring-only" {
+                        (
+                            "Profile reference not found in ~/.aws/config",
+                            "This profile no longer exists in ~/.aws/config. \
+                             Its credentials entry may still be in ~/.aws/credentials. \
+                             You can re-add the profile manually or remove this connection binding.",
+                        )
+                    } else {
+                        (
+                            "Profile config file is missing",
+                            "The AWS config file for this profile could not be located. \
+                             Check ~/.aws/config and re-add the profile if needed.",
+                        )
+                    };
+
+                    content.child(
+                        div()
+                            .p_3()
+                            .rounded(Radii::SM)
+                            .border_1()
+                            .border_color(theme.warning)
+                            .bg(theme.secondary)
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .child(
+                                div()
+                                    .flex()
+                                    .items_center()
+                                    .gap_2()
+                                    .child(
+                                        FluxIcon::new(AppIcon::TriangleAlert)
+                                            .size(Heights::ICON_SM)
+                                            .color(theme.warning),
+                                    )
+                                    .child(Label::new(banner_text)),
+                            )
+                            .child(Text::caption(hint_text)),
+                    )
+                })
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap_1()
+                        .child(Label::new("Source"))
+                        .child(Text::body("Reflected from ~/.aws/config — read-only")),
+                )
+                .children(field_rows.into_iter().map(|(label, value)| {
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap_1()
+                        .child(Label::new(label))
+                        .child(Text::body(value))
+                })),
+            None,
+            &theme,
+        )
+    }
+
+    fn render_editor_panel(&mut self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
+        // Read-only (reflected) profiles get a mirror view with no editable
+        // inputs and no save/delete controls.
+        if self.profile_is_read_only {
+            return self.render_read_only_mirror(cx).into_any_element();
+        }
+
         let theme = cx.theme().clone();
         let is_editing = self.editing_profile_id.is_some();
 
@@ -2117,6 +2126,7 @@ impl AuthProfilesSection {
             None,
             &theme,
         )
+        .into_any_element()
     }
 
     fn render_section_footer_actions(&self, cx: &mut Context<Self>) -> AnyElement {
@@ -2333,6 +2343,11 @@ impl SettingsSection for AuthProfilesSection {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
+        // Read-only profiles have no editable state — suppress Save/Delete.
+        if self.profile_is_read_only {
+            return None;
+        }
+
         Some(self.render_section_footer_actions(cx))
     }
 }
@@ -2354,8 +2369,7 @@ impl Render for AuthProfilesSection {
             });
         }
 
-        let profiles = self.app_state.read(cx).auth_profiles().to_vec();
-        let detected_profiles = self.detected_unimported_profiles(cx);
+        let profiles = self.app_state.read(cx).list_auth_profiles();
         let show_delete_dialog = self.pending_delete_profile_id.is_some();
 
         let (delete_name, affected_connections) = self
@@ -2379,11 +2393,7 @@ impl Render for AuthProfilesSection {
                     "Auth Profiles",
                     "Manage reusable authentication profiles for connection access",
                     cx,
-                )
-                .when(!detected_profiles.is_empty(), |root| {
-                    root.child(self.render_import_banner(&detected_profiles, cx))
-                })
-                ,
+                ),
                 self.render_profile_list(&profiles, cx),
                 self.render_editor_panel(window, cx),
             )
@@ -2746,6 +2756,105 @@ mod tests {
         assert!(
             Instant::now() <= fresh.expires_at,
             "fresh entry must not be expired"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // T-5.2: read_only profile → no save/delete in UI logic
+    // -----------------------------------------------------------------------
+
+    /// `build_form_rows` should always include a SaveButton row; the guard that
+    /// suppresses it for read-only profiles lives in `render_footer_actions`
+    /// (UI path), not in the form-row builder. Verify the builder is
+    /// unaffected so it continues to serve editable profiles.
+    #[::core::prelude::v1::test]
+    fn form_rows_include_save_and_delete_when_editing() {
+        let rows = build_form_rows(true, 0, false, true);
+        assert!(
+            rows.iter()
+                .any(|row| row.contains(&AuthFormField::SaveButton)),
+            "SaveButton must appear in form rows when editing a stored profile"
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.contains(&AuthFormField::DeleteButton)),
+            "DeleteButton must appear in form rows when editing a stored profile"
+        );
+    }
+
+    /// When creating a new profile (not editing), there must be no DeleteButton.
+    #[::core::prelude::v1::test]
+    fn form_rows_no_delete_when_creating() {
+        let rows = build_form_rows(true, 0, false, false);
+        assert!(
+            !rows
+                .iter()
+                .any(|row| row.contains(&AuthFormField::DeleteButton)),
+            "DeleteButton must not appear when creating a new profile"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // T-5.3: read-only guard in save_profile is enforced by profile_is_read_only
+    // -----------------------------------------------------------------------
+
+    /// `build_auth_profile_from_form` always produces `read_only: false` —
+    /// read-only is only set by the load path from the reflected provider.
+    #[::core::prelude::v1::test]
+    fn build_auth_profile_from_form_always_produces_writable_profile() {
+        let profile =
+            build_auth_profile_from_form(Uuid::nil(), "test", "aws-sso", HashMap::new(), true)
+                .expect("should build");
+        assert!(
+            !profile.read_only,
+            "profiles built from the form must be writable (read_only = false)"
+        );
+        assert!(
+            profile.dangling_origin.is_none(),
+            "profiles built from the form must have no dangling origin"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // T-5.4: dangling-reference guard produces distinct messages per origin
+    // -----------------------------------------------------------------------
+
+    /// The message for a "keyring-only" dangling profile must reference
+    /// `~/.aws/credentials` and must not mention any secret value.
+    #[::core::prelude::v1::test]
+    fn dangling_keyring_only_message_references_credentials_file() {
+        let msg = format!(
+            "Auth profile '{}' is only in the DBFlux keyring and no longer has a \
+             corresponding entry in ~/.aws/config or ~/.aws/credentials. \
+             Add the credentials to ~/.aws/credentials to connect with this profile.",
+            "legacy-key"
+        );
+        assert!(
+            msg.contains("~/.aws/credentials"),
+            "keyring-only dangling message must direct user to ~/.aws/credentials"
+        );
+        assert!(
+            !msg.to_ascii_lowercase().contains("secret"),
+            "keyring-only dangling message must not expose the word 'secret'"
+        );
+        assert!(
+            msg.contains("legacy-key"),
+            "dangling message must name the profile"
+        );
+    }
+
+    /// The message for a "file-gone" dangling profile must reference
+    /// `~/.aws/config`.
+    #[::core::prelude::v1::test]
+    fn dangling_file_gone_message_references_config_file() {
+        let msg = format!(
+            "Auth profile '{}' could not be found in ~/.aws/config. \
+             Please recreate the profile or update the connection binding.",
+            "old-env"
+        );
+        assert!(
+            msg.contains("~/.aws/config"),
+            "file-gone dangling message must reference ~/.aws/config"
         );
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -837,26 +837,38 @@ impl AuthProfilesSection {
             let dep_hash = Self::hash_deps(&deps);
             let cache_key = (provider_id, field_id.clone(), dep_hash);
 
-            if let Some(cached) = self.options_cache.get(&cache_key) {
-                let current_value = self
-                    .form_inputs
-                    .get(&field_id)
-                    .map(|input| input.read(cx).value().to_string())
-                    .unwrap_or_default();
+            let current_value = self
+                .form_inputs
+                .get(&field_id)
+                .map(|input| input.read(cx).value().to_string())
+                .unwrap_or_default();
 
-                let items: Vec<DropdownItem> = cached
+            // Always re-sync the dropdown: the entity is reused across profiles
+            // (keyed by field id), so a cache miss must reset it rather than
+            // leave a stale label from a previously loaded profile. With no
+            // fetched options (cache cleared on load, or session expired), fall
+            // back to the profile's own stored value as a single item.
+            let items: Vec<DropdownItem> = match self.options_cache.get(&cache_key) {
+                Some(cached) => cached
                     .options
                     .iter()
                     .map(|opt| DropdownItem::with_value(opt.label.clone(), opt.value.clone()))
-                    .collect();
+                    .collect(),
+                None if !current_value.is_empty() => {
+                    vec![DropdownItem::with_value(
+                        current_value.clone(),
+                        current_value.clone(),
+                    )]
+                }
+                None => Vec::new(),
+            };
 
-                let selected_index = items.iter().position(|item| item.value == current_value);
+            let selected_index = items.iter().position(|item| item.value == current_value);
 
-                dropdown.update(cx, |d, cx| {
-                    d.set_items(items, cx);
-                    d.set_selected_index(selected_index, cx);
-                });
-            }
+            dropdown.update(cx, |d, cx| {
+                d.set_items(items, cx);
+                d.set_selected_index(selected_index, cx);
+            });
         }
 
         let login_hint = self.field_login_hint.get(&field_id).cloned();
@@ -905,14 +917,14 @@ impl AuthProfilesSection {
             "— None —".to_string(),
             String::new(),
         )];
-        // Stored-only access is intentional: ref-type dropdowns list only
-        // profiles that exist in storage (reflected profiles cannot be
-        // referenced across profiles since they have no writable UUID).
-        #[allow(deprecated)]
+        // Use the reflected union, not the stored-only slice: AWS sso-session
+        // profiles are reflected from ~/.aws/config and are absent from storage,
+        // while stale stored AWS rows are excluded by list_auth_profiles(). Their
+        // deterministic UUIDs match the expansion lookup, which reads the same seam.
         let referenced_profiles: Vec<(String, String)> = self
             .app_state
             .read(cx)
-            .auth_profiles()
+            .list_auth_profiles()
             .iter()
             .filter(|profile| profile.provider_id == *ref_provider_id && profile.enabled)
             .map(|profile| (profile.id.to_string(), profile.name.clone()))
@@ -1383,7 +1395,7 @@ impl AuthProfilesSection {
 
         // Build the edited fields map.  Blank WriteOnly fields are excluded so
         // the provider treats them as "preserve existing on-disk value".
-        let fields: HashMap<String, String> = self
+        let raw_fields: HashMap<String, String> = self
             .form_inputs
             .iter()
             .filter_map(|(field_id, input)| {
@@ -1398,6 +1410,32 @@ impl AuthProfilesSection {
             })
             .collect();
 
+        // Expand AuthProfileRef fields so save_edit() receives the referenced
+        // profile's name (e.g. `sso_session_ref_name`) and can persist the
+        // `sso_session = NAME` indirection. Mirrors the login path; a no-op for
+        // providers whose form declares no AuthProfileRef fields.
+        let registry_snapshot: Vec<AuthProfile> = self.app_state.read(cx).list_auth_profiles();
+        let raw_profile = AuthProfile {
+            id: self.editing_profile_id.unwrap_or_else(Uuid::new_v4),
+            name: name.clone(),
+            provider_id: provider_id.clone(),
+            fields: raw_fields,
+            enabled: self.profile_enabled,
+            read_only: false,
+            dangling_origin: None,
+        };
+        let fields = dbflux_core::auth::expand_auth_profile_refs(
+            &raw_profile,
+            provider.form_def(),
+            &|target_id| {
+                registry_snapshot
+                    .iter()
+                    .find(|p| p.id == *target_id)
+                    .cloned()
+            },
+        )
+        .fields;
+
         let outcome = provider.save_edit(&name, &fields, &snapshot);
 
         match outcome {
@@ -1409,14 +1447,17 @@ impl AuthProfilesSection {
                     cx.emit(AppStateChanged);
                 });
 
-                self.provider_login_status =
-                    Some(("Profile saved to ~/.aws/config.".to_string(), true));
-
                 // Reload the form to pick up the new values and a fresh snapshot.
+                // This must run before setting the status: load_profile_into_form
+                // resets provider_login_status, which would otherwise wipe the
+                // success message before it is ever rendered.
                 let profile_id = self.editing_profile_id;
                 if let Some(id) = profile_id {
                     self.load_profile_into_form(id, window, cx);
                 }
+
+                self.provider_login_status = Some(("Profile saved.".to_string(), true));
+                cx.notify();
             }
 
             AuthSaveOutcome::Conflict { file } => {

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -176,6 +176,7 @@ fn build_auth_profile_from_form(
         provider_id: provider_id.to_string(),
         fields,
         enabled,
+        read_only: false,
     })
 }
 
@@ -639,6 +640,7 @@ impl AuthProfilesSection {
             provider_id: provider_id_snap,
             fields: fields_snap,
             enabled: self.profile_enabled,
+            read_only: false,
         };
 
         // Expand AuthProfileRef fields so the provider sees the same flat
@@ -1154,6 +1156,7 @@ impl AuthProfilesSection {
             provider_id,
             fields,
             enabled: self.profile_enabled,
+            read_only: false,
         };
 
         let is_edit = self.editing_profile_id.is_some();
@@ -1485,6 +1488,7 @@ impl AuthProfilesSection {
                     provider_id: profile.provider_id,
                     fields: profile.fields,
                     enabled: true,
+                    read_only: false,
                 });
 
                 existing.insert(key);

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -12,7 +12,8 @@ use dbflux_components::primitives::focus_frame;
 use dbflux_components::primitives::{Icon as FluxIcon, Label, Text};
 use dbflux_components::tokens::{Heights, Radii, Spacing};
 use dbflux_core::{
-    AccessKind, AuthProfile, FetchOptionsError, FetchOptionsRequest, FormFieldKind, RefreshTrigger,
+    AccessKind, AuthProfile, AuthSaveOutcome, AwsEditFile, AwsEditSnapshot, FetchOptionsError,
+    FetchOptionsRequest, FormFieldKind, RefreshTrigger,
 };
 use dbflux_ui_base::keymap::key_chord_from_gpui;
 use dbflux_ui_base::{AppStateChanged, AppStateEntity};
@@ -47,13 +48,30 @@ pub(super) struct AuthProfilesSection {
     pending_delete_profile_id: Option<Uuid>,
     pending_sync_from_app_state: bool,
 
-    /// Whether the currently-displayed profile is read-only (i.e. reflected
-    /// from an external config such as `~/.aws/config`). When `true` the form
-    /// is rendered in mirror mode: no editable inputs, no Save/Delete buttons.
+    /// Whether the currently-displayed profile is read-only (i.e. it is a
+    /// dangling reflected profile with no on-disk section to target). When
+    /// `true` the form is rendered in mirror mode: no editable inputs, no
+    /// Save/Delete buttons.
+    ///
+    /// Non-dangling reflected AWS profiles have `read_only = false` and are
+    /// editable — their edits are written directly to `~/.aws/config` /
+    /// `~/.aws/credentials` via `save_edit` (design §13, §14).
     profile_is_read_only: bool,
     /// Why the currently-displayed profile is dangling, if it is.
     /// Known values: `"keyring-only"`, `"file-gone"`. `None` for healthy profiles.
     profile_dangling_origin: Option<String>,
+
+    /// Opaque snapshot token captured when an editable reflected AWS profile is
+    /// loaded for editing. Passed back to `save_edit` at save time for the
+    /// optimistic-concurrency check (spec R9.3.1, design §10).
+    ///
+    /// `None` for stored (non-reflected) profiles — those use the standard
+    /// SQLite save path which has no snapshot concept.
+    edit_snapshot: Option<AwsEditSnapshot>,
+    /// Non-`None` when a `save_edit` call returned `Conflict` or `PartialSaved`.
+    /// Contains a human-readable message to display, plus `true` if a Reload
+    /// button should be shown.
+    edit_conflict_msg: Option<(String, bool)>,
 
     input_name: Entity<InputState>,
     form_inputs: HashMap<String, Entity<InputState>>,
@@ -138,11 +156,12 @@ fn build_form_rows(
     dynamic_field_count: usize,
     selected_provider_supports_login: bool,
     is_editing: bool,
+    is_reflected: bool,
 ) -> Vec<Vec<AuthFormField>> {
     let mut rows = vec![vec![AuthFormField::Name]];
 
-    // The provider selector is always a single dropdown widget — one focusable slot.
-    if has_providers {
+    // Reflected profiles have a fixed provider; the selector is not shown.
+    if has_providers && !is_reflected {
         rows.push(vec![AuthFormField::Provider(0)]);
     }
 
@@ -154,9 +173,13 @@ fn build_form_rows(
         rows.push(vec![AuthFormField::ProviderLogin]);
     }
 
-    rows.push(vec![AuthFormField::Enabled]);
+    // Reflected profiles do not expose the Enabled toggle (it is managed by
+    // the file) and do not have a Delete button.
+    if !is_reflected {
+        rows.push(vec![AuthFormField::Enabled]);
+    }
 
-    if is_editing {
+    if is_editing && !is_reflected {
         rows.push(vec![AuthFormField::DeleteButton, AuthFormField::SaveButton]);
     } else {
         rows.push(vec![AuthFormField::SaveButton]);
@@ -186,6 +209,15 @@ fn build_auth_profile_from_form(
         read_only: false,
         dangling_origin: None,
     })
+}
+
+/// Returns a human-readable label for an `AwsEditFile` variant, used in
+/// conflict and partial-save messages shown in the Settings UI.
+fn file_label(file: AwsEditFile) -> &'static str {
+    match file {
+        AwsEditFile::Config => "~/.aws/config",
+        AwsEditFile::Credentials => "~/.aws/credentials",
+    }
 }
 
 /// Update `field_login_hint` and `provider_login_status` for a
@@ -323,6 +355,8 @@ impl AuthProfilesSection {
             pending_sync_from_app_state: false,
             profile_is_read_only: false,
             profile_dangling_origin: None,
+            edit_snapshot: None,
+            edit_conflict_msg: None,
             input_name,
             form_inputs: HashMap::new(),
             provider_field_order: Vec::new(),
@@ -492,7 +526,9 @@ impl AuthProfilesSection {
                     let input = cx.new(|cx| {
                         let state = InputState::new(window, cx).placeholder(placeholder);
                         match kind {
-                            FormFieldKind::Password => state.masked(true),
+                            FormFieldKind::Password | FormFieldKind::WriteOnly => {
+                                state.masked(true)
+                            }
                             _ => state,
                         }
                     });
@@ -911,6 +947,8 @@ impl AuthProfilesSection {
     fn clear_form(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.editing_profile_id = None;
         self.profile_enabled = true;
+        self.edit_snapshot = None;
+        self.edit_conflict_msg = None;
 
         self.input_name.update(cx, |state, cx| {
             state.set_value("", window, cx);
@@ -1118,10 +1156,13 @@ impl AuthProfilesSection {
         self.selected_profile_id = Some(profile.id);
         self.profile_is_read_only = profile.read_only;
         self.profile_dangling_origin = profile.dangling_origin.clone();
+        self.edit_conflict_msg = None;
 
-        // Read-only profiles (reflected from external config) are never
-        // set as editing targets — no SQLite writes occur for them.
-        self.editing_profile_id = if profile.read_only {
+        // Reflected (file-backed) profiles use the edit-save path; stored
+        // profiles use the SQLite path.  Both require an editing_profile_id
+        // for the save-button to appear.
+        self.editing_profile_id = if profile.dangling_origin.is_some() {
+            // Dangling profiles are truly read-only: no section to write to.
             None
         } else {
             Some(profile.id)
@@ -1136,12 +1177,52 @@ impl AuthProfilesSection {
 
         self.rebuild_form_inputs(window, cx);
 
+        // Determine which field ids are WriteOnly so we never pre-fill them.
+        let write_only_fields: std::collections::HashSet<String> = self
+            .selected_provider(cx)
+            .map(|provider| {
+                provider
+                    .form_def()
+                    .tabs
+                    .iter()
+                    .flat_map(|tab| tab.sections.iter())
+                    .flat_map(|section| section.fields.iter())
+                    .filter(|field| field.kind == FormFieldKind::WriteOnly)
+                    .map(|field| field.id.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+
         for (field_id, input) in &self.form_inputs {
-            let value = profile.fields.get(field_id).cloned().unwrap_or_default();
+            // WriteOnly fields are always rendered empty (spec R9.4.1, S33).
+            let value = if write_only_fields.contains(field_id) {
+                String::new()
+            } else {
+                profile.fields.get(field_id).cloned().unwrap_or_default()
+            };
+
             input.update(cx, |state, cx| {
-                state.set_value(value.clone(), window, cx);
+                state.set_value(value, window, cx);
             });
         }
+
+        // Capture the edit snapshot for editable reflected profiles.  The
+        // snapshot is used at save time for the optimistic-concurrency check
+        // (spec R9.3.1, design §10).
+        //
+        // Dangling profiles have no snapshot (no section to hash); stored
+        // profiles don't need one (they go through SQLite, not save_edit).
+        self.edit_snapshot = if profile.dangling_origin.is_none() && !profile.read_only {
+            // Reflected, editable profile — snapshot the on-disk section.
+            let provider = self
+                .app_state
+                .read(cx)
+                .auth_provider_by_id(&profile.provider_id);
+
+            provider.map(|p| p.open_edit_snapshot(&profile.name))
+        } else {
+            None
+        };
 
         // Clear options cache so DynamicSelect dropdowns are re-fetched for
         // the newly loaded profile's field values.
@@ -1164,8 +1245,7 @@ impl AuthProfilesSection {
     }
 
     fn save_profile(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        // Read-only profiles are reflected from external config; they cannot
-        // be saved through this path.
+        // Dangling profiles (truly read-only) cannot be saved.
         if self.profile_is_read_only {
             return;
         }
@@ -1178,6 +1258,13 @@ impl AuthProfilesSection {
         let Some(provider_id) = self.selected_provider_id.clone() else {
             return;
         };
+
+        // When an edit snapshot is present, this is a reflected AWS profile.
+        // Route through save_edit rather than SQLite.
+        if let Some(snapshot) = self.edit_snapshot.clone() {
+            self.save_edit_profile(name, provider_id, snapshot, window, cx);
+            return;
+        }
 
         let profile_id = self.editing_profile_id.unwrap_or_else(Uuid::new_v4);
         let fields = self
@@ -1260,6 +1347,109 @@ impl AuthProfilesSection {
 
         self.selected_profile_id = Some(profile_id);
         self.load_profile_into_form(profile_id, window, cx);
+    }
+
+    /// Save path for reflected AWS profiles: calls `save_edit` with the
+    /// optimistic-concurrency snapshot and handles `Conflict` / `PartialSaved`
+    /// outcomes (spec R9.3.4, R9.3.6, S29, S35, design §14).
+    ///
+    /// Fields with `FormFieldKind::WriteOnly` that are left blank are omitted
+    /// from the field map so the provider preserves the existing on-disk value
+    /// (spec R9.4.2, S27). Secret values transit only through this method's
+    /// stack frame — they are never stored in `self` beyond the call site
+    /// (spec R9.6.1, R9.6.4).
+    fn save_edit_profile(
+        &mut self,
+        name: String,
+        provider_id: String,
+        snapshot: AwsEditSnapshot,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(provider) = self.app_state.read(cx).auth_provider_by_id(&provider_id) else {
+            return;
+        };
+
+        // Determine which fields are WriteOnly so blank values can be omitted.
+        let write_only_ids: std::collections::HashSet<String> = provider
+            .form_def()
+            .tabs
+            .iter()
+            .flat_map(|tab| tab.sections.iter())
+            .flat_map(|section| section.fields.iter())
+            .filter(|field| field.kind == FormFieldKind::WriteOnly)
+            .map(|field| field.id.clone())
+            .collect();
+
+        // Build the edited fields map.  Blank WriteOnly fields are excluded so
+        // the provider treats them as "preserve existing on-disk value".
+        let fields: HashMap<String, String> = self
+            .form_inputs
+            .iter()
+            .filter_map(|(field_id, input)| {
+                let value = input.read(cx).value().to_string();
+                if write_only_ids.contains(field_id) && value.is_empty() {
+                    // Blank secret field — omit so the provider preserves the
+                    // existing on-disk value (spec R9.4.2).
+                    None
+                } else {
+                    Some((field_id.clone(), value))
+                }
+            })
+            .collect();
+
+        let outcome = provider.save_edit(&name, &fields, &snapshot);
+
+        match outcome {
+            AuthSaveOutcome::Saved => {
+                // Write succeeded. Signal a refresh so reflection picks up the
+                // updated section (mtime change drives cache invalidation).
+                self.edit_conflict_msg = None;
+                self.app_state.update(cx, |_, cx| {
+                    cx.emit(AppStateChanged);
+                });
+
+                self.provider_login_status =
+                    Some(("Profile saved to ~/.aws/config.".to_string(), true));
+
+                // Reload the form to pick up the new values and a fresh snapshot.
+                let profile_id = self.editing_profile_id;
+                if let Some(id) = profile_id {
+                    self.load_profile_into_form(id, window, cx);
+                }
+            }
+
+            AuthSaveOutcome::Conflict { file } => {
+                // Section changed on disk since the form was opened — block save.
+                let file_label = file_label(file);
+                self.edit_conflict_msg = Some((
+                    format!(
+                        "This profile was modified on disk ({file_label}) since you opened it. \
+                         Reload to see the current values before saving."
+                    ),
+                    true,
+                ));
+                cx.notify();
+            }
+
+            AuthSaveOutcome::PartialSaved {
+                written,
+                conflicted,
+            } => {
+                // One file succeeded; the other conflicted.
+                let written_label = file_label(written);
+                let conflicted_label = file_label(conflicted);
+                self.edit_conflict_msg = Some((
+                    format!(
+                        "{written_label} was saved successfully, but {conflicted_label} was \
+                         modified on disk since you opened the form. Reload to refresh the \
+                         credentials section and re-apply your changes."
+                    ),
+                    true,
+                ));
+                cx.notify();
+            }
+        }
     }
 
     fn login_selected_profile(&mut self, cx: &mut Context<Self>) {
@@ -1504,17 +1694,6 @@ impl AuthProfilesSection {
                     )
             })
             .count()
-    }
-
-    fn render_input_row(
-        &self,
-        label: &str,
-        input: &Entity<InputState>,
-        field: AuthFormField,
-        is_focused: bool,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
-        self.render_input_row_disabled(label, input, field, is_focused, false, None, None, cx)
     }
 
     /// Renders the inline login-URL panel: shows the verification URL with
@@ -2017,7 +2196,18 @@ impl AuthProfilesSection {
                         })
                         .unwrap_or((false, None, None));
 
-                    self.render_input_row_disabled(
+                    // WriteOnly fields get a help hint appended below the input
+                    // to clarify write-only semantics (spec S33, R9.4.1).
+                    let extra_hint: Option<String> =
+                        if field.kind == FormFieldKind::WriteOnly && !disabled {
+                            Some(field.help.clone().unwrap_or_else(|| {
+                                "Leave blank to keep the current value.".to_string()
+                            }))
+                        } else {
+                            None
+                        };
+
+                    let rendered = self.render_input_row_disabled(
                         &field.label,
                         input,
                         form_field,
@@ -2026,13 +2216,27 @@ impl AuthProfilesSection {
                         disabled_hint,
                         inherited_value,
                         cx,
-                    )
-                    .into_any_element()
+                    );
+
+                    // Wrap with extra write-only hint if needed.
+                    if let Some(hint) = extra_hint {
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_1()
+                            .child(rendered)
+                            .child(Text::caption(hint))
+                            .into_any_element()
+                    } else {
+                        rendered.into_any_element()
+                    }
                 } else {
                     div().into_any_element()
                 }
             })
             .collect();
+
+        let conflict_msg = self.edit_conflict_msg.clone();
 
         layout::sticky_form_shell(
             div()
@@ -2047,15 +2251,63 @@ impl AuthProfilesSection {
                 .flex()
                 .flex_col()
                 .gap_4()
+                .when_some(conflict_msg, |content, (msg, show_reload)| {
+                    let theme = cx.theme().clone();
+                    content.child(
+                        div()
+                            .p_3()
+                            .rounded(Radii::SM)
+                            .border_1()
+                            .border_color(theme.warning)
+                            .bg(theme.secondary)
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .child(
+                                div()
+                                    .flex()
+                                    .items_center()
+                                    .gap_2()
+                                    .child(
+                                        FluxIcon::new(AppIcon::TriangleAlert)
+                                            .size(Heights::ICON_SM)
+                                            .color(theme.warning),
+                                    )
+                                    .child(Label::new("Profile Changed on Disk")),
+                            )
+                            .child(Text::caption(msg))
+                            .when(show_reload, |panel| {
+                                panel.child(
+                                    Button::new("edit-reload-profile", "Reload")
+                                        .small()
+                                        .on_click(cx.listener(|this, _, window, cx| {
+                                            if let Some(id) = this.selected_profile_id {
+                                                this.load_profile_into_form(id, window, cx);
+                                            }
+                                        })),
+                                )
+                            }),
+                    )
+                })
                 .child({
                     let is_focused = self.auth_form_field == AuthFormField::Name
                         && self.auth_focus == AuthFocus::Form
                         && self.content_focused;
-                    self.render_input_row(
+                    let is_reflected = self.edit_snapshot.is_some();
+                    // Reflected profiles: name is the section key in ~/.aws/config
+                    // and cannot be renamed from the DBFlux edit form (spec non-req).
+                    self.render_input_row_disabled(
                         "Name",
                         &self.input_name,
                         AuthFormField::Name,
                         is_focused,
+                        is_reflected,
+                        if is_reflected {
+                            Some("Profile name is read from ~/.aws/config and cannot be renamed here.".to_string())
+                        } else {
+                            None
+                        },
+                        None,
                         cx,
                     )
                 })
@@ -2065,7 +2317,24 @@ impl AuthProfilesSection {
                         .flex_col()
                         .gap_2()
                         .child(Label::new("Provider"))
-                        .child(self.render_provider_selector(window, cx)),
+                        .when(self.edit_snapshot.is_none(), |row| {
+                            row.child(self.render_provider_selector(window, cx))
+                        })
+                        .when(self.edit_snapshot.is_some(), |row| {
+                            // Reflected profiles: provider is fixed by the file section type.
+                            let provider_label = self
+                                .selected_provider_id
+                                .as_deref()
+                                .and_then(|id| {
+                                    self.app_state
+                                        .read(cx)
+                                        .auth_provider_by_id(id)
+                                        .map(|p| p.display_name().to_string())
+                                })
+                                .or_else(|| self.selected_provider_id.clone())
+                                .unwrap_or_default();
+                            row.child(Text::body(provider_label))
+                        }),
                 )
                 .children(dynamic_fields)
                 .when(self.selected_provider_supports_login, |content| {
@@ -2108,21 +2377,26 @@ impl AuthProfilesSection {
                             content.child(self.render_login_url_panel(url, cx))
                         })
                 })
-                .child(
-                    div()
-                        .flex()
-                        .items_center()
-                        .gap_2()
-                        .child(
-                            Checkbox::new("auth-profile-enabled")
-                                .checked(self.profile_enabled)
-                                .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                    this.profile_enabled = *checked;
-                                    cx.notify();
-                                })),
-                        )
-                        .child(Text::body("Enabled")),
-                ),
+                .when(self.edit_snapshot.is_none(), |content| {
+                    // The enabled toggle only applies to stored (SQLite-backed)
+                    // profiles. Reflected AWS profiles are always enabled and
+                    // managed by the ~/.aws/config file.
+                    content.child(
+                        div()
+                            .flex()
+                            .items_center()
+                            .gap_2()
+                            .child(
+                                Checkbox::new("auth-profile-enabled")
+                                    .checked(self.profile_enabled)
+                                    .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                        this.profile_enabled = *checked;
+                                        cx.notify();
+                                    })),
+                            )
+                            .child(Text::body("Enabled")),
+                    )
+                }),
             None,
             &theme,
         )
@@ -2131,6 +2405,9 @@ impl AuthProfilesSection {
 
     fn render_section_footer_actions(&self, cx: &mut Context<Self>) -> AnyElement {
         let is_editing = self.editing_profile_id.is_some();
+        // Reflected profiles are edited in-place via save_edit; they cannot be
+        // deleted from DBFlux (the file section is the source of truth).
+        let is_reflected = self.edit_snapshot.is_some();
         let is_form_focused = self.auth_focus == AuthFocus::Form && self.content_focused;
         let primary = cx.theme().primary;
 
@@ -2138,7 +2415,7 @@ impl AuthProfilesSection {
             .flex()
             .items_center()
             .gap_3()
-            .when(is_editing, |root| {
+            .when(is_editing && !is_reflected, |root| {
                 root.child(layout::footer_action_frame(
                     is_form_focused && self.auth_form_field == AuthFormField::DeleteButton,
                     primary,
@@ -2171,7 +2448,13 @@ impl AuthProfilesSection {
                 primary,
                 Button::new(
                     "save-auth-profile",
-                    if is_editing { "Update" } else { "Create" },
+                    if is_reflected {
+                        "Save to File"
+                    } else if is_editing {
+                        "Update"
+                    } else {
+                        "Create"
+                    },
                 )
                 .small()
                 .primary()
@@ -2242,6 +2525,7 @@ impl FormSection for AuthProfilesSection {
             self.provider_field_order.len(),
             self.selected_provider_supports_login,
             self.editing_profile_id.is_some(),
+            self.edit_snapshot.is_some(),
         )
     }
 
@@ -2441,7 +2725,7 @@ mod tests {
 
     #[::core::prelude::v1::test]
     fn form_rows_include_generic_provider_login_without_aws_feature() {
-        let rows = build_form_rows(true, 2, true, false);
+        let rows = build_form_rows(true, 2, true, false, false);
 
         assert!(
             rows.iter()
@@ -2769,7 +3053,7 @@ mod tests {
     /// unaffected so it continues to serve editable profiles.
     #[::core::prelude::v1::test]
     fn form_rows_include_save_and_delete_when_editing() {
-        let rows = build_form_rows(true, 0, false, true);
+        let rows = build_form_rows(true, 0, false, true, false);
         assert!(
             rows.iter()
                 .any(|row| row.contains(&AuthFormField::SaveButton)),
@@ -2785,7 +3069,7 @@ mod tests {
     /// When creating a new profile (not editing), there must be no DeleteButton.
     #[::core::prelude::v1::test]
     fn form_rows_no_delete_when_creating() {
-        let rows = build_form_rows(true, 0, false, false);
+        let rows = build_form_rows(true, 0, false, false, false);
         assert!(
             !rows
                 .iter()
@@ -2856,5 +3140,270 @@ mod tests {
             msg.contains("~/.aws/config"),
             "file-gone dangling message must reference ~/.aws/config"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // WU-E4: Editable form state-transition logic (non-GPUI-render parts)
+    // -----------------------------------------------------------------------
+
+    /// E4: Reflected profiles (non-dangling) must NOT produce a Delete button
+    /// row in `build_form_rows` — they are edited via `save_edit`, not deleted
+    /// from DBFlux (spec S36, design §14).
+    #[::core::prelude::v1::test]
+    fn reflected_profile_has_no_delete_button_row() {
+        let rows = build_form_rows(true, 3, false, true, /* is_reflected */ true);
+        assert!(
+            !rows
+                .iter()
+                .any(|row| row.contains(&AuthFormField::DeleteButton)),
+            "reflected profiles must not expose a Delete button"
+        );
+        assert!(
+            rows.iter()
+                .any(|row| row.contains(&AuthFormField::SaveButton)),
+            "reflected profiles must still expose a Save button"
+        );
+    }
+
+    /// E4: Reflected profiles must NOT include the Enabled row — the enabled
+    /// state is managed by the AWS file, not DBFlux.
+    #[::core::prelude::v1::test]
+    fn reflected_profile_has_no_enabled_row() {
+        let rows = build_form_rows(true, 2, false, true, /* is_reflected */ true);
+        assert!(
+            !rows.iter().any(|row| row.contains(&AuthFormField::Enabled)),
+            "reflected profiles must not expose the Enabled toggle"
+        );
+    }
+
+    /// E4: Reflected profiles must NOT include the Provider selector row —
+    /// provider is fixed by the file section type.
+    #[::core::prelude::v1::test]
+    fn reflected_profile_has_no_provider_selector_row() {
+        let rows = build_form_rows(
+            /* has_providers */ true, 2, false, true, /* is_reflected */ true,
+        );
+        assert!(
+            !rows
+                .iter()
+                .any(|row| { row.iter().any(|f| matches!(f, AuthFormField::Provider(_))) }),
+            "reflected profiles must not expose the provider selector row"
+        );
+    }
+
+    /// E4: `collect_edited_fields` omits blank `WriteOnly` fields so the
+    /// provider preserves the existing on-disk value (spec R9.4.2, S27).
+    ///
+    /// This exercises the logic inline rather than through the GPUI form
+    /// (render code cannot be unit-tested without a GPUI context).
+    #[::core::prelude::v1::test]
+    fn edited_fields_omit_blank_write_only_field() {
+        let write_only_ids: std::collections::HashSet<String> = [
+            "aws_secret_access_key".to_string(),
+            "aws_session_token".to_string(),
+        ]
+        .into_iter()
+        .collect();
+
+        // Simulate the form value map: access key present, secret blank.
+        let form_values: Vec<(String, String)> = vec![
+            (
+                "aws_access_key_id".to_string(),
+                "AKIAIOSFODNN7EXAMPLE".to_string(),
+            ),
+            ("aws_secret_access_key".to_string(), String::new()), // blank — must be omitted
+            ("aws_session_token".to_string(), String::new()),     // blank — must be omitted
+        ];
+
+        let fields: HashMap<String, String> = form_values
+            .into_iter()
+            .filter_map(|(field_id, value)| {
+                if write_only_ids.contains(&field_id) && value.is_empty() {
+                    None
+                } else {
+                    Some((field_id, value))
+                }
+            })
+            .collect();
+
+        assert!(
+            fields.contains_key("aws_access_key_id"),
+            "non-secret fields must be included"
+        );
+        assert!(
+            !fields.contains_key("aws_secret_access_key"),
+            "blank secret field must be omitted so provider preserves on-disk value"
+        );
+        assert!(
+            !fields.contains_key("aws_session_token"),
+            "blank session token must be omitted"
+        );
+    }
+
+    /// E4: A non-blank `WriteOnly` field IS included in the edited fields map
+    /// so the provider overwrites the on-disk value (spec R9.4.3, S26).
+    #[::core::prelude::v1::test]
+    fn edited_fields_include_non_blank_write_only_field() {
+        let write_only_ids: std::collections::HashSet<String> =
+            ["aws_secret_access_key".to_string()].into_iter().collect();
+
+        let form_values: Vec<(String, String)> = vec![
+            (
+                "aws_access_key_id".to_string(),
+                "AKIAIOSFODNN7EXAMPLE".to_string(),
+            ),
+            (
+                "aws_secret_access_key".to_string(),
+                "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".to_string(),
+            ),
+        ];
+
+        let fields: HashMap<String, String> = form_values
+            .into_iter()
+            .filter_map(|(field_id, value)| {
+                if write_only_ids.contains(&field_id) && value.is_empty() {
+                    None
+                } else {
+                    Some((field_id, value))
+                }
+            })
+            .collect();
+
+        assert!(
+            fields.contains_key("aws_secret_access_key"),
+            "non-blank secret field must be included in the save payload"
+        );
+    }
+
+    /// E4: `Conflict` outcome produces a conflict message that names the file
+    /// and offers a Reload affordance (spec R9.3.4, S29). The state-transition
+    /// logic in `save_edit_profile` is tested indirectly through the helpers
+    /// that compute the conflict message — the GPUI state mutation itself
+    /// is render-only and cannot be unit-tested here.
+    #[::core::prelude::v1::test]
+    fn conflict_message_references_file_and_suggests_reload() {
+        // Simulate what `save_edit_profile` produces on Conflict { Config }.
+        let file = AwsEditFile::Config;
+        let file_name = file_label(file);
+        let msg = format!(
+            "This profile was modified on disk ({file_name}) since you opened it. \
+             Reload to see the current values before saving."
+        );
+        assert!(
+            msg.contains("~/.aws/config"),
+            "conflict message must name the affected file"
+        );
+        assert!(
+            msg.to_lowercase().contains("reload"),
+            "conflict message must mention the Reload action"
+        );
+        assert!(
+            !msg.contains("AKIA"),
+            "conflict message must not contain credential patterns"
+        );
+    }
+
+    /// E4: `PartialSaved` outcome produces a message that names BOTH files
+    /// (written and conflicted) and offers a Reload affordance (spec S35).
+    #[::core::prelude::v1::test]
+    fn partial_saved_message_names_both_files() {
+        let written = AwsEditFile::Config;
+        let conflicted = AwsEditFile::Credentials;
+        let msg = format!(
+            "{} was saved successfully, but {} was modified on disk since you opened \
+             the form. Reload to refresh the credentials section and re-apply your changes.",
+            file_label(written),
+            file_label(conflicted),
+        );
+        assert!(
+            msg.contains("~/.aws/config"),
+            "partial-saved message must name the written file"
+        );
+        assert!(
+            msg.contains("~/.aws/credentials"),
+            "partial-saved message must name the conflicted file"
+        );
+        assert!(
+            msg.to_lowercase().contains("reload"),
+            "partial-saved message must mention the Reload action"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // WU-E5: Security audit — outcomes and types carry no secrets
+    // -----------------------------------------------------------------------
+
+    /// E5.1: `AuthSaveOutcome` Debug representation contains no secret patterns.
+    /// This is also tested in dbflux_core, but we re-verify at the UI boundary
+    /// where the type is matched and messages are constructed.
+    #[::core::prelude::v1::test]
+    fn auth_save_outcome_debug_has_no_secrets() {
+        use dbflux_core::AuthSaveOutcome;
+
+        let outcomes = [
+            AuthSaveOutcome::Saved,
+            AuthSaveOutcome::Conflict {
+                file: AwsEditFile::Config,
+            },
+            AuthSaveOutcome::PartialSaved {
+                written: AwsEditFile::Config,
+                conflicted: AwsEditFile::Credentials,
+            },
+        ];
+
+        let secret_patterns = ["AKIA", "wJalrX", "aws_secret_access_key", "SECRET"];
+
+        for outcome in &outcomes {
+            let repr = format!("{outcome:?}");
+            for pattern in &secret_patterns {
+                assert!(
+                    !repr.contains(pattern),
+                    "AuthSaveOutcome debug must not contain '{pattern}' (found in: {repr})"
+                );
+            }
+        }
+    }
+
+    /// E5.2: `file_label` returns the correct file path strings.
+    #[::core::prelude::v1::test]
+    fn file_label_returns_correct_paths() {
+        assert_eq!(file_label(AwsEditFile::Config), "~/.aws/config");
+        assert_eq!(file_label(AwsEditFile::Credentials), "~/.aws/credentials");
+    }
+
+    /// E5.3: `AwsEditFile` variants are distinct and `file_label` output
+    /// contains no credential values.
+    #[::core::prelude::v1::test]
+    fn file_label_contains_no_credential_material() {
+        for file in [AwsEditFile::Config, AwsEditFile::Credentials] {
+            let label = file_label(file);
+            assert!(
+                !label.contains("AKIA"),
+                "file label must not contain access key patterns"
+            );
+            assert!(
+                !label.contains("secret"),
+                "file label must not contain 'secret'"
+            );
+        }
+    }
+
+    /// E5.4: `build_form_rows` for a reflected profile never exposes the
+    /// Enabled or Delete rows, regardless of the field count.
+    #[::core::prelude::v1::test]
+    fn reflected_form_rows_have_no_enabled_or_delete_for_any_field_count() {
+        for field_count in [0usize, 1, 5, 10] {
+            let rows = build_form_rows(true, field_count, false, true, true);
+            assert!(
+                !rows.iter().any(|r| r.contains(&AuthFormField::Enabled)),
+                "Enabled row must be absent for reflected profiles (field_count={field_count})"
+            );
+            assert!(
+                !rows
+                    .iter()
+                    .any(|r| r.contains(&AuthFormField::DeleteButton)),
+                "Delete row must be absent for reflected profiles (field_count={field_count})"
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #148

## Type

New feature / breaking change (removes the DBFlux-owned `aws-static-credentials` provider; one-time migration rebinds existing profiles). Breaking changes are acceptable on `-dev`.

> `size:exception` — transversal change (core auth, AWS crate, storage migration, app union seam, UI editing). Delivered as one reviewed PR by maintainer decision.

## Summary

- `~/.aws/config` + `~/.aws/credentials` become the single source of truth for AWS auth profiles. SSO, `[sso-session]`, and shared-credentials profiles are reflected **live** (mtime-cached) and unioned with stored non-AWS profiles behind one `list_auth_profiles()` seam — the import step is gone.
- Profile identity is a deterministic `UUIDv5(provider_id + ":" + name)` (frozen namespace), so connections keep their UUID binding while the identity is effectively the name.
- **Profiles are editable from the UI with safe write-back.** Editing/creating a profile writes the relevant section directly to `~/.aws/config` (and `~/.aws/credentials` for access keys), always **surgical** (other sections left byte-identical) and **atomic** (process-wide lock + temp-file rename). No implicit writes — only explicit user create/edit.
- **Optimistic-concurrency guard**: a per-section SHA-256 of the on-disk section is snapshotted at edit-open and re-checked under the lock at save. If that section changed on disk in between, the save is **blocked** with a conflict and a reload prompt (per-section granularity; no silent overwrite). Dual-file edits surface `PartialSaved` if one file conflicts.
- **DBFlux stores zero AWS secrets**, even with editing. Access keys are write-only in the UI (never pre-filled/displayed; blank = keep existing), written directly to `~/.aws/credentials` and never persisted in DBFlux's DB/keyring, never logged, never returned to the UI. The credentials file is parsed names-only for enumeration.
- One-time migration (`mod_010`) rebinds existing connections to the deterministic UUIDs transactionally and drops redundant stored AWS rows; name-unmatched profiles are marked dangling with a warning. Keyring secrets are never deleted — orphaned secrets are only logged.
- Also fixes the data-loss root cause: all AWS-file writes go through a process-wide lock + atomic temp-file rename, with temp/backup permissions restricted to the source file's mode (≤ 0600 for credentials).

## Changes

| File | Change |
|------|--------|
| `crates/dbflux_core/src/auth/identity.rs` | Frozen `AWS_AUTH_NAMESPACE` + `aws_profile_uuid()` deterministic identity |
| `crates/dbflux_core/src/auth/edit.rs` | Edit-session types: `AwsEditSnapshot`, `AwsSectionHash`, `AuthSaveOutcome` (Saved/Conflict/PartialSaved), `AwsEditFile` |
| `crates/dbflux_core/src/auth/{mod,types}.rs` | `reflect_profiles()`, `open_edit_snapshot()`, `save_edit()` trait methods; `read_only` + `dangling_origin` on `AuthProfile` |
| `crates/dbflux_core/src/driver/form.rs` | `FormFieldKind::WriteOnly` (generic write-only/secret field seam) |
| `crates/dbflux_aws/src/config.rs` | `update_aws_config_atomic` + `update_aws_credentials_atomic` (shared lock, atomic, perm-preserving); section-hash helpers; names-only credentials parser; surgical merge-write |
| `crates/dbflux_aws/src/auth.rs` | `reflect_profiles()` + `open_edit_snapshot`/`save_edit` for the 3 AWS providers; deleted `AwsStaticCredentialsAuthProvider` and all implicit write-back paths |
| `crates/dbflux_app/src/app_state.rs` | `list_auth_profiles()` union seam; migration startup hook |
| `crates/dbflux_app/src/aws_config_reflect_migration.rs` | Transactional one-time migration + dangling handling |
| `crates/dbflux_storage/.../mod_010_*.rs`, `app_meta.rs`, `auth_profiles.rs` | Migration 010, idempotency marker, `dangling_origin` |
| `crates/dbflux_mcp_server/src/state.rs` | Dropped static-provider registration |
| `crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs` | Editable AWS forms, save flow, conflict block+reload UX, write-only secret inputs |
| `crates/dbflux_ui_windows/src/connection_manager/{form,mod,render}.rs` | Union-seam dropdown; `WriteOnly` masking; connect-time dangling/missing-credentials guards |

## Test plan

- [x] `cargo nextest run --workspace` — 2585 pass (known pre-existing `hook_executor` failure only when `lua` feature is off; `palette_filtering` timing test flaky, passes on re-run)
- [x] `cargo check --workspace`, `cargo fmt --all -- --check`, `cargo clippy --workspace -- -D warnings`
- [x] `cargo build -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws`
- [x] Security: secret never in `AuthSaveOutcome`/logs/DB/keyring; credentials parser names-only; write-only blank preserves existing key; temp/backup perms ≤ 0600 for credentials
- [x] Optimistic concurrency: no-change → Saved; same-section changed → Conflict (nothing written); different-section → Saved; PartialSaved on dual-file conflict
- [x] Surgical write byte-identity (config + credentials); atomic rename-failure restore
- [x] Migration: matched rebind, dangling (file-gone and keyring-only), idempotency, keyring never deleted
- [ ] Manual GPUI verification of editable forms, conflict/reload banner, write-only secret rendering (not auto-testable in CI)

## Notes

- All fixtures use AWS documentation dummy values; no real credentials or client identifiers anywhere.
- Editability/secret-masking is driven by the generic `FormFieldKind::WriteOnly` seam — no concrete provider-id branching in UI.
- No `Co-Authored-By` trailers.