### PR TITLE
fix(branding): nix build, About color, launcher icon + nightly DB-share toggle (#183)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,7 +196,7 @@ jobs:
           convert "$BRAND_DIR/mark.svg" -resize 256x256 packaging/icons/256x256/apps/dbflux.png
           convert "$BRAND_DIR/mark.svg" -resize 128x128 packaging/icons/128x128/apps/dbflux.png
           convert "$BRAND_DIR/mark.svg" -resize 64x64 packaging/icons/64x64/apps/dbflux.png
-          convert "$BRAND_DIR/mark.svg" -resize 48x48 packaging/icons/48x48/apps/dbflux.png
+          convert "$BRAND_DIR/mark-small.svg" -resize 48x48 packaging/icons/48x48/apps/dbflux.png
           convert "$BRAND_DIR/mark-small.svg" -resize 32x32 packaging/icons/32x32/apps/dbflux.png
           convert "$BRAND_DIR/mark-small.svg" -resize 16x16 packaging/icons/16x16/apps/dbflux.png
 
@@ -495,7 +495,7 @@ jobs:
           magick convert -background none -resize 256x256 "$BrandDir/mark.svg" dbflux-256.png
           magick convert -background none -resize 128x128 "$BrandDir/mark.svg" dbflux-128.png
           magick convert -background none -resize 64x64 "$BrandDir/mark.svg" dbflux-64.png
-          magick convert -background none -resize 48x48 "$BrandDir/mark.svg" dbflux-48.png
+          magick convert -background none -resize 48x48 "$BrandDir/mark-small.svg" dbflux-48.png
           magick convert -background none -resize 32x32 "$BrandDir/mark-small.svg" dbflux-32.png
           magick convert -background none -resize 16x16 "$BrandDir/mark-small.svg" dbflux-16.png
           magick convert dbflux-16.png dbflux-32.png dbflux-48.png dbflux-64.png dbflux-128.png dbflux-256.png dbflux.ico

--- a/crates/dbflux_storage/src/paths.rs
+++ b/crates/dbflux_storage/src/paths.rs
@@ -28,12 +28,63 @@ pub fn data_dir() -> Result<PathBuf, StorageError> {
     Ok(dir)
 }
 
+/// Marker file inside the data directory that opts a nightly build into the
+/// stable database. Its presence is the whole signal — the file is empty.
+///
+/// This setting cannot live in the database itself: it decides *which* database
+/// to open, so it must be readable before any database is opened.
+fn shared_db_marker_path() -> Result<PathBuf, StorageError> {
+    Ok(data_dir()?.join("use-stable-db"))
+}
+
+/// Whether the running nightly build is configured to share the stable
+/// database instead of its own `dbflux-nightly.db`.
+///
+/// Always `false` outside nightly. Best-effort: a probing error is treated as
+/// "not shared" so a filesystem hiccup never silently redirects writes onto the
+/// stable database.
+pub fn nightly_shares_stable_db() -> bool {
+    if dbflux_core::ReleaseChannel::current() != dbflux_core::ReleaseChannel::Nightly {
+        return false;
+    }
+
+    shared_db_marker_path()
+        .map(|path| path.exists())
+        .unwrap_or(false)
+}
+
+/// Opts the nightly build into (`enabled`) or out of (`!enabled`) the stable
+/// database. The change takes effect on the next launch, since the database is
+/// opened once at startup.
+pub fn set_nightly_shares_stable_db(enabled: bool) -> Result<(), StorageError> {
+    let path = shared_db_marker_path()?;
+
+    if enabled {
+        std::fs::write(&path, b"").map_err(|source| StorageError::Io {
+            path: path.clone(),
+            source,
+        })?;
+    } else if path.exists() {
+        std::fs::remove_file(&path).map_err(|source| StorageError::Io {
+            path: path.clone(),
+            source,
+        })?;
+    }
+
+    Ok(())
+}
+
 /// Returns the path for the unified database inside the data directory.
 ///
 /// The file name is channel-specific: nightly builds use `dbflux-nightly.db`
 /// so a pre-release migration cannot corrupt the stable `dbflux.db` of a user
-/// who runs both channels side by side.
+/// who runs both channels side by side. A nightly build may opt into the stable
+/// database via [`set_nightly_shares_stable_db`].
 pub fn dbflux_db_path() -> Result<PathBuf, StorageError> {
-    let file_name = dbflux_core::ReleaseChannel::current().db_file_name();
+    let file_name = if nightly_shares_stable_db() {
+        "dbflux.db"
+    } else {
+        dbflux_core::ReleaseChannel::current().db_file_name()
+    };
     Ok(data_dir()?.join(file_name))
 }

--- a/crates/dbflux_ui/src/assets.rs
+++ b/crates/dbflux_ui/src/assets.rs
@@ -7,6 +7,22 @@ pub struct Assets;
 
 impl AssetSource for Assets {
     fn load(&self, path: &str) -> gpui::Result<Option<Cow<'static, [u8]>>> {
+        // Full-color brand marks, served for `img(...)` (which renders the SVG
+        // in color) rather than the monochrome `svg()` icon path.
+        match path {
+            "branding/stable/mark.svg" => {
+                return Ok(Some(Cow::Borrowed(include_bytes!(
+                    "../../../resources/branding/stable/mark.svg"
+                ))));
+            }
+            "branding/nightly/mark.svg" => {
+                return Ok(Some(Cow::Borrowed(include_bytes!(
+                    "../../../resources/branding/nightly/mark.svg"
+                ))));
+            }
+            _ => {}
+        }
+
         if let Some(icon) = ALL_ICONS.iter().find(|icon| icon.path() == path) {
             return Ok(Some(Cow::Borrowed(embedded_bytes(*icon))));
         }

--- a/crates/dbflux_ui_windows/src/settings/about_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/about_section.rs
@@ -1,6 +1,4 @@
 use super::{SettingsSection, SettingsSectionId};
-use dbflux_components::icons::AppIcon;
-use dbflux_components::primitives::Icon;
 use dbflux_components::typography::{Body, FieldLabel, Headline, MonoCaption};
 use gpui::prelude::*;
 use gpui::*;
@@ -35,6 +33,13 @@ impl Render for AboutSection {
         #[cfg(not(debug_assertions))]
         const PROFILE: &str = "release";
 
+        // Rendered through `img` (full color) rather than the monochrome icon
+        // path so the channel-specific mark — including nightly — shows in color.
+        let mark_path = match dbflux_core::ReleaseChannel::current() {
+            dbflux_core::ReleaseChannel::Nightly => "branding/nightly/mark.svg",
+            _ => "branding/stable/mark.svg",
+        };
+
         let issues_url = format!("{}/issues", REPOSITORY);
         let author_name = AUTHORS.split('<').next().unwrap_or(AUTHORS).trim();
         let license_display = LICENSE.replace(" OR ", " and ");
@@ -61,7 +66,7 @@ impl Render for AboutSection {
                                 .flex()
                                 .items_center()
                                 .gap_3()
-                                .child(Icon::new(AppIcon::DbFlux).size(px(65.0)).primary())
+                                .child(img(mark_path).size(px(65.0)))
                                 .child(
                                     div()
                                         .flex()

--- a/crates/dbflux_ui_windows/src/settings/general.rs
+++ b/crates/dbflux_ui_windows/src/settings/general.rs
@@ -7,6 +7,7 @@ use dbflux_components::typography::{Body, FieldLabel, SubSectionLabel};
 use dbflux_ui_base::keymap::key_chord_from_gpui;
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
 use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
+use gpui::prelude::FluentBuilder;
 use gpui::*;
 use gpui_component::ActiveTheme;
 use gpui_component::Sizable;
@@ -54,7 +55,7 @@ impl GeneralSection {
     }
 
     pub(super) fn gen_form_rows(&self) -> Vec<GeneralFormRow> {
-        vec![
+        let mut rows = vec![
             GeneralFormRow::Theme,
             GeneralFormRow::Style,
             GeneralFormRow::RestoreSession,
@@ -70,8 +71,32 @@ impl GeneralSection {
             GeneralFormRow::ConfirmDangerous,
             GeneralFormRow::RequiresWhere,
             GeneralFormRow::RequiresPreview,
-            GeneralFormRow::SaveButton,
-        ]
+        ];
+
+        // The shared-database toggle only makes sense on nightly, which is the
+        // only channel that uses a separate database by default.
+        if Self::is_nightly() {
+            rows.push(GeneralFormRow::ShareStableDb);
+        }
+
+        rows.push(GeneralFormRow::SaveButton);
+        rows
+    }
+
+    fn is_nightly() -> bool {
+        dbflux_core::ReleaseChannel::current() == dbflux_core::ReleaseChannel::Nightly
+    }
+
+    /// Toggles whether this nightly build shares the stable database. The change
+    /// is persisted to the pre-database marker immediately and applies on the
+    /// next launch; a write failure is logged and leaves the toggle unchanged.
+    fn set_share_stable_db(&mut self, value: bool) {
+        match dbflux_storage::paths::set_nightly_shares_stable_db(value) {
+            Ok(()) => self.gen_share_stable_db = value,
+            Err(error) => {
+                log::error!("Failed to update the shared-database setting: {error}")
+            }
+        }
     }
 
     fn gen_current_row(&self) -> Option<GeneralFormRow> {
@@ -158,6 +183,10 @@ impl GeneralSection {
             Some(GeneralFormRow::RequiresPreview) => {
                 self.gen_settings.dangerous_requires_preview =
                     !self.gen_settings.dangerous_requires_preview;
+                cx.notify();
+            }
+            Some(GeneralFormRow::ShareStableDb) => {
+                self.set_share_stable_db(!self.gen_share_stable_db);
                 cx.notify();
             }
             Some(GeneralFormRow::MaxHistory)
@@ -583,7 +612,30 @@ impl GeneralSection {
                     GeneralFormRow::RequiresPreview,
                     |this, value| this.gen_settings.dangerous_requires_preview = value,
                     cx,
-                )),
+                ))
+                .when(Self::is_nightly(), |column| {
+                    column
+                        .child(self.render_gen_group_header("Storage", border, muted_fg))
+                        .child(self.render_gen_checkbox(
+                            "share-stable-db",
+                            "Use the stable database",
+                            self.gen_share_stable_db,
+                            is_at(GeneralFormRow::ShareStableDb),
+                            GeneralFormRow::ShareStableDb,
+                            |this, value| this.set_share_stable_db(value),
+                            cx,
+                        ))
+                        .child(
+                            div().px_2().child(
+                                Body::new(
+                                    "Applied on next launch. Shares the stable database \
+                                     (dbflux.db) instead of this nightly build's \
+                                     dbflux-nightly.db.",
+                                )
+                                .color(muted_fg),
+                            ),
+                        )
+                }),
         )
     }
 

--- a/crates/dbflux_ui_windows/src/settings/general_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/general_section.rs
@@ -25,6 +25,7 @@ pub(super) enum GeneralFormRow {
     ConfirmDangerous,
     RequiresWhere,
     RequiresPreview,
+    ShareStableDb,
     SaveButton,
 }
 
@@ -33,6 +34,9 @@ pub(super) struct GeneralSection {
     pub(super) gen_settings: GeneralSettings,
     pub(super) gen_form_cursor: usize,
     pub(super) gen_editing_field: bool,
+    /// Nightly-only: whether this build is opted into the stable database.
+    /// Backed by a pre-database marker file, applied on the next launch.
+    pub(super) gen_share_stable_db: bool,
     pub(super) dropdown_theme: Entity<Dropdown>,
     pub(super) dropdown_style: Entity<Dropdown>,
     pub(super) dropdown_default_focus: Entity<Dropdown>,
@@ -194,6 +198,7 @@ impl GeneralSection {
             gen_settings: settings,
             gen_form_cursor: 0,
             gen_editing_field: false,
+            gen_share_stable_db: dbflux_storage::paths::nightly_shares_stable_db(),
             dropdown_theme,
             dropdown_style,
             dropdown_default_focus,

--- a/nix/binary.nix
+++ b/nix/binary.nix
@@ -110,21 +110,32 @@ stdenv.mkDerivation {
 
     install -Dm755 dbflux $out/bin/dbflux
 
-    # Desktop entry — resolve the templated placeholders. This derivation ships
-    # the stable identity.
+    # Desktop entry. This derivation installs a published release tarball whose
+    # resource layout is fixed at release time, so it must tolerate both the
+    # pre- and post-branding-split layouts. @EXEC_PATH@ is present in every
+    # tarball; the @APP_*@ identity placeholders only exist in newer ones, so
+    # resolve them with sed (a no-op when absent). This derivation ships the
+    # stable identity.
     install -Dm644 resources/desktop/dbflux.desktop \
       $out/share/applications/dbflux.desktop
     substituteInPlace $out/share/applications/dbflux.desktop \
-      --replace-fail '@EXEC_PATH@' "$out/bin/dbflux" \
-      --replace-fail '@APP_NAME@' 'DBFlux' \
-      --replace-fail '@APP_ID@' 'dbflux'
+      --replace-fail '@EXEC_PATH@' "$out/bin/dbflux"
+    sed -i -e 's/@APP_NAME@/DBFlux/g' -e 's/@APP_ID@/dbflux/g' \
+      $out/share/applications/dbflux.desktop
 
-    install -Dm644 resources/branding/stable/mark.svg \
-      $out/share/icons/hicolor/scalable/apps/dbflux.svg
+    # Brand mark. Tarballs before the branding split ship it at
+    # resources/icons/dbflux.svg; newer ones ship per-channel marks.
+    if [ -f resources/branding/stable/mark.svg ]; then
+      install -Dm644 resources/branding/stable/mark.svg \
+        $out/share/icons/hicolor/scalable/apps/dbflux.svg
+    else
+      install -Dm644 resources/icons/dbflux.svg \
+        $out/share/icons/hicolor/scalable/apps/dbflux.svg
+    fi
+
     install -Dm644 resources/mime/dbflux-sql.xml \
       $out/share/mime/packages/dbflux-sql.xml
-    substituteInPlace $out/share/mime/packages/dbflux-sql.xml \
-      --replace-fail '@APP_ID@' 'dbflux'
+    sed -i 's/@APP_ID@/dbflux/g' $out/share/mime/packages/dbflux-sql.xml
 
     install -Dm644 LICENSE-MIT    $out/share/licenses/dbflux/LICENSE-MIT
     install -Dm644 LICENSE-APACHE $out/share/licenses/dbflux/LICENSE-APACHE


### PR DESCRIPTION
## Summary

Follow-ups reported after #193 merged. Four independent fixes:

1. **Nix binary build** — the prebuilt-binary derivation no longer fails against release tarballs that predate the branding split.
2. **About icon** — the channel-specific mark renders in full color, so nightly shows its distinct green mark.
3. **Launcher icon** — the 48px packaging icon uses the bolder small mark so it stays legible in the menu/taskbar.
4. **Nightly DB-share toggle** — a General setting (nightly only) to point nightly at the stable database instead of its own.

## What does this resolve?

Follow-ups to #183 / #191 / #193.

## How was this solved?

**1. `nix/binary.nix`** — installs a published release tarball whose layout is frozen at release time. With `release-info` pinned at the pre-branding-split v0.6.0-rc.3, installing `resources/branding/...` and `substituteInPlace --replace-fail '@APP_NAME@'` both errored. It now falls back to the legacy icon path when the branding marks are absent and resolves `@APP_*@` with `sed` (a no-op when missing). Verified with `nix build .#dbflux-bin`.

**2. About full-color mark** — the About icon went through the monochrome icon path (`Icon::...primary()`), which tints an SVG one color and cannot convey the channel. It now renders the channel mark with `img` (gpui rasterizes SVG in color), served from the asset source.

**3. 48px launcher icon** — at small sizes the detailed mark reads faint next to solid app icons; the 48px PNG/ICO is now generated from `mark-small.svg` (already used for 16/32px). 64px+ keep the full mark.

**4. Nightly → stable DB toggle** — nightly defaults to `dbflux-nightly.db` for migration safety. This adds an opt-out. The choice can't live in the database (it decides *which* database to open), so it is an empty marker file in the data dir, read before the DB opens. `dbflux_db_path()` consults it; a General settings toggle (shown only on nightly) writes it and applies on next launch.

## Validation

- `nix build .#dbflux-bin` — succeeds against the pinned tarball; installed desktop/mime/icon have no leftover placeholders.
- `cargo check -p dbflux_storage -p dbflux_ui_windows` — passes; `cargo clippy … -D warnings` — clean; `cargo fmt --all --check` — clean.

**Untested locally:** the GPUI rendering (About icon, the new General toggle) and the packaging icon sizing are only fully verifiable by running the app / a release build.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [x] Other: `nix build .#dbflux-bin`

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` (git-cliff generates it from the conventional commits)
- [x] I applied the appropriate labels

## Labels to apply

- `ui:bug`, `storage:feature`, `platform:linux`