### PR TITLE
refactor(connection-manager): decompose ConnectionManagerWindow into flat state sub-structs (REFAC-1)

### DIFF
--- a/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
@@ -19,22 +19,26 @@ impl ConnectionManagerWindow {
         let show_focus =
             self.edit_state == EditState::Navigating && self.active_tab == ActiveTab::Access;
 
-        self.access_method_dropdown.update(cx, |dropdown, cx| {
-            let focus_color = if show_focus && self.form_focus == FormFocus::AccessMethod {
-                Some(ring_color)
-            } else {
-                None
-            };
+        self.access
+            .access_method_dropdown
+            .update(cx, |dropdown, cx| {
+                let focus_color = if show_focus && self.form_focus == FormFocus::AccessMethod {
+                    Some(ring_color)
+                } else {
+                    None
+                };
 
-            dropdown.set_focus_ring(focus_color, cx);
-        });
+                dropdown.set_focus_ring(focus_color, cx);
+            });
 
-        self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-            dropdown.set_focus_ring(None, cx);
-        });
+        self.auth_profile
+            .auth_profile_dropdown
+            .update(cx, |dropdown, cx| {
+                dropdown.set_focus_ring(None, cx);
+            });
 
-        let login_enabled =
-            !self.auth_profile_login_in_progress && self.selected_auth_profile_needs_login(cx);
+        let login_enabled = !self.auth_profile.auth_profile_login_in_progress
+            && self.selected_auth_profile_needs_login(cx);
         let auth_profile_is_valid = self.selected_auth_profile_is_valid(cx);
 
         let mut sections = vec![
@@ -49,7 +53,7 @@ impl ConnectionManagerWindow {
                         .child(
                             div()
                                 .min_w(Widths::CM_FORM_DROPDOWN)
-                                .child(self.access_method_dropdown.clone()),
+                                .child(self.access.access_method_dropdown.clone()),
                         ),
                 ),
                 &theme,
@@ -57,7 +61,7 @@ impl ConnectionManagerWindow {
             .into_any_element(),
         ];
 
-        match self.access_tab_mode {
+        match self.access.access_tab_mode {
             AccessTabMode::Direct => {
                 sections.push(
                     div()
@@ -75,7 +79,7 @@ impl ConnectionManagerWindow {
                                     self.render_focus_shell(
                                         show_focus && self.form_focus == FormFocus::SsmAuthProfile,
                                         ring_color,
-                                        self.auth_profile_dropdown.clone(),
+                                        self.auth_profile.auth_profile_dropdown.clone(),
                                         cx,
                                     )
                                         .min_w(px(280.0))
@@ -181,7 +185,7 @@ impl ConnectionManagerWindow {
                                     .label("Auth profile session is valid"),
                             )
                         })
-                        .when_some(self.auth_profile_action_message.as_ref(), |d, message| {
+                        .when_some(self.auth_profile.auth_profile_action_message.as_ref(), |d, message| {
                             d.child(Text::caption(message.clone()))
                         })
                         .into_any_element(),
@@ -200,8 +204,8 @@ impl ConnectionManagerWindow {
         let ring_color = theme.ring;
         let show_focus =
             self.edit_state == EditState::Navigating && self.active_tab == ActiveTab::Access;
-        let login_enabled =
-            !self.auth_profile_login_in_progress && self.selected_auth_profile_needs_login(cx);
+        let login_enabled = !self.auth_profile.auth_profile_login_in_progress
+            && self.selected_auth_profile_needs_login(cx);
         let auth_profile_is_valid = self.selected_auth_profile_is_valid(cx);
 
         self.render_section(
@@ -212,8 +216,8 @@ impl ConnectionManagerWindow {
                 .gap_3()
                 .child(self.render_ssm_value_field(
                     "Instance ID",
-                    &self.input_ssm_instance_id,
-                    self.ssm_instance_id_value_source_selector.clone(),
+                    &self.access.input_ssm_instance_id,
+                    self.access.ssm_instance_id_value_source_selector.clone(),
                     true,
                     show_focus && self.form_focus == FormFocus::SsmInstanceIdValueSource,
                     show_focus && self.form_focus == FormFocus::SsmInstanceId,
@@ -224,8 +228,8 @@ impl ConnectionManagerWindow {
                 ))
                 .child(self.render_ssm_value_field(
                     "Region",
-                    &self.input_ssm_region,
-                    self.ssm_region_value_source_selector.clone(),
+                    &self.access.input_ssm_region,
+                    self.access.ssm_region_value_source_selector.clone(),
                     true,
                     show_focus && self.form_focus == FormFocus::SsmRegionValueSource,
                     show_focus && self.form_focus == FormFocus::SsmRegion,
@@ -236,8 +240,8 @@ impl ConnectionManagerWindow {
                 ))
                 .child(self.render_ssm_value_field(
                     "Remote Port",
-                    &self.input_ssm_remote_port,
-                    self.ssm_remote_port_value_source_selector.clone(),
+                    &self.access.input_ssm_remote_port,
+                    self.access.ssm_remote_port_value_source_selector.clone(),
                     false,
                     show_focus && self.form_focus == FormFocus::SsmRemotePortValueSource,
                     show_focus && self.form_focus == FormFocus::SsmRemotePort,
@@ -257,7 +261,7 @@ impl ConnectionManagerWindow {
                             self.render_focus_shell(
                                 show_focus && self.form_focus == FormFocus::SsmAuthProfile,
                                 ring_color,
-                                self.auth_profile_dropdown.clone(),
+                                self.auth_profile.auth_profile_dropdown.clone(),
                                 cx,
                             )
                                 .min_w(px(280.0))
@@ -413,7 +417,7 @@ impl ConnectionManagerWindow {
 
     pub(super) fn render_proxy_tab(&mut self, cx: &mut Context<Self>) -> Vec<AnyElement> {
         let proxies = self.app_state.read(cx).proxies().to_vec();
-        let selected_proxy_id = self.selected_proxy_id;
+        let selected_proxy_id = self.access.selected_proxy_id;
 
         let show_focus =
             self.edit_state == EditState::Navigating && self.active_tab == ActiveTab::Access;
@@ -458,14 +462,14 @@ impl ConnectionManagerWindow {
                 DropdownItem::with_value(&label, p.id.to_string())
             })
             .collect();
-        self.proxy_uuids = proxies.iter().map(|p| p.id).collect();
+        self.access.proxy_uuids = proxies.iter().map(|p| p.id).collect();
 
         let selected_proxy_index =
             selected_proxy_id.and_then(|id| proxies.iter().position(|p| p.id == id));
 
         let proxy_selector_focused = show_focus && focus == FormFocus::ProxySelector;
         let proxy_clear_focused = show_focus && focus == FormFocus::ProxyClear;
-        self.proxy_dropdown.update(cx, |dropdown, cx| {
+        self.access.proxy_dropdown.update(cx, |dropdown, cx| {
             dropdown.set_items(proxy_items, cx);
             dropdown.set_selected_index(selected_proxy_index, cx);
 
@@ -489,7 +493,7 @@ impl ConnectionManagerWindow {
                     .flex()
                     .items_center()
                     .gap_2()
-                    .child(div().flex_1().child(self.proxy_dropdown.clone()))
+                    .child(div().flex_1().child(self.access.proxy_dropdown.clone()))
                     .when(has_selection, |d| {
                         d.child(
                             div()
@@ -560,12 +564,12 @@ impl ConnectionManagerWindow {
     }
 
     pub(super) fn render_ssh_tab(&mut self, cx: &mut Context<Self>) -> Vec<AnyElement> {
-        let ssh_enabled = self.ssh_enabled;
-        let ssh_auth_method = self.ssh_auth_method;
+        let ssh_enabled = self.access.ssh_enabled;
+        let ssh_auth_method = self.access.ssh_auth_method;
         let keyring_available = self.app_state.read(cx).secret_store_available();
-        let save_ssh_secret = self.form_save_ssh_secret;
+        let save_ssh_secret = self.form.form_save_ssh_secret;
         let ssh_tunnels = self.app_state.read(cx).ssh_tunnels().to_vec();
-        let selected_tunnel_id = self.selected_ssh_tunnel_id;
+        let selected_tunnel_id = self.access.selected_ssh_tunnel_id;
         let has_selected_tunnel = selected_tunnel_id.is_some();
 
         let show_focus =
@@ -590,7 +594,7 @@ impl ConnectionManagerWindow {
                 Checkbox::new("ssh-enabled")
                     .checked(ssh_enabled)
                     .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                        this.ssh_enabled = *checked;
+                        this.access.ssh_enabled = *checked;
                         cx.notify();
                     })),
             )
@@ -600,14 +604,14 @@ impl ConnectionManagerWindow {
             .iter()
             .map(|t| DropdownItem::with_value(&t.name, t.id.to_string()))
             .collect();
-        self.ssh_tunnel_uuids = ssh_tunnels.iter().map(|t| t.id).collect();
+        self.access.ssh_tunnel_uuids = ssh_tunnels.iter().map(|t| t.id).collect();
 
         let selected_tunnel_index =
             selected_tunnel_id.and_then(|id| ssh_tunnels.iter().position(|t| t.id == id));
 
         let tunnel_selector_focused = show_focus && focus == FormFocus::SshTunnelSelector;
         let tunnel_clear_focused = show_focus && focus == FormFocus::SshTunnelClear;
-        self.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
+        self.access.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
             dropdown.set_items(tunnel_items, cx);
             dropdown.set_selected_index(selected_tunnel_index, cx);
             let focus_color = if tunnel_selector_focused {
@@ -634,7 +638,11 @@ impl ConnectionManagerWindow {
                             .flex()
                             .items_center()
                             .gap_2()
-                            .child(div().flex_1().child(self.ssh_tunnel_dropdown.clone()))
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .child(self.access.ssh_tunnel_dropdown.clone()),
+                            )
                             .when(selected_tunnel_name.is_some(), |d| {
                                 d.child(
                                     div()
@@ -760,7 +768,7 @@ impl ConnectionManagerWindow {
                                 .gap_3()
                                 .child(div().flex_1().child(self.form_field_input(
                                     "Host",
-                                    &self.input_ssh_host,
+                                    &self.access.input_ssh_host,
                                     true,
                                     show_focus && focus == FormFocus::SshHost,
                                     ring_color,
@@ -769,7 +777,7 @@ impl ConnectionManagerWindow {
                                 )))
                                 .child(div().w(px(80.0)).child(self.form_field_input(
                                     "Port",
-                                    &self.input_ssh_port,
+                                    &self.access.input_ssh_port,
                                     false,
                                     show_focus && focus == FormFocus::SshPort,
                                     ring_color,
@@ -779,7 +787,7 @@ impl ConnectionManagerWindow {
                         )
                         .child(div().id(3usize).child(self.form_field_input(
                             "Username",
-                            &self.input_ssh_user,
+                            &self.access.input_ssh_user,
                             true,
                             show_focus && focus == FormFocus::SshUser,
                             ring_color,
@@ -936,11 +944,11 @@ impl ConnectionManagerWindow {
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let click_key = cx.listener(|this, _, _, cx| {
-            this.ssh_auth_method = SshAuthSelection::PrivateKey;
+            this.access.ssh_auth_method = SshAuthSelection::PrivateKey;
             cx.notify();
         });
         let click_pw = cx.listener(|this, _, _, cx| {
-            this.ssh_auth_method = SshAuthSelection::Password;
+            this.access.ssh_auth_method = SshAuthSelection::Password;
             cx.notify();
         });
 
@@ -1013,7 +1021,7 @@ impl ConnectionManagerWindow {
                 Checkbox::new("save-ssh-passphrase")
                     .checked(save_ssh_secret)
                     .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                        this.form_save_ssh_secret = *checked;
+                        this.form.form_save_ssh_secret = *checked;
                         cx.notify();
                     })),
             )
@@ -1026,7 +1034,7 @@ impl ConnectionManagerWindow {
                 Checkbox::new("save-ssh-password")
                     .checked(save_ssh_secret)
                     .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                        this.form_save_ssh_secret = *checked;
+                        this.form.form_save_ssh_secret = *checked;
                         cx.notify();
                     })),
             )
@@ -1079,7 +1087,7 @@ impl ConnectionManagerWindow {
                                                 );
                                             }),
                                         )
-                                        .child(Input::new(&self.input_ssh_key_path).small()),
+                                        .child(Input::new(&self.access.input_ssh_key_path).small()),
                                 )
                                 .child(
                                     div()
@@ -1135,17 +1143,18 @@ impl ConnectionManagerWindow {
                                                 );
                                             }),
                                         )
-                                        .child(Input::new(&self.input_ssh_key_passphrase)),
+                                        .child(Input::new(&self.access.input_ssh_key_passphrase)),
                                 )
                                 .child(
                                     Self::render_password_toggle(
-                                        self.show_ssh_passphrase,
+                                        self.form.show_ssh_passphrase,
                                         "toggle-ssh-passphrase",
                                         theme,
                                     )
                                     .on_click(cx.listener(
                                         |this, _, _, cx| {
-                                            this.show_ssh_passphrase = !this.show_ssh_passphrase;
+                                            this.form.show_ssh_passphrase =
+                                                !this.form.show_ssh_passphrase;
                                             cx.notify();
                                         },
                                     )),
@@ -1211,17 +1220,18 @@ impl ConnectionManagerWindow {
                                                 );
                                             }),
                                         )
-                                        .child(Input::new(&self.input_ssh_password)),
+                                        .child(Input::new(&self.access.input_ssh_password)),
                                 )
                                 .child(
                                     Self::render_password_toggle(
-                                        self.show_ssh_password,
+                                        self.form.show_ssh_password,
                                         "toggle-ssh-password",
                                         theme,
                                     )
                                     .on_click(cx.listener(
                                         |this, _, _, cx| {
-                                            this.show_ssh_password = !this.show_ssh_password;
+                                            this.form.show_ssh_password =
+                                                !this.form.show_ssh_password;
                                             cx.notify();
                                         },
                                     )),

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -14,11 +14,12 @@ use super::{ConnectionManagerWindow, DismissEvent, TestStatus};
 
 impl ConnectionManagerWindow {
     fn collect_mcp_governance(&self, cx: &Context<Self>) -> Option<ConnectionMcpGovernance> {
-        if !self.conn_mcp_enabled {
+        if !self.mcp_tab.conn_mcp_enabled {
             return None;
         }
 
         let actor_id = self
+            .mcp_tab
             .conn_mcp_actor_dropdown
             .read(cx)
             .selected_value()
@@ -26,14 +27,20 @@ impl ConnectionManagerWindow {
             .unwrap_or_default();
 
         let mut role_ids = Vec::new();
-        if let Some(primary_role) = self.conn_mcp_role_dropdown.read(cx).selected_value() {
+        if let Some(primary_role) = self
+            .mcp_tab
+            .conn_mcp_role_dropdown
+            .read(cx)
+            .selected_value()
+        {
             let primary_str = primary_role.to_string();
             if !primary_str.is_empty() {
                 role_ids.push(primary_str);
             }
         }
         role_ids.extend(
-            self.conn_mcp_role_multi_select
+            self.mcp_tab
+                .conn_mcp_role_multi_select
                 .read(cx)
                 .selected_values()
                 .into_iter()
@@ -41,14 +48,20 @@ impl ConnectionManagerWindow {
         );
 
         let mut policy_ids = Vec::new();
-        if let Some(primary_policy) = self.conn_mcp_policy_dropdown.read(cx).selected_value() {
+        if let Some(primary_policy) = self
+            .mcp_tab
+            .conn_mcp_policy_dropdown
+            .read(cx)
+            .selected_value()
+        {
             let primary_str = primary_policy.to_string();
             if !primary_str.is_empty() {
                 policy_ids.push(primary_str);
             }
         }
         policy_ids.extend(
-            self.conn_mcp_policy_multi_select
+            self.mcp_tab
+                .conn_mcp_policy_multi_select
                 .read(cx)
                 .selected_values()
                 .into_iter()
@@ -75,14 +88,14 @@ impl ConnectionManagerWindow {
         self.validation_errors.clear();
 
         if require_name {
-            let name = self.input_name.read(cx).value().to_string();
+            let name = self.form.input_name.read(cx).value().to_string();
             if name.trim().is_empty() {
                 self.validation_errors
                     .push("Connection name is required".to_string());
             }
         }
 
-        let Some(driver) = &self.selected_driver else {
+        let Some(driver) = &self.form.selected_driver else {
             self.validation_errors
                 .push("No driver selected".to_string());
             return false;
@@ -103,6 +116,7 @@ impl ConnectionManagerWindow {
                     }
 
                     let value = self
+                        .form
                         .driver_inputs
                         .get(&field.id)
                         .map(|input| input.read(cx).value().to_string())
@@ -127,20 +141,20 @@ impl ConnectionManagerWindow {
             }
         }
 
-        if self.ssh_enabled && form.supports_ssh() {
-            let ssh_host = self.input_ssh_host.read(cx).value().to_string();
+        if self.access.ssh_enabled && form.supports_ssh() {
+            let ssh_host = self.access.input_ssh_host.read(cx).value().to_string();
             if ssh_host.trim().is_empty() {
                 self.validation_errors
                     .push("SSH Host is required when SSH is enabled".to_string());
             }
 
-            let ssh_user = self.input_ssh_user.read(cx).value().to_string();
+            let ssh_user = self.access.input_ssh_user.read(cx).value().to_string();
             if ssh_user.trim().is_empty() {
                 self.validation_errors
                     .push("SSH User is required when SSH is enabled".to_string());
             }
 
-            let ssh_port_str = self.input_ssh_port.read(cx).value().to_string();
+            let ssh_port_str = self.access.input_ssh_port.read(cx).value().to_string();
             if !ssh_port_str.trim().is_empty() && ssh_port_str.parse::<u16>().is_err() {
                 self.validation_errors
                     .push("SSH Port must be a valid number".to_string());
@@ -149,7 +163,12 @@ impl ConnectionManagerWindow {
 
         // Validate SSM fields if SSM access method is selected (T-7.3)
         if self.is_ssm_selected() {
-            let instance_id = self.input_ssm_instance_id.read(cx).value().to_string();
+            let instance_id = self
+                .access
+                .input_ssm_instance_id
+                .read(cx)
+                .value()
+                .to_string();
             if instance_id.trim().is_empty() {
                 self.validation_errors
                     .push("SSM Instance ID is required".to_string());
@@ -161,13 +180,18 @@ impl ConnectionManagerWindow {
                     .push("SSM Instance ID must start with 'i-' or 'mi-'".to_string());
             }
 
-            let region = self.input_ssm_region.read(cx).value().to_string();
+            let region = self.access.input_ssm_region.read(cx).value().to_string();
             if region.trim().is_empty() {
                 self.validation_errors
                     .push("SSM Region is required".to_string());
             }
 
-            let port_str = self.input_ssm_remote_port.read(cx).value().to_string();
+            let port_str = self
+                .access
+                .input_ssm_remote_port
+                .read(cx)
+                .value()
+                .to_string();
             if !self.has_dynamic_value_ref_for_field("ssm_remote_port", cx) {
                 match port_str.parse::<u16>() {
                     Ok(0) => {
@@ -187,7 +211,7 @@ impl ConnectionManagerWindow {
         // longer resolves to any entry in the current reflected+stored union,
         // block the connect with a user-facing message. When the stored profile
         // is present but marked dangling, tailor the message to the origin.
-        if let Some(auth_profile_id) = self.selected_auth_profile_id {
+        if let Some(auth_profile_id) = self.auth_profile.selected_auth_profile_id {
             let bound_profile = self
                 .app_state
                 .read(cx)
@@ -233,7 +257,7 @@ impl ConnectionManagerWindow {
         });
 
         if uses_dynamic_auth_sources {
-            let Some(auth_profile_id) = self.selected_auth_profile_id else {
+            let Some(auth_profile_id) = self.auth_profile.selected_auth_profile_id else {
                 self.validation_errors.push(
                     "Dynamic value sources require an Auth Profile. Select one in Access tab."
                         .to_string(),
@@ -310,26 +334,26 @@ impl ConnectionManagerWindow {
     }
 
     pub(super) fn build_ssh_config(&self, cx: &Context<Self>) -> Option<SshTunnelConfig> {
-        if !self.ssh_enabled {
+        if !self.access.ssh_enabled {
             return None;
         }
 
-        let host = self.input_ssh_host.read(cx).value().to_string();
-        let port_str = self.input_ssh_port.read(cx).value().to_string();
-        let user = self.input_ssh_user.read(cx).value().to_string();
-        let key_path_str = self.input_ssh_key_path.read(cx).value().to_string();
+        let host = self.access.input_ssh_host.read(cx).value().to_string();
+        let port_str = self.access.input_ssh_port.read(cx).value().to_string();
+        let user = self.access.input_ssh_user.read(cx).value().to_string();
+        let key_path_str = self.access.input_ssh_key_path.read(cx).value().to_string();
 
         Some(ssh_shared::build_ssh_config(
             &host,
             &port_str,
             &user,
-            self.ssh_auth_method,
+            self.access.ssh_auth_method,
             &key_path_str,
         ))
     }
 
     pub(super) fn build_config(&self, cx: &Context<Self>) -> Option<DbConfig> {
-        let driver = self.selected_driver.as_ref()?;
+        let driver = self.form.selected_driver.as_ref()?;
         let values = self.collect_form_values(driver.form_definition(), cx);
 
         let mut config = match driver.build_config(&values) {
@@ -342,8 +366,8 @@ impl ConnectionManagerWindow {
 
         // Persist the SSL mode id string selected in the UI. Drivers hardcode a default; we
         // overwrite here so the user's selection is saved without each driver reading form values.
-        if !self.selected_ssl_mode.is_empty() {
-            let selected = self.selected_ssl_mode.clone();
+        if !self.form.selected_ssl_mode.is_empty() {
+            let selected = self.form.selected_ssl_mode.clone();
             match &mut config {
                 DbConfig::Postgres { ssl_mode, .. }
                 | DbConfig::MySQL { ssl_mode, .. }
@@ -358,15 +382,15 @@ impl ConnectionManagerWindow {
 
         // Apply SSL cert path inputs.
         let ssl_root_cert = {
-            let v = self.ssl_ca_cert_input.read(cx).value().to_string();
+            let v = self.form.ssl_ca_cert_input.read(cx).value().to_string();
             if v.trim().is_empty() { None } else { Some(v) }
         };
         let ssl_client_cert = {
-            let v = self.ssl_client_cert_input.read(cx).value().to_string();
+            let v = self.form.ssl_client_cert_input.read(cx).value().to_string();
             if v.trim().is_empty() { None } else { Some(v) }
         };
         let ssl_client_key = {
-            let v = self.ssl_client_key_input.read(cx).value().to_string();
+            let v = self.form.ssl_client_key_input.read(cx).value().to_string();
             if v.trim().is_empty() { None } else { Some(v) }
         };
 
@@ -402,7 +426,7 @@ impl ConnectionManagerWindow {
             _ => {}
         }
 
-        let ssh_tunnel_profile_id = self.selected_ssh_tunnel_id;
+        let ssh_tunnel_profile_id = self.access.selected_ssh_tunnel_id;
         let ssh_tunnel = if ssh_tunnel_profile_id.is_some() {
             None
         } else {
@@ -449,7 +473,7 @@ impl ConnectionManagerWindow {
     }
 
     pub(super) fn build_profile(&self, cx: &Context<Self>) -> Option<ConnectionProfile> {
-        let name = self.input_name.read(cx).value().to_string();
+        let name = self.form.input_name.read(cx).value().to_string();
         let kind = self.selected_kind()?;
         let driver_id = self.selected_driver_id()?;
         let config = self.build_config(cx)?;
@@ -462,9 +486,9 @@ impl ConnectionManagerWindow {
             ConnectionProfile::new_with_driver(name, kind, driver_id, config)
         };
 
-        profile.save_password = self.form_save_password;
-        profile.proxy_profile_id = self.selected_proxy_id;
-        profile.auth_profile_id = self.selected_auth_profile_id;
+        profile.save_password = self.form.form_save_password;
+        profile.proxy_profile_id = self.access.selected_proxy_id;
+        profile.auth_profile_id = self.auth_profile.selected_auth_profile_id;
         profile.value_refs = self.collect_value_refs(cx);
         profile.settings_overrides = self.collect_connection_overrides(cx);
         profile.connection_settings = self.collect_connection_settings(cx);
@@ -475,14 +499,14 @@ impl ConnectionManagerWindow {
         // of flattening them into inline connection fields.
         let access_kind = if self.is_ssm_selected() {
             Some(self.collect_managed_access_kind(cx))
-        } else if let Some(ssh_tunnel_profile_id) = self.selected_ssh_tunnel_id {
+        } else if let Some(ssh_tunnel_profile_id) = self.access.selected_ssh_tunnel_id {
             Some(AccessKind::Ssh {
                 ssh_tunnel_profile_id,
             })
-        } else if let Some(proxy_profile_id) = self.selected_proxy_id {
+        } else if let Some(proxy_profile_id) = self.access.selected_proxy_id {
             Some(AccessKind::Proxy { proxy_profile_id })
         } else {
-            self.access_kind.clone()
+            self.access.access_kind.clone()
         };
         profile.access_kind = access_kind;
 
@@ -503,14 +527,19 @@ impl ConnectionManagerWindow {
     }
 
     pub(super) fn get_ssh_secret(&self, cx: &Context<Self>) -> Option<String> {
-        if !self.ssh_enabled {
+        if !self.access.ssh_enabled {
             return None;
         }
 
-        let passphrase = self.input_ssh_key_passphrase.read(cx).value().to_string();
-        let password = self.input_ssh_password.read(cx).value().to_string();
+        let passphrase = self
+            .access
+            .input_ssh_key_passphrase
+            .read(cx)
+            .value()
+            .to_string();
+        let password = self.access.input_ssh_password.read(cx).value().to_string();
 
-        ssh_shared::get_ssh_secret(self.ssh_auth_method, &passphrase, &password)
+        ssh_shared::get_ssh_secret(self.access.ssh_auth_method, &passphrase, &password)
     }
 
     pub(super) fn save_profile(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -528,7 +557,7 @@ impl ConnectionManagerWindow {
 
         let saved_profile_id = profile.id;
 
-        let mut password = self.input_password.read(cx).value().to_string();
+        let mut password = self.form.input_password.read(cx).value().to_string();
         let uri_password = profile.config.strip_uri_password();
 
         if password.is_empty()
@@ -539,8 +568,11 @@ impl ConnectionManagerWindow {
 
         let ssh_secret = self.get_ssh_secret(cx);
         let is_edit = self.editing_profile_id.is_some();
-        let password_source_is_literal =
-            self.password_value_source_selector.read(cx).is_literal(cx);
+        let password_source_is_literal = self
+            .form
+            .password_value_source_selector
+            .read(cx)
+            .is_literal(cx);
 
         info!(
             "{} profile: {}, save_password={}, password_len={}, ssh_enabled={}, ssh_auth={:?}",
@@ -548,11 +580,11 @@ impl ConnectionManagerWindow {
             profile.name,
             profile.save_password,
             password.len(),
-            self.ssh_enabled,
-            self.ssh_auth_method
+            self.access.ssh_enabled,
+            self.access.ssh_auth_method
         );
 
-        if self.conn_override_refresh_interval
+        if self.settings_tab.conn_override_refresh_interval
             && profile
                 .settings_overrides
                 .as_ref()
@@ -564,7 +596,7 @@ impl ConnectionManagerWindow {
         }
 
         if let Some(ref conn_settings) = profile.connection_settings
-            && let Some(driver) = &self.selected_driver
+            && let Some(driver) = &self.form.selected_driver
             && let Some(schema) = driver.settings_schema()
         {
             let warnings = form_renderer::validate_values(&schema, conn_settings);
@@ -583,7 +615,7 @@ impl ConnectionManagerWindow {
                 state.delete_password(&profile);
             }
 
-            if self.form_save_ssh_secret {
+            if self.form.form_save_ssh_secret {
                 if let Some(ref secret) = ssh_secret {
                     info!("Saving SSH secret to keyring for profile {}", profile.id);
                     state.save_ssh_password(&profile, &SecretString::from(secret.clone()));
@@ -694,7 +726,7 @@ impl ConnectionManagerWindow {
             return;
         };
 
-        let Some(driver) = self.selected_driver.clone() else {
+        let Some(driver) = self.form.selected_driver.clone() else {
             self.test_status = TestStatus::Failed;
             self.test_error = Some("No driver selected".to_string());
             cx.notify();
@@ -746,7 +778,7 @@ impl ConnectionManagerWindow {
                 )
             })
         } else {
-            let password = self.input_password.read(cx).value().to_string();
+            let password = self.form.input_password.read(cx).value().to_string();
             let password_opt = if password.is_empty() {
                 None
             } else {

--- a/crates/dbflux_ui_windows/src/connection_manager/hooks_tab.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/hooks_tab.rs
@@ -7,38 +7,52 @@ use gpui_component::ActiveTheme;
 impl ConnectionManagerWindow {
     fn selected_hook_ids(&self, cx: &Context<Self>) -> Vec<String> {
         let pre_connect = Self::merge_hook_ids(
-            self.conn_pre_hook_dropdown
+            self.settings_tab
+                .conn_pre_hook_dropdown
                 .read(cx)
                 .selected_value()
                 .map(|value| value.to_string()),
-            self.conn_pre_hook_extra_input.read(cx).value().to_string(),
+            self.settings_tab
+                .conn_pre_hook_extra_input
+                .read(cx)
+                .value()
+                .to_string(),
         );
 
         let post_connect = Self::merge_hook_ids(
-            self.conn_post_hook_dropdown
+            self.settings_tab
+                .conn_post_hook_dropdown
                 .read(cx)
                 .selected_value()
                 .map(|value| value.to_string()),
-            self.conn_post_hook_extra_input.read(cx).value().to_string(),
+            self.settings_tab
+                .conn_post_hook_extra_input
+                .read(cx)
+                .value()
+                .to_string(),
         );
 
         let pre_disconnect = Self::merge_hook_ids(
-            self.conn_pre_disconnect_hook_dropdown
+            self.settings_tab
+                .conn_pre_disconnect_hook_dropdown
                 .read(cx)
                 .selected_value()
                 .map(|value| value.to_string()),
-            self.conn_pre_disconnect_hook_extra_input
+            self.settings_tab
+                .conn_pre_disconnect_hook_extra_input
                 .read(cx)
                 .value()
                 .to_string(),
         );
 
         let post_disconnect = Self::merge_hook_ids(
-            self.conn_post_disconnect_hook_dropdown
+            self.settings_tab
+                .conn_post_disconnect_hook_dropdown
                 .read(cx)
                 .selected_value()
                 .map(|value| value.to_string()),
-            self.conn_post_disconnect_hook_extra_input
+            self.settings_tab
+                .conn_post_disconnect_hook_extra_input
                 .read(cx)
                 .value()
                 .to_string(),
@@ -101,7 +115,7 @@ impl ConnectionManagerWindow {
                     .child(
                         div()
                             .w(Widths::CM_FORM_DROPDOWN)
-                            .child(self.conn_pre_hook_dropdown.clone()),
+                            .child(self.settings_tab.conn_pre_hook_dropdown.clone()),
                     ),
             )
             .child(
@@ -120,7 +134,7 @@ impl ConnectionManagerWindow {
                     .child(
                         div()
                             .w(Widths::CM_FORM_DROPDOWN)
-                            .child(self.conn_post_hook_dropdown.clone()),
+                            .child(self.settings_tab.conn_post_hook_dropdown.clone()),
                     ),
             )
             .child(
@@ -139,7 +153,7 @@ impl ConnectionManagerWindow {
                     .child(
                         div()
                             .w(Widths::CM_FORM_DROPDOWN)
-                            .child(self.conn_pre_disconnect_hook_dropdown.clone()),
+                            .child(self.settings_tab.conn_pre_disconnect_hook_dropdown.clone()),
                     ),
             )
             .child(
@@ -158,7 +172,7 @@ impl ConnectionManagerWindow {
                     .child(
                         div()
                             .w(Widths::CM_FORM_DROPDOWN)
-                            .child(self.conn_post_disconnect_hook_dropdown.clone()),
+                            .child(self.settings_tab.conn_post_disconnect_hook_dropdown.clone()),
                     ),
             )
             .child(

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -223,16 +223,27 @@ struct FormState {
     form_save_password: bool,
     form_save_ssh_secret: bool,
     input_name: Entity<InputState>,
+    /// Filter text for the driver-select picker. Bound to a text input that
+    /// is focused on `/` from anywhere within the picker. The query is read
+    /// directly off the input in `render_driver_select`, so no cached field
+    /// is needed.
     driver_filter_input: Entity<InputState>,
+    /// Tracks whether the driver-picker filter input currently owns focus.
+    /// Used to decide whether Esc should blur the input or close the window.
     driver_filter_focused: bool,
+    /// Driver-specific field inputs, keyed by field ID.
     driver_inputs: HashMap<String, Entity<InputState>>,
+    /// Password is separate due to visibility toggle and save checkbox UI.
     input_password: Entity<InputState>,
     host_value_source_selector: Entity<ValueSourceSelector>,
     database_value_source_selector: Entity<ValueSourceSelector>,
     user_value_source_selector: Entity<ValueSourceSelector>,
     password_value_source_selector: Entity<ValueSourceSelector>,
+    /// Checkbox states keyed by field ID (e.g., "use_uri" -> true).
     checkbox_states: HashMap<String, bool>,
+    /// Active SSL mode id for the TRANSPORT section segmented control.
     selected_ssl_mode: String,
+    /// SSL certificate path inputs — shown conditionally based on selected_ssl_mode and driver metadata.
     ssl_ca_cert_input: Entity<InputState>,
     ssl_client_cert_input: Entity<InputState>,
     ssl_client_key_input: Entity<InputState>,
@@ -325,8 +336,11 @@ struct PendingActions {
     ssh_tunnel_selection: Option<Uuid>,
     ssh_key_path: Option<String>,
     file_path: Option<String>,
+    /// Pending cert-file path drained into `ssl_ca_cert_input` on next render.
     ssl_ca_cert_path: Option<String>,
+    /// Pending cert-file path drained into `ssl_client_cert_input` on next render.
     ssl_client_cert_path: Option<String>,
+    /// Pending cert-file path drained into `ssl_client_key_input` on next render.
     ssl_client_key_path: Option<String>,
 }
 

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -216,119 +216,51 @@ struct DriverInfo {
     uri_scheme: String,
 }
 
-pub struct ConnectionManagerWindow {
-    app_state: Entity<AppStateEntity>,
-    view: View,
-    /// In-window import panel. Rendered when `view == View::Import`. Holds the
-    /// multi-step import state so it never bloats this struct.
-    import_panel: Entity<ImportConnectionsPanel>,
-    active_tab: ActiveTab,
-    available_drivers: Vec<DriverInfo>,
+/// Driver and credential input widgets for the connection form's main tab.
+struct FormState {
     selected_driver_id: Option<String>,
     selected_driver: Option<Arc<dyn DbDriver>>,
     form_save_password: bool,
     form_save_ssh_secret: bool,
-    editing_profile_id: Option<uuid::Uuid>,
-
     input_name: Entity<InputState>,
-    /// Filter text for the driver-select picker. Bound to a text input that
-    /// is focused on `/` from anywhere within the picker. The query is read
-    /// directly off the input in `render_driver_select`, so no cached field
-    /// is needed.
     driver_filter_input: Entity<InputState>,
-    /// Tracks whether the driver-picker filter input currently owns focus.
-    /// Used to decide whether Esc should blur the input or close the window.
     driver_filter_focused: bool,
-    /// Driver-specific field inputs, keyed by field ID.
     driver_inputs: HashMap<String, Entity<InputState>>,
-    /// Password is separate due to visibility toggle and save checkbox UI.
     input_password: Entity<InputState>,
     host_value_source_selector: Entity<ValueSourceSelector>,
     database_value_source_selector: Entity<ValueSourceSelector>,
     user_value_source_selector: Entity<ValueSourceSelector>,
     password_value_source_selector: Entity<ValueSourceSelector>,
+    checkbox_states: HashMap<String, bool>,
+    selected_ssl_mode: String,
+    ssl_ca_cert_input: Entity<InputState>,
+    ssl_client_cert_input: Entity<InputState>,
+    ssl_client_key_input: Entity<InputState>,
+    show_password: bool,
+    show_ssh_passphrase: bool,
+    show_ssh_password: bool,
+    syncing_uri: bool,
+}
 
-    selected_proxy_id: Option<Uuid>,
-    proxy_dropdown: Entity<Dropdown>,
-    proxy_uuids: Vec<Uuid>,
-    pending_proxy_selection: Option<Uuid>,
-
+/// SSH tunnel, proxy, and SSM inline connection access widgets.
+struct AccessState {
     ssh_enabled: bool,
     ssh_auth_method: SshAuthSelection,
-    /// Checkbox states keyed by field ID (e.g., "use_uri" -> true).
-    checkbox_states: HashMap<String, bool>,
     selected_ssh_tunnel_id: Option<Uuid>,
     ssh_tunnel_dropdown: Entity<dbflux_components::controls::Dropdown>,
+    ssh_tunnel_uuids: Vec<Uuid>,
     input_ssh_host: Entity<InputState>,
     input_ssh_port: Entity<InputState>,
     input_ssh_user: Entity<InputState>,
     input_ssh_key_path: Entity<InputState>,
     input_ssh_key_passphrase: Entity<InputState>,
     input_ssh_password: Entity<InputState>,
-
-    validation_errors: Vec<String>,
-    test_status: TestStatus,
-    test_error: Option<String>,
-    /// Enriched test-connection result for the success banner body.
-    test_result: Option<dbflux_core::TestConnectionResult>,
-    /// Active SSL mode id for the TRANSPORT section segmented control.
-    selected_ssl_mode: String,
-    /// SSL certificate path inputs — shown conditionally based on selected_ssl_mode and driver metadata.
-    ssl_ca_cert_input: Entity<InputState>,
-    ssl_client_cert_input: Entity<InputState>,
-    ssl_client_key_input: Entity<InputState>,
-    ssh_test_status: TestStatus,
-    ssh_test_error: Option<String>,
-    pending_ssh_key_path: Option<String>,
-    pending_file_path: Option<String>,
-    /// Pending cert-file path drained into `ssl_ca_cert_input` on next render.
-    pending_ssl_ca_cert_path: Option<String>,
-    /// Pending cert-file path drained into `ssl_client_cert_input` on next render.
-    pending_ssl_client_cert_path: Option<String>,
-    /// Pending cert-file path drained into `ssl_client_key_input` on next render.
-    pending_ssl_client_key_path: Option<String>,
-    pending_ssh_tunnel_selection: Option<Uuid>,
-
-    show_password: bool,
-    show_ssh_passphrase: bool,
-    show_ssh_password: bool,
-
-    // Keyboard navigation state
-    focus_handle: FocusHandle,
-    keymap: &'static KeymapStack,
-    driver_focus: DriverFocus,
-    form_focus: FormFocus,
-    edit_state: EditState,
-
-    // Scroll handle for form content
-    form_scroll_handle: ScrollHandle,
-
-    // Dropdown state
-    ssh_tunnel_uuids: Vec<Uuid>,
-    _subscriptions: Vec<Subscription>,
-
-    // Target folder for new connections
-    target_folder_id: Option<Uuid>,
-
-    syncing_uri: bool,
-
-    // Auth profile dropdown (T-7.1)
-    auth_profile_dropdown: Entity<Dropdown>,
-    auth_profile_uuids: Vec<Uuid>,
-    selected_auth_profile_id: Option<Uuid>,
-    pending_auth_profile_selection: Option<Option<Uuid>>,
-    auth_profile_session_states: HashMap<Uuid, AuthSessionState>,
-    auth_profile_login_in_progress: bool,
-    auth_profile_action_message: Option<String>,
-    pending_wizard_auth_profile_selection: bool,
-    known_auth_profile_ids: HashSet<Uuid>,
-
-    // Access method dropdown (T-7.2)
+    selected_proxy_id: Option<Uuid>,
+    proxy_dropdown: Entity<Dropdown>,
+    proxy_uuids: Vec<Uuid>,
     access_method_dropdown: Entity<Dropdown>,
     access_kind: Option<AccessKind>,
     access_tab_mode: AccessTabMode,
-
-    // SSM inline fields (T-7.3)
     input_ssm_instance_id: Entity<InputState>,
     ssm_instance_id_value_source_selector: Entity<ValueSourceSelector>,
     input_ssm_region: Entity<InputState>,
@@ -338,9 +270,22 @@ pub struct ConnectionManagerWindow {
     ssm_auth_profile_dropdown: Entity<Dropdown>,
     ssm_auth_profile_uuids: Vec<Uuid>,
     selected_ssm_auth_profile_id: Option<Uuid>,
-    pending_ssm_auth_profile_selection: Option<Option<Uuid>>,
+}
 
-    // Settings tab state
+/// Auth profile dropdown and per-session login state.
+struct AuthProfileState {
+    auth_profile_dropdown: Entity<Dropdown>,
+    auth_profile_uuids: Vec<Uuid>,
+    selected_auth_profile_id: Option<Uuid>,
+    auth_profile_session_states: HashMap<Uuid, AuthSessionState>,
+    auth_profile_login_in_progress: bool,
+    auth_profile_action_message: Option<String>,
+    pending_wizard_auth_profile_selection: bool,
+    known_auth_profile_ids: HashSet<Uuid>,
+}
+
+/// Per-connection settings and hooks tab widgets.
+struct SettingsTabState {
     conn_override_refresh_policy: bool,
     conn_override_refresh_interval: bool,
     conn_refresh_policy_dropdown: Entity<Dropdown>,
@@ -359,14 +304,71 @@ pub struct ConnectionManagerWindow {
     conn_form_state: FormRendererState,
     conn_form_subscriptions: Vec<Subscription>,
     conn_loading_settings: bool,
+}
 
-    // MCP tab state
+/// MCP governance tab widgets.
+struct McpTabState {
     conn_mcp_enabled: bool,
     conn_mcp_actor_dropdown: Entity<Dropdown>,
     conn_mcp_role_dropdown: Entity<Dropdown>,
     conn_mcp_role_multi_select: Entity<MultiSelect>,
     conn_mcp_policy_dropdown: Entity<Dropdown>,
     conn_mcp_policy_multi_select: Entity<MultiSelect>,
+}
+
+/// Deferred actions written by background tasks or event handlers and drained on the next render.
+#[derive(Default)]
+struct PendingActions {
+    proxy_selection: Option<Uuid>,
+    auth_profile_selection: Option<Option<Uuid>>,
+    ssm_auth_profile_selection: Option<Option<Uuid>>,
+    ssh_tunnel_selection: Option<Uuid>,
+    ssh_key_path: Option<String>,
+    file_path: Option<String>,
+    ssl_ca_cert_path: Option<String>,
+    ssl_client_cert_path: Option<String>,
+    ssl_client_key_path: Option<String>,
+}
+
+pub struct ConnectionManagerWindow {
+    app_state: Entity<AppStateEntity>,
+    view: View,
+    /// In-window import panel. Rendered when `view == View::Import`. Holds the
+    /// multi-step import state so it never bloats this struct.
+    import_panel: Entity<ImportConnectionsPanel>,
+    active_tab: ActiveTab,
+    available_drivers: Vec<DriverInfo>,
+    editing_profile_id: Option<uuid::Uuid>,
+
+    validation_errors: Vec<String>,
+    test_status: TestStatus,
+    test_error: Option<String>,
+    /// Enriched test-connection result for the success banner body.
+    test_result: Option<dbflux_core::TestConnectionResult>,
+    ssh_test_status: TestStatus,
+    ssh_test_error: Option<String>,
+
+    // Keyboard navigation state
+    focus_handle: FocusHandle,
+    keymap: &'static KeymapStack,
+    driver_focus: DriverFocus,
+    form_focus: FormFocus,
+    edit_state: EditState,
+
+    // Scroll handle for form content
+    form_scroll_handle: ScrollHandle,
+
+    _subscriptions: Vec<Subscription>,
+
+    // Target folder for new connections
+    target_folder_id: Option<Uuid>,
+
+    form: FormState,
+    access: AccessState,
+    auth_profile: AuthProfileState,
+    settings_tab: SettingsTabState,
+    mcp_tab: McpTabState,
+    pending: PendingActions,
 }
 
 impl ConnectionManagerWindow {
@@ -600,11 +602,11 @@ impl ConnectionManagerWindow {
             window,
             |this, _, event: &InputEvent, _window, cx| match event {
                 InputEvent::Focus => {
-                    this.driver_filter_focused = true;
+                    this.form.driver_filter_focused = true;
                     cx.notify();
                 }
                 InputEvent::Blur => {
-                    this.driver_filter_focused = false;
+                    this.form.driver_filter_focused = false;
                     cx.notify();
                 }
                 _ => {}
@@ -657,120 +659,117 @@ impl ConnectionManagerWindow {
             import_panel,
             active_tab: ActiveTab::Main,
             available_drivers,
-            selected_driver_id: None,
-            selected_driver: None,
-            form_save_password: true,
-            form_save_ssh_secret: true,
             editing_profile_id: None,
-            input_name,
-            driver_filter_input,
-            driver_filter_focused: false,
-            driver_inputs: HashMap::new(),
-            input_password,
-            host_value_source_selector,
-            database_value_source_selector,
-            user_value_source_selector,
-            password_value_source_selector,
-            selected_proxy_id: None,
-            proxy_dropdown,
-            proxy_uuids: Vec::new(),
-            pending_proxy_selection: None,
-
-            ssh_enabled: false,
-            ssh_auth_method: SshAuthSelection::PrivateKey,
-            checkbox_states: HashMap::new(),
-            selected_ssh_tunnel_id: None,
-            ssh_tunnel_dropdown,
-            input_ssh_host,
-            input_ssh_port,
-            input_ssh_user,
-            input_ssh_key_path,
-            input_ssh_key_passphrase,
-            input_ssh_password,
             validation_errors: Vec::new(),
             test_status: TestStatus::None,
             test_error: None,
             test_result: None,
-            selected_ssl_mode: String::new(),
-            ssl_ca_cert_input,
-            ssl_client_cert_input,
-            ssl_client_key_input,
             ssh_test_status: TestStatus::None,
             ssh_test_error: None,
-            pending_ssh_key_path: None,
-            pending_file_path: None,
-            pending_ssl_ca_cert_path: None,
-            pending_ssl_client_cert_path: None,
-            pending_ssl_client_key_path: None,
-            pending_ssh_tunnel_selection: None,
-            show_password: false,
-            show_ssh_passphrase: false,
-            show_ssh_password: false,
             focus_handle,
             keymap: dbflux_ui_base::keymap::default_keymap(),
             driver_focus: DriverFocus::First,
             form_focus: FormFocus::Name,
             edit_state: EditState::Navigating,
             form_scroll_handle: ScrollHandle::new(),
-            ssh_tunnel_uuids: Vec::new(),
             _subscriptions: subscriptions,
             target_folder_id: None,
-            syncing_uri: false,
-
-            auth_profile_dropdown,
-            auth_profile_uuids: Vec::new(),
-            selected_auth_profile_id: None,
-            pending_auth_profile_selection: None,
-            auth_profile_session_states: HashMap::new(),
-            auth_profile_login_in_progress: false,
-            auth_profile_action_message: None,
-            pending_wizard_auth_profile_selection: false,
-            known_auth_profile_ids: app_state
-                .read(cx)
-                .list_auth_profiles()
-                .iter()
-                .map(|profile| profile.id)
-                .collect(),
-
-            access_method_dropdown,
-            access_kind: None,
-            access_tab_mode: AccessTabMode::Direct,
-
-            input_ssm_instance_id,
-            ssm_instance_id_value_source_selector,
-            input_ssm_region,
-            ssm_region_value_source_selector,
-            input_ssm_remote_port,
-            ssm_remote_port_value_source_selector,
-            ssm_auth_profile_dropdown,
-            ssm_auth_profile_uuids: Vec::new(),
-            selected_ssm_auth_profile_id: None,
-            pending_ssm_auth_profile_selection: None,
-
-            conn_override_refresh_policy: false,
-            conn_override_refresh_interval: false,
-            conn_refresh_policy_dropdown,
-            conn_refresh_interval_input,
-            conn_confirm_dangerous_dropdown,
-            conn_requires_where_dropdown,
-            conn_requires_preview_dropdown,
-            conn_pre_hook_dropdown,
-            conn_post_hook_dropdown,
-            conn_pre_disconnect_hook_dropdown,
-            conn_post_disconnect_hook_dropdown,
-            conn_pre_hook_extra_input,
-            conn_post_hook_extra_input,
-            conn_pre_disconnect_hook_extra_input,
-            conn_post_disconnect_hook_extra_input,
-            conn_form_state: FormRendererState::default(),
-            conn_form_subscriptions: Vec::new(),
-            conn_loading_settings: false,
-            conn_mcp_enabled: false,
-            conn_mcp_actor_dropdown,
-            conn_mcp_role_dropdown,
-            conn_mcp_role_multi_select,
-            conn_mcp_policy_dropdown,
-            conn_mcp_policy_multi_select,
+            form: FormState {
+                selected_driver_id: None,
+                selected_driver: None,
+                form_save_password: true,
+                form_save_ssh_secret: true,
+                input_name,
+                driver_filter_input,
+                driver_filter_focused: false,
+                driver_inputs: HashMap::new(),
+                input_password,
+                host_value_source_selector,
+                database_value_source_selector,
+                user_value_source_selector,
+                password_value_source_selector,
+                checkbox_states: HashMap::new(),
+                selected_ssl_mode: String::new(),
+                ssl_ca_cert_input,
+                ssl_client_cert_input,
+                ssl_client_key_input,
+                show_password: false,
+                show_ssh_passphrase: false,
+                show_ssh_password: false,
+                syncing_uri: false,
+            },
+            access: AccessState {
+                ssh_enabled: false,
+                ssh_auth_method: SshAuthSelection::PrivateKey,
+                selected_ssh_tunnel_id: None,
+                ssh_tunnel_dropdown,
+                ssh_tunnel_uuids: Vec::new(),
+                input_ssh_host,
+                input_ssh_port,
+                input_ssh_user,
+                input_ssh_key_path,
+                input_ssh_key_passphrase,
+                input_ssh_password,
+                selected_proxy_id: None,
+                proxy_dropdown,
+                proxy_uuids: Vec::new(),
+                access_method_dropdown,
+                access_kind: None,
+                access_tab_mode: AccessTabMode::Direct,
+                input_ssm_instance_id,
+                ssm_instance_id_value_source_selector,
+                input_ssm_region,
+                ssm_region_value_source_selector,
+                input_ssm_remote_port,
+                ssm_remote_port_value_source_selector,
+                ssm_auth_profile_dropdown,
+                ssm_auth_profile_uuids: Vec::new(),
+                selected_ssm_auth_profile_id: None,
+            },
+            auth_profile: AuthProfileState {
+                auth_profile_dropdown,
+                auth_profile_uuids: Vec::new(),
+                selected_auth_profile_id: None,
+                auth_profile_session_states: HashMap::new(),
+                auth_profile_login_in_progress: false,
+                auth_profile_action_message: None,
+                pending_wizard_auth_profile_selection: false,
+                known_auth_profile_ids: app_state
+                    .read(cx)
+                    .list_auth_profiles()
+                    .iter()
+                    .map(|profile| profile.id)
+                    .collect(),
+            },
+            settings_tab: SettingsTabState {
+                conn_override_refresh_policy: false,
+                conn_override_refresh_interval: false,
+                conn_refresh_policy_dropdown,
+                conn_refresh_interval_input,
+                conn_confirm_dangerous_dropdown,
+                conn_requires_where_dropdown,
+                conn_requires_preview_dropdown,
+                conn_pre_hook_dropdown,
+                conn_post_hook_dropdown,
+                conn_pre_disconnect_hook_dropdown,
+                conn_post_disconnect_hook_dropdown,
+                conn_pre_hook_extra_input,
+                conn_post_hook_extra_input,
+                conn_pre_disconnect_hook_extra_input,
+                conn_post_disconnect_hook_extra_input,
+                conn_form_state: FormRendererState::default(),
+                conn_form_subscriptions: Vec::new(),
+                conn_loading_settings: false,
+            },
+            mcp_tab: McpTabState {
+                conn_mcp_enabled: false,
+                conn_mcp_actor_dropdown,
+                conn_mcp_role_dropdown,
+                conn_mcp_role_multi_select,
+                conn_mcp_policy_dropdown,
+                conn_mcp_policy_multi_select,
+            },
+            pending: PendingActions::default(),
         }
     }
 
@@ -804,15 +803,15 @@ impl ConnectionManagerWindow {
         instance.editing_profile_id = Some(profile.id);
 
         let driver = app_state.read(cx).driver_for_profile(profile);
-        instance.selected_driver = driver.clone();
-        instance.selected_driver_id = Some(profile.driver_id());
-        instance.form_save_password = profile.save_password;
+        instance.form.selected_driver = driver.clone();
+        instance.form.selected_driver_id = Some(profile.driver_id());
+        instance.form.form_save_password = profile.save_password;
         instance.view = View::EditForm;
 
         if let Some(driver) = &driver {
             // Restore the SSL mode from the saved config; fall back to the driver's first
             // declared mode if the config doesn't carry one (e.g. URI mode or non-SSL drivers).
-            instance.selected_ssl_mode =
+            instance.form.selected_ssl_mode =
                 ssl_mode_from_config(&profile.config).unwrap_or_else(|| {
                     driver
                         .metadata()
@@ -861,29 +860,29 @@ impl ConnectionManagerWindow {
             };
 
             if !root_cert.is_empty() {
-                instance.ssl_ca_cert_input.update(cx, |state, cx| {
+                instance.form.ssl_ca_cert_input.update(cx, |state, cx| {
                     state.set_value(&root_cert, window, cx);
                 });
             }
             if !client_cert.is_empty() {
-                instance.ssl_client_cert_input.update(cx, |state, cx| {
+                instance.form.ssl_client_cert_input.update(cx, |state, cx| {
                     state.set_value(&client_cert, window, cx);
                 });
             }
             if !client_key.is_empty() {
-                instance.ssl_client_key_input.update(cx, |state, cx| {
+                instance.form.ssl_client_key_input.update(cx, |state, cx| {
                     state.set_value(&client_key, window, cx);
                 });
             }
         }
 
-        instance.input_name.update(cx, |state, cx| {
+        instance.form.input_name.update(cx, |state, cx| {
             state.set_value(&profile.name, window, cx);
         });
 
         if let Some(password) = app_state.read(cx).get_password(profile) {
             let password = password.expose_secret().to_string();
-            instance.input_password.update(cx, |state, cx| {
+            instance.form.input_password.update(cx, |state, cx| {
                 state.set_value(password.clone(), window, cx);
             });
         }
@@ -896,7 +895,8 @@ impl ConnectionManagerWindow {
             cx,
         );
 
-        instance.conn_mcp_enabled = profile.mcp_governance.as_ref().is_some_and(|g| g.enabled);
+        instance.mcp_tab.conn_mcp_enabled =
+            profile.mcp_governance.as_ref().is_some_and(|g| g.enabled);
 
         #[cfg(feature = "mcp")]
         {
@@ -908,21 +908,24 @@ impl ConnectionManagerWindow {
             instance.load_mcp_dropdowns(first_binding.as_ref(), window, cx);
         }
 
-        instance.selected_proxy_id = profile.proxy_profile_id;
-        instance.selected_auth_profile_id = profile.auth_profile_id;
-        instance.selected_ssm_auth_profile_id = None;
-        instance.access_kind = profile.access_kind.clone();
+        instance.access.selected_proxy_id = profile.proxy_profile_id;
+        instance.auth_profile.selected_auth_profile_id = profile.auth_profile_id;
+        instance.access.selected_ssm_auth_profile_id = None;
+        instance.access.access_kind = profile.access_kind.clone();
 
         if let Some(AccessKind::Proxy { proxy_profile_id }) = &profile.access_kind {
-            instance.selected_proxy_id.get_or_insert(*proxy_profile_id);
+            instance
+                .access
+                .selected_proxy_id
+                .get_or_insert(*proxy_profile_id);
         }
 
         if let Some(AccessKind::Ssh {
             ssh_tunnel_profile_id,
         }) = &profile.access_kind
         {
-            instance.selected_ssh_tunnel_id = Some(*ssh_tunnel_profile_id);
-            instance.ssh_enabled = true;
+            instance.access.selected_ssh_tunnel_id = Some(*ssh_tunnel_profile_id);
+            instance.access.ssh_enabled = true;
 
             let selected_tunnel = app_state
                 .read(cx)
@@ -947,65 +950,74 @@ impl ConnectionManagerWindow {
             let auth_profile_id: Option<uuid::Uuid> =
                 params.get("auth_profile_id").and_then(|s| s.parse().ok());
 
-            instance.input_ssm_instance_id.update(cx, |state, cx| {
-                state.set_value(instance_id, window, cx);
-            });
-            instance.input_ssm_region.update(cx, |state, cx| {
+            instance
+                .access
+                .input_ssm_instance_id
+                .update(cx, |state, cx| {
+                    state.set_value(instance_id, window, cx);
+                });
+            instance.access.input_ssm_region.update(cx, |state, cx| {
                 state.set_value(region, window, cx);
             });
-            instance.input_ssm_remote_port.update(cx, |state, cx| {
-                state.set_value(remote_port, window, cx);
-            });
-            instance.selected_ssm_auth_profile_id = auth_profile_id;
-            if instance.selected_auth_profile_id.is_none() {
-                instance.selected_auth_profile_id = auth_profile_id;
+            instance
+                .access
+                .input_ssm_remote_port
+                .update(cx, |state, cx| {
+                    state.set_value(remote_port, window, cx);
+                });
+            instance.access.selected_ssm_auth_profile_id = auth_profile_id;
+            if instance.auth_profile.selected_auth_profile_id.is_none() {
+                instance.auth_profile.selected_auth_profile_id = auth_profile_id;
             }
         }
 
         instance.populate_auth_profile_dropdown(cx);
         instance.refresh_auth_profile_sessions(cx);
         if let Some(ssh) = profile.config.ssh_tunnel() {
-            instance.ssh_enabled = true;
-            instance.input_ssh_host.update(cx, |state, cx| {
+            instance.access.ssh_enabled = true;
+            instance.access.input_ssh_host.update(cx, |state, cx| {
                 state.set_value(&ssh.host, window, cx);
             });
-            instance.input_ssh_port.update(cx, |state, cx| {
+            instance.access.input_ssh_port.update(cx, |state, cx| {
                 state.set_value(ssh.port.to_string(), window, cx);
             });
-            instance.input_ssh_user.update(cx, |state, cx| {
+            instance.access.input_ssh_user.update(cx, |state, cx| {
                 state.set_value(&ssh.user, window, cx);
             });
 
             match &ssh.auth_method {
                 dbflux_core::SshAuthMethod::PrivateKey { key_path } => {
-                    instance.ssh_auth_method = SshAuthSelection::PrivateKey;
+                    instance.access.ssh_auth_method = SshAuthSelection::PrivateKey;
                     if let Some(path) = key_path {
                         let path_str: String = path.to_string_lossy().into_owned();
-                        instance.input_ssh_key_path.update(cx, |state, cx| {
+                        instance.access.input_ssh_key_path.update(cx, |state, cx| {
                             state.set_value(path_str, window, cx);
                         });
                     }
                 }
                 dbflux_core::SshAuthMethod::Password => {
-                    instance.ssh_auth_method = SshAuthSelection::Password;
+                    instance.access.ssh_auth_method = SshAuthSelection::Password;
                 }
             }
 
             if let Some(ssh_secret) = app_state.read(cx).get_ssh_password(profile) {
                 let ssh_secret = ssh_secret.expose_secret().to_string();
-                match instance.ssh_auth_method {
+                match instance.access.ssh_auth_method {
                     SshAuthSelection::PrivateKey => {
-                        instance.input_ssh_key_passphrase.update(cx, |state, cx| {
-                            state.set_value(ssh_secret.clone(), window, cx);
-                        });
+                        instance
+                            .access
+                            .input_ssh_key_passphrase
+                            .update(cx, |state, cx| {
+                                state.set_value(ssh_secret.clone(), window, cx);
+                            });
                     }
                     SshAuthSelection::Password => {
-                        instance.input_ssh_password.update(cx, |state, cx| {
+                        instance.access.input_ssh_password.update(cx, |state, cx| {
                             state.set_value(ssh_secret.clone(), window, cx);
                         });
                     }
                 }
-                instance.form_save_ssh_secret = true;
+                instance.form.form_save_ssh_secret = true;
             }
         }
 
@@ -1018,29 +1030,29 @@ impl ConnectionManagerWindow {
 
     fn select_driver(&mut self, driver_id: &str, window: &mut Window, cx: &mut Context<Self>) {
         let driver = self.app_state.read(cx).drivers().get(driver_id).cloned();
-        self.selected_driver_id = Some(driver_id.to_string());
-        self.selected_driver = driver.clone();
-        self.form_save_password = true;
-        self.ssh_enabled = false;
-        self.ssh_auth_method = SshAuthSelection::PrivateKey;
-        self.form_save_ssh_secret = true;
+        self.form.selected_driver_id = Some(driver_id.to_string());
+        self.form.selected_driver = driver.clone();
+        self.form.form_save_password = true;
+        self.access.ssh_enabled = false;
+        self.access.ssh_auth_method = SshAuthSelection::PrivateKey;
+        self.form.form_save_ssh_secret = true;
         self.active_tab = ActiveTab::Main;
         self.validation_errors.clear();
         self.test_status = TestStatus::None;
         self.test_error = None;
 
-        self.selected_auth_profile_id = None;
-        self.selected_ssm_auth_profile_id = None;
-        self.access_kind = None;
-        self.access_tab_mode = AccessTabMode::Direct;
+        self.auth_profile.selected_auth_profile_id = None;
+        self.access.selected_ssm_auth_profile_id = None;
+        self.access.access_kind = None;
+        self.access.access_tab_mode = AccessTabMode::Direct;
 
-        self.input_name.update(cx, |state, cx| {
+        self.form.input_name.update(cx, |state, cx| {
             state.set_value("", window, cx);
         });
 
         if let Some(driver) = driver {
             // Initialize SSL mode to the driver's first declared ssl mode option, if any.
-            self.selected_ssl_mode = driver
+            self.form.selected_ssl_mode = driver
                 .metadata()
                 .ssl_modes
                 .and_then(|modes| modes.first())
@@ -1073,7 +1085,7 @@ impl ConnectionManagerWindow {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.driver_inputs.clear();
+        self.form.driver_inputs.clear();
 
         let fields: Vec<&FormFieldDef> = form
             .tabs
@@ -1121,7 +1133,7 @@ impl ConnectionManagerWindow {
             );
             self._subscriptions.push(subscription);
 
-            self.driver_inputs.insert(field.id.to_string(), input);
+            self.form.driver_inputs.insert(field.id.to_string(), input);
         }
     }
 
@@ -1138,14 +1150,16 @@ impl ConnectionManagerWindow {
                     if field.kind == FormFieldKind::Checkbox {
                         let is_checked =
                             values.get(&field.id).map(|v| v == "true").unwrap_or(false);
-                        self.checkbox_states.insert(field.id.clone(), is_checked);
+                        self.form
+                            .checkbox_states
+                            .insert(field.id.clone(), is_checked);
                     }
                 }
             }
         }
 
         for (field_id, value) in values {
-            if let Some(input) = self.driver_inputs.get(field_id) {
+            if let Some(input) = self.form.driver_inputs.get(field_id) {
                 input.update(cx, |state, cx| {
                     state.set_value(value, window, cx);
                 });
@@ -1162,37 +1176,46 @@ impl ConnectionManagerWindow {
 
         form_renderer::collect_values(
             form,
-            &self.driver_inputs,
-            &self.checkbox_states,
+            &self.form.driver_inputs,
+            &self.form.checkbox_states,
             &dropdowns,
             cx,
         )
     }
 
     fn reset_value_source_selectors(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.host_value_source_selector.update(cx, |selector, cx| {
-            let _ = selector.set_value_ref(None, window, cx);
-        });
-        self.ssm_instance_id_value_source_selector
+        self.form
+            .host_value_source_selector
             .update(cx, |selector, cx| {
                 let _ = selector.set_value_ref(None, window, cx);
             });
-        self.ssm_region_value_source_selector
+        self.access
+            .ssm_instance_id_value_source_selector
             .update(cx, |selector, cx| {
                 let _ = selector.set_value_ref(None, window, cx);
             });
-        self.ssm_remote_port_value_source_selector
+        self.access
+            .ssm_region_value_source_selector
             .update(cx, |selector, cx| {
                 let _ = selector.set_value_ref(None, window, cx);
             });
-        self.database_value_source_selector
+        self.access
+            .ssm_remote_port_value_source_selector
             .update(cx, |selector, cx| {
                 let _ = selector.set_value_ref(None, window, cx);
             });
-        self.user_value_source_selector.update(cx, |selector, cx| {
-            let _ = selector.set_value_ref(None, window, cx);
-        });
-        self.password_value_source_selector
+        self.form
+            .database_value_source_selector
+            .update(cx, |selector, cx| {
+                let _ = selector.set_value_ref(None, window, cx);
+            });
+        self.form
+            .user_value_source_selector
+            .update(cx, |selector, cx| {
+                let _ = selector.set_value_ref(None, window, cx);
+            });
+        self.form
+            .password_value_source_selector
             .update(cx, |selector, cx| {
                 let _ = selector.set_value_ref(None, window, cx);
             });
@@ -1204,56 +1227,48 @@ impl ConnectionManagerWindow {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.ssm_instance_id_value_source_selector
+        self.access
+            .ssm_instance_id_value_source_selector
             .update(cx, |selector, cx| {
                 let primary =
                     selector.set_value_ref(profile.value_refs.get("ssm_instance_id"), window, cx);
                 if !primary.is_empty() {
-                    self.input_ssm_instance_id.update(cx, |state, cx| {
+                    self.access.input_ssm_instance_id.update(cx, |state, cx| {
                         state.set_value(primary.clone(), window, cx);
                     });
                 }
             });
 
-        self.ssm_region_value_source_selector
+        self.access
+            .ssm_region_value_source_selector
             .update(cx, |selector, cx| {
                 let primary =
                     selector.set_value_ref(profile.value_refs.get("ssm_region"), window, cx);
                 if !primary.is_empty() {
-                    self.input_ssm_region.update(cx, |state, cx| {
+                    self.access.input_ssm_region.update(cx, |state, cx| {
                         state.set_value(primary.clone(), window, cx);
                     });
                 }
             });
 
-        self.ssm_remote_port_value_source_selector
+        self.access
+            .ssm_remote_port_value_source_selector
             .update(cx, |selector, cx| {
                 let primary =
                     selector.set_value_ref(profile.value_refs.get("ssm_remote_port"), window, cx);
                 if !primary.is_empty() {
-                    self.input_ssm_remote_port.update(cx, |state, cx| {
+                    self.access.input_ssm_remote_port.update(cx, |state, cx| {
                         state.set_value(primary.clone(), window, cx);
                     });
                 }
             });
 
-        self.host_value_source_selector.update(cx, |selector, cx| {
-            let primary = selector.set_value_ref(profile.value_refs.get("host"), window, cx);
-            if !primary.is_empty()
-                && let Some(input) = self.driver_inputs.get("host")
-            {
-                input.update(cx, |state, cx| {
-                    state.set_value(primary.clone(), window, cx);
-                });
-            }
-        });
-
-        self.database_value_source_selector
+        self.form
+            .host_value_source_selector
             .update(cx, |selector, cx| {
-                let primary =
-                    selector.set_value_ref(profile.value_refs.get("database"), window, cx);
+                let primary = selector.set_value_ref(profile.value_refs.get("host"), window, cx);
                 if !primary.is_empty()
-                    && let Some(input) = self.driver_inputs.get("database")
+                    && let Some(input) = self.form.driver_inputs.get("host")
                 {
                     input.update(cx, |state, cx| {
                         state.set_value(primary.clone(), window, cx);
@@ -1261,23 +1276,40 @@ impl ConnectionManagerWindow {
                 }
             });
 
-        self.user_value_source_selector.update(cx, |selector, cx| {
-            let primary = selector.set_value_ref(profile.value_refs.get("user"), window, cx);
-            if !primary.is_empty()
-                && let Some(input) = self.driver_inputs.get("user")
-            {
-                input.update(cx, |state, cx| {
-                    state.set_value(primary.clone(), window, cx);
-                });
-            }
-        });
+        self.form
+            .database_value_source_selector
+            .update(cx, |selector, cx| {
+                let primary =
+                    selector.set_value_ref(profile.value_refs.get("database"), window, cx);
+                if !primary.is_empty()
+                    && let Some(input) = self.form.driver_inputs.get("database")
+                {
+                    input.update(cx, |state, cx| {
+                        state.set_value(primary.clone(), window, cx);
+                    });
+                }
+            });
 
-        self.password_value_source_selector
+        self.form
+            .user_value_source_selector
+            .update(cx, |selector, cx| {
+                let primary = selector.set_value_ref(profile.value_refs.get("user"), window, cx);
+                if !primary.is_empty()
+                    && let Some(input) = self.form.driver_inputs.get("user")
+                {
+                    input.update(cx, |state, cx| {
+                        state.set_value(primary.clone(), window, cx);
+                    });
+                }
+            });
+
+        self.form
+            .password_value_source_selector
             .update(cx, |selector, cx| {
                 let primary =
                     selector.set_value_ref(profile.value_refs.get("password"), window, cx);
                 if !primary.is_empty() {
-                    self.input_password.update(cx, |state, cx| {
+                    self.form.input_password.update(cx, |state, cx| {
                         state.set_value(primary, window, cx);
                     });
                 }
@@ -1289,8 +1321,14 @@ impl ConnectionManagerWindow {
     pub(super) fn collect_value_refs(&self, cx: &App) -> HashMap<String, ValueRef> {
         let mut refs = HashMap::new();
 
-        let ssm_instance_id = self.input_ssm_instance_id.read(cx).value().to_string();
+        let ssm_instance_id = self
+            .access
+            .input_ssm_instance_id
+            .read(cx)
+            .value()
+            .to_string();
         if let Some(value_ref) = self
+            .access
             .ssm_instance_id_value_source_selector
             .read(cx)
             .value_ref(&ssm_instance_id, cx)
@@ -1298,8 +1336,9 @@ impl ConnectionManagerWindow {
             refs.insert("ssm_instance_id".to_string(), value_ref);
         }
 
-        let ssm_region = self.input_ssm_region.read(cx).value().to_string();
+        let ssm_region = self.access.input_ssm_region.read(cx).value().to_string();
         if let Some(value_ref) = self
+            .access
             .ssm_region_value_source_selector
             .read(cx)
             .value_ref(&ssm_region, cx)
@@ -1307,8 +1346,14 @@ impl ConnectionManagerWindow {
             refs.insert("ssm_region".to_string(), value_ref);
         }
 
-        let ssm_remote_port = self.input_ssm_remote_port.read(cx).value().to_string();
+        let ssm_remote_port = self
+            .access
+            .input_ssm_remote_port
+            .read(cx)
+            .value()
+            .to_string();
         if let Some(value_ref) = self
+            .access
             .ssm_remote_port_value_source_selector
             .read(cx)
             .value_ref(&ssm_remote_port, cx)
@@ -1317,11 +1362,13 @@ impl ConnectionManagerWindow {
         }
 
         let host_value = self
+            .form
             .driver_inputs
             .get("host")
             .map(|input| input.read(cx).value().to_string())
             .unwrap_or_default();
         if let Some(value_ref) = self
+            .form
             .host_value_source_selector
             .read(cx)
             .value_ref(&host_value, cx)
@@ -1330,11 +1377,13 @@ impl ConnectionManagerWindow {
         }
 
         let database_value = self
+            .form
             .driver_inputs
             .get("database")
             .map(|input| input.read(cx).value().to_string())
             .unwrap_or_default();
         if let Some(value_ref) = self
+            .form
             .database_value_source_selector
             .read(cx)
             .value_ref(&database_value, cx)
@@ -1343,11 +1392,13 @@ impl ConnectionManagerWindow {
         }
 
         let user_value = self
+            .form
             .driver_inputs
             .get("user")
             .map(|input| input.read(cx).value().to_string())
             .unwrap_or_default();
         if let Some(value_ref) = self
+            .form
             .user_value_source_selector
             .read(cx)
             .value_ref(&user_value, cx)
@@ -1355,8 +1406,9 @@ impl ConnectionManagerWindow {
             refs.insert("user".to_string(), value_ref);
         }
 
-        let password_value = self.input_password.read(cx).value().to_string();
+        let password_value = self.form.input_password.read(cx).value().to_string();
         if let Some(value_ref) = self
+            .form
             .password_value_source_selector
             .read(cx)
             .value_ref(&password_value, cx)
@@ -1370,21 +1422,32 @@ impl ConnectionManagerWindow {
     pub(super) fn has_dynamic_value_ref_for_field(&self, field_id: &str, cx: &App) -> bool {
         match field_id {
             "ssm_instance_id" => !self
+                .access
                 .ssm_instance_id_value_source_selector
                 .read(cx)
                 .is_literal(cx),
             "ssm_region" => !self
+                .access
                 .ssm_region_value_source_selector
                 .read(cx)
                 .is_literal(cx),
             "ssm_remote_port" => !self
+                .access
                 .ssm_remote_port_value_source_selector
                 .read(cx)
                 .is_literal(cx),
-            "host" => !self.host_value_source_selector.read(cx).is_literal(cx),
-            "database" => !self.database_value_source_selector.read(cx).is_literal(cx),
-            "user" => !self.user_value_source_selector.read(cx).is_literal(cx),
-            "password" => !self.password_value_source_selector.read(cx).is_literal(cx),
+            "host" => !self.form.host_value_source_selector.read(cx).is_literal(cx),
+            "database" => !self
+                .form
+                .database_value_source_selector
+                .read(cx)
+                .is_literal(cx),
+            "user" => !self.form.user_value_source_selector.read(cx).is_literal(cx),
+            "password" => !self
+                .form
+                .password_value_source_selector
+                .read(cx)
+                .is_literal(cx),
             _ => false,
         }
     }
@@ -1392,8 +1455,8 @@ impl ConnectionManagerWindow {
     fn back_to_driver_select(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         window.focus(&self.focus_handle);
         self.view = View::DriverSelect;
-        self.selected_driver_id = None;
-        self.selected_driver = None;
+        self.form.selected_driver_id = None;
+        self.form.selected_driver = None;
         self.validation_errors.clear();
         self.test_status = TestStatus::None;
         self.test_error = None;
@@ -1401,18 +1464,18 @@ impl ConnectionManagerWindow {
     }
 
     fn selected_kind(&self) -> Option<DbKind> {
-        self.selected_driver.as_ref().map(|d| d.kind())
+        self.form.selected_driver.as_ref().map(|d| d.kind())
     }
 
     fn selected_driver_id(&self) -> Option<&str> {
-        self.selected_driver_id.as_deref()
+        self.form.selected_driver_id.as_deref()
     }
 
     /// Returns true if this driver uses the server form (host/port/user/database)
     /// instead of a file-based form (path only).
     #[allow(dead_code)]
     fn uses_server_form(&self) -> bool {
-        let Some(driver) = &self.selected_driver else {
+        let Some(driver) = &self.form.selected_driver else {
             return false;
         };
         !driver.form_definition().uses_file_form()
@@ -1420,7 +1483,7 @@ impl ConnectionManagerWindow {
 
     /// Returns true if this driver uses a file-based form (path only).
     fn uses_file_form(&self) -> bool {
-        let Some(driver) = &self.selected_driver else {
+        let Some(driver) = &self.form.selected_driver else {
             return false;
         };
         driver.form_definition().uses_file_form()
@@ -1429,7 +1492,7 @@ impl ConnectionManagerWindow {
     /// Returns true if this driver supports SSH tunneling.
     #[allow(dead_code)]
     fn supports_ssh(&self) -> bool {
-        let Some(driver) = &self.selected_driver else {
+        let Some(driver) = &self.form.selected_driver else {
             return false;
         };
         driver.form_definition().supports_ssh()
@@ -1441,28 +1504,28 @@ impl ConnectionManagerWindow {
     }
 
     fn input_state_for_field(&self, field_id: &str) -> Option<&Entity<InputState>> {
-        if let Some(input) = self.driver_inputs.get(field_id) {
+        if let Some(input) = self.form.driver_inputs.get(field_id) {
             return Some(input);
         }
 
         if field_id == "password" {
-            return Some(&self.input_password);
+            return Some(&self.form.input_password);
         }
 
         match field_id {
-            "ssh_host" => Some(&self.input_ssh_host),
-            "ssh_port" => Some(&self.input_ssh_port),
-            "ssh_user" => Some(&self.input_ssh_user),
-            "ssh_key_path" => Some(&self.input_ssh_key_path),
-            "ssh_passphrase" => Some(&self.input_ssh_key_passphrase),
-            "ssh_password" => Some(&self.input_ssh_password),
+            "ssh_host" => Some(&self.access.input_ssh_host),
+            "ssh_port" => Some(&self.access.input_ssh_port),
+            "ssh_user" => Some(&self.access.input_ssh_user),
+            "ssh_key_path" => Some(&self.access.input_ssh_key_path),
+            "ssh_passphrase" => Some(&self.access.input_ssh_key_passphrase),
+            "ssh_password" => Some(&self.access.input_ssh_password),
             _ => None,
         }
     }
 
     /// Check if a field is enabled based on its conditional dependencies.
     fn is_field_enabled(&self, field: &FormFieldDef) -> bool {
-        form_renderer::is_field_enabled(field, &self.checkbox_states)
+        form_renderer::is_field_enabled(field, &self.form.checkbox_states)
     }
 
     /// Map a field ID to its FormFocus variant.
@@ -1517,30 +1580,33 @@ impl ConnectionManagerWindow {
 
     fn input_for_focus(&self, focus: FormFocus) -> Option<&Entity<InputState>> {
         let uri_mode = self
+            .form
             .checkbox_states
             .get("use_uri")
             .copied()
             .unwrap_or(false);
 
         if focus == FormFocus::Host && uri_mode {
-            return self.driver_inputs.get("uri");
+            return self.form.driver_inputs.get("uri");
         }
 
         if let Some(field_id) = Self::focus_to_field_id(focus)
-            && let Some(input) = self.driver_inputs.get(field_id)
+            && let Some(input) = self.form.driver_inputs.get(field_id)
         {
             return Some(input);
         }
 
         match focus {
             FormFocus::Host => self
+                .form
                 .driver_inputs
                 .get("uri")
-                .or_else(|| self.driver_inputs.get("host")),
+                .or_else(|| self.form.driver_inputs.get("host")),
             FormFocus::Database => self
+                .form
                 .driver_inputs
                 .get("path")
-                .or_else(|| self.driver_inputs.get("database")),
+                .or_else(|| self.form.driver_inputs.get("database")),
             _ => None,
         }
     }
@@ -1617,15 +1683,15 @@ impl ConnectionManagerWindow {
             })
         });
 
-        self.conn_mcp_actor_dropdown.update(cx, |d, cx| {
+        self.mcp_tab.conn_mcp_actor_dropdown.update(cx, |d, cx| {
             d.set_items(actor_items, cx);
             d.set_selected_index(actor_index, cx);
         });
-        self.conn_mcp_role_dropdown.update(cx, |d, cx| {
+        self.mcp_tab.conn_mcp_role_dropdown.update(cx, |d, cx| {
             d.set_items(role_items, cx);
             d.set_selected_index(role_index.or(Some(0)), cx);
         });
-        self.conn_mcp_policy_dropdown.update(cx, |d, cx| {
+        self.mcp_tab.conn_mcp_policy_dropdown.update(cx, |d, cx| {
             d.set_items(policy_items.clone(), cx);
             d.set_selected_index(policy_index.or(Some(0)), cx);
         });
@@ -1651,26 +1717,34 @@ impl ConnectionManagerWindow {
             })
             .collect();
 
-        self.conn_mcp_role_multi_select.update(cx, |ms, cx| {
-            ms.set_items(all_role_items, cx);
-        });
+        self.mcp_tab
+            .conn_mcp_role_multi_select
+            .update(cx, |ms, cx| {
+                ms.set_items(all_role_items, cx);
+            });
 
-        self.conn_mcp_policy_multi_select.update(cx, |ms, cx| {
-            ms.set_items(all_policy_items, cx);
-        });
+        self.mcp_tab
+            .conn_mcp_policy_multi_select
+            .update(cx, |ms, cx| {
+                ms.set_items(all_policy_items, cx);
+            });
 
         // Set selected values from binding
         if let Some(binding) = binding {
             let extra_roles: Vec<String> = binding.role_ids.iter().skip(1).cloned().collect();
             let extra_policies: Vec<String> = binding.policy_ids.iter().skip(1).cloned().collect();
 
-            self.conn_mcp_role_multi_select.update(cx, |ms, cx| {
-                ms.set_selected_values(&extra_roles, cx);
-            });
+            self.mcp_tab
+                .conn_mcp_role_multi_select
+                .update(cx, |ms, cx| {
+                    ms.set_selected_values(&extra_roles, cx);
+                });
 
-            self.conn_mcp_policy_multi_select.update(cx, |ms, cx| {
-                ms.set_selected_values(&extra_policies, cx);
-            });
+            self.mcp_tab
+                .conn_mcp_policy_multi_select
+                .update(cx, |ms, cx| {
+                    ms.set_selected_values(&extra_policies, cx);
+                });
         }
     }
 
@@ -1684,14 +1758,15 @@ impl ConnectionManagerWindow {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.conn_loading_settings = true;
-        self.conn_form_subscriptions.clear();
-        self.conn_form_state.clear();
+        self.settings_tab.conn_loading_settings = true;
+        self.settings_tab.conn_form_subscriptions.clear();
+        self.settings_tab.conn_form_state.clear();
 
         let overrides = overrides.cloned().unwrap_or_default();
 
-        self.conn_override_refresh_policy = overrides.refresh_policy.is_some();
-        self.conn_override_refresh_interval = overrides.refresh_interval_secs.is_some();
+        self.settings_tab.conn_override_refresh_policy = overrides.refresh_policy.is_some();
+        self.settings_tab.conn_override_refresh_interval =
+            overrides.refresh_interval_secs.is_some();
 
         let effective = self.resolve_driver_effective_settings(cx);
 
@@ -1703,7 +1778,8 @@ impl ConnectionManagerWindow {
             dbflux_core::RefreshPolicySetting::Manual => 0,
             dbflux_core::RefreshPolicySetting::Interval => 1,
         };
-        self.conn_refresh_policy_dropdown
+        self.settings_tab
+            .conn_refresh_policy_dropdown
             .update(cx, |dropdown, cx| {
                 dropdown.set_items(policy_items, cx);
                 dropdown.set_selected_index(Some(policy_index), cx);
@@ -1712,9 +1788,11 @@ impl ConnectionManagerWindow {
         let interval_val = overrides
             .refresh_interval_secs
             .unwrap_or(effective.refresh_interval_secs);
-        self.conn_refresh_interval_input.update(cx, |input, cx| {
-            input.set_value(interval_val.to_string(), window, cx);
-        });
+        self.settings_tab
+            .conn_refresh_interval_input
+            .update(cx, |input, cx| {
+                input.set_value(interval_val.to_string(), window, cx);
+            });
 
         let boolean_items = vec![
             dbflux_components::controls::DropdownItem::with_value("Use Driver Default", "default"),
@@ -1730,17 +1808,20 @@ impl ConnectionManagerWindow {
             }
         };
 
-        self.conn_confirm_dangerous_dropdown
+        self.settings_tab
+            .conn_confirm_dangerous_dropdown
             .update(cx, |dropdown, cx| {
                 dropdown.set_items(boolean_items.clone(), cx);
                 dropdown.set_selected_index(Some(bool_index(overrides.confirm_dangerous)), cx);
             });
-        self.conn_requires_where_dropdown
+        self.settings_tab
+            .conn_requires_where_dropdown
             .update(cx, |dropdown, cx| {
                 dropdown.set_items(boolean_items.clone(), cx);
                 dropdown.set_selected_index(Some(bool_index(overrides.requires_where)), cx);
             });
-        self.conn_requires_preview_dropdown
+        self.settings_tab
+            .conn_requires_preview_dropdown
             .update(cx, |dropdown, cx| {
                 dropdown.set_items(boolean_items, cx);
                 dropdown.set_selected_index(Some(bool_index(overrides.requires_preview)), cx);
@@ -1788,70 +1869,83 @@ impl ConnectionManagerWindow {
         let pre_disconnect_index = selection_index(&pre_disconnect_selected);
         let post_disconnect_index = selection_index(&post_disconnect_selected);
 
-        self.conn_pre_hook_dropdown.update(cx, |dropdown, cx| {
-            dropdown.set_items(hook_items.clone(), cx);
-            dropdown.set_selected_index(Some(pre_index), cx);
-        });
+        self.settings_tab
+            .conn_pre_hook_dropdown
+            .update(cx, |dropdown, cx| {
+                dropdown.set_items(hook_items.clone(), cx);
+                dropdown.set_selected_index(Some(pre_index), cx);
+            });
 
-        self.conn_post_hook_dropdown.update(cx, |dropdown, cx| {
-            dropdown.set_items(hook_items.clone(), cx);
-            dropdown.set_selected_index(Some(post_index), cx);
-        });
+        self.settings_tab
+            .conn_post_hook_dropdown
+            .update(cx, |dropdown, cx| {
+                dropdown.set_items(hook_items.clone(), cx);
+                dropdown.set_selected_index(Some(post_index), cx);
+            });
 
-        self.conn_pre_hook_extra_input.update(cx, |input, cx| {
-            input.set_value(pre_extra, window, cx);
-        });
+        self.settings_tab
+            .conn_pre_hook_extra_input
+            .update(cx, |input, cx| {
+                input.set_value(pre_extra, window, cx);
+            });
 
-        self.conn_post_hook_extra_input.update(cx, |input, cx| {
-            input.set_value(post_extra, window, cx);
-        });
+        self.settings_tab
+            .conn_post_hook_extra_input
+            .update(cx, |input, cx| {
+                input.set_value(post_extra, window, cx);
+            });
 
-        self.conn_pre_disconnect_hook_dropdown
+        self.settings_tab
+            .conn_pre_disconnect_hook_dropdown
             .update(cx, |dropdown, cx| {
                 dropdown.set_items(hook_items.clone(), cx);
                 dropdown.set_selected_index(Some(pre_disconnect_index), cx);
             });
 
-        self.conn_pre_disconnect_hook_extra_input
+        self.settings_tab
+            .conn_pre_disconnect_hook_extra_input
             .update(cx, |input, cx| {
                 input.set_value(pre_disconnect_extra, window, cx);
             });
 
-        self.conn_post_disconnect_hook_dropdown
+        self.settings_tab
+            .conn_post_disconnect_hook_dropdown
             .update(cx, |dropdown, cx| {
                 dropdown.set_items(hook_items, cx);
                 dropdown.set_selected_index(Some(post_disconnect_index), cx);
             });
 
-        self.conn_post_disconnect_hook_extra_input
+        self.settings_tab
+            .conn_post_disconnect_hook_extra_input
             .update(cx, |input, cx| {
                 input.set_value(post_disconnect_extra, window, cx);
             });
 
-        if let Some(driver) = &self.selected_driver
+        if let Some(driver) = &self.form.selected_driver
             && let Some(schema) = driver.settings_schema()
         {
             let values = connection_settings.cloned().unwrap_or_default();
-            self.conn_form_state = form_renderer::create_inputs(&schema, &values, window, cx);
+            self.settings_tab.conn_form_state =
+                form_renderer::create_inputs(&schema, &values, window, cx);
 
             let mut subscriptions = Vec::new();
-            for input in self.conn_form_state.inputs.values() {
+            for input in self.settings_tab.conn_form_state.inputs.values() {
                 subscriptions.push(cx.subscribe_in(
                     input,
                     window,
                     |_this, _, _event: &InputEvent, _window, _cx| {},
                 ));
             }
-            for dropdown in self.conn_form_state.dropdowns.values() {
+            for dropdown in self.settings_tab.conn_form_state.dropdowns.values() {
                 subscriptions.push(cx.subscribe(
                     dropdown,
                     |_this, _dropdown, _event: &DropdownSelectionChanged, _cx| {},
                 ));
             }
-            self.conn_form_subscriptions = subscriptions;
+            self.settings_tab.conn_form_subscriptions = subscriptions;
         }
 
-        self.conn_loading_settings = false;
+        self.settings_tab.conn_loading_settings = false;
     }
 
     /// Resolve driver-level effective settings (without connection overrides)
@@ -1861,7 +1955,7 @@ impl ConnectionManagerWindow {
         cx: &Context<Self>,
     ) -> dbflux_core::EffectiveSettings {
         let state = self.app_state.read(cx);
-        if let Some(driver) = &self.selected_driver {
+        if let Some(driver) = &self.form.selected_driver {
             state.effective_settings(&driver.driver_key())
         } else {
             let empty = dbflux_core::FormValues::new();
@@ -1879,8 +1973,9 @@ impl ConnectionManagerWindow {
     fn collect_connection_overrides(&self, cx: &Context<Self>) -> Option<GlobalOverrides> {
         let mut overrides = GlobalOverrides::default();
 
-        if self.conn_override_refresh_policy {
+        if self.settings_tab.conn_override_refresh_policy {
             let value = self
+                .settings_tab
                 .conn_refresh_policy_dropdown
                 .read(cx)
                 .selected_value()
@@ -1894,8 +1989,9 @@ impl ConnectionManagerWindow {
             });
         }
 
-        if self.conn_override_refresh_interval {
+        if self.settings_tab.conn_override_refresh_interval {
             let text = self
+                .settings_tab
                 .conn_refresh_interval_input
                 .read(cx)
                 .value()
@@ -1925,10 +2021,11 @@ impl ConnectionManagerWindow {
         }
 
         overrides.confirm_dangerous =
-            parse_boolean_dropdown(&self.conn_confirm_dangerous_dropdown, cx);
-        overrides.requires_where = parse_boolean_dropdown(&self.conn_requires_where_dropdown, cx);
+            parse_boolean_dropdown(&self.settings_tab.conn_confirm_dangerous_dropdown, cx);
+        overrides.requires_where =
+            parse_boolean_dropdown(&self.settings_tab.conn_requires_where_dropdown, cx);
         overrides.requires_preview =
-            parse_boolean_dropdown(&self.conn_requires_preview_dropdown, cx);
+            parse_boolean_dropdown(&self.settings_tab.conn_requires_preview_dropdown, cx);
 
         if overrides.is_empty() {
             None
@@ -1942,14 +2039,14 @@ impl ConnectionManagerWindow {
     /// Unchecked checkboxes are stored as `"false"` (not stripped) so they can
     /// explicitly override a driver-level `"true"` value.
     fn collect_connection_settings(&self, cx: &Context<Self>) -> Option<dbflux_core::FormValues> {
-        let driver = self.selected_driver.as_ref()?;
+        let driver = self.form.selected_driver.as_ref()?;
         let schema = driver.settings_schema()?;
 
         let collected = form_renderer::collect_values(
             &schema,
-            &self.conn_form_state.inputs,
-            &self.conn_form_state.checkboxes,
-            &self.conn_form_state.dropdowns,
+            &self.settings_tab.conn_form_state.inputs,
+            &self.settings_tab.conn_form_state.checkboxes,
+            &self.settings_tab.conn_form_state.dropdowns,
             cx,
         );
 
@@ -1981,38 +2078,52 @@ impl ConnectionManagerWindow {
 
     fn collect_hook_bindings(&self, cx: &Context<Self>) -> Option<ConnectionHookBindings> {
         let pre_connect = Self::merge_hook_ids(
-            self.conn_pre_hook_dropdown
+            self.settings_tab
+                .conn_pre_hook_dropdown
                 .read(cx)
                 .selected_value()
                 .map(|value| value.to_string()),
-            self.conn_pre_hook_extra_input.read(cx).value().to_string(),
+            self.settings_tab
+                .conn_pre_hook_extra_input
+                .read(cx)
+                .value()
+                .to_string(),
         );
 
         let post_connect = Self::merge_hook_ids(
-            self.conn_post_hook_dropdown
+            self.settings_tab
+                .conn_post_hook_dropdown
                 .read(cx)
                 .selected_value()
                 .map(|value| value.to_string()),
-            self.conn_post_hook_extra_input.read(cx).value().to_string(),
+            self.settings_tab
+                .conn_post_hook_extra_input
+                .read(cx)
+                .value()
+                .to_string(),
         );
 
         let pre_disconnect = Self::merge_hook_ids(
-            self.conn_pre_disconnect_hook_dropdown
+            self.settings_tab
+                .conn_pre_disconnect_hook_dropdown
                 .read(cx)
                 .selected_value()
                 .map(|value| value.to_string()),
-            self.conn_pre_disconnect_hook_extra_input
+            self.settings_tab
+                .conn_pre_disconnect_hook_extra_input
                 .read(cx)
                 .value()
                 .to_string(),
         );
 
         let post_disconnect = Self::merge_hook_ids(
-            self.conn_post_disconnect_hook_dropdown
+            self.settings_tab
+                .conn_post_disconnect_hook_dropdown
                 .read(cx)
                 .selected_value()
                 .map(|value| value.to_string()),
-            self.conn_post_disconnect_hook_extra_input
+            self.settings_tab
+                .conn_post_disconnect_hook_extra_input
                 .read(cx)
                 .value()
                 .to_string(),
@@ -2068,7 +2179,7 @@ impl ConnectionManagerWindow {
 
     /// Returns the number of driver schema fields (for Settings tab navigation).
     fn settings_driver_field_count(&self) -> u8 {
-        let Some(driver) = &self.selected_driver else {
+        let Some(driver) = &self.form.selected_driver else {
             return 0;
         };
         let Some(schema) = driver.settings_schema() else {
@@ -2084,7 +2195,7 @@ impl ConnectionManagerWindow {
 
     /// Returns the field definition for a driver schema field at the given flat index.
     fn settings_driver_field_def(&self, idx: u8) -> Option<FormFieldDef> {
-        let driver = self.selected_driver.as_ref()?;
+        let driver = self.form.selected_driver.as_ref()?;
         let schema = driver.settings_schema()?;
         schema
             .tabs
@@ -2096,11 +2207,12 @@ impl ConnectionManagerWindow {
     }
 
     fn handle_field_change(&mut self, field_id: &str, window: &mut Window, cx: &mut Context<Self>) {
-        if self.syncing_uri {
+        if self.form.syncing_uri {
             return;
         }
 
         let use_uri = self
+            .form
             .checkbox_states
             .get("use_uri")
             .copied()
@@ -2114,7 +2226,7 @@ impl ConnectionManagerWindow {
     }
 
     pub(super) fn sync_fields_to_uri(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(driver) = &self.selected_driver else {
+        let Some(driver) = &self.form.selected_driver else {
             return;
         };
 
@@ -2123,6 +2235,7 @@ impl ConnectionManagerWindow {
         // mongodb+srv:// (or any URI-mode) connection with a reconstructed
         // mongodb://host:port/... string built from fallback fields.
         let use_uri = self
+            .form
             .checkbox_states
             .get("use_uri")
             .copied()
@@ -2137,14 +2250,14 @@ impl ConnectionManagerWindow {
             || self.has_dynamic_value_ref_for_field("password", cx);
 
         if has_dynamic_refs {
-            if let Some(uri_input) = self.driver_inputs.get("uri") {
+            if let Some(uri_input) = self.form.driver_inputs.get("uri") {
                 let current = uri_input.read(cx).value().to_string();
                 if !current.is_empty() {
-                    self.syncing_uri = true;
+                    self.form.syncing_uri = true;
                     uri_input.update(cx, |state, cx| {
                         state.set_value("", window, cx);
                     });
-                    self.syncing_uri = false;
+                    self.form.syncing_uri = false;
                 }
             }
             return;
@@ -2152,30 +2265,30 @@ impl ConnectionManagerWindow {
 
         let form = driver.form_definition();
         let values = self.collect_form_values(form, cx);
-        let password = self.input_password.read(cx).value().to_string();
+        let password = self.form.input_password.read(cx).value().to_string();
 
         let Some(uri) = driver.build_uri(&values, &password) else {
             return;
         };
 
-        if let Some(uri_input) = self.driver_inputs.get("uri") {
+        if let Some(uri_input) = self.form.driver_inputs.get("uri") {
             let current = uri_input.read(cx).value().to_string();
             if current != uri {
-                self.syncing_uri = true;
+                self.form.syncing_uri = true;
                 uri_input.update(cx, |state, cx| {
                     state.set_value(&uri, window, cx);
                 });
-                self.syncing_uri = false;
+                self.form.syncing_uri = false;
             }
         }
     }
 
     pub(super) fn sync_uri_to_fields(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(driver) = &self.selected_driver else {
+        let Some(driver) = &self.form.selected_driver else {
             return;
         };
 
-        let Some(uri_input) = self.driver_inputs.get("uri") else {
+        let Some(uri_input) = self.form.driver_inputs.get("uri") else {
             return;
         };
         let uri_value = uri_input.read(cx).value().to_string();
@@ -2188,7 +2301,7 @@ impl ConnectionManagerWindow {
             return;
         };
 
-        self.syncing_uri = true;
+        self.form.syncing_uri = true;
 
         for (field_id, value) in &parsed {
             // `password` lives on its own InputState outside the
@@ -2197,16 +2310,16 @@ impl ConnectionManagerWindow {
             // password silently disappeared when toggling URI → form,
             // leaving users to save an empty/stale value.
             if field_id == "password" {
-                let current = self.input_password.read(cx).value().to_string();
+                let current = self.form.input_password.read(cx).value().to_string();
                 if current != *value {
-                    self.input_password.update(cx, |state, cx| {
+                    self.form.input_password.update(cx, |state, cx| {
                         state.set_value(value, window, cx);
                     });
                 }
                 continue;
             }
 
-            if let Some(input) = self.driver_inputs.get(field_id.as_str()) {
+            if let Some(input) = self.form.driver_inputs.get(field_id.as_str()) {
                 let current = input.read(cx).value().to_string();
                 if current != *value {
                     input.update(cx, |state, cx| {
@@ -2216,7 +2329,7 @@ impl ConnectionManagerWindow {
             }
         }
 
-        self.syncing_uri = false;
+        self.form.syncing_uri = false;
     }
 
     // -----------------------------------------------------------------
@@ -2240,8 +2353,8 @@ impl ConnectionManagerWindow {
             "",
         )];
 
-        self.auth_profile_uuids.clear();
-        self.ssm_auth_profile_uuids.clear();
+        self.auth_profile.auth_profile_uuids.clear();
+        self.access.ssm_auth_profile_uuids.clear();
 
         for profile in &profiles {
             if !profile.enabled {
@@ -2250,7 +2363,11 @@ impl ConnectionManagerWindow {
             if reference_only.contains(&profile.provider_id) {
                 continue;
             }
-            let session_status = match self.auth_profile_session_states.get(&profile.id) {
+            let session_status = match self
+                .auth_profile
+                .auth_profile_session_states
+                .get(&profile.id)
+            {
                 Some(AuthSessionState::Valid { .. }) => "valid",
                 Some(AuthSessionState::Expired) => "expired",
                 Some(AuthSessionState::LoginRequired) => "login required",
@@ -2269,8 +2386,8 @@ impl ConnectionManagerWindow {
                 ssm_label,
                 profile.id.to_string(),
             ));
-            self.auth_profile_uuids.push(profile.id);
-            self.ssm_auth_profile_uuids.push(profile.id);
+            self.auth_profile.auth_profile_uuids.push(profile.id);
+            self.access.ssm_auth_profile_uuids.push(profile.id);
         }
 
         auth_items.push(dbflux_components::controls::DropdownItem::with_value(
@@ -2287,9 +2404,14 @@ impl ConnectionManagerWindow {
         // add a "(profile not found)" placeholder entry so the dropdown shows
         // something instead of falling back silently to "None".
         let auth_selected_index = self
+            .auth_profile
             .selected_auth_profile_id
             .and_then(|id| {
-                let pos = self.auth_profile_uuids.iter().position(|uid| *uid == id);
+                let pos = self
+                    .auth_profile
+                    .auth_profile_uuids
+                    .iter()
+                    .position(|uid| *uid == id);
                 pos.map(|p| p + 1).or_else(|| {
                     // Bound profile is not reflected — insert a dangling sentinel.
                     let dangling_label = format!("(profile not found) [{}]", id);
@@ -2297,21 +2419,25 @@ impl ConnectionManagerWindow {
                         dangling_label,
                         id.to_string(),
                     ));
-                    self.auth_profile_uuids.push(id);
-                    Some(self.auth_profile_uuids.len())
+                    self.auth_profile.auth_profile_uuids.push(id);
+                    Some(self.auth_profile.auth_profile_uuids.len())
                 })
             })
             .unwrap_or(0);
 
-        self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-            dropdown.set_items(auth_items, cx);
-            dropdown.set_selected_index(Some(auth_selected_index), cx);
-        });
+        self.auth_profile
+            .auth_profile_dropdown
+            .update(cx, |dropdown, cx| {
+                dropdown.set_items(auth_items, cx);
+                dropdown.set_selected_index(Some(auth_selected_index), cx);
+            });
 
         let ssm_selected_index = self
+            .access
             .selected_ssm_auth_profile_id
             .and_then(|id| {
                 let pos = self
+                    .access
                     .ssm_auth_profile_uuids
                     .iter()
                     .position(|uid| *uid == id);
@@ -2321,20 +2447,22 @@ impl ConnectionManagerWindow {
                         dangling_label,
                         id.to_string(),
                     ));
-                    self.ssm_auth_profile_uuids.push(id);
-                    Some(self.ssm_auth_profile_uuids.len())
+                    self.access.ssm_auth_profile_uuids.push(id);
+                    Some(self.access.ssm_auth_profile_uuids.len())
                 })
             })
             .unwrap_or(0);
 
-        self.ssm_auth_profile_dropdown.update(cx, |dropdown, cx| {
-            dropdown.set_items(ssm_items, cx);
-            dropdown.set_selected_index(Some(ssm_selected_index), cx);
-        });
+        self.access
+            .ssm_auth_profile_dropdown
+            .update(cx, |dropdown, cx| {
+                dropdown.set_items(ssm_items, cx);
+                dropdown.set_selected_index(Some(ssm_selected_index), cx);
+            });
     }
 
     fn selected_auth_profile(&self, cx: &App) -> Option<AuthProfile> {
-        let selected_id = self.selected_auth_profile_id?;
+        let selected_id = self.auth_profile.selected_auth_profile_id?;
 
         self.app_state
             .read(cx)
@@ -2374,7 +2502,9 @@ impl ConnectionManagerWindow {
                 if cx
                     .update(|cx| {
                         this.update(cx, |this, cx| {
-                            this.auth_profile_session_states.insert(profile.id, status);
+                            this.auth_profile
+                                .auth_profile_session_states
+                                .insert(profile.id, status);
                             this.populate_auth_profile_dropdown(cx);
                         });
                     })
@@ -2392,8 +2522,8 @@ impl ConnectionManagerWindow {
     }
 
     fn open_sso_wizard(&mut self, cx: &mut Context<Self>) {
-        self.pending_wizard_auth_profile_selection = true;
-        self.known_auth_profile_ids = self
+        self.auth_profile.pending_wizard_auth_profile_selection = true;
+        self.auth_profile.known_auth_profile_ids = self
             .app_state
             .read(cx)
             .list_auth_profiles()
@@ -2433,42 +2563,48 @@ impl ConnectionManagerWindow {
             .map(|profile| profile.id)
             .collect::<HashSet<_>>();
 
-        if self.pending_wizard_auth_profile_selection {
+        if self.auth_profile.pending_wizard_auth_profile_selection {
             let newest = current_profiles
                 .iter()
                 .rev()
-                .find(|profile| !self.known_auth_profile_ids.contains(&profile.id))
+                .find(|profile| {
+                    !self
+                        .auth_profile
+                        .known_auth_profile_ids
+                        .contains(&profile.id)
+                })
                 .map(|profile| profile.id);
 
             if let Some(profile_id) = newest {
-                self.selected_auth_profile_id = Some(profile_id);
+                self.auth_profile.selected_auth_profile_id = Some(profile_id);
 
-                if self.selected_ssm_auth_profile_id.is_none() {
-                    self.selected_ssm_auth_profile_id = Some(profile_id);
+                if self.access.selected_ssm_auth_profile_id.is_none() {
+                    self.access.selected_ssm_auth_profile_id = Some(profile_id);
                 }
 
-                self.auth_profile_action_message =
+                self.auth_profile.auth_profile_action_message =
                     Some("Selected profile created by AWS SSO wizard.".to_string());
             }
 
-            self.pending_wizard_auth_profile_selection = false;
+            self.auth_profile.pending_wizard_auth_profile_selection = false;
         }
 
-        self.known_auth_profile_ids = current_ids;
+        self.auth_profile.known_auth_profile_ids = current_ids;
         self.populate_auth_profile_dropdown(cx);
         self.refresh_auth_profile_sessions(cx);
         cx.notify();
     }
 
     fn handle_auth_profile_created(&mut self, profile_id: Uuid, cx: &mut Context<Self>) {
-        self.selected_auth_profile_id = Some(profile_id);
+        self.auth_profile.selected_auth_profile_id = Some(profile_id);
 
-        if self.selected_ssm_auth_profile_id.is_none() {
-            self.selected_ssm_auth_profile_id = Some(profile_id);
+        if self.access.selected_ssm_auth_profile_id.is_none() {
+            self.access.selected_ssm_auth_profile_id = Some(profile_id);
         }
 
-        self.pending_wizard_auth_profile_selection = false;
-        self.auth_profile_action_message = Some("Selected profile created by wizard.".to_string());
+        self.auth_profile.pending_wizard_auth_profile_selection = false;
+        self.auth_profile.auth_profile_action_message =
+            Some("Selected profile created by wizard.".to_string());
 
         self.populate_auth_profile_dropdown(cx);
         self.refresh_auth_profile_sessions(cx);
@@ -2476,14 +2612,15 @@ impl ConnectionManagerWindow {
     }
 
     fn refresh_auth_profile_statuses(&mut self, cx: &mut Context<Self>) {
-        self.auth_profile_action_message = Some("Refreshing auth profile sessions...".to_string());
+        self.auth_profile.auth_profile_action_message =
+            Some("Refreshing auth profile sessions...".to_string());
         self.refresh_auth_profile_sessions(cx);
         cx.notify();
     }
 
     fn login_selected_auth_profile(&mut self, cx: &mut Context<Self>) {
         let Some(profile) = self.selected_auth_profile(cx) else {
-            self.auth_profile_action_message =
+            self.auth_profile.auth_profile_action_message =
                 Some("Select an auth profile before logging in.".to_string());
             cx.notify();
             return;
@@ -2494,7 +2631,7 @@ impl ConnectionManagerWindow {
             .read(cx)
             .auth_provider_by_id(&profile.provider_id)
         else {
-            self.auth_profile_action_message = Some(format!(
+            self.auth_profile.auth_profile_action_message = Some(format!(
                 "Auth provider '{}' is not available.",
                 profile.provider_id
             ));
@@ -2503,14 +2640,14 @@ impl ConnectionManagerWindow {
         };
 
         if !provider.capabilities().login.supported {
-            self.auth_profile_action_message =
+            self.auth_profile.auth_profile_action_message =
                 Some("Interactive login is not available for this auth profile.".to_string());
             cx.notify();
             return;
         }
 
-        self.auth_profile_login_in_progress = true;
-        self.auth_profile_action_message = Some(format!(
+        self.auth_profile.auth_profile_login_in_progress = true;
+        self.auth_profile.auth_profile_action_message = Some(format!(
             "Starting auth-provider login for '{}'...",
             profile.name
         ));
@@ -2524,8 +2661,8 @@ impl ConnectionManagerWindow {
             if cx
                 .update(|cx| {
                     this.update(cx, |this, cx| {
-                        this.auth_profile_login_in_progress = false;
-                        this.auth_profile_action_message = Some(match result {
+                        this.auth_profile.auth_profile_login_in_progress = false;
+                        this.auth_profile.auth_profile_action_message = Some(match result {
                             Ok(_) => "Auth-provider login completed.".to_string(),
                             Err(error) => format!("Auth-provider login failed: {}", error),
                         });
@@ -2544,7 +2681,10 @@ impl ConnectionManagerWindow {
     fn selected_auth_profile_status_text(&self, cx: &App) -> Option<String> {
         let profile = self.selected_auth_profile(cx)?;
 
-        let status = self.auth_profile_session_states.get(&profile.id)?;
+        let status = self
+            .auth_profile
+            .auth_profile_session_states
+            .get(&profile.id)?;
         let text = match status {
             AuthSessionState::Valid { expires_at } => {
                 if let Some(expires_at) = expires_at {
@@ -2566,7 +2706,9 @@ impl ConnectionManagerWindow {
         };
 
         matches!(
-            self.auth_profile_session_states.get(&profile.id),
+            self.auth_profile
+                .auth_profile_session_states
+                .get(&profile.id),
             Some(AuthSessionState::Valid { .. })
         )
     }
@@ -2584,7 +2726,9 @@ impl ConnectionManagerWindow {
 
         auth_profile_needs_login(
             provider_supports_login,
-            self.auth_profile_session_states.get(&profile.id),
+            self.auth_profile
+                .auth_profile_session_states
+                .get(&profile.id),
         )
     }
 
@@ -2594,36 +2738,40 @@ impl ConnectionManagerWindow {
         cx: &mut Context<Self>,
     ) {
         if event.index == AUTH_PROFILE_NONE_INDEX {
-            self.pending_auth_profile_selection = Some(None);
+            self.pending.auth_profile_selection = Some(None);
         } else if event.item.value.as_ref() == "__new_auth_profile__" {
             self.open_auth_profiles_settings(cx);
 
             let selected_index = self
+                .auth_profile
                 .selected_auth_profile_id
                 .and_then(|id| {
-                    self.auth_profile_uuids
+                    self.auth_profile
+                        .auth_profile_uuids
                         .iter()
                         .position(|uid| *uid == id)
                         .map(|pos| pos + 1)
                 })
                 .unwrap_or(AUTH_PROFILE_NONE_INDEX);
 
-            self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-                dropdown.set_selected_index(Some(selected_index), cx);
-            });
+            self.auth_profile
+                .auth_profile_dropdown
+                .update(cx, |dropdown, cx| {
+                    dropdown.set_selected_index(Some(selected_index), cx);
+                });
         } else {
             let uuid_index = event.index - 1;
-            if let Some(&id) = self.auth_profile_uuids.get(uuid_index) {
-                self.pending_auth_profile_selection = Some(Some(id));
+            if let Some(&id) = self.auth_profile.auth_profile_uuids.get(uuid_index) {
+                self.pending.auth_profile_selection = Some(Some(id));
             }
         }
         cx.notify();
     }
 
     fn apply_pending_auth_profile(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(selection) = self.pending_auth_profile_selection.take() {
-            self.selected_auth_profile_id = selection;
-            self.selected_ssm_auth_profile_id = selection;
+        if let Some(selection) = self.pending.auth_profile_selection.take() {
+            self.auth_profile.selected_auth_profile_id = selection;
+            self.access.selected_ssm_auth_profile_id = selection;
 
             self.sync_driver_fields_from_auth_profile(window, cx);
         }
@@ -2635,12 +2783,12 @@ impl ConnectionManagerWindow {
         cx: &mut Context<Self>,
     ) {
         let auth_profile_ref_field_id =
-            match auth_profile_ref_field_id(self.selected_driver.as_ref()) {
+            match auth_profile_ref_field_id(self.form.selected_driver.as_ref()) {
                 Some(id) => id,
                 None => return,
             };
 
-        let Some(auth_profile_id) = self.selected_auth_profile_id else {
+        let Some(auth_profile_id) = self.auth_profile.selected_auth_profile_id else {
             return;
         };
 
@@ -2662,6 +2810,7 @@ impl ConnectionManagerWindow {
             .unwrap_or_else(|| profile.name.clone());
 
         if let Some(input) = self
+            .form
             .driver_inputs
             .get(auth_profile_ref_field_id.as_str())
             .cloned()
@@ -2672,7 +2821,7 @@ impl ConnectionManagerWindow {
         }
 
         if let Some(region) = profile.fields.get("region").cloned()
-            && let Some(input) = self.driver_inputs.get("region").cloned()
+            && let Some(input) = self.form.driver_inputs.get("region").cloned()
         {
             input.update(cx, |state, cx| {
                 state.set_value(region, window, cx);
@@ -2686,27 +2835,31 @@ impl ConnectionManagerWindow {
         cx: &mut Context<Self>,
     ) {
         if event.index == 0 {
-            self.pending_ssm_auth_profile_selection = Some(None);
+            self.pending.ssm_auth_profile_selection = Some(None);
         } else if event.item.value.as_ref() == "__new_auth_profile__" {
             self.open_sso_wizard(cx);
 
             let selected_index = self
+                .access
                 .selected_ssm_auth_profile_id
                 .and_then(|id| {
-                    self.ssm_auth_profile_uuids
+                    self.access
+                        .ssm_auth_profile_uuids
                         .iter()
                         .position(|uid| *uid == id)
                         .map(|pos| pos + 1)
                 })
                 .unwrap_or(0);
 
-            self.ssm_auth_profile_dropdown.update(cx, |dropdown, cx| {
-                dropdown.set_selected_index(Some(selected_index), cx);
-            });
+            self.access
+                .ssm_auth_profile_dropdown
+                .update(cx, |dropdown, cx| {
+                    dropdown.set_selected_index(Some(selected_index), cx);
+                });
         } else {
             let uuid_index = event.index - 1;
-            if let Some(&id) = self.ssm_auth_profile_uuids.get(uuid_index) {
-                self.pending_ssm_auth_profile_selection = Some(Some(id));
+            if let Some(&id) = self.access.ssm_auth_profile_uuids.get(uuid_index) {
+                self.pending.ssm_auth_profile_selection = Some(Some(id));
             }
         }
 
@@ -2714,8 +2867,8 @@ impl ConnectionManagerWindow {
     }
 
     fn apply_pending_ssm_auth_profile(&mut self) {
-        if let Some(selection) = self.pending_ssm_auth_profile_selection.take() {
-            self.selected_ssm_auth_profile_id = selection;
+        if let Some(selection) = self.pending.ssm_auth_profile_selection.take() {
+            self.access.selected_ssm_auth_profile_id = selection;
         }
     }
 
@@ -2724,8 +2877,8 @@ impl ConnectionManagerWindow {
         event: &DropdownSelectionChanged,
         cx: &mut Context<Self>,
     ) {
-        if let Some(uuid) = self.proxy_uuids.get(event.index).copied() {
-            self.pending_proxy_selection = Some(uuid);
+        if let Some(uuid) = self.access.proxy_uuids.get(event.index).copied() {
+            self.pending.proxy_selection = Some(uuid);
             cx.notify();
         }
     }
@@ -2735,11 +2888,11 @@ impl ConnectionManagerWindow {
         proxy: &dbflux_core::ProxyProfile,
         _cx: &mut Context<Self>,
     ) {
-        self.selected_proxy_id = Some(proxy.id);
+        self.access.selected_proxy_id = Some(proxy.id);
     }
 
     pub(super) fn clear_proxy_selection(&mut self, cx: &mut Context<Self>) {
-        self.selected_proxy_id = None;
+        self.access.selected_proxy_id = None;
         cx.notify();
     }
 
@@ -2748,8 +2901,8 @@ impl ConnectionManagerWindow {
         event: &DropdownSelectionChanged,
         cx: &mut Context<Self>,
     ) {
-        if let Some(uuid) = self.ssh_tunnel_uuids.get(event.index).copied() {
-            self.pending_ssh_tunnel_selection = Some(uuid);
+        if let Some(uuid) = self.access.ssh_tunnel_uuids.get(event.index).copied() {
+            self.pending.ssh_tunnel_selection = Some(uuid);
             cx.notify();
         }
     }
@@ -2761,46 +2914,48 @@ impl ConnectionManagerWindow {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.selected_ssh_tunnel_id = Some(tunnel.id);
-        self.ssh_enabled = true;
+        self.access.selected_ssh_tunnel_id = Some(tunnel.id);
+        self.access.ssh_enabled = true;
 
-        self.input_ssh_host.update(cx, |state, cx| {
+        self.access.input_ssh_host.update(cx, |state, cx| {
             state.set_value(&tunnel.config.host, window, cx);
         });
-        self.input_ssh_port.update(cx, |state, cx| {
+        self.access.input_ssh_port.update(cx, |state, cx| {
             state.set_value(tunnel.config.port.to_string(), window, cx);
         });
-        self.input_ssh_user.update(cx, |state, cx| {
+        self.access.input_ssh_user.update(cx, |state, cx| {
             state.set_value(&tunnel.config.user, window, cx);
         });
 
         match &tunnel.config.auth_method {
             SshAuthMethod::PrivateKey { key_path } => {
-                self.ssh_auth_method = SshAuthSelection::PrivateKey;
+                self.access.ssh_auth_method = SshAuthSelection::PrivateKey;
                 if let Some(path) = key_path {
-                    self.input_ssh_key_path.update(cx, |state, cx| {
+                    self.access.input_ssh_key_path.update(cx, |state, cx| {
                         state.set_value(path.to_string_lossy().to_string(), window, cx);
                     });
                 }
                 if let Some(ref passphrase) = secret {
                     let passphrase = passphrase.expose_secret().to_string();
-                    self.input_ssh_key_passphrase.update(cx, |state, cx| {
-                        state.set_value(passphrase.clone(), window, cx);
-                    });
+                    self.access
+                        .input_ssh_key_passphrase
+                        .update(cx, |state, cx| {
+                            state.set_value(passphrase.clone(), window, cx);
+                        });
                 }
             }
             SshAuthMethod::Password => {
-                self.ssh_auth_method = SshAuthSelection::Password;
+                self.access.ssh_auth_method = SshAuthSelection::Password;
                 if let Some(ref password) = secret {
                     let password = password.expose_secret().to_string();
-                    self.input_ssh_password.update(cx, |state, cx| {
+                    self.access.input_ssh_password.update(cx, |state, cx| {
                         state.set_value(password.clone(), window, cx);
                     });
                 }
             }
         }
 
-        self.form_save_ssh_secret = tunnel.save_secret && secret.is_some();
+        self.form.form_save_ssh_secret = tunnel.save_secret && secret.is_some();
         self.ssh_test_status = TestStatus::None;
         self.ssh_test_error = None;
         cx.notify();
@@ -2811,29 +2966,31 @@ impl ConnectionManagerWindow {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.selected_ssh_tunnel_id = None;
+        self.access.selected_ssh_tunnel_id = None;
 
-        self.input_ssh_host.update(cx, |state, cx| {
+        self.access.input_ssh_host.update(cx, |state, cx| {
             state.set_value("", window, cx);
         });
-        self.input_ssh_port.update(cx, |state, cx| {
+        self.access.input_ssh_port.update(cx, |state, cx| {
             state.set_value("22", window, cx);
         });
-        self.input_ssh_user.update(cx, |state, cx| {
+        self.access.input_ssh_user.update(cx, |state, cx| {
             state.set_value("", window, cx);
         });
-        self.input_ssh_key_path.update(cx, |state, cx| {
+        self.access.input_ssh_key_path.update(cx, |state, cx| {
             state.set_value("", window, cx);
         });
-        self.input_ssh_key_passphrase.update(cx, |state, cx| {
-            state.set_value("", window, cx);
-        });
-        self.input_ssh_password.update(cx, |state, cx| {
+        self.access
+            .input_ssh_key_passphrase
+            .update(cx, |state, cx| {
+                state.set_value("", window, cx);
+            });
+        self.access.input_ssh_password.update(cx, |state, cx| {
             state.set_value("", window, cx);
         });
 
-        self.ssh_auth_method = SshAuthSelection::PrivateKey;
-        self.form_save_ssh_secret = true;
+        self.access.ssh_auth_method = SshAuthSelection::PrivateKey;
+        self.form.form_save_ssh_secret = true;
         self.ssh_test_status = TestStatus::None;
         self.ssh_test_error = None;
         cx.notify();
@@ -2851,7 +3008,7 @@ impl ConnectionManagerWindow {
             id: Uuid::new_v4(),
             name,
             config,
-            save_secret: self.form_save_ssh_secret,
+            save_secret: self.form.form_save_ssh_secret,
         };
 
         self.app_state.update(cx, |state, cx| {
@@ -2864,7 +3021,7 @@ impl ConnectionManagerWindow {
             cx.emit(dbflux_ui_base::AppStateChanged);
         });
 
-        self.selected_ssh_tunnel_id = Some(tunnel.id);
+        self.access.selected_ssh_tunnel_id = Some(tunnel.id);
         cx.notify();
     }
 
@@ -2872,7 +3029,7 @@ impl ConnectionManagerWindow {
         &self,
         cx: &Context<Self>,
     ) -> Option<(dbflux_core::SshTunnelConfig, Option<String>)> {
-        if let Some(tunnel_id) = self.selected_ssh_tunnel_id {
+        if let Some(tunnel_id) = self.access.selected_ssh_tunnel_id {
             let tunnel = self
                 .app_state
                 .read(cx)
@@ -2897,7 +3054,7 @@ impl ConnectionManagerWindow {
     }
 
     pub(super) fn test_ssh_connection(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        if !self.ssh_enabled {
+        if !self.access.ssh_enabled {
             return;
         }
 
@@ -2964,7 +3121,7 @@ impl ConnectionManagerWindow {
             if let Some(path) = path
                 && let Err(error) = cx.update(|cx| {
                     this.update(cx, |this, cx| {
-                        this.pending_ssh_key_path = Some(path.to_string_lossy().to_string());
+                        this.pending.ssh_key_path = Some(path.to_string_lossy().to_string());
                         cx.notify();
                     });
                 })
@@ -3022,13 +3179,13 @@ impl ConnectionManagerWindow {
                         let path_str = path.to_string_lossy().to_string();
                         match slot {
                             SslCertSlot::CaCert => {
-                                this.pending_ssl_ca_cert_path = Some(path_str);
+                                this.pending.ssl_ca_cert_path = Some(path_str);
                             }
                             SslCertSlot::ClientCert => {
-                                this.pending_ssl_client_cert_path = Some(path_str);
+                                this.pending.ssl_client_cert_path = Some(path_str);
                             }
                             SslCertSlot::ClientKey => {
-                                this.pending_ssl_client_key_path = Some(path_str);
+                                this.pending.ssl_client_key_path = Some(path_str);
                             }
                         }
                         cx.notify();
@@ -3052,9 +3209,9 @@ impl ConnectionManagerWindow {
         cx: &mut Context<Self>,
     ) {
         let input = match slot {
-            SslCertSlot::CaCert => &self.ssl_ca_cert_input,
-            SslCertSlot::ClientCert => &self.ssl_client_cert_input,
-            SslCertSlot::ClientKey => &self.ssl_client_key_input,
+            SslCertSlot::CaCert => &self.form.ssl_ca_cert_input,
+            SslCertSlot::ClientCert => &self.form.ssl_client_cert_input,
+            SslCertSlot::ClientKey => &self.form.ssl_client_key_input,
         };
         input.update(cx, |state, cx| {
             state.set_value(String::new(), window, cx);
@@ -3066,6 +3223,7 @@ impl ConnectionManagerWindow {
         let this = cx.entity().clone();
 
         let current_value = self
+            .form
             .driver_inputs
             .get("path")
             .map(|input| input.read(cx).value().to_string());
@@ -3093,7 +3251,7 @@ impl ConnectionManagerWindow {
             if let Some(path) = path
                 && let Err(error) = cx.update(|cx| {
                     this.update(cx, |this, cx| {
-                        this.pending_file_path = Some(path.to_string_lossy().to_string());
+                        this.pending.file_path = Some(path.to_string_lossy().to_string());
                         cx.notify();
                     });
                 })
@@ -3112,20 +3270,21 @@ impl ConnectionManagerWindow {
     // -----------------------------------------------------------------
 
     fn sync_access_tab_mode_from_state(&mut self) {
-        self.access_tab_mode = if matches!(self.access_kind, Some(AccessKind::Managed { .. })) {
-            AccessTabMode::ManagedSsm
-        } else if self.selected_proxy_id.is_some()
-            || matches!(self.access_kind, Some(AccessKind::Proxy { .. }))
-        {
-            AccessTabMode::Proxy
-        } else if self.ssh_enabled
-            || self.selected_ssh_tunnel_id.is_some()
-            || matches!(self.access_kind, Some(AccessKind::Ssh { .. }))
-        {
-            AccessTabMode::Ssh
-        } else {
-            AccessTabMode::Direct
-        };
+        self.access.access_tab_mode =
+            if matches!(self.access.access_kind, Some(AccessKind::Managed { .. })) {
+                AccessTabMode::ManagedSsm
+            } else if self.access.selected_proxy_id.is_some()
+                || matches!(self.access.access_kind, Some(AccessKind::Proxy { .. }))
+            {
+                AccessTabMode::Proxy
+            } else if self.access.ssh_enabled
+                || self.access.selected_ssh_tunnel_id.is_some()
+                || matches!(self.access.access_kind, Some(AccessKind::Ssh { .. }))
+            {
+                AccessTabMode::Ssh
+            } else {
+                AccessTabMode::Direct
+            };
     }
 
     /// Populate the access method dropdown with the unified access modes.
@@ -3139,14 +3298,16 @@ impl ConnectionManagerWindow {
 
         let selected_index = self.access_tab_mode_to_dropdown_index();
 
-        self.access_method_dropdown.update(cx, |dropdown, cx| {
-            dropdown.set_items(items, cx);
-            dropdown.set_selected_index(Some(selected_index), cx);
-        });
+        self.access
+            .access_method_dropdown
+            .update(cx, |dropdown, cx| {
+                dropdown.set_items(items, cx);
+                dropdown.set_selected_index(Some(selected_index), cx);
+            });
     }
 
     fn access_tab_mode_to_dropdown_index(&self) -> usize {
-        match self.access_tab_mode {
+        match self.access.access_tab_mode {
             AccessTabMode::Direct => 0,
             AccessTabMode::Ssh => 1,
             AccessTabMode::Proxy => 2,
@@ -3159,35 +3320,35 @@ impl ConnectionManagerWindow {
         event: &DropdownSelectionChanged,
         cx: &mut Context<Self>,
     ) {
-        self.access_tab_mode = match event.index {
+        self.access.access_tab_mode = match event.index {
             1 => AccessTabMode::Ssh,
             2 => AccessTabMode::Proxy,
             3 => AccessTabMode::ManagedSsm,
             _ => AccessTabMode::Direct,
         };
 
-        match self.access_tab_mode {
+        match self.access.access_tab_mode {
             AccessTabMode::Direct => {
-                self.ssh_enabled = false;
-                self.selected_ssh_tunnel_id = None;
-                self.selected_proxy_id = None;
-                self.access_kind = None;
+                self.access.ssh_enabled = false;
+                self.access.selected_ssh_tunnel_id = None;
+                self.access.selected_proxy_id = None;
+                self.access.access_kind = None;
             }
             AccessTabMode::Ssh => {
-                self.ssh_enabled = true;
-                self.selected_proxy_id = None;
-                self.access_kind = None;
+                self.access.ssh_enabled = true;
+                self.access.selected_proxy_id = None;
+                self.access.access_kind = None;
             }
             AccessTabMode::Proxy => {
-                self.ssh_enabled = false;
-                self.selected_ssh_tunnel_id = None;
-                self.access_kind = None;
+                self.access.ssh_enabled = false;
+                self.access.selected_ssh_tunnel_id = None;
+                self.access.access_kind = None;
             }
             AccessTabMode::ManagedSsm => {
-                self.ssh_enabled = false;
-                self.selected_ssh_tunnel_id = None;
-                self.selected_proxy_id = None;
-                self.access_kind = Some(self.collect_managed_access_kind(cx));
+                self.access.ssh_enabled = false;
+                self.access.selected_ssh_tunnel_id = None;
+                self.access.selected_proxy_id = None;
+                self.access.access_kind = Some(self.collect_managed_access_kind(cx));
             }
         }
 
@@ -3196,18 +3357,29 @@ impl ConnectionManagerWindow {
 
     /// Returns true when SSM Tunnel is the currently selected access method.
     fn is_ssm_selected(&self) -> bool {
-        self.access_tab_mode == AccessTabMode::ManagedSsm
+        self.access.access_tab_mode == AccessTabMode::ManagedSsm
     }
 
     /// Collect the current managed (aws-ssm) AccessKind from the inline fields.
     fn collect_managed_access_kind(&self, cx: &Context<Self>) -> AccessKind {
-        let instance_id = self.input_ssm_instance_id.read(cx).value().to_string();
-        let region = self.input_ssm_region.read(cx).value().to_string();
-        let remote_port = self.input_ssm_remote_port.read(cx).value().to_string();
+        let instance_id = self
+            .access
+            .input_ssm_instance_id
+            .read(cx)
+            .value()
+            .to_string();
+        let region = self.access.input_ssm_region.read(cx).value().to_string();
+        let remote_port = self
+            .access
+            .input_ssm_remote_port
+            .read(cx)
+            .value()
+            .to_string();
 
         let auth_profile_id = self
+            .access
             .selected_ssm_auth_profile_id
-            .or(self.selected_auth_profile_id);
+            .or(self.auth_profile.selected_auth_profile_id);
 
         let mut params = std::collections::HashMap::new();
         params.insert("instance_id".to_string(), instance_id);

--- a/crates/dbflux_ui_windows/src/connection_manager/navigation.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/navigation.rs
@@ -879,12 +879,12 @@ impl ConnectionManagerWindow {
 
         match command {
             Command::FocusSearch => {
-                self.driver_filter_input.update(cx, |state, cx| {
+                self.form.driver_filter_input.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
                 true
             }
-            Command::Cancel if self.driver_filter_focused => {
+            Command::Cancel if self.form.driver_filter_focused => {
                 window.focus(&self.focus_handle);
                 true
             }
@@ -954,29 +954,31 @@ impl ConnectionManagerWindow {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        if self.proxy_dropdown.read(cx).is_open() && self.handle_proxy_dropdown_command(command, cx)
+        if self.access.proxy_dropdown.read(cx).is_open()
+            && self.handle_proxy_dropdown_command(command, cx)
         {
             return true;
         }
 
-        if self.ssh_tunnel_dropdown.read(cx).is_open() && self.handle_dropdown_command(command, cx)
+        if self.access.ssh_tunnel_dropdown.read(cx).is_open()
+            && self.handle_dropdown_command(command, cx)
         {
             return true;
         }
 
-        if self.access_method_dropdown.read(cx).is_open()
+        if self.access.access_method_dropdown.read(cx).is_open()
             && self.handle_access_method_dropdown_command(command, cx)
         {
             return true;
         }
 
-        if self.auth_profile_dropdown.read(cx).is_open()
+        if self.auth_profile.auth_profile_dropdown.read(cx).is_open()
             && self.handle_auth_profile_dropdown_command(command, cx)
         {
             return true;
         }
 
-        if self.ssm_auth_profile_dropdown.read(cx).is_open()
+        if self.access.ssm_auth_profile_dropdown.read(cx).is_open()
             && self.handle_ssm_auth_profile_dropdown_command(command, cx)
         {
             return true;
@@ -996,37 +998,37 @@ impl ConnectionManagerWindow {
     fn handle_dropdown_command(&mut self, command: Command, cx: &mut Context<Self>) -> bool {
         match command {
             Command::SelectNext => {
-                self.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
+                self.access.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
                     dropdown.select_next_item(cx);
                 });
                 true
             }
             Command::SelectPrev => {
-                self.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
+                self.access.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
                     dropdown.select_prev_item(cx);
                 });
                 true
             }
             Command::Execute => {
-                self.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
+                self.access.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
                     dropdown.accept_selection(cx);
                 });
                 true
             }
             Command::PageDown => {
-                self.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
+                self.access.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
                     dropdown.select_next_page(cx);
                 });
                 true
             }
             Command::PageUp => {
-                self.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
+                self.access.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
                     dropdown.select_prev_page(cx);
                 });
                 true
             }
             Command::Cancel => {
-                self.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
+                self.access.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
                     dropdown.close(cx);
                 });
                 true
@@ -1038,37 +1040,37 @@ impl ConnectionManagerWindow {
     fn handle_proxy_dropdown_command(&mut self, command: Command, cx: &mut Context<Self>) -> bool {
         match command {
             Command::SelectNext => {
-                self.proxy_dropdown.update(cx, |dropdown, cx| {
+                self.access.proxy_dropdown.update(cx, |dropdown, cx| {
                     dropdown.select_next_item(cx);
                 });
                 true
             }
             Command::SelectPrev => {
-                self.proxy_dropdown.update(cx, |dropdown, cx| {
+                self.access.proxy_dropdown.update(cx, |dropdown, cx| {
                     dropdown.select_prev_item(cx);
                 });
                 true
             }
             Command::Execute => {
-                self.proxy_dropdown.update(cx, |dropdown, cx| {
+                self.access.proxy_dropdown.update(cx, |dropdown, cx| {
                     dropdown.accept_selection(cx);
                 });
                 true
             }
             Command::PageDown => {
-                self.proxy_dropdown.update(cx, |dropdown, cx| {
+                self.access.proxy_dropdown.update(cx, |dropdown, cx| {
                     dropdown.select_next_page(cx);
                 });
                 true
             }
             Command::PageUp => {
-                self.proxy_dropdown.update(cx, |dropdown, cx| {
+                self.access.proxy_dropdown.update(cx, |dropdown, cx| {
                     dropdown.select_prev_page(cx);
                 });
                 true
             }
             Command::Cancel => {
-                self.proxy_dropdown.update(cx, |dropdown, cx| {
+                self.access.proxy_dropdown.update(cx, |dropdown, cx| {
                     dropdown.close(cx);
                 });
                 true
@@ -1084,39 +1086,51 @@ impl ConnectionManagerWindow {
     ) -> bool {
         match command {
             Command::SelectNext => {
-                self.access_method_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_next_item(cx);
-                });
+                self.access
+                    .access_method_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_next_item(cx);
+                    });
                 true
             }
             Command::SelectPrev => {
-                self.access_method_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_prev_item(cx);
-                });
+                self.access
+                    .access_method_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_prev_item(cx);
+                    });
                 true
             }
             Command::Execute => {
-                self.access_method_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.accept_selection(cx);
-                });
+                self.access
+                    .access_method_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.accept_selection(cx);
+                    });
                 true
             }
             Command::PageDown => {
-                self.access_method_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_next_page(cx);
-                });
+                self.access
+                    .access_method_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_next_page(cx);
+                    });
                 true
             }
             Command::PageUp => {
-                self.access_method_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_prev_page(cx);
-                });
+                self.access
+                    .access_method_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_prev_page(cx);
+                    });
                 true
             }
             Command::Cancel => {
-                self.access_method_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.close(cx);
-                });
+                self.access
+                    .access_method_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.close(cx);
+                    });
                 true
             }
             _ => false,
@@ -1130,39 +1144,51 @@ impl ConnectionManagerWindow {
     ) -> bool {
         match command {
             Command::SelectNext => {
-                self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_next_item(cx);
-                });
+                self.auth_profile
+                    .auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_next_item(cx);
+                    });
                 true
             }
             Command::SelectPrev => {
-                self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_prev_item(cx);
-                });
+                self.auth_profile
+                    .auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_prev_item(cx);
+                    });
                 true
             }
             Command::PageDown => {
-                self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_next_page(cx);
-                });
+                self.auth_profile
+                    .auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_next_page(cx);
+                    });
                 true
             }
             Command::PageUp => {
-                self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_prev_page(cx);
-                });
+                self.auth_profile
+                    .auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_prev_page(cx);
+                    });
                 true
             }
             Command::Execute => {
-                self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.accept_selection(cx);
-                });
+                self.auth_profile
+                    .auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.accept_selection(cx);
+                    });
                 true
             }
             Command::Cancel => {
-                self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.close(cx);
-                });
+                self.auth_profile
+                    .auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.close(cx);
+                    });
                 true
             }
             _ => false,
@@ -1176,39 +1202,51 @@ impl ConnectionManagerWindow {
     ) -> bool {
         match command {
             Command::SelectNext => {
-                self.ssm_auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_next_item(cx);
-                });
+                self.access
+                    .ssm_auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_next_item(cx);
+                    });
                 true
             }
             Command::SelectPrev => {
-                self.ssm_auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_prev_item(cx);
-                });
+                self.access
+                    .ssm_auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_prev_item(cx);
+                    });
                 true
             }
             Command::PageDown => {
-                self.ssm_auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_next_page(cx);
-                });
+                self.access
+                    .ssm_auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_next_page(cx);
+                    });
                 true
             }
             Command::PageUp => {
-                self.ssm_auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.select_prev_page(cx);
-                });
+                self.access
+                    .ssm_auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.select_prev_page(cx);
+                    });
                 true
             }
             Command::Execute => {
-                self.ssm_auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.accept_selection(cx);
-                });
+                self.access
+                    .ssm_auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.accept_selection(cx);
+                    });
                 true
             }
             Command::Cancel => {
-                self.ssm_auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.close(cx);
-                });
+                self.access
+                    .ssm_auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.close(cx);
+                    });
                 true
             }
             _ => false,
@@ -1222,13 +1260,13 @@ impl ConnectionManagerWindow {
         use FormFocus::*;
 
         match self.form_focus {
-            HostValueSource => Some(&self.host_value_source_selector),
-            DatabaseValueSource => Some(&self.database_value_source_selector),
-            UserValueSource => Some(&self.user_value_source_selector),
-            PasswordValueSource => Some(&self.password_value_source_selector),
-            SsmInstanceIdValueSource => Some(&self.ssm_instance_id_value_source_selector),
-            SsmRegionValueSource => Some(&self.ssm_region_value_source_selector),
-            SsmRemotePortValueSource => Some(&self.ssm_remote_port_value_source_selector),
+            HostValueSource => Some(&self.form.host_value_source_selector),
+            DatabaseValueSource => Some(&self.form.database_value_source_selector),
+            UserValueSource => Some(&self.form.user_value_source_selector),
+            PasswordValueSource => Some(&self.form.password_value_source_selector),
+            SsmInstanceIdValueSource => Some(&self.access.ssm_instance_id_value_source_selector),
+            SsmRegionValueSource => Some(&self.access.ssm_region_value_source_selector),
+            SsmRemotePortValueSource => Some(&self.access.ssm_remote_port_value_source_selector),
             _ => None,
         }
     }
@@ -1385,13 +1423,13 @@ impl ConnectionManagerWindow {
     pub(super) fn ssh_nav_state(&self, cx: &Context<Self>) -> SshNavState {
         let state = self.app_state.read(cx);
         let has_tunnels = !state.ssh_tunnels().is_empty();
-        let has_selected_tunnel = self.selected_ssh_tunnel_id.is_some();
-        let can_save_tunnel = self.selected_ssh_tunnel_id.is_none();
+        let has_selected_tunnel = self.access.selected_ssh_tunnel_id.is_some();
+        let can_save_tunnel = self.access.selected_ssh_tunnel_id.is_none();
         SshNavState::new(
-            self.ssh_enabled,
+            self.access.ssh_enabled,
             has_tunnels,
             has_selected_tunnel,
-            self.ssh_auth_method,
+            self.access.ssh_auth_method,
             can_save_tunnel,
         )
     }
@@ -1399,12 +1437,13 @@ impl ConnectionManagerWindow {
     pub(super) fn proxy_nav_state(&self, cx: &Context<Self>) -> ProxyNavState {
         let state = self.app_state.read(cx);
         let has_proxies = !state.proxies().is_empty();
-        let has_selected_proxy = self.selected_proxy_id.is_some();
+        let has_selected_proxy = self.access.selected_proxy_id.is_some();
         ProxyNavState::new(has_proxies, has_selected_proxy)
     }
 
     pub(super) fn main_nav_state(&self, cx: &Context<Self>) -> MainNavState {
         let has_uri_option = self
+            .form
             .selected_driver
             .as_ref()
             .and_then(|d| d.form_definition().field("use_uri"))
@@ -1412,13 +1451,17 @@ impl ConnectionManagerWindow {
 
         let uri_mode_active = has_uri_option
             && self
+                .form
                 .checkbox_states
                 .get("use_uri")
                 .copied()
                 .unwrap_or(false);
 
-        let password_source_is_literal =
-            self.password_value_source_selector.read(cx).is_literal(cx);
+        let password_source_is_literal = self
+            .form
+            .password_value_source_selector
+            .read(cx)
+            .is_literal(cx);
         let can_save_password =
             password_source_is_literal && self.app_state.read(cx).secret_store_available();
 
@@ -1432,7 +1475,8 @@ impl ConnectionManagerWindow {
     }
 
     fn ssm_auth_login_enabled(&self, cx: &Context<Self>) -> bool {
-        !self.auth_profile_login_in_progress && self.selected_auth_profile_needs_login(cx)
+        !self.auth_profile.auth_profile_login_in_progress
+            && self.selected_auth_profile_needs_login(cx)
     }
 
     pub(super) fn normalize_focus_for_state(&mut self, cx: &Context<Self>) -> bool {
@@ -1457,8 +1501,8 @@ impl ConnectionManagerWindow {
                 }
             }
             ActiveTab::Access => {
-                if (self.access_tab_mode == AccessTabMode::ManagedSsm
-                    || self.access_tab_mode == AccessTabMode::Direct)
+                if (self.access.access_tab_mode == AccessTabMode::ManagedSsm
+                    || self.access.access_tab_mode == AccessTabMode::Direct)
                     && !self.ssm_auth_login_enabled(cx)
                     && next_focus == SsmAuthLogin
                 {
@@ -1485,7 +1529,7 @@ impl ConnectionManagerWindow {
                 | Password | PasswordToggle | PasswordSave => 1,
                 _ => 0,
             },
-            ActiveTab::Access => match self.access_tab_mode {
+            ActiveTab::Access => match self.access.access_tab_mode {
                 AccessTabMode::Direct => match self.form_focus {
                     AccessMethod => 0,
                     SsmAuthProfile => 1,
@@ -1504,7 +1548,8 @@ impl ConnectionManagerWindow {
                     _ => 3,
                 },
                 AccessTabMode::Ssh => {
-                    let has_tunnels = self.ssh_enabled && !self.ssh_tunnel_uuids.is_empty();
+                    let has_tunnels =
+                        self.access.ssh_enabled && !self.access.ssh_tunnel_uuids.is_empty();
                     let tunnel_offset = if has_tunnels { 1 } else { 0 };
 
                     match self.form_focus {
@@ -1547,7 +1592,7 @@ impl ConnectionManagerWindow {
         self.form_focus = match self.active_tab {
             ActiveTab::Main => self.form_focus.down_main(self.main_nav_state(cx)),
             ActiveTab::Access => self.form_focus.down_access(
-                self.access_tab_mode,
+                self.access.access_tab_mode,
                 self.ssh_nav_state(cx),
                 self.proxy_nav_state(cx),
             ),
@@ -1565,7 +1610,7 @@ impl ConnectionManagerWindow {
         self.form_focus = match self.active_tab {
             ActiveTab::Main => self.form_focus.up_main(self.main_nav_state(cx)),
             ActiveTab::Access => self.form_focus.up_access(
-                self.access_tab_mode,
+                self.access.access_tab_mode,
                 self.ssh_nav_state(cx),
                 self.proxy_nav_state(cx),
             ),
@@ -1583,7 +1628,7 @@ impl ConnectionManagerWindow {
         self.form_focus = match self.active_tab {
             ActiveTab::Main => self.form_focus.left_main(self.main_nav_state(cx)),
             ActiveTab::Access => self.form_focus.left_access(
-                self.access_tab_mode,
+                self.access.access_tab_mode,
                 self.ssh_nav_state(cx),
                 self.proxy_nav_state(cx),
             ),
@@ -1592,8 +1637,8 @@ impl ConnectionManagerWindow {
         };
 
         if self.active_tab == ActiveTab::Access
-            && (self.access_tab_mode == AccessTabMode::ManagedSsm
-                || self.access_tab_mode == AccessTabMode::Direct)
+            && (self.access.access_tab_mode == AccessTabMode::ManagedSsm
+                || self.access.access_tab_mode == AccessTabMode::Direct)
             && self.form_focus == FormFocus::SsmAuthLogin
             && !self.ssm_auth_login_enabled(cx)
         {
@@ -1609,7 +1654,7 @@ impl ConnectionManagerWindow {
         self.form_focus = match self.active_tab {
             ActiveTab::Main => self.form_focus.right_main(self.main_nav_state(cx)),
             ActiveTab::Access => self.form_focus.right_access(
-                self.access_tab_mode,
+                self.access.access_tab_mode,
                 self.ssh_nav_state(cx),
                 self.proxy_nav_state(cx),
             ),
@@ -1618,8 +1663,8 @@ impl ConnectionManagerWindow {
         };
 
         if self.active_tab == ActiveTab::Access
-            && (self.access_tab_mode == AccessTabMode::ManagedSsm
-                || self.access_tab_mode == AccessTabMode::Direct)
+            && (self.access.access_tab_mode == AccessTabMode::ManagedSsm
+                || self.access.access_tab_mode == AccessTabMode::Direct)
             && self.form_focus == FormFocus::SsmAuthLogin
             && !self.ssm_auth_login_enabled(cx)
         {
@@ -1679,7 +1724,7 @@ impl ConnectionManagerWindow {
         match self.form_focus {
             FormFocus::Name => {
                 self.edit_state = EditState::Editing;
-                self.input_name.update(cx, |state, cx| {
+                self.form.input_name.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
@@ -1694,26 +1739,32 @@ impl ConnectionManagerWindow {
             }
 
             FormFocus::HostValueSource => {
-                self.host_value_source_selector.update(cx, |selector, cx| {
-                    selector.open_source_dropdown(cx);
-                });
+                self.form
+                    .host_value_source_selector
+                    .update(cx, |selector, cx| {
+                        selector.open_source_dropdown(cx);
+                    });
             }
 
             FormFocus::DatabaseValueSource => {
-                self.database_value_source_selector
+                self.form
+                    .database_value_source_selector
                     .update(cx, |selector, cx| {
                         selector.open_source_dropdown(cx);
                     });
             }
 
             FormFocus::UserValueSource => {
-                self.user_value_source_selector.update(cx, |selector, cx| {
-                    selector.open_source_dropdown(cx);
-                });
+                self.form
+                    .user_value_source_selector
+                    .update(cx, |selector, cx| {
+                        selector.open_source_dropdown(cx);
+                    });
             }
 
             FormFocus::PasswordValueSource => {
-                self.password_value_source_selector
+                self.form
+                    .password_value_source_selector
                     .update(cx, |selector, cx| {
                         selector.open_source_dropdown(cx);
                     });
@@ -1721,68 +1772,78 @@ impl ConnectionManagerWindow {
 
             FormFocus::Password => {
                 self.edit_state = EditState::Editing;
-                self.input_password.update(cx, |state, cx| {
+                self.form.input_password.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
 
             FormFocus::PasswordToggle => {
-                if self.password_value_source_selector.read(cx).is_literal(cx) {
-                    self.show_password = !self.show_password;
+                if self
+                    .form
+                    .password_value_source_selector
+                    .read(cx)
+                    .is_literal(cx)
+                {
+                    self.form.show_password = !self.form.show_password;
                 }
             }
 
             FormFocus::AccessMethod => {
-                self.access_method_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.open(cx);
-                });
+                self.access
+                    .access_method_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.open(cx);
+                    });
             }
 
             FormFocus::SshHost => {
                 self.edit_state = EditState::Editing;
-                self.input_ssh_host.update(cx, |state, cx| {
+                self.access.input_ssh_host.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
             FormFocus::SshPort => {
                 self.edit_state = EditState::Editing;
-                self.input_ssh_port.update(cx, |state, cx| {
+                self.access.input_ssh_port.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
             FormFocus::SshUser => {
                 self.edit_state = EditState::Editing;
-                self.input_ssh_user.update(cx, |state, cx| {
+                self.access.input_ssh_user.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
             FormFocus::SshKeyPath => {
                 self.edit_state = EditState::Editing;
-                self.input_ssh_key_path.update(cx, |state, cx| {
+                self.access.input_ssh_key_path.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
             FormFocus::SshPassphrase => {
                 self.edit_state = EditState::Editing;
-                self.input_ssh_key_passphrase.update(cx, |state, cx| {
-                    state.focus(window, cx);
-                });
+                self.access
+                    .input_ssh_key_passphrase
+                    .update(cx, |state, cx| {
+                        state.focus(window, cx);
+                    });
             }
             FormFocus::SshPassword => {
                 self.edit_state = EditState::Editing;
-                self.input_ssh_password.update(cx, |state, cx| {
+                self.access.input_ssh_password.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
             FormFocus::SsmInstanceId => {
                 self.edit_state = EditState::Editing;
-                self.input_ssm_instance_id.update(cx, |state, cx| {
+                self.access.input_ssm_instance_id.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
 
             FormFocus::SsmInstanceIdValueSource => {
-                self.ssm_instance_id_value_source_selector
+                self.access
+                    .ssm_instance_id_value_source_selector
                     .update(cx, |selector, cx| {
                         selector.open_source_dropdown(cx);
                     });
@@ -1790,13 +1851,14 @@ impl ConnectionManagerWindow {
 
             FormFocus::SsmRegion => {
                 self.edit_state = EditState::Editing;
-                self.input_ssm_region.update(cx, |state, cx| {
+                self.access.input_ssm_region.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
 
             FormFocus::SsmRegionValueSource => {
-                self.ssm_region_value_source_selector
+                self.access
+                    .ssm_region_value_source_selector
                     .update(cx, |selector, cx| {
                         selector.open_source_dropdown(cx);
                     });
@@ -1804,22 +1866,25 @@ impl ConnectionManagerWindow {
 
             FormFocus::SsmRemotePort => {
                 self.edit_state = EditState::Editing;
-                self.input_ssm_remote_port.update(cx, |state, cx| {
+                self.access.input_ssm_remote_port.update(cx, |state, cx| {
                     state.focus(window, cx);
                 });
             }
 
             FormFocus::SsmRemotePortValueSource => {
-                self.ssm_remote_port_value_source_selector
+                self.access
+                    .ssm_remote_port_value_source_selector
                     .update(cx, |selector, cx| {
                         selector.open_source_dropdown(cx);
                     });
             }
 
             FormFocus::SsmAuthProfile => {
-                self.auth_profile_dropdown.update(cx, |dropdown, cx| {
-                    dropdown.open(cx);
-                });
+                self.auth_profile
+                    .auth_profile_dropdown
+                    .update(cx, |dropdown, cx| {
+                        dropdown.open(cx);
+                    });
             }
 
             FormFocus::SsmAuthManage => {
@@ -1827,7 +1892,7 @@ impl ConnectionManagerWindow {
             }
 
             FormFocus::SsmAuthLogin => {
-                if !self.auth_profile_login_in_progress
+                if !self.auth_profile.auth_profile_login_in_progress
                     && self.selected_auth_profile_needs_login(cx)
                 {
                     self.login_selected_auth_profile(cx);
@@ -1848,12 +1913,14 @@ impl ConnectionManagerWindow {
 
             FormFocus::UseUri => {
                 let current = self
+                    .form
                     .checkbox_states
                     .get("use_uri")
                     .copied()
                     .unwrap_or(false);
                 let new_value = !current;
-                self.checkbox_states
+                self.form
+                    .checkbox_states
                     .insert("use_uri".to_string(), new_value);
 
                 if new_value {
@@ -1863,10 +1930,14 @@ impl ConnectionManagerWindow {
                 }
             }
             FormFocus::PasswordSave => {
-                if self.password_value_source_selector.read(cx).is_literal(cx)
+                if self
+                    .form
+                    .password_value_source_selector
+                    .read(cx)
+                    .is_literal(cx)
                     && self.app_state.read(cx).secret_store_available()
                 {
-                    self.form_save_password = !self.form_save_password;
+                    self.form.form_save_password = !self.form.form_save_password;
                 }
             }
             FormFocus::ProxySelector => {
@@ -1882,9 +1953,9 @@ impl ConnectionManagerWindow {
                         DropdownItem::with_value(&label, p.id.to_string())
                     })
                     .collect();
-                self.proxy_uuids = proxies.iter().map(|p| p.id).collect();
+                self.access.proxy_uuids = proxies.iter().map(|p| p.id).collect();
 
-                self.proxy_dropdown.update(cx, |dropdown, cx| {
+                self.access.proxy_dropdown.update(cx, |dropdown, cx| {
                     dropdown.set_items(proxy_items, cx);
                     dropdown.open(cx);
                 });
@@ -1895,10 +1966,10 @@ impl ConnectionManagerWindow {
             }
 
             FormFocus::SshEnabled => {
-                self.ssh_enabled = !self.ssh_enabled;
+                self.access.ssh_enabled = !self.access.ssh_enabled;
             }
             FormFocus::SshSaveSecret => {
-                self.form_save_ssh_secret = !self.form_save_ssh_secret;
+                self.form.form_save_ssh_secret = !self.form.form_save_ssh_secret;
             }
 
             FormFocus::SshTunnelSelector => {
@@ -1907,9 +1978,9 @@ impl ConnectionManagerWindow {
                     .iter()
                     .map(|t| DropdownItem::with_value(&t.name, t.id.to_string()))
                     .collect();
-                self.ssh_tunnel_uuids = ssh_tunnels.iter().map(|t| t.id).collect();
+                self.access.ssh_tunnel_uuids = ssh_tunnels.iter().map(|t| t.id).collect();
 
-                self.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
+                self.access.ssh_tunnel_dropdown.update(cx, |dropdown, cx| {
                     dropdown.set_items(tunnel_items, cx);
                     dropdown.open(cx);
                 });
@@ -1920,10 +1991,10 @@ impl ConnectionManagerWindow {
             }
 
             FormFocus::SshAuthPrivateKey => {
-                self.ssh_auth_method = SshAuthSelection::PrivateKey;
+                self.access.ssh_auth_method = SshAuthSelection::PrivateKey;
             }
             FormFocus::SshAuthPassword => {
-                self.ssh_auth_method = SshAuthSelection::Password;
+                self.access.ssh_auth_method = SshAuthSelection::Password;
             }
 
             FormFocus::SshEditInSettings => {
@@ -1942,16 +2013,19 @@ impl ConnectionManagerWindow {
             }
 
             FormFocus::SettingsRefreshPolicy => {
-                self.conn_override_refresh_policy = !self.conn_override_refresh_policy;
+                self.settings_tab.conn_override_refresh_policy =
+                    !self.settings_tab.conn_override_refresh_policy;
             }
             FormFocus::SettingsRefreshInterval => {
-                if self.conn_override_refresh_interval {
+                if self.settings_tab.conn_override_refresh_interval {
                     self.edit_state = EditState::Editing;
-                    self.conn_refresh_interval_input.update(cx, |state, cx| {
-                        state.focus(window, cx);
-                    });
+                    self.settings_tab
+                        .conn_refresh_interval_input
+                        .update(cx, |state, cx| {
+                            state.focus(window, cx);
+                        });
                 } else {
-                    self.conn_override_refresh_interval = true;
+                    self.settings_tab.conn_override_refresh_interval = true;
                 }
             }
             FormFocus::SettingsConfirmDangerous
@@ -1965,18 +2039,25 @@ impl ConnectionManagerWindow {
                     match &field.kind {
                         FormFieldKind::Checkbox => {
                             let current = self
+                                .settings_tab
                                 .conn_form_state
                                 .checkboxes
                                 .get(&field.id)
                                 .copied()
                                 .unwrap_or(false);
-                            self.conn_form_state
+                            self.settings_tab
+                                .conn_form_state
                                 .checkboxes
                                 .insert(field.id.clone(), !current);
                         }
                         FormFieldKind::Select { .. } => {}
                         _ => {
-                            if let Some(input) = self.conn_form_state.inputs.get(&field.id).cloned()
+                            if let Some(input) = self
+                                .settings_tab
+                                .conn_form_state
+                                .inputs
+                                .get(&field.id)
+                                .cloned()
                             {
                                 self.edit_state = EditState::Editing;
                                 input.update(cx, |state, cx| {

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -94,8 +94,11 @@ impl ConnectionManagerWindow {
     ) -> AnyElement {
         let theme = cx.theme().clone();
         let focus = self.form_focus;
-        let password_source_is_literal =
-            self.password_value_source_selector.read(cx).is_literal(cx);
+        let password_source_is_literal = self
+            .form
+            .password_value_source_selector
+            .read(cx)
+            .is_literal(cx);
 
         let selector_focused = show_focus && focus == FormFocus::PasswordValueSource;
         let password_focused = show_focus && focus == FormFocus::Password;
@@ -131,7 +134,7 @@ impl ConnectionManagerWindow {
                                     );
                                 }),
                             )
-                            .child(self.password_value_source_selector.clone()),
+                            .child(self.form.password_value_source_selector.clone()),
                     )
                     .child(
                         div()
@@ -149,7 +152,7 @@ impl ConnectionManagerWindow {
                                     this.enter_edit_mode_for_field(FormFocus::Password, window, cx);
                                 }),
                             )
-                            .child(Input::new(&self.input_password)),
+                            .child(Input::new(&self.form.input_password)),
                     )
                     .when(password_source_is_literal, |d| {
                         d.child(
@@ -162,13 +165,13 @@ impl ConnectionManagerWindow {
                                 })
                                 .child(
                                     Self::render_password_toggle(
-                                        self.show_password,
+                                        self.form.show_password,
                                         "toggle-password",
                                         &theme,
                                     )
                                     .on_click(cx.listener(
                                         |this, _, _, cx| {
-                                            this.show_password = !this.show_password;
+                                            this.form.show_password = !this.form.show_password;
                                             cx.notify();
                                         },
                                     )),
@@ -192,7 +195,7 @@ impl ConnectionManagerWindow {
                                     Checkbox::new("save-password")
                                         .checked(save_password)
                                         .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                            this.form_save_password = *checked;
+                                            this.form.form_save_password = *checked;
                                             cx.notify();
                                         })),
                                 )
@@ -245,7 +248,7 @@ impl ConnectionManagerWindow {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let Some(driver) = &self.selected_driver else {
+        let Some(driver) = &self.form.selected_driver else {
             return div().into_any_element();
         };
 
@@ -308,6 +311,7 @@ impl ConnectionManagerWindow {
                     })
                     .child({
                         let brand_icon = self
+                            .form
                             .selected_driver
                             .as_ref()
                             .map(|driver| AppIcon::from_icon(driver.metadata().icon));
@@ -328,7 +332,7 @@ impl ConnectionManagerWindow {
                     .child(div().flex_1())
                     .child(self.form_field_input_inline(
                         "Name",
-                        &self.input_name,
+                        &self.form.input_name,
                         show_focus && focus == FormFocus::Name,
                         ring_color,
                         FormFocus::Name,
@@ -493,13 +497,13 @@ impl ConnectionManagerWindow {
                 if !is_ssh_tab && (field_def.id == "database" || field_def.id == "user") {
                     let (selector, selector_focus, input_focus) = if field_def.id == "database" {
                         (
-                            self.database_value_source_selector.clone(),
+                            self.form.database_value_source_selector.clone(),
                             FormFocus::DatabaseValueSource,
                             FormFocus::Database,
                         )
                     } else {
                         (
-                            self.user_value_source_selector.clone(),
+                            self.form.user_value_source_selector.clone(),
                             FormFocus::UserValueSource,
                             FormFocus::User,
                         )
@@ -673,9 +677,10 @@ impl ConnectionManagerWindow {
             FormFieldKind::Checkbox => {
                 let field_id = field_def.id.clone();
                 let is_checked = if field_id == "ssh_enabled" {
-                    self.ssh_enabled
+                    self.access.ssh_enabled
                 } else {
-                    self.checkbox_states
+                    self.form
+                        .checkbox_states
                         .get(&field_id)
                         .copied()
                         .unwrap_or(false)
@@ -694,9 +699,9 @@ impl ConnectionManagerWindow {
                             .label(field_def.label.as_str())
                             .on_click(cx.listener(move |this, checked: &bool, window, cx| {
                                 if field_id == "ssh_enabled" {
-                                    this.ssh_enabled = *checked;
+                                    this.access.ssh_enabled = *checked;
                                 } else {
-                                    this.checkbox_states.insert(field_id.clone(), *checked);
+                                    this.form.checkbox_states.insert(field_id.clone(), *checked);
                                 }
                                 window.focus(&this.focus_handle);
                                 cx.notify();
@@ -710,7 +715,7 @@ impl ConnectionManagerWindow {
 
             FormFieldKind::Select { options } => {
                 if field_def.id == "ssh_auth_method" {
-                    let selected_index = match self.ssh_auth_method {
+                    let selected_index = match self.access.ssh_auth_method {
                         SshAuthSelection::PrivateKey => 0,
                         SshAuthSelection::Password => 1,
                     };
@@ -728,7 +733,7 @@ impl ConnectionManagerWindow {
                                 .on_mouse_down(
                                     MouseButton::Left,
                                     cx.listener(move |this, _, window, cx| {
-                                        this.ssh_auth_method = if idx == 0 {
+                                        this.access.ssh_auth_method = if idx == 0 {
                                             SshAuthSelection::PrivateKey
                                         } else {
                                             SshAuthSelection::Password
@@ -784,7 +789,7 @@ impl ConnectionManagerWindow {
                             }),
                         )
                     })
-                    .child(self.auth_profile_dropdown.clone());
+                    .child(self.auth_profile.auth_profile_dropdown.clone());
 
                 Self::field_row_cm(
                     field_def.label.clone(),
@@ -893,6 +898,7 @@ impl ConnectionManagerWindow {
         };
 
         let uri_mode_active = self
+            .form
             .checkbox_states
             .get("use_uri")
             .copied()
@@ -957,7 +963,7 @@ impl ConnectionManagerWindow {
                             }),
                         )
                     })
-                    .child(self.host_value_source_selector.clone()),
+                    .child(self.form.host_value_source_selector.clone()),
             )
             .child(
                 div()
@@ -1108,39 +1114,39 @@ impl ConnectionManagerWindow {
 
 impl Render for ConnectionManagerWindow {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        if let Some(path) = self.pending_ssh_key_path.take() {
-            self.input_ssh_key_path.update(cx, |state, cx| {
+        if let Some(path) = self.pending.ssh_key_path.take() {
+            self.access.input_ssh_key_path.update(cx, |state, cx| {
                 state.set_value(path, window, cx);
             });
         }
 
-        if let Some(path) = self.pending_file_path.take()
-            && let Some(input) = self.driver_inputs.get("path").cloned()
+        if let Some(path) = self.pending.file_path.take()
+            && let Some(input) = self.form.driver_inputs.get("path").cloned()
         {
             input.update(cx, |state, cx| {
                 state.set_value(path, window, cx);
             });
         }
 
-        if let Some(path) = self.pending_ssl_ca_cert_path.take() {
-            self.ssl_ca_cert_input.update(cx, |state, cx| {
+        if let Some(path) = self.pending.ssl_ca_cert_path.take() {
+            self.form.ssl_ca_cert_input.update(cx, |state, cx| {
                 state.set_value(path, window, cx);
             });
         }
 
-        if let Some(path) = self.pending_ssl_client_cert_path.take() {
-            self.ssl_client_cert_input.update(cx, |state, cx| {
+        if let Some(path) = self.pending.ssl_client_cert_path.take() {
+            self.form.ssl_client_cert_input.update(cx, |state, cx| {
                 state.set_value(path, window, cx);
             });
         }
 
-        if let Some(path) = self.pending_ssl_client_key_path.take() {
-            self.ssl_client_key_input.update(cx, |state, cx| {
+        if let Some(path) = self.pending.ssl_client_key_path.take() {
+            self.form.ssl_client_key_input.update(cx, |state, cx| {
                 state.set_value(path, window, cx);
             });
         }
 
-        if let Some(proxy_id) = self.pending_proxy_selection.take() {
+        if let Some(proxy_id) = self.pending.proxy_selection.take() {
             let proxy = self
                 .app_state
                 .read(cx)
@@ -1156,7 +1162,7 @@ impl Render for ConnectionManagerWindow {
         self.apply_pending_auth_profile(window, cx);
         self.apply_pending_ssm_auth_profile();
 
-        if let Some(tunnel_id) = self.pending_ssh_tunnel_selection.take() {
+        if let Some(tunnel_id) = self.pending.ssh_tunnel_selection.take() {
             let tunnel = self
                 .app_state
                 .read(cx)
@@ -1174,20 +1180,25 @@ impl Render for ConnectionManagerWindow {
             cx.notify();
         }
 
-        let show_password = self.show_password;
-        let password_source_is_literal =
-            self.password_value_source_selector.read(cx).is_literal(cx);
-        let show_ssh_passphrase = self.show_ssh_passphrase;
-        let show_ssh_password = self.show_ssh_password;
+        let show_password = self.form.show_password;
+        let password_source_is_literal = self
+            .form
+            .password_value_source_selector
+            .read(cx)
+            .is_literal(cx);
+        let show_ssh_passphrase = self.form.show_ssh_passphrase;
+        let show_ssh_password = self.form.show_ssh_password;
 
-        self.input_password.update(cx, |state, cx| {
+        self.form.input_password.update(cx, |state, cx| {
             let should_mask = password_source_is_literal && !show_password;
             state.set_masked(should_mask, window, cx);
         });
-        self.input_ssh_key_passphrase.update(cx, |state, cx| {
-            state.set_masked(!show_ssh_passphrase, window, cx);
-        });
-        self.input_ssh_password.update(cx, |state, cx| {
+        self.access
+            .input_ssh_key_passphrase
+            .update(cx, |state, cx| {
+                state.set_masked(!show_ssh_passphrase, window, cx);
+            });
+        self.access.input_ssh_password.update(cx, |state, cx| {
             state.set_masked(!show_ssh_password, window, cx);
         });
 

--- a/crates/dbflux_ui_windows/src/connection_manager/render_driver_select.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_driver_select.rs
@@ -54,7 +54,8 @@ impl ConnectionManagerWindow {
 
     /// Lowercased filter query, read live from the filter input each render.
     pub(super) fn current_driver_filter(&self, cx: &App) -> String {
-        self.driver_filter_input
+        self.form
+            .driver_filter_input
             .read(cx)
             .value()
             .to_string()
@@ -104,7 +105,7 @@ impl ConnectionManagerWindow {
                     .items_center()
                     .gap_2()
                     .w(px(360.0))
-                    .child(render_filter_input(&self.driver_filter_input))
+                    .child(render_filter_input(&self.form.driver_filter_input))
                     .child(KbdBadge::new("/")),
             )
     }

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -107,13 +107,13 @@ impl ConnectionManagerWindow {
     pub(super) fn render_main_tab(&mut self, cx: &mut Context<Self>) -> Vec<AnyElement> {
         // Clone the driver Arc up front so we don't hold a reference into `self`
         // across mutable calls like `render_form_tab` below.
-        let Some(driver) = self.selected_driver.clone() else {
+        let Some(driver) = self.form.selected_driver.clone() else {
             return Vec::new();
         };
 
         let keyring_available = self.app_state.read(cx).secret_store_available();
         let requires_password = driver.requires_password();
-        let save_password = self.form_save_password;
+        let save_password = self.form.form_save_password;
         let ssl_modes = driver.metadata().ssl_modes;
 
         let show_focus =
@@ -175,7 +175,7 @@ impl ConnectionManagerWindow {
         ssl_modes: &'static [dbflux_core::SslModeOption],
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        let current_ssl_mode = self.selected_ssl_mode.clone();
+        let current_ssl_mode = self.form.selected_ssl_mode.clone();
 
         let ssl_items: Vec<SegmentedItem> = ssl_modes
             .iter()
@@ -190,7 +190,7 @@ impl ConnectionManagerWindow {
             move |selected: &SharedString, _window, cx| {
                 let mode = selected.to_string();
                 entity.update(cx, |this, cx| {
-                    this.selected_ssl_mode = mode;
+                    this.form.selected_ssl_mode = mode;
                     cx.notify();
                 });
             },
@@ -215,7 +215,7 @@ impl ConnectionManagerWindow {
 
         // Cert path inputs — shown only when the driver declares ssl_cert_fields and the
         // selected mode requires certificate verification.
-        if let Some(driver) = &self.selected_driver {
+        if let Some(driver) = &self.form.selected_driver {
             let metadata = driver.metadata();
             if let Some(cert_fields) = &metadata.ssl_cert_fields {
                 let mode_requires_root =
@@ -265,9 +265,9 @@ impl ConnectionManagerWindow {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let input_entity = match slot {
-            super::SslCertSlot::CaCert => &self.ssl_ca_cert_input,
-            super::SslCertSlot::ClientCert => &self.ssl_client_cert_input,
-            super::SslCertSlot::ClientKey => &self.ssl_client_key_input,
+            super::SslCertSlot::CaCert => &self.form.ssl_ca_cert_input,
+            super::SslCertSlot::ClientCert => &self.form.ssl_client_cert_input,
+            super::SslCertSlot::ClientKey => &self.form.ssl_client_key_input,
         };
 
         let current_value = input_entity.read(cx).value().to_string();
@@ -362,9 +362,9 @@ impl ConnectionManagerWindow {
                     .p(px(2.0))
                     .child(
                         Checkbox::new("conn-override-refresh-policy")
-                            .checked(self.conn_override_refresh_policy)
+                            .checked(self.settings_tab.conn_override_refresh_policy)
                             .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                this.conn_override_refresh_policy = *checked;
+                                this.settings_tab.conn_override_refresh_policy = *checked;
                                 cx.notify();
                             })),
                     )
@@ -373,13 +373,13 @@ impl ConnectionManagerWindow {
                         div()
                             .min_w(px(160.0))
                             .relative()
-                            .opacity(if self.conn_override_refresh_policy {
+                            .opacity(if self.settings_tab.conn_override_refresh_policy {
                                 1.0
                             } else {
                                 0.6
                             })
-                            .child(self.conn_refresh_policy_dropdown.clone())
-                            .when(!self.conn_override_refresh_policy, |d| {
+                            .child(self.settings_tab.conn_refresh_policy_dropdown.clone())
+                            .when(!self.settings_tab.conn_override_refresh_policy, |d| {
                                 d.child(
                                     div()
                                         .absolute()
@@ -411,9 +411,9 @@ impl ConnectionManagerWindow {
                     .p(px(2.0))
                     .child(
                         Checkbox::new("conn-override-refresh-interval")
-                            .checked(self.conn_override_refresh_interval)
+                            .checked(self.settings_tab.conn_override_refresh_interval)
                             .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                this.conn_override_refresh_interval = *checked;
+                                this.settings_tab.conn_override_refresh_interval = *checked;
                                 cx.notify();
                             })),
                     )
@@ -421,15 +421,15 @@ impl ConnectionManagerWindow {
                     .child(
                         div()
                             .w(px(100.0))
-                            .opacity(if self.conn_override_refresh_interval {
+                            .opacity(if self.settings_tab.conn_override_refresh_interval {
                                 1.0
                             } else {
                                 0.6
                             })
                             .child(
-                                Input::new(&self.conn_refresh_interval_input)
+                                Input::new(&self.settings_tab.conn_refresh_interval_input)
                                     .small()
-                                    .disabled(!self.conn_override_refresh_interval),
+                                    .disabled(!self.settings_tab.conn_override_refresh_interval),
                             ),
                     )
                     .child(Text::caption(format!(
@@ -463,7 +463,7 @@ impl ConnectionManagerWindow {
                     .child(
                         div()
                             .min_w(px(160.0))
-                            .child(self.conn_confirm_dangerous_dropdown.clone()),
+                            .child(self.settings_tab.conn_confirm_dangerous_dropdown.clone()),
                     )
                     .child(Text::caption(format!(
                         "Default: {}",
@@ -495,7 +495,7 @@ impl ConnectionManagerWindow {
                     .child(
                         div()
                             .min_w(px(160.0))
-                            .child(self.conn_requires_where_dropdown.clone()),
+                            .child(self.settings_tab.conn_requires_where_dropdown.clone()),
                     )
                     .child(Text::caption(format!(
                         "Default: {}",
@@ -527,7 +527,7 @@ impl ConnectionManagerWindow {
                     .child(
                         div()
                             .min_w(px(160.0))
-                            .child(self.conn_requires_preview_dropdown.clone()),
+                            .child(self.settings_tab.conn_requires_preview_dropdown.clone()),
                     )
                     .child(Text::caption(format!(
                         "Default: {}",
@@ -552,7 +552,7 @@ impl ConnectionManagerWindow {
         );
 
         // --- Driver Schema Section ---
-        if let Some(driver) = &self.selected_driver
+        if let Some(driver) = &self.form.selected_driver
             && let Some(schema) = driver.settings_schema()
         {
             let mut field_idx: u8 = 0;
@@ -570,12 +570,13 @@ impl ConnectionManagerWindow {
                             show_focus && focus == FormFocus::SettingsDriverField(current_idx);
                         let enabled = form_renderer::is_field_enabled(
                             field,
-                            &self.conn_form_state.checkboxes,
+                            &self.settings_tab.conn_form_state.checkboxes,
                         );
 
                         match &field.kind {
                             FormFieldKind::Checkbox => {
                                 let checked = self
+                                    .settings_tab
                                     .conn_form_state
                                     .checkboxes
                                     .get(&field.id)
@@ -613,7 +614,8 @@ impl ConnectionManagerWindow {
                                                     if !enabled {
                                                         return;
                                                     }
-                                                    this.conn_form_state
+                                                    this.settings_tab
+                                                        .conn_form_state
                                                         .checkboxes
                                                         .insert(field_id.clone(), *checked);
                                                     cx.notify();
@@ -626,8 +628,12 @@ impl ConnectionManagerWindow {
                             }
 
                             FormFieldKind::Select { .. } => {
-                                let dropdown =
-                                    self.conn_form_state.dropdowns.get(&field.id)?.clone();
+                                let dropdown = self
+                                    .settings_tab
+                                    .conn_form_state
+                                    .dropdowns
+                                    .get(&field.id)?
+                                    .clone();
                                 let default_val = effective
                                     .driver_values
                                     .get(&field.id)
@@ -664,7 +670,12 @@ impl ConnectionManagerWindow {
                             }
 
                             _ => {
-                                let input = self.conn_form_state.inputs.get(&field.id)?.clone();
+                                let input = self
+                                    .settings_tab
+                                    .conn_form_state
+                                    .inputs
+                                    .get(&field.id)?
+                                    .clone();
                                 let default_val = effective
                                     .driver_values
                                     .get(&field.id)
@@ -717,16 +728,18 @@ impl ConnectionManagerWindow {
 
     pub(super) fn render_mcp_tab(&self, cx: &mut Context<Self>) -> Vec<AnyElement> {
         let theme = cx.theme().clone();
-        let enabled = self.conn_mcp_enabled;
+        let enabled = self.mcp_tab.conn_mcp_enabled;
         let opacity = if enabled { 1.0 } else { 0.5 };
 
         let actor_label = self
+            .mcp_tab
             .conn_mcp_actor_dropdown
             .read(cx)
             .selected_label()
             .map(|l| l.to_string())
             .unwrap_or_default();
         let role_label = self
+            .mcp_tab
             .conn_mcp_role_dropdown
             .read(cx)
             .selected_value()
@@ -734,6 +747,7 @@ impl ConnectionManagerWindow {
             .map(|v| v.to_string())
             .unwrap_or_else(|| "none".to_string());
         let policy_label = self
+            .mcp_tab
             .conn_mcp_policy_dropdown
             .read(cx)
             .selected_value()
@@ -763,7 +777,7 @@ impl ConnectionManagerWindow {
                     .gap_2()
                     .child(Checkbox::new("conn-mcp-enabled").checked(enabled).on_click(
                         cx.listener(|this, checked: &bool, _, cx| {
-                            this.conn_mcp_enabled = *checked;
+                            this.mcp_tab.conn_mcp_enabled = *checked;
                             cx.notify();
                         }),
                     ))
@@ -779,7 +793,7 @@ impl ConnectionManagerWindow {
                     .child(Text::caption(
                         "AI agent identity — configure in Settings → MCP",
                     ))
-                    .child(self.conn_mcp_actor_dropdown.clone()),
+                    .child(self.mcp_tab.conn_mcp_actor_dropdown.clone()),
             )
             .child(
                 div()
@@ -791,9 +805,9 @@ impl ConnectionManagerWindow {
                     .child(Text::caption(
                         "Configure roles in Settings \u{2192} MCP \u{2192} Roles",
                     ))
-                    .child(self.conn_mcp_role_dropdown.clone())
+                    .child(self.mcp_tab.conn_mcp_role_dropdown.clone())
                     .child(Text::caption("Additional roles (optional)"))
-                    .child(self.conn_mcp_role_multi_select.clone()),
+                    .child(self.mcp_tab.conn_mcp_role_multi_select.clone()),
             )
             .child(
                 div()
@@ -805,9 +819,9 @@ impl ConnectionManagerWindow {
                     .child(Text::caption(
                         "Configure policies in Settings \u{2192} MCP \u{2192} Policies",
                     ))
-                    .child(self.conn_mcp_policy_dropdown.clone())
+                    .child(self.mcp_tab.conn_mcp_policy_dropdown.clone())
                     .child(Text::caption("Additional policies (optional)"))
-                    .child(self.conn_mcp_policy_multi_select.clone()),
+                    .child(self.mcp_tab.conn_mcp_policy_multi_select.clone()),
             )
             .child(Text::caption("Scope/policy assignment preview").into_any_element())
             .child(Text::body(preview_text));


### PR DESCRIPTION
## Summary

Behavior-preserving refactor of the `ConnectionManagerWindow` monolith (REFAC-1, EPIC-MONOLITHS). The window struct went from **76 direct fields** to **26**, with the rest grouped into six flat state sub-structs, following the same pattern REFAC-2..6 (#209) used for the other UI monoliths.

This is a **pure relocation refactor**: no behavior change, no new features, no API changes. Every hunk is a field move plus an access-path rewrite (`self.x` to `self.group.x`). Per the GPUI single-`Context` borrow model, the groups are **plain sub-structs, not sub-`Entity`s** (the same constraint that kept `KeyValueView`/`LogStreamView` as file-level boundaries).

## Changes

| Group (new sub-struct) | Fields | Purpose |
|------------------------|:------:|---------|
| `FormState` | 22 | Per-driver field inputs, password, value-source selectors, checkboxes, SSL inputs |
| `AccessState` | 26 | SSH / proxy / SSM inputs and dropdowns, access method/kind/tab-mode |
| `AuthProfileState` | 8 | Auth-profile dropdown, session/login state, SSO wizard flags |
| `SettingsTabState` | 18 | Hook dropdowns/inputs, refresh policy, override dropdowns, `conn_form_subscriptions` |
| `McpTabState` | 6 | MCP enabled + actor/role/policy selectors |
| `PendingActions` | 9 | `Option<T>` render-time actions, drained via `.take()` |

`validation_errors`, `test_*`, `ssh_test_*`, and the focus/keymap/subscription infrastructure fields stay top-level on purpose: they are written from async callbacks and read in render, so grouping them would force split-borrow workarounds. Final top-level count: 26 fields.

Touched: `connection_manager/` (`mod.rs`, `render.rs`, `render_tabs.rs`, `render_driver_select.rs`, `navigation.rs`, `form.rs`, `access_tab.rs`, `hooks_tab.rs`). ~1230/900 lines, almost entirely mechanical renames. Over the 400-line budget by design, hence `size:exception` (splitting a single struct's field relocation across PRs would be more churn than signal).

## Test plan

- `cargo check -p dbflux_ui_windows` and `cargo check -p dbflux_ui_windows --features mcp` clean.
- `cargo nextest run -p dbflux_ui_windows` green (140 passed), including the `connection_manager_has_no_driver_id_branching` guardrail; the 12 connection-manager unit tests pass unchanged.
- `cargo clippy -p dbflux_ui_windows --features mcp -- -D warnings` clean; `cargo fmt` applied; doctests pass.
- Reviewed as relocation-only: an independent dual review confirmed no control-flow, `cx.notify()`, `.take()` drain, subscription-lifecycle, or focus/blur state-machine change, and that no field was dropped or reordered (109 fields before and after).

## Manual smoke required before merge

There is **no GPUI widget test coverage** for this window, so the automated gates above cannot prove runtime UI behavior. Please exercise the Connection Manager window before merging:

1. Open the window, create a new connection, edit fields (dirty tracking updates).
2. Switch drivers; the per-driver form re-renders correctly.
3. Configure access: SSH (key/agent), proxy, SSM (inputs + value-source selectors).
4. Auth profile: dropdown populates; open the SSO wizard; login flow.
5. Settings tab: hooks, overrides, refresh policy.
6. MCP tab: enable + actor/role/policy selectors.
7. Run a connection test and an SSH test (status + error banners).
8. Tab switching and focus/blur (`/` to focus the driver filter, Esc behavior).
9. Save a profile, reopen it for edit, confirm values round-trip.
