### PR TITLE
chore(version): move main to the 0.7.0-dev.0 marker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2378,7 +2378,7 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dbflux"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_app"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2445,7 +2445,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_approval"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_policy",
  "serde",
@@ -2456,7 +2456,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_audit"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "dbflux_storage",
@@ -2472,7 +2472,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_aws"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_components"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "chrono",
  "dbflux_core",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_core"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_cloudwatch"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "aws-config",
  "aws-sdk-cloudwatch",
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_dynamodb"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_host"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "dbflux_driver_dynamodb",
@@ -2589,7 +2589,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_influxdb"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2607,7 +2607,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_ipc"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "bincode",
  "dbflux_core",
@@ -2623,7 +2623,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_mongodb"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_mssql"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_mysql"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_postgres"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_redis"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
  "dbflux_core",
@@ -2713,7 +2713,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_driver_sqlite"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "dbflux_test_support",
@@ -2726,7 +2726,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_export"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "base64 0.22.1",
  "csv",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_ipc"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_lua"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "log",
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_mcp"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_approval",
  "dbflux_audit",
@@ -2779,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_mcp_server"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_policy"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_proxy"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "dbflux_tunnel_core",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_ssh"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "dbflux_tunnel_core",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_ssm"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "dbflux_tunnel_core",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_storage"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "chrono",
  "dbflux_approval",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_test_support"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "dbflux_driver_cloudwatch",
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_tunnel_core"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "log",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_ui"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2950,7 +2950,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_ui_base"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2972,7 +2972,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_ui_document"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "anyhow",
  "dbflux_app",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_ui_sidebar"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "anyhow",
  "dbflux_app",
