### PR TITLE
feat(ui): centralize user-facing error reporting with toast + audit emission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,23 @@ manager. Windows and macOS use their default linker and are unaffected.
 
 - Avoid `unwrap()` and functions that panic; use `?` to propagate errors
 - Be careful with indexing operations that may panic on out-of-bounds
-- Never silently discard errors with `let _ =` on fallible operations:
-  - Propagate with `?` when the caller should handle them
-  - Use `.log_err()` when ignoring but wanting visibility
-  - Use `match` or `if let Err(...)` for custom logic
-- Ensure async errors propagate to UI so users get meaningful feedback
+- **Never use `let _ =` on a fallible expression.** Silently discarding `Result` / `Option` errors hides real failures from users, logs, and the audit trail. This rule has no exceptions for "fire and forget" — pick one of the alternatives below instead:
+  - **Propagate** with `?` when the caller should handle it.
+  - **Log** with `.log_err()` (from `dbflux_core`) when ignoring but wanting at least one stderr/audit trace.
+  - **Branch explicitly** with `match` / `if let Err(e) = ...` when you need custom logic.
+  - **Surface to the user** with `report_error` / `report_error_async` (`dbflux_ui_base::user_error`) when the failure is something the user just triggered. Producing a toast + audit row is preferred over `log::error!` for any user-facing operation; this also drives the status-bar error badge.
+  - If you genuinely want to drop a value — not an error — bind it to `_name` instead of `_`. Reserve the bare `let _ =` pattern for that intent only.
+- Ensure async errors propagate to the UI so users get meaningful feedback. Background tasks that fail without a path to the foreground are a bug, not a feature.
+
+#### User-facing error reporting (`dbflux_ui_base::user_error`)
+
+When a user-triggered operation fails (storage, network, driver, config, hook, auth), route it through the centralized seam instead of `log::error!` + manual `Toast::error(...)`. The seam attaches a UUID v7 correlation id to the toast and the audit row, drives the status-bar error badge, and provides a "View in Audit" action wired to that correlation id.
+
+- Foreground (`&mut App` / `&mut Context<T>`): `report_error(UserFacingError::new(ErrorKind::Storage, msg), cx)`
+- Background (`cx.spawn(async ...)` / `background_executor`): `report_error_async(UserFacingError::new(ErrorKind::Network, msg), &cx)`
+- Driver errors: prefer `UserFacingError::from_formatted(ErrorKind::Driver, fe)` so the driver's `ErrorFormatter` output feeds `cause` directly — keeps the UI driver-agnostic.
+- `ErrorKind` variants: `Storage`, `Network`, `Auth`, `Hook`, `Driver`, `User`, `Config`.
+- Convention: only the **first catch site** reports. Propagators above must NOT re-report — there is no runtime deduplication, double-toasts are a code-review concern.
 
 ### File Organization
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,7 +23,7 @@ flowchart TB
 
     subgraph UI["Presentation — 6 UI crates"]
         uicomp["dbflux_components<br/>(theme, tokens, icons, primitives,<br/>composites, controls, data_table,<br/>document_tree, result_panel, charts,<br/>modals, saved_chart — no dbflux_app dep)"]
-        uibase["dbflux_ui_base<br/>(AppStateEntity, events, keymap helpers,<br/>toast, modal_frame, platform,<br/>sql_preview_modal, sso_wizard)"]
+        uibase["dbflux_ui_base<br/>(AppStateEntity, events, keymap helpers,<br/>toast + throttle, user_error,<br/>modal_frame, platform,<br/>sql_preview_modal, sso_wizard)"]
         uidoc["dbflux_ui_document<br/>(tab/pane system, documents,<br/>data_grid_panel, governance)"]
         uisidebar["dbflux_ui_sidebar<br/>(connections + scripts sidebar tree)"]
         uiwindows["dbflux_ui_windows<br/>(connection_manager + settings windows)"]
@@ -166,10 +166,13 @@ crates/
       typography.rs
   dbflux_ui_base/           # AppStateEntity + events, keymap helpers, platform utilities
     src/
-      app_state_entity.rs   # AppStateEntity wrapper (Deref + EventEmitter)
+      app_state_entity.rs   # AppStateEntity wrapper (Deref + EventEmitter), AppStateGlobal,
+                            # UserErrorReported + OpenAuditRequested events, unread_error_count
       keymap.rs             # default_keymap, key_chord_from_gpui
       async_ext.rs          # AsyncUpdateResultExt
-      toast.rs              # Custom toast notification system
+      toast.rs              # Toast + ToastHost with severity-aware token-bucket throttle
+      user_error/           # Centralized user-facing error reporting (UserFacingError,
+                            # ErrorKind, report_error, report_error_async) + throttle
       modal_frame.rs        # Reusable modal chrome/frame
       platform.rs           # X11/Wayland detection, window options
       sql_preview_modal.rs  # SQL/query preview modal (dual-mode: SQL and generic)
@@ -523,6 +526,18 @@ crates/
 - CLI and single-instance: `crates/dbflux/src/cli.rs` parses arguments; `crates/dbflux_ui/src/ipc_server.rs` runs the app-control IPC server for `Focus` and `OpenScript` commands.
 - Assets: `crates/dbflux_ui/src/assets.rs` implements GPUI's `AssetSource` to serve embedded SVG icons.
 - Workspace UI shell: `crates/dbflux_ui/src/ui/views/workspace/` wires panes (sidebar/dock, document area, bottom dock), command palette, and focus routing. Split across `mod.rs`, `actions.rs`, `dispatch.rs`, and `render.rs`. This module stays in `dbflux_ui`.
