### PR TITLE
fix(nix,settings): channel coexistence in nix + General input width (#183)

### DIFF
--- a/crates/dbflux_ui_windows/src/settings/general.rs
+++ b/crates/dbflux_ui_windows/src/settings/general.rs
@@ -812,7 +812,7 @@ impl GeneralSection {
                             cx.notify();
                         }),
                     )
-                    .child(Input::new(input).small()),
+                    .child(Input::new(input).small().w_full()),
             )
     }
 }

--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,15 @@
 }:
 
 let
+  # Per-channel install identity. Mirrors the runtime `ReleaseChannel` and the
+  # deb/rpm packaging: a nightly build installs under distinct binary/desktop/
+  # icon names so a stable and a nightly package can coexist in one profile
+  # (e.g. a home-manager `buildEnv`) without colliding on `bin/dbflux`.
+  isNightly = pkgs.lib.hasInfix "nightly" version;
+  appId = if isNightly then "dbflux-nightly" else "dbflux";
+  appName = if isNightly then "DBFlux Nightly" else "DBFlux";
+  brandDir = if isNightly then "nightly" else "stable";
+
   # Build inputs needed at runtime
   buildInputs = with pkgs; [
     openssl
@@ -81,20 +90,24 @@ let
     mkdir -p $out/share/mime/packages
     mkdir -p $out/share/dbflux
 
+    # cargo always emits a binary named `dbflux`; rename it for non-stable
+    # channels so two channels can coexist in one profile.
+    ${pkgs.lib.optionalString isNightly "mv $out/bin/dbflux $out/bin/${appId}"}
+
     # Copy desktop file and resolve the templated placeholders
-    install -Dm644 ${fullSrc}/resources/desktop/dbflux.desktop $out/share/applications/dbflux.desktop
-    substituteInPlace $out/share/applications/dbflux.desktop \
-      --replace '@EXEC_PATH@' "$out/bin/dbflux" \
-      --replace '@APP_NAME@' 'DBFlux' \
-      --replace '@APP_ID@' 'dbflux'
+    install -Dm644 ${fullSrc}/resources/desktop/dbflux.desktop $out/share/applications/${appId}.desktop
+    substituteInPlace $out/share/applications/${appId}.desktop \
+      --replace '@EXEC_PATH@' "$out/bin/${appId}" \
+      --replace '@APP_NAME@' '${appName}' \
+      --replace '@APP_ID@' '${appId}'
 
     # Copy icon
-    install -Dm644 ${fullSrc}/resources/branding/stable/mark.svg $out/share/icons/hicolor/scalable/apps/dbflux.svg
+    install -Dm644 ${fullSrc}/resources/branding/${brandDir}/mark.svg $out/share/icons/hicolor/scalable/apps/${appId}.svg
 
     # Copy mime type
-    install -Dm644 ${fullSrc}/resources/mime/dbflux-sql.xml $out/share/mime/packages/dbflux-sql.xml
-    substituteInPlace $out/share/mime/packages/dbflux-sql.xml \
-      --replace '@APP_ID@' 'dbflux'
+    install -Dm644 ${fullSrc}/resources/mime/dbflux-sql.xml $out/share/mime/packages/${appId}-sql.xml
+    substituteInPlace $out/share/mime/packages/${appId}-sql.xml \
+      --replace '@APP_ID@' '${appId}'
 
     # Copy resources (with proper permissions)
     cp -r --no-preserve=mode ${fullSrc}/resources $out/share/dbflux/
@@ -107,7 +120,7 @@ let
 
     # Wrap binary with LD_LIBRARY_PATH for Wayland/Vulkan/X11
     # Include common system paths for GPU drivers on non-NixOS systems
-    wrapProgram $out/bin/dbflux \
+    wrapProgram $out/bin/${appId} \
       --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}" \
       --suffix LD_LIBRARY_PATH : "/run/opengl-driver/lib:/usr/lib/x86_64-linux-gnu:/usr/lib64:/usr/lib"
   '';
