### PR TITLE
fix(export): probe file-dialog backend, fall back to home, add clipboard export

### DIFF
--- a/crates/dbflux_ui_base/src/file_dialog.rs
+++ b/crates/dbflux_ui_base/src/file_dialog.rs
@@ -1,0 +1,97 @@
+//! File-dialog availability probe and export fallback path.
+//!
+//! `rfd::AsyncFileDialog::save_file()` returns `Option<FileHandle>` and cannot
+//! distinguish "user cancelled" from "backend failed" (no portal, no zenity/
+//! kdialog). To avoid silent failures on Linux when the host has neither a
+//! working XDG desktop portal nor a zenity/kdialog fallback installed, callers
+//! probe `is_native_file_dialog_available()` before invoking rfd and route to
+//! `fallback_export_dir()` when the probe fails.
+
+use std::path::PathBuf;
+
+/// Returns `true` when a native file picker is expected to work on this host.
+///
+/// On Windows and macOS this is unconditionally `true` — the native pickers
+/// are part of the OS.
+///
+/// On Linux this is a heuristic that succeeds when at least one of the
+/// following binaries is on `PATH`:
+/// - `xdg-desktop-portal` (the XDG portal backend rfd prefers)
+/// - `zenity` (rfd's fallback when the portal call fails)
+/// - `kdialog` (KDE's equivalent fallback)
+///
+/// The heuristic is intentionally lenient: rfd may still fail at runtime when
+/// the portal binary exists but the FileChooser interface is unimplemented by
+/// the active desktop. The Linux user pain we're solving — a missing portal AND
+/// missing zenity, which makes rfd return `None` silently — is reliably caught
+/// by this probe.
+pub fn is_native_file_dialog_available() -> bool {
+    #[cfg(not(target_os = "linux"))]
+    {
+        true
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        binary_on_path("xdg-desktop-portal")
+            || binary_on_path("zenity")
+            || binary_on_path("kdialog")
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn binary_on_path(bin: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+
+    std::env::split_paths(&paths).any(|dir| {
+        let candidate = dir.join(bin);
+        candidate.is_file()
+    })
+}
+
+/// Returns the fallback directory for exports written when no native file
+/// picker is available, creating it if missing.
+///
+/// Resolves to `~/.local/share/dbflux/exports/` via
+/// `dbflux_storage::paths::data_dir()`.
+pub fn fallback_export_dir() -> Result<PathBuf, String> {
+    let data_dir = dbflux_storage::paths::data_dir()
+        .map_err(|e| format!("Failed to resolve data directory: {}", e))?;
+
+    let exports = data_dir.join("exports");
+
+    std::fs::create_dir_all(&exports)
+        .map_err(|e| format!("Failed to create exports directory {}: {}", exports.display(), e))?;
+
+    Ok(exports)
+}
+
+/// Builds a non-clobbering path inside `dir` for `filename`. If the file
+/// already exists, suffixes `-2`, `-3`, ... before the extension until a free
+/// slot is found.
+pub fn unique_path_in(dir: &std::path::Path, filename: &str) -> PathBuf {
+    let initial = dir.join(filename);
+    if !initial.exists() {
+        return initial;
+    }
+
+    let (stem, ext) = match filename.rfind('.') {
+        Some(i) if i > 0 => (&filename[..i], Some(&filename[i + 1..])),
+        _ => (filename, None),
+    };
+
+    for n in 2..u32::MAX {
+        let candidate_name = match ext {
+            Some(ext) => format!("{}-{}.{}", stem, n, ext),
+            None => format!("{}-{}", stem, n),
+        };
+        let candidate = dir.join(candidate_name);
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+
+    initial
+}

--- a/crates/dbflux_ui_base/src/file_dialog.rs
+++ b/crates/dbflux_ui_base/src/file_dialog.rs
@@ -62,8 +62,13 @@ pub fn fallback_export_dir() -> Result<PathBuf, String> {
 
     let exports = data_dir.join("exports");
 
-    std::fs::create_dir_all(&exports)
-        .map_err(|e| format!("Failed to create exports directory {}: {}", exports.display(), e))?;
+    std::fs::create_dir_all(&exports).map_err(|e| {
+        format!(
+            "Failed to create exports directory {}: {}",
+            exports.display(),
+            e
+        )
+    })?;
 
     Ok(exports)
 }

--- a/crates/dbflux_ui_base/src/lib.rs
+++ b/crates/dbflux_ui_base/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod app_state_entity;
 pub mod async_ext;
 pub mod dashboard_manager;
+pub mod file_dialog;
 pub mod keymap;
 pub mod modal_frame;
 pub mod modals;

--- a/crates/dbflux_ui_document/src/code/file_ops.rs
+++ b/crates/dbflux_ui_document/src/code/file_ops.rs
@@ -76,44 +76,87 @@ impl CodeDocument {
 
         let entity = cx.entity().clone();
         let app_state = self.app_state.clone();
+        let dialog_available = dbflux_ui_base::file_dialog::is_native_file_dialog_available();
 
         self._pending_save = Some(cx.spawn(async move |_this, cx| {
-            let file_handle = rfd::AsyncFileDialog::new()
-                .set_title("Save Script As")
-                .set_file_name(&suggested_name)
-                .add_filter(language_name, &[default_ext])
-                .add_filter("All Files", &["*"])
-                .save_file()
-                .await;
+            let target: Option<(std::path::PathBuf, bool)> = if dialog_available {
+                let file_handle = rfd::AsyncFileDialog::new()
+                    .set_title("Save Script As")
+                    .set_file_name(&suggested_name)
+                    .add_filter(&language_name, &[&default_ext])
+                    .add_filter("All Files", &["*"])
+                    .save_file()
+                    .await;
 
-            let Some(handle) = file_handle else {
+                file_handle.map(|handle| (handle.path().to_path_buf(), false))
+            } else {
+                match dbflux_ui_base::file_dialog::fallback_export_dir() {
+                    Ok(dir) => Some((
+                        dbflux_ui_base::file_dialog::unique_path_in(&dir, &suggested_name),
+                        true,
+                    )),
+                    Err(err) => {
+                        let err_text = format!(
+                            "Save failed — file dialog unavailable and fallback directory could not be created: {}",
+                            err
+                        );
+                        log::error!("{}", err_text);
+                        cx.update(|cx| {
+                            dbflux_ui_base::toast::Toast::error(err_text)
+                                .meta_right(dbflux_ui_base::toast::now_hms())
+                                .push(cx);
+                        })
+                        .ok();
+                        return;
+                    }
+                }
+            };
+
+            let Some((path, used_fallback)) = target else {
+                // Native dialog was available and user cancelled — no toast.
                 return;
             };
 
-            let path = handle.path().to_path_buf();
             let write_result = std::fs::write(&path, &content);
 
             match write_result {
                 Ok(()) => {
+                    let path_for_update = path.clone();
                     cx.update(|cx| {
                         entity.update(cx, |doc, cx| {
                             if let Some(scratch) = doc.scratch_path.take() {
                                 let _ = std::fs::remove_file(&scratch);
                             }
 
-                            doc.path = Some(path.clone());
+                            doc.path = Some(path_for_update.clone());
                             doc.mark_clean(cx);
                         });
 
                         app_state.update(cx, |state, cx| {
-                            state.record_recent_file(path);
+                            state.record_recent_file(path_for_update.clone());
                             cx.emit(dbflux_ui_base::AppStateChanged);
                         });
+
+                        if used_fallback {
+                            dbflux_ui_base::toast::Toast::warning(format!(
+                                "Native file picker unavailable — script saved to {} instead. Install xdg-desktop-portal, zenity, or kdialog for a save dialog.",
+                                path_for_update.display()
+                            ))
+                            .meta_right(dbflux_ui_base::toast::now_hms())
+                            .push(cx);
+                        }
                     })
                     .ok();
                 }
                 Err(e) => {
-                    log::error!("Failed to save file: {}", e);
+                    let err_text = format!("Failed to save script: {}", e);
+                    log::error!("{}", err_text);
+                    cx.update(|cx| {
+                        dbflux_ui_base::toast::Toast::error(err_text)
+                            .meta_right(dbflux_ui_base::toast::now_hms())
+                            .push(cx);
+                    })
+                    .ok();
                 }
             }
         }));

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu.rs
@@ -864,14 +864,11 @@ impl DataGridPanel {
             return;
         }
 
-        let formats = dbflux_export::available_formats(&self.result.shape);
+        let _ = window;
+        let _formats = dbflux_export::available_formats(&self.result.shape);
 
-        if formats.len() == 1 {
-            self.export_with_format(formats[0], window, cx);
-        } else {
-            self.export_menu_open = !self.export_menu_open;
-            cx.notify();
-        }
+        self.export_menu_open = !self.export_menu_open;
+        cx.notify();
     }
 
     pub fn export_with_format(
@@ -889,33 +886,84 @@ impl DataGridPanel {
         let format_name = format.name();
 
         let entity = cx.entity().clone();
+        let audit_service = self.app_state.read(cx).audit_service().clone();
+        let dialog_available = dbflux_ui_base::file_dialog::is_native_file_dialog_available();
 
         cx.spawn(async move |_this, cx| {
-            let file_handle = rfd::AsyncFileDialog::new()
-                .set_title(format!("Export as {}", format_name))
-                .set_file_name(&suggested_name)
-                .add_filter(format_name, &[extension])
-                .save_file()
-                .await;
+            let target: Option<(std::path::PathBuf, bool)> = if dialog_available {
+                let file_handle = rfd::AsyncFileDialog::new()
+                    .set_title(format!("Export as {}", format_name))
+                    .set_file_name(&suggested_name)
+                    .add_filter(format_name, &[extension])
+                    .save_file()
+                    .await;
 
-            let Some(handle) = file_handle else {
+                file_handle.map(|handle| (handle.path().to_path_buf(), false))
+            } else {
+                match dbflux_ui_base::file_dialog::fallback_export_dir() {
+                    Ok(dir) => Some((
+                        dbflux_ui_base::file_dialog::unique_path_in(&dir, &suggested_name),
+                        true,
+                    )),
+                    Err(err) => {
+                        record_export_audit(
+                            &audit_service,
+                            format_name,
+                            None,
+                            true,
+                            false,
+                            Some(&err),
+                        );
+                        let message = format!(
+                            "Export failed — file dialog unavailable and fallback directory could not be created: {}",
+                            err
+                        );
+                        cx.update(|cx| {
+                            entity.update(cx, |panel, cx| {
+                                panel.pending_toast =
+                                    Some(PendingToast { message, is_error: true });
+                                cx.notify();
+                            });
+                        })
+                        .log_if_dropped();
+                        return;
+                    }
+                }
+            };
+
+            let Some((target_path, used_fallback)) = target else {
+                // Native dialog was available and the user cancelled — no
+                // toast, no audit. Cancellations are not failures.
                 return;
             };
 
-            let path = handle.path().to_path_buf();
-
             let export_result = (|| {
-                let file = File::create(&path)?;
+                let file = File::create(&target_path)?;
                 let mut writer = BufWriter::new(file);
                 dbflux_export::export(&result, format, &mut writer)?;
                 Ok::<_, dbflux_export::ExportError>(())
             })();
 
-            let message = match &export_result {
-                Ok(()) => format!("Exported to {}", path.display()),
-                Err(e) => format!("Export failed: {}", e),
+            let (message, is_error) = match &export_result {
+                Ok(()) if used_fallback => (
+                    format!(
+                        "Native file picker unavailable — exported to {} instead. Install xdg-desktop-portal, zenity, or kdialog for a save dialog.",
+                        target_path.display()
+                    ),
+                    false,
+                ),
+                Ok(()) => (format!("Exported to {}", target_path.display()), false),
+                Err(e) => (format!("Export failed: {}", e), true),
             };
-            let is_error = export_result.is_err();
+
+            record_export_audit(
+                &audit_service,
+                format_name,
+                Some(&target_path),
+                is_error,
+                used_fallback,
+                export_result.as_ref().err().map(|e| e.to_string()).as_deref(),
+            );
 
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
@@ -926,6 +974,68 @@ impl DataGridPanel {
             .log_if_dropped();
         })
         .detach();
+    }
+
+    pub fn copy_to_clipboard_with_format(
+        &mut self,
+        format: ExportFormat,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.export_menu_open = false;
+
+        if matches!(format, ExportFormat::Binary) {
+            self.pending_toast = Some(PendingToast {
+                message:
+                    "Raw binary cannot be copied to the clipboard — choose Hex or Base64 instead."
+                        .to_string(),
+                is_error: true,
+            });
+            cx.notify();
+            return;
+        }
+
+        let mut buffer: Vec<u8> = Vec::new();
+        let export_result = dbflux_export::export(&self.result, format, &mut buffer);
+
+        let format_name = format.name();
+        let audit_service = self.app_state.read(cx).audit_service().clone();
+
+        match export_result {
+            Ok(()) => match String::from_utf8(buffer) {
+                Ok(text) => {
+                    let byte_len = text.len();
+                    cx.write_to_clipboard(ClipboardItem::new_string(text));
+                    record_clipboard_audit(&audit_service, format_name, Some(byte_len), None);
+                    self.pending_toast = Some(PendingToast {
+                        message: format!(
+                            "Copied {} ({} bytes) to clipboard",
+                            format_name, byte_len
+                        ),
+                        is_error: false,
+                    });
+                    cx.notify();
+                }
+                Err(e) => {
+                    let err_text = format!("Cannot copy non-UTF8 output: {}", e);
+                    record_clipboard_audit(&audit_service, format_name, None, Some(&err_text));
+                    self.pending_toast = Some(PendingToast {
+                        message: err_text,
+                        is_error: true,
+                    });
+                    cx.notify();
+                }
+            },
+            Err(e) => {
+                let err_text = e.to_string();
+                record_clipboard_audit(&audit_service, format_name, None, Some(&err_text));
+                self.pending_toast = Some(PendingToast {
+                    message: format!("Copy failed: {}", err_text),
+                    is_error: true,
+                });
+                cx.notify();
+            }
+        }
     }
 
     fn export_base_name(&self) -> String {
@@ -4317,6 +4427,113 @@ impl DataGridPanel {
             CellKind::Unsupported(type_name) => Value::Unsupported(type_name.to_string()),
             CellKind::AutoGenerated(expr) => Value::Text(format!("DEFAULT({})", expr)),
         }
+    }
+}
+
+fn record_export_audit(
+    audit_service: &dbflux_audit::AuditService,
+    format_name: &str,
+    path: Option<&std::path::Path>,
+    is_error: bool,
+    used_fallback: bool,
+    error_text: Option<&str>,
+) {
+    use dbflux_core::chrono::Utc;
+    use dbflux_core::observability::{
+        EventCategory, EventOutcome, EventRecord, EventSeverity, EventSink,
+    };
+
+    let (severity, outcome) = match (is_error, used_fallback) {
+        (true, _) => (EventSeverity::Error, EventOutcome::Failure),
+        (false, true) => (EventSeverity::Warn, EventOutcome::Success),
+        (false, false) => (EventSeverity::Info, EventOutcome::Success),
+    };
+
+    let action = if is_error {
+        "result_export_failed"
+    } else if used_fallback {
+        "result_export_fallback"
+    } else {
+        "result_export"
+    };
+
+    let mut summary = format!("Result export ({})", format_name);
+    if used_fallback && !is_error {
+        summary.push_str(" — fallback directory used (no native file picker)");
+    }
+    if let Some(p) = path {
+        summary.push_str(&format!(" -> {}", p.display()));
+    }
+    if let Some(err) = error_text {
+        summary.push_str(&format!(": {}", err));
+    }
+
+    let event = EventRecord::new(
+        Utc::now().timestamp_millis(),
+        severity,
+        EventCategory::Query,
+        outcome,
+    )
+    .with_action(action.to_string())
+    .with_summary(summary)
+    .with_actor_id("ui:user");
+
+    if let Err(e) = audit_service.record(event) {
+        log::warn!("Failed to record export audit event: {}", e);
+    }
+}
+
+fn record_clipboard_audit(
+    audit_service: &dbflux_audit::AuditService,
+    format_name: &str,
+    byte_len: Option<usize>,
+    error_text: Option<&str>,
+) {
+    use dbflux_core::chrono::Utc;
+    use dbflux_core::observability::{
+        EventCategory, EventOutcome, EventRecord, EventSeverity, EventSink,
+    };
+
+    let is_error = error_text.is_some();
+    let severity = if is_error {
+        EventSeverity::Error
+    } else {
+        EventSeverity::Info
+    };
+    let outcome = if is_error {
+        EventOutcome::Failure
+    } else {
+        EventOutcome::Success
+    };
+
+    let mut summary = if is_error {
+        format!("Clipboard export failed ({})", format_name)
+    } else {
+        format!("Clipboard export ({})", format_name)
+    };
+    if let Some(len) = byte_len {
+        summary.push_str(&format!(" — {} bytes", len));
+    }
+    if let Some(err) = error_text {
+        summary.push_str(&format!(": {}", err));
+    }
+
+    let event = EventRecord::new(
+        Utc::now().timestamp_millis(),
+        severity,
+        EventCategory::Query,
+        outcome,
+    )
+    .with_action(if is_error {
+        "result_clipboard_failed".to_string()
+    } else {
+        "result_clipboard".to_string()
+    })
+    .with_summary(summary)
+    .with_actor_id("ui:user");
+
+    if let Err(e) = audit_service.record(event) {
+        log::warn!("Failed to record clipboard audit event: {}", e);
     }
 }
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -3184,12 +3184,6 @@ impl DataGridPanel {
         let formats = dbflux_export::available_formats(&self.result.shape);
         let menu_open = self.export_menu_open;
 
-        let label = if formats.len() == 1 {
-            format!("Export {}", formats[0].name())
-        } else {
-            "Export".to_string()
-        };
-
         div()
             .id("export-trigger")
             .relative()
@@ -3209,14 +3203,12 @@ impl DataGridPanel {
                     .small()
                     .color(theme.muted_foreground),
             )
-            .child(Text::caption(label).muted_foreground())
-            .when(formats.len() > 1, |d| {
-                d.child(
-                    Icon::new(AppIcon::ChevronDown)
-                        .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
-                        .color(theme.muted_foreground),
-                )
-            })
+            .child(Text::caption("Export").muted_foreground())
+            .child(
+                Icon::new(AppIcon::ChevronDown)
+                    .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
+                    .color(theme.muted_foreground),
+            )
             .when(menu_open, |d| {
                 d.child(self.render_export_menu(formats, theme, cx))
             })
@@ -3228,12 +3220,28 @@ impl DataGridPanel {
         theme: &gpui_component::theme::Theme,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let items: Vec<AnyElement> = formats
-            .iter()
-            .enumerate()
-            .map(|(idx, &format)| {
+        let section_header = |label: &'static str| -> AnyElement {
+            div()
+                .px(Spacing::SM)
+                .mx(Spacing::XS)
+                .pt(Spacing::XS)
+                .pb_0()
+                .child(
+                    Text::caption(label)
+                        .font_size(FontSizes::XS)
+                        .muted_foreground(),
+                )
+                .into_any_element()
+        };
+
+        let mut items: Vec<AnyElement> = Vec::with_capacity(formats.len() * 2 + 3);
+
+        items.push(section_header("Save as file"));
+
+        for (idx, &format) in formats.iter().enumerate() {
+            items.push(
                 div()
-                    .id(SharedString::from(format!("export-{}", idx)))
+                    .id(SharedString::from(format!("export-save-{}", idx)))
                     .flex()
                     .items_center()
                     .gap(Spacing::SM)
@@ -3247,10 +3255,56 @@ impl DataGridPanel {
                     .on_click(cx.listener(move |this, _, window, cx| {
                         this.export_with_format(format, window, cx);
                     }))
+                    .child(
+                        Icon::new(AppIcon::Download)
+                            .small()
+                            .color(theme.muted_foreground),
+                    )
                     .child(Text::body(format.name()))
-                    .into_any_element()
-            })
-            .collect();
+                    .into_any_element(),
+            );
+        }
+
+        items.push(
+            div()
+                .mx(Spacing::XS)
+                .my(Spacing::XS)
+                .h(px(1.0))
+                .bg(theme.border)
+                .into_any_element(),
+        );
+
+        items.push(section_header("Copy to clipboard"));
+
+        for (idx, &format) in formats.iter().enumerate() {
+            let copyable = !matches!(format, dbflux_export::ExportFormat::Binary);
+            let row = div()
+                .id(SharedString::from(format!("export-copy-{}", idx)))
+                .flex()
+                .items_center()
+                .gap(Spacing::SM)
+                .h(Heights::ROW_COMPACT)
+                .px(Spacing::SM)
+                .mx(Spacing::XS)
+                .rounded(Radii::SM)
+                .text_size(FontSizes::SM)
+                .when(copyable, |d| {
+                    d.cursor_pointer()
+                        .hover(|d| d.bg(theme.secondary))
+                        .on_click(cx.listener(move |this, _, window, cx| {
+                            this.copy_to_clipboard_with_format(format, window, cx);
+                        }))
+                })
+                .when(!copyable, |d| d.opacity(0.5))
+                .child(
+                    Icon::new(AppIcon::Copy)
+                        .small()
+                        .color(theme.muted_foreground),
+                )
+                .child(Text::body(format.name()))
+                .into_any_element();
+            items.push(row);
+        }
 
         deferred(
             surface_raised(cx)
@@ -3258,7 +3312,7 @@ impl DataGridPanel {
                 .bottom_full()
                 .right_0()
                 .mb(Spacing::XS)
-                .w(px(160.0))
+                .w(px(200.0))
                 .shadow_lg()
                 .py(Spacing::XS)
                 .occlude()


### PR DESCRIPTION
## Summary

Fixes a silent-failure mode in the data-grid export and script *Save As* on Linux hosts that lack a working XDG desktop portal **and** the zenity/kdialog fallback. In that combination `rfd::AsyncFileDialog::save_file()` resolves to `None` and the action evaporates with no toast, no audit, no log. Adds clipboard export as a first-class option in the same menu.

Repro of the original failure (excerpt from the user log):

```
ERROR rfd::backend::xdg_desktop_portal::portal] OpenFile failed: org.freedesktop.DBus.Error.UnknownMethod
WARN  rfd::backend::xdg_desktop_portal] Using zenity fallback
ERROR rfd::backend::xdg_desktop_portal] Failed to save file with zenity: No such file or directory
```

## What changed

- New `dbflux_ui_base::file_dialog` helper:
  - `is_native_file_dialog_available()` — Linux probe that checks `xdg-desktop-portal`, `zenity`, and `kdialog` on `PATH`; unconditionally `true` on Windows/macOS.
  - `fallback_export_dir()` resolves to `~/.local/share/dbflux/exports/` via `dbflux_storage::paths::data_dir()`.
  - `unique_path_in()` adds `-2`, `-3`, … suffixes to avoid clobbering.
- Data-grid result export (`data_grid_panel/context_menu.rs`, `render.rs`):
  - Pre-flights the probe. No backend → writes to the fallback directory, raises a warning toast pointing at the path, and records a `Query`-category audit event with action `result_export_fallback`. Backend present → uses `rfd` and treats `None` as a real user cancel (no toast, no audit).
  - On hard failure (export error or unwritable fallback dir) emits an error toast and `result_export_failed`.
  - Adds a **Copy to clipboard** section to the export menu alongside **Save as file**, one row per format. `Binary` is disabled with a hint to use `Hex` or `Base64`. Clipboard outcomes are audited as `result_clipboard` / `result_clipboard_failed`.
  - The trigger always opens the menu now (the previous single-format shortcut wouldn't make sense once clipboard is a peer action).
- Script *Save As* (`code/file_ops.rs`):
  - Same probe + fallback pattern.
  - Replaces the silent `log::error!` on write errors with an error toast.

## What I deliberately did **not** touch

- `audit/mod.rs::do_export` already writes directly to `~/Downloads` and never calls `rfd`, so it doesn't have this bug.
- The `rfd` import flows (connection manager, SSH tunnels, workspace open) are read paths — fallback-to-home doesn't apply.

## Design notes

- `rfd::AsyncFileDialog::save_file()` cannot distinguish *cancelled* from *failed* at the API level. The pre-flight probe is the honest fix: on hosts that have a working picker we still respect cancellations, and on hosts where the dialog reliably won't work we never invoke it.
- Audit events route through `app_state.read(cx).audit_service().clone()` — `AuditService` is `Clone` and implements `EventSink`.

## Test plan

- [ ] Open a query result, click **Export**, pick **Save as file → CSV**: native picker opens, file written, success toast, audit shows `result_export` (Query / Info).
- [ ] Same flow, cancel the picker: no toast, no audit entry (cancel is silent).
- [ ] Uninstall/mask zenity, kdialog, and the desktop portal (or run on a minimal headless Linux box), repeat **Save as file → CSV**: warning toast points at `~/.local/share/dbflux/exports/<name>.csv`, file present on disk, audit shows `result_export_fallback` (Query / Warn).
- [ ] **Copy to clipboard → JSON (pretty)**: clipboard contains the serialized JSON, success toast with byte count, audit shows `result_clipboard`.
- [ ] **Copy to clipboard → Binary**: row is dimmed and shows the "use Hex or Base64" toast on click.
- [ ] Open a code document, **Save As** on a host without a picker: file lands in `~/.local/share/dbflux/exports/`, warning toast displayed.
- [ ] `cargo check --workspace` clean on Linux.