### PR TITLE
fix(drivers): correct ColumnKind so chart auto-detection works across four drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ All notable changes to DBFlux will be documented in this file.
   Flux and InfluxQL kind mappers classify `boolean` as `Integer`. Across all
   drivers, `Value::Bool` now plots as 0/1, matching MSSQL BIT behaviour. The
   chart engine now extracts `Value::DateTime` and `Value::Date` as
-  epoch-milliseconds (DateTime unconditionally; Date as midnight UTC), so
-  datetime/date columns from any driver can drive a time axis. `Value::Time`
-  has no absolute epoch and remains unplottable.
+  epoch-milliseconds on a time axis (Date as midnight UTC), so datetime/date
+  columns from any driver can drive a time axis. `Value::Time` has no absolute
+  epoch and remains unplottable, so SQL Server `TIME` columns are now
+  classified `Unknown` instead of `Timestamp` (they would otherwise be offered
+  as an empty time axis).
 
 ## [0.6.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,20 @@ All notable changes to DBFlux will be documented in this file.
 ### Fixed
 
 * **Chart auto-detection across four drivers (#204)** — Drivers now assign
-  `ColumnKind` honestly so the chart engine includes genuine numeric and
-  timestamp columns and excludes non-numeric ones. CloudWatch CWL Insights
-  fields that are not recognized timestamps/text fall back to `Unknown`
-  instead of `Float` (their values are built as `Value::Text`), so string
-  fields like `errorCode` are no longer offered as chart Y axes; the
-  stats/metrics path that already sets `Float` is untouched. DynamoDB infers
-  column kind from the `AttributeValue` type (`N` → `Float`, `S` → `Text`,
-  otherwise `Unknown`), making numeric scans chart-able. MongoDB
-  operation-result integer columns (`count`, `insertedCount`,
-  `matchedCount`, `modifiedCount`, `deletedCount`) are now `Integer` and the
-  schema-listing text columns (`field_name`, `common_type`, `index_names`)
-  are `Text`. InfluxDB Flux and InfluxQL kind mappers gain an explicit,
-  documented `boolean → Unknown` arm. No `ColumnKind::Bool` variant is
-  introduced; the chart engine and UI remain driver-agnostic.
+  `ColumnKind` honestly so the chart engine includes genuine numeric columns
+  and excludes non-plottable ones. CloudWatch CWL Insights numeric fields are
+  now emitted as typed `Value::Int` or `Value::Float` (parsed from the raw
+  string at result-construction time), making them genuinely chart-able;
+  non-numeric and annotation fields stay `Value::Text` / `Unknown`. DynamoDB
+  infers column kind from `AttributeValue` (`N` → `Integer` when the string
+  parses as `i64`, else `Float`; `S` → `Text`; anything else → `Unknown`),
+  making numeric scans chart-able. MongoDB document and query results infer
+  column kinds from BSON value types (Int32/Int64 → Integer,
+  Double/Decimal128 → Float, String → Text); date and timestamp columns are
+  left `Unknown` because the chart engine cannot yet plot `Value::DateTime`
+  or the textual `Timestamp(…)` representation. InfluxDB Flux and InfluxQL
+  kind mappers gain an explicit `boolean → Unknown` arm. No `ColumnKind::Bool`
+  variant is introduced; the chart engine and UI remain driver-agnostic.
 
 ## [0.6.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,20 @@ All notable changes to DBFlux will be documented in this file.
 
 * **Chart auto-detection across four drivers (#204)** — Drivers now assign
   `ColumnKind` honestly so the chart engine includes genuine numeric columns
-  and excludes non-plottable ones. CloudWatch CWL Insights numeric fields are
-  now emitted as typed `Value::Int` or `Value::Float` (parsed from the raw
-  string at result-construction time), making them genuinely chart-able;
-  non-numeric and annotation fields stay `Value::Text` / `Unknown`. DynamoDB
-  infers column kind from `AttributeValue` (`N` → `Integer` when the string
-  parses as `i64`, else `Float`; `S` → `Text`; anything else → `Unknown`),
-  making numeric scans chart-able. MongoDB document and query results infer
-  column kinds from BSON value types (Int32/Int64 → Integer,
-  Double/Decimal128 → Float, String → Text); date and timestamp columns are
-  left `Unknown` because the chart engine cannot yet plot `Value::DateTime`
-  or the textual `Timestamp(…)` representation. InfluxDB Flux and InfluxQL
-  kind mappers gain an explicit `boolean → Unknown` arm. No `ColumnKind::Bool`
-  variant is introduced; the chart engine and UI remain driver-agnostic.
+  and excludes non-plottable ones. CloudWatch CWL Insights `@timestamp` and
+  `@ingestionTime` values are normalised from CWLI format (`YYYY-MM-DD
+  HH:MM:SS.mmm`, UTC) to RFC3339 so the time axis can parse them; the kind
+  scanner now skips `Text` samples and keeps scanning for a numeric value,
+  so mixed-type columns resolve correctly. DynamoDB infers column kind from
+  `AttributeValue` (`N` → `Integer` when the string parses as `i64`, else
+  `Float`; `S` → `Text`; `Bool` → `Integer`; anything else → `Unknown`).
+  MongoDB document and query results infer column kinds from BSON value types
+  (Int32/Int64 → Integer, Double/Decimal128 → Float, Boolean → Integer,
+  String → Text); date and timestamp columns are left `Unknown` because the
+  chart engine cannot yet plot `Value::DateTime` or the textual
+  `Timestamp(…)` representation. InfluxDB Flux and InfluxQL kind mappers
+  classify `boolean` as `Integer`. Across all drivers, `Value::Bool` now
+  plots as 0/1, matching MSSQL BIT behaviour.
 
 ## [0.6.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to DBFlux will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+* **Chart auto-detection across four drivers (#204)** — Drivers now assign
+  `ColumnKind` honestly so the chart engine includes genuine numeric and
+  timestamp columns and excludes non-numeric ones. CloudWatch CWL Insights
+  fields that are not recognized timestamps/text fall back to `Unknown`
+  instead of `Float` (their values are built as `Value::Text`), so string
+  fields like `errorCode` are no longer offered as chart Y axes; the
+  stats/metrics path that already sets `Float` is untouched. DynamoDB infers
+  column kind from the `AttributeValue` type (`N` → `Float`, `S` → `Text`,
+  otherwise `Unknown`), making numeric scans chart-able. MongoDB
+  operation-result integer columns (`count`, `insertedCount`,
+  `matchedCount`, `modifiedCount`, `deletedCount`) are now `Integer` and the
+  schema-listing text columns (`field_name`, `common_type`, `index_names`)
+  are `Text`. InfluxDB Flux and InfluxQL kind mappers gain an explicit,
+  documented `boolean → Unknown` arm. No `ColumnKind::Bool` variant is
+  introduced; the chart engine and UI remain driver-agnostic.
+
 ## [0.6.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ All notable changes to DBFlux will be documented in this file.
   `Float`; `S` → `Text`; `Bool` → `Integer`; anything else → `Unknown`).
   MongoDB document and query results infer column kinds from BSON value types
   (Int32/Int64 → Integer, Double/Decimal128 → Float, Boolean → Integer,
-  String → Text); date and timestamp columns are left `Unknown` because the
-  chart engine cannot yet plot `Value::DateTime` or the textual
-  `Timestamp(…)` representation. InfluxDB Flux and InfluxQL kind mappers
-  classify `boolean` as `Integer`. Across all drivers, `Value::Bool` now
-  plots as 0/1, matching MSSQL BIT behaviour.
+  String → Text, DateTime → Timestamp); BSON `Timestamp` (oplog logical
+  clock) stays `Unknown` because it carries no wall-clock meaning. InfluxDB
+  Flux and InfluxQL kind mappers classify `boolean` as `Integer`. Across all
+  drivers, `Value::Bool` now plots as 0/1, matching MSSQL BIT behaviour. The
+  chart engine now extracts `Value::DateTime` and `Value::Date` as
+  epoch-milliseconds (DateTime unconditionally; Date as midnight UTC), so
+  datetime/date columns from any driver can drive a time axis. `Value::Time`
+  has no absolute epoch and remains unplottable.
 
 ## [0.6.0] - 2026-06-04
 

--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -2440,8 +2440,10 @@ fn extract_f64(value: &Value, is_time: bool) -> Option<f64> {
             }
         }
         // Temporal values are only meaningful as epoch-ms on a time axis; gated
-        // on is_time (like the Text arm) so a datetime mistakenly placed on a
-        // value axis is dropped rather than blowing the scale up to ~1e12.
+        // on is_time (like the Text arm). Defensive: the Y pickers never offer
+        // Timestamp columns, so this only drops a non-Timestamp column that
+        // happens to carry a datetime value, instead of blowing the value-axis
+        // scale up to ~1e12.
         Value::DateTime(dt) if is_time => Some(dt.timestamp_millis() as f64),
         // Date maps to midnight UTC for a consistent, unambiguous epoch-ms value.
         Value::Date(d) if is_time => d

--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -2439,6 +2439,17 @@ fn extract_f64(value: &Value, is_time: bool) -> Option<f64> {
                 None
             }
         }
+        // A DateTime<Utc> is always an absolute instant; convert to epoch-ms
+        // unconditionally so time-axis and numeric-axis charts both receive a
+        // plottable value (mirrors how Int/Float extract regardless of is_time).
+        Value::DateTime(dt) => Some(dt.timestamp_millis() as f64),
+        // Date maps to midnight UTC so it lands on a consistent, unambiguous
+        // epoch-ms value. and_hms_opt(0,0,0) always succeeds for a valid date.
+        Value::Date(d) => d
+            .and_hms_opt(0, 0, 0)
+            .map(|ndt| ndt.and_utc().timestamp_millis() as f64),
+        // Time is a wall-clock time-of-day with no date component; there is no
+        // meaningful epoch origin to assign, so it cannot be placed on a time axis.
         Value::Null => None,
         _ => None,
     }
@@ -2811,6 +2822,37 @@ mod tests {
     fn extract_f64_maps_bool_to_zero_or_one() {
         assert_eq!(extract_f64(&Value::Bool(true), false), Some(1.0));
         assert_eq!(extract_f64(&Value::Bool(false), false), Some(0.0));
+    }
+
+    #[test]
+    fn extract_f64_datetime_yields_epoch_ms() {
+        use dbflux_core::chrono::{DateTime, TimeZone, Utc};
+        let dt: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 3, 15, 12, 0, 0).unwrap();
+        let expected = dt.timestamp_millis() as f64;
+        assert_eq!(extract_f64(&Value::DateTime(dt), true), Some(expected));
+        // Unconditional: is_time=false should also extract.
+        let dt2: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 3, 15, 12, 0, 0).unwrap();
+        assert_eq!(extract_f64(&Value::DateTime(dt2), false), Some(expected));
+    }
+
+    #[test]
+    fn extract_f64_date_yields_midnight_utc_epoch_ms() {
+        use dbflux_core::chrono::NaiveDate;
+        let date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        let expected = date
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc()
+            .timestamp_millis() as f64;
+        assert_eq!(extract_f64(&Value::Date(date), false), Some(expected));
+    }
+
+    #[test]
+    fn extract_f64_time_returns_none() {
+        use dbflux_core::chrono::NaiveTime;
+        let t = NaiveTime::from_hms_opt(10, 30, 0).unwrap();
+        assert_eq!(extract_f64(&Value::Time(t), true), None);
+        assert_eq!(extract_f64(&Value::Time(t), false), None);
     }
 
     #[test]

--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -2439,17 +2439,17 @@ fn extract_f64(value: &Value, is_time: bool) -> Option<f64> {
                 None
             }
         }