+
+### User-facing error reporting
+
+User-triggered failures route through a single seam in `crates/dbflux_ui_base/src/user_error/mod.rs` so every actionable error produces a toast, an audit row, and a status-bar badge increment — all keyed by the same UUID v7 correlation id.
+
+- **Entry points**: `report_error(UserFacingError, &mut App)` (foreground) and `report_error_async(UserFacingError, &AsyncApp)` (background / `cx.spawn` / `background_executor`). The sync variant must NOT be called from a background context — it requires `&mut App`.
+- **Taxonomy**: `ErrorKind { Storage, Network, Auth, Hook, Driver, User, Config }` drives badge/toast styling and the audit `action` discriminator. Severity reuses `dbflux_core::observability::EventSeverity`; `report_error` does not add a parallel enum.
+- **Driver feed**: `UserFacingError::from_formatted(kind, FormattedError)` consumes the existing driver `ErrorFormatter` output. UI code never branches on driver id.
+- **Audit bridge**: the seam emits `tracing::error!(target = "dbflux_ui::user_error", correlation_id = %id, kind, action = "user_error", outcome = "failure", ...)`. `AuditFieldVisitor` (`crates/dbflux_core/src/observability/tracing_bridge/layer.rs`) routes both `record_str` and `record_debug` through `record_string_by_name` so the typed `EventRecord.correlation_id` slot is populated regardless of whether the field is recorded via the `%` (Display) or `?` (Debug) sigil.
+- **Toast throttle**: `ToastHost` keeps a per-severity token bucket (capacity 5, refill 1 token / 2 s) for Info and Warn so connection-loss storms do not bury the screen. Error and Fatal bypass the throttle. The bucket's clock is injectable for deterministic tests.
+- **Badge + navigation**: `AppStateEntity::note_user_error` increments `unread_error_count` and emits `UserErrorReported`. The status-bar badge subscribes and, on click, calls `AppStateEntity::request_open_audit(None, cx)` which emits `OpenAuditRequested`. The toast "View in Audit" action emits the same event with `Some(correlation_id)`. The workspace subscribes once to `OpenAuditRequested` and steers `AuditDocument` via `set_correlation_filter` or `new_with_correlation_id`.
+- **Convention**: only the first catch site reports. Propagators above must NOT re-report — there is no runtime deduplication, double-toasts are a code-review concern (see AGENTS.md § Error Handling).
 
 ### Document System
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Centralized user-facing error reporting (`report_error` / `report_error_async` in `dbflux_ui_base`). Failures across mutations, file save, settings, and workspace actions now surface as a styled toast with a "View in Audit" action, increment a status-bar error badge, and emit a tracing event correlated with the audit row (#156).
+- `EventRecord.correlation_id` is now populated from the `correlation_id` tracing field across all `dbflux` targets, regardless of whether the field is recorded via `%` (Display) or `?` (Debug) sigil (#156).
+
+### Changed
+
+- Toast host applies a severity-aware throttle (capacity 5, refill 1 token / 2 s) to Warning and Info toasts so connection-storm noise does not bury the UI; Error and Fatal toasts bypass the throttle (#156).
+
 ## [0.6.0-dev.10] - 2026-05-29
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,10 @@ manager. Windows and macOS use their default linker and are unaffected.
   - Use `.log_err()` when ignoring but wanting visibility
   - Use `match` or `if let Err(...)` for custom logic
 - Ensure async errors propagate to UI so users get meaningful feedback
+- For user-visible operation failures (storage, network, driver, config), use `report_error` / `report_error_async` from `dbflux_ui_base::user_error` instead of `log::error!` + manual `Toast::error()`. This ensures the status bar badge count is updated and the failure is correlated via UUID v7 in the audit trail.
+  - Foreground context (`&mut App` or `&mut Context<T>`): `report_error(UserFacingError::new(ErrorKind::Storage, msg), cx)`
+  - Async context (`cx.spawn` / background): `report_error_async(UserFacingError::new(ErrorKind::Network, msg), &cx)`
+  - `ErrorKind` variants: `Storage`, `Network`, `Auth`, `Hook`, `Driver`, `User`, `Config`
 
 ### File Organization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,15 +66,23 @@ manager. Windows and macOS use their default linker and are unaffected.
 
 - Avoid `unwrap()` and functions that panic; use `?` to propagate errors
 - Be careful with indexing operations that may panic on out-of-bounds
-- Never silently discard errors with `let _ =` on fallible operations:
-  - Propagate with `?` when the caller should handle them
-  - Use `.log_err()` when ignoring but wanting visibility
-  - Use `match` or `if let Err(...)` for custom logic
-- Ensure async errors propagate to UI so users get meaningful feedback
-- For user-visible operation failures (storage, network, driver, config), use `report_error` / `report_error_async` from `dbflux_ui_base::user_error` instead of `log::error!` + manual `Toast::error()`. This ensures the status bar badge count is updated and the failure is correlated via UUID v7 in the audit trail.
-  - Foreground context (`&mut App` or `&mut Context<T>`): `report_error(UserFacingError::new(ErrorKind::Storage, msg), cx)`
-  - Async context (`cx.spawn` / background): `report_error_async(UserFacingError::new(ErrorKind::Network, msg), &cx)`
-  - `ErrorKind` variants: `Storage`, `Network`, `Auth`, `Hook`, `Driver`, `User`, `Config`
+- **Never use `let _ =` on a fallible expression.** Silently discarding `Result` / `Option` errors hides real failures from users, logs, and the audit trail. This rule has no exceptions for "fire and forget" — pick one of the alternatives below instead:
+  - **Propagate** with `?` when the caller should handle it.
+  - **Log** with `.log_err()` (from `dbflux_core`) when ignoring but wanting at least one stderr/audit trace.
+  - **Branch explicitly** with `match` / `if let Err(e) = ...` when you need custom logic.
+  - **Surface to the user** with `report_error` / `report_error_async` (`dbflux_ui_base::user_error`) when the failure is something the user just triggered. Producing a toast + audit row is preferred over `log::error!` for any user-facing operation; this also drives the status-bar error badge.
+  - If you genuinely want to drop a value — not an error — bind it to `_name` instead of `_`. Reserve the bare `let _ =` pattern for that intent only.
+- Ensure async errors propagate to the UI so users get meaningful feedback. Background tasks that fail without a path to the foreground are a bug, not a feature.
+
+#### User-facing error reporting (`dbflux_ui_base::user_error`)
+
+When a user-triggered operation fails (storage, network, driver, config, hook, auth), route it through the centralized seam instead of `log::error!` + manual `Toast::error(...)`. The seam attaches a UUID v7 correlation id to the toast and the audit row, drives the status-bar error badge, and provides a "View in Audit" action wired to that correlation id.
+
+- Foreground (`&mut App` / `&mut Context<T>`): `report_error(UserFacingError::new(ErrorKind::Storage, msg), cx)`
+- Background (`cx.spawn(async ...)` / `background_executor`): `report_error_async(UserFacingError::new(ErrorKind::Network, msg), &cx)`
+- Driver errors: prefer `UserFacingError::from_formatted(ErrorKind::Driver, fe)` so the driver's `ErrorFormatter` output feeds `cause` directly — keeps the UI driver-agnostic.
+- `ErrorKind` variants: `Storage`, `Network`, `Auth`, `Hook`, `Driver`, `User`, `Config`.
+- Convention: only the **first catch site** reports. Propagators above must NOT re-report — there is no runtime deduplication, double-toasts are a code-review concern.
 
 ### File Organization
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,6 +2953,7 @@ dependencies = [
  "rusqlite",
  "serde_json",
  "tempfile",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ rfd = "0.17"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-uuid = { version = "1", features = ["v4", "v5", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "v7", "serde"] }
 thiserror = "2"
 dirs = "5"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/dbflux_core/src/observability/mod.rs
+++ b/crates/dbflux_core/src/observability/mod.rs
@@ -57,7 +57,12 @@ pub use types::{
 /// Call sites MUST use this function — never inline the `tracing::error!`
 /// call — to guarantee the field set remains consistent with the bridge.
 #[cfg(feature = "tracing-bridge")]
-pub fn emit_user_error_event(level: tracing::Level, summary: &str, correlation_id: &str, kind: &str) {
+pub fn emit_user_error_event(
+    level: tracing::Level,
+    summary: &str,
+    correlation_id: &str,
+    kind: &str,
+) {
     match level {
         tracing::Level::WARN => tracing::warn!(
             target: "dbflux_ui::user_error",

--- a/crates/dbflux_core/src/observability/mod.rs
+++ b/crates/dbflux_core/src/observability/mod.rs
@@ -46,39 +46,3 @@ pub use types::{
     AuditQuerySource, EventActorType, EventCapturePolicy, EventCategory, EventObjectRef,
     EventOutcome, EventRecord, EventRetentionPolicy, EventSeverity, EventSourceId,
 };
-
-/// Emits a structured tracing event for a user-facing error.
-///
-/// This helper centralises the field-name contract for user-error events so
-/// that `AuditFieldVisitor` and call sites stay in sync without duplication.
-/// The `correlation_id` field is captured by `AuditFieldVisitor` and written
-/// directly to `EventRecord.correlation_id` (not `details_json`).
-///
-/// Call sites MUST use this function — never inline the `tracing::error!`
-/// call — to guarantee the field set remains consistent with the bridge.
-#[cfg(feature = "tracing-bridge")]
-pub fn emit_user_error_event(
-    level: tracing::Level,
-    summary: &str,
-    correlation_id: &str,
-    kind: &str,
-) {
-    match level {
-        tracing::Level::WARN => tracing::warn!(
-            target: "dbflux_ui::user_error",
-            correlation_id = %correlation_id,
-            kind            = %kind,
-            outcome         = "failure",
-            action          = "user_error",
-            "{summary}",
-        ),
-        _ => tracing::error!(
-            target: "dbflux_ui::user_error",
-            correlation_id = %correlation_id,
-            kind            = %kind,
-            outcome         = "failure",
-            action          = "user_error",
-            "{summary}",
-        ),
-    }
-}

--- a/crates/dbflux_core/src/observability/mod.rs
+++ b/crates/dbflux_core/src/observability/mod.rs
@@ -46,3 +46,34 @@ pub use types::{
     AuditQuerySource, EventActorType, EventCapturePolicy, EventCategory, EventObjectRef,
     EventOutcome, EventRecord, EventRetentionPolicy, EventSeverity, EventSourceId,
 };
+
+/// Emits a structured tracing event for a user-facing error.
+///
+/// This helper centralises the field-name contract for user-error events so
+/// that `AuditFieldVisitor` and call sites stay in sync without duplication.
+/// The `correlation_id` field is captured by `AuditFieldVisitor` and written
+/// directly to `EventRecord.correlation_id` (not `details_json`).
+///
+/// Call sites MUST use this function — never inline the `tracing::error!`
+/// call — to guarantee the field set remains consistent with the bridge.
+#[cfg(feature = "tracing-bridge")]
+pub fn emit_user_error_event(level: tracing::Level, summary: &str, correlation_id: &str, kind: &str) {
+    match level {
+        tracing::Level::WARN => tracing::warn!(
+            target: "dbflux_ui::user_error",
+            correlation_id = %correlation_id,
+            kind            = %kind,
+            outcome         = "failure",
+            action          = "user_error",
+            "{summary}",
+        ),
+        _ => tracing::error!(
+            target: "dbflux_ui::user_error",
+            correlation_id = %correlation_id,
+            kind            = %kind,
+            outcome         = "failure",
+            action          = "user_error",
+            "{summary}",
+        ),
+    }
+}

--- a/crates/dbflux_core/src/observability/tracing_bridge/layer.rs
+++ b/crates/dbflux_core/src/observability/tracing_bridge/layer.rs
@@ -264,11 +264,14 @@ impl Visit for AuditFieldVisitor {
         let name = field.name();
         if name == "message" {
             self.message = Some(format!("{value:?}").trim_matches('"').to_owned());
-        } else {
-            let string_value = format!("{value:?}");
-            self.extra_fields
-                .insert(name.to_owned(), serde_json::Value::String(string_value));
+            return;
         }
+
+        // Strip the surrounding `"..."` that Debug adds for string-like values
+        // so the % / Display sigil round-trips into the typed slots cleanly.
+        let raw = format!("{value:?}");
+        let string_value = raw.trim_matches('"').to_owned();
+        self.record_string_by_name(name, string_value);
     }
 
     fn record_f64(&mut self, field: &Field, value: f64) {

--- a/crates/dbflux_core/src/observability/tracing_bridge/layer.rs
+++ b/crates/dbflux_core/src/observability/tracing_bridge/layer.rs
@@ -177,6 +177,10 @@ fn build_record(event: &tracing::Event<'_>) -> Option<EventRecord> {
         }
     }
 
+    if let Some(cid) = visitor.correlation_id {
+        record.correlation_id = Some(cid);
+    }
+
     if let Some(details_json_raw) = visitor.details_json {
         record = record.with_details_json(details_json_raw);
     } else if !visitor.extra_fields.is_empty() || overflow_message.is_some() {
@@ -233,6 +237,8 @@ fn parse_actor_type(s: &str) -> Option<EventActorType> {
 /// Visits tracing event fields and extracts known named fields into typed slots.
 ///
 /// Unknown fields accumulate in `extra_fields` for inclusion in `details_json`.
+/// The `correlation_id` slot is populated explicitly so the value lands in
+/// `EventRecord.correlation_id` rather than in `details_json`/`extra_fields`.
 #[derive(Default)]
 struct AuditFieldVisitor {
     pub category: Option<String>,
@@ -245,6 +251,7 @@ struct AuditFieldVisitor {
     pub outcome: Option<String>,
     pub details_json: Option<String>,
     pub message: Option<String>,
+    pub correlation_id: Option<String>,
     pub extra_fields: serde_json::Map<String, serde_json::Value>,
 }
 
@@ -295,7 +302,11 @@ impl Visit for AuditFieldVisitor {
 
 impl AuditFieldVisitor {
     fn record_string(&mut self, field: &Field, value: String) {
-        match field.name() {
+        self.record_string_by_name(field.name(), value);
+    }
+
+    fn record_string_by_name(&mut self, name: &str, value: String) {
+        match name {
             "message" => self.message = Some(value),
             "category" => self.category = Some(value),
             "actor_type" => self.actor_type = Some(value),
@@ -306,6 +317,7 @@ impl AuditFieldVisitor {
             "action" => self.action = Some(value),
             "outcome" => self.outcome = Some(value),
             "details_json" => self.details_json = Some(value),
+            "correlation_id" => self.correlation_id = Some(value),
             other => {
                 self.extra_fields
                     .insert(other.to_owned(), serde_json::Value::String(value));
@@ -317,6 +329,37 @@ impl AuditFieldVisitor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -- M1-T1: AuditFieldVisitor correlation_id extraction tests --
+
+    #[test]
+    fn visitor_captures_correlation_id_into_slot_not_extra_fields() {
+        let mut visitor = AuditFieldVisitor::default();
+
+        visitor.record_string_by_name("correlation_id", "0192cf4a-dead-7000-beef-000000000001".to_owned());
+
+        assert_eq!(
+            visitor.correlation_id.as_deref(),
+            Some("0192cf4a-dead-7000-beef-000000000001"),
+            "correlation_id must land in the dedicated slot"
+        );
+        assert!(
+            !visitor.extra_fields.contains_key("correlation_id"),
+            "correlation_id must NOT appear in extra_fields"
+        );
+    }
+
+    #[test]
+    fn visitor_other_unknown_fields_go_to_extra_fields() {
+        let mut visitor = AuditFieldVisitor::default();
+        visitor.record_string_by_name("some_custom_field", "some_value".to_owned());
+
+        assert!(
+            visitor.extra_fields.contains_key("some_custom_field"),
+            "unknown fields still go to extra_fields"
+        );
+        assert!(visitor.correlation_id.is_none());
+    }
 
     #[test]
     fn passes_level_gate_filters_debug_and_trace() {

--- a/crates/dbflux_core/src/observability/tracing_bridge/layer.rs
+++ b/crates/dbflux_core/src/observability/tracing_bridge/layer.rs
@@ -336,7 +336,10 @@ mod tests {
     fn visitor_captures_correlation_id_into_slot_not_extra_fields() {
         let mut visitor = AuditFieldVisitor::default();
 
-        visitor.record_string_by_name("correlation_id", "0192cf4a-dead-7000-beef-000000000001".to_owned());
+        visitor.record_string_by_name(
+            "correlation_id",
+            "0192cf4a-dead-7000-beef-000000000001".to_owned(),
+        );
 
         assert_eq!(
             visitor.correlation_id.as_deref(),

--- a/crates/dbflux_core/tests/bridge_correlation_id.rs
+++ b/crates/dbflux_core/tests/bridge_correlation_id.rs
@@ -1,0 +1,88 @@
+/// Round-trip integration test for the tracing-to-audit bridge correlation_id
+/// extraction (REQ-UE-8, SC-6).
+///
+/// Verifies that a `tracing::error!(correlation_id = ..., ...)` event arrives at
+/// the audit sink with the value populated on `EventRecord.correlation_id` —
+/// NOT buried inside `details_json`. Without this contract the "View in Audit"
+/// toast action and the badge-click correlation filter would silently return
+/// no rows.
+#[cfg(feature = "tracing-bridge")]
+mod correlation_id_round_trip {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use dbflux_core::observability::source::{EventSink, EventSinkError};
+    use dbflux_core::observability::tracing_bridge::{BridgeConfig, FmtWriter, init_tracing};
+    use dbflux_core::observability::{EventRecord, EventSeverity};
+
+    struct CapturingSink {
+        events: Arc<Mutex<Vec<EventRecord>>>,
+    }
+
+    impl EventSink for CapturingSink {
+        fn record(&self, event: EventRecord) -> Result<EventRecord, EventSinkError> {
+            self.events.lock().unwrap().push(event.clone());
+            Ok(event)
+        }
+    }
+
+    #[test]
+    fn correlation_id_is_extracted_into_event_record_slot() {
+        let handle = init_tracing(BridgeConfig {
+            include_audit_layer: true,
+            fmt_writer: FmtWriter::Stderr,
+            min_level: EventSeverity::Info,
+            env_filter_default: "info",
+            ..BridgeConfig::default()
+        })
+        .expect("tracing subscriber init failed");
+
+        let events: Arc<Mutex<Vec<EventRecord>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = CapturingSink {
+            events: events.clone(),
+        };
+        handle
+            .install_sink(Arc::new(sink))
+            .expect("sink install failed");
+
+        let expected_id = "01952f7a-c8de-7000-8000-000000000001";
+
+        // The bridge gates on `target.starts_with("dbflux")`; this is also the
+        // exact target that `report_error` uses in production.
+        tracing::error!(
+            target: "dbflux_ui::user_error",
+            correlation_id = %expected_id,
+            kind            = "storage",
+            outcome         = "failure",
+            action          = "user_error",
+            "round-trip test event",
+        );
+
+        // Give the drain thread time to forward the record to the sink.
+        std::thread::sleep(Duration::from_millis(200));
+
+        let captured = events.lock().unwrap();
+        let matching: Vec<&EventRecord> = captured
+            .iter()
+            .filter(|e| e.correlation_id.as_deref() == Some(expected_id))
+            .collect();
+
+        assert_eq!(
+            matching.len(),
+            1,
+            "expected exactly one event with correlation_id = {expected_id}; got {} captured events overall",
+            captured.len()
+        );
+
+        let record = matching[0];
+
+        // correlation_id must land on the typed slot, not in details_json.
+        if let Some(details) = record.details_json.as_deref() {
+            assert!(
+                !details.contains(expected_id),
+                "correlation_id leaked into details_json: {details}"
+            );
+        }
+    }
+}

--- a/crates/dbflux_ui/src/ui/views/status_bar.rs
+++ b/crates/dbflux_ui/src/ui/views/status_bar.rs
@@ -294,30 +294,29 @@ impl Render for StatusBar {
                     .flex_shrink_0()
                     .items_center()
                     .when(unread > 0, |this| {
-                        this.child(Self::vertical_divider(divider_color))
-                            .child(
-                                div()
-                                    .id("error-badge")
-                                    .flex()
-                                    .items_center()
-                                    .gap_1()
-                                    .px(px(10.0))
-                                    .h(px(22.0))
-                                    .cursor_pointer()
-                                    .hover(|s| s.bg(cx.theme().secondary))
-                                    .child(
-                                        Icon::new(crate::ui::icons::AppIcon::CircleAlert)
-                                            .size(Heights::ICON_SM)
-                                            .color(SemBannerColors::for_current(cx).error_fg),
-                                    )
-                                    .child(Self::metadata_text(unread.to_string()))
-                                    .on_click(cx.listener(|this, _, _, cx| {
-                                        this.app_state.update(cx, |s, cx| {
-                                            s.clear_unread_errors(cx);
-                                        });
-                                        cx.emit(OpenAuditWithCorrelation(None));
-                                    })),
-                            )
+                        this.child(Self::vertical_divider(divider_color)).child(
+                            div()
+                                .id("error-badge")
+                                .flex()
+                                .items_center()
+                                .gap_1()
+                                .px(px(10.0))
+                                .h(px(22.0))
+                                .cursor_pointer()
+                                .hover(|s| s.bg(cx.theme().secondary))
+                                .child(
+                                    Icon::new(crate::ui::icons::AppIcon::CircleAlert)
+                                        .size(Heights::ICON_SM)
+                                        .color(SemBannerColors::for_current(cx).error_fg),
+                                )
+                                .child(Self::metadata_text(unread.to_string()))
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    this.app_state.update(cx, |s, cx| {
+                                        s.clear_unread_errors(cx);
+                                    });
+                                    cx.emit(OpenAuditWithCorrelation(None));
+                                })),
+                        )
                     })
                     .child(Self::vertical_divider(divider_color))
                     .child(

--- a/crates/dbflux_ui/src/ui/views/status_bar.rs
+++ b/crates/dbflux_ui/src/ui/views/status_bar.rs
@@ -1,14 +1,22 @@
 use crate::app::{AppStateChanged, AppStateEntity};
 use crate::ui::theme::ghost_border_color;
 use dbflux_components::primitives::{Icon, StatusDot, StatusDotVariant};
-use dbflux_components::tokens::{Anim, ChromeColors, FontSizes};
+use dbflux_components::semantic::BannerColors as SemBannerColors;
+use dbflux_components::tokens::{Anim, ChromeColors, FontSizes, Heights};
 use dbflux_components::typography::{MonoCaption, MonoMeta};
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::ActiveTheme;
 use std::time::Duration;
+use uuid::Uuid;
 
 pub struct ToggleTasksPanel;
+
+/// Emitted by `StatusBar` when the user clicks the error badge.
+///
+/// The workspace subscribes to this and calls `open_audit_viewer_with_correlation`.
+/// `None` means "open the audit viewer with the default user-error filter".
+pub struct OpenAuditWithCorrelation(pub Option<Uuid>);
 
 pub struct StatusBar {
     app_state: Entity<AppStateEntity>,
@@ -22,6 +30,7 @@ pub struct StatusBar {
 }
 
 impl EventEmitter<ToggleTasksPanel> for StatusBar {}
+impl EventEmitter<OpenAuditWithCorrelation> for StatusBar {}
 
 impl StatusBar {
     pub fn new(
@@ -212,6 +221,7 @@ impl Render for StatusBar {
         };
 
         let divider_color = ChromeColors::ghost_border();
+        let unread = app_state.unread_error_count;
 
         div()
             .flex()
@@ -277,12 +287,38 @@ impl Render for StatusBar {
                         )
                     }),
             )
-            // Right section: tasks toggle
+            // Right section: error badge (when present) + tasks toggle
             .child(
                 div()
                     .flex()
                     .flex_shrink_0()
                     .items_center()
+                    .when(unread > 0, |this| {
+                        this.child(Self::vertical_divider(divider_color))
+                            .child(
+                                div()
+                                    .id("error-badge")
+                                    .flex()
+                                    .items_center()
+                                    .gap_1()
+                                    .px(px(10.0))
+                                    .h(px(22.0))
+                                    .cursor_pointer()
+                                    .hover(|s| s.bg(cx.theme().secondary))
+                                    .child(
+                                        Icon::new(crate::ui::icons::AppIcon::CircleAlert)
+                                            .size(Heights::ICON_SM)
+                                            .color(SemBannerColors::for_current(cx).error_fg),
+                                    )
+                                    .child(Self::metadata_text(unread.to_string()))
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.app_state.update(cx, |s, cx| {
+                                            s.clear_unread_errors(cx);
+                                        });
+                                        cx.emit(OpenAuditWithCorrelation(None));
+                                    })),
+                            )
+                    })
                     .child(Self::vertical_divider(divider_color))
                     .child(
                         div()

--- a/crates/dbflux_ui/src/ui/views/status_bar.rs
+++ b/crates/dbflux_ui/src/ui/views/status_bar.rs
@@ -8,15 +8,8 @@ use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::ActiveTheme;
 use std::time::Duration;
-use uuid::Uuid;
 
 pub struct ToggleTasksPanel;
-
-/// Emitted by `StatusBar` when the user clicks the error badge.
-///
-/// The workspace subscribes to this and calls `open_audit_viewer_with_correlation`.
-/// `None` means "open the audit viewer with the default user-error filter".
-pub struct OpenAuditWithCorrelation(pub Option<Uuid>);
 
 pub struct StatusBar {
     app_state: Entity<AppStateEntity>,
@@ -30,7 +23,6 @@ pub struct StatusBar {
 }
 
 impl EventEmitter<ToggleTasksPanel> for StatusBar {}
-impl EventEmitter<OpenAuditWithCorrelation> for StatusBar {}
 
 impl StatusBar {
     pub fn new(
@@ -313,8 +305,8 @@ impl Render for StatusBar {
                                 .on_click(cx.listener(|this, _, _, cx| {
                                     this.app_state.update(cx, |s, cx| {
                                         s.clear_unread_errors(cx);
+                                        s.request_open_audit(None, cx);
                                     });
-                                    cx.emit(OpenAuditWithCorrelation(None));
                                 })),
                         )
                     })

--- a/crates/dbflux_ui/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions.rs
@@ -236,6 +236,66 @@ impl Workspace {
             .push(cx);
     }
 
+    /// Opens (or focuses) the audit viewer pre-filtered by correlation id.
+    ///
+    /// When an audit tab is already open, the correlation filter is applied to
+    /// the existing tab and it is brought to focus. When `correlation_id` is
+    /// `None`, the audit viewer opens with the default user-error filter
+    /// (`action = "user_error"`). When no tab is open and a specific id was
+    /// provided, a new tab is created pre-filtered by that id.
+    pub(super) fn open_audit_viewer_with_correlation(
+        &mut self,
+        correlation_id: Option<uuid::Uuid>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        use crate::ui::document::AuditDocument;
+        use crate::ui::document::DocumentKey;
+
+        let existing_id = self
+            .tab_manager
+            .read(cx)
+            .find_by_key(&DocumentKey::Audit, cx);
+
+        if let Some(id) = existing_id {
+            self.tab_manager.update(cx, |mgr, cx| {
+                if let Some(tab) = mgr.documents().iter().find(|t| t.id() == id) {
+                    let pane = tab.as_pane();
+                    if let Some(f) = &pane.set_correlation_filter {
+                        f(correlation_id.map(|u| u.to_string()), cx);
+                    }
+                }
+                mgr.activate(id, cx);
+            });
+
+            self.set_focus(crate::keymap::FocusTarget::Document, window, cx);
+            return;
+        }
+
+        match correlation_id {
+            Some(id) => {
+                let doc = cx.new(|cx| {
+                    AuditDocument::new_with_correlation_id(
+                        id,
+                        self.app_state.clone(),
+                        window,
+                        cx,
+                    )
+                });
+                let pane = AuditDocument::into_pane(doc, cx);
+                self.tab_manager.update(cx, |mgr, cx| {
+                    mgr.open(Tab::Pane(Box::new(pane)), cx);
+                });
+            }
+            None => {
+                self.open_audit_viewer(window, cx);
+                return;
+            }
+        }
+
+        self.set_focus(crate::keymap::FocusTarget::Document, window, cx);
+    }
+
     /// Opens a `ChartDocument` pre-populated with the metric selected in the
     /// sidebar and immediately executes it.
     ///

--- a/crates/dbflux_ui/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::platform;
 use dbflux_core::{DriverCapabilities, DriverMetadata};
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error, report_error_async};
 
 /// Returns `true` when the given driver metadata advertises the `METRIC_SERIES`
 /// capability, meaning the driver can execute `MetricQuery` requests.
@@ -275,12 +276,7 @@ impl Workspace {
         match correlation_id {
             Some(id) => {
                 let doc = cx.new(|cx| {
-                    AuditDocument::new_with_correlation_id(
-                        id,
-                        self.app_state.clone(),
-                        window,
-                        cx,
-                    )
+                    AuditDocument::new_with_correlation_id(id, self.app_state.clone(), window, cx)
                 });
                 let pane = AuditDocument::into_pane(doc, cx);
                 self.tab_manager.update(cx, |mgr, cx| {
@@ -381,7 +377,13 @@ impl Workspace {
     pub(super) fn refresh_mcp_governance(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         self.app_state.update(cx, |state, cx| {
             if let Err(e) = state.persist_mcp_governance() {
-                log::error!("Failed to persist MCP governance: {}", e);
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Config,
+                        format!("Failed to persist MCP governance: {e}"),
+                    ),
+                    cx,
+                );
                 return;
             }
 
@@ -447,7 +449,13 @@ impl Workspace {
                     });
                 }
                 Err(e) => {
-                    log::error!("Failed to refresh schema: {:?}", e);
+                    report_error(
+                        UserFacingError::new(
+                            ErrorKind::Driver,
+                            format!("Failed to refresh schema: {e}"),
+                        ),
+                        cx,
+                    );
                 }
             }) {
                 log::warn!(
@@ -920,7 +928,13 @@ impl Workspace {
             let content = match content {
                 Ok(c) => c,
                 Err(e) => {
-                    log::error!("Failed to read file {}: {}", path.display(), e);
+                    report_error_async(
+                        UserFacingError::new(
+                            ErrorKind::Storage,
+                            format!("Failed to read file {}: {e}", path.display()),
+                        ),
+                        cx,
+                    );
                     return;
                 }
             };
@@ -972,7 +986,13 @@ impl Workspace {
             let content = match content {
                 Ok(c) => c,
                 Err(e) => {
-                    log::error!("Failed to read file {}: {}", path.display(), e);
+                    report_error_async(
+                        UserFacingError::new(
+                            ErrorKind::Storage,
+                            format!("Failed to read file {}: {e}", path.display()),
+                        ),
+                        cx,
+                    );
                     return;
                 }
             };
@@ -1329,7 +1349,13 @@ impl Workspace {
         if let Some(path) = script_path {
             let content = doc.read(cx).build_file_content(cx);
             if let Err(e) = std::fs::write(&path, &content) {
-                log::error!("Failed to write initial script content: {}", e);
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Storage,
+                        format!("Failed to write initial script content: {e}"),
+                    ),
+                    cx,
+                );
             }
         }
 
@@ -1757,10 +1783,10 @@ impl Workspace {
                 // Validate before allocating an entity — from_saved checks the source variant.
                 let validation = crate::ui::document::ChartDocument::validate_saved_source(&chart);
                 if let Err(e) = validation {
-                    log::error!("Failed to open saved chart: {e}");
-                    Toast::error(format!("Cannot open chart: {e}"))
-                        .meta_right(now_hms())
-                        .push(cx);
+                    report_error(
+                        UserFacingError::new(ErrorKind::Storage, format!("Cannot open chart: {e}")),
+                        cx,
+                    );
                     return;
                 }
 
@@ -2065,7 +2091,7 @@ impl Workspace {
         let (profile_id, specs) = match import_result {
             Ok(v) => v,
             Err(e) => {
-                Toast::error(e).meta_right(now_hms()).push(cx);
+                report_error(UserFacingError::new(ErrorKind::Driver, e), cx);
                 return;
             }
         };
@@ -2245,9 +2271,13 @@ impl Workspace {
             });
 
         if let Err((name, message)) = persist_result {
-            Toast::error(format!("Failed to save dashboard '{name}': {message}"))
-                .meta_right(now_hms())
-                .push(cx);
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    format!("Failed to save dashboard '{name}': {message}"),
+                ),
+                cx,
+            );
             return;
         }
 
@@ -2335,7 +2365,8 @@ impl Workspace {
                 let specs = match result {
                     Ok((_body, specs)) => specs,
                     Err(message) => {
-                        return Toast::error(message).meta_right(now_hms()).push(cx);
+                        report_error(UserFacingError::new(ErrorKind::Network, message), cx);
+                        return;
                     }
                 };
 
@@ -2607,10 +2638,13 @@ impl Workspace {
                 self.open_dashboard(dashboard_id, window, cx);
             }
             Err(e) => {
-                log::error!("Failed to create dashboard: {e}");
-                Toast::error(format!("Failed to create dashboard: {e}"))
-                    .meta_right(now_hms())
-                    .push(cx);
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Storage,
+                        format!("Failed to create dashboard: {e}"),
+                    ),
+                    cx,
+                );
             }
         }
     }
@@ -2717,10 +2751,13 @@ impl Workspace {
                 });
             }
             Err(e) => {
-                log::error!("Failed to delete dashboard: {e}");
-                Toast::error(format!("Failed to delete dashboard: {e}"))
-                    .meta_right(now_hms())
-                    .push(cx);
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Storage,
+                        format!("Failed to delete dashboard: {e}"),
+                    ),
+                    cx,
+                );
             }
         }
     }
@@ -2738,10 +2775,13 @@ impl Workspace {
                 });
             }
             Err(e) => {
-                log::error!("Failed to duplicate dashboard: {e}");
-                Toast::error(format!("Failed to duplicate dashboard: {e}"))
-                    .meta_right(now_hms())
-                    .push(cx);
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Storage,
+                        format!("Failed to duplicate dashboard: {e}"),
+                    ),
+                    cx,
+                );
             }
         }
     }
@@ -2807,10 +2847,10 @@ impl Workspace {
                 });
             }
             Err(e) => {
-                log::error!("Failed to rename item: {e}");
-                Toast::error(format!("Failed to rename: {e}"))
-                    .meta_right(now_hms())
-                    .push(cx);
+                report_error(
+                    UserFacingError::new(ErrorKind::Storage, format!("Failed to rename: {e}")),
+                    cx,
+                );
             }
         }
     }
@@ -2885,10 +2925,13 @@ impl Workspace {
                 });
             }
             Err(e) => {
-                log::error!("Failed to delete saved chart: {e}");
-                Toast::error(format!("Failed to delete saved chart: {e}"))
-                    .meta_right(now_hms())
-                    .push(cx);
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Storage,
+                        format!("Failed to delete saved chart: {e}"),
+                    ),
+                    cx,
+                );
             }
         }
     }
@@ -2906,10 +2949,13 @@ impl Workspace {
                 });
             }
             Err(e) => {
-                log::error!("Failed to duplicate saved chart: {e}");
-                Toast::error(format!("Failed to duplicate saved chart: {e}"))
-                    .meta_right(now_hms())
-                    .push(cx);
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Storage,
+                        format!("Failed to duplicate saved chart: {e}"),
+                    ),
+                    cx,
+                );
             }
         }
     }
