### PR TITLE
fix(query-builder): compute the pre-execution mutation row count

### DIFF
--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -6,14 +6,15 @@ use dbflux_components::controls::{
     CompletionProvider, Dropdown, DropdownItem, DropdownSelectionChanged, InputEvent, InputState,
 };
 use dbflux_core::{
-    AggFn, BoolOp, ColumnInfo, ColumnKind, Comparator, FilterNode, GroupByEntry, JoinFilterNode,
-    JoinKind, JoinOn, JoinPredicate, JoinStep, LiteralValue, Predicate, PredicateValue,
-    ProjectedColumn, Projection, SchemaForeignKeyInfo, SelectQuery, SortEntry, SourceTable,
-    VisualAggregateSpec, VisualQuerySpec, VisualSortDirection,
+    AggFn, BoolOp, ColumnInfo, ColumnKind, Comparator, CountSpec, FilterNode, GroupByEntry,
+    JoinFilterNode, JoinKind, JoinOn, JoinPredicate, JoinStep, LiteralValue, Predicate,
+    PredicateValue, ProjectedColumn, Projection, SchemaForeignKeyInfo, SelectQuery, SortEntry,
+    SourceTable, VisualAggregateSpec, VisualQuerySpec, VisualSortDirection, inline_params,
+    render_filter_node_sql,
 };
 use gpui::{
-    App, AppContext, Context, Entity, EventEmitter, FocusHandle, Render, Subscription, WeakEntity,
-    Window,
+    App, AppContext, Context, Entity, EventEmitter, FocusHandle, Render, Subscription, Task,
+    WeakEntity, Window,
 };
 use uuid::Uuid;
 
@@ -31,6 +32,29 @@ use crate::query_builder::tree_ops::{
 
 /// Default page limit applied when the builder opens without a prior spec.
 const DEFAULT_LIMIT: u64 = 100;
+
+/// Builds the pre-execution `SELECT COUNT(*)` for a mutation's target rows.
+///
+/// Filter values are inlined into the SQL because drivers in this codebase do
+/// not bind `QueryRequest.params`; without inlining a filtered count fails with
+/// a parameter-count error and the estimate is never produced.
+fn build_mutation_count_sql(spec: &CountSpec, dialect: &dyn dbflux_core::SqlDialect) -> String {
+    let qualified = dialect.qualified_table(spec.from.schema.as_deref(), &spec.from.name);
+
+    let mut params = Vec::new();
+    let mut param_index = 1;
+    let where_clause =
+        render_filter_node_sql(spec.filter.as_ref(), dialect, &mut params, &mut param_index);
+
+    let sql = match where_clause {
+        Some(clause) if !clause.is_empty() => {
+            format!("SELECT COUNT(*) FROM {qualified} WHERE {clause}")
+        }
+        _ => format!("SELECT COUNT(*) FROM {qualified}"),
+    };
+
+    inline_params(&sql, &params, dialect)
+}
 
 /// Maximum nested group depth the UI will allow the user to create.
 ///
@@ -339,6 +363,17 @@ pub struct QueryBuilderPanel {
     /// string literal. Empty when no type information is available, in which
     /// case values stay textual.
     pub(crate) column_kinds: std::collections::HashMap<String, dbflux_core::ColumnKind>,
+
+    /// Serialized `(table, filter)` signature of the last mutation row-count
+    /// request. Used so the count is recomputed only when the target rows
+    /// actually change, not on every render or assignment edit. `None` while in
+    /// SELECT mode.
+    pub(crate) count_signature: Option<String>,
+
+    /// Debounced background task that runs the pre-execution row count and
+    /// writes the result into `mutation_state.count_state`. Replacing it cancels
+    /// any in-flight count, so rapid filter edits coalesce to the latest spec.
+    pub(crate) _count_debounce: Option<Task<()>>,
 
     /// Shared schema cache for completion providers.
     ///
@@ -718,6 +753,8 @@ impl QueryBuilderPanel {
             join_cond_op_dropdowns: HashMap::new(),
             available_columns,
             column_kinds: std::collections::HashMap::new(),
+            count_signature: None,
+            _count_debounce: None,
             schema_cache,
             app_state_weak,
             schema_profile_id: profile_id,
@@ -3092,6 +3129,87 @@ impl QueryBuilderPanel {
         assignment
     }
 
+    /// Recomputes the pre-execution row count when the target rows change.
+    ///
+    /// No-op in SELECT mode. The count depends only on `(table, filter)`, so it
+    /// is skipped when that signature is unchanged (assignment edits and the
+    /// Update/Delete toggle do not retrigger it). The query runs on a debounced
+    /// background task with a deadline and its result is written into
+    /// `mutation_state.count_state`; filter values are inlined because drivers
+    /// do not bind `QueryRequest.params`.
+    ///
+    /// Called from the render cycle, which fires after every state change.
+    pub(crate) fn maybe_refresh_mutation_count(&mut self, cx: &mut Context<Self>) {
+        use crate::data_grid_panel::mutation_executor::{CountState, count_with_deadline};
+        use std::time::Duration;
+
+        let in_mutation_mode = self
+            .mutation_state
+            .as_ref()
+            .map(|s| s.mode.is_mutation())
+            .unwrap_or(false);
+
+        if !in_mutation_mode {
+            self.count_signature = None;
+            return;
+        }
+
+        let count_spec = CountSpec {
+            from: dbflux_core::TableRef {
+                schema: self.current_spec.source.schema.clone(),
+                name: self.current_spec.source.table.clone(),
+            },
+            filter: self.current_spec.filter.clone(),
+        };
+
+        let signature = serde_json::to_string(&count_spec).unwrap_or_default();
+        if self.count_signature.as_deref() == Some(signature.as_str()) {
+            return;
+        }
+
+        let Some(app) = self.app_state_weak.upgrade() else {
+            return;
+        };
+        let Some(connection) = app
+            .read(cx)
+            .connections()
+            .get(&self.schema_profile_id)
+            .map(|c| c.connection.clone())
+        else {
+            return;
+        };
+
+        self.count_signature = Some(signature);
+        if let Some(state) = self.mutation_state.as_mut() {
+            state.count_state = CountState::Counting;
+        }
+
+        let count_sql = build_mutation_count_sql(&count_spec, connection.dialect());
+
+        self._count_debounce = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(300))
+                .await;
+
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    count_with_deadline(connection, count_sql, Vec::new(), Duration::from_secs(2))
+                })
+                .await;
+
+            this.update(cx, |panel, cx| {
+                if let Some(state) = panel.mutation_state.as_mut() {
+                    state.count_state = result;
+                }
+                cx.notify();
+            })
+            .ok();
+        }));
+
+        cx.notify();
+    }
+
     // -----------------------------------------------------------------------
     // Grouped mode transition helpers
     // -----------------------------------------------------------------------
