### PR TITLE
fix(nix): probe brand-mark locations so the nightly binary build succeeds (#183)

### DIFF
--- a/nix/binary.nix
+++ b/nix/binary.nix
@@ -57,6 +57,7 @@ let
   isNightly = lib.hasInfix "nightly" releaseInfo.version;
   appId = if isNightly then "dbflux-nightly" else "dbflux";
   appName = if isNightly then "DBFlux Nightly" else "DBFlux";
+  brandDir = if isNightly then "nightly" else "stable";
 in
 stdenv.mkDerivation {
   pname = appId;
@@ -131,14 +132,22 @@ stdenv.mkDerivation {
     sed -i -e 's/@APP_NAME@/${appName}/g' -e 's/@APP_ID@/${appId}/g' \
       $out/share/applications/${appId}.desktop
 
-    # Brand mark. Tarballs before the branding split ship it at
-    # resources/icons/dbflux.svg; newer ones ship per-channel marks.
-    if [ -f resources/branding/${if isNightly then "nightly" else "stable"}/mark.svg ]; then
-      install -Dm644 resources/branding/${if isNightly then "nightly" else "stable"}/mark.svg \
-        $out/share/icons/hicolor/scalable/apps/${appId}.svg
+    # Brand mark. The mark layout inside a published tarball varies by release:
+    # the channel packaging writes the active channel's mark to
+    # resources/branding/stable/mark.svg (the channel dir name is not preserved),
+    # and tarballs from before the branding split shipped resources/icons/dbflux.svg.
+    # Probe each known location and install the first that exists so the build
+    # never breaks on a layout this derivation did not author.
+    icon_dst=$out/share/icons/hicolor/scalable/apps/${appId}.svg
+    if [ -f resources/branding/${brandDir}/mark.svg ]; then
+      install -Dm644 resources/branding/${brandDir}/mark.svg "$icon_dst"
+    elif [ -f resources/branding/stable/mark.svg ]; then
+      install -Dm644 resources/branding/stable/mark.svg "$icon_dst"
+    elif [ -f resources/icons/dbflux.svg ]; then
+      install -Dm644 resources/icons/dbflux.svg "$icon_dst"
     else
-      install -Dm644 resources/icons/dbflux.svg \
-        $out/share/icons/hicolor/scalable/apps/${appId}.svg
+      echo "dbflux: no brand mark found in the release tarball" >&2
+      exit 1
     fi
 
     install -Dm644 resources/mime/dbflux-sql.xml \


### PR DESCRIPTION
Closes #183

Follow-up to #196. Installing the nightly prebuilt package
(`dbflux-nightly`) failed at build time:

```
install: cannot stat 'resources/icons/dbflux.svg': No such file or directory
```

## Root cause

`nix/binary.nix` installed the brand mark from `resources/branding/<channel>/mark.svg`, falling back to the pre-split `resources/icons/dbflux.svg`. In a published nightly tarball **neither path exists**:

- The channel packaging (`build.yml`) copies the active channel's mark but writes it to the hardcoded `resources/branding/stable/mark.svg` — the channel dir name is not preserved, so there is never a `branding/nightly/` dir.
- The legacy `resources/icons/dbflux.svg` was deleted in the branding split.

So `installPhase` hit the fallback and crashed.

## Fix

Probe the known mark locations and install the first that exists:

1. `resources/branding/<channel>/mark.svg` (self-describing layout, if a future tarball preserves the dir)
2. `resources/branding/stable/mark.svg` (current tarballs — already holds the active channel's artwork)
3. `resources/icons/dbflux.svg` (pre-split tarballs)
4. otherwise fail with a clear message

The nightly tarball's stable-path mark already contains the nightly artwork, so the installed `dbflux-nightly.svg` is the correct channel mark.

## Test plan

- [x] Built `binary.nix` against the **exact published nightly tarball** (`releases/download/nightly`, `0.7.0-nightly+76cbadb`) -> succeeds; emits `bin/dbflux-nightly`, `dbflux-nightly.{desktop,svg}`, `dbflux-nightly-sql.xml`; desktop `Name=DBFlux Nightly` / `Icon=dbflux-nightly` / `StartupWMClass=dbflux-nightly`; installed icon byte-matches the tarball's channel mark.
- [x] `nix build .#dbflux-bin` (stable v0.6.0-rc.3 tarball) still builds via the legacy-icon fallback — no regression.

## Out of scope

The `build.yml` hardcoded `branding/stable/` write path is left as-is (it delivers the correct mark *content*, only the dir name is misleading); probe order #1 already supports a corrected layout if it is fixed later.