### PR TITLE
feat(portability): export/import standalone profiles from Settings (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+* **Export / import standalone profiles from Settings (#214)** — SSH tunnels,
+  proxies, and auth profiles can now be exported and imported directly from
+  their Settings sections, building on the connection portability pipeline
+  (#213). Each profile editor gains an **Export** action in its footer
+  (keyboard-navigable alongside Save / Delete) that opens the same
+  passphrase-encrypted TOML bundle modal, scoped to that single profile; each
+  section's list header gains an **Import…** action (also reachable with `i`
+  when the profile list is focused) that opens the existing import wizard with
+  its conflict / required-reference resolution. AWS reflected auth profiles stay
+  reference-only and cannot be exported. Secret material travels only inside the
+  encrypted secrets section, passphrase encryption is on by default, and the
+  bundle format is unchanged.
+
 ### Fixed
 
 * **Chart auto-detection across four drivers (#204)** — Drivers now assign

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,22 @@ All notable changes to DBFlux will be documented in this file.
   (keyboard-navigable alongside Save / Delete) that opens the same
   passphrase-encrypted TOML bundle modal, scoped to that single profile; each
   section's list header gains an **Import…** action (also reachable with `i`
-  when the profile list is focused) that opens the existing import wizard with
-  its conflict / required-reference resolution. AWS reflected auth profiles stay
-  reference-only and cannot be exported. Secret material travels only inside the
-  encrypted secrets section, passphrase encryption is on by default, and the
-  bundle format is unchanged.
+  when the profile list is focused) that opens the import wizard with its
+  conflict / required-reference resolution. The import wizard now presents as a
+  modal dialog with the same chrome as the export modal — in Settings and in the
+  Connection Manager alike — so export and import look and behave consistently.
+  AWS reflected auth profiles stay reference-only and cannot be exported. Secret
+  material travels only inside the encrypted secrets section, passphrase
+  encryption is on by default, and the bundle format is unchanged.
 
 ### Fixed
+
+* **SSH tunnel / proxy list icon vanishing on long hosts** — The globe icon in
+  the Settings SSH tunnels and proxies lists could be squeezed to zero width by
+  long, unbreakable hostnames (e.g. EC2 `ec2-…compute.amazonaws.com` addresses),
+  so some rows appeared to have no icon. The icon container is now
+  `flex_shrink_0` and the text column `min_w_0`, so the icon always renders and
+  the subtitle truncates instead.
 
 * **Chart auto-detection across four drivers (#204)** — Drivers now assign
   `ColumnKind` honestly so the chart engine includes genuine numeric columns

--- a/crates/dbflux_app/src/portability.rs
+++ b/crates/dbflux_app/src/portability.rs
@@ -157,7 +157,9 @@ impl SecretReader for AppSecretReader {
 /// Input data needed to assemble an `ExportGraph`.
 ///
 /// The caller (UI layer) extracts this from `AppState` and passes it here so
-/// the assembly function has no dependency on GPUI types.
+/// the assembly function has no dependency on GPUI types. `Default` yields an
+/// empty graph, which a standalone-profile export fills with a single entry.
+#[derive(Default)]
 pub struct ExportInputs {
     /// Selected connection profiles with their driver-extracted form values.
     pub connections_with_values: Vec<(ConnectionProfile, FormValues)>,

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -294,7 +294,7 @@ pub struct Workspace {
     modal_add_panel: Entity<ModalAddPanelPicker>,
 
     /// In-app single-connection export modal (overlay, not an OS window).
-    export_modal: Entity<dbflux_ui_windows::connection_manager::ExportConnectionModal>,
+    export_modal: Entity<dbflux_ui_windows::connection_manager::ExportBundleModal>,
 
     tasks_state: PanelState,
     pending_command: Option<&'static str>,
@@ -381,7 +381,7 @@ impl Workspace {
         let modal_add_panel = cx.new(|cx| ModalAddPanelPicker::new(window, cx));
 
         let export_modal = cx.new(|cx| {
-            dbflux_ui_windows::connection_manager::ExportConnectionModal::new(
+            dbflux_ui_windows::connection_manager::ExportBundleModal::new(
                 app_state.clone(),
                 window,
                 cx,

--- a/crates/dbflux_ui_windows/src/connection_manager/export_modal.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/export_modal.rs
@@ -523,7 +523,10 @@ impl ExportBundleModal {
     }
 
     fn browse_output_path(&mut self, cx: &mut Context<Self>) {
-        let kind_label = self.target.map(ExportTarget::kind_label).unwrap_or("bundle");
+        let kind_label = self
+            .target
+            .map(ExportTarget::kind_label)
+            .unwrap_or("bundle");
 
         let file_name = if self.default_file_name.is_empty() {
             format!("{}.toml", kind_label.replace(' ', "-"))

--- a/crates/dbflux_ui_windows/src/connection_manager/export_modal.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/export_modal.rs
@@ -26,11 +26,37 @@ use gpui::*;
 use gpui_component::ActiveTheme;
 use uuid::Uuid;
 
-/// Event emitted by [`ExportConnectionModal`] so the workspace host can react
+/// Event emitted by [`ExportBundleModal`] so the workspace host can react
 /// to dismissal (closing the overlay clears the rendered child).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ExportConnectionModalEvent {
+pub enum ExportBundleModalEvent {
     Close,
+}
+
+/// What the modal exports: a full connection (plus its referenced profiles) or a
+/// single standalone profile from a Settings section.
+///
+/// The portability pipeline already supports a bundle with no connections, so a
+/// standalone profile travels as a one-entry bundle of the matching kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExportTarget {
+    Connection(Uuid),
+    AuthProfile(Uuid),
+    SshTunnel(Uuid),
+    Proxy(Uuid),
+}
+
+impl ExportTarget {
+    /// Human label for the exported entity kind, used in the modal title and the
+    /// summary block.
+    fn kind_label(self) -> &'static str {
+        match self {
+            ExportTarget::Connection(_) => "connection",
+            ExportTarget::AuthProfile(_) => "auth profile",
+            ExportTarget::SshTunnel(_) => "SSH tunnel",
+            ExportTarget::Proxy(_) => "proxy",
+        }
+    }
 }
 
 /// Auth-profile export-mode dropdown values (kept in sync with `auth_mode_from_id`).
@@ -50,13 +76,19 @@ struct AuthProfileRow {
 
 /// A short, read-only summary of everything that will travel in the bundle.
 ///
-/// Computed once in [`ExportConnectionModal::open`] so the body renders from
+/// Computed once in [`ExportBundleModal::open`] so the body renders from
 /// stable values instead of re-reading `AppState` on every frame.
 struct ExportSummary {
-    connection_name: String,
+    /// Name of the primary entity being exported (connection or standalone profile).
+    primary_name: String,
+    /// Auth profiles referenced by the connection, or the single auth profile when
+    /// the target is a standalone auth profile.
     auth_profiles: Vec<AuthProfileRow>,
     proxy_name: Option<String>,
     ssh_name: Option<String>,
+    /// For an SSH target: whether the tunnel authenticates with a password (vs a
+    /// private key). Drives which secret control the credentials section shows.
+    ssh_uses_password: bool,
 }
 
 /// Result of a completed export run, shown as a banner in the modal body.
@@ -70,17 +102,17 @@ enum ExportResult {
     Failed(String),
 }
 
-/// In-app, single-connection export modal.
+/// In-app export modal for a single portability target.
 ///
-/// Scoped to exactly one connection (plus its referenced auth / proxy / SSH
-/// profiles). Opened from a connection's three-dots menu via
-/// [`ExportConnectionModal::open`] and hosted as a workspace overlay — it never
-/// opens an OS window.
-pub struct ExportConnectionModal {
+/// Scoped to exactly one entity: a connection (plus its referenced auth / proxy /
+/// SSH profiles) when opened from a connection's three-dots menu, or a single
+/// standalone profile when opened from a Settings section. Hosted as an overlay —
+/// it never opens an OS window.
+pub struct ExportBundleModal {
     app_state: Entity<AppStateEntity>,
 
     visible: bool,
-    profile_id: Option<Uuid>,
+    target: Option<ExportTarget>,
     summary: Option<ExportSummary>,
 
     // Per-category include/exclude controls.
@@ -122,9 +154,9 @@ pub struct ExportConnectionModal {
     _subscriptions: Vec<Subscription>,
 }
 
-impl EventEmitter<ExportConnectionModalEvent> for ExportConnectionModal {}
+impl EventEmitter<ExportBundleModalEvent> for ExportBundleModal {}
 
-impl ExportConnectionModal {
+impl ExportBundleModal {
     pub fn new(
         app_state: Entity<AppStateEntity>,
         window: &mut Window,
@@ -171,7 +203,7 @@ impl ExportConnectionModal {
         Self {
             app_state,
             visible: false,
-            profile_id: None,
+            target: None,
             summary: None,
             include_connection_password: true,
             include_proxy_credentials: false,
@@ -202,17 +234,41 @@ impl ExportConnectionModal {
 
     /// Open the modal for a single connection profile.
     ///
-    /// Resets all run state to defaults, computes the read-only summary of the
-    /// connection and its referenced profiles, and seeds the per-auth-profile
-    /// export modes (AWS reflected profiles are locked to a reference).
+    /// Thin wrapper over [`Self::open_target`] kept for the connection entry
+    /// points (three-dots menu, command palette).
     pub fn open(&mut self, profile_id: Uuid, window: &mut Window, cx: &mut Context<Self>) {
-        self.profile_id = Some(profile_id);
-        self.summary = self.build_summary(profile_id, cx);
+        self.open_target(ExportTarget::Connection(profile_id), window, cx);
+    }
 
-        // Reset to ready-to-use defaults on every open.
-        self.include_connection_password = true;
-        self.include_proxy_credentials = false;
-        self.include_ssh_password = false;
+    /// Open the modal for any portability target.
+    ///
+    /// Resets all run state to defaults, computes the read-only summary of the
+    /// target (and, for a connection, its referenced profiles), and seeds the
+    /// per-secret defaults appropriate for the target kind. AWS reflected auth
+    /// profiles are locked to a reference.
+    pub fn open_target(
+        &mut self,
+        target: ExportTarget,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.target = Some(target);
+        self.summary = self.build_summary(target, cx);
+
+        let ssh_uses_password = self
+            .summary
+            .as_ref()
+            .map(|summary| summary.ssh_uses_password)
+            .unwrap_or(false);
+
+        // Reset to ready-to-use defaults on every open. For a standalone profile
+        // the profile's own secret is the subject of the export, so its primary
+        // secret defaults on (mirroring the connection-password default);
+        // embedding SSH keys stays consent-gated and off.
+        self.include_connection_password = matches!(target, ExportTarget::Connection(_));
+        self.include_proxy_credentials = matches!(target, ExportTarget::Proxy(_));
+        self.include_ssh_password =
+            matches!(target, ExportTarget::SshTunnel(_)) && ssh_uses_password;
         self.embed_ssh_keys = false;
         self.force_plaintext = false;
         self.show_passphrase = false;
@@ -221,8 +277,9 @@ impl ExportConnectionModal {
         self.pending_result = None;
         self.validation_error = None;
 
-        // The export is scoped to one connection, which references at most one
-        // auth profile. Seed the default mode (AWS reflected = locked reference).
+        // The connection references at most one auth profile; a standalone auth
+        // target is itself the single profile. Seed the default export mode (AWS
+        // reflected = locked reference; everything else = include values).
         self.auth_profile = self
             .summary
             .as_ref()
@@ -250,14 +307,14 @@ impl ExportConnectionModal {
         self.confirm_input
             .update(cx, |state, cx| state.set_value("", window, cx));
 
-        // Default file name = sanitized connection name; pre-fill the output
-        // path with it under the exports directory so Export works out of the
-        // box and the user can still edit or browse to another location.
+        // Default file name = sanitized entity name; pre-fill the output path with
+        // it under the exports directory so Export works out of the box and the
+        // user can still edit or browse to another location.
         let stem = self
             .summary
             .as_ref()
-            .map(|summary| sanitize_filename(&summary.connection_name))
-            .unwrap_or_else(|| "connection".to_string());
+            .map(|summary| sanitize_filename(&summary.primary_name))
+            .unwrap_or_else(|| target.kind_label().replace(' ', "-"));
         self.default_file_name = format!("{stem}.toml");
 
         let default_path = dbflux_ui_base::file_dialog::fallback_export_dir()
@@ -326,7 +383,7 @@ impl ExportConnectionModal {
 
     pub fn close(&mut self, cx: &mut Context<Self>) {
         self.visible = false;
-        self.profile_id = None;
+        self.target = None;
         self.summary = None;
         self.auth_profile = None;
         self.auth_dropdown = None;
@@ -334,9 +391,23 @@ impl ExportConnectionModal {
         cx.notify();
     }
 
-    /// Collect the connection and its referenced auth / proxy / SSH profile
-    /// names for the read-only summary block.
-    fn build_summary(&self, profile_id: Uuid, cx: &Context<Self>) -> Option<ExportSummary> {
+    /// Build the read-only summary block for the target.
+    fn build_summary(&self, target: ExportTarget, cx: &Context<Self>) -> Option<ExportSummary> {
+        match target {
+            ExportTarget::Connection(profile_id) => self.build_connection_summary(profile_id, cx),
+            ExportTarget::AuthProfile(auth_id) => self.build_auth_summary(auth_id, cx),
+            ExportTarget::SshTunnel(ssh_id) => self.build_ssh_summary(ssh_id, cx),
+            ExportTarget::Proxy(proxy_id) => self.build_proxy_summary(proxy_id, cx),
+        }
+    }
+
+    /// Collect the connection and its referenced auth / proxy / SSH profile names
+    /// for the read-only summary block.
+    fn build_connection_summary(
+        &self,
+        profile_id: Uuid,
+        cx: &Context<Self>,
+    ) -> Option<ExportSummary> {
         let state = self.app_state.read(cx);
 
         let profile = state
@@ -380,10 +451,62 @@ impl ExportConnectionModal {
         };
 
         Some(ExportSummary {
-            connection_name: profile.name.clone(),
+            primary_name: profile.name.clone(),
             auth_profiles,
             proxy_name,
             ssh_name,
+            ssh_uses_password: false,
+        })
+    }
+
+    /// Summary for a standalone auth profile. The profile itself is the single
+    /// entry in `auth_profiles` so the auth-mode control renders for it.
+    fn build_auth_summary(&self, auth_id: Uuid, cx: &Context<Self>) -> Option<ExportSummary> {
+        let state = self.app_state.read(cx);
+        let all_auth = state.list_auth_profiles();
+        let auth = all_auth.iter().find(|a| a.id == auth_id)?;
+
+        Some(ExportSummary {
+            primary_name: auth.name.clone(),
+            auth_profiles: vec![AuthProfileRow {
+                id: auth.id,
+                name: auth.name.clone(),
+                locked: auth.read_only,
+            }],
+            proxy_name: None,
+            ssh_name: None,
+            ssh_uses_password: false,
+        })
+    }
+
+    /// Summary for a standalone SSH tunnel profile.
+    fn build_ssh_summary(&self, ssh_id: Uuid, cx: &Context<Self>) -> Option<ExportSummary> {
+        let state = self.app_state.read(cx);
+        let ssh = state.ssh_tunnels().iter().find(|s| s.id == ssh_id)?.clone();
+
+        let ssh_uses_password =
+            matches!(ssh.config.auth_method, dbflux_core::SshAuthMethod::Password);
+
+        Some(ExportSummary {
+            primary_name: ssh.name.clone(),
+            auth_profiles: Vec::new(),
+            proxy_name: None,
+            ssh_name: Some(ssh.name.clone()),
+            ssh_uses_password,
+        })
+    }
+
+    /// Summary for a standalone proxy profile.
+    fn build_proxy_summary(&self, proxy_id: Uuid, cx: &Context<Self>) -> Option<ExportSummary> {
+        let state = self.app_state.read(cx);
+        let proxy = state.proxies().iter().find(|p| p.id == proxy_id)?.clone();
+
+        Some(ExportSummary {
+            primary_name: proxy.name.clone(),
+            auth_profiles: Vec::new(),
+            proxy_name: Some(proxy.name.clone()),
+            ssh_name: None,
+            ssh_uses_password: false,
         })
     }
 
@@ -400,17 +523,21 @@ impl ExportConnectionModal {
     }
 
     fn browse_output_path(&mut self, cx: &mut Context<Self>) {
+        let kind_label = self.target.map(ExportTarget::kind_label).unwrap_or("bundle");
+
         let file_name = if self.default_file_name.is_empty() {
-            "connection.toml".to_string()
+            format!("{}.toml", kind_label.replace(' ', "-"))
         } else {
             self.default_file_name.clone()
         };
+
+        let title = format!("Export {kind_label}");
 
         if dbflux_ui_base::file_dialog::is_native_file_dialog_available() {
             let this = cx.entity().clone();
             let task = cx.background_executor().spawn(async move {
                 rfd::FileDialog::new()
-                    .set_title("Export Connection")
+                    .set_title(title)
                     .add_filter("TOML bundle", &["toml"])
                     .add_filter("All files", &["*"])
                     .set_file_name(file_name)
@@ -445,10 +572,10 @@ impl ExportConnectionModal {
         }
     }
 
-    /// Validate inputs, assemble the export graph for the single connection, and
-    /// run the export on a background thread.
+    /// Validate inputs, assemble the export graph for the target, and run the
+    /// export on a background thread.
     fn do_export(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(profile_id) = self.profile_id else {
+        let Some(target) = self.target else {
             return;
         };
 
@@ -484,9 +611,10 @@ impl ExportConnectionModal {
 
         let output_path = PathBuf::from(&output_value);
 
-        let Some((inputs, drivers, secret_store)) = self.assemble_inputs(profile_id, cx) else {
-            self.validation_error =
-                Some("Connection driver is not registered; cannot export.".to_string());
+        let Some((inputs, drivers, secret_store)) = self.assemble_inputs(target, cx) else {
+            self.validation_error = Some(
+                "This profile can no longer be exported; it may have been removed.".to_string(),
+            );
             cx.notify();
             return;
         };
@@ -549,13 +677,17 @@ impl ExportConnectionModal {
                     this.is_exporting = false;
                     match &outcome {
                         ExportResult::Success { path, .. } => {
+                            let kind = this
+                                .target
+                                .map(ExportTarget::kind_label)
+                                .unwrap_or("bundle");
                             dbflux_ui_base::toast::Toast::success(format!(
-                                "Exported connection to {}",
+                                "Exported {kind} to {}",
                                 path.display()
                             ))
                             .push(cx);
                             this.close(cx);
-                            cx.emit(ExportConnectionModalEvent::Close);
+                            cx.emit(ExportBundleModalEvent::Close);
                         }
                         ExportResult::Failed(_) => {
                             this.pending_result = Some(outcome.clone());
@@ -577,15 +709,16 @@ impl ExportConnectionModal {
         .detach();
     }
 
-    /// Assemble the `ExportInputs` for one connection plus its references.
+    /// Assemble the `ExportInputs`, drivers, and secret store for the target.
     ///
-    /// Returns `None` when the connection's driver is not registered (export of
-    /// a connection with an unknown driver is rejected rather than producing an
-    /// empty-fields entry).
+    /// For a connection, returns `None` when its driver is not registered (export
+    /// of a connection with an unknown driver is rejected rather than producing an
+    /// empty-fields entry). For a standalone profile, returns `None` only when the
+    /// profile no longer exists.
     #[allow(clippy::type_complexity)]
     fn assemble_inputs(
         &self,
-        profile_id: Uuid,
+        target: ExportTarget,
         cx: &Context<Self>,
     ) -> Option<(
         ExportInputs,
@@ -594,6 +727,54 @@ impl ExportConnectionModal {
     )> {
         let state = self.app_state.read(cx);
 
+        let inputs = match target {
+            ExportTarget::Connection(profile_id) => {
+                self.assemble_connection_inputs(state, profile_id)?
+            }
+            ExportTarget::AuthProfile(auth_id) => {
+                let all_auth = state.list_auth_profiles();
+                let auth = all_auth.iter().find(|a| a.id == auth_id)?;
+
+                // AWS reflected profiles are read-only mirrors of ~/.aws and have
+                // no standalone payload; the Settings UI disables Export for them.
+                if auth.read_only {
+                    return None;
+                }
+
+                ExportInputs {
+                    auth_profiles: vec![auth.clone()],
+                    ..Default::default()
+                }
+            }
+            ExportTarget::SshTunnel(ssh_id) => {
+                let ssh = state.ssh_tunnels().iter().find(|s| s.id == ssh_id)?.clone();
+                ExportInputs {
+                    ssh_tunnels: vec![ssh],
+                    ..Default::default()
+                }
+            }
+            ExportTarget::Proxy(proxy_id) => {
+                let proxy = state.proxies().iter().find(|p| p.id == proxy_id)?.clone();
+                ExportInputs {
+                    proxies: vec![proxy],
+                    ..Default::default()
+                }
+            }
+        };
+
+        let drivers = state.drivers().clone();
+        let secret_store = state.facade.secrets.secret_store_arc();
+
+        Some((inputs, drivers, secret_store))
+    }
+
+    /// Assemble inputs for a connection plus its referenced auth / proxy / SSH
+    /// profiles. Returns `None` when the connection or its driver is missing.
+    fn assemble_connection_inputs(
+        &self,
+        state: &AppStateEntity,
+        profile_id: Uuid,
+    ) -> Option<ExportInputs> {
         let profile = state
             .profiles()
             .iter()
@@ -642,18 +823,13 @@ impl ExportConnectionModal {
             _ => {}
         }
 
-        let inputs = ExportInputs {
+        Some(ExportInputs {
             connections_with_values: vec![(profile, values)],
             auth_profiles,
             aws_references,
             ssh_tunnels,
             proxies,
-        };
-
-        let drivers = state.drivers().clone();
-        let secret_store = state.facade.secrets.secret_store_arc();
-
-        Some((inputs, drivers, secret_store))
+        })
     }
 }
 
@@ -719,7 +895,7 @@ fn auth_mode_items() -> Vec<DropdownItem> {
     ]
 }
 
-impl Render for ExportConnectionModal {
+impl Render for ExportBundleModal {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         if !self.visible {
             return div().into_any_element();
@@ -750,7 +926,7 @@ impl Render for ExportConnectionModal {
             .on_key_down(cx.listener(|this, ev: &KeyDownEvent, _w, cx| {
                 if ev.keystroke.key == "escape" {
                     this.close(cx);
-                    cx.emit(ExportConnectionModalEvent::Close);
+                    cx.emit(ExportBundleModalEvent::Close);
                 }
             }))
             .flex()
@@ -770,7 +946,7 @@ impl Render for ExportConnectionModal {
 
         let on_cancel = cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
             this.close(cx);
-            cx.emit(ExportConnectionModalEvent::Close);
+            cx.emit(ExportBundleModalEvent::Close);
         });
 
         let export_label = if is_exporting {
@@ -800,23 +976,24 @@ impl Render for ExportConnectionModal {
 
         let close_for_x = cx.entity().clone();
 
-        ModalShell::new(
-            "Export connection",
-            body.into_any_element(),
-            footer.into_any_element(),
-        )
-        .width(px(640.0))
-        .on_close(move |_window, cx| {
-            close_for_x.update(cx, |this, cx| {
-                this.close(cx);
-                cx.emit(ExportConnectionModalEvent::Close);
-            });
-        })
-        .into_any_element()
+        let title = match self.target {
+            Some(target) => format!("Export {}", target.kind_label()),
+            None => "Export".to_string(),
+        };
+
+        ModalShell::new(title, body.into_any_element(), footer.into_any_element())
+            .width(px(640.0))
+            .on_close(move |_window, cx| {
+                close_for_x.update(cx, |this, cx| {
+                    this.close(cx);
+                    cx.emit(ExportBundleModalEvent::Close);
+                });
+            })
+            .into_any_element()
     }
 }
 
-impl ExportConnectionModal {
+impl ExportBundleModal {
     fn render_summary(&self, cx: &Context<Self>) -> AnyElement {
         let theme = cx.theme().clone();
 
@@ -824,16 +1001,22 @@ impl ExportConnectionModal {
             return div().into_any_element();
         };
 
+        // Referenced-profile lines only make sense for a connection; a standalone
+        // profile is fully named by the primary block above.
+        let is_connection = matches!(self.target, Some(ExportTarget::Connection(_)));
+
         let mut lines: Vec<String> = Vec::new();
-        for auth in &summary.auth_profiles {
-            let suffix = if auth.locked { " (reference)" } else { "" };
-            lines.push(format!("Auth profile: {}{}", auth.name, suffix));
-        }
-        if let Some(proxy) = &summary.proxy_name {
-            lines.push(format!("Proxy: {proxy}"));
-        }
-        if let Some(ssh) = &summary.ssh_name {
-            lines.push(format!("SSH tunnel: {ssh}"));
+        if is_connection {
+            for auth in &summary.auth_profiles {
+                let suffix = if auth.locked { " (reference)" } else { "" };
+                lines.push(format!("Auth profile: {}{}", auth.name, suffix));
+            }
+            if let Some(proxy) = &summary.proxy_name {
+                lines.push(format!("Proxy: {proxy}"));
+            }
+            if let Some(ssh) = &summary.ssh_name {
+                lines.push(format!("SSH tunnel: {ssh}"));
+            }
         }
 
         let mut block = surface_raised(cx)
@@ -848,7 +1031,7 @@ impl ExportConnectionModal {
                     .text_size(FontSizes::SM)
                     .font_family(AppFonts::MONO)
                     .text_color(theme.foreground)
-                    .child(summary.connection_name.clone()),
+                    .child(summary.primary_name.clone()),
             );
 
         for line in lines {
@@ -860,36 +1043,68 @@ impl ExportConnectionModal {
             );
         }
 
+        let intro = if is_connection {
+            "This connection and its profiles will be exported."
+        } else {
+            "This profile will be exported."
+        };
+
         div()
             .flex()
             .flex_col()
             .gap(Spacing::XS)
-            .child(
-                Text::body("This connection and its profiles will be exported.")
-                    .color(theme.muted_foreground),
-            )
+            .child(Text::body(intro).color(theme.muted_foreground))
             .child(block)
             .into_any_element()
     }
 
     fn render_credentials_section(&self, cx: &Context<Self>) -> AnyElement {
         let theme = cx.theme().clone();
-        let summary = self.summary.as_ref();
-        let has_proxy = summary.map(|s| s.proxy_name.is_some()).unwrap_or(false);
-        let has_ssh = summary.map(|s| s.ssh_name.is_some()).unwrap_or(false);
 
+        // An auth profile carries no credential checkboxes; its secret material is
+        // governed by the export-mode control rendered below.
+        if matches!(self.target, Some(ExportTarget::AuthProfile(_))) {
+            return div().into_any_element();
+        }
+
+        let summary = self.summary.as_ref();
         let conn_pw = self.include_connection_password;
         let proxy_creds = self.include_proxy_credentials;
         let ssh_pw = self.include_ssh_password;
         let embed_keys = self.embed_ssh_keys;
         let force_plaintext = self.force_plaintext;
 
+        // Which controls apply depends on the target. A connection shows its
+        // password plus controls for any referenced proxy / SSH profile; a
+        // standalone profile shows only its own secret control.
+        let show_conn_pw = matches!(self.target, Some(ExportTarget::Connection(_)));
+        let show_proxy = match self.target {
+            Some(ExportTarget::Connection(_)) => {
+                summary.map(|s| s.proxy_name.is_some()).unwrap_or(false)
+            }
+            Some(ExportTarget::Proxy(_)) => true,
+            _ => false,
+        };
+        let (show_ssh_pw, show_embed) = match self.target {
+            Some(ExportTarget::Connection(_)) => {
+                let has_ssh = summary.map(|s| s.ssh_name.is_some()).unwrap_or(false);
+                (has_ssh, has_ssh)
+            }
+            Some(ExportTarget::SshTunnel(_)) => {
+                let uses_password = summary.map(|s| s.ssh_uses_password).unwrap_or(false);
+                (uses_password, !uses_password)
+            }
+            _ => (false, false),
+        };
+
         let mut col = div()
             .flex()
             .flex_col()
             .gap(Spacing::SM)
-            .child(Text::body("Credentials").color(theme.muted_foreground))
-            .child(
+            .child(Text::body("Credentials").color(theme.muted_foreground));
+
+        if show_conn_pw {
+            col = col.child(
                 Checkbox::new("export-conn-pw")
                     .checked(conn_pw)
                     .label("Include connection password")
@@ -898,8 +1113,9 @@ impl ExportConnectionModal {
                         cx.notify();
                     })),
             );
+        }
 
-        if has_proxy {
+        if show_proxy {
             col = col.child(
                 Checkbox::new("export-proxy-creds")
                     .checked(proxy_creds)
@@ -911,7 +1127,7 @@ impl ExportConnectionModal {
             );
         }
 
-        if has_ssh {
+        if show_ssh_pw {
             col = col.child(
                 Checkbox::new("export-ssh-pw")
                     .checked(ssh_pw)
@@ -921,7 +1137,9 @@ impl ExportConnectionModal {
                         cx.notify();
                     })),
             );
+        }
 
+        if show_embed {
             col = col.child(
                 Checkbox::new("export-embed-ssh-keys")
                     .checked(embed_keys && !force_plaintext)

--- a/crates/dbflux_ui_windows/src/connection_manager/import_panel.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/import_panel.rs
@@ -697,7 +697,7 @@ impl ImportConnectionsPanel {
             .py(Spacing::MD)
             .border_b_1()
             .border_color(theme.border)
-            .child(Text::heading("Import Connections").font_size(FontSizes::LG))
+            .child(Text::heading("Import").font_size(FontSizes::LG))
             .child(Text::muted("Load a TOML bundle exported from DBFlux.").font_size(FontSizes::SM))
             .into_any_element()
     }

--- a/crates/dbflux_ui_windows/src/connection_manager/import_panel.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/import_panel.rs
@@ -6,6 +6,7 @@ use dbflux_app::portability::{
 };
 use dbflux_components::controls::{Button, Checkbox, Input, InputEvent, InputState};
 use dbflux_components::icons::AppIcon;
+use dbflux_components::modals::shell::ModalShell;
 use dbflux_components::primitives::{
     BannerBlock, BannerVariant, IconButton, SegmentedControl, SegmentedItem, Text, surface_raised,
 };
@@ -652,9 +653,7 @@ impl Render for ImportConnectionsPanel {
             state.set_masked(!show_passphrase, window, cx);
         });
 
-        let theme = cx.theme().clone();
-
-        let body: AnyElement = match self.step {
+        let body_content: AnyElement = match self.step {
             Step::SelectFile => self.render_select_file(cx),
             Step::Preview => self.render_preview(cx),
             Step::Conflicts => self.render_conflicts(cx),
@@ -662,46 +661,28 @@ impl Render for ImportConnectionsPanel {
             Step::Outcome => self.render_outcome(cx),
         };
 
-        div()
+        let body = div()
             .track_focus(&self.focus_handle)
             .flex()
             .flex_col()
-            .size_full()
-            .bg(theme.background)
-            .child(self.render_header(cx))
-            .child(
-                div()
-                    .id("import-panel-body")
-                    .flex_1()
-                    .flex()
-                    .flex_col()
-                    .gap(Spacing::MD)
-                    .px(Spacing::LG)
-                    .py(Spacing::MD)
-                    .overflow_scroll()
-                    .child(body),
-            )
-            .child(self.render_footer(cx))
+            .gap(Spacing::MD)
+            .child(body_content)
+            .into_any_element();
+
+        let close_for_x = cx.entity().clone();
+
+        ModalShell::new("Import", body, self.render_footer(cx))
+            .width(px(640.0))
+            .on_close(move |_window, cx| {
+                close_for_x.update(cx, |_this, cx| {
+                    cx.emit(ImportConnectionsPanelEvent::Cancelled);
+                });
+            })
+            .into_any_element()
     }
 }
 
 impl ImportConnectionsPanel {
-    fn render_header(&self, cx: &Context<Self>) -> AnyElement {
-        let theme = cx.theme().clone();
-
-        div()
-            .flex()
-            .items_center()
-            .justify_between()
-            .px(Spacing::LG)
-            .py(Spacing::MD)
-            .border_b_1()
-            .border_color(theme.border)
-            .child(Text::heading("Import").font_size(FontSizes::LG))
-            .child(Text::muted("Load a TOML bundle exported from DBFlux.").font_size(FontSizes::SM))
-            .into_any_element()
-    }
-
     fn render_select_file(&self, cx: &Context<Self>) -> AnyElement {
         let theme = cx.theme().clone();
         let entity = cx.entity().clone();
@@ -1229,8 +1210,6 @@ impl ImportConnectionsPanel {
     }
 
     fn render_footer(&self, cx: &Context<Self>) -> AnyElement {
-        let theme = cx.theme().clone();
-
         let left = match self.step {
             Step::SelectFile => {
                 Button::new("import-cancel", "Cancel")
@@ -1274,12 +1253,9 @@ impl ImportConnectionsPanel {
 
         div()
             .flex()
+            .w_full()
             .items_center()
             .justify_between()
-            .px(Spacing::LG)
-            .py(Spacing::MD)
-            .border_t_1()
-            .border_color(theme.border)
             .child(left)
             .when_some(primary, |el, btn| el.child(btn))
             .into_any_element()

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -8,7 +8,7 @@ mod render;
 mod render_driver_select;
 mod render_tabs;
 
-pub use export_modal::{ExportConnectionModal, ExportConnectionModalEvent};
+pub use export_modal::{ExportBundleModal, ExportBundleModalEvent, ExportTarget};
 pub use import_panel::{ImportConnectionsPanel, ImportConnectionsPanelEvent};
 
 use crate::ssh_shared::SshAuthSelection;

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -1224,7 +1224,12 @@ impl Render for ConnectionManagerWindow {
             .child(match self.view {
                 View::DriverSelect => self.render_driver_select(window, cx).into_any_element(),
                 View::EditForm => self.render_form(window, cx).into_any_element(),
-                View::Import => self.import_panel.clone().into_any_element(),
+                View::Import => div()
+                    .relative()
+                    .size_full()
+                    .child(self.render_driver_select(window, cx))
+                    .child(self.import_panel.clone())
+                    .into_any_element(),
             })
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -2,7 +2,8 @@ use super::SettingsSection;
 use super::SettingsSectionId;
 use super::form_section::{FormSection, create_blur_subscription};
 use super::layout;
-use super::section_trait::SectionFocusEvent;
+use super::section_trait::{SectionFocusEvent, SectionPortabilityEvent};
+use crate::connection_manager::ExportTarget;
 use dbflux_app::keymap::Modifiers;
 use dbflux_components::controls::InputState;
 use dbflux_components::controls::{Button, Checkbox, Input};
@@ -133,6 +134,7 @@ pub(super) enum AuthFormField {
     DynamicField(usize),
     ProviderLogin,
     Enabled,
+    ExportButton,
     DeleteButton,
     SaveButton,
 }
@@ -152,6 +154,7 @@ pub(super) enum AuthProfilesSectionEvent {
 
 impl EventEmitter<AuthProfilesSectionEvent> for AuthProfilesSection {}
 impl EventEmitter<SectionFocusEvent> for AuthProfilesSection {}
+impl EventEmitter<SectionPortabilityEvent> for AuthProfilesSection {}
 
 fn build_form_rows(
     has_providers: bool,
@@ -182,7 +185,11 @@ fn build_form_rows(
     }
 
     if is_editing && !is_reflected {
-        rows.push(vec![AuthFormField::DeleteButton, AuthFormField::SaveButton]);
+        rows.push(vec![
+            AuthFormField::ExportButton,
+            AuthFormField::DeleteButton,
+            AuthFormField::SaveButton,
+        ]);
     } else {
         rows.push(vec![AuthFormField::SaveButton]);
     }
@@ -449,6 +456,25 @@ impl AuthProfilesSection {
         }
 
         section
+    }
+
+    /// Ask the coordinator to export the auth profile currently loaded in the form.
+    ///
+    /// Only emits for a stored, non-reflected, non-read-only profile being edited.
+    pub(super) fn request_export(&mut self, cx: &mut Context<Self>) {
+        if !self.profile_is_read_only
+            && self.edit_snapshot.is_none()
+            && let Some(id) = self.editing_profile_id
+        {
+            cx.emit(SectionPortabilityEvent::OpenExport(
+                ExportTarget::AuthProfile(id),
+            ));
+        }
+    }
+
+    /// Ask the coordinator to open the import wizard.
+    pub(super) fn request_import(&mut self, cx: &mut Context<Self>) {
+        cx.emit(SectionPortabilityEvent::OpenImport);
     }
 
     fn provider_entries(&self, cx: &App) -> Vec<(String, String)> {
@@ -1149,6 +1175,9 @@ impl AuthProfilesSection {
                 }
                 ("d", modifiers) if modifiers == Modifiers::none() => {
                     self.request_delete_selected_profile(cx);
+                }
+                ("i", modifiers) if modifiers == Modifiers::none() => {
+                    self.request_import(cx);
                 }
                 ("l", modifiers) | ("right", modifiers) | ("enter", modifiers)
                     if modifiers == Modifiers::none() =>
@@ -2120,6 +2149,16 @@ impl AuthProfilesSection {
                                 this.auth_focus = AuthFocus::Form;
                                 this.begin_create_profile(window, cx);
                             })),
+                    )
+                    .child(
+                        Button::new("import-auth-profile", "Import\u{2026}")
+                            .icon(Icon::new(AppIcon::Download))
+                            .small()
+                            .ghost()
+                            .w_full()
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.request_import(cx);
+                            })),
                     ),
             )
             .child(
@@ -2614,6 +2653,17 @@ impl AuthProfilesSection {
             .gap_3()
             .when(is_editing && !is_reflected, |root| {
                 root.child(layout::footer_action_frame(
+                    is_form_focused && self.auth_form_field == AuthFormField::ExportButton,
+                    primary,
+                    Button::new("export-auth-profile", "Export")
+                        .small()
+                        .ghost()
+                        .w_full()
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.request_export(cx);
+                        })),
+                ))
+                .child(layout::footer_action_frame(
                     is_form_focused && self.auth_form_field == AuthFormField::DeleteButton,
                     primary,
                     Button::new("delete-auth-profile", "Delete")
@@ -2770,6 +2820,9 @@ impl FormSection for AuthProfilesSection {
             }
             AuthFormField::ProviderLogin => {
                 self.login_selected_profile(cx);
+            }
+            AuthFormField::ExportButton => {
+                self.request_export(cx);
             }
             AuthFormField::SaveButton => {
                 self.save_profile(window, cx);
@@ -3359,6 +3412,35 @@ mod tests {
             rows.iter()
                 .any(|row| row.contains(&AuthFormField::SaveButton)),
             "reflected profiles must still expose a Save button"
+        );
+    }
+
+    /// Reflected (AWS) profiles are read-only mirrors and must NOT expose an
+    /// Export button; a stored editable profile must.
+    #[::core::prelude::v1::test]
+    fn export_button_only_for_stored_editable_profile() {
+        let reflected = build_form_rows(true, 2, false, true, /* is_reflected */ true);
+        assert!(
+            !reflected
+                .iter()
+                .any(|row| row.contains(&AuthFormField::ExportButton)),
+            "reflected profiles must not expose an Export button"
+        );
+
+        let stored = build_form_rows(true, 2, false, /* is_editing */ true, false);
+        assert!(
+            stored
+                .iter()
+                .any(|row| row.contains(&AuthFormField::ExportButton)),
+            "stored editable profiles must expose an Export button"
+        );
+
+        let creating = build_form_rows(true, 2, false, /* is_editing */ false, false);
+        assert!(
+            !creating
+                .iter()
+                .any(|row| row.contains(&AuthFormField::ExportButton)),
+            "a not-yet-saved profile must not expose an Export button"
         );
     }
 

--- a/crates/dbflux_ui_windows/src/settings/lifecycle.rs
+++ b/crates/dbflux_ui_windows/src/settings/lifecycle.rs
@@ -5,7 +5,7 @@ use dbflux_components::components::tree_nav::TreeNavAction;
 use dbflux_ui_base::keymap::key_chord_from_gpui;
 #[cfg(feature = "mcp")]
 use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
-use section_trait::SectionFocusEvent;
+use section_trait::{SectionFocusEvent, SectionPortabilityEvent};
 
 impl SettingsCoordinator {
     pub fn new(
@@ -33,6 +33,19 @@ impl SettingsCoordinator {
             Self::new_section_entity(active_section, app_state.clone(), window, cx);
         let active_section_view = active_section_entity.as_view();
 
+        let export_modal = cx.new(|cx| ExportBundleModal::new(app_state.clone(), window, cx));
+        let import_panel = cx.new(|cx| ImportConnectionsPanel::new(app_state.clone(), window, cx));
+
+        let import_sub = cx.subscribe(
+            &import_panel,
+            |this, _, event: &ImportConnectionsPanelEvent, cx| match event {
+                ImportConnectionsPanelEvent::Cancelled | ImportConnectionsPanelEvent::Completed => {
+                    this.import_visible = false;
+                    cx.notify();
+                }
+            },
+        );
+
         Self {
             app_state,
             sidebar_tree,
@@ -47,8 +60,33 @@ impl SettingsCoordinator {
             sidebar_is_resizing: false,
             sidebar_resize_start_x: None,
             sidebar_resize_start_width: None,
+            export_modal,
+            import_panel,
+            import_visible: false,
+            pending_export_target: None,
+            pending_import_open: false,
             _subscriptions: section_subscription,
+            _portability_subscriptions: vec![import_sub],
         }
+    }
+
+    /// Subscribe to a profile section's portability events, deferring the actual
+    /// overlay open to `render` (where a `Window` is in scope).
+    fn subscribe_portability<S>(section: &Entity<S>, cx: &mut Context<Self>) -> Subscription
+    where
+        S: EventEmitter<SectionPortabilityEvent> + 'static,
+    {
+        cx.subscribe(section, |this, _, event: &SectionPortabilityEvent, cx| {
+            match event {
+                SectionPortabilityEvent::OpenExport(target) => {
+                    this.pending_export_target = Some(*target);
+                }
+                SectionPortabilityEvent::OpenImport => {
+                    this.pending_import_open = true;
+                }
+            }
+            cx.notify();
+        })
     }
 
     fn new_section_entity(
@@ -129,7 +167,11 @@ impl SettingsCoordinator {
                         cx.notify();
                     }
                 });
-                (ActiveSettingsSection::Proxies(section), vec![focus_sub])
+                let portability_sub = Self::subscribe_portability(&section, cx);
+                (
+                    ActiveSettingsSection::Proxies(section),
+                    vec![focus_sub, portability_sub],
+                )
             }
             SettingsSectionId::AuthProfiles => {
                 let section = cx.new(|cx| AuthProfilesSection::new(app_state, window, cx));
@@ -161,9 +203,10 @@ impl SettingsCoordinator {
                         }
                     });
 
+                let portability_sub = Self::subscribe_portability(&section, cx);
                 (
                     ActiveSettingsSection::AuthProfiles(section),
-                    vec![focus_sub, login_sub],
+                    vec![focus_sub, login_sub, portability_sub],
                 )
             }
             SettingsSectionId::SshTunnels => {
@@ -174,7 +217,11 @@ impl SettingsCoordinator {
                         cx.notify();
                     }
                 });
-                (ActiveSettingsSection::SshTunnels(section), vec![focus_sub])
+                let portability_sub = Self::subscribe_portability(&section, cx);
+                (
+                    ActiveSettingsSection::SshTunnels(section),
+                    vec![focus_sub, portability_sub],
+                )
             }
             SettingsSectionId::Services => {
                 let section = cx.new(|cx| ServicesSection::new(app_state, window, cx));

--- a/crates/dbflux_ui_windows/src/settings/mod.rs
+++ b/crates/dbflux_ui_windows/src/settings/mod.rs
@@ -28,6 +28,9 @@ mod sidebar_nav;
 mod ssh_tunnels;
 mod ssh_tunnels_section;
 
+use crate::connection_manager::{
+    ExportBundleModal, ExportTarget, ImportConnectionsPanel, ImportConnectionsPanelEvent,
+};
 use about_section::AboutSection;
 use audit_section::AuditSection;
 use auth_profiles_section::AuthProfilesSection;
@@ -322,7 +325,17 @@ pub struct SettingsCoordinator {
     sidebar_is_resizing: bool,
     sidebar_resize_start_x: Option<Pixels>,
     sidebar_resize_start_width: Option<Pixels>,
+    /// Shared export modal and import wizard overlays for standalone profile
+    /// portability, opened from the SSH / proxy / auth profile sections.
+    export_modal: Entity<ExportBundleModal>,
+    import_panel: Entity<ImportConnectionsPanel>,
+    import_visible: bool,
+    /// Deferred opens drained in `render`, where a `Window` is available (the
+    /// section-event subscriptions that set them have no window in scope).
+    pending_export_target: Option<ExportTarget>,
+    pending_import_open: bool,
     _subscriptions: Vec<Subscription>,
+    _portability_subscriptions: Vec<Subscription>,
 }
 
 pub type SettingsWindow = SettingsCoordinator;

--- a/crates/dbflux_ui_windows/src/settings/proxies.rs
+++ b/crates/dbflux_ui_windows/src/settings/proxies.rs
@@ -68,6 +68,7 @@ impl ProxyFormNav {
 
         if self.editing_id.is_some() {
             rows.push(vec![
+                ProxyFormField::ExportButton,
                 ProxyFormField::DeleteButton,
                 ProxyFormField::SaveButton,
             ]);
@@ -479,6 +480,9 @@ impl ProxiesSection {
                         }
                     }
                 }
+                ("i", modifiers) if modifiers == Modifiers::none() => {
+                    self.request_import(cx);
+                }
                 ("g", modifiers) if modifiers == Modifiers::none() => {
                     self.proxy_selected_idx = None;
                     self.proxy_load_selected_profile(window, cx);
@@ -753,6 +757,9 @@ impl ProxiesSection {
             ProxyFormField::SaveButton => {
                 self.save_proxy(window, cx);
             }
+            ProxyFormField::ExportButton => {
+                self.request_export(cx);
+            }
             ProxyFormField::DeleteButton => {
                 if let Some(proxy_id) = self.editing_proxy_id {
                     self.request_delete_proxy(proxy_id, cx);
@@ -827,6 +834,22 @@ mod tests {
         let all_fields: Vec<_> = rows.iter().flatten().collect();
         assert!(all_fields.contains(&&ProxyFormField::DeleteButton));
         assert!(all_fields.contains(&&ProxyFormField::SaveButton));
+    }
+
+    #[test]
+    fn form_rows_editing_has_export_button() {
+        let nav = nav_basic_auth_editing();
+        let rows = nav.form_rows();
+        let all_fields: Vec<_> = rows.iter().flatten().collect();
+        assert!(all_fields.contains(&&ProxyFormField::ExportButton));
+    }
+
+    #[test]
+    fn form_rows_new_proxy_no_export_button() {
+        let nav = nav_no_auth_new();
+        let rows = nav.form_rows();
+        let all_fields: Vec<_> = rows.iter().flatten().collect();
+        assert!(!all_fields.contains(&&ProxyFormField::ExportButton));
     }
 
     #[test]

--- a/crates/dbflux_ui_windows/src/settings/proxies_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/proxies_section.rs
@@ -631,6 +631,7 @@ impl ProxiesSection {
                                     .child(
                                         div()
                                             .flex()
+                                            .flex_shrink_0()
                                             .items_center()
                                             .gap_1()
                                             .mt(px(2.0))
@@ -647,6 +648,7 @@ impl ProxiesSection {
                                         div()
                                             .flex()
                                             .flex_col()
+                                            .min_w_0()
                                             .gap_1()
                                             .child(Body::new(proxy.name.clone()))
                                             .child(MonoMeta::new(subtitle)),

--- a/crates/dbflux_ui_windows/src/settings/proxies_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/proxies_section.rs
@@ -3,7 +3,8 @@ use super::SettingsSectionId;
 use super::form_section::FormSection;
 use super::layout;
 use super::proxies::ProxyFormNav;
-use super::section_trait::SectionFocusEvent;
+use super::section_trait::{SectionFocusEvent, SectionPortabilityEvent};
+use crate::connection_manager::ExportTarget;
 use dbflux_components::controls::Button;
 use dbflux_components::controls::{GpuiInput as Input, InputEvent, InputState};
 use dbflux_components::icons::AppIcon;
@@ -47,6 +48,7 @@ pub(super) enum ProxyFormField {
     NoProxy,
     Enabled,
     SaveSecret,
+    ExportButton,
     SaveButton,
     DeleteButton,
 }
@@ -84,8 +86,21 @@ pub(super) struct ProxiesSection {
 }
 
 impl EventEmitter<SectionFocusEvent> for ProxiesSection {}
+impl EventEmitter<SectionPortabilityEvent> for ProxiesSection {}
 
 impl ProxiesSection {
+    /// Ask the coordinator to export the proxy currently loaded in the form.
+    pub(super) fn request_export(&mut self, cx: &mut Context<Self>) {
+        if let Some(id) = self.editing_proxy_id {
+            cx.emit(SectionPortabilityEvent::OpenExport(ExportTarget::Proxy(id)));
+        }
+    }
+
+    /// Ask the coordinator to open the import wizard.
+    pub(super) fn request_import(&mut self, cx: &mut Context<Self>) {
+        cx.emit(SectionPortabilityEvent::OpenImport);
+    }
+
     pub(super) fn new(
         app_state: Entity<AppStateEntity>,
         window: &mut Window,
@@ -518,29 +533,46 @@ impl ProxiesSection {
             .flex()
             .flex_col()
             .child(
-                div().p_2().border_b_1().border_color(theme.border).child(
-                    div()
-                        .rounded(Radii::SM)
-                        .border_1()
-                        .border_color(if is_new_button_focused {
-                            theme.primary
-                        } else {
-                            transparent_black()
-                        })
-                        .child(
-                            Button::new("new-proxy", "New Proxy")
-                                .icon(Icon::new(AppIcon::Plus))
-                                .small()
-                                .w_full()
-                                .on_click(cx.listener(|this, _, window, cx| {
-                                    this.request_proxy_action(
-                                        PendingProxyAction::ClearForm,
-                                        window,
-                                        cx,
-                                    );
-                                })),
-                        ),
-                ),
+                div()
+                    .p_2()
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .flex()
+                    .flex_col()
+                    .gap_2()
+                    .child(
+                        div()
+                            .rounded(Radii::SM)
+                            .border_1()
+                            .border_color(if is_new_button_focused {
+                                theme.primary
+                            } else {
+                                transparent_black()
+                            })
+                            .child(
+                                Button::new("new-proxy", "New Proxy")
+                                    .icon(Icon::new(AppIcon::Plus))
+                                    .small()
+                                    .w_full()
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.request_proxy_action(
+                                            PendingProxyAction::ClearForm,
+                                            window,
+                                            cx,
+                                        );
+                                    })),
+                            ),
+                    )
+                    .child(
+                        Button::new("import-proxy", "Import\u{2026}")
+                            .icon(Icon::new(AppIcon::Download))
+                            .small()
+                            .ghost()
+                            .w_full()
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.request_import(cx);
+                            })),
+                    ),
             )
             .child(
                 div()
@@ -751,6 +783,17 @@ impl ProxiesSection {
                 let proxy_id = editing_id.expect("checked is_some");
 
                 root.child(layout::footer_action_frame(
+                    is_form_focused && field == ProxyFormField::ExportButton,
+                    primary,
+                    Button::new("export-proxy", "Export")
+                        .small()
+                        .ghost()
+                        .w_full()
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.request_export(cx);
+                        })),
+                ))
+                .child(layout::footer_action_frame(
                     is_form_focused && field == ProxyFormField::DeleteButton,
                     primary,
                     Button::new("delete-proxy", "Delete")

--- a/crates/dbflux_ui_windows/src/settings/render.rs
+++ b/crates/dbflux_ui_windows/src/settings/render.rs
@@ -222,12 +222,29 @@ impl Render for SettingsCoordinator {
             self.focus_handle.focus(_window);
         }
 
+        // A section asked to open a portability overlay; do it here where a
+        // `Window` is available (the section-event subscription had none).
+        if let Some(target) = self.pending_export_target.take() {
+            self.import_visible = false;
+            self.export_modal.update(cx, |modal, cx| {
+                modal.open_target(target, _window, cx);
+            });
+        }
+        if std::mem::take(&mut self.pending_import_open) {
+            self.export_modal.update(cx, |modal, cx| modal.close(cx));
+            self.import_visible = true;
+            self.import_panel.update(cx, |panel, cx| {
+                panel.reset(_window, cx);
+            });
+        }
+
         let _ = self.app_state.read(cx);
 
         let csd_title_bar = platform::render_csd_title_bar(_window, cx, "Settings");
 
         div()
             .size_full()
+            .relative()
             .bg(cx.theme().background)
             .flex()
             .flex_col()
@@ -284,6 +301,12 @@ impl Render for SettingsCoordinator {
                             section_name
                         ))),
                 )
+            })
+            .when(self.export_modal.read(cx).is_visible(), |root| {
+                root.child(self.export_modal.clone())
+            })
+            .when(self.import_visible, |root| {
+                root.child(div().absolute().inset_0().child(self.import_panel.clone()))
             })
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/render.rs
+++ b/crates/dbflux_ui_windows/src/settings/render.rs
@@ -306,7 +306,7 @@ impl Render for SettingsCoordinator {
                 root.child(self.export_modal.clone())
             })
             .when(self.import_visible, |root| {
-                root.child(div().absolute().inset_0().child(self.import_panel.clone()))
+                root.child(self.import_panel.clone())
             })
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/section_trait.rs
+++ b/crates/dbflux_ui_windows/src/settings/section_trait.rs
@@ -77,3 +77,14 @@ pub trait SettingsSection: 'static {
 pub enum SectionFocusEvent {
     RequestFocusReturn,
 }
+
+/// Portability actions a profile section (SSH tunnels, proxies, auth profiles)
+/// asks the settings coordinator to perform. The coordinator owns the export
+/// modal and import wizard overlays; the section only signals intent.
+#[derive(Clone, Debug)]
+pub enum SectionPortabilityEvent {
+    /// Export the section's currently selected profile as a portable bundle.
+    OpenExport(crate::connection_manager::ExportTarget),
+    /// Open the import wizard to bring in a profile from a bundle file.
+    OpenImport,
+}

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
@@ -63,6 +63,7 @@ impl SshFormNav {
 
         if self.editing_id.is_some() {
             rows.push(vec![
+                SshFormField::ExportButton,
                 SshFormField::DeleteButton,
                 SshFormField::TestButton,
                 SshFormField::SaveButton,
@@ -552,6 +553,9 @@ impl SshTunnelsSection {
                         }
                     }
                 }
+                ("i", modifiers) if modifiers == Modifiers::none() => {
+                    self.request_import(cx);
+                }
                 ("g", modifiers) if modifiers == Modifiers::none() => {
                     self.ssh_selected_idx = None;
                     self.ssh_load_selected_profile(window, cx);
@@ -793,6 +797,22 @@ mod tests {
         assert!(all_fields.contains(&&SshFormField::DeleteButton));
         assert!(all_fields.contains(&&SshFormField::TestButton));
         assert!(all_fields.contains(&&SshFormField::SaveButton));
+    }
+
+    #[test]
+    fn form_rows_editing_has_export_button() {
+        let nav = nav_private_key_editing();
+        let rows = nav.form_rows();
+        let all_fields: Vec<_> = rows.iter().flatten().collect();
+        assert!(all_fields.contains(&&SshFormField::ExportButton));
+    }
+
+    #[test]
+    fn form_rows_new_tunnel_no_export_button() {
+        let nav = nav_private_key_new();
+        let rows = nav.form_rows();
+        let all_fields: Vec<_> = rows.iter().flatten().collect();
+        assert!(!all_fields.contains(&&SshFormField::ExportButton));
     }
 
     #[test]

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
@@ -2,8 +2,9 @@ use super::SettingsSection;
 use super::SettingsSectionId;
 use super::form_section::{FormSection, create_blur_subscription};
 use super::layout;
-use super::section_trait::SectionFocusEvent;
+use super::section_trait::{SectionFocusEvent, SectionPortabilityEvent};
 use super::ssh_tunnels::SshFormNav;
+use crate::connection_manager::ExportTarget;
 use crate::ssh_shared::{self, SshAuthSelection};
 use dbflux_components::controls::Button;
 use dbflux_components::controls::{GpuiInput as Input, InputState};
@@ -40,6 +41,7 @@ pub(super) enum SshFormField {
     Passphrase,
     Password,
     SaveSecret,
+    ExportButton,
     DeleteButton,
     TestButton,
     SaveButton,
@@ -82,6 +84,23 @@ pub(super) struct SshTunnelsSection {
 }
 
 impl EventEmitter<SectionFocusEvent> for SshTunnelsSection {}
+impl EventEmitter<SectionPortabilityEvent> for SshTunnelsSection {}
+
+impl SshTunnelsSection {
+    /// Ask the coordinator to export the SSH tunnel currently loaded in the form.
+    pub(super) fn request_export(&mut self, cx: &mut Context<Self>) {
+        if let Some(id) = self.editing_tunnel_id {
+            cx.emit(SectionPortabilityEvent::OpenExport(
+                ExportTarget::SshTunnel(id),
+            ));
+        }
+    }
+
+    /// Ask the coordinator to open the import wizard.
+    pub(super) fn request_import(&mut self, cx: &mut Context<Self>) {
+        cx.emit(SectionPortabilityEvent::OpenImport);
+    }
+}
 
 impl FormSection for SshTunnelsSection {
     type Focus = SshFocus;
@@ -213,6 +232,9 @@ impl FormSection for SshTunnelsSection {
                 if let Some(id) = self.editing_tunnel_id {
                     self.request_delete_tunnel(id, cx);
                 }
+            }
+            SshFormField::ExportButton => {
+                self.request_export(cx);
             }
             field if Self::is_input_field(field) => {
                 self.focus_current_field(window, cx);
@@ -647,25 +669,42 @@ impl SshTunnelsSection {
             .flex()
             .flex_col()
             .child(
-                div().p_2().border_b_1().border_color(theme.border).child(
-                    div()
-                        .rounded(Radii::SM)
-                        .border_1()
-                        .border_color(if is_new_button_focused {
-                            theme.primary
-                        } else {
-                            transparent_black()
-                        })
-                        .child(
-                            Button::new("new-ssh-tunnel", "New Tunnel")
-                                .icon(Icon::new(AppIcon::Plus))
-                                .small()
-                                .w_full()
-                                .on_click(cx.listener(|this, _, window, cx| {
-                                    this.clear_form(window, cx);
-                                })),
-                        ),
-                ),
+                div()
+                    .p_2()
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .flex()
+                    .flex_col()
+                    .gap_2()
+                    .child(
+                        div()
+                            .rounded(Radii::SM)
+                            .border_1()
+                            .border_color(if is_new_button_focused {
+                                theme.primary
+                            } else {
+                                transparent_black()
+                            })
+                            .child(
+                                Button::new("new-ssh-tunnel", "New Tunnel")
+                                    .icon(Icon::new(AppIcon::Plus))
+                                    .small()
+                                    .w_full()
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.clear_form(window, cx);
+                                    })),
+                            ),
+                    )
+                    .child(
+                        Button::new("import-ssh-tunnel", "Import\u{2026}")
+                            .icon(Icon::new(AppIcon::Download))
+                            .small()
+                            .ghost()
+                            .w_full()
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.request_import(cx);
+                            })),
+                    ),
             )
             .child(
                 div()
@@ -858,6 +897,17 @@ impl SshTunnelsSection {
                 let tunnel_id = editing_id.expect("checked is_some");
 
                 root.child(layout::footer_action_frame(
+                    is_form_focused && field == SshFormField::ExportButton,
+                    primary,
+                    Button::new("export-ssh-tunnel", "Export")
+                        .small()
+                        .ghost()
+                        .w_full()
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.request_export(cx);
+                        })),
+                ))
+                .child(layout::footer_action_frame(
                     is_form_focused && field == SshFormField::DeleteButton,
                     primary,
                     Button::new("delete-ssh-tunnel", "Delete")

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
@@ -764,14 +764,17 @@ impl SshTunnelsSection {
                                     .items_start()
                                     .gap_2()
                                     .child(
-                                        FluxIcon::new(AppIcon::Globe)
-                                            .size(px(14.0))
-                                            .color(theme.muted_foreground),
+                                        div().flex_shrink_0().mt(px(2.0)).child(
+                                            FluxIcon::new(AppIcon::Globe)
+                                                .size(px(14.0))
+                                                .color(theme.muted_foreground),
+                                        ),
                                     )
                                     .child(
                                         div()
                                             .flex()
                                             .flex_col()
+                                            .min_w_0()
                                             .gap_1()
                                             .child(Body::new(tunnel.name.clone()))
                                             .child(MonoMeta::new(subtitle))


### PR DESCRIPTION
## Summary

- Surfaces the connection portability pipeline (#213) **per Settings section** so SSH tunnels, proxies, and auth profiles can be exported and imported on their own — without wrapping them inside a connection bundle.
- Each profile editor gains an **Export** action; each section's list gains an **Import…** action. Both reuse the existing passphrase-encrypted TOML bundle, export modal, and import wizard.

## What does this resolve?

- Resolves #214

## How was this solved?

The pure `dbflux_portability` crate and `dbflux_app::portability` (export builders, import `plan`/`apply`, conflict predicates, persistence) **already supported a bundle with zero connections plus a single standalone profile** — the export builders iterate the auth/ssh/proxy lists independently of connections. So this change is UI wiring plus app-layer entry points, **not new core logic**.

| Area | Change |
|------|--------|
| `dbflux_app` | `ExportInputs` derives `Default` so a single standalone profile can be assembled into an otherwise-empty export graph |
| `dbflux_ui_windows` (export modal) | `ExportConnectionModal` → generic **`ExportBundleModal`** driven by `ExportTarget { Connection \| AuthProfile \| SshTunnel \| Proxy }`; per-target summary, credentials controls, inputs, title, and default file name. `open(profile_id)` kept as a thin wrapper for the connection entry points |
| `dbflux_ui_windows` (import panel) | Header copy generalized ("Import Connections" → "Import"); the wizard already handles all entity types |
| `dbflux_ui_windows` (Settings) | New `SectionPortabilityEvent`; the SSH / proxy / auth sections expose **Export** (editor footer, keyboard-navigable) and **Import…** (list header, also reachable with `i` in list focus); `SettingsCoordinator` owns and hosts the shared export modal + import wizard overlays |
| `dbflux_ui` | Updated the renamed-modal references in the workspace integrator |

**Security model (unchanged from #213):** secret material travels only inside the encrypted secrets section; passphrase encryption is on by default; SSH key embedding stays consent-gated and off by default. **AWS reflected auth profiles** (read-only `~/.aws` mirrors) stay reference-only and cannot be exported — blocked at the UI gate, at `request_export`, and at `assemble_inputs`.

This change was reviewed with a blind dual adversarial review (Judgment Day): one confirmed real issue (leftover "connection"-specific copy in the generalized modal) plus follow-ups were fixed, then re-judged to approval.

## Validation

```
cargo check -p dbflux_ui_windows                 # clean
cargo check -p dbflux_ui -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws   # clean
cargo clippy -p dbflux_app -p dbflux_ui_windows --all-targets -- -D warnings   # clean on changed code*
cargo nextest run -p dbflux_ui_windows           # 140 passed (incl. 5 new ExportButton form-row tests)
cargo nextest run -p dbflux_app -p dbflux_portability   # pass (1 pre-existing, unrelated Lua-gated hook_executor failure, as noted in #213)
cargo fmt --all -- --check                        # clean
```

\* The only remaining clippy finding is a pre-existing `crates/dbflux_ui_windows/src/settings/sidebar_nav.rs:163` `unused_mut`, outside this diff (surfaced by a newer local clippy).

The GPUI render/event layer is compile-checked and adversarially reviewed (consistent with #213, where the `dbflux_ui_windows` test binary cannot link under GPUI's proc-macro recursion); pure logic and the new keyboard/form-row wiring are unit-tested. Manual click-through of the running app was not performed.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s) — _compile-checked + dual-reviewed + unit-tested; manual UI run pending (GPUI layer not unit-testable, see above)_
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

`ui:feature`, `ssh:feature`, `proxy:feature`, `aws:feature`, `ssh`, `proxy`, `aws`, `size:exception`

### Why `size:exception`

~697/-150 lines across 14 files. The change spans a core-modal generalization, the app-layer `Default`, and three Settings sections with their overlay host — tightly coupled (the import wizard and export modal are shared across all three sections), so it is delivered as one consolidated PR rather than chained slices.
