### PR TITLE
chore(clippy): resolve all --all-targets lints across the workspace

### DIFF
--- a/crates/dbflux_aws/src/auth.rs
+++ b/crates/dbflux_aws/src/auth.rs
@@ -2997,7 +2997,7 @@ sso_region = us-east-1
             .find(|p| p.name == "my-profile")
             .expect("my-profile");
         assert!(
-            p.fields.get("region").is_none(),
+            !p.fields.contains_key("region"),
             "absent region must not appear in fields"
         );
     }

--- a/crates/dbflux_components/src/components/data_table/state.rs
+++ b/crates/dbflux_components/src/components/data_table/state.rs
@@ -1033,6 +1033,8 @@ mod tests {
 
     /// Harness that wraps a DataTableState entity so it can be placed in a window.
     struct StateHarness {
+        // Keeps the DataTableState entity owned by the window view for the test's lifetime.
+        #[allow(dead_code)]
         state: gpui::Entity<super::DataTableState>,
     }
 
@@ -1116,7 +1118,7 @@ mod tests {
         let state_holder = std::rc::Rc::new(std::cell::RefCell::new(None));
         let holder_clone = state_holder.clone();
 
-        let (_, window) = cx.add_window_view(move |window, cx| {
+        let (_, window) = cx.add_window_view(move |_window, cx| {
             let model = one_row_model();
             let state = cx.new(|cx| {
                 let mut s = super::DataTableState::new(model, cx);
@@ -1161,7 +1163,7 @@ mod tests {
         let state_holder = std::rc::Rc::new(std::cell::RefCell::new(None));
         let holder_clone = state_holder.clone();
 
-        let (_, window) = cx.add_window_view(move |window, cx| {
+        let (_, window) = cx.add_window_view(move |_window, cx| {
             let model = one_row_model();
             let state = cx.new(|cx| {
                 let mut s = super::DataTableState::new(model, cx);

--- a/crates/dbflux_core/src/driver/form.rs
+++ b/crates/dbflux_core/src/driver/form.rs
@@ -445,7 +445,7 @@ mod tests {
         ];
 
         for hint in &variants {
-            let cloned = hint.clone();
+            let cloned = *hint;
             assert_eq!(hint, &cloned);
             let debug_str = format!("{:?}", hint);
             assert!(!debug_str.is_empty());

--- a/crates/dbflux_core/src/query/generator.rs
+++ b/crates/dbflux_core/src/query/generator.rs
@@ -2124,6 +2124,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn materialize_question_mark_float() {
         let q = SelectQuery {
             sql: "SELECT * FROM t WHERE score > ?".to_string(),
@@ -2989,9 +2990,7 @@ mod tests {
     // T-13 — [RED] Tests for QueryGenerator trait extensions (spec B-5, DR-3.1, DR-3.3)
 
     mod mutation_generator_tests {
-        use super::super::{
-            GeneratedMutation, GeneratorError, MockMutationGenerator, QueryGenerator,
-        };
+        use super::super::{GeneratorError, MockMutationGenerator, QueryGenerator};
         use crate::query::table_browser::TableRef;
         use crate::query::visual_query::{
             Assignment, AssignmentValue, MutationKind, ScalarLiteral, VisualMutationSpec,
@@ -3084,8 +3083,8 @@ mod tests {
         use crate::Value;
         use crate::query::table_browser::TableRef;
         use crate::query::visual_query::{
-            Assignment, AssignmentValue, BoolOp, Comparator, FilterNode, LiteralValue,
-            MutationKind, Predicate, PredicateValue, ScalarLiteral, VisualMutationSpec,
+            Assignment, AssignmentValue, Comparator, FilterNode, LiteralValue, MutationKind,
+            Predicate, PredicateValue, ScalarLiteral, VisualMutationSpec,
         };
         use crate::sql::dialect::{PlaceholderStyle, SqlDialect};
 

--- a/crates/dbflux_core/src/query/relational_filter/parser.rs
+++ b/crates/dbflux_core/src/query/relational_filter/parser.rs
@@ -813,6 +813,7 @@ mod tests {
 
     // T06: integers, floats, booleans, NULL
     #[test]
+    #[allow(clippy::approx_constant)]
     fn tokenize_number_and_bool() {
         assert_eq!(
             tok("42 3.14 true FALSE null"),
@@ -840,6 +841,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn tokenize_negative_float() {
         let tokens = tok("-3.14");
         assert!(matches!(tokens[0], Token::Float(f) if (f - (-3.14)).abs() < 1e-10));
@@ -914,6 +916,7 @@ mod tests {
 
     // T09: value RHS
     #[test]
+    #[allow(clippy::approx_constant)]
     fn parse_rhs_values() {
         let ast_str = parse("col = 'hello'").unwrap();
         let ast_int = parse("col = 42").unwrap();

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -4292,25 +4292,25 @@ mod tests {
 
         // Integer N
         assert_eq!(
-            infer_field_kind(&[n_int_item.clone()], "count"),
+            infer_field_kind(std::slice::from_ref(&n_int_item), "count"),
             ColumnKind::Integer
         );
 
         // Decimal N
         assert_eq!(
-            infer_field_kind(&[n_float_item.clone()], "score"),
+            infer_field_kind(std::slice::from_ref(&n_float_item), "score"),
             ColumnKind::Float
         );
 
         // S → Text
         assert_eq!(
-            infer_field_kind(&[s_item.clone()], "name"),
+            infer_field_kind(std::slice::from_ref(&s_item), "name"),
             ColumnKind::Text
         );
 
         // Bool → Integer (Value::Bool plots as 0/1 in the chart engine, like MSSQL BIT).
         assert_eq!(
-            infer_field_kind(&[bool_item.clone()], "active"),
+            infer_field_kind(std::slice::from_ref(&bool_item), "active"),
             ColumnKind::Integer
         );
 
@@ -4319,7 +4319,7 @@ mod tests {
 
         // Missing field → Unknown
         assert_eq!(
-            infer_field_kind(&[n_int_item.clone()], "missing"),
+            infer_field_kind(std::slice::from_ref(&n_int_item), "missing"),
             ColumnKind::Unknown
         );
 

--- a/crates/dbflux_driver_postgres/tests/instance_catalog.rs
+++ b/crates/dbflux_driver_postgres/tests/instance_catalog.rs
@@ -196,13 +196,13 @@ fn all_numeric_metrics_return_ok_on_empty_instance() {
                 "metric {metric_id} must return at least one row"
             );
 
-            if metric_id == "pg.cache_hit_ratio" {
-                if let Some(dbflux_core::Value::Float(ratio)) = result.rows[0].get(1) {
-                    assert!(
-                        *ratio >= 0.0 && *ratio <= 100.0,
-                        "cache_hit_ratio must be in [0, 100] on empty instance; got {ratio}"
-                    );
-                }
+            if metric_id == "pg.cache_hit_ratio"
+                && let Some(dbflux_core::Value::Float(ratio)) = result.rows[0].get(1)
+            {
+                assert!(
+                    *ratio >= 0.0 && *ratio <= 100.0,
+                    "cache_hit_ratio must be in [0, 100] on empty instance; got {ratio}"
+                );
             }
         }
 

--- a/crates/dbflux_driver_postgres/tests/relational_filter_live.rs
+++ b/crates/dbflux_driver_postgres/tests/relational_filter_live.rs
@@ -6,7 +6,8 @@
     clippy::unwrap_used,
     clippy::expect_used,
     clippy::panic,
-    clippy::indexing_slicing
+    clippy::indexing_slicing,
+    clippy::result_large_err
 )]
 
 use dbflux_core::{ConnectionProfile, DbConfig, DbDriver, DbError, QueryRequest, Value};

--- a/crates/dbflux_lua/src/api/dbflux.rs
+++ b/crates/dbflux_lua/src/api/dbflux.rs
@@ -555,15 +555,12 @@ mod tests {
         let state = test_state(None, Instant::now(), None);
 
         let result = run_process(&lua, &state, options);
-        match result {
-            Err(e) => {
-                let msg = e.to_string();
-                assert!(
-                    !msg.contains("requires a timeout_ms"),
-                    "unexpected timeout-required error: {msg}"
-                );
-            }
-            Ok(_) => {}
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("requires a timeout_ms"),
+                "unexpected timeout-required error: {msg}"
+            );
         }
     }
 
@@ -577,15 +574,12 @@ mod tests {
         let state = test_state(Some(Duration::from_secs(60)), Instant::now(), None);
 
         let result = run_process(&lua, &state, options);
-        match result {
-            Err(e) => {
-                let msg = e.to_string();
-                assert!(
-                    !msg.contains("requires a timeout_ms"),
-                    "unexpected timeout-required error when hook timeout is set: {msg}"
-                );
-            }
-            Ok(_) => {}
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("requires a timeout_ms"),
+                "unexpected timeout-required error when hook timeout is set: {msg}"
+            );
         }
     }
 
@@ -600,15 +594,12 @@ mod tests {
         let state = test_state(None, Instant::now(), None);
 
         let result = run_process(&lua, &state, options);
-        match result {
-            Err(e) => {
-                let msg = e.to_string();
-                assert!(
-                    !msg.contains("requires a timeout_ms"),
-                    "detached run must not require timeout_ms, got: {msg}"
-                );
-            }
-            Ok(_) => {}
+        if let Err(e) = result {
+            let msg = e.to_string();
+            assert!(
+                !msg.contains("requires a timeout_ms"),
+                "detached run must not require timeout_ms, got: {msg}"
+            );
         }
     }
 

--- a/crates/dbflux_storage/src/migrations/mod_002_audit_extended.rs
+++ b/crates/dbflux_storage/src/migrations/mod_002_audit_extended.rs
@@ -188,7 +188,7 @@ mod tests {
 
     use super::column_exists;
 
-    fn open_tx(conn: &Connection) -> rusqlite::Transaction {
+    fn open_tx(conn: &Connection) -> rusqlite::Transaction<'_> {
         conn.unchecked_transaction().unwrap()
     }
 

--- a/crates/dbflux_storage/src/migrations/mod_011_viz_saved_chart_metric_source.rs
+++ b/crates/dbflux_storage/src/migrations/mod_011_viz_saved_chart_metric_source.rs
@@ -219,16 +219,6 @@ mod tests {
         Connection::open_in_memory().unwrap()
     }
 
-    fn columns(conn: &Connection, table: &str) -> std::collections::HashSet<String> {
-        let mut stmt = conn
-            .prepare(&format!("PRAGMA table_info({table})"))
-            .unwrap();
-        stmt.query_map([], |row| row.get::<_, String>(1))
-            .unwrap()
-            .filter_map(|r| r.ok())
-            .collect()
-    }
-
     /// Migration 011 created scalar `source_metric_*` columns and the
     /// dimensions table keyed on `(chart_id, dim_index)`. Migration 012 drops
     /// those columns and re-keys the dimensions table. After running ALL

--- a/crates/dbflux_storage/src/repositories/viz_dashboard_panels.rs
+++ b/crates/dbflux_storage/src/repositories/viz_dashboard_panels.rs
@@ -434,7 +434,7 @@ mod tests {
             grid_height: 4,
         };
 
-        repo.replace_panels_for_dashboard(dashboard_id, &[inspector_panel.clone()])
+        repo.replace_panels_for_dashboard(dashboard_id, std::slice::from_ref(&inspector_panel))
             .expect("replace with inspector panel");
 
         let loaded = repo.list_for_dashboard(dashboard_id).expect("list");

--- a/crates/dbflux_storage/tests/audit_settings_migration_014.rs
+++ b/crates/dbflux_storage/tests/audit_settings_migration_014.rs
@@ -60,6 +60,7 @@ fn repository_reads_log_capture_min_level_from_db() {
     let conn = Connection::open_in_memory().unwrap();
     MigrationRegistry::new().run_all(&conn).unwrap();
 
+    #[allow(clippy::arc_with_non_send_sync)]
     let shared = std::sync::Arc::new(conn);
     let repo = AuditSettingsRepository::new(shared);
 
@@ -81,6 +82,7 @@ fn update_log_capture_min_level_persists_new_value() {
     let conn = Connection::open_in_memory().unwrap();
     MigrationRegistry::new().run_all(&conn).unwrap();
 
+    #[allow(clippy::arc_with_non_send_sync)]
     let shared = std::sync::Arc::new(conn);
     let repo = AuditSettingsRepository::new(shared);
 

--- a/crates/dbflux_ui_base/src/dashboard_manager.rs
+++ b/crates/dbflux_ui_base/src/dashboard_manager.rs
@@ -1426,7 +1426,7 @@ mod tests {
         //   panel 2: col=0, row=3, w=6, h=3
         //   panel 3: col=6, row=3, w=6, h=3
         //   panel 4: col=0, row=6, w=12, h=4  (full-width inspector)
-        let layouts = vec![
+        let layouts = [
             DraftGridLayout {
                 grid_row: 0,
                 grid_column: 0,
@@ -1573,7 +1573,9 @@ mod tests {
 
         let dashboard = sample_dashboard("test");
         let dashboard_id = dashboard.id;
-        manager.upsert_dashboard(dashboard);
+        manager
+            .upsert_dashboard(dashboard)
+            .expect("upsert should persist the dashboard");
 
         let chart_id1 = Uuid::new_v4();
         let chart_id2 = Uuid::new_v4();

--- a/crates/dbflux_ui_base/src/modals/delete_confirm.rs
+++ b/crates/dbflux_ui_base/src/modals/delete_confirm.rs
@@ -290,10 +290,7 @@ impl Render for ModalDeleteSavedChartConfirm {
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        DeleteDashboardOutcome, DeleteDashboardRequest, DeleteSavedChartOutcome,
-        DeleteSavedChartRequest, ModalDeleteDashboardConfirm, ModalDeleteSavedChartConfirm,
-    };
+    use super::{DeleteDashboardRequest, DeleteSavedChartRequest, ModalDeleteDashboardConfirm};
     use uuid::Uuid;
 
     fn test_uuid() -> Uuid {

--- a/crates/dbflux_ui_base/src/modals/rename_item.rs
+++ b/crates/dbflux_ui_base/src/modals/rename_item.rs
@@ -175,7 +175,7 @@ impl Render for ModalRenameItem {
 
 #[cfg(test)]
 mod tests {
-    use super::{ModalRenameItem, RenameItemOutcome, RenameItemRequest, RenameTarget};
+    use super::{RenameItemOutcome, RenameItemRequest, RenameTarget};
     use uuid::Uuid;
 
     fn test_uuid() -> Uuid {

--- a/crates/dbflux_ui_base/src/saved_chart_manager.rs
+++ b/crates/dbflux_ui_base/src/saved_chart_manager.rs
@@ -834,7 +834,9 @@ mod tests {
         let chart_id = chart.id;
 
         let mut manager = SavedChartManager::new(Arc::clone(&repo));
-        manager.upsert(chart);
+        manager
+            .upsert(chart)
+            .expect("upsert should persist the chart");
 
         // In-memory cache contains the chart.
         assert_eq!(manager.all_charts().len(), 1);
@@ -923,7 +925,7 @@ mod tests {
         let chart = sample_chart("Original", profile_id);
         let id = chart.id;
         let mut mgr = SavedChartManager::new(Arc::clone(&repo));
-        mgr.upsert(chart);
+        mgr.upsert(chart).expect("upsert should persist the chart");
 
         mgr.rename_chart(id, "Renamed".to_string()).unwrap();
 
@@ -961,7 +963,7 @@ mod tests {
         let chart = sample_chart("ToDelete", profile_id);
         let id = chart.id;
         let mut mgr = SavedChartManager::new(Arc::clone(&repo));
-        mgr.upsert(chart);
+        mgr.upsert(chart).expect("upsert should persist the chart");
         assert_eq!(mgr.all_charts().len(), 1);
 
         mgr.delete_chart(id).unwrap();
@@ -989,7 +991,7 @@ mod tests {
         let chart = sample_chart("Original", profile_id);
         let orig_id = chart.id;
         let mut mgr = SavedChartManager::new(Arc::clone(&repo));
-        mgr.upsert(chart);
+        mgr.upsert(chart).expect("upsert should persist the chart");
 
         let dup_id = mgr.duplicate_chart(orig_id).unwrap();
 
@@ -1032,7 +1034,9 @@ mod tests {
         let chart_id = chart.id;
 
         let mut manager = SavedChartManager::new(Arc::clone(&repo));
-        manager.upsert(chart);
+        manager
+            .upsert(chart)
+            .expect("upsert should persist the chart");
 
         // Reload from storage.
         let manager2 = SavedChartManager::new(Arc::clone(&repo));
@@ -1122,7 +1126,9 @@ mod tests {
         let chart_id = chart.id;
 
         let mut manager = SavedChartManager::new(Arc::clone(&repo));
-        manager.upsert(chart);
+        manager
+            .upsert(chart)
+            .expect("upsert should persist the chart");
 
         let manager2 = SavedChartManager::new(Arc::clone(&repo));
         assert_eq!(manager2.all_charts().len(), 1);

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -2260,14 +2260,15 @@ mod tests {
     fn drift_query_with_pending_action_survives_put_back() {
         use super::{DriftAction, PendingActions, PendingDriftQuery};
 
-        let mut pending = PendingActions::default();
-
-        pending.drift_query = Some(PendingDriftQuery {
-            query: "SELECT 2".to_string(),
-            in_new_tab: true,
-            action: DriftAction::Pending,
-            cache_updates: Vec::new(),
-        });
+        let mut pending = PendingActions {
+            drift_query: Some(PendingDriftQuery {
+                query: "SELECT 2".to_string(),
+                in_new_tab: true,
+                action: DriftAction::Pending,
+                cache_updates: Vec::new(),
+            }),
+            ..Default::default()
+        };
 
         // Simulate the put-back logic: take the value, inspect action, re-store.
         let taken = pending.drift_query.take().unwrap();

--- a/crates/dbflux_ui_document/src/dashboard/mod.rs
+++ b/crates/dbflux_ui_document/src/dashboard/mod.rs
@@ -2373,19 +2373,16 @@ mod tests {
         }
     }
 
+    // The cap constant must stay consistent with the concurrency counter's
+    // initial value (0 < PANEL_REEXEC_CAP); enforced at compile time.
+    const _: () = assert!(0 < PANEL_REEXEC_CAP);
+
     /// F.2 — `DashboardDocument` state defaults: `Clean`, `can_close` = true,
     /// `is_backgrounded` = false, `pending_refresh_on_focus` = false,
     /// concurrency counter starts at zero. Tested without GPUI runtime by
     /// inspecting the invariants in the constructor logic directly.
     #[test]
     fn dashboard_document_default_state_invariants() {
-        // Validate that the cap constant is consistent with the concurrency
-        // counter initial value (0 < PANEL_REEXEC_CAP).
-        assert!(
-            0 < PANEL_REEXEC_CAP,
-            "initial inflight_reexec_count (0) must be less than PANEL_REEXEC_CAP"
-        );
-
         // Validate the orphan/loaded slot enum has exactly the expected variants
         // by constructing both and matching without panicking.
         let orphan = DashboardPanelSlot::Orphan {
@@ -2552,7 +2549,7 @@ mod tests {
             grid_width: 1,
             grid_height: 1,
         };
-        let slots = vec![
+        let slots = [
             DashboardPanelSlot::Orphan {
                 saved_chart_id: Uuid::nil(),
                 grid_pos: default_pos,

--- a/crates/dbflux_ui_document/src/dashboard/render.rs
+++ b/crates/dbflux_ui_document/src/dashboard/render.rs
@@ -649,10 +649,7 @@ mod tests {
 
     /// Render-level invariant: `PANEL_REEXEC_CAP` is visible from render.rs
     /// (same crate, `pub(crate)` const). Compile-only assertion.
-    #[test]
-    fn render_can_reference_panel_reexec_cap() {
-        assert!(PANEL_REEXEC_CAP > 0);
-    }
+    const _: () = assert!(PANEL_REEXEC_CAP > 0);
 
     /// `panel_height(1)` is exactly one `DASHBOARD_ROW_PX` row.
     #[test]
@@ -760,7 +757,7 @@ mod tests {
             },
         };
 
-        let mut slots = vec![make_orphan(1, 1), make_orphan(0, 1), make_orphan(0, 0)];
+        let mut slots = [make_orphan(1, 1), make_orphan(0, 1), make_orphan(0, 0)];
 
         slots.sort_by_key(|s| {
             let p = s.grid_pos();

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutation_executor.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutation_executor.rs
@@ -2039,7 +2039,7 @@ mod tests {
             });
             let rollback_pos = calls
                 .iter()
-                .position(|c| c.to_ascii_uppercase() == "ROLLBACK");
+                .position(|c| c.eq_ignore_ascii_case("ROLLBACK"));
             assert!(
                 rollback_pos.is_some(),
                 "ROLLBACK must be issued after DML cancel; calls: {:?}",
@@ -2052,7 +2052,7 @@ mod tests {
             );
             // COMMIT must NOT appear.
             assert!(
-                !calls.iter().any(|c| c.to_ascii_uppercase() == "COMMIT"),
+                !calls.iter().any(|c| c.eq_ignore_ascii_case("COMMIT")),
                 "COMMIT must NOT be issued when cancelled after DML; calls: {:?}",
                 calls
             );
@@ -2524,7 +2524,7 @@ mod tests {
             // ROLLBACK must have been issued
             let calls = conn_ref.calls.lock().unwrap().clone();
             assert!(
-                calls.iter().any(|c| c.to_ascii_uppercase() == "ROLLBACK"),
+                calls.iter().any(|c| c.eq_ignore_ascii_case("ROLLBACK")),
                 "expected ROLLBACK in calls: {:?}",
                 calls
             );
@@ -3583,8 +3583,8 @@ mod tests {
                 .position(|c| c.to_ascii_uppercase().contains("SESSION"));
             let begin_pos = calls.iter().position(|c| {
                 c.to_ascii_uppercase().contains("START TRANSACTION")
-                    || c.to_ascii_uppercase() == "BEGIN"
-                    || c.to_ascii_uppercase() == "BEGIN TRANSACTION"
+                    || c.eq_ignore_ascii_case("BEGIN")
+                    || c.eq_ignore_ascii_case("BEGIN TRANSACTION")
             });
             let dml_pos = calls.iter().position(|c| {
                 let u = c.to_ascii_uppercase();

--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -4980,10 +4980,10 @@ mod tests {
         t_add_predicate(&mut panel, vec![], "name");
 
         // Update value at path [0] (email predicate).
-        if let Some(root) = &mut panel.current_spec.filter {
-            if let Some(FilterNode::Predicate(pred)) = filter_node_at_path_mut(root, &[0]) {
-                pred.value = PredicateValue::Single(LiteralValue::Text("%foo%".to_string()));
-            }
+        if let Some(root) = &mut panel.current_spec.filter
+            && let Some(FilterNode::Predicate(pred)) = filter_node_at_path_mut(root, &[0])
+        {
+            pred.value = PredicateValue::Single(LiteralValue::Text("%foo%".to_string()));
         }
         panel.rebuild_spec_pure();
 

--- a/crates/dbflux_ui_document/src/task_runner.rs
+++ b/crates/dbflux_ui_document/src/task_runner.rs
@@ -42,80 +42,6 @@ impl MutationCancelHandle {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    // Import only what we need — avoid `use gpui::*` which triggers macro recursion.
-    use dbflux_core::CancelToken;
-
-    use super::MutationCancelHandle;
-
-    // T-21 — [RED] Tests for MutationCancelHandle (spec J-1, J-2, DR-15.1)
-
-    #[test]
-    fn j1_new_handle_is_not_cancelled() {
-        // We test the standalone handle directly since start_mutation requires GPUI context.
-        let handle = MutationCancelHandle::new();
-        assert!(
-            !handle.is_cancelled(),
-            "new handle must start as not-cancelled"
-        );
-    }
-
-    #[test]
-    fn j2_cancel_flips_is_cancelled_to_true() {
-        let handle = MutationCancelHandle::new();
-        assert!(!handle.is_cancelled());
-        handle.cancel();
-        assert!(handle.is_cancelled());
-    }
-
-    #[test]
-    fn mutation_cancel_handle_clone_shares_state() {
-        let handle = MutationCancelHandle::new();
-        let clone = handle.clone();
-        handle.cancel();
-        assert!(
-            clone.is_cancelled(),
-            "clone must see cancellation from original"
-        );
-    }
-
-    // F-R2-2: DR-15.1 — cancellation via the task manager's CancelToken must propagate
-    // to the MutationCancelHandle that the executor polls.
-    //
-    // `start_mutation` now wraps the token returned by `start_task_for_target` into the
-    // handle via `from_token`. This test proves the shared-state invariant without
-    // requiring a GPUI context: cancelling the original token must flip the handle.
-    #[test]
-    fn cancel_mutation_via_task_runner_flips_executor_handle() {
-        let token = CancelToken::new();
-        let handle = MutationCancelHandle::from_token(token.clone());
-
-        assert!(!handle.is_cancelled(), "handle must start as not-cancelled");
-
-        token.cancel();
-
-        assert!(
-            handle.is_cancelled(),
-            "cancelling the CancelToken must flip is_cancelled() on the handle (DR-15.1)"
-        );
-    }
-
-    // Inverse: cancelling the handle must also flip the shared token.
-    #[test]
-    fn cancel_on_handle_also_cancels_shared_token() {
-        let token = CancelToken::new();
-        let handle = MutationCancelHandle::from_token(token.clone());
-
-        handle.cancel();
-
-        assert!(
-            token.is_cancelled(),
-            "cancelling the handle must propagate to the shared CancelToken"
-        );
-    }
-}
-
 pub struct DocumentTaskRunner {
     primary: TaskSlot,
     app_state: Entity<AppStateEntity>,
@@ -255,5 +181,79 @@ impl DocumentTaskRunner {
             state.fail_task(task_id, error);
             cx.emit(AppStateChanged);
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Import only what we need — avoid `use gpui::*` which triggers macro recursion.
+    use dbflux_core::CancelToken;
+
+    use super::MutationCancelHandle;
+
+    // T-21 — [RED] Tests for MutationCancelHandle (spec J-1, J-2, DR-15.1)
+
+    #[test]
+    fn j1_new_handle_is_not_cancelled() {
+        // We test the standalone handle directly since start_mutation requires GPUI context.
+        let handle = MutationCancelHandle::new();
+        assert!(
+            !handle.is_cancelled(),
+            "new handle must start as not-cancelled"
+        );
+    }
+
+    #[test]
+    fn j2_cancel_flips_is_cancelled_to_true() {
+        let handle = MutationCancelHandle::new();
+        assert!(!handle.is_cancelled());
+        handle.cancel();
+        assert!(handle.is_cancelled());
+    }
+
+    #[test]
+    fn mutation_cancel_handle_clone_shares_state() {
+        let handle = MutationCancelHandle::new();
+        let clone = handle.clone();
+        handle.cancel();
+        assert!(
+            clone.is_cancelled(),
+            "clone must see cancellation from original"
+        );
+    }
+
+    // F-R2-2: DR-15.1 — cancellation via the task manager's CancelToken must propagate
+    // to the MutationCancelHandle that the executor polls.
+    //
+    // `start_mutation` now wraps the token returned by `start_task_for_target` into the
+    // handle via `from_token`. This test proves the shared-state invariant without
+    // requiring a GPUI context: cancelling the original token must flip the handle.
+    #[test]
+    fn cancel_mutation_via_task_runner_flips_executor_handle() {
+        let token = CancelToken::new();
+        let handle = MutationCancelHandle::from_token(token.clone());
+
+        assert!(!handle.is_cancelled(), "handle must start as not-cancelled");
+
+        token.cancel();
+
+        assert!(
+            handle.is_cancelled(),
+            "cancelling the CancelToken must flip is_cancelled() on the handle (DR-15.1)"
+        );
+    }
+
+    // Inverse: cancelling the handle must also flip the shared token.
+    #[test]
+    fn cancel_on_handle_also_cancels_shared_token() {
+        let token = CancelToken::new();
+        let handle = MutationCancelHandle::from_token(token.clone());
+
+        handle.cancel();
+
+        assert!(
+            token.is_cancelled(),
+            "cancelling the handle must propagate to the shared CancelToken"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Makes the whole workspace pass `cargo clippy --workspace --all-targets -- -D warnings`. Every lint resolved was in **test code** (`#[cfg(test)]` modules, test helpers, integration tests) — which is why the CI clippy gate (`cargo clippy --workspace`, without `--all-targets`) never flagged them: it only lints the lib/bin targets, not the unit-test harness build. No production code path changed.

## Changes

Auto-applied via `cargo clippy --fix` plus manual fixes for the non-machine-applicable cases, across 23 files:

| Lint | Fix |
|------|-----|
| `cloned_ref_to_slice_refs` (×6) | `&[x.clone()]` → `std::slice::from_ref(&x)` |
| redundant `match`→`if let`, `collapsible_if`→let-chains | mechanical rewrites |
| `clone_on_copy`, `unnecessary_get_then_check`, `eq_ignore_ascii_case`, `field_reassign_with_default`, useless `vec!`, unused imports/vars | mechanical |
| `items_after_test_module` | moved `task_runner.rs`'s `mod tests` to the file end |
| `mismatched_lifetime_syntaxes` | `Transaction` → `Transaction<'_>` |
| `assertions_on_constants` (×2) | runtime `assert!(CONST)` → compile-time `const _: () = assert!(...)` |
| `dead_code` | removed an unused test helper (`columns` in `mod_011`); kept `StateHarness::state` under `#[allow(dead_code)]` (it owns the entity for the test's lifetime) |
| `unused_must_use` (×7) | `.expect(...)` on the `Result` in tests (not `let _ =`, per project rule) |
| `result_large_err`, `arc_with_non_send_sync`, `approx_constant` | local `#[allow]` in the affected tests, where the lint is a test-ergonomics false positive (e.g. `3.14` is asserted as the string `"3.14"`, not used as π) |

## Test plan

- `cargo clippy --workspace --all-targets --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,lua,aws,mcp -- -D warnings` → clean (the gate this PR fixes).
- `cargo check --workspace` clean; `cargo nextest run --workspace` green (3897 passed, 0 failed, 185 skipped); `cargo test --doc --workspace` 0 failed; `cargo fmt --all --check` clean.

## Notes

This unblocks tightening the CI clippy job to `--all-targets` in a follow-up, so test-only lints can't accumulate again.
