### PR TITLE
chore(nix): point release-info at v0.6.0-rc.4

### DIFF
--- a/nix/release-info.nix
+++ b/nix/release-info.nix
@@ -1,5 +1,5 @@
 {
-  version = "0.6.0-rc.3";
+  version = "0.6.0-rc.4";
 
   # SHA256 SRI hashes of each prebuilt artifact published in the matching
   # GitHub Release. This file is a per-branch channel pointer: on `main` it
@@ -21,12 +21,12 @@
   # Then update `version`, the two `url`s, and the two `hash`es below.
   artifacts = {
     "x86_64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0-rc.3/dbflux-linux-amd64.tar.gz";
-      hash = "sha256-V+DmItSGHblb7ohYuBWAqX7bmPBq1s0+TCJOD6NO9Jc=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0-rc.4/dbflux-linux-amd64.tar.gz";
+      hash = "sha256-WGoF805bXSR0+dFe4SUWBf7RUgJl15y7kwUxo31Hcm0=";
     };
     "aarch64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0-rc.3/dbflux-linux-arm64.tar.gz";
-      hash = "sha256-yK75hk0C9+lxkP0eQrSsGVRuiM1cD1NKNZ8so9pOnq0=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0-rc.4/dbflux-linux-arm64.tar.gz";
+      hash = "sha256-yyitlFplEZcZD7FDaD97sR17iDFHZgGKRgYws09CnYg=";
     };
   };
 }


### PR DESCRIPTION
Post-publish channel-pointer update: `main`'s `nix/release-info.nix` now tracks the newest published tag, `v0.6.0-rc.4`. Updates the version and both Linux prebuilt URLs + SRI hashes.

The `release/v0.6` branch was updated the same way directly on the branch (`89a2ac14`). Verified locally: `nix build .#dbflux-bin` fetches the rc.4 amd64 tarball and the hash matches.

Mechanical release follow-up — no code change.