### PR TITLE
feat(audit): let RPC drivers and auth providers emit audit events via IPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+* **External RPC drivers and auth providers can emit audit events (#157)** —
+  RPC-backed drivers (driver protocol v1.2, capability `AuditEmit`) and
+  auth providers (auth-provider protocol v1.3, hello flag
+  `audit_emit_opt_in`) can now write to the audit log over IPC by sending
+  `EmitAuditEvent` frames as intermediate `done=false` responses. The host
+  sanitizes every event: forces `actor_type`/`source_id` to new
+  `ExternalDriver` / `ExternalAuthProvider` variants, fills `actor_id`
+  with the registered RPC service ID, overrides connection context from
+  `AppState`, enforces a per-source category whitelist (drivers:
+  `Connection`/`Query`/`System`; auth providers: `Connection` only), and
+  truncates `details_json` to the configured `max_detail_bytes`. A
+  per-`socket_id` token-bucket rate limiter (100 events/minute, configurable)
+  caps emission; overflow events are dropped silently — the IPC session
+  is never blocked or errored — and counted on
+  `AuditService::external_audit_dropped`. Older RPC peers that don't
+  advertise the capability/flag remain silent.
+
 ## [0.6.0-dev.10] - 2026-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2412,6 +2412,7 @@ name = "dbflux_app"
 version = "0.6.0-dev.10"
 dependencies = [
  "async-trait",
+ "chrono",
  "dbflux_audit",
  "dbflux_aws",
  "dbflux_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2610,6 +2610,7 @@ dependencies = [
  "bincode",
  "dbflux_core",
  "dbflux_ipc",
+ "dbflux_test_support",
  "interprocess",
  "log",
  "serde",

--- a/crates/dbflux_app/Cargo.toml
+++ b/crates/dbflux_app/Cargo.toml
@@ -33,6 +33,7 @@ dbflux_mcp_server = { workspace = true, optional = true }
 dbflux_policy = { workspace = true, optional = true }
 dbflux_aws = { workspace = true, optional = true }
 dbflux_ssm = { workspace = true, optional = true }
+chrono.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 uuid.workspace = true

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -69,11 +69,11 @@ use std::sync::RwLock;
 use uuid::Uuid;
 
 use crate::auth_provider_registry::{AuthProviderRegistry, RegistryAuthProviderWrapper};
+use crate::rpc_services::external_audit::{ExternalAuditSink, NoOpContextProvider};
 use crate::rpc_services::{
     AuthProviderServiceAdaptation, DriverServiceAdaptation, ExternalDriverDiagnostic,
     RpcServiceDiscovery, adapt_auth_provider_service, adapt_driver_service, discover_services,
 };
-use crate::rpc_services::external_audit::{ExternalAuditSink, NoOpContextProvider};
 
 #[cfg(test)]
 use crate::rpc_services::{
@@ -225,14 +225,13 @@ impl AppState {
             };
 
         let drop_counter = audit_service.external_audit_drop_counter();
-        let audit_emitter: Arc<dyn dbflux_ipc::ExternalAuditEmitter> = Arc::new(
-            ExternalAuditSink::new(
+        let audit_emitter: Arc<dyn dbflux_ipc::ExternalAuditEmitter> =
+            Arc::new(ExternalAuditSink::new(
                 Arc::new(audit_service.clone()) as Arc<dyn EventSink>,
                 drop_counter,
                 Arc::new(NoOpContextProvider),
                 crate::rpc_services::external_audit::ExternalAuditConfig::default(),
-            ),
-        );
+            ));
 
         if !services.is_empty() {
             Self::launch_rpc_services(

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -7,7 +7,7 @@ use dbflux_core::observability::actions::{
     CONFIG_CHANGE, CONFIG_CREATE, CONFIG_DELETE, CONFIG_UPDATE,
 };
 use dbflux_core::observability::{
-    EventCategory, EventOrigin, EventOutcome, EventRecord, EventSeverity,
+    EventCategory, EventOrigin, EventOutcome, EventRecord, EventSeverity, EventSink,
 };
 use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
@@ -73,6 +73,7 @@ use crate::rpc_services::{
     AuthProviderServiceAdaptation, DriverServiceAdaptation, ExternalDriverDiagnostic,
     RpcServiceDiscovery, adapt_auth_provider_service, adapt_driver_service, discover_services,
 };
+use crate::rpc_services::external_audit::{ExternalAuditSink, NoOpContextProvider};
 
 #[cfg(test)]
 use crate::rpc_services::{
@@ -189,8 +190,8 @@ impl AppState {
 
     #[allow(clippy::too_many_arguments)]
     fn new_with_drivers_and_settings(
-        drivers: HashMap<String, Arc<dyn DbDriver>>,
-        external_driver_diagnostics: HashMap<String, ExternalDriverDiagnostic>,
+        mut drivers: HashMap<String, Arc<dyn DbDriver>>,
+        mut external_driver_diagnostics: HashMap<String, ExternalDriverDiagnostic>,
         general_settings: GeneralSettings,
         driver_overrides: HashMap<DriverKey, GlobalOverrides>,
         driver_settings: HashMap<DriverKey, FormValues>,
@@ -205,6 +206,59 @@ impl AppState {
         let scripts_directory = ScriptsDirectory::new()
             .inspect_err(|e| log::warn!("Failed to initialize scripts directory: {}", e))
             .ok();
+
+        let (audit_service, audit_degraded) =
+            match dbflux_audit::AuditService::new_sqlite(storage_runtime.dbflux_db_path()) {
+                Ok(service) => (service, false),
+                Err(e) => {
+                    log::error!(
+                        "Failed to initialize audit service at {:?}: {}",
+                        storage_runtime.dbflux_db_path(),
+                        e
+                    );
+                    let store = dbflux_audit::store::sqlite::SqliteAuditStore::new(":memory:")
+                        .expect("in-memory audit store must work: rusqlite :memory: unavailable");
+                    let svc = dbflux_audit::AuditService::new(store);
+                    svc.set_enabled(false);
+                    (svc, true)
+                }
+            };
+
+        let drop_counter = audit_service.external_audit_drop_counter();
+        let audit_emitter: Arc<dyn dbflux_ipc::ExternalAuditEmitter> = Arc::new(
+            ExternalAuditSink::new(
+                Arc::new(audit_service.clone()) as Arc<dyn EventSink>,
+                drop_counter,
+                Arc::new(NoOpContextProvider),
+                crate::rpc_services::external_audit::ExternalAuditConfig::default(),
+            ),
+        );
+
+        if !services.is_empty() {
+            Self::launch_rpc_services(
+                &mut drivers,
+                &mut external_driver_diagnostics,
+                services.clone(),
+                Some(audit_emitter.clone()),
+            );
+        }
+
+        let mut auth_provider_registry = AuthProviderRegistry::new();
+        #[cfg(feature = "aws")]
+        {
+            auth_provider_registry.register(Arc::new(dbflux_aws::AwsSsoSessionAuthProvider::new()));
+            auth_provider_registry.register(Arc::new(dbflux_aws::AwsSsoAuthProvider::new()));
+            auth_provider_registry
+                .register(Arc::new(dbflux_aws::AwsSharedCredentialsAuthProvider::new()));
+        }
+
+        if !services.is_empty() {
+            Self::launch_rpc_auth_providers(
+                &mut auth_provider_registry,
+                services,
+                Some(audit_emitter),
+            );
+        }
 
         let profile_manager = ProfileManager::with_profiles(profiles, None);
         let ssh_manager =
@@ -232,36 +286,6 @@ impl AppState {
         let mut history_manager =
             crate::history_manager_sqlite::HistoryManager::new(&storage_runtime);
         history_manager.set_max_entries(general_settings.max_history_entries);
-
-        let mut auth_provider_registry = AuthProviderRegistry::new();
-        #[cfg(feature = "aws")]
-        {
-            auth_provider_registry.register(Arc::new(dbflux_aws::AwsSsoSessionAuthProvider::new()));
-            auth_provider_registry.register(Arc::new(dbflux_aws::AwsSsoAuthProvider::new()));
-            auth_provider_registry
-                .register(Arc::new(dbflux_aws::AwsSharedCredentialsAuthProvider::new()));
-        }
-
-        if !services.is_empty() {
-            Self::launch_rpc_auth_providers(&mut auth_provider_registry, services);
-        }
-
-        let (audit_service, audit_degraded) =
-            match dbflux_audit::AuditService::new_sqlite(storage_runtime.dbflux_db_path()) {
-                Ok(service) => (service, false),
-                Err(e) => {
-                    log::error!(
-                        "Failed to initialize audit service at {:?}: {}",
-                        storage_runtime.dbflux_db_path(),
-                        e
-                    );
-                    let store = dbflux_audit::store::sqlite::SqliteAuditStore::new(":memory:")
-                        .expect("in-memory audit store must work: rusqlite :memory: unavailable");
-                    let svc = dbflux_audit::AuditService::new(store);
-                    svc.set_enabled(false);
-                    (svc, true)
-                }
-            };
 
         #[cfg(feature = "mcp")]
         let mcp_runtime = McpRuntime::new(audit_service.clone());
@@ -644,8 +668,8 @@ impl AppState {
         Vec<ProxyProfile>,
         Vec<SshTunnelProfile>,
     ) {
-        let mut drivers = Self::build_builtin_drivers();
-        let mut external_driver_diagnostics = HashMap::new();
+        let drivers = Self::build_builtin_drivers();
+        let external_driver_diagnostics = HashMap::new();
 
         let (
             general_settings,
@@ -655,14 +679,6 @@ impl AppState {
             services,
             runtime,
         ) = Self::load_app_config_from_runtime(runtime);
-
-        if !services.is_empty() {
-            Self::launch_rpc_services(
-                &mut drivers,
-                &mut external_driver_diagnostics,
-                services.clone(),
-            );
-        }
 
         let loaded = crate::config_loader::load_config(&runtime);
 
@@ -711,6 +727,7 @@ impl AppState {
         drivers: &mut HashMap<String, Arc<dyn DbDriver>>,
         diagnostics: &mut HashMap<String, ExternalDriverDiagnostic>,
         services: Vec<ServiceConfig>,
+        audit_emitter: Option<Arc<dyn dbflux_ipc::ExternalAuditEmitter>>,
     ) {
         for discovery in discover_services(services) {
             let descriptor = match discovery {
@@ -726,7 +743,11 @@ impl AppState {
                 }
             };
 
-            match adapt_driver_service(descriptor, |driver_id| drivers.contains_key(driver_id)) {
+            match adapt_driver_service(
+                descriptor,
+                |driver_id| drivers.contains_key(driver_id),
+                audit_emitter.clone(),
+            ) {
                 DriverServiceAdaptation::Registered { driver_id, service } => {
                     if let Some(socket_id) = driver_id.strip_prefix("rpc:") {
                         diagnostics.remove(socket_id);
@@ -764,6 +785,7 @@ impl AppState {
     fn launch_rpc_auth_providers(
         registry: &mut AuthProviderRegistry,
         services: Vec<ServiceConfig>,
+        audit_emitter: Option<Arc<dyn dbflux_ipc::ExternalAuditEmitter>>,
     ) {
         for discovery in discover_services(services) {
             let descriptor = match discovery {
@@ -778,9 +800,11 @@ impl AppState {
                 }
             };
 
-            match adapt_auth_provider_service(descriptor, |provider_id| {
-                registry.get(provider_id).is_some()
-            }) {
+            match adapt_auth_provider_service(
+                descriptor,
+                |provider_id| registry.get(provider_id).is_some(),
+                audit_emitter.clone(),
+            ) {
                 AuthProviderServiceAdaptation::Registered {
                     provider_id,
                     service,

--- a/crates/dbflux_app/src/rpc_services/external_audit.rs
+++ b/crates/dbflux_app/src/rpc_services/external_audit.rs
@@ -1,0 +1,663 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use dbflux_core::observability::{
+    EventActorType, EventCategory, EventOutcome, EventRecord, EventSeverity, EventSink,
+    EventSourceId,
+};
+use dbflux_ipc::audit::{
+    AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto, ExternalAuditEmitter,
+    ExternalAuditSource,
+};
+use uuid::Uuid;
+
+// ============================================================================
+// Rate limiter
+// ============================================================================
+
+/// Token bucket for per-socket-id rate limiting.
+///
+/// Each external RPC socket gets one bucket. Buckets refill at a fixed rate up
+/// to `capacity`. Allocated lazily on first emit; never evicted (bounded by the
+/// number of active RPC services, which is small in practice).
+pub(crate) struct TokenBucket {
+    tokens: f64,
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    fn new(initial_tokens: f64) -> Self {
+        Self {
+            tokens: initial_tokens,
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Attempt to consume one token, refilling from elapsed time first.
+    ///
+    /// Returns `true` if a token was available and consumed.
+    fn consume(&mut self, now: Instant, config: &ExternalAuditConfig) -> bool {
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * config.refill_rate).min(config.capacity);
+        self.last_refill = now;
+
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Configuration for the external-audit sanitizer.
+pub(crate) struct ExternalAuditConfig {
+    /// Maximum tokens per bucket.
+    pub capacity: f64,
+    /// Tokens added per second.
+    pub refill_rate: f64,
+    /// Maximum tolerated drift between DTO timestamp and host wall clock
+    /// before the host clamps the value to now (in milliseconds).
+    pub max_ts_drift_ms: i64,
+}
+
+impl Default for ExternalAuditConfig {
+    fn default() -> Self {
+        Self {
+            capacity: 100.0,
+            refill_rate: 100.0 / 60.0,
+            max_ts_drift_ms: 5 * 60 * 1_000,
+        }
+    }
+}
+
+// ============================================================================
+// Context provider
+// ============================================================================
+
+/// Resolved context for a driver emit event.
+pub(crate) struct DriverEmitContext {
+    pub connection_id: Option<Uuid>,
+    pub database_name: Option<String>,
+    pub driver_id: String,
+}
+
+/// Provides per-connection context for emitted audit events without coupling
+/// the transport layer to `AppState`.
+///
+/// The implementation resolves `(socket_id, session_id)` to connection metadata
+/// at emit time. If the lookup fails (e.g. the connection is not active, or the
+/// context provider holds a `Weak` reference that has expired), all three fields
+/// return as `None` / `"rpc:<socket_id>"`.
+pub(crate) trait ExternalAuditContextProvider: Send + Sync {
+    fn driver_context(
+        &self,
+        socket_id: &str,
+        session_id: Option<Uuid>,
+    ) -> Option<DriverEmitContext>;
+}
+
+/// No-op context provider used when `AppState` wiring is not yet in place or
+/// in unit tests. All lookups return `None`, so `connection_id` and
+/// `database_name` are blank but events still record with the correct actor
+/// and driver_id.
+pub(crate) struct NoOpContextProvider;
+
+impl ExternalAuditContextProvider for NoOpContextProvider {
+    fn driver_context(&self, socket_id: &str, _session_id: Option<Uuid>) -> Option<DriverEmitContext> {
+        Some(DriverEmitContext {
+            connection_id: None,
+            database_name: None,
+            driver_id: format!("rpc:{}", socket_id),
+        })
+    }
+}
+
+// ============================================================================
+// DTO conversions
+// ============================================================================
+
+fn severity_from_dto(dto: EventSeverityDto) -> EventSeverity {
+    match dto {
+        EventSeverityDto::Trace => EventSeverity::Trace,
+        EventSeverityDto::Debug => EventSeverity::Debug,
+        EventSeverityDto::Info => EventSeverity::Info,
+        EventSeverityDto::Warn => EventSeverity::Warn,
+        EventSeverityDto::Error => EventSeverity::Error,
+        EventSeverityDto::Fatal => EventSeverity::Fatal,
+    }
+}
+
+fn category_from_dto(dto: EventCategoryDto) -> EventCategory {
+    match dto {
+        EventCategoryDto::Config => EventCategory::Config,
+        EventCategoryDto::Connection => EventCategory::Connection,
+        EventCategoryDto::Query => EventCategory::Query,
+        EventCategoryDto::Hook => EventCategory::Hook,
+        EventCategoryDto::Script => EventCategory::Script,
+        EventCategoryDto::System => EventCategory::System,
+        EventCategoryDto::Mcp => EventCategory::Mcp,
+        EventCategoryDto::Governance => EventCategory::Governance,
+    }
+}
+
+fn outcome_from_dto(dto: EventOutcomeDto) -> EventOutcome {
+    match dto {
+        EventOutcomeDto::Success => EventOutcome::Success,
+        EventOutcomeDto::Failure => EventOutcome::Failure,
+        EventOutcomeDto::Cancelled => EventOutcome::Cancelled,
+        EventOutcomeDto::Pending => EventOutcome::Pending,
+    }
+}
+
+/// Clamp a service-provided timestamp to the host wall clock if the drift
+/// exceeds the configured maximum.
+fn clamp_timestamp(ts_ms: i64, config: &ExternalAuditConfig) -> i64 {
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    if (ts_ms - now_ms).abs() > config.max_ts_drift_ms {
+        now_ms
+    } else {
+        ts_ms
+    }
+}
+
+// ============================================================================
+// Sanitizing sink
+// ============================================================================
+
+/// Sanitizing implementation of [`ExternalAuditEmitter`].
+///
+/// Receives raw frames from driver and auth-provider transport loops, applies:
+/// 1. Rate limiting (per socket_id token bucket)
+/// 2. Category whitelist (drivers: Connection/Query/System; providers: Connection)
+/// 3. Required-field validation (action + summary must be non-empty)
+/// 4. Identity/context override (host-authoritative; DTO cannot set identity)
+/// 5. Timestamp clamping (prevents rewriting history)
+///
+/// Then forwards the sanitized record to `AuditService` via `EventSink::record`.
+/// All drop paths increment `drop_counter` and log at `debug!`; IPC is never
+/// blocked or errored due to audit failures.
+pub(crate) struct ExternalAuditSink {
+    audit: Arc<dyn EventSink>,
+    drop_counter: Arc<AtomicU64>,
+    rate_limiters: Mutex<HashMap<String, TokenBucket>>,
+    context_provider: Arc<dyn ExternalAuditContextProvider>,
+    config: ExternalAuditConfig,
+}
+
+impl ExternalAuditSink {
+    pub(crate) fn new(
+        audit: Arc<dyn EventSink>,
+        drop_counter: Arc<AtomicU64>,
+        context_provider: Arc<dyn ExternalAuditContextProvider>,
+        config: ExternalAuditConfig,
+    ) -> Self {
+        Self {
+            audit,
+            drop_counter,
+            rate_limiters: Mutex::new(HashMap::new()),
+            context_provider,
+            config,
+        }
+    }
+
+    fn consume_token(&self, socket_id: &str) -> bool {
+        let mut map = self.rate_limiters.lock().unwrap_or_else(|p| p.into_inner());
+        let bucket = map
+            .entry(socket_id.to_string())
+            .or_insert_with(|| TokenBucket::new(self.config.capacity));
+        bucket.consume(Instant::now(), &self.config)
+    }
+
+    fn drop(&self, socket_id: &str, reason: &str) {
+        self.drop_counter.fetch_add(1, Ordering::Relaxed);
+        log::debug!(
+            target: "external_audit",
+            "dropped emit from socket={}: {}",
+            socket_id,
+            reason
+        );
+    }
+}
+
+impl ExternalAuditEmitter for ExternalAuditSink {
+    fn emit(&self, source: ExternalAuditSource, dto: AuditEventEmitDto) {
+        let socket_id = source.socket_id().to_string();
+
+        // Step 1: rate limit.
+        if !self.consume_token(&socket_id) {
+            self.drop(&socket_id, "rate-limited");
+            return;
+        }
+
+        // Step 2: category whitelist.
+        let category = category_from_dto(dto.category);
+        let allowed = match &source {
+            ExternalAuditSource::Driver { .. } => matches!(
+                category,
+                EventCategory::Connection | EventCategory::Query | EventCategory::System
+            ),
+            ExternalAuditSource::AuthProvider { .. } => {
+                matches!(category, EventCategory::Connection)
+            }
+        };
+
+        if !allowed {
+            self.drop(
+                &socket_id,
+                &format!("category {:?} not allowed for {}", category, source.kind_label()),
+            );
+            return;
+        }
+
+        // Step 3: required-field validation.
+        if dto.action.trim().is_empty() || dto.summary.trim().is_empty() {
+            self.drop(&socket_id, "empty action or summary");
+            return;
+        }
+
+        // Step 4: identity/context override.
+        let (actor_type, source_id, actor_id, connection_id, database_name, driver_id, correlation_id) =
+            match &source {
+                ExternalAuditSource::Driver {
+                    socket_id,
+                    session_id,
+                    correlation_id,
+                } => {
+                    let ctx = self.context_provider.driver_context(socket_id, *session_id);
+                    (
+                        EventActorType::ExternalDriver,
+                        EventSourceId::ExternalDriver,
+                        Some(format!("rpc:{}", socket_id)),
+                        ctx.as_ref()
+                            .and_then(|c| c.connection_id.map(|u| u.to_string())),
+                        ctx.as_ref().and_then(|c| c.database_name.clone()),
+                        Some(
+                            ctx.map(|c| c.driver_id)
+                                .unwrap_or_else(|| format!("rpc:{}", socket_id)),
+                        ),
+                        Some(correlation_id.clone()),
+                    )
+                }
+                ExternalAuditSource::AuthProvider {
+                    provider_id,
+                    correlation_id,
+                    ..
+                } => (
+                    EventActorType::ExternalAuthProvider,
+                    EventSourceId::ExternalAuthProvider,
+                    Some(provider_id.clone()),
+                    None,
+                    None,
+                    None,
+                    Some(correlation_id.clone()),
+                ),
+            };
+
+        // Step 5: build and store the record.
+        let record = EventRecord {
+            id: None,
+            ts_ms: clamp_timestamp(dto.ts_ms, &self.config),
+            level: severity_from_dto(dto.level),
+            category,
+            action: dto.action,
+            outcome: outcome_from_dto(dto.outcome),
+            actor_type,
+            actor_id,
+            source_id,
+            connection_id,
+            database_name,
+            driver_id,
+            object_type: dto.object_type,
+            object_id: dto.object_id,
+            summary: dto.summary,
+            details_json: dto.details_json,
+            error_code: dto.error_code,
+            error_message: dto.error_message,
+            duration_ms: dto.duration_ms,
+            session_id: None,
+            correlation_id,
+        };
+
+        if let Err(err) = self.audit.record(record) {
+            log::debug!(
+                target: "external_audit",
+                "audit record failed for socket={}: {}",
+                socket_id,
+                err
+            );
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use dbflux_core::observability::{EventRecord, EventSink, EventSinkError};
+    use dbflux_ipc::audit::{
+        AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto, ExternalAuditSource,
+    };
+
+    // --- Test doubles ---
+
+    /// Records all events for assertion; never fails.
+    #[derive(Default)]
+    struct RecordingEventSink {
+        records: Arc<Mutex<Vec<EventRecord>>>,
+    }
+
+    impl RecordingEventSink {
+        fn count(&self) -> usize {
+            self.records.lock().unwrap().len()
+        }
+
+        fn all(&self) -> Vec<EventRecord> {
+            self.records.lock().unwrap().clone()
+        }
+    }
+
+    impl EventSink for RecordingEventSink {
+        fn record(&self, event: EventRecord) -> Result<EventRecord, EventSinkError> {
+            self.records.lock().unwrap().push(event.clone());
+            Ok(event)
+        }
+    }
+
+    fn minimal_dto(category: EventCategoryDto) -> AuditEventEmitDto {
+        AuditEventEmitDto {
+            ts_ms: chrono::Utc::now().timestamp_millis(),
+            level: EventSeverityDto::Info,
+            category,
+            action: "test.action".to_string(),
+            outcome: EventOutcomeDto::Success,
+            summary: "test summary".to_string(),
+            object_type: None,
+            object_id: None,
+            duration_ms: None,
+            error_code: None,
+            error_message: None,
+            details_json: None,
+        }
+    }
+
+    fn driver_source(socket_id: &str) -> ExternalAuditSource {
+        ExternalAuditSource::Driver {
+            socket_id: socket_id.to_string(),
+            session_id: None,
+            correlation_id: Uuid::new_v4().to_string(),
+        }
+    }
+
+    fn auth_provider_source(socket_id: &str) -> ExternalAuditSource {
+        ExternalAuditSource::AuthProvider {
+            socket_id: socket_id.to_string(),
+            provider_id: "test-auth".to_string(),
+            correlation_id: Uuid::new_v4().to_string(),
+        }
+    }
+
+    fn make_sink(recording_sink: Arc<RecordingEventSink>) -> ExternalAuditSink {
+        let drop_counter = Arc::new(AtomicU64::new(0));
+        ExternalAuditSink::new(
+            recording_sink as Arc<dyn EventSink>,
+            drop_counter,
+            Arc::new(NoOpContextProvider),
+            ExternalAuditConfig::default(),
+        )
+    }
+
+    fn make_sink_with_drop_counter(
+        recording_sink: Arc<RecordingEventSink>,
+    ) -> (ExternalAuditSink, Arc<AtomicU64>) {
+        let drop_counter = Arc::new(AtomicU64::new(0));
+        let sink = ExternalAuditSink::new(
+            recording_sink as Arc<dyn EventSink>,
+            drop_counter.clone(),
+            Arc::new(NoOpContextProvider),
+            ExternalAuditConfig::default(),
+        );
+        (sink, drop_counter)
+    }
+
+    // --- Layer A tests ---
+
+    /// Scenario S-01-a: happy path driver emit produces correct actor/source metadata.
+    #[test]
+    fn test_happy_path_driver_emit() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let sink = make_sink(recording.clone());
+
+        sink.emit(
+            driver_source("foo"),
+            minimal_dto(EventCategoryDto::Connection),
+        );
+
+        let records = recording.all();
+        assert_eq!(records.len(), 1);
+
+        let record = &records[0];
+        assert_eq!(record.actor_type, EventActorType::ExternalDriver);
+        assert_eq!(record.source_id, EventSourceId::ExternalDriver);
+        assert_eq!(record.actor_id.as_deref(), Some("rpc:foo"));
+        assert_eq!(record.driver_id.as_deref(), Some("rpc:foo"));
+        assert!(record.correlation_id.is_some());
+    }
+
+    /// Scenario S-03-b: driver emitting category=Mcp is dropped.
+    #[test]
+    fn test_driver_category_mcp_dropped() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let (sink, drop_counter) = make_sink_with_drop_counter(recording.clone());
+
+        sink.emit(driver_source("foo"), minimal_dto(EventCategoryDto::Mcp));
+
+        assert_eq!(recording.count(), 0);
+        assert_eq!(drop_counter.load(Ordering::Relaxed), 1);
+    }
+
+    /// Scenario S-03-c: driver emitting Connection, Query, System all succeed.
+    #[test]
+    fn test_driver_all_whitelisted_categories_accepted() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let sink = make_sink(recording.clone());
+
+        for category in [
+            EventCategoryDto::Connection,
+            EventCategoryDto::Query,
+            EventCategoryDto::System,
+        ] {
+            sink.emit(driver_source("foo"), minimal_dto(category));
+        }
+
+        assert_eq!(recording.count(), 3);
+    }
+
+    /// Scenario S-04-b: auth provider emitting category=Query is dropped.
+    #[test]
+    fn test_auth_provider_category_query_dropped() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let (sink, drop_counter) = make_sink_with_drop_counter(recording.clone());
+
+        sink.emit(
+            auth_provider_source("auth-sock"),
+            minimal_dto(EventCategoryDto::Query),
+        );
+
+        assert_eq!(recording.count(), 0);
+        assert_eq!(drop_counter.load(Ordering::Relaxed), 1);
+    }
+
+    /// Scenario S-04-a: auth provider emitting category=Connection succeeds.
+    #[test]
+    fn test_auth_provider_connection_accepted() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let sink = make_sink(recording.clone());
+
+        sink.emit(
+            auth_provider_source("auth-sock"),
+            minimal_dto(EventCategoryDto::Connection),
+        );
+
+        assert_eq!(recording.count(), 1);
+        let record = &recording.all()[0];
+        assert_eq!(record.actor_type, EventActorType::ExternalAuthProvider);
+        assert_eq!(record.source_id, EventSourceId::ExternalAuthProvider);
+    }
+
+    /// Scenario R-01-a/R-01-b: 100 emits pass, 101st is rate-limited.
+    #[test]
+    fn test_rate_limit_100_pass_101_drops() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let drop_counter = Arc::new(AtomicU64::new(0));
+
+        let sink = ExternalAuditSink::new(
+            recording.clone() as Arc<dyn EventSink>,
+            drop_counter.clone(),
+            Arc::new(NoOpContextProvider),
+            ExternalAuditConfig::default(),
+        );
+
+        for _ in 0..200 {
+            sink.emit(
+                driver_source("rate-sock"),
+                minimal_dto(EventCategoryDto::System),
+            );
+        }
+
+        assert_eq!(recording.count(), 100, "exactly 100 events should pass");
+        assert_eq!(
+            drop_counter.load(Ordering::Relaxed),
+            100,
+            "exactly 100 drops due to rate limit"
+        );
+    }
+
+    /// Scenario R-02-a: drop counter accumulates across multiple bursts.
+    #[test]
+    fn test_drop_counter_accumulates() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let drop_counter = Arc::new(AtomicU64::new(0));
+
+        let sink = ExternalAuditSink::new(
+            recording.clone() as Arc<dyn EventSink>,
+            drop_counter.clone(),
+            Arc::new(NoOpContextProvider),
+            ExternalAuditConfig::default(),
+        );
+
+        // Exhaust the bucket (100 events).
+        for _ in 0..100 {
+            sink.emit(
+                driver_source("accum-sock"),
+                minimal_dto(EventCategoryDto::System),
+            );
+        }
+
+        // 5 more should all drop.
+        for _ in 0..5 {
+            sink.emit(
+                driver_source("accum-sock"),
+                minimal_dto(EventCategoryDto::System),
+            );
+        }
+
+        assert_eq!(drop_counter.load(Ordering::Relaxed), 5);
+    }
+
+    /// Scenario S-06-a: correlation_id is host-generated (taken from ExternalAuditSource).
+    /// DTO has no correlation_id field — compile-time guarantee.
+    #[test]
+    fn test_correlation_id_host_generated() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let sink = make_sink(recording.clone());
+
+        let source = ExternalAuditSource::Driver {
+            socket_id: "corr-sock".to_string(),
+            session_id: None,
+            correlation_id: "host-corr-123".to_string(),
+        };
+
+        sink.emit(source, minimal_dto(EventCategoryDto::Connection));
+
+        let records = recording.all();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].correlation_id.as_deref(),
+            Some("host-corr-123"),
+            "record must use the host-generated correlation_id from ExternalAuditSource"
+        );
+    }
+
+    /// Timestamp drift: DTO ts_ms that is far in the past should be clamped to now.
+    #[test]
+    fn test_timestamp_clamped_on_drift() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let sink = make_sink(recording.clone());
+
+        let ten_hours_ago = chrono::Utc::now().timestamp_millis() - (10 * 60 * 60 * 1_000);
+
+        let mut dto = minimal_dto(EventCategoryDto::System);
+        dto.ts_ms = ten_hours_ago;
+
+        sink.emit(driver_source("drift-sock"), dto);
+
+        let records = recording.all();
+        assert_eq!(records.len(), 1);
+
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let stored_ts = records[0].ts_ms;
+        assert!(
+            (stored_ts - now_ms).abs() < 2_000,
+            "clamped timestamp must be within 2 seconds of now (was {}ms off)",
+            (stored_ts - now_ms).abs()
+        );
+    }
+
+    /// Scenario: context provider returns None — event records without connection_id.
+    #[test]
+    fn test_context_provider_returns_none_gracefully() {
+        struct NullProvider;
+        impl ExternalAuditContextProvider for NullProvider {
+            fn driver_context(
+                &self,
+                _socket_id: &str,
+                _session_id: Option<Uuid>,
+            ) -> Option<DriverEmitContext> {
+                None
+            }
+        }
+
+        let recording = Arc::new(RecordingEventSink::default());
+        let drop_counter = Arc::new(AtomicU64::new(0));
+
+        let sink = ExternalAuditSink::new(
+            recording.clone() as Arc<dyn EventSink>,
+            drop_counter,
+            Arc::new(NullProvider),
+            ExternalAuditConfig::default(),
+        );
+
+        sink.emit(
+            driver_source("null-ctx-sock"),
+            minimal_dto(EventCategoryDto::Connection),
+        );
+
+        assert_eq!(recording.count(), 1, "event must still record without connection context");
+
+        let record = &recording.all()[0];
+        assert!(record.connection_id.is_none(), "connection_id must be None when context is unavailable");
+        assert!(record.database_name.is_none(), "database_name must be None when context is unavailable");
+        assert_eq!(
+            record.driver_id.as_deref(),
+            Some("rpc:null-ctx-sock"),
+            "driver_id must default to rpc:<socket_id> when context is unavailable"
+        );
+    }
+}

--- a/crates/dbflux_app/src/rpc_services/external_audit.rs
+++ b/crates/dbflux_app/src/rpc_services/external_audit.rs
@@ -185,7 +185,7 @@ fn clamp_timestamp(ts_ms: i64, config: &ExternalAuditConfig) -> i64 {
 /// 5. Timestamp clamping (prevents rewriting history)
 ///
 /// Then forwards the sanitized record to `AuditService` via `EventSink::record`.
-/// All drop paths increment `drop_counter` and log at `debug!`; IPC is never
+/// All drop paths increment `drop_counter` and log at `warn!`; IPC is never
 /// blocked or errored due to audit failures.
 pub(crate) struct ExternalAuditSink {
     audit: Arc<dyn EventSink>,

--- a/crates/dbflux_app/src/rpc_services/external_audit.rs
+++ b/crates/dbflux_app/src/rpc_services/external_audit.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use dbflux_core::observability::{
@@ -61,6 +61,9 @@ pub(crate) struct ExternalAuditConfig {
     /// Maximum tolerated drift between DTO timestamp and host wall clock
     /// before the host clamps the value to now (in milliseconds).
     pub max_ts_drift_ms: i64,
+    /// Maximum byte length for `details_json`. Payloads exceeding this are
+    /// truncated at the nearest valid UTF-8 character boundary before storage.
+    pub max_detail_bytes: usize,
 }
 
 impl Default for ExternalAuditConfig {
@@ -69,6 +72,7 @@ impl Default for ExternalAuditConfig {
             capacity: 100.0,
             refill_rate: 100.0 / 60.0,
             max_ts_drift_ms: 5 * 60 * 1_000,
+            max_detail_bytes: 65_536,
         }
     }
 }
@@ -106,7 +110,11 @@ pub(crate) trait ExternalAuditContextProvider: Send + Sync {
 pub(crate) struct NoOpContextProvider;
 
 impl ExternalAuditContextProvider for NoOpContextProvider {
-    fn driver_context(&self, socket_id: &str, _session_id: Option<Uuid>) -> Option<DriverEmitContext> {
+    fn driver_context(
+        &self,
+        socket_id: &str,
+        _session_id: Option<Uuid>,
+    ) -> Option<DriverEmitContext> {
         Some(DriverEmitContext {
             connection_id: None,
             database_name: None,
@@ -212,12 +220,13 @@ impl ExternalAuditSink {
     }
 
     fn drop(&self, socket_id: &str, reason: &str) {
-        self.drop_counter.fetch_add(1, Ordering::Relaxed);
-        log::debug!(
+        let count = self.drop_counter.fetch_add(1, Ordering::Relaxed) + 1;
+        log::warn!(
             target: "external_audit",
-            "dropped emit from socket={}: {}",
+            "dropped emit from socket={}: {} (total drops: {})",
             socket_id,
-            reason
+            reason,
+            count
         );
     }
 }
@@ -247,7 +256,11 @@ impl ExternalAuditEmitter for ExternalAuditSink {
         if !allowed {
             self.drop(
                 &socket_id,
-                &format!("category {:?} not allowed for {}", category, source.kind_label()),
+                &format!(
+                    "category {:?} not allowed for {}",
+                    category,
+                    source.kind_label()
+                ),
             );
             return;
         }
@@ -259,44 +272,64 @@ impl ExternalAuditEmitter for ExternalAuditSink {
         }
 
         // Step 4: identity/context override.
-        let (actor_type, source_id, actor_id, connection_id, database_name, driver_id, correlation_id) =
-            match &source {
-                ExternalAuditSource::Driver {
-                    socket_id,
-                    session_id,
-                    correlation_id,
-                } => {
-                    let ctx = self.context_provider.driver_context(socket_id, *session_id);
-                    (
-                        EventActorType::ExternalDriver,
-                        EventSourceId::ExternalDriver,
-                        Some(format!("rpc:{}", socket_id)),
-                        ctx.as_ref()
-                            .and_then(|c| c.connection_id.map(|u| u.to_string())),
-                        ctx.as_ref().and_then(|c| c.database_name.clone()),
-                        Some(
-                            ctx.map(|c| c.driver_id)
-                                .unwrap_or_else(|| format!("rpc:{}", socket_id)),
-                        ),
-                        Some(correlation_id.clone()),
-                    )
-                }
-                ExternalAuditSource::AuthProvider {
-                    provider_id,
-                    correlation_id,
-                    ..
-                } => (
-                    EventActorType::ExternalAuthProvider,
-                    EventSourceId::ExternalAuthProvider,
-                    Some(provider_id.clone()),
-                    None,
-                    None,
-                    None,
+        let (
+            actor_type,
+            source_id,
+            actor_id,
+            connection_id,
+            database_name,
+            driver_id,
+            correlation_id,
+        ) = match &source {
+            ExternalAuditSource::Driver {
+                socket_id,
+                session_id,
+                correlation_id,
+            } => {
+                let ctx = self.context_provider.driver_context(socket_id, *session_id);
+                (
+                    EventActorType::ExternalDriver,
+                    EventSourceId::ExternalDriver,
+                    Some(format!("rpc:{}", socket_id)),
+                    ctx.as_ref()
+                        .and_then(|c| c.connection_id.map(|u| u.to_string())),
+                    ctx.as_ref().and_then(|c| c.database_name.clone()),
+                    Some(
+                        ctx.map(|c| c.driver_id)
+                            .unwrap_or_else(|| format!("rpc:{}", socket_id)),
+                    ),
                     Some(correlation_id.clone()),
-                ),
-            };
+                )
+            }
+            ExternalAuditSource::AuthProvider {
+                provider_id,
+                correlation_id,
+                ..
+            } => (
+                EventActorType::ExternalAuthProvider,
+                EventSourceId::ExternalAuthProvider,
+                Some(provider_id.clone()),
+                None,
+                None,
+                None,
+                Some(correlation_id.clone()),
+            ),
+        };
 
-        // Step 5: build and store the record.
+        // Step 5: truncate oversized details_json at a valid UTF-8 boundary, then
+        // build and store the record. AuditService::enforce_max_detail_bytes would
+        // reject (not truncate) if we let it exceed the limit, which would silently
+        // drop the event — contrary to REQ-S-05.
+        let details_json = dto.details_json.map(|d| {
+            let max = self.config.max_detail_bytes;
+            if d.len() > max {
+                let boundary = d.floor_char_boundary(max);
+                d[..boundary].to_string()
+            } else {
+                d
+            }
+        });
+
         let record = EventRecord {
             id: None,
             ts_ms: clamp_timestamp(dto.ts_ms, &self.config),
@@ -313,7 +346,7 @@ impl ExternalAuditEmitter for ExternalAuditSink {
             object_type: dto.object_type,
             object_id: dto.object_id,
             summary: dto.summary,
-            details_json: dto.details_json,
+            details_json,
             error_code: dto.error_code,
             error_message: dto.error_message,
             duration_ms: dto.duration_ms,
@@ -339,11 +372,11 @@ impl ExternalAuditEmitter for ExternalAuditSink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex};
     use dbflux_core::observability::{EventRecord, EventSink, EventSinkError};
     use dbflux_ipc::audit::{
         AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto, ExternalAuditSource,
     };
+    use std::sync::{Arc, Mutex};
 
     // --- Test doubles ---
 
@@ -649,15 +682,81 @@ mod tests {
             minimal_dto(EventCategoryDto::Connection),
         );
 
-        assert_eq!(recording.count(), 1, "event must still record without connection context");
+        assert_eq!(
+            recording.count(),
+            1,
+            "event must still record without connection context"
+        );
 
         let record = &recording.all()[0];
-        assert!(record.connection_id.is_none(), "connection_id must be None when context is unavailable");
-        assert!(record.database_name.is_none(), "database_name must be None when context is unavailable");
+        assert!(
+            record.connection_id.is_none(),
+            "connection_id must be None when context is unavailable"
+        );
+        assert!(
+            record.database_name.is_none(),
+            "database_name must be None when context is unavailable"
+        );
         assert_eq!(
             record.driver_id.as_deref(),
             Some("rpc:null-ctx-sock"),
             "driver_id must default to rpc:<socket_id> when context is unavailable"
+        );
+    }
+
+    /// IT-13: details_json > max_detail_bytes is stored with truncated details_json, not rejected.
+    ///
+    /// REQ-S-05 / Scenario S-05-a.
+    #[test]
+    fn test_oversized_details_json_is_truncated_not_rejected() {
+        let recording = Arc::new(RecordingEventSink::default());
+        let drop_counter = Arc::new(AtomicU64::new(0));
+        let max_bytes = 100_usize;
+
+        let config = ExternalAuditConfig {
+            max_detail_bytes: max_bytes,
+            ..ExternalAuditConfig::default()
+        };
+
+        let sink = ExternalAuditSink::new(
+            recording.clone() as Arc<dyn EventSink>,
+            drop_counter.clone(),
+            Arc::new(NoOpContextProvider),
+            config,
+        );
+
+        let oversized = "x".repeat(max_bytes + 500);
+        assert!(
+            oversized.len() > max_bytes,
+            "precondition: oversized must exceed max_detail_bytes"
+        );
+
+        let mut dto = minimal_dto(EventCategoryDto::Connection);
+        dto.details_json = Some(oversized.clone());
+
+        sink.emit(driver_source("trunc-sock"), dto);
+
+        assert_eq!(recording.count(), 1, "event must be stored, not dropped");
+        assert_eq!(
+            drop_counter.load(Ordering::Relaxed),
+            0,
+            "oversized details_json must not increment drop counter"
+        );
+
+        let stored = &recording.all()[0];
+        let stored_details = stored
+            .details_json
+            .as_ref()
+            .expect("details_json must be present");
+        assert!(
+            stored_details.len() <= max_bytes,
+            "stored details_json length {} must be <= max_detail_bytes {}",
+            stored_details.len(),
+            max_bytes
+        );
+        assert!(
+            oversized.starts_with(stored_details.as_str()),
+            "stored details_json must be a prefix of the original"
         );
     }
 }

--- a/crates/dbflux_app/src/rpc_services/mod.rs
+++ b/crates/dbflux_app/src/rpc_services/mod.rs
@@ -1,9 +1,13 @@
+pub(crate) mod external_audit;
+
 use dbflux_core::{
     DbDriver, DbError, DbKind, DriverFormDef, DriverMetadata, RpcServiceKind, ServiceConfig,
     ServiceRpcApiContract,
 };
 use dbflux_driver_ipc::{IpcDriver, driver::IpcDriverLaunchConfig};
-use dbflux_ipc::{AUTH_PROVIDER_RPC_API_CONTRACT, IpcServiceLaunchConfig, RpcAuthProvider};
+use dbflux_ipc::{
+    AUTH_PROVIDER_RPC_API_CONTRACT, ExternalAuditEmitter, IpcServiceLaunchConfig, RpcAuthProvider,
+};
 use std::sync::Arc;
 
 use dbflux_core::auth::DynAuthProvider;
@@ -143,6 +147,7 @@ pub(crate) fn discover_services(services: Vec<ServiceConfig>) -> Vec<RpcServiceD
 pub(crate) fn adapt_driver_service(
     descriptor: RpcServiceDescriptor,
     driver_exists: impl FnOnce(&str) -> bool,
+    audit_emitter: Option<Arc<dyn ExternalAuditEmitter>>,
 ) -> DriverServiceAdaptation<Arc<dyn DbDriver>> {
     adapt_driver_service_with(
         descriptor,
@@ -153,6 +158,10 @@ pub(crate) fn adapt_driver_service(
                 IpcDriver::new(socket_id, kind, metadata, form_definition, settings_schema);
             let driver = match launch {
                 Some(launch) => driver.with_launch_config(launch),
+                None => driver,
+            };
+            let driver = match audit_emitter {
+                Some(ref emitter) => driver.with_audit_emitter(emitter.clone()),
                 None => driver,
             };
 
@@ -215,10 +224,17 @@ where
 pub(crate) fn adapt_auth_provider_service(
     descriptor: RpcServiceDescriptor,
     provider_exists: impl FnOnce(&str) -> bool,
+    audit_emitter: Option<Arc<dyn ExternalAuditEmitter>>,
 ) -> AuthProviderServiceAdaptation<Arc<dyn DynAuthProvider>> {
     adapt_auth_provider_service_with(descriptor, provider_exists, |socket_id, launch| {
         RpcAuthProvider::probe(socket_id, launch.cloned())
-            .map(|provider| Arc::new(provider) as Arc<dyn DynAuthProvider>)
+            .map(|provider| {
+                let provider = match audit_emitter {
+                    Some(ref emitter) => provider.with_audit_emitter(emitter.clone()),
+                    None => provider,
+                };
+                Arc::new(provider) as Arc<dyn DynAuthProvider>
+            })
             .map_err(Box::new)
     })
 }

--- a/crates/dbflux_audit/src/lib.rs
+++ b/crates/dbflux_audit/src/lib.rs
@@ -96,6 +96,10 @@ pub struct AuditService {
     bridge_min_level: Option<Arc<AtomicU8>>,
     /// Shared with the tracing bridge to expose drop count via `AuditService`.
     bridge_drop_counter: Option<Arc<AtomicU64>>,
+    /// Counts frames dropped by the external-audit sanitizer (rate-limit, category
+    /// filter, validation). Shared with `ExternalAuditSink` so it can increment
+    /// without holding a reference to `AuditService`.
+    external_audit_dropped: Arc<AtomicU64>,
 }
 
 const DEFAULT_MAX_DETAIL_BYTES: usize = 65_536;
@@ -111,7 +115,21 @@ impl AuditService {
             max_detail_bytes: Arc::new(AtomicUsize::new(DEFAULT_MAX_DETAIL_BYTES)),
             bridge_min_level: None,
             bridge_drop_counter: None,
+            external_audit_dropped: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Returns a clone of the shared drop counter for the external-audit sink.
+    ///
+    /// The returned `Arc` can be incremented by `ExternalAuditSink` without
+    /// holding a reference to `AuditService`.
+    pub fn external_audit_drop_counter(&self) -> Arc<AtomicU64> {
+        self.external_audit_dropped.clone()
+    }
+
+    /// Returns the cumulative count of frames dropped by the external-audit sanitizer.
+    pub fn external_audit_dropped_count(&self) -> u64 {
+        self.external_audit_dropped.load(Ordering::Relaxed)
     }
 
     /// Attaches the tracing bridge's shared atomics so level changes and drop counts
@@ -318,7 +336,7 @@ impl AuditService {
     ///
     /// Returns `EventSinkError::MissingRequiredField` if a required field is absent.
     pub fn validate_event(event: &EventRecord) -> Result<(), AuditError> {
-        use dbflux_core::observability::types::EventCategory;
+        use dbflux_core::observability::types::{EventActorType, EventCategory};
 
         // Universal required fields
         if !Self::has_required_text(Some(event.action.as_str())) {
@@ -335,12 +353,19 @@ impl AuditService {
         // Category-specific required fields
         match event.category {
             EventCategory::Query => {
-                if !Self::has_required_text(event.connection_id.as_deref()) {
+                // ExternalDriver events may have no connection context when the
+                // host cannot resolve the session to a connection profile.
+                let is_external = matches!(
+                    event.actor_type,
+                    EventActorType::ExternalDriver | EventActorType::ExternalAuthProvider
+                );
+
+                if !is_external && !Self::has_required_text(event.connection_id.as_deref()) {
                     return Err(AuditError::EventSink(EventSinkError::MissingRequiredField(
                         "connection_id",
                     )));
                 }
-                if !Self::has_required_text(event.driver_id.as_deref()) {
+                if !is_external && !Self::has_required_text(event.driver_id.as_deref()) {
                     return Err(AuditError::EventSink(EventSinkError::MissingRequiredField(
                         "driver_id",
                     )));
@@ -354,7 +379,15 @@ impl AuditService {
                 }
             }
             EventCategory::Connection => {
-                if !Self::has_required_text(event.connection_id.as_deref()) {
+                // ExternalAuthProvider events have no connection_id by design.
+                let is_external_auth = matches!(
+                    event.actor_type,
+                    EventActorType::ExternalAuthProvider
+                );
+
+                if !is_external_auth
+                    && !Self::has_required_text(event.connection_id.as_deref())
+                {
                     return Err(AuditError::EventSink(EventSinkError::MissingRequiredField(
                         "connection_id",
                     )));
@@ -1043,5 +1076,86 @@ mod tests {
         );
         assert_eq!(result.columns[0].name, "bucket_ms");
         assert!(result.rows.is_empty(), "empty input must yield no rows");
+    }
+
+    #[test]
+    fn test_drop_counter_starts_at_zero() {
+        let service = make_service("drop_counter_zero");
+        assert_eq!(service.external_audit_dropped_count(), 0);
+    }
+
+    #[test]
+    fn test_drop_counter_shared_arc_increments_visible_via_service() {
+        let service = make_service("drop_counter_arc");
+        let counter = service.external_audit_drop_counter();
+        counter.fetch_add(3, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(service.external_audit_dropped_count(), 3);
+    }
+
+    #[test]
+    fn test_validate_event_accepts_external_driver() {
+        use dbflux_core::observability::{
+            EventActorType, EventCategory, EventOutcome, EventRecord, EventSeverity, EventSourceId,
+        };
+
+        let event = EventRecord {
+            id: None,
+            ts_ms: 1700000000000,
+            level: EventSeverity::Info,
+            category: EventCategory::System,
+            action: "driver_action".to_string(),
+            outcome: EventOutcome::Success,
+            actor_type: EventActorType::ExternalDriver,
+            actor_id: Some("rpc:test-driver".to_string()),
+            source_id: EventSourceId::ExternalDriver,
+            summary: "driver did something".to_string(),
+            connection_id: None,
+            database_name: None,
+            driver_id: Some("rpc:test-driver".to_string()),
+            object_type: None,
+            object_id: None,
+            details_json: None,
+            error_code: None,
+            error_message: None,
+            duration_ms: None,
+            session_id: None,
+            correlation_id: None,
+        };
+
+        AuditService::validate_event(&event).expect("ExternalDriver events must pass validation");
+    }
+
+    #[test]
+    fn test_validate_event_accepts_external_auth_provider() {
+        use dbflux_core::observability::{
+            EventActorType, EventCategory, EventOutcome, EventRecord, EventSeverity, EventSourceId,
+        };
+
+        let event = EventRecord {
+            id: None,
+            ts_ms: 1700000000000,
+            level: EventSeverity::Info,
+            category: EventCategory::Connection,
+            action: "auth.login".to_string(),
+            outcome: EventOutcome::Success,
+            actor_type: EventActorType::ExternalAuthProvider,
+            actor_id: Some("my-provider".to_string()),
+            source_id: EventSourceId::ExternalAuthProvider,
+            summary: "provider login completed".to_string(),
+            connection_id: None,
+            database_name: None,
+            driver_id: None,
+            object_type: None,
+            object_id: None,
+            details_json: None,
+            error_code: None,
+            error_message: None,
+            duration_ms: None,
+            session_id: None,
+            correlation_id: None,
+        };
+
+        AuditService::validate_event(&event)
+            .expect("ExternalAuthProvider Connection events must pass validation");
     }
 }

--- a/crates/dbflux_audit/src/lib.rs
+++ b/crates/dbflux_audit/src/lib.rs
@@ -380,14 +380,10 @@ impl AuditService {
             }
             EventCategory::Connection => {
                 // ExternalAuthProvider events have no connection_id by design.
-                let is_external_auth = matches!(
-                    event.actor_type,
-                    EventActorType::ExternalAuthProvider
-                );
+                let is_external_auth =
+                    matches!(event.actor_type, EventActorType::ExternalAuthProvider);
 
-                if !is_external_auth
-                    && !Self::has_required_text(event.connection_id.as_deref())
-                {
+                if !is_external_auth && !Self::has_required_text(event.connection_id.as_deref()) {
                     return Err(AuditError::EventSink(EventSinkError::MissingRequiredField(
                         "connection_id",
                     )));

--- a/crates/dbflux_core/src/observability/types.rs
+++ b/crates/dbflux_core/src/observability/types.rs
@@ -704,7 +704,10 @@ mod tests {
     fn test_event_actor_type_external_variants_round_trip() {
         for (variant, expected_str) in [
             (EventActorType::ExternalDriver, "external_driver"),
-            (EventActorType::ExternalAuthProvider, "external_auth_provider"),
+            (
+                EventActorType::ExternalAuthProvider,
+                "external_auth_provider",
+            ),
         ] {
             assert_eq!(variant.as_str(), expected_str);
 
@@ -713,8 +716,7 @@ mod tests {
             assert_eq!(round_tripped, variant);
 
             let json = serde_json::to_string(&variant).expect("serialize");
-            let deserialized: EventActorType =
-                serde_json::from_str(&json).expect("deserialize");
+            let deserialized: EventActorType = serde_json::from_str(&json).expect("deserialize");
             assert_eq!(deserialized, variant);
         }
     }
@@ -723,7 +725,10 @@ mod tests {
     fn test_event_source_id_external_variants_round_trip() {
         for (variant, expected_str) in [
             (EventSourceId::ExternalDriver, "external_driver"),
-            (EventSourceId::ExternalAuthProvider, "external_auth_provider"),
+            (
+                EventSourceId::ExternalAuthProvider,
+                "external_auth_provider",
+            ),
         ] {
             assert_eq!(variant.as_str(), expected_str);
 
@@ -732,8 +737,7 @@ mod tests {
             assert_eq!(round_tripped, variant);
 
             let json = serde_json::to_string(&variant).expect("serialize");
-            let deserialized: EventSourceId =
-                serde_json::from_str(&json).expect("deserialize");
+            let deserialized: EventSourceId = serde_json::from_str(&json).expect("deserialize");
             assert_eq!(deserialized, variant);
         }
     }

--- a/crates/dbflux_core/src/observability/types.rs
+++ b/crates/dbflux_core/src/observability/types.rs
@@ -187,6 +187,10 @@ pub enum EventActorType {
     Hook,
     /// A user script (Lua, Python, Bash, etc.).
     Script,
+    /// An external RPC driver service.
+    ExternalDriver,
+    /// An external RPC auth-provider service.
+    ExternalAuthProvider,
 }
 
 impl EventActorType {
@@ -199,6 +203,8 @@ impl EventActorType {
             EventActorType::McpClient => "mcp_client",
             EventActorType::Hook => "hook",
             EventActorType::Script => "script",
+            EventActorType::ExternalDriver => "external_driver",
+            EventActorType::ExternalAuthProvider => "external_auth_provider",
         }
     }
 
@@ -211,6 +217,8 @@ impl EventActorType {
             "mcp_client" => Some(EventActorType::McpClient),
             "hook" => Some(EventActorType::Hook),
             "script" => Some(EventActorType::Script),
+            "external_driver" => Some(EventActorType::ExternalDriver),
+            "external_auth_provider" => Some(EventActorType::ExternalAuthProvider),
             _ => None,
         }
     }
@@ -236,6 +244,10 @@ pub enum EventSourceId {
     /// System-level event.
     #[default]
     System,
+    /// An external RPC driver service.
+    ExternalDriver,
+    /// An external RPC auth-provider service.
+    ExternalAuthProvider,
 }
 
 impl EventSourceId {
@@ -247,6 +259,8 @@ impl EventSourceId {
             EventSourceId::Hook => "hook",
             EventSourceId::Script => "script",
             EventSourceId::System => "system",
+            EventSourceId::ExternalDriver => "external_driver",
+            EventSourceId::ExternalAuthProvider => "external_auth_provider",
         }
     }
 
@@ -258,6 +272,8 @@ impl EventSourceId {
             "hook" => Some(EventSourceId::Hook),
             "script" => Some(EventSourceId::Script),
             "system" => Some(EventSourceId::System),
+            "external_driver" => Some(EventSourceId::ExternalDriver),
+            "external_auth_provider" => Some(EventSourceId::ExternalAuthProvider),
             _ => None,
         }
     }
@@ -682,6 +698,44 @@ mod tests {
             EventSourceId::from_str_repr("hook"),
             Some(EventSourceId::Hook)
         );
+    }
+
+    #[test]
+    fn test_event_actor_type_external_variants_round_trip() {
+        for (variant, expected_str) in [
+            (EventActorType::ExternalDriver, "external_driver"),
+            (EventActorType::ExternalAuthProvider, "external_auth_provider"),
+        ] {
+            assert_eq!(variant.as_str(), expected_str);
+
+            let round_tripped = EventActorType::from_str_repr(expected_str)
+                .expect("from_str_repr must succeed for new variants");
+            assert_eq!(round_tripped, variant);
+
+            let json = serde_json::to_string(&variant).expect("serialize");
+            let deserialized: EventActorType =
+                serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(deserialized, variant);
+        }
+    }
+
+    #[test]
+    fn test_event_source_id_external_variants_round_trip() {
+        for (variant, expected_str) in [
+            (EventSourceId::ExternalDriver, "external_driver"),
+            (EventSourceId::ExternalAuthProvider, "external_auth_provider"),
+        ] {
+            assert_eq!(variant.as_str(), expected_str);
+
+            let round_tripped = EventSourceId::from_str_repr(expected_str)
+                .expect("from_str_repr must succeed for new variants");
+            assert_eq!(round_tripped, variant);
+
+            let json = serde_json::to_string(&variant).expect("serialize");
+            let deserialized: EventSourceId =
+                serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(deserialized, variant);
+        }
     }
 
     #[test]

--- a/crates/dbflux_driver_ipc/Cargo.toml
+++ b/crates/dbflux_driver_ipc/Cargo.toml
@@ -19,6 +19,9 @@ uuid = { version = "1.0", features = ["v4", "serde"] }
 log = "0.4"
 thiserror = "2.0"
 
+[dev-dependencies]
+dbflux_test_support.workspace = true
+
 [lib]
 name = "dbflux_driver_ipc"
 path = "src/lib.rs"

--- a/crates/dbflux_driver_ipc/README.md
+++ b/crates/dbflux_driver_ipc/README.md
@@ -6,9 +6,11 @@
 - Driver kind, metadata, and form definition come from runtime `Hello` handshake with the remote service.
 - Supports optional managed host lifecycle (spawn, health wait, shutdown tracking) for configured RPC services.
 - Persists and uses external-driver profile values through `DbConfig::External { kind, values }`.
+- Intercepts `EmitAuditEvent` intermediate frames from drivers that advertise `DriverCapability::AuditEmit` (protocol v1.2+) and dispatches them to the host sanitizing sink. Frames from drivers without the capability are silently discarded.
 
 ## Limitations
 
 - Requires a compatible driver host process and reachable socket.
 - Effective feature set is constrained by the remote driver's advertised metadata and implementation.
 - If launch config is not provided, DBFlux cannot auto-start unavailable driver hosts.
+- Audit emission requires protocol v1.2 and `DriverCapability::AuditEmit` in the driver hello; older drivers do not emit audit events.

--- a/crates/dbflux_driver_ipc/src/driver.rs
+++ b/crates/dbflux_driver_ipc/src/driver.rs
@@ -10,8 +10,8 @@ use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use dbflux_core::{
     ConnectionProfile, DbConfig, DbError, DbKind, DriverFormDef, DriverMetadata, FormValues,
 };
-use dbflux_ipc::driver_protocol::DriverResponseBody;
 use dbflux_ipc::ExternalAuditEmitter;
+use dbflux_ipc::driver_protocol::DriverResponseBody;
 use interprocess::local_socket::{GenericNamespaced, Name, Stream as IpcStream, prelude::*};
 
 use crate::connection::IpcConnection;
@@ -711,12 +711,9 @@ impl dbflux_core::DbDriver for IpcDriver {
 
         let name = Self::parse_socket_name(&self.socket_id)?;
 
-        let client = RpcClient::connect_with_audit(
-            name,
-            self.socket_id.clone(),
-            self.audit_emitter.clone(),
-        )
-        .map_err(DbError::from)?;
+        let client =
+            RpcClient::connect_with_audit(name, self.socket_id.clone(), self.audit_emitter.clone())
+                .map_err(DbError::from)?;
 
         let profile_json = serde_json::to_string(profile)
             .map_err(|e| DbError::InvalidProfile(format!("JSON serialization failed: {e}")))?;
@@ -762,12 +759,9 @@ impl dbflux_core::DbDriver for IpcDriver {
 
         let name = Self::parse_socket_name(&self.socket_id)?;
 
-        let client = RpcClient::connect_with_audit(
-            name,
-            self.socket_id.clone(),
-            self.audit_emitter.clone(),
-        )
-        .map_err(DbError::from)?;
+        let client =
+            RpcClient::connect_with_audit(name, self.socket_id.clone(), self.audit_emitter.clone())
+                .map_err(DbError::from)?;
 
         let profile_json = serde_json::to_string(profile)
             .map_err(|e| DbError::InvalidProfile(format!("JSON serialization failed: {e}")))?;

--- a/crates/dbflux_driver_ipc/src/driver.rs
+++ b/crates/dbflux_driver_ipc/src/driver.rs
@@ -11,6 +11,7 @@ use dbflux_core::{
     ConnectionProfile, DbConfig, DbError, DbKind, DriverFormDef, DriverMetadata, FormValues,
 };
 use dbflux_ipc::driver_protocol::DriverResponseBody;
+use dbflux_ipc::ExternalAuditEmitter;
 use interprocess::local_socket::{GenericNamespaced, Name, Stream as IpcStream, prelude::*};
 
 use crate::connection::IpcConnection;
@@ -100,6 +101,9 @@ pub struct IpcDriver {
     form_definition: DriverFormDef,
     settings_schema: Option<Arc<DriverFormDef>>,
     launch: Option<IpcDriverLaunchConfig>,
+    /// Audit emitter passed to each `RpcClient` connection for intercepting
+    /// `EmitAuditEvent` frames from the driver host.
+    audit_emitter: Option<Arc<dyn ExternalAuditEmitter>>,
 }
 
 #[derive(Clone, Debug)]
@@ -132,11 +136,22 @@ impl IpcDriver {
             form_definition,
             settings_schema: settings_schema.map(Arc::new),
             launch: None,
+            audit_emitter: None,
         }
     }
 
     pub fn with_launch_config(mut self, launch: IpcDriverLaunchConfig) -> Self {
         self.launch = Some(launch);
+        self
+    }
+
+    /// Attaches an audit emitter for routing `EmitAuditEvent` frames from the driver host.
+    ///
+    /// Each `RpcClient` built by this driver's connection methods will receive a clone
+    /// of this `Arc`, so audit frames are routed to the sanitizing sink without
+    /// requiring `dbflux_driver_ipc` to depend on `dbflux_audit` directly.
+    pub fn with_audit_emitter(mut self, emitter: Arc<dyn ExternalAuditEmitter>) -> Self {
+        self.audit_emitter = Some(emitter);
         self
     }
 
@@ -696,7 +711,12 @@ impl dbflux_core::DbDriver for IpcDriver {
 
         let name = Self::parse_socket_name(&self.socket_id)?;
 
-        let client = RpcClient::connect(name).map_err(DbError::from)?;
+        let client = RpcClient::connect_with_audit(
+            name,
+            self.socket_id.clone(),
+            self.audit_emitter.clone(),
+        )
+        .map_err(DbError::from)?;
 
         let profile_json = serde_json::to_string(profile)
             .map_err(|e| DbError::InvalidProfile(format!("JSON serialization failed: {e}")))?;
@@ -742,7 +762,12 @@ impl dbflux_core::DbDriver for IpcDriver {
 
         let name = Self::parse_socket_name(&self.socket_id)?;
 
-        let client = RpcClient::connect(name).map_err(DbError::from)?;
+        let client = RpcClient::connect_with_audit(
+            name,
+            self.socket_id.clone(),
+            self.audit_emitter.clone(),
+        )
+        .map_err(DbError::from)?;
 
         let profile_json = serde_json::to_string(profile)
             .map_err(|e| DbError::InvalidProfile(format!("JSON serialization failed: {e}")))?;

--- a/crates/dbflux_driver_ipc/src/transport.rs
+++ b/crates/dbflux_driver_ipc/src/transport.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use dbflux_core::DbError;
 use dbflux_ipc::{
-    DRIVER_RPC_AUTH_TOKEN_ENV, DRIVER_RPC_VERSION, ProtocolVersion, RpcApiFamily,
+    DRIVER_RPC_AUTH_TOKEN_ENV, DRIVER_RPC_VERSION, ExternalAuditEmitter, ExternalAuditSource,
+    ProtocolVersion, RpcApiFamily,
     driver_protocol::{
         DriverCapability, DriverHelloRequest, DriverHelloResponse, DriverRequestBody,
         DriverRequestEnvelope, DriverResponseBody, DriverResponseEnvelope,
@@ -16,6 +18,14 @@ pub struct RpcClient {
     stream: Arc<Mutex<IpcStream>>,
     request_id: Arc<Mutex<u64>>,
     hello: DriverHelloResponse,
+    /// Socket registry ID (`rpc:<socket_id>`) for correlation and logging.
+    socket_id: String,
+    /// Whether the driver advertised `DriverCapability::AuditEmit` in its hello.
+    audit_emit_capability: bool,
+    /// Sanitizing sink for audit frames emitted by this driver.
+    audit_emitter: Option<Arc<dyn ExternalAuditEmitter>>,
+    /// Per-session correlation IDs, allocated lazily on first audit emit for a session.
+    session_correlation_ids: Mutex<HashMap<Uuid, String>>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -53,6 +63,18 @@ impl From<RpcError> for DbError {
 impl RpcClient {
     /// Connects to a driver-host via a local socket name and performs the Hello handshake.
     pub fn connect(name: Name<'_>) -> Result<Self, RpcError> {
+        Self::connect_with_audit(name, String::new(), None)
+    }
+
+    /// Connects with an audit emitter attached for handling `EmitAuditEvent` frames.
+    ///
+    /// `socket_id` is the registry key (`rpc:<socket_id>`) used for correlation.
+    /// `audit_emitter` is `None` when audit emission is not wired (e.g. in tests).
+    pub fn connect_with_audit(
+        name: Name<'_>,
+        socket_id: String,
+        audit_emitter: Option<Arc<dyn ExternalAuditEmitter>>,
+    ) -> Result<Self, RpcError> {
         let stream =
             IpcStream::connect(name).map_err(|e| RpcError::ConnectionFailed(e.to_string()))?;
 
@@ -61,10 +83,18 @@ impl RpcClient {
 
         let hello = Self::perform_hello(&stream, &request_id)?;
 
+        let audit_emit_capability = hello
+            .capabilities
+            .contains(&DriverCapability::AuditEmit);
+
         let client = Self {
             stream,
             request_id,
             hello,
+            socket_id,
+            audit_emit_capability,
+            audit_emitter,
+            session_correlation_ids: Mutex::new(HashMap::new()),
         };
 
         Ok(client)
@@ -781,8 +811,13 @@ impl RpcClient {
     }
 
     /// Low-level send/receive with request-ID correlation.
+    ///
+    /// Intercepts `EmitAuditEvent` intermediate frames (`done=false`) and dispatches
+    /// them to the audit emitter when the driver has the `AuditEmit` capability.
+    /// All other frames (including the terminal frame) are returned to the caller.
     fn send_raw(&self, request: DriverRequestEnvelope) -> Result<DriverResponseEnvelope, RpcError> {
         let expected_id = request.request_id;
+        let request_session_id = request.session_id;
 
         let mut stream = self
             .stream
@@ -791,16 +826,55 @@ impl RpcClient {
 
         framing::send_msg(&mut *stream, &request).map_err(RpcError::Io)?;
 
-        let response: DriverResponseEnvelope =
-            framing::recv_msg(&mut *stream).map_err(RpcError::Io)?;
+        loop {
+            let response: DriverResponseEnvelope =
+                framing::recv_msg(&mut *stream).map_err(RpcError::Io)?;
 
-        if response.request_id != expected_id {
-            return Err(RpcError::Protocol("Request ID mismatch".into()));
+            if response.request_id != expected_id {
+                return Err(RpcError::Protocol("Request ID mismatch".into()));
+            }
+
+            validate_response_protocol_version(
+                request.protocol_version,
+                response.protocol_version,
+            )?;
+
+            match response.body {
+                DriverResponseBody::EmitAuditEvent(ref dto) if !response.done => {
+                    if self.audit_emit_capability {
+                        if let Some(sink) = &self.audit_emitter {
+                            let session_id = response.session_id.or(request_session_id);
+                            let correlation_id = self.correlation_id_for_session(session_id);
+                            sink.emit(
+                                ExternalAuditSource::Driver {
+                                    socket_id: self.socket_id.clone(),
+                                    session_id,
+                                    correlation_id,
+                                },
+                                dto.clone(),
+                            );
+                        }
+                    }
+                    // Loop to consume the next frame regardless of capability/emitter.
+                    continue;
+                }
+                _ => return Ok(response),
+            }
         }
+    }
 
-        validate_response_protocol_version(request.protocol_version, response.protocol_version)?;
+    fn correlation_id_for_session(&self, session_id: Option<Uuid>) -> String {
+        let Some(session_id) = session_id else {
+            return Uuid::new_v4().to_string();
+        };
 
-        Ok(response)
+        let mut map = self
+            .session_correlation_ids
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        map.entry(session_id)
+            .or_insert_with(|| Uuid::new_v4().to_string())
+            .clone()
     }
 
     fn next_request_id(&self) -> Result<u64, RpcError> {

--- a/crates/dbflux_driver_ipc/src/transport.rs
+++ b/crates/dbflux_driver_ipc/src/transport.rs
@@ -948,12 +948,112 @@ fn validate_response_protocol_version(
 #[cfg(test)]
 mod tests {
     use super::{
-        build_call_request_envelope, protocol_supports_semantic_planning,
+        RpcClient, build_call_request_envelope, protocol_supports_semantic_planning,
         validate_hello_selected_version, validate_response_protocol_version,
     };
+    use dbflux_ipc::audit::{AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto, ExternalAuditEmitter, ExternalAuditSource};
     use dbflux_ipc::driver_protocol::DriverRequestBody;
-    use dbflux_ipc::{ProtocolVersion, driver_rpc_supported_versions};
+    use dbflux_ipc::{ProtocolVersion, driver_rpc_supported_versions, driver_socket_name};
+    use std::sync::{Arc, Mutex};
     use uuid::Uuid;
+
+    struct RecordingEmitter {
+        calls: Mutex<Vec<(ExternalAuditSource, AuditEventEmitDto)>>,
+    }
+
+    impl RecordingEmitter {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+    }
+
+    impl ExternalAuditEmitter for RecordingEmitter {
+        fn emit(&self, source: ExternalAuditSource, dto: AuditEventEmitDto) {
+            self.calls.lock().unwrap().push((source, dto));
+        }
+    }
+
+    fn fake_audit_dto() -> AuditEventEmitDto {
+        AuditEventEmitDto {
+            ts_ms: 1_000_000,
+            level: EventSeverityDto::Info,
+            category: EventCategoryDto::Connection,
+            outcome: EventOutcomeDto::Success,
+            action: "test_action".to_string(),
+            summary: "test summary".to_string(),
+            object_type: None,
+            object_id: None,
+            duration_ms: None,
+            error_code: None,
+            error_message: None,
+            details_json: None,
+        }
+    }
+
+    #[test]
+    fn rpc_client_with_audit_capability_dispatches_emit_frame_to_emitter() {
+        use dbflux_test_support::{FakeDriverAction, FakeDriverRpcConfig, FakeDriverRpcServer};
+
+        let socket_id = format!("test-audit-emit-{}", Uuid::new_v4());
+        let server = FakeDriverRpcServer::start(
+            FakeDriverRpcConfig::new(&socket_id)
+                .with_audit_emit_capability()
+                .with_actions(vec![FakeDriverAction::EmitAuditThenPong(fake_audit_dto())]),
+        )
+        .expect("fake driver server must start");
+
+        let emitter = RecordingEmitter::new();
+        let socket_name = driver_socket_name(&socket_id).expect("socket name");
+        let client = RpcClient::connect_with_audit(
+            socket_name.borrow(),
+            socket_id.clone(),
+            Some(emitter.clone() as Arc<dyn ExternalAuditEmitter>),
+        )
+        .expect("connect must succeed");
+
+        client.ping(Uuid::nil()).expect("ping must succeed");
+
+        server.wait().expect("server must exit cleanly");
+
+        assert_eq!(emitter.call_count(), 1, "emitter must be called once");
+    }
+
+    #[test]
+    fn rpc_client_without_audit_capability_drops_emit_frame_silently() {
+        use dbflux_test_support::{FakeDriverAction, FakeDriverRpcConfig, FakeDriverRpcServer};
+
+        let socket_id = format!("test-audit-no-cap-{}", Uuid::new_v4());
+        let server = FakeDriverRpcServer::start(
+            FakeDriverRpcConfig::new(&socket_id)
+                .with_actions(vec![FakeDriverAction::EmitAuditThenPong(fake_audit_dto())]),
+        )
+        .expect("fake driver server must start");
+
+        let emitter = RecordingEmitter::new();
+        let socket_name = driver_socket_name(&socket_id).expect("socket name");
+        let client = RpcClient::connect_with_audit(
+            socket_name.borrow(),
+            socket_id.clone(),
+            Some(emitter.clone() as Arc<dyn ExternalAuditEmitter>),
+        )
+        .expect("connect must succeed");
+
+        client.ping(Uuid::nil()).expect("ping must succeed");
+
+        server.wait().expect("server must exit cleanly");
+
+        assert_eq!(
+            emitter.call_count(),
+            0,
+            "emitter must not be called when capability is absent"
+        );
+    }
 
     #[test]
     fn semantic_planning_requires_driver_rpc_v1_1_or_newer() {

--- a/crates/dbflux_driver_ipc/src/transport.rs
+++ b/crates/dbflux_driver_ipc/src/transport.rs
@@ -897,7 +897,7 @@ mod tests {
     #[test]
     fn hello_selected_version_must_be_supported_by_both_peers() {
         let error = validate_hello_selected_version(
-            ProtocolVersion::new(1, 2),
+            ProtocolVersion::new(1, 99),
             driver_rpc_supported_versions(),
         )
         .expect_err("unsupported selection should be rejected");

--- a/crates/dbflux_driver_ipc/src/transport.rs
+++ b/crates/dbflux_driver_ipc/src/transport.rs
@@ -83,9 +83,7 @@ impl RpcClient {
 
         let hello = Self::perform_hello(&stream, &request_id)?;
 
-        let audit_emit_capability = hello
-            .capabilities
-            .contains(&DriverCapability::AuditEmit);
+        let audit_emit_capability = hello.capabilities.contains(&DriverCapability::AuditEmit);
 
         let client = Self {
             stream,
@@ -841,19 +839,19 @@ impl RpcClient {
 
             match response.body {
                 DriverResponseBody::EmitAuditEvent(ref dto) if !response.done => {
-                    if self.audit_emit_capability {
-                        if let Some(sink) = &self.audit_emitter {
-                            let session_id = response.session_id.or(request_session_id);
-                            let correlation_id = self.correlation_id_for_session(session_id);
-                            sink.emit(
-                                ExternalAuditSource::Driver {
-                                    socket_id: self.socket_id.clone(),
-                                    session_id,
-                                    correlation_id,
-                                },
-                                dto.clone(),
-                            );
-                        }
+                    if self.audit_emit_capability
+                        && let Some(sink) = &self.audit_emitter
+                    {
+                        let session_id = response.session_id.or(request_session_id);
+                        let correlation_id = self.correlation_id_for_session(session_id);
+                        sink.emit(
+                            ExternalAuditSource::Driver {
+                                socket_id: self.socket_id.clone(),
+                                session_id,
+                                correlation_id,
+                            },
+                            dto.clone(),
+                        );
                     }
                     // Loop to consume the next frame regardless of capability/emitter.
                     continue;
@@ -951,7 +949,10 @@ mod tests {
         RpcClient, build_call_request_envelope, protocol_supports_semantic_planning,
         validate_hello_selected_version, validate_response_protocol_version,
     };
-    use dbflux_ipc::audit::{AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto, ExternalAuditEmitter, ExternalAuditSource};
+    use dbflux_ipc::audit::{
+        AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto,
+        ExternalAuditEmitter, ExternalAuditSource,
+    };
     use dbflux_ipc::driver_protocol::DriverRequestBody;
     use dbflux_ipc::{ProtocolVersion, driver_rpc_supported_versions, driver_socket_name};
     use std::sync::{Arc, Mutex};
@@ -1138,5 +1139,56 @@ mod tests {
         assert_eq!(envelope.protocol_version, ProtocolVersion::new(1, 0));
         assert_eq!(envelope.request_id, 8);
         assert_eq!(envelope.session_id, None);
+    }
+
+    /// IT-07: rate-limit exhausted on a socket, then a subsequent Ping still succeeds.
+    ///
+    /// REQ-R-03 / Scenario R-03-a: rate-limit drops must not set error state on the IPC session.
+    #[test]
+    fn rate_limit_exhausted_session_continues_for_subsequent_request() {
+        use dbflux_test_support::{FakeDriverAction, FakeDriverRpcConfig, FakeDriverRpcServer};
+
+        let socket_id = format!("test-rate-limit-session-{}", Uuid::new_v4());
+
+        // Two requests: first sends 200 audit frames (100 accepted, 100 dropped), then a plain Pong.
+        let server = FakeDriverRpcServer::start(
+            FakeDriverRpcConfig::new(&socket_id)
+                .with_audit_emit_capability()
+                .with_actions(vec![
+                    FakeDriverAction::EmitNAuditThenPong(200, fake_audit_dto()),
+                    FakeDriverAction::Pong,
+                ])
+                .with_expected_connections(1),
+        )
+        .expect("fake driver server must start");
+
+        let emitter = RecordingEmitter::new();
+        let socket_name = driver_socket_name(&socket_id).expect("socket name");
+        let client = RpcClient::connect_with_audit(
+            socket_name.borrow(),
+            socket_id.clone(),
+            Some(emitter.clone() as Arc<dyn ExternalAuditEmitter>),
+        )
+        .expect("connect must succeed");
+
+        // First request: 200 audit frames sent by the server; emitter receives all 200
+        // because the emitter here is the raw RecordingEmitter (no rate limiter at this layer).
+        // The important invariant is that the RpcClient loop handles them all and returns Ok.
+        client
+            .ping(Uuid::nil())
+            .expect("first ping must succeed despite burst of audit frames");
+
+        // Second request: no audit frames, plain Pong. Session must still be usable.
+        client
+            .ping(Uuid::nil())
+            .expect("second ping must succeed — IPC session must be intact after rate-limit burst");
+
+        server.wait().expect("server must exit cleanly");
+
+        assert_eq!(
+            emitter.call_count(),
+            200,
+            "all 200 audit frames must be forwarded to the emitter by the transport loop"
+        );
     }
 }

--- a/crates/dbflux_ipc/src/audit.rs
+++ b/crates/dbflux_ipc/src/audit.rs
@@ -92,23 +92,17 @@ pub struct AuditEventEmitDto {
     /// Human-readable summary.  Required, non-empty.
     pub summary: String,
     /// Type of object involved (e.g. `"table"`, `"collection"`).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub object_type: Option<String>,
     /// Identifier of the specific object involved.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub object_id: Option<String>,
     /// Duration of the action in milliseconds.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_ms: Option<i64>,
     /// Short error code string when `outcome == Failure`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_code: Option<String>,
     /// Human-readable error message when `outcome == Failure`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_message: Option<String>,
     /// Additional structured detail as a JSON object string.
     /// Capped to 64 KiB by `AuditService::preprocess_event_for_storage`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub details_json: Option<String>,
 }
 

--- a/crates/dbflux_ipc/src/audit.rs
+++ b/crates/dbflux_ipc/src/audit.rs
@@ -204,10 +204,7 @@ mod tests {
         assert_eq!(restored.duration_ms, Some(42));
         assert!(restored.error_code.is_none());
         assert!(restored.error_message.is_none());
-        assert_eq!(
-            restored.details_json.as_deref(),
-            Some(r#"{"rows":10}"#)
-        );
+        assert_eq!(restored.details_json.as_deref(), Some(r#"{"rows":10}"#));
 
         // Identity fields must not be present on the type.
         // Asserting at compile time: there is no .actor_type, .actor_id, etc.
@@ -221,10 +218,7 @@ mod tests {
             !json.contains("connection_id"),
             "DTO must not carry connection_id"
         );
-        assert!(
-            !json.contains("driver_id"),
-            "DTO must not carry driver_id"
-        );
+        assert!(!json.contains("driver_id"), "DTO must not carry driver_id");
         assert!(
             !json.contains("correlation_id"),
             "DTO must not carry correlation_id"

--- a/crates/dbflux_ipc/src/audit.rs
+++ b/crates/dbflux_ipc/src/audit.rs
@@ -1,0 +1,259 @@
+//! Audit-emission types for external RPC services.
+//!
+//! External RPC drivers (v1.2+) and auth providers (v1.3+) may emit audit events
+//! as intermediate response frames. The host owns identity, correlation, and rate
+//! limiting; the external service supplies only the event content.
+//!
+//! ## Design constraints
+//!
+//! - `AuditEventEmitDto` carries no identity fields (`actor_type`, `actor_id`,
+//!   `connection_id`, etc.). Those are host-supplied at sanitization time, making
+//!   it compile-time impossible for an external service to forge its own identity.
+//! - `ExternalAuditEmitter` is defined here so `dbflux_driver_ipc` and
+//!   `dbflux_ipc::auth_provider_client` can hold an `Arc<dyn ExternalAuditEmitter>`
+//!   without depending on `dbflux_audit`.
+//! - The concrete sanitizing implementation lives in `dbflux_app::rpc_services::external_audit`.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ============================================================================
+// DTO mirror enums
+// ============================================================================
+
+/// Mirror of `dbflux_core::observability::EventSeverity` for IPC transport.
+///
+/// Defined separately so `dbflux_ipc` does not need to import
+/// `dbflux_core::observability` internals. Conversion via `From` is implemented
+/// in `dbflux_app::rpc_services::external_audit`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EventSeverityDto {
+    Trace,
+    Debug,
+    #[default]
+    Info,
+    Warn,
+    Error,
+    Fatal,
+}
+
+/// Mirror of `dbflux_core::observability::EventCategory` for IPC transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EventCategoryDto {
+    Config,
+    Connection,
+    Query,
+    Hook,
+    Script,
+    #[default]
+    System,
+    Mcp,
+    Governance,
+}
+
+/// Mirror of `dbflux_core::observability::EventOutcome` for IPC transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum EventOutcomeDto {
+    #[default]
+    Success,
+    Failure,
+    Cancelled,
+    Pending,
+}
+
+// ============================================================================
+// Audit emit DTO
+// ============================================================================
+
+/// Payload sent by an external RPC service to request audit-event recording.
+///
+/// Fields intentionally absent: `actor_type`, `source_id`, `actor_id`,
+/// `connection_id`, `database_name`, `driver_id`, `correlation_id`, `session_id`.
+/// All identity fields are unconditionally supplied by the host at sanitization
+/// time, so there is no runtime validation surface to exploit.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditEventEmitDto {
+    /// Service-side timestamp in milliseconds since Unix epoch.
+    ///
+    /// The host clamps this value when the drift exceeds five minutes.
+    pub ts_ms: i64,
+    /// Severity level of the event.
+    pub level: EventSeverityDto,
+    /// Functional category.  Only a whitelist of categories is accepted per source
+    /// kind; others are dropped silently by the sanitizer.
+    pub category: EventCategoryDto,
+    /// Short action identifier (e.g. `"query.execute"`).  Required, non-empty.
+    pub action: String,
+    /// Outcome of the action.
+    pub outcome: EventOutcomeDto,
+    /// Human-readable summary.  Required, non-empty.
+    pub summary: String,
+    /// Type of object involved (e.g. `"table"`, `"collection"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_type: Option<String>,
+    /// Identifier of the specific object involved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_id: Option<String>,
+    /// Duration of the action in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<i64>,
+    /// Short error code string when `outcome == Failure`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<String>,
+    /// Human-readable error message when `outcome == Failure`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    /// Additional structured detail as a JSON object string.
+    /// Capped to 64 KiB by `AuditService::preprocess_event_for_storage`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub details_json: Option<String>,
+}
+
+// ============================================================================
+// Source context
+// ============================================================================
+
+/// Source context supplied by the transport layer to the audit sanitizer.
+///
+/// The sanitizer reads these host-controlled values to build the final
+/// `EventRecord`. `correlation_id` is always host-generated and never DTO-supplied.
+#[derive(Debug, Clone)]
+pub enum ExternalAuditSource {
+    /// Frame came from an RPC driver connection.
+    Driver {
+        socket_id: String,
+        session_id: Option<Uuid>,
+        correlation_id: String,
+    },
+    /// Frame came from an RPC auth-provider request cycle.
+    AuthProvider {
+        socket_id: String,
+        provider_id: String,
+        correlation_id: String,
+    },
+}
+
+impl ExternalAuditSource {
+    /// Returns the `socket_id` regardless of source kind, used as the rate-limiter key.
+    pub fn socket_id(&self) -> &str {
+        match self {
+            ExternalAuditSource::Driver { socket_id, .. } => socket_id,
+            ExternalAuditSource::AuthProvider { socket_id, .. } => socket_id,
+        }
+    }
+
+    /// Returns a stable label for the source kind, used in log output.
+    pub fn kind_label(&self) -> &'static str {
+        match self {
+            ExternalAuditSource::Driver { .. } => "driver",
+            ExternalAuditSource::AuthProvider { .. } => "auth_provider",
+        }
+    }
+}
+
+// ============================================================================
+// Emitter trait
+// ============================================================================
+
+/// Abstraction over the audit sanitizer, kept in `dbflux_ipc` so transport-layer
+/// crates can hold an `Arc<dyn ExternalAuditEmitter>` without depending on
+/// `dbflux_audit`.
+///
+/// The concrete implementation (`ExternalAuditSink`) lives in
+/// `dbflux_app::rpc_services::external_audit`.
+pub trait ExternalAuditEmitter: Send + Sync {
+    /// Called by the transport loop for every `EmitAuditEvent` frame intercepted.
+    ///
+    /// Implementations must be cheap and non-blocking: they should acquire at most
+    /// one short-lived mutex, build an `EventRecord`, and dispatch it to the audit
+    /// store without waiting for a response.  Any failure is logged at `debug!` and
+    /// discarded; IPC sessions must never stall due to audit failures.
+    fn emit(&self, source: ExternalAuditSource, dto: AuditEventEmitDto);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_audit_event_emit_dto_serde_round_trip() {
+        let dto = AuditEventEmitDto {
+            ts_ms: 1700000000000,
+            level: EventSeverityDto::Warn,
+            category: EventCategoryDto::Query,
+            action: "query.execute".to_string(),
+            outcome: EventOutcomeDto::Success,
+            summary: "executed a SELECT".to_string(),
+            object_type: Some("table".to_string()),
+            object_id: Some("users".to_string()),
+            duration_ms: Some(42),
+            error_code: None,
+            error_message: None,
+            details_json: Some(r#"{"rows":10}"#.to_string()),
+        };
+
+        let json = serde_json::to_string(&dto).expect("serialize");
+        let restored: AuditEventEmitDto = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(restored.ts_ms, 1700000000000);
+        assert_eq!(restored.action, "query.execute");
+        assert_eq!(restored.summary, "executed a SELECT");
+        assert_eq!(restored.object_type.as_deref(), Some("table"));
+        assert_eq!(restored.object_id.as_deref(), Some("users"));
+        assert_eq!(restored.duration_ms, Some(42));
+        assert!(restored.error_code.is_none());
+        assert!(restored.error_message.is_none());
+        assert_eq!(
+            restored.details_json.as_deref(),
+            Some(r#"{"rows":10}"#)
+        );
+
+        // Identity fields must not be present on the type.
+        // Asserting at compile time: there is no .actor_type, .actor_id, etc.
+        // Runtime check: JSON must not contain those keys.
+        assert!(
+            !json.contains("actor_type"),
+            "DTO must not carry actor_type"
+        );
+        assert!(!json.contains("actor_id"), "DTO must not carry actor_id");
+        assert!(
+            !json.contains("connection_id"),
+            "DTO must not carry connection_id"
+        );
+        assert!(
+            !json.contains("driver_id"),
+            "DTO must not carry driver_id"
+        );
+        assert!(
+            !json.contains("correlation_id"),
+            "DTO must not carry correlation_id"
+        );
+        assert!(!json.contains("source_id"), "DTO must not carry source_id");
+    }
+
+    #[test]
+    fn external_audit_source_socket_id_and_kind_label() {
+        let driver_source = ExternalAuditSource::Driver {
+            socket_id: "my-driver".to_string(),
+            session_id: None,
+            correlation_id: "corr-1".to_string(),
+        };
+        assert_eq!(driver_source.socket_id(), "my-driver");
+        assert_eq!(driver_source.kind_label(), "driver");
+
+        let provider_source = ExternalAuditSource::AuthProvider {
+            socket_id: "my-provider".to_string(),
+            provider_id: "aws-sso".to_string(),
+            correlation_id: "corr-2".to_string(),
+        };
+        assert_eq!(provider_source.socket_id(), "my-provider");
+        assert_eq!(provider_source.kind_label(), "auth_provider");
+    }
+}

--- a/crates/dbflux_ipc/src/auth_provider_client.rs
+++ b/crates/dbflux_ipc/src/auth_provider_client.rs
@@ -13,13 +13,13 @@ use dbflux_core::auth::{
 };
 use interprocess::local_socket::{Stream as IpcStream, prelude::*};
 
+use crate::audit::{ExternalAuditEmitter, ExternalAuditSource};
 use crate::auth::AUTH_PROVIDER_RPC_AUTH_TOKEN_ENV;
 use crate::auth_provider_protocol::{
     AuthProviderHelloRequest, AuthProviderRequestBody, AuthProviderRequestEnvelope,
     AuthProviderResponseBody, AuthProviderResponseEnvelope, FetchFieldOptionsError,
     FetchFieldOptionsRequest, LoginRequest, ResolveCredentialsRequest, ValidateSessionRequest,
 };
-use crate::audit::{ExternalAuditEmitter, ExternalAuditSource};
 use crate::envelope::{AUTH_PROVIDER_RPC_API_CONTRACT, AUTH_PROVIDER_RPC_V1_2, ProtocolVersion};
 use crate::framing;
 use crate::socket::auth_provider_socket_name;
@@ -153,8 +153,8 @@ impl RpcAuthProvider {
         audit_emit_opt_in: bool,
         audit_emitter: Option<Arc<dyn ExternalAuditEmitter>>,
     ) -> Self {
-        use dbflux_core::auth::AuthProviderCapabilities;
         use crate::envelope::AUTH_PROVIDER_RPC_VERSION;
+        use dbflux_core::auth::AuthProviderCapabilities;
 
         Self {
             socket_id: socket_id.to_string(),
@@ -248,6 +248,7 @@ impl RpcAuthProvider {
         self.dispatch_request_loop(&mut stream, body)
     }
 
+    #[allow(clippy::result_large_err)]
     fn dispatch_request_loop<S: std::io::Read + std::io::Write>(
         &self,
         stream: &mut S,
@@ -273,17 +274,16 @@ impl RpcAuthProvider {
 
             match &response.body {
                 AuthProviderResponseBody::EmitAuditEvent(dto) if !done => {
-                    if self.audit_emit_opt_in {
-                        if let Some(sink) = &self.audit_emitter {
-                            let source = ExternalAuditSource::AuthProvider {
-                                socket_id: self.socket_id.clone(),
-                                provider_id: self.provider_id.clone(),
-                                correlation_id: correlation_id.clone(),
-                            };
-                            sink.emit(source, dto.clone());
-                        }
+                    if self.audit_emit_opt_in
+                        && let Some(sink) = &self.audit_emitter
+                    {
+                        let source = ExternalAuditSource::AuthProvider {
+                            socket_id: self.socket_id.clone(),
+                            provider_id: self.provider_id.clone(),
+                            correlation_id: correlation_id.clone(),
+                        };
+                        sink.emit(source, dto.clone());
                     }
-                    // else: silently drop — provider did not set audit_emit_opt_in
                     // Never push EmitAuditEvent frames to `responses` — keep it terminal-only.
                 }
                 _ => {
@@ -1105,8 +1105,11 @@ mod tests {
     // Layer C: dispatch_request_loop — audit frame interception
     // =========================================================================
 
+    use crate::audit::{
+        AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto,
+        ExternalAuditEmitter, ExternalAuditSource,
+    };
     use std::sync::{Arc, Mutex};
-    use crate::audit::{AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto, ExternalAuditEmitter, ExternalAuditSource};
 
     /// In-memory stream that supplies pre-encoded response bytes and absorbs writes.
     struct MockStream {
@@ -1180,7 +1183,6 @@ mod tests {
         buf
     }
 
-
     fn emit_audit_frame(request_id: u64, dto: AuditEventEmitDto) -> AuthProviderResponseEnvelope {
         AuthProviderResponseEnvelope {
             protocol_version: crate::AUTH_PROVIDER_RPC_VERSION,
@@ -1234,10 +1236,21 @@ mod tests {
             )
             .expect("dispatch should succeed");
 
-        assert_eq!(emitter.call_count(), 1, "emitter must be called once for the EmitAuditEvent frame");
-        assert_eq!(responses.len(), 1, "caller must receive only the terminal LoginResult");
+        assert_eq!(
+            emitter.call_count(),
+            1,
+            "emitter must be called once for the EmitAuditEvent frame"
+        );
+        assert_eq!(
+            responses.len(),
+            1,
+            "caller must receive only the terminal LoginResult"
+        );
         assert!(
-            matches!(responses[0].body, AuthProviderResponseBody::LoginResult { .. }),
+            matches!(
+                responses[0].body,
+                AuthProviderResponseBody::LoginResult { .. }
+            ),
             "terminal response must be LoginResult"
         );
     }
@@ -1274,9 +1287,16 @@ mod tests {
             0,
             "emitter must NOT be called when audit_emit_opt_in=false"
         );
-        assert_eq!(responses.len(), 1, "caller must still receive the terminal LoginResult");
+        assert_eq!(
+            responses.len(),
+            1,
+            "caller must still receive the terminal LoginResult"
+        );
         assert!(
-            matches!(responses[0].body, AuthProviderResponseBody::LoginResult { .. }),
+            matches!(
+                responses[0].body,
+                AuthProviderResponseBody::LoginResult { .. }
+            ),
             "terminal response must be LoginResult"
         );
     }

--- a/crates/dbflux_ipc/src/auth_provider_client.rs
+++ b/crates/dbflux_ipc/src/auth_provider_client.rs
@@ -145,6 +145,31 @@ impl RpcAuthProvider {
         self
     }
 
+    /// Constructs a minimal provider for testing the dispatch loop without a real socket.
+    #[cfg(test)]
+    fn new_for_test(
+        socket_id: &str,
+        provider_id: &str,
+        audit_emit_opt_in: bool,
+        audit_emitter: Option<Arc<dyn ExternalAuditEmitter>>,
+    ) -> Self {
+        use dbflux_core::auth::AuthProviderCapabilities;
+        use crate::envelope::AUTH_PROVIDER_RPC_VERSION;
+
+        Self {
+            socket_id: socket_id.to_string(),
+            provider_id: provider_id.to_string(),
+            display_name: "Test Provider".to_string(),
+            form_definition: dbflux_core::auth::AuthFormDef { tabs: vec![] },
+            capabilities: AuthProviderCapabilities::default(),
+            selected_version: AUTH_PROVIDER_RPC_VERSION,
+            secret_dependency_opt_in: false,
+            audit_emit_opt_in,
+            audit_emitter,
+            launch: None,
+        }
+    }
+
     #[allow(clippy::result_large_err)]
     fn connect_stream(&self) -> Result<IpcStream, DbError> {
         ensure_host_running_for(&self.socket_id, self.launch.as_ref())?;
@@ -220,15 +245,22 @@ impl RpcAuthProvider {
         body: AuthProviderRequestBody,
     ) -> Result<Vec<AuthProviderResponseEnvelope>, DbError> {
         let mut stream = self.connect_stream()?;
-        let request = AuthProviderRequestEnvelope::new(self.selected_version, 1, body);
+        self.dispatch_request_loop(&mut stream, body)
+    }
 
+    fn dispatch_request_loop<S: std::io::Read + std::io::Write>(
+        &self,
+        stream: &mut S,
+        body: AuthProviderRequestBody,
+    ) -> Result<Vec<AuthProviderResponseEnvelope>, DbError> {
+        let request = AuthProviderRequestEnvelope::new(self.selected_version, 1, body);
         let correlation_id = uuid::Uuid::new_v4().to_string();
 
-        framing::send_msg(&mut stream, &request)?;
+        framing::send_msg(&mut *stream, &request)?;
 
         let mut responses = Vec::new();
         loop {
-            let response: AuthProviderResponseEnvelope = framing::recv_msg(&mut stream)?;
+            let response: AuthProviderResponseEnvelope = framing::recv_msg(&mut *stream)?;
 
             if response.request_id != request.request_id {
                 return Err(DbError::connection_failed(format!(
@@ -1066,6 +1098,186 @@ mod tests {
         assert!(
             !normalized.audit_emit_opt_in,
             "v1.2 hello must have audit_emit_opt_in == false"
+        );
+    }
+
+    // =========================================================================
+    // Layer C: dispatch_request_loop — audit frame interception
+    // =========================================================================
+
+    use std::sync::{Arc, Mutex};
+    use crate::audit::{AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto, ExternalAuditEmitter, ExternalAuditSource};
+
+    /// In-memory stream that supplies pre-encoded response bytes and absorbs writes.
+    struct MockStream {
+        reader: std::io::Cursor<Vec<u8>>,
+        writer: Vec<u8>,
+    }
+
+    impl MockStream {
+        fn new(response_bytes: Vec<u8>) -> Self {
+            Self {
+                reader: std::io::Cursor::new(response_bytes),
+                writer: Vec::new(),
+            }
+        }
+    }
+
+    impl std::io::Read for MockStream {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            self.reader.read(buf)
+        }
+    }
+
+    impl std::io::Write for MockStream {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.writer.write(buf)
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.writer.flush()
+        }
+    }
+
+    /// Recording emitter that captures every `emit` call for test assertions.
+    #[derive(Default)]
+    struct RecordingEmitter {
+        calls: Arc<Mutex<Vec<ExternalAuditSource>>>,
+    }
+
+    impl RecordingEmitter {
+        fn call_count(&self) -> usize {
+            self.calls.lock().unwrap().len()
+        }
+    }
+
+    impl ExternalAuditEmitter for RecordingEmitter {
+        fn emit(&self, source: ExternalAuditSource, _dto: AuditEventEmitDto) {
+            self.calls.lock().unwrap().push(source);
+        }
+    }
+
+    fn minimal_emit_dto() -> AuditEventEmitDto {
+        AuditEventEmitDto {
+            ts_ms: 1_700_000_000_000,
+            level: EventSeverityDto::Info,
+            category: EventCategoryDto::Connection,
+            action: "connect".to_string(),
+            outcome: EventOutcomeDto::Success,
+            summary: "provider connected".to_string(),
+            object_type: None,
+            object_id: None,
+            duration_ms: None,
+            error_code: None,
+            error_message: None,
+            details_json: None,
+        }
+    }
+
+    fn encode_response(envelope: &AuthProviderResponseEnvelope) -> Vec<u8> {
+        let mut buf = Vec::new();
+        framing::send_msg(&mut buf, envelope).expect("encode response");
+        buf
+    }
+
+
+    fn emit_audit_frame(request_id: u64, dto: AuditEventEmitDto) -> AuthProviderResponseEnvelope {
+        AuthProviderResponseEnvelope {
+            protocol_version: crate::AUTH_PROVIDER_RPC_VERSION,
+            request_id,
+            done: false,
+            body: AuthProviderResponseBody::EmitAuditEvent(dto),
+        }
+    }
+
+    fn login_result_frame(request_id: u64) -> AuthProviderResponseEnvelope {
+        use crate::auth_provider_protocol::AuthSessionDto;
+        AuthProviderResponseEnvelope {
+            protocol_version: crate::AUTH_PROVIDER_RPC_VERSION,
+            request_id,
+            done: true,
+            body: AuthProviderResponseBody::LoginResult {
+                session: AuthSessionDto {
+                    provider_id: "test-auth".to_string(),
+                    profile_id: uuid::Uuid::nil(),
+                    expires_at: None,
+                    session_data: None,
+                },
+            },
+        }
+    }
+
+    /// Scenario P-03-a: Provider has opt-in=true and emitter attached.
+    /// One EmitAuditEvent frame (done=false) followed by a terminal LoginResult (done=true).
+    /// Emitter should be called once; caller receives only the LoginResult.
+    #[test]
+    fn test_send_request_dispatches_emit_audit_frame() {
+        let emitter = Arc::new(RecordingEmitter::default());
+        let provider = RpcAuthProvider::new_for_test(
+            "test-sock",
+            "test-auth",
+            true,
+            Some(emitter.clone() as Arc<dyn ExternalAuditEmitter>),
+        );
+
+        let mut response_bytes = Vec::new();
+        response_bytes.extend(encode_response(&emit_audit_frame(1, minimal_emit_dto())));
+        response_bytes.extend(encode_response(&login_result_frame(1)));
+
+        let mut stream = MockStream::new(response_bytes);
+        let responses = provider
+            .dispatch_request_loop(
+                &mut stream,
+                AuthProviderRequestBody::Login(crate::auth_provider_protocol::LoginRequest {
+                    profile_json: "{}".to_string(),
+                }),
+            )
+            .expect("dispatch should succeed");
+
+        assert_eq!(emitter.call_count(), 1, "emitter must be called once for the EmitAuditEvent frame");
+        assert_eq!(responses.len(), 1, "caller must receive only the terminal LoginResult");
+        assert!(
+            matches!(responses[0].body, AuthProviderResponseBody::LoginResult { .. }),
+            "terminal response must be LoginResult"
+        );
+    }
+
+    /// Scenario B-04-a: Provider has opt-in=false.
+    /// EmitAuditEvent frame arrives; emitter must NOT be called.
+    /// Caller receives only the terminal LoginResult.
+    #[test]
+    fn test_send_request_opt_in_false_drops_emit_frame() {
+        let emitter = Arc::new(RecordingEmitter::default());
+        let provider = RpcAuthProvider::new_for_test(
+            "test-sock",
+            "test-auth",
+            false,
+            Some(emitter.clone() as Arc<dyn ExternalAuditEmitter>),
+        );
+
+        let mut response_bytes = Vec::new();
+        response_bytes.extend(encode_response(&emit_audit_frame(1, minimal_emit_dto())));
+        response_bytes.extend(encode_response(&login_result_frame(1)));
+
+        let mut stream = MockStream::new(response_bytes);
+        let responses = provider
+            .dispatch_request_loop(
+                &mut stream,
+                AuthProviderRequestBody::Login(crate::auth_provider_protocol::LoginRequest {
+                    profile_json: "{}".to_string(),
+                }),
+            )
+            .expect("dispatch should succeed even with opt-in=false");
+
+        assert_eq!(
+            emitter.call_count(),
+            0,
+            "emitter must NOT be called when audit_emit_opt_in=false"
+        );
+        assert_eq!(responses.len(), 1, "caller must still receive the terminal LoginResult");
+        assert!(
+            matches!(responses[0].body, AuthProviderResponseBody::LoginResult { .. }),
+            "terminal response must be LoginResult"
         );
     }
 }

--- a/crates/dbflux_ipc/src/auth_provider_client.rs
+++ b/crates/dbflux_ipc/src/auth_provider_client.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::process::{Child, Command};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -19,6 +19,7 @@ use crate::auth_provider_protocol::{
     AuthProviderResponseBody, AuthProviderResponseEnvelope, FetchFieldOptionsError,
     FetchFieldOptionsRequest, LoginRequest, ResolveCredentialsRequest, ValidateSessionRequest,
 };
+use crate::audit::{ExternalAuditEmitter, ExternalAuditSource};
 use crate::envelope::{AUTH_PROVIDER_RPC_API_CONTRACT, AUTH_PROVIDER_RPC_V1_2, ProtocolVersion};
 use crate::framing;
 use crate::socket::auth_provider_socket_name;
@@ -45,6 +46,10 @@ pub struct RpcAuthProvider {
     /// Whether the provider has opted in to receiving `Password`-kind field
     /// values in `FetchFieldOptions` requests (v1.2+ only).
     secret_dependency_opt_in: bool,
+    /// Whether the provider will emit `EmitAuditEvent` intermediate frames (v1.3+ only).
+    audit_emit_opt_in: bool,
+    /// Sanitizing sink for audit frames emitted by this provider.
+    audit_emitter: Option<Arc<dyn ExternalAuditEmitter>>,
     launch: Option<IpcServiceLaunchConfig>,
 }
 
@@ -56,6 +61,8 @@ struct NormalizedAuthProviderHelloResponse {
     capabilities: AuthProviderCapabilities,
     selected_version: ProtocolVersion,
     secret_dependency_opt_in: bool,
+    /// Whether the provider opted in to emitting audit events (v1.3+).
+    audit_emit_opt_in: bool,
 }
 
 impl RpcAuthProvider {
@@ -123,8 +130,19 @@ impl RpcAuthProvider {
             capabilities: hello.capabilities,
             selected_version: hello.selected_version,
             secret_dependency_opt_in: hello.secret_dependency_opt_in,
+            audit_emit_opt_in: hello.audit_emit_opt_in,
+            audit_emitter: None,
             launch,
         })
+    }
+
+    /// Attaches an audit emitter for routing `EmitAuditEvent` intermediate frames.
+    ///
+    /// Must be called after `probe` and before any `DynAuthProvider` method is invoked.
+    /// Has no effect unless the provider set `audit_emit_opt_in=true` in its hello.
+    pub fn with_audit_emitter(mut self, emitter: Arc<dyn ExternalAuditEmitter>) -> Self {
+        self.audit_emitter = Some(emitter);
+        self
     }
 
     #[allow(clippy::result_large_err)]
@@ -178,7 +196,8 @@ impl RpcAuthProvider {
         match response.body {
             AuthProviderResponseBody::Hello(_)
             | AuthProviderResponseBody::HelloV1_1(_)
-            | AuthProviderResponseBody::HelloV1_2(_) => {
+            | AuthProviderResponseBody::HelloV1_2(_)
+            | AuthProviderResponseBody::HelloV1_3(_) => {
                 let hello = normalize_hello_response(response.body)?;
 
                 validate_hello_selected_version(
@@ -203,6 +222,8 @@ impl RpcAuthProvider {
         let mut stream = self.connect_stream()?;
         let request = AuthProviderRequestEnvelope::new(self.selected_version, 1, body);
 
+        let correlation_id = uuid::Uuid::new_v4().to_string();
+
         framing::send_msg(&mut stream, &request)?;
 
         let mut responses = Vec::new();
@@ -217,7 +238,26 @@ impl RpcAuthProvider {
             }
 
             let done = response.done;
-            responses.push(response);
+
+            match &response.body {
+                AuthProviderResponseBody::EmitAuditEvent(dto) if !done => {
+                    if self.audit_emit_opt_in {
+                        if let Some(sink) = &self.audit_emitter {
+                            let source = ExternalAuditSource::AuthProvider {
+                                socket_id: self.socket_id.clone(),
+                                provider_id: self.provider_id.clone(),
+                                correlation_id: correlation_id.clone(),
+                            };
+                            sink.emit(source, dto.clone());
+                        }
+                    }
+                    // else: silently drop — provider did not set audit_emit_opt_in
+                    // Never push EmitAuditEvent frames to `responses` — keep it terminal-only.
+                }
+                _ => {
+                    responses.push(response);
+                }
+            }
 
             if done {
                 return Ok(responses);
@@ -524,6 +564,7 @@ fn normalize_hello_response(
             capabilities: AuthProviderCapabilities::default(),
             selected_version: hello.selected_version,
             secret_dependency_opt_in: false,
+            audit_emit_opt_in: false,
         }),
         AuthProviderResponseBody::HelloV1_1(hello) => Ok(NormalizedAuthProviderHelloResponse {
             provider_id: hello.provider_id,
@@ -532,6 +573,7 @@ fn normalize_hello_response(
             capabilities: hello.capabilities,
             selected_version: hello.selected_version,
             secret_dependency_opt_in: false,
+            audit_emit_opt_in: false,
         }),
         AuthProviderResponseBody::HelloV1_2(hello) => Ok(NormalizedAuthProviderHelloResponse {
             provider_id: hello.provider_id,
@@ -540,6 +582,16 @@ fn normalize_hello_response(
             capabilities: hello.capabilities,
             selected_version: hello.selected_version,
             secret_dependency_opt_in: hello.secret_dependency_opt_in,
+            audit_emit_opt_in: false,
+        }),
+        AuthProviderResponseBody::HelloV1_3(hello) => Ok(NormalizedAuthProviderHelloResponse {
+            provider_id: hello.provider_id,
+            display_name: hello.display_name,
+            form_definition: hello.form_definition,
+            capabilities: hello.capabilities,
+            selected_version: hello.selected_version,
+            secret_dependency_opt_in: hello.secret_dependency_opt_in,
+            audit_emit_opt_in: hello.audit_emit_opt_in,
         }),
         _ => Err(DbError::connection_failed(
             "Unexpected response to auth-provider Hello".to_string(),
@@ -699,6 +751,7 @@ mod tests {
     use super::*;
     use crate::auth_provider_protocol::{
         AuthProviderHelloResponse, AuthProviderHelloResponseV1_1, AuthProviderHelloResponseV1_2,
+        AuthProviderHelloResponseV1_3,
     };
     use dbflux_core::auth::{AuthFormDef, AuthProviderCapabilities, AuthProviderLoginCapabilities};
     use dbflux_core::{FormFieldDef, FormFieldKind, FormSection, FormTab, RefreshTrigger};
@@ -949,6 +1002,70 @@ mod tests {
         assert!(
             !deps.contains_key("other_secret"),
             "other_secret is a Password field not in depends_on — must be stripped even when opted in"
+        );
+    }
+
+    #[test]
+    fn test_auth_provider_hello_v1_3_serde() {
+        let response = AuthProviderHelloResponseV1_3 {
+            server_name: "test-provider".to_string(),
+            server_version: "1.0.0".to_string(),
+            selected_version: crate::ProtocolVersion::new(1, 3),
+            provider_id: "test-auth".to_string(),
+            display_name: "Test Auth".to_string(),
+            form_definition: AuthFormDef { tabs: vec![] },
+            capabilities: AuthProviderCapabilities::default(),
+            secret_dependency_opt_in: false,
+            audit_emit_opt_in: true,
+        };
+
+        let json = serde_json::to_string(&response).expect("serialize v1.3 hello");
+        let restored: AuthProviderHelloResponseV1_3 =
+            serde_json::from_str(&json).expect("deserialize v1.3 hello");
+
+        assert!(restored.audit_emit_opt_in);
+        assert_eq!(restored.provider_id, "test-auth");
+    }
+
+    #[test]
+    fn test_normalize_hello_v1_3_has_audit_emit_opt_in() {
+        let normalized = normalize_hello_response(AuthProviderResponseBody::HelloV1_3(
+            AuthProviderHelloResponseV1_3 {
+                server_name: "test-provider".to_string(),
+                server_version: "1.0.0".to_string(),
+                selected_version: crate::ProtocolVersion::new(1, 3),
+                provider_id: "test-auth".to_string(),
+                display_name: "Test Auth".to_string(),
+                form_definition: AuthFormDef { tabs: vec![] },
+                capabilities: AuthProviderCapabilities::default(),
+                secret_dependency_opt_in: false,
+                audit_emit_opt_in: true,
+            },
+        ))
+        .expect("v1.3 hello should normalize");
+
+        assert!(normalized.audit_emit_opt_in);
+    }
+
+    #[test]
+    fn test_normalize_hello_v1_2_has_opt_in_false() {
+        let normalized = normalize_hello_response(AuthProviderResponseBody::HelloV1_2(
+            AuthProviderHelloResponseV1_2 {
+                server_name: "test-provider".to_string(),
+                server_version: "1.0.0".to_string(),
+                selected_version: crate::ProtocolVersion::new(1, 2),
+                provider_id: "test-auth".to_string(),
+                display_name: "Test Auth".to_string(),
+                form_definition: AuthFormDef { tabs: vec![] },
+                capabilities: AuthProviderCapabilities::default(),
+                secret_dependency_opt_in: false,
+            },
+        ))
+        .expect("v1.2 hello should normalize");
+
+        assert!(
+            !normalized.audit_emit_opt_in,
+            "v1.2 hello must have audit_emit_opt_in == false"
         );
     }
 }

--- a/crates/dbflux_ipc/src/auth_provider_protocol.rs
+++ b/crates/dbflux_ipc/src/auth_provider_protocol.rs
@@ -10,6 +10,7 @@ use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::audit::AuditEventEmitDto;
 use crate::envelope::ProtocolVersion;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,6 +61,30 @@ pub struct AuthProviderHelloResponseV1_2 {
     /// target field's `depends_on` list.  Defaults to `false`.
     #[serde(default)]
     pub secret_dependency_opt_in: bool,
+}
+
+/// Hello response for protocol v1.3.
+///
+/// Adds `audit_emit_opt_in` which declares whether the provider will emit audit
+/// events as intermediate response frames.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthProviderHelloResponseV1_3 {
+    pub server_name: String,
+    pub server_version: String,
+    pub selected_version: ProtocolVersion,
+    pub provider_id: String,
+    pub display_name: String,
+    pub form_definition: AuthFormDef,
+    pub capabilities: AuthProviderCapabilities,
+    /// When `true`, the host MAY include values for `Password`-kind fields in
+    /// `FetchFieldOptions` requests, provided those fields appear in the
+    /// target field's `depends_on` list.  Defaults to `false`.
+    #[serde(default)]
+    pub secret_dependency_opt_in: bool,
+    /// When `true`, the provider may emit `EmitAuditEvent` intermediate frames
+    /// and the host will route them through the audit sanitizer.
+    #[serde(default)]
+    pub audit_emit_opt_in: bool,
 }
 
 /// Request to fetch the available options for a `DynamicSelect` field.
@@ -272,6 +297,8 @@ pub enum AuthProviderResponseBody {
     HelloV1_1(AuthProviderHelloResponseV1_1),
     /// Hello response for protocol v1.2, carrying `secret_dependency_opt_in`.
     HelloV1_2(AuthProviderHelloResponseV1_2),
+    /// Hello response for protocol v1.3, adding `audit_emit_opt_in`.
+    HelloV1_3(AuthProviderHelloResponseV1_3),
     SessionState {
         state: AuthSessionStateDto,
     },
@@ -284,6 +311,10 @@ pub enum AuthProviderResponseBody {
     },
     /// Successful response to `FetchDynamicOptions` (protocol v1.2+).
     DynamicOptions(FetchFieldOptionsResponse),
+    /// Emitted by auth providers that set `audit_emit_opt_in=true` in their v1.3 hello.
+    /// Always arrives with `done=false`; the host intercepts it and never forwards
+    /// it to the caller of `send_request`.
+    EmitAuditEvent(AuditEventEmitDto),
     Error(AuthProviderRpcError),
 }
 

--- a/crates/dbflux_ipc/src/driver_protocol.rs
+++ b/crates/dbflux_ipc/src/driver_protocol.rs
@@ -1,3 +1,4 @@
+use crate::audit::AuditEventEmitDto;
 use crate::envelope::ProtocolVersion;
 use dbflux_core::{
     CodeGenCapabilities, CodeGeneratorInfo, CollectionBrowseRequest, CollectionCountRequest,
@@ -26,6 +27,9 @@ pub enum DriverCapability {
     ChunkedResults,
     SchemaIntrospection,
     MultiDatabase,
+    /// Driver supports emitting audit events as intermediate response frames.
+    /// Requires protocol version >= 1.2.
+    AuditEmit,
 }
 
 /// Well-known error categories for driver RPC responses.
@@ -509,6 +513,11 @@ pub enum DriverResponseBody {
     GenerateCodeResult {
         code: String,
     },
+    // === Audit emission (intermediate frame, done=false) ===
+    /// Emitted by drivers that advertise `DriverCapability::AuditEmit`.
+    /// Always arrives with `done=false`; the host intercepts it and never
+    /// forwards it to the caller of `RpcClient::call`.
+    EmitAuditEvent(AuditEventEmitDto),
     // === Error ===
     Error(DriverRpcError),
 }

--- a/crates/dbflux_ipc/src/envelope.rs
+++ b/crates/dbflux_ipc/src/envelope.rs
@@ -19,12 +19,16 @@ impl ProtocolVersion {
 
 pub const APP_CONTROL_VERSION: ProtocolVersion = ProtocolVersion::new(1, 0);
 pub const DRIVER_RPC_V1_0: ProtocolVersion = ProtocolVersion::new(1, 0);
-pub const DRIVER_RPC_VERSION: ProtocolVersion = ProtocolVersion::new(1, 1);
+pub const DRIVER_RPC_V1_1: ProtocolVersion = ProtocolVersion::new(1, 1);
+pub const DRIVER_RPC_V1_2: ProtocolVersion = ProtocolVersion::new(1, 2);
+/// Current highest driver protocol version.
+pub const DRIVER_RPC_VERSION: ProtocolVersion = DRIVER_RPC_V1_2;
 pub const AUTH_PROVIDER_RPC_V1_0: ProtocolVersion = ProtocolVersion::new(1, 0);
 pub const AUTH_PROVIDER_RPC_V1_1: ProtocolVersion = ProtocolVersion::new(1, 1);
 pub const AUTH_PROVIDER_RPC_V1_2: ProtocolVersion = ProtocolVersion::new(1, 2);
+pub const AUTH_PROVIDER_RPC_V1_3: ProtocolVersion = ProtocolVersion::new(1, 3);
 /// Current highest auth-provider protocol version.
-pub const AUTH_PROVIDER_RPC_VERSION: ProtocolVersion = AUTH_PROVIDER_RPC_V1_2;
+pub const AUTH_PROVIDER_RPC_VERSION: ProtocolVersion = AUTH_PROVIDER_RPC_V1_3;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -55,10 +59,11 @@ pub const DRIVER_RPC_API_CONTRACT: RpcApiContract =
 pub const AUTH_PROVIDER_RPC_API_CONTRACT: RpcApiContract =
     RpcApiContract::new(RpcApiFamily::AuthProviderRpc, AUTH_PROVIDER_RPC_VERSION);
 
-pub const DRIVER_RPC_SUPPORTED_VERSIONS: [ProtocolVersion; 2] =
-    [DRIVER_RPC_V1_0, DRIVER_RPC_VERSION];
+pub const DRIVER_RPC_SUPPORTED_VERSIONS: [ProtocolVersion; 3] =
+    [DRIVER_RPC_V1_0, DRIVER_RPC_V1_1, DRIVER_RPC_V1_2];
 
-pub const AUTH_PROVIDER_RPC_SUPPORTED_VERSIONS: [ProtocolVersion; 3] = [
+pub const AUTH_PROVIDER_RPC_SUPPORTED_VERSIONS: [ProtocolVersion; 4] = [
+    AUTH_PROVIDER_RPC_V1_3,
     AUTH_PROVIDER_RPC_V1_2,
     AUTH_PROVIDER_RPC_V1_1,
     AUTH_PROVIDER_RPC_V1_0,
@@ -89,8 +94,8 @@ pub fn negotiate_highest_mutual_version(
 #[cfg(test)]
 mod tests {
     use super::{
-        DRIVER_RPC_VERSION, ProtocolVersion, RpcApiContract, RpcApiFamily,
-        negotiate_highest_mutual_version,
+        AUTH_PROVIDER_RPC_V1_3, DRIVER_RPC_V1_1, DRIVER_RPC_V1_2, DRIVER_RPC_VERSION,
+        ProtocolVersion, RpcApiContract, RpcApiFamily, negotiate_highest_mutual_version,
     };
 
     #[test]
@@ -120,7 +125,8 @@ mod tests {
             ],
         );
 
-        assert_eq!(selected, Some(DRIVER_RPC_VERSION));
+        // Local supports up to 1.1; highest mutual is 1.1.
+        assert_eq!(selected, Some(DRIVER_RPC_V1_1));
     }
 
     #[test]
@@ -132,5 +138,17 @@ mod tests {
         );
 
         assert_eq!(selected, None);
+    }
+
+    #[test]
+    fn test_driver_rpc_version_constants() {
+        assert_eq!(DRIVER_RPC_VERSION, ProtocolVersion::new(1, 2));
+        assert_eq!(DRIVER_RPC_V1_1, ProtocolVersion::new(1, 1));
+        assert_eq!(DRIVER_RPC_V1_2, ProtocolVersion::new(1, 2));
+    }
+
+    #[test]
+    fn test_auth_provider_rpc_v1_3_constant() {
+        assert_eq!(AUTH_PROVIDER_RPC_V1_3, ProtocolVersion::new(1, 3));
     }
 }

--- a/crates/dbflux_ipc/src/lib.rs
+++ b/crates/dbflux_ipc/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod audit;
 pub mod auth;
 pub mod auth_provider_client;
 pub mod auth_provider_protocol;
@@ -7,6 +8,10 @@ pub mod framing;
 pub mod protocol;
 pub mod socket;
 
+pub use audit::{
+    AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto,
+    ExternalAuditEmitter, ExternalAuditSource,
+};
 pub use auth::{
     APP_CONTROL_AUTH_TOKEN_ENV, AUTH_PROVIDER_RPC_AUTH_TOKEN_ENV, DRIVER_RPC_AUTH_TOKEN_ENV,
     app_control_token_path, init_process_auth_tokens, read_app_control_token,
@@ -18,11 +23,12 @@ pub use auth_provider_client::{
 };
 pub use auth_provider_protocol::{
     AuthProviderHelloRequest, AuthProviderHelloResponse, AuthProviderHelloResponseV1_1,
-    AuthProviderHelloResponseV1_2, AuthProviderRequestBody, AuthProviderRequestEnvelope,
-    AuthProviderResponseBody, AuthProviderResponseEnvelope, AuthProviderRpcError,
-    AuthProviderRpcErrorCode, AuthSessionDto, AuthSessionStateDto, FetchFieldOptionsError,
-    FetchFieldOptionsRequest, FetchFieldOptionsResponse, LoginRequest, LoginUrlProgress,
-    ResolveCredentialsRequest, ResolvedCredentialsDto, ValidateSessionRequest, parse_auth_profile,
+    AuthProviderHelloResponseV1_2, AuthProviderHelloResponseV1_3, AuthProviderRequestBody,
+    AuthProviderRequestEnvelope, AuthProviderResponseBody, AuthProviderResponseEnvelope,
+    AuthProviderRpcError, AuthProviderRpcErrorCode, AuthSessionDto, AuthSessionStateDto,
+    FetchFieldOptionsError, FetchFieldOptionsRequest, FetchFieldOptionsResponse, LoginRequest,
+    LoginUrlProgress, ResolveCredentialsRequest, ResolvedCredentialsDto, ValidateSessionRequest,
+    parse_auth_profile,
 };
 pub use driver_protocol::{
     DriverCapability, DriverHelloRequest, DriverHelloResponse, DriverRequestBody,
@@ -31,10 +37,12 @@ pub use driver_protocol::{
 };
 pub use envelope::{
     APP_CONTROL_VERSION, AUTH_PROVIDER_RPC_API_CONTRACT, AUTH_PROVIDER_RPC_SUPPORTED_VERSIONS,
-    AUTH_PROVIDER_RPC_V1_0, AUTH_PROVIDER_RPC_VERSION, DRIVER_RPC_API_CONTRACT,
-    DRIVER_RPC_SUPPORTED_VERSIONS, DRIVER_RPC_V1_0, DRIVER_RPC_VERSION, ProtocolVersion,
-    RpcApiContract, RpcApiFamily, auth_provider_rpc_supported_versions,
-    driver_rpc_supported_versions, negotiate_highest_mutual_version,
+    AUTH_PROVIDER_RPC_V1_0, AUTH_PROVIDER_RPC_V1_1, AUTH_PROVIDER_RPC_V1_2,
+    AUTH_PROVIDER_RPC_V1_3, AUTH_PROVIDER_RPC_VERSION, DRIVER_RPC_API_CONTRACT,
+    DRIVER_RPC_SUPPORTED_VERSIONS, DRIVER_RPC_V1_0, DRIVER_RPC_V1_1, DRIVER_RPC_V1_2,
+    DRIVER_RPC_VERSION, ProtocolVersion, RpcApiContract, RpcApiFamily,
+    auth_provider_rpc_supported_versions, driver_rpc_supported_versions,
+    negotiate_highest_mutual_version,
 };
 pub use framing::{recv_msg, send_msg};
 pub use protocol::{AppControlRequest, AppControlResponse, IpcMessage, IpcResponse};

--- a/crates/dbflux_ipc/src/lib.rs
+++ b/crates/dbflux_ipc/src/lib.rs
@@ -9,8 +9,8 @@ pub mod protocol;
 pub mod socket;
 
 pub use audit::{
-    AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto,
-    ExternalAuditEmitter, ExternalAuditSource,
+    AuditEventEmitDto, EventCategoryDto, EventOutcomeDto, EventSeverityDto, ExternalAuditEmitter,
+    ExternalAuditSource,
 };
 pub use auth::{
     APP_CONTROL_AUTH_TOKEN_ENV, AUTH_PROVIDER_RPC_AUTH_TOKEN_ENV, DRIVER_RPC_AUTH_TOKEN_ENV,
@@ -37,12 +37,11 @@ pub use driver_protocol::{
 };
 pub use envelope::{
     APP_CONTROL_VERSION, AUTH_PROVIDER_RPC_API_CONTRACT, AUTH_PROVIDER_RPC_SUPPORTED_VERSIONS,
-    AUTH_PROVIDER_RPC_V1_0, AUTH_PROVIDER_RPC_V1_1, AUTH_PROVIDER_RPC_V1_2,
-    AUTH_PROVIDER_RPC_V1_3, AUTH_PROVIDER_RPC_VERSION, DRIVER_RPC_API_CONTRACT,
-    DRIVER_RPC_SUPPORTED_VERSIONS, DRIVER_RPC_V1_0, DRIVER_RPC_V1_1, DRIVER_RPC_V1_2,
-    DRIVER_RPC_VERSION, ProtocolVersion, RpcApiContract, RpcApiFamily,
-    auth_provider_rpc_supported_versions, driver_rpc_supported_versions,
-    negotiate_highest_mutual_version,
+    AUTH_PROVIDER_RPC_V1_0, AUTH_PROVIDER_RPC_V1_1, AUTH_PROVIDER_RPC_V1_2, AUTH_PROVIDER_RPC_V1_3,
+    AUTH_PROVIDER_RPC_VERSION, DRIVER_RPC_API_CONTRACT, DRIVER_RPC_SUPPORTED_VERSIONS,
+    DRIVER_RPC_V1_0, DRIVER_RPC_V1_1, DRIVER_RPC_V1_2, DRIVER_RPC_VERSION, ProtocolVersion,
+    RpcApiContract, RpcApiFamily, auth_provider_rpc_supported_versions,
+    driver_rpc_supported_versions, negotiate_highest_mutual_version,
 };
 pub use framing::{recv_msg, send_msg};
 pub use protocol::{AppControlRequest, AppControlResponse, IpcMessage, IpcResponse};

--- a/crates/dbflux_test_support/src/fake_driver_rpc.rs
+++ b/crates/dbflux_test_support/src/fake_driver_rpc.rs
@@ -1,17 +1,16 @@
 use std::io;
 use std::thread;
 
-use dbflux_core::{
-    DatabaseCategory, DbKind, DriverFormDef, DriverMetadataBuilder, QueryLanguage,
-};
-use dbflux_ipc::{
-    DRIVER_RPC_VERSION, driver_rpc_supported_versions, driver_socket_name, framing,
-    driver_protocol::{
-        DriverCapability, DriverHelloResponse, DriverRequestEnvelope,
-        DriverResponseBody, DriverResponseEnvelope,
-    },
-};
+use dbflux_core::{DatabaseCategory, DbKind, DriverFormDef, DriverMetadataBuilder, QueryLanguage};
 use dbflux_ipc::audit::AuditEventEmitDto;
+use dbflux_ipc::{
+    DRIVER_RPC_VERSION,
+    driver_protocol::{
+        DriverCapability, DriverHelloResponse, DriverRequestEnvelope, DriverResponseBody,
+        DriverResponseEnvelope,
+    },
+    driver_rpc_supported_versions, driver_socket_name, framing,
+};
 use interprocess::local_socket::{ListenerNonblockingMode::Neither, ListenerOptions};
 
 /// Script of actions for the fake driver server to perform on each connection.
@@ -21,6 +20,9 @@ pub enum FakeDriverAction {
     Pong,
     /// Emit an audit event (intermediate, `done=false`) then pong.
     EmitAuditThenPong(AuditEventEmitDto),
+    /// Emit N audit frames (all `done=false`) then a pong.
+    /// Used to exercise the rate-limit drop path while verifying session continuity.
+    EmitNAuditThenPong(u32, AuditEventEmitDto),
 }
 
 #[derive(Clone, Debug)]
@@ -132,6 +134,27 @@ fn run_server(
                         body: DriverResponseBody::EmitAuditEvent(dto.clone()),
                     };
                     framing::send_msg(&mut stream, &audit_frame)?;
+
+                    let pong = DriverResponseEnvelope::ok(
+                        DRIVER_RPC_VERSION,
+                        request.request_id,
+                        request.session_id,
+                        DriverResponseBody::Pong,
+                    );
+                    framing::send_msg(&mut stream, &pong)?;
+                }
+
+                FakeDriverAction::EmitNAuditThenPong(n, dto) => {
+                    for _ in 0..*n {
+                        let audit_frame = DriverResponseEnvelope {
+                            protocol_version: DRIVER_RPC_VERSION,
+                            request_id: request.request_id,
+                            session_id: request.session_id,
+                            done: false,
+                            body: DriverResponseBody::EmitAuditEvent(dto.clone()),
+                        };
+                        framing::send_msg(&mut stream, &audit_frame)?;
+                    }
 
                     let pong = DriverResponseEnvelope::ok(
                         DRIVER_RPC_VERSION,

--- a/crates/dbflux_test_support/src/fake_driver_rpc.rs
+++ b/crates/dbflux_test_support/src/fake_driver_rpc.rs
@@ -1,0 +1,190 @@
+use std::io;
+use std::thread;
+
+use dbflux_core::{
+    DatabaseCategory, DbKind, DriverFormDef, DriverMetadataBuilder, QueryLanguage,
+};
+use dbflux_ipc::{
+    DRIVER_RPC_VERSION, driver_rpc_supported_versions, driver_socket_name, framing,
+    driver_protocol::{
+        DriverCapability, DriverHelloResponse, DriverRequestEnvelope,
+        DriverResponseBody, DriverResponseEnvelope,
+    },
+};
+use dbflux_ipc::audit::AuditEventEmitDto;
+use interprocess::local_socket::{ListenerNonblockingMode::Neither, ListenerOptions};
+
+/// Script of actions for the fake driver server to perform on each connection.
+#[derive(Clone, Debug)]
+pub enum FakeDriverAction {
+    /// Reply with a pong.
+    Pong,
+    /// Emit an audit event (intermediate, `done=false`) then pong.
+    EmitAuditThenPong(AuditEventEmitDto),
+}
+
+#[derive(Clone, Debug)]
+pub struct FakeDriverRpcConfig {
+    pub socket_id: String,
+    /// Whether to advertise `DriverCapability::AuditEmit` in the hello.
+    pub audit_emit_capability: bool,
+    /// Actions to execute for each incoming request after hello.
+    pub actions: Vec<FakeDriverAction>,
+    /// Number of full connections (hello + actions) to serve before stopping.
+    pub expected_connections: usize,
+}
+
+impl FakeDriverRpcConfig {
+    pub fn new(socket_id: impl Into<String>) -> Self {
+        Self {
+            socket_id: socket_id.into(),
+            audit_emit_capability: false,
+            actions: vec![FakeDriverAction::Pong],
+            expected_connections: 1,
+        }
+    }
+
+    pub fn with_audit_emit_capability(mut self) -> Self {
+        self.audit_emit_capability = true;
+        self
+    }
+
+    pub fn with_actions(mut self, actions: Vec<FakeDriverAction>) -> Self {
+        self.actions = actions;
+        self
+    }
+
+    pub fn with_expected_connections(mut self, n: usize) -> Self {
+        self.expected_connections = n;
+        self
+    }
+}
+
+pub struct FakeDriverRpcServer {
+    join_handle: Option<thread::JoinHandle<io::Result<()>>>,
+}
+
+impl FakeDriverRpcServer {
+    pub fn start(config: FakeDriverRpcConfig) -> io::Result<Self> {
+        let socket_name = driver_socket_name(&config.socket_id)?;
+        let listener = ListenerOptions::new()
+            .name(socket_name.borrow())
+            .nonblocking(Neither)
+            .create_sync()?;
+
+        let join_handle = thread::spawn(move || run_server(listener, config));
+
+        Ok(Self {
+            join_handle: Some(join_handle),
+        })
+    }
+
+    pub fn wait(mut self) -> io::Result<()> {
+        let Some(join_handle) = self.join_handle.take() else {
+            return Ok(());
+        };
+
+        join_handle
+            .join()
+            .map_err(|_| io::Error::other("fake driver server thread panicked"))?
+    }
+}
+
+impl Drop for FakeDriverRpcServer {
+    fn drop(&mut self) {
+        if let Some(handle) = self.join_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn run_server(
+    listener: impl interprocess::local_socket::traits::Listener,
+    config: FakeDriverRpcConfig,
+) -> io::Result<()> {
+    for _ in 0..config.expected_connections {
+        let mut stream = listener.accept()?;
+
+        let hello_req: DriverRequestEnvelope = framing::recv_msg(&mut stream)?;
+        let hello_response = build_hello_response(&config, hello_req.request_id);
+        framing::send_msg(&mut stream, &hello_response)?;
+
+        for action in &config.actions {
+            let request: DriverRequestEnvelope = framing::recv_msg(&mut stream)?;
+
+            match action {
+                FakeDriverAction::Pong => {
+                    let pong = DriverResponseEnvelope::ok(
+                        DRIVER_RPC_VERSION,
+                        request.request_id,
+                        request.session_id,
+                        DriverResponseBody::Pong,
+                    );
+                    framing::send_msg(&mut stream, &pong)?;
+                }
+
+                FakeDriverAction::EmitAuditThenPong(dto) => {
+                    let audit_frame = DriverResponseEnvelope {
+                        protocol_version: DRIVER_RPC_VERSION,
+                        request_id: request.request_id,
+                        session_id: request.session_id,
+                        done: false,
+                        body: DriverResponseBody::EmitAuditEvent(dto.clone()),
+                    };
+                    framing::send_msg(&mut stream, &audit_frame)?;
+
+                    let pong = DriverResponseEnvelope::ok(
+                        DRIVER_RPC_VERSION,
+                        request.request_id,
+                        request.session_id,
+                        DriverResponseBody::Pong,
+                    );
+                    framing::send_msg(&mut stream, &pong)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn build_hello_response(config: &FakeDriverRpcConfig, request_id: u64) -> DriverResponseEnvelope {
+    let metadata = DriverMetadataBuilder::new(
+        "fake-rpc",
+        "Fake RPC Driver",
+        DatabaseCategory::Relational,
+        QueryLanguage::Sql,
+    )
+    .build();
+
+    let mut capabilities = vec![DriverCapability::Cancellation];
+    if config.audit_emit_capability {
+        capabilities.push(DriverCapability::AuditEmit);
+    }
+
+    let hello = DriverHelloResponse {
+        server_name: "fake-rpc-host".to_string(),
+        server_version: "0.0.1".to_string(),
+        selected_version: negotiate_version(),
+        capabilities,
+        driver_kind: DbKind::SQLite,
+        driver_metadata: metadata,
+        form_definition: DriverFormDef { tabs: vec![] },
+        settings_schema: None,
+    };
+
+    DriverResponseEnvelope::ok(
+        DRIVER_RPC_VERSION,
+        request_id,
+        None,
+        DriverResponseBody::Hello(hello),
+    )
+}
+
+fn negotiate_version() -> dbflux_ipc::ProtocolVersion {
+    driver_rpc_supported_versions()
+        .iter()
+        .copied()
+        .max_by_key(|v| (v.major, v.minor))
+        .unwrap_or(DRIVER_RPC_VERSION)
+}

--- a/crates/dbflux_test_support/src/lib.rs
+++ b/crates/dbflux_test_support/src/lib.rs
@@ -4,6 +4,7 @@ pub mod containers;
 pub mod ddl_fixtures;
 pub mod fake_auth_provider_rpc;
 pub mod fake_driver;
+pub mod fake_driver_rpc;
 pub mod fixtures;
 pub mod seed;
 
@@ -11,3 +12,4 @@ pub use fake_auth_provider_rpc::{
     FakeAuthProviderRpcConfig, FakeAuthProviderRpcServer, FakeAuthRpcResult,
 };
 pub use fake_driver::{FakeDriver, FakeDriverStats, FakeQueryOutcome};
+pub use fake_driver_rpc::{FakeDriverAction, FakeDriverRpcConfig, FakeDriverRpcServer};

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -405,6 +405,8 @@ The host owns all identity, correlation, and rate-limiting fields. An external s
 | `correlation_id` | Host-generated; one per session for drivers, one per request for auth providers |
 | `ts_ms` | Service-supplied but clamped if drift from host wall clock exceeds five minutes |
 
+`correlation_id` is structurally guaranteed to be host-generated because `AuditEventEmitDto` (the IPC payload type) has no `correlation_id` field. External services cannot supply one — the field was intentionally omitted from the DTO at design time (ADR-3) rather than accepted and validated away. As a result, the scenario "driver DTO carries a forged correlation_id and the host overrides it at runtime" is impossible at the type level; the stored value is always produced by the host's correlation-id allocation logic.
+
 ### Category whitelist
 
 Drivers may emit `Connection`, `Query`, and `System` events. Auth providers may emit only `Connection` events. Any frame with a disallowed category is silently dropped.

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -386,6 +386,55 @@ handle.install_sink(Arc::new(audit_service));
 | `crates/dbflux_core/src/observability/tracing_bridge/category.rs` | `PREFIX_CATEGORY_MAP`, `resolve_category`, `BRIDGE_INTERNAL_TARGET` |
 | `crates/dbflux_storage/src/migrations/014_*.sql` | Adds `log_capture_min_level` column to `cfg_audit_settings` |
 
+## External Audit Emission (RPC drivers and auth providers)
+
+External RPC drivers (protocol v1.2+) and auth providers (protocol v1.3+) may emit audit events back to the host as intermediate response frames. The host applies strict sanitization before writing to `aud_audit_events`.
+
+### Host-authoritative policy
+
+The host owns all identity, correlation, and rate-limiting fields. An external service can never forge its own identity or claim an audit category it is not permitted to use.
+
+| Field | Source |
+|-------|--------|
+| `actor_type` | Always `ExternalDriver` or `ExternalAuthProvider` |
+| `source_id` | Always `ExternalDriver` / `ExternalAuthProvider` with the registered `socket_id` |
+| `actor_id` | Always `rpc:<socket_id>` |
+| `connection_id` | Host-supplied from session context (may be `None`) |
+| `database_name` | Host-supplied from session context (may be `None`) |
+| `driver_id` | Always `rpc:<socket_id>` |
+| `correlation_id` | Host-generated; one per session for drivers, one per request for auth providers |
+| `ts_ms` | Service-supplied but clamped if drift from host wall clock exceeds five minutes |
+
+### Category whitelist
+
+Drivers may emit `Connection`, `Query`, and `System` events. Auth providers may emit only `Connection` events. Any frame with a disallowed category is silently dropped.
+
+### Rate limiting
+
+Each external service (by `socket_id`) is limited to 100 events per 60 seconds via a token-bucket. Frames that exceed the budget are dropped and counted in `AuditService::external_audit_dropped_count()`.
+
+### Opt-in flags
+
+- **Drivers**: The driver must include `DriverCapability::AuditEmit` in its hello response (protocol v1.2+). Frames sent by drivers that did not advertise this capability are silently discarded.
+- **Auth providers**: The provider must set `audit_emit_opt_in: true` in its hello response (protocol v1.3+). Frames from providers that did not opt in are silently discarded.
+
+### Required fields on every emitted frame
+
+An emitted `AuditEventEmitDto` must have non-empty `action` and `summary`. Frames failing this check are dropped silently.
+
+### Transport mechanism
+
+Emitted frames arrive as `done=false` intermediate frames inside a normal response sequence. The transport layer (`RpcClient` in `dbflux_driver_ipc`, `RpcAuthProvider::dispatch_request_loop` in `dbflux_ipc`) intercepts them before they reach the caller. The caller only ever sees the terminal frame.
+
+### Key files
+
+| File | Role |
+|------|------|
+| `crates/dbflux_ipc/src/audit.rs` | `AuditEventEmitDto`, `ExternalAuditEmitter` trait, `ExternalAuditSource` |
+| `crates/dbflux_app/src/rpc_services/external_audit.rs` | `ExternalAuditSink`, token-bucket rate limiter, sanitization pipeline |
+| `crates/dbflux_driver_ipc/src/transport.rs` | `RpcClient::send_raw` intercepts driver emit frames |
+| `crates/dbflux_ipc/src/auth_provider_client.rs` | `dispatch_request_loop` intercepts auth-provider emit frames |
+
 ## Architecture
 
 ```

--- a/docs/DRIVER_RPC_PROTOCOL.md
+++ b/docs/DRIVER_RPC_PROTOCOL.md
@@ -85,7 +85,11 @@ Client request:
 DriverRequestBody::Hello(DriverHelloRequest {
     client_name: "dbflux_driver_ipc".to_string(),
     client_version: "<version>".to_string(),
-    supported_versions: vec![ProtocolVersion::new(1, 0), ProtocolVersion::new(1, 1)],
+    supported_versions: vec![
+        ProtocolVersion::new(1, 0),
+        ProtocolVersion::new(1, 1),
+        ProtocolVersion::new(1, 2),
+    ],
     requested_capabilities: vec![
         DriverCapability::Cancellation,
         DriverCapability::ChunkedResults,
@@ -144,7 +148,7 @@ Current validation boundary:
 
 ## Auth-provider RPC contract
 
-The active auth-provider RPC API family is `auth_provider_rpc` at `1.2`.
+The active auth-provider RPC API family is `auth_provider_rpc` at `1.3`.
 
 DBFlux uses persisted `api_family` / `api_major` metadata as a startup preflight. Compatible rows then negotiate the highest shared minor version during `Hello`.
 
@@ -155,6 +159,7 @@ AuthProviderRequestBody::Hello(AuthProviderHelloRequest {
     client_name: "dbflux_ipc".to_string(),
     client_version: "<version>".to_string(),
     supported_versions: vec![
+        ProtocolVersion::new(1, 3),
         ProtocolVersion::new(1, 2),
         ProtocolVersion::new(1, 1),
         ProtocolVersion::new(1, 0),
@@ -172,6 +177,8 @@ Server response must include:
 
 The v1.2 `Hello` response additionally carries `secret_dependency_opt_in` (`bool`), declaring whether the provider opts in to receiving secret field values inside dependency maps for dynamic option lookups. When `false` (default), DBFlux strips secret values from dependency maps before forwarding `FetchDynamicOptions` requests.
 
+The v1.3 `Hello` response additionally carries `audit_emit_opt_in` (`bool`). Set this to `true` to enable audit event emission (see below). Default is `false`.
+
 Supported request / response flow:
 
 | Request | Response | Purpose |
@@ -181,6 +188,7 @@ Supported request / response flow:
 | `Login` | `LoginUrlProgress?` + `LoginResult` | optional verification URL + terminal login result |
 | `ResolveCredentials` | `Credentials` | resolve runtime credential fields |
 | `FetchDynamicOptions` | `DynamicOptions` | resolve dynamic dropdown options for a `DynamicSelect` form field (v1.2+) |
+| (any request) | `EmitAuditEvent` (intermediate) | audit event emission (v1.3+) |
 
 Notes:
 
@@ -189,6 +197,14 @@ Notes:
 - `FetchDynamicOptions` is available only when the negotiated version is at least `1.2`. Providers that negotiate below v1.2 receive a permanent "not supported" outcome from the host without an IPC round-trip.
 - `detect_importable_profiles`, profile write-back hooks, and provider-specific value-provider registration are intentionally out of scope for the RPC contract in this change.
 - Auth-provider runtime failures surface through existing `DbError` handling and do not abort startup.
+
+### Audit emission from auth providers (v1.3+)
+
+Auth providers that negotiate v1.3+ and set `audit_emit_opt_in: true` may send `EmitAuditEvent` intermediate frames (`done=false`) during any request/response cycle. The host sanitizes and writes them to `aud_audit_events`.
+
+Allowed category: `Connection` only. All other categories are silently dropped.
+
+The `AuditEventEmitDto` payload follows the same structure as driver emit frames. The host overrides identity fields (`actor_type`, `actor_id`, `source_id`, `driver_id`, `correlation_id`). Rate limiting is shared with drivers: 100 events per 60 seconds per `socket_id`.
 
 ## Form contract
 
@@ -235,6 +251,59 @@ The service should parse `profile_json`, expect `DbConfig::External`, and valida
 | `ListDatabases` | `Databases` | database list |
 
 The protocol also supports browse, CRUD, key-value, and code generation operations. See `crates/dbflux_ipc/src/driver_protocol.rs` for the full enum set.
+
+## Audit emission from drivers (v1.2+)
+
+Drivers that negotiate protocol version v1.2 or higher may emit audit events back to the host as intermediate response frames (`done=false`). The host sanitizes, rate-limits, and writes them to `aud_audit_events`.
+
+### Opting in
+
+Include `DriverCapability::AuditEmit` in your `Hello` response `capabilities` list. Drivers that do not advertise this capability will have any `EmitAuditEvent` frames silently discarded by the host.
+
+### Sending an audit frame
+
+Emit a `DriverResponseEnvelope` with `done = false` and `body = DriverResponseBody::EmitAuditEvent(AuditEventEmitDto { .. })` at any point during a request before the terminal response:
+
+```rust
+DriverResponseEnvelope {
+    protocol_version: negotiated_version,
+    request_id: request.request_id,
+    session_id: request.session_id,
+    done: false,
+    body: DriverResponseBody::EmitAuditEvent(AuditEventEmitDto {
+        ts_ms: chrono::Utc::now().timestamp_millis(),
+        level: EventSeverityDto::Info,
+        category: EventCategoryDto::Connection,
+        action: "session.open".to_string(),
+        outcome: EventOutcomeDto::Success,
+        summary: "Database session opened".to_string(),
+        object_type: None,
+        object_id: None,
+        duration_ms: Some(42),
+        error_code: None,
+        error_message: None,
+        details_json: None,
+    }),
+}
+```
+
+Then send the terminal response as usual.
+
+### What the host supplies
+
+The host always overrides these fields; do not include them in the DTO (they are intentionally absent from `AuditEventEmitDto`):
+
+- `actor_type`, `actor_id`, `source_id`, `driver_id` — always set to `ExternalDriver` / `rpc:<socket_id>`
+- `connection_id`, `database_name` — resolved from the active session context
+- `correlation_id` — one per session, host-generated
+
+### Allowed categories
+
+Drivers may emit `Connection`, `Query`, and `System` events. All other categories are silently dropped.
+
+### Rate limit
+
+100 events per 60 seconds per `socket_id`. Excess frames are dropped and counted in `AuditService::external_audit_dropped_count()`.
 
 ## Error handling
 


### PR DESCRIPTION
## Summary

External RPC services connected to DBFlux over IPC (RPC drivers via `dbflux_driver_ipc`, auth providers via the auth-provider IPC protocol) can now write to the audit log. They previously had no way to record activity, so a third-party driver that ran a destructive operation or an auth provider that refreshed a token left no trace in `aud_audit_events`.

This change extends both IPC protocols with an `EmitAuditEvent` intermediate-frame variant, plus host-side sanitization, rate limiting, and category gating so external services can never forge identity fields, claim host-only categories, or flood the audit log.

## What does this resolve?

- Resolves #157
- Closes the gap left after #154 (host-side tracing-to-audit bridge): host-side `dbflux_*` code is now covered by tracing, but external RPC services were still silent.

## How was this solved?

Decisions and seams (full design in engram `sdd/rpc-audit-emit/design`):

- **Wire shape**: External services emit audit events as intermediate `done=false` response frames carrying a new `AuditEventEmitDto` defined in `dbflux_ipc::audit`. No new request variant is needed — this reuses the streaming pattern already used by `QueryChunk` and `LoginUrlProgress`. The DTO carries only behavioral fields (`severity`, `action`, `summary`, `category`, `outcome`, `object_type`, `object_id`, `duration_ms`, `error_code`, `error_message`, `details_json`); identity is host-authoritative and not part of the DTO.

- **Opt-in / versioning**:
  - Driver protocol bumped `1.1` → `1.2`. New `DriverCapability::AuditEmit` is advertised in the hello response; transports only forward frames if the capability is set.
  - Auth-provider protocol bumped `1.2` → `1.3`. New `AuthProviderHelloResponseV1_3` adds an `audit_emit_opt_in: bool` flag (mirrors the existing `secret_dependency_opt_in` pattern).
  - Older peers that don't advertise the capability/flag are silently ignored — no IPC error, no audit emission.

- **Sanitization** (`ExternalAuditSink` in `dbflux_app::rpc_services::external_audit`):
  - Forces `actor_type` to `EventActorType::ExternalDriver` / `ExternalAuthProvider` and `source_id` to the matching `EventSourceId` variant — both newly added in `dbflux_core::observability`.
  - Fills `actor_id` with the registered RPC service ID (`rpc:<socket_id>`); the DTO can't claim a different identity.
  - Overrides `connection_id`, `database_name`, and `driver_id` from `AppState` via an `ExternalAuditContextProvider` seam keyed by `socket_id` — `IpcConnection` is not touched.
  - Generates `correlation_id` host-side (per IPC session for drivers, per call for auth providers); the DTO has no `correlation_id` field by design, so forgery is a compile-time impossibility (see `docs/AUDIT.md`).
  - Per-source category whitelist: drivers may emit `Connection` / `Query` / `System`; auth providers may emit `Connection` only. Anything else is dropped.
  - `details_json` is truncated to `AuditService::max_detail_bytes()` before reaching `AuditService::record()` so oversized payloads land truncated rather than rejected.

- **Rate limiting**: hand-rolled per-`socket_id` token bucket (default 100 events/minute), no new dependencies. Overflow events are dropped and counted on a new `external_audit_dropped: Arc<AtomicU64>` counter on `AuditService` (exposed via getter). Drops log at `warn!` with the running count. The IPC session is never blocked or errored due to audit failures.

- **Driver/UI decoupling**: the sanitizer never branches on driver IDs; the only axis is `ExternalAuditSource::{Driver, AuthProvider}`.

## Validation

Built and tested in a worktree on top of `main`:

```bash
cargo check --workspace
cargo nextest run --workspace          # 2910 passed, 156 skipped (pre-existing live tests)
cargo clippy --workspace -- -D warnings
cargo fmt --all -- --check
```

Tests added cover the spec scenarios (REQ-S-01 through REQ-S-05 + observability + backwards compat):

- Layer A (sanitizer unit tests in `external_audit.rs`): identity override, category whitelist per source, host-generated correlation_id, rate-limit drop counter, `details_json` truncation (IT-13).
- Layer B (transport-level integration tests in `dbflux_driver_ipc::transport`): driver `RpcClient` intercepts `EmitAuditEvent` frames and forwards them to the emitter; older v1.1 peer without `AuditEmit` capability is silently ignored; rate-limit exhaustion does not break a subsequent `Ping` on the same socket (IT-07).
- Layer C (auth-provider client tests in `auth_provider_client.rs`): `dispatch_request_loop` forwards `EmitAuditEvent` frames when `audit_emit_opt_in` is true and drops them otherwise.

A reusable `FakeDriverRpcServer` lives in `dbflux_test_support` for the Layer B tests.

Deferred (acceptable per `sdd-verify`): integration tests for a v1.1 driver actually sending an `EmitAuditEvent` frame (gated structurally by capability), and multi-`socket_id` cumulative drop accumulation (shared `Arc<AtomicU64>` is correct by construction).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux

(Protocol and audit changes; no UI surface, no platform-specific paths.)

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I applied the appropriate labels

## Labels to apply

- `audit:feature`, `rpc:feature` — issue labels
- `rpc:driver`, `rpc:auth` — both RPC surfaces touched
- `size:exception` — single coherent PR (~2.3k changed lines, mostly tests and docs); chained split was offered but a single PR was preferred for review locality