### PR TITLE
chore(nix): point release-info at v0.6.0-rc.2

### DIFF
--- a/nix/release-info.nix
+++ b/nix/release-info.nix
@@ -1,15 +1,15 @@
 {
-  version = "0.6.0-rc.1";
+  version = "0.6.0-rc.2";
 
   # SHA256 SRI hashes of each prebuilt artifact published in the matching
-  # GitHub Release. This pins the prebuilt package to whatever release line the
-  # default branch currently carries: a -dev.N during normal development, or the
-  # active -rc.N while a release stabilizes (main tracks the release line during
-  # the RC window — see docs/RELEASE.md), and finally the stable vX.Y.Z.
+  # GitHub Release. This file is a per-branch channel pointer: on `main` it
+  # tracks the newest published tag of any kind (-dev.N, -rc.N, or stable); on
+  # a release/vX.Y branch it tracks that line's newest tag (-rc.N, then vX.Y.0,
+  # then patches). See docs/RELEASE.md.
   #
   # To refresh after a new release:
   #
-  #   ver=X.Y.Z[-dev.N]
+  #   ver=X.Y.Z[-dev.N|-rc.N]
   #   for arch in amd64 arm64; do
   #     curl -fsSL -o /tmp/dbflux-$arch.tar.gz \
   #       "https://github.com/0xErwin1/dbflux/releases/download/v$ver/dbflux-linux-$arch.tar.gz"
@@ -20,12 +20,12 @@
   # Then update `version`, the two `url`s, and the two `hash`es below.
   artifacts = {
     "x86_64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0-rc.1/dbflux-linux-amd64.tar.gz";
-      hash = "sha256-BmVYwKdSVGhOP5pnKAueNWJOiEWMWUC5gVX0gWY954Y=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0-rc.2/dbflux-linux-amd64.tar.gz";
+      hash = "sha256-80DoQVFac1Sb8q9Cy6mks5R5pIFdfRv+rHpCngGMT54=";
     };
     "aarch64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0-rc.1/dbflux-linux-arm64.tar.gz";
-      hash = "sha256-uPidMVbDrCAtuf1FtFtMTtlRL6y+65MFnXztMMJVbT4=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0-rc.2/dbflux-linux-arm64.tar.gz";
+      hash = "sha256-+v0cHv2fHkU//wkuWSpQvobgIzy7waRRjLtkiXJVjzQ=";
     };
   };
 }


### PR DESCRIPTION
Bumps `main`'s nix prebuilt channel to the newest published tag, `v0.6.0-rc.2`.

Per the per-branch channel policy (#179), `main`'s `release-info.nix` tracks the latest release of any kind. `release/v0.6` gets the same `rc.2` bump on its own branch.

- `version` → `0.6.0-rc.2`
- Both tarball `url`s and SRI `hash`es taken from the published `.sha256` sidecars of `v0.6.0-rc.2`.
- `nix build .#dbflux-bin` verified locally (resolves and builds `dbflux-0.6.0-rc.2`).
- Stale comment updated to the per-branch channel wording.