-        // A DateTime<Utc> is always an absolute instant; convert to epoch-ms
-        // unconditionally so time-axis and numeric-axis charts both receive a
-        // plottable value (mirrors how Int/Float extract regardless of is_time).
-        Value::DateTime(dt) => Some(dt.timestamp_millis() as f64),
-        // Date maps to midnight UTC so it lands on a consistent, unambiguous
-        // epoch-ms value. and_hms_opt(0,0,0) always succeeds for a valid date.
-        Value::Date(d) => d
+        // Temporal values are only meaningful as epoch-ms on a time axis; gated
+        // on is_time (like the Text arm) so a datetime mistakenly placed on a
+        // value axis is dropped rather than blowing the scale up to ~1e12.
+        Value::DateTime(dt) if is_time => Some(dt.timestamp_millis() as f64),
+        // Date maps to midnight UTC for a consistent, unambiguous epoch-ms value.
+        Value::Date(d) if is_time => d
             .and_hms_opt(0, 0, 0)
             .map(|ndt| ndt.and_utc().timestamp_millis() as f64),
         // Time is a wall-clock time-of-day with no date component; there is no
         // meaningful epoch origin to assign, so it cannot be placed on a time axis.
+        Value::Time(_) => None,
         Value::Null => None,
         _ => None,
     }
@@ -2827,24 +2827,26 @@ mod tests {
     #[test]
     fn extract_f64_datetime_yields_epoch_ms() {
         use dbflux_core::chrono::{DateTime, TimeZone, Utc};
-        let dt: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 3, 15, 12, 0, 0).unwrap();
-        let expected = dt.timestamp_millis() as f64;
-        assert_eq!(extract_f64(&Value::DateTime(dt), true), Some(expected));
-        // Unconditional: is_time=false should also extract.
-        let dt2: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 3, 15, 12, 0, 0).unwrap();
-        assert_eq!(extract_f64(&Value::DateTime(dt2), false), Some(expected));
+        // 2024-01-01T00:00:00Z, hardcoded ms to pin the unit (catches a
+        // secs/micros regression that a self-derived expected would mask).
+        let dt: DateTime<Utc> = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        assert_eq!(
+            extract_f64(&Value::DateTime(dt), true),
+            Some(1_704_067_200_000.0)
+        );
+        // Gated on is_time: on a value axis a datetime is dropped, not plotted.
+        assert_eq!(extract_f64(&Value::DateTime(dt), false), None);
     }
 
     #[test]
     fn extract_f64_date_yields_midnight_utc_epoch_ms() {
         use dbflux_core::chrono::NaiveDate;
         let date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
-        let expected = date
-            .and_hms_opt(0, 0, 0)
-            .unwrap()
-            .and_utc()
-            .timestamp_millis() as f64;
-        assert_eq!(extract_f64(&Value::Date(date), false), Some(expected));
+        assert_eq!(
+            extract_f64(&Value::Date(date), true),
+            Some(1_704_067_200_000.0)
+        );
+        assert_eq!(extract_f64(&Value::Date(date), false), None);
     }
 
     #[test]

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -382,7 +382,7 @@ impl Connection for CloudWatchConnection {
 
                             let value = field
                                 .value()
-                                .map(|value| Value::Text(value.to_string()))
+                                .map(|raw| cwli_field_value(&field_name, raw))
                                 .unwrap_or(Value::Null);
                             row_map.insert(field_name, value);
                         }
@@ -998,37 +998,52 @@ fn cloudwatch_column_kind(name: &str) -> ColumnKind {
     }
 }
 
+/// Produce a typed `Value` for a CWLI result field.
+///
+/// Known text/timestamp annotation names keep `Value::Text` so their values
+/// remain consumable by the log-stream viewer unchanged. For all other fields
+/// the raw string is parsed: integer strings become `Value::Int`, finite
+/// floating-point strings become `Value::Float`, and everything else
+/// (non-numeric, NaN, infinite) stays `Value::Text`.
+fn cwli_field_value(name: &str, raw: &str) -> Value {
+    match name {
+        "@timestamp" | "@ingestionTime" | "@message" | "@logStream" | "@log" => {
+            Value::Text(raw.to_string())
+        }
+        _ => {
+            if let Ok(i) = raw.parse::<i64>() {
+                return Value::Int(i);
+            }
+            if let Ok(f) = raw.parse::<f64>()
+                && f.is_finite()
+            {
+                return Value::Float(f);
+            }
+            Value::Text(raw.to_string())
+        }
+    }
+}
+
 /// Determine the `ColumnKind` for a CWLI result column using name-based rules
 /// first, falling back to value sampling across `row_maps` for unknown names.
 ///
