### PR TITLE
fix(ci): generate rc/stable release body from git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -603,24 +603,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract changelog section
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff
+
+      - name: Generate changelog section
         id: changelog
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          VERSION="${VERSION#v}"
 
-          # Extract the section between this version's header and the next (or EOF),
-          # then strip trailing blank lines and --- separators.
-          awk -v ver="$VERSION" '
-            /^## \[/ {
-              if (found) exit
-              if (index($0, "[" ver "]")) { found=1; next }
-            }
-            found { print }
-          ' CHANGELOG.md | sed '/^---$/d' | sed '1{/^[[:space:]]*$/d}' | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }' > changelog_section.md
+          # Derive the changelog from git history instead of a hand-maintained
+          # CHANGELOG.md section. The old awk approach looked for a `## [x.y.z]`
+          # header that never exists for rc tags, leaving the release body empty.
+          #
+          # Stable: notes for exactly this tag (range since the previous stable).
+          # rc/prerelease: unreleased range since the last stable tag. cliff.toml
+          # treats -rc.N / -dev.N as non-boundaries via skip_tags, so the range
+          # is always measured from the last real stable release.
+          if [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            git-cliff --config cliff.toml --current --tag "$VERSION" \
+              --strip header -o changelog_section.md 2>/dev/null || true
+          else
+            git-cliff --config cliff.toml --unreleased --tag "$VERSION" \
+              --strip header -o changelog_section.md 2>/dev/null || true
+          fi
 
           if [ ! -s changelog_section.md ]; then
-            echo "WARNING: No changelog section found for version $VERSION"
+            echo "No conventional-commit entries found for this range." > changelog_section.md
           fi
 
       - name: Compose release body

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,80 @@
+# git-cliff configuration for DBFlux.
+#
+# Generates CHANGELOG.md and GitHub release notes from Conventional Commits.
+# The changelog is DERIVED from git history, not hand-edited: `[Unreleased]`
+# is whatever sits between the last stable tag and HEAD. See docs/RELEASE.md.
+#
+# Commit types map to Keep a Changelog sections; internal-only types
+# (refactor/test/ci/chore/build/style) are skipped so the changelog stays
+# user-facing. Mark a security-relevant change with a `security` scope
+# (e.g. `fix(security): ...`) or a `Security:` footer to land it under Security.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to DBFlux will be documented in this file.
+"""
+
+# Tera template. One section per release, grouped by Keep a Changelog category.
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+* {{ commit.message | upper_first }}\
+{% if commit.remote.pr_number %} (#{{ commit.remote.pr_number }}){% endif %}\
+{% endfor %}
+{% endfor %}\n
+"""
+
+trim = true
+footer = ""
+
+# Fold same-version-line churn at promote time is done by hand; here we only
+# postprocess PR/commit links for the GitHub release body.
+[changelog.remote.github]
+owner = "0xErwin1"
+repo = "dbflux"
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+
+# Order matters: the FIRST matching parser wins.
+commit_parsers = [
+  { message = "^feat",      group = "<!-- 0 -->Added" },
+  { message = "^fix",       group = "<!-- 2 -->Fixed" },
+  { message = "^perf",      group = "<!-- 1 -->Changed" },
+  { message = "^revert",    group = "<!-- 2 -->Fixed" },
+  # Security: opt-in via `(security)` scope or a `Security:` footer.
+  { footer = "^[Ss]ecurity:", group = "<!-- 3 -->Security" },
+  { message = "^\\w+\\(security\\)", group = "<!-- 3 -->Security" },
+  # Internal-only types never reach users — drop them.
+  { message = "^docs",      skip = true },
+  { message = "^test",      skip = true },
+  { message = "^ci",        skip = true },
+  { message = "^chore",     skip = true },
+  { message = "^build",     skip = true },
+  { message = "^style",     skip = true },
+  { message = "^refactor",  skip = true },
+  # Anything else conventional but unmapped: drop rather than mislabel.
+  { message = ".*", skip = true },
+]
+
+# Breaking changes (a `!` after type/scope or a `BREAKING CHANGE:` footer) are
+# surfaced regardless of the type's normal group.
+protect_breaking_commits = true
+filter_commits = false
+tag_pattern = "v[0-9]+\\.[0-9]+\\.[0-9]+"
+# Treat dev/rc prereleases as boundaries too, so `[Unreleased]` means
+# "since the last STABLE tag" — prerelease tags do not close the section.
+skip_tags = "v[0-9]+\\.[0-9]+\\.[0-9]+-(dev|rc|nightly)"
+topo_order = false
+sort_commits = "newest"


### PR DESCRIPTION
## Summary

- Generate the rc/stable release body with `git-cliff` instead of extracting a `## [x.y.z]` section from `CHANGELOG.md`, so rc tags stop producing empty release notes.

## What does this resolve?

The release body was built by an `awk` pass that looked for a `## [x.y.z]` header in `CHANGELOG.md`. That header never exists for rc tags (the changelog only carries `[Unreleased]` / stable / `-dev.N` sections), so `v0.6.0-rc.4` shipped with an empty changelog in its body — only the install template was rendered.

No tracking issue — internal CI fix on the release branch, following the precedent of #198.

## How was this solved?

Surgical port of just the changelog-generation piece from `main`, scoped to this stabilizing release branch:

- Install `git-cliff` and derive the section from git history (stable → `--current --tag`; rc → `--unreleased --tag`).
- Add `cliff.toml` (the branch did not have it).
- Leave the "Compose release body" step untouched — it still consumes `changelog_section.md`; only the source changed.

**Out of scope (deliberately not cherry-picked):** the `build.yml` split, the nightly channel, and the per-channel branding feature (#183). The new `release.yml`/`build.yml` on `main` reference `resources/branding/${channel}/mark.svg`, which this branch does not carry; pulling them in would drag the branding **feature** onto a release branch, against the "bugfixes only on a release branch" rule in `docs/RELEASE.md`. This change fixes the body without that.

## Validation

- Workflow YAML parses (`js-yaml`).
- `git-cliff` ranges reviewed against the added `cliff.toml`.
- Full verification lands on the next `release/v0.6` tag (`rc.5` or `v0.6.0`).

## Where was this tested?

- [x] Other: CI workflow — YAML validated locally; executes on the next rc/stable tag

## Checklist

- [x] I verified the change against the affected user flow(s) — static review of the release job
- [ ] I added or updated tests when needed — n/a (CI workflow)
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible — n/a (CI only, not user-visible)
- [x] I applied the appropriate labels (see CONTRIBUTING.md)

## Labels to apply

- `bug` (CI fix; no CI-specific area axis exists in the taxonomy)
