### PR TITLE
feat(query-builder): schema-aware autocomplete for builder and DataView filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to DBFlux will be documented in this file.
 
 ### Added
 
+* **Schema-aware autocomplete for the visual query builder and DataView
+  filter (#165)** — Inline suggestion popovers now appear on the
+  builder rail's single-line inputs (filter / sort / projected columns,
+  join target table, join `ON` left and right sides) and on the
+  DataView toolbar's WHERE filter input. Suggestions are sourced from
+  the live schema and the builder's own spec — source-table columns,
+  declared join aliases (`alias.column`), and joined-table columns
+  fetched lazily through the existing background metadata pattern.
+  After typing `<alias>.`, results are scoped to that alias's columns
+  only. Arrow keys navigate, `Tab` / `Enter` commits, `Esc` and focus
+  loss dismiss. Prefix-only filtering for now (substring and SQL
+  keyword completion are deliberately deferred). Driver-agnostic by
+  construction: suggestions consume `dbflux_core` metadata types
+  without branching on driver id, so every relational driver picks the
+  feature up automatically.
+
 * **Relational filters in the DataView filter bar (#162)** — The filter
   bar now accepts ORM-style dotted paths like
   `created_by.email LIKE '%@acme.com'` or

--- a/crates/dbflux_components/src/controls/input.rs
+++ b/crates/dbflux_components/src/controls/input.rs
@@ -1,5 +1,7 @@
 use gpui::prelude::*;
-use gpui::{App, Div, Entity, FontWeight, IntoElement, KeyBinding, Window, div};
+use gpui::{
+    App, Div, Entity, EntityInputHandler, FontWeight, IntoElement, KeyBinding, Window, actions, div,
+};
 use gpui_component::Sizable;
 
 use crate::tokens::FontSizes;
@@ -11,6 +13,15 @@ pub use gpui_component::input::{
     MoveDown as InputMoveDown, MoveUp as InputMoveUp, OutdentInline as InputOutdentInline,
     Position as InputPosition, Rope,
 };
+
+actions!(
+    dbflux_input,
+    [
+        /// Manually open the completion popover for the focused single-line
+        /// input. Bound to `ctrl-space` by default.
+        TriggerCompletion
+    ]
+);
 
 /// Key context for `gpui-component`'s `InputState` element.
 const INPUT_CONTEXT: &str = "Input";
@@ -28,6 +39,7 @@ pub fn register_input_overrides(cx: &mut App) {
     cx.bind_keys([
         KeyBinding::new("ctrl-j", InputMoveDown, Some(INPUT_CONTEXT)),
         KeyBinding::new("ctrl-k", InputMoveUp, Some(INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-space", TriggerCompletion, Some(INPUT_CONTEXT)),
     ]);
 }
 
@@ -49,8 +61,17 @@ pub fn completion_input_keys_wrapper(state: &Entity<InputState>) -> Div {
     let state_down = state.clone();
     let state_tab = state.clone();
     let state_shift_tab = state.clone();
+    let state_trigger = state.clone();
 
     div()
+        .on_action(
+            move |_: &TriggerCompletion, window: &mut Window, cx: &mut App| {
+                state_trigger.update(cx, |s, cx| {
+                    s.replace_text_in_range(None, "", window, cx);
+                });
+                cx.stop_propagation();
+            },
+        )
         .on_action(move |_: &InputMoveUp, window: &mut Window, cx: &mut App| {
             let handled = state_up.update(cx, |s, cx| {
                 s.handle_action_for_context_menu(Box::new(InputMoveUp), window, cx)

--- a/crates/dbflux_components/src/controls/input.rs
+++ b/crates/dbflux_components/src/controls/input.rs
@@ -1,14 +1,35 @@
 use gpui::prelude::*;
-use gpui::{App, Div, Entity, FontWeight, IntoElement, Window, div};
+use gpui::{App, Div, Entity, FontWeight, IntoElement, KeyBinding, Window, div};
 use gpui_component::Sizable;
 
 use crate::tokens::FontSizes;
 use crate::typography::AppFonts;
 
 pub use gpui_component::input::{
-    CompletionProvider, Enter as InputEnter, Escape as InputEscape, Input as GpuiInput, InputEvent,
-    InputState, MoveDown as InputMoveDown, MoveUp as InputMoveUp, Position as InputPosition, Rope,
+    CompletionProvider, Enter as InputEnter, Escape as InputEscape,
+    IndentInline as InputIndentInline, Input as GpuiInput, InputEvent, InputState,
+    MoveDown as InputMoveDown, MoveUp as InputMoveUp, OutdentInline as InputOutdentInline,
+    Position as InputPosition, Rope,
 };
+
+/// Key context for `gpui-component`'s `InputState` element.
+const INPUT_CONTEXT: &str = "Input";
+
+/// Register DBFlux-specific keybindings that complement the defaults from
+/// `gpui_component::init`. Call this once at app startup, after
+/// `gpui_component::init`.
+///
+/// Adds vim-style `ctrl-j` / `ctrl-k` chords as aliases for `MoveDown` /
+/// `MoveUp` inside any focused input. These dispatch the same actions
+/// `gpui-component` already routes to the completion popover (via
+/// `handle_action_for_context_menu`), so single-line inputs wrapped with
+/// [`completion_input_keys_wrapper`] navigate suggestions with the chord too.
+pub fn register_input_overrides(cx: &mut App) {
+    cx.bind_keys([
+        KeyBinding::new("ctrl-j", InputMoveDown, Some(INPUT_CONTEXT)),
+        KeyBinding::new("ctrl-k", InputMoveUp, Some(INPUT_CONTEXT)),
+    ]);
+}
 
 /// Build a focus-region wrapper that routes `MoveUp` / `MoveDown` actions to
 /// the input's completion popover.
@@ -26,6 +47,8 @@ pub use gpui_component::input::{
 pub fn completion_input_keys_wrapper(state: &Entity<InputState>) -> Div {
     let state_up = state.clone();
     let state_down = state.clone();
+    let state_tab = state.clone();
+    let state_shift_tab = state.clone();
 
     div()
         .on_action(move |_: &InputMoveUp, window: &mut Window, cx: &mut App| {
@@ -40,6 +63,30 @@ pub fn completion_input_keys_wrapper(state: &Entity<InputState>) -> Div {
             move |_: &InputMoveDown, window: &mut Window, cx: &mut App| {
                 let handled = state_down.update(cx, |s, cx| {
                     s.handle_action_for_context_menu(Box::new(InputMoveDown), window, cx)
+                });
+                if handled {
+                    cx.stop_propagation();
+                }
+            },
+        )
+        .on_action(
+            move |_: &InputIndentInline, window: &mut Window, cx: &mut App| {
+                let handled = state_tab.update(cx, |s, cx| {
+                    s.handle_action_for_context_menu(
+                        Box::new(InputEnter { secondary: false }),
+                        window,
+                        cx,
+                    )
+                });
+                if handled {
+                    cx.stop_propagation();
+                }
+            },
+        )
+        .on_action(
+            move |_: &InputOutdentInline, window: &mut Window, cx: &mut App| {
+                let handled = state_shift_tab.update(cx, |s, cx| {
+                    s.handle_action_for_context_menu(Box::new(InputEscape), window, cx)
                 });
                 if handled {
                     cx.stop_propagation();

--- a/crates/dbflux_components/src/controls/input.rs
+++ b/crates/dbflux_components/src/controls/input.rs
@@ -1,13 +1,52 @@
 use gpui::prelude::*;
-use gpui::{App, Entity, FontWeight, IntoElement, Window};
+use gpui::{App, Div, Entity, FontWeight, IntoElement, Window, div};
 use gpui_component::Sizable;
 
 use crate::tokens::FontSizes;
 use crate::typography::AppFonts;
 
 pub use gpui_component::input::{
-    CompletionProvider, Input as GpuiInput, InputEvent, InputState, Position as InputPosition, Rope,
+    CompletionProvider, Enter as InputEnter, Escape as InputEscape, Input as GpuiInput, InputEvent,
+    InputState, MoveDown as InputMoveDown, MoveUp as InputMoveUp, Position as InputPosition, Rope,
 };
+
+/// Build a focus-region wrapper that routes `MoveUp` / `MoveDown` actions to
+/// the input's completion popover.
+///
+/// Why this exists: `gpui-component` only attaches `MoveUp` / `MoveDown`
+/// listeners to `InputState` when `state.mode.is_multi_line()` is true.
+/// Single-line inputs that opt into a `CompletionProvider` therefore see
+/// arrow keys bubble past the input to whatever parent context owns them
+/// (e.g. the data table), so the completion popover never receives them.
+///
+/// Wrap any single-line input that uses a `CompletionProvider` with this
+/// helper to forward arrow keys to `handle_action_for_context_menu`. When
+/// the popover is closed the listeners do not call `stop_propagation`, so
+/// arrows continue to behave normally for the surrounding UI.
+pub fn completion_input_keys_wrapper(state: &Entity<InputState>) -> Div {
+    let state_up = state.clone();
+    let state_down = state.clone();
+
+    div()
+        .on_action(move |_: &InputMoveUp, window: &mut Window, cx: &mut App| {
+            let handled = state_up.update(cx, |s, cx| {
+                s.handle_action_for_context_menu(Box::new(InputMoveUp), window, cx)
+            });
+            if handled {
+                cx.stop_propagation();
+            }
+        })
+        .on_action(
+            move |_: &InputMoveDown, window: &mut Window, cx: &mut App| {
+                let handled = state_down.update(cx, |s, cx| {
+                    s.handle_action_for_context_menu(Box::new(InputMoveDown), window, cx)
+                });
+                if handled {
+                    cx.stop_propagation();
+                }
+            },
+        )
+}
 
 /// Thin wrapper around `gpui_component::input::Input` that pre-applies
 /// DBFlux design token defaults (height, size).

--- a/crates/dbflux_components/src/controls/mod.rs
+++ b/crates/dbflux_components/src/controls/mod.rs
@@ -11,7 +11,8 @@ pub use button::{Button, ButtonSize, ButtonVariant};
 pub use checkbox::Checkbox;
 pub use dropdown::{Dropdown, DropdownDismissed, DropdownItem, DropdownSelectionChanged};
 pub use input::{
-    CompletionProvider, GpuiInput, Input, InputEvent, InputPosition, InputState, Rope,
+    CompletionProvider, GpuiInput, Input, InputEnter, InputEscape, InputEvent, InputMoveDown,
+    InputMoveUp, InputPosition, InputState, Rope, completion_input_keys_wrapper,
 };
 pub use readonly_text_view::ReadonlyTextView;
 pub use select::Select;

--- a/crates/dbflux_components/src/controls/mod.rs
+++ b/crates/dbflux_components/src/controls/mod.rs
@@ -13,7 +13,7 @@ pub use dropdown::{Dropdown, DropdownDismissed, DropdownItem, DropdownSelectionC
 pub use input::{
     CompletionProvider, GpuiInput, Input, InputEnter, InputEscape, InputEvent, InputIndentInline,
     InputMoveDown, InputMoveUp, InputOutdentInline, InputPosition, InputState, Rope,
-    completion_input_keys_wrapper, register_input_overrides,
+    TriggerCompletion, completion_input_keys_wrapper, register_input_overrides,
 };
 pub use readonly_text_view::ReadonlyTextView;
 pub use select::Select;

--- a/crates/dbflux_components/src/controls/mod.rs
+++ b/crates/dbflux_components/src/controls/mod.rs
@@ -11,8 +11,9 @@ pub use button::{Button, ButtonSize, ButtonVariant};
 pub use checkbox::Checkbox;
 pub use dropdown::{Dropdown, DropdownDismissed, DropdownItem, DropdownSelectionChanged};
 pub use input::{
-    CompletionProvider, GpuiInput, Input, InputEnter, InputEscape, InputEvent, InputMoveDown,
-    InputMoveUp, InputPosition, InputState, Rope, completion_input_keys_wrapper,
+    CompletionProvider, GpuiInput, Input, InputEnter, InputEscape, InputEvent, InputIndentInline,
+    InputMoveDown, InputMoveUp, InputOutdentInline, InputPosition, InputState, Rope,
+    completion_input_keys_wrapper, register_input_overrides,
 };
 pub use readonly_text_view::ReadonlyTextView;
 pub use select::Select;

--- a/crates/dbflux_components/src/theme.rs
+++ b/crates/dbflux_components/src/theme.rs
@@ -16,6 +16,7 @@ pub fn ghost_border_color() -> Hsla {
 
 pub fn init(cx: &mut App) {
     gpui_component::init(cx);
+    crate::controls::register_input_overrides(cx);
     load_bundled_fonts(cx);
     apply_theme(ThemeSetting::Dark, AppStyle::Default, None, cx);
 }

--- a/crates/dbflux_ui_document/src/code/completion.rs
+++ b/crates/dbflux_ui_document/src/code/completion.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::completion_support::{
+    byte_offset_to_lsp_position, completion_replace_range, extract_identifier_prefix,
+    is_identifier_byte, normalize_identifier, push_completion_item, scan_identifier_start,
+};
 
 pub(super) struct QueryCompletionProvider {
     query_language: dbflux_core::QueryLanguage,
@@ -1016,71 +1020,6 @@ fn redis_argument_options(command: &str, argument_index: usize) -> Option<&'stat
     }
 }
 
-fn byte_offset_to_lsp_position(source: &str, offset: usize) -> LspPosition {
-    let before = &source[..offset];
-    let line = before.matches('\n').count() as u32;
-    let line_start = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
-    let character = source[line_start..offset].chars().count() as u32;
-
-    LspPosition { line, character }
-}
-
-fn completion_replace_range(source: &str, prefix_start: usize, cursor: usize) -> LspRange {
-    LspRange {
-        start: byte_offset_to_lsp_position(source, prefix_start),
-        end: byte_offset_to_lsp_position(source, cursor),
-    }
-}
-
-fn push_completion_item(
-    items: &mut Vec<CompletionItem>,
-    seen: &mut HashSet<String>,
-    label: &str,
-    kind: CompletionItemKind,
-    filter_prefix: &str,
-    replace_range: LspRange,
-) {
-    let key = label.to_uppercase();
-    if !seen.insert(key) {
-        return;
-    }
-
-    items.push(CompletionItem {
-        label: label.to_string(),
-        kind: Some(kind),
-        insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
-        filter_text: Some(filter_prefix.to_string()),
-        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
-            range: replace_range,
-            new_text: label.to_string(),
-        })),
-        ..CompletionItem::default()
-    });
-}
-
-fn normalize_identifier(value: &str) -> String {
-    value.trim_matches('"').to_lowercase()
-}
-
-fn is_identifier_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
-}
-
-fn scan_identifier_start(source: &str, end: usize) -> usize {
-    let bytes = source.as_bytes();
-    let mut start = end;
-
-    while start > 0 {
-        let idx = start - 1;
-        if !is_identifier_byte(bytes[idx]) {
-            break;
-        }
-
-        start -= 1;
-    }
-
-    start
-}
 
 fn scan_redis_token_start(source: &str, end: usize) -> usize {
     let bytes = source.as_bytes();
@@ -1096,12 +1035,6 @@ fn scan_redis_token_start(source: &str, end: usize) -> usize {
     }
 
     start
-}
-
-fn extract_identifier_prefix(source: &str, cursor: usize) -> (usize, String) {
-    let cursor = min(cursor, source.len());
-    let prefix_start = scan_identifier_start(source, cursor);
-    (prefix_start, source[prefix_start..cursor].to_string())
 }
 
 fn tokenize_sql_identifiers(sql: &str) -> Vec<String> {

--- a/crates/dbflux_ui_document/src/code/completion.rs
+++ b/crates/dbflux_ui_document/src/code/completion.rs
@@ -1020,7 +1020,6 @@ fn redis_argument_options(command: &str, argument_index: usize) -> Option<&'stat
     }
 }
 
-
 fn scan_redis_token_start(source: &str, end: usize) -> usize {
     let bytes = source.as_bytes();
     let mut start = end;

--- a/crates/dbflux_ui_document/src/completion_support.rs
+++ b/crates/dbflux_ui_document/src/completion_support.rs
@@ -1,0 +1,82 @@
+use lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionTextEdit, InsertTextFormat,
+    Position as LspPosition, Range as LspRange, TextEdit,
+};
+use std::cmp::min;
+use std::collections::HashSet;
+
+pub(crate) fn byte_offset_to_lsp_position(source: &str, offset: usize) -> LspPosition {
+    let before = &source[..offset];
+    let line = before.matches('\n').count() as u32;
+    let line_start = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let character = source[line_start..offset].chars().count() as u32;
+
+    LspPosition { line, character }
+}
+
+pub(crate) fn completion_replace_range(
+    source: &str,
+    prefix_start: usize,
+    cursor: usize,
+) -> LspRange {
+    LspRange {
+        start: byte_offset_to_lsp_position(source, prefix_start),
+        end: byte_offset_to_lsp_position(source, cursor),
+    }
+}
+
+pub(crate) fn push_completion_item(
+    items: &mut Vec<CompletionItem>,
+    seen: &mut HashSet<String>,
+    label: &str,
+    kind: CompletionItemKind,
+    filter_prefix: &str,
+    replace_range: LspRange,
+) {
+    let key = label.to_uppercase();
+    if !seen.insert(key) {
+        return;
+    }
+
+    items.push(CompletionItem {
+        label: label.to_string(),
+        kind: Some(kind),
+        insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
+        filter_text: Some(filter_prefix.to_string()),
+        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+            range: replace_range,
+            new_text: label.to_string(),
+        })),
+        ..CompletionItem::default()
+    });
+}
+
+pub(crate) fn normalize_identifier(value: &str) -> String {
+    value.trim_matches('"').to_lowercase()
+}
+
+pub(crate) fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+pub(crate) fn scan_identifier_start(source: &str, end: usize) -> usize {
+    let bytes = source.as_bytes();
+    let mut start = end;
+
+    while start > 0 {
+        let idx = start - 1;
+        if !is_identifier_byte(bytes[idx]) {
+            break;
+        }
+
+        start -= 1;
+    }
+
+    start
+}
+
+pub(crate) fn extract_identifier_prefix(source: &str, cursor: usize) -> (usize, String) {
+    let cursor = min(cursor, source.len());
+    let prefix_start = scan_identifier_start(source, cursor);
+    (prefix_start, source[prefix_start..cursor].to_string())
+}

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -753,13 +753,6 @@ impl DataGridPanel {
                     .unwrap_or_default()
             };
 
-            log::info!(
-                "[autocomplete] new_internal: building filter cache for table={} \
-                 initial_source_columns={}",
-                table.name,
-                source_columns.len()
-            );
-
             let filter_cache = Rc::new(RefCell::new(SchemaCache {
                 source_table: table.name.clone(),
                 source_columns,
@@ -2541,7 +2534,6 @@ impl DataGridPanel {
     /// would require recursive FK metadata and is deferred.
     fn refresh_filter_fk_links(&mut self) {
         let Some(cache) = self.filter_completion_cache.as_ref() else {
-            log::info!("[autocomplete] refresh_filter_fk_links: no filter cache");
             return;
         };
 
@@ -2551,13 +2543,7 @@ impl DataGridPanel {
 
         let fks = match &self.fk_cache {
             FkLoadState::Ready(fks) => fks,
-            _ => {
-                log::info!(
-                    "[autocomplete] refresh_filter_fk_links: fk_cache not Ready (state={:?})",
-                    std::mem::discriminant(&self.fk_cache)
-                );
-                return;
-            }
+            _ => return,
         };
 
         let source_table_lower = table.name.to_lowercase();
@@ -2580,13 +2566,6 @@ impl DataGridPanel {
                 },
             );
         }
-
-        log::info!(
-            "[autocomplete] refresh_filter_fk_links: table={} fks_total={} links_built={}",
-            table.name,
-            fks.len(),
-            links.len()
-        );
 
         cache.borrow_mut().fk_links = links;
     }
@@ -2705,9 +2684,6 @@ impl DataGridPanel {
     /// pushed into `AppState` so other panels benefit.
     fn ensure_filter_source_columns_loaded(&mut self, cx: &mut Context<Self>) {
         let Some(cache_rc) = self.filter_completion_cache.clone() else {
-            log::info!(
-                "[autocomplete] ensure_filter_source_columns_loaded: no cache (non-table source)"
-            );
             return;
         };
 
@@ -2718,10 +2694,7 @@ impl DataGridPanel {
                 database,
                 ..
             } => (*profile_id, table.clone(), database.clone()),
-            _ => {
-                log::info!("[autocomplete] ensure_filter_source_columns_loaded: non-Table source");
-                return;
-            }
+            _ => return,
         };
 
         let key: (Option<String>, String) = (
@@ -2731,16 +2704,6 @@ impl DataGridPanel {
 
         {
             let cache = cache_rc.borrow();
-            log::info!(
-                "[autocomplete] ensure_filter_source_columns_loaded: table={} key={:?} \
-                 source_columns_len={} fetching={} failed={}",
-                table.qualified_name(),
-                key,
-                cache.source_columns.len(),
-                cache.fetching.contains(&key),
-                cache.failed.contains(&key),
-            );
-
             if !cache.source_columns.is_empty()
                 || cache.fetching.contains(&key)
                 || cache.failed.contains(&key)
@@ -2767,21 +2730,8 @@ impl DataGridPanel {
             .get(&profile_id)
             .map(|c| c.connection_for_database(&database))
         else {
-            log::warn!(
-                "[autocomplete] ensure_filter_source_columns_loaded: no live connection for \
-                 profile_id={}",
-                profile_id
-            );
             return;
         };
-
-        log::info!(
-            "[autocomplete] ensure_filter_source_columns_loaded: spawning fetch db={} \
-             schema={:?} table={}",
-            database,
-            table.schema,
-            table.name
-        );
 
         cache_rc.borrow_mut().fetching.insert(key.clone());
 
@@ -2812,13 +2762,6 @@ impl DataGridPanel {
 
             match result {
                 Ok(details) => {
-                    let column_count = details.columns.as_ref().map(|c| c.len()).unwrap_or(0);
-                    log::info!(
-                        "[autocomplete] source_columns fetch OK: table={} columns={}",
-                        table_for_finish.qualified_name(),
-                        column_count
-                    );
-
                     if let Some(cols) = details.columns.clone() {
                         cache_for_finish.borrow_mut().source_columns = cols;
 
@@ -2836,20 +2779,10 @@ impl DataGridPanel {
                             .ok();
                         }
                     } else {
-                        log::warn!(
-                            "[autocomplete] source_columns fetch returned details but \
-                             columns=None for table={}",
-                            table_for_finish.qualified_name()
-                        );
                         cache_for_finish.borrow_mut().failed.insert(key_for_finish);
                     }
                 }
-                Err(e) => {
-                    log::warn!(
-                        "[autocomplete] source_columns fetch FAILED: table={} err={}",
-                        table_for_finish.qualified_name(),
-                        e
-                    );
+                Err(_) => {
                     cache_for_finish.borrow_mut().failed.insert(key_for_finish);
                 }
             }

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -7,6 +7,9 @@ mod render;
 pub mod row_inspector;
 mod utils;
 
+use super::query_builder::completion::{
+    AliasBinding, CompletionMode, SchemaCache, SchemaCompletionProvider,
+};
 use super::query_builder::{BuilderEvent, FkLoadState, QueryBuilderPanel};
 use super::result_view::{
     ResultViewMode, default_bindings_for_time_series, should_auto_select_chart_for_time_series,
@@ -23,6 +26,7 @@ use dbflux_components::components::data_table::{
 use dbflux_components::components::document_tree::{
     DocumentTree, DocumentTreeEvent, DocumentTreeState,
 };
+use dbflux_components::controls::CompletionProvider;
 use dbflux_components::controls::{Dropdown, DropdownItem, DropdownSelectionChanged};
 use dbflux_components::controls::{InputEvent, InputState};
 use dbflux_components::modals::cell_editor::{
@@ -40,6 +44,9 @@ use dbflux_ui_base::AsyncUpdateResultExt;
 use dbflux_ui_base::toast::PendingToast;
 use gpui::*;
 use gpui_component::Sizable;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -714,6 +721,61 @@ impl DataGridPanel {
         let filter_placeholder = Self::filter_placeholder_for_source(&source, &app_state, cx);
 
         let filter_input = cx.new(|cx| InputState::new(window, cx).placeholder(filter_placeholder));
+
+        if let DataSource::Table {
+            profile_id,
+            table,
+            database,
+            ..
+        } = &source
+        {
+            let source_columns: Vec<dbflux_core::ColumnInfo> = {
+                let state = app_state.read(cx);
+                state
+                    .connections()
+                    .get(profile_id)
+                    .and_then(|conn| {
+                        let db = database
+                            .as_deref()
+                            .or(conn.active_database.as_deref())
+                            .unwrap_or("default");
+                        conn.table_details
+                            .get(&(db.to_string(), table.name.clone()))
+                            .and_then(|info| info.columns.clone())
+                    })
+                    .unwrap_or_default()
+            };
+
+            let table_alias = table.name.clone();
+            let source_schema = table.schema.clone();
+
+            let filter_cache = Rc::new(RefCell::new(SchemaCache {
+                source_table: table_alias.clone(),
+                source_columns,
+                joined_columns: HashMap::new(),
+                fetching: HashSet::new(),
+                failed: HashSet::new(),
+            }));
+
+            let filter_provider: Rc<dyn CompletionProvider> =
+                Rc::new(SchemaCompletionProvider::new(
+                    app_state.downgrade(),
+                    *profile_id,
+                    CompletionMode::FilterExpression {
+                        aliases: vec![AliasBinding {
+                            alias: table_alias,
+                            schema: source_schema,
+                            table: table.name.clone(),
+                            is_source: true,
+                        }],
+                    },
+                    filter_cache,
+                ));
+
+            filter_input.update(cx, |state, _| {
+                state.lsp.completion_provider = Some(filter_provider);
+            });
+        }
 
         let limit_input = cx.new(|cx| {
             let mut state = InputState::new(window, cx).placeholder("100");

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -742,11 +742,12 @@ impl DataGridPanel {
                     .get(profile_id)
                     .and_then(|conn| {
                         let db = database
-                            .as_deref()
-                            .or(conn.active_database.as_deref())
-                            .unwrap_or("default");
+                            .clone()
+                            .or_else(|| conn.active_database.clone())
+                            .or_else(|| table.schema.clone())
+                            .unwrap_or_else(|| "default".to_string());
                         conn.table_details
-                            .get(&(db.to_string(), table.name.clone()))
+                            .get(&(db, table.name.clone()))
                             .and_then(|info| info.columns.clone())
                     })
                     .unwrap_or_default()
@@ -2630,18 +2631,26 @@ impl DataGridPanel {
             }
         }
 
-        let (profile_id, database) = match &self.source {
+        let (profile_id, database, source_table_schema) = match &self.source {
             DataSource::Table {
                 profile_id,
                 database,
+                table,
                 ..
-            } => (*profile_id, database.clone()),
+            } => (*profile_id, database.clone(), table.schema.clone()),
             _ => return,
         };
 
-        let Some(database) = database else {
-            return;
-        };
+        let database = database
+            .or_else(|| {
+                self.app_state
+                    .read(cx)
+                    .connections()
+                    .get(&profile_id)
+                    .and_then(|c| c.active_database.clone())
+            })
+            .or(source_table_schema)
+            .unwrap_or_else(|| "default".to_string());
 
         let Some(conn) = self
             .app_state
@@ -2740,21 +2749,16 @@ impl DataGridPanel {
             }
         }
 
-        let database = database.or_else(|| {
-            self.app_state
-                .read(cx)
-                .connections()
-                .get(&profile_id)
-                .and_then(|c| c.active_database.clone())
-        });
-
-        let Some(database) = database else {
-            log::warn!(
-                "[autocomplete] ensure_filter_source_columns_loaded: no database for table {}",
-                table.qualified_name()
-            );
-            return;
-        };
+        let database = database
+            .or_else(|| {
+                self.app_state
+                    .read(cx)
+                    .connections()
+                    .get(&profile_id)
+                    .and_then(|c| c.active_database.clone())
+            })
+            .or_else(|| table.schema.clone())
+            .unwrap_or_else(|| "default".to_string());
 
         let Some(conn) = self
             .app_state

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -2658,6 +2658,8 @@ impl DataGridPanel {
         let key_for_finish = key.clone();
         let cache_for_finish = cache_rc.clone();
 
+        let ref_table_for_log = ref_table.clone();
+        let database_for_log = database.clone();
         cx.spawn(async move |_this, _cx| {
             let result = task.await;
             let mut cache = cache_for_finish.borrow_mut();
@@ -2667,10 +2669,22 @@ impl DataGridPanel {
                     if let Some(cols) = details.columns {
                         cache.joined_columns.insert(key_for_finish, cols);
                     } else {
+                        log::warn!(
+                            "autocomplete: FK-target table_details returned no columns for \
+                             {}.{}",
+                            database_for_log,
+                            ref_table_for_log
+                        );
                         cache.failed.insert(key_for_finish);
                     }
                 }
-                Err(_) => {
+                Err(err) => {
+                    log::warn!(
+                        "autocomplete: failed to fetch FK-target columns for {}.{}: {}",
+                        database_for_log,
+                        ref_table_for_log,
+                        err
+                    );
                     cache.failed.insert(key_for_finish);
                 }
             }
@@ -2779,10 +2793,21 @@ impl DataGridPanel {
                             .ok();
                         }
                     } else {
+                        log::warn!(
+                            "autocomplete: table_details returned no columns for {}.{}",
+                            database_for_finish,
+                            table_for_finish.qualified_name()
+                        );
                         cache_for_finish.borrow_mut().failed.insert(key_for_finish);
                     }
                 }
-                Err(_) => {
+                Err(err) => {
+                    log::warn!(
+                        "autocomplete: failed to fetch columns for {}.{}: {}",
+                        database_for_finish,
+                        table_for_finish.qualified_name(),
+                        err
+                    );
                     cache_for_finish.borrow_mut().failed.insert(key_for_finish);
                 }
             }

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -569,6 +569,9 @@ impl DataGridPanel {
             panel.fetch_table_details_for_pk(profile_id, &table, cx);
         }
 
+        panel.ensure_filter_source_columns_loaded(cx);
+        panel.ensure_fk_cache_loaded(cx);
+
         panel
     }
 
@@ -799,6 +802,7 @@ impl DataGridPanel {
                     {
                         this.ensure_fk_cache_loaded(cx);
                     }
+                    this.ensure_filter_source_columns_loaded(cx);
                     this.ensure_filter_fk_columns_loaded(&text, cx);
                 }
                 _ => {}
@@ -2659,6 +2663,119 @@ impl DataGridPanel {
                 }
                 Err(_) => {
                     cache.failed.insert(key_for_finish);
+                }
+            }
+        })
+        .detach();
+    }
+
+    /// If the filter cache has no source columns yet, kick off a background
+    /// fetch of `table_details` for the source table. The result is written
+    /// into the cache so subsequent completion calls have data, and is also
+    /// pushed into `AppState` so other panels benefit.
+    fn ensure_filter_source_columns_loaded(&mut self, cx: &mut Context<Self>) {
+        let Some(cache_rc) = self.filter_completion_cache.clone() else {
+            return;
+        };
+
+        let (profile_id, table, database) = match &self.source {
+            DataSource::Table {
+                profile_id,
+                table,
+                database,
+                ..
+            } => (*profile_id, table.clone(), database.clone()),
+            _ => return,
+        };
+
+        let key: (Option<String>, String) = (
+            table.schema.as_ref().map(|s| s.to_lowercase()),
+            table.name.to_lowercase(),
+        );
+
+        {
+            let cache = cache_rc.borrow();
+            if !cache.source_columns.is_empty()
+                || cache.fetching.contains(&key)
+                || cache.failed.contains(&key)
+            {
+                return;
+            }
+        }
+
+        let database = database.or_else(|| {
+            self.app_state
+                .read(cx)
+                .connections()
+                .get(&profile_id)
+                .and_then(|c| c.active_database.clone())
+        });
+
+        let Some(database) = database else {
+            return;
+        };
+
+        let Some(conn) = self
+            .app_state
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .map(|c| c.connection.clone())
+        else {
+            return;
+        };
+
+        cache_rc.borrow_mut().fetching.insert(key.clone());
+
+        let table_for_task = table.clone();
+        let database_for_task = database.clone();
+
+        let task = cx.background_executor().spawn(async move {
+            conn.table_details(
+                &database_for_task,
+                table_for_task.schema.as_deref(),
+                &table_for_task.name,
+            )
+        });
+
+        let key_for_finish = key.clone();
+        let cache_for_finish = cache_rc.clone();
+        let app_state_weak = self.app_state.downgrade();
+        let database_for_finish = database;
+        let table_for_finish = table.clone();
+
+        cx.spawn(async move |_this, cx| {
+            let result = task.await;
+
+            cache_for_finish
+                .borrow_mut()
+                .fetching
+                .remove(&key_for_finish);
+
+            match result {
+                Ok(details) => {
+                    if let Some(cols) = details.columns.clone() {
+                        cache_for_finish.borrow_mut().source_columns = cols;
+
+                        if let Some(app) = app_state_weak.upgrade() {
+                            cx.update(|cx| {
+                                app.update(cx, |state, _| {
+                                    state.set_table_details(
+                                        profile_id,
+                                        database_for_finish.clone(),
+                                        table_for_finish.name.clone(),
+                                        details,
+                                    );
+                                });
+                            })
+                            .ok();
+                        }
+                    } else {
+                        cache_for_finish.borrow_mut().failed.insert(key_for_finish);
+                    }
+                }
+                Err(_) => {
+                    cache_for_finish.borrow_mut().failed.insert(key_for_finish);
                 }
             }
         })

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -8,7 +8,7 @@ pub mod row_inspector;
 mod utils;
 
 use super::query_builder::completion::{
-    AliasBinding, CompletionMode, SchemaCache, SchemaCompletionProvider,
+    CompletionMode, FkLink, SchemaCache, SchemaCompletionProvider,
 };
 use super::query_builder::{BuilderEvent, FkLoadState, QueryBuilderPanel};
 use super::result_view::{
@@ -371,6 +371,9 @@ pub struct DataGridPanel {
 
     // Filter & limit inputs
     filter_input: Entity<InputState>,
+    /// Schema cache backing the WHERE filter's autocomplete. `Some` only when
+    /// `source` is `DataSource::Table` and a completion provider was wired.
+    filter_completion_cache: Option<Rc<RefCell<SchemaCache>>>,
     limit_input: Entity<InputState>,
 
     // In-memory sort state (for QueryResult source)
@@ -722,7 +725,7 @@ impl DataGridPanel {
 
         let filter_input = cx.new(|cx| InputState::new(window, cx).placeholder(filter_placeholder));
 
-        if let DataSource::Table {
+        let filter_completion_cache: Option<Rc<RefCell<SchemaCache>>> = if let DataSource::Table {
             profile_id,
             table,
             database,
@@ -746,13 +749,11 @@ impl DataGridPanel {
                     .unwrap_or_default()
             };
 
-            let table_alias = table.name.clone();
-            let source_schema = table.schema.clone();
-
             let filter_cache = Rc::new(RefCell::new(SchemaCache {
-                source_table: table_alias.clone(),
+                source_table: table.name.clone(),
                 source_columns,
                 joined_columns: HashMap::new(),
+                fk_links: HashMap::new(),
                 fetching: HashSet::new(),
                 failed: HashSet::new(),
             }));
@@ -761,21 +762,18 @@ impl DataGridPanel {
                 Rc::new(SchemaCompletionProvider::new(
                     app_state.downgrade(),
                     *profile_id,
-                    CompletionMode::FilterExpression {
-                        aliases: vec![AliasBinding {
-                            alias: table_alias,
-                            schema: source_schema,
-                            table: table.name.clone(),
-                            is_source: true,
-                        }],
-                    },
-                    filter_cache,
+                    CompletionMode::FilterExpression,
+                    filter_cache.clone(),
                 ));
 
             filter_input.update(cx, |state, _| {
                 state.lsp.completion_provider = Some(filter_provider);
             });
-        }
+
+            Some(filter_cache)
+        } else {
+            None
+        };
 
         let limit_input = cx.new(|cx| {
             let mut state = InputState::new(window, cx).placeholder("100");
@@ -801,6 +799,7 @@ impl DataGridPanel {
                     {
                         this.ensure_fk_cache_loaded(cx);
                     }
+                    this.ensure_filter_fk_columns_loaded(&text, cx);
                 }
                 _ => {}
             },
@@ -949,6 +948,7 @@ impl DataGridPanel {
             table_state: None,
             table_subscription: None,
             filter_input,
+            filter_completion_cache,
             limit_input,
             local_sort_state: None,
             original_row_order: None,
@@ -2510,6 +2510,8 @@ impl DataGridPanel {
             FkLoadState::Ready(foreign_keys)
         };
 
+        self.refresh_filter_fk_links();
+
         if matches!(
             self.relational_filter_state,
             filter_bar::RelationalFilterState::Resolving
@@ -2518,6 +2520,181 @@ impl DataGridPanel {
         }
 
         cx.notify();
+    }
+
+    /// Rebuild `filter_completion_cache.fk_links` from `fk_cache`.
+    ///
+    /// Single-hop only: maps each FK column on the source table to its
+    /// referenced table. Multi-hop traversal (e.g. `created_by.organization.name`)
+    /// would require recursive FK metadata and is deferred.
+    fn refresh_filter_fk_links(&mut self) {
+        let Some(cache) = self.filter_completion_cache.as_ref() else {
+            return;
+        };
+
+        let DataSource::Table { table, .. } = &self.source else {
+            return;
+        };
+
+        let fks = match &self.fk_cache {
+            FkLoadState::Ready(fks) => fks,
+            _ => return,
+        };
+
+        let source_table_lower = table.name.to_lowercase();
+        let mut links: HashMap<String, FkLink> = HashMap::new();
+
+        for fk in fks {
+            if fk.table_name.to_lowercase() != source_table_lower {
+                continue;
+            }
+
+            let Some(col) = fk.columns.first() else {
+                continue;
+            };
+
+            links.insert(
+                col.to_lowercase(),
+                FkLink {
+                    referenced_schema: fk.referenced_schema.clone(),
+                    referenced_table: fk.referenced_table.clone(),
+                },
+            );
+        }
+
+        cache.borrow_mut().fk_links = links;
+    }
+
+    /// If the filter text contains a `<col>.` qualifier whose left side is an
+    /// FK column on the source table, kick off a background fetch of the
+    /// referenced table's columns so dotted-path completion has data to show.
+    fn ensure_filter_fk_columns_loaded(&mut self, text: &str, cx: &mut Context<Self>) {
+        let Some(cache_rc) = self.filter_completion_cache.clone() else {
+            return;
+        };
+
+        let qualifier = match Self::extract_filter_qualifier(text) {
+            Some(q) => q,
+            None => return,
+        };
+
+        let qualifier_lower = qualifier.to_lowercase();
+        let (ref_schema, ref_table) = {
+            let cache = cache_rc.borrow();
+            match cache.fk_links.get(&qualifier_lower) {
+                Some(link) => (
+                    link.referenced_schema.clone(),
+                    link.referenced_table.clone(),
+                ),
+                None => return,
+            }
+        };
+
+        let key = (
+            ref_schema.as_ref().map(|s| s.to_lowercase()),
+            ref_table.to_lowercase(),
+        );
+
+        {
+            let cache = cache_rc.borrow();
+            if cache.joined_columns.contains_key(&key)
+                || cache.fetching.contains(&key)
+                || cache.failed.contains(&key)
+            {
+                return;
+            }
+        }
+
+        let (profile_id, database) = match &self.source {
+            DataSource::Table {
+                profile_id,
+                database,
+                ..
+            } => (*profile_id, database.clone()),
+            _ => return,
+        };
+
+        let Some(database) = database else {
+            return;
+        };
+
+        let Some(conn) = self
+            .app_state
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .map(|c| c.connection.clone())
+        else {
+            return;
+        };
+
+        cache_rc.borrow_mut().fetching.insert(key.clone());
+
+        let ref_table_for_task = ref_table.clone();
+        let ref_schema_for_task = ref_schema.clone();
+        let database_for_task = database.clone();
+
+        let task = cx.background_executor().spawn(async move {
+            conn.table_details(
+                &database_for_task,
+                ref_schema_for_task.as_deref(),
+                &ref_table_for_task,
+            )
+        });
+
+        let key_for_finish = key.clone();
+        let cache_for_finish = cache_rc.clone();
+
+        cx.spawn(async move |_this, _cx| {
+            let result = task.await;
+            let mut cache = cache_for_finish.borrow_mut();
+            cache.fetching.remove(&key_for_finish);
+            match result {
+                Ok(details) => {
+                    if let Some(cols) = details.columns {
+                        cache.joined_columns.insert(key_for_finish, cols);
+                    } else {
+                        cache.failed.insert(key_for_finish);
+                    }
+                }
+                Err(_) => {
+                    cache.failed.insert(key_for_finish);
+                }
+            }
+        })
+        .detach();
+    }
+
+    /// Extract the identifier just before a trailing `.` (or the dot before
+    /// the active prefix at end-of-string) from filter text.
+    ///
+    /// Returns `Some("created_by")` for inputs like `created_by.`,
+    /// `created_by.ema`, or `name = 'x' AND created_by.`. Returns `None`
+    /// when there is no dot-qualified identifier at the current cursor
+    /// position (end of string for autocomplete typing).
+    fn extract_filter_qualifier(text: &str) -> Option<String> {
+        let bytes = text.as_bytes();
+        let mut i = bytes.len();
+
+        while i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || bytes[i - 1] == b'_') {
+            i -= 1;
+        }
+
+        if i == 0 || bytes[i - 1] != b'.' {
+            return None;
+        }
+
+        let dot_pos = i - 1;
+        let mut start = dot_pos;
+        while start > 0 && (bytes[start - 1].is_ascii_alphanumeric() || bytes[start - 1] == b'_') {
+            start -= 1;
+        }
+
+        if start == dot_pos {
+            return None;
+        }
+
+        Some(text[start..dot_pos].to_string())
     }
 
     /// Transitions the panel's `fk_cache` to `Unavailable`.

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -2401,6 +2401,8 @@ impl DataGridPanel {
                     initial_spec,
                     Some(weak_self.clone()),
                     available_columns,
+                    self.app_state.clone(),
+                    profile_id,
                     generate_preview,
                     window,
                     cx,

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -752,6 +752,13 @@ impl DataGridPanel {
                     .unwrap_or_default()
             };
 
+            log::info!(
+                "[autocomplete] new_internal: building filter cache for table={} \
+                 initial_source_columns={}",
+                table.name,
+                source_columns.len()
+            );
+
             let filter_cache = Rc::new(RefCell::new(SchemaCache {
                 source_table: table.name.clone(),
                 source_columns,
@@ -2533,6 +2540,7 @@ impl DataGridPanel {
     /// would require recursive FK metadata and is deferred.
     fn refresh_filter_fk_links(&mut self) {
         let Some(cache) = self.filter_completion_cache.as_ref() else {
+            log::info!("[autocomplete] refresh_filter_fk_links: no filter cache");
             return;
         };
 
@@ -2542,7 +2550,13 @@ impl DataGridPanel {
 
         let fks = match &self.fk_cache {
             FkLoadState::Ready(fks) => fks,
-            _ => return,
+            _ => {
+                log::info!(
+                    "[autocomplete] refresh_filter_fk_links: fk_cache not Ready (state={:?})",
+                    std::mem::discriminant(&self.fk_cache)
+                );
+                return;
+            }
         };
 
         let source_table_lower = table.name.to_lowercase();
@@ -2565,6 +2579,13 @@ impl DataGridPanel {
                 },
             );
         }
+
+        log::info!(
+            "[autocomplete] refresh_filter_fk_links: table={} fks_total={} links_built={}",
+            table.name,
+            fks.len(),
+            links.len()
+        );
 
         cache.borrow_mut().fk_links = links;
     }
@@ -2675,6 +2696,9 @@ impl DataGridPanel {
     /// pushed into `AppState` so other panels benefit.
     fn ensure_filter_source_columns_loaded(&mut self, cx: &mut Context<Self>) {
         let Some(cache_rc) = self.filter_completion_cache.clone() else {
+            log::info!(
+                "[autocomplete] ensure_filter_source_columns_loaded: no cache (non-table source)"
+            );
             return;
         };
 
@@ -2685,7 +2709,10 @@ impl DataGridPanel {
                 database,
                 ..
             } => (*profile_id, table.clone(), database.clone()),
-            _ => return,
+            _ => {
+                log::info!("[autocomplete] ensure_filter_source_columns_loaded: non-Table source");
+                return;
+            }
         };
 
         let key: (Option<String>, String) = (
@@ -2695,6 +2722,16 @@ impl DataGridPanel {
 
         {
             let cache = cache_rc.borrow();
+            log::info!(
+                "[autocomplete] ensure_filter_source_columns_loaded: table={} key={:?} \
+                 source_columns_len={} fetching={} failed={}",
+                table.qualified_name(),
+                key,
+                cache.source_columns.len(),
+                cache.fetching.contains(&key),
+                cache.failed.contains(&key),
+            );
+
             if !cache.source_columns.is_empty()
                 || cache.fetching.contains(&key)
                 || cache.failed.contains(&key)
@@ -2712,6 +2749,10 @@ impl DataGridPanel {
         });
 
         let Some(database) = database else {
+            log::warn!(
+                "[autocomplete] ensure_filter_source_columns_loaded: no database for table {}",
+                table.qualified_name()
+            );
             return;
         };
 
@@ -2722,8 +2763,21 @@ impl DataGridPanel {
             .get(&profile_id)
             .map(|c| c.connection.clone())
         else {
+            log::warn!(
+                "[autocomplete] ensure_filter_source_columns_loaded: no live connection for \
+                 profile_id={}",
+                profile_id
+            );
             return;
         };
+
+        log::info!(
+            "[autocomplete] ensure_filter_source_columns_loaded: spawning fetch db={} \
+             schema={:?} table={}",
+            database,
+            table.schema,
+            table.name
+        );
 
         cache_rc.borrow_mut().fetching.insert(key.clone());
 
@@ -2754,6 +2808,13 @@ impl DataGridPanel {
 
             match result {
                 Ok(details) => {
+                    let column_count = details.columns.as_ref().map(|c| c.len()).unwrap_or(0);
+                    log::info!(
+                        "[autocomplete] source_columns fetch OK: table={} columns={}",
+                        table_for_finish.qualified_name(),
+                        column_count
+                    );
+
                     if let Some(cols) = details.columns.clone() {
                         cache_for_finish.borrow_mut().source_columns = cols;
 
@@ -2771,10 +2832,20 @@ impl DataGridPanel {
                             .ok();
                         }
                     } else {
+                        log::warn!(
+                            "[autocomplete] source_columns fetch returned details but \
+                             columns=None for table={}",
+                            table_for_finish.qualified_name()
+                        );
                         cache_for_finish.borrow_mut().failed.insert(key_for_finish);
                     }
                 }
-                Err(_) => {
+                Err(e) => {
+                    log::warn!(
+                        "[autocomplete] source_columns fetch FAILED: table={} err={}",
+                        table_for_finish.qualified_name(),
+                        e
+                    );
                     cache_for_finish.borrow_mut().failed.insert(key_for_finish);
                 }
             }

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -2657,7 +2657,7 @@ impl DataGridPanel {
             .read(cx)
             .connections()
             .get(&profile_id)
-            .map(|c| c.connection.clone())
+            .map(|c| c.connection_for_database(&database))
         else {
             return;
         };
@@ -2765,7 +2765,7 @@ impl DataGridPanel {
             .read(cx)
             .connections()
             .get(&profile_id)
-            .map(|c| c.connection.clone())
+            .map(|c| c.connection_for_database(&database))
         else {
             log::warn!(
                 "[autocomplete] ensure_filter_source_columns_loaded: no live connection for \

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -16,7 +16,7 @@ use dbflux_components::chart::{
 use dbflux_components::chart::{SourceRowRef, point_inspector_element};
 use dbflux_components::common::time_range::view::TimeRangePanel;
 use dbflux_components::components::data_table::SortState as TableSortState;
-use dbflux_components::controls::{Checkbox, Input, InputState};
+use dbflux_components::controls::{Checkbox, Input, InputState, completion_input_keys_wrapper};
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{BannerBlock, BannerVariant, Icon, Text, surface_raised};
 use dbflux_components::semantic::ChartColors;
@@ -610,7 +610,11 @@ pub(super) fn render_filter_bar_as_segment(
                                     });
                                 }
                             })
-                            .child(div().flex_1().child(Input::new(&filter_input).small()))
+                            .child(
+                                completion_input_keys_wrapper(&filter_input)
+                                    .flex_1()
+                                    .child(Input::new(&filter_input).small()),
+                            )
                             .when(filter_has_value, move |d| {
                                 let grid = grid_for_clear_event.clone();
                                 let theme_hover = theme_clear.clone();
@@ -863,7 +867,11 @@ impl DataGridPanel {
                                         cx.notify();
                                     }),
                                 )
-                                .child(div().flex_1().child(Input::new(filter_input).small()))
+                                .child(
+                                    completion_input_keys_wrapper(filter_input)
+                                        .flex_1()
+                                        .child(Input::new(filter_input).small()),
+                                )
                                 .when(filter_has_value, |d| {
                                     d.child(
                                         div()

--- a/crates/dbflux_ui_document/src/lib.rs
+++ b/crates/dbflux_ui_document/src/lib.rs
@@ -2,12 +2,12 @@
 #![allow(unused_imports)]
 
 mod add_member_modal;
-pub(crate) mod completion_support;
 mod audit;
 pub mod chart;
 pub mod chart_document;
 mod chrome;
 mod code;
+pub(crate) mod completion_support;
 pub mod dashboard;
 mod data_document;
 mod data_grid_panel;

--- a/crates/dbflux_ui_document/src/lib.rs
+++ b/crates/dbflux_ui_document/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(unused_imports)]
 
 mod add_member_modal;
+pub(crate) mod completion_support;
 mod audit;
 pub mod chart;
 pub mod chart_document;

--- a/crates/dbflux_ui_document/src/query_builder/completion.rs
+++ b/crates/dbflux_ui_document/src/query_builder/completion.rs
@@ -29,6 +29,18 @@ pub(crate) struct AliasBinding {
     pub is_source: bool,
 }
 
+/// Resolved foreign-key edge originating in the source table.
+///
+/// Lets the filter-bar provider follow ORM-style dotted paths
+/// (`created_by.email`) without re-parsing FK metadata at suggest time.
+#[derive(Clone, Debug)]
+pub(crate) struct FkLink {
+    /// Schema of the referenced table, if known.
+    pub referenced_schema: Option<String>,
+    /// Bare name of the referenced table.
+    pub referenced_table: String,
+}
+
 /// In-memory cache of column metadata for the current builder panel.
 ///
 /// Populated at panel construction (source table) and incrementally via
@@ -44,6 +56,11 @@ pub(crate) struct SchemaCache {
     /// Lazily fetched columns for joined tables.
     /// Key: (schema, table) where both are normalized (lowercase, unquoted).
     pub joined_columns: HashMap<(Option<String>, String), Vec<ColumnInfo>>,
+
+    /// Foreign-key edges from the source table.
+    /// Key: normalized source column name. Used by `FilterExpression` to
+    /// suggest dotted paths like `created_by.email`.
+    pub fk_links: HashMap<String, FkLink>,
 
     /// Keys for which a background fetch is in flight (dedup guard).
     pub fetching: HashSet<(Option<String>, String)>,
@@ -76,8 +93,11 @@ pub(crate) enum CompletionMode {
 
     /// DataView WHERE filter bar: multi-token free-form input.
     ///
-    /// Uses the same alias/column logic but seeded with only the source table.
-    FilterExpression { aliases: Vec<AliasBinding> },
+    /// Suggests bare columns of the source table directly (no alias prefix),
+    /// and follows FK paths declared in `SchemaCache::fk_links` when the user
+    /// types `<fk_column>.`. Driver-agnostic: the FK metadata is supplied by
+    /// the panel from `fk_cache`, never inspected by mode-specific code.
+    FilterExpression,
 }
 
 /// Schema-aware completion provider for single-line builder inputs.
@@ -181,8 +201,7 @@ pub(crate) fn compute_suggestions(
         }
 
         CompletionMode::AliasOrColumn { aliases }
-        | CompletionMode::JoinConditionRight { aliases }
-        | CompletionMode::FilterExpression { aliases } => {
+        | CompletionMode::JoinConditionRight { aliases } => {
             let mut seen = HashSet::new();
             let mut items = Vec::new();
 
@@ -273,6 +292,76 @@ pub(crate) fn compute_suggestions(
 
             items
         }
+
+        CompletionMode::FilterExpression => {
+            let mut seen = HashSet::new();
+            let mut items = Vec::new();
+
+            if let Some(qualifier_str) = qualifier {
+                let qualifier_norm = normalize_identifier(qualifier_str);
+
+                if let Some(link) = cache.fk_links.get(&qualifier_norm) {
+                    let key = (
+                        link.referenced_schema
+                            .as_ref()
+                            .map(|s| normalize_identifier(s)),
+                        normalize_identifier(&link.referenced_table),
+                    );
+
+                    if let Some(cols) = cache.joined_columns.get(&key) {
+                        for col in cols {
+                            if !prefix_upper.is_empty()
+                                && !col.name.to_uppercase().starts_with(&prefix_upper)
+                            {
+                                continue;
+                            }
+
+                            push_completion_item(
+                                &mut items,
+                                &mut seen,
+                                &col.name,
+                                CompletionItemKind::FIELD,
+                                prefix,
+                                replace_range,
+                            );
+                        }
+                    }
+                }
+
+                return items;
+            }
+
+            for col in &cache.source_columns {
+                if !prefix_upper.is_empty() && !col.name.to_uppercase().starts_with(&prefix_upper) {
+                    continue;
+                }
+
+                let normalized = normalize_identifier(&col.name);
+                let detail = cache
+                    .fk_links
+                    .get(&normalized)
+                    .map(|link| format!("→ {}", link.referenced_table));
+
+                let label = col.name.clone();
+                let upper_key = label.to_uppercase();
+                if seen.insert(upper_key) {
+                    items.push(CompletionItem {
+                        label: label.clone(),
+                        kind: Some(CompletionItemKind::FIELD),
+                        detail,
+                        insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
+                        filter_text: Some(prefix.to_string()),
+                        text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                            range: replace_range,
+                            new_text: label,
+                        })),
+                        ..CompletionItem::default()
+                    });
+                }
+            }
+
+            items
+        }
     }
 }
 
@@ -358,6 +447,7 @@ mod tests {
             source_table: "users".to_string(),
             source_columns: columns,
             joined_columns: HashMap::new(),
+            fk_links: HashMap::new(),
             fetching: HashSet::new(),
             failed: HashSet::new(),
         }
@@ -591,22 +681,124 @@ mod tests {
 
     // --- FilterExpression mode ---
 
-    #[test]
-    fn filter_expression_mode_uses_source_alias_only() {
-        let mode = CompletionMode::FilterExpression {
-            aliases: vec![AliasBinding {
-                alias: "users".to_string(),
-                schema: None,
-                table: "users".to_string(),
-                is_source: true,
-            }],
-        };
-        let cache = make_source_cache(vec![make_column("email", "varchar")]);
+    fn make_filter_mode() -> CompletionMode {
+        CompletionMode::FilterExpression
+    }
 
-        let items = compute_suggestions(&mode, &cache, "em", Some("users"), empty_replace_range());
+    #[test]
+    fn filter_expression_no_qualifier_suggests_source_columns_only() {
+        let mode = make_filter_mode();
+        let cache = make_source_cache(vec![
+            make_column("email", "varchar"),
+            make_column("name", "varchar"),
+        ]);
+
+        let items = compute_suggestions(&mode, &cache, "", None, empty_replace_range());
+        let labels = label_set(&items);
+
+        assert_eq!(labels, vec!["email", "name"]);
+        assert!(
+            !labels.iter().any(|l| l == "users"),
+            "source table name must not appear as a suggestion"
+        );
+    }
+
+    #[test]
+    fn filter_expression_prefix_filters_source_columns() {
+        let mode = make_filter_mode();
+        let cache = make_source_cache(vec![
+            make_column("email", "varchar"),
+            make_column("name", "varchar"),
+        ]);
+
+        let items = compute_suggestions(&mode, &cache, "em", None, empty_replace_range());
         let labels = label_set(&items);
 
         assert_eq!(labels, vec!["email"]);
+    }
+
+    #[test]
+    fn filter_expression_marks_fk_columns_with_arrow_detail() {
+        let mode = make_filter_mode();
+        let mut cache = make_source_cache(vec![
+            make_column("created_by", "uuid"),
+            make_column("email", "varchar"),
+        ]);
+        cache.fk_links.insert(
+            "created_by".to_string(),
+            FkLink {
+                referenced_schema: None,
+                referenced_table: "users".to_string(),
+            },
+        );
+
+        let items = compute_suggestions(&mode, &cache, "", None, empty_replace_range());
+
+        let fk_item = items
+            .iter()
+            .find(|i| i.label == "created_by")
+            .expect("created_by must be present");
+        assert_eq!(fk_item.detail.as_deref(), Some("→ users"));
+
+        let plain_item = items
+            .iter()
+            .find(|i| i.label == "email")
+            .expect("email must be present");
+        assert!(plain_item.detail.is_none());
+    }
+
+    #[test]
+    fn filter_expression_with_fk_qualifier_suggests_referenced_columns() {
+        let mode = make_filter_mode();
+        let mut cache = make_source_cache(vec![make_column("created_by", "uuid")]);
+        cache.fk_links.insert(
+            "created_by".to_string(),
+            FkLink {
+                referenced_schema: None,
+                referenced_table: "users".to_string(),
+            },
+        );
+        cache.joined_columns.insert(
+            (None, "users".to_string()),
+            vec![make_column("id", "uuid"), make_column("email", "varchar")],
+        );
+
+        let items =
+            compute_suggestions(&mode, &cache, "", Some("created_by"), empty_replace_range());
+        let labels = label_set(&items);
+
+        assert_eq!(labels, vec!["email", "id"]);
+    }
+
+    #[test]
+    fn filter_expression_unknown_qualifier_returns_empty() {
+        let mode = make_filter_mode();
+        let cache = make_source_cache(vec![make_column("email", "varchar")]);
+
+        let items = compute_suggestions(&mode, &cache, "", Some("nope"), empty_replace_range());
+
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn filter_expression_with_fk_qualifier_before_fetch_returns_empty() {
+        let mode = make_filter_mode();
+        let mut cache = make_source_cache(vec![make_column("created_by", "uuid")]);
+        cache.fk_links.insert(
+            "created_by".to_string(),
+            FkLink {
+                referenced_schema: None,
+                referenced_table: "users".to_string(),
+            },
+        );
+
+        let items =
+            compute_suggestions(&mode, &cache, "", Some("created_by"), empty_replace_range());
+
+        assert!(
+            items.is_empty(),
+            "no joined_columns entry yet must yield empty (pending fetch)"
+        );
     }
 
     // --- JoinConditionRight mode ---

--- a/crates/dbflux_ui_document/src/query_builder/completion.rs
+++ b/crates/dbflux_ui_document/src/query_builder/completion.rs
@@ -1,0 +1,648 @@
+use crate::completion_support::{
+    completion_replace_range, extract_identifier_prefix, normalize_identifier,
+    push_completion_item, scan_identifier_start,
+};
+use dbflux_components::controls::{CompletionProvider, InputState, Rope};
+use dbflux_core::ColumnInfo;
+use gpui::{Context, Task, WeakEntity, Window};
+use lsp_types::{
+    CompletionContext, CompletionItem, CompletionItemKind, CompletionResponse, CompletionTextEdit,
+    InsertTextFormat, Range as LspRange, TextEdit,
+};
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
+use uuid::Uuid;
+
+use dbflux_ui_base::AppStateEntity;
+
+/// A single alias-to-table binding in the visual query builder.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(crate) struct AliasBinding {
+    /// The alias as it appears in the query (e.g. `u`, `orders`).
+    pub alias: String,
+    /// Schema qualifier, if any.
+    pub schema: Option<String>,
+    /// The underlying table name.
+    pub table: String,
+    /// True for the source table; false for join targets.
+    pub is_source: bool,
+}
+
+/// In-memory cache of column metadata for the current builder panel.
+///
+/// Populated at panel construction (source table) and incrementally via
+/// background fetches (joined tables). Shared between the panel and all
+/// completion providers via `Rc<RefCell<SchemaCache>>`.
+#[derive(Default)]
+#[allow(dead_code)]
+pub(crate) struct SchemaCache {
+    /// Columns for the source (primary) table, keyed by the table name.
+    pub source_table: String,
+    pub source_columns: Vec<ColumnInfo>,
+
+    /// Lazily fetched columns for joined tables.
+    /// Key: (schema, table) where both are normalized (lowercase, unquoted).
+    pub joined_columns: HashMap<(Option<String>, String), Vec<ColumnInfo>>,
+
+    /// Keys for which a background fetch is in flight (dedup guard).
+    pub fetching: HashSet<(Option<String>, String)>,
+
+    /// Keys that failed to fetch; the provider will not retry these.
+    pub failed: HashSet<(Option<String>, String)>,
+}
+
+/// Which input site the provider is attached to.
+#[derive(Clone, Debug)]
+#[allow(dead_code)]
+pub(crate) enum CompletionMode {
+    /// Join `to_table` input: suggest table names.
+    Tables {
+        table_names: Vec<String>,
+        default_schema: Option<String>,
+    },
+
+    /// The `alias.column` inputs in Columns, Sort, and Filter predicate sections.
+    ///
+    /// Before a dot: suggest aliases and unqualified source-table columns.
+    /// After `<alias>.`: suggest only the columns of that alias's table.
+    AliasOrColumn { aliases: Vec<AliasBinding> },
+
+    /// Join ON-clause right-hand side.
+    ///
+    /// Same logic as `AliasOrColumn`. The distinct variant exists so future
+    /// bias toward the most-recently-added join can be added without touching
+    /// attach-site code.
+    JoinConditionRight { aliases: Vec<AliasBinding> },
+
+    /// DataView WHERE filter bar: multi-token free-form input.
+    ///
+    /// Uses the same alias/column logic but seeded with only the source table.
+    FilterExpression { aliases: Vec<AliasBinding> },
+}
+
+/// Schema-aware completion provider for single-line builder inputs.
+#[allow(dead_code)]
+pub(crate) struct SchemaCompletionProvider {
+    #[allow(dead_code)]
+    app_state: WeakEntity<AppStateEntity>,
+    #[allow(dead_code)]
+    profile_id: Uuid,
+    mode: CompletionMode,
+    schema_cache: Rc<RefCell<SchemaCache>>,
+}
+
+#[allow(dead_code)]
+impl SchemaCompletionProvider {
+    pub(crate) fn new(
+        app_state: WeakEntity<AppStateEntity>,
+        profile_id: Uuid,
+        mode: CompletionMode,
+        schema_cache: Rc<RefCell<SchemaCache>>,
+    ) -> Self {
+        Self {
+            app_state,
+            profile_id,
+            mode,
+            schema_cache,
+        }
+    }
+}
+
+/// Extract the qualifier just before a dot that precedes `prefix_start`.
+///
+/// For input like `users.em` with `prefix_start` pointing at `em`, this
+/// returns `Some("users")`. Returns `None` when no dot-qualifier is present.
+#[allow(dead_code)]
+pub(crate) fn compute_qualifier(source: &str, prefix_start: usize) -> Option<String> {
+    if prefix_start == 0 {
+        return None;
+    }
+
+    let has_dot = source.as_bytes().get(prefix_start - 1) == Some(&b'.');
+    if !has_dot {
+        return None;
+    }
+
+    let qualifier_end = prefix_start - 1;
+    let qualifier_start = scan_identifier_start(source, qualifier_end);
+    if qualifier_start == qualifier_end {
+        return None;
+    }
+
+    Some(source[qualifier_start..qualifier_end].to_string())
+}
+
+/// Compute completion suggestions as a pure function with no GPUI dependencies.
+///
+/// `mode` determines which data sources to draw from. `cache` is borrowed
+/// read-only at the call site. `prefix` and `qualifier` are derived from the
+/// cursor position in the current input text.
+#[allow(dead_code)]
+pub(crate) fn compute_suggestions(
+    mode: &CompletionMode,
+    cache: &SchemaCache,
+    prefix: &str,
+    qualifier: Option<&str>,
+    replace_range: LspRange,
+) -> Vec<CompletionItem> {
+    let prefix_upper = prefix.to_uppercase();
+
+    match mode {
+        CompletionMode::Tables {
+            table_names,
+            default_schema,
+        } => {
+            let mut seen = HashSet::new();
+            let mut items = Vec::new();
+
+            for name in table_names {
+                let display_name = match default_schema {
+                    Some(schema) if name.starts_with(&format!("{}.", schema)) => {
+                        name[schema.len() + 1..].to_string()
+                    }
+                    _ => name.clone(),
+                };
+
+                if !prefix_upper.is_empty()
+                    && !display_name.to_uppercase().starts_with(&prefix_upper)
+                {
+                    continue;
+                }
+
+                push_completion_item(
+                    &mut items,
+                    &mut seen,
+                    &display_name,
+                    CompletionItemKind::STRUCT,
+                    prefix,
+                    replace_range,
+                );
+            }
+
+            items
+        }
+
+        CompletionMode::AliasOrColumn { aliases }
+        | CompletionMode::JoinConditionRight { aliases }
+        | CompletionMode::FilterExpression { aliases } => {
+            let mut seen = HashSet::new();
+            let mut items = Vec::new();
+
+            if let Some(qualifier_str) = qualifier {
+                let qualifier_norm = normalize_identifier(qualifier_str);
+
+                let matched_binding = aliases
+                    .iter()
+                    .find(|b| normalize_identifier(&b.alias) == qualifier_norm);
+
+                let Some(binding) = matched_binding else {
+                    return items;
+                };
+
+                let columns: &[ColumnInfo] = if binding.is_source {
+                    &cache.source_columns
+                } else {
+                    let key = (
+                        binding.schema.as_ref().map(|s| normalize_identifier(s)),
+                        normalize_identifier(&binding.table),
+                    );
+
+                    match cache.joined_columns.get(&key) {
+                        Some(cols) => cols,
+                        None => return items,
+                    }
+                };
+
+                for col in columns {
+                    if !prefix_upper.is_empty()
+                        && !col.name.to_uppercase().starts_with(&prefix_upper)
+                    {
+                        continue;
+                    }
+
+                    push_completion_item(
+                        &mut items,
+                        &mut seen,
+                        &col.name,
+                        CompletionItemKind::FIELD,
+                        prefix,
+                        replace_range,
+                    );
+                }
+            } else {
+                for binding in aliases {
+                    if !prefix_upper.is_empty()
+                        && !binding.alias.to_uppercase().starts_with(&prefix_upper)
+                    {
+                        continue;
+                    }
+
+                    let detail = binding.table.clone();
+                    let key = binding.alias.to_uppercase();
+                    if seen.insert(key) {
+                        items.push(CompletionItem {
+                            label: binding.alias.clone(),
+                            kind: Some(CompletionItemKind::REFERENCE),
+                            detail: Some(detail),
+                            insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
+                            filter_text: Some(prefix.to_string()),
+                            text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                                range: replace_range,
+                                new_text: binding.alias.clone(),
+                            })),
+                            ..CompletionItem::default()
+                        });
+                    }
+                }
+
+                for col in &cache.source_columns {
+                    if !prefix_upper.is_empty()
+                        && !col.name.to_uppercase().starts_with(&prefix_upper)
+                    {
+                        continue;
+                    }
+
+                    push_completion_item(
+                        &mut items,
+                        &mut seen,
+                        &col.name,
+                        CompletionItemKind::FIELD,
+                        prefix,
+                        replace_range,
+                    );
+                }
+            }
+
+            items
+        }
+    }
+}
+
+impl CompletionProvider for SchemaCompletionProvider {
+    fn completions(
+        &self,
+        text: &Rope,
+        offset: usize,
+        _trigger: CompletionContext,
+        _window: &mut Window,
+        _cx: &mut Context<InputState>,
+    ) -> Task<anyhow::Result<CompletionResponse>> {
+        let source = text.to_string();
+        let cursor = offset.min(source.len());
+        let (prefix_start, prefix) = extract_identifier_prefix(&source, cursor);
+        let replace_range = completion_replace_range(&source, prefix_start, cursor);
+        let qualifier = compute_qualifier(&source, prefix_start);
+
+        let cache = self.schema_cache.borrow();
+        let items = compute_suggestions(
+            &self.mode,
+            &cache,
+            &prefix,
+            qualifier.as_deref(),
+            replace_range,
+        );
+
+        Task::ready(Ok(CompletionResponse::Array(items)))
+    }
+
+    fn is_completion_trigger(
+        &self,
+        _offset: usize,
+        new_text: &str,
+        _cx: &mut Context<InputState>,
+    ) -> bool {
+        if new_text.len() != 1 {
+            return false;
+        }
+
+        let ch = new_text.as_bytes()[0] as char;
+        ch.is_ascii_alphanumeric() || ch == '_' || ch == '.'
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_column(name: &str, type_name: &str) -> ColumnInfo {
+        ColumnInfo {
+            name: name.to_string(),
+            type_name: type_name.to_string(),
+            nullable: true,
+            is_primary_key: false,
+            default_value: None,
+            enum_values: None,
+        }
+    }
+
+    fn empty_replace_range() -> LspRange {
+        use lsp_types::{Position, Range};
+        Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 0,
+            },
+        }
+    }
+
+    fn label_set(items: &[CompletionItem]) -> Vec<String> {
+        let mut labels: Vec<String> = items.iter().map(|i| i.label.clone()).collect();
+        labels.sort();
+        labels
+    }
+
+    fn make_source_cache(columns: Vec<ColumnInfo>) -> SchemaCache {
+        SchemaCache {
+            source_table: "users".to_string(),
+            source_columns: columns,
+            joined_columns: HashMap::new(),
+            fetching: HashSet::new(),
+            failed: HashSet::new(),
+        }
+    }
+
+    // --- Tables mode ---
+
+    #[test]
+    fn tables_mode_lists_tables_by_prefix() {
+        let mode = CompletionMode::Tables {
+            table_names: vec![
+                "public.users".to_string(),
+                "public.user_logs".to_string(),
+                "public.orders".to_string(),
+            ],
+            default_schema: Some("public".to_string()),
+        };
+        let cache = SchemaCache::default();
+
+        let items = compute_suggestions(&mode, &cache, "us", None, empty_replace_range());
+        let labels = label_set(&items);
+
+        assert_eq!(labels, vec!["user_logs", "users"]);
+        assert!(
+            items
+                .iter()
+                .all(|i| i.kind == Some(CompletionItemKind::STRUCT))
+        );
+    }
+
+    #[test]
+    fn tables_mode_qualifies_cross_schema_tables() {
+        let mode = CompletionMode::Tables {
+            table_names: vec!["public.users".to_string(), "analytics.events".to_string()],
+            default_schema: Some("public".to_string()),
+        };
+        let cache = SchemaCache::default();
+
+        let items = compute_suggestions(&mode, &cache, "a", None, empty_replace_range());
+        let labels = label_set(&items);
+
+        assert_eq!(labels, vec!["analytics.events"]);
+    }
+
+    // --- AliasOrColumn mode — no qualifier ---
+
+    #[test]
+    fn alias_or_column_no_qualifier_suggests_aliases_and_source_columns() {
+        let mode = CompletionMode::AliasOrColumn {
+            aliases: vec![
+                AliasBinding {
+                    alias: "u".to_string(),
+                    schema: None,
+                    table: "users".to_string(),
+                    is_source: true,
+                },
+                AliasBinding {
+                    alias: "o".to_string(),
+                    schema: None,
+                    table: "orders".to_string(),
+                    is_source: false,
+                },
+            ],
+        };
+        let cache = make_source_cache(vec![
+            make_column("name", "text"),
+            make_column("user_id", "int"),
+            make_column("updated_at", "timestamp"),
+        ]);
+
+        let items = compute_suggestions(&mode, &cache, "u", None, empty_replace_range());
+        let labels = label_set(&items);
+
+        assert!(
+            labels.contains(&"u".to_string()),
+            "alias u must be included"
+        );
+        assert!(
+            labels.contains(&"user_id".to_string()),
+            "user_id must be included"
+        );
+        assert!(
+            labels.contains(&"updated_at".to_string()),
+            "updated_at must be included"
+        );
+        assert!(
+            !labels.contains(&"o".to_string()),
+            "alias o must be filtered by prefix"
+        );
+        assert!(
+            !labels.contains(&"name".to_string()),
+            "name must be filtered by prefix"
+        );
+    }
+
+    // --- AliasOrColumn mode — with source alias qualifier ---
+
+    #[test]
+    fn alias_or_column_with_source_alias_qualifier_suggests_source_columns() {
+        let mode = CompletionMode::AliasOrColumn {
+            aliases: vec![AliasBinding {
+                alias: "u".to_string(),
+                schema: None,
+                table: "users".to_string(),
+                is_source: true,
+            }],
+        };
+        let cache = make_source_cache(vec![
+            make_column("email", "varchar"),
+            make_column("id", "int"),
+            make_column("name", "text"),
+        ]);
+
+        let items = compute_suggestions(&mode, &cache, "em", Some("u"), empty_replace_range());
+        let labels = label_set(&items);
+
+        assert_eq!(labels, vec!["email"]);
+        assert_eq!(items[0].kind, Some(CompletionItemKind::FIELD));
+    }
+
+    // --- AliasOrColumn mode — with joined alias qualifier ---
+
+    #[test]
+    fn alias_or_column_with_joined_alias_qualifier_suggests_joined_columns() {
+        let mode = CompletionMode::AliasOrColumn {
+            aliases: vec![AliasBinding {
+                alias: "o".to_string(),
+                schema: None,
+                table: "orders".to_string(),
+                is_source: false,
+            }],
+        };
+
+        let mut cache = SchemaCache::default();
+        cache.joined_columns.insert(
+            (None, "orders".to_string()),
+            vec![
+                make_column("status", "text"),
+                make_column("total_cents", "int"),
+            ],
+        );
+
+        let items = compute_suggestions(&mode, &cache, "sta", Some("o"), empty_replace_range());
+        let labels = label_set(&items);
+
+        assert_eq!(labels, vec!["status"]);
+    }
+
+    // --- AliasOrColumn mode — unfetched join ---
+
+    #[test]
+    fn alias_or_column_with_unfetched_join_returns_empty() {
+        let mode = CompletionMode::AliasOrColumn {
+            aliases: vec![AliasBinding {
+                alias: "o".to_string(),
+                schema: None,
+                table: "orders".to_string(),
+                is_source: false,
+            }],
+        };
+        let cache = SchemaCache::default();
+
+        let items = compute_suggestions(&mode, &cache, "sta", Some("o"), empty_replace_range());
+        assert!(items.is_empty(), "unfetched join must yield empty list");
+    }
+
+    // --- Case insensitive prefix ---
+
+    #[test]
+    fn prefix_filter_is_case_insensitive() {
+        let mode = CompletionMode::AliasOrColumn {
+            aliases: vec![AliasBinding {
+                alias: "u".to_string(),
+                schema: None,
+                table: "users".to_string(),
+                is_source: true,
+            }],
+        };
+        let cache = make_source_cache(vec![make_column("email", "varchar")]);
+
+        let items = compute_suggestions(&mode, &cache, "EM", Some("U"), empty_replace_range());
+        let labels = label_set(&items);
+
+        assert_eq!(labels, vec!["email"]);
+    }
+
+    // --- Starts-with, not contains ---
+
+    #[test]
+    fn prefix_filter_is_starts_with_not_contains() {
+        let mode = CompletionMode::AliasOrColumn {
+            aliases: vec![AliasBinding {
+                alias: "u".to_string(),
+                schema: None,
+                table: "users".to_string(),
+                is_source: true,
+            }],
+        };
+        let cache = make_source_cache(vec![make_column("email", "varchar")]);
+
+        let items = compute_suggestions(&mode, &cache, "mail", Some("u"), empty_replace_range());
+        assert!(items.is_empty(), "substring match must not produce results");
+    }
+
+    // --- Deduplication ---
+
+    #[test]
+    fn dedup_by_uppercased_label() {
+        let mode = CompletionMode::AliasOrColumn {
+            aliases: vec![
+                AliasBinding {
+                    alias: "u".to_string(),
+                    schema: None,
+                    table: "users".to_string(),
+                    is_source: true,
+                },
+                AliasBinding {
+                    alias: "u".to_string(),
+                    schema: None,
+                    table: "USERS".to_string(),
+                    is_source: true,
+                },
+            ],
+        };
+        let cache = SchemaCache::default();
+
+        let items = compute_suggestions(&mode, &cache, "", None, empty_replace_range());
+        let u_count = items.iter().filter(|i| i.label == "u").count();
+        assert_eq!(u_count, 1, "duplicate alias u must appear only once");
+    }
+
+    // --- FilterExpression mode ---
+
+    #[test]
+    fn filter_expression_mode_uses_source_alias_only() {
+        let mode = CompletionMode::FilterExpression {
+            aliases: vec![AliasBinding {
+                alias: "users".to_string(),
+                schema: None,
+                table: "users".to_string(),
+                is_source: true,
+            }],
+        };
+        let cache = make_source_cache(vec![make_column("email", "varchar")]);
+
+        let items = compute_suggestions(&mode, &cache, "em", Some("users"), empty_replace_range());
+        let labels = label_set(&items);
+
+        assert_eq!(labels, vec!["email"]);
+    }
+
+    // --- JoinConditionRight mode ---
+
+    #[test]
+    fn join_condition_right_mode_matches_alias_or_column_behavior() {
+        let mode = CompletionMode::JoinConditionRight {
+            aliases: vec![
+                AliasBinding {
+                    alias: "u".to_string(),
+                    schema: None,
+                    table: "users".to_string(),
+                    is_source: true,
+                },
+                AliasBinding {
+                    alias: "o".to_string(),
+                    schema: None,
+                    table: "orders".to_string(),
+                    is_source: false,
+                },
+            ],
+        };
+
+        let mut cache = SchemaCache::default();
+        cache.joined_columns.insert(
+            (None, "orders".to_string()),
+            vec![make_column("status", "text")],
+        );
+
+        let items = compute_suggestions(&mode, &cache, "st", Some("o"), empty_replace_range());
+        let labels = label_set(&items);
+
+        assert_eq!(labels, vec!["status"]);
+    }
+}

--- a/crates/dbflux_ui_document/src/query_builder/completion.rs
+++ b/crates/dbflux_ui_document/src/query_builder/completion.rs
@@ -410,6 +410,14 @@ impl CompletionProvider for SchemaCompletionProvider {
         new_text: &str,
         _cx: &mut Context<InputState>,
     ) -> bool {
+        // Empty `new_text` covers both backspace (deleted text) and the
+        // manual Ctrl+Space trigger (replace_text_in_range(None, "", ...)).
+        // In both cases the popover should re-evaluate against the current
+        // text and cursor.
+        if new_text.is_empty() {
+            return true;
+        }
+
         if new_text.len() != 1 {
             return false;
         }

--- a/crates/dbflux_ui_document/src/query_builder/completion.rs
+++ b/crates/dbflux_ui_document/src/query_builder/completion.rs
@@ -18,7 +18,6 @@ use dbflux_ui_base::AppStateEntity;
 
 /// A single alias-to-table binding in the visual query builder.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub(crate) struct AliasBinding {
     /// The alias as it appears in the query (e.g. `u`, `orders`).
     pub alias: String,
@@ -36,9 +35,9 @@ pub(crate) struct AliasBinding {
 /// background fetches (joined tables). Shared between the panel and all
 /// completion providers via `Rc<RefCell<SchemaCache>>`.
 #[derive(Default)]
-#[allow(dead_code)]
 pub(crate) struct SchemaCache {
     /// Columns for the source (primary) table, keyed by the table name.
+    #[allow(dead_code)]
     pub source_table: String,
     pub source_columns: Vec<ColumnInfo>,
 
@@ -55,7 +54,6 @@ pub(crate) struct SchemaCache {
 
 /// Which input site the provider is attached to.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub(crate) enum CompletionMode {
     /// Join `to_table` input: suggest table names.
     Tables {
@@ -83,17 +81,17 @@ pub(crate) enum CompletionMode {
 }
 
 /// Schema-aware completion provider for single-line builder inputs.
-#[allow(dead_code)]
 pub(crate) struct SchemaCompletionProvider {
+    /// Retained for future use (e.g., refreshing the table list on demand).
     #[allow(dead_code)]
     app_state: WeakEntity<AppStateEntity>,
+    /// Retained for future use alongside `app_state`.
     #[allow(dead_code)]
     profile_id: Uuid,
     mode: CompletionMode,
     schema_cache: Rc<RefCell<SchemaCache>>,
 }
 
-#[allow(dead_code)]
 impl SchemaCompletionProvider {
     pub(crate) fn new(
         app_state: WeakEntity<AppStateEntity>,
@@ -114,7 +112,6 @@ impl SchemaCompletionProvider {
 ///
 /// For input like `users.em` with `prefix_start` pointing at `em`, this
 /// returns `Some("users")`. Returns `None` when no dot-qualifier is present.
-#[allow(dead_code)]
 pub(crate) fn compute_qualifier(source: &str, prefix_start: usize) -> Option<String> {
     if prefix_start == 0 {
         return None;
@@ -139,7 +136,6 @@ pub(crate) fn compute_qualifier(source: &str, prefix_start: usize) -> Option<Str
 /// `mode` determines which data sources to draw from. `cache` is borrowed
 /// read-only at the call site. `prefix` and `qualifier` are derived from the
 /// cursor position in the current input text.
-#[allow(dead_code)]
 pub(crate) fn compute_suggestions(
     mode: &CompletionMode,
     cache: &SchemaCache,

--- a/crates/dbflux_ui_document/src/query_builder/completion.rs
+++ b/crates/dbflux_ui_document/src/query_builder/completion.rs
@@ -389,18 +389,6 @@ impl CompletionProvider for SchemaCompletionProvider {
             replace_range,
         );
 
-        log::info!(
-            "[autocomplete] completions: mode={:?} prefix={:?} qualifier={:?} \
-             source_cols={} fk_links={} joined_keys={} -> {} items",
-            std::mem::discriminant(&self.mode),
-            prefix,
-            qualifier,
-            cache.source_columns.len(),
-            cache.fk_links.len(),
-            cache.joined_columns.len(),
-            items.len(),
-        );
-
         Task::ready(Ok(CompletionResponse::Array(items)))
     }
 

--- a/crates/dbflux_ui_document/src/query_builder/completion.rs
+++ b/crates/dbflux_ui_document/src/query_builder/completion.rs
@@ -389,6 +389,18 @@ impl CompletionProvider for SchemaCompletionProvider {
             replace_range,
         );
 
+        log::info!(
+            "[autocomplete] completions: mode={:?} prefix={:?} qualifier={:?} \
+             source_cols={} fk_links={} joined_keys={} -> {} items",
+            std::mem::discriminant(&self.mode),
+            prefix,
+            qualifier,
+            cache.source_columns.len(),
+            cache.fk_links.len(),
+            cache.joined_columns.len(),
+            items.len(),
+        );
+
         Task::ready(Ok(CompletionResponse::Array(items)))
     }
 

--- a/crates/dbflux_ui_document/src/query_builder/mod.rs
+++ b/crates/dbflux_ui_document/src/query_builder/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod completion;
 mod events;
 mod panel;
 mod sections;

--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -427,6 +427,7 @@ impl QueryBuilderPanel {
             source_table: spec.source.table.clone(),
             source_columns,
             joined_columns: HashMap::new(),
+            fk_links: HashMap::new(),
             fetching: HashSet::new(),
             failed: HashSet::new(),
         }));

--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -1093,8 +1093,7 @@ impl QueryBuilderPanel {
                         let conn = state.connections().get(&self.schema_profile_id)?;
                         let schema = conn.schema.as_ref()?;
                         if let dbflux_core::DataStructure::Relational(rel) = &schema.structure {
-                            let default = conn.active_database.clone().unwrap_or_default();
-                            let schema_name = conn
+                            let default_schema = conn
                                 .active_database
                                 .clone()
                                 .or_else(|| rel.schemas.first().map(|s| s.name.clone()))
@@ -1103,7 +1102,7 @@ impl QueryBuilderPanel {
                                 .schemas
                                 .iter()
                                 .flat_map(|s| {
-                                    let default_schema = schema_name.clone();
+                                    let default_schema = default_schema.clone();
                                     s.tables.iter().map(move |t| {
                                         if s.name == default_schema {
                                             t.name.clone()
@@ -1114,7 +1113,6 @@ impl QueryBuilderPanel {
                                 })
                                 .chain(rel.tables.iter().map(|t| t.name.clone()))
                                 .collect();
-                            let _ = default;
                             Some(names)
                         } else {
                             None

--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -403,21 +403,20 @@ impl QueryBuilderPanel {
 
         let source_columns: Vec<ColumnInfo> = {
             let state = app_state.read(cx);
-            let source_table_name = &spec.source.table;
-            let source_schema = spec.source.schema.as_deref();
+            let source_table_name = spec.source.table.clone();
+            let source_schema = spec.source.schema.clone();
 
             state
                 .connections()
                 .get(&profile_id)
                 .and_then(|conn| {
-                    let db_name = conn.active_database.clone().unwrap_or_default();
-                    let table_key = if let Some(schema) = source_schema {
-                        format!("{}.{}", schema, source_table_name)
-                    } else {
-                        source_table_name.clone()
-                    };
+                    let db_name = conn
+                        .active_database
+                        .clone()
+                        .or(source_schema)
+                        .unwrap_or_else(|| "default".to_string());
                     conn.table_details
-                        .get(&(db_name, table_key))
+                        .get(&(db_name, source_table_name))
                         .and_then(|info| info.columns.clone())
                 })
                 .unwrap_or_default()
@@ -431,6 +430,17 @@ impl QueryBuilderPanel {
             fetching: HashSet::new(),
             failed: HashSet::new(),
         }));
+
+        if schema_cache.borrow().source_columns.is_empty() {
+            Self::spawn_source_columns_fetch(
+                schema_cache.clone(),
+                app_state.downgrade(),
+                profile_id,
+                spec.source.schema.clone(),
+                spec.source.table.clone(),
+                cx,
+            );
+        }
 
         let source_alias_binding = AliasBinding {
             alias: spec.source.alias.clone(),
@@ -1833,6 +1843,93 @@ impl QueryBuilderPanel {
     /// fetch is in flight, or the fetch previously failed. Fetch failures are
     /// silent (the popover shows aliases only for that join) and stored in the
     /// `failed` set to prevent retries.
+    /// Background-fetch column metadata for the builder's source table.
+    ///
+    /// Called from the panel constructor when the source-table columns are
+    /// not yet cached in `AppState`. Writes the fetched columns into the
+    /// shared `SchemaCache` so attached completion providers see them as
+    /// soon as the fetch resolves; failures are silent (autocomplete is not
+    /// a user-facing operation).
+    fn spawn_source_columns_fetch(
+        schema_cache: Rc<RefCell<SchemaCache>>,
+        app_state_weak: gpui::WeakEntity<AppStateEntity>,
+        profile_id: uuid::Uuid,
+        source_schema: Option<String>,
+        source_table: String,
+        cx: &mut Context<Self>,
+    ) {
+        use crate::completion_support::normalize_identifier;
+
+        let key = (
+            source_schema.as_ref().map(|s| normalize_identifier(s)),
+            normalize_identifier(&source_table),
+        );
+
+        {
+            let cache = schema_cache.borrow();
+            if cache.fetching.contains(&key) || cache.failed.contains(&key) {
+                return;
+            }
+        }
+
+        let Some(app) = app_state_weak.upgrade() else {
+            return;
+        };
+
+        let db_name = app
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .and_then(|c| c.active_database.clone())
+            .or_else(|| source_schema.clone())
+            .unwrap_or_else(|| "default".to_string());
+
+        let Some(conn) = app
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .map(|c| c.connection_for_database(&db_name))
+        else {
+            return;
+        };
+
+        schema_cache.borrow_mut().fetching.insert(key.clone());
+
+        let schema_owned = source_schema;
+        let table_owned = source_table;
+        let db_for_task = db_name;
+        let key_for_task = key.clone();
+
+        let task = cx.background_executor().spawn(async move {
+            conn.table_details(&db_for_task, schema_owned.as_deref(), &table_owned)
+        });
+
+        let schema_cache_for_finish = schema_cache.clone();
+        cx.spawn(async move |_this, cx| {
+            let result = task.await;
+            let _ = cx.update(|cx| {
+                {
+                    let mut cache = schema_cache_for_finish.borrow_mut();
+                    cache.fetching.remove(&key_for_task);
+                    match result {
+                        Ok(info) => {
+                            if let Some(cols) = info.columns {
+                                cache.source_columns = cols;
+                            } else {
+                                cache.failed.insert(key_for_task);
+                            }
+                        }
+                        Err(_) => {
+                            cache.failed.insert(key_for_task);
+                        }
+                    }
+                }
+                _this.update(cx, |_panel, cx| cx.notify()).ok();
+            });
+        })
+        .detach();
+    }
+
     pub(crate) fn ensure_joined_columns(
         &self,
         schema: Option<&str>,
@@ -1858,17 +1955,6 @@ impl QueryBuilderPanel {
 
         self.schema_cache.borrow_mut().fetching.insert(key.clone());
 
-        let Some(conn) = self.app_state_weak.upgrade().as_ref().and_then(|app| {
-            app.read(cx)
-                .connections()
-                .get(&self.schema_profile_id)
-                .map(|c| c.connection.clone())
-        }) else {
-            self.schema_cache.borrow_mut().fetching.remove(&key);
-            self.schema_cache.borrow_mut().failed.insert(key);
-            return;
-        };
-
         let db_name = self
             .app_state_weak
             .upgrade()
@@ -1879,7 +1965,19 @@ impl QueryBuilderPanel {
                     .get(&self.schema_profile_id)
                     .and_then(|c| c.active_database.clone())
             })
-            .unwrap_or_default();
+            .or_else(|| schema.map(|s| s.to_string()))
+            .unwrap_or_else(|| "default".to_string());
+
+        let Some(conn) = self.app_state_weak.upgrade().as_ref().and_then(|app| {
+            app.read(cx)
+                .connections()
+                .get(&self.schema_profile_id)
+                .map(|c| c.connection_for_database(&db_name))
+        }) else {
+            self.schema_cache.borrow_mut().fetching.remove(&key);
+            self.schema_cache.borrow_mut().failed.insert(key);
+            return;
+        };
 
         let schema_owned = schema.map(|s| s.to_string());
         let table_owned = table.to_string();

--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -1,11 +1,13 @@
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
 
 use dbflux_components::controls::{
-    Dropdown, DropdownItem, DropdownSelectionChanged, InputEvent, InputState,
+    CompletionProvider, Dropdown, DropdownItem, DropdownSelectionChanged, InputEvent, InputState,
 };
 use dbflux_core::{
-    BoolOp, ColumnKind, Comparator, FilterNode, JoinFilterNode, JoinKind, JoinOn, JoinPredicate,
-    JoinStep, LiteralValue, Predicate, PredicateValue, ProjectedColumn, Projection,
+    BoolOp, ColumnInfo, ColumnKind, Comparator, FilterNode, JoinFilterNode, JoinKind, JoinOn,
+    JoinPredicate, JoinStep, LiteralValue, Predicate, PredicateValue, ProjectedColumn, Projection,
     SchemaForeignKeyInfo, SelectQuery, SortEntry, SourceTable, VisualQuerySpec,
     VisualSortDirection,
 };
@@ -15,7 +17,12 @@ use gpui::{
 };
 use uuid::Uuid;
 
+use dbflux_ui_base::AppStateEntity;
+
 use crate::data_grid_panel::DataGridPanel;
+use crate::query_builder::completion::{
+    AliasBinding, CompletionMode, SchemaCache, SchemaCompletionProvider,
+};
 use crate::query_builder::events::BuilderEvent;
 use crate::query_builder::tree_ops::{
     collect_filter_predicate_ids, collect_join_predicate_ids, filter_node_at_path_mut,
@@ -266,6 +273,22 @@ pub struct QueryBuilderPanel {
     /// once at panel construction from the data grid's current result.
     pub(crate) available_columns: Vec<String>,
 
+    /// Shared schema cache for completion providers.
+    ///
+    /// `source_columns` is populated at panel construction. `joined_columns`
+    /// is populated lazily via `ensure_joined_columns`. The cache is shared
+    /// via `Rc<RefCell<…>>` between the panel (writer) and all attached
+    /// `SchemaCompletionProvider` instances (readers). Everything runs on the
+    /// foreground thread, so `RefCell` is sufficient.
+    pub(crate) schema_cache: Rc<RefCell<SchemaCache>>,
+
+    /// Weak handle to `AppStateEntity`, used inside `ensure_joined_columns`
+    /// to reach the active connection without capturing a strong reference.
+    pub(crate) app_state_weak: WeakEntity<AppStateEntity>,
+
+    /// Profile ID for this builder panel, used to look up the connection.
+    pub(crate) schema_profile_id: Uuid,
+
     /// Set to `true` after any filter mutation so the render cycle sweeps stale
     /// entries from `predicate_input_states`.
     pub(crate) pending_filter_input_sweep: bool,
@@ -288,11 +311,14 @@ impl QueryBuilderPanel {
     /// previously run the builder; `None` produces the default spec.
     /// `generate_preview` is a closure that calls the driver's
     /// `QueryGenerator::generate_select` and returns the SQL text.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         source: SourceTable,
         initial_spec: Option<VisualQuerySpec>,
         data_grid: Option<WeakEntity<DataGridPanel>>,
         available_columns: Vec<String>,
+        app_state: Entity<AppStateEntity>,
+        profile_id: Uuid,
         generate_preview: Box<dyn Fn(&VisualQuerySpec) -> String + Send + Sync>,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -375,11 +401,68 @@ impl QueryBuilderPanel {
             state
         });
 
+        let source_columns: Vec<ColumnInfo> = {
+            let state = app_state.read(cx);
+            let source_table_name = &spec.source.table;
+            let source_schema = spec.source.schema.as_deref();
+
+            state
+                .connections()
+                .get(&profile_id)
+                .and_then(|conn| {
+                    let db_name = conn.active_database.clone().unwrap_or_default();
+                    let table_key = if let Some(schema) = source_schema {
+                        format!("{}.{}", schema, source_table_name)
+                    } else {
+                        source_table_name.clone()
+                    };
+                    conn.table_details
+                        .get(&(db_name, table_key))
+                        .and_then(|info| info.columns.clone())
+                })
+                .unwrap_or_default()
+        };
+
+        let schema_cache = Rc::new(RefCell::new(SchemaCache {
+            source_table: spec.source.table.clone(),
+            source_columns,
+            joined_columns: HashMap::new(),
+            fetching: HashSet::new(),
+            failed: HashSet::new(),
+        }));
+
+        let source_alias_binding = AliasBinding {
+            alias: spec.source.alias.clone(),
+            schema: spec.source.schema.clone(),
+            table: spec.source.table.clone(),
+            is_source: true,
+        };
+
+        let app_state_weak = app_state.downgrade();
+
         let add_column_input_state =
             cx.new(|cx| InputState::new(window, cx).placeholder("alias.column"));
 
         let add_sort_input_state =
             cx.new(|cx| InputState::new(window, cx).placeholder("alias.column"));
+
+        let alias_or_column_provider: Rc<dyn CompletionProvider> =
+            Rc::new(SchemaCompletionProvider::new(
+                app_state_weak.clone(),
+                profile_id,
+                CompletionMode::AliasOrColumn {
+                    aliases: vec![source_alias_binding.clone()],
+                },
+                schema_cache.clone(),
+            ));
+
+        add_column_input_state.update(cx, |state, _| {
+            state.lsp.completion_provider = Some(alias_or_column_provider.clone());
+        });
+
+        add_sort_input_state.update(cx, |state, _| {
+            state.lsp.completion_provider = Some(alias_or_column_provider.clone());
+        });
 
         let limit_sub = cx.subscribe_in(
             &limit_input_state,
@@ -438,6 +521,9 @@ impl QueryBuilderPanel {
             join_cond_right_inputs: HashMap::new(),
             join_cond_op_dropdowns: HashMap::new(),
             available_columns,
+            schema_cache,
+            app_state_weak,
+            schema_profile_id: profile_id,
             pending_filter_input_sweep: false,
             pending_join_condition_sweep: false,
         }
@@ -847,6 +933,19 @@ impl QueryBuilderPanel {
             s
         });
 
+        let predicate_col_provider: Rc<dyn CompletionProvider> =
+            Rc::new(SchemaCompletionProvider::new(
+                self.app_state_weak.clone(),
+                self.schema_profile_id,
+                CompletionMode::AliasOrColumn {
+                    aliases: self.make_alias_bindings(),
+                },
+                self.schema_cache.clone(),
+            ));
+        state.update(cx, |s, _| {
+            s.lsp.completion_provider = Some(predicate_col_provider);
+        });
+
         let sub = cx.subscribe_in(
             &state,
             window,
@@ -985,6 +1084,64 @@ impl QueryBuilderPanel {
                     state
                 });
 
+                let table_names = self
+                    .app_state_weak
+                    .upgrade()
+                    .as_ref()
+                    .and_then(|app| {
+                        let state = app.read(cx);
+                        let conn = state.connections().get(&self.schema_profile_id)?;
+                        let schema = conn.schema.as_ref()?;
+                        if let dbflux_core::DataStructure::Relational(rel) = &schema.structure {
+                            let default = conn.active_database.clone().unwrap_or_default();
+                            let schema_name = conn
+                                .active_database
+                                .clone()
+                                .or_else(|| rel.schemas.first().map(|s| s.name.clone()))
+                                .unwrap_or_default();
+                            let names: Vec<String> = rel
+                                .schemas
+                                .iter()
+                                .flat_map(|s| {
+                                    let default_schema = schema_name.clone();
+                                    s.tables.iter().map(move |t| {
+                                        if s.name == default_schema {
+                                            t.name.clone()
+                                        } else {
+                                            format!("{}.{}", s.name, t.name)
+                                        }
+                                    })
+                                })
+                                .chain(rel.tables.iter().map(|t| t.name.clone()))
+                                .collect();
+                            let _ = default;
+                            Some(names)
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_default();
+
+                let tables_provider: Rc<dyn CompletionProvider> =
+                    Rc::new(SchemaCompletionProvider::new(
+                        self.app_state_weak.clone(),
+                        self.schema_profile_id,
+                        CompletionMode::Tables {
+                            table_names,
+                            default_schema: None,
+                        },
+                        self.schema_cache.clone(),
+                    ));
+
+                to_table_state.update(cx, |state, _| {
+                    state.lsp.completion_provider = Some(tables_provider);
+                });
+
+                if !to_table_val.is_empty() {
+                    let row = &self.join_rows[i];
+                    self.ensure_joined_columns(row.to_schema.as_deref(), &to_table_val, cx);
+                }
+
                 let on_expr_state = cx.new(|cx| {
                     let mut state = InputState::new(window, cx).placeholder("a.id = b.a_id");
                     state.set_value(&on_expr_val, window, cx);
@@ -1062,6 +1219,27 @@ impl QueryBuilderPanel {
                 self.join_kind_dropdowns.push(kind_dropdown);
                 self._input_subs.push(kind_sub);
             }
+        }
+
+        let refreshed_aliases = self.make_alias_bindings();
+        let refreshed_provider: Rc<dyn CompletionProvider> =
+            Rc::new(SchemaCompletionProvider::new(
+                self.app_state_weak.clone(),
+                self.schema_profile_id,
+                CompletionMode::AliasOrColumn {
+                    aliases: refreshed_aliases,
+                },
+                self.schema_cache.clone(),
+            ));
+
+        if let Some(col_input) = &self.add_column_input_state {
+            let p = refreshed_provider.clone();
+            col_input.update(cx, |s, _| s.lsp.completion_provider = Some(p));
+        }
+
+        if let Some(sort_input) = &self.add_sort_input_state {
+            let p = refreshed_provider.clone();
+            sort_input.update(cx, |s, _| s.lsp.completion_provider = Some(p));
         }
     }
 
@@ -1275,6 +1453,19 @@ impl QueryBuilderPanel {
                 s.set_value(&left_owned, window, cx);
                 s
             });
+
+            let left_provider: Rc<dyn CompletionProvider> = Rc::new(SchemaCompletionProvider::new(
+                self.app_state_weak.clone(),
+                self.schema_profile_id,
+                CompletionMode::AliasOrColumn {
+                    aliases: self.make_alias_bindings(),
+                },
+                self.schema_cache.clone(),
+            ));
+            state.update(cx, |s, _| {
+                s.lsp.completion_provider = Some(left_provider);
+            });
+
             let id_for_sub = node_id;
             let sub = cx.subscribe_in(
                 &state,
@@ -1298,6 +1489,20 @@ impl QueryBuilderPanel {
                 s.set_value(&right_owned, window, cx);
                 s
             });
+
+            let right_provider: Rc<dyn CompletionProvider> =
+                Rc::new(SchemaCompletionProvider::new(
+                    self.app_state_weak.clone(),
+                    self.schema_profile_id,
+                    CompletionMode::JoinConditionRight {
+                        aliases: self.make_alias_bindings(),
+                    },
+                    self.schema_cache.clone(),
+                ));
+            state.update(cx, |s, _| {
+                s.lsp.completion_provider = Some(right_provider);
+            });
+
             let id_for_sub = node_id;
             let sub = cx.subscribe_in(
                 &state,
@@ -1592,6 +1797,126 @@ impl QueryBuilderPanel {
     pub fn data_grid(&self) -> Option<&WeakEntity<DataGridPanel>> {
         self.data_grid.as_ref()
     }
+
+    // -----------------------------------------------------------------------
+    // Completion support
+    // -----------------------------------------------------------------------
+
+    /// Builds the alias binding list from the current spec's source and join rows.
+    ///
+    /// Used when re-attaching providers after the join list changes.
+    pub(crate) fn make_alias_bindings(&self) -> Vec<AliasBinding> {
+        let mut bindings = vec![AliasBinding {
+            alias: self.current_spec.source.alias.clone(),
+            schema: self.current_spec.source.schema.clone(),
+            table: self.current_spec.source.table.clone(),
+            is_source: true,
+        }];
+
+        for row in &self.join_rows {
+            if !row.to_table.is_empty() {
+                bindings.push(AliasBinding {
+                    alias: row.to_alias.clone(),
+                    schema: row.to_schema.clone(),
+                    table: row.to_table.clone(),
+                    is_source: false,
+                });
+            }
+        }
+
+        bindings
+    }
+
+    /// Fetches column metadata for a joined table in the background and stores
+    /// it in `self.schema_cache`.
+    ///
+    /// Idempotent: returns immediately if the columns are already cached, a
+    /// fetch is in flight, or the fetch previously failed. Fetch failures are
+    /// silent (the popover shows aliases only for that join) and stored in the
+    /// `failed` set to prevent retries.
+    pub(crate) fn ensure_joined_columns(
+        &self,
+        schema: Option<&str>,
+        table: &str,
+        cx: &mut Context<Self>,
+    ) {
+        use crate::completion_support::normalize_identifier;
+
+        let key = (
+            schema.map(normalize_identifier),
+            normalize_identifier(table),
+        );
+
+        {
+            let cache = self.schema_cache.borrow();
+            if cache.joined_columns.contains_key(&key)
+                || cache.fetching.contains(&key)
+                || cache.failed.contains(&key)
+            {
+                return;
+            }
+        }
+
+        self.schema_cache.borrow_mut().fetching.insert(key.clone());
+
+        let Some(conn) = self.app_state_weak.upgrade().as_ref().and_then(|app| {
+            app.read(cx)
+                .connections()
+                .get(&self.schema_profile_id)
+                .map(|c| c.connection.clone())
+        }) else {
+            self.schema_cache.borrow_mut().fetching.remove(&key);
+            self.schema_cache.borrow_mut().failed.insert(key);
+            return;
+        };
+
+        let db_name = self
+            .app_state_weak
+            .upgrade()
+            .as_ref()
+            .and_then(|app| {
+                app.read(cx)
+                    .connections()
+                    .get(&self.schema_profile_id)
+                    .and_then(|c| c.active_database.clone())
+            })
+            .unwrap_or_default();
+
+        let schema_owned = schema.map(|s| s.to_string());
+        let table_owned = table.to_string();
+        let key_for_task = key.clone();
+
+        let task = cx.background_executor().spawn(async move {
+            conn.table_details(&db_name, schema_owned.as_deref(), &table_owned)
+        });
+
+        let schema_cache = self.schema_cache.clone();
+        cx.spawn(async move |_this, cx| {
+            let result = task.await;
+            cx.update(|cx| {
+                {
+                    let mut cache = schema_cache.borrow_mut();
+                    cache.fetching.remove(&key_for_task);
+                    match result {
+                        Ok(table_info) => {
+                            let cols = table_info.columns.unwrap_or_default();
+                            cache.joined_columns.insert(key_for_task, cols);
+                        }
+                        Err(err) => {
+                            log::debug!(
+                                "schema autocomplete: column fetch failed, suppressed: {}",
+                                err
+                            );
+                            cache.failed.insert(key_for_task);
+                        }
+                    }
+                }
+                _this.update(cx, |_panel, cx| cx.notify()).ok();
+            })
+            .ok();
+        })
+        .detach();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1753,6 +2078,10 @@ mod tests {
         let offset_text = spec.offset.to_string();
         let sql_preview = no_op_preview(&spec);
 
+        use std::cell::RefCell;
+        use std::rc::Rc;
+        use uuid::Uuid;
+
         QueryBuilderPanel {
             current_spec: spec,
             projection_mode: ProjectionMode::All,
@@ -1786,6 +2115,9 @@ mod tests {
             join_cond_right_inputs: HashMap::new(),
             join_cond_op_dropdowns: HashMap::new(),
             available_columns: Vec::new(),
+            schema_cache: Rc::new(RefCell::new(SchemaCache::default())),
+            app_state_weak: WeakEntity::new_invalid(),
+            schema_profile_id: Uuid::nil(),
             pending_filter_input_sweep: false,
             pending_join_condition_sweep: false,
         }

--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -1899,6 +1899,8 @@ impl QueryBuilderPanel {
         let table_owned = source_table;
         let db_for_task = db_name;
         let key_for_task = key.clone();
+        let db_for_log = db_for_task.clone();
+        let table_for_log = table_owned.clone();
 
         let task = cx.background_executor().spawn(async move {
             conn.table_details(&db_for_task, schema_owned.as_deref(), &table_owned)
@@ -1916,10 +1918,23 @@ impl QueryBuilderPanel {
                             if let Some(cols) = info.columns {
                                 cache.source_columns = cols;
                             } else {
+                                log::warn!(
+                                    "autocomplete: builder source table_details returned no \
+                                     columns for {}.{}",
+                                    db_for_log,
+                                    table_for_log
+                                );
                                 cache.failed.insert(key_for_task);
                             }
                         }
-                        Err(_) => {
+                        Err(err) => {
+                            log::warn!(
+                                "autocomplete: failed to fetch builder source columns for \
+                                 {}.{}: {}",
+                                db_for_log,
+                                table_for_log,
+                                err
+                            );
                             cache.failed.insert(key_for_task);
                         }
                     }
@@ -1982,6 +1997,8 @@ impl QueryBuilderPanel {
         let schema_owned = schema.map(|s| s.to_string());
         let table_owned = table.to_string();
         let key_for_task = key.clone();
+        let db_for_log = db_name.clone();
+        let table_for_log = table_owned.clone();
 
         let task = cx.background_executor().spawn(async move {
             conn.table_details(&db_name, schema_owned.as_deref(), &table_owned)
@@ -2000,8 +2017,11 @@ impl QueryBuilderPanel {
                             cache.joined_columns.insert(key_for_task, cols);
                         }
                         Err(err) => {
-                            log::debug!(
-                                "schema autocomplete: column fetch failed, suppressed: {}",
+                            log::warn!(
+                                "autocomplete: failed to fetch joined-table columns for \
+                                 {}.{}: {}",
+                                db_for_log,
+                                table_for_log,
                                 err
                             );
                             cache.failed.insert(key_for_task);

--- a/crates/dbflux_ui_document/src/query_builder/sections/columns.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/columns.rs
@@ -12,7 +12,7 @@ pub fn render_columns(
     panel: &mut QueryBuilderPanel,
     cx: &mut Context<QueryBuilderPanel>,
 ) -> impl IntoElement {
-    use dbflux_components::controls::{Button, Checkbox, Input};
+    use dbflux_components::controls::{Button, Checkbox, Input, completion_input_keys_wrapper};
     use gpui::SharedString;
     use gpui::prelude::*;
 
@@ -99,10 +99,12 @@ pub fn render_columns(
                 .gap_1()
                 .items_center()
                 .child(
-                    Input::new(add_state)
-                        .small()
-                        .w_full()
-                        .placeholder("alias.column"),
+                    completion_input_keys_wrapper(add_state).flex_1().child(
+                        Input::new(add_state)
+                            .small()
+                            .w_full()
+                            .placeholder("alias.column"),
+                    ),
                 )
                 .child(
                     Button::new("qb-add-col", "Add")

--- a/crates/dbflux_ui_document/src/query_builder/sections/filters.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/filters.rs
@@ -238,7 +238,7 @@ fn render_filter_predicate(
     comparator_dropdown: Option<Entity<Dropdown>>,
     cx: &mut Context<QueryBuilderPanel>,
 ) -> impl IntoElement {
-    use dbflux_components::controls::{Button, Input};
+    use dbflux_components::controls::{Button, Input, completion_input_keys_wrapper};
     use gpui::SharedString;
     use gpui::prelude::*;
 
@@ -253,7 +253,7 @@ fn render_filter_predicate(
 
     if let Some(col_state) = column_input_state {
         row = row.child(
-            div()
+            completion_input_keys_wrapper(&col_state)
                 .flex_1()
                 .child(Input::new(&col_state).small().w_full()),
         );

--- a/crates/dbflux_ui_document/src/query_builder/sections/joins.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/joins.rs
@@ -17,7 +17,7 @@ pub fn render_joins(
     panel: &mut QueryBuilderPanel,
     cx: &mut Context<QueryBuilderPanel>,
 ) -> impl IntoElement {
-    use dbflux_components::controls::{Button, Input};
+    use dbflux_components::controls::{Button, Input, completion_input_keys_wrapper};
     use dbflux_core::JoinOn;
     use gpui::SharedString;
     use gpui::prelude::*;
@@ -97,12 +97,15 @@ pub fn render_joins(
 
         if let Some((to_table_state, _on_expr_state)) = join_states.get(i) {
             header = header.child(
-                div().flex_1().min_w(gpui::px(0.0)).child(
-                    Input::new(to_table_state)
-                        .small()
-                        .w_full()
-                        .placeholder("table"),
-                ),
+                completion_input_keys_wrapper(to_table_state)
+                    .flex_1()
+                    .min_w(gpui::px(0.0))
+                    .child(
+                        Input::new(to_table_state)
+                            .small()
+                            .w_full()
+                            .placeholder("table"),
+                    ),
             );
         } else {
             header = header.child(
@@ -205,7 +208,7 @@ fn render_join_tree(
     cond_ops: &HashMap<u64, Entity<Dropdown>>,
     cx: &mut Context<QueryBuilderPanel>,
 ) -> AnyElement {
-    use dbflux_components::controls::{Button, Input};
+    use dbflux_components::controls::{Button, Input, completion_input_keys_wrapper};
     use dbflux_components::tokens::{Heights, Radii};
     use dbflux_core::{BoolOp, JoinFilterNode};
     use gpui::prelude::*;
@@ -223,12 +226,15 @@ fn render_join_tree(
 
             if let Some(state) = left {
                 row = row.child(
-                    div().flex_1().min_w(gpui::px(0.0)).child(
-                        Input::new(&state)
-                            .small()
-                            .w_full()
-                            .placeholder("alias.column"),
-                    ),
+                    completion_input_keys_wrapper(&state)
+                        .flex_1()
+                        .min_w(gpui::px(0.0))
+                        .child(
+                            Input::new(&state)
+                                .small()
+                                .w_full()
+                                .placeholder("alias.column"),
+                        ),
                 );
             }
 
@@ -249,12 +255,15 @@ fn render_join_tree(
 
             if let Some(state) = right {
                 row = row.child(
-                    div().flex_1().min_w(gpui::px(0.0)).child(
-                        Input::new(&state)
-                            .small()
-                            .w_full()
-                            .placeholder("alias.column"),
-                    ),
+                    completion_input_keys_wrapper(&state)
+                        .flex_1()
+                        .min_w(gpui::px(0.0))
+                        .child(
+                            Input::new(&state)
+                                .small()
+                                .w_full()
+                                .placeholder("alias.column"),
+                        ),
                 );
             }
 

--- a/crates/dbflux_ui_document/src/query_builder/sections/sort.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/sort.rs
@@ -11,7 +11,7 @@ pub fn render_sort(
     panel: &mut QueryBuilderPanel,
     cx: &mut Context<QueryBuilderPanel>,
 ) -> impl IntoElement {
-    use dbflux_components::controls::{Button, Input};
+    use dbflux_components::controls::{Button, Input, completion_input_keys_wrapper};
     use dbflux_core::VisualSortDirection;
     use gpui::SharedString;
     use gpui::prelude::*;
@@ -85,10 +85,12 @@ pub fn render_sort(
                 .gap_1()
                 .items_center()
                 .child(
-                    Input::new(add_state)
-                        .small()
-                        .w_full()
-                        .placeholder("alias.column"),
+                    completion_input_keys_wrapper(add_state).flex_1().child(
+                        Input::new(add_state)
+                            .small()
+                            .w_full()
+                            .placeholder("alias.column"),
+                    ),
                 )
                 .child(
                     Button::new("qb-add-sort", "Add")


### PR DESCRIPTION
## Summary

- Adds schema-aware autocomplete to the visual query builder rail and the DataView WHERE filter input.
- Suggestions cover tables, source-table columns, declared join aliases, and joined-table columns; all driver-agnostic via `dbflux_core` metadata.
- Reuses gpui-component's existing single-line completion seam (`InputState.lsp.completion_provider`) instead of introducing a new component.

## What does this resolve?

- Resolves #165

## How was this solved?

### Architectural pivot from the issue sketch

The issue proposed a new `CompletionInput` component in `dbflux_components`. While auditing `gpui-component 0.5.1`, the single-line `Input` already renders a completion popover when `InputState.lsp.completion_provider` is set (the same path the multi-line SQL editor uses). The popover supports arrow navigation, prefix filtering, Tab/Enter commit, and Esc/focus-loss dismissal out of the box. Building a parallel component would have duplicated rendering and key-routing logic that the framework already provides correctly.

This avoids cross-crate coupling: a `dbflux_components::CompletionInput` would need to know about schema metadata, which would either drag domain types into the leaf component crate (breaking the layer map) or require a generic seam reimplementing what `CompletionProvider` already gives us.

### Implementation

- **`crates/dbflux_ui_document/src/completion_support.rs`** (new): extracts shared helpers from `code/completion.rs` (`extract_identifier_prefix`, `scan_identifier_start`, `completion_replace_range`, `push_completion_item`, identifier-byte helpers). Behavior-preserving move.
- **`crates/dbflux_ui_document/src/query_builder/completion.rs`** (new): defines `CompletionMode { Tables, AliasOrColumn, JoinConditionRight, FilterExpression }`, `SchemaCache`, `SchemaCompletionProvider`, and the pure `compute_suggestions` free function (~640 lines incl. 11 unit tests).
- **`QueryBuilderPanel`**: gains `app_state` + `profile_id` constructor params plus a `Rc<RefCell<SchemaCache>>` shared with every attached provider. Joined-table columns are fetched eagerly when a join's `to_table` is set, using the existing FK-fetch background pattern (`background_executor().spawn` → `cx.spawn` → cache update + `cx.notify()`).
- **DataView WHERE filter**: gets a `FilterExpression`-mode provider backed by the current table's `ColumnInfo` list.

### Suggestion sourcing rules

| Input site | Mode | Source |
|------------|------|--------|
| Filter predicate column | `AliasOrColumn` | source columns + declared aliases (`alias.column`) + joined-table columns |
| Sort column | `AliasOrColumn` | same |
| Projected column | `AliasOrColumn` | same |
| Join `to_table` | `Tables` | tables in active schema (with cross-schema qualification) |
| Join condition left | `AliasOrColumn` | same as filter column |
| Join condition right | `JoinConditionRight` | alias-prefix scoping after `<alias>.` |
| DataView WHERE filter | `FilterExpression` | current table's columns only |

### Driver-agnostic by construction

No new code references a driver id, name, or category enum branch. Suggestions consume `ColumnInfo`, `TableInfo`, and `QualifiedTableRef` from `dbflux_core`. Verified via grep across the diff.

### Out of scope (deferred per issue body)

- SQL keywords/functions (`LIKE`, `COALESCE`, `CAST`, …).
- Multi-line editor completion (existing `code/completion.rs` path is untouched apart from the helper move).
- Fuzzy matching across tokens (prefix-only for now).
- Persisted user dictionaries / recently-used columns.

### Known UX boundary

First-keystroke completions on a freshly-added join's right-hand input can be empty for the round-trip duration of the `table_details` fetch. Matches the existing FK-cache UX and is acceptable per the spec.

## Validation

| Gate | Result |
|------|--------|
| `cargo fmt --all --check` | pass |
| `cargo clippy --workspace -- -D warnings` | pass |
| `cargo nextest run --workspace` | **3314/3314** (was 3233 baseline; +81 from this branch + prior merges) |
| `cargo test --doc --workspace` | pass |

11 new unit tests in `query_builder/completion.rs` exercise:

- Tables mode prefix filter + cross-schema qualification
- AliasOrColumn with no qualifier → aliases + source columns
- AliasOrColumn with source alias qualifier → source columns only
- AliasOrColumn with joined alias qualifier → joined columns only
- AliasOrColumn with unfetched join → empty (no stale data)
- Case-insensitive prefix filter
- Starts-with (not contains) semantics
- Deduplication by uppercased label
- FilterExpression mode → source columns only
- JoinConditionRight parity with AliasOrColumn

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [x] X11
- [ ] Wayland
- [ ] Other:

Manual smoke testing of the GPUI popover behavior is left to the reviewer — the framework owns rendering and key routing for the completion popover, so unit tests cover the suggestion logic exhaustively but cannot exercise the actual UI overlay. Recommended smoke flow:

1. Open a table in DataView, type a partial column name in the WHERE filter → popover lists matching columns.
2. Open the visual query builder, add a join to `orders`, click the right side of the ON condition, type `o` → `orders` columns appear.
3. Esc dismisses; Tab/Enter commits; arrows navigate.

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

- `ui:feature`
- `query:feature`