### PR TITLE
fix(branding): in-app glyph + desktop/mime placeholder substitution (#183)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,12 +156,13 @@ jobs:
           cp target/${{ matrix.target }}/release/dbflux AppDir/usr/bin/
           chmod +x AppDir/usr/bin/dbflux
 
-          APP_ID="$APP_ID" APP_NAME="$APP_NAME" envsubst < resources/desktop/dbflux.desktop > "AppDir/usr/share/applications/$APP_ID.desktop"
-          sed -i "s|@EXEC_PATH@|$APP_ID|g" "AppDir/usr/share/applications/$APP_ID.desktop"
+          cp resources/desktop/dbflux.desktop "AppDir/usr/share/applications/$APP_ID.desktop"
+          sed -i -e "s|@EXEC_PATH@|dbflux|g" -e "s|@APP_NAME@|$APP_NAME|g" -e "s|@APP_ID@|$APP_ID|g" "AppDir/usr/share/applications/$APP_ID.desktop"
 
           cp "$BRAND_DIR/mark.svg" "AppDir/usr/share/icons/hicolor/scalable/apps/$APP_ID.svg"
 
           cp resources/mime/dbflux-sql.xml AppDir/usr/share/mime/packages/
+          sed -i "s|@APP_ID@|$APP_ID|g" AppDir/usr/share/mime/packages/dbflux-sql.xml
 
           cp LICENSE-MIT AppDir/usr/share/licenses/dbflux/
           cp LICENSE-APACHE AppDir/usr/share/licenses/dbflux/
@@ -216,7 +217,7 @@ jobs:
           export TARGET=${{ matrix.target }}
           export APP_ID APP_NAME PKG_NAME BUNDLE_ID BRAND_DIR
 
-          envsubst < packaging/dbflux.desktop > packaging/dbflux.desktop.tmp && mv packaging/dbflux.desktop.tmp packaging/dbflux.desktop
+          sed -i -e "s|@APP_NAME@|$APP_NAME|g" -e "s|@APP_ID@|$APP_ID|g" packaging/dbflux.desktop
 
           envsubst < packaging/nfpm.deb.yaml > nfpm.deb.yaml
           ~/go/bin/nfpm package --packager deb --config nfpm.deb.yaml --target ${PKG_NAME}_${VERSION}_linux_${{ matrix.deb_arch }}.deb

--- a/crates/dbflux_ui/src/ui/icons/mod.rs
+++ b/crates/dbflux_ui/src/ui/icons/mod.rs
@@ -236,23 +236,10 @@ pub(crate) fn embedded_bytes(icon: AppIcon) -> &'static [u8] {
         AppIcon::BrandInfluxDb => {
             include_bytes!("../../../../../resources/icons/brand/influxdb.svg")
         }
-        AppIcon::DbFlux => dbflux_mark_bytes(),
+        AppIcon::DbFlux => include_bytes!("../../../../../resources/branding/glyph.svg"),
         AppIcon::BrainCircuit => {
             include_bytes!("../../../../../resources/icons/ui/brain-circuit.svg")
         }
         AppIcon::Bot => include_bytes!("../../../../../resources/icons/ui/bot.svg"),
-    }
-}
-
-/// Returns the DBFlux brand mark for the running release channel. Nightly ships
-/// a visually distinct mark so it can be told apart from stable at a glance.
-fn dbflux_mark_bytes() -> &'static [u8] {
-    match dbflux_core::ReleaseChannel::current() {
-        dbflux_core::ReleaseChannel::Nightly => {
-            include_bytes!("../../../../../resources/branding/nightly/mark.svg")
-        }
-        dbflux_core::ReleaseChannel::Stable | dbflux_core::ReleaseChannel::Rc => {
-            include_bytes!("../../../../../resources/branding/stable/mark.svg")
-        }
     }
 }

--- a/default.nix
+++ b/default.nix
@@ -81,16 +81,20 @@ let
     mkdir -p $out/share/mime/packages
     mkdir -p $out/share/dbflux
 
-    # Copy desktop file and set correct Exec path
+    # Copy desktop file and resolve the templated placeholders
     install -Dm644 ${fullSrc}/resources/desktop/dbflux.desktop $out/share/applications/dbflux.desktop
     substituteInPlace $out/share/applications/dbflux.desktop \
-      --replace '@EXEC_PATH@' "$out/bin/dbflux"
+      --replace '@EXEC_PATH@' "$out/bin/dbflux" \
+      --replace '@APP_NAME@' 'DBFlux' \
+      --replace '@APP_ID@' 'dbflux'
 
     # Copy icon
     install -Dm644 ${fullSrc}/resources/branding/stable/mark.svg $out/share/icons/hicolor/scalable/apps/dbflux.svg
 
     # Copy mime type
     install -Dm644 ${fullSrc}/resources/mime/dbflux-sql.xml $out/share/mime/packages/dbflux-sql.xml