@@ -3015,9 +3061,13 @@ impl Workspace {
                     Err(err) => {
                         let msg = err.to_string();
                         app_state.update(cx, |state, _| state.fail_task(task_id, msg.clone()));
-                        Toast::error(format!("Failed to load metric namespaces: {msg}"))
-                            .meta_right(now_hms())
-                            .push(cx);
+                        report_error(
+                            UserFacingError::new(
+                                ErrorKind::Network,
+                                format!("Failed to load metric namespaces: {msg}"),
+                            ),
+                            cx,
+                        );
                         modal.update(cx, |m, cx| m.set_metric_namespaces(Vec::new(), cx));
                     }
                 });
@@ -3085,9 +3135,13 @@ impl Workspace {
                 Err(err) => {
                     let msg = err.to_string();
                     app_state.update(cx, |state, _| state.fail_task(task_id, msg.clone()));
-                    Toast::error(format!("Failed to load metrics: {msg}"))
-                        .meta_right(now_hms())
-                        .push(cx);
+                    report_error(
+                        UserFacingError::new(
+                            ErrorKind::Network,
+                            format!("Failed to load metrics: {msg}"),
+                        ),
+                        cx,
+                    );
                     modal.update(cx, |m, cx| {
                         m.set_metrics_for_namespace(namespace, Vec::new(), cx);
                     });
@@ -3165,9 +3219,10 @@ impl Workspace {
                 });
             }
             Err(e) => {
-                Toast::error(format!("Failed to add panel: {e}"))
-                    .meta_right(now_hms())
-                    .push(cx);
+                report_error(
+                    UserFacingError::new(ErrorKind::Storage, format!("Failed to add panel: {e}")),
+                    cx,
+                );
             }
         }
     }
