### PR TITLE
docs: add user-facing guides and correct stale documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,10 +274,10 @@ The UI layer is split into six crates (see `ARCHITECTURE.md` § Layered crate ma
 
 - `dbflux_components` — domain-free leaf: theme, tokens, icons, primitives, composites, controls, data_table, document_tree, result_panel, chart engine, modals. No `dbflux_app` dependency.
 - `dbflux_ui_base` — AppStateEntity, events, keymap helpers, toast, modal_frame, platform detection, sql_preview_modal, sso_wizard.
-- `dbflux_ui_document` — tab/pane system, all document types (CodeDocument, DataDocument, ChartDocument, KeyValueDocument, AuditDocument), data_grid_panel, governance view.
+- `dbflux_ui_document` — tab/pane system, all document types (CodeDocument, DataDocument, ChartDocument, DashboardDocument, KeyValueDocument, AuditDocument, InstanceInspectorDocument), data_grid_panel, governance view.
 - `dbflux_ui_sidebar` — connections + scripts sidebar tree.
 - `dbflux_ui_windows` — settings window and connection manager window.
-- `dbflux_ui` — thin integrator (~11.5k LOC): workspace, status_bar, tasks_panel, dock, remaining overlays (command_palette, login_modal, shutdown_overlay), keymap glue, assets, ipc_server. Re-exports moved subsystems via `pub use` shims at the old module paths so internal call-sites still compile against `crate::ui::...`.
+- `dbflux_ui` — thin integrator (~13.5k LOC): workspace, status_bar, tasks_panel, dock, remaining overlays (command_palette, login_modal, shutdown_overlay), keymap glue, assets, ipc_server. Re-exports moved subsystems via `pub use` shims at the old module paths so internal call-sites still compile against `crate::ui::...`.
 
 `dbflux_ui` has **no per-driver feature flags** and no driver dependencies. Per-driver features live on `dbflux_app` (which registers drivers) and on the `dbflux` binary. The cross-cutting `lua`/`aws`/`mcp` features on UI crates only forward to `dbflux_app` and sibling UI crates.
 
@@ -350,7 +350,7 @@ Key abstractions for UI adaptation:
 - The runtime seam for service discovery/classification lives in `dbflux_app::rpc_services`; extend that boundary for future RPC capabilities instead of hardcoding new driver-only bootstrap logic in `app_state.rs`.
 - Preserve compatibility for external driver registration IDs as `rpc:<socket_id>`.
 - `DynAuthProvider::fetch_dynamic_options` is a real trait method (default implementation returns `Permanent("not supported")`); `RpcAuthProvider` implements it by dispatching `FetchDynamicOptions` requests over IPC.
-- The auth-provider IPC protocol is at v1.2 and gained `FetchDynamicOptions` request / `DynamicOptions` response variants, plus the `secret_dependency_opt_in` manifest flag. Providers advertising v1.2 have `fetch_dynamic_options` available; older providers get `Permanent("not supported")`.
+- The auth-provider IPC protocol is at v1.3. v1.2 added the `FetchDynamicOptions` request / `DynamicOptions` response variants plus the `secret_dependency_opt_in` manifest flag; v1.3 added the `audit_emit_opt_in` manifest flag and audit event emission (`EmitAuditEvent`). Providers advertising v1.2+ have `fetch_dynamic_options` available; older providers get `Permanent("not supported")`.
 - The Settings UI for Auth Profiles is provider-agnostic. To surface dynamic dropdowns a provider must declare `FormFieldKind::DynamicSelect` fields in its manifest. The host strips secret field values from dependency maps unless the provider sets `secret_dependency_opt_in: true`.
 - `AuthSession.data` round-trips opaquely through the IPC DTO via JSON downcast and is never persisted.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -204,10 +204,14 @@ crates/
       data_grid_panel/      # Data grid with table/document view modes
         mod.rs
         context_menu.rs
+        filter_bar.rs
+        mutation_confirm.rs
+        mutation_executor.rs
         mutations.rs
         navigation.rs
         query.rs
         render.rs
+        row_inspector.rs
         utils.rs
       code/                 # CodeDocument: query/script editor
         mod.rs
@@ -241,6 +245,16 @@ crates/
         filters.rs
         saved_filter.rs
         source_adapter.rs
+      chart/                # ChartShell host for metric/instance charts (distinct from chart_document/)
+        mod.rs
+        shell.rs            # ChartShell host entity
+        host.rs
+        metric_picker.rs
+        metric_picker_render.rs
+        toolbar.rs
+      instance_inspector/   # InstanceInspectorDocument (backs DocumentKey::InstanceInspector)
+        mod.rs
+        pane.rs             # into_pane constructor
   dbflux_ui_sidebar/        # Connections + scripts sidebar tree with folders, drag-drop
     src/
       lib.rs                # SidebarView entity (re-exported by dbflux_ui)
@@ -277,7 +291,9 @@ crates/
         hooks.rs            # Hook definitions CRUD
         drivers.rs          # Per-driver settings overrides
         rpc_services.rs     # RPC services settings UI (Driver/Auth Provider descriptors)
-        mcp_section.rs      # MCP settings (trusted clients, roles, policies, audit)
+        audit_section.rs    # Audit settings section
+        about_section.rs    # About section
+        mcp_section.rs      # MCP settings (trusted clients, roles, policies, audit; feature-gated)
       connection_manager/   # Connection manager window
         mod.rs
         access_tab.rs       # Unified access mode editor (Direct/SSH/Proxy/SSM)
@@ -287,7 +303,7 @@ crates/
         render_driver_select.rs
         render_tabs.rs
         hooks_tab.rs        # Per-profile hook bindings
-  dbflux_ui/                # Thin integrator (~11.5k LOC): wires the six UI crates together
+  dbflux_ui/                # Thin integrator (~13.5k LOC): wires the six UI crates together
     src/                    # Re-exports moved subsystems via pub use shims at old module paths
       lib.rs                # Crate root; re-exports via shim modules
       app.rs                # GPUI app bootstrap
@@ -335,11 +351,11 @@ crates/
       hook_executor.rs       # Composite hook executor routing
       proxy.rs               # create_proxy_tunnel callback for CreateTunnelFn
       config_loader.rs       # SQLite-backed configuration persistence
-      rpc_services.rs        # RPC service discovery/adaptation seam for runtime bootstrap
+      rpc_services/          # RPC service discovery/adaptation seam for runtime bootstrap (external_audit, ...)
       history_manager_sqlite.rs # SQLite-backed query history
       mcp_command.rs         # MCP subcommand integration and arg parsing
       keymap/                # Keyboard system (pure domain types)
-        command.rs           # Command enum (pure domain)
+        mod.rs               # Re-exports Command/ContextId from dbflux_core::keymap_types
         focus.rs             # FocusTarget enum (pure domain)
   dbflux_core/              # Traits, core types, storage, errors
     src/access/             # AccessKind, AccessManager, and managed-access serialization
@@ -563,6 +579,8 @@ User-triggered failures route through a single seam in `crates/dbflux_ui_base/sr
 - `CodeDocument` (`crates/dbflux_ui_document/src/code/`) — multi-tab editor. Each result tab wraps its `DataGridPanel` in its own `ResultPanel`. Outer chrome (editor, context bar, tab strip) is self-rendered.
 - `KeyValueDocument` (`crates/dbflux_ui_document/src/key_value/`) — self-renders. `KeyValueView` is a file-level boundary struct (not a separate GPUI entity) grouping render helpers extracted from `key_value/render.rs`.
 - `AuditDocument` (`crates/dbflux_ui_document/src/audit/`) — self-renders. `LogStreamView` is a file-level boundary struct. Body extracted to `audit/render.rs` and `audit/commands.rs` as sibling `impl AuditDocument` files.
+- `InstanceInspectorDocument` (`crates/dbflux_ui_document/src/instance_inspector/`) — tabular instance-inspector snapshot tab, keyed by `DocumentKey::InstanceInspector`.
+- `chart/` (`crates/dbflux_ui_document/src/chart/`) — the `ChartShell` host (`shell.rs`, `host.rs`) plus metric picker (`metric_picker*.rs`) and `toolbar.rs`, distinct from `chart_document/`; it backs metric/instance charts.
 
 **Adding a new document type** (no changes required outside the new module):
 1. Create `crates/dbflux_ui_document/src/<name>/mod.rs` with the entity.
@@ -631,7 +649,7 @@ See `docs/DASHBOARDS.md` for the full reference (including instance metrics and 
 - Driver-owned child resources under collections/containers are published through generic `CollectionChildInfo` metadata. The sidebar must not infer driver-specific children from names, field types, or driver IDs.
 - Routines (functions, procedures, aggregates, window functions) appear as a per-schema "Routines" folder when the driver sets the `ROUTINES` capability and populates the `schema_routines` seam. The UI renders the folder generically; it does not special-case any driver.
 - Sidebar dock: `crates/dbflux_ui/src/ui/dock/sidebar_dock.rs` provides collapsible, resizable sidebar with ToggleSidebar command (Ctrl+B).
-- Connection tree: `crates/dbflux_core/src/connection/tree.rs` models folders and connections as a tree structure with persistence via `connection_tree_store.rs`.
+- Connection tree: `crates/dbflux_core/src/connection/tree.rs` models folders and connections as a tree structure with persistence via `tree_store.rs`.
 
 ### Driver System
 
@@ -690,7 +708,7 @@ See `docs/DASHBOARDS.md` for the full reference (including instance metrics and 
 
 ### Settings Window
 
-- Settings is organized into 8 sections: General, Keybindings, Auth Profiles, Proxies, SSH Tunnels, Services, Hooks, Drivers.
+- Settings is organized into the following sections: General, Keybindings, Auth Profiles, Proxies, SSH Tunnels, Services, Hooks, Drivers, Audit, and About. MCP sections (trusted clients, roles, policies) are feature-gated under the `mcp` feature.
 - Sidebar uses `TreeNav` component with collapsible Network/Connection categories.
 - `UiStateStore` persists sidebar collapse state to `st_ui_state` table in `~/.local/share/dbflux/dbflux.db`.
 - Auth Profiles section is provider-driven (`DynAuthProvider::form_def`) and supports importing provider-discovered profiles (for AWS, from `~/.aws/config`).
@@ -886,7 +904,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 
 ## Keyboard & Focus Architecture
 
-- Keymap system: `crates/dbflux_ui/src/keymap/` (stays in `dbflux_ui`) defines keymap glue (`actions.rs`, `dispatcher.rs`). Keymap helpers (`default_keymap`, `key_chord_from_gpui`) live in `crates/dbflux_ui_base/src/keymap.rs`. Domain command types live in `crates/dbflux_app/src/keymap/`.
+- Keymap system: `crates/dbflux_ui/src/keymap/` (stays in `dbflux_ui`) defines keymap glue (`actions.rs`, `dispatcher.rs`). Keymap helpers (`default_keymap`, `key_chord_from_gpui`) live in `crates/dbflux_ui_base/src/keymap.rs`. Domain command types (`Command`, `ContextId`) are defined in `dbflux_core::keymap_types` and re-exported through `crates/dbflux_app/src/keymap/`.
 - Command dispatch: `Workspace` implements `CommandDispatcher` trait; `dispatch()` in `views/workspace/dispatch.rs` routes commands based on `focus_target` (Document, Sidebar, BackgroundTasks).
 - Document-focused design: FocusTarget was simplified from Editor/Results/Sidebar/BackgroundTasks to Document/Sidebar/BackgroundTasks, letting documents manage their own internal focus state.
 - Focus layers: Each context has its own keymap layer with vim-style bindings (j/k/h/l navigation).
@@ -912,7 +930,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 ## Configuration
 
 - Workspace settings: `Cargo.toml` defines workspace members and shared dependencies.
-- App features: `crates/dbflux/Cargo.toml` gates `sqlite`, `postgres`, `mysql`, `mongodb`, `redis`, `dynamodb`, `lua`, and `aws` (enabled by default in this branch).
+- App features: `crates/dbflux/Cargo.toml` gates `sqlite`, `postgres`, `mysql`, `mongodb`, `redis`, `dynamodb`, `cloudwatch`, `influxdb`, `mssql`, `lua`, `aws`, and `mcp` (enabled by default in this branch).
 - Runtime data: All runtime configuration is stored in `~/.local/share/dbflux/dbflux.db` (single SQLite file).
   - `cfg_connection_profiles` + child tables (auth, proxy, SSH bindings)
   - `cfg_auth_profiles` (provider-agnostic auth profile storage)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ Key abstractions for UI adaptation:
 - The runtime seam for service discovery/classification lives in `dbflux_app::rpc_services`; extend that boundary for future RPC capabilities instead of hardcoding new driver-only bootstrap logic in `app_state.rs`.
 - Preserve compatibility for external driver registration IDs as `rpc:<socket_id>`.
 - `DynAuthProvider::fetch_dynamic_options` is a real trait method (default implementation returns `Permanent("not supported")`); `RpcAuthProvider` implements it by dispatching `FetchDynamicOptions` requests over IPC.
-- The auth-provider IPC protocol is at v1.2 and gained `FetchDynamicOptions` request / `DynamicOptions` response variants, plus the `secret_dependency_opt_in` manifest flag. Providers advertising v1.2 have `fetch_dynamic_options` available; older providers get `Permanent("not supported")`.
+- The auth-provider IPC protocol is at v1.3. v1.2 added the `FetchDynamicOptions` request / `DynamicOptions` response variants plus the `secret_dependency_opt_in` manifest flag; v1.3 added the `audit_emit_opt_in` manifest flag and audit event emission (`EmitAuditEvent`). Providers advertising v1.2+ have `fetch_dynamic_options` available; older providers get `Permanent("not supported")`.
 - The Settings UI for Auth Profiles is provider-agnostic. To surface dynamic dropdowns a provider must declare `FormFieldKind::DynamicSelect` fields in its manifest. The host strips secret field values from dependency maps unless the provider sets `secret_dependency_opt_in: true`.
 - `AuthSession.data` round-trips opaquely through the IPC DTO via JSON downcast and is never persisted.
 

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -1,5 +1,11 @@
 # Code Style
 
+> Note: Since the UI crate split, `crates/dbflux_ui/src/ui/...` paths referenced
+> below are compatibility shims (`pub use` re-exports) at the old module paths.
+> The canonical homes are `dbflux_components`, `dbflux_ui_base`,
+> `dbflux_ui_document`, `dbflux_ui_sidebar`, and `dbflux_ui_windows`. See
+> `ARCHITECTURE.md` for the layered crate map.
+
 ## Naming Conventions
 
 | Element                   | Convention           | Examples                                    | References                                                      |

--- a/README.md
+++ b/README.md
@@ -12,21 +12,30 @@ The long-term goal is to provide a fully open-source alternative to DBeaver, sup
 
 ## Documentation
 
+### User guides
+
 - [Usage Guide](docs/USAGE.md) — getting started: connect, query, chart, export
-- [Architecture](ARCHITECTURE.md) — layered diagrams, query/connection flow, crate map
+- [Connecting — Advanced Setup](docs/CONNECTIONS.md) — SSH tunnels, proxies, AWS SSO auth profiles, value sources
+- [Settings & Hooks](docs/SETTINGS.md) — every Settings section and connection hooks
+- [Data & Privacy](docs/DATA_AND_PRIVACY.md) — where your data and secrets live, backup and reset
+- [Dashboards & Audit — User Guide](docs/DASHBOARDS_AND_AUDIT.md) — charts, dashboards, instance metrics, audit viewer
 - [Drivers Overview](docs/DRIVERS.md) — supported databases, capabilities, limitations
+- [Lua Scripting](docs/LUA.md) — the embedded Lua runtime for hooks
+
+### Reference & internals
+
+- [Architecture](ARCHITECTURE.md) — layered diagrams, query/connection flow, crate map
 - [Charts](docs/CHARTS.md) — chart types, column kinds, axis auto-detection
 - [Dashboards](docs/DASHBOARDS.md) — dashboards, saved charts, instance metrics and inspectors
-- [Contributing](CONTRIBUTING.md)
-- [Release Process](docs/RELEASE.md)
-- [Code Style](CODE_STYLE.md)
-- [Agent Instructions](AGENTS.md)
-- [Claude Instructions](CLAUDE.md)
-- [Audit](docs/AUDIT.md)
+- [Audit](docs/AUDIT.md) — audit event schema and redaction
 - [AI + MCP Integration Guide](docs/MCP_AI_INTEGRATION.md)
 - [Driver RPC Protocol](docs/DRIVER_RPC_PROTOCOL.md)
 - [RPC Services Config](docs/RPC_SERVICES_CONFIG.md)
-- [Lua Scripting](docs/LUA.md)
+- [Release Process](docs/RELEASE.md)
+- [Contributing](CONTRIBUTING.md)
+- [Code Style](CODE_STYLE.md)
+- [Agent Instructions](AGENTS.md)
+- [Claude Instructions](CLAUDE.md)
 
 ## Installation
 

--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -146,7 +146,7 @@ ORDER BY category, outcome;
 
 ### Via MCP Tools (AI clients)
 
-The MCP tool surface exposes three audit tools (requires `admin` execution class):
+The MCP tool surface exposes three audit tools (classified as the `read` execution class):
 
 ```
 query_audit_logs    — Filter events by actor, tool, date range, decision
@@ -185,8 +185,8 @@ Use the `EventSink` trait. All components that emit audit events accept an `Arc<
 
 ```rust
 use dbflux_core::observability::{
-    EventRecord, EventSink,
-    types::{EventCategory, EventSeverity, EventOutcome, EventActorType, EventSourceId},
+    EventOrigin, EventRecord, EventSink,
+    types::{EventCategory, EventSeverity, EventOutcome},
     actions,
 };
 
@@ -199,11 +199,11 @@ let event = EventRecord::new(
 )
 .with_typed_action(actions::QUERY_EXECUTE)
 .with_summary("SELECT executed on users table")
-.with_actor(EventActorType::User, None)
-.with_source(EventSourceId::Local)
-.with_connection("my-profile-id", Some("mydb"), Some("postgres"))
-.with_object("table", "users")
-.with_duration(42);
+.with_actor_id("my-actor-id")
+.with_origin(EventOrigin::local())
+.with_connection_context("my-profile-id", "mydb", "postgres")
+.with_object_ref("table", "users")
+.with_duration_ms(42);
 
 // Emit through the sink (injected via constructor or DI)
 event_sink.record(event)?;
@@ -219,14 +219,15 @@ Action strings are defined in `dbflux_core/src/observability/actions.rs`. Use co
 | `QUERY_EXECUTE_FAILED` | `query_execute_failed` | Query |
 | `CONNECTION_CONNECT` | `connection_connect` | Connection |
 | `CONNECTION_DISCONNECT` | `connection_disconnect` | Connection |
-| `HOOK_PRE_CONNECT` | `hook_pre_connect` | Hook |
-| `HOOK_POST_CONNECT` | `hook_post_connect` | Hook |
-| `HOOK_PRE_DISCONNECT` | `hook_pre_disconnect` | Hook |
-| `HOOK_POST_DISCONNECT` | `hook_post_disconnect` | Hook |
+| `HOOK_EXECUTE` | `hook_execute` | Hook |
+| `HOOK_EXECUTE_FAILED` | `hook_execute_failed` | Hook |
 | `SCRIPT_EXECUTE` | `script_execute` | Script |
 | `SCRIPT_EXECUTE_FAILED` | `script_execute_failed` | Script |
-| `MCP_TOOL_CALL` | `mcp_tool_call` | Mcp |
-| `MCP_TOOL_DENIED` | `mcp_tool_denied` | Mcp |
+| `MCP_AUTHORIZE` | `mcp_authorize` | Mcp |
+| `MCP_APPROVE_EXECUTION` | `mcp_approve_execution` | Mcp |
+| `MCP_REJECT_EXECUTION` | `mcp_reject_execution` | Mcp |
+| `MCP_TOOL_EXECUTE` | `mcp_tool_execute` | Mcp |
+| `MCP_TOOL_EXECUTE_FAILED` | `mcp_tool_execute_failed` | Mcp |
 | `SYSTEM_PANIC` | `system_panic` | System |
 
 ### Required Fields Checklist
@@ -278,7 +279,7 @@ tracing::info!("…")  ───────────────────
                                                     AuditLayer::on_event
                                                           │ level gate + recursion guard
                                                           │
-                                                    bounded mpsc::sync_channel (1024)
+                                                    bounded mpsc::sync_channel (512)
                                                           │
                                                     drain thread
                                                           │ AuditService::record()
@@ -320,7 +321,7 @@ Valid values: `trace`, `debug`, `info`, `warn`, `error`.
 
 ### Drop Counter
 
-When the bounded channel is full (1024 events), the bridge drops the incoming event rather than blocking and increments an `Arc<AtomicU64>` drop counter. This prevents the audit path from introducing backpressure into application code. The current drop count is accessible via `BridgeHandle::drop_count()` and is exposed through `AppState::bridge_drop_counter()` for observability, but is not persisted or surfaced in the UI in V1.
+When the bounded channel is full (512 events by default, configurable via `BridgeConfig::queue_capacity`), the bridge drops the incoming event rather than blocking and increments an `Arc<AtomicU64>` drop counter. This prevents the audit path from introducing backpressure into application code. The current drop count is accessible via `BridgeHandle::drop_count()` and is exposed through `AuditService::dropped_log_event_count()` for observability, but is not persisted or surfaced in the UI in V1.
 
 ### Startup Window
 
@@ -414,7 +415,7 @@ handle.install_sink(Arc::new(audit_service));
 | `crates/dbflux_core/src/observability/tracing_bridge/mod.rs` | `init_tracing`, `BridgeHandle`, `BridgeConfig`, `LevelCode` |
 | `crates/dbflux_core/src/observability/tracing_bridge/layer.rs` | `AuditLayer`, `AuditFieldVisitor`, level gate |
 | `crates/dbflux_core/src/observability/tracing_bridge/category.rs` | `PREFIX_CATEGORY_MAP`, `resolve_category`, `BRIDGE_INTERNAL_TARGET` |
-| `crates/dbflux_storage/src/migrations/014_*.sql` | Adds `log_capture_min_level` column to `cfg_audit_settings` |
+| `crates/dbflux_storage/src/migrations/mod_014_audit_settings_log_capture_min_level.rs` | Adds `log_capture_min_level` column to `cfg_audit_settings` |
 
 ## External Audit Emission (RPC drivers and auth providers)
 

--- a/docs/CHARTS.md
+++ b/docs/CHARTS.md
@@ -131,9 +131,12 @@ When the engine extracts a numeric value from a cell (`extract_f64` in
 ## Saved charts
 
 A persisted chart is a `SavedChart` record, defined in
-`crates/dbflux_components/src/saved_chart.rs`. Saved charts are stored as JSON
-in `~/.config/dbflux/saved_charts.json` through `SavedChartStore` (a
-`JsonStore<SavedChart>` type alias) and managed by `SavedChartManager`.
+`crates/dbflux_components/src/saved_chart.rs`. Saved charts are stored in the
+unified SQLite database — the `viz_saved_charts` table and its related
+`viz_saved_chart_*` tables — through `SavedChartsRepository`, with an in-memory
+cache managed by `SavedChartManager`
+(`crates/dbflux_ui_base/src/saved_chart_manager.rs`). Writes go to the
+repository first; the cache updates only on success.
 
 A `SavedChart` persists:
 

--- a/docs/CONNECTIONS.md
+++ b/docs/CONNECTIONS.md
@@ -1,0 +1,245 @@
+# Connecting to a Database — Advanced Setup
+
+This guide covers everything in the Connection Manager beyond the basic "host,
+port, user, password" form: reaching a database through an SSH tunnel, a proxy,
+or AWS SSM; authenticating with provider-driven Auth Profiles (AWS SSO); and
+pulling individual field values from a secret manager or parameter store instead
+of typing them in.
+
+For the day-to-day flow (creating a connection, browsing the schema, running
+queries) see the [Usage Guide](USAGE.md). This document picks up at the
+Connection Manager's **Access** tab and the value-source selectors.
+
+---
+
+## The Access tab: how DBFlux reaches the database
+
+Every connection uses exactly **one** access method, chosen from the **Access
+Method** dropdown. Switching methods clears the settings of the others — a
+connection is either Direct, or SSH, or Proxy, or SSM, never a combination.
+
+| Method | What it does |
+|--------|--------------|
+| **Direct** | Connect straight to the host/port from the Main tab. Can still resolve per-field value sources (see [Value sources](#value-sources-secret-manager-parameter-store-auth-session)). |
+| **SSH Tunnel** | Open a local port-forward through an SSH host, then connect through it. |
+| **Proxy** | Route the connection through a SOCKS5 or HTTP/HTTPS proxy. |
+| **SSM Port Forwarding** | Use AWS Systems Manager to port-forward to an instance, then connect through the tunnel. Requires the `aws` build feature. |
+
+### What happens when you press Connect
+
+DBFlux runs a fixed pre-connect pipeline before the driver ever opens a socket:
+
+1. **Authenticating** — validate or refresh the selected Auth Profile's session
+   (this is where an AWS SSO browser login can happen).
+2. **Resolving values** — resolve every per-field value source (secret manager,
+   parameter store, env var, auth-session field) and patch them into the config.
+3. **Opening access** — establish the SSH tunnel, proxy, or SSM session (or
+   nothing, for Direct).
+4. **Driver connect + schema fetch** — the driver connects and DBFlux loads the
+   shallow schema.
+
+Connection **hooks** (if you have any bound) run at the PreConnect, PostConnect,
+PreDisconnect, and PostDisconnect phases around this pipeline. See
+[Settings & Hooks](SETTINGS.md#connection-hooks).
+
+---
+
+## SSH tunnels
+
+You can use an SSH tunnel in two ways:
+
+- **Reference a saved tunnel** — pick a tunnel profile you manage centrally in
+  **Settings → SSH Tunnels**. Recommended when you reuse the same bastion across
+  several connections.
+- **Inline** — fill the SSH fields directly on the Access tab. You can later
+  press **Save as tunnel** to promote it into a reusable profile.
+
+### SSH fields
+
+| Field | Notes |
+|-------|-------|
+| **Host** / **Port** | The SSH server. Port is typically `22`. |
+| **Username** | SSH user. |
+| **Auth method** | **Private Key** or **Password**. |
+| **Key path** (Private Key) | Path to the private key. **Leave it empty to use your SSH agent or default keys** (`~/.ssh/id_rsa`, etc.). |
+| **Key passphrase** (Private Key) | Optional; stored in your OS keyring when you tick **Save**. |
+| **Password** (Password auth) | Stored in your OS keyring when you tick **Save**. |
+
+There is no separate "SSH agent" option — agent-based auth is what you get when
+you choose **Private Key** and leave the key path blank.
+
+**Test SSH** verifies the tunnel without saving the connection.
+
+### Where SSH secrets live
+
+Passphrases and passwords are stored in the **OS keyring**, never in the
+database. The **Save** checkbox only appears when a keyring is available; if it
+isn't, secrets aren't persisted and you'll re-enter them each session. See
+[Data & Privacy → Secrets](DATA_AND_PRIVACY.md#secrets-and-the-os-keyring).
+
+---
+
+## Proxies
+
+Proxies are managed in **Settings → Proxies**; the Access tab only *selects* a
+saved proxy and shows its details. If you have none, the tab links you to
+Settings.
+
+| Field | Notes |
+|-------|-------|
+| **Type** | `SOCKS5`, `HTTP`, or `HTTPS`. Default port: `1080` for SOCKS5, `8080` for HTTP/HTTPS. |
+| **Host** / **Port** | The proxy endpoint. |
+| **Auth** | `None`, or `Basic` with a username (the password is stored in the keyring). |
+| **No Proxy** | Comma-separated hosts/patterns to bypass. Supports `*` (all), exact hosts, and suffix matches (with or without a leading dot), case-insensitive. **CIDR ranges are not supported.** |
+| **Enabled** | When a proxy profile is disabled, the connection falls back to a **direct** connection (with a warning) instead of failing. |
+
+> **Heads-up:** a disabled proxy, or a remote host that matches **No Proxy**,
+> results in a silent direct connection. If you expected traffic to go through
+> the proxy and it didn't, check both of these first.
+
+---
+
+## Auth Profiles (AWS SSO and shared credentials)
+
+Auth Profiles hold provider-driven authentication that DBFlux resolves at
+connect time. They're created in **Settings → Auth Profiles** and selected per
+connection. In this build the built-in providers are **AWS only**:
+
+| Provider | Use it for |
+|----------|------------|
+| **AWS SSO** | IAM Identity Center (SSO) login that resolves an account + role. |
+| **AWS SSO Session** | A reusable SSO session (Start URL + region + scopes) that AWS SSO profiles can inherit from. |
+| **AWS Shared Credentials** | A named profile written to `~/.aws/credentials` (access key / secret / optional session token). |
+
+Externally registered RPC auth providers can add more entries here; see
+[RPC Services](RPC_SERVICES_CONFIG.md).
+
+> AWS profiles that DBFlux reflects live from your `~/.aws/config` appear as
+> **read-only** — you can select them but not edit them here; edit the AWS files
+> directly.
+
+### Creating an AWS SSO profile
+
+The form is provider-driven. For AWS SSO you fill:
+
+| Field | Notes |
+|-------|-------|
+| **Profile name** | e.g. `dev`. |
+| **SSO session** | Optional reference to an **AWS SSO Session** profile. When set, Start URL and Region are inherited and their inline fields grey out. |
+| **SSO Start URL** | Your Identity Center portal URL (skip if using a session). |
+| **Region** | e.g. `us-east-1`. |
+| **Account** | A dropdown that populates **after you log in** — it lists the accounts your SSO session can access. |
+| **Role** | A dropdown that populates once an account is chosen. |
+
+The **Account** and **Role** dropdowns are dynamic: they require a live SSO
+session and refresh as their dependencies change. If they're empty, log in first
+(see below).
+
+The **SSO Wizard** offers the same flow as a guided, step-by-step creator:
+enter name, Start URL, and region; it logs you in and then lists accounts and
+roles for you to pick.
+
+### The SSO login flow
+
+When a connection (or the Account/Role dropdowns) needs an SSO session, DBFlux
+opens a login modal:
+
+- It **opens your browser automatically** to the verification URL.
+- If the browser can't be opened, the modal shows the URL with a **Copy URL**
+  action so you can open it manually.
+- DBFlux continues automatically once you finish authenticating in the browser.
+- **SSO login times out after 5 minutes.**
+
+### Selecting an Auth Profile per connection
+
+- **Direct mode** — the Auth Profile is *optional*. Use it only to resolve
+  Secret/Parameter/Auth value sources (next section).
+- **SSM mode** — the Auth Profile is **required**.
+- If any field uses a Secret/Parameter value source whose provider is an auth
+  provider, a matching Auth Profile is **required** or the connection is rejected
+  before connecting.
+
+Each profile row has **Manage**, **Login**, and **Refresh** buttons. **Login**
+is enabled only when the selected profile actually needs a login.
+
+---
+
+## SSM Port Forwarding (managed access)
+
+"Managed" access lets a provider open the path to the host for you. The shipped
+implementation is **AWS SSM Port Forwarding** (`aws` feature required).
+
+| Field | Notes |
+|-------|-------|
+| **Instance ID** | Target EC2 instance. Supports a value-source selector. |
+| **Region** | Defaults to `us-east-1` if left blank. |
+| **Remote Port** | The port on the instance to forward to. |
+| **Auth Profile** | **Required** — the AWS profile used to start the SSM session. |
+
+The **local** tunnel port is assigned automatically by DBFlux and the OS — only
+the remote port is configurable.
+
+---
+
+## Value sources: Secret Manager, Parameter Store, Auth Session
+
+Any individual connection field (host, password, etc.) can pull its value from
+an external source instead of a literal. Click the source selector next to a
+field and choose:
+
+| Source | What it does |
+|--------|--------------|
+| **Literal** | The value you type (default). |
+| **Environment Variable** | Read from an env var by name. |
+| **Secret Manager** | Fetch from a secret provider (AWS Secrets Manager). |
+| **Parameter Store** | Fetch from a parameter provider (AWS SSM Parameter Store). |
+| **Auth Session Field** | Pull a field from the resolved Auth Profile's session/credentials. |
+
+Notes:
+
+- Secret/Parameter sources can target a **JSON key** inside a JSON secret, so one
+  stored JSON document can feed several fields.
+- Resolved values are cached for **5 minutes** to avoid re-fetching on every
+  reconnect.
+- Secret/Parameter sources backed by an auth provider **require an Auth Profile**
+  on the connection (enforced before connecting).
+
+---
+
+## Form mode vs. direct URI
+
+Most relational drivers let you supply connection details either as individual
+fields or as a single connection string. A **Use URI** toggle on the Main tab
+switches between them.
+
+- URI mode is available for **PostgreSQL, MySQL/MariaDB, SQL Server, MongoDB, and
+  Redis**. SQLite, DynamoDB, CloudWatch, and InfluxDB use their own field-based
+  forms instead.
+- With URI mode **on**, the single URI field is authoritative and the individual
+  fields are ignored; with it **off**, the fields are used.
+- A password embedded in a URI is extracted and stored separately (in the
+  keyring when you save it), not kept in the URI text.
+- When you connect through an SSH/proxy/SSM tunnel, DBFlux always uses the
+  field-based config (rewritten to `127.0.0.1:<local port>`), even if you typed a
+  URI.
+
+---
+
+## Quick reference: gotchas
+
+- **One access method per connection.** Switching methods clears the others.
+- **Secrets live in your OS keyring**, never in the DBFlux database. If the
+  keyring is unavailable, "Save" checkboxes disappear and secrets aren't kept.
+- **A disabled proxy or a No-Proxy match silently connects directly.**
+- **`No Proxy` does not support CIDR** — list hosts/suffixes, not IP ranges.
+- **SSM and auth-backed value sources both require an Auth Profile.**
+- **Only AWS auth providers are built in** (SSO, SSO Session, Shared
+  Credentials). Other providers come from external RPC services.
+- **SSO login auto-opens the browser and times out after 5 minutes.**
+
+## Related
+
+- [Usage Guide](USAGE.md) — the basic connect/query/results flow.
+- [Settings & Hooks](SETTINGS.md) — managing SSH/proxy/auth profiles and hooks.
+- [Data & Privacy](DATA_AND_PRIVACY.md) — where credentials and data are stored.
+- [RPC Services](RPC_SERVICES_CONFIG.md) — external drivers and auth providers.

--- a/docs/DASHBOARDS.md
+++ b/docs/DASHBOARDS.md
@@ -122,7 +122,7 @@ Inspectors are the third dashboard panel kind, alongside `Chart` and `Divider`:
 |------------|---------|-------|
 | `Chart` | `SavedChart` reference (`saved_chart_id`) | Time-series chart |
 | `Divider` | Inline markdown | Header strip; no toolbar |
-| `Inspector` | `InstanceInspectorQuery` (`metric_id`) | Tabular snapshot; refreshes on the shared interval |
+| `Inspector` | `DashboardPanelKind::Inspector { metric_id }` | Tabular snapshot; refreshes on the shared interval |
 
 `DashboardPanelKind::Inspector { metric_id }`
 (`crates/dbflux_ui_base/src/dashboard_manager.rs`) carries no chart reference —
@@ -210,7 +210,7 @@ to materialize it locally.
   (`crates/dbflux_core/src/connection/instance_catalog.rs`)
 - **Capabilities**: `DriverCapabilities::INSTANCE_METRICS` (time-series),
   `DriverCapabilities::INSTANCE_INSPECTOR` (tabular snapshots)
-- **Value types**: `InstanceMetric`, `InstanceInspector`,
+- **Value types**: `InstanceMetricDef`, `InstanceInspectorDef`,
   `DefaultInstanceDashboard`, `InspectorRowAction`
 
 Drivers expose live server metrics (e.g. `pg.tps`,

--- a/docs/DASHBOARDS_AND_AUDIT.md
+++ b/docs/DASHBOARDS_AND_AUDIT.md
@@ -1,0 +1,214 @@
+# Dashboards & Audit — User Guide
+
+How to chart and save queries, build dashboards, watch live instance metrics, and
+use the audit viewer. This is the *how do I use it* companion to the internals
+docs: [Charts](CHARTS.md), [Dashboards](DASHBOARDS.md), and [Audit](AUDIT.md).
+
+---
+
+## Saved charts
+
+### Chart a query result
+
+1. Run a query that returns tabular data.
+2. Right-click in the result grid and choose **Chart this query**.
+
+A chart document opens, seeded with your query, and runs automatically. The
+option only appears when the result has a usable original query and DBFlux can
+auto-detect chartable columns. Supported chart types: Line, Bar, Scatter, Area,
+Stacked Bar, Pie. Axis detection uses each column's kind (time, numeric, text);
+see [Charts](CHARTS.md) for the rules.
+
+### Save and reopen
+
+- In a chart document, press **Save** and give it a name. Re-saving the same chart
+  overwrites it (no duplicate).
+- Reopen a saved chart with **Open Chart…** in the command palette — it lists the
+  saved charts for the active connection. (If there are none: *"No saved charts
+  for the current profile"*.)
+- Saved charts also appear in the sidebar under **Saved Charts**, where each chart
+  has **Open / Rename… / Duplicate / Delete…**.
+
+Charts are saved per connection profile.
+
+---
+
+## Dashboards
+
+A dashboard is a named 12-column grid of panels that share one time range and one
+refresh policy.
+
+### Create one
+
+1. Run **New Dashboard…** from the command palette (or **New Dashboard…** on the
+   sidebar's **Dashboards** folder).
+2. Name it. It opens with a 12-column grid and refresh turned off.
+
+New dashboards open in **View** mode. The sidebar's Dashboards folder lists saved
+dashboards with **Open / Rename… / Duplicate / Delete…**.
+
+### Edit vs. view
+
+Toggle the **pencil / eye** button in the toolbar:
+
+- **Edit** mode shows drag handles — drag panels to reorder, drag the edges or
+  corner to resize within the 12-column grid.
+- **View** mode is read-only.
+
+In Edit mode you can also use the keyboard on a focused panel: `F2` to rename,
+`Delete`/`Backspace` to remove, `Enter` to open its Configure popover.
+
+### Add panels
+
+Click **+ Add Panel**. The picker has up to three tabs:
+
+| Tab | Creates |
+|-----|---------|
+| **Saved** | A panel from one or more existing saved charts. |
+| **Query** | A new panel from a name + a query you type. |
+| **Metric** | A panel from a driver metric (only shown when the connection's driver exposes a metric catalog). |
+
+Each panel's kebab menu (Edit mode) offers **Configure / Edit title / Remove
+panel**. The **Configure** popover lets you change the chart type (Line, Bar,
+Scatter, Area, Stacked, Pie), adjust axis bindings, view **Stats**, and **Export
+PNG**.
+
+Dashboards can also contain **Divider** strips — markdown headers that visually
+group panels and collapse the panels beneath them when clicked.
+
+> A **Chart** panel references a saved chart. If you delete that saved chart, the
+> panel becomes a placeholder ("Chart not found — saved chart was deleted") rather
+> than disappearing.
+
+### Time range and refresh
+
+The toolbar has:
+
+- A **time-range** dropdown: Last 15 min, Last 1 hour, Last 6 hours, Last 24
+  hours, Last 7 days, or **Custom** (which reveals date and hour/minute pickers).
+  The range applies to every chart panel at once.
+- A **refresh** split-button: click to refresh all panels now; the dropdown sets
+  an auto-refresh interval (or Off / refresh-on-open).
+
+> **Disconnected connections are handled gracefully.** When a panel's connection
+> is closed, its refresh tick is skipped — the timer stays alive and resumes
+> automatically when you reconnect, with no need to re-open the dashboard.
+
+---
+
+## Instance Overview, metrics, and inspectors
+
+For drivers that support it — **PostgreSQL, MySQL/MariaDB, MongoDB, Redis, and SQL
+Server** — a connected profile shows an **Instance Overview** entry in the
+sidebar, above the **Instance Metrics** and **Instance Inspectors** folders.
+
+- **Instance Overview** is a read-only dashboard synthesized from the driver's
+  default layout (one tab per connection). You can't edit it or add panels, but
+  you can press **Save as editable** to clone its layout into a new, fully
+  editable dashboard.
+- **Instance Metrics** are time-series charts (e.g. connections, throughput).
+- **Instance Inspectors** are tabular snapshots of live server state (e.g.
+  Postgres `pg_stat_activity`, MySQL process list, MongoDB current operations,
+  Redis client list), refreshed on the shared interval.
+
+### Inspector row actions
+
+Some inspectors offer per-row actions (for example **Kill connection** /
+**Terminate session**). These are:
+
+- **Permission-gated** — an action you don't have the privilege to run is hidden,
+  so you never see a button that would just fail.
+- **Confirmed when destructive** — destructive actions prompt before running.
+- **Audited** — every attempt records an audit event, and failures surface a toast
+  with a link to the matching audit row.
+
+---
+
+## Remote dashboards (CloudWatch)
+
+When a driver supports it (CloudWatch is the reference implementation), DBFlux can
+**browse** and **import** upstream dashboards.
+
+- **Browse**: upstream dashboards appear in the sidebar. Opening one fetches and
+  renders it as an **in-memory, read-only** dashboard — nothing is written back to
+  the source, and nothing is saved locally. A **Refresh** action re-fetches the
+  listing. The listing is session-scoped and is **not** kept across restarts.
+- **Import**: the **Import Dashboard** command (palette or sidebar) parses the
+  upstream definition into a new **local** dashboard with imported charts. It's
+  only available when the active connection's driver supports import — otherwise
+  you'll see *"The active connection does not support dashboard import."*
+
+Remote dashboards are read-only browsing/import; DBFlux never modifies the source.
+
+---
+
+## Audit viewer
+
+The audit viewer is the single place to review everything DBFlux logged: queries,
+connections, hooks, scripts, config changes, and AI/MCP governance decisions.
+
+### Open it
+
+- Keyboard: **Ctrl+Shift+A** (**Cmd+Shift+A** on macOS).
+- Command palette: **Open Audit Viewer**.
+
+There's one audit tab; reopening focuses the existing one.
+
+### What you see
+
+Each row shows a timestamp, a **severity** chip (ERROR/WARN/INFO), a **category**
+chip, and a summary. Expand a row to see **Category, Outcome, Actor, Action,
+Duration, and Summary**.
+
+Categories at a glance:
+
+| Category | Covers |
+|----------|--------|
+| **Query** | Query execution and scans. |
+| **Connection** | Connect / disconnect / reconnect. |
+| **Hook** | Connection-hook runs. |
+| **Script** | Lua / Python / Bash script runs. |
+| **Mcp** | AI client tool calls. |
+| **Governance** | Policy decisions. |
+| **Config** | Profile and settings changes. |
+| **System** | Startup, migrations, and internal log events. |
+
+### Filter
+
+The toolbar offers free-text **search**, a **time range** (same presets as
+dashboards, plus Custom), a **timestamp mode** (Local / UTC), and multi-select
+filters for **Level** (Error/Warn/Info), **Category**, and **Outcome**
+(Success/Failure/Cancelled). **Clear** resets them.
+
+A row's context menu adds **Copy Row as CSV**, **Copy Summary**, and — when the
+event has a correlation id — **Filter by Correlation**.
+
+### Follow an error to its audit row
+
+When something you did fails, DBFlux shows a toast with a **View in Audit** action.
+Clicking it opens the audit viewer filtered to that exact event (matched by a
+correlation id shared between the toast and the audit row). The **error badge** in
+the status bar opens the viewer pre-filtered to recent user-facing failures.
+
+### Export
+
+The **Export** button writes the currently visible events to **CSV** or **JSON**
+in your `~/Downloads` folder (`audit_export.csv` / `audit_export.json`), using the
+extended schema (all fields, including structured details). A success toast
+reports how many events were written and where.
+
+### Retention
+
+Old events can be purged on a retention schedule when configured (see
+[Settings → Audit](SETTINGS.md#audit)). The audit log otherwise grows with use; it
+lives in the same `dbflux.db` as everything else
+([Data & Privacy](DATA_AND_PRIVACY.md#audit-and-privacy)).
+
+---
+
+## Related
+
+- [Charts](CHARTS.md) — chart types, column kinds, axis auto-detection.
+- [Dashboards](DASHBOARDS.md) — storage model and driver seams.
+- [Audit](AUDIT.md) — full event schema and redaction.
+- [Settings & Hooks](SETTINGS.md) — audit and refresh settings.

--- a/docs/DATA_AND_PRIVACY.md
+++ b/docs/DATA_AND_PRIVACY.md
@@ -1,0 +1,200 @@
+# Data & Privacy
+
+Where DBFlux stores your data, how it protects your credentials, what the audit
+log keeps, and how to back up or fully reset.
+
+## At a glance
+
+| Your data | Where it lives |
+|-----------|----------------|
+| Connection profiles, settings, history, saved charts/queries, audit log | One SQLite file: `dbflux.db` in the data directory |
+| Open tabs / session | The same `dbflux.db`, plus scratch files in the data directory |
+| Passwords, passphrases, API secrets | Your **OS keyring** — never in `dbflux.db` |
+| IPC/MCP auth token | A `0600` file in the config directory |
+
+DBFlux keeps almost everything in a single SQLite database. Secrets are the
+deliberate exception: they go to the operating system's keyring, and the database
+only stores a *reference* to them.
+
+---
+
+## Data locations
+
+DBFlux uses your platform's standard directories.
+
+| Platform | Data directory | Config directory |
+|----------|----------------|------------------|
+| **Linux** | `~/.local/share/dbflux/` | `~/.config/dbflux/` |
+| **macOS** | `~/Library/Application Support/dbflux/` | `~/Library/Application Support/dbflux/` |
+| **Windows** | `%APPDATA%\dbflux\` | `%APPDATA%\dbflux\` |
+
+The data directory holds:
+
+- **`dbflux.db`** — the unified database (everything below in [What's in the
+  database](#whats-in-the-database)).
+- **`st_sessions/`** — scratch/shadow files for open editor tabs.
+
+The config directory holds the **IPC auth token** (see [below](#ipcmcp-auth-token)).
+
+### Stable vs. Nightly
+
+A Nightly build uses a separate database file, `dbflux-nightly.db`, so a
+pre-release migration can never touch your stable data. Stable and release
+candidate builds both use `dbflux.db`.
+
+You can make a Nightly build share the stable database via **Settings → General →
+Storage → Use the stable database** (applies on next launch). Internally this
+just drops an empty `use-stable-db` marker file in the data directory.
+
+---
+
+## What's in the database
+
+`dbflux.db` is a single SQLite file. Its tables are grouped by prefix:
+
+| Prefix | Contains |
+|--------|----------|
+| `cfg_*` | Configuration: connection profiles, auth/proxy/SSH tunnel profiles, RPC services, connection hooks, MCP governance, and the General/Audit settings. (Secret *values* are **not** here — only keyring references.) |
+| `st_*` | Workbench state: open sessions/tabs, **query history** (full query text), saved queries, recent items, schema cache, UI state. |
+| `aud_*` | The audit log and saved audit filters. |
+| `viz_*` | Saved charts and dashboards. |
+| `qry_*` | Visual Query Builder saved queries. |
+| `sys_*` | Internal: schema migration version, app metadata. |
+
+> **Note on query history.** The workbench query history (`st_*`) stores the
+> **full text** of queries you run, in the clear. This is separate from the audit
+> log, which fingerprints query text by default (see below). If you don't want
+> query text retained, lower **Max history entries** in Settings → General, or
+> clear history from the editor's history view.
+
+---
+
+## Secrets and the OS keyring
+
+Passwords, SSH passphrases, proxy credentials, and provider secrets are stored in
+your operating system's keyring, **not** in `dbflux.db`.
+
+| Platform | Keyring backend |
+|----------|-----------------|
+| **Linux** | Secret Service (GNOME Keyring / KWallet, via libsecret) |
+| **macOS** | Keychain |
+| **Windows** | Windows Credential Manager |
+
+All entries are stored under the service name **`dbflux`**. The database holds
+only a reference string per secret:
+
+| Secret | Reference |
+|--------|-----------|
+| Connection password | `dbflux:conn:<profile-id>` |
+| Inline SSH password/passphrase | `dbflux:ssh:<profile-id>` |
+| Saved SSH tunnel | `dbflux:ssh_tunnel:<tunnel-id>` |
+| Proxy credential | `dbflux:proxy:<proxy-id>` |
+| Auth-profile field | `dbflux:auth:<profile-id>:<field>` (one per field) |
+
+### When secrets are (and aren't) saved
+
+- A connection password is only stored when you tick **Save password**; SSH and
+  proxy secrets only when you tick their **Save** checkbox.
+- If no keyring is available, DBFlux hides the **Save** checkboxes and does not
+  persist secrets — you re-enter them each session.
+- A *locked* keyring still counts as available: writes may fail until you unlock
+  it, but DBFlux keeps secret support enabled.
+
+---
+
+## Session and tabs restore
+
+Which tabs you have open — their kind, file paths, order, active tab, and pin
+state — is recorded in `dbflux.db` (`st_sessions` / `st_session_tabs`). The
+actual scratch/shadow file contents live alongside it under `st_sessions/` in the
+data directory. On startup DBFlux restores this session when **Settings → General
+→ Restore session on startup** is on (the default).
+
+---
+
+## Audit and privacy
+
+DBFlux logs significant operations (queries, connections, hooks, scripts, config
+changes, MCP/governance decisions) to the audit log in `dbflux.db`. It's designed
+to be privacy-preserving by default:
+
+| Behavior | Default | Effect |
+|----------|---------|--------|
+| **Capture query text** | Off | Query text is replaced with a SHA-256 **fingerprint** plus its length — the full text is never stored in the audit row. |
+| **Redact sensitive values** | On | Sensitive patterns (AWS keys, JWTs, connection strings with credentials, etc.) are replaced with `[REDACTED]`. |
+| **Detail size cap** | 64 KiB | Oversized event payloads are truncated to a small partial envelope. |
+
+Sensitive **JSON keys** (`password`, `token`, `secret`, `api_key`,
+`access_key`, `session_token`, `connection_string`, `url`, …) are always redacted
+— even if you turn off pattern-based redaction.
+
+> Remember the [query-history caveat](#whats-in-the-database): the audit log
+> fingerprints query text, but the *workbench history* stores it in full. They're
+> two different stores.
+
+For the complete event schema, categories, and the viewer, see
+[Audit](AUDIT.md) and [Dashboards & Audit → Audit viewer](DASHBOARDS_AND_AUDIT.md#audit-viewer).
+
+---
+
+## IPC/MCP auth token
+
+DBFlux exposes a local IPC surface (used by the MCP server and external RPC
+services). It authenticates callers with a token stored at:
+
+```
+<config dir>/dbflux/ipc_auth_token
+```
+
+(on Linux, `~/.config/dbflux/ipc_auth_token`). It's a random value regenerated on
+each startup, written with owner-only `0600` permissions, and also exported to the
+`DBFLUX_IPC_TOKEN`, `DBFLUX_DRIVER_IPC_TOKEN`, and `DBFLUX_AUTH_PROVIDER_IPC_TOKEN`
+environment variables for child processes.
+
+This token is **process-identity only** — any local process that can read it can
+connect. Do not expose the IPC/MCP surface beyond localhost without an additional
+authentication layer. See [AI + MCP Integration](MCP_AI_INTEGRATION.md) for the
+trust model.
+
+---
+
+## Backup and reset
+
+DBFlux has no dedicated backup/restore command, but because everything lives in
+one file, both are straightforward.
+
+### Back up
+
+Copy the single database file while DBFlux is closed:
+
+```
+~/.local/share/dbflux/dbflux.db        # Linux (adjust per platform)
+```
+
+That file contains your profiles, history, saved charts/queries, and audit log.
+Your **secrets are not in it** — they stay in the OS keyring — so a copied
+database on another machine will reference keyring entries that don't exist there
+until you re-enter the secrets.
+
+### Full reset
+
+To wipe DBFlux's data:
+
+1. Delete the **data directory** (`~/.local/share/dbflux/` on Linux) — removes the
+   database and session files.
+2. Delete the **config directory** (`~/.config/dbflux/` on Linux) — removes the
+   IPC auth token.
+3. **Clear keyring entries manually.** Secrets under the `dbflux` service remain
+   in your OS keyring after deleting the directories; remove them with your
+   platform's keyring tool if you want a complete wipe.
+
+> Deleting the data directory is irreversible. Back up `dbflux.db` first if you
+> might want your profiles or history back.
+
+---
+
+## Related
+
+- [Settings & Hooks](SETTINGS.md) — the General/Audit/Storage controls referenced here.
+- [Connecting → Advanced Setup](CONNECTIONS.md) — where secrets are entered.
+- [Audit](AUDIT.md) — the full audit event schema and redaction details.

--- a/docs/LUA.md
+++ b/docs/LUA.md
@@ -1,14 +1,14 @@
 # The Embedded Lua Runtime
 
-Personal working notes on the `dbflux_lua` crate: DBFlux's sandboxed Lua 5.4 runtime for connection hooks.
+The `dbflux_lua` crate is DBFlux's sandboxed Lua 5.4 runtime for connection hooks. This document describes the crate's architecture, the Lua API exposed to hook scripts, the sandbox and timeout model, and how the runtime is wired into the application.
 
 ---
 
 ## What This Crate Does
 
-`dbflux_lua` lets users write Lua scripts that run during connection lifecycle events (pre-connect, post-connect, pre-disconnect, post-disconnect). Think of it like database migration hooks but more general — you can use them for SSO login flows, environment setup, audit logging, or triggering external tools before/after a connection opens.
+`dbflux_lua` lets users write Lua scripts that run during connection lifecycle events (pre-connect, post-connect, pre-disconnect, post-disconnect). The hooks are general-purpose: they can drive SSO login flows, environment setup, audit logging, or triggering external tools before/after a connection opens.
 
-The crate exposes exactly one public type: `LuaExecutor`. Everything else — the VM factory, the API modules, the shared state — is crate-internal. From the outside, you call `executor.execute_hook(hook, context, cancel_token, parent_cancel_token, output)` and get back a `HookResult`.
+The crate exposes exactly one public type: `LuaExecutor`. Everything else — the VM factory, the API modules, the shared state — is crate-internal. From the outside, you call `executor.execute_hook(hook, context, cancel_token, parent_cancel_token, output, detached)` and get back a `HookResult`. The final `detached: Option<&DetachedProcessSender>` argument lets the executor hand long-running detached processes back to the caller.
 
 ---
 
@@ -100,6 +100,10 @@ Plus the Lua built-ins that don't require library loading: `type()`, `tostring()
 | `coroutine` | Not dangerous per se, but adds complexity to the timeout/cancellation model (coroutines can yield past the instruction hook).                                |
 
 The sandbox is "allowlist, not blocklist." Only the four explicitly loaded libraries plus the registered API functions exist. If it's not in the list above, it doesn't exist in the Lua VM.
+
+### Memory Limit
+
+Each VM is created with an enforced memory cap of 16 MiB (`lua.set_memory_limit(16 * 1024 * 1024)` in `engine.rs`). A script that allocates past this limit fails with a memory error rather than being allowed to exhaust the host's memory.
 
 ---
 
@@ -204,18 +208,22 @@ hook.ok()
 
 | Field        | Type     | Required | Description                                                            |
 | ------------ | -------- | -------- | ---------------------------------------------------------------------- |
-| `program`    | string   | yes      | Executable name or path                                                |
+| `program`    | string   | yes      | Bare command name (no path separators)                                 |
 | `allowlist`  | string   | yes      | Must match a known allowlist name                                      |
 | `args`       | string[] | no       | Command arguments                                                      |
-| `timeout_ms` | integer  | no       | Per-process timeout (ms). Hook-level timeout still applies above this. |
+| `timeout_ms` | integer  | no\*     | Per-process timeout (ms). Hook-level timeout still applies above this. |
 | `cwd`        | string   | no       | Working directory                                                      |
 | `stream`     | boolean  | no       | Stream stdout/stderr to the caller while the process is still running  |
+| `detached`   | boolean  | no       | Hand the spawned process back to the caller and return immediately, instead of waiting for it to exit |
+
+\* For a non-detached `run`, `timeout_ms` is effectively required when there is no hook-level timeout: a call with neither a `timeout_ms` nor a hook-level timeout fails with the runtime error `"dbflux.process.run requires a timeout_ms when no hook-level timeout is set"`. A detached `run` is exempt from this constraint.
 
 **Return value:**
 
 | Field       | Type        | Description                                |
 | ----------- | ----------- | ------------------------------------------ |
-| `ok`        | boolean     | `true` if exit code is 0 and not timed out |
+| `ok`        | boolean     | `true` if the process was detached, or if exit code is 0 and not timed out |
+| `detached`  | boolean     | `true` if the process was handed off as detached (in which case the output/exit fields below are empty/nil) |
 | `exit_code` | integer/nil | Process exit code                          |
 | `stdout`    | string      | Captured stdout                            |
 | `stderr`    | string      | Captured stderr                            |
@@ -232,9 +240,9 @@ hook.ok()
 | `gcloud_cli`  | `gcloud`, `gcloud.cmd`, `gcloud.exe`             |
 | `az_cli`      | `az`, `az.cmd`, `az.exe`                         |
 
-Program matching is case-insensitive, and only the filename is checked (not the full path). So `program = "/usr/local/bin/aws"` matches the `aws_cli` allowlist because the filename is `aws`.
+`program` must be a **bare command name**. Path-qualified names are rejected before the allowlist is checked: any program containing a `/` or `\`, made up of multiple path components, or starting with `~` fails with the runtime error `"Program '...' must be a bare command name (no path separators)"`. So `program = "/usr/local/bin/aws"` is rejected outright — pass `program = "aws"` instead and let it resolve via `PATH`. Matching of the bare name against the allowlist is case-insensitive.
 
-This design serves a specific use case: hooks that need to trigger cloud CLI tools (SSO login, tunnel setup, secrets retrieval) without opening a full shell escape. The hardcoded allowlists can be extended later as new use cases emerge.
+This design serves a specific use case: hooks that need to trigger cloud CLI tools (SSO login, tunnel setup, secrets retrieval) without opening a full shell escape. The allowlist is an ergonomics and footgun guard — it prevents typos and accidental execution of unexpected programs. It is **not** a security isolation boundary: a user who controls `PATH` can still substitute a different binary under the same name. The hardcoded allowlists can be extended later as new use cases emerge.
 
 ---
 
@@ -352,6 +360,7 @@ pub struct LuaRuntimeState {
     pub outcome: Arc<Mutex<LuaHookOutcome>>,
     pub log_buffer: Arc<Mutex<Vec<String>>>,
     pub output: Option<OutputSender>,
+    pub detached: Option<DetachedProcessSender>,
     pub cancel_token: CancelToken,
     pub parent_cancel_token: Option<CancelToken>,
     pub hook_started_at: Instant,
@@ -508,6 +517,10 @@ The process allowlists are hardcoded. Adding a new tool requires a code change, 
 
 gpui-component (v0.5.0) does not include a `tree-sitter-lua` grammar. When editing Lua scripts in the code editor, there's no syntax highlighting. The `editor_mode()` returns `"lua"` which gracefully falls back to plaintext. Python and Bash scripts get full highlighting.
 
+### Bounded Memory
+
+Each VM is capped at 16 MiB of Lua-allocated memory. Scripts that try to build very large data structures in memory will hit this ceiling and fail. This is a sandbox guard, not a tunable per-hook setting.
+
 ### Output Is API-Driven
 
 The supported way to communicate progress and diagnostics is `dbflux.log.*`. That output is buffered into the final `HookResult`, and it can also be streamed live when the caller requests it.
@@ -518,23 +531,31 @@ The supported way to communicate progress and diagnostics is `dbflux.log.*`. Tha
 
 ### Feature Flag
 
-In `crates/dbflux/Cargo.toml`:
+The optional `dbflux_lua` dependency and its `lua` feature live on the app crate, `crates/dbflux_app/Cargo.toml`:
 
 ```toml
 dbflux_lua = { workspace = true, optional = true }
 # ...
 [features]
 lua = ["dbflux_lua"]
-default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "lua"]
+```
+
+The binary crate, `crates/dbflux/Cargo.toml`, has no direct `dbflux_lua` dependency. Its `lua` feature simply forwards to the app and UI crates, and is part of the default set:
+
+```toml
+[features]
+lua = ["dbflux_app/lua", "dbflux_ui/lua"]
+default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "influxdb", "mssql", "lua", "aws", "mcp"]
 ```
 
 The `lua` feature is in the default set, so it's always enabled in normal builds. It can be disabled for builds that don't need Lua (reduces binary size by ~200KB).
 
 ### CompositeExecutor
 
-`crates/dbflux/src/hook_executor.rs` defines the router:
+`crates/dbflux_app/src/hook_executor.rs` defines the router (re-exported from `crates/dbflux_app/src/lib.rs`):
 
 ```rust
+#[derive(Clone)]
 pub struct CompositeExecutor {
     process: ProcessExecutor,
     #[cfg(feature = "lua")]
@@ -586,7 +607,7 @@ The instruction hook fires every 1,000 instructions. This means:
 - Setting it too low (e.g., every instruction) measurably impacts performance for computational scripts
 - Setting it too high (e.g., every 100,000) makes cancellation feel sluggish
 
-1,000 is the sweet spot found through testing.
+1,000 balances cancellation responsiveness against per-check overhead.
 
 ### process_run Timeout Layering
 
@@ -594,7 +615,7 @@ The three-layer timeout (instruction hook, shared process executor, per-process 
 
 ### Why Not Just Allow `os.execute()`?
 
-It might seem simpler to load the `os` library and let users run whatever they want. The problem is that `os.execute()` provides no output capture, no timeout, no cancellation, and no program filtering. The `dbflux.process.run` API gives us all of these. The allowlist is the price of having a reasonable security model for a GUI app that runs user scripts.
+It might seem simpler to load the `os` library and let users run whatever they want. The problem is that `os.execute()` provides no output capture, no timeout, no cancellation, and no program filtering. The `dbflux.process.run` API gives us all of these. The allowlist is the price of constraining which programs a hook can launch in a GUI app that runs user scripts. It is an ergonomics/footgun guard rather than a security isolation boundary — PATH substitution can still swap the binary behind an allowed name.
 
 ### Fresh VM Per Execution — Cost vs. Safety
 

--- a/docs/MCP_AI_INTEGRATION.md
+++ b/docs/MCP_AI_INTEGRATION.md
@@ -109,7 +109,7 @@ All six layers run inside the server process on every `tools/call` request. None
 | DDL | `create_table` | admin | Create a table |
 | DDL | `alter_table` | admin_safe / admin / admin_destructive | Alter a table; classification is computed per change kind |
 | DDL | `create_index` | admin | Create an index |
-| DDL | `drop_index` | admin | Drop an index |
+| DDL Destructive | `drop_index` | admin_destructive | Drop an index |
 | DDL | `create_type` | admin | Create a user-defined type |
 | DDL Destructive | `drop_table` | admin_destructive | Drop a table |
 | DDL Destructive | `drop_database` | admin_destructive | Drop a database |
@@ -167,7 +167,7 @@ Three policies and three roles are shipped as immutable built-ins. They are alwa
 | `builtin/write` | `builtin/write` |
 | `builtin/admin` | `builtin/admin` |
 
-Built-ins are injected at startup in both the GUI app (`AppState`) and the MCP server (`bootstrap::init`). They are never written to disk. Any attempt to delete a built-in returns an error.
+Built-ins are injected at startup in both the GUI app (`AppState`) and the MCP server (via the `builtin_policies()` / `builtin_roles()` loops in `dbflux_mcp_server::governance`). They are never written to disk. Any attempt to delete a built-in returns an error.
 
 For most integrations, assign `builtin/read-only` to start and escalate to `builtin/write` or a custom policy only when write access is explicitly needed.
 
@@ -266,7 +266,7 @@ let outcome = authorize_request(
     &AuthorizationRequest {
         identity: RequestIdentity { client_id: "agent-a".into(), issuer: None },
         connection_id: connection_id.to_string(),
-        tool_id: "read_query".to_string(),
+        tool_id: "select_data".to_string(),
         classification: ExecutionClassification::Read,
         mcp_enabled_for_connection: true,
     },
@@ -322,7 +322,7 @@ To avoid polluting developer machines during tests:
 - Confirm the actor has an assignment on that connection scope.
 - Confirm the tool ID is in the assigned policy's allowed tools.
 - Confirm the execution class is in the policy's allowed classes.
-- If using `builtin/read-only`, write tools (`preview_mutation`, `create_script`, etc.) are excluded by design.
+- If using `builtin/read-only`, write tools (`create_script`, etc.) are excluded by design.
 
 ### Approval stuck pending
 
@@ -332,7 +332,7 @@ To avoid polluting developer machines during tests:
 ### Audit export missing events
 
 - Verify filters (`actor_id`, `tool_id`, time range, decision) are not over-restrictive.
-- `export_audit_logs` requires the `admin` execution class.
+- `export_audit_logs` is classified as the `read` execution class.
 
 ### Cannot delete policy or role
 

--- a/docs/RPC_SERVICES_CONFIG.md
+++ b/docs/RPC_SERVICES_CONFIG.md
@@ -21,26 +21,33 @@ RPC services are stored in SQLite at `~/.local/share/dbflux/dbflux.db`, not in a
 ## Schema
 
 ```sql
+-- Base table (migration 001). `service_kind` is added by migration 005 and
+-- `api_family`/`api_major`/`api_minor` by migration 006; they are shown here
+-- inline for reference but are not part of the base DDL.
 CREATE TABLE cfg_services (
-    socket_id TEXT NOT NULL UNIQUE,
-    service_kind TEXT NOT NULL DEFAULT 'driver',
-    command TEXT,
-    startup_timeout_ms INTEGER DEFAULT 5000,
+    socket_id TEXT PRIMARY KEY,
     enabled INTEGER DEFAULT 1,
-    api_family TEXT,
-    api_major INTEGER,
-    api_minor INTEGER
+    command TEXT,
+    startup_timeout_ms INTEGER,        -- no SQL-level default; the 5000ms
+                                       -- fallback (DEFAULT_STARTUP_TIMEOUT_MS)
+                                       -- is applied in app code
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    service_kind TEXT NOT NULL DEFAULT 'driver',  -- added by migration 005
+    api_family TEXT,                              -- added by migration 006
+    api_major INTEGER,                            -- added by migration 006
+    api_minor INTEGER                             -- added by migration 006
 );
 
 CREATE TABLE cfg_service_args (
-    id INTEGER PRIMARY KEY,
+    id TEXT PRIMARY KEY,
     service_id TEXT NOT NULL REFERENCES cfg_services(socket_id),
     position INTEGER NOT NULL,
     value TEXT NOT NULL
 );
 
 CREATE TABLE cfg_service_env (
-    id INTEGER PRIMARY KEY,
+    id TEXT PRIMARY KEY,
     service_id TEXT NOT NULL REFERENCES cfg_services(socket_id),
     key TEXT NOT NULL,
     value TEXT NOT NULL
@@ -64,7 +71,7 @@ Notes:
 - `Auth Provider` services are active in runtime auth-provider registries only; they never appear as drivers.
 - DBFlux preserves compatibility for driver registration IDs as `rpc:<socket_id>`.
 - If API metadata is missing on an existing driver row, DBFlux defaults it to the current `driver_rpc` contract at version `1.1`.
-- If API metadata is missing on an auth-provider row, DBFlux defaults it to the current `auth_provider_rpc` contract at version `1.0`.
+- If API metadata is missing on an auth-provider row, DBFlux defaults it to the current `auth_provider_rpc` contract at version `1.2`.
 - `api_family` / `api_major` are used as startup preflight for auth providers before DBFlux probes the socket.
 
 ## Semantics

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,0 +1,261 @@
+# Settings & Connection Hooks
+
+A reference for every Settings section and for connection hooks — the commands,
+scripts, or Lua snippets DBFlux runs around a connection's lifecycle.
+
+Open Settings from the command palette (**Open Settings**) or the sidebar. The
+window is organized into sections down the left side.
+
+| Section | Covers |
+|---------|--------|
+| [General](#general) | App-wide behavior: theme, startup, refresh, query safety. |
+| [Audit](#audit) | What the audit log captures and how long it's kept. |
+| [Keybindings](#keybindings) | Browse the keymap (read-only). |
+| [Auth Profiles](#auth-profiles-proxies-ssh-tunnels) | AWS SSO / shared-credentials profiles. |
+| [Proxies](#auth-profiles-proxies-ssh-tunnels) | SOCKS5 / HTTP proxy profiles. |
+| [SSH Tunnels](#auth-profiles-proxies-ssh-tunnels) | Reusable SSH tunnel profiles. |
+| [Services](#services-rpc) | External RPC drivers and auth providers. |
+| [Hooks](#connection-hooks) | Reusable connection-hook definitions. |
+| [Drivers](#drivers) | Per-driver overrides and settings. |
+
+MCP-related sections (Clients, Roles, Policies) appear only when the binary is
+built with the `mcp` feature; see [AI + MCP Integration](MCP_AI_INTEGRATION.md).
+
+---
+
+## General
+
+### Appearance
+
+| Setting | Options | Default |
+|---------|---------|---------|
+| **Theme** | Dark, Mirage, Light | Dark |
+| **Style** | Default, Compact | Default |
+
+### Startup & session
+
+| Setting | Default | What it does |
+|---------|---------|--------------|
+| **Restore session on startup** | On | Reopen the tabs you had open last time. |
+| **Reopen last connections** | Off | Reconnect to the connections that were active. |
+| **Default focus** | Sidebar | Where focus lands on launch (Sidebar or the last tab). |
+| **Max history entries** | 1000 | Query-history cap (minimum 10). |
+| **Auto-save interval (ms)** | 2000 | How often editor buffers auto-save (minimum 500). |
+
+### Refresh & background
+
+| Setting | Default | What it does |
+|---------|---------|--------------|
+| **Default refresh policy** | Manual | Manual or Interval auto-refresh for data views. |
+| **Default refresh interval (seconds)** | 5 | Interval used when the policy is Interval (minimum 1). |
+| **Max concurrent background tasks** | 8 | Cap on simultaneous background work (minimum 1). |
+| **Pause auto-refresh on error** | On | Stop auto-refreshing a view after it errors. |
+| **Auto-refresh only if tab is visible** | Off | Skip refreshing tabs you're not looking at. |
+
+### Execution safety (dangerous-query confirmation)
+
+These three settings govern how DBFlux treats risky queries across **all**
+drivers and query languages. There is no per-database toggle — the same rules
+apply to SQL `DELETE`/`DROP`/`TRUNCATE`, MongoDB `deleteMany`/`drop`, Redis
+`FLUSHALL`/`FLUSHDB`, and so on.
+
+| Setting | Default | What it does |
+|---------|---------|--------------|
+| **Confirm dangerous queries** | On | Show a confirmation before running a dangerous query. Turn off to allow them without prompting. |
+| **Require WHERE for DELETE/UPDATE** | On | Treat a `DELETE`/`UPDATE` with no `WHERE` as dangerous. |
+| **Always require preview (ignore suppressions)** | Off | Force the confirm/preview modal even for queries you previously chose to stop confirming. |
+
+### Storage (Nightly builds only)
+
+| Setting | Default | What it does |
+|---------|---------|--------------|
+| **Use the stable database** | Off | Make a Nightly build share the stable `dbflux.db` instead of `dbflux-nightly.db`. Applies on next launch. |
+
+See [Data & Privacy](DATA_AND_PRIVACY.md#data-locations) for how the Nightly and
+stable databases are separated.
+
+---
+
+## Audit
+
+The Audit section controls the unified audit log. The main user-facing control
+is **Log Capture → Minimum Level** (trace / debug / info / warn / error), which
+sets how much of DBFlux's internal logging is folded into the audit trail. Saving
+takes effect without a restart.
+
+Retention (how long events are kept) drives a periodic background purge when
+configured. For the day-to-day audit experience — opening the viewer, filtering,
+exporting — see [Dashboards & Audit](DASHBOARDS_AND_AUDIT.md#audit-viewer). For
+the full event schema and redaction behavior see [Audit](AUDIT.md) and
+[Data & Privacy](DATA_AND_PRIVACY.md#audit-and-privacy).
+
+---
+
+## Keybindings
+
+This section is a **read-only viewer**. It lists the active keymap grouped by
+context, with a text filter and inline warnings when a chord is bound to more
+than one command. It does **not** currently let you rebind or save custom
+shortcuts from the UI. Use it to discover and verify bindings; the full default
+keymap is documented in [Usage → Keyboard Reference](USAGE.md#7-keyboard-reference).
+
+---
+
+## Auth Profiles, Proxies, SSH Tunnels
+
+These three sections manage the reusable profiles you then select per connection
+on the Access tab. They're documented in full — fields, AWS SSO flow, no-proxy
+rules, SSH auth methods — in
+[Connecting to a Database → Advanced Setup](CONNECTIONS.md):
+
+- [Auth Profiles](CONNECTIONS.md#auth-profiles-aws-sso-and-shared-credentials)
+- [Proxies](CONNECTIONS.md#proxies)
+- [SSH Tunnels](CONNECTIONS.md#ssh-tunnels)
+
+Credentials entered here are stored in your OS keyring, not the database. See
+[Data & Privacy → Secrets](DATA_AND_PRIVACY.md#secrets-and-the-os-keyring).
+
+---
+
+## Services (RPC)
+
+External drivers and auth providers run as separate processes that DBFlux talks
+to over a local socket. Each service you add here has:
+
+| Field | Notes |
+|-------|-------|
+| **Socket ID** | Unique identifier, used as the socket filename. ASCII letters, digits, `.`, `_`, `-` only. |
+| **Command** | The executable to launch (optional for some setups). |
+| **Startup Timeout (ms)** | How long to wait for the process to come up. Default 5000. |
+| **Service Type** | **Driver** or **Auth Provider**. |
+| **Enable this service** | Whether the service starts. Default on. |
+| **Arguments** | Ordered process arguments. |
+| **Environment Variables** | `KEY=value` pairs passed to the process. |
+
+Changes here **take effect on the next launch**. Full reference:
+[RPC Services Config](RPC_SERVICES_CONFIG.md) and the
+[Driver RPC Protocol](DRIVER_RPC_PROTOCOL.md).
+
+---
+
+## Drivers
+
+Pick a driver to see and override its behavior. Two groups are editable:
+
+**Global overrides** — per-driver versions of the General settings. Each is a
+tri-state (Inherit / On / Off, or an explicit value); leaving it on *Inherit*
+uses the General default shown next to the control:
+
+- Refresh policy and interval
+- Confirm dangerous queries
+- Require WHERE
+- Require preview
+
+**Driver settings** — options defined by the driver itself (rendered generically
+from the driver's own schema, so the available fields depend on the driver).
+
+The section also shows, read-only, the driver's **capability matrix**, category,
+and query language.
+
+---
+
+## Connection Hooks
+
+Hooks are reusable commands, scripts, or Lua snippets that run around a
+connection's lifecycle. You **define** them globally in **Settings → Hooks**, then
+**bind** them to phases on individual connections in the Connection Manager's
+**Hooks** tab.
+
+### Quick path
+
+1. **Settings → Hooks → add a hook.** Give it a **Hook ID**, pick a **Type**, and
+   fill in the command/script.
+2. Open a connection in the **Connection Manager → Hooks tab**.
+3. Select your hook in one of the four phase dropdowns (Pre-connect, Post-connect,
+   Pre-disconnect, Post-disconnect).
+4. Connect. Hook output streams into the **Tasks** panel.
+
+### Hook types
+
+| Type | What it runs | What you provide |
+|------|--------------|------------------|
+| **Command** | An executable | A command and space-separated arguments. |
+| **Script** | A Bash or Python file | A language, a file path, and an optional interpreter override (blank = `bash` / `python3`, platform-adjusted). |
+| **Lua** | An in-process Lua script | A file path and a set of capabilities (see below). Lua runs inside DBFlux — no external interpreter. |
+
+Scripts are edited in DBFlux's editor and stored under a `hooks/` folder by
+default.
+
+#### Lua capabilities
+
+A Lua hook only gets the abilities you enable:
+
+| Capability | Default | Grants |
+|------------|---------|--------|
+| **Logging** | On | Write to the hook's output. |
+| **Environment read** | On | Read environment variables. |
+| **Connection metadata** | On | Read the connecting profile's metadata. |
+| **Controlled process run** | Off | Call `dbflux.process.run(...)` to launch external processes. |
+
+> Enabling **Controlled process run** lets the hook execute arbitrary external
+> commands. DBFlux shows a security warning when it's on, both in the hook
+> definition and on the per-connection binding. Enable it only for hooks you
+> trust.
+
+The embedded Lua runtime (available APIs, sandboxing) is documented in
+[Lua Scripting](LUA.md).
+
+### Hook options
+
+| Option | Notes |
+|--------|-------|
+| **Enabled** | Disabled hooks are skipped. |
+| **Working Directory** | Process/script cwd (not used by Lua). |
+| **Environment** | Extra `KEY=value` pairs. |
+| **Inherit parent environment** | On by default; pass DBFlux's env to the hook. |
+| **Env Denylist** | Variable names to strip from the inherited env. |
+| **Timeout (ms)** | Blank = no timeout. On timeout the process group is killed. |
+| **Execution mode** | **Blocking** (default) waits for the hook; **Detached** runs in the background and does not block connect/disconnect. |
+| **Ready signal** (Detached) | Text DBFlux waits for in the hook's output before continuing. |
+| **On Failure** | The failure policy — see below. |
+
+DBFlux always injects context env vars into process hooks: `DBFLUX_PROFILE_ID`,
+`DBFLUX_PROFILE_NAME`, `DBFLUX_DB_KIND`, and, when known, `DBFLUX_HOST`,
+`DBFLUX_PORT`, `DBFLUX_DATABASE`.
+
+> **Secrets never leak into hooks by accident.** On top of your Env Denylist,
+> DBFlux always strips inherited variables whose name contains `SECRET`, `TOKEN`,
+> `PASSWORD`, or `_KEY`, and any `AWS_*` variable.
+
+### Failure policies
+
+What happens when a hook fails (non-zero exit, timeout, or error):
+
+| Policy | Effect |
+|--------|--------|
+| **Disconnect** (default) | Abort the phase — the connect or disconnect flow stops. |
+| **Warn** | Continue, but surface a warning. |
+| **Ignore** | Continue; the failure is only logged. |
+
+### Phases
+
+| Phase | Runs |
+|-------|------|
+| **Pre-connect** | Before the connection opens. |
+| **Post-connect** | After a successful connect. |
+| **Pre-disconnect** | Before disconnecting. |
+| **Post-disconnect** | After disconnecting. |
+
+A connection's Hooks tab has one dropdown per phase (plus an "Extra" input for
+binding additional hook IDs). The dropdowns list the reusable hooks you defined
+in Settings → Hooks. Each hook runs as its own background task with live
+stdout/stderr in the Tasks panel; output is capped at 4 MiB per hook.
+
+---
+
+## Related
+
+- [Usage Guide](USAGE.md) — core workflow and keyboard reference.
+- [Connecting → Advanced Setup](CONNECTIONS.md) — SSH, proxy, auth, value sources.
+- [Data & Privacy](DATA_AND_PRIVACY.md) — where settings and secrets are stored.
+- [Lua Scripting](LUA.md) — the embedded Lua runtime for hooks.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,7 +6,8 @@ and the keyboard model.
 
 DBFlux is keyboard-first. Almost every action has both a mouse affordance and a
 keyboard binding. The keybindings listed in this guide are the application
-defaults; they can be customized from Settings.
+defaults; you can review the full active keymap in **Settings → Keybindings**
+(a read-only viewer — see the [Settings overview](#8-settings-overview)).
 
 ---
 
@@ -537,23 +538,39 @@ stay `Ctrl` on all platforms (to avoid clashing with macOS system shortcuts).
 
 ## 8. Settings Overview
 
-Settings is organized into eight sections:
+Settings has these sections (the MCP sections appear only in builds with AI/MCP
+support, which is the default):
 
-1. **General** — application-wide preferences (including the dangerous-query
-   confirmation behavior).
-2. **Keybindings** — view and customize the keymap.
-3. **Auth Profiles** — provider-driven authentication profiles (for example AWS;
-   supports importing provider-discovered profiles).
-4. **Proxies** — SOCKS5 / HTTP CONNECT proxy profiles.
-5. **SSH Tunnels** — SSH tunnel profiles selectable per connection.
-6. **Services** — externally registered RPC services (drivers and auth
-   providers). See `docs/RPC_SERVICES_CONFIG.md`.
-7. **Hooks** — global connection-hook definitions (Command, Script, and Lua
-   modes). Per-profile phase bindings live in the Connection Manager's Hooks tab.
-8. **Drivers** — per-driver settings overrides.
+- **General** — application-wide preferences: theme, startup/session, refresh
+  defaults, and the dangerous-query confirmation behavior.
+- **Audit** — what the audit log captures (log-capture minimum level) and
+  retention.
+- **MCP Clients / Roles / Policies** — AI client governance (trusted clients,
+  roles, policies). See `docs/MCP_AI_INTEGRATION.md`.
+- **Keybindings** — a **read-only** viewer for the active keymap, with a text
+  filter and conflict warnings. Rebinding from the UI is not available.
+- **Proxies** — SOCKS5 / HTTP CONNECT proxy profiles.
+- **SSH Tunnels** — SSH tunnel profiles selectable per connection.
+- **Auth Profiles** — provider-driven authentication profiles (AWS SSO / shared
+  credentials).
+- **Services** — externally registered RPC services (drivers and auth
+  providers). See `docs/RPC_SERVICES_CONFIG.md`.
+- **Hooks** — global connection-hook definitions (Command, Script, and Lua
+  modes). Per-profile phase bindings live in the Connection Manager's Hooks tab.
+- **Drivers** — per-driver overrides and settings.
+- **About** — version and build information.
+
+For a full per-setting reference and the connection-hooks guide, see
+`docs/SETTINGS.md`.
 
 ### Related documentation
 
+- Advanced connection setup (SSH, proxy, AWS SSO, value sources):
+  `docs/CONNECTIONS.md`
+- Full Settings reference and connection hooks: `docs/SETTINGS.md`
+- Data storage and privacy (where data and secrets live, backup, reset):
+  `docs/DATA_AND_PRIVACY.md`
+- Dashboards, saved charts, and the audit viewer (usage): `docs/DASHBOARDS_AND_AUDIT.md`
 - Connection hooks and the embedded Lua runtime: `docs/LUA.md`
 - AI client integration (MCP): `docs/MCP_AI_INTEGRATION.md`
 - Audit log and event schema: `docs/AUDIT.md`


### PR DESCRIPTION
## Summary

- Adds four end-user guides and regroups the README docs index into **User guides** / **Reference**.
- Audits every existing doc against the code and fixes inaccuracies: broken code examples, wrong paths/types, stale defaults. No code changes.

## What to review first

The four new guides under `docs/` are net-new prose and most of the diff. The edits to existing docs are surgical accuracy fixes, each verified against the cited code.

## New guides

| File | Covers |
|------|--------|
| `docs/CONNECTIONS.md` | Advanced connection setup: Access modes, SSH tunnels, proxies, AWS SSO auth profiles, SSM managed access, value sources, form vs URI. |
| `docs/SETTINGS.md` | Every Settings section with defaults, plus the connection-hooks guide. |
| `docs/DATA_AND_PRIVACY.md` | Data locations, the SQLite store, OS-keyring secrets, session restore, audit privacy, backup and reset. |
| `docs/DASHBOARDS_AND_AUDIT.md` | Saved charts, dashboards, Instance Overview/metrics/inspectors, remote dashboards, the audit viewer. |

## Accuracy fixes to existing docs

| File | Fix |
|------|-----|
| `docs/USAGE.md` | Keybindings section is read-only (not customizable); corrected the Settings section list (Audit/About/MCP); linked the new guides. |
| `docs/CHARTS.md` | SavedChart persists to SQLite (`viz_*`), not a JSON file. |
| `docs/AUDIT.md` | Real `EventRecord` builder API, real action constants, audit MCP tools are read-class, drop-counter accessor, channel capacity 512, Rust migration path. |
| `docs/LUA.md` | Correct `execute_hook` signature, `CompositeExecutor` path, allowlist rejects path-qualified programs, default feature set, `process.run` detached/timeout, memory limit; reframed from personal notes into reference documentation. |
| `docs/MCP_AI_INTEGRATION.md` | `bootstrap::init`, `select_data`, `drop_index` class, `preview_mutation`, `export_audit_logs` class. |
| `docs/RPC_SERVICES_CONFIG.md` | Auth-provider default contract 1.2, real `cfg_services` DDL, `id TEXT`. |
| `docs/DASHBOARDS.md` | `InstanceMetricDef`/`InstanceInspectorDef` names, inspector panel kind. |
| `ARCHITECTURE.md` | `Command` enum location, `tree_store.rs`, `rpc_services/` dir, LOC, document types, settings sections, default features. |
| `CODE_STYLE.md` | Note that `dbflux_ui/src/ui/...` paths are post-split compatibility shims. |
| `CLAUDE.md`, `AGENTS.md` | Auth-provider IPC protocol bumped to v1.3; corrected `dbflux_ui` LOC and document-type list. |

## Scope and size

Single consolidated PR. ~1.0k added lines, almost entirely the four new guides, so it trips the 400-line budget; flagged `size:exception` rather than splitting, since the guides form one coherent set. Docs-only, so fmt/clippy/tests are unaffected.