### PR TITLE
refactor(drivers): shared DynamoDB runtime, SQLite URI-mode tests, InfluxDB icon (MISC-5/7/11)

### DIFF
--- a/crates/dbflux_components/src/icons/mod.rs
+++ b/crates/dbflux_components/src/icons/mod.rs
@@ -275,7 +275,6 @@ impl AppIcon {
             Icon::Mongodb => Self::BrandMongodb,
             Icon::Redis => Self::BrandRedis,
             Icon::Dynamodb => Self::Database,
-            // TODO(influxdb-icon): real brand SVG already exists at icons/brand/influxdb.svg
             Icon::Influxdb => Self::BrandInfluxDb,
             Icon::Logs => Self::Logs,
             Icon::Database => Self::Database,
@@ -292,5 +291,19 @@ impl From<AppIcon> for IconSource {
 impl From<AppIcon> for gpui_component::Icon {
     fn from(icon: AppIcon) -> Self {
         gpui_component::Icon::default().path(icon.path())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppIcon;
+    use dbflux_core::Icon;
+
+    #[test]
+    fn influxdb_icon_maps_to_brand_svg() {
+        assert_eq!(
+            AppIcon::from_icon(Icon::Influxdb).path(),
+            "icons/brand/influxdb.svg"
+        );
     }
 }

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -764,7 +764,7 @@ impl Connection for DynamoConnection {
             table: Some(table_name.to_string()),
         };
 
-        let runtime = runtime()?;
+        let runtime = runtime();
         let request = self.client.delete_table().table_name(table_name);
 
         match runtime.block_on(request.send()) {
@@ -801,7 +801,7 @@ impl Connection for DynamoConnection {
             table: self.default_table.clone(),
         };
 
-        let runtime = runtime()?;
+        let runtime = runtime();
         let output = runtime
             .block_on(self.client.describe_table().table_name(table).send())
             .map_err(|error| {
@@ -852,7 +852,7 @@ impl Connection for DynamoConnection {
             table: self.default_table.clone(),
         };
 
-        let runtime = runtime()?;
+        let runtime = runtime();
 
         if plan.total_items == 0 {
             return Err(DbError::query_failed("Document payload is required"));
@@ -888,7 +888,7 @@ impl Connection for DynamoConnection {
                 &self.client,
                 &plan.table,
                 write_requests,
-                &runtime,
+                runtime,
                 &config,
             )?;
         }
@@ -914,7 +914,7 @@ impl Connection for DynamoConnection {
                 table: self.default_table.clone(),
             };
 
-            let runtime = runtime()?;
+            let runtime = runtime();
 
             let mut condition_attribute_names = HashMap::new();
             condition_attribute_names.insert("#ck0".to_string(), plan.partition_key_name.clone());
@@ -986,7 +986,7 @@ impl Connection for DynamoConnection {
 
         if update.many {
             let many_plan = self.plan_update_many_operation(update)?;
-            let runtime = runtime()?;
+            let runtime = runtime();
 
             let mut updated_count: usize = 0;
 
@@ -1018,7 +1018,7 @@ impl Connection for DynamoConnection {
         }
 
         let plan = self.plan_update_operation(update)?;
-        let runtime = runtime()?;
+        let runtime = runtime();
         runtime
             .block_on(
                 self.client
@@ -1048,7 +1048,7 @@ impl Connection for DynamoConnection {
 
         if delete.many {
             let many_plan = self.plan_delete_many_operation(delete)?;
-            let runtime = runtime()?;
+            let runtime = runtime();
 
             let mut deleted_count: usize = 0;
 
@@ -1074,7 +1074,7 @@ impl Connection for DynamoConnection {
 
         let plan = self.plan_delete_operation(delete)?;
 
-        let runtime = runtime()?;
+        let runtime = runtime();
         runtime
             .block_on(
                 self.client
@@ -1308,7 +1308,7 @@ impl DynamoConnection {
             table: self.default_table.clone(),
         };
 
-        let runtime = runtime()?;
+        let runtime = runtime();
         let mut names = Vec::new();
         let mut cursor: Option<String> = None;
 
@@ -1350,7 +1350,7 @@ impl DynamoConnection {
             table: self.default_table.clone(),
         };
 
-        let runtime = runtime()?;
+        let runtime = runtime();
 
         // Retry up to 2 times on dispatch failure (transient SDK errors)
         let mut last_error = None;
@@ -1439,7 +1439,7 @@ impl DynamoConnection {
             ));
         }
 
-        let runtime = runtime()?;
+        let runtime = runtime();
         let mut remaining_skip = offset;
         let mut collected = Vec::new();
         let mut cursor: Option<HashMap<String, AttributeValue>> = None;
@@ -1465,7 +1465,7 @@ impl DynamoConnection {
                 strategy,
                 request_limit,
                 cursor.clone(),
-                &runtime,
+                runtime,
                 config,
             )?;
 
@@ -1521,7 +1521,7 @@ impl DynamoConnection {
             ));
         }
 
-        let runtime = runtime()?;
+        let runtime = runtime();
         let mut total: u64 = 0;
         let mut cursor: Option<HashMap<String, AttributeValue>> = None;
 
@@ -1532,7 +1532,7 @@ impl DynamoConnection {
                     table,
                     strategy,
                     cursor.clone(),
-                    &runtime,
+                    runtime,
                     config,
                 )?;
 
@@ -1554,7 +1554,7 @@ impl DynamoConnection {
                 strategy,
                 100,
                 cursor.clone(),
-                &runtime,
+                runtime,
                 config,
             )?;
 
@@ -1708,7 +1708,7 @@ impl DynamoConnection {
             table: self.default_table.clone(),
         };
 
-        let runtime = runtime()?;
+        let runtime = runtime();
         let mut cursor: Option<HashMap<String, AttributeValue>> = None;
         let mut key_maps = Vec::new();
 
@@ -1719,7 +1719,7 @@ impl DynamoConnection {
                 strategy,
                 READ_PAGE_LIMIT,
                 cursor.clone(),
-                &runtime,
+                runtime,
                 &config,
             )?;
 
@@ -3591,7 +3591,7 @@ fn build_client(config: &DynamoProfileConfig) -> Result<Client, DbError> {
         loader = loader.profile_name(profile);
     }
 
-    let runtime = runtime()?;
+    let runtime = runtime();
     let sdk_config = runtime.block_on(loader.load());
 
     let mut builder = DynamoConfigBuilder::from(&sdk_config);
@@ -3636,7 +3636,7 @@ fn endpoint_looks_local(endpoint: &str) -> bool {
 }
 
 fn probe_connection(client: &Client, config: &DynamoProfileConfig) -> Result<(), DbError> {
-    let runtime = runtime()?;
+    let runtime = runtime();
     runtime
         .block_on(client.list_tables().limit(1).send())
         .map_err(|error| {
@@ -3647,9 +3647,13 @@ fn probe_connection(client: &Client, config: &DynamoProfileConfig) -> Result<(),
     Ok(())
 }
 
-fn runtime() -> Result<tokio::runtime::Runtime, DbError> {
-    tokio::runtime::Runtime::new()
-        .map_err(|error| DbError::connection_failed(format!("Tokio runtime setup failed: {error}")))
+#[allow(clippy::expect_used)]
+static DYNAMODB_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    tokio::runtime::Runtime::new().expect("DynamoDB driver failed to construct tokio runtime")
+});
+
+fn runtime() -> &'static tokio::runtime::Runtime {
+    &DYNAMODB_RUNTIME
 }
 
 fn normalize_table_names(mut table_names: Vec<String>) -> Result<Vec<String>, DbError> {
@@ -4243,8 +4247,8 @@ mod tests {
         ensure_item_contains_required_keys, extract_key_map_from_filter,
         extract_non_key_update_attributes, infer_field_kind, json_value_to_attribute_value,
         key_components_to_fields, key_components_to_indexes, normalize_table_names,
-        plan_dynamo_semantic_request, resolve_upsert_key_map, strip_key_fields_from_update_payload,
-        unsupported_operation, validate_read_options,
+        plan_dynamo_semantic_request, resolve_upsert_key_map, runtime,
+        strip_key_fields_from_update_payload, unsupported_operation, validate_read_options,
     };
     use crate::query_parser::{DynamoFilterFallback, DynamoReadOptions};
     use aws_sdk_dynamodb::types::{
@@ -5401,6 +5405,11 @@ mod tests {
             "DynamoDB 'profile' field must be AuthProfileRef {{ provider_id: None }}, got {:?}",
             profile_field.kind
         );
+    }
+
+    #[test]
+    fn dynamodb_runtime_is_shared() {
+        assert!(std::ptr::eq(runtime(), runtime()));
     }
 
     #[test]

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -3647,8 +3647,18 @@ fn probe_connection(client: &Client, config: &DynamoProfileConfig) -> Result<(),
     Ok(())
 }
 
+/// Process-wide tokio runtime shared across every DynamoDB SDK call.
+///
+/// Constructing a fresh runtime per call is expensive in file descriptors and
+/// defeats connection pooling — hyper's pool is keyed to the runtime that
+/// issued the request, so per-call runtimes lose keep-alive. A `LazyLock<Runtime>`
+/// lives for the lifetime of the process and is never dropped, which also avoids
+/// any Runtime-in-async-context panic risk.
 #[allow(clippy::expect_used)]
 static DYNAMODB_RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| {
+    // Fatal at process scope: the driver cannot operate without a tokio
+    // runtime and there is no recoverable path. A panic here surfaces the
+    // OS-level reason (typically EMFILE / out-of-memory).
     tokio::runtime::Runtime::new().expect("DynamoDB driver failed to construct tokio runtime")
 });
 

--- a/crates/dbflux_driver_sqlite/src/driver.rs
+++ b/crates/dbflux_driver_sqlite/src/driver.rs
@@ -24,7 +24,7 @@ use dbflux_core::{
     generate_insert_template, generate_select_star, generate_update_template,
     render_semantic_filter_sql,
 };
-use rusqlite::{Connection as RusqliteConnection, InterruptHandle};
+use rusqlite::{Connection as RusqliteConnection, InterruptHandle, OpenFlags};
 
 pub static SQLITE_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef {
     tabs: vec![FormTab {
@@ -330,6 +330,20 @@ impl Default for SqliteDriver {
     }
 }
 
+fn open_sqlite(path: &std::path::Path) -> rusqlite::Result<RusqliteConnection> {
+    let path_str = path.to_string_lossy();
+    if path_str.starts_with("file:") {
+        RusqliteConnection::open_with_flags(
+            path_str.as_ref(),
+            OpenFlags::SQLITE_OPEN_URI
+                | OpenFlags::SQLITE_OPEN_READ_WRITE
+                | OpenFlags::SQLITE_OPEN_CREATE,
+        )
+    } else {
+        RusqliteConnection::open(path)
+    }
+}
+
 impl DbDriver for SqliteDriver {
     fn kind(&self) -> DbKind {
         DbKind::SQLite
@@ -389,8 +403,7 @@ impl DbDriver for SqliteDriver {
             }
         }
 
-        let conn = RusqliteConnection::open(&path)
-            .map_err(|e| DbError::connection_failed(e.to_string()))?;
+        let conn = open_sqlite(&path).map_err(|e| DbError::connection_failed(e.to_string()))?;
 
         let interrupt_handle = conn.get_interrupt_handle();
 
@@ -430,8 +443,7 @@ impl DbDriver for SqliteDriver {
             }
         };
 
-        let conn = RusqliteConnection::open(&path)
-            .map_err(|e| DbError::connection_failed(e.to_string()))?;
+        let conn = open_sqlite(&path).map_err(|e| DbError::connection_failed(e.to_string()))?;
 
         conn.execute_batch("SELECT 1")
             .map_err(|e| DbError::connection_failed(e.to_string()))?;
@@ -2187,8 +2199,8 @@ pub fn fetch_dependents(
 #[cfg(test)]
 mod tests {
     use super::{
-        SqliteDialect, SqliteDriver, kind_from_decltype, plan_sqlite_semantic_request,
-        sqlite_generate_create_table,
+        RusqliteConnection, SqliteDialect, SqliteDriver, kind_from_decltype, open_sqlite,
+        plan_sqlite_semantic_request, sqlite_generate_create_table,
     };
     use dbflux_core::{
         ColumnInfo, ColumnKind, DatabaseCategory, DbConfig, DbDriver, FormValues, MutationRequest,
@@ -2356,9 +2368,28 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "TODO: sqlite URI mode support"]
-    fn pending_sqlite_uri_mode_support() {
-        panic!("TODO: implement URI mode for SQLite driver and replace this pending test");
+    fn sqlite_uri_mode_ro_opens_read_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("ro.db");
+        RusqliteConnection::open(&db)
+            .unwrap()
+            .execute_batch("CREATE TABLE seed(x);")
+            .unwrap();
+
+        let uri = format!("file:{}?mode=ro", db.display());
+        let conn =
+            open_sqlite(std::path::Path::new(&uri)).expect("read-only URI open should succeed");
+        let write = conn.execute_batch("CREATE TABLE t(x);");
+        assert!(write.is_err(), "write must fail on a mode=ro connection");
+    }
+
+    #[test]
+    fn sqlite_plain_path_opens_read_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = dir.path().join("rw.db");
+        let conn = open_sqlite(&db).expect("plain path open should succeed");
+        conn.execute_batch("CREATE TABLE t(x);")
+            .expect("write must succeed on a normal file path");
     }
 
     #[test]

--- a/crates/dbflux_driver_sqlite/src/driver.rs
+++ b/crates/dbflux_driver_sqlite/src/driver.rs
@@ -24,7 +24,7 @@ use dbflux_core::{
     generate_insert_template, generate_select_star, generate_update_template,
     render_semantic_filter_sql,
 };
-use rusqlite::{Connection as RusqliteConnection, InterruptHandle, OpenFlags};
+use rusqlite::{Connection as RusqliteConnection, InterruptHandle};
 
 pub static SQLITE_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef {
     tabs: vec![FormTab {
@@ -330,20 +330,6 @@ impl Default for SqliteDriver {
     }
 }
 
-fn open_sqlite(path: &std::path::Path) -> rusqlite::Result<RusqliteConnection> {
-    let path_str = path.to_string_lossy();
-    if path_str.starts_with("file:") {
-        RusqliteConnection::open_with_flags(
-            path_str.as_ref(),
-            OpenFlags::SQLITE_OPEN_URI
-                | OpenFlags::SQLITE_OPEN_READ_WRITE
-                | OpenFlags::SQLITE_OPEN_CREATE,
-        )
-    } else {
-        RusqliteConnection::open(path)
-    }
-}
-
 impl DbDriver for SqliteDriver {
     fn kind(&self) -> DbKind {
         DbKind::SQLite
@@ -403,7 +389,8 @@ impl DbDriver for SqliteDriver {
             }
         }
 
-        let conn = open_sqlite(&path).map_err(|e| DbError::connection_failed(e.to_string()))?;
+        let conn = RusqliteConnection::open(&path)
+            .map_err(|e| DbError::connection_failed(e.to_string()))?;
 
         let interrupt_handle = conn.get_interrupt_handle();
 
@@ -443,7 +430,8 @@ impl DbDriver for SqliteDriver {
             }
         };
 
-        let conn = open_sqlite(&path).map_err(|e| DbError::connection_failed(e.to_string()))?;
+        let conn = RusqliteConnection::open(&path)
+            .map_err(|e| DbError::connection_failed(e.to_string()))?;
 
         conn.execute_batch("SELECT 1")
             .map_err(|e| DbError::connection_failed(e.to_string()))?;
@@ -2199,7 +2187,7 @@ pub fn fetch_dependents(
 #[cfg(test)]
 mod tests {
     use super::{
-        RusqliteConnection, SqliteDialect, SqliteDriver, kind_from_decltype, open_sqlite,
+        RusqliteConnection, SqliteDialect, SqliteDriver, kind_from_decltype,
         plan_sqlite_semantic_request, sqlite_generate_create_table,
     };
     use dbflux_core::{
@@ -2377,8 +2365,7 @@ mod tests {
             .unwrap();
 
         let uri = format!("file:{}?mode=ro", db.display());
-        let conn =
-            open_sqlite(std::path::Path::new(&uri)).expect("read-only URI open should succeed");
+        let conn = RusqliteConnection::open(&uri).expect("read-only URI open should succeed");
         let write = conn.execute_batch("CREATE TABLE t(x);");
         assert!(write.is_err(), "write must fail on a mode=ro connection");
     }
@@ -2387,7 +2374,7 @@ mod tests {
     fn sqlite_plain_path_opens_read_write() {
         let dir = tempfile::tempdir().unwrap();
         let db = dir.path().join("rw.db");
-        let conn = open_sqlite(&db).expect("plain path open should succeed");
+        let conn = RusqliteConnection::open(&db).expect("plain path open should succeed");
         conn.execute_batch("CREATE TABLE t(x);")
             .expect("write must succeed on a normal file path");
     }


### PR DESCRIPTION
## Summary

Three P3-Low board items, one consolidated PR:

- **MISC-5 (DynamoDB, perf)** — the driver built a brand-new `tokio::runtime::Runtime` on every operation. It now shares a single process-wide runtime via `LazyLock`, mirroring the existing CloudWatch pattern. ~15 call sites updated.
- **MISC-7 (SQLite, URI mode)** — `file:test.db?mode=ro` connection strings are honored (the connection opens read-only). It turns out rusqlite's default `open()` already enables `SQLITE_OPEN_URI`, so the driver already supported this. This PR therefore adds **regression tests** proving it and closes the pending `#[ignore]`d stub — **no production behavior change**.
- **MISC-11 (InfluxDB icon)** — the brand icon was already wired to the real SVG; this removes a stale `TODO` and adds a lock-in test for the mapping.

## Changes

| Item | Crate | Change |
|------|-------|--------|
| MISC-5 | `dbflux_driver_dynamodb` | `static DYNAMODB_RUNTIME: LazyLock<Runtime>` + `runtime() -> &'static Runtime`; ~15 call sites drop the per-op runtime build |
| MISC-7 | `dbflux_driver_sqlite` | two tests (`file:...?mode=ro` opens read-only; plain path opens read-write); pending stub removed. No production change |
| MISC-11 | `dbflux_components` | stale `TODO(influxdb-icon)` removed; mapping lock-in test added |

## Test plan

- New tests: `dynamodb_runtime_is_shared` (`ptr::eq` proves one shared runtime), `sqlite_uri_mode_ro_opens_read_only` + `sqlite_plain_path_opens_read_write`, `influxdb_icon_maps_to_brand_svg`.
- `cargo nextest run` green (435 passed across the three crates); `cargo check --workspace` clean; `cargo clippy --all-targets -- -D warnings` clean per crate; `cargo fmt` applied.
- Reviewed via independent dual adversarial review across two rounds: it confirmed the DynamoDB runtime builder is byte-parity with CloudWatch (no `enable_all`/threading regression, no nested-runtime risk), and caught that an initial MISC-7 `file:` open branch was redundant and dropped `SQLITE_OPEN_NO_MUTEX` — that branch was removed, leaving production identical to before.