@@ -134,16 +147,17 @@ let
     craneLib.buildPackage (
       commonArgs
       // {
-        pname = "dbflux";
+        pname = appId;
         inherit version cargoArtifacts;
         cargoExtraArgs = "-p dbflux";
         postInstall = postInstallScript;
+        meta.mainProgram = appId;
       }
     );
 
   # Build with rustPlatform (for non-flake usage)
   buildWithRustPlatform = pkgs.rustPlatform.buildRustPackage {
-    pname = "dbflux";
+    pname = appId;
     inherit version;
     src = fullSrc;
 
@@ -168,7 +182,7 @@ let
     postInstall = postInstallScript;
 
     postFixup = ''
-      wrapProgram $out/bin/dbflux \
+      wrapProgram $out/bin/${appId} \
         --prefix LD_LIBRARY_PATH : "${runtimeLibraryPath}" \
         --suffix LD_LIBRARY_PATH : "/run/opengl-driver/lib:/usr/lib/x86_64-linux-gnu:/usr/lib64:/usr/lib"
     '';
@@ -182,7 +196,7 @@ let
       ];
       maintainers = [ ];
       platforms = platforms.linux;
-      mainProgram = "dbflux";
+      mainProgram = appId;
     };
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,7 @@
           } // (if hasPrebuilt then {
             dbflux-nightly = flake-utils.lib.mkApp {
               drv = dbfluxNightly;
-              exePath = "/bin/dbflux";
+              exePath = "/bin/dbflux-nightly";
             };
           } else { });
         }

--- a/nix/binary.nix
+++ b/nix/binary.nix
@@ -49,9 +49,17 @@ let
   artifact = releaseInfo.artifacts.${system} or (throw
     "dbflux: no prebuilt binary published for system '${system}'. "
     + "Use the source build (packages.dbflux-source) instead.");