@@ -3299,9 +3354,10 @@ impl Workspace {
                 });
             }
             Err(e) => {
-                Toast::error(format!("Failed to add panel: {e}"))
-                    .meta_right(now_hms())
-                    .push(cx);
+                report_error(
+                    UserFacingError::new(ErrorKind::Storage, format!("Failed to add panel: {e}")),
+                    cx,
+                );
             }
         }
     }
@@ -3332,10 +3388,10 @@ impl Workspace {
                 });
             }
             Err(e) => {
-                log::error!("Failed to add panels: {e}");
-                Toast::error(format!("Failed to add panels: {e}"))
-                    .meta_right(now_hms())
-                    .push(cx);
+                report_error(
+                    UserFacingError::new(ErrorKind::Storage, format!("Failed to add panels: {e}")),
+                    cx,
+                );
             }
         }
     }

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -7,9 +7,9 @@ mod render;
 pub use inspector::{WorkspaceInspector, WorkspaceInspectorEvent};
 
 use crate::app::{AppStateChanged, AppStateEntity};
-use dbflux_ui_base::AppStateGlobal;
 use dbflux_components;
 use dbflux_core::observability::actions::CONFIG_CHANGE;
+use dbflux_ui_base::AppStateGlobal;
 use dbflux_ui_base::modals::{
     AddPanelOutcome, AddPanelRequest, CreateDashboardOutcome, CreateDashboardRequest,
     DeleteDashboardOutcome, DeleteDashboardRequest, DeleteSavedChartOutcome,

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -9,7 +9,6 @@ pub use inspector::{WorkspaceInspector, WorkspaceInspectorEvent};
 use crate::app::{AppStateChanged, AppStateEntity};
 use dbflux_components;
 use dbflux_core::observability::actions::CONFIG_CHANGE;
-use dbflux_ui_base::AppStateGlobal;
 use dbflux_ui_base::modals::{
     AddPanelOutcome, AddPanelRequest, CreateDashboardOutcome, CreateDashboardRequest,
     DeleteDashboardOutcome, DeleteDashboardRequest, DeleteSavedChartOutcome,
@@ -17,6 +16,7 @@ use dbflux_ui_base::modals::{
     ModalDeleteDashboardConfirm, ModalDeleteSavedChartConfirm, ModalRenameItem, RenameItemOutcome,
     RenameItemRequest, RenameTarget, RequestMetricsForNamespace,
 };
+use dbflux_ui_base::{AppStateGlobal, OpenAuditRequested};
 
 #[cfg(feature = "mcp")]
 use crate::app::McpRuntimeEventRaised;
@@ -43,7 +43,7 @@ use crate::ui::overlays::sql_preview_modal::SqlPreviewModal;
 use crate::ui::overlays::sso_wizard::{SsoWizard, SsoWizardEvent};
 use crate::ui::tokens::{Heights, Radii, Spacing};
 use crate::ui::views::sidebar::{Sidebar, SidebarEvent, SidebarTab};
-use crate::ui::views::status_bar::{OpenAuditWithCorrelation, StatusBar, ToggleTasksPanel};
+use crate::ui::views::status_bar::{StatusBar, ToggleTasksPanel};
 use crate::ui::views::tasks_panel::TasksPanel;
 use crate::ui::windows::connection_manager::ConnectionManagerWindow;
 #[cfg(test)]
@@ -509,9 +509,9 @@ impl Workspace {
         .detach();
 
         cx.subscribe_in(
-            &status_bar,
+            &app_state,
             window,
-            |this, _, event: &OpenAuditWithCorrelation, window, cx| {
+            |this, _, event: &OpenAuditRequested, window, cx| {
                 this.open_audit_viewer_with_correlation(event.0, window, cx);
             },
         )

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -7,6 +7,7 @@ mod render;
 pub use inspector::{WorkspaceInspector, WorkspaceInspectorEvent};
 
 use crate::app::{AppStateChanged, AppStateEntity};
+use dbflux_ui_base::AppStateGlobal;
 use dbflux_components;
 use dbflux_core::observability::actions::CONFIG_CHANGE;
 use dbflux_ui_base::modals::{
@@ -42,7 +43,7 @@ use crate::ui::overlays::sql_preview_modal::SqlPreviewModal;
 use crate::ui::overlays::sso_wizard::{SsoWizard, SsoWizardEvent};
 use crate::ui::tokens::{Heights, Radii, Spacing};
 use crate::ui::views::sidebar::{Sidebar, SidebarEvent, SidebarTab};
-use crate::ui::views::status_bar::{StatusBar, ToggleTasksPanel};
+use crate::ui::views::status_bar::{OpenAuditWithCorrelation, StatusBar, ToggleTasksPanel};
 use crate::ui::views::tasks_panel::TasksPanel;
 use crate::ui::windows::connection_manager::ConnectionManagerWindow;
 #[cfg(test)]
@@ -338,6 +339,9 @@ impl Workspace {
         cx.set_global(ToastGlobal {
             host: toast_host.clone(),
         });
+        cx.set_global(AppStateGlobal {
+            entity: app_state.clone(),
+        });
 
         let sidebar = cx.new(|cx| Sidebar::new(app_state.clone(), window, cx));
         let sidebar_dock = cx.new(|cx| SidebarDock::new(sidebar.clone(), cx));
@@ -502,6 +506,15 @@ impl Workspace {
         cx.subscribe(&status_bar, |this, _, _: &ToggleTasksPanel, cx| {
             this.toggle_tasks_panel(cx);
         })
+        .detach();
+
+        cx.subscribe_in(
+            &status_bar,
+            window,
+            |this, _, event: &OpenAuditWithCorrelation, window, cx| {
+                this.open_audit_viewer_with_correlation(event.0, window, cx);
+            },
+        )
         .detach();
 
         cx.subscribe_in(

--- a/crates/dbflux_ui_base/Cargo.toml
+++ b/crates/dbflux_ui_base/Cargo.toml
@@ -19,6 +19,7 @@ dbflux_components.workspace = true
 dbflux_core.workspace = true
 dbflux_mcp = { workspace = true, optional = true }
 dbflux_aws = { workspace = true, optional = true }
+tracing.workspace = true
 uuid.workspace = true
 log.workspace = true
 anyhow = "1"

--- a/crates/dbflux_ui_base/src/app_state_entity.rs
+++ b/crates/dbflux_ui_base/src/app_state_entity.rs
@@ -6,8 +6,9 @@
 use std::sync::Arc;
 
 use dbflux_app::AppState;
+use dbflux_core::observability::EventSeverity;
 use dbflux_storage::bootstrap::StorageRuntime;
-use gpui::{EventEmitter, WindowHandle};
+use gpui::{Entity, EventEmitter, Global, WindowHandle};
 use gpui_component::Root;
 use uuid::Uuid;
 
@@ -20,6 +21,16 @@ use crate::saved_chart_manager::SavedChartManager;
 
 /// Emitted when the app state changes in ways that require UI updates.
 pub struct AppStateChanged;
+
+/// Emitted each time `report_error` fires for a new user-facing failure.
+///
+/// Subscribers (e.g., `StatusBar`) use this to update the unread-error badge
+/// without depending on `AppStateChanged` polling.
+#[derive(Clone, Copy)]
+pub struct UserErrorReported {
+    pub correlation_id: Uuid,
+    pub severity: EventSeverity,
+}
 
 /// Emitted when an auth profile is created (used to update the sidebar).
 #[derive(Clone)]
@@ -74,6 +85,11 @@ pub struct AppStateEntity {
     /// Picked up by the sidebar on `AppStateChanged` to drive
     /// disconnect + connect for that profile.
     pub pending_reconnect_request: Option<Uuid>,
+
+    /// Count of user-facing errors reported since the last `clear_unread_errors`
+    /// call. Ephemeral — resets to 0 on every app start. The audit log is the
+    /// durable record; this counter only drives the status-bar badge.
+    pub unread_error_count: u32,
 }
 
 impl AppStateEntity {
@@ -98,6 +114,7 @@ impl AppStateEntity {
             dashboards,
             pending_edit_reconnect_prompt: None,
             pending_reconnect_request: None,
+            unread_error_count: 0,
         }
     }
 
@@ -122,7 +139,37 @@ impl AppStateEntity {
             dashboards,
             pending_edit_reconnect_prompt: None,
             pending_reconnect_request: None,
+            unread_error_count: 0,
         }
+    }
+
+    /// Increments the unread-error counter and notifies subscribers.
+    ///
+    /// Called exclusively by `report_error` — no other path should increment
+    /// the counter to avoid double-counting.
+    pub fn note_user_error(
+        &mut self,
+        correlation_id: Uuid,
+        severity: EventSeverity,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        self.unread_error_count = self.unread_error_count.saturating_add(1);
+        cx.emit(UserErrorReported { correlation_id, severity });
+        cx.emit(AppStateChanged);
+        cx.notify();
+    }
+
+    /// Resets the unread-error counter to zero.
+    ///
+    /// Called when the user opens the audit panel via the badge click,
+    /// acknowledging all pending error notifications.
+    pub fn clear_unread_errors(&mut self, cx: &mut gpui::Context<Self>) {
+        if self.unread_error_count == 0 {
+            return;
+        }
+        self.unread_error_count = 0;
+        cx.emit(AppStateChanged);
+        cx.notify();
     }
 }
 
@@ -152,6 +199,21 @@ impl std::ops::DerefMut for AppStateEntity {
 
 impl EventEmitter<AppStateChanged> for AppStateEntity {}
 impl EventEmitter<AuthProfileCreated> for AppStateEntity {}
+impl EventEmitter<UserErrorReported> for AppStateEntity {}
 
 #[cfg(feature = "mcp")]
 impl EventEmitter<McpRuntimeEventRaised> for AppStateEntity {}
+
+// ============================================================================
+// AppStateGlobal — GPUI global wrapper for the AppStateEntity
+// ============================================================================
+
+/// GPUI global that holds the `AppStateEntity` handle so that `report_error`
+/// can reach it without requiring callers to pass the entity explicitly.
+///
+/// Registered in workspace startup via `cx.set_global(AppStateGlobal { entity })`.
+pub struct AppStateGlobal {
+    pub entity: Entity<AppStateEntity>,
+}
+
+impl Global for AppStateGlobal {}

--- a/crates/dbflux_ui_base/src/app_state_entity.rs
+++ b/crates/dbflux_ui_base/src/app_state_entity.rs
@@ -32,6 +32,16 @@ pub struct UserErrorReported {
     pub severity: EventSeverity,
 }
 
+/// Requests that the workspace open the audit document, optionally filtered
+/// by a specific `correlation_id`.
+///
+/// Emitted by the status-bar badge click (with `None`, opens with the default
+/// user-error filter) and by the "View in Audit" action on error toasts (with
+/// the toast's correlation id). Keeping a single event keeps the audit-open
+/// path uniform — the workspace subscribes once.
+#[derive(Clone, Copy)]
+pub struct OpenAuditRequested(pub Option<Uuid>);
+
 /// Emitted when an auth profile is created (used to update the sidebar).
 #[derive(Clone)]
 pub struct AuthProfileCreated {
@@ -162,6 +172,16 @@ impl AppStateEntity {
         cx.notify();
     }
 
+    /// Emits an `OpenAuditRequested` event so the workspace opens (or focuses)
+    /// the audit document with the matching correlation filter.
+    pub fn request_open_audit(
+        &mut self,
+        correlation_id: Option<Uuid>,
+        cx: &mut gpui::Context<Self>,
+    ) {
+        cx.emit(OpenAuditRequested(correlation_id));
+    }
+
     /// Resets the unread-error counter to zero.
     ///
     /// Called when the user opens the audit panel via the badge click,
@@ -203,6 +223,7 @@ impl std::ops::DerefMut for AppStateEntity {
 impl EventEmitter<AppStateChanged> for AppStateEntity {}
 impl EventEmitter<AuthProfileCreated> for AppStateEntity {}
 impl EventEmitter<UserErrorReported> for AppStateEntity {}
+impl EventEmitter<OpenAuditRequested> for AppStateEntity {}
 
 #[cfg(feature = "mcp")]
 impl EventEmitter<McpRuntimeEventRaised> for AppStateEntity {}

--- a/crates/dbflux_ui_base/src/app_state_entity.rs
+++ b/crates/dbflux_ui_base/src/app_state_entity.rs
@@ -154,7 +154,10 @@ impl AppStateEntity {
         cx: &mut gpui::Context<Self>,
     ) {
         self.unread_error_count = self.unread_error_count.saturating_add(1);
-        cx.emit(UserErrorReported { correlation_id, severity });
+        cx.emit(UserErrorReported {
+            correlation_id,
+            severity,
+        });
         cx.emit(AppStateChanged);
         cx.notify();
     }

--- a/crates/dbflux_ui_base/src/lib.rs
+++ b/crates/dbflux_ui_base/src/lib.rs
@@ -18,15 +18,19 @@ pub mod saved_chart_manager;
 pub mod sql_preview_modal;
 pub mod sso_wizard;
 pub mod toast;
+pub mod user_error;
 
 mod style_guardrails;
 
 #[cfg(feature = "mcp")]
 pub use app_state_entity::McpRuntimeEventRaised;
-pub use app_state_entity::{AppStateChanged, AppStateEntity, AuthProfileCreated};
+pub use app_state_entity::{
+    AppStateChanged, AppStateEntity, AppStateGlobal, AuthProfileCreated, UserErrorReported,
+};
 pub use async_ext::AsyncUpdateResultExt;
 pub use dashboard_manager::{
     Dashboard, DashboardManager, DashboardPanel, DashboardPanelDraft, DashboardPanelKind,
 };
 pub use keymap::{default_keymap, key_chord_from_gpui};
 pub use saved_chart_manager::SavedChartManager;
+pub use user_error::{ErrorKind, UserFacingError, report_error, report_error_async};

--- a/crates/dbflux_ui_base/src/lib.rs
+++ b/crates/dbflux_ui_base/src/lib.rs
@@ -25,7 +25,8 @@ mod style_guardrails;
 #[cfg(feature = "mcp")]
 pub use app_state_entity::McpRuntimeEventRaised;
 pub use app_state_entity::{
-    AppStateChanged, AppStateEntity, AppStateGlobal, AuthProfileCreated, UserErrorReported,
+    AppStateChanged, AppStateEntity, AppStateGlobal, AuthProfileCreated, OpenAuditRequested,
+    UserErrorReported,
 };
 pub use async_ext::AsyncUpdateResultExt;
 pub use dashboard_manager::{

--- a/crates/dbflux_ui_base/src/toast.rs
+++ b/crates/dbflux_ui_base/src/toast.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use crate::user_error::throttle::TokenBucket;
+
 use dbflux_components::controls::Button;
 use dbflux_components::icon::IconSource;
 use dbflux_components::primitives::{Icon, IconButton, Text};
@@ -285,6 +287,8 @@ pub struct ToastHost {
     /// Set of toast ids whose collapsible block is currently collapsed.
     collapsed: HashSet<u64>,
     next_id: u64,
+    /// Token bucket for Warning/Info toasts. Error toasts bypass this entirely.
+    warn_info_bucket: TokenBucket,
 }
 
 impl ToastHost {
@@ -293,10 +297,22 @@ impl ToastHost {
             toasts: Vec::new(),
             collapsed: HashSet::new(),
             next_id: 1,
+            warn_info_bucket: TokenBucket::new(),
         }
     }
 
     pub fn push_rich(&mut self, toast: Toast, cx: &mut Context<Self>) {
+        if matches!(toast.kind, ToastKind::Warning | ToastKind::Info)
+            && !self.warn_info_bucket.try_consume()
+        {
+            log::debug!(
+                target: "dbflux_ui::toast",
+                "toast dropped by throttle: kind={:?} title={}",
+                toast.kind, toast.title
+            );
+            return;
+        }
+
         let id = self.next_id;
         self.next_id += 1;
 

--- a/crates/dbflux_ui_base/src/user_error/mod.rs
+++ b/crates/dbflux_ui_base/src/user_error/mod.rs
@@ -1,0 +1,250 @@
+use dbflux_core::FormattedError;
+use dbflux_core::observability::EventSeverity;
+use gpui::{App, AsyncApp};
+use uuid::Uuid;
+
+pub mod throttle;
+
+/// Coarse-grained taxonomy of user-visible failures.
+///
+/// Used for styling, audit `action` discrimination, and badge classification.
+/// The free-form `summary` carries the actionable message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorKind {
+    Storage,
+    Network,
+    Auth,
+    Hook,
+    Driver,
+    User,
+    Config,
+}
+
+impl ErrorKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Storage => "storage",
+            Self::Network => "network",
+            Self::Auth => "auth",
+            Self::Hook => "hook",
+            Self::Driver => "driver",
+            Self::User => "user",
+            Self::Config => "config",
+        }
+    }
+}
+
+/// A user-visible failure with enough context to render a toast and an audit
+/// event that share a correlation id.
+///
+/// Construction is always at the *first catch site*. Propagators above MUST NOT
+/// re-report — there is no runtime deduplication.
+#[derive(Debug, Clone)]
+pub struct UserFacingError {
+    pub kind: ErrorKind,
+    /// Severity drives toast styling and throttle eligibility.
+    /// Default for `UserFacingError::new` is `EventSeverity::Error`.
+    pub severity: EventSeverity,
+    pub summary: String,
+    pub cause: Option<String>,
+    pub suggested_action: Option<String>,
+    pub correlation_id: Uuid,
+}
+
+impl UserFacingError {
+    /// Constructs a new error with `severity = Error` and a freshly generated
+    /// UUID v7 correlation id.
+    pub fn new(kind: ErrorKind, summary: impl Into<String>) -> Self {
+        Self {
+            kind,
+            severity: EventSeverity::Error,
+            summary: summary.into(),
+            cause: None,
+            suggested_action: None,
+            correlation_id: Uuid::now_v7(),
+        }
+    }
+
+    pub fn with_severity(mut self, severity: EventSeverity) -> Self {
+        self.severity = severity;
+        self
+    }
+
+    pub fn with_cause(mut self, cause: impl Into<String>) -> Self {
+        self.cause = Some(cause.into());
+        self
+    }
+
+    pub fn with_suggested_action(mut self, action: impl Into<String>) -> Self {
+        self.suggested_action = Some(action.into());
+        self
+    }
+
+    /// Test-only seam: override the auto-generated correlation id.
+    pub fn with_correlation_id(mut self, id: Uuid) -> Self {
+        self.correlation_id = id;
+        self
+    }
+
+    /// Driver-agnostic constructor: takes the already-formatted output of a
+    /// driver's error formatter. The driver-side formatter call lives in the
+    /// call site (drivers, not UI).
+    pub fn from_formatted(kind: ErrorKind, fe: FormattedError) -> Self {
+        let cause = match (&fe.detail, &fe.hint, &fe.code) {
+            (None, None, None) => None,
+            _ => Some(fe.to_string()),
+        };
+
+        Self {
+            kind,
+            severity: EventSeverity::Error,
+            summary: fe.message,
+            cause,
+            suggested_action: None,
+            correlation_id: Uuid::now_v7(),
+        }
+    }
+}
+
+/// Foreground-only entry point.
+///
+/// MUST be called from the foreground (`&mut App`). Calling from a
+/// `background_executor().spawn()` closure panics — the GPUI global pulled
+/// in for `ToastHost` is foreground-only. Background callers MUST use
+/// `report_error_async` instead.
+///
+/// | Caller context                          | Use                     |
+/// | --------------------------------------- | ----------------------- |
+/// | `&mut Context<T>`, `&mut App`           | `report_error`          |
+/// | Inside `background_executor().spawn()`  | `report_error_async`    |
+/// | Inside `cx.spawn(async ...)`            | `report_error_async`    |
+/// | Inside a `cx.update(|cx| { ... })`      | `report_error`          |
+pub fn report_error(err: UserFacingError, cx: &mut App) {
+    use crate::app_state_entity::AppStateGlobal;
+    use crate::toast::{copy_action, now_hms, Toast};
+
+    let id_str = err.correlation_id.to_string();
+    let kind_str = err.kind.as_str();
+    let summary = &err.summary;
+
+    match err.severity {
+        EventSeverity::Warn => tracing::warn!(
+            target: "dbflux_ui::user_error",
+            correlation_id = %id_str,
+            kind            = %kind_str,
+            outcome         = "failure",
+            action          = "user_error",
+            "{summary}",
+        ),
+        _ => tracing::error!(
+            target: "dbflux_ui::user_error",
+            correlation_id = %id_str,
+            kind            = %kind_str,
+            outcome         = "failure",
+            action          = "user_error",
+            "{summary}",
+        ),
+    }
+
+    let mut toast = match err.severity {
+        EventSeverity::Warn => Toast::warning(err.summary.clone()),
+        _ => Toast::error(err.summary.clone()),
+    };
+
+    if let Some(c) = &err.cause {
+        toast = toast.code_block(c.clone());
+    }
+
+    if let Some(a) = &err.suggested_action {
+        toast = toast.body(a.clone());
+    }
+
+    toast = toast
+        .meta_right(now_hms())
+        .details(format!("Correlation: {id_str}"))
+        .action(copy_action(format!("{summary}\nCorrelation: {id_str}")));
+
+    toast.push(cx);
+
+    if let Some(app_state_global) = cx.try_global::<AppStateGlobal>() {
+        let entity = app_state_global.entity.clone();
+        entity.update(cx, |s, cx| {
+            s.note_user_error(err.correlation_id, err.severity, cx);
+        });
+    }
+}
+
+/// Background-safe entry point. Marshals to the foreground via `cx.update`.
+///
+/// Fire-and-forget: if the foreground has been dropped the call is silently
+/// ignored.
+///
+/// | Caller context                          | Use                     |
+/// | --------------------------------------- | ----------------------- |
+/// | `&mut Context<T>`, `&mut App`           | `report_error`          |
+/// | Inside `background_executor().spawn()`  | `report_error_async`    |
+/// | Inside `cx.spawn(async ...)`            | `report_error_async`    |
+/// | Inside a `cx.update(|cx| { ... })`      | `report_error`          |
+pub fn report_error_async(err: UserFacingError, cx: &AsyncApp) {
+    let cx = cx.clone();
+    let _ = cx.update(move |cx| report_error(err, cx));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_defaults_to_error_severity() {
+        let err = UserFacingError::new(ErrorKind::Driver, "something failed");
+        assert_eq!(err.severity, EventSeverity::Error);
+        assert_eq!(err.kind, ErrorKind::Driver);
+        assert_eq!(err.summary, "something failed");
+        assert!(err.cause.is_none());
+        assert!(err.suggested_action.is_none());
+    }
+
+    #[test]
+    fn with_correlation_id_overrides_generated_uuid() {
+        let known = Uuid::nil();
+        let err = UserFacingError::new(ErrorKind::Storage, "io error")
+            .with_correlation_id(known);
+        assert_eq!(err.correlation_id, known);
+    }
+
+    #[test]
+    fn with_severity_round_trips() {
+        let err = UserFacingError::new(ErrorKind::User, "mild problem")
+            .with_severity(EventSeverity::Warn);
+        assert_eq!(err.severity, EventSeverity::Warn);
+    }
+
+    #[test]
+    fn from_formatted_sets_driver_kind_and_populates_cause() {
+        let fe = FormattedError::new("connection refused")
+            .with_detail("no route to host")
+            .with_code("08006");
+        let err = UserFacingError::from_formatted(ErrorKind::Driver, fe);
+        assert_eq!(err.kind, ErrorKind::Driver);
+        assert_eq!(err.summary, "connection refused");
+        assert!(err.cause.is_some(), "cause must be populated from detail/code");
+    }
+
+    #[test]
+    fn from_formatted_no_extras_has_no_cause() {
+        let fe = FormattedError::new("simple error");
+        let err = UserFacingError::from_formatted(ErrorKind::Network, fe);
+        assert!(err.cause.is_none(), "cause must be None when no detail/hint/code");
+    }
+
+    #[test]
+    fn error_kind_as_str_returns_lowercase() {
+        assert_eq!(ErrorKind::Storage.as_str(), "storage");
+        assert_eq!(ErrorKind::Network.as_str(), "network");
+        assert_eq!(ErrorKind::Auth.as_str(), "auth");
+        assert_eq!(ErrorKind::Hook.as_str(), "hook");
+        assert_eq!(ErrorKind::Driver.as_str(), "driver");
+        assert_eq!(ErrorKind::User.as_str(), "user");
+        assert_eq!(ErrorKind::Config.as_str(), "config");
+    }
+}

--- a/crates/dbflux_ui_base/src/user_error/mod.rs
+++ b/crates/dbflux_ui_base/src/user_error/mod.rs
@@ -121,7 +121,7 @@ impl UserFacingError {
 /// | Inside a `cx.update(|cx| { ... })`      | `report_error`          |
 pub fn report_error(err: UserFacingError, cx: &mut App) {
     use crate::app_state_entity::AppStateGlobal;
-    use crate::toast::{Toast, copy_action, now_hms};
+    use crate::toast::{Toast, ToastAction, copy_action, now_hms};
 
     let id_str = err.correlation_id.to_string();
     let kind_str = err.kind.as_str();
@@ -159,10 +159,20 @@ pub fn report_error(err: UserFacingError, cx: &mut App) {
         toast = toast.body(a.clone());
     }
 
+    let id_for_action = err.correlation_id;
+    let view_in_audit =
+        ToastAction::new("view-in-audit", "View in Audit").on_click(move |cx: &mut App| {
+            if let Some(g) = cx.try_global::<AppStateGlobal>() {
+                let entity = g.entity.clone();
+                entity.update(cx, |s, cx| s.request_open_audit(Some(id_for_action), cx));
+            }
+        });
+
     toast = toast
         .meta_right(now_hms())
         .details(format!("Correlation: {id_str}"))
-        .action(copy_action(format!("{summary}\nCorrelation: {id_str}")));
+        .action(copy_action(format!("{summary}\nCorrelation: {id_str}")))
+        .action(view_in_audit);
 
     toast.push(cx);
 

--- a/crates/dbflux_ui_base/src/user_error/mod.rs
+++ b/crates/dbflux_ui_base/src/user_error/mod.rs
@@ -196,8 +196,10 @@ pub fn report_error(err: UserFacingError, cx: &mut App) {
 /// | Inside `cx.spawn(async ...)`            | `report_error_async`    |
 /// | Inside a `cx.update(|cx| { ... })`      | `report_error`          |
 pub fn report_error_async(err: UserFacingError, cx: &AsyncApp) {
+    use crate::AsyncUpdateResultExt;
+
     let cx = cx.clone();
-    let _ = cx.update(move |cx| report_error(err, cx));
+    cx.update(move |cx| report_error(err, cx)).log_if_dropped();
 }
 
 #[cfg(test)]

--- a/crates/dbflux_ui_base/src/user_error/mod.rs
+++ b/crates/dbflux_ui_base/src/user_error/mod.rs
@@ -121,7 +121,7 @@ impl UserFacingError {
 /// | Inside a `cx.update(|cx| { ... })`      | `report_error`          |
 pub fn report_error(err: UserFacingError, cx: &mut App) {
     use crate::app_state_entity::AppStateGlobal;
-    use crate::toast::{copy_action, now_hms, Toast};
+    use crate::toast::{Toast, copy_action, now_hms};
 
     let id_str = err.correlation_id.to_string();
     let kind_str = err.kind.as_str();
@@ -207,8 +207,7 @@ mod tests {
     #[test]
     fn with_correlation_id_overrides_generated_uuid() {
         let known = Uuid::nil();
-        let err = UserFacingError::new(ErrorKind::Storage, "io error")
-            .with_correlation_id(known);
+        let err = UserFacingError::new(ErrorKind::Storage, "io error").with_correlation_id(known);
         assert_eq!(err.correlation_id, known);
     }
 
@@ -227,14 +226,20 @@ mod tests {
         let err = UserFacingError::from_formatted(ErrorKind::Driver, fe);
         assert_eq!(err.kind, ErrorKind::Driver);
         assert_eq!(err.summary, "connection refused");
-        assert!(err.cause.is_some(), "cause must be populated from detail/code");
+        assert!(
+            err.cause.is_some(),
+            "cause must be populated from detail/code"
+        );
     }
 
     #[test]
     fn from_formatted_no_extras_has_no_cause() {
         let fe = FormattedError::new("simple error");
         let err = UserFacingError::from_formatted(ErrorKind::Network, fe);
-        assert!(err.cause.is_none(), "cause must be None when no detail/hint/code");
+        assert!(
+            err.cause.is_none(),
+            "cause must be None when no detail/hint/code"
+        );
     }
 
     #[test]

--- a/crates/dbflux_ui_base/src/user_error/throttle.rs
+++ b/crates/dbflux_ui_base/src/user_error/throttle.rs
@@ -49,7 +49,10 @@ impl TokenBucket {
         let refill_count =
             (elapsed.as_millis() / REFILL_INTERVAL.as_millis()).min(u8::MAX as u128) as u8;
         if refill_count > 0 {
-            self.tokens = self.tokens.saturating_add(refill_count).min(BUCKET_CAPACITY);
+            self.tokens = self
+                .tokens
+                .saturating_add(refill_count)
+                .min(BUCKET_CAPACITY);
             self.last_refill = now;
         }
     }
@@ -99,7 +102,10 @@ mod tests {
             bucket.try_consume();
         }
 
-        assert!(!bucket.try_consume(), "sixth consume must fail when bucket is empty");
+        assert!(
+            !bucket.try_consume(),
+            "sixth consume must fail when bucket is empty"
+        );
     }
 
     #[test]
@@ -116,7 +122,10 @@ mod tests {
 
         // Advance past one refill interval.
         set_fake_now(base + REFILL_INTERVAL + Duration::from_millis(1));
-        assert!(bucket.try_consume(), "one refilled token should allow one more consume");
+        assert!(
+            bucket.try_consume(),
+            "one refilled token should allow one more consume"
+        );
     }
 
     #[test]
@@ -135,8 +144,14 @@ mod tests {
 
         // Must succeed exactly BUCKET_CAPACITY times, then fail.
         for i in 1..=BUCKET_CAPACITY {
-            assert!(bucket.try_consume(), "consume {i} after refill must succeed");
+            assert!(
+                bucket.try_consume(),
+                "consume {i} after refill must succeed"
+            );
         }
-        assert!(!bucket.try_consume(), "capacity cap: no more than BUCKET_CAPACITY tokens");
+        assert!(
+            !bucket.try_consume(),
+            "capacity cap: no more than BUCKET_CAPACITY tokens"
+        );
     }
 }

--- a/crates/dbflux_ui_base/src/user_error/throttle.rs
+++ b/crates/dbflux_ui_base/src/user_error/throttle.rs
@@ -1,0 +1,142 @@
+use std::time::{Duration, Instant};
+
+pub const BUCKET_CAPACITY: u8 = 5;
+pub const REFILL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Token-bucket rate limiter for `Warning`/`Info` toasts.
+///
+/// The bucket starts full. Each `try_consume` call attempts to take one token.
+/// Tokens refill based on elapsed time since the last refill, up to the
+/// `BUCKET_CAPACITY` cap. The algorithm is O(1) per call.
+///
+/// `Error` and `Fatal` toasts bypass this entirely — callers skip
+/// `try_consume` for those severities.
+pub struct TokenBucket {
+    tokens: u8,
+    last_refill: Instant,
+    now_fn: fn() -> Instant,
+}
+
+impl TokenBucket {
+    pub fn new() -> Self {
+        Self::with_clock(Instant::now)
+    }
+
+    /// Constructs a bucket with an injectable clock — use this in tests for
+    /// deterministic time control.
+    pub fn with_clock(now_fn: fn() -> Instant) -> Self {
+        Self {
+            tokens: BUCKET_CAPACITY,
+            last_refill: (now_fn)(),
+            now_fn,
+        }
+    }
+
+    /// Returns `true` if the caller may proceed (a token was consumed).
+    /// Returns `false` when the bucket was empty after attempting a refill.
+    pub fn try_consume(&mut self) -> bool {
+        self.refill();
+        if self.tokens == 0 {
+            return false;
+        }
+        self.tokens -= 1;
+        true
+    }
+
+    fn refill(&mut self) {
+        let now = (self.now_fn)();
+        let elapsed = now.duration_since(self.last_refill);
+        let refill_count =
+            (elapsed.as_millis() / REFILL_INTERVAL.as_millis()).min(u8::MAX as u128) as u8;
+        if refill_count > 0 {
+            self.tokens = self.tokens.saturating_add(refill_count).min(BUCKET_CAPACITY);
+            self.last_refill = now;
+        }
+    }
+}
+
+impl Default for TokenBucket {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    thread_local! {
+        static FAKE_NOW: Cell<Option<Instant>> = const { Cell::new(None) };
+    }
+
+    fn fake_clock() -> Instant {
+        FAKE_NOW.with(|c| c.get().expect("fake clock not initialised"))
+    }
+
+    fn set_fake_now(t: Instant) {
+        FAKE_NOW.with(|c| c.set(Some(t)));
+    }
+
+    #[test]
+    fn five_consecutive_consumes_succeed() {
+        let base = Instant::now();
+        set_fake_now(base);
+        let mut bucket = TokenBucket::with_clock(fake_clock);
+
+        for i in 1..=5 {
+            assert!(bucket.try_consume(), "consume {i} should succeed");
+        }
+    }
+
+    #[test]
+    fn sixth_consume_fails_immediately() {
+        let base = Instant::now();
+        set_fake_now(base);
+        let mut bucket = TokenBucket::with_clock(fake_clock);
+
+        for _ in 0..5 {
+            bucket.try_consume();
+        }
+
+        assert!(!bucket.try_consume(), "sixth consume must fail when bucket is empty");
+    }
+
+    #[test]
+    fn one_token_refills_after_refill_interval() {
+        let base = Instant::now();
+        set_fake_now(base);
+        let mut bucket = TokenBucket::with_clock(fake_clock);
+
+        // Drain the bucket.
+        for _ in 0..5 {
+            bucket.try_consume();
+        }
+        assert!(!bucket.try_consume());
+
+        // Advance past one refill interval.
+        set_fake_now(base + REFILL_INTERVAL + Duration::from_millis(1));
+        assert!(bucket.try_consume(), "one refilled token should allow one more consume");
+    }
+
+    #[test]
+    fn bucket_caps_at_capacity_after_long_idle() {
+        let base = Instant::now();
+        set_fake_now(base);
+        let mut bucket = TokenBucket::with_clock(fake_clock);
+
+        // Drain completely.
+        for _ in 0..5 {
+            bucket.try_consume();
+        }
+
+        // Advance by 60 s — far beyond 5 * REFILL_INTERVAL.
+        set_fake_now(base + Duration::from_secs(60));
+
+        // Must succeed exactly BUCKET_CAPACITY times, then fail.
+        for i in 1..=BUCKET_CAPACITY {
+            assert!(bucket.try_consume(), "consume {i} after refill must succeed");
+        }
+        assert!(!bucket.try_consume(), "capacity cap: no more than BUCKET_CAPACITY tokens");
+    }
+}

--- a/crates/dbflux_ui_document/src/audit/mod.rs
+++ b/crates/dbflux_ui_document/src/audit/mod.rs
@@ -1493,10 +1493,35 @@ impl AuditDocument {
         self.focus_handle.focus(window);
     }
 
-    pub(self) fn filter_by_correlation(&mut self, correlation_id: String, cx: &mut Context<Self>) {
+    pub fn filter_by_correlation(&mut self, correlation_id: String, cx: &mut Context<Self>) {
         self.filters.correlation_id = Some(correlation_id);
         self.reset_pagination();
         self.load_events(cx);
+    }
+
+    /// Clears the correlation-id filter and reloads events.
+    pub fn clear_correlation_filter(&mut self, cx: &mut Context<Self>) {
+        if self.filters.correlation_id.is_none() {
+            return;
+        }
+        self.filters.correlation_id = None;
+        self.reset_pagination();
+        self.load_events(cx);
+    }
+
+    /// Creates a new audit document pre-filtered by correlation id.
+    ///
+    /// Mirrors the `new_with_category` constructor pattern.
+    pub fn new_with_correlation_id(
+        correlation_id: uuid::Uuid,
+        app_state: Entity<AppStateEntity>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let mut doc = Self::new(app_state, window, cx);
+        doc.filter_by_correlation(correlation_id.to_string(), cx);
+        doc.pending_initial_load = false;
+        doc
     }
 
     fn do_export(&mut self, format: String, cx: &mut Context<Self>) {

--- a/crates/dbflux_ui_document/src/audit/pane.rs
+++ b/crates/dbflux_ui_document/src/audit/pane.rs
@@ -134,6 +134,16 @@ impl AuditDocument {
             ))
         };
 
+        // set_correlation_filter — applied by the workspace when the user clicks
+        // "View in Audit" from a toast, or when clicking the error badge.
+        pane.set_correlation_filter = {
+            let e = entity.clone();
+            Some(Box::new(move |id: Option<String>, cx: &mut App| match id {
+                Some(s) => e.update(cx, |d, cx| d.filter_by_correlation(s, cx)),
+                None => e.update(cx, |d, cx| d.clear_correlation_filter(cx)),
+            }))
+        };
+
         pane
     }
 }

--- a/crates/dbflux_ui_document/src/code/file_ops.rs
+++ b/crates/dbflux_ui_document/src/code/file_ops.rs
@@ -1,4 +1,5 @@
 use super::*;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error_async};
 
 fn build_file_content_for_language(
     editor_content: &str,
@@ -45,7 +46,13 @@ impl CodeDocument {
                     .ok();
                 }
                 Err(e) => {
-                    log::error!("Failed to save file: {}", e);
+                    report_error_async(
+                        UserFacingError::new(
+                            ErrorKind::Storage,
+                            format!("Failed to save file: {e}"),
+                        ),
+                        cx,
+                    );
                 }
             }
         }));
@@ -96,17 +103,15 @@ impl CodeDocument {
                         true,
                     )),
                     Err(err) => {
-                        let err_text = format!(
-                            "Save failed — file dialog unavailable and fallback directory could not be created: {}",
-                            err
+                        report_error_async(
+                            UserFacingError::new(
+                                ErrorKind::Storage,
+                                format!(
+                                    "Save failed — file dialog unavailable and fallback directory could not be created: {err}"
+                                ),
+                            ),
+                            cx,
                         );
-                        log::error!("{}", err_text);
-                        cx.update(|cx| {
-                            dbflux_ui_base::toast::Toast::error(err_text)
-                                .meta_right(dbflux_ui_base::toast::now_hms())
-                                .push(cx);
-                        })
-                        .ok();
                         return;
                     }
                 }
@@ -149,14 +154,10 @@ impl CodeDocument {
                     .ok();
                 }
                 Err(e) => {
-                    let err_text = format!("Failed to save script: {}", e);
-                    log::error!("{}", err_text);
-                    cx.update(|cx| {
-                        dbflux_ui_base::toast::Toast::error(err_text)
-                            .meta_right(dbflux_ui_base::toast::now_hms())
-                            .push(cx);
-                    })
-                    .ok();
+                    report_error_async(
+                        UserFacingError::new(ErrorKind::Storage, format!("Failed to save script: {e}")),
+                        cx,
+                    );
                 }
             }
         }));

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
@@ -7,6 +7,7 @@ use dbflux_core::{
 };
 use dbflux_ui_base::AsyncUpdateResultExt;
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error, report_error_async};
 use gpui::*;
 use std::collections::BTreeMap;
 use uuid::Uuid;
