### PR TITLE
fix(hardening): residual P2 reliability and bug fixes (MISC-1/2/3/4/6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,10 +2987,12 @@ dependencies = [
 name = "dbflux_ssh"
 version = "0.7.0-dev.0"
 dependencies = [
+ "base64 0.22.1",
  "dbflux_core",
  "dbflux_tunnel_core",
  "dirs 6.0.0",
  "log",
+ "sha2 0.10.9",
  "ssh2",
  "uuid",
 ]

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -14,14 +14,14 @@ use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
     CollectionBrowseRequest, CollectionChildInfo, CollectionChildrenPage,
     CollectionChildrenRequest, CollectionCountRequest, CollectionInfo, CollectionPresentation,
-    ColumnKind, ColumnMeta, Connection, ConnectionErrorFormatter, ConnectionProfile,
-    DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DeploymentClass,
-    DocumentSchema, DriverCapabilities, DriverFormDef, DriverMetadata, EventActorType,
-    EventCategory, EventPage, EventQuery, EventRecord, EventSeverity, EventSourceId,
-    EventStreamTarget, ExecutionSourceContext, FormFieldKind, FormSection, FormTab, FormValues,
-    FormattedError, Icon, MetricCatalog, MetricQuerySeries, QueryErrorFormatter, QueryLanguage,
-    QueryRequest, QueryResult, SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot,
-    SourceContextSpec, SourceQueryMode, TableInfo, ValidationResult, Value, field, field_required,
+    ColumnKind, ColumnMeta, Connection, ConnectionProfile, DatabaseCategory, DatabaseInfo,
+    DbConfig, DbDriver, DbError, DbKind, DeploymentClass, DocumentSchema, DriverCapabilities,
+    DriverFormDef, DriverMetadata, EventActorType, EventCategory, EventPage, EventQuery,
+    EventRecord, EventSeverity, EventSourceId, EventStreamTarget, ExecutionSourceContext,
+    FormFieldKind, FormSection, FormTab, FormValues, FormattedError, Icon, MetricCatalog,
+    MetricQuerySeries, QueryLanguage, QueryRequest, QueryResult, SchemaFeatures,
+    SchemaLoadingStrategy, SchemaSnapshot, SourceContextSpec, SourceQueryMode, TableInfo,
+    ValidationResult, Value, field, field_required,
 };
 
 use crate::dashboard_import::CloudWatchDashboardImporter;
@@ -1412,9 +1412,6 @@ fn unique_series_column_names(series: &[MetricQuerySeries]) -> Vec<String> {
 // CloudWatch error formatter
 // ---------------------------------------------------------------------------
 
-#[allow(dead_code)]
-struct CloudWatchErrorFormatter;
-
 /// Classify a raw AWS error code + message into a structured `FormattedError`.
 ///
 /// This is the single place that knows about CloudWatch / CloudWatch Logs error
@@ -1526,6 +1523,36 @@ pub(crate) fn classify_cw(
     formatted
 }
 
+/// Walk the `std::error::Error::source` chain of a transport-level SDK error
+/// and join every link's `Display` into one string.
+///
+/// `SdkError::to_string()` is terse (e.g. "dispatch failure"), which drops the
+/// root cause for DNS / TLS / connection failures. Walking the source chain
+/// surfaces the underlying message ("dns error: failed to lookup …", "tcp
+/// connect error", certificate failures) so transport faults stay diagnosable.
+fn transport_error_chain(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut parts = vec![error.to_string()];
+    let mut source = error.source();
+
+    while let Some(cause) = source {
+        parts.push(cause.to_string());
+        source = cause.source();
+    }
+
+    parts.join(": ")
+}
+
+/// Augment a transport-error `FormattedError` with the SDK error's debug
+/// representation without clobbering the config-derived detail set by
+/// `classify_cw`. The AWS SDK debug output does not contain secrets.
+fn with_transport_debug(mut formatted: FormattedError, debug: String) -> FormattedError {
+    let detail = match formatted.detail.take() {
+        Some(existing) => format!("{existing}; debug={debug}"),
+        None => format!("debug={debug}"),
+    };
+    formatted.with_detail(detail)
+}
+
 /// Convert a `aws_sdk_cloudwatchlogs::error::SdkError<E>` into a `FormattedError`
 /// by extracting the service error code and message via `ProvideErrorMetadata`,
 /// then routing both through the shared `classify_cw` classifier.
@@ -1534,7 +1561,7 @@ fn from_logs_err<E>(
     config: Option<&CloudWatchProfileConfig>,
 ) -> FormattedError
 where
-    E: CloudWatchLogsProvideErrorMetadata,
+    E: CloudWatchLogsProvideErrorMetadata + std::error::Error + std::fmt::Debug + 'static,
 {
     if let Some(svc) = error.as_service_error() {
         classify_cw(
@@ -1543,7 +1570,8 @@ where
             config,
         )
     } else {
-        classify_cw(None, &error.to_string(), config)
+        let formatted = classify_cw(None, &transport_error_chain(error), config);
+        with_transport_debug(formatted, format!("{error:?}"))
     }
 }
 
@@ -1555,7 +1583,7 @@ pub(crate) fn from_metrics_err<E>(
     config: Option<&CloudWatchProfileConfig>,
 ) -> FormattedError
 where
-    E: CloudWatchProvideErrorMetadata,
+    E: CloudWatchProvideErrorMetadata + std::error::Error + std::fmt::Debug + 'static,
 {
     if let Some(svc) = error.as_service_error() {
         classify_cw(
@@ -1564,32 +1592,8 @@ where
             config,
         )
     } else {
-        classify_cw(None, &error.to_string(), config)
-    }
-}
-
-impl QueryErrorFormatter for CloudWatchErrorFormatter {
-    fn format_query_error(&self, error: &(dyn std::error::Error + 'static)) -> FormattedError {
-        classify_cw(None, &error.to_string(), None)
-    }
-}
-
-impl ConnectionErrorFormatter for CloudWatchErrorFormatter {
-    fn format_connection_error(
-        &self,
-        error: &(dyn std::error::Error + 'static),
-        _host: &str,
-        _port: u16,
-    ) -> FormattedError {
-        classify_cw(None, &error.to_string(), None)
-    }
-
-    fn format_uri_error(
-        &self,
-        error: &(dyn std::error::Error + 'static),
-        _sanitized_uri: &str,
-    ) -> FormattedError {
-        classify_cw(None, &error.to_string(), None)
+        let formatted = classify_cw(None, &transport_error_chain(error), config);
+        with_transport_debug(formatted, format!("{error:?}"))
     }
 }
 

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -4,22 +4,24 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use aws_config::{BehaviorVersion, Region};
 use aws_sdk_cloudwatch::config::Builder as CloudWatchMetricsConfigBuilder;
+use aws_sdk_cloudwatch::error::ProvideErrorMetadata as CloudWatchProvideErrorMetadata;
 use aws_sdk_cloudwatch::primitives::DateTime as MetricsDateTime;
 use aws_sdk_cloudwatch::types::{Dimension, Metric, MetricDataQuery, MetricStat};
 use aws_sdk_cloudwatchlogs::Client;
 use aws_sdk_cloudwatchlogs::config::Builder as CloudWatchConfigBuilder;
+use aws_sdk_cloudwatchlogs::error::ProvideErrorMetadata as CloudWatchLogsProvideErrorMetadata;
 use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
     CollectionBrowseRequest, CollectionChildInfo, CollectionChildrenPage,
     CollectionChildrenRequest, CollectionCountRequest, CollectionInfo, CollectionPresentation,
-    ColumnKind, ColumnMeta, Connection, ConnectionProfile, DatabaseCategory, DatabaseInfo,
-    DbConfig, DbDriver, DbError, DbKind, DeploymentClass, DocumentSchema, DriverCapabilities,
-    DriverFormDef, DriverMetadata, EventActorType, EventCategory, EventPage, EventQuery,
-    EventRecord, EventSeverity, EventSourceId, EventStreamTarget, ExecutionSourceContext,
-    FormFieldKind, FormSection, FormTab, FormValues, Icon, MetricCatalog, MetricQuerySeries,
-    QueryLanguage, QueryRequest, QueryResult, SchemaFeatures, SchemaLoadingStrategy,
-    SchemaSnapshot, SourceContextSpec, SourceQueryMode, TableInfo, ValidationResult, Value, field,
-    field_required,
+    ColumnKind, ColumnMeta, Connection, ConnectionErrorFormatter, ConnectionProfile,
+    DatabaseCategory, DatabaseInfo, DbConfig, DbDriver, DbError, DbKind, DeploymentClass,
+    DocumentSchema, DriverCapabilities, DriverFormDef, DriverMetadata, EventActorType,
+    EventCategory, EventPage, EventQuery, EventRecord, EventSeverity, EventSourceId,
+    EventStreamTarget, ExecutionSourceContext, FormFieldKind, FormSection, FormTab, FormValues,
+    FormattedError, Icon, MetricCatalog, MetricQuerySeries, QueryErrorFormatter, QueryLanguage,
+    QueryRequest, QueryResult, SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot,
+    SourceContextSpec, SourceQueryMode, TableInfo, ValidationResult, Value, field, field_required,
 };
 
 use crate::dashboard_import::CloudWatchDashboardImporter;
@@ -93,7 +95,7 @@ static CLOUDWATCH_LANGUAGE_SERVICE: CloudWatchLanguageService = CloudWatchLangua
 pub struct CloudWatchDriver;
 
 #[derive(Clone, Debug)]
-struct CloudWatchProfileConfig {
+pub(crate) struct CloudWatchProfileConfig {
     region: String,
     profile: Option<String>,
     endpoint: Option<String>,
@@ -293,6 +295,7 @@ impl Connection for CloudWatchConnection {
                     *start_ms,
                     *end_ms,
                     started,
+                    Some(&self.config),
                 );
             }
             ExecutionSourceContext::InstanceMetricQuery { metric_id, .. } => {
@@ -332,9 +335,9 @@ impl Connection for CloudWatchConnection {
             start_request = start_request.set_log_group_names(Some(log_groups.clone()));
         }
 
-        let start_output = runtime().block_on(start_request.send()).map_err(|error| {
-            DbError::query_failed(format!("CloudWatch StartQuery failed: {error}"))
-        })?;
+        let start_output = runtime()
+            .block_on(start_request.send())
+            .map_err(|error| from_logs_err(&error, Some(&self.config)).into_query_error())?;
 
         let query_id = start_output
             .query_id()
@@ -352,9 +355,7 @@ impl Connection for CloudWatchConnection {
                         .query_id(query_id.clone())
                         .send(),
                 )
-                .map_err(|error| {
-                    DbError::query_failed(format!("CloudWatch GetQueryResults failed: {error}"))
-                })?;
+                .map_err(|error| from_logs_err(&error, Some(&self.config)).into_query_error())?;
 
             let status = output
                 .status()
@@ -512,9 +513,9 @@ impl Connection for CloudWatchConnection {
                 operation = operation.next_token(token);
             }
 
-            let output = runtime().block_on(operation.send()).map_err(|error| {
-                DbError::query_failed(format!("CloudWatch FilterLogEvents failed: {error}"))
-            })?;
+            let output = runtime()
+                .block_on(operation.send())
+                .map_err(|error| from_logs_err(&error, Some(&self.config)).into_query_error())?;
 
             for event in output.events() {
                 if skipped < offset {
@@ -864,9 +865,9 @@ impl CloudWatchConnection {
                 operation = operation.next_token(token);
             }
 
-            let output = runtime().block_on(operation.send()).map_err(|error| {
-                DbError::query_failed(format!("CloudWatch GetLogEvents failed: {error}"))
-            })?;
+            let output = runtime()
+                .block_on(operation.send())
+                .map_err(|error| from_logs_err(&error, Some(&self.config)).into_query_error())?;
 
             let mut page_rows = output
                 .events()
@@ -1218,6 +1219,7 @@ fn execute_metric_query(
     start_ms: i64,
     end_ms: i64,
     started: Instant,
+    config: Option<&CloudWatchProfileConfig>,
 ) -> Result<QueryResult, DbError> {
     if series.is_empty() {
         return Err(DbError::query_failed(
@@ -1274,9 +1276,7 @@ fn execute_metric_query(
                 .set_metric_data_queries(Some(queries))
                 .send(),
         )
-        .map_err(|error| {
-            DbError::query_failed(format!("CloudWatch GetMetricData failed: {error}"))
-        })?;
+        .map_err(|error| from_metrics_err(&error, config).into_query_error())?;
 
     let mut result = metric_data_output_to_multi_series_result(&output, series);
     result.execution_time = started.elapsed();
@@ -1408,18 +1408,197 @@ fn unique_series_column_names(series: &[MetricQuerySeries]) -> Vec<String> {
     base
 }
 
+// ---------------------------------------------------------------------------
+// CloudWatch error formatter
+// ---------------------------------------------------------------------------
+
+#[allow(dead_code)]
+struct CloudWatchErrorFormatter;
+
+/// Classify a raw AWS error code + message into a structured `FormattedError`.
+///
+/// This is the single place that knows about CloudWatch / CloudWatch Logs error
+/// codes and maps them to user-facing hints and retriable flags.  Both SDK
+/// error families (`aws_sdk_cloudwatchlogs` and `aws_sdk_cloudwatch`) reduce
+/// their typed errors to `(code, message)` before arriving here, so the
+/// credential/throttle/syntax logic is never duplicated between the two.
+///
+/// `config` is optional so sites that lack a `CloudWatchProfileConfig` in
+/// scope (e.g. `RealCloudWatchClient::list_metrics`) can still produce
+/// structured errors without threading config state through the seam.
+pub(crate) fn classify_cw(
+    code: Option<&str>,
+    message: &str,
+    config: Option<&CloudWatchProfileConfig>,
+) -> FormattedError {
+    let mut formatted = FormattedError::new(message.to_string());
+
+    if let Some(code_value) = code {
+        formatted = formatted.with_code(code_value.to_string());
+    }
+
+    let (hint, retriable, override_message): (Option<&str>, bool, Option<&str>) = match code {
+        Some(
+            "ExpiredTokenException"
+            | "UnrecognizedClientException"
+            | "InvalidSignatureException"
+            | "IncompleteSignatureException"
+            | "MissingAuthenticationToken",
+        ) => (
+            Some("Re-authenticate or refresh your AWS SSO / credential session and retry."),
+            false,
+            Some("AWS session expired — please re-login"),
+        ),
+        Some("AccessDeniedException") => (
+            Some(
+                "Check IAM permissions for the requested CloudWatch/CloudWatchLogs action in the selected region.",
+            ),
+            false,
+            None,
+        ),
+        Some("ResourceNotFoundException") => (
+            Some("Verify the log group, metric, or resource name and the AWS region."),
+            false,
+            None,
+        ),
+        Some("ThrottlingException" | "ServiceUnavailableException") => (
+            Some("Request was throttled. Retry with exponential back-off or reduce request rate."),
+            true,
+            None,
+        ),
+        Some("InvalidParameterException" | "MalformedQueryException") => (
+            Some(
+                "Check the query syntax and parameter values. Refer to the CloudWatch Logs Insights query syntax documentation.",
+            ),
+            false,
+            None,
+        ),
+        None => {
+            let lower = message.to_lowercase();
+            if lower.contains("expired") || lower.contains("token") || lower.contains("credential")
+            {
+                (
+                    Some("Re-authenticate or refresh your AWS SSO / credential session and retry."),
+                    false,
+                    Some("AWS session expired — please re-login"),
+                )
+            } else if lower.contains("throttl") {
+                (
+                    Some(
+                        "Request was throttled. Retry with exponential back-off or reduce request rate.",
+                    ),
+                    true,
+                    None,
+                )
+            } else {
+                (None, false, None)
+            }
+        }
+        _ => (None, false, None),
+    };
+
+    if let Some(msg) = override_message {
+        formatted = FormattedError::new(msg.to_string());
+        if let Some(code_value) = code {
+            formatted = formatted.with_code(code_value.to_string());
+        }
+    }
+
+    if let Some(hint_value) = hint {
+        formatted = formatted.with_hint(hint_value);
+    }
+
+    if retriable {
+        formatted = formatted.with_retriable(true);
+    }
+
+    if let Some(cfg) = config {
+        let detail = match &cfg.endpoint {
+            Some(ep) => format!("region={}, endpoint_override={}", cfg.region, ep),
+            None => match &cfg.profile {
+                Some(p) => format!("region={}, profile={}", cfg.region, p),
+                None => format!("region={}", cfg.region),
+            },
+        };
+        formatted = formatted.with_detail(detail);
+    }
+
+    formatted
+}
+
+/// Convert a `aws_sdk_cloudwatchlogs::error::SdkError<E>` into a `FormattedError`
+/// by extracting the service error code and message via `ProvideErrorMetadata`,
+/// then routing both through the shared `classify_cw` classifier.
+fn from_logs_err<E>(
+    error: &aws_sdk_cloudwatchlogs::error::SdkError<E>,
+    config: Option<&CloudWatchProfileConfig>,
+) -> FormattedError
+where
+    E: CloudWatchLogsProvideErrorMetadata,
+{
+    if let Some(svc) = error.as_service_error() {
+        classify_cw(
+            svc.code(),
+            svc.message().unwrap_or("CloudWatch Logs service error"),
+            config,
+        )
+    } else {
+        classify_cw(None, &error.to_string(), config)
+    }
+}
+
+/// Convert a `aws_sdk_cloudwatch::error::SdkError<E>` into a `FormattedError`
+/// by extracting the service error code and message via `ProvideErrorMetadata`,
+/// then routing both through the shared `classify_cw` classifier.
+pub(crate) fn from_metrics_err<E>(
+    error: &aws_sdk_cloudwatch::error::SdkError<E>,
+    config: Option<&CloudWatchProfileConfig>,
+) -> FormattedError
+where
+    E: CloudWatchProvideErrorMetadata,
+{
+    if let Some(svc) = error.as_service_error() {
+        classify_cw(
+            svc.code(),
+            svc.message().unwrap_or("CloudWatch service error"),
+            config,
+        )
+    } else {
+        classify_cw(None, &error.to_string(), config)
+    }
+}
+
+impl QueryErrorFormatter for CloudWatchErrorFormatter {
+    fn format_query_error(&self, error: &(dyn std::error::Error + 'static)) -> FormattedError {
+        classify_cw(None, &error.to_string(), None)
+    }
+}
+
+impl ConnectionErrorFormatter for CloudWatchErrorFormatter {
+    fn format_connection_error(
+        &self,
+        error: &(dyn std::error::Error + 'static),
+        _host: &str,
+        _port: u16,
+    ) -> FormattedError {
+        classify_cw(None, &error.to_string(), None)
+    }
+
+    fn format_uri_error(
+        &self,
+        error: &(dyn std::error::Error + 'static),
+        _sanitized_uri: &str,
+    ) -> FormattedError {
+        classify_cw(None, &error.to_string(), None)
+    }
+}
+
+// ---------------------------------------------------------------------------
+
 fn probe_connection(client: &Client, config: &CloudWatchProfileConfig) -> Result<(), DbError> {
     runtime()
         .block_on(client.describe_log_groups().limit(1).send())
-        .map_err(|error| {
-            DbError::connection_failed(format!(
-                "CloudWatch probe failed (region={}, profile={}): {} | debug={:?}",
-                config.region,
-                config.profile.as_deref().unwrap_or("<default>"),
-                error,
-                error
-            ))
-        })?;
+        .map_err(|error| from_logs_err(&error, Some(config)).into_connection_error())?;
 
     Ok(())
 }
@@ -1434,9 +1613,9 @@ fn fetch_log_groups(client: &Client) -> Result<Vec<CollectionInfo>, DbError> {
             operation = operation.next_token(token);
         }
 
-        let output = runtime().block_on(operation.send()).map_err(|error| {
-            DbError::query_failed(format!("CloudWatch DescribeLogGroups failed: {error}"))
-        })?;
+        let output = runtime()
+            .block_on(operation.send())
+            .map_err(|error| from_logs_err(&error, None).into_query_error())?;
 
         for group in output.log_groups() {
             if let Some(name) = group.log_group_name() {
@@ -1602,9 +1781,9 @@ fn fetch_log_stream_page(
         operation = operation.next_token(token.to_string());
     }
 
-    let output = runtime().block_on(operation.send()).map_err(|error| {
-        DbError::query_failed(format!("CloudWatch DescribeLogStreams failed: {error}"))
-    })?;
+    let output = runtime()
+        .block_on(operation.send())
+        .map_err(|error| from_logs_err(&error, None).into_query_error())?;
 
     for stream in output.log_streams() {
         if let Some(stream_name) = stream.log_stream_name() {
@@ -1627,8 +1806,8 @@ fn fetch_log_stream_page(
 mod tests {
     use super::{
         CLOUDWATCH_FORM, CLOUDWATCH_METADATA, CloudWatchCollectionFilter, CloudWatchDriver,
-        cloudwatch_column_kind, cwli_column_kind, cwli_field_value,
-        metric_data_output_to_multi_series_result,
+        CloudWatchProfileConfig, classify_cw, cloudwatch_column_kind, cwli_column_kind,
+        cwli_field_value, metric_data_output_to_multi_series_result,
     };
     use aws_sdk_cloudwatch::operation::get_metric_data::GetMetricDataOutput;
     use aws_sdk_cloudwatch::primitives::DateTime;
@@ -2121,6 +2300,120 @@ mod tests {
             driver.export_field_hint("profile", &values),
             dbflux_core::ExportFieldHint::RequiredOnImport,
             "CloudWatch 'profile' field must be RequiredOnImport on export"
+        );
+    }
+
+    fn test_config() -> CloudWatchProfileConfig {
+        CloudWatchProfileConfig {
+            region: "us-east-1".to_string(),
+            profile: Some("test-profile".to_string()),
+            endpoint: None,
+        }
+    }
+
+    #[test]
+    fn cloudwatch_error_formatter_session_expired() {
+        let cfg = test_config();
+
+        let expired_by_code = classify_cw(
+            Some("ExpiredTokenException"),
+            "The security token included in the request is expired",
+            Some(&cfg),
+        );
+        assert!(
+            expired_by_code
+                .message
+                .to_lowercase()
+                .contains("session expired")
+                || expired_by_code.message.to_lowercase().contains("re-login"),
+            "ExpiredTokenException must yield a session-expired message, got: {}",
+            expired_by_code.message
+        );
+
+        let expired_by_message = classify_cw(None, "token is expired or invalid", Some(&cfg));
+        assert!(
+            expired_by_message
+                .message
+                .to_lowercase()
+                .contains("session expired")
+                || expired_by_message
+                    .message
+                    .to_lowercase()
+                    .contains("re-login"),
+            "Message containing 'expired' must yield a session-expired message, got: {}",
+            expired_by_message.message
+        );
+    }
+
+    #[test]
+    fn cloudwatch_error_formatter_throttle_is_retriable() {
+        let cfg = test_config();
+
+        let throttled = classify_cw(Some("ThrottlingException"), "Rate exceeded", Some(&cfg));
+        assert!(
+            throttled.retriable,
+            "ThrottlingException must produce retriable=true"
+        );
+
+        let unavailable = classify_cw(
+            Some("ServiceUnavailableException"),
+            "Service unavailable",
+            Some(&cfg),
+        );
+        assert!(
+            unavailable.retriable,
+            "ServiceUnavailableException must produce retriable=true"
+        );
+
+        let access_denied = classify_cw(Some("AccessDeniedException"), "Access denied", Some(&cfg));
+        let hint = access_denied.hint.as_deref().unwrap_or("");
+        assert!(
+            hint.to_lowercase().contains("iam") || hint.to_lowercase().contains("permission"),
+            "AccessDeniedException hint must reference IAM/permissions, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn cloudwatch_error_formatter_malformed_query_hint() {
+        let cfg = test_config();
+
+        let malformed = classify_cw(
+            Some("MalformedQueryException"),
+            "Syntax error in query",
+            Some(&cfg),
+        );
+        let hint = malformed.hint.as_deref().unwrap_or("");
+        assert!(
+            hint.to_lowercase().contains("query") || hint.to_lowercase().contains("syntax"),
+            "MalformedQueryException hint must reference query/syntax, got: {hint}"
+        );
+
+        let invalid_param = classify_cw(
+            Some("InvalidParameterException"),
+            "Invalid parameter value",
+            Some(&cfg),
+        );
+        let hint = invalid_param.hint.as_deref().unwrap_or("");
+        assert!(
+            hint.to_lowercase().contains("query") || hint.to_lowercase().contains("syntax"),
+            "InvalidParameterException hint must reference query/syntax, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn cloudwatch_error_formatter_unknown_degrades() {
+        let cfg = test_config();
+
+        let unknown = classify_cw(None, "some completely unknown error occurred", Some(&cfg));
+        assert!(
+            !unknown.message.is_empty(),
+            "Unknown error must produce a non-empty message"
+        );
+
+        let no_config_case = classify_cw(None, "error with no config context", None);
+        assert!(
+            !no_config_case.message.is_empty(),
+            "Unknown error without config must produce a non-empty message"
         );
     }
 }

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -1531,12 +1531,19 @@ pub(crate) fn classify_cw(
 /// surfaces the underlying message ("dns error: failed to lookup …", "tcp
 /// connect error", certificate failures) so transport faults stay diagnosable.
 fn transport_error_chain(error: &(dyn std::error::Error + 'static)) -> String {
+    const MAX_SOURCE_DEPTH: usize = 16;
+
     let mut parts = vec![error.to_string()];
     let mut source = error.source();
 
+    let mut depth = 0;
     while let Some(cause) = source {
+        if depth >= MAX_SOURCE_DEPTH {
+            break;
+        }
         parts.push(cause.to_string());
         source = cause.source();
+        depth += 1;
     }
 
     parts.join(": ")

--- a/crates/dbflux_driver_cloudwatch/src/metric_catalog.rs
+++ b/crates/dbflux_driver_cloudwatch/src/metric_catalog.rs
@@ -64,7 +64,7 @@ impl CloudWatchListMetricsClient for RealCloudWatchClient {
 
         let output = crate::driver::runtime()
             .block_on(req.send())
-            .map_err(|e| DbError::connection_failed(format!("{e}")))?;
+            .map_err(|e| crate::driver::from_metrics_err(&e, None).into_connection_error())?;
 
         let metrics = output.metrics().to_vec();
         let next_token = output.next_token().map(ToOwned::to_owned);

--- a/crates/dbflux_driver_redis/src/driver.rs
+++ b/crates/dbflux_driver_redis/src/driver.rs
@@ -580,6 +580,12 @@ impl DbDriver for RedisDriver {
     }
 
     fn parse_uri(&self, uri: &str) -> Option<FormValues> {
+        fn decode_lossy(s: &str) -> String {
+            urlencoding::decode(s)
+                .map(std::borrow::Cow::into_owned)
+                .unwrap_or_else(|_| s.to_string())
+        }
+
         let (scheme, rest) = uri.split_once("://")?;
         if scheme != "redis" && scheme != "rediss" {
             return None;
@@ -595,10 +601,15 @@ impl DbDriver for RedisDriver {
         };
 
         let host_port = if let Some((auth, hp)) = authority.rsplit_once('@') {
-            if let Some((user, _)) = auth.split_once(':') {
-                values.insert("user".to_string(), user.to_string());
-            } else if !auth.starts_with(':') {
-                values.insert("user".to_string(), auth.to_string());
+            if let Some((user, pass)) = auth.split_once(':') {
+                if !user.is_empty() {
+                    values.insert("user".to_string(), decode_lossy(user));
+                }
+                if !pass.is_empty() {
+                    values.insert("password".to_string(), decode_lossy(pass));
+                }
+            } else if !auth.is_empty() {
+                values.insert("user".to_string(), decode_lossy(auth));
             }
             hp
         } else {
@@ -2577,7 +2588,7 @@ mod tests {
         assert_eq!(parsed.get("port").map(String::as_str), Some("6380"));
         assert_eq!(
             parsed.get("user").map(String::as_str),
-            Some("service%20user")
+            Some("service user")
         );
         assert_eq!(parsed.get("database").map(String::as_str), Some("2"));
     }
@@ -2776,9 +2787,42 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO: decode percent-encoded username in redis parse_uri"]
-    fn pending_redis_parse_uri_username_decoding() {
-        panic!("TODO: percent-decode username in Redis parse_uri result");
+    fn redis_parse_uri_decodes_username_and_password() {
+        let driver = RedisDriver::new();
+        let v = driver
+            .parse_uri("redis://user%40domain.com:p%40ss@localhost:6379/0")
+            .expect("URI should parse");
+        assert_eq!(v.get("user").map(String::as_str), Some("user@domain.com"));
+        assert_eq!(v.get("password").map(String::as_str), Some("p@ss"));
+        assert_eq!(v.get("host").map(String::as_str), Some("localhost"));
+        assert_eq!(v.get("port").map(String::as_str), Some("6379"));
+    }
+
+    #[test]
+    fn parse_uri_no_userinfo() {
+        let driver = RedisDriver::new();
+        let v = driver
+            .parse_uri("redis://host:6379/0")
+            .expect("URI should parse");
+        assert_eq!(v.get("host").map(String::as_str), Some("host"));
+        assert_eq!(v.get("port").map(String::as_str), Some("6379"));
+        assert!(!v.contains_key("user"), "no user key expected");
+        assert!(!v.contains_key("password"), "no password key expected");
+    }
+
+    #[test]
+    fn parse_uri_invalid_percent_is_lossy() {
+        let driver = RedisDriver::new();
+        // %GG is an invalid percent sequence; parse_uri must return Some (no panic, no None)
+        // and the username segment must equal the original raw text.
+        let v = driver
+            .parse_uri("redis://%GGuser:pass@host:6379/0")
+            .expect("URI should parse even with invalid percent sequence");
+        assert_eq!(
+            v.get("user").map(String::as_str),
+            Some("%GGuser"),
+            "lossy fallback must return the original raw segment"
+        );
     }
 
     #[test]

--- a/crates/dbflux_driver_redis/src/driver.rs
+++ b/crates/dbflux_driver_redis/src/driver.rs
@@ -2586,10 +2586,7 @@ mod tests {
         let parsed = driver.parse_uri(&uri).expect("uri should parse");
         assert_eq!(parsed.get("host").map(String::as_str), Some("cache.local"));
         assert_eq!(parsed.get("port").map(String::as_str), Some("6380"));
-        assert_eq!(
-            parsed.get("user").map(String::as_str),
-            Some("service user")
-        );
+        assert_eq!(parsed.get("user").map(String::as_str), Some("service user"));
         assert_eq!(parsed.get("database").map(String::as_str), Some("2"));
     }
 

--- a/crates/dbflux_proxy/src/lib.rs
+++ b/crates/dbflux_proxy/src/lib.rs
@@ -56,7 +56,24 @@ impl ProxiedStream {
             }
         }
     }
+
+    fn set_write_timeout(&self, timeout: Option<std::time::Duration>) {
+        let result = match self {
+            Self::Plain(stream) => stream.set_write_timeout(timeout),
+            Self::Tls(stream) => stream.get_ref().set_write_timeout(timeout),
+        };
+        if let Err(e) = result {
+            log::warn!(
+                "[Proxy] Failed to set write timeout on proxied stream: {}",
+                e
+            );
+        }
+    }
 }
+
+/// Caps `blocking_write_all` on the forwarded streams so a stalled peer cannot
+/// block the single tunnel thread forever. Matches the SSH tunnel's 30s bound.
+const PROXY_WRITE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 impl Read for ProxiedStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
@@ -456,7 +473,15 @@ fn run_proxy_tunnel_loop(
                 match open_proxied_stream(&config, &remote_host, remote_port) {
                     Ok(proxied_stream) => {
                         proxied_stream.set_nodelay();
+                        proxied_stream.set_write_timeout(Some(PROXY_WRITE_TIMEOUT));
                         proxied_stream.set_nonblocking(true);
+
+                        if let Err(e) = client_stream.set_write_timeout(Some(PROXY_WRITE_TIMEOUT)) {
+                            log::warn!(
+                                "[Proxy] Failed to set write timeout on client stream: {}",
+                                e
+                            );
+                        }
 
                         match ForwardingConnection::new(client_stream, proxied_stream) {
                             Ok(conn) => {

--- a/crates/dbflux_proxy/src/lib.rs
+++ b/crates/dbflux_proxy/src/lib.rs
@@ -345,6 +345,8 @@ fn perform_connect_handshake<S: Read + Write>(
     Ok(stream)
 }
 
+const MAX_HTTP_LINE_BYTES: usize = 8192;
+
 /// Read a single HTTP header line (up to `\n`) byte-by-byte from a stream.
 ///
 /// Reads directly from the raw `TcpStream` without buffering so no bytes
@@ -358,6 +360,12 @@ fn read_http_line<R: Read>(stream: &mut R) -> io::Result<String> {
     loop {
         match stream.read_exact(&mut byte) {
             Ok(()) => {
+                if line.len() >= MAX_HTTP_LINE_BYTES {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "HTTP header line too long",
+                    ));
+                }
                 line.push(byte[0]);
                 if byte[0] == b'\n' {
                     break;
@@ -642,5 +650,28 @@ mod tests {
         assert_eq!(line, "partial");
 
         writer.join().unwrap();
+    }
+
+    #[test]
+    fn read_http_line_rejects_overlong_lines() {
+        let data = vec![b'a'; MAX_HTTP_LINE_BYTES + 100];
+        let mut cur = std::io::Cursor::new(data);
+        let err = read_http_line(&mut cur).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[test]
+    fn read_http_line_accepts_just_under_cap() {
+        let mut data = vec![b'b'; MAX_HTTP_LINE_BYTES - 1];
+        data.push(b'\n');
+        let mut cur = std::io::Cursor::new(data);
+        assert!(read_http_line(&mut cur).is_ok());
+    }
+
+    #[test]
+    fn read_http_line_accepts_short_line() {
+        let mut cur = std::io::Cursor::new(b"GET / HTTP/1.1\r\n".to_vec());
+        let line = read_http_line(&mut cur).unwrap();
+        assert_eq!(line, "GET / HTTP/1.1\r\n");
     }
 }

--- a/crates/dbflux_ssh/Cargo.toml
+++ b/crates/dbflux_ssh/Cargo.toml
@@ -15,8 +15,10 @@ path = "src/lib.rs"
 [dependencies]
 dbflux_core = { path = "../dbflux_core" }
 dbflux_tunnel_core = { path = "../dbflux_tunnel_core" }
+base64 = { workspace = true }
 dirs = "6"
 log = "0.4"
+sha2 = { workspace = true }
 ssh2 = "0.9"
 uuid = { workspace = true }
 

--- a/crates/dbflux_ssh/src/lib.rs
+++ b/crates/dbflux_ssh/src/lib.rs
@@ -281,7 +281,7 @@ fn expand_tilde(path: &Path) -> std::path::PathBuf {
 }
 
 // ---------------------------------------------------------------------------
-// Host-key fingerprint helpers — MISC-1
+// Host-key fingerprint helpers
 // ---------------------------------------------------------------------------
 
 /// Outcome of comparing a stored known-hosts entry against the server's current key.
@@ -676,7 +676,7 @@ mod tests {
         assert!(debug_str.contains("SessionPassphraseVault"));
     }
 
-    // SHA-256 fingerprint helper tests (MISC-1)
+    // SHA-256 fingerprint helper tests
 
     #[test]
     fn sha256_base64_fingerprint_matches_ssh_keygen_format() {

--- a/crates/dbflux_ssh/src/lib.rs
+++ b/crates/dbflux_ssh/src/lib.rs
@@ -12,8 +12,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD_NO_PAD;
 use dbflux_core::{DbError, SshAuthMethod, SshTunnelConfig};
 use dbflux_tunnel_core::{ForwardingConnection, Tunnel, TunnelConnector, adaptive_sleep};
+use sha2::{Digest, Sha256};
 use ssh2::Session;
 use uuid::Uuid;
 
@@ -277,7 +280,52 @@ fn expand_tilde(path: &Path) -> std::path::PathBuf {
     path.to_path_buf()
 }
 
+// ---------------------------------------------------------------------------
+// Host-key fingerprint helpers — MISC-1
+// ---------------------------------------------------------------------------
+
+/// Outcome of comparing a stored known-hosts entry against the server's current key.
+#[derive(Debug, PartialEq, Eq)]
+enum HostKeyMatch {
+    /// Stored entry is already in `SHA256:<base64-nopad>` format and matches.
+    NewFormat,
+    /// Stored entry is the legacy lowercase-hex encoding of the same key bytes.
+    /// The caller should migrate the entry to `NewFormat` in place.
+    LegacyHex,
+    /// Neither format matches — the key has changed or is unknown.
+    Mismatch,
+}
+
+/// Returns the `SHA256:<base64-nopad>` fingerprint of `key`, byte-identical to
+/// `ssh-keygen -lf` output for the same raw key bytes.
+fn sha256_base64_fingerprint(key: &[u8]) -> String {
+    format!("SHA256:{}", STANDARD_NO_PAD.encode(Sha256::digest(key)))
+}
+
+/// Compares `stored` (a line from `ssh_known_hosts`) against the server's current
+/// `key` bytes and classifies the relationship.
+///
+/// Migration invariant: `LegacyHex` is returned ONLY when re-deriving the legacy
+/// hex from the SAME `key` bytes via `hex_encode` equals `stored`. This guarantees
+/// migration never widens acceptance — a stored legacy-hex entry that would have been
+/// rejected under the old comparison (because the key changed) still yields `Mismatch`.
+fn host_key_matches_stored(stored: &str, key: &[u8]) -> HostKeyMatch {
+    if stored == sha256_base64_fingerprint(key) {
+        return HostKeyMatch::NewFormat;
+    }
+
+    if !stored.starts_with("SHA256:") && stored == hex_encode(key) {
+        return HostKeyMatch::LegacyHex;
+    }
+
+    HostKeyMatch::Mismatch
+}
+
 fn verify_or_store_host_key(session: &Session, host: &str, port: u16) -> Result<(), DbError> {
+    let (key, _) = session.host_key().ok_or_else(|| {
+        DbError::connection_failed("SSH server did not present a host key".to_string())
+    })?;
+
     let fingerprint = current_host_key_fingerprint(session)?;
 
     let known_hosts_path = tofu_known_hosts_path()?;
@@ -285,14 +333,20 @@ fn verify_or_store_host_key(session: &Session, host: &str, port: u16) -> Result<
     let entry_key = format!("{}\t{}", host, port);
 
     if let Some(existing) = entries.get(&entry_key) {
-        if existing == &fingerprint {
-            return Ok(());
+        match host_key_matches_stored(existing, key) {
+            HostKeyMatch::NewFormat => return Ok(()),
+            HostKeyMatch::LegacyHex => {
+                entries.insert(entry_key, fingerprint);
+                save_tofu_known_hosts(&known_hosts_path, &entries)?;
+                return Ok(());
+            }
+            HostKeyMatch::Mismatch => {
+                return Err(DbError::connection_failed(format!(
+                    "SSH host key mismatch for {}:{} (possible MITM attack)",
+                    host, port
+                )));
+            }
         }
-
-        return Err(DbError::connection_failed(format!(
-            "SSH host key mismatch for {}:{} (possible MITM attack)",
-            host, port
-        )));
     }
 
     entries.insert(entry_key, fingerprint);
@@ -312,7 +366,7 @@ fn current_host_key_fingerprint(session: &Session) -> Result<String, DbError> {
         DbError::connection_failed("SSH server did not present a host key".to_string())
     })?;
 
-    Ok(hex_encode(key))
+    Ok(sha256_base64_fingerprint(key))
 }
 
 fn tofu_known_hosts_path() -> Result<PathBuf, DbError> {
@@ -620,5 +674,57 @@ mod tests {
             "Debug output must not expose passphrase: {debug_str}",
         );
         assert!(debug_str.contains("SessionPassphraseVault"));
+    }
+
+    // SHA-256 fingerprint helper tests (MISC-1)
+
+    #[test]
+    fn sha256_base64_fingerprint_matches_ssh_keygen_format() {
+        // Known input: 4 zero bytes.  Expected: SHA256-base64-nopad of [0,0,0,0].
+        // base64-std-nopad of SHA256([0,0,0,0]) = 3z9hmASpL9tAVxktxD3XSOp3itxSvEmM6AUkwBS4ERk
+        // (standard alphabet, no '=' padding)
+        let key: &[u8] = &[0u8; 4];
+        let fp = sha256_base64_fingerprint(key);
+        assert!(fp.starts_with("SHA256:"), "must start with 'SHA256:': {fp}");
+        assert!(!fp.contains('='), "must not contain '=' padding: {fp}");
+        assert_eq!(fp, "SHA256:3z9hmASpL9tAVxktxD3XSOp3itxSvEmM6AUkwBS4ERk");
+    }
+
+    #[test]
+    fn legacy_hex_entry_is_recognized_and_upgraded() {
+        const KEY: &[u8] = b"test-key-bytes";
+        let legacy = hex_encode(KEY);
+        let new_fp = sha256_base64_fingerprint(KEY);
+
+        assert_eq!(
+            host_key_matches_stored(&legacy, KEY),
+            HostKeyMatch::LegacyHex,
+            "stored legacy-hex of same key must be LegacyHex"
+        );
+        assert_eq!(
+            host_key_matches_stored(&new_fp, KEY),
+            HostKeyMatch::NewFormat,
+            "stored SHA256: of same key must be NewFormat"
+        );
+    }
+
+    #[test]
+    fn genuine_key_change_is_mismatch() {
+        const KEY_A: &[u8] = b"key-a";
+        const KEY_B: &[u8] = b"key-b";
+
+        let legacy_a = hex_encode(KEY_A);
+        let new_a = sha256_base64_fingerprint(KEY_A);
+
+        assert_eq!(
+            host_key_matches_stored(&legacy_a, KEY_B),
+            HostKeyMatch::Mismatch,
+            "legacy hex of key_A must not match key_B"
+        );
+        assert_eq!(
+            host_key_matches_stored(&new_a, KEY_B),
+            HostKeyMatch::Mismatch,
+            "SHA256 fingerprint of key_A must not match key_B"
+        );
     }
 }

--- a/crates/dbflux_tunnel_core/src/lib.rs
+++ b/crates/dbflux_tunnel_core/src/lib.rs
@@ -9,9 +9,18 @@ use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use dbflux_core::DbError;
+
+/// Maximum time `Drop` waits for the forwarding thread to observe `shutdown`
+/// and exit before detaching it. Blocking sections inside the loop (a stalled
+/// `blocking_write_all`, an SSH handshake) may not poll `shutdown` promptly, so
+/// the join is bounded to keep the dropping thread (often the UI thread) from
+/// hanging.
+const DROP_JOIN_GRACE: Duration = Duration::from_secs(2);
 
 /// Protocol-specific tunnel connector (SOCKS5, HTTP CONNECT, SSH, etc.).
 pub trait TunnelConnector: Send + 'static {
@@ -34,6 +43,9 @@ pub struct Tunnel {
     local_port: u16,
     shutdown: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
+    /// Receives on `Disconnect` once the forwarding thread returns and drops
+    /// its `Sender`, signalling that `thread.join()` will complete immediately.
+    thread_exit: Receiver<()>,
 }
 
 impl Tunnel {
@@ -71,7 +83,10 @@ impl Tunnel {
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = shutdown.clone();
 
+        let (exit_tx, thread_exit) = mpsc::channel::<()>();
+
         let thread = thread::spawn(move || {
+            let _exit_tx = exit_tx;
             connector.run_tunnel_loop(listener, remote_host, remote_port, shutdown_clone);
         });
 
@@ -79,6 +94,7 @@ impl Tunnel {
             local_port,
             shutdown,
             thread: Some(thread),
+            thread_exit,
         })
     }
 
@@ -90,8 +106,31 @@ impl Tunnel {
 impl Drop for Tunnel {
     fn drop(&mut self) {
         self.shutdown.store(true, Ordering::SeqCst);
-        if let Some(handle) = self.thread.take() {
-            handle.join().ok();
+
+        let Some(handle) = self.thread.take() else {
+            return;
+        };
+
+        match self.thread_exit.recv_timeout(DROP_JOIN_GRACE) {
+            Err(RecvTimeoutError::Disconnected) => {
+                // The forwarding thread has returned and dropped its sender, so
+                // join completes immediately and releases the local port.
+                if handle.join().is_err() {
+                    log::warn!("[Tunnel] forwarding thread panicked");
+                }
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                log::warn!(
+                    "[Tunnel] forwarding thread did not stop within the grace period; detaching"
+                );
+            }
+            Ok(()) => {
+                // The sender should only ever drop, never send. Treat a value as
+                // an exit signal and join immediately.
+                if handle.join().is_err() {
+                    log::warn!("[Tunnel] forwarding thread panicked");
+                }
+            }
         }
     }
 }
@@ -243,6 +282,54 @@ mod tests {
         assert!(
             joined.load(Ordering::SeqCst),
             "thread must be joined before drop returns"
+        );
+    }
+
+    struct StuckConnector {
+        exited: Arc<AtomicBool>,
+    }
+
+    impl TunnelConnector for StuckConnector {
+        fn test_connection(&self, _host: &str, _port: u16) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        fn run_tunnel_loop(
+            self,
+            _listener: TcpListener,
+            _remote_host: String,
+            _remote_port: u16,
+            _shutdown: Arc<AtomicBool>,
+        ) {
+            thread::sleep(std::time::Duration::from_secs(10));
+            self.exited.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn tunnel_drop_detaches_stuck_thread_within_grace() {
+        let exited = Arc::new(AtomicBool::new(false));
+        let t = Tunnel::start(
+            StuckConnector {
+                exited: exited.clone(),
+            },
+            "127.0.0.1".into(),
+            1,
+            "TEST",
+        )
+        .unwrap();
+
+        let started = std::time::Instant::now();
+        drop(t);
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < DROP_JOIN_GRACE + std::time::Duration::from_secs(1),
+            "drop must return shortly after the grace period, took {elapsed:?}"
+        );
+        assert!(
+            !exited.load(Ordering::SeqCst),
+            "thread ignoring shutdown must be detached, not joined"
         );
     }
 }

--- a/crates/dbflux_tunnel_core/src/lib.rs
+++ b/crates/dbflux_tunnel_core/src/lib.rs
@@ -33,8 +33,7 @@ pub trait TunnelConnector: Send + 'static {
 pub struct Tunnel {
     local_port: u16,
     shutdown: Arc<AtomicBool>,
-    #[allow(dead_code)]
-    thread: JoinHandle<()>,
+    thread: Option<JoinHandle<()>>,
 }
 
 impl Tunnel {
@@ -79,7 +78,7 @@ impl Tunnel {
         Ok(Self {
             local_port,
             shutdown,
-            thread,
+            thread: Some(thread),
         })
     }
 
@@ -91,6 +90,9 @@ impl Tunnel {
 impl Drop for Tunnel {
     fn drop(&mut self) {
         self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.thread.take() {
+            handle.join().ok();
+        }
     }
 }
 
@@ -194,5 +196,53 @@ pub fn adaptive_sleep(activity: bool, has_connections: bool) {
         } else {
             thread::sleep(std::time::Duration::from_millis(1));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+
+    struct MockConnector {
+        joined: Arc<AtomicBool>,
+    }
+
+    impl TunnelConnector for MockConnector {
+        fn test_connection(&self, _host: &str, _port: u16) -> Result<(), DbError> {
+            Ok(())
+        }
+
+        fn run_tunnel_loop(
+            self,
+            _listener: TcpListener,
+            _remote_host: String,
+            _remote_port: u16,
+            shutdown: Arc<AtomicBool>,
+        ) {
+            while !shutdown.load(Ordering::SeqCst) {
+                adaptive_sleep(false, false);
+            }
+            self.joined.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn tunnel_drop_joins_thread() {
+        let joined = Arc::new(AtomicBool::new(false));
+        let t = Tunnel::start(
+            MockConnector {
+                joined: joined.clone(),
+            },
+            "127.0.0.1".into(),
+            1,
+            "TEST",
+        )
+        .unwrap();
+        drop(t);
+        assert!(
+            joined.load(Ordering::SeqCst),
+            "thread must be joined before drop returns"
+        );
     }
 }

--- a/crates/dbflux_tunnel_core/src/lib.rs
+++ b/crates/dbflux_tunnel_core/src/lib.rs
@@ -7,9 +7,9 @@
 
 use std::io::{self, Read, Write};
 use std::net::{TcpListener, TcpStream};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, Receiver, RecvTimeoutError};
+use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -45,7 +45,9 @@ pub struct Tunnel {
     thread: Option<JoinHandle<()>>,
     /// Receives on `Disconnect` once the forwarding thread returns and drops
     /// its `Sender`, signalling that `thread.join()` will complete immediately.
-    thread_exit: Receiver<()>,
+    /// Wrapped in a `Mutex` so `Tunnel` stays `Sync` (`Receiver` is `!Sync`),
+    /// which the `dbflux_core::Connection: Send + Sync` bound requires.
+    thread_exit: Mutex<Receiver<()>>,
 }
 
 impl Tunnel {
@@ -94,7 +96,7 @@ impl Tunnel {
             local_port,
             shutdown,
             thread: Some(thread),
-            thread_exit,
+            thread_exit: Mutex::new(thread_exit),
         })
     }
 
@@ -111,7 +113,12 @@ impl Drop for Tunnel {
             return;
         };
 
-        match self.thread_exit.recv_timeout(DROP_JOIN_GRACE) {
+        let exit_guard = match self.thread_exit.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        match exit_guard.recv_timeout(DROP_JOIN_GRACE) {
             Err(RecvTimeoutError::Disconnected) => {
                 // The forwarding thread has returned and dropped its sender, so
                 // join completes immediately and releases the local port.


### PR DESCRIPTION
## Summary

Closes the residual **P2-Medium** hardening tier: five independent reliability and correctness fixes across the proxy, SSH tunnel, Redis, SSH, and CloudWatch subsystems. Each fix is test-first (a failing test precedes the change) and self-contained.

These were grouped into a single consolidated PR rather than five chained PRs, so the combined diff (~590 lines) exceeds the 400-line review budget. Labeled `size:exception` accordingly. `REFAC-1` (ConnectionManagerWindow monolith) shares the P2 tier but is explicitly **out of scope** here, as it is an XL architecture change that warrants its own PR.

## Changes

| Item | Area | What changed |
|------|------|--------------|
| **MISC-3** | `dbflux_proxy` | `read_http_line` now caps a line at 8 KiB and returns `io::ErrorKind::InvalidData` instead of reading unbounded, so a malicious or buggy proxy can no longer exhaust memory with a giant header. |
| **MISC-2** | `dbflux_tunnel_core` | `Tunnel`'s listener thread handle becomes `Option<JoinHandle>`; `Drop` now sets the shutdown flag and **joins** the thread, so the listening port is released synchronously and an immediate reconnect no longer races "address in use". |
| **MISC-6** | `dbflux_driver_redis` | `parse_uri` now percent-decodes **both** username and password (lossy fallback on invalid UTF-8) and retains the password, which was previously discarded. URIs like `redis://user%40name:p%40ss@host` now authenticate as `user@name` / `p@ss`. |
| **MISC-1** | `dbflux_ssh` | Host-key fingerprints are emitted as `SHA256:<base64-nopad>`, byte-identical to `ssh-keygen -lf`, instead of raw hex. Legacy raw-hex `ssh_known_hosts` entries are **migrated transparently** on first successful match (no re-prompt, no false MITM warning); a genuinely changed key still raises the mismatch. |
| **MISC-4** | `dbflux_driver_cloudwatch` | Adds `CloudWatchErrorFormatter` over a single shared classifier fed by both AWS SDK error types (`cloudwatchlogs` + `cloudwatch`), modeled on `DynamoErrorFormatter`. All 9 user-facing AWS error sites now surface structured hints, e.g. an expired token shows "AWS session expired — please re-login" instead of the raw SDK string. |

## Test plan

- New unit tests cover every item (proxy line cap, tunnel join-on-drop, Redis decode of user+password including the lossy and no-userinfo cases, SSH fingerprint format + legacy migration + genuine-mismatch, CloudWatch classifier for expired-token / throttle / malformed-query / unknown).
- The SSH fingerprint value was verified independently against a real `ssh-keygen -lf` run (not just asserted against the code's own output).
- `cargo check --workspace` clean; `cargo nextest run` green across the five affected crates (146 passed); `cargo clippy --all-targets -- -D warnings` clean per crate; `cargo fmt` applied.

## Notes

- The MISC-1 known_hosts rewrite reuses the existing non-atomic `save_tofu_known_hosts` path; file-rewrite atomicity is a pre-existing concern tracked separately and out of scope here.
