### PR TITLE
fix(schema): stop false "FK changed" drift modal on every SELECT

### DIFF
--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -2521,7 +2521,7 @@ impl MssqlConnection {
             );
         }
 
-        Ok(builder.build())
+        Ok(builder.build_sorted())
     }
 
     fn fetch_constraints(

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -3221,7 +3221,7 @@ fn fetch_foreign_keys(
         );
     }
 
-    Ok(builder.build())
+    Ok(builder.build_sorted())
 }
 
 /// Translate a Value filter expression to a SQL WHERE clause string for MySQL.


### PR DESCRIPTION
## What changed

The schema-drift preflight popped a **"Schema has changed since this query was opened"** modal on every SELECT for tables with two or more foreign keys, reporting a phantom `FK changed`. This makes the MySQL/MariaDB and MSSQL per-table FK list deterministic so the cached and freshly-fetched schemas compare equal.

## Root cause

- `ForeignKeyBuilder::build()` (`crates/dbflux_core/src/schema/builder.rs`) returns `self.map.into_values().collect()` over a `HashMap` — **nondeterministic order** per call.
- Drift compares cached vs fresh `TableInfo.foreign_keys` **positionally** (`zip`) in `diff_table_info` (`crates/dbflux_core/src/schema/schema_drift.rs`), and the fingerprint hashes FKs **in order** (`fingerprint.rs`).
- So two identical `table_details()` fetches returning the same FKs in a different order looked like a change. It fired on every SELECT, and "Refresh and re-run" never settled because the next fetch reshuffled the order.

## The fix

Use `build_sorted()` instead of `build()` in the per-table FK fetch:

| Driver | File | Note |
|--------|------|------|
| MySQL / MariaDB | `crates/dbflux_driver_mysql/src/driver.rs` | reported case |
| MSSQL | `crates/dbflux_driver_mssql/src/driver.rs` | same latent bug |

Both SQL queries already `ORDER BY` the constraint name, so sorting the built list by name matches the query's intent. `build_sorted()` only orders the outer FK list; composite-key column order inside each FK is preserved. Postgres already used `build_sorted()`, which is why it was unaffected.

## What to review first

`build()` → `build_sorted()` in the two driver files. Two-line change, no behavior change beyond ordering.

## Out of scope

- The drift comparison and fingerprint still treat FKs **order-sensitively** even though FK declaration order carries no query semantics. Today all three SQL drivers sort by name, so it is robust; a future driver emitting unsorted FKs would reintroduce the false positive. Making the FK comparison order-insensitive in core is a larger change with its own test burden — not included here.
- `SchemaForeignKeyBuilder::build()` (bulk schema-FK cache) is also nondeterministic but does not feed the drift comparison, so it is left untouched.

## Verification

- [x] `cargo check -p dbflux_driver_mysql -p dbflux_driver_mssql` passes.
- [ ] On MariaDB, run a SELECT against a table with ≥2 foreign keys (e.g. `businesses`) repeatedly — the drift modal no longer appears.
- [ ] Live driver tests not run (require Docker-backed databases).