### PR TITLE
fix(query-builder): show and execute structured mutation values

### DIFF
--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -135,9 +135,9 @@ pub use query::{
     VisualAggregateSpec, VisualMutationSpec, VisualQuerySpec, VisualSortDirection,
     classify_query_for_governance, classify_query_for_language, classify_sql_execution,
     classify_visual_mutation, contains_time_macros, detect_dangerous_query, detect_dangerous_sql,
-    infer_column_kind, is_safe_read_query, lower_keyset_predicate, parse_semantic_filter_json,
-    project_aggregate_kinds, render_filter_node_sql, render_semantic_filter_sql,
-    strip_leading_comments, substitute_time_macros,
+    infer_column_kind, inline_params, is_safe_read_query, lower_keyset_predicate,
+    parse_semantic_filter_json, project_aggregate_kinds, render_filter_node_sql,
+    render_semantic_filter_sql, strip_leading_comments, substitute_time_macros,
 };
 
 pub use query::relational_filter::{

--- a/crates/dbflux_core/src/query/generator.rs
+++ b/crates/dbflux_core/src/query/generator.rs
@@ -66,21 +66,24 @@ impl SelectQuery {
     /// - `$N` placeholders (PostgreSQL): each `$N` is replaced by `params[N-1]`.
     /// - `@pN` placeholders (SQL Server): each `@pN` is replaced by `params[N-1]`.
     pub fn materialize_for_editor(&self, dialect: &dyn crate::sql::dialect::SqlDialect) -> String {
-        materialize_placeholders(&self.sql, &self.params, dialect)
+        inline_params(&self.sql, &self.params, dialect)
     }
 }
 
 /// Replace every parameter placeholder in `sql` with its dialect-quoted literal.
 ///
-/// Shared by `SelectQuery::materialize_for_editor` and
-/// `GeneratedMutation::materialize_for_editor`. The result is for display only
-/// (read-only editor tabs, builder preview, confirmation dialogs) — it is NOT
-/// suitable for execution. The substitution respects the dialect's placeholder
-/// style:
+/// This is both the display path (read-only editor tabs, builder preview,
+/// confirmation dialogs) and the execution path for the visual query builder:
+/// drivers in this codebase execute `QueryRequest.sql` verbatim and do not bind
+/// `QueryRequest.params`, so structured mutations/selects must inline their
+/// values before dispatch. The dialect's `value_to_literal` performs the
+/// quoting/escaping, mirroring how every other mutation path executes.
+///
+/// The substitution respects the dialect's placeholder style:
 /// - `?` placeholders (SQLite/MySQL): replaced left-to-right.
 /// - `$N` placeholders (PostgreSQL): each `$N` is replaced by `params[N-1]`.
 /// - `@pN` placeholders (SQL Server): each `@pN` is replaced by `params[N-1]`.
-fn materialize_placeholders(
+pub fn inline_params(
     sql: &str,
     params: &[crate::Value],
     dialect: &dyn crate::sql::dialect::SqlDialect,
@@ -273,7 +276,7 @@ impl GeneratedMutation {
     /// use `sql` + `params` so values stay bound. See
     /// [`SelectQuery::materialize_for_editor`] for the SELECT counterpart.
     pub fn materialize_for_editor(&self, dialect: &dyn crate::sql::dialect::SqlDialect) -> String {
-        materialize_placeholders(&self.sql, &self.params, dialect)
+        inline_params(&self.sql, &self.params, dialect)
     }
 }
 

--- a/crates/dbflux_core/src/query/generator.rs
+++ b/crates/dbflux_core/src/query/generator.rs
@@ -66,41 +66,57 @@ impl SelectQuery {
     /// - `$N` placeholders (PostgreSQL): each `$N` is replaced by `params[N-1]`.
     /// - `@pN` placeholders (SQL Server): each `@pN` is replaced by `params[N-1]`.
     pub fn materialize_for_editor(&self, dialect: &dyn crate::sql::dialect::SqlDialect) -> String {
-        use crate::sql::dialect::PlaceholderStyle;
+        materialize_placeholders(&self.sql, &self.params, dialect)
+    }
+}
 
-        let style = dialect.placeholder_style();
+/// Replace every parameter placeholder in `sql` with its dialect-quoted literal.
+///
+/// Shared by `SelectQuery::materialize_for_editor` and
+/// `GeneratedMutation::materialize_for_editor`. The result is for display only
+/// (read-only editor tabs, builder preview, confirmation dialogs) — it is NOT
+/// suitable for execution. The substitution respects the dialect's placeholder
+/// style:
+/// - `?` placeholders (SQLite/MySQL): replaced left-to-right.
+/// - `$N` placeholders (PostgreSQL): each `$N` is replaced by `params[N-1]`.
+/// - `@pN` placeholders (SQL Server): each `@pN` is replaced by `params[N-1]`.
+fn materialize_placeholders(
+    sql: &str,
+    params: &[crate::Value],
+    dialect: &dyn crate::sql::dialect::SqlDialect,
+) -> String {
+    use crate::sql::dialect::PlaceholderStyle;
 
-        match style {
-            PlaceholderStyle::QuestionMark | PlaceholderStyle::NamedColon => {
-                let mut result = String::with_capacity(self.sql.len());
-                let mut param_iter = self.params.iter();
-                let chars: Vec<char> = self.sql.chars().collect();
-                let mut i = 0;
+    match dialect.placeholder_style() {
+        PlaceholderStyle::QuestionMark | PlaceholderStyle::NamedColon => {
+            let mut result = String::with_capacity(sql.len());
+            let mut param_iter = params.iter();
+            let chars: Vec<char> = sql.chars().collect();
+            let mut i = 0;
 
-                while i < chars.len() {
-                    if chars[i] == '?' {
-                        if let Some(val) = param_iter.next() {
-                            result.push_str(&dialect.value_to_literal(val));
-                        } else {
-                            result.push('?');
-                        }
-                        i += 1;
+            while i < chars.len() {
+                if chars[i] == '?' {
+                    if let Some(val) = param_iter.next() {
+                        result.push_str(&dialect.value_to_literal(val));
                     } else {
-                        result.push(chars[i]);
-                        i += 1;
+                        result.push('?');
                     }
+                    i += 1;
+                } else {
+                    result.push(chars[i]);
+                    i += 1;
                 }
-
-                result
             }
 
-            PlaceholderStyle::DollarNumber => {
-                materialize_numbered_placeholders(&self.sql, &self.params, dialect, '$', "")
-            }
+            result
+        }
 
-            PlaceholderStyle::AtSign => {
-                materialize_numbered_placeholders(&self.sql, &self.params, dialect, '@', "p")
-            }
+        PlaceholderStyle::DollarNumber => {
+            materialize_numbered_placeholders(sql, params, dialect, '$', "")
+        }
+
+        PlaceholderStyle::AtSign => {
+            materialize_numbered_placeholders(sql, params, dialect, '@', "p")
         }
     }
 }
@@ -246,6 +262,19 @@ pub struct GeneratedMutation {
     pub params: Vec<crate::Value>,
     /// True when at least one assignment used `AssignmentValue::Expression`.
     pub used_raw_expression: bool,
+}
+
+impl GeneratedMutation {
+    /// Produces a human-readable SQL string with all parameter placeholders
+    /// replaced by their dialect-quoted literal values.
+    ///
+    /// Intended for display in the visual builder preview and the mutation
+    /// confirmation dialog. It is NOT suitable for execution — execution must
+    /// use `sql` + `params` so values stay bound. See
+    /// [`SelectQuery::materialize_for_editor`] for the SELECT counterpart.
+    pub fn materialize_for_editor(&self, dialect: &dyn crate::sql::dialect::SqlDialect) -> String {
+        materialize_placeholders(&self.sql, &self.params, dialect)
+    }
 }
 
 pub trait QueryGenerator: Send + Sync {
@@ -2051,6 +2080,19 @@ mod tests {
         assert_eq!(
             q.materialize_for_editor(&DIALECT),
             "SELECT * FROM t WHERE id = 42"
+        );
+    }
+
+    #[test]
+    fn mutation_materialize_inlines_set_and_where_literals() {
+        let m = super::GeneratedMutation {
+            sql: "UPDATE t\nSET x = ?\nWHERE id = ?".to_string(),
+            params: vec![Value::Text("1".to_string()), Value::Int(7)],
+            used_raw_expression: false,
+        };
+        assert_eq!(
+            m.materialize_for_editor(&DIALECT),
+            "UPDATE t\nSET x = '1'\nWHERE id = 7"
         );
     }
 

--- a/crates/dbflux_core/src/query/mod.rs
+++ b/crates/dbflux_core/src/query/mod.rs
@@ -15,7 +15,7 @@ pub use column_kind::{infer_column_kind, project_aggregate_kinds};
 pub use generator::{
     CollectionTemplateRequest, GeneratedMutation, GeneratedQuery, GeneratorError, MutationCategory,
     MutationTemplateOperation, MutationTemplateRequest, QueryGenError, QueryGenerator,
-    ReadTemplateOperation, ReadTemplateRequest, SelectQuery, SqlMutationGenerator,
+    ReadTemplateOperation, ReadTemplateRequest, SelectQuery, SqlMutationGenerator, inline_params,
     render_filter_node_sql,
 };
 pub use keyset::lower_keyset_predicate;

--- a/crates/dbflux_core/src/query/visual_query.rs
+++ b/crates/dbflux_core/src/query/visual_query.rs
@@ -430,6 +430,38 @@ pub enum ScalarLiteral {
     Null,
 }
 
+impl ScalarLiteral {
+    /// Interprets raw user input as a scalar literal of the target column's kind.
+    ///
+    /// The visual builder captures every SET value as free text. Binding that
+    /// text to a typed column (e.g. an `Integer`) as a string literal relies on
+    /// the database's implicit coercion and is fragile across dialects, so the
+    /// value is promoted to the column's `ColumnKind` when the text parses
+    /// cleanly. Anything that does not parse — or a `Text`/`Timestamp`/`Unknown`
+    /// column — stays `Text`, which preserves values that must not be reshaped
+    /// (a zero-padded code like `"007"` in a text column, for instance).
+    pub fn from_input_for_kind(text: &str, kind: crate::ColumnKind) -> Self {
+        use crate::ColumnKind;
+
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return ScalarLiteral::Text(text.to_string());
+        }
+
+        match kind {
+            ColumnKind::Integer => trimmed
+                .parse::<i64>()
+                .map(ScalarLiteral::Integer)
+                .unwrap_or_else(|_| ScalarLiteral::Text(text.to_string())),
+            ColumnKind::Float => trimmed
+                .parse::<f64>()
+                .map(ScalarLiteral::Float)
+                .unwrap_or_else(|_| ScalarLiteral::Text(text.to_string())),
+            _ => ScalarLiteral::Text(text.to_string()),
+        }
+    }
+}
+
 /// The value to assign to a column in an UPDATE SET clause.
 ///
 /// `Expression` is an explicit escape hatch that embeds raw SQL text inline
@@ -650,6 +682,48 @@ mod tests {
 
     fn make_group(op: BoolOp, children: Vec<FilterNode>) -> FilterNode {
         FilterNode::Group { op, children }
+    }
+
+    // --- ScalarLiteral::from_input_for_kind ---
+
+    #[test]
+    fn from_input_promotes_integer_when_parseable() {
+        assert_eq!(
+            ScalarLiteral::from_input_for_kind("12", crate::ColumnKind::Integer),
+            ScalarLiteral::Integer(12)
+        );
+    }
+
+    #[test]
+    fn from_input_keeps_text_when_integer_does_not_parse() {
+        assert_eq!(
+            ScalarLiteral::from_input_for_kind("12abc", crate::ColumnKind::Integer),
+            ScalarLiteral::Text("12abc".to_string())
+        );
+    }
+
+    #[test]
+    fn from_input_promotes_float() {
+        assert_eq!(
+            ScalarLiteral::from_input_for_kind("3.5", crate::ColumnKind::Float),
+            ScalarLiteral::Float(3.5)
+        );
+    }
+
+    #[test]
+    fn from_input_text_column_preserves_zero_padded_value() {
+        assert_eq!(
+            ScalarLiteral::from_input_for_kind("007", crate::ColumnKind::Text),
+            ScalarLiteral::Text("007".to_string())
+        );
+    }
+
+    #[test]
+    fn from_input_empty_stays_text() {
+        assert_eq!(
+            ScalarLiteral::from_input_for_kind("", crate::ColumnKind::Integer),
+            ScalarLiteral::Text(String::new())
+        );
     }
 
     // --- FilterNode::depth ---

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -2697,7 +2697,7 @@ impl DataGridPanel {
                 Box::new(move |spec: &VisualQuerySpec| {
                     conn.query_generator()
                         .and_then(|qgen| qgen.generate_select(spec).ok().flatten())
-                        .map(|q| q.sql)
+                        .map(|q| q.materialize_for_editor(conn.dialect()))
                         .unwrap_or_default()
                 })
             } else {
@@ -2711,14 +2711,13 @@ impl DataGridPanel {
                 conn.query_generator()
                     .and_then(|qgen| {
                         use dbflux_core::MutationKind;
-                        match &spec.kind {
-                            MutationKind::Delete => {
-                                qgen.generate_delete_from_spec(spec).ok().map(|m| m.sql)
-                            }
+                        let generated = match &spec.kind {
+                            MutationKind::Delete => qgen.generate_delete_from_spec(spec).ok(),
                             MutationKind::Update { .. } => {
-                                qgen.generate_update_from_spec(spec).ok().map(|m| m.sql)
+                                qgen.generate_update_from_spec(spec).ok()
                             }
-                        }
+                        };
+                        generated.map(|m| m.materialize_for_editor(conn.dialect()))
                     })
                     .unwrap_or_default()
             })
@@ -3468,19 +3467,17 @@ impl DataGridPanel {
 
             let policy = connected.mutation_policy;
 
+            let dialect = connected.connection.dialect();
             let sql_preview = connected
                 .connection
                 .query_generator()
                 .and_then(|qgen| {
                     use dbflux_core::MutationKind;
-                    match &spec.kind {
-                        MutationKind::Delete => {
-                            qgen.generate_delete_from_spec(&spec).ok().map(|m| m.sql)
-                        }
-                        MutationKind::Update { .. } => {
-                            qgen.generate_update_from_spec(&spec).ok().map(|m| m.sql)
-                        }
-                    }
+                    let generated = match &spec.kind {
+                        MutationKind::Delete => qgen.generate_delete_from_spec(&spec).ok(),
+                        MutationKind::Update { .. } => qgen.generate_update_from_spec(&spec).ok(),
+                    };
+                    generated.map(|m| m.materialize_for_editor(dialect))
                 })
                 .unwrap_or_else(|| "<SQL preview unavailable>".to_string());
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -2728,12 +2728,20 @@ impl DataGridPanel {
         let available_columns: Vec<String> =
             self.result.columns.iter().map(|c| c.name.clone()).collect();
 
+        let column_kinds: std::collections::HashMap<String, dbflux_core::ColumnKind> = self
+            .result
+            .columns
+            .iter()
+            .map(|c| (c.name.clone(), c.kind))
+            .collect();
+
         let panel = if let Some(existing) = &self.builder_panel {
             existing.update(cx, |p, cx| {
                 if let Some(spec) = initial_spec.clone() {
                     p.set_spec(spec, cx);
                 }
                 p.available_columns = available_columns.clone();
+                p.column_kinds = column_kinds.clone();
             });
             existing.clone()
         } else {
@@ -2750,6 +2758,10 @@ impl DataGridPanel {
                     window,
                     cx,
                 )
+            });
+
+            new_panel.update(cx, |p, _| {
+                p.column_kinds = column_kinds;
             });
 
             let run_sub = cx.subscribe_in(

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -3458,32 +3458,14 @@ impl DataGridPanel {
             _ => return,
         };
 
-        let (policy, sql_preview, connection) = {
+        let (policy, connection) = {
             let state = self.app_state.read(cx);
             let connected = match state.connections().get(&profile_id) {
                 Some(c) => c,
                 None => return,
             };
 
-            let policy = connected.mutation_policy;
-
-            let dialect = connected.connection.dialect();
-            let sql_preview = connected
-                .connection
-                .query_generator()
-                .and_then(|qgen| {
-                    use dbflux_core::MutationKind;
-                    let generated = match &spec.kind {
-                        MutationKind::Delete => qgen.generate_delete_from_spec(&spec).ok(),
-                        MutationKind::Update { .. } => qgen.generate_update_from_spec(&spec).ok(),
-                    };
-                    generated.map(|m| m.materialize_for_editor(dialect))
-                })
-                .unwrap_or_else(|| "<SQL preview unavailable>".to_string());
-
-            let connection = Arc::clone(&connected.connection);
-
-            (policy, sql_preview, connection)
+            (connected.mutation_policy, Arc::clone(&connected.connection))
         };
 
         // Gate on mutation policy — state borrow has been released above.
@@ -3536,6 +3518,18 @@ impl DataGridPanel {
             }
             MutationPolicy::Allowed => {}
         }
+
+        let sql_preview = connection
+            .query_generator()
+            .and_then(|qgen| {
+                use dbflux_core::MutationKind;
+                let generated = match &spec.kind {
+                    MutationKind::Delete => qgen.generate_delete_from_spec(&spec).ok(),
+                    MutationKind::Update { .. } => qgen.generate_update_from_spec(&spec).ok(),
+                };
+                generated.map(|m| m.materialize_for_editor(connection.dialect()))
+            })
+            .unwrap_or_else(|| "<SQL preview unavailable>".to_string());
 
         // Fetch sample rows synchronously on background thread (2s deadline).
         let (sample_columns, sample_rows) =

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutation_executor.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutation_executor.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use dbflux_core::{
     Connection, DriverCapabilities, EventCategory, EventOutcome, EventRecord, EventSeverity,
     EventSink, MutationKind, MutationPolicy, QueryRequest, TransactionVocab, Value,
-    VisualMutationSpec, render_filter_node_sql,
+    VisualMutationSpec, inline_params, render_filter_node_sql,
 };
 
 /// Execution modes for visual bulk mutations.
@@ -447,8 +447,12 @@ impl MutationExecutor {
             }
         }
 
-        let mut dml_req = QueryRequest::new(generated.sql.clone());
-        dml_req.params = generated.params.clone();
+        let dml_sql = inline_params(
+            &generated.sql,
+            &generated.params,
+            self.deps.connection.dialect(),
+        );
+        let dml_req = QueryRequest::new(dml_sql);
         let dml_result = self.deps.connection.execute(&dml_req);
 
         match dml_result {
@@ -578,8 +582,12 @@ impl MutationExecutor {
             false
         };
 
-        let mut dml_req = QueryRequest::new(generated.sql.clone());
-        dml_req.params = generated.params.clone();
+        let dml_sql = inline_params(
+            &generated.sql,
+            &generated.params,
+            self.deps.connection.dialect(),
+        );
+        let dml_req = QueryRequest::new(dml_sql);
 
         match self.deps.connection.execute(&dml_req) {
             Err(e) => {
@@ -802,8 +810,7 @@ impl MutationExecutor {
                 )
             };
 
-            let mut select_req = QueryRequest::new(select_sql);
-            select_req.params = select_params;
+            let select_req = QueryRequest::new(inline_params(&select_sql, &select_params, dialect));
 
             let pk_rows = match self.deps.connection.execute(&select_req) {
                 Ok(r) => r.rows,
@@ -898,8 +905,8 @@ impl MutationExecutor {
                 }
             }
 
-            let mut dml_req = QueryRequest::new(generated.sql);
-            dml_req.params = generated.params;
+            let dml_req =
+                QueryRequest::new(inline_params(&generated.sql, &generated.params, dialect));
             let dml_result = self.deps.connection.execute(&dml_req);
 
             match dml_result {
@@ -1285,7 +1292,7 @@ mod tests {
                 spec: &VisualMutationSpec,
             ) -> Result<GeneratedMutation, dbflux_core::GeneratorError> {
                 Ok(GeneratedMutation {
-                    sql: format!("UPDATE {} SET col = $1", spec.from.name),
+                    sql: format!("UPDATE {} SET col = ?", spec.from.name),
                     params: vec![dbflux_core::Value::Int(1)],
                     used_raw_expression: false,
                 })
@@ -1330,6 +1337,34 @@ mod tests {
                 event_sink,
                 policy: MutationPolicy::Allowed,
             }
+        }
+
+        // Regression: drivers do not bind QueryRequest.params, so the executor
+        // must inline parameter values into the SQL before dispatch. The DML the
+        // connection receives must carry the literal, not a `?` placeholder.
+        #[test]
+        fn single_tx_inlines_params_into_dml_sql() {
+            let conn = RecordingConnection::new(DbKind::Postgres, 1);
+            let conn_ref = Arc::clone(&conn);
+            let spec = make_update_spec("products");
+            let opts = MutationExecOptions::single_transaction();
+            let deps = make_deps(conn, None);
+            let executor = MutationExecutor::new(spec, opts, deps);
+
+            let result = executor.run_single_tx(&no_cancel());
+            assert!(result.is_ok(), "expected success, got: {:?}", result);
+
+            let calls = conn_ref.calls.lock().unwrap().clone();
+            let dml = calls
+                .iter()
+                .find(|s| s.starts_with("UPDATE"))
+                .expect("a DML statement must have been executed");
+
+            assert_eq!(dml, "UPDATE products SET col = 1");
+            assert!(
+                !dml.contains('?'),
+                "DML must not contain an unbound placeholder: {dml}"
+            );
         }
 
         // G-1: parent event emitted at run start with outcome Pending

--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -333,6 +333,13 @@ pub struct QueryBuilderPanel {
     /// once at panel construction from the data grid's current result.
     pub(crate) available_columns: Vec<String>,
 
+    /// Semantic kind of each source column, keyed by column name. Used to
+    /// promote free-text SET values to a typed `ScalarLiteral` (e.g. integer)
+    /// when building the mutation spec, so a numeric column is not assigned a
+    /// string literal. Empty when no type information is available, in which
+    /// case values stay textual.
+    pub(crate) column_kinds: std::collections::HashMap<String, dbflux_core::ColumnKind>,
+
     /// Shared schema cache for completion providers.
     ///
     /// `source_columns` is populated at panel construction. `joined_columns`
@@ -710,6 +717,7 @@ impl QueryBuilderPanel {
             join_cond_right_inputs: HashMap::new(),
             join_cond_op_dropdowns: HashMap::new(),
             available_columns,
+            column_kinds: std::collections::HashMap::new(),
             schema_cache,
             app_state_weak,
             schema_profile_id: profile_id,
@@ -3047,7 +3055,7 @@ impl QueryBuilderPanel {
                     .assignments
                     .iter()
                     .filter(|r| !r.assignment.column.is_empty())
-                    .map(|r| r.assignment.clone())
+                    .map(|r| self.typed_assignment(r))
                     .collect();
                 MutationKind::Update { assignments }
             }
@@ -3060,6 +3068,28 @@ impl QueryBuilderPanel {
         };
 
         Some((spec, state.exec_options.clone()))
+    }
+
+    /// Clones an assignment row into its spec `Assignment`, promoting a free-text
+    /// literal to the target column's typed `ScalarLiteral` when the column kind
+    /// is known. Non-literal values (Expression / Null / Default) and columns
+    /// with unknown kind are left untouched.
+    fn typed_assignment(
+        &self,
+        row: &crate::query_builder::mutation_state::AssignmentRow,
+    ) -> dbflux_core::Assignment {
+        use dbflux_core::{AssignmentValue, ScalarLiteral};
+
+        let mut assignment = row.assignment.clone();
+
+        if let AssignmentValue::Literal(ScalarLiteral::Text(_)) = &assignment.value
+            && let Some(kind) = self.column_kinds.get(&assignment.column)
+        {
+            assignment.value =
+                AssignmentValue::Literal(ScalarLiteral::from_input_for_kind(&row.raw_text, *kind));
+        }
+
+        assignment
     }
 
     // -----------------------------------------------------------------------
@@ -3684,6 +3714,7 @@ mod tests {
             join_cond_right_inputs: HashMap::new(),
             join_cond_op_dropdowns: HashMap::new(),
             available_columns: Vec::new(),
+            column_kinds: std::collections::HashMap::new(),
             schema_cache: Rc::new(RefCell::new(SchemaCache::default())),
             app_state_weak: WeakEntity::new_invalid(),
             schema_profile_id: Uuid::nil(),
@@ -5311,6 +5342,49 @@ mod tests {
             first.assignment.value,
             AssignmentValue::Literal(ScalarLiteral::Text("alice@example.com".to_string())),
         );
+    }
+
+    #[test]
+    fn build_mutation_spec_promotes_text_to_integer_for_integer_column() {
+        use crate::query_builder::mutation_state::{AssignmentRow, BuilderMode};
+        use dbflux_core::{Assignment, AssignmentValue, ColumnKind, MutationKind, ScalarLiteral};
+
+        let mut panel = make_panel(make_spec(test_source()));
+        panel
+            .column_kinds
+            .insert("id".to_string(), ColumnKind::Integer);
+        panel.t_switch_builder_mode(BuilderMode::Update);
+
+        panel
+            .mutation_state
+            .as_mut()
+            .unwrap()
+            .assignments
+            .push(AssignmentRow {
+                assignment: Assignment {
+                    column: String::new(),
+                    value: AssignmentValue::Literal(ScalarLiteral::Text(String::new())),
+                },
+                raw_text: String::new(),
+            });
+
+        panel.t_set_assignment_column(0, "id".to_string());
+        panel.t_set_assignment_raw_text(0, "12".to_string());
+
+        let (spec, _opts) = panel
+            .build_mutation_spec_and_opts()
+            .expect("update spec must build");
+
+        match spec.kind {
+            MutationKind::Update { assignments } => {
+                assert_eq!(
+                    assignments[0].value,
+                    AssignmentValue::Literal(ScalarLiteral::Integer(12)),
+                    "an integer column must receive a typed integer literal, not a string"
+                );
+            }
+            other => panic!("expected Update, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes the visual query builder mutations end to end: the SQL preview now shows real values, and UPDATE/DELETE actually execute and apply them.

## The bug

Builder UPDATE/DELETE never executed. The builder generated parameterized SQL (`SET x = ?`) plus a separate `params` vec and relied on the driver binding `QueryRequest.params`. No driver in this codebase binds those params, they all run `req.sql` verbatim, so any builder mutation with a SET literal or a WHERE value failed with `Wrong number of parameters passed to query. Got 0, needed N`. Verified against the real SQLite driver.

Every other mutation path already inlines values via `dialect.value_to_literal` (for example inline cell edit). The builder was the only path assuming a binding mechanism that does not exist here. The preview had the same root symptom: it rendered the raw `?` SQL, so values never showed.

## The fix

1. Preview: materialize parameters for display in all three preview sites (builder SELECT, builder mutation, confirmation dialog), so you see `SET x = 1` instead of `SET x = ?`.
2. Execution: inline params into the SQL before dispatch at every executor site (single-transaction, direct autocommit, chunked DML, chunked keyset SELECT), via a shared public `dbflux_core::inline_params` helper that also backs the preview. Requests now go out with no params.
3. Typing: promote free-text SET values to the target column's typed `ScalarLiteral` using its `ColumnKind`, so an integer column receives `12`, not the string `'12'`. Values that do not parse, or non-numeric columns, stay textual to preserve inputs like a zero-padded `007`.

Inlining is safe here because `value_to_literal` does the quoting and escaping, same as the rest of the codebase. The dangerous-query gate is unaffected (it classifies the spec, not the SQL string).

## Verification

End to end against the real SQLite driver: generator then `inline_params` then execute produces `UPDATE "obs" SET "n" = 42` and the row updates to 42.

Unit coverage added: `inline_params` on a mutation, `ScalarLiteral::from_input_for_kind` typing (including the `007` preservation case), the executor inlining the DML literal (no `?` reaches the connection), and the panel promoting a text value to a typed integer literal. Local run: core 898 + ui_document 529 tests pass, clippy clean, `cargo check --workspace` green.

## Out of scope

The builder "Counting rows..." preview uses a separate count path not touched here. Its filtered variant likely has the same params issue and deserves a follow-up.