-/// For fields not covered by `cloudwatch_column_kind`, samples all non-empty
-/// string values for `name` across `row_maps`. If all non-empty values parse
-/// as `i64` the column is Integer; if all parse as `f64` it is Float;
-/// otherwise Unknown. A column with no non-empty values is Unknown.
+/// Because `cwli_field_value` already emits typed values, this function
+/// samples the first non-null value for `name` and maps its variant:
+/// `Value::Int` → Integer, `Value::Float` → Float, anything else → Unknown.
+/// A column with no non-null values is Unknown.
 fn cwli_column_kind(name: &str, row_maps: &[HashMap<String, Value>]) -> ColumnKind {
     let name_kind = cloudwatch_column_kind(name);
     if name_kind != ColumnKind::Unknown {
         return name_kind;
     }
 
-    let non_empty: Vec<&str> = row_maps
-        .iter()
-        .filter_map(|row| match row.get(name) {
-            Some(Value::Text(s)) if !s.is_empty() => Some(s.as_str()),
-            _ => None,
-        })
-        .collect();
-
-    if non_empty.is_empty() {
-        return ColumnKind::Unknown;
-    }
-
-    if non_empty.iter().all(|s| s.parse::<i64>().is_ok()) {
-        return ColumnKind::Integer;
-    }
-
-    if non_empty.iter().all(|s| s.parse::<f64>().is_ok()) {
-        return ColumnKind::Float;
+    for row in row_maps {
+        match row.get(name) {
+            Some(Value::Int(_)) => return ColumnKind::Integer,
+            Some(Value::Float(_)) => return ColumnKind::Float,
+            Some(Value::Null) | None => continue,
+            Some(_) => return ColumnKind::Unknown,
+        }
     }
 
     ColumnKind::Unknown
@@ -1600,7 +1615,8 @@ fn fetch_log_stream_page(
 mod tests {
     use super::{
         CLOUDWATCH_FORM, CLOUDWATCH_METADATA, CloudWatchCollectionFilter, CloudWatchDriver,
-        cloudwatch_column_kind, cwli_column_kind, metric_data_output_to_multi_series_result,
+        cloudwatch_column_kind, cwli_column_kind, cwli_field_value,
+        metric_data_output_to_multi_series_result,
     };
     use aws_sdk_cloudwatch::operation::get_metric_data::GetMetricDataOutput;
     use aws_sdk_cloudwatch::primitives::DateTime;
@@ -1625,15 +1641,49 @@ mod tests {
         assert_eq!(cloudwatch_column_kind("count"), ColumnKind::Unknown);
     }
 
-    fn row_maps_for(field: &str, values: &[&str]) -> Vec<HashMap<String, Value>> {
-        values
+    fn typed_row_maps_for(field: &str, typed_values: &[Value]) -> Vec<HashMap<String, Value>> {
+        typed_values
             .iter()
             .map(|v| {
                 let mut m = HashMap::new();
-                m.insert(field.to_string(), Value::Text(v.to_string()));
+                m.insert(field.to_string(), v.clone());
                 m
             })
             .collect()
+    }
+
+    #[test]
+    fn cwli_field_value_typed_output() {
+        assert_eq!(cwli_field_value("count", "123"), Value::Int(123));
+        assert_eq!(cwli_field_value("latency", "1.5"), Value::Float(1.5));
+        assert_eq!(
+            cwli_field_value("errorCode", "BadRequest"),
+            Value::Text("BadRequest".to_string())
+        );
+
+        // Annotation names always stay Text regardless of numeric content.
+        assert_eq!(
+            cwli_field_value("@timestamp", "1234567890"),
+            Value::Text("1234567890".to_string())
+        );
+        assert_eq!(
+            cwli_field_value("@message", "42"),
+            Value::Text("42".to_string())
+        );
+
+        // Non-finite floats must not produce Value::Float.
+        assert_eq!(
+            cwli_field_value("ratio", "NaN"),
+            Value::Text("NaN".to_string())
+        );
+        assert_eq!(
+            cwli_field_value("ratio", "inf"),
+            Value::Text("inf".to_string())
+        );
+        assert_eq!(
+            cwli_field_value("ratio", "-inf"),
+            Value::Text("-inf".to_string())
+        );
     }
 
     #[test]
@@ -1648,13 +1698,19 @@ mod tests {
 
     #[test]
     fn cwli_column_kind_value_based_numeric() {
-        let int_rows = row_maps_for("count", &["123", "456", "789"]);
+        let int_rows = typed_row_maps_for("count", &[Value::Int(123), Value::Int(456)]);
         assert_eq!(cwli_column_kind("count", &int_rows), ColumnKind::Integer);
 
-        let float_rows = row_maps_for("latency", &["1.5", "2.3", "0.9"]);
+        let float_rows = typed_row_maps_for("latency", &[Value::Float(1.5), Value::Float(2.3)]);
         assert_eq!(cwli_column_kind("latency", &float_rows), ColumnKind::Float);
 
-        let string_rows = row_maps_for("errorCode", &["500", "BadRequest", "Timeout"]);
+        let string_rows = typed_row_maps_for(
+            "errorCode",
+            &[
+                Value::Text("500".to_string()),
+                Value::Text("BadRequest".to_string()),
+            ],
+        );
         assert_eq!(
             cwli_column_kind("errorCode", &string_rows),
             ColumnKind::Unknown

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -395,7 +395,7 @@ impl Connection for CloudWatchConnection {
                         .map(|name| ColumnMeta {
                             name: name.clone(),
                             type_name: "text".to_string(),
-                            kind: cloudwatch_column_kind(name),
+                            kind: cwli_column_kind(name, &row_maps),
                             nullable: true,
                             is_primary_key: false,
                         })
@@ -985,17 +985,53 @@ impl dbflux_core::LanguageService for CloudWatchLanguageService {
     }
 }
 
-/// Classify a CloudWatch Insights column name to a semantic `ColumnKind`.
-///
-/// Known annotation fields map to Timestamp or Text. All other names return
-/// Unknown because CWLI constructs field values as `Value::Text`; the stats/metrics
-/// code path sets Float directly on its own columns and is unaffected by this function.
+/// Classify a CloudWatch Insights column name to a semantic `ColumnKind` using
+/// name-based rules only. Known annotation fields are authoritative: timestamp
+/// fields map to Timestamp, message/stream/log fields map to Text. All other
+/// names return Unknown; callers that have row data should use
+/// `cwli_column_kind` instead.
 fn cloudwatch_column_kind(name: &str) -> ColumnKind {
     match name {
         "@timestamp" | "@ingestionTime" => ColumnKind::Timestamp,
         "@message" | "@logStream" | "@log" => ColumnKind::Text,
         _ => ColumnKind::Unknown,
     }
+}
+
+/// Determine the `ColumnKind` for a CWLI result column using name-based rules
+/// first, falling back to value sampling across `row_maps` for unknown names.
+///
+/// For fields not covered by `cloudwatch_column_kind`, samples all non-empty
+/// string values for `name` across `row_maps`. If all non-empty values parse
+/// as `i64` the column is Integer; if all parse as `f64` it is Float;
+/// otherwise Unknown. A column with no non-empty values is Unknown.
+fn cwli_column_kind(name: &str, row_maps: &[HashMap<String, Value>]) -> ColumnKind {
+    let name_kind = cloudwatch_column_kind(name);
+    if name_kind != ColumnKind::Unknown {
+        return name_kind;
+    }
+
+    let non_empty: Vec<&str> = row_maps
+        .iter()
+        .filter_map(|row| match row.get(name) {
+            Some(Value::Text(s)) if !s.is_empty() => Some(s.as_str()),
+            _ => None,
+        })
+        .collect();
+
+    if non_empty.is_empty() {
+        return ColumnKind::Unknown;
+    }
+
+    if non_empty.iter().all(|s| s.parse::<i64>().is_ok()) {
+        return ColumnKind::Integer;
+    }
+
+    if non_empty.iter().all(|s| s.parse::<f64>().is_ok()) {
+        return ColumnKind::Float;
+    }
+
+    ColumnKind::Unknown
 }
 
 fn cloudwatch_query_modes() -> Vec<SourceQueryMode> {
@@ -1564,7 +1600,7 @@ fn fetch_log_stream_page(
 mod tests {
     use super::{
         CLOUDWATCH_FORM, CLOUDWATCH_METADATA, CloudWatchCollectionFilter, CloudWatchDriver,
-        cloudwatch_column_kind, metric_data_output_to_multi_series_result,
+        cloudwatch_column_kind, cwli_column_kind, metric_data_output_to_multi_series_result,
     };
     use aws_sdk_cloudwatch::operation::get_metric_data::GetMetricDataOutput;
     use aws_sdk_cloudwatch::primitives::DateTime;
@@ -1572,9 +1608,10 @@ mod tests {
     use dbflux_core::{
         ColumnKind, DbConfig, DbDriver, DriverCapabilities, FormFieldKind, MetricQuerySeries, Value,
     };
+    use std::collections::HashMap;
 
     #[test]
-    fn cloudwatch_column_kind_unknown_default() {
+    fn cloudwatch_column_kind_name_based() {
         assert_eq!(cloudwatch_column_kind("@timestamp"), ColumnKind::Timestamp);
         assert_eq!(
             cloudwatch_column_kind("@ingestionTime"),
@@ -1586,6 +1623,57 @@ mod tests {
         assert_eq!(cloudwatch_column_kind("avg_latency"), ColumnKind::Unknown);
         assert_eq!(cloudwatch_column_kind("p99"), ColumnKind::Unknown);
         assert_eq!(cloudwatch_column_kind("count"), ColumnKind::Unknown);
+    }
+
+    fn row_maps_for(field: &str, values: &[&str]) -> Vec<HashMap<String, Value>> {
+        values
+            .iter()
+            .map(|v| {
+                let mut m = HashMap::new();
+                m.insert(field.to_string(), Value::Text(v.to_string()));
+                m
+            })
+            .collect()
+    }
+
+    #[test]
+    fn cwli_column_kind_name_authoritative() {
+        let empty: Vec<HashMap<String, Value>> = vec![];
+        assert_eq!(
+            cwli_column_kind("@timestamp", &empty),
+            ColumnKind::Timestamp
+        );
+        assert_eq!(cwli_column_kind("@message", &empty), ColumnKind::Text);
+    }
+
+    #[test]
+    fn cwli_column_kind_value_based_numeric() {
+        let int_rows = row_maps_for("count", &["123", "456", "789"]);
+        assert_eq!(cwli_column_kind("count", &int_rows), ColumnKind::Integer);
+
+        let float_rows = row_maps_for("latency", &["1.5", "2.3", "0.9"]);
+        assert_eq!(cwli_column_kind("latency", &float_rows), ColumnKind::Float);
+
+        let string_rows = row_maps_for("errorCode", &["500", "BadRequest", "Timeout"]);
+        assert_eq!(
+            cwli_column_kind("errorCode", &string_rows),
+            ColumnKind::Unknown
+        );
+    }
+
+    #[test]
+    fn cwli_column_kind_empty_or_missing_values() {
+        let empty: Vec<HashMap<String, Value>> = vec![];
+        assert_eq!(cwli_column_kind("count", &empty), ColumnKind::Unknown);
+
+        let null_rows: Vec<HashMap<String, Value>> = vec![
+            {
+                let mut m = HashMap::new();
+                m.insert("count".to_string(), Value::Null);
+                m
+            },
+        ];
+        assert_eq!(cwli_column_kind("count", &null_rows), ColumnKind::Unknown);
     }
 
     fn series(namespace: &str, metric_name: &str) -> MetricQuerySeries {

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -1576,7 +1576,10 @@ mod tests {
     #[test]
     fn cloudwatch_column_kind_unknown_default() {
         assert_eq!(cloudwatch_column_kind("@timestamp"), ColumnKind::Timestamp);
-        assert_eq!(cloudwatch_column_kind("@ingestionTime"), ColumnKind::Timestamp);
+        assert_eq!(
+            cloudwatch_column_kind("@ingestionTime"),
+            ColumnKind::Timestamp
+        );
         assert_eq!(cloudwatch_column_kind("@message"), ColumnKind::Text);
         assert_eq!(cloudwatch_column_kind("@logStream"), ColumnKind::Text);
         assert_eq!(cloudwatch_column_kind("@log"), ColumnKind::Text);

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -1000,16 +1000,29 @@ fn cloudwatch_column_kind(name: &str) -> ColumnKind {
 
 /// Produce a typed `Value` for a CWLI result field.
 ///
-/// Known text/timestamp annotation names keep `Value::Text` so their values
-/// remain consumable by the log-stream viewer unchanged. For all other fields
-/// the raw string is parsed: integer strings become `Value::Int`, finite
-/// floating-point strings become `Value::Float`, and everything else
-/// (non-numeric, NaN, infinite) stays `Value::Text`.
+/// `@timestamp` and `@ingestionTime` arrive from CWLI in the format
+/// `"YYYY-MM-DD HH:MM:SS.mmm"` (space separator, no timezone, UTC). They are
+/// normalised to RFC3339 (`"...T...+00:00"`) so the chart engine can parse
+/// them as time-axis values. On parse failure the raw string is preserved
+/// unchanged.
+///
+/// `@message`, `@logStream`, and `@log` stay as `Value::Text`. For all other
+/// fields the raw string is parsed: integer strings become `Value::Int`,
+/// finite floating-point strings become `Value::Float`, and everything else
+/// stays `Value::Text`.
 fn cwli_field_value(name: &str, raw: &str) -> Value {
+    use dbflux_core::chrono::{NaiveDateTime, TimeZone, Utc};
+
     match name {
-        "@timestamp" | "@ingestionTime" | "@message" | "@logStream" | "@log" => {
-            Value::Text(raw.to_string())
+        "@timestamp" | "@ingestionTime" => {
+            let parsed = NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.3f")
+                .or_else(|_| NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S"));
+            match parsed {
+                Ok(naive) => Value::Text(Utc.from_utc_datetime(&naive).to_rfc3339()),
+                Err(_) => Value::Text(raw.to_string()),
+            }
         }
+        "@message" | "@logStream" | "@log" => Value::Text(raw.to_string()),
         _ => {
             if let Ok(i) = raw.parse::<i64>() {
                 return Value::Int(i);
@@ -1028,9 +1041,9 @@ fn cwli_field_value(name: &str, raw: &str) -> Value {
 /// first, falling back to value sampling across `row_maps` for unknown names.
 ///
 /// Because `cwli_field_value` already emits typed values, this function
-/// samples the first non-null value for `name` and maps its variant:
-/// `Value::Int` → Integer, `Value::Float` → Float, anything else → Unknown.
-/// A column with no non-null values is Unknown.
+/// scans rows for the first `Value::Int` (→ Integer) or `Value::Float` (→ Float),
+/// skipping `Null` and `Text` samples. Returns `Unknown` only when no numeric
+/// value is found across all rows.
 fn cwli_column_kind(name: &str, row_maps: &[HashMap<String, Value>]) -> ColumnKind {
     let name_kind = cloudwatch_column_kind(name);
     if name_kind != ColumnKind::Unknown {
@@ -1041,8 +1054,7 @@ fn cwli_column_kind(name: &str, row_maps: &[HashMap<String, Value>]) -> ColumnKi
         match row.get(name) {
             Some(Value::Int(_)) => return ColumnKind::Integer,
             Some(Value::Float(_)) => return ColumnKind::Float,
-            Some(Value::Null) | None => continue,
-            Some(_) => return ColumnKind::Unknown,
+            _ => continue,
         }
     }
 
@@ -1687,6 +1699,48 @@ mod tests {
     }
 
     #[test]
+    fn cwli_field_value_timestamp_to_rfc3339() {
+        use dbflux_core::chrono::DateTime;
+
+        // CWLI format with milliseconds → must round-trip through parse_from_rfc3339.
+        let v = cwli_field_value("@timestamp", "2023-01-15 12:34:56.789");
+        match &v {
+            Value::Text(s) => {
+                DateTime::parse_from_rfc3339(s)
+                    .unwrap_or_else(|e| panic!("RFC3339 parse failed: {e} — got: {s}"));
+            }
+            other => panic!("expected Value::Text, got {other:?}"),
+        }
+
+        // Same for @ingestionTime.
+        let v = cwli_field_value("@ingestionTime", "2023-01-15 12:34:56.789");
+        match &v {
+            Value::Text(s) => {
+                DateTime::parse_from_rfc3339(s)
+                    .unwrap_or_else(|e| panic!("RFC3339 parse failed: {e} — got: {s}"));
+            }
+            other => panic!("expected Value::Text, got {other:?}"),
+        }
+
+        // Without milliseconds must also parse as RFC3339.
+        let v = cwli_field_value("@timestamp", "2023-01-15 12:34:56");
+        match &v {
+            Value::Text(s) => {
+                DateTime::parse_from_rfc3339(s)
+                    .unwrap_or_else(|e| panic!("RFC3339 parse failed: {e} — got: {s}"));
+            }
+            other => panic!("expected Value::Text, got {other:?}"),
+        }
+
+        // Unparseable raw value falls back to unchanged raw text.
+        let raw = "not-a-timestamp";
+        assert_eq!(
+            cwli_field_value("@timestamp", raw),
+            Value::Text(raw.to_string())
+        );
+    }
+
+    #[test]
     fn cwli_column_kind_name_authoritative() {
         let empty: Vec<HashMap<String, Value>> = vec![];
         assert_eq!(
@@ -1728,6 +1782,24 @@ mod tests {
             m
         }];
         assert_eq!(cwli_column_kind("count", &null_rows), ColumnKind::Unknown);
+    }
+
+    #[test]
+    fn cwli_column_kind_skips_text_to_find_numeric() {
+        // Text samples are skipped; a later Int sample resolves Integer.
+        let rows = typed_row_maps_for("field", &[Value::Text("x".to_string()), Value::Int(42)]);
+        assert_eq!(cwli_column_kind("field", &rows), ColumnKind::Integer);
+
+        // Null is skipped; a later Float sample resolves Float.
+        let rows = typed_row_maps_for("field", &[Value::Null, Value::Float(1.5)]);
+        assert_eq!(cwli_column_kind("field", &rows), ColumnKind::Float);
+
+        // All Text samples → Unknown (no numeric found).
+        let rows = typed_row_maps_for(
+            "field",
+            &[Value::Text("a".to_string()), Value::Text("b".to_string())],
+        );
+        assert_eq!(cwli_column_kind("field", &rows), ColumnKind::Unknown);
     }
 
     fn series(namespace: &str, metric_name: &str) -> MetricQuerySeries {

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -987,17 +987,14 @@ impl dbflux_core::LanguageService for CloudWatchLanguageService {
 
 /// Classify a CloudWatch Insights column name to a semantic `ColumnKind`.
 ///
-/// CloudWatch Insights uses known annotation fields (@timestamp, @ingestionTime)
-/// and dynamic stats fields. This function maps the driver's own canonical field
-/// names — not a generic heuristic.
+/// Known annotation fields map to Timestamp or Text. All other names return
+/// Unknown because CWLI constructs field values as `Value::Text`; the stats/metrics
+/// code path sets Float directly on its own columns and is unaffected by this function.
 fn cloudwatch_column_kind(name: &str) -> ColumnKind {
     match name {
         "@timestamp" | "@ingestionTime" => ColumnKind::Timestamp,
         "@message" | "@logStream" | "@log" => ColumnKind::Text,
-        _ => {
-            // stats query numeric fields: treat as Float (safest choice for chart)
-            ColumnKind::Float
-        }
+        _ => ColumnKind::Unknown,
     }
 }
 
@@ -1567,7 +1564,7 @@ fn fetch_log_stream_page(
 mod tests {
     use super::{
         CLOUDWATCH_FORM, CLOUDWATCH_METADATA, CloudWatchCollectionFilter, CloudWatchDriver,
-        metric_data_output_to_multi_series_result,
+        cloudwatch_column_kind, metric_data_output_to_multi_series_result,
     };
     use aws_sdk_cloudwatch::operation::get_metric_data::GetMetricDataOutput;
     use aws_sdk_cloudwatch::primitives::DateTime;
@@ -1575,6 +1572,18 @@ mod tests {
     use dbflux_core::{
         ColumnKind, DbConfig, DbDriver, DriverCapabilities, FormFieldKind, MetricQuerySeries, Value,
     };
+
+    #[test]
+    fn cloudwatch_column_kind_unknown_default() {
+        assert_eq!(cloudwatch_column_kind("@timestamp"), ColumnKind::Timestamp);
+        assert_eq!(cloudwatch_column_kind("@ingestionTime"), ColumnKind::Timestamp);
+        assert_eq!(cloudwatch_column_kind("@message"), ColumnKind::Text);
+        assert_eq!(cloudwatch_column_kind("@logStream"), ColumnKind::Text);
+        assert_eq!(cloudwatch_column_kind("@log"), ColumnKind::Text);
+        assert_eq!(cloudwatch_column_kind("avg_latency"), ColumnKind::Unknown);
+        assert_eq!(cloudwatch_column_kind("p99"), ColumnKind::Unknown);
+        assert_eq!(cloudwatch_column_kind("count"), ColumnKind::Unknown);
+    }
 
     fn series(namespace: &str, metric_name: &str) -> MetricQuerySeries {
         MetricQuerySeries {

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -1666,13 +1666,11 @@ mod tests {
         let empty: Vec<HashMap<String, Value>> = vec![];
         assert_eq!(cwli_column_kind("count", &empty), ColumnKind::Unknown);
 
-        let null_rows: Vec<HashMap<String, Value>> = vec![
-            {
-                let mut m = HashMap::new();
-                m.insert("count".to_string(), Value::Null);
-                m
-            },
-        ];
+        let null_rows: Vec<HashMap<String, Value>> = vec![{
+            let mut m = HashMap::new();
+            m.insert("count".to_string(), Value::Null);
+            m
+        }];
         assert_eq!(cwli_column_kind("count", &null_rows), ColumnKind::Unknown);
     }
 

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -4324,10 +4324,7 @@ mod tests {
 
         // Polymorphic: first present sample is Bool (Unknown-mapping), later sample is N → Integer
         // Proves the scanner skips Unknown-mapping attrs and keeps looking.
-        let poly: Vec<HashMap<String, AttributeValue>> = vec![
-            bool_item,
-            n_int_item,
-        ];
+        let poly: Vec<HashMap<String, AttributeValue>> = vec![bool_item, n_int_item];
         assert_eq!(infer_field_kind(&poly, "count"), ColumnKind::Integer);
     }
 

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -4327,9 +4327,9 @@ mod tests {
         assert_eq!(infer_field_kind(&[], "count"), ColumnKind::Unknown);
 
         // Polymorphic: both items share the same field "count". The first item
-        // holds a Null attribute (which maps to Unknown), the second holds an N
-        // integer. The scanner must skip the Unknown-mapping Null and return
-        // Integer from the second item, proving the skip-Unknown path.
+        // holds a Null attribute (which matches none of the known-kind checks
+        // and is skipped), the second holds an N integer. The scanner must skip
+        // the Null and return Integer from the second item, proving the skip path.
         let poly_null_item: HashMap<String, AttributeValue> =
             [("count".to_string(), AttributeValue::Null(true))]
                 .into_iter()

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -4322,9 +4322,15 @@ mod tests {
         // Empty items → Unknown
         assert_eq!(infer_field_kind(&[], "count"), ColumnKind::Unknown);
 
-        // Polymorphic: first present sample is Bool (Unknown-mapping), later sample is N → Integer
-        // Proves the scanner skips Unknown-mapping attrs and keeps looking.
-        let poly: Vec<HashMap<String, AttributeValue>> = vec![bool_item, n_int_item];
+        // Polymorphic: both items share the same field "count". The first item
+        // holds a Bool (which maps to Unknown), the second holds an N integer.
+        // The scanner must skip the Unknown-mapping Bool and return Integer from
+        // the second item, proving the skip-Unknown path rather than missing-field.
+        let poly_bool_item: HashMap<String, AttributeValue> =
+            [("count".to_string(), AttributeValue::Bool(true))]
+                .into_iter()
+                .collect();
+        let poly: Vec<HashMap<String, AttributeValue>> = vec![poly_bool_item, n_int_item];
         assert_eq!(infer_field_kind(&poly, "count"), ColumnKind::Integer);
     }
 

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -3037,7 +3037,7 @@ fn items_to_query_result(
             ColumnMeta {
                 name: name.clone(),
                 type_name: infer_field_type_label(items, name),
-                kind: ColumnKind::Unknown,
+                kind: infer_field_kind(items, name),
                 nullable: true,
                 is_primary_key,
             }
@@ -3115,6 +3115,27 @@ fn infer_field_type_label(
         }
     }
     String::new()
+}
+
+/// Infer the `ColumnKind` for `field_name` from the first item in `items` that
+/// carries a typed value for it. Returns `Unknown` when no item provides a typed
+/// value or when the type token is not `N` or `S`.
+fn infer_field_kind(
+    items: &[std::collections::HashMap<String, AttributeValue>],
+    field_name: &str,
+) -> ColumnKind {
+    for item in items {
+        if let Some(attr) = item.get(field_name) {
+            if attr.as_n().is_ok() {
+                return ColumnKind::Float;
+            }
+            if attr.as_s().is_ok() {
+                return ColumnKind::Text;
+            }
+            return ColumnKind::Unknown;
+        }
+    }
+    ColumnKind::Unknown
 }
 
 fn attribute_value_to_value(value: &AttributeValue) -> Value {
@@ -4212,10 +4233,10 @@ mod tests {
         classify_connection_error, classify_query_error, decide_read_strategy,
         dynamo_filter_json_from_semantic, ensure_default_database,
         ensure_item_contains_required_keys, extract_key_map_from_filter,
-        extract_non_key_update_attributes, json_value_to_attribute_value, key_components_to_fields,
-        key_components_to_indexes, normalize_table_names, plan_dynamo_semantic_request,
-        resolve_upsert_key_map, strip_key_fields_from_update_payload, unsupported_operation,
-        validate_read_options,
+        extract_non_key_update_attributes, infer_field_kind, json_value_to_attribute_value,
+        key_components_to_fields, key_components_to_indexes, normalize_table_names,
+        plan_dynamo_semantic_request, resolve_upsert_key_map,
+        strip_key_fields_from_update_payload, unsupported_operation, validate_read_options,
     };
     use crate::query_parser::{DynamoFilterFallback, DynamoReadOptions};
     use aws_sdk_dynamodb::types::{
@@ -4223,13 +4244,59 @@ mod tests {
         TableDescription,
     };
     use dbflux_core::{
-        CollectionBrowseRequest, CollectionCountRequest, CollectionRef, ConnectionProfile,
+        CollectionBrowseRequest, CollectionCountRequest, CollectionRef, ColumnKind, ConnectionProfile,
         DangerousQueryKind, DatabaseCategory, DbConfig, DbDriver, DbError, DocumentFilter,
         DocumentUpdate, DriverCapabilities, FormFieldKind, FormValues, IndexData, LanguageService,
         QueryLanguage, SemanticFilter, SemanticPlanKind, SemanticRequest, Value, WhereOperator,
     };
     use serde_json::json;
     use std::collections::HashMap;
+
+    #[test]
+    fn infer_field_kind_cases() {
+        let n_item: HashMap<String, AttributeValue> = [(
+            "score".to_string(),
+            AttributeValue::N("42.5".to_string()),
+        )]
+        .into_iter()
+        .collect();
+
+        let s_item: HashMap<String, AttributeValue> = [(
+            "name".to_string(),
+            AttributeValue::S("alice".to_string()),
+        )]
+        .into_iter()
+        .collect();
+
+        let bool_item: HashMap<String, AttributeValue> = [(
+            "active".to_string(),
+            AttributeValue::Bool(true),
+        )]
+        .into_iter()
+        .collect();
+
+        let bin_item: HashMap<String, AttributeValue> = [(
+            "data".to_string(),
+            AttributeValue::B(aws_sdk_dynamodb::primitives::Blob::new(vec![0u8])),
+        )]
+        .into_iter()
+        .collect();
+
+        assert_eq!(infer_field_kind(&[n_item.clone()], "score"), ColumnKind::Float);
+        assert_eq!(infer_field_kind(&[s_item.clone()], "name"), ColumnKind::Text);
+        assert_eq!(infer_field_kind(&[bool_item], "active"), ColumnKind::Unknown);
+        assert_eq!(infer_field_kind(&[bin_item], "data"), ColumnKind::Unknown);
+
+        // Missing field → Unknown
+        assert_eq!(infer_field_kind(&[n_item.clone()], "missing"), ColumnKind::Unknown);
+
+        // Empty items → Unknown
+        assert_eq!(infer_field_kind(&[], "score"), ColumnKind::Unknown);
+
+        // Polymorphic: first sample wins (S before N)
+        let poly: Vec<HashMap<String, AttributeValue>> = vec![s_item, n_item];
+        assert_eq!(infer_field_kind(&poly, "name"), ColumnKind::Text);
+    }
 
     #[test]
     fn metadata_uses_document_semantics_with_truthful_phase4_caps() {

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -3117,22 +3117,26 @@ fn infer_field_type_label(
     String::new()
 }
 
-/// Infer the `ColumnKind` for `field_name` from the first item in `items` that
-/// carries a typed value for it. Returns `Unknown` when no item provides a typed
-/// value or when the type token is not `N` or `S`.
+/// Infer the `ColumnKind` for `field_name` by scanning `items` for the first
+/// attribute that maps to a known kind (Integer, Float, or Text). Attributes
+/// whose type maps to Unknown are skipped so that a polymorphic column whose
+/// early samples are Bool can still resolve Integer or Float from a later
+/// sample. Returns `Unknown` when no item yields a known kind.
 fn infer_field_kind(
     items: &[std::collections::HashMap<String, AttributeValue>],
     field_name: &str,
 ) -> ColumnKind {
     for item in items {
         if let Some(attr) = item.get(field_name) {
-            if attr.as_n().is_ok() {
+            if let Ok(n_str) = attr.as_n() {
+                if n_str.parse::<i64>().is_ok() {
+                    return ColumnKind::Integer;
+                }
                 return ColumnKind::Float;
             }
             if attr.as_s().is_ok() {
                 return ColumnKind::Text;
             }
-            return ColumnKind::Unknown;
         }
     }
     ColumnKind::Unknown
@@ -4255,8 +4259,13 @@ mod tests {
 
     #[test]
     fn infer_field_kind_cases() {
-        let n_item: HashMap<String, AttributeValue> =
-            [("score".to_string(), AttributeValue::N("42.5".to_string()))]
+        let n_int_item: HashMap<String, AttributeValue> =
+            [("count".to_string(), AttributeValue::N("42".to_string()))]
+                .into_iter()
+                .collect();
+
+        let n_float_item: HashMap<String, AttributeValue> =
+            [("score".to_string(), AttributeValue::N("3.14".to_string()))]
                 .into_iter()
                 .collect();
 
@@ -4277,32 +4286,49 @@ mod tests {
         .into_iter()
         .collect();
 
+        // Integer N
         assert_eq!(
-            infer_field_kind(&[n_item.clone()], "score"),
+            infer_field_kind(&[n_int_item.clone()], "count"),
+            ColumnKind::Integer
+        );
+
+        // Decimal N
+        assert_eq!(
+            infer_field_kind(&[n_float_item.clone()], "score"),
             ColumnKind::Float
         );
+
+        // S → Text
         assert_eq!(
             infer_field_kind(&[s_item.clone()], "name"),
             ColumnKind::Text
         );
+
+        // Bool → Unknown
         assert_eq!(
-            infer_field_kind(&[bool_item], "active"),
+            infer_field_kind(&[bool_item.clone()], "active"),
             ColumnKind::Unknown
         );
+
+        // Binary → Unknown
         assert_eq!(infer_field_kind(&[bin_item], "data"), ColumnKind::Unknown);
 
         // Missing field → Unknown
         assert_eq!(
-            infer_field_kind(&[n_item.clone()], "missing"),
+            infer_field_kind(&[n_int_item.clone()], "missing"),
             ColumnKind::Unknown
         );
 
         // Empty items → Unknown
-        assert_eq!(infer_field_kind(&[], "score"), ColumnKind::Unknown);
+        assert_eq!(infer_field_kind(&[], "count"), ColumnKind::Unknown);
 
-        // Polymorphic: first sample wins (S before N)
-        let poly: Vec<HashMap<String, AttributeValue>> = vec![s_item, n_item];
-        assert_eq!(infer_field_kind(&poly, "name"), ColumnKind::Text);
+        // Polymorphic: first present sample is Bool (Unknown-mapping), later sample is N → Integer
+        // Proves the scanner skips Unknown-mapping attrs and keeps looking.
+        let poly: Vec<HashMap<String, AttributeValue>> = vec![
+            bool_item,
+            n_int_item,
+        ];
+        assert_eq!(infer_field_kind(&poly, "count"), ColumnKind::Integer);
     }
 
     #[test]

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -4235,8 +4235,8 @@ mod tests {
         ensure_item_contains_required_keys, extract_key_map_from_filter,
         extract_non_key_update_attributes, infer_field_kind, json_value_to_attribute_value,
         key_components_to_fields, key_components_to_indexes, normalize_table_names,
-        plan_dynamo_semantic_request, resolve_upsert_key_map,
-        strip_key_fields_from_update_payload, unsupported_operation, validate_read_options,
+        plan_dynamo_semantic_request, resolve_upsert_key_map, strip_key_fields_from_update_payload,
+        unsupported_operation, validate_read_options,
     };
     use crate::query_parser::{DynamoFilterFallback, DynamoReadOptions};
     use aws_sdk_dynamodb::types::{
@@ -4244,36 +4244,31 @@ mod tests {
         TableDescription,
     };
     use dbflux_core::{
-        CollectionBrowseRequest, CollectionCountRequest, CollectionRef, ColumnKind, ConnectionProfile,
-        DangerousQueryKind, DatabaseCategory, DbConfig, DbDriver, DbError, DocumentFilter,
-        DocumentUpdate, DriverCapabilities, FormFieldKind, FormValues, IndexData, LanguageService,
-        QueryLanguage, SemanticFilter, SemanticPlanKind, SemanticRequest, Value, WhereOperator,
+        CollectionBrowseRequest, CollectionCountRequest, CollectionRef, ColumnKind,
+        ConnectionProfile, DangerousQueryKind, DatabaseCategory, DbConfig, DbDriver, DbError,
+        DocumentFilter, DocumentUpdate, DriverCapabilities, FormFieldKind, FormValues, IndexData,
+        LanguageService, QueryLanguage, SemanticFilter, SemanticPlanKind, SemanticRequest, Value,
+        WhereOperator,
     };
     use serde_json::json;
     use std::collections::HashMap;
 
     #[test]
     fn infer_field_kind_cases() {
-        let n_item: HashMap<String, AttributeValue> = [(
-            "score".to_string(),
-            AttributeValue::N("42.5".to_string()),
-        )]
-        .into_iter()
-        .collect();
+        let n_item: HashMap<String, AttributeValue> =
+            [("score".to_string(), AttributeValue::N("42.5".to_string()))]
+                .into_iter()
+                .collect();
 
-        let s_item: HashMap<String, AttributeValue> = [(
-            "name".to_string(),
-            AttributeValue::S("alice".to_string()),
-        )]
-        .into_iter()
-        .collect();
+        let s_item: HashMap<String, AttributeValue> =
+            [("name".to_string(), AttributeValue::S("alice".to_string()))]
+                .into_iter()
+                .collect();
 
-        let bool_item: HashMap<String, AttributeValue> = [(
-            "active".to_string(),
-            AttributeValue::Bool(true),
-        )]
-        .into_iter()
-        .collect();
+        let bool_item: HashMap<String, AttributeValue> =
+            [("active".to_string(), AttributeValue::Bool(true))]
+                .into_iter()
+                .collect();
 
         let bin_item: HashMap<String, AttributeValue> = [(
             "data".to_string(),
@@ -4282,13 +4277,25 @@ mod tests {
         .into_iter()
         .collect();
 
-        assert_eq!(infer_field_kind(&[n_item.clone()], "score"), ColumnKind::Float);
-        assert_eq!(infer_field_kind(&[s_item.clone()], "name"), ColumnKind::Text);
-        assert_eq!(infer_field_kind(&[bool_item], "active"), ColumnKind::Unknown);
+        assert_eq!(
+            infer_field_kind(&[n_item.clone()], "score"),
+            ColumnKind::Float
+        );
+        assert_eq!(
+            infer_field_kind(&[s_item.clone()], "name"),
+            ColumnKind::Text
+        );
+        assert_eq!(
+            infer_field_kind(&[bool_item], "active"),
+            ColumnKind::Unknown
+        );
         assert_eq!(infer_field_kind(&[bin_item], "data"), ColumnKind::Unknown);
 
         // Missing field → Unknown
-        assert_eq!(infer_field_kind(&[n_item.clone()], "missing"), ColumnKind::Unknown);
+        assert_eq!(
+            infer_field_kind(&[n_item.clone()], "missing"),
+            ColumnKind::Unknown
+        );
 
         // Empty items → Unknown
         assert_eq!(infer_field_kind(&[], "score"), ColumnKind::Unknown);

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -3118,10 +3118,11 @@ fn infer_field_type_label(
 }
 
 /// Infer the `ColumnKind` for `field_name` by scanning `items` for the first
-/// attribute that maps to a known kind (Integer, Float, or Text). Attributes
-/// whose type maps to Unknown are skipped so that a polymorphic column whose
-/// early samples are Bool can still resolve Integer or Float from a later
-/// sample. Returns `Unknown` when no item yields a known kind.
+/// attribute that maps to a known kind (Integer, Float, or Text). Bool
+/// attributes map to Integer because `Value::Bool` plots as 0/1 in the chart
+/// engine (mirroring MSSQL BIT). Attributes whose type maps to Unknown are
+/// skipped so a polymorphic column can resolve a kind from a later sample.
+/// Returns `Unknown` when no item yields a known kind.
 fn infer_field_kind(
     items: &[std::collections::HashMap<String, AttributeValue>],
     field_name: &str,
@@ -3136,6 +3137,9 @@ fn infer_field_kind(
             }
             if attr.as_s().is_ok() {
                 return ColumnKind::Text;
+            }
+            if attr.as_bool().is_ok() {
+                return ColumnKind::Integer;
             }
         }
     }
@@ -4304,10 +4308,10 @@ mod tests {
             ColumnKind::Text
         );
 
-        // Bool → Unknown
+        // Bool → Integer (Value::Bool plots as 0/1 in the chart engine, like MSSQL BIT).
         assert_eq!(
             infer_field_kind(&[bool_item.clone()], "active"),
-            ColumnKind::Unknown
+            ColumnKind::Integer
         );
 
         // Binary → Unknown
@@ -4323,14 +4327,14 @@ mod tests {
         assert_eq!(infer_field_kind(&[], "count"), ColumnKind::Unknown);
 
         // Polymorphic: both items share the same field "count". The first item
-        // holds a Bool (which maps to Unknown), the second holds an N integer.
-        // The scanner must skip the Unknown-mapping Bool and return Integer from
-        // the second item, proving the skip-Unknown path rather than missing-field.
-        let poly_bool_item: HashMap<String, AttributeValue> =
-            [("count".to_string(), AttributeValue::Bool(true))]
+        // holds a Null attribute (which maps to Unknown), the second holds an N
+        // integer. The scanner must skip the Unknown-mapping Null and return
+        // Integer from the second item, proving the skip-Unknown path.
+        let poly_null_item: HashMap<String, AttributeValue> =
+            [("count".to_string(), AttributeValue::Null(true))]
                 .into_iter()
                 .collect();
-        let poly: Vec<HashMap<String, AttributeValue>> = vec![poly_bool_item, n_int_item];
+        let poly: Vec<HashMap<String, AttributeValue>> = vec![poly_null_item, n_int_item];
         assert_eq!(infer_field_kind(&poly, "count"), ColumnKind::Integer);
     }
 

--- a/crates/dbflux_driver_influxdb/src/parser/flux.rs
+++ b/crates/dbflux_driver_influxdb/src/parser/flux.rs
@@ -33,6 +33,8 @@ fn kind_from_influx_type_name(s: &str) -> ColumnKind {
         "integer" | "int" => ColumnKind::Integer,
         "double" | "float" | "float64" | "unsignedLong" | "long" => ColumnKind::Float,
         "text" | "string" => ColumnKind::Text,
+        // No ColumnKind::Bool variant exists; booleans are intentionally excluded from charts.
+        "boolean" => ColumnKind::Unknown,
         _ => ColumnKind::Unknown,
     }
 }
@@ -397,5 +399,12 @@ mod tests {
     fn whitespace_only_body_returns_empty_result() {
         let result = parse_flux_csv("   \n\n  ").expect("parse must succeed");
         assert!(result.rows.is_empty());
+    }
+
+    #[test]
+    fn kind_from_influx_type_name_boolean_is_unknown() {
+        assert_eq!(kind_from_influx_type_name("boolean"), ColumnKind::Unknown);
+        assert_eq!(kind_from_influx_type_name("timestamp"), ColumnKind::Timestamp);
+        assert_eq!(kind_from_influx_type_name("double"), ColumnKind::Float);
     }
 }

--- a/crates/dbflux_driver_influxdb/src/parser/flux.rs
+++ b/crates/dbflux_driver_influxdb/src/parser/flux.rs
@@ -33,8 +33,9 @@ fn kind_from_influx_type_name(s: &str) -> ColumnKind {
         "integer" | "int" => ColumnKind::Integer,
         "double" | "float" | "float64" | "unsignedLong" | "long" => ColumnKind::Float,
         "text" | "string" => ColumnKind::Text,
-        // No ColumnKind::Bool variant exists; booleans are intentionally excluded from charts.
-        "boolean" => ColumnKind::Unknown,
+        // Value::Bool plots as 0/1 in the chart engine (like MSSQL BIT), so
+        // Integer is the correct kind.
+        "boolean" => ColumnKind::Integer,
         _ => ColumnKind::Unknown,
     }
 }
@@ -402,8 +403,9 @@ mod tests {
     }
 
     #[test]
-    fn kind_from_influx_type_name_boolean_is_unknown() {
-        assert_eq!(kind_from_influx_type_name("boolean"), ColumnKind::Unknown);
+    fn kind_from_influx_type_name_boolean_is_integer() {
+        // Value::Bool plots as 0/1 (like MSSQL BIT), so boolean maps to Integer.
+        assert_eq!(kind_from_influx_type_name("boolean"), ColumnKind::Integer);
         assert_eq!(
             kind_from_influx_type_name("timestamp"),
             ColumnKind::Timestamp

--- a/crates/dbflux_driver_influxdb/src/parser/flux.rs
+++ b/crates/dbflux_driver_influxdb/src/parser/flux.rs
@@ -404,7 +404,10 @@ mod tests {
     #[test]
     fn kind_from_influx_type_name_boolean_is_unknown() {
         assert_eq!(kind_from_influx_type_name("boolean"), ColumnKind::Unknown);
-        assert_eq!(kind_from_influx_type_name("timestamp"), ColumnKind::Timestamp);
+        assert_eq!(
+            kind_from_influx_type_name("timestamp"),
+            ColumnKind::Timestamp
+        );
         assert_eq!(kind_from_influx_type_name("double"), ColumnKind::Float);
     }
 }

--- a/crates/dbflux_driver_influxdb/src/parser/influxql.rs
+++ b/crates/dbflux_driver_influxdb/src/parser/influxql.rs
@@ -496,7 +496,10 @@ mod tests {
     #[test]
     fn kind_from_influx_type_name_boolean_is_unknown() {
         assert_eq!(kind_from_influx_type_name("boolean"), ColumnKind::Unknown);
-        assert_eq!(kind_from_influx_type_name("timestamp"), ColumnKind::Timestamp);
+        assert_eq!(
+            kind_from_influx_type_name("timestamp"),
+            ColumnKind::Timestamp
+        );
         assert_eq!(kind_from_influx_type_name("double"), ColumnKind::Float);
     }
 }

--- a/crates/dbflux_driver_influxdb/src/parser/influxql.rs
+++ b/crates/dbflux_driver_influxdb/src/parser/influxql.rs
@@ -37,8 +37,9 @@ fn kind_from_influx_type_name(s: &str) -> ColumnKind {
         "integer" => ColumnKind::Integer,
         "double" | "float" | "float64" => ColumnKind::Float,
         "text" | "string" => ColumnKind::Text,
-        // No ColumnKind::Bool variant exists; booleans are intentionally excluded from charts.
-        "boolean" => ColumnKind::Unknown,
+        // Value::Bool plots as 0/1 in the chart engine (like MSSQL BIT), so
+        // Integer is the correct kind.
+        "boolean" => ColumnKind::Integer,
         _ => ColumnKind::Unknown,
     }
 }
@@ -494,8 +495,9 @@ mod tests {
     }
 
     #[test]
-    fn kind_from_influx_type_name_boolean_is_unknown() {
-        assert_eq!(kind_from_influx_type_name("boolean"), ColumnKind::Unknown);
+    fn kind_from_influx_type_name_boolean_is_integer() {
+        // Value::Bool plots as 0/1 (like MSSQL BIT), so boolean maps to Integer.
+        assert_eq!(kind_from_influx_type_name("boolean"), ColumnKind::Integer);
         assert_eq!(
             kind_from_influx_type_name("timestamp"),
             ColumnKind::Timestamp

--- a/crates/dbflux_driver_influxdb/src/parser/influxql.rs
+++ b/crates/dbflux_driver_influxdb/src/parser/influxql.rs
@@ -37,6 +37,8 @@ fn kind_from_influx_type_name(s: &str) -> ColumnKind {
         "integer" => ColumnKind::Integer,
         "double" | "float" | "float64" => ColumnKind::Float,
         "text" | "string" => ColumnKind::Text,
+        // No ColumnKind::Bool variant exists; booleans are intentionally excluded from charts.
+        "boolean" => ColumnKind::Unknown,
         _ => ColumnKind::Unknown,
     }
 }
@@ -489,5 +491,12 @@ mod tests {
             }
             other => panic!("expected QueryError, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn kind_from_influx_type_name_boolean_is_unknown() {
+        assert_eq!(kind_from_influx_type_name("boolean"), ColumnKind::Unknown);
+        assert_eq!(kind_from_influx_type_name("timestamp"), ColumnKind::Timestamp);
+        assert_eq!(kind_from_influx_type_name("double"), ColumnKind::Float);
     }
 }

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -2138,7 +2138,12 @@ impl Connection for MongoConnection {
             })
             .collect();
 
-        Ok(QueryResult::table(schema_listing_columns(), rows, None, start.elapsed()))
+        Ok(QueryResult::table(
+            schema_listing_columns(),
+            rows,
+            None,
+            start.elapsed(),
+        ))
     }
 
     fn view_details(
@@ -3632,9 +3637,9 @@ mod tests {
     use super::*;
     use crate::query_parser::parse_query;
     use dbflux_core::{
-        CollectionBrowseRequest, CollectionCountRequest, CollectionRef, ColumnKind, DatabaseCategory,
-        DbDriver, DbError, QueryLanguage, SemanticFilter, SemanticPlanKind, SemanticRequest, Value,
-        WhereOperator,
+        CollectionBrowseRequest, CollectionCountRequest, CollectionRef, ColumnKind,
+        DatabaseCategory, DbDriver, DbError, QueryLanguage, SemanticFilter, SemanticPlanKind,
+        SemanticRequest, Value, WhereOperator,
     };
 
     #[test]
@@ -3655,7 +3660,11 @@ mod tests {
         assert_eq!(find("index_names").kind, ColumnKind::Text);
         assert_eq!(find("nested_field_count").kind, ColumnKind::Integer);
 
-        assert_eq!(columns.len(), 6, "column count must match describe_table output");
+        assert_eq!(
+            columns.len(),
+            6,
+            "column count must match describe_table output"
+        );
     }
 
     #[test]

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -3224,8 +3224,8 @@ fn execute_db_operation(
 }
 
 /// Map a single BSON value to a `ColumnKind`. Returns `Unknown` for types
-/// that have no useful chart representation (arrays, documents, booleans,
-/// object IDs, etc.).
+/// that have no useful chart representation (arrays, documents, object IDs,
+/// dates/timestamps, etc.).
 fn bson_to_column_kind(value: &Bson) -> ColumnKind {
     match value {
         Bson::Int32(_) | Bson::Int64(_) => ColumnKind::Integer,

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -3013,7 +3013,7 @@ fn execute_mongo_query(
                 columns: vec![ColumnMeta {
                     name: "result".to_string(),
                     type_name: "Text".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Text,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -3051,7 +3051,7 @@ fn execute_db_operation(
                 columns: vec![ColumnMeta {
                     name: "name".to_string(),
                     type_name: "Text".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Text,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -3072,7 +3072,7 @@ fn execute_db_operation(
                 columns: vec![ColumnMeta {
                     name: "collection".to_string(),
                     type_name: "Text".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Text,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -3134,7 +3134,7 @@ fn execute_db_operation(
                 columns: vec![ColumnMeta {
                     name: "result".to_string(),
                     type_name: "Text".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Text,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -3150,7 +3150,7 @@ fn execute_db_operation(
                 columns: vec![ColumnMeta {
                     name: "result".to_string(),
                     type_name: "Text".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Text,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -3190,7 +3190,7 @@ fn execute_db_operation(
                 columns: vec![ColumnMeta {
                     name: "version".to_string(),
                     type_name: "Text".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Text,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -3664,6 +3664,22 @@ mod tests {
             columns.len(),
             6,
             "column count must match describe_table output"
+        );
+
+        // Assert exact column order so any future reordering breaks this test.
+        // Order must match the row values produced in describe_table.
+        let names: Vec<&str> = columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "field_name",
+                "common_type",
+                "occurrence_rate",
+                "is_indexed",
+                "index_names",
+                "nested_field_count",
+            ],
+            "column order must match describe_table row construction"
         );
     }
 

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -3230,7 +3230,9 @@ fn bson_to_column_kind(value: &Bson) -> ColumnKind {
     match value {
         Bson::Int32(_) | Bson::Int64(_) => ColumnKind::Integer,
         Bson::Double(_) | Bson::Decimal128(_) => ColumnKind::Float,
-        Bson::DateTime(_) | Bson::Timestamp(_) => ColumnKind::Timestamp,
+        // DateTime is emitted as Value::DateTime and Timestamp as Value::Text;
+        // neither is extractable by the chart engine, so leave both Unknown.
+        Bson::DateTime(_) | Bson::Timestamp(_) => ColumnKind::Unknown,
         Bson::String(_) => ColumnKind::Text,
         _ => ColumnKind::Unknown,
     }
@@ -4299,6 +4301,7 @@ mod tests {
             "label": Bson::String("hello".to_string()),
             "active": Bson::Boolean(true),
             "id": Bson::ObjectId(ObjectId::new()),
+            "created_at": Bson::DateTime(bson::DateTime::now()),
         }];
 
         let result = documents_to_result(docs).expect("should succeed");
@@ -4317,6 +4320,9 @@ mod tests {
         assert_eq!(kind_of("label"), ColumnKind::Text);
         assert_eq!(kind_of("active"), ColumnKind::Unknown);
         assert_eq!(kind_of("id"), ColumnKind::Unknown);
+        // DateTime is emitted as Value::DateTime which the chart engine cannot
+        // extract, so it must be Unknown rather than Timestamp.
+        assert_eq!(kind_of("created_at"), ColumnKind::Unknown);
     }
 
     #[test]

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -1656,6 +1656,57 @@ fn plan_mongo_semantic_request(request: &SemanticRequest) -> Result<SemanticPlan
     }
 }
 
+/// Column definitions for the schema field-listing result returned by `describe_table`.
+///
+/// Extracted as a pure function so tests can assert `ColumnKind` values without a
+/// live MongoDB connection. Column order must match the row values built in `describe_table`.
+fn schema_listing_columns() -> Vec<ColumnMeta> {
+    vec![
+        ColumnMeta {
+            name: "field_name".to_string(),
+            type_name: "text".to_string(),
+            kind: ColumnKind::Text,
+            nullable: false,
+            is_primary_key: false,
+        },
+        ColumnMeta {
+            name: "common_type".to_string(),
+            type_name: "text".to_string(),
+            kind: ColumnKind::Text,
+            nullable: false,
+            is_primary_key: false,
+        },
+        ColumnMeta {
+            name: "occurrence_rate".to_string(),
+            type_name: "float".to_string(),
+            kind: ColumnKind::Float,
+            nullable: true,
+            is_primary_key: false,
+        },
+        ColumnMeta {
+            name: "is_indexed".to_string(),
+            type_name: "bool".to_string(),
+            kind: ColumnKind::Unknown,
+            nullable: false,
+            is_primary_key: false,
+        },
+        ColumnMeta {
+            name: "index_names".to_string(),
+            type_name: "text".to_string(),
+            kind: ColumnKind::Text,
+            nullable: true,
+            is_primary_key: false,
+        },
+        ColumnMeta {
+            name: "nested_field_count".to_string(),
+            type_name: "int".to_string(),
+            kind: ColumnKind::Integer,
+            nullable: false,
+            is_primary_key: false,
+        },
+    ]
+}
+
 impl Connection for MongoConnection {
     fn metadata(&self) -> &DriverMetadata {
         &MONGODB_METADATA
@@ -2087,52 +2138,7 @@ impl Connection for MongoConnection {
             })
             .collect();
 
-        let columns = vec![
-            ColumnMeta {
-                name: "field_name".to_string(),
-                type_name: "text".to_string(),
-                kind: ColumnKind::Unknown,
-                nullable: false,
-                is_primary_key: false,
-            },
-            ColumnMeta {
-                name: "common_type".to_string(),
-                type_name: "text".to_string(),
-                kind: ColumnKind::Unknown,
-                nullable: false,
-                is_primary_key: false,
-            },
-            ColumnMeta {
-                name: "occurrence_rate".to_string(),
-                type_name: "float".to_string(),
-                kind: ColumnKind::Float,
-                nullable: true,
-                is_primary_key: false,
-            },
-            ColumnMeta {
-                name: "is_indexed".to_string(),
-                type_name: "bool".to_string(),
-                kind: ColumnKind::Unknown,
-                nullable: false,
-                is_primary_key: false,
-            },
-            ColumnMeta {
-                name: "index_names".to_string(),
-                type_name: "text".to_string(),
-                kind: ColumnKind::Unknown,
-                nullable: true,
-                is_primary_key: false,
-            },
-            ColumnMeta {
-                name: "nested_field_count".to_string(),
-                type_name: "int".to_string(),
-                kind: ColumnKind::Integer,
-                nullable: false,
-                is_primary_key: false,
-            },
-        ];
-
-        Ok(QueryResult::table(columns, rows, None, start.elapsed()))
+        Ok(QueryResult::table(schema_listing_columns(), rows, None, start.elapsed()))
     }
 
     fn view_details(
@@ -2746,7 +2752,7 @@ fn execute_mongo_query(
                 columns: vec![ColumnMeta {
                     name: "count".to_string(),
                     type_name: "Int64".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Integer,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -2788,7 +2794,7 @@ fn execute_mongo_query(
                 columns: vec![ColumnMeta {
                     name: "insertedCount".to_string(),
                     type_name: "Int64".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Integer,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -2820,14 +2826,14 @@ fn execute_mongo_query(
                     ColumnMeta {
                         name: "matchedCount".to_string(),
                         type_name: "Int64".to_string(),
-                        kind: ColumnKind::Unknown,
+                        kind: ColumnKind::Integer,
                         nullable: false,
                         is_primary_key: false,
                     },
                     ColumnMeta {
                         name: "modifiedCount".to_string(),
                         type_name: "Int64".to_string(),
-                        kind: ColumnKind::Unknown,
+                        kind: ColumnKind::Integer,
                         nullable: false,
                         is_primary_key: false,
                     },
@@ -2871,14 +2877,14 @@ fn execute_mongo_query(
                     ColumnMeta {
                         name: "matchedCount".to_string(),
                         type_name: "Int64".to_string(),
-                        kind: ColumnKind::Unknown,
+                        kind: ColumnKind::Integer,
                         nullable: false,
                         is_primary_key: false,
                     },
                     ColumnMeta {
                         name: "modifiedCount".to_string(),
                         type_name: "Int64".to_string(),
-                        kind: ColumnKind::Unknown,
+                        kind: ColumnKind::Integer,
                         nullable: false,
                         is_primary_key: false,
                     },
@@ -2911,7 +2917,7 @@ fn execute_mongo_query(
                 columns: vec![ColumnMeta {
                     name: "deletedCount".to_string(),
                     type_name: "Int64".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Integer,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -2932,7 +2938,7 @@ fn execute_mongo_query(
                 columns: vec![ColumnMeta {
                     name: "deletedCount".to_string(),
                     type_name: "Int64".to_string(),
-                    kind: ColumnKind::Unknown,
+                    kind: ColumnKind::Integer,
                     nullable: false,
                     is_primary_key: false,
                 }],
@@ -2964,14 +2970,14 @@ fn execute_mongo_query(
                     ColumnMeta {
                         name: "matchedCount".to_string(),
                         type_name: "Int64".to_string(),
-                        kind: ColumnKind::Unknown,
+                        kind: ColumnKind::Integer,
                         nullable: false,
                         is_primary_key: false,
                     },
                     ColumnMeta {
                         name: "modifiedCount".to_string(),
                         type_name: "Int64".to_string(),
-                        kind: ColumnKind::Unknown,
+                        kind: ColumnKind::Integer,
                         nullable: false,
                         is_primary_key: false,
                     },
@@ -3626,10 +3632,31 @@ mod tests {
     use super::*;
     use crate::query_parser::parse_query;
     use dbflux_core::{
-        CollectionBrowseRequest, CollectionCountRequest, CollectionRef, DatabaseCategory, DbDriver,
-        DbError, QueryLanguage, SemanticFilter, SemanticPlanKind, SemanticRequest, Value,
+        CollectionBrowseRequest, CollectionCountRequest, CollectionRef, ColumnKind, DatabaseCategory,
+        DbDriver, DbError, QueryLanguage, SemanticFilter, SemanticPlanKind, SemanticRequest, Value,
         WhereOperator,
     };
+
+    #[test]
+    fn schema_listing_column_kinds() {
+        let columns = schema_listing_columns();
+
+        let find = |name: &str| {
+            columns
+                .iter()
+                .find(|c| c.name == name)
+                .unwrap_or_else(|| panic!("column '{name}' not found in schema_listing_columns"))
+        };
+
+        assert_eq!(find("field_name").kind, ColumnKind::Text);
+        assert_eq!(find("common_type").kind, ColumnKind::Text);
+        assert_eq!(find("occurrence_rate").kind, ColumnKind::Float);
+        assert_eq!(find("is_indexed").kind, ColumnKind::Unknown);
+        assert_eq!(find("index_names").kind, ColumnKind::Text);
+        assert_eq!(find("nested_field_count").kind, ColumnKind::Integer);
+
+        assert_eq!(columns.len(), 6, "column count must match describe_table output");
+    }
 
     #[test]
     fn build_config_requires_uri_in_uri_mode() {

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -1686,7 +1686,7 @@ fn schema_listing_columns() -> Vec<ColumnMeta> {
         ColumnMeta {
             name: "is_indexed".to_string(),
             type_name: "bool".to_string(),
-            kind: ColumnKind::Unknown,
+            kind: ColumnKind::Integer,
             nullable: false,
             is_primary_key: false,
         },
@@ -2845,7 +2845,7 @@ fn execute_mongo_query(
                     ColumnMeta {
                         name: "upserted".to_string(),
                         type_name: "Bool".to_string(),
-                        kind: ColumnKind::Unknown,
+                        kind: ColumnKind::Integer,
                         nullable: false,
                         is_primary_key: false,
                     },
@@ -2896,7 +2896,7 @@ fn execute_mongo_query(
                     ColumnMeta {
                         name: "upserted".to_string(),
                         type_name: "Bool".to_string(),
-                        kind: ColumnKind::Unknown,
+                        kind: ColumnKind::Integer,
                         nullable: false,
                         is_primary_key: false,
                     },
@@ -2989,7 +2989,7 @@ fn execute_mongo_query(
                     ColumnMeta {
                         name: "upserted".to_string(),
                         type_name: "Bool".to_string(),
-                        kind: ColumnKind::Unknown,
+                        kind: ColumnKind::Integer,
                         nullable: false,
                         is_primary_key: false,
                     },
@@ -3230,6 +3230,8 @@ fn bson_to_column_kind(value: &Bson) -> ColumnKind {
     match value {
         Bson::Int32(_) | Bson::Int64(_) => ColumnKind::Integer,
         Bson::Double(_) | Bson::Decimal128(_) => ColumnKind::Float,
+        // Value::Bool plots as 0/1 in the chart engine (like MSSQL BIT).
+        Bson::Boolean(_) => ColumnKind::Integer,
         // DateTime is emitted as Value::DateTime and Timestamp as Value::Text;
         // neither is extractable by the chart engine, so leave both Unknown.
         Bson::DateTime(_) | Bson::Timestamp(_) => ColumnKind::Unknown,
@@ -3685,7 +3687,8 @@ mod tests {
         assert_eq!(find("field_name").kind, ColumnKind::Text);
         assert_eq!(find("common_type").kind, ColumnKind::Text);
         assert_eq!(find("occurrence_rate").kind, ColumnKind::Float);
-        assert_eq!(find("is_indexed").kind, ColumnKind::Unknown);
+        // Value::Bool plots as 0/1 in the chart engine (like MSSQL BIT).
+        assert_eq!(find("is_indexed").kind, ColumnKind::Integer);
         assert_eq!(find("index_names").kind, ColumnKind::Text);
         assert_eq!(find("nested_field_count").kind, ColumnKind::Integer);
 
@@ -4318,7 +4321,8 @@ mod tests {
         assert_eq!(kind_of("count"), ColumnKind::Integer);
         assert_eq!(kind_of("ratio"), ColumnKind::Float);
         assert_eq!(kind_of("label"), ColumnKind::Text);
-        assert_eq!(kind_of("active"), ColumnKind::Unknown);
+        // Value::Bool plots as 0/1 in the chart engine (like MSSQL BIT).
+        assert_eq!(kind_of("active"), ColumnKind::Integer);
         assert_eq!(kind_of("id"), ColumnKind::Unknown);
         // DateTime is emitted as Value::DateTime which the chart engine cannot
         // extract, so it must be Unknown rather than Timestamp.

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -3223,6 +3223,33 @@ fn execute_db_operation(
     }
 }
 
+/// Map a single BSON value to a `ColumnKind`. Returns `Unknown` for types
+/// that have no useful chart representation (arrays, documents, booleans,
+/// object IDs, etc.).
+fn bson_to_column_kind(value: &Bson) -> ColumnKind {
+    match value {
+        Bson::Int32(_) | Bson::Int64(_) => ColumnKind::Integer,
+        Bson::Double(_) | Bson::Decimal128(_) => ColumnKind::Float,
+        Bson::DateTime(_) | Bson::Timestamp(_) => ColumnKind::Timestamp,
+        Bson::String(_) => ColumnKind::Text,
+        _ => ColumnKind::Unknown,
+    }
+}
+
+/// Infer the `ColumnKind` for `field` by scanning `documents` for the first
+/// value that maps to a known kind, skipping Unknown-mapping values.
+fn infer_document_field_kind(documents: &[Document], field: &str) -> ColumnKind {
+    for doc in documents {
+        if let Some(value) = doc.get(field) {
+            let kind = bson_to_column_kind(value);
+            if kind != ColumnKind::Unknown {
+                return kind;
+            }
+        }
+    }
+    ColumnKind::Unknown
+}
+
 fn documents_to_result(documents: Vec<Document>) -> Result<QueryResultInternal, DbError> {
     if documents.is_empty() {
         return Ok(QueryResultInternal {
@@ -3256,7 +3283,7 @@ fn documents_to_result(documents: Vec<Document>) -> Result<QueryResultInternal, 
         .map(|name| ColumnMeta {
             name: name.clone(),
             type_name: "BSON".to_string(),
-            kind: ColumnKind::Unknown,
+            kind: infer_document_field_kind(&documents, name),
             nullable: true,
             is_primary_key: name == "_id",
         })
@@ -4260,6 +4287,38 @@ mod tests {
         if let Value::Document(map) = value {
             assert_eq!(map.len(), 2);
         }
+    }
+
+    #[test]
+    fn documents_to_result_bson_column_kind_inference() {
+        use bson::oid::ObjectId;
+
+        let docs = vec![
+            doc! {
+                "count": Bson::Int64(10),
+                "ratio": Bson::Double(0.5),
+                "label": Bson::String("hello".to_string()),
+                "active": Bson::Boolean(true),
+                "id": Bson::ObjectId(ObjectId::new()),
+            },
+        ];
+
+        let result = documents_to_result(docs).expect("should succeed");
+
+        let kind_of = |name: &str| {
+            result
+                .columns
+                .iter()
+                .find(|c| c.name == name)
+                .unwrap_or_else(|| panic!("column '{name}' not found"))
+                .kind
+        };
+
+        assert_eq!(kind_of("count"), ColumnKind::Integer);
+        assert_eq!(kind_of("ratio"), ColumnKind::Float);
+        assert_eq!(kind_of("label"), ColumnKind::Text);
+        assert_eq!(kind_of("active"), ColumnKind::Unknown);
+        assert_eq!(kind_of("id"), ColumnKind::Unknown);
     }
 
     #[test]

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -4293,15 +4293,13 @@ mod tests {
     fn documents_to_result_bson_column_kind_inference() {
         use bson::oid::ObjectId;
 
-        let docs = vec![
-            doc! {
-                "count": Bson::Int64(10),
-                "ratio": Bson::Double(0.5),
-                "label": Bson::String("hello".to_string()),
-                "active": Bson::Boolean(true),
-                "id": Bson::ObjectId(ObjectId::new()),
-            },
-        ];
+        let docs = vec![doc! {
+            "count": Bson::Int64(10),
+            "ratio": Bson::Double(0.5),
+            "label": Bson::String("hello".to_string()),
+            "active": Bson::Boolean(true),
+            "id": Bson::ObjectId(ObjectId::new()),
+        }];
 
         let result = documents_to_result(docs).expect("should succeed");
 

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -3224,17 +3224,25 @@ fn execute_db_operation(
 }
 
 /// Map a single BSON value to a `ColumnKind`. Returns `Unknown` for types
-/// that have no useful chart representation (arrays, documents, object IDs,
-/// dates/timestamps, etc.).
+/// that have no useful chart representation (arrays, documents, object IDs, etc.).
+///
+/// `Bson::DateTime` maps to `ColumnKind::Timestamp` because `bson_to_value`
+/// converts it to `Value::DateTime`, which the chart engine extracts as epoch-ms.
+/// `Bson::Timestamp` is an oplog logical clock emitted as `Value::Text`; it
+/// carries no wall-clock meaning and remains `Unknown`.
 fn bson_to_column_kind(value: &Bson) -> ColumnKind {
     match value {
         Bson::Int32(_) | Bson::Int64(_) => ColumnKind::Integer,
         Bson::Double(_) | Bson::Decimal128(_) => ColumnKind::Float,
         // Value::Bool plots as 0/1 in the chart engine (like MSSQL BIT).
         Bson::Boolean(_) => ColumnKind::Integer,
-        // DateTime is emitted as Value::DateTime and Timestamp as Value::Text;
-        // neither is extractable by the chart engine, so leave both Unknown.
-        Bson::DateTime(_) | Bson::Timestamp(_) => ColumnKind::Unknown,
+        // Bson::DateTime is converted to Value::DateTime by bson_to_value and
+        // can now be plotted on a time axis as epoch-ms.
+        Bson::DateTime(_) => ColumnKind::Timestamp,
+        // Bson::Timestamp is an oplog logical clock, not a wall-clock instant.
+        // bson_to_value renders it as Value::Text("Timestamp(t, i)"), which is
+        // not plottable on a time axis.
+        Bson::Timestamp(_) => ColumnKind::Unknown,
         Bson::String(_) => ColumnKind::Text,
         _ => ColumnKind::Unknown,
     }
@@ -4305,6 +4313,7 @@ mod tests {
             "active": Bson::Boolean(true),
             "id": Bson::ObjectId(ObjectId::new()),
             "created_at": Bson::DateTime(bson::DateTime::now()),
+            "oplog_ts": Bson::Timestamp(bson::Timestamp { time: 1, increment: 0 }),
         }];
 
         let result = documents_to_result(docs).expect("should succeed");
@@ -4324,9 +4333,12 @@ mod tests {
         // Value::Bool plots as 0/1 in the chart engine (like MSSQL BIT).
         assert_eq!(kind_of("active"), ColumnKind::Integer);
         assert_eq!(kind_of("id"), ColumnKind::Unknown);
-        // DateTime is emitted as Value::DateTime which the chart engine cannot
-        // extract, so it must be Unknown rather than Timestamp.
-        assert_eq!(kind_of("created_at"), ColumnKind::Unknown);
+        // Bson::DateTime maps to Value::DateTime, which the chart engine now
+        // extracts as epoch-ms, so it must be Timestamp.
+        assert_eq!(kind_of("created_at"), ColumnKind::Timestamp);
+        // Bson::Timestamp is an oplog logical clock emitted as Value::Text;
+        // it has no wall-clock meaning and must remain Unknown.
+        assert_eq!(kind_of("oplog_ts"), ColumnKind::Unknown);
     }
 
     #[test]

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1412,7 +1412,9 @@ fn tiberius_value_to_value(row: &tiberius::Row, idx: usize) -> Value {
 ///
 /// Variants whose semantic category isn't representable (`Guid`, `Xml`, `Udt`,
 /// `BigVarBin`/`BigBinary`/`Image`, `SSVariant`, `Null`) map to `Unknown` so
-/// chart auto-detect excludes them rather than treating them as text.
+/// chart auto-detect excludes them rather than treating them as text. `TIME`
+/// also maps to `Unknown`: it yields a wall-clock `Value::Time` the chart
+/// engine cannot place on a time axis.
 fn tiberius_column_to_kind(column_type: tiberius::ColumnType) -> dbflux_core::ColumnKind {
     use dbflux_core::ColumnKind;
     use tiberius::ColumnType;
@@ -1436,14 +1438,7 @@ fn tiberius_column_to_kind(column_type: tiberius::ColumnType) -> dbflux_core::Co
         | ColumnType::Datetimen
         | ColumnType::Datetime2
         | ColumnType::Daten
-        | ColumnType::Timen
         | ColumnType::DatetimeOffsetn => ColumnKind::Timestamp,
-        ColumnType::BigVarChar
-        | ColumnType::BigChar
-        | ColumnType::NVarchar
-        | ColumnType::NChar
-        | ColumnType::Text
-        | ColumnType::NText => ColumnKind::Text,
         ColumnType::Null
         | ColumnType::Guid
         | ColumnType::Xml
@@ -1451,7 +1446,17 @@ fn tiberius_column_to_kind(column_type: tiberius::ColumnType) -> dbflux_core::Co
         | ColumnType::BigVarBin
         | ColumnType::BigBinary
         | ColumnType::Image
-        | ColumnType::SSVariant => ColumnKind::Unknown,
+        | ColumnType::SSVariant
+        // TIME yields Value::Time (a wall-clock time-of-day with no absolute
+        // instant); the chart engine cannot plot it on a time axis, so it must
+        // not advertise Timestamp.
+        | ColumnType::Timen => ColumnKind::Unknown,
+        ColumnType::BigVarChar
+        | ColumnType::BigChar
+        | ColumnType::NVarchar
+        | ColumnType::NChar
+        | ColumnType::Text
+        | ColumnType::NText => ColumnKind::Text,
     }
 }
 
@@ -3646,6 +3651,33 @@ fn format_mssql_uri_error(e: &tiberius::error::Error, uri: &str) -> DbError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn time_type_is_not_classified_as_timestamp() {
+        use dbflux_core::ColumnKind;
+        use tiberius::ColumnType;
+
+        // TIME emits Value::Time, which the chart engine cannot place on a time
+        // axis (no absolute instant), so it must not advertise Timestamp.
+        assert_eq!(
+            tiberius_column_to_kind(ColumnType::Timen),
+            ColumnKind::Unknown
+        );
+
+        // DATE (Value::Date) and the datetime types stay Timestamp — those plot.
+        assert_eq!(
+            tiberius_column_to_kind(ColumnType::Daten),
+            ColumnKind::Timestamp
+        );
+        assert_eq!(
+            tiberius_column_to_kind(ColumnType::Datetime2),
+            ColumnKind::Timestamp
+        );
+        assert_eq!(
+            tiberius_column_to_kind(ColumnType::DatetimeOffsetn),
+            ColumnKind::Timestamp
+        );
+    }
 
     #[test]
     fn mssql_type_to_routine_kind_mapping() {


### PR DESCRIPTION
## Summary

Four drivers assigned `ColumnKind` dishonestly, so the chart engine — which selects chart-able columns from `ColumnKind` — either failed to offer real numeric/timestamp columns or offered non-numeric fields as Y axes. Adversarial review surfaced a second gate: a column is only *plottable* if its `Value` is extractable by `extract_f64`. This PR makes both the kind AND the value honest, closes a long-standing engine gap where typed datetimes could not drive a time axis, and removes a SQL Server kind/value mismatch the review uncovered. Closes the epic "Charts utilizables en todos los drivers" (CHART-1..4).

## What does this resolve?

- Resolves #204

## How was this solved?

Driver-local kind/value corrections plus one generic chart-engine fix (no UI changes, no per-driver branching in the UI).

- **CloudWatch (CHART-1)** — CWL Insights fields are typed at construction: numeric strings become `Value::Int`/`Value::Float` (non-finite rejected), non-numeric stay `Value::Text`; `@timestamp`/`@ingestionTime` are normalized to RFC3339. Column kind is derived from the typed values (first numeric sample wins, skipping empty/null/text).
- **DynamoDB (CHART-2)** — `infer_field_kind` samples the `AttributeValue` type: `N` -> `Integer` when it parses as i64 else `Float`, `S` -> `Text`, `BOOL` -> `Integer` (0/1), else scans on.
- **MongoDB (CHART-3)** — operation-result Int64 columns -> `Integer`; `schema_listing_columns()` extracted (order preserved) with text columns -> `Text`; document/query results infer kind from BSON value types (Int32/Int64 -> Integer, Double/Decimal128 -> Float, String -> Text, Boolean -> Integer, DateTime -> Timestamp, oplog Timestamp -> Unknown).
- **InfluxDB (CHART-4)** — explicit `"boolean" => ColumnKind::Integer` in both Flux and InfluxQL mappers (booleans plot as 0/1).
- **Chart engine** — `extract_f64` now plots `Value::DateTime`/`Value::Date` as epoch-ms, gated on the time axis, closing a gap where Postgres/MySQL/SQLite/MSSQL/MongoDB typed timestamps produced empty time-axis charts. `Value::Time` stays unplottable (no absolute epoch).
- **SQL Server** — the `TIME` type emits `Value::Time` and so is reclassified from `Timestamp` to `Unknown` (it was previously offered as a time axis that never plotted).

Booleans classify as `Integer` (no `ColumnKind::Bool` variant introduced). Columns whose values the engine cannot extract are left `Unknown` rather than offered as broken axes.

## Validation

- `cargo nextest run` across the affected crates (cloudwatch, dynamodb, mongodb, influxdb, mssql, dbflux_components) — all green; new unit tests are TDD (red before each fix).
- `cargo test --doc` — ok.
- `cargo clippy --workspace -- -D warnings` — 0 warnings.
- New non-live unit tests cover value typing, first-numeric-sample skipping, RFC3339 round-trip, BSON kind inference, boolean->Integer, the DynamoDB skip-Unknown path, `extract_f64` epoch-ms for DateTime/Date (hardcoded literal, gated on the time axis), and SQL Server `TIME` -> Unknown.
- Six rounds of adversarial dual review (Judgment Day) plus a TDD follow-up; final verdict CLEAN.

## Known limitations / follow-ups

- MongoDB BSON `Timestamp` (oplog logical clock) stays `Unknown` — not a wall-clock instant.
- CWLI columns keep `type_name: "text"` even when the kind is numeric/timestamp (engine reads `kind` only; cosmetic).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]`
- [x] I applied the appropriate labels

## Labels to apply

`driver:bug`, `driver:cloudwatch`, `driver:dynamodb`, `driver:mongodb`, `driver:influxdb`, `driver:mssql`