@@ -3715,6 +3833,8 @@ mod tests {
             join_cond_op_dropdowns: HashMap::new(),
             available_columns: Vec::new(),
             column_kinds: std::collections::HashMap::new(),
+            count_signature: None,
+            _count_debounce: None,
             schema_cache: Rc::new(RefCell::new(SchemaCache::default())),
             app_state_weak: WeakEntity::new_invalid(),
             schema_profile_id: Uuid::nil(),
@@ -5385,6 +5505,59 @@ mod tests {
             }
             other => panic!("expected Update, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn build_mutation_count_sql_inlines_filter_value() {
+        use dbflux_core::{
+            Comparator, CountSpec, DefaultSqlDialect, FilterNode, LiteralValue, Predicate,
+            PredicateValue, TableRef,
+        };
+
+        let spec = CountSpec {
+            from: TableRef {
+                schema: None,
+                name: "obs".to_string(),
+            },
+            filter: Some(FilterNode::Predicate(Predicate {
+                source_alias: "obs".to_string(),
+                column: "status".to_string(),
+                comparator: Comparator::Eq,
+                value: PredicateValue::Single(LiteralValue::Integer(3)),
+                node_id: 0,
+            })),
+        };
+
+        let sql = build_mutation_count_sql(&spec, &DefaultSqlDialect);
+
+        assert!(sql.starts_with("SELECT COUNT(*) FROM"), "got: {sql}");
+        assert!(
+            sql.contains("WHERE"),
+            "filtered count must have WHERE: {sql}"
+        );
+        assert!(
+            !sql.contains('?'),
+            "filter value must be inlined, not a placeholder: {sql}"
+        );
+        assert!(sql.contains('3'), "inlined filter value missing: {sql}");
+    }
+
+    #[test]
+    fn build_mutation_count_sql_without_filter_has_no_where() {
+        use dbflux_core::{CountSpec, DefaultSqlDialect, TableRef};
+
+        let spec = CountSpec {
+            from: TableRef {
+                schema: None,
+                name: "obs".to_string(),
+            },
+            filter: None,
+        };
+
+        let sql = build_mutation_count_sql(&spec, &DefaultSqlDialect);
+
+        assert!(!sql.contains("WHERE"), "got: {sql}");
+        assert!(!sql.contains('?'), "got: {sql}");
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/query_builder/view.rs
+++ b/crates/dbflux_ui_document/src/query_builder/view.rs
@@ -66,6 +66,8 @@ pub fn render_panel(
         panel.rebuild_assign_inputs(window, cx);
     }
 
+    panel.maybe_refresh_mutation_count(cx);
+
     let theme = cx.theme().clone();
 
     let show_mode_selector = panel.shows_mutation_selector(cx);


### PR DESCRIPTION
Follow-up to #176. The builder's "Counting rows..." estimate never resolved.

## The bug

The count was never computed in production. `MutationBuilderState.count_state` starts at `Counting` and only tests ever set it to `Done`, so the label hung forever and `est_rows` at run time was always unknown (the confirmation modal always fell back to its Hard variant). The filtered case was doubly broken: even once wired, a filtered count would fail on the same params-binding issue fixed in #176.

## The fix

`maybe_refresh_mutation_count` (called from the render cycle) builds `SELECT COUNT(*) FROM table [WHERE filter]` via `build_mutation_count_sql`, inlines the filter values (drivers do not bind `QueryRequest.params`), and runs it on a debounced background task with a 2s deadline, writing the result into `count_state`.

The count depends only on `(table, filter)`, so it is gated by a serialized `CountSpec` signature: assignment edits and the Update/Delete toggle do not retrigger it, and replacing the stored task coalesces rapid filter edits to the latest spec. Side benefit: `est_rows` now works, so the confirmation modal picks Light vs Hard correctly.

## Tests

`build_mutation_count_sql` with and without a filter (value inlined, no `?` placeholder). Full `dbflux_ui_document` suite passes (531), clippy clean, `cargo check --workspace` green.

## Note

`count_with_deadline` keeps a `params` argument that drivers ignore. The new caller passes empty params and an already-inlined SQL, so it is correct here. Left as is to avoid touching its test callers.