@@ -323,10 +324,13 @@ impl DataGridPanel {
                         }
                         Err(error) => {
                             panel.runner.fail_mutation(task_id, error.to_string(), cx);
-                            panel.pending_toast = Some(PendingToast {
-                                message: format!("Failed to update document: {}", error),
-                                is_error: true,
-                            });
+                            report_error(
+                                UserFacingError::new(
+                                    ErrorKind::Driver,
+                                    format!("Failed to update document: {error}"),
+                                ),
+                                cx,
+                            );
                         }
                     }
                     cx.notify();
@@ -428,20 +432,16 @@ impl DataGridPanel {
             .iter()
             .any(|value| matches!(value, Value::Unsupported(_)))
         {
-            let message = "Cannot save row: primary key uses an unsupported value type".to_string();
-            log::error!("[SAVE] {}", message);
+            let message = "Cannot save row: primary key uses an unsupported value type";
 
             table_state.update(cx, |state, cx| {
                 state
                     .edit_buffer_mut()
-                    .set_row_state(row_idx, RowState::Error(message.clone()));
+                    .set_row_state(row_idx, RowState::Error(message.to_string()));
                 cx.notify();
             });
 
-            self.pending_toast = Some(PendingToast {
-                message,
-                is_error: true,
-            });
+            report_error(UserFacingError::new(ErrorKind::Driver, message), cx);
             return;
         }
 
@@ -467,20 +467,16 @@ impl DataGridPanel {
             .iter()
             .any(|a| matches!(a.value, Value::Unsupported(_)))
         {
-            let message = "Cannot save row: unsupported values are read-only".to_string();
-            log::error!("[SAVE] {}", message);
+            let message = "Cannot save row: unsupported values are read-only";
 
             table_state.update(cx, |state, cx| {
                 state
                     .edit_buffer_mut()
-                    .set_row_state(row_idx, RowState::Error(message.clone()));
+                    .set_row_state(row_idx, RowState::Error(message.to_string()));
                 cx.notify();
             });
 
-            self.pending_toast = Some(PendingToast {
-                message,
-                is_error: true,
-            });
+            report_error(UserFacingError::new(ErrorKind::Driver, message), cx);
             return;
         }
 
@@ -710,17 +706,16 @@ impl DataGridPanel {
                 });
             }
             Err(e) => {
-                log::error!("[SAVE] Failed to save row {}: {}", row_idx, e);
                 table_state.update(cx, |state, cx| {
                     state
                         .edit_buffer_mut()
                         .set_row_state(row_idx, RowState::Error(e.to_string()));
                     cx.notify();
                 });
-                self.pending_toast = Some(PendingToast {
-                    message: format!("Save failed: {}", e),
-                    is_error: true,
-                });
+                report_error(
+                    UserFacingError::new(ErrorKind::Driver, format!("Save failed: {e}")),
+                    cx,
+                );
             }
         }
 
