### PR TITLE
docs: document release-channel/branding seam and DEC-1 auth-profile decoupling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -329,6 +329,7 @@ Key abstractions for UI adaptation:
 - `CollectionChildInfo`: Declares driver-owned child sources that appear in the sidebar without the UI inferring them from driver-specific conventions
 - `EventStreamTarget`: Lets the workspace/audit viewer open driver-backed event streams without embedding driver-specific routing
 - `SourceContextSpec`: Lets drivers declare extra query-context controls while the UI stays generic
+- `FormFieldKind::AuthProfileRef { provider_id: Option<String> }`: Drives the connection-manager auth-profile dropdown. Drivers that need the picker declare a `profile` field as `AuthProfileRef { provider_id: None }`; the UI renders and field-syncs this arm generically instead of matching driver ids (DEC-1). A `None` filter enumerates built-in and external RPC-backed providers alike.
 
 ### Generic Deduplication Patterns
 
@@ -571,6 +572,13 @@ MCP provides a preview-before-execute workflow for schema changes:
 - `apply_window_options()` sets min size so X11 WMs emit `WM_NORMAL_HINTS`
 
 A `pub use dbflux_ui_base::platform::*` shim remains at `crates/dbflux_ui/src/platform.rs` for internal compatibility.
+
+### Release Channels & Branding
+
+- `ReleaseChannel` (`crates/dbflux_core/src/release_channel.rs`) derives the channel (`Stable` / `Rc` / `Nightly`) once from the compiled `CARGO_PKG_VERSION`. CI stamps the version before building, so the channel is baked into the binary.
+- Read channel identity through the accessors — `app_id()`, `display_name()`, `db_file_name()` — never branch on the raw version string and never hardcode `dbflux` / `dbflux-nightly` identifiers. Nightly returns a distinct `app_id` and DB file so it coexists with stable; `Rc` shares stable's identity.
+- The channel-aware DB path lives in `crates/dbflux_storage/src/paths.rs` (`dbflux_db_path`); nightly can opt into the stable DB via `set_nightly_shares_stable_db` / `nightly_shares_stable_db`.
+- Brand assets live under `resources/branding/{stable,nightly}/` (served per channel in `crates/dbflux_ui/src/assets.rs`). Packaging and Nix files substitute channel placeholders. The release/nightly flow is documented in `docs/RELEASE.md`.
 
 ## Common Pitfalls
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -664,6 +664,7 @@ See `docs/DASHBOARDS.md` for the full reference (including instance metrics and 
 - `crates/dbflux_core/src/access/mod.rs` introduces provider-agnostic `AccessKind::Managed { provider, params }` with transparent migration from legacy `method = "ssm"` profile JSON.
 - `crates/dbflux_core/src/pipeline/mod.rs` runs pre-connect stages (`Authenticating` -> `ResolvingValues` -> `OpeningAccess`) and publishes `PipelineState` updates to UI watchers.
 - `crates/dbflux_app/src/access_manager.rs` provides the app-side `AccessManager` implementation for direct and managed access providers (currently `aws-ssm`).
+- **Auth-profile dropdown decoupling (DEC-1)**: the connection manager renders its auth-profile picker from the generic `FormFieldKind::AuthProfileRef { provider_id: Option<String> }` form-field seam, never by matching driver ids. Drivers that want the picker (e.g. DynamoDB, CloudWatch) declare a `profile` field as `AuthProfileRef { provider_id: None }`; a `None` filter enumerates profiles provider-agnostically, so built-in and external RPC-backed providers both appear. The form-field kind is not persisted, so adding/removing it needs no storage migration.
 
 ### Tunnel Infrastructure
 
@@ -734,7 +735,7 @@ See `docs/DASHBOARDS.md` for the full reference (including instance metrics and 
 
 **Storage crate** (`dbflux_storage/`):
 - `bootstrap.rs`: `StorageRuntime` manages the single `dbflux.db` connection with lazy initialization
-- `paths.rs`: `dbflux_db_path()` returns the database path
+- `paths.rs`: `dbflux_db_path()` returns the channel-aware database path (`dbflux.db`, or `dbflux-nightly.db` on the nightly channel unless `nightly_shares_stable_db()` opts back into the stable file via `set_nightly_shares_stable_db`). See § Release Channels & Branding
 - `migrations/`: Trait-based migration system (`Migration` trait with `name()` and `run(&Transaction)`). `MigrationRegistry` holds all migrations and runs them in order, tracking completion in `sys_migrations`. Idempotent — checks `sys_migrations` before running.
 - `repositories/`: All domain repositories implement the `Repository` trait (`all()`, `find_by_id()`, `upsert()`, `delete()`). `AuditRepository` handles audit events with `AuditEventDto`.
 - `legacy.rs`: Imports legacy JSON files into SQLite on first startup (idempotent, tracked in `sys_legacy_imports`)
@@ -752,6 +753,18 @@ See `docs/DASHBOARDS.md` for the full reference (including instance metrics and 
 **Execution context**: `crates/dbflux_core/src/connection/context.rs` tracks per-tab connection, database, schema, and generic driver-declared source context. The current generic source-window shape is `ExecutionSourceContext::CollectionWindow { targets, start_ms, end_ms }`. Only connection/database/schema annotations are serialized into saved file headers.
 
 **History modal**: `crates/dbflux_ui_document/src/history_modal.rs` provides a unified modal for browsing recent queries and saved queries with search, favorites, and rename support.
+
+### Release Channels & Branding
+
+**Channel seam** (`crates/dbflux_core/src/release_channel.rs`): `ReleaseChannel` (`Stable`, `Rc`, `Nightly`) is derived once from the compiled `CARGO_PKG_VERSION` via `ReleaseChannel::current()`. The CI release pipeline stamps the workspace version before building, so the channel is encoded in the binary itself: `-nightly` → `Nightly`, `-rc.N` → `Rc`, plain `MAJOR.MINOR.PATCH` → `Stable` (nightly wins if both markers appear). This single signal feeds the channel-specific identity the runtime needs:
+
+- `app_id()` — GPUI `app_id` (Wayland app id / X11 `WM_CLASS`). Nightly returns `dbflux-nightly` so it coexists with stable instead of sharing its taskbar entry and icon; `Stable`/`Rc` return `dbflux`. Consumed in `crates/dbflux/src/main.rs`.
+- `display_name()` — window title and bundle name (`DBFlux Nightly` vs `DBFlux`).
+- `db_file_name()` — `dbflux-nightly.db` vs `dbflux.db`, so a migration that breaks on a pre-release build cannot corrupt a stable database when both channels run side by side. A nightly build can opt into the stable database through the `set_nightly_shares_stable_db` marker (see § Storage & Configuration).
+
+**Branding assets**: full-color brand marks live under `resources/branding/{stable,nightly}/` (`mark.svg`, `mark-256.png`, `mark-small.svg`, `wordmark.svg`) plus the shared `resources/branding/glyph.svg`. `crates/dbflux_ui/src/assets.rs` serves the pre-rendered PNG mark per channel for `img(...)`. Packaging metadata (`packaging/*.yaml`, `resources/desktop/dbflux.desktop`, `resources/macos/Info.plist`, `resources/windows/installer.iss`) and the Nix build (`nix/binary.nix`, `nix/nightly-info.nix`, `nix/release-info.nix`) substitute channel placeholders so the desktop entry, MIME association, and launcher icon match the running channel.
+
+The channel/branding model is a runtime seam: UI and app code read `ReleaseChannel` accessors; never branch on the raw version string or hardcode `dbflux`/`dbflux-nightly` identifiers. The release/nightly flow itself is documented in `docs/RELEASE.md`.
 
 ### Driver Implementations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,7 @@ Key abstractions for UI adaptation:
 - `CollectionChildInfo`: Declares driver-owned child sources that appear in the sidebar without the UI inferring them from driver-specific conventions
 - `EventStreamTarget`: Lets the workspace/audit viewer open driver-backed event streams without embedding driver-specific routing
 - `SourceContextSpec`: Lets drivers declare extra query-context controls while the UI stays generic
+- `FormFieldKind::AuthProfileRef { provider_id: Option<String> }`: Drives the connection-manager auth-profile dropdown. Drivers that need the picker declare a `profile` field as `AuthProfileRef { provider_id: None }`; the UI renders and field-syncs this arm generically instead of matching driver ids (DEC-1). A `None` filter enumerates built-in and external RPC-backed providers alike.
 
 ### Generic Deduplication Patterns
 
@@ -523,6 +524,13 @@ The right-rail builder composes SELECT / UPDATE / DELETE without writing SQL. It
 - `apply_window_options()` sets min size so X11 WMs emit `WM_NORMAL_HINTS`
 
 A `pub use dbflux_ui_base::platform::*` shim remains at `crates/dbflux_ui/src/platform.rs` for internal compatibility.
+
+### Release Channels & Branding
+
+- `ReleaseChannel` (`crates/dbflux_core/src/release_channel.rs`) derives the channel (`Stable` / `Rc` / `Nightly`) once from the compiled `CARGO_PKG_VERSION`. CI stamps the version before building, so the channel is baked into the binary.
+- Read channel identity through the accessors — `app_id()`, `display_name()`, `db_file_name()` — never branch on the raw version string and never hardcode `dbflux` / `dbflux-nightly` identifiers. Nightly returns a distinct `app_id` and DB file so it coexists with stable; `Rc` shares stable's identity.
+- The channel-aware DB path lives in `crates/dbflux_storage/src/paths.rs` (`dbflux_db_path`); nightly can opt into the stable DB via `set_nightly_shares_stable_db` / `nightly_shares_stable_db`.
+- Brand assets live under `resources/branding/{stable,nightly}/` (served per channel in `crates/dbflux_ui/src/assets.rs`). Packaging and Nix files substitute channel placeholders. The release/nightly flow is documented in `docs/RELEASE.md`.
 
 ## Common Pitfalls
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ nix run    github:0xErwin1/dbflux#dbflux-source
 nix build  github:0xErwin1/dbflux#dbflux-source
 ```
 
+Nightly builds track `main` and install side by side with stable (distinct app id, icon, and `dbflux-nightly.db` database). Consume them from the `nightly` ref:
+
+```bash
+nix run github:0xErwin1/dbflux/nightly#dbflux-nightly
+nix profile install github:0xErwin1/dbflux/nightly#dbflux-nightly
+```
+
+See [docs/RELEASE.md](docs/RELEASE.md) for the channel model.
+
 NixOS / nix-darwin via overlay:
 
 ```nix


### PR DESCRIPTION
## Summary

Syncs the prose docs with changes landed since the last docs commit (`34741b7a`) that were not yet reflected:

- Per-channel branding / nightly channel (#183)
- Auth-profile dropdown decoupling (DEC-1, #192)

`docs/RELEASE.md`, the release skill, and `docs/MCP_AI_INTEGRATION.md` were already updated in that same range, so they are untouched here. No code changes.

## Changes

| File | Change |
|------|--------|
| `ARCHITECTURE.md` | New "Release Channels & Branding" section (`ReleaseChannel` seam: `app_id` / `display_name` / `db_file_name`, nightly DB isolation + stable opt-in, `resources/branding/{stable,nightly}/` layout); DEC-1 `AuthProfileRef` note under Auth & Access Pipeline; channel-aware `paths.rs` entry |
| `CLAUDE.md` | `FormFieldKind::AuthProfileRef` added to Driver/UI decoupling abstractions; new "Release Channels & Branding" rule |
| `AGENTS.md` | Same two additions as `CLAUDE.md`, kept in sync |
| `README.md` | Nightly Nix install instructions under the Nix section |

## Notes

- Auth-profile secret routing to the keyring (#175) was already covered by the existing `HasSecretRef` / `SecretManager` docs; no change needed.
- A pre-existing divergence between `CLAUDE.md` and `AGENTS.md` in the MCP classification wording predates this range and was left as-is to keep scope tight.

## Test plan

- [x] Docs-only change; no build/test impact
- [x] Verified every referenced symbol/path exists in the tree (`ReleaseChannel`, `dbflux_db_path`, `set_nightly_shares_stable_db`, `resources/branding/*`, `FormFieldKind::AuthProfileRef`)