+
+  # Per-channel install identity. Mirrors the runtime `ReleaseChannel` and the
+  # deb/rpm packaging: nightly installs under distinct binary/desktop/icon names
+  # so a stable and a nightly package can coexist in one profile (e.g. a
+  # home-manager `buildEnv`) without colliding on `bin/dbflux`.
+  isNightly = lib.hasInfix "nightly" releaseInfo.version;
+  appId = if isNightly then "dbflux-nightly" else "dbflux";
+  appName = if isNightly then "DBFlux Nightly" else "DBFlux";
 in
 stdenv.mkDerivation {
-  pname = "dbflux";
+  pname = appId;
   version = releaseInfo.version;
 
   src = fetchurl {
@@ -108,37 +116,37 @@ stdenv.mkDerivation {
 
     cd source
 
-    install -Dm755 dbflux $out/bin/dbflux
+    install -Dm755 dbflux $out/bin/${appId}
 
     # Desktop entry. This derivation installs a published release tarball whose
     # resource layout is fixed at release time, so it must tolerate both the
     # pre- and post-branding-split layouts. @EXEC_PATH@ is present in every
     # tarball; the @APP_*@ identity placeholders only exist in newer ones, so
-    # resolve them with sed (a no-op when absent). This derivation ships the
-    # stable identity.
+    # resolve them with sed (a no-op when absent). Names are channel-scoped so a
+    # stable and a nightly package can coexist in one profile.
     install -Dm644 resources/desktop/dbflux.desktop \
-      $out/share/applications/dbflux.desktop
-    substituteInPlace $out/share/applications/dbflux.desktop \
-      --replace-fail '@EXEC_PATH@' "$out/bin/dbflux"
-    sed -i -e 's/@APP_NAME@/DBFlux/g' -e 's/@APP_ID@/dbflux/g' \
-      $out/share/applications/dbflux.desktop
+      $out/share/applications/${appId}.desktop
+    substituteInPlace $out/share/applications/${appId}.desktop \
+      --replace-fail '@EXEC_PATH@' "$out/bin/${appId}"
+    sed -i -e 's/@APP_NAME@/${appName}/g' -e 's/@APP_ID@/${appId}/g' \
+      $out/share/applications/${appId}.desktop
 
     # Brand mark. Tarballs before the branding split ship it at
     # resources/icons/dbflux.svg; newer ones ship per-channel marks.
-    if [ -f resources/branding/stable/mark.svg ]; then
-      install -Dm644 resources/branding/stable/mark.svg \
-        $out/share/icons/hicolor/scalable/apps/dbflux.svg
+    if [ -f resources/branding/${if isNightly then "nightly" else "stable"}/mark.svg ]; then
+      install -Dm644 resources/branding/${if isNightly then "nightly" else "stable"}/mark.svg \
+        $out/share/icons/hicolor/scalable/apps/${appId}.svg
     else
       install -Dm644 resources/icons/dbflux.svg \
-        $out/share/icons/hicolor/scalable/apps/dbflux.svg
+        $out/share/icons/hicolor/scalable/apps/${appId}.svg
     fi
 
     install -Dm644 resources/mime/dbflux-sql.xml \
-      $out/share/mime/packages/dbflux-sql.xml
-    sed -i 's/@APP_ID@/dbflux/g' $out/share/mime/packages/dbflux-sql.xml
+      $out/share/mime/packages/${appId}-sql.xml
+    sed -i 's/@APP_ID@/${appId}/g' $out/share/mime/packages/${appId}-sql.xml
 
-    install -Dm644 LICENSE-MIT    $out/share/licenses/dbflux/LICENSE-MIT
-    install -Dm644 LICENSE-APACHE $out/share/licenses/dbflux/LICENSE-APACHE
+    install -Dm644 LICENSE-MIT    $out/share/licenses/${appId}/LICENSE-MIT
+    install -Dm644 LICENSE-APACHE $out/share/licenses/${appId}/LICENSE-APACHE
 
     runHook postInstall
   '';
@@ -147,7 +155,7 @@ stdenv.mkDerivation {
   # cannot detect these because they are not in DT_NEEDED. Inject them
   # via LD_LIBRARY_PATH on the wrapper.
   postFixup = ''
-    wrapProgram $out/bin/dbflux \
+    wrapProgram $out/bin/${appId} \
       --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
         wayland
         libxkbcommon
@@ -166,7 +174,7 @@ stdenv.mkDerivation {
     description = "A fast, keyboard-first database client (prebuilt binary)";
     homepage = "https://github.com/0xErwin1/dbflux";
     license = with licenses; [ mit asl20 ];
-    mainProgram = "dbflux";
+    mainProgram = appId;
     platforms = builtins.attrNames releaseInfo.artifacts;
     sourceProvenance = with sourceTypes; [ binaryNativeCode ];
   };


### PR DESCRIPTION
Closes #183

Two regressions surfaced after the per-channel branding work landed on `main`.

## What changed

- **Nix coexistence.** Installing a stable and a nightly DBFlux into one profile (a home-manager `buildEnv`) failed with a `buildEnv` conflict on `bin/.dbflux-wrapped`. The deb/rpm packaging already installs per-channel names, but the nix derivations always installed `bin/dbflux` plus `dbflux.desktop/.svg/-sql.xml`, so any two channels collided. The derivations now derive the channel from the version string (same signal as the runtime `ReleaseChannel`) and scope the binary, desktop entry, icon, mime file and license dir to `dbflux` / `dbflux-nightly`.
- **General number inputs.** The previous fix put `w_full` on the field wrapper divs, but the `Input` element itself still shrank to content width, so the fields rendered as tiny squares until the window was resized. `w_full` now sits on the `Input` directly, matching every other `Input` call site.

## Review path

1. `nix/binary.nix` + `default.nix` — the `isNightly` / `appId` derivation and the renamed install targets are the core change.
2. `flake.nix` — `dbflux-nightly` app `exePath` follows the renamed binary.
3. `general.rs` — one-line `.w_full()` on the `Input`.

## Out of scope

- The dev-launcher menu icon (a desktop-environment icon-cache concern, only correct after a real deb/AppImage install) is unchanged.

| File | Change |
|------|--------|
| `nix/binary.nix` | Channel-scoped bin/desktop/icon/mime/license names |
| `default.nix` | Same for the source build; rename cargo's `dbflux` binary on nightly |
| `flake.nix` | `dbflux-nightly` app `exePath` -> `/bin/dbflux-nightly` |
| `crates/dbflux_ui_windows/src/settings/general.rs` | `w_full` on the input element |

## Test plan

- [x] `nix build .#dbflux-bin` — stable output unchanged (`bin/dbflux`, `dbflux.desktop/.svg`).
- [x] Built `binary.nix` with a nightly info file -> emits `bin/dbflux-nightly`, `dbflux-nightly.desktop/.svg/-sql.xml`; no shared paths with stable.
- [x] Source nightly build (`default.nix` with a `-nightly` version) renames the binary to `dbflux-nightly`.
- [x] General settings: number inputs render at full width on first paint.