@@ -849,12 +844,14 @@ impl DataGridPanel {
                             panel.queue_refresh_after_mutation_success(cx);
                         }
                         Err(e) => {
-                            log::error!("[INSERT] Failed: {}", e);
                             panel.runner.fail_mutation(task_id, e.to_string(), cx);
-                            panel.pending_toast = Some(PendingToast {
-                                message: format!("Insert failed: {}", e),
-                                is_error: true,
-                            });
+                            report_error(
+                                UserFacingError::new(
+                                    ErrorKind::Driver,
+                                    format!("Insert failed: {e}"),
+                                ),
+                                cx,
+                            );
                         }
                     }
                     cx.notify();
@@ -915,11 +912,10 @@ impl DataGridPanel {
         };
 
         if assignments.is_empty() {
-            self.pending_toast = Some(PendingToast {
-                message: "Cannot insert: no values provided".to_string(),
-                is_error: true,
-            });
-            cx.notify();
+            report_error(
+                UserFacingError::new(ErrorKind::Driver, "Cannot insert: no values provided"),
+                cx,
+            );
             return;
         }
 
@@ -987,12 +983,14 @@ impl DataGridPanel {
                             panel.queue_refresh_after_mutation_success(cx);
                         }
                         Err(e) => {
-                            log::error!("[INSERT] Failed: {}", e);
                             panel.runner.fail_mutation(task_id, e.to_string(), cx);
-                            panel.pending_toast = Some(PendingToast {
-                                message: format!("Insert failed: {}", e),
-                                is_error: true,
-                            });
+                            report_error(
+                                UserFacingError::new(
+                                    ErrorKind::Driver,
+                                    format!("Insert failed: {e}"),
+                                ),
+                                cx,
+                            );
                         }
                     }
                     cx.notify();