@@ -3019,7 +3019,7 @@ dependencies = [
 
 [[package]]
 name = "dbflux_ui_windows"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 dependencies = [
  "anyhow",
  "dbflux_app",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-version = "0.6.0-rc.1"
+version = "0.7.0-dev.0"
 authors = ["Ignacio Perez <ignacio@feuer.me>"]
 description = "A fast, keyboard-first database client"
 repository = "https://github.com/0xErwin1/dbflux"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -67,7 +67,7 @@ The workspace version (`Cargo.toml` `[workspace.package].version`) is the source
 
 **On `main`:**
 
-The manifest version is a `-rc.0` marker for the next minor during the RC stabilization window, and is bumped to the next minor's base (`X.(Y+1).0`) only after the stable `vX.Y.0` ships. Between stable releases, `main` carries whatever the current minor's next version will be.
+The manifest version is `X.(Y+1).0-dev.0`, where `X.Y` is the minor currently being stabilized on `release/vX.Y`. This marker is set when `release/vX.Y` is cut and stays on `main` through the entire stabilization window and beyond, until the next cut. It is a development marker only — no `-dev.N` releases are ever published. The nightly workflow derives `X.(Y+1).0-nightly+<sha>` from it by stripping the pre-release suffix and appending `-nightly+<short-sha>`.
 
 **On `release/vX.Y`:**
 
@@ -79,15 +79,15 @@ The manifest version is a `-rc.0` marker for the next minor during the RC stabil
 
 1. Features land on `main`. No manual changelog entries required.
 2. When ready to stabilize, cut `release/v0.7` from `main` HEAD.
-   - Bump every versioned artifact to `0.7.0-rc.0`.
-   - Commit on the release branch: `chore(release): cut release/v0.7 at v0.7.0-rc.0`.
+   - On `release/v0.7`: bump every versioned artifact to `0.7.0-rc.0`. Commit and push.
+   - On `main`: bump every versioned artifact to `0.8.0-dev.0`. Commit and push. `main` now targets the next minor.
    - Tag `v0.7.0-rc.0` on the release branch. git-cliff renders the unreleased range as the RC body automatically.
 3. A bug is found during RC:
    - Commit the fix on `main`.
    - `git cherry-pick -x <sha>` into `release/v0.7`.
    - Bump to `v0.7.0-rc.1` and tag.
 4. When clean, bump the release branch from `v0.7.0-rc.N` to `v0.7.0`. Tag `v0.7.0`. git-cliff renders the full unreleased range (since `v0.6.0`) as the stable release notes.
-5. On `main`, bump to `v0.8.0-rc.0` and open the next cycle.
+5. `main` is already on `0.8.0-dev.0` — no further bump needed after stable.
 6. Patches (`v0.7.1`, `v0.7.2`, …) come from the same release branch via cherry-picks from `main`.
 
 ## Cut Procedure: `main` → `release/vX.Y`
@@ -118,8 +118,8 @@ The manifest version is a `-rc.0` marker for the next minor during the RC stabil
    - Push: `git push -u origin release/vX.Y`.
 
 5. Back on `main`:
-   - Bump every versioned artifact to `X.Y.0-rc.0` (mirrors the release branch — main stays on the RC marker during the stabilization window).
-   - Commit: `chore(release): align main to vX.Y.0-rc.0`.
+   - Bump every versioned artifact to `X.(Y+1).0-dev.0` (main now targets the next minor).
+   - Commit: `chore(version): move main to X.(Y+1).0-dev.0 marker`.
    - Push.
 
 6. Tag `vX.Y.0-rc.0` on the release branch.
@@ -148,16 +148,9 @@ git-cliff generates the curated release notes from all user-visible commits sinc
 
 > **Optional curation:** if you want to add a human-written intro or editorial note to the stable release body, you can do so directly in the GitHub Release edit UI after the workflow publishes it. This does not touch CHANGELOG.md.
 
-## Begin Next Dev Cycle: after stable `vX.Y.0`
+## Next Dev Cycle
 
-Run this **only after** the stable `vX.Y.0` tag is pushed from `release/vX.Y`.
-
-On `main`:
-- Bump every versioned artifact to `X.(Y+1).0-rc.0`.
-- Commit: `chore(version): begin X.(Y+1).0 cycle`.
-- Push.
-
-`main` now targets the next minor. Nightly builds continue from `main` HEAD automatically.
+`main` is bumped to `X.(Y+1).0-dev.0` **when `release/vX.Y` is cut** (see Cut Procedure, step 5). No further bump to `main` is required after the stable tag. Nightly builds continue from `main` HEAD automatically, producing `X.(Y+1).0-nightly+<sha>` throughout the stabilization window.
 
 ## Files to Bump
 
@@ -178,7 +171,7 @@ The AUR `PKGBUILD` lives in an **external AUR repository**, not in this repo. It
 
 `.github/workflows/nightly.yml` runs daily at 03:17 UTC:
 
-1. Reads the workspace version from `Cargo.toml`, strips any existing pre-release suffix, and appends `-nightly+<short-sha>` (e.g. `0.7.0-nightly+abc1234`). No `Cargo.toml` commit required.
+1. Reads the workspace version from `Cargo.toml`, strips any existing pre-release suffix, and appends `-nightly+<short-sha>` (e.g. `0.8.0-nightly+abc1234` when `main` carries `0.8.0-dev.0`). No `Cargo.toml` commit required. Because `main` tracks the **next** minor from the moment `release/vX.Y` is cut, the nightly version is always clearly ahead of the stabilizing line.
 2. Calls `build.yml` with `channel: nightly`.
 3. Computes the SHA256 SRI hash of each Linux tarball and regenerates `nix/nightly-info.nix` with the real hashes and the rolling release URLs.
 4. Commits the updated `nix/nightly-info.nix` on top of the current `main` HEAD. This commit is **not pushed to `main`** — it becomes the sole target of the `nightly` tag.

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
           # Import default.nix with crane support
           dbflux = import ./default.nix {
             inherit pkgs craneLib;
-            version = "0.6.0-rc.1";
+            version = "0.7.0-dev.0";
           };
 
           # Source build (current behavior, compiles locally via crane).

--- a/resources/windows/installer.iss
+++ b/resources/windows/installer.iss
@@ -1,6 +1,6 @@
 #define MyAppName "DBFlux"
 #ifndef MyAppVersion
-#define MyAppVersion "0.6.0-rc.1"
+#define MyAppVersion "0.7.0-dev.0"
 #endif
 #define MyAppPublisher "Ignacio Perez"
 #define MyAppURL "https://github.com/0xErwin1/dbflux"

--- a/skills/dbflux-release/SKILL.md
+++ b/skills/dbflux-release/SKILL.md
@@ -89,6 +89,10 @@ Working tree must be clean before any tag.
 
 Source-of-truth for the workspace version is `Cargo.toml` (`[workspace.package].version`). All other manifests must be kept in lockstep.
 
+**On `main`:**
+
+`main` always carries `X.(Y+1).0-dev.0`, where `X.Y` is the minor currently being stabilized on `release/vX.Y`. This marker is set when `release/vX.Y` is cut and stays until the next release branch is cut. The nightly workflow derives the nightly version from it: `X.(Y+1).0-nightly+<sha>`. No `-dev.N` releases are published — the marker is development-only.
+
 **On `release/vX.Y`:**
 
 - Next RC: if last tag on the branch is `vX.Y.Z-rc.N` → `-rc.(N+1)`. If none → `-rc.0`.
@@ -124,8 +128,8 @@ When stabilization for a minor begins:
    - Push: `git push -u origin release/vX.Y`.
 
 6. Back on `main`:
-   - Bump every versioned artifact to `X.Y.0-rc.0` (mirrors the release branch during the stabilization window).
-   - Commit: `chore(release): align main to vX.Y.0-rc.0`.
+   - Bump every versioned artifact to `X.(Y+1).0-dev.0` (main now targets the next minor).
+   - Commit: `chore(version): move main to X.(Y+1).0-dev.0 marker`.
    - Push.
 
 7. Tag `vX.Y.0-rc.0` on the release branch (see "Tag Procedure").
@@ -153,12 +157,9 @@ Run on `release/vX.Y` when the RC is clean:
 
 After the GitHub Release publishes, run post-release steps (see "Post-Release Channels").
 
-## Begin Next Dev Cycle: after stable `vX.Y.0`
+## Next Dev Cycle
 
-On `main`:
-- Bump every versioned artifact to `X.(Y+1).0-rc.0`.
-- Commit: `chore(version): begin X.(Y+1).0 cycle`.
-- Push.
+`main` is bumped to `X.(Y+1).0-dev.0` when `release/vX.Y` is cut (step 6 of the Cut Procedure). No further bump to `main` is needed after the stable tag ships. `main` has already been targeting the next minor throughout stabilization.
 
 ## Tag Procedure (any tag)
 


### PR DESCRIPTION
Makes the nightly version forward-looking and stops `main` from carrying a version of the line being stabilized.

## Problem
`main` carried `0.6.0-rc.1`. The nightly workflow derives its version from main's `Cargo.toml` (strip the pre-release suffix, append `-nightly+<sha>`), so it produced `0.6.0-nightly+<sha>` — confusingly NOT ahead of the released `0.6.0-rc.3`. Bumping main to match the latest rc would not help (the suffix is stripped either way); the real fix is for main to track the **next** minor.

## Change
- Bump the version marker `0.6.0-rc.1` → **`0.7.0-dev.0`** in `Cargo.toml`, `flake.nix`, `resources/windows/installer.iss` (+ `Cargo.lock`). `-dev.0` is a development **marker** only — the `-dev.N` release channel stays retired. `nix/release-info.nix` is unchanged (it points at the latest published tag, rc.3).
- The nightly now derives **`0.7.0-nightly+<sha>`** — clearly ahead of the whole 0.6.x line.

## Model adjustment (docs)
Updated `docs/RELEASE.md` and the `dbflux-release` skill: **main moves to the next minor's `-dev.0` marker when `release/vX.Y` is cut** (standard trunk-based), instead of staying on the rc marker until stable. The old rationale (avoid `-dev.N` releases during stabilization) is moot now that `-dev.N` is retired.

## Validation
- `cargo check --workspace` + `cargo fmt --check`: clean; `Cargo.lock` at `0.7.0-dev.0`.
- No `0.6.0-rc.1` left in the version artifacts.
- Nightly compute simulation: `0.7.0-dev.0` → strips to `0.7.0` → `0.7.0-nightly+<sha>`.

Pairs with #189 (which makes the built binary actually report this version).