### PR TITLE
feat(connection-manager): decouple auth-profile dropdown from driver ids

### DIFF
--- a/crates/dbflux_app/src/app_state.rs
+++ b/crates/dbflux_app/src/app_state.rs
@@ -3232,7 +3232,10 @@ impl AppState {
             for tab in &form.tabs {
                 for section in &tab.sections {
                     for field in &section.fields {
-                        if let FormFieldKind::AuthProfileRef { provider_id } = &field.kind {
+                        if let FormFieldKind::AuthProfileRef {
+                            provider_id: Some(provider_id),
+                        } = &field.kind
+                        {
                             ids.insert(provider_id.clone());
                         }
                     }
@@ -4293,6 +4296,73 @@ mod tests {
             !state.saved_charts_repo.list().unwrap().is_empty()
                 || state.saved_charts_repo.list().unwrap().is_empty(),
             "fresh in-memory DB list is empty — but call must not panic"
+        );
+    }
+
+    // --- reference_only_auth_provider_ids ---
+
+    /// Scans `form` the same way `reference_only_auth_provider_ids` does and
+    /// returns collected ids. Used to unit-test the scanning logic in isolation.
+    fn collect_ref_ids_from_form(form: &dbflux_core::DriverFormDef) -> HashSet<String> {
+        use dbflux_core::FormFieldKind;
+        let mut ids = HashSet::new();
+        for tab in &form.tabs {
+            for section in &tab.sections {
+                for field in &section.fields {
+                    if let FormFieldKind::AuthProfileRef {
+                        provider_id: Some(provider_id),
+                    } = &field.kind
+                    {
+                        ids.insert(provider_id.clone());
+                    }
+                }
+            }
+        }
+        ids
+    }
+
+    fn make_form_with_auth_profile_ref(provider_id: Option<String>) -> dbflux_core::DriverFormDef {
+        use dbflux_core::{FormFieldDef, FormFieldKind, FormSection, FormTab};
+        dbflux_core::DriverFormDef {
+            tabs: vec![FormTab {
+                id: "main".to_string(),
+                label: "Main".to_string(),
+                sections: vec![FormSection {
+                    title: "Auth".to_string(),
+                    fields: vec![FormFieldDef {
+                        id: "ref_field".to_string(),
+                        label: "Ref".to_string(),
+                        kind: FormFieldKind::AuthProfileRef { provider_id },
+                        placeholder: String::new(),
+                        required: false,
+                        default_value: String::new(),
+                        enabled_when_checked: None,
+                        enabled_when_unchecked: None,
+                        disabled_when_field_set: None,
+                        help: None,
+                    }],
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn reference_only_auth_provider_ids_ignores_none_filter() {
+        let form = make_form_with_auth_profile_ref(None);
+        let ids = collect_ref_ids_from_form(&form);
+        assert!(
+            ids.is_empty(),
+            "AuthProfileRef with provider_id: None must not contribute any id to the reference-only set"
+        );
+    }
+
+    #[test]
+    fn reference_only_auth_provider_ids_inserts_some_filter() {
+        let form = make_form_with_auth_profile_ref(Some("aws-sso-session".to_string()));
+        let ids = collect_ref_ids_from_form(&form);
+        assert!(
+            ids.contains("aws-sso-session"),
+            "AuthProfileRef with Some(provider_id) must contribute that id to the reference-only set"
         );
     }
 }

--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -650,7 +650,7 @@ fn build_aws_sso_form() -> AuthFormDef {
                         id: "sso_session_ref".to_string(),
                         label: "SSO Session".to_string(),
                         kind: FormFieldKind::AuthProfileRef {
-                            provider_id: "aws-sso-session".to_string(),
+                            provider_id: Some("aws-sso-session".to_string()),
                         },
                         placeholder: String::new(),
                         required: false,

--- a/crates/dbflux_core/src/auth/refs.rs
+++ b/crates/dbflux_core/src/auth/refs.rs
@@ -115,7 +115,7 @@ mod tests {
                         id: consumer_field_id.to_string(),
                         label: "Session".to_string(),
                         kind: FormFieldKind::AuthProfileRef {
-                            provider_id: ref_provider_id.to_string(),
+                            provider_id: Some(ref_provider_id.to_string()),
                         },
                         placeholder: String::new(),
                         required: false,

--- a/crates/dbflux_core/src/driver/form.rs
+++ b/crates/dbflux_core/src/driver/form.rs
@@ -77,16 +77,22 @@ pub enum FormFieldKind {
         allow_freeform: bool,
     },
     /// A dropdown that references another `AuthProfile`. The UI populates
-    /// options by listing AuthProfiles whose `provider_id` equals
-    /// `provider_id`. The stored value is the referenced profile's UUID.
+    /// options based on the `provider_id` filter.
+    ///
+    /// - `None` — all eligible auth profiles are listed regardless of their
+    ///   provider origin (built-in or external/RPC). Used by driver forms.
+    /// - `Some(id)` — only AuthProfiles whose `provider_id` equals `id` are
+    ///   shown. Used by auth-provider forms that reference a specific provider
+    ///   (e.g. an SSO-session reference on an SSO profile).
     ///
     /// When `expand_auth_profile_refs` runs, it follows this reference and
     /// merges the referenced profile's fields into the consumer profile so
     /// downstream code (login, validation, dynamic options) sees a single
     /// flat field map.
     AuthProfileRef {
-        /// Filter: only AuthProfiles with this `provider_id` are shown.
-        provider_id: String,
+        /// Optional filter: `None` lists all eligible auth profiles;
+        /// `Some(id)` filters to profiles whose `provider_id` equals `id`.
+        provider_id: Option<String>,
     },
 }
 

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -66,8 +66,8 @@ pub static CLOUDWATCH_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFor
                 field(
                     "profile",
                     "Profile",
-                    FormFieldKind::Text,
-                    "optional AWS profile",
+                    FormFieldKind::AuthProfileRef { provider_id: None },
+                    "",
                 ),
                 field(
                     "endpoint",
@@ -1573,7 +1573,7 @@ mod tests {
     use aws_sdk_cloudwatch::primitives::DateTime;
     use aws_sdk_cloudwatch::types::MetricDataResult;
     use dbflux_core::{
-        ColumnKind, DbConfig, DbDriver, DriverCapabilities, MetricQuerySeries, Value,
+        ColumnKind, DbConfig, DbDriver, DriverCapabilities, FormFieldKind, MetricQuerySeries, Value,
     };
 
     fn series(namespace: &str, metric_name: &str) -> MetricQuerySeries {
@@ -1863,6 +1863,26 @@ mod tests {
                 .capabilities
                 .contains(DriverCapabilities::CHART_AUTHORING),
             "CHART_AUTHORING must be advertised so the sidebar surfaces Dashboards / Saved Charts folders for CW connections"
+        );
+    }
+
+    #[test]
+    fn cloudwatch_profile_field_is_auth_profile_ref_with_none_provider_id() {
+        let profile_field = CLOUDWATCH_FORM
+            .tabs
+            .iter()
+            .flat_map(|t| t.sections.iter())
+            .flat_map(|s| s.fields.iter())
+            .find(|f| f.id == "profile")
+            .expect("CloudWatch form must have a 'profile' field");
+
+        assert!(
+            matches!(
+                &profile_field.kind,
+                FormFieldKind::AuthProfileRef { provider_id: None }
+            ),
+            "CloudWatch 'profile' field must be AuthProfileRef {{ provider_id: None }}, got {:?}",
+            profile_field.kind
         );
     }
 }

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -52,8 +52,8 @@ pub static DYNAMODB_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormD
                     field(
                         "profile",
                         "Profile",
-                        FormFieldKind::Text,
-                        "optional AWS profile",
+                        FormFieldKind::AuthProfileRef { provider_id: None },
+                        "",
                     ),
                 ],
             },
@@ -4204,11 +4204,11 @@ pub fn unsupported_mvp_message(flow: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        DYNAMODB_DEFAULT_DATABASE, DYNAMODB_METADATA, DynamoDriver, DynamoErrorFormatter,
-        DynamoFilterFallbackPolicy, DynamoIndexKind, DynamoKeyComponent, DynamoKeyRole,
-        DynamoLanguageService, DynamoProfileConfig, DynamoReadStrategy, DynamoTableKeySchema,
-        append_window_items, apply_item_filter, attribute_value_to_value, build_item_batches,
-        build_table_info_from_description, build_update_expression_from_json,
+        DYNAMODB_DEFAULT_DATABASE, DYNAMODB_FORM, DYNAMODB_METADATA, DynamoDriver,
+        DynamoErrorFormatter, DynamoFilterFallbackPolicy, DynamoIndexKind, DynamoKeyComponent,
+        DynamoKeyRole, DynamoLanguageService, DynamoProfileConfig, DynamoReadStrategy,
+        DynamoTableKeySchema, append_window_items, apply_item_filter, attribute_value_to_value,
+        build_item_batches, build_table_info_from_description, build_update_expression_from_json,
         classify_connection_error, classify_query_error, decide_read_strategy,
         dynamo_filter_json_from_semantic, ensure_default_database,
         ensure_item_contains_required_keys, extract_key_map_from_filter,
@@ -4225,8 +4225,8 @@ mod tests {
     use dbflux_core::{
         CollectionBrowseRequest, CollectionCountRequest, CollectionRef, ConnectionProfile,
         DangerousQueryKind, DatabaseCategory, DbConfig, DbDriver, DbError, DocumentFilter,
-        DocumentUpdate, DriverCapabilities, FormValues, IndexData, LanguageService, QueryLanguage,
-        SemanticFilter, SemanticPlanKind, SemanticRequest, Value, WhereOperator,
+        DocumentUpdate, DriverCapabilities, FormFieldKind, FormValues, IndexData, LanguageService,
+        QueryLanguage, SemanticFilter, SemanticPlanKind, SemanticRequest, Value, WhereOperator,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -5274,5 +5274,25 @@ mod tests {
 
         assert!(matches!(error, DbError::NotSupported(_)));
         assert!(error.to_string().contains("aggregate requests"));
+    }
+
+    #[test]
+    fn dynamodb_profile_field_is_auth_profile_ref_with_none_provider_id() {
+        let profile_field = DYNAMODB_FORM
+            .tabs
+            .iter()
+            .flat_map(|t| t.sections.iter())
+            .flat_map(|s| s.fields.iter())
+            .find(|f| f.id == "profile")
+            .expect("DynamoDB form must have a 'profile' field");
+
+        assert!(
+            matches!(
+                &profile_field.kind,
+                FormFieldKind::AuthProfileRef { provider_id: None }
+            ),
+            "DynamoDB 'profile' field must be AuthProfileRef {{ provider_id: None }}, got {:?}",
+            profile_field.kind
+        );
     }
 }

--- a/crates/dbflux_ui_document/src/style_guardrails.rs
+++ b/crates/dbflux_ui_document/src/style_guardrails.rs
@@ -152,7 +152,12 @@ mod style_guardrails {
     /// - `match driver_id` — match arm switching on driver ID string
     #[test]
     fn document_has_no_driver_id_branching() {
-        let forbidden: &[&str] = &["driver_id ==", "driver_id !=", "match driver_id"];
+        let forbidden: &[&str] = &[
+            "driver_id ==",
+            "driver_id !=",
+            "match driver_id",
+            "matches!(driver_id",
+        ];
         let violations = check_violations(forbidden);
         assert!(
             violations.is_empty(),

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -42,8 +42,26 @@ fn auth_profile_needs_login(
         )
 }
 
-fn uses_aws_auth_profile_dropdown(driver_id: Option<&str>) -> bool {
-    matches!(driver_id, Some("dynamodb") | Some("cloudwatch"))
+/// Returns the `id` of the first `AuthProfileRef` field found in a form definition,
+/// or `None` if the form has no such field.
+fn auth_profile_ref_field_id_from_form(form: &DriverFormDef) -> Option<String> {
+    for tab in &form.tabs {
+        for section in &tab.sections {
+            for field in &section.fields {
+                if matches!(&field.kind, FormFieldKind::AuthProfileRef { .. }) {
+                    return Some(field.id.clone());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Returns the `id` of the first `AuthProfileRef` field found in the driver's form
+/// definition, or `None` if the driver is absent or has no such field.
+fn auth_profile_ref_field_id(driver: Option<&Arc<dyn DbDriver>>) -> Option<String> {
+    let driver = driver?;
+    auth_profile_ref_field_id_from_form(driver.form_definition())
 }
 
 /// Extracts the current SSL mode id string from a `DbConfig` for display in the UI segmented
@@ -2573,18 +2591,20 @@ impl ConnectionManagerWindow {
             self.selected_auth_profile_id = selection;
             self.selected_ssm_auth_profile_id = selection;
 
-            self.sync_aws_driver_fields_from_auth_profile(window, cx);
+            self.sync_driver_fields_from_auth_profile(window, cx);
         }
     }
 
-    fn sync_aws_driver_fields_from_auth_profile(
+    fn sync_driver_fields_from_auth_profile(
         &mut self,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !uses_aws_auth_profile_dropdown(self.selected_driver_id()) {
-            return;
-        }
+        let auth_profile_ref_field_id =
+            match auth_profile_ref_field_id(self.selected_driver.as_ref()) {
+                Some(id) => id,
+                None => return,
+            };
 
         let Some(auth_profile_id) = self.selected_auth_profile_id else {
             return;
@@ -2607,7 +2627,11 @@ impl ConnectionManagerWindow {
             .cloned()
             .unwrap_or_else(|| profile.name.clone());
 
-        if let Some(input) = self.driver_inputs.get("profile").cloned() {
+        if let Some(input) = self
+            .driver_inputs
+            .get(auth_profile_ref_field_id.as_str())
+            .cloned()
+        {
             input.update(cx, |state, cx| {
                 state.set_value(profile_name, window, cx);
             });
@@ -3174,7 +3198,7 @@ impl EventEmitter<DismissEvent> for ConnectionManagerWindow {}
 mod tests {
     use super::ConnectionManagerWindow;
     use super::auth_profile_needs_login;
-    use super::uses_aws_auth_profile_dropdown;
+    use super::auth_profile_ref_field_id_from_form;
     use dbflux_core::AuthSessionState;
 
     // --- parse_hook_ids ---
@@ -3278,10 +3302,52 @@ mod tests {
     }
 
     #[test]
-    fn aws_auth_profile_dropdown_is_enabled_for_dynamodb_and_cloudwatch() {
-        assert!(uses_aws_auth_profile_dropdown(Some("dynamodb")));
-        assert!(uses_aws_auth_profile_dropdown(Some("cloudwatch")));
-        assert!(!uses_aws_auth_profile_dropdown(Some("postgres")));
-        assert!(!uses_aws_auth_profile_dropdown(None));
+    fn form_has_auth_profile_ref_field_detects_kind() {
+        use dbflux_core::{DriverFormDef, FormFieldDef, FormFieldKind, FormSection, FormTab};
+
+        fn make_form(kind: FormFieldKind) -> DriverFormDef {
+            DriverFormDef {
+                tabs: vec![FormTab {
+                    id: "main".to_string(),
+                    label: "Main".to_string(),
+                    sections: vec![FormSection {
+                        title: "Settings".to_string(),
+                        fields: vec![FormFieldDef {
+                            id: "profile".to_string(),
+                            label: "Profile".to_string(),
+                            kind,
+                            placeholder: String::new(),
+                            required: false,
+                            default_value: String::new(),
+                            enabled_when_checked: None,
+                            enabled_when_unchecked: None,
+                            disabled_when_field_set: None,
+                            help: None,
+                        }],
+                    }],
+                }],
+            }
+        }
+
+        let auth_ref_form = make_form(FormFieldKind::AuthProfileRef { provider_id: None });
+        assert_eq!(
+            auth_profile_ref_field_id_from_form(&auth_ref_form).as_deref(),
+            Some("profile"),
+            "Form with AuthProfileRef field must return the field id"
+        );
+
+        let text_only_form = make_form(FormFieldKind::Text);
+        assert_eq!(
+            auth_profile_ref_field_id_from_form(&text_only_form),
+            None,
+            "Form with only Text fields must return None"
+        );
+
+        let empty_form = DriverFormDef { tabs: vec![] };
+        assert_eq!(
+            auth_profile_ref_field_id_from_form(&empty_form),
+            None,
+            "Empty form must return None"
+        );
     }
 }

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -20,10 +20,7 @@ use gpui_component::checkbox::Checkbox;
 /// Label column width for horizontal field rows (matches design spec).
 const FIELD_LABEL_WIDTH: Pixels = px(140.0);
 
-use super::{
-    ActiveTab, ConnectionManagerWindow, EditState, FormFocus, TestStatus, View,
-    uses_aws_auth_profile_dropdown,
-};
+use super::{ActiveTab, ConnectionManagerWindow, EditState, FormFocus, TestStatus, View};
 
 impl ConnectionManagerWindow {
     /// Build a standard horizontal form row: 140 px label column on the left, flex-1 control
@@ -477,34 +474,6 @@ impl ConnectionManagerWindow {
         ring_color: Hsla,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        if !is_ssh_tab
-            && field_def.id == "profile"
-            && uses_aws_auth_profile_dropdown(self.selected_driver_id())
-        {
-            let field_enabled = self.is_field_enabled(field_def);
-
-            let dropdown = div()
-                .when(!field_enabled, |d| d.opacity(0.5))
-                .when(field_enabled, |d| {
-                    d.on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(|this, _, _, cx| {
-                            this.begin_inline_editor_interaction(cx);
-                        }),
-                    )
-                })
-                .child(self.auth_profile_dropdown.clone());
-
-            return Self::field_row_cm(
-                field_def.label.clone(),
-                field_def.required && field_enabled,
-                dropdown,
-                None::<&str>,
-                cx,
-            )
-            .into_any_element();
-        }
-
         let field_focus = Self::field_id_to_focus(&field_def.id, is_ssh_tab);
         let focused = show_focus && field_focus == Some(self.form_focus);
 
@@ -802,11 +771,33 @@ impl ConnectionManagerWindow {
                 }
             }
 
-            // DynamicSelect and AuthProfileRef are not used in driver connection forms;
-            // they are rendered by the auth-provider settings UI.
-            FormFieldKind::DynamicSelect { .. } | FormFieldKind::AuthProfileRef { .. } => {
-                div().into_any_element()
+            FormFieldKind::AuthProfileRef { .. } => {
+                let field_enabled = self.is_field_enabled(field_def);
+
+                let dropdown = div()
+                    .when(!field_enabled, |d| d.opacity(0.5))
+                    .when(field_enabled, |d| {
+                        d.on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|this, _, _, cx| {
+                                this.begin_inline_editor_interaction(cx);
+                            }),
+                        )
+                    })
+                    .child(self.auth_profile_dropdown.clone());
+
+                Self::field_row_cm(
+                    field_def.label.clone(),
+                    field_def.required && field_enabled,
+                    dropdown,
+                    None::<&str>,
+                    cx,
+                )
+                .into_any_element()
             }
+
+            // DynamicSelect is not used in driver connection forms.
+            FormFieldKind::DynamicSelect { .. } => div().into_any_element(),
         }
     }
 

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -957,7 +957,7 @@ impl AuthProfilesSection {
         let help = field.help.clone();
 
         let FormFieldKind::AuthProfileRef {
-            provider_id: ref_provider_id,
+            provider_id: Some(ref_provider_id),
         } = &field.kind
         else {
             return div();

--- a/crates/dbflux_ui_windows/src/style_guardrails.rs
+++ b/crates/dbflux_ui_windows/src/style_guardrails.rs
@@ -139,4 +139,27 @@ mod style_guardrails {
             violations.join("\n")
         );
     }
+
+    /// Connection Manager code must not branch on driver IDs. Use
+    /// `FormFieldKind`, `DriverCapabilities`, or `DatabaseCategory` instead.
+    ///
+    /// Heuristic patterns checked:
+    /// - `driver_id ==` or `driver_id !=` — string equality on driver ID
+    /// - `match driver_id` — match arm switching on driver ID string
+    /// - `matches!(driver_id` — macro matching on driver ID string
+    #[test]
+    fn connection_manager_has_no_driver_id_branching() {
+        let forbidden: &[&str] = &[
+            "driver_id ==",
+            "driver_id !=",
+            "match driver_id",
+            "matches!(driver_id",
+        ];
+        let violations = check_violations(forbidden);
+        assert!(
+            violations.is_empty(),
+            "Connection Manager code must not branch on driver_id strings (use FormFieldKind, DriverCapabilities, or DatabaseCategory instead):\n{}",
+            violations.join("\n")
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- The connection manager picked the auth-profile dropdown by matching literal driver ids (`matches!(driver_id, Some("dynamodb") | Some("cloudwatch"))`), coupling the UI to specific drivers and excluding auth profiles backed by external RPC providers.
- The dropdown is now driven by the generic `FormFieldKind::AuthProfileRef` seam, so any driver form opts in by declaring the field — no UI changes needed for future AWS-family or RPC-backed drivers.
- No persisted data changes: the form-field kind is never stored, so existing connections are unaffected.

## What does this resolve?

Tracked as **DEC-1** under the "Decoupling driver/UI" epic on the project board (draft issue, no numbered GitHub issue). DEC-2 and DEC-3 were already resolved in earlier work and are marked Done on the board.

- Resolves # <!-- no numbered issue; link manually if one is created -->

## How was this solved?

- `FormFieldKind::AuthProfileRef.provider_id` becomes `Option<String>`. Driver forms use `None` (no provider filter); auth-provider forms keep `Some(id)` (unchanged filtering). The four named construction/match sites were updated accordingly.
- DynamoDB and CloudWatch declare their `profile` field as `AuthProfileRef { provider_id: None }`. `DbConfig.profile` stays the AWS profile-name string consumed by the SDK — the connect path is untouched.
- The connection-manager render arm for `AuthProfileRef` is now generic (the driver-id gate is deleted), and field-sync discovers the field by kind via `auth_profile_ref_field_id_from_form`. `uses_aws_auth_profile_dropdown` is removed.
- Because `provider_id: None` imposes no filter and the reference-only set is built only from auth-provider forms, external/RPC auth-provider profiles continue to appear in the dropdown.
- Added guardrail coverage for the `matches!(driver_id` pattern in both `dbflux_ui_windows` and `dbflux_ui_document` — the exact form that slipped past the existing driver-id branching checks.

## What to review first

1. The seam change in `crates/dbflux_core/src/driver/form.rs` and its four call sites compile and preserve behavior.
2. `connection_manager/render.rs` + `mod.rs`: the generic arm matches the deleted gate's behavior and no driver-id check remains.
3. The core constraint: `populate_auth_profile_dropdown` applies no provider filter for `None`, so RPC/external profiles still show.

Out of scope: DEC-2/DEC-3, any new driver, broader auth-profile redesign, storage migrations.

## Validation

```
cargo nextest run -p dbflux_core -p dbflux_app -p dbflux_driver_dynamodb -p dbflux_driver_cloudwatch -p dbflux_ui_windows -p dbflux_ui_document
cargo test --doc --workspace
cargo clippy --workspace -- -D warnings
cargo fmt --all -- --check
```

All targeted tests pass (new: `reference_only_auth_provider_ids_*`, `form_has_auth_profile_ref_field_detects_kind`, `*_profile_field_is_auth_profile_ref_with_none_provider_id`, both guardrails). The single failing workspace test (`hook_executor::composite_executor_routes_mixed_hook_types`) is pre-existing and unrelated (Lua feature not enabled). Clippy, fmt, and doctests are clean.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [ ] I applied the appropriate labels (see CONTRIBUTING.md#label-guide)

## Labels to apply

`ui:feature`, `aws`, `rpc:auth`
