### PR TITLE
fix(ci): scope nightly changelog to commits since the previous nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -103,6 +103,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # The `nightly` tag (and its pin commit) is needed to scope the
+          # changelog to commits since the previous nightly.
+          fetch-tags: true
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -118,14 +121,32 @@ jobs:
 
       - name: Generate changelog for nightly body
         run: |
-          # Unreleased range: commits since the last STABLE tag.
-          # cliff.toml already skips -rc.N and -nightly tags via skip_tags.
-          git-cliff --config cliff.toml --unreleased \
-            --strip header \
-            -o cliff_notes.md 2>/dev/null || true
+          # Scope the changelog to commits since the previous nightly.
+          #
+          # `nightly^` is the first parent of the previous nightly's pin commit,
+          # i.e. the main HEAD that nightly was built from. At this point the
+          # `nightly` tag still points at the previous run (the force-move
+          # happens in a later step), so `nightly^..HEAD` is exactly "what
+          # changed on main since the last nightly".
+          #
+          # The since-last-STABLE range is deliberately avoided here: no stable
+          # tag is an ancestor of main (stable/rc tags live on release/vX.Y and
+          # are never merged back), so that range is pinned at the last legacy
+          # stable and grows without bound. See docs/RELEASE.md.
+          if PREV_NIGHTLY="$(git rev-parse --verify --quiet nightly^)"; then
+            git-cliff --config cliff.toml "${PREV_NIGHTLY}..HEAD" \
+              --strip header \
+              -o cliff_notes.md 2>/dev/null || true
+          else
+            # First nightly, or the tag is missing: fall back to the unreleased
+            # range so the body is never empty on the initial run.
+            git-cliff --config cliff.toml --unreleased \
+              --strip header \
+              -o cliff_notes.md 2>/dev/null || true
+          fi
 
           if [ ! -s cliff_notes.md ]; then
-            echo "No conventional-commit entries since last stable release." > cliff_notes.md
+            echo "No user-facing changes since the previous nightly." > cliff_notes.md
           fi
 
       - name: Compose nightly release body
@@ -144,7 +165,7 @@ jobs:
           EOF
 
           if [ -s cliff_notes.md ]; then
-            echo "## Changes since last stable release" >> release_body.md
+            echo "## Changes since the previous nightly" >> release_body.md
             echo "" >> release_body.md
             cat cliff_notes.md >> release_body.md
           fi


### PR DESCRIPTION
## Summary

- Scope the nightly release body to the commits added since the **previous nightly**, instead of an ever-growing range measured from the last stable tag.

## What does this resolve?

The nightly body was generated with `git-cliff --unreleased`, whose range is measured from the last **stable** tag reachable from `HEAD`. Under the current branching model no stable tag is ever an ancestor of `main` — stable/rc tags live on `release/vX.Y` and are never merged back — so the range stayed pinned at the last legacy stable (`v0.5.0`) and grew on every run. Each nightly re-listed weeks of already-shipped changes.

No tracking issue — internal CI fix, following the precedent of #198.

## How was this solved?

- Generate the body from `nightly^..HEAD`. `nightly^` is the first parent of the previous nightly's pin commit, i.e. the `main` HEAD that nightly was built from. At changelog time the `nightly` tag still points at the previous run (it is force-moved later in the same job), so the range is exactly "what changed on `main` since the last nightly".
- Fall back to `--unreleased` on the first run, when no `nightly` tag exists yet, so the body is never empty.
- Add `fetch-tags: true` to the release job's checkout so `nightly^` resolves.
- Reword the body heading to "Changes since the previous nightly".

**Out of scope:** the rolling/overwrite publish model is unchanged (deliberate — keep rolling). The frozen-boundary problem only affected the nightly; rc/stable notes are generated on the release branch, where the since-last-stable boundary works correctly.

## Validation

- Range logic reviewed against `cliff.toml` (`skip_tags` keeps `-rc.N`/`-nightly` as non-boundaries; only stable `vX.Y.Z` would bound, which is why the old range was stuck at `v0.5.0`).
- Workflow YAML parses (`js-yaml`).
- End-to-end runs only on `0xErwin1/dbflux` via cron — full verification lands on the next scheduled nightly or a manual `workflow_dispatch`.

## Where was this tested?

- [x] Other: CI workflow — YAML validated locally; executes on the next nightly run

## Checklist

- [x] I verified the change against the affected user flow(s) — static review of the workflow path
- [ ] I added or updated tests when needed — n/a (CI workflow)
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible — n/a (CI only, not user-visible)
- [x] I applied the appropriate labels (see CONTRIBUTING.md)

## Labels to apply

- `bug` (CI fix; no CI-specific area axis exists in the taxonomy)
