### PR TITLE
fix(ui): align chart/table/document views with GPUI render contract

### DIFF
--- a/crates/dbflux_components/src/components/data_table/state.rs
+++ b/crates/dbflux_components/src/components/data_table/state.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::controls::{InputEvent, InputState};
 use gpui::{
     AppContext, Context, Entity, EventEmitter, FocusHandle, Focusable, Pixels, Point, ScrollHandle,
-    Size, UniformListScrollHandle, Window, px,
+    Size, Subscription, UniformListScrollHandle, Window, px,
 };
 
 use super::clipboard;
@@ -56,6 +56,13 @@ pub struct DataTableState {
 
     /// Dropdown for editing enum/set columns inline.
     enum_dropdown: Option<Entity<Dropdown>>,
+
+    /// Subscriptions for the currently active inline editor (cell input or
+    /// enum dropdown). Held so a new `start_editing` drops the previous
+    /// editor's subscriptions before installing its own — otherwise a stale
+    /// `Blur` from the old input would arrive after the new edit started and
+    /// silently cancel it.
+    _editing_subs: Vec<Subscription>,
 
     /// Buffer for tracking local edits before committing.
     edit_buffer: EditBuffer,
@@ -118,6 +125,7 @@ impl DataTableState {
             editing_cell: None,
             cell_input: None,
             enum_dropdown: None,
+            _editing_subs: Vec::new(),
             edit_buffer,
             pk_columns: Vec::new(),
             fk_columns: HashSet::new(),
@@ -681,22 +689,22 @@ impl DataTableState {
             // GPUI may deliver dismissal before selection, and `cancel_enum_edit`
             // would otherwise clear `editing_cell` and cause the selection to
             // be silently discarded.
-            cx.subscribe(
+            self._editing_subs.clear();
+
+            self._editing_subs.push(cx.subscribe(
                 &dropdown,
                 move |this, _dropdown, event: &DropdownSelectionChanged, cx| {
                     let value = event.item.value.to_string();
                     this.apply_enum_selection_at(coord, &value, cx);
                 },
-            )
-            .detach();
+            ));
 
-            cx.subscribe(
+            self._editing_subs.push(cx.subscribe(
                 &dropdown,
                 |this, _dropdown, _event: &DropdownDismissed, cx| {
                     this.cancel_enum_edit(cx);
                 },
-            )
-            .detach();
+            ));
 
             self.editing_cell = Some(coord);
             self.enum_dropdown = Some(dropdown);
@@ -716,12 +724,15 @@ impl DataTableState {
             state.focus(window, cx);
         });
 
-        cx.subscribe(&input, |this, _input, event: &InputEvent, cx| match event {
-            InputEvent::PressEnter { .. } => this.stop_editing(true, cx),
-            InputEvent::Blur => this.stop_editing(false, cx),
-            _ => {}
-        })
-        .detach();
+        self._editing_subs.clear();
+
+        self._editing_subs.push(
+            cx.subscribe(&input, |this, _input, event: &InputEvent, cx| match event {
+                InputEvent::PressEnter { .. } => this.stop_editing(true, cx),
+                InputEvent::Blur => this.stop_editing(false, cx),
+                _ => {}
+            }),
+        );
 
         self.editing_cell = Some(coord);
         self.cell_input = Some(input);
@@ -1063,6 +1074,39 @@ mod tests {
         std::sync::Arc::new(TableModel::new(columns, rows))
     }
 
+    fn two_row_model() -> std::sync::Arc<super::super::model::TableModel> {
+        use crate::components::data_table::model::{
+            CellValue, ColumnKind, ColumnSpec, RowData, TableModel,
+        };
+        use gpui::TextAlign;
+
+        let columns = vec![
+            ColumnSpec {
+                id: "id".into(),
+                title: "id".into(),
+                kind: ColumnKind::Integer,
+                align: TextAlign::Left,
+                type_name: "int4".into(),
+            },
+            ColumnSpec {
+                id: "name".into(),
+                title: "name".into(),
+                kind: ColumnKind::Text,
+                align: TextAlign::Left,
+                type_name: "text".into(),
+            },
+        ];
+        let rows = vec![
+            RowData {
+                cells: vec![CellValue::int(1), CellValue::text("alice")],
+            },
+            RowData {
+                cells: vec![CellValue::int(2), CellValue::text("bob")],
+            },
+        ];
+        std::sync::Arc::new(TableModel::new(columns, rows))
+    }
+
     /// Negative: start_editing on a column in readonly_columns returns false.
     #[gpui::test]
     fn start_editing_blocked_by_readonly_column(cx: &mut gpui::TestAppContext) {
@@ -1151,6 +1195,66 @@ mod tests {
             editing_cell,
             Some(CellCoord::new(0, 1)),
             "editing_cell must be set to the requested coord after successful start_editing"
+        );
+    }
+
+    /// Regression: switching the inline editor to another cell must drop the
+    /// previous editor's subscriptions. Otherwise a late `Blur` from the old
+    /// input is delivered to its still-live subscription and calls
+    /// `stop_editing`, which clears `editing_cell` and silently cancels the
+    /// freshly opened edit.
+    #[gpui::test]
+    fn rapid_cell_switch_ignores_stale_blur(cx: &mut gpui::TestAppContext) {
+        use super::super::selection::CellCoord;
+        use crate::controls::InputEvent;
+        use std::collections::HashSet;
+
+        let state_holder = std::rc::Rc::new(std::cell::RefCell::new(None));
+        let holder_clone = state_holder.clone();
+
+        let (_, window) = cx.add_window_view(move |_window, cx| {
+            let model = two_row_model();
+            let state = cx.new(|cx| {
+                let mut s = super::DataTableState::new(model, cx);
+                s.set_pk_columns(vec![0]);
+                s.set_readonly_columns(HashSet::new());
+                s
+            });
+            holder_clone.replace(Some(state.clone()));
+            StateHarness { state }
+        });
+
+        let state = state_holder
+            .borrow()
+            .clone()
+            .expect("state entity must be created");
+
+        // Open the editor on (0,1) and capture its input entity.
+        let input_a = window.update(|window, app| {
+            state.update(app, |s, cx| {
+                assert!(s.start_editing(CellCoord::new(0, 1), window, cx));
+                s.cell_input().cloned().expect("cell input for (0,1)")
+            })
+        });
+
+        // Switch the editor to (1,1): installs new subscriptions and drops the
+        // ones bound to input_a.
+        window.update(|window, app| {
+            state.update(app, |s, cx| {
+                assert!(s.start_editing(CellCoord::new(1, 1), window, cx));
+            })
+        });
+
+        // A late Blur from the previous input must be ignored.
+        window.update(|_window, app| {
+            input_a.update(app, |_input, cx| cx.emit(InputEvent::Blur));
+        });
+
+        let editing_cell = window.update(|_, app| state.read(app).editing_cell());
+        assert_eq!(
+            editing_cell,
+            Some(CellCoord::new(1, 1)),
+            "a stale Blur from the previous input must not cancel the new edit"
         );
     }
 }

--- a/crates/dbflux_components/src/components/data_table/table.rs
+++ b/crates/dbflux_components/src/components/data_table/table.rs
@@ -8,7 +8,7 @@ use gpui::ElementId;
 use gpui::prelude::FluentBuilder;
 use gpui::{
     AnyElement, App, ClickEvent, Context, Entity, InteractiveElement, IntoElement, KeyBinding,
-    ListSizingBehavior, MouseButton, MouseDownEvent, ParentElement, ScrollWheelEvent,
+    ListSizingBehavior, MouseButton, MouseDownEvent, ParentElement, ScrollWheelEvent, SharedString,
     StatefulInteractiveElement, Styled, Window, actions, canvas, div, px, uniform_list,
 };
 use gpui_component::scroll::{Scrollbar, ScrollbarShow};
@@ -711,7 +711,7 @@ impl DataTable {
                 let is_pk = pk_cols.contains(&col_ix);
                 let is_fk = fk_cols.contains(&col_ix);
 
-                let type_label: String = col_spec.type_name.as_ref().to_string();
+                let type_label: SharedString = col_spec.type_name.clone().into();
 
                 let state_for_click = state_entity.clone();
                 let resize_drag_for_down = resize_drag.clone();
@@ -771,7 +771,7 @@ impl DataTable {
                             // It pushes the (secondary) type label out of the cell
                             // before its own characters get truncated.
                             .child(div().flex_shrink_0().whitespace_nowrap().child(
-                                Text::label_sm(col_spec.title.to_string()).color(if is_sorted {
+                                Text::label_sm(col_spec.title.clone()).color(if is_sorted {
                                     theme.primary
                                 } else {
                                     theme.foreground

--- a/crates/dbflux_ui_document/src/chart_document/mod.rs
+++ b/crates/dbflux_ui_document/src/chart_document/mod.rs
@@ -935,6 +935,7 @@ impl ChartDocument {
                 let display_clone = display_result.clone();
                 self.chart_shell.update(cx, |shell, cx| {
                     shell.set_result(&display_clone, was_chart_mode, cx);
+                    shell.ensure_chart_view(&display_clone, cx);
                 });
 
                 self.last_result = Some(display_result);
@@ -1233,6 +1234,21 @@ impl ChartDocument {
     ) {
         self.chart_shell
             .update(cx, |shell, cx| shell.apply_bindings(bindings, cx));
+        self.rebuild_chart_view(cx);
+    }
+
+    /// Rebuild the `ChartView` entity from the current `last_result`.
+    ///
+    /// Called after any chart-config mutation that clears `chart_view`
+    /// (binding changes, fresh query results) so the view is constructed at
+    /// event time rather than inside the render pass. No-op when there is no
+    /// result to chart.
+    fn rebuild_chart_view(&mut self, cx: &mut Context<Self>) {
+        if let Some(result) = self.last_result.clone() {
+            self.chart_shell.update(cx, |shell, cx| {
+                shell.ensure_chart_view(&result, cx);
+            });
+        }
     }
 
     /// Toggle the stats rail on the underlying `ChartShell`. Mirrors the

--- a/crates/dbflux_ui_document/src/chart_document/render.rs
+++ b/crates/dbflux_ui_document/src/chart_document/render.rs
@@ -165,15 +165,6 @@ impl Render for ChartDocument {
             self.request_reexecute(window, cx);
         }
 
-        // -- Ensure chart view is built for the current result --
-        // Must happen before ViewHandle::render is called so ensure_chart_view
-        // has a chance to construct the ChartView entity.
-        if let Some(result) = self.last_result.clone() {
-            self.chart_shell.update(cx, |shell, cx| {
-                shell.ensure_chart_view(&result, cx);
-            });
-        }
-
         // -- Lazily build ResultPanel on first render --
         // Self-referential construction requires a live entity handle, which
         // is available from within the render closure via cx.entity().
@@ -393,10 +384,10 @@ impl ChartDocument {
         };
 
         let chart_shell_for_pill = self.chart_shell.clone();
-        let chart_shell_for_x = self.chart_shell.clone();
-        let chart_shell_for_y = self.chart_shell.clone();
-        let chart_shell_for_group = self.chart_shell.clone();
-        let chart_shell_for_agg = self.chart_shell.clone();
+        let doc_for_x = cx.entity();
+        let doc_for_y = cx.entity();
+        let doc_for_group = cx.entity();
+        let doc_for_agg = cx.entity();
 
         let chart_colors = ChartColors::for_current(cx);
 
@@ -409,37 +400,49 @@ impl ChartDocument {
                 chart_shell_for_pill.update(cx, |s, cx| s.toggle_axis_pill(pill, cx));
             },
             move |col_idx, _window, cx| {
-                chart_shell_for_x.update(cx, |s, cx| {
-                    let mut b = s.active_bindings();
-                    b.x = col_idx;
-                    s.apply_bindings(b, cx);
+                doc_for_x.update(cx, |this, cx| {
+                    this.chart_shell.update(cx, |s, cx| {
+                        let mut b = s.active_bindings();
+                        b.x = col_idx;
+                        s.apply_bindings(b, cx);
+                    });
+                    this.rebuild_chart_view(cx);
                 });
             },
             move |col_idx, checked, _window, cx| {
-                chart_shell_for_y.update(cx, |s, cx| {
-                    let mut b = s.active_bindings();
-                    if checked {
-                        if !b.y.contains(&col_idx) {
-                            b.y.push(col_idx);
+                doc_for_y.update(cx, |this, cx| {
+                    this.chart_shell.update(cx, |s, cx| {
+                        let mut b = s.active_bindings();
+                        if checked {
+                            if !b.y.contains(&col_idx) {
+                                b.y.push(col_idx);
+                            }
+                        } else {
+                            b.y.retain(|&i| i != col_idx);
                         }
-                    } else {
-                        b.y.retain(|&i| i != col_idx);
-                    }
-                    s.apply_bindings(b, cx);
+                        s.apply_bindings(b, cx);
+                    });
+                    this.rebuild_chart_view(cx);
                 });
             },
             move |group_col, _window, cx| {
-                chart_shell_for_group.update(cx, |s, cx| {
-                    let mut b = s.active_bindings();
-                    b.group_by = group_col;
-                    s.apply_bindings(b, cx);
+                doc_for_group.update(cx, |this, cx| {
+                    this.chart_shell.update(cx, |s, cx| {
+                        let mut b = s.active_bindings();
+                        b.group_by = group_col;
+                        s.apply_bindings(b, cx);
+                    });
+                    this.rebuild_chart_view(cx);
                 });
             },
             move |agg, _window, cx| {
-                chart_shell_for_agg.update(cx, |s, cx| {
-                    let mut b = s.active_bindings();
-                    b.aggregation = agg;
-                    s.apply_bindings(b, cx);
+                doc_for_agg.update(cx, |this, cx| {
+                    this.chart_shell.update(cx, |s, cx| {
+                        let mut b = s.active_bindings();
+                        b.aggregation = agg;
+                        s.apply_bindings(b, cx);
+                    });
+                    this.rebuild_chart_view(cx);
                 });
             },
         );

--- a/crates/dbflux_ui_document/src/code/context_bar.rs
+++ b/crates/dbflux_ui_document/src/code/context_bar.rs
@@ -431,6 +431,13 @@ impl CodeDocument {
     }
 
     pub(super) fn on_source_time_range_changed(&mut self, cx: &mut Context<Self>) {
+        // Ignore the `Change` events produced by programmatically seeding the
+        // inputs; only genuine user edits should re-derive the exec context.
+        if self.source_seed_suppress > 0 {
+            self.source_seed_suppress -= 1;
+            return;
+        }
+
         self.sync_source_exec_context(cx);
         cx.emit(DocumentEvent::MetaChanged);
         cx.notify();

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -241,6 +241,13 @@ pub struct CodeDocument {
     source_start_input: Entity<InputState>,
     source_end_input: Entity<InputState>,
     pending_source_input_values: Option<(String, String)>,
+    /// Number of upcoming `InputEvent::Change` emissions from the source
+    /// start/end inputs that originate from a programmatic seed rather than a
+    /// user edit, and must therefore be ignored. `InputState::set_value` always
+    /// emits `Change`, so seeding both inputs while draining
+    /// `pending_source_input_values` queues two handler calls that would
+    /// otherwise re-derive the exec context from the values just written.
+    source_seed_suppress: usize,
     /// Present when the active connection's `SourceContextSpec` declares both
     /// a non-empty `start_label` and `end_label`. The panel replaces the raw
     /// RFC3339 text inputs and forwards epoch-ms bounds into `exec_ctx.source`.
@@ -761,6 +768,7 @@ impl CodeDocument {
             source_start_input,
             source_end_input,
             pending_source_input_values: None,
+            source_seed_suppress: 0,
             source_time_range_panel: None,
             _source_time_range_sub: None,
             _context_subscriptions: vec![

--- a/crates/dbflux_ui_document/src/code/render.rs
+++ b/crates/dbflux_ui_document/src/code/render.rs
@@ -761,6 +761,10 @@ impl Render for CodeDocument {
         self.process_pending_drift_continue(window, cx);
 
         if let Some((start_value, end_value)) = self.pending_source_input_values.take() {
+            // Each `set_value` emits an `InputEvent::Change`; mark both as
+            // seed-originated so the subscription handler skips them.
+            self.source_seed_suppress = self.source_seed_suppress.saturating_add(2);
+
             self.source_start_input
                 .update(cx, |state, cx| state.set_value(&start_value, window, cx));
             self.source_end_input

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -445,6 +445,12 @@ pub struct DataGridPanel {
     document_tree_state: Option<Entity<DocumentTreeState>>,
     document_tree_subscription: Option<Subscription>,
 
+    // Virtualized state for the document-card fallback view (used when no
+    // `document_tree` is built). Cards have variable height, so this relies on
+    // `gpui::list` rather than `uniform_list`. Rebuilt with the row count on
+    // every `rebuild_table`.
+    document_card_list: Option<ListState>,
+
     // Document preview modal for viewing/editing full documents
     document_preview_modal: Entity<DocumentPreviewModal>,
     pending_document_preview: Option<PendingDocumentPreview>,
@@ -1099,6 +1105,7 @@ impl DataGridPanel {
             document_tree: None,
             document_tree_state: None,
             document_tree_subscription: None,
+            document_card_list: None,
             document_preview_modal,
             pending_document_preview: None,
             row_inspector_content: None,
@@ -2026,6 +2033,15 @@ impl DataGridPanel {
         if should_build_tree {
             self.rebuild_document_tree(cx);
         }
+
+        // Reset the variable-height card-list state to match the new row count.
+        // Only the document-card fallback (no tree) consumes it, but building it
+        // unconditionally keeps the row count in sync with `self.result`.
+        self.document_card_list = Some(ListState::new(
+            self.result.rows.len(),
+            ListAlignment::Top,
+            px(400.0),
+        ));
     }
 
     fn rebuild_document_tree(&mut self, cx: &mut Context<Self>) {

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -1338,23 +1338,32 @@ impl DataGridPanel {
                 .size_full()
                 .child(tree.clone())
         } else {
-            let rows = &self.result.rows;
-            let columns = &self.result.columns;
+            let entity = _cx.entity();
+            let list_state = self.document_card_list.clone().unwrap_or_else(|| {
+                ListState::new(self.result.rows.len(), ListAlignment::Top, px(400.0))
+            });
 
-            let cards: Vec<_> = rows
-                .iter()
-                .enumerate()
-                .map(|(row_idx, row)| self.render_document_card(row_idx, row, columns, _theme))
-                .collect();
+            let card_list = list(list_state, move |row_idx, _window, cx: &mut App| {
+                let theme = cx.theme().clone();
+                let this = entity.read(cx);
+                let Some(row) = this.result.rows.get(row_idx) else {
+                    return div().into_any_element();
+                };
+
+                // Variable-height cards: each gets bottom spacing instead of the
+                // container `gap`, which a virtualized list cannot apply.
+                div()
+                    .pb(Spacing::MD)
+                    .child(this.render_document_card(row_idx, row, &this.result.columns, &theme))
+                    .into_any_element()
+            })
+            .size_full();
 
             div()
                 .id("document-view-container")
-                .flex()
-                .flex_col()
                 .size_full()
                 .p(Spacing::MD)
-                .gap(Spacing::MD)
-                .children(cards)
+                .child(card_list)
         }
     }
 


### PR DESCRIPTION
## Summary

Resolves the **Patrones GPUI consistentes** epic (board items GPUI-1..5): removes out-of-contract GPUI patterns (entity construction inside render, leaked editor subscriptions, per-frame allocations, an unvirtualized list, and a spurious event during render) that caused subtle focus bugs and jank. No public APIs change; behavior is preserved except for the targeted bug fixes.

## Changes

| Item | File(s) | What |
|------|---------|------|
| GPUI-1 | `chart_document/render.rs`, `chart_document/mod.rs` | Build the `ChartView` entity at event time (`apply_result` and binding changes) via a new `rebuild_chart_view`, instead of calling `ensure_chart_view` inside the render closure. Axis callbacks now route through the document entity. |
| GPUI-2 | `data_grid_panel/render.rs`, `data_grid_panel/mod.rs` | Virtualize the document-card fallback view with `gpui::list` + a `ListState` reset in `rebuild_table`. Cards have variable height, so `uniform_list` is unsuitable; `gpui::list` is the correct primitive. |
| GPUI-3 | `data_table/state.rs` | Hold inline-editor subscriptions in a `Vec<Subscription>` and clear them on `start_editing` so a stale `Blur` from the previous cell cannot cancel the newly opened edit. Adds a regression test. |
| GPUI-4 | `data_table/table.rs` | Reuse `Arc<str>` as `SharedString` for column headers instead of allocating a `String` per column per frame. |
| GPUI-5 | `code/mod.rs`, `code/render.rs`, `code/context_bar.rs` | Suppress the spurious `InputEvent::Change` emitted while seeding the source time-range inputs during render, so it no longer re-derives the exec context. |

### Notes
- GPUI-2: the document-card branch is a rare fallback — the normal Document path uses `DocumentTree`, which is already virtualized via `uniform_list`.
- GPUI-5: `InputState::set_value` (gpui-component 0.5.1) emits `Change` unconditionally, and the source inputs are subscribed; a per-document seed-suppression counter ignores exactly the seed-induced events while leaving genuine user edits untouched.

## Test plan

- `cargo check -p dbflux_ui_document -p dbflux_components --features lua` — clean
- `cargo clippy -p dbflux_ui_document -p dbflux_components --features lua -- -D warnings` — clean
- `cargo nextest run -p dbflux_ui_document -p dbflux_components --features lua` — all pass (incl. new `rapid_cell_switch_ignores_stale_blur` regression test)
- Adversarial dual review (Judgment Day) over two rounds: APPROVED, no CRITICAL/real-WARNING findings.