### PR TITLE
fix(auth): route auth profile secrets to the OS keyring (AUTH-1..5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to DBFlux will be documented in this file.
 
+## [Unreleased]
+
+### Security
+
+* **Auth profile secrets moved to the OS keyring** — Secret-kind auth
+  profile fields (`Password` / `WriteOnly`, such as credentials for
+  external RPC auth providers) are now held in memory as `SecretString`,
+  persisted to the OS keyring, and stored in SQLite only as a keyring
+  reference, never in plaintext. The derived `Debug` and serialization no
+  longer expose secret values. Profiles saved before this change are
+  migrated out of plaintext SQLite into the keyring on first launch.
+  Keyring availability detection now tells a locked keyring apart from an
+  absent one, and a secret write that cannot reach the keyring surfaces a
+  warning (and a toast in the auth profile editor) instead of silently
+  dropping the secret. The AWS file-backed write path carries credentials
+  as `SecretString` up to the point they are written to
+  `~/.aws/credentials`. (Security audit AUTH-1, AUTH-2, AUTH-3, AUTH-4,
+  AUTH-5.)
+
 ## [0.6.0] - 2026-06-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2744,6 +2744,7 @@ dependencies = [
  "dbflux_core",
  "dirs 5.0.1",
  "interprocess",
+ "secrecy",
  "serde",
  "serde_json",
  "uuid",

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -364,7 +364,101 @@ impl AppState {
             }
         }
 
+        state.hydrate_and_migrate_auth_secrets();
+
         state
+    }
+
+    /// Re-hydrates secret-kind auth profile fields from the OS keyring and
+    /// migrates any legacy plaintext secrets out of SQLite.
+    ///
+    /// Runs once at startup, after the provider registry and secret manager
+    /// exist. For every stored profile it asks the owning provider's form
+    /// definition which fields are secret-kind (`Password` / `WriteOnly`), then:
+    ///
+    /// - if the value is still sitting in `fields` as plaintext (a profile saved
+    ///   before secrets were keyring-routed), it is moved into the keyring,
+    ///   removed from `fields`, and the profile is re-persisted so SQLite keeps
+    ///   only a keyring-reference marker; otherwise
+    /// - the value is read back from the keyring into `secret_fields`.
+    ///
+    /// Providers not present in the registry are skipped (their secret layout is
+    /// unknown), leaving their data untouched.
+    fn hydrate_and_migrate_auth_secrets(&mut self) {
+        let mut needs_persist = false;
+        let count = self.facade.auth_profiles.items.len();
+
+        for idx in 0..count {
+            let provider_id = self.facade.auth_profiles.items[idx].provider_id.clone();
+            let profile_id = self.facade.auth_profiles.items[idx].id;
+
+            let Some(provider) = self.auth_provider_by_id(&provider_id) else {
+                continue;
+            };
+
+            let secret_field_ids: Vec<String> = provider
+                .form_def()
+                .tabs
+                .iter()
+                .flat_map(|tab| tab.sections.iter())
+                .flat_map(|section| section.fields.iter())
+                .filter(|field| {
+                    matches!(
+                        field.kind,
+                        dbflux_core::FormFieldKind::Password
+                            | dbflux_core::FormFieldKind::WriteOnly
+                    )
+                })
+                .map(|field| field.id.clone())
+                .collect();
+            drop(provider);
+
+            for field_id in secret_field_ids {
+                let secret_ref = dbflux_core::auth_field_secret_ref(&profile_id, &field_id);
+
+                if let Some(plaintext) = self.facade.auth_profiles.items[idx]
+                    .fields
+                    .remove(&field_id)
+                {
+                    let secret = dbflux_core::secrecy::SecretString::from(plaintext);
+                    self.facade.secrets.set_by_ref(&secret_ref, &secret);
+                    self.facade.auth_profiles.items[idx]
+                        .secret_fields
+                        .insert(field_id, secret);
+                    needs_persist = true;
+                } else if let Some(secret) = self.facade.secrets.get_by_ref(&secret_ref) {
+                    self.facade.auth_profiles.items[idx]
+                        .secret_fields
+                        .insert(field_id, secret);
+                }
+            }
+        }
+
+        if needs_persist
+            && let Err(e) = crate::config_loader::save_auth_profiles(
+                &self.storage_runtime,
+                &self.facade.auth_profiles.items,
+            )
+        {
+            log::error!("Failed to persist migrated auth profile secrets: {}", e);
+        }
+    }
+
+    /// Writes a profile's secret-kind field values to the OS keyring under
+    /// per-field references. The matching SQLite rows store only the reference.
+    fn persist_auth_secret_fields(&self, profile: &dbflux_core::AuthProfile) {
+        for (field_id, secret) in &profile.secret_fields {
+            let secret_ref = dbflux_core::auth_field_secret_ref(&profile.id, field_id);
+            self.facade.secrets.set_by_ref(&secret_ref, secret);
+        }
+    }
+
+    /// Deletes a profile's secret-kind field values from the OS keyring.
+    fn delete_auth_secret_fields(&self, profile: &dbflux_core::AuthProfile) {
+        for field_id in profile.secret_fields.keys() {
+            let secret_ref = dbflux_core::auth_field_secret_ref(&profile.id, field_id);
+            self.facade.secrets.delete_by_ref(&secret_ref);
+        }
     }
 
     #[cfg(feature = "mcp")]
@@ -1969,8 +2063,9 @@ impl AppState {
             error_msg,
         );
 
-        if let Err(e) = save_result {
-            log::error!("Failed to save auth profiles: {}", e);
+        match save_result {
+            Ok(()) => self.persist_auth_secret_fields(&profile),
+            Err(e) => log::error!("Failed to save auth profiles: {}", e),
         }
     }
 
@@ -2001,8 +2096,9 @@ impl AppState {
             error_msg,
         );
 
-        if let Err(e) = save_result {
-            log::error!("Failed to save auth profiles after remove: {}", e);
+        match save_result {
+            Ok(()) => self.delete_auth_secret_fields(&removed),
+            Err(e) => log::error!("Failed to save auth profiles after remove: {}", e),
         }
         Some(removed)
     }
@@ -2037,8 +2133,9 @@ impl AppState {
                 error_msg,
             );
 
-            if let Err(e) = save_result {
-                log::error!("Failed to save auth profiles: {}", e);
+            match save_result {
+                Ok(()) => self.persist_auth_secret_fields(&profile),
+                Err(e) => log::error!("Failed to save auth profiles: {}", e),
             }
         }
     }
