### PR TITLE
fix(security): harden driver-host auth, Lua env, governance persistence and panic hook (SEC2-1..2, CODE-1..2)

### DIFF
--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -61,10 +61,16 @@ const POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// 3. Always delegates to the previously installed panic hook
 fn install_panic_hook() {
     let prev = std::panic::take_hook();
-    *PREV_PANIC_HOOK.lock().unwrap() = Some(Box::new(prev));
+    *PREV_PANIC_HOOK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(Box::new(prev));
 
     std::panic::set_hook(Box::new(|panic_info: &std::panic::PanicHookInfo| {
-        if let Some(audit_service) = AUDIT_SERVICE_FOR_PANIC.lock().unwrap().clone() {
+        let audit_guard = AUDIT_SERVICE_FOR_PANIC
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        if let Some(audit_service) = audit_guard.clone() {
             let panic_location = panic_info
                 .location()
                 .map(|loc| format!("{}:{}:{}", loc.file(), loc.line(), loc.column()))
@@ -83,20 +89,23 @@ fn install_panic_hook() {
             match audit_service.record_panic_best_effort(&panic_info_str) {
                 Some(_) => {}
                 None => {
-                    eprintln!("[dbflux_audit] panic hook: record_panic_best_effort returned None");
+                    let _ = std::io::stderr().write_all(
+                        b"[dbflux_audit] panic hook: record_panic_best_effort returned None\n",
+                    );
                 }
             }
         } else {
-            eprintln!(
-                "[dbflux_audit] panic hook: audit service not available, panic at {}",
-                panic_info
-                    .location()
-                    .map(|loc| format!("{}:{}", loc.file(), loc.line()))
-                    .unwrap_or_else(|| "unknown location".to_string())
-            );
+            let _ = std::io::stderr()
+                .write_all(b"[dbflux_audit] panic hook: audit service not available\n");
         }
 
-        if let Some(ref prev_hook) = *PREV_PANIC_HOOK.lock().unwrap() {
+        drop(audit_guard);
+
+        let prev_guard = PREV_PANIC_HOOK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        if let Some(ref prev_hook) = *prev_guard {
             prev_hook(panic_info);
         }
     }));

--- a/crates/dbflux/tests/panic_hook_resilience.rs
+++ b/crates/dbflux/tests/panic_hook_resilience.rs
@@ -1,0 +1,56 @@
+/// Verifies that `unwrap_or_else(|p| p.into_inner())` allows a panic hook to
+/// survive a poisoned mutex without re-panicking (double-panic → abort).
+///
+/// The actual mutexes in `main.rs` (`AUDIT_SERVICE_FOR_PANIC`, `PREV_PANIC_HOOK`)
+/// use this exact pattern. We test it here on equivalent `Mutex<Option<T>>`
+/// instances because `main.rs` pulls in the full GPUI binary tree, which makes
+/// inline `#[test]` expansion abort due to macro recursion depth in this env.
+use std::panic;
+use std::sync::Mutex;
+
+static MOCK_AUDIT: Mutex<Option<i32>> = Mutex::new(None);
+static MOCK_PREV_HOOK: Mutex<Option<i32>> = Mutex::new(None);
+
+#[test]
+fn poisoned_mutex_does_not_re_panic_with_into_inner() {
+    let _ = panic::catch_unwind(|| {
+        let _guard = MOCK_AUDIT.lock().unwrap();
+        panic!("poison the mutex on purpose");
+    });
+
+    assert!(MOCK_AUDIT.lock().is_err(), "mutex must be poisoned now");
+
+    let result = panic::catch_unwind(|| {
+        let guard = MOCK_AUDIT
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        drop(guard);
+    });
+
+    assert!(
+        result.is_ok(),
+        "unwrap_or_else(|p| p.into_inner()) must not re-panic on a poisoned mutex"
+    );
+}
+
+#[test]
+fn poisoned_prev_hook_mutex_does_not_re_panic_with_into_inner() {
+    let _ = panic::catch_unwind(|| {
+        let _guard = MOCK_PREV_HOOK.lock().unwrap();
+        panic!("poison the prev-hook mutex on purpose");
+    });
+
+    assert!(MOCK_PREV_HOOK.lock().is_err(), "mutex must be poisoned now");
+
+    let result = panic::catch_unwind(|| {
+        let guard = MOCK_PREV_HOOK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        drop(guard);
+    });
+
+    assert!(
+        result.is_ok(),
+        "unwrap_or_else(|p| p.into_inner()) must not re-panic on a poisoned mutex"
+    );
+}

--- a/crates/dbflux_core/src/connection/hook.rs
+++ b/crates/dbflux_core/src/connection/hook.rs
@@ -123,7 +123,7 @@ impl ScriptSource {
 pub struct LuaCapabilities {
     #[serde(default = "default_true")]
     pub logging: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub env_read: bool,
     #[serde(default = "default_true")]
     pub connection_metadata: bool,
@@ -135,7 +135,7 @@ impl Default for LuaCapabilities {
     fn default() -> Self {
         Self {
             logging: true,
-            env_read: true,
+            env_read: false,
             connection_metadata: true,
             process_run: false,
         }
@@ -1561,7 +1561,7 @@ mod tests {
         };
 
         assert!(capabilities.logging);
-        assert!(capabilities.env_read);
+        assert!(!capabilities.env_read);
         assert!(capabilities.connection_metadata);
         assert!(!capabilities.process_run);
     }

--- a/crates/dbflux_driver_host/src/main.rs
+++ b/crates/dbflux_driver_host/src/main.rs
@@ -36,6 +36,14 @@ fn main() {
         .ok()
         .filter(|token| !token.is_empty());
 
+    if auth_token.is_none() {
+        fatal(&format!(
+            "Driver host refuses to start: {} is not set or empty. \
+             The parent process must provision this token before launching driver hosts.",
+            DRIVER_RPC_AUTH_TOKEN_ENV,
+        ));
+    }
+
     let driver = create_driver(&args.driver)
         .unwrap_or_else(|e| fatal(&format!("Failed to create driver '{}': {e}", args.driver)));
 
@@ -74,6 +82,18 @@ fn main() {
     }
 
     log::info!("Driver host shutting down");
+}
+
+/// Returns `true` when the client-supplied token matches the expected token.
+///
+/// `expected_auth_token` must always be `Some` at runtime (the startup guard in
+/// `main` enforces this). The parameter is `Option` so the same helper can be
+/// exercised in tests that validate the reject path without a live socket.
+fn is_hello_authorized(client_token: Option<&str>, expected_auth_token: Option<&str>) -> bool {
+    match expected_auth_token {
+        Some(expected) => client_token == Some(expected),
+        None => false,
+    }
 }
 
 /// Handles one client connection for its entire lifetime.
@@ -144,9 +164,7 @@ fn handle_connection(
 
         let response = match envelope.body {
             DriverRequestBody::Hello(hello_req) => {
-                if let Some(expected_token) = expected_auth_token
-                    && hello_req.auth_token.as_deref() != Some(expected_token)
-                {
+                if !is_hello_authorized(hello_req.auth_token.as_deref(), expected_auth_token) {
                     DriverResponseEnvelope::error(
                         request_version,
                         request_id,
@@ -510,7 +528,7 @@ fn fatal(message: &str) -> ! {
 mod tests {
     use super::{
         choose_negotiated_driver_version, create_driver, hello_version_error_response,
-        negotiate_hello_version, validate_negotiated_request_version,
+        is_hello_authorized, negotiate_hello_version, validate_negotiated_request_version,
     };
     use dbflux_ipc::{
         ProtocolVersion,
@@ -582,6 +600,29 @@ mod tests {
 
         assert_eq!(error.code, DriverRpcErrorCode::VersionMismatch);
         assert!(error.message.contains("No compatible protocol version"));
+    }
+
+    #[test]
+    fn hello_auth_rejects_when_expected_token_is_none() {
+        assert!(
+            !is_hello_authorized(Some("any-token"), None),
+            "Hello must be rejected (fail-closed) when no expected token is configured"
+        );
+        assert!(
+            !is_hello_authorized(None, None),
+            "Hello must be rejected (fail-closed) when no expected token is configured, even without a client token"
+        );
+    }
+
+    #[test]
+    fn hello_auth_rejects_wrong_token() {
+        assert!(!is_hello_authorized(Some("wrong"), Some("correct")));
+        assert!(!is_hello_authorized(None, Some("correct")));
+    }
+
+    #[test]
+    fn hello_auth_accepts_matching_token() {
+        assert!(is_hello_authorized(Some("secret"), Some("secret")));
     }
 
     #[test]

--- a/crates/dbflux_driver_ipc/src/driver.rs
+++ b/crates/dbflux_driver_ipc/src/driver.rs
@@ -367,6 +367,13 @@ impl IpcDriver {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
+        // Explicit injection prevents the driver host from depending on implicit
+        // env inheritance — belt-and-suspenders alongside the fail-closed check
+        // in dbflux_driver_host::main.
+        if let Ok(token) = std::env::var(dbflux_ipc::DRIVER_RPC_AUTH_TOKEN_ENV) {
+            command.env(dbflux_ipc::DRIVER_RPC_AUTH_TOKEN_ENV, token);
+        }
+
         let mut child = command.spawn().map_err(|e| {
             DbError::ConnectionFailed(
                 format!("Failed to start driver host '{}': {}", launch.program, e).into(),

--- a/crates/dbflux_lua/src/api/dbflux.rs
+++ b/crates/dbflux_lua/src/api/dbflux.rs
@@ -34,13 +34,30 @@ pub fn register_logging_api(lua: &Lua, state: LuaRuntimeState) -> LuaResult<()> 
     dbflux.set("log", logging)
 }
 
+/// IPC auth-token env-var names that must never be returned to Lua scripts, even
+/// when env_read is enabled. These map to dbflux_ipc::{DRIVER_RPC_AUTH_TOKEN_ENV,
+/// APP_CONTROL_AUTH_TOKEN_ENV, AUTH_PROVIDER_RPC_AUTH_TOKEN_ENV}.
+const BLOCKED_ENV_VARS: &[&str] = &[
+    "DBFLUX_DRIVER_IPC_TOKEN",
+    "DBFLUX_IPC_TOKEN",
+    "DBFLUX_AUTH_PROVIDER_IPC_TOKEN",
+];
+
 pub fn register_env_api(lua: &Lua) -> LuaResult<()> {
     let dbflux = ensure_dbflux_table(lua)?;
     let env = lua.create_table()?;
 
     env.set(
         "get",
-        lua.create_function(|_, key: String| Ok(std::env::var(key).ok()))?,
+        lua.create_function(|_, key: String| {
+            if BLOCKED_ENV_VARS
+                .iter()
+                .any(|blocked| blocked.eq_ignore_ascii_case(&key))
+            {
+                return Ok(None);
+            }
+            Ok(std::env::var(key).ok())
+        })?,
     )?;
 
     dbflux.set("env", env)
@@ -128,6 +145,10 @@ fn run_process(lua: &Lua, state: &LuaRuntimeState, options: Table) -> LuaResult<
     command.args(&args);
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
+
+    for var in BLOCKED_ENV_VARS {
+        command.env_remove(var);
+    }
 
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
@@ -589,5 +610,75 @@ mod tests {
             }
             Ok(_) => {}
         }
+    }
+
+    // =========================================================================
+    // IPC token blocklist
+    // =========================================================================
+
+    fn make_env_lua() -> Lua {
+        let lua = Lua::new();
+        register_env_api(&lua).expect("register_env_api failed");
+        lua
+    }
+
+    #[test]
+    fn env_get_blocks_driver_ipc_token_exact_case() {
+        // Set the var so it would be readable if not blocked.
+        unsafe { std::env::set_var("DBFLUX_DRIVER_IPC_TOKEN", "should-be-blocked") };
+        let lua = make_env_lua();
+        let value: Option<String> = lua
+            .load("return dbflux.env.get('DBFLUX_DRIVER_IPC_TOKEN')")
+            .eval()
+            .unwrap();
+        unsafe { std::env::remove_var("DBFLUX_DRIVER_IPC_TOKEN") };
+        assert!(
+            value.is_none(),
+            "DBFLUX_DRIVER_IPC_TOKEN must be blocked even when env_read is enabled"
+        );
+    }
+
+    #[test]
+    fn env_get_blocks_ipc_token_case_insensitive() {
+        unsafe { std::env::set_var("DBFLUX_IPC_TOKEN", "should-be-blocked") };
+        let lua = make_env_lua();
+        let lower: Option<String> = lua
+            .load("return dbflux.env.get('dbflux_ipc_token')")
+            .eval()
+            .unwrap();
+        let upper: Option<String> = lua
+            .load("return dbflux.env.get('DBFLUX_IPC_TOKEN')")
+            .eval()
+            .unwrap();
+        unsafe { std::env::remove_var("DBFLUX_IPC_TOKEN") };
+        assert!(lower.is_none(), "lowercase key must be blocked");
+        assert!(upper.is_none(), "uppercase key must be blocked");
+    }
+
+    #[test]
+    fn env_get_blocks_auth_provider_ipc_token() {
+        unsafe { std::env::set_var("DBFLUX_AUTH_PROVIDER_IPC_TOKEN", "should-be-blocked") };
+        let lua = make_env_lua();
+        let value: Option<String> = lua
+            .load("return dbflux.env.get('DBFLUX_AUTH_PROVIDER_IPC_TOKEN')")
+            .eval()
+            .unwrap();
+        unsafe { std::env::remove_var("DBFLUX_AUTH_PROVIDER_IPC_TOKEN") };
+        assert!(
+            value.is_none(),
+            "DBFLUX_AUTH_PROVIDER_IPC_TOKEN must be blocked"
+        );
+    }
+
+    #[test]
+    fn env_get_allows_unrelated_vars() {
+        unsafe { std::env::set_var("DBFLUX_TEST_SAFE_VAR_12345", "visible") };
+        let lua = make_env_lua();
+        let value: Option<String> = lua
+            .load("return dbflux.env.get('DBFLUX_TEST_SAFE_VAR_12345')")
+            .eval()
+            .unwrap();
+        unsafe { std::env::remove_var("DBFLUX_TEST_SAFE_VAR_12345") };
+        assert_eq!(value.as_deref(), Some("visible"));
     }
 }

--- a/crates/dbflux_lua/src/engine.rs
+++ b/crates/dbflux_lua/src/engine.rs
@@ -207,7 +207,10 @@ mod tests {
     #[test]
     fn logging_and_env_api_are_available_when_enabled() {
         let context = test_context();
-        let capabilities = LuaCapabilities::default();
+        let capabilities = LuaCapabilities {
+            env_read: true,
+            ..LuaCapabilities::default()
+        };
         let vm = LuaEngine::create_vm(test_vm_config(
             &context,
             HookPhase::PreConnect,
@@ -231,6 +234,29 @@ mod tests {
         assert!(has_logging);
         assert!(has_env);
         assert!(path_value.is_some());
+    }
+
+    #[test]
+    fn env_api_is_hidden_by_default() {
+        let context = test_context();
+        let capabilities = LuaCapabilities::default();
+        let vm = LuaEngine::create_vm(test_vm_config(
+            &context,
+            HookPhase::PreConnect,
+            &capabilities,
+        ))
+        .unwrap();
+
+        let env_is_nil: bool = vm
+            .lua
+            .load("return dbflux == nil or dbflux.env == nil")
+            .eval()
+            .unwrap();
+
+        assert!(
+            env_is_nil,
+            "env_read defaults to false; dbflux.env must be nil"
+        );
     }
 
     #[test]

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -609,6 +609,8 @@ impl ConnectionManagerWindow {
 
             #[cfg(feature = "mcp")]
             {
+                use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
+
                 if let Some(governance) = state
                     .profiles()
                     .iter()
@@ -634,7 +636,13 @@ impl ConnectionManagerWindow {
                             assignments,
                         },
                     ) {
-                        log::error!("Failed to save MCP connection policy assignment: {}", e);
+                        report_error(
+                            UserFacingError::new(
+                                ErrorKind::Config,
+                                format!("Failed to save MCP connection policy assignment: {e}"),
+                            ),
+                            cx,
+                        );
                     }
                 } else if let Err(e) = state.save_mcp_connection_policy_assignment(
                     dbflux_mcp::ConnectionPolicyAssignmentDto {
@@ -642,7 +650,13 @@ impl ConnectionManagerWindow {
                         assignments: Vec::new(),
                     },
                 ) {
-                    log::error!("Failed to clear MCP connection policy assignment: {}", e);
+                    report_error(
+                        UserFacingError::new(
+                            ErrorKind::Config,
+                            format!("Failed to clear MCP connection policy assignment: {e}"),
+                        ),
+                        cx,
+                    );
                 }
 
                 cx.emit(dbflux_ui_base::McpRuntimeEventRaised {

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -628,23 +628,21 @@ impl ConnectionManagerWindow {
                         })
                         .collect();
 
-                    let _ = state.save_mcp_connection_policy_assignment(
+                    if let Err(e) = state.save_mcp_connection_policy_assignment(
                         dbflux_mcp::ConnectionPolicyAssignmentDto {
                             connection_id: saved_profile_id.to_string(),
                             assignments,
                         },
-                    );
-                } else {
-                    let _ = state.save_mcp_connection_policy_assignment(
-                        dbflux_mcp::ConnectionPolicyAssignmentDto {
-                            connection_id: saved_profile_id.to_string(),
-                            assignments: Vec::new(),
-                        },
-                    );
-                }
-
-                if let Err(e) = state.persist_mcp_governance() {
-                    log::error!("Failed to persist MCP governance: {}", e);
+                    ) {
+                        log::error!("Failed to save MCP connection policy assignment: {}", e);
+                    }
+                } else if let Err(e) = state.save_mcp_connection_policy_assignment(
+                    dbflux_mcp::ConnectionPolicyAssignmentDto {
+                        connection_id: saved_profile_id.to_string(),
+                        assignments: Vec::new(),
+                    },
+                ) {
+                    log::error!("Failed to clear MCP connection policy assignment: {}", e);
                 }
 
                 cx.emit(dbflux_ui_base::McpRuntimeEventRaised {


### PR DESCRIPTION
## What changed

Four residual hardening findings from the second security review, fixed as one commit per finding on this branch. Two are auth/secret vulnerabilities that block a stable release; two are silent-failure bugs in persistence and crash auditing.

| Finding | Type | Fix |
|---------|------|-----|
| **SEC2-1** fail-open driver-host auth | `fix(security)` | The Hello handler only checked the token inside an `if let Some(expected)` arm, so a host launched without `DRIVER_RPC_AUTH_TOKEN_ENV` accepted **any** client. Now fail-closed: the host refuses to start without a token, Hello is rejected when no expected token is configured, and the launcher injects the token explicitly instead of relying on implicit env inheritance. |
| **SEC2-2** Lua environment leak | `fix(security)` | `dbflux.env.get` wrapped `std::env::var` unfiltered and `env_read` defaulted to `true`, so any Lua hook could read the DBFlux IPC auth tokens (and pass them to spawned processes). Now `env_read` defaults to `false` (opt-in), the IPC token vars are blocklisted case-insensitively even when `env_read` is on, and they are stripped from Lua-spawned process env. |
| **CODE-1** discarded governance Result | `fix` | `save_mcp_connection_policy_assignment`'s `Result` was dropped with `let _`, hiding validation/persistence failures. Both call sites now handle the error, and the redundant trailing `persist_mcp_governance()` (the save already persists internally) is removed. |
| **CODE-2** panic-hook double-panic | `fix` | The panic hook used `.lock().unwrap()` on poisonable mutexes, so a panic holding either lock double-panicked and aborted, losing the audit record the hook exists to write. Now it accepts poisoned guards via `into_inner()`, uses allocation-free stderr for fallback diagnostics, and releases the audit lock before chaining the previous hook. |

## Review path

1. **SEC2-1** — `crates/dbflux_driver_host/src/main.rs` (startup guard + `is_hello_authorized` helper) and the explicit token injection in `crates/dbflux_driver_ipc/src/driver.rs`.
2. **SEC2-2** — `LuaCapabilities::default()` in `crates/dbflux_core/src/connection/hook.rs` and the blocklist + `env_remove` in `crates/dbflux_lua/src/api/dbflux.rs`. The blocklist strings are hardcoded with a doc comment mapping them to the `dbflux_ipc` consts because `dbflux_lua` intentionally does not depend on `dbflux_ipc`; values verified against `crates/dbflux_ipc/src/auth.rs`.
3. **CODE-1** — `crates/dbflux_ui_windows/src/connection_manager/form.rs`.
4. **CODE-2** — `crates/dbflux/src/main.rs` and the new `crates/dbflux/tests/panic_hook_resilience.rs`.

## Out of scope (deferred to v0.6.1)

SEC2-3/4/5 and LEG-4 — valid but lower-urgency findings that do not block a stable release.

## Notes for reviewers

- **CODE-1** surfaces the failure via `report_error` (toast + audit row + status-bar badge, `ErrorKind::Config`). `report_error` routes to the app-global toast/status-bar host rather than the connection-manager window, so it survives that window closing.
- **CODE-2** tests live in an integration file rather than inline in `main.rs`: compiling `main.rs` (which pulls in `gpui::*`) as a test binary blows past the macro recursion limit. The integration test validates the same poisoned-mutex tolerance pattern directly.

## Verification

- [x] `cargo nextest run` across touched crates (`dbflux_driver_host` 11/11, `dbflux_lua`/`dbflux_core`/`dbflux_driver_ipc` 1088/1088, `dbflux --test panic_hook_resilience` 2/2)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all` clean

New tests: fail-closed Hello auth (3), IPC-token blocklist incl. case-insensitive + allow-unrelated (4), env API hidden by default (1), poisoned-mutex resilience (2).
