### PR TITLE
fix(nix/ci): expose dbflux-nightly via overlay and stamp the build version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,9 @@ jobs:
           cache-targets: true
           cache-on-failure: true
 
+      - name: Stamp workspace version
+        run: sed -i 's/^version = ".*"/version = "${{ inputs.version }}"/' Cargo.toml
+
       - name: Build DBFlux
         run: cargo build --release --features "$FEATURES" --target ${{ matrix.target }}
 
@@ -312,6 +315,9 @@ jobs:
           cache-targets: true
           cache-on-failure: true
 
+      - name: Stamp workspace version
+        run: sed -i.bak 's/^version = ".*"/version = "${{ inputs.version }}"/' Cargo.toml
+
       - name: Build DBFlux
         # vendored-openssl makes ssh2/libssh2 compile OpenSSL from source for the
         # target instead of linking the runner's system OpenSSL. Required to
@@ -408,6 +414,11 @@ jobs:
           shared-key: windows-amd64
           cache-targets: true
           cache-on-failure: true
+
+      - name: Stamp workspace version
+        shell: pwsh
+        run: |
+          (Get-Content Cargo.toml) -replace '^version = ".*"', 'version = "${{ inputs.version }}"' | Set-Content Cargo.toml
 
       - name: Build DBFlux
         run: cargo build --release --features "$env:FEATURES" --target x86_64-pc-windows-msvc

--- a/flake.nix
+++ b/flake.nix
@@ -155,17 +155,26 @@
       #   nixpkgs.overlays = [ inputs.dbflux.overlays.default ];
       #   environment.systemPackages = [ pkgs.dbflux ];
       #
-      # `pkgs.dbflux`        -> prebuilt binary (fast)
-      # `pkgs.dbflux-source` -> built from source via crane
+      # `pkgs.dbflux`         -> prebuilt binary (fast)
+      # `pkgs.dbflux-source`  -> built from source via crane
+      # `pkgs.dbflux-bin`     -> explicit prebuilt (only on prebuilt systems)
+      # `pkgs.dbflux-nightly` -> rolling nightly prebuilt (only on prebuilt systems)
       overlays.default = final: prev:
         let
           system = prev.stdenv.hostPlatform.system;
           hasSystem = perSystem.packages ? ${system};
+          sysPkgs = perSystem.packages.${system};
         in
         if hasSystem then
           {
-            dbflux = perSystem.packages.${system}.dbflux;
-            dbflux-source = perSystem.packages.${system}.dbflux-source;
+            dbflux = sysPkgs.dbflux;
+            dbflux-source = sysPkgs.dbflux-source;
+          }
+          // nixpkgs.lib.optionalAttrs (sysPkgs ? dbflux-nightly) {
+            dbflux-nightly = sysPkgs.dbflux-nightly;
+          }
+          // nixpkgs.lib.optionalAttrs (sysPkgs ? dbflux-bin) {
+            dbflux-bin = sysPkgs.dbflux-bin;
           }
         else
           { };


### PR DESCRIPTION
Two fixes so the nightly build is consumable via overlays **and** identifies itself as nightly. Relates to #183 (per-channel branding).

## Problems
- **The overlay never exposed the nightly.** `overlays.default` only added `dbflux` (= the `release-info.nix` prebuilt) and `dbflux-source`. Overlay users pointing the input at the `nightly` ref got the release-channel prebuilt (currently rc.2 at that ref), not the nightly.
- **The binary reported the wrong version.** The app shows `env!("CARGO_PKG_VERSION")` (`ipc_server.rs`, `about_section.rs`), resolved at compile time from `Cargo.toml`. `build.yml` ran `cargo build` without injecting `inputs.version`, so nightly binaries (built from `main`, version `0.6.0-rc.1`) reported `0.6.0-rc.1` and never said "nightly".

## Fixes
- **`flake.nix`** — `overlays.default` now also exposes `dbflux-nightly` and `dbflux-bin`, guarded with `lib.optionalAttrs` so they only appear on prebuilt systems (x86_64-linux, aarch64-linux) and the overlay stays error-free elsewhere. Verified: overlay now yields `[ dbflux dbflux-bin dbflux-nightly dbflux-source ]` (was `[ dbflux dbflux-source ]`).
- **`build.yml`** — a 'Stamp workspace version' step sets `[workspace.package] version` to `${{ inputs.version }}` before `cargo build` in all three jobs. Nightly binaries now report `0.6.0-nightly+<sha>`. For rc/stable the value already matches Cargo.toml, so it is a no-op.

## Consuming the nightly

Pin the input to the **`nightly` ref**, not to `main`. On `main`, `nix/nightly-info.nix` is a deliberate seed with placeholder (`sha256-AAAA…`) hashes; the real hash is written only on the `nightly` ref by `nightly.yml`. Pinning to `main` fails with a hash mismatch (`specified: sha256-AAAA…` vs `got: <real>`).

```nix
# flake input
dbflux.url = "github:0xErwin1/dbflux/nightly";

# overlay
nixpkgs.overlays = [ (final: prev: inputs.dbflux.overlays.default final prev) ];

# package
environment.systemPackages = [ pkgs.dbflux-nightly ];
```

To move to a newer nightly, update the input:

```bash
nix flake update dbflux
```

That single command is the whole workflow: **a new nightly = `nix flake update dbflux`**. The rolling release reuses one tag and overwrites its tarball each night, so a stale lock eventually fails with a hash mismatch (this time `specified` is a real hash, not the seed). The fix is the same `nix flake update dbflux`. If you would rather never deal with the pinned hash, use `pkgs.dbflux-source` instead: it builds from the pinned source with no hash, at the cost of a local compile.

## Validation
- Overlay eval confirms `dbflux-nightly` resolves through `overlays.default`.
- Cargo accepts the `+`-build-metadata version (scratch `cargo metadata` test).
- `actionlint` on build.yml: no new findings.

After this, the overlay snippet `pkgs.dbflux-nightly` works and the app's About/`--version` shows the nightly version. Per-channel **icon** stays tracked in #183.