@@ -2083,6 +2180,21 @@ impl AppState {
     #[deprecated(note = "use list_auth_profiles(); stored-only view hides reflected AWS profiles")]
     pub fn auth_profiles(&self) -> &[dbflux_core::AuthProfile] {
         &self.facade.auth_profiles.items
+    }
+
+    /// Returns a clone of the re-hydrated secret-kind fields for a stored
+    /// profile, used by the Settings UI to preserve a WriteOnly secret the user
+    /// left blank when re-saving. `None` if no stored profile matches `id`.
+    pub fn stored_auth_profile_secret_fields(
+        &self,
+        id: Uuid,
+    ) -> Option<HashMap<String, SecretString>> {
+        self.facade
+            .auth_profiles
+            .items
+            .iter()
+            .find(|profile| profile.id == id)
+            .map(|profile| profile.secret_fields.clone())
     }
 
     // --- ConnectionTreeManager ---
@@ -3945,6 +4057,7 @@ mod tests {
             name: name.to_string(),
             provider_id: "aws-sso".to_string(),
             fields: HashMap::new(),
+            secret_fields: HashMap::new(),
             enabled: true,
             read_only: true,
             dangling_origin: None,
@@ -3991,6 +4104,7 @@ mod tests {
             name: "OIDC Provider".to_string(),
             provider_id: "custom-oidc".to_string(),
             fields: HashMap::new(),
+            secret_fields: HashMap::new(),
             enabled: true,
             read_only: false,
             dangling_origin: None,
@@ -4035,6 +4149,7 @@ mod tests {
             name: "legacy-sso".to_string(),
             provider_id: "aws-sso".to_string(),
             fields: HashMap::new(),
+            secret_fields: HashMap::new(),
             enabled: true,
             read_only: false,
             dangling_origin: None,

--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -377,9 +377,11 @@ impl AppState {
     /// definition which fields are secret-kind (`Password` / `WriteOnly`), then:
     ///
     /// - if the value is still sitting in `fields` as plaintext (a profile saved
-    ///   before secrets were keyring-routed), it is moved into the keyring,
-    ///   removed from `fields`, and the profile is re-persisted so SQLite keeps
-    ///   only a keyring-reference marker; otherwise
+    ///   before secrets were keyring-routed), it is moved into the keyring and,
+    ///   ONLY once the keyring write is confirmed, dropped from `fields` and the
+    ///   profile re-persisted so SQLite keeps just a keyring-reference marker.
+    ///   If the keyring is unavailable the plaintext is left untouched so the
+    ///   secret is never destroyed; migration retries on a later launch; otherwise
     /// - the value is read back from the keyring into `secret_fields`.
     ///
     /// Providers not present in the registry are skipped (their secret layout is
@@ -416,20 +418,38 @@ impl AppState {
             for field_id in secret_field_ids {
                 let secret_ref = dbflux_core::auth_field_secret_ref(&profile_id, &field_id);
 
-                if let Some(plaintext) = self.facade.auth_profiles.items[idx]
+                // Already-migrated profile: the secret lives in the keyring only.
+                let Some(plaintext) = self.facade.auth_profiles.items[idx]
                     .fields
-                    .remove(&field_id)
-                {
-                    let secret = dbflux_core::secrecy::SecretString::from(plaintext);
-                    self.facade.secrets.set_by_ref(&secret_ref, &secret);
+                    .get(&field_id)
+                    .cloned()
+                else {
+                    if let Some(secret) = self.facade.secrets.get_by_ref(&secret_ref) {
+                        self.facade.auth_profiles.items[idx]
+                            .secret_fields
+                            .insert(field_id, secret);
+                    }
+                    continue;
+                };
+
+                // Legacy plaintext secret: move it to the keyring, but only drop
+                // the plaintext copy once the write is confirmed. A locked or
+                // unavailable keyring must never destroy the only copy.
+                let secret = dbflux_core::secrecy::SecretString::from(plaintext);
+                if self.facade.secrets.set_by_ref(&secret_ref, &secret) {
+                    self.facade.auth_profiles.items[idx]
+                        .fields
+                        .remove(&field_id);
                     self.facade.auth_profiles.items[idx]
                         .secret_fields
                         .insert(field_id, secret);
                     needs_persist = true;
-                } else if let Some(secret) = self.facade.secrets.get_by_ref(&secret_ref) {
-                    self.facade.auth_profiles.items[idx]
-                        .secret_fields
-                        .insert(field_id, secret);
+                } else {
+                    log::warn!(
+                        "Deferred auth secret migration for field '{}': keyring \
+                         unavailable; leaving the existing value in place",
+                        field_id
+                    );
                 }
             }
         }
@@ -446,11 +466,20 @@ impl AppState {
 
     /// Writes a profile's secret-kind field values to the OS keyring under
     /// per-field references. The matching SQLite rows store only the reference.
-    fn persist_auth_secret_fields(&self, profile: &dbflux_core::AuthProfile) {
+    ///
+    /// Returns `true` only if every secret was actually persisted (vacuously
+    /// true when the profile has none). A `false` result means at least one
+    /// secret could not be written (e.g. the keyring is unavailable) and the
+    /// caller should warn the user.
+    fn persist_auth_secret_fields(&self, profile: &dbflux_core::AuthProfile) -> bool {
+        let mut all_persisted = true;
         for (field_id, secret) in &profile.secret_fields {
             let secret_ref = dbflux_core::auth_field_secret_ref(&profile.id, field_id);
-            self.facade.secrets.set_by_ref(&secret_ref, secret);
+            if !self.facade.secrets.set_by_ref(&secret_ref, secret) {
+                all_persisted = false;
+            }
         }
+        all_persisted
     }
 
     /// Deletes a profile's secret-kind field values from the OS keyring.
@@ -2040,7 +2069,10 @@ impl AppState {
 
     // --- AuthProfileManager ---
 
-    pub fn add_auth_profile(&mut self, profile: dbflux_core::AuthProfile) {
+    /// Adds a stored auth profile. Returns `true` if its secret-kind fields (if
+    /// any) were persisted to the keyring; `false` means the secret could not be
+    /// stored and the caller should warn the user.
+    pub fn add_auth_profile(&mut self, profile: dbflux_core::AuthProfile) -> bool {
         let profile_name = profile.name.clone();
         let profile_id = profile.id.to_string();
         self.facade.auth_profiles.items.push(profile.clone());
@@ -2065,7 +2097,10 @@ impl AppState {
 
         match save_result {
             Ok(()) => self.persist_auth_secret_fields(&profile),
-            Err(e) => log::error!("Failed to save auth profiles: {}", e),
+            Err(e) => {
+                log::error!("Failed to save auth profiles: {}", e);
+                false
+            }
         }
     }
 
@@ -2103,39 +2138,69 @@ impl AppState {
         Some(removed)
     }
 
-    pub fn update_auth_profile(&mut self, profile: dbflux_core::AuthProfile) {
+    /// Updates a stored auth profile. Returns `true` if its secret-kind fields
+    /// (if any) were persisted to the keyring; `false` means the secret could
+    /// not be stored and the caller should warn the user. A profile that is not
+    /// present is a no-op and returns `true`.
+    pub fn update_auth_profile(&mut self, profile: dbflux_core::AuthProfile) -> bool {
         let profile_name = profile.name.clone();
         let profile_id = profile.id.to_string();
-        if let Some(existing) = self
+
+        // Delete keyring entries for secret fields that the updated profile no
+        // longer carries, so a removed or replaced secret does not linger in the
+        // OS keyring as orphaned credential material.
+        let old_secret_keys: Vec<String> = self
+            .facade
+            .auth_profiles
+            .items
+            .iter()
+            .find(|i| i.id == profile.id)
+            .map(|existing| existing.secret_fields.keys().cloned().collect())
+            .unwrap_or_default();
+
+        for field_id in old_secret_keys
+            .iter()
+            .filter(|key| !profile.secret_fields.contains_key(*key))
+        {
+            let secret_ref = dbflux_core::auth_field_secret_ref(&profile.id, field_id);
+            self.facade.secrets.delete_by_ref(&secret_ref);
+        }
+
+        let Some(existing) = self
             .facade
             .auth_profiles
             .items
             .iter_mut()
             .find(|i| i.id == profile.id)
-        {
-            *existing = profile.clone();
-            let save_result = crate::config_loader::save_auth_profiles(
-                &self.storage_runtime,
-                &self.facade.auth_profiles.items,
-            );
+        else {
+            return true;
+        };
 
-            let (outcome, error_msg) = match &save_result {
-                Ok(()) => (EventOutcome::Success, None),
-                Err(e) => (EventOutcome::Failure, Some(e.to_string())),
-            };
+        *existing = profile.clone();
+        let save_result = crate::config_loader::save_auth_profiles(
+            &self.storage_runtime,
+            &self.facade.auth_profiles.items,
+        );
 
-            self.record_config_event(
-                outcome,
-                CONFIG_UPDATE,
-                "auth_profile",
-                profile_id,
-                format!("Updated auth profile '{}'", profile_name),
-                error_msg,
-            );
+        let (outcome, error_msg) = match &save_result {
+            Ok(()) => (EventOutcome::Success, None),
+            Err(e) => (EventOutcome::Failure, Some(e.to_string())),
+        };
 
-            match save_result {
-                Ok(()) => self.persist_auth_secret_fields(&profile),
-                Err(e) => log::error!("Failed to save auth profiles: {}", e),
+        self.record_config_event(
+            outcome,
+            CONFIG_UPDATE,
+            "auth_profile",
+            profile_id,
+            format!("Updated auth profile '{}'", profile_name),
+            error_msg,
+        );
+
+        match save_result {
+            Ok(()) => self.persist_auth_secret_fields(&profile),
+            Err(e) => {
+                log::error!("Failed to save auth profiles: {}", e);
+                false
             }
         }
     }

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -759,15 +759,27 @@ pub fn save_auth_profiles(
             dangling_origin: None,
         };
 
+        // Secret-kind fields are persisted as keyring-reference markers only;
+        // the values themselves are written to the keyring by the caller
+        // (AppState), never to SQLite. `fields` already excludes them.
+        let secret_refs: std::collections::HashMap<String, String> = profile
+            .secret_fields
+            .keys()
+            .map(|key| {
+                (
+                    key.clone(),
+                    dbflux_core::auth_field_secret_ref(&profile.id, key),
+                )
+            })
+            .collect();
+
         if existing_ids.contains(&dto.id) {
             repo.update(&dto)?;
-            // Update fields in child table
-            repo.set_fields(&dto.id, &profile.fields)?;
         } else {
             repo.insert(&dto)?;
-            // Insert fields in child table
-            repo.set_fields(&dto.id, &profile.fields)?;
         }
+
+        repo.set_fields_and_secrets(&dto.id, &profile.fields, &secret_refs)?;
     }
 
     // Delete profiles that are in DB but not in the desired state.
@@ -1517,6 +1529,10 @@ fn load_auth_profiles(
                     name: dto.name,
                     provider_id: dto.provider_id,
                     fields,
+                    // Re-hydrated from the keyring by AppState after load, where
+                    // the auth-provider registry is available to identify which
+                    // fields are secret-kind.
+                    secret_fields: std::collections::HashMap::new(),
                     enabled: dto.enabled,
                     read_only: false,
                     dangling_origin: dto.dangling_origin,

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use sha1::{Digest, Sha1};
 
 use aws_sdk_sts::config::ProvideCredentials;
@@ -1565,14 +1565,21 @@ impl dbflux_core::auth::DynAuthProvider for AwsSharedCredentialsAuthProvider {
             .filter_map(|&key| fields.get(key).map(|v| (key.to_string(), v.clone())))
             .collect();
 
-        // Credentials-side fields (includes write-only secrets).
-        let creds_fields: Vec<(String, String)> = [
+        // Credentials-side fields (includes write-only secrets). Held as
+        // SecretString and exposed only at the point the credentials block is
+        // written, so the in-process copies are zeroized on drop. (The ultimate
+        // sink is the plaintext `~/.aws/credentials` file the AWS SDK reads.)
+        let creds_fields: Vec<(String, SecretString)> = [
             "aws_access_key_id",
             "aws_secret_access_key",
             "aws_session_token",
         ]
         .iter()
-        .filter_map(|&key| fields.get(key).map(|v| (key.to_string(), v.clone())))
+        .filter_map(|&key| {
+            fields
+                .get(key)
+                .map(|v| (key.to_string(), SecretString::from(v.clone())))
+        })
         .collect();
 
         let has_config_fields = !config_fields.is_empty();
@@ -1640,7 +1647,7 @@ impl dbflux_core::auth::DynAuthProvider for AwsSharedCredentialsAuthProvider {
 
                     let borrowed: Vec<(&str, &str)> = creds_fields_borrowed
                         .iter()
-                        .map(|(k, v)| (k.as_str(), v.as_str()))
+                        .map(|(k, v)| (k.as_str(), v.expose_secret()))
                         .collect();
                     crate::config::replace_or_append_credentials_block(existing, name, &borrowed)
                 });

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -435,6 +435,9 @@ impl AwsSsoAuthProvider {
                     name: p.name.clone(),
                     provider_id: "aws-sso".to_string(),
                     fields,
+                    // Reflected AWS profiles never carry key material; secrets
+                    // live in ~/.aws/credentials, not in DBFlux storage.
+                    secret_fields: std::collections::HashMap::new(),
                     enabled: true,
                     // Reflected non-dangling profiles are editable (design §13).
                     read_only: false,
@@ -508,6 +511,9 @@ impl AwsSsoSessionAuthProvider {
                     name: p.name.clone(),
                     provider_id: "aws-sso-session".to_string(),
                     fields,
+                    // Reflected AWS profiles never carry key material; secrets
+                    // live in ~/.aws/credentials, not in DBFlux storage.
+                    secret_fields: std::collections::HashMap::new(),
                     enabled: true,
                     // Reflected non-dangling profiles are editable (design §13).
                     read_only: false,
@@ -597,6 +603,9 @@ impl AwsSharedCredentialsAuthProvider {
                     name: name.clone(),
                     provider_id: "aws-shared-credentials".to_string(),
                     fields,
+                    // Reflected AWS profiles never carry key material; secrets
+                    // live in ~/.aws/credentials, not in DBFlux storage.
+                    secret_fields: std::collections::HashMap::new(),
                     enabled: true,
                     // Reflected non-dangling profiles are editable (design §13).
                     read_only: false,
@@ -2600,6 +2609,7 @@ mod tests {
             name: "Test".to_string(),
             provider_id: "aws-sso".to_string(),
             fields,
+            secret_fields: std::collections::HashMap::new(),
             enabled: true,
             read_only: false,
             dangling_origin: None,
@@ -3151,6 +3161,7 @@ sso_region = us-east-1
             name: "dev-sso".to_string(),
             provider_id: "aws-sso".to_string(),
             fields,
+            secret_fields: std::collections::HashMap::new(),
             enabled: true,
             read_only: true,
             dangling_origin: None,

--- a/crates/dbflux_core/src/auth/types.rs
+++ b/crates/dbflux_core/src/auth/types.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use secrecy::SecretString;
 use serde::de::Deserializer;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -71,12 +72,22 @@ pub struct AuthProviderLoginCapabilities {
 /// files and must not be edited in DBFlux. Stored profiles always have
 /// `read_only = false`. This field is never persisted to SQLite; reflected
 /// profiles are never serialized.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Clone, Serialize)]
 pub struct AuthProfile {
     pub id: Uuid,
     pub name: String,
     pub provider_id: String,
     pub fields: HashMap<String, String>,
+    /// Secret-kind field values (`Password` / `WriteOnly`).
+    ///
+    /// Held as `SecretString` so the value is zeroized on drop and never leaks
+    /// through `Debug` or serde output. These are persisted to the OS keyring,
+    /// never to SQLite in plaintext, and re-hydrated at load time. The default
+    /// derived `Serialize` skips this field; the only place secrets are exposed
+    /// on the wire is the auth-provider IPC boundary, which re-merges them into
+    /// the flat `fields` map the external provider expects.
+    #[serde(skip)]
+    pub secret_fields: HashMap<String, SecretString>,
     pub enabled: bool,
     /// Whether this profile is a live reflection and must not be edited in DBFlux.
     ///
@@ -95,6 +106,26 @@ pub struct AuthProfile {
     /// from the `dangling_origin` column in `cfg_auth_profiles`.
     #[serde(skip)]
     pub dangling_origin: Option<String>,
+}
+
+impl std::fmt::Debug for AuthProfile {
+    /// Redacts secret values: `secret_fields` prints its key names only, never
+    /// the `SecretString` contents. Mirrors the `ResolvedCredentials` Debug
+    /// policy so `{:?}` in logs can never leak credentials.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let secret_keys: Vec<&str> = self.secret_fields.keys().map(String::as_str).collect();
+
+        f.debug_struct("AuthProfile")
+            .field("id", &self.id)
+            .field("name", &self.name)
+            .field("provider_id", &self.provider_id)
+            .field("fields", &self.fields)
+            .field("secret_fields", &secret_keys)
+            .field("enabled", &self.enabled)
+            .field("read_only", &self.read_only)
+            .field("dangling_origin", &self.dangling_origin)
+            .finish()
+    }
 }
 
 /// Provider ID rewrites for old `config.type` values.
@@ -197,6 +228,7 @@ impl<'de> Deserialize<'de> for AuthProfile {
             name,
             provider_id,
             fields,
+            secret_fields: HashMap::new(),
             enabled,
             read_only,
             dangling_origin: None,
@@ -215,14 +247,11 @@ impl AuthProfile {
             name: name.into(),
             provider_id: provider_id.into(),
             fields,
+            secret_fields: HashMap::new(),
             enabled: true,
             read_only: false,
             dangling_origin: None,
         }
-    }
-
-    pub fn secret_ref(&self) -> String {
-        format!("dbflux:auth:{}", self.id)
     }
 }
 
@@ -395,6 +424,7 @@ mod tests {
             name: "Prod".to_string(),
             provider_id: "aws-sso".to_string(),
             fields: fields.clone(),
+            secret_fields: HashMap::new(),
             enabled: true,
             read_only: false,
             dangling_origin: None,
@@ -408,6 +438,75 @@ mod tests {
         assert_eq!(deserialized.provider_id, original.provider_id);
         assert_eq!(deserialized.fields, original.fields);
         assert_eq!(deserialized.enabled, original.enabled);
+    }
+
+    #[test]
+    fn serialize_omits_secret_fields() {
+        let mut secret_fields = HashMap::new();
+        secret_fields.insert(
+            "secret_access_key".to_string(),
+            SecretString::from("AKIAVERYSECRETVALUE".to_string()),
+        );
+
+        let mut fields = HashMap::new();
+        fields.insert("region".to_string(), "us-east-1".to_string());
+
+        let profile = AuthProfile {
+            id: Uuid::parse_str(&make_uuid()).unwrap(),
+            name: "Static".to_string(),
+            provider_id: "custom".to_string(),
+            fields,
+            secret_fields,
+            enabled: true,
+            read_only: false,
+            dangling_origin: None,
+        };
+
+        let json = serde_json::to_string(&profile).unwrap();
+
+        assert!(
+            !json.contains("AKIAVERYSECRETVALUE"),
+            "serialized profile must not contain the secret value: {json}"
+        );
+        assert!(
+            !json.contains("secret_access_key"),
+            "serialized profile must not even name the secret field: {json}"
+        );
+        assert!(
+            json.contains("region"),
+            "non-secret fields must still serialize: {json}"
+        );
+    }
+
+    #[test]
+    fn debug_redacts_secret_values() {
+        let mut secret_fields = HashMap::new();
+        secret_fields.insert(
+            "secret_access_key".to_string(),
+            SecretString::from("AKIAVERYSECRETVALUE".to_string()),
+        );
+
+        let profile = AuthProfile {
+            id: Uuid::parse_str(&make_uuid()).unwrap(),
+            name: "Static".to_string(),
+            provider_id: "custom".to_string(),
+            fields: HashMap::new(),
+            secret_fields,
+            enabled: true,
+            read_only: false,
+            dangling_origin: None,
+        };
+
+        let debug = format!("{profile:?}");
+
+        assert!(
+            !debug.contains("AKIAVERYSECRETVALUE"),
+            "Debug must never print the secret value: {debug}"
+        );
+        assert!(
+            debug.contains("secret_access_key"),
+            "Debug should still list the secret field key: {debug}"
+        );
     }
 
     #[test]

--- a/crates/dbflux_core/src/auth/types.rs
+++ b/crates/dbflux_core/src/auth/types.rs
@@ -86,6 +86,11 @@ pub struct AuthProfile {
     /// derived `Serialize` skips this field; the only place secrets are exposed
     /// on the wire is the auth-provider IPC boundary, which re-merges them into
     /// the flat `fields` map the external provider expects.
+    ///
+    /// A secret saved before this routing existed may still live in `fields` as
+    /// plaintext until startup migration moves it here. That migration is
+    /// deferred (never destructive) when the keyring is unavailable, so such a
+    /// legacy value can remain in `fields` for a session.
     #[serde(skip)]
     pub secret_fields: HashMap<String, SecretString>,
     pub enabled: bool,

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -216,7 +216,8 @@ pub use storage::{
     KeyringSecretStore, NoopSecretStore, ProfileStore, ProxyStore, RecentFile, RecentFilesStore,
     SavedQuery, SavedQueryManager, SavedQueryStore, SecretManager, SecretStore, SessionManifest,
     SessionStore, SessionTab, SessionTabKind, SshTunnelStore, UiState, UiStateStore,
-    connection_secret_ref, create_secret_store, proxy_secret_ref, ssh_tunnel_secret_ref,
+    auth_field_secret_ref, connection_secret_ref, create_secret_store, proxy_secret_ref,
+    ssh_tunnel_secret_ref,
 };
 
 pub use observability::{

--- a/crates/dbflux_core/src/storage/mod.rs
+++ b/crates/dbflux_core/src/storage/mod.rs
@@ -17,8 +17,8 @@ pub use saved_query::{SavedQuery, SavedQueryStore};
 pub use saved_query_manager::SavedQueryManager;
 pub use secret_manager::{HasSecretRef, SecretManager};
 pub use secrets::{
-    KeyringSecretStore, NoopSecretStore, SecretStore, connection_secret_ref, create_secret_store,
-    proxy_secret_ref, ssh_tunnel_secret_ref,
+    KeyringSecretStore, NoopSecretStore, SecretStore, auth_field_secret_ref, connection_secret_ref,
+    create_secret_store, proxy_secret_ref, ssh_tunnel_secret_ref,
 };
 pub use session::{SessionManifest, SessionStore, SessionTab, SessionTabKind};
 pub use ui_state::{UiState, UiStateStore};

--- a/crates/dbflux_core/src/storage/secret_manager.rs
+++ b/crates/dbflux_core/src/storage/secret_manager.rs
@@ -1,6 +1,4 @@
-use crate::{
-    AuthProfile, ConnectionProfile, DbConfig, ProxyProfile, SecretStore, SshTunnelProfile,
-};
+use crate::{ConnectionProfile, DbConfig, ProxyProfile, SecretStore, SshTunnelProfile};
 use log::error;
 use secrecy::SecretString;
 use std::sync::Arc;
@@ -18,12 +16,6 @@ impl HasSecretRef for SshTunnelProfile {
 }
 
 impl HasSecretRef for ProxyProfile {
-    fn secret_ref(&self) -> String {
-        self.secret_ref()
-    }
-}
-
-impl HasSecretRef for AuthProfile {
     fn secret_ref(&self) -> String {
         self.secret_ref()
     }
@@ -56,6 +48,54 @@ impl SecretManager {
 
     pub fn secret_store_arc(&self) -> Arc<RwLock<Box<dyn SecretStore>>> {
         self.secret_store.clone()
+    }
+
+    /// Reads a secret stored under an explicit keyring reference.
+    ///
+    /// Used for per-field auth-profile secrets, whose reference is computed as
+    /// `dbflux:auth:{profile_id}:{field_id}` rather than derived from a single
+    /// `HasSecretRef` value (a profile can hold several independent secrets).
+    pub fn get_by_ref(&self, secret_ref: &str) -> Option<SecretString> {
+        let store = self.store_read();
+
+        if !store.is_available() {
+            return None;
+        }
+
+        match store.get(secret_ref) {
+            Ok(secret) => secret,
+            Err(e) => {
+                error!("Failed to get secret '{}': {:?}", secret_ref, e);
+                None
+            }
+        }
+    }
+
+    /// Writes a secret under an explicit keyring reference. No-op when the
+    /// keyring backend is unavailable.
+    pub fn set_by_ref(&self, secret_ref: &str, secret: &SecretString) {
+        let store = self.store_read();
+
+        if !store.is_available() {
+            return;
+        }
+
+        if let Err(e) = store.set(secret_ref, secret) {
+            error!("Failed to save secret '{}': {:?}", secret_ref, e);
+        }
+    }
+
+    /// Deletes a secret stored under an explicit keyring reference.
+    pub fn delete_by_ref(&self, secret_ref: &str) {
+        let store = self.store_read();
+
+        if !store.is_available() {
+            return;
+        }
+
+        if let Err(e) = store.delete(secret_ref) {
+            log::warn!("Failed to delete secret '{}': {:?}", secret_ref, e);
+        }
     }
 
     pub fn get_secret<T: HasSecretRef>(&self, item: &T, label: &str) -> Option<SecretString> {

--- a/crates/dbflux_core/src/storage/secret_manager.rs
+++ b/crates/dbflux_core/src/storage/secret_manager.rs
@@ -73,20 +73,26 @@ impl SecretManager {
 
     /// Writes a secret under an explicit keyring reference.
     ///
-    /// When the keyring backend is unavailable the write is skipped, but this is
-    /// logged rather than swallowed silently — callers that need the user to
-    /// know (e.g. saving an auth profile secret) should also check
-    /// `is_available()` and surface a warning.
-    pub fn set_by_ref(&self, secret_ref: &str, secret: &SecretString) {
+    /// Returns `true` only when the value was actually persisted. A `false`
+    /// result (store unavailable, or the backend rejected the write — e.g. a
+    /// locked keyring) is logged, and callers that must not lose data (the
+    /// plaintext->keyring migration) or that need to tell the user (the auth
+    /// profile editor) MUST act on it rather than assume success.
+    #[must_use]
+    pub fn set_by_ref(&self, secret_ref: &str, secret: &SecretString) -> bool {
         let store = self.store_read();
 
         if !store.is_available() {
             log::warn!("Secret store unavailable; secret '{secret_ref}' was NOT persisted");
-            return;
+            return false;
         }
 
-        if let Err(e) = store.set(secret_ref, secret) {
-            error!("Failed to save secret '{}': {:?}", secret_ref, e);
+        match store.set(secret_ref, secret) {
+            Ok(()) => true,
+            Err(e) => {
+                error!("Failed to save secret '{}': {:?}", secret_ref, e);
+                false
+            }
         }
     }
 

--- a/crates/dbflux_core/src/storage/secret_manager.rs
+++ b/crates/dbflux_core/src/storage/secret_manager.rs
@@ -71,12 +71,17 @@ impl SecretManager {
         }
     }
 
-    /// Writes a secret under an explicit keyring reference. No-op when the
-    /// keyring backend is unavailable.
+    /// Writes a secret under an explicit keyring reference.
+    ///
+    /// When the keyring backend is unavailable the write is skipped, but this is
+    /// logged rather than swallowed silently — callers that need the user to
+    /// know (e.g. saving an auth profile secret) should also check
+    /// `is_available()` and surface a warning.
     pub fn set_by_ref(&self, secret_ref: &str, secret: &SecretString) {
         let store = self.store_read();
 
         if !store.is_available() {
+            log::warn!("Secret store unavailable; secret '{secret_ref}' was NOT persisted");
             return;
         }
 
@@ -112,6 +117,7 @@ impl SecretManager {
         let store = self.store_read();
 
         if !store.is_available() {
+            log::warn!("Secret store unavailable; {label} secret was NOT persisted");
             return;
         }
 
@@ -140,6 +146,7 @@ impl SecretManager {
         let store = self.store_read();
 
         if !store.is_available() {
+            log::warn!("Secret store unavailable; connection password was NOT persisted");
             return;
         }
 
@@ -196,6 +203,7 @@ impl SecretManager {
         let store = self.store_read();
 
         if !store.is_available() {
+            log::warn!("Secret store unavailable; SSH password was NOT persisted");
             return;
         }
 

--- a/crates/dbflux_core/src/storage/secrets.rs
+++ b/crates/dbflux_core/src/storage/secrets.rs
@@ -125,6 +125,13 @@ pub fn proxy_secret_ref(proxy_id: &uuid::Uuid) -> String {
     format!("dbflux:proxy:{}", proxy_id)
 }
 
+/// Keyring reference for a single secret-kind auth profile field
+/// (`Password` / `WriteOnly`). One entry per (profile, field) so a profile can
+/// hold several independent secrets (e.g. `secret_access_key` + `session_token`).
+pub fn auth_field_secret_ref(profile_id: &uuid::Uuid, field_id: &str) -> String {
+    format!("dbflux:auth:{}:{}", profile_id, field_id)
+}
+
 pub fn create_secret_store() -> Box<dyn SecretStore> {
     let keyring_store = KeyringSecretStore::new();
     if keyring_store.is_available() {

--- a/crates/dbflux_core/src/storage/secrets.rs
+++ b/crates/dbflux_core/src/storage/secrets.rs
@@ -40,14 +40,44 @@ impl KeyringSecretStore {
         Self { available }
     }
 
+    /// Probes the platform secret store and classifies the outcome so a locked
+    /// keyring is not mistaken for a missing one.
+    ///
+    /// - `Ok` / `NoEntry`: backend reachable -> available.
+    /// - `NoStorageAccess`: backend present but locked or access-denied (e.g. a
+    ///   locked login keyring). Reported available so we do NOT downgrade to the
+    ///   no-op store and silently drop secrets; individual writes will surface
+    ///   their own errors until it is unlocked.
+    /// - `PlatformFailure` / other: no working secure storage -> unavailable.
+    ///
+    /// Each case logs a distinct message so a locked keyring can be told apart
+    /// from an absent one when diagnosing.
     fn check_availability() -> bool {
-        let test_entry = keyring::Entry::new(SERVICE_NAME, "__dbflux_test__");
-        match test_entry {
-            Ok(entry) => {
-                let _ = entry.get_password();
+        let entry = match keyring::Entry::new(SERVICE_NAME, "__dbflux_test__") {
+            Ok(entry) => entry,
+            Err(e) => {
+                log::warn!("Keyring backend not constructible; secrets disabled: {e}");
+                return false;
+            }
+        };
+
+        match entry.get_password() {
+            Ok(_) | Err(keyring::Error::NoEntry) => true,
+            Err(keyring::Error::NoStorageAccess(e)) => {
+                log::warn!(
+                    "Keyring present but locked or access-denied; \
+                     secret writes may fail until it is unlocked: {e}"
+                );
                 true
             }
-            Err(_) => false,
+            Err(keyring::Error::PlatformFailure(e)) => {
+                log::warn!("Keyring platform unavailable; secrets disabled: {e}");
+                false
+            }
+            Err(e) => {
+                log::warn!("Keyring probe failed; secrets disabled: {e}");
+                false
+            }
         }
     }
 }

--- a/crates/dbflux_ipc/Cargo.toml
+++ b/crates/dbflux_ipc/Cargo.toml
@@ -16,4 +16,5 @@ dbflux_core.workspace = true
 uuid.workspace = true
 dirs.workspace = true
 serde_json.workspace = true
+secrecy = "0.10"
 async-trait = "0.1"

--- a/crates/dbflux_ipc/src/auth_provider_client.rs
+++ b/crates/dbflux_ipc/src/auth_provider_client.rs
@@ -332,7 +332,7 @@ impl RpcAuthProvider {
             self.secret_dependency_opt_in,
         );
 
-        let profile_json = serde_json::to_string(profile).map_err(|error| {
+        let profile_json = profile_to_wire_json(profile).map_err(|error| {
             FetchFieldOptionsError::Permanent(format!("could not serialize profile: {error}"))
         })?;
 
@@ -442,6 +442,31 @@ pub fn hash_dependencies(dependencies: &HashMap<String, String>) -> u64 {
     hasher.finish()
 }
 
+/// Serialize an auth profile for the IPC wire, re-merging secret-kind field
+/// values back into the flat `fields` map the external provider expects.
+///
+/// This is the single boundary where `AuthProfile::secret_fields` are exposed
+/// in plaintext. The derived `Serialize` skips that map, so without this merge
+/// an external provider would never receive the secret values it needs to
+/// authenticate. The output shape is identical to the legacy
+/// `serde_json::to_string(profile)` that kept secrets inline in `fields`.
+fn profile_to_wire_json(profile: &AuthProfile) -> Result<String, serde_json::Error> {
+    use secrecy::ExposeSecret;
+
+    let mut value = serde_json::to_value(profile)?;
+
+    if let Some(fields) = value.get_mut("fields").and_then(|f| f.as_object_mut()) {
+        for (key, secret) in &profile.secret_fields {
+            fields.insert(
+                key.clone(),
+                serde_json::Value::String(secret.expose_secret().to_string()),
+            );
+        }
+    }
+
+    serde_json::to_string(&value)
+}
+
 #[async_trait::async_trait]
 impl DynAuthProvider for RpcAuthProvider {
     fn provider_id(&self) -> &str {
@@ -461,7 +486,7 @@ impl DynAuthProvider for RpcAuthProvider {
     }
 
     async fn validate_session(&self, profile: &AuthProfile) -> Result<AuthSessionState, DbError> {
-        let profile_json = serde_json::to_string(profile)
+        let profile_json = profile_to_wire_json(profile)
             .map_err(|error| DbError::QueryFailed(error.to_string().into()))?;
 
         let responses = self.send_request(AuthProviderRequestBody::ValidateSession(
@@ -486,7 +511,7 @@ impl DynAuthProvider for RpcAuthProvider {
         profile: &AuthProfile,
         url_callback: UrlCallback,
     ) -> Result<AuthSession, DbError> {
-        let profile_json = serde_json::to_string(profile)
+        let profile_json = profile_to_wire_json(profile)
             .map_err(|error| DbError::QueryFailed(error.to_string().into()))?;
 
         let responses = self.send_request(AuthProviderRequestBody::Login(LoginRequest {
@@ -530,7 +555,7 @@ impl DynAuthProvider for RpcAuthProvider {
         &self,
         profile: &AuthProfile,
     ) -> Result<ResolvedCredentials, DbError> {
-        let profile_json = serde_json::to_string(profile)
+        let profile_json = profile_to_wire_json(profile)
             .map_err(|error| DbError::QueryFailed(error.to_string().into()))?;
 
         let responses = self.send_request(AuthProviderRequestBody::ResolveCredentials(

--- a/crates/dbflux_mcp_server/src/state.rs
+++ b/crates/dbflux_mcp_server/src/state.rs
@@ -277,6 +277,10 @@ fn load_auth_profiles(runtime: &StorageRuntime) -> Result<Vec<dbflux_core::AuthP
                 name: dto.name,
                 provider_id: dto.provider_id,
                 fields,
+                // Secret-kind fields live in the keyring, not in SQLite; the MCP
+                // server lists persisted profile metadata and does not hydrate
+                // them.
+                secret_fields: std::collections::HashMap::new(),
                 enabled: dto.enabled,
                 read_only: false,
                 dangling_origin: dto.dangling_origin,

--- a/crates/dbflux_storage/src/repositories/auth_profiles.rs
+++ b/crates/dbflux_storage/src/repositories/auth_profiles.rs
@@ -75,6 +75,46 @@ impl AuthProfileRepository {
         Ok(())
     }
 
+    /// Persists a profile's fields, splitting secret-kind fields from plaintext.
+    ///
+    /// Non-secret values in `fields` are written as `text` rows. For each entry
+    /// in `secret_refs` (field_key -> keyring reference) a `secret` row is
+    /// written that stores ONLY the keyring reference — the secret value itself
+    /// never touches SQLite. A key present in both maps is treated as a secret
+    /// (the text row is skipped) so the unique (profile, field_key) index can
+    /// never be violated.
+    pub fn set_fields_and_secrets(
+        &self,
+        id: &str,
+        fields: &HashMap<String, String>,
+        secret_refs: &HashMap<String, String>,
+    ) -> Result<(), StorageError> {
+        let repo = self.fields_repo();
+        repo.delete_for_profile(id)?;
+
+        for (key, value) in fields.iter() {
+            if secret_refs.contains_key(key) {
+                continue;
+            }
+
+            repo.insert(&AuthProfileFieldDto::new_text(
+                id.to_string(),
+                key.clone(),
+                value.clone(),
+            ))?;
+        }
+
+        for (key, secret_ref) in secret_refs.iter() {
+            repo.insert(&AuthProfileFieldDto::new_secret(
+                id.to_string(),
+                key.clone(),
+                secret_ref.clone(),
+            ))?;
+        }
+
+        Ok(())
+    }
+
     /// Fetches all auth profiles.
     pub fn all(&self) -> Result<Vec<AuthProfileDto>, StorageError> {
         let mut stmt = self
@@ -398,6 +438,71 @@ mod tests {
         let fetched = repo.all().expect("should fetch");
         assert_eq!(fetched.len(), 1);
         assert_eq!(fetched[0].name, "AWS SSO");
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+        let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+    }
+
+    #[test]
+    fn set_fields_and_secrets_keeps_secret_value_off_disk() {
+        let path = temp_db("auth_secret_split");
+        let _ = std::fs::remove_file(&path);
+
+        let conn = open_database(&path).expect("should open");
+        MigrationRegistry::new()
+            .run_all(&conn)
+            .expect("migration should run");
+
+        let dto = AuthProfileDto::new(Uuid::new_v4(), "Static".to_string(), "custom".to_string());
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let repo = AuthProfileRepository::new(Arc::new(conn));
+        repo.insert(&dto).expect("should insert");
+
+        let mut fields = HashMap::new();
+        fields.insert("region".to_string(), "us-east-1".to_string());
+
+        let mut secret_refs = HashMap::new();
+        secret_refs.insert(
+            "secret_access_key".to_string(),
+            format!("dbflux:auth:{}:secret_access_key", dto.id),
+        );
+
+        repo.set_fields_and_secrets(&dto.id, &fields, &secret_refs)
+            .expect("should persist split fields");
+
+        // get_fields returns only non-secret text fields.
+        let text_fields = repo.get_fields(&dto.id).expect("should read text fields");
+        assert_eq!(
+            text_fields.get("region").map(String::as_str),
+            Some("us-east-1")
+        );
+        assert!(
+            !text_fields.contains_key("secret_access_key"),
+            "secret field must not surface as a plaintext field"
+        );
+
+        // The raw rows prove the secret value never reached SQLite.
+        let rows = repo
+            .fields_repo()
+            .get_for_profile(&dto.id)
+            .expect("should read raw rows");
+
+        let secret_row = rows
+            .iter()
+            .find(|row| row.field_key == "secret_access_key")
+            .expect("secret marker row must exist");
+
+        assert_eq!(secret_row.value_kind, "secret");
+        assert!(
+            secret_row.value_text.is_none(),
+            "secret row must not store plaintext"
+        );
+        assert_eq!(
+            secret_row.value_secret_ref.as_deref(),
+            Some(format!("dbflux:auth:{}:secret_access_key", dto.id).as_str())
+        );
 
         let _ = std::fs::remove_file(&path);
         let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));

--- a/crates/dbflux_ui_base/src/sso_wizard.rs
+++ b/crates/dbflux_ui_base/src/sso_wizard.rs
@@ -150,6 +150,8 @@ impl SsoWizard {
                 name: profile_name,
                 provider_id: "aws-sso".to_string(),
                 fields,
+                // AWS SSO profiles carry only non-secret config; no key material.
+                secret_fields: std::collections::HashMap::new(),
                 enabled: true,
                 read_only: false,
                 dangling_origin: None,

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -11,6 +11,7 @@ use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::focus_frame;
 use dbflux_components::primitives::{Icon as FluxIcon, Label, Text};
 use dbflux_components::tokens::{Heights, Radii, Spacing};
+use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use dbflux_core::{
     AccessKind, AuthEditCapabilities, AuthEditSnapshot, AuthProfile, AuthSaveOutcome,
     DanglingMessage, FetchOptionsError, FetchOptionsRequest, FormFieldKind, RefreshTrigger,
@@ -205,6 +206,10 @@ fn build_auth_profile_from_form(
         name: trimmed_name.to_string(),
         provider_id: provider_id.to_string(),
         fields,
+        // Transient form profile used for live provider calls (validation,
+        // option fetching); secret values stay inline and are never persisted
+        // from here. The SQLite save path splits them out separately.
+        secret_fields: HashMap::new(),
         enabled,
         read_only: false,
         dangling_origin: None,
@@ -740,6 +745,9 @@ impl AuthProfilesSection {
             name: self.input_name.read(cx).value().to_string(),
             provider_id: provider_id_snap,
             fields: fields_snap,
+            // Transient snapshot for live option fetching: secrets stay inline
+            // and are sent to the provider verbatim; nothing here is persisted.
+            secret_fields: HashMap::new(),
             enabled: self.profile_enabled,
             read_only: false,
             dangling_origin: None,
@@ -1240,26 +1248,44 @@ impl AuthProfilesSection {
 
         self.rebuild_form_inputs(window, cx);
 
-        // Determine which field ids are WriteOnly so we never pre-fill them.
-        let write_only_fields: std::collections::HashSet<String> = self
-            .selected_provider(cx)
-            .map(|provider| {
-                provider
-                    .form_def()
-                    .tabs
-                    .iter()
-                    .flat_map(|tab| tab.sections.iter())
-                    .flat_map(|section| section.fields.iter())
-                    .filter(|field| field.kind == FormFieldKind::WriteOnly)
-                    .map(|field| field.id.clone())
-                    .collect()
-            })
-            .unwrap_or_default();
+        // Classify secret-kind fields. `WriteOnly` fields are never pre-filled;
+        // `Password` fields are pre-filled from the re-hydrated `secret_fields`
+        // so the user sees the stored value (masked) and can keep or change it.
+        let mut write_only_fields: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        let mut password_fields: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+
+        if let Some(provider) = self.selected_provider(cx) {
+            for field in provider
+                .form_def()
+                .tabs
+                .iter()
+                .flat_map(|tab| tab.sections.iter())
+                .flat_map(|section| section.fields.iter())
+            {
+                match field.kind {
+                    FormFieldKind::WriteOnly => {
+                        write_only_fields.insert(field.id.clone());
+                    }
+                    FormFieldKind::Password => {
+                        password_fields.insert(field.id.clone());
+                    }
+                    _ => {}
+                }
+            }
+        }
 
         for (field_id, input) in &self.form_inputs {
             // WriteOnly fields are always rendered empty (spec R9.4.1, S33).
             let value = if write_only_fields.contains(field_id) {
                 String::new()
+            } else if password_fields.contains(field_id) {
+                profile
+                    .secret_fields
+                    .get(field_id)
+                    .map(|secret| secret.expose_secret().to_string())
+                    .unwrap_or_default()
             } else {
                 profile.fields.get(field_id).cloned().unwrap_or_default()
             };
@@ -1330,17 +1356,68 @@ impl AuthProfilesSection {
         }
 
         let profile_id = self.editing_profile_id.unwrap_or_else(Uuid::new_v4);
-        let fields = self
-            .form_inputs
-            .iter()
-            .map(|(field_id, input)| (field_id.clone(), input.read(cx).value().to_string()))
-            .collect::<HashMap<_, _>>();
+
+        // Secret-kind fields (Password / WriteOnly) are split out of `fields`
+        // into `secret_fields` so they are routed to the keyring and never
+        // persisted as plaintext.
+        let secret_field_ids: HashSet<String> = self
+            .selected_provider(cx)
+            .map(|provider| {
+                provider
+                    .form_def()
+                    .tabs
+                    .iter()
+                    .flat_map(|tab| tab.sections.iter())
+                    .flat_map(|section| section.fields.iter())
+                    .filter(|field| {
+                        matches!(
+                            field.kind,
+                            FormFieldKind::Password | FormFieldKind::WriteOnly
+                        )
+                    })
+                    .map(|field| field.id.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Secrets already stored for the profile being edited, used to preserve
+        // a WriteOnly value the user intentionally left blank (spec R9.4.2).
+        let existing_secrets: HashMap<String, SecretString> = self
+            .editing_profile_id
+            .and_then(|id| {
+                self.app_state
+                    .read(cx)
+                    .stored_auth_profile_secret_fields(id)
+            })
+            .unwrap_or_default();
+
+        let mut fields: HashMap<String, String> = HashMap::new();
+        let mut secret_fields: HashMap<String, SecretString> = HashMap::new();
+
+        for (field_id, input) in &self.form_inputs {
+            let value = input.read(cx).value().to_string();
+
+            if !secret_field_ids.contains(field_id) {
+                fields.insert(field_id.clone(), value);
+                continue;
+            }
+
+            if value.is_empty() {
+                // Blank secret input: keep the existing stored secret, if any.
+                if let Some(existing) = existing_secrets.get(field_id) {
+                    secret_fields.insert(field_id.clone(), existing.clone());
+                }
+            } else {
+                secret_fields.insert(field_id.clone(), SecretString::from(value));
+            }
+        }
 
         let profile = AuthProfile {
             id: profile_id,
             name,
             provider_id,
             fields,
+            secret_fields,
             enabled: self.profile_enabled,
             read_only: false,
             dangling_origin: None,
@@ -1477,6 +1554,9 @@ impl AuthProfilesSection {
             name: name.clone(),
             provider_id: provider_id.clone(),
             fields: raw_fields,
+            // File-backed save path: secrets transit inline to save_edit (which
+            // writes them to the external config file), never to DBFlux storage.
+            secret_fields: HashMap::new(),
             enabled: self.profile_enabled,
             read_only: false,
             dangling_origin: None,

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -1476,25 +1476,27 @@ impl AuthProfilesSection {
         }
 
         let is_edit = self.editing_profile_id.is_some();
-        self.app_state.update(cx, |state, cx| {
-            if is_edit {
-                state.update_auth_profile(profile.clone());
+        let secrets_persisted = self.app_state.update(cx, |state, cx| {
+            let persisted = if is_edit {
+                state.update_auth_profile(profile.clone())
             } else {
-                state.add_auth_profile(profile.clone());
-            }
+                state.add_auth_profile(profile.clone())
+            };
 
             cx.emit(AppStateChanged);
+            persisted
         });
 
         // The profile row is saved, but secret-kind fields live in the OS
-        // keyring. If it is unavailable the secret could not be persisted and
-        // will be gone after restart — tell the user instead of failing silently.
-        if has_secret_fields && !self.app_state.read(cx).secret_store_available() {
+        // keyring. Drive this off the actual write result (not a cached
+        // availability probe): a locked keyring reports available yet rejects
+        // writes, so only the real outcome tells us the secret was lost.
+        if has_secret_fields && !secrets_persisted {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    "Keyring unavailable: the profile's secret was not stored and \
-                     will not persist after restart.",
+                    "The profile's secret could not be stored (the OS keyring may \
+                     be locked or unavailable) and will not persist after restart.",
                 ),
                 cx,
             );

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -17,6 +17,7 @@ use dbflux_core::{
     DanglingMessage, FetchOptionsError, FetchOptionsRequest, FormFieldKind, RefreshTrigger,
 };
 use dbflux_ui_base::keymap::key_chord_from_gpui;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use dbflux_ui_base::{AppStateChanged, AppStateEntity};
 use gpui::prelude::*;
 use gpui::*;
@@ -1412,6 +1413,8 @@ impl AuthProfilesSection {
             }
         }
 
+        let has_secret_fields = !secret_fields.is_empty();
+
         let profile = AuthProfile {
             id: profile_id,
             name,
@@ -1482,6 +1485,20 @@ impl AuthProfilesSection {
 
             cx.emit(AppStateChanged);
         });
+
+        // The profile row is saved, but secret-kind fields live in the OS
+        // keyring. If it is unavailable the secret could not be persisted and
+        // will be gone after restart — tell the user instead of failing silently.
+        if has_secret_fields && !self.app_state.read(cx).secret_store_available() {
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    "Keyring unavailable: the profile's secret was not stored and \
+                     will not persist after restart.",
+                ),
+                cx,
+            );
+        }
 
         if let Some(provider) = self
             .app_state


### PR DESCRIPTION
## Summary

- Auth profile secret-kind fields (`Password` / `WriteOnly`) now live in memory as `SecretString`, persist to the OS keyring, and never reach SQLite or logs in plaintext.
- Hardens keyring availability detection (locked vs absent) and surfaces secret-store write failures instead of dropping secrets silently.
- Closes the v0.6 security audit items AUTH-1 through AUTH-5; AUTH-6 is intentionally left as-is.

## What does this resolve?

There is no tracking issue for these: the audit items live as draft cards in the v0.6 Audit project (Project 5), per the agreed workflow of iterating on them directly. This PR resolves:

- **AUTH-1** — `AuthProfile` persisted every field (including secrets for non-file-backed RPC providers) as plaintext in `cfg_auth_profile_fields`.
- **AUTH-2** — the derived `Debug` dumped secret values into logs.
- **AUTH-3** — keyring availability could not tell a locked keyring from an absent one, so a locked login keyring silently downgraded to the no-op store.
- **AUTH-4** — secret writes to an unavailable store were discarded with no trace.
- **AUTH-5** — the AWS file-backed write path held credentials as a plain `String`.
- **AUTH-6** (SSO verification URL in DEBUG logs) is intentionally kept. The trace is useful for diagnosing the UI bug where the URL is unreachable, so removing it would remove the only evidence.

## How was this solved?

Secrets are split out of the flat `fields` map into a new `AuthProfile.secret_fields: HashMap<String, SecretString>` that is `#[serde(skip)]`, so serialization can never emit them and a custom `Debug` prints only the field names. They are persisted to the OS keyring under per-field references (`dbflux:auth:{profile_id}:{field_id}`); SQLite keeps only a `value_secret_ref` marker row, never the value. The single place secrets are exposed is the auth-provider IPC boundary (`profile_to_wire_json`), which re-merges them into the flat map the external provider expects.

At load the keyring values are re-hydrated, and any profile saved before this change is migrated out of plaintext SQLite into the keyring on first launch (`hydrate_and_migrate_auth_secrets`, driven by the provider form definition so the UI stays driver-agnostic).

For the hardening commit: keyring `check_availability` now classifies the probe (`NoEntry`/`Ok` and `NoStorageAccess` are available so a locked keyring is not lost; `PlatformFailure` is unavailable), `SecretManager` warns on every skipped write, the auth editor shows a toast when the keyring is unavailable, and the AWS write path carries credentials as `SecretString` up to the `~/.aws/credentials` write.

One honest limitation: the AWS shared-credentials sink is the plaintext `~/.aws/credentials` file the SDK reads, so the `SecretString` there is defense-in-depth for in-memory copies, not end-to-end encryption.

## Validation

- `cargo check --workspace --all-targets` and `cargo check -p dbflux_app --all-targets --features aws`: clean.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace -- -D warnings`: no findings in the changed files (remaining warnings are pre-existing, in unrelated test modules).
- `cargo nextest run` across core/storage/ipc/app/aws/ui: 1269 passing, including new tests (serialized profile omits the secret value, `Debug` redacts it, secret rows persist with `value_text` NULL).
- Not automatable here: the real keyring round-trip (tests use `NoopSecretStore`). Manual check: create a profile with a secret on an RPC provider, restart, confirm the Password field re-fills and the SQLite `value_text` for the secret is NULL.
- Pre-existing unrelated failure: `hook_executor::composite_executor_routes_mixed_hook_types` fails on base `main` too (needs the `lua` feature); not touched by this PR.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (code-level; full keyring round-trip needs an RPC auth provider with a secret field)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I applied the appropriate labels

## Labels to apply

`storage:bug`, `aws`, `rpc:auth`