@@ -1186,12 +1184,14 @@ impl DataGridPanel {
                             panel.pending_refresh = true;
                         }
                         Err(e) => {
-                            log::error!("[DELETE] Failed: {}", e);
                             panel.runner.fail_mutation(task_id, e.to_string(), cx);
-                            panel.pending_toast = Some(PendingToast {
-                                message: format!("Delete failed: {}", e),
-                                is_error: true,
-                            });
+                            report_error(
+                                UserFacingError::new(
+                                    ErrorKind::Driver,
+                                    format!("Delete failed: {e}"),
+                                ),
+                                cx,
+                            );
                         }
                     }
                     cx.notify();
@@ -1241,21 +1241,21 @@ impl DataGridPanel {
         };
 
         if pk_count == 0 {
-            self.pending_toast = Some(PendingToast {
-                message: "Cannot delete: no primary key defined for this table".to_string(),
-                is_error: true,
-            });
-            cx.notify();
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Driver,
+                    "Cannot delete: no primary key defined for this table",
+                ),
+                cx,
+            );
             return;
         }
 
         if pk_columns.len() != pk_count || pk_values.len() != pk_count {
-            log::error!("[DELETE] Failed to build row identity");
-            self.pending_toast = Some(PendingToast {
-                message: "Cannot delete: failed to identify row".to_string(),
-                is_error: true,
-            });
-            cx.notify();
+            report_error(
+                UserFacingError::new(ErrorKind::Driver, "Cannot delete: failed to identify row"),
+                cx,
+            );
             return;
         }
 
@@ -1318,12 +1318,14 @@ impl DataGridPanel {
                             panel.pending_refresh = true;
                         }
                         Err(e) => {
-                            log::error!("[DELETE] Failed: {}", e);
                             panel.runner.fail_mutation(task_id, e.to_string(), cx);
-                            panel.pending_toast = Some(PendingToast {
-                                message: format!("Delete failed: {}", e),
-                                is_error: true,
-                            });
+                            report_error(
+                                UserFacingError::new(
+                                    ErrorKind::Driver,
+                                    format!("Delete failed: {e}"),
+                                ),
+                                cx,
+                            );
                         }
                     }
                     cx.notify();
@@ -1453,11 +1455,13 @@ impl DataGridPanel {
         };
 
         if pk_indices.is_empty() {
-            self.pending_toast = Some(PendingToast {
-                message: "Cannot delete: no primary key defined for this table".to_string(),
-                is_error: true,
-            });
-            cx.notify();
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Driver,
+                    "Cannot delete: no primary key defined for this table",
+                ),
+                cx,
+            );
             return;
         }
 
@@ -1493,11 +1497,13 @@ impl DataGridPanel {
         }
 
         if identities.is_empty() {
-            self.pending_toast = Some(PendingToast {
-                message: "Cannot delete: failed to identify any rows".to_string(),
-                is_error: true,
-            });
-            cx.notify();
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Driver,
+                    "Cannot delete: failed to identify any rows",
+                ),
+                cx,
+            );
             return;
         }
 