+    substituteInPlace $out/share/mime/packages/dbflux-sql.xml \
+      --replace '@APP_ID@' 'dbflux'
 
     # Copy resources (with proper permissions)
     cp -r --no-preserve=mode ${fullSrc}/resources $out/share/dbflux/

--- a/nix/binary.nix
+++ b/nix/binary.nix
@@ -110,16 +110,21 @@ stdenv.mkDerivation {
 
     install -Dm755 dbflux $out/bin/dbflux
 
-    # Desktop entry — substitute the placeholder used by the release tarball.
+    # Desktop entry — resolve the templated placeholders. This derivation ships
+    # the stable identity.
     install -Dm644 resources/desktop/dbflux.desktop \
       $out/share/applications/dbflux.desktop
     substituteInPlace $out/share/applications/dbflux.desktop \
-      --replace-fail '@EXEC_PATH@' "$out/bin/dbflux"
+      --replace-fail '@EXEC_PATH@' "$out/bin/dbflux" \
+      --replace-fail '@APP_NAME@' 'DBFlux' \
+      --replace-fail '@APP_ID@' 'dbflux'
 
     install -Dm644 resources/branding/stable/mark.svg \
       $out/share/icons/hicolor/scalable/apps/dbflux.svg
     install -Dm644 resources/mime/dbflux-sql.xml \
       $out/share/mime/packages/dbflux-sql.xml
+    substituteInPlace $out/share/mime/packages/dbflux-sql.xml \
+      --replace-fail '@APP_ID@' 'dbflux'
 
     install -Dm644 LICENSE-MIT    $out/share/licenses/dbflux/LICENSE-MIT
     install -Dm644 LICENSE-APACHE $out/share/licenses/dbflux/LICENSE-APACHE

--- a/packaging/dbflux.desktop
+++ b/packaging/dbflux.desktop
@@ -1,14 +1,14 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=${APP_NAME}
+Name=@APP_NAME@
 GenericName=Database Client
 Comment=A fast, keyboard-first database client for SQL and NoSQL databases
-Exec=${APP_ID} %F
-Icon=${APP_ID}
+Exec=@APP_ID@ %F
+Icon=@APP_ID@
 Terminal=false
 StartupNotify=true
-StartupWMClass=${APP_ID}
+StartupWMClass=@APP_ID@
 Categories=Development;Database;IDE;
 Keywords=database;sql;query;postgres;sqlite;mysql;mongodb;redis;
 MimeType=text/x-sql;application/sql;

--- a/resources/branding/glyph.svg
+++ b/resources/branding/glyph.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" fill="none" role="img" aria-label="DBFlux">
+  <circle cx="64" cy="64" r="42" fill="none" stroke="#FFB454" stroke-width="2.5"></circle>
+  <g stroke="#FFB454" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <ellipse cx="64" cy="40" rx="20" ry="5.5"></ellipse>
+    <path d="M44 40 V58"></path>
+    <path d="M84 40 V58"></path>
+    <path d="M44 58 a20 5.5 0 0 0 40 0"></path>
+    <path d="M44 58 V76"></path>
+    <path d="M84 58 V76"></path>
+    <path d="M44 76 a20 5.5 0 0 0 40 0"></path>
+    <path d="M44 76 V92"></path>
+    <path d="M84 76 V92"></path>
+    <path d="M44 92 a20 5.5 0 0 0 40 0"></path>
+  </g>
+  <path d="M74 28 L48 66 L60 66 L54 100 L80 62 L68 62 Z" fill="#FFB454"></path>
+</svg>

--- a/resources/desktop/dbflux.desktop
+++ b/resources/desktop/dbflux.desktop
@@ -1,14 +1,14 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=${APP_NAME}
+Name=@APP_NAME@
 GenericName=Database Client
 Comment=A fast, keyboard-first database client for SQL databases
 Exec=@EXEC_PATH@ %F
-Icon=${APP_ID}
+Icon=@APP_ID@
 Terminal=false
 StartupNotify=true
-StartupWMClass=${APP_ID}
+StartupWMClass=@APP_ID@
 Categories=Development;Database;IDE;
 Keywords=database;sql;query;postgres;sqlite;mysql;
 MimeType=text/x-sql;application/sql;

--- a/resources/mime/dbflux-sql.xml
+++ b/resources/mime/dbflux-sql.xml
@@ -3,11 +3,11 @@
   <mime-type type="text/x-sql">
     <comment>SQL Database Query</comment>
     <glob pattern="*.sql"/>
-    <icon name="${APP_ID}"/>
+    <icon name="@APP_ID@"/>
   </mime-type>
   <mime-type type="application/sql">
     <comment>SQL Database Query</comment>
     <glob pattern="*.sql"/>
-    <icon name="${APP_ID}"/>
+    <icon name="@APP_ID@"/>
   </mime-type>
 </mime-info>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -461,8 +461,14 @@ install_files() {
             echo "[DRY-RUN] sed -i 's|@EXEC_PATH@|$PREFIX/bin/dbflux|g' $PREFIX/share/applications/dbflux.desktop"
         else
             cp "$src_dir/resources/desktop/dbflux.desktop" "$PREFIX/share/applications/dbflux.desktop"
-            # Replace @EXEC_PATH@ with the actual binary path
-            sed -i "s|@EXEC_PATH@|$PREFIX/bin/dbflux|g" "$PREFIX/share/applications/dbflux.desktop"
+            # Resolve the binary path and the stable branding placeholders. This
+            # installer ships the stable identity; per-channel coexistence is
+            # provided by the deb/rpm/AppImage artifacts.
+            sed -i \
+                -e "s|@EXEC_PATH@|$PREFIX/bin/dbflux|g" \
+                -e "s|@APP_NAME@|DBFlux|g" \
+                -e "s|@APP_ID@|dbflux|g" \
+                "$PREFIX/share/applications/dbflux.desktop"
             chmod 644 "$PREFIX/share/applications/dbflux.desktop"
         fi
     fi
@@ -478,6 +484,9 @@ install_files() {
     if [[ -f "$src_dir/resources/mime/dbflux-sql.xml" ]]; then
         mkdir_safe "$PREFIX/share/mime/packages"
         cp_safe "$src_dir/resources/mime/dbflux-sql.xml" "$PREFIX/share/mime/packages/dbflux-sql.xml"
+        if [[ "$DRY_RUN" == "false" ]]; then
+            sed -i "s|@APP_ID@|dbflux|g" "$PREFIX/share/mime/packages/dbflux-sql.xml"
+        fi
         chmod_safe "$PREFIX/share/mime/packages/dbflux-sql.xml" 644
 
         if [[ "$DRY_RUN" == "false" ]] && command -v update-mime-database &>/dev/null; then


### PR DESCRIPTION
## Summary

- Fixes two rendering regressions from #191 (per-channel branding): the in-app brand icon showed as a solid square, and installed `.desktop`/mime files showed the literal `${APP_NAME}` placeholder.
- Per-channel variants are preserved — the fix corrects *how* the values are substituted, it does not drop the nightly identity.

## What does this resolve?

Follow-up bug fixes for #183 (delivered in #191).

## How was this solved?

Two reviewable commits:

**1. In-app icon → tint-friendly glyph**
The About view renders the mark via the monochrome icon path (`Icon::new(AppIcon::DbFlux).primary()`), which draws an SVG as a single-color mask. The full-color channel marks under `resources/branding` have an opaque background rect, so the mask collapsed into a solid square. `AppIcon::DbFlux` now points at a dedicated line-art glyph (transparent background), like every other brand icon in the set, so it tints cleanly. The full-color marks stay in use for OS-level packaging icons (rendered in color by the platform). The in-app glyph is channel-agnostic; the channel is conveyed by the OS icon and the version string.

**2. Desktop/mime templating → `@VAR@` convention**
Root cause of the `${APP_NAME}` regression: the templates used envsubst-style `${...}`, but only two CI steps run `envsubst`. Every other consumer — `scripts/install.sh`, `nix/binary.nix`, `default.nix`, and the AppImage mime copy — substitutes only the existing `@EXEC_PATH@` placeholder or copies the file verbatim, so the `${...}` survived literally. The fix switches the desktop/mime templates to the repo's existing `@VAR@` sed convention (the same one `@EXEC_PATH@` uses) and has every consumer resolve `@APP_NAME@`/`@APP_ID@`:

- CI (AppImage, deb/rpm) substitutes the channel identity → nightly keeps its distinct name/icon/StartupWMClass.
- The portable-tarball installer and the Nix derivations substitute the stable identity (single-channel by design).

`Info.plist` (`${...}`, consumed only by the macOS `sed` step) and the nfpm YAML (`${...}`, consumed only by `envsubst`) are single-consumer and left as-is.

## Validation

- `cargo check -p dbflux_ui` — passes; `cargo fmt --all --check` — clean.
- `bash -n scripts/install.sh` — OK.
- Simulated the sed substitution for both channels: nightly AppImage desktop renders `Name=DBFlux Nightly` / `Icon=dbflux-nightly` / `StartupWMClass=dbflux-nightly`; stable install.sh + mime render `dbflux`; zero leftover `@…@` / `${…}` placeholders in any rendered output.

**Note:** the packaging paths (deb/rpm/AppImage/nix) are still only fully verifiable in a real release/nightly workflow run; the substitution was validated by simulation here.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [x] Other: CI packaging validated by simulation (see Note)

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` (git-cliff generates it from the conventional commits)
- [x] I applied the appropriate labels

## Labels to apply

- `ui:bug`, `platform:linux`