### PR TITLE
fix(reliability): atomic migration bootstrap, non-panicking SystemTime, bounded IPC reads (MISC-12/13/15)

### DIFF
--- a/crates/dbflux_ipc/src/framing.rs
+++ b/crates/dbflux_ipc/src/framing.rs
@@ -27,7 +27,7 @@ pub fn recv_msg<R: Read, T: DeserializeOwned>(mut reader: R) -> io::Result<T> {
         return Err(io::Error::other("message too large"));
     }
 
-    let mut buf = Vec::new();
+    let mut buf = Vec::with_capacity(len.min(64 * 1024));
     reader.take(len as u64).read_to_end(&mut buf)?;
     if buf.len() != len {
         return Err(io::Error::new(

--- a/crates/dbflux_ipc/src/framing.rs
+++ b/crates/dbflux_ipc/src/framing.rs
@@ -27,8 +27,50 @@ pub fn recv_msg<R: Read, T: DeserializeOwned>(mut reader: R) -> io::Result<T> {
         return Err(io::Error::other("message too large"));
     }
 
-    let mut buf = vec![0u8; len];
-    reader.read_exact(&mut buf)?;
+    let mut buf = Vec::new();
+    reader.take(len as u64).read_to_end(&mut buf)?;
+    if buf.len() != len {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "framed message body shorter than announced length",
+        ));
+    }
 
     bincode::deserialize(&buf).map_err(io::Error::other)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn recv_msg_short_body_returns_unexpected_eof() {
+        let announced: u32 = 1024;
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&announced.to_le_bytes());
+        framed.extend_from_slice(&[0u8; 10]);
+
+        let err = recv_msg::<_, Vec<u8>>(Cursor::new(framed)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn send_recv_roundtrip_near_cap() {
+        let payload: Vec<u8> = vec![0xABu8; 4 * 1024 * 1024];
+        let mut buf = Vec::new();
+        send_msg(&mut buf, &payload).unwrap();
+        let decoded: Vec<u8> = recv_msg(Cursor::new(buf)).unwrap();
+        assert_eq!(decoded, payload);
+    }
+
+    #[test]
+    fn recv_msg_rejects_oversized_header() {
+        let oversized_len: u32 = MAX_MSG_SIZE + 1;
+        let mut framed = Vec::new();
+        framed.extend_from_slice(&oversized_len.to_le_bytes());
+
+        let result = recv_msg::<_, Vec<u8>>(Cursor::new(framed));
+        assert!(result.is_err());
+    }
 }

--- a/crates/dbflux_storage/src/bootstrap.rs
+++ b/crates/dbflux_storage/src/bootstrap.rs
@@ -107,8 +107,8 @@ impl StorageRuntime {
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
         );
 
         let temp_dir = std::env::temp_dir().join(&temp_label);
@@ -360,8 +360,8 @@ mod tests {
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
         ));
         let _ = std::fs::remove_dir_all(&dir);
         dir

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -176,41 +176,85 @@ impl MigrationRegistry {
     /// already been applied and skips them. Runs remaining migrations in
     /// registration order.
     ///
+    /// The `sys_migrations` DDL and the first pending migration's body are committed
+    /// as one atomic unit so there is no window in which the table exists but the
+    /// first migration's record does not. Migrations 2..N each run in their own
+    /// transaction, unchanged from the original behavior.
+    ///
     /// # Errors
     ///
     /// Returns [`MigrationError`] if:
     /// - A database error occurs while checking applied migrations
     /// - A migration's `run()` method returns an error
     pub fn run_all(&self, conn: &Connection) -> Result<(), MigrationError> {
-        // Ensure sys_migrations table exists
-        self.ensure_sys_migrations(conn)?;
+        let mut pending_iter = {
+            let outer_tx =
+                conn.unchecked_transaction()
+                    .map_err(|source| MigrationError::Sqlite {
+                        path: conn_path(conn),
+                        source,
+                    })?;
 
-        // Get set of already-applied migration names
-        let applied: std::collections::HashSet<String> = self
-            .get_applied_migrations(conn)
-            .map_err(|e| MigrationError::Sqlite {
-                path: conn_path(conn),
-                source: e,
+            self.ensure_sys_migrations(&outer_tx)?;
+
+            let applied = self.get_applied_migrations(&outer_tx).map_err(|source| {
+                MigrationError::Sqlite {
+                    path: conn_path(conn),
+                    source,
+                }
             })?;
 
-        info!(
-            "MigrationRegistry: {} migrations already applied, checking {} registered",
-            applied.len(),
-            self.migrations.len()
-        );
+            info!(
+                "MigrationRegistry: {} migrations already applied, checking {} registered",
+                applied.len(),
+                self.migrations.len()
+            );
 
-        // Run each pending migration
-        for migration in &self.migrations {
-            let name = migration.name();
+            let mut pending: Vec<&dyn Migration> = self
+                .migrations
+                .iter()
+                .filter(|m| !applied.contains(m.name()))
+                .map(|m| m.as_ref())
+                .collect();
 
-            if applied.contains(name) {
-                info!("MigrationRegistry: skipping '{}' (already applied)", name);
-                continue;
+            if let Some(first) = pending.first() {
+                let name = first.name();
+                info!("MigrationRegistry: applying migration '{}'", name);
+
+                first.run(&outer_tx)?;
+
+                outer_tx
+                    .execute(
+                        "INSERT INTO sys_migrations (name, applied_at) VALUES (?1, datetime('now'))",
+                        rusqlite::params![name],
+                    )
+                    .map_err(|source| MigrationError::Sqlite {
+                        path: conn_path(conn),
+                        source,
+                    })?;
+
+                outer_tx.commit().map_err(|source| MigrationError::Sqlite {
+                    path: conn_path(conn),
+                    source,
+                })?;
+
+                info!("MigrationRegistry: '{}' applied successfully", name);
+                pending.remove(0);
+            } else {
+                outer_tx.commit().map_err(|source| MigrationError::Sqlite {
+                    path: conn_path(conn),
+                    source,
+                })?;
             }
+
+            pending
+        };
+
+        for migration in pending_iter.drain(..) {
+            let name = migration.name();
 
             info!("MigrationRegistry: applying migration '{}'", name);
 
-            // Run migration in a transaction
             let tx = conn
                 .unchecked_transaction()
                 .map_err(|source| MigrationError::Sqlite {
@@ -220,7 +264,6 @@ impl MigrationRegistry {
 
             migration.run(&tx)?;
 
-            // Record the migration
             tx.execute(
                 "INSERT INTO sys_migrations (name, applied_at) VALUES (?1, datetime('now'))",
                 rusqlite::params![name],
@@ -230,7 +273,6 @@ impl MigrationRegistry {
                 source,
             })?;
 
-            // Commit the transaction
             tx.commit().map_err(|source| MigrationError::Sqlite {
                 path: conn_path(conn),
                 source,
@@ -795,6 +837,84 @@ mod tests {
                 "table '{expected}' must still be present after idempotent rerun"
             );
         }
+
+        drop(conn);
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    struct FailingMigration;
+
+    impl Migration for FailingMigration {
+        fn name(&self) -> &str {
+            "000_failing_test_migration"
+        }
+
+        fn run(&self, _tx: &Transaction) -> Result<(), MigrationError> {
+            Err(MigrationError::Failed {
+                name: self.name().to_owned(),
+                details: "injected failure".to_owned(),
+            })
+        }
+    }
+
+    #[test]
+    fn test_first_migration_failure_rolls_back_sys_table() {
+        let temp_dir = temp_dir("first_fail_rollback");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.db");
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            let mut registry = MigrationRegistry {
+                migrations: Vec::new(),
+            };
+            registry.register(FailingMigration);
+
+            assert!(
+                registry.run_all(&conn).is_err(),
+                "run_all must return Err when first migration fails"
+            );
+        }
+
+        let conn2 = Connection::open(&db_path).unwrap();
+        let tables = table_names(&conn2);
+        assert!(
+            !tables.contains("sys_migrations"),
+            "sys_migrations must not exist after a rolled-back first migration"
+        );
+
+        drop(conn2);
+        let _ = std::fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn test_run_all_recovers_from_partial_first_migration_crash() {
+        let temp_dir = temp_dir("partial_crash");
+        let _ = std::fs::remove_dir_all(&temp_dir);
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let db_path = temp_dir.join("test.db");
+
+        {
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute(
+                "CREATE TABLE sys_migrations (name TEXT PRIMARY KEY, \
+                 applied_at TEXT NOT NULL DEFAULT (datetime('now')))",
+                [],
+            )
+            .unwrap();
+        }
+
+        let conn = Connection::open(&db_path).unwrap();
+        let registry = MigrationRegistry::new();
+        registry
+            .run_all(&conn)
+            .expect("run_all must recover from empty sys_migrations");
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sys_migrations", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, registry.migrations.len() as i64);
 
         drop(conn);
         let _ = std::fs::remove_dir_all(temp_dir);

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -187,7 +187,7 @@ impl MigrationRegistry {
     /// - A database error occurs while checking applied migrations
     /// - A migration's `run()` method returns an error
     pub fn run_all(&self, conn: &Connection) -> Result<(), MigrationError> {
-        let mut pending_iter = {
+        let mut remaining_migrations = {
             let outer_tx =
                 conn.unchecked_transaction()
                     .map_err(|source| MigrationError::Sqlite {
@@ -250,7 +250,7 @@ impl MigrationRegistry {
             pending
         };
 
-        for migration in pending_iter.drain(..) {
+        for migration in remaining_migrations.drain(..) {
             let name = migration.name();
 
             info!("MigrationRegistry: applying migration '{}'", name);

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -421,8 +421,8 @@ mod tests {
             std::process::id(),
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
         ))
     }
 


### PR DESCRIPTION
## Summary

Three P3-Low reliability fixes (MISC-12/13/15), grouped into one consolidated PR. All test-first and behavior-preserving where intended.

## Changes

| Item | Area | What changed |
|------|------|--------------|
| **MISC-12** | `dbflux_storage` | `run_all` now wraps the `sys_migrations` DDL **and** the first pending migration (its body + its `INSERT INTO sys_migrations`) in one transaction. Previously the `CREATE TABLE` committed in autocommit, so a failure/crash during the first migration left a half-initialized bookkeeping state. Migrations 2..N keep their existing per-migration transactions unchanged. |
| **MISC-13** | `dbflux_storage` | Replaced `SystemTime::now().duration_since(UNIX_EPOCH).unwrap()` with `.map(\|d\| d.as_nanos()).unwrap_or(0)` at three sites (one production + two test helpers). A clock set before the epoch no longer panics; the value is only a temp-name suffix. |
| **MISC-15** | `dbflux_ipc` | `recv_msg` no longer pre-allocates the announced length. It now reads incrementally with `take(len).read_to_end` (bounded initial capacity `len.min(64 KiB)`) and verifies `buf.len() == len`. A compromised driver-host that announces 16 MiB without sending a body can no longer force a 16 MiB allocation per call. The 16 MiB cap is kept (large `SchemaSnapshot` responses legitimately reach several MiB). |

## Test plan

- New tests: `test_first_migration_failure_rolls_back_sys_table` (MISC-12 atomicity — red before the fix), `recv_msg_short_body_returns_unexpected_eof` / `send_recv_roundtrip_near_cap` / `recv_msg_rejects_oversized_header` (MISC-15).
- `cargo nextest run -p dbflux_storage -p dbflux_ipc` green (246 passed); `cargo check --workspace` clean; `cargo clippy -p dbflux_storage -p dbflux_ipc -- -D warnings` clean (the CI gate); `cargo fmt` applied.
- Reviewed via independent dual adversarial review: MISC-12 confirmed correct across all migration states (fully-applied, zero-pending, partial prior apply, error rollback, no nested transactions); MISC-15 confirmed to consume exactly `len` bytes and preserve the next frame boundary.

## Notes

- `dbflux_storage` currently fails `clippy --all-targets -D warnings` due to **pre-existing** lints in files untouched by this PR (surfaced by a newer toolchain). The CI clippy gate does not use `--all-targets`, and this PR introduces no new warnings. Worth a separate cleanup.