@@ -1542,7 +1548,7 @@ impl DataGridPanel {
             let mut success_count = 0usize;
             let mut last_error: Option<dbflux_core::DbError> = None;
 
-            for (row_idx, identity) in &identities {
+            for (_row_idx, identity) in &identities {
                 let delete =
                     RowDelete::new(identity.clone(), table_name.clone(), schema_name.clone());
 
@@ -1557,7 +1563,6 @@ impl DataGridPanel {
                         success_count += 1;
                     }
                     Err(e) => {
-                        log::error!("[BULK DELETE] Failed to delete row {}: {}", row_idx, e);
                         last_error = Some(e);
                         // Stop on first error — remaining rows may depend on consistency
                         break;
@@ -1569,15 +1574,17 @@ impl DataGridPanel {
                 entity.update(cx, |panel, cx| {
                     if let Some(e) = last_error {
                         panel.runner.fail_mutation(task_id, e.to_string(), cx);
-                        panel.pending_toast = Some(PendingToast {
-                            message: format!(
-                                "Deleted {} of {} row(s), then failed: {}",
-                                success_count,
-                                identities.len(),
-                                e
+                        report_error(
+                            UserFacingError::new(
+                                ErrorKind::Driver,
+                                format!(
+                                    "Deleted {} of {} row(s), then failed: {e}",
+                                    success_count,
+                                    identities.len()
+                                ),
                             ),
-                            is_error: true,
-                        });
+                            cx,
+                        );
                     } else {
                         panel.runner.complete_mutation(task_id, cx);
 
@@ -1673,11 +1680,13 @@ impl DataGridPanel {
         }
 
         if filters.is_empty() {
-            self.pending_toast = Some(PendingToast {
-                message: "Cannot delete: failed to identify any documents".to_string(),
-                is_error: true,
-            });
-            cx.notify();
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Driver,
+                    "Cannot delete: failed to identify any documents",
+                ),
+                cx,
+            );
             return;
         }
 
@@ -1718,7 +1727,7 @@ impl DataGridPanel {
             let mut success_count = 0usize;
             let mut last_error: Option<dbflux_core::DbError> = None;
 
-            for (row_idx, filter) in &filters {
+            for (_row_idx, filter) in &filters {
                 let delete =
                     dbflux_core::DocumentDelete::new(collection_name.clone(), filter.clone())
                         .with_database(collection_db.clone());
@@ -1734,11 +1743,6 @@ impl DataGridPanel {
                         success_count += 1;
                     }
                     Err(e) => {
-                        log::error!(
-                            "[BULK DELETE] Failed to delete document at row {}: {}",
-                            row_idx,
-                            e
-                        );
                         last_error = Some(e);
                         break;
                     }
@@ -1749,15 +1753,17 @@ impl DataGridPanel {
                 entity.update(cx, |panel, cx| {
                     if let Some(e) = last_error {
                         panel.runner.fail_mutation(task_id, e.to_string(), cx);
-                        panel.pending_toast = Some(PendingToast {
-                            message: format!(
-                                "Deleted {} of {} document(s), then failed: {}",
-                                success_count,
-                                filters.len(),
-                                e
+                        report_error(
+                            UserFacingError::new(
+                                ErrorKind::Driver,
+                                format!(
+                                    "Deleted {} of {} document(s), then failed: {e}",
+                                    success_count,
+                                    filters.len()
+                                ),
                             ),
-                            is_error: true,
-                        });
+                            cx,
+                        );
                     } else {
                         panel.runner.complete_mutation(task_id, cx);
 
@@ -1785,5 +1791,35 @@ impl DataGridPanel {
             .log_if_dropped();
         })
         .detach();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// M5-T1: Stubs documenting the mutation error paths that are now routed
+    /// through `report_error`. Full integration assertions require a GPUI test
+    /// harness with a live `AppStateGlobal` and `ToastGlobal` — deferred until
+    /// the test-support crate gains that infrastructure.
+
+    #[test]
+    #[ignore = "requires GPUI harness with AppStateGlobal and ToastGlobal"]
+    fn insert_failure_routed_through_report_error() {
+        // When an INSERT fails the error path calls report_error(ErrorKind::Driver, …)
+        // which increments AppStateEntity::unread_error_count and emits a toast.
+        // Verified manually: trigger a duplicate-key INSERT and confirm toast + audit row.
+    }
+
+    #[test]
+    #[ignore = "requires GPUI harness with AppStateGlobal and ToastGlobal"]
+    fn update_failure_routed_through_report_error() {
+        // When a row UPDATE (save) fails the error path calls report_error.
+        // Verified manually: edit a read-only column and confirm toast + audit row.
+    }
+
+    #[test]
+    #[ignore = "requires GPUI harness with AppStateGlobal and ToastGlobal"]
+    fn delete_failure_routed_through_report_error() {
+        // When a DELETE fails the error path calls report_error.
+        // Verified manually: delete a row with a FK violation and confirm toast + audit row.
     }
 }

--- a/crates/dbflux_ui_document/src/pane.rs
+++ b/crates/dbflux_ui_document/src/pane.rs
@@ -86,6 +86,12 @@ pub struct PaneHandle {
     /// Sets the category filter on audit-style documents.
     pub set_category_filter: Option<Box<dyn Fn(Option<String>, &mut App)>>,
 
+    /// Sets (or clears) the correlation-id filter on audit-style documents.
+    ///
+    /// `Some(id_string)` applies the filter; `None` clears it.
+    /// `None` on the outer `Option` means the document does not support this operation.
+    pub set_correlation_filter: Option<Box<dyn Fn(Option<String>, &mut App)>>,
+
     /// Returns true when this pane matches a given event-stream target.
     pub matches_event_stream:
         Option<Box<dyn Fn(uuid::Uuid, &dbflux_core::EventStreamTarget, &App) -> bool>>,
@@ -148,6 +154,7 @@ impl PaneHandle {
             matches_dedup_key,
             subscribe,
             set_category_filter: None,
+            set_correlation_filter: None,
             matches_event_stream: None,
             is_file_backed_empty: None,
             session_tab_snapshot: None,

--- a/crates/dbflux_ui_windows/src/settings/drivers.rs
+++ b/crates/dbflux_ui_windows/src/settings/drivers.rs
@@ -17,6 +17,7 @@ use dbflux_core::{
     DriverCapabilities, FormFieldKind, FormValues, GlobalOverrides, RefreshPolicySetting,
 };
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::ActiveTheme;
@@ -612,13 +613,13 @@ impl DriversSection {
             &self.drv_overrides,
             &self.drv_settings,
         ) {
-            log::error!("Failed to save driver settings to SQLite: {}", e);
-            let toast_body = e.to_string();
-            Toast::error("Failed to save")
-                .meta_right(now_hms())
-                .body(toast_body.clone())
-                .action(copy_action(format!("Failed to save: {}", toast_body)))
-                .push(cx);
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    format!("Failed to save driver settings: {e}"),
+                ),
+                cx,
+            );
             return;
         }
 

--- a/crates/dbflux_ui_windows/src/settings/general.rs
+++ b/crates/dbflux_ui_windows/src/settings/general.rs
@@ -6,6 +6,7 @@ use dbflux_components::tokens::Radii;
 use dbflux_components::typography::{Body, FieldLabel, SubSectionLabel};
 use dbflux_ui_base::keymap::key_chord_from_gpui;
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use gpui::*;
 use gpui_component::ActiveTheme;
 use gpui_component::Sizable;
@@ -401,13 +402,13 @@ impl GeneralSection {
         if let Err(e) =
             dbflux_app::config_loader::save_general_settings(runtime, &self.gen_settings)
         {
-            log::error!("Failed to save general settings to SQLite: {}", e);
-            let body = e.to_string();
-            Toast::error("Failed to save")
-                .meta_right(now_hms())
-                .body(body.clone())
-                .action(copy_action(format!("Failed to save: {}", body)))
-                .push(cx);
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    format!("Failed to save general settings: {e}"),
+                ),
+                cx,
+            );
             return;
         }
 

--- a/crates/dbflux_ui_windows/src/settings/hooks.rs
+++ b/crates/dbflux_ui_windows/src/settings/hooks.rs
@@ -687,13 +687,11 @@ impl HooksSection {
         if let Err(e) =
             dbflux_app::config_loader::save_hook_definitions(runtime, &self.hook_definitions)
         {
-            log::error!("Failed to save hooks to SQLite: {}", e);
-            let toast_body = e.to_string();
-            Toast::error("Failed to save hooks")
-                .meta_right(now_hms())
-                .body(toast_body.clone())
-                .action(copy_action(format!("Failed to save hooks: {}", toast_body)))
-                .push(cx);
+            report_error(
+                UserFacingError::new(ErrorKind::Storage, "Failed to save hooks")
+                    .with_cause(e.to_string()),
+                cx,
+            );
             return;
         }
 

--- a/crates/dbflux_ui_windows/src/settings/hooks.rs
+++ b/crates/dbflux_ui_windows/src/settings/hooks.rs
@@ -11,6 +11,7 @@ use dbflux_core::{
 use dbflux_ui_base::AppStateChanged;
 use dbflux_ui_base::keymap::key_chord_from_gpui;
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::ActiveTheme;
@@ -290,11 +291,13 @@ impl HooksSection {
         };
 
         if let Err(error) = open::that(&path) {
-            let toast_msg = (format!("Failed to open script: {error}")).to_string();
-            Toast::error(toast_msg.clone())
-                .meta_right(now_hms())
-                .action(copy_action(toast_msg))
-                .push(cx);
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    format!("Failed to open script: {error}"),
+                ),
+                cx,
+            );
         }
     }
 

--- a/crates/dbflux_ui_windows/src/settings/lifecycle.rs
+++ b/crates/dbflux_ui_windows/src/settings/lifecycle.rs
@@ -3,6 +3,8 @@ use auth_profiles_section::AuthProfilesSectionEvent;
 use dbflux_app::keymap::Modifiers;
 use dbflux_components::components::tree_nav::TreeNavAction;
 use dbflux_ui_base::keymap::key_chord_from_gpui;
+#[cfg(feature = "mcp")]
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use section_trait::SectionFocusEvent;
 
 impl SettingsCoordinator {
@@ -242,7 +244,13 @@ impl SettingsCoordinator {
         #[cfg(feature = "mcp")]
         self.app_state.update(cx, |state, cx| {
             if let Err(e) = state.persist_mcp_governance() {
-                log::error!("Failed to persist MCP governance: {}", e);
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Config,
+                        format!("Failed to persist MCP governance: {e}"),
+                    ),
+                    cx,
+                );
             }
             cx.emit(dbflux_ui_base::McpRuntimeEventRaised {
                 event: dbflux_mcp::McpRuntimeEvent::TrustedClientsUpdated,

--- a/crates/dbflux_ui_windows/src/settings/proxies.rs
+++ b/crates/dbflux_ui_windows/src/settings/proxies.rs
@@ -3,6 +3,7 @@ use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use dbflux_core::{ProxyAuth, ProxyKind, ProxyProfile};
 use dbflux_ui_base::AppStateChanged;
 use dbflux_ui_base::keymap::key_chord_from_gpui;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use gpui::*;
 use uuid::Uuid;
 
@@ -274,7 +275,13 @@ impl ProxiesSection {
             runtime,
             self.app_state.read(cx).proxies(),
         ) {
-            log::error!("Failed to save proxy profiles: {}", e);
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    format!("Failed to save proxy profiles: {e}"),
+                ),
+                cx,
+            );
         }
 
         self.proxy_selected_idx = self

--- a/crates/dbflux_ui_windows/src/settings/rpc_services.rs
+++ b/crates/dbflux_ui_windows/src/settings/rpc_services.rs
@@ -6,6 +6,7 @@ use dbflux_components::typography::{Body, MonoCaption, MonoLabel, MonoMeta, Pane
 use dbflux_core::{RpcServiceKind, ServiceConfig};
 use dbflux_storage::bootstrap::StorageRuntime;
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::ActiveTheme;
@@ -369,16 +370,13 @@ impl ServicesSection {
 
         let runtime = self.app_state.read(cx).storage_runtime();
         if let Err(e) = dbflux_app::config_loader::save_services(runtime, &self.svc_services) {
-            log::error!("Failed to save services to SQLite: {}", e);
-            let toast_body = e.to_string();
-            Toast::error("Failed to save config")
-                .meta_right(now_hms())
-                .body(toast_body.clone())
-                .action(copy_action(format!(
-                    "Failed to save config: {}",
-                    toast_body
-                )))
-                .push(cx);
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    format!("Failed to save RPC service config: {e}"),
+                ),
+                cx,
+            );
             return;
         }
         Toast::info("RPC service saved. Restart required to apply changes.")
@@ -428,13 +426,13 @@ impl ServicesSection {
 
         let runtime = self.app_state.read(cx).storage_runtime();
         if let Err(e) = dbflux_app::config_loader::save_services(runtime, &self.svc_services) {
-            log::error!("Failed to save services to SQLite: {}", e);
-            let body = e.to_string();
-            Toast::error("Failed to save config")
-                .meta_right(now_hms())
-                .body(body.clone())
-                .action(copy_action(format!("Failed to save config: {}", body)))
-                .push(cx);
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    format!("Failed to save RPC service config: {e}"),
+                ),
+                cx,
+            );
             return;
         }
         Toast::info("RPC service deleted. Restart required to apply changes.")

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
@@ -4,6 +4,7 @@ use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use dbflux_core::{SshAuthMethod, SshTunnelProfile};
 use dbflux_ui_base::AppStateChanged;
 use dbflux_ui_base::keymap::key_chord_from_gpui;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use gpui::*;
 use uuid::Uuid;
 
@@ -268,7 +269,13 @@ impl SshTunnelsSection {
             runtime,
             self.app_state.read(cx).ssh_tunnels(),
         ) {
-            log::error!("Failed to save SSH tunnel profiles: {}", e);
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    format!("Failed to save SSH tunnel profiles: {e}"),
+                ),
+                cx,
+            );
         }
 
         self.ssh_selected_idx = self

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -357,6 +357,29 @@ The bridge recognizes these named fields on tracing events and maps them to `Eve
 
 Unknown fields accumulate in `details_json` as a JSON object. If the message exceeds 512 characters it is truncated with `…` and the full message is stored in `details_json["message"]`.
 
+The bridge also maps `correlation_id` directly to `EventRecord.correlation_id` (not into `details_json`), enabling cross-component correlation between user-facing error toasts and their corresponding audit records.
+
+### User-Facing Error Events
+
+User-facing errors (storage failures, driver errors, network problems, config persistence failures) are reported through `report_error` / `report_error_async` from `dbflux_ui_base::user_error`. Each call emits a tracing event that flows through the bridge and also pushes a toast notification.
+
+The tracing event shape:
+
+| Tracing field | Value |
+|---------------|-------|
+| `target` | `dbflux_ui::user_error` |
+| `action` | `user_error` |
+| `outcome` | `failure` |
+| `kind` | `ErrorKind` as string (`storage`, `network`, `auth`, `hook`, `driver`, `user`, `config`) |
+| `correlation_id` | UUID v7 linking the toast to the audit record |
+| `message` | The human-readable summary shown in the toast |
+
+The `correlation_id` field is extracted by `AuditFieldVisitor` into `EventRecord.correlation_id`. Clicking the error badge in the status bar opens the Audit viewer filtered to that correlation ID so the user can see the full context of a reported error.
+
+Severity mapping from `EventSeverity`:
+- `EventSeverity::Info` and `EventSeverity::Warning` — emitted at `WARN` level; throttled (5-token bucket, 1 refill per 2 seconds)
+- `EventSeverity::Error` and `EventSeverity::Fatal` — emitted at `ERROR` level; bypass throttle
+
 ### Enabling the Bridge
 
 The bridge is enabled by building `dbflux_core` with the `tracing-bridge` feature (on by default for `dbflux`, `dbflux_mcp_server`). Call `init_tracing(BridgeConfig { .. })` once at process start:

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -374,10 +374,17 @@ The tracing event shape:
 | `correlation_id` | UUID v7 linking the toast to the audit record |
 | `message` | The human-readable summary shown in the toast |
 
-The `correlation_id` field is extracted by `AuditFieldVisitor` into `EventRecord.correlation_id`. Clicking the error badge in the status bar opens the Audit viewer filtered to that correlation ID so the user can see the full context of a reported error.
+The `correlation_id` field is extracted by `AuditFieldVisitor` into `EventRecord.correlation_id`. Note that the visitor routes both `record_str` (Display sigil `%val`) and `record_debug` (Debug sigil `?val`) through the same `record_string_by_name` dispatcher, so new typed slots added in the future are picked up regardless of which sigil the caller uses.
+
+There are two paths from the UI back into the audit document:
+
+- **Per-toast "View in Audit" action** — emits `OpenAuditRequested(Some(correlation_id))`. The workspace opens (or focuses) the Audit document and applies the matching correlation filter so the user sees exactly the one event tied to the toast.
+- **Status-bar error badge click** — emits `OpenAuditRequested(None)`. The workspace opens the Audit document with the default user-error filter (`target = dbflux_ui::user_error` over a recent time window) so the user can browse every recent user-facing failure.
+
+Both events flow through `AppStateEntity::request_open_audit` so the workspace subscribes once.
 
 Severity mapping from `EventSeverity`:
-- `EventSeverity::Info` and `EventSeverity::Warning` — emitted at `WARN` level; throttled (5-token bucket, 1 refill per 2 seconds)
+- `EventSeverity::Info` and `EventSeverity::Warn` — emitted at `WARN` level; throttled (5-token bucket, 1 refill per 2 seconds, per severity)
 - `EventSeverity::Error` and `EventSeverity::Fatal` — emitted at `ERROR` level; bypass throttle
 
 ### Enabling the Bridge


### PR DESCRIPTION
## Summary

Introduce a single `report_error` / `report_error_async` seam (`dbflux_ui_base::user_error`) that every user-facing fallible operation routes through. Each call produces a styled toast, increments a status-bar error badge, and emits a `tracing::error!` event at `target = dbflux_ui::user_error` whose `correlation_id` lands on the typed `EventRecord.correlation_id` slot via the audit bridge. The "View in Audit" toast action and the badge click both open the audit document already filtered to the matching event.

## What does this resolve?

- Resolves #156

Today, errors across mutations, file save, settings forms, workspace actions, and file-dialog flows are logged with `log::error!` and the user is left with no UI feedback. After #147 those logs reach the audit table, but the user has to know to open the audit document. This PR closes that feedback gap.

## How was this solved?

- New `UserFacingError { kind, severity, summary, cause, suggested_action, correlation_id }` in `dbflux_ui_base::user_error`. `ErrorKind` is a fixed taxonomy (`Storage`, `Network`, `Auth`, `Hook`, `Driver`, `User`, `Config`).
- `report_error(err, &mut App)` (foreground) and `report_error_async(err, &AsyncApp)` (background_executor / `cx.spawn`).
- UUID v7 correlation ids; the test-only `with_correlation_id` seam lets the caller pin one.
- `UserFacingError::from_formatted(kind, FormattedError)` consumes the existing driver `ErrorFormatter` output so the UI stays driver-agnostic.
- ToastHost gains a severity-aware token-bucket throttle (capacity 5, refill 1 token / 2 s) for Warning and Info; Error and Fatal bypass.
- `AppStateEntity` exposes `unread_error_count` and emits `UserErrorReported` + `OpenAuditRequested`. The status-bar badge subscribes to the counter; the toast "View in Audit" action and the badge click dispatch the same `OpenAuditRequested` event so the workspace has a single subscription.
- `AuditDocument::new_with_correlation_id` + a new `PaneHandle::set_correlation_filter` closure so the existing audit tab can be steered onto a correlation id without reopening.
- Bridge fix: `AuditFieldVisitor::record_debug` now routes through `record_string_by_name` so the `correlation_id`, `action`, and other typed slots are populated regardless of whether the field is recorded via the `%` (Display) or `?` (Debug) sigil. This was a silent failure in the previous bridge — the dedicated slot stayed empty while the value leaked into `details_json`.
- Call-site refactor across the priority list: `data_grid_panel/mutations.rs`, `code/file_ops.rs`, `workspace/actions.rs`, and the settings forms (`drivers`, `general`, `hooks`, `lifecycle`, `proxies`, `rpc_services`, `ssh_tunnels`). Background-only paths (auto-save, session manifest write) remain on `log::error!` because they only have `&App`; documented as known gaps.

Locked design decisions worth flagging:

- `EventSeverity` is **not** extended with `Critical`; `ToastKind` is **not** extended with `Critical`. The proposal's "Critical" wording maps to `EventSeverity::Error` (or `Fatal`). Adding a new severity variant touches `LevelCode`, audit query filter, SQLite enum storage — out of scope for this PR.
- Throttle deduplication is convention-only ("first catch site toasts; propagation does not re-toast"); no runtime suppression.
- `EventCategory::System` + `action = "user_error"` is reused; no migration, no new category.

## Validation

```bash
cargo fmt --all -- --check
cargo check --workspace --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws
cargo clippy --workspace --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws -- -D warnings
cargo nextest run --workspace --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws
cargo test --doc --workspace --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws
```

All gates pass locally: **2894 tests run, 2894 passed, 159 skipped**. The new bridge integration test (`crates/dbflux_core/tests/bridge_correlation_id.rs`) round-trips `tracing::error!(correlation_id = %id, ...)` through the `AuditLayer` into a captured `EventRecord` and asserts `correlation_id` lands on the typed slot and is **not** leaked into `details_json`.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland
- [ ] Other:

## Known limitations / follow-ups

- Auto-save (`file_ops.rs` debounced background path) and `write_session_manifest(&App)` keep `log::error!` because their context is `&App` — they cannot push toasts. Tracked as follow-up scope.
- `save_hook` validation-only `Toast::error` calls in `settings/hooks.rs` were kept as-is — they are user-input guidance, not system errors. Converting them would add badge noise.
- Throttle deduplication relies on the "first catch site toasts" convention. No runtime dedup; reviewers should still watch for nested error paths that double-report.

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

- `ui:feature` — new public UI seam (`report_error`) + new status-bar badge.
- `audit:feature` — `EventRecord.correlation_id` is now populated end-to-end; audit document gains a correlation filter constructor.
- `size:exception` — full feature ships as one PR per the project preference. Estimated diff: ~1100 added / ~230 removed across 28 files.