### PR TITLE
fix(query-builder): materialize bound literals in SQL previews

### DIFF
--- a/crates/dbflux_core/src/query/generator.rs
+++ b/crates/dbflux_core/src/query/generator.rs
@@ -66,41 +66,57 @@ impl SelectQuery {
     /// - `$N` placeholders (PostgreSQL): each `$N` is replaced by `params[N-1]`.
     /// - `@pN` placeholders (SQL Server): each `@pN` is replaced by `params[N-1]`.
     pub fn materialize_for_editor(&self, dialect: &dyn crate::sql::dialect::SqlDialect) -> String {
-        use crate::sql::dialect::PlaceholderStyle;
+        materialize_placeholders(&self.sql, &self.params, dialect)
+    }
+}
 
-        let style = dialect.placeholder_style();
+/// Replace every parameter placeholder in `sql` with its dialect-quoted literal.
+///
+/// Shared by `SelectQuery::materialize_for_editor` and
+/// `GeneratedMutation::materialize_for_editor`. The result is for display only
+/// (read-only editor tabs, builder preview, confirmation dialogs) — it is NOT
+/// suitable for execution. The substitution respects the dialect's placeholder
+/// style:
+/// - `?` placeholders (SQLite/MySQL): replaced left-to-right.
+/// - `$N` placeholders (PostgreSQL): each `$N` is replaced by `params[N-1]`.
+/// - `@pN` placeholders (SQL Server): each `@pN` is replaced by `params[N-1]`.
+fn materialize_placeholders(
+    sql: &str,
+    params: &[crate::Value],
+    dialect: &dyn crate::sql::dialect::SqlDialect,
+) -> String {
+    use crate::sql::dialect::PlaceholderStyle;
 
-        match style {
-            PlaceholderStyle::QuestionMark | PlaceholderStyle::NamedColon => {
-                let mut result = String::with_capacity(self.sql.len());
-                let mut param_iter = self.params.iter();
-                let chars: Vec<char> = self.sql.chars().collect();
-                let mut i = 0;
+    match dialect.placeholder_style() {
+        PlaceholderStyle::QuestionMark | PlaceholderStyle::NamedColon => {
+            let mut result = String::with_capacity(sql.len());
+            let mut param_iter = params.iter();
+            let chars: Vec<char> = sql.chars().collect();
+            let mut i = 0;
 
-                while i < chars.len() {
-                    if chars[i] == '?' {
-                        if let Some(val) = param_iter.next() {
-                            result.push_str(&dialect.value_to_literal(val));
-                        } else {
-                            result.push('?');
-                        }
-                        i += 1;
+            while i < chars.len() {
+                if chars[i] == '?' {
+                    if let Some(val) = param_iter.next() {
+                        result.push_str(&dialect.value_to_literal(val));
                     } else {
-                        result.push(chars[i]);
-                        i += 1;
+                        result.push('?');
                     }
+                    i += 1;
+                } else {
+                    result.push(chars[i]);
+                    i += 1;
                 }
-
-                result
             }
 
-            PlaceholderStyle::DollarNumber => {
-                materialize_numbered_placeholders(&self.sql, &self.params, dialect, '$', "")
-            }
+            result
+        }
 
-            PlaceholderStyle::AtSign => {
-                materialize_numbered_placeholders(&self.sql, &self.params, dialect, '@', "p")
-            }
+        PlaceholderStyle::DollarNumber => {
+            materialize_numbered_placeholders(sql, params, dialect, '$', "")
+        }
+
+        PlaceholderStyle::AtSign => {
+            materialize_numbered_placeholders(sql, params, dialect, '@', "p")
         }
     }
 }
@@ -246,6 +262,19 @@ pub struct GeneratedMutation {
     pub params: Vec<crate::Value>,
     /// True when at least one assignment used `AssignmentValue::Expression`.
     pub used_raw_expression: bool,
+}
+
+impl GeneratedMutation {
+    /// Produces a human-readable SQL string with all parameter placeholders
+    /// replaced by their dialect-quoted literal values.
+    ///
+    /// Intended for display in the visual builder preview and the mutation
+    /// confirmation dialog. It is NOT suitable for execution — execution must
+    /// use `sql` + `params` so values stay bound. See
+    /// [`SelectQuery::materialize_for_editor`] for the SELECT counterpart.
+    pub fn materialize_for_editor(&self, dialect: &dyn crate::sql::dialect::SqlDialect) -> String {
+        materialize_placeholders(&self.sql, &self.params, dialect)
+    }
 }
 
 pub trait QueryGenerator: Send + Sync {
@@ -2051,6 +2080,19 @@ mod tests {
         assert_eq!(
             q.materialize_for_editor(&DIALECT),
             "SELECT * FROM t WHERE id = 42"
+        );
+    }
+
+    #[test]
+    fn mutation_materialize_inlines_set_and_where_literals() {
+        let m = super::GeneratedMutation {
+            sql: "UPDATE t\nSET x = ?\nWHERE id = ?".to_string(),
+            params: vec![Value::Text("1".to_string()), Value::Int(7)],
+            used_raw_expression: false,
+        };
+        assert_eq!(
+            m.materialize_for_editor(&DIALECT),
+            "UPDATE t\nSET x = '1'\nWHERE id = 7"
         );
     }
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -2697,7 +2697,7 @@ impl DataGridPanel {
                 Box::new(move |spec: &VisualQuerySpec| {
                     conn.query_generator()
                         .and_then(|qgen| qgen.generate_select(spec).ok().flatten())
-                        .map(|q| q.sql)
+                        .map(|q| q.materialize_for_editor(conn.dialect()))
                         .unwrap_or_default()
                 })
             } else {
@@ -2711,14 +2711,13 @@ impl DataGridPanel {
                 conn.query_generator()
                     .and_then(|qgen| {
                         use dbflux_core::MutationKind;
-                        match &spec.kind {
-                            MutationKind::Delete => {
-                                qgen.generate_delete_from_spec(spec).ok().map(|m| m.sql)
-                            }
+                        let generated = match &spec.kind {
+                            MutationKind::Delete => qgen.generate_delete_from_spec(spec).ok(),
                             MutationKind::Update { .. } => {
-                                qgen.generate_update_from_spec(spec).ok().map(|m| m.sql)
+                                qgen.generate_update_from_spec(spec).ok()
                             }
-                        }
+                        };
+                        generated.map(|m| m.materialize_for_editor(conn.dialect()))
                     })
                     .unwrap_or_default()
             })
@@ -3468,19 +3467,17 @@ impl DataGridPanel {
 
             let policy = connected.mutation_policy;
 
+            let dialect = connected.connection.dialect();
             let sql_preview = connected
                 .connection
                 .query_generator()
                 .and_then(|qgen| {
                     use dbflux_core::MutationKind;
-                    match &spec.kind {
-                        MutationKind::Delete => {
-                            qgen.generate_delete_from_spec(&spec).ok().map(|m| m.sql)
-                        }
-                        MutationKind::Update { .. } => {
-                            qgen.generate_update_from_spec(&spec).ok().map(|m| m.sql)
-                        }
-                    }
+                    let generated = match &spec.kind {
+                        MutationKind::Delete => qgen.generate_delete_from_spec(&spec).ok(),
+                        MutationKind::Update { .. } => qgen.generate_update_from_spec(&spec).ok(),
+                    };
+                    generated.map(|m| m.materialize_for_editor(dialect))
                 })
                 .unwrap_or_else(|| "<SQL preview unavailable>".to_string());
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -3458,32 +3458,14 @@ impl DataGridPanel {
             _ => return,
         };
 
-        let (policy, sql_preview, connection) = {
+        let (policy, connection) = {
             let state = self.app_state.read(cx);
             let connected = match state.connections().get(&profile_id) {
                 Some(c) => c,
                 None => return,
             };
 
-            let policy = connected.mutation_policy;
-
-            let dialect = connected.connection.dialect();
-            let sql_preview = connected
-                .connection
-                .query_generator()
-                .and_then(|qgen| {
-                    use dbflux_core::MutationKind;
-                    let generated = match &spec.kind {
-                        MutationKind::Delete => qgen.generate_delete_from_spec(&spec).ok(),
-                        MutationKind::Update { .. } => qgen.generate_update_from_spec(&spec).ok(),
-                    };
-                    generated.map(|m| m.materialize_for_editor(dialect))
-                })
-                .unwrap_or_else(|| "<SQL preview unavailable>".to_string());
-
-            let connection = Arc::clone(&connected.connection);
-
-            (policy, sql_preview, connection)
+            (connected.mutation_policy, Arc::clone(&connected.connection))
         };
 
         // Gate on mutation policy — state borrow has been released above.
@@ -3536,6 +3518,18 @@ impl DataGridPanel {
             }
             MutationPolicy::Allowed => {}
         }
+
+        let sql_preview = connection
+            .query_generator()
+            .and_then(|qgen| {
+                use dbflux_core::MutationKind;
+                let generated = match &spec.kind {
+                    MutationKind::Delete => qgen.generate_delete_from_spec(&spec).ok(),
+                    MutationKind::Update { .. } => qgen.generate_update_from_spec(&spec).ok(),
+                };
+                generated.map(|m| m.materialize_for_editor(connection.dialect()))
+            })
+            .unwrap_or_else(|| "<SQL preview unavailable>".to_string());
 
         // Fetch sample rows synchronously on background thread (2s deadline).
         let (sample_columns, sample_rows) =


### PR DESCRIPTION
## What

Visual builder previews and the mutation confirmation dialog showed bound literals as `?` instead of their values, e.g. `SET \`auto_retr_count\` = ?`. This made it look like the value wasn't applied, and for an UPDATE with a WHERE the preview mixed inlined and placeholder values.

## Why

The three preview sites rendered the raw parameterized SQL (`m.sql` / `q.sql`). Execution was always correct (params are bound at run time via `MutationExecutor`), but the preview misrepresented what would run.

## Change

- Add `GeneratedMutation::materialize_for_editor`, mirroring the existing `SelectQuery` method, backed by a shared `materialize_placeholders` helper (no logic duplicated).
- Use it in all three display-only preview sites: builder SELECT preview, builder mutation preview, and the confirmation dialog.
- Materialization is display-only; execution still uses `sql` + `params`, so bound parameters and the dangerous-query gate are unaffected.

## Notes

- Literals typed in the builder arrive as `ScalarLiteral::Text`, so a numeric value previews quoted (`= '1'`). Execution relies on the driver's implicit cast. Making numeric inputs derive a numeric `ScalarLiteral` is a separate change.

## Tests

- New `mutation_materialize_inlines_set_and_where_literals` in `dbflux_core` locks in `SET x = '1' WHERE id = 7`.
- Existing generator + materialization tests pass (`cargo test -p dbflux_core --lib query::generator`).
