### PR TITLE
fix(security): residual SEC2 hardening — MySQL hex literals, storage permissions, process.run PATH visibility (SEC2-3/4/5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,7 +2588,6 @@ version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
  "dbflux_storage",
- "dirs 5.0.1",
  "hex",
  "regex",
  "rusqlite",

--- a/crates/dbflux_audit/Cargo.toml
+++ b/crates/dbflux_audit/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/lib.rs"
 [dependencies]
 dbflux_core.workspace = true
 dbflux_storage.workspace = true
-dirs.workspace = true
 hex.workspace = true
 regex.workspace = true
 rusqlite.workspace = true

--- a/crates/dbflux_audit/src/lib.rs
+++ b/crates/dbflux_audit/src/lib.rs
@@ -170,10 +170,8 @@ impl AuditService {
     }
 
     pub fn new_sqlite_default() -> Result<Self, AuditError> {
-        let data_dir = dirs::data_dir().ok_or(AuditError::ConfigDirUnavailable)?;
-        let db_dir = data_dir.join("dbflux");
-        std::fs::create_dir_all(&db_dir)?;
-
+        let db_dir = dbflux_storage::paths::data_dir()
+            .map_err(|e| AuditError::Io(std::io::Error::other(e.to_string())))?;
         let store = SqliteAuditStore::new(db_dir.join("dbflux.db"))?;
         Ok(Self::new(store))
     }

--- a/crates/dbflux_audit/src/store/sqlite.rs
+++ b/crates/dbflux_audit/src/store/sqlite.rs
@@ -118,6 +118,9 @@ impl SqliteAuditStore {
         dbflux_storage::paths::secure_file_permissions(&path)
             .map_err(|e| AuditError::Io(std::io::Error::other(e.to_string())))?;
 
+        dbflux_storage::paths::secure_db_sidecars(&path)
+            .map_err(|e| AuditError::Io(std::io::Error::other(e.to_string())))?;
+
         // Wrap in Arc<Mutex<Connection>> for AuditRepository
         let conn = Arc::new(Mutex::new(conn));
         let repo = AuditRepository::new(conn);

--- a/crates/dbflux_audit/src/store/sqlite.rs
+++ b/crates/dbflux_audit/src/store/sqlite.rs
@@ -115,6 +115,9 @@ impl SqliteAuditStore {
 
         aud_schema::create_aud_audit_events(&conn, false)?;
 
+        dbflux_storage::paths::secure_file_permissions(&path)
+            .map_err(|e| AuditError::Io(std::io::Error::other(e.to_string())))?;
+
         // Wrap in Arc<Mutex<Connection>> for AuditRepository
         let conn = Arc::new(Mutex::new(conn));
         let repo = AuditRepository::new(conn);

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -360,13 +360,17 @@ impl SqlDialect for MysqlDialect {
         value_to_mysql_literal(value)
     }
 
+    /// Satisfies the `SqlDialect` trait contract.
+    ///
+    /// MySQL string literals are produced exclusively by `value_to_literal` /
+    /// `mysql_text_literal` (mode-independent hex encoding). This method is
+    /// never reached for MySQL because `MysqlDialect::value_to_literal`
+    /// overrides the default body that would otherwise call `escape_string`.
+    /// No production caller should use this method to construct MySQL literals:
+    /// no single inner-quote escaping strategy is safe under both the default
+    /// sql_mode and `NO_BACKSLASH_ESCAPES`.
     fn escape_string(&self, s: &str) -> String {
-        s.replace('\\', "\\\\")
-            .replace('\'', "\\'")
-            .replace('"', "\\\"")
-            .replace('\0', "\\0")
-            .replace('\n', "\\n")
-            .replace('\r', "\\r")
+        s.replace('\'', "''")
     }
 
     fn placeholder_style(&self) -> PlaceholderStyle {

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -361,7 +361,12 @@ impl SqlDialect for MysqlDialect {
     }
 
     fn escape_string(&self, s: &str) -> String {
-        mysql_escape_string(s)
+        s.replace('\\', "\\\\")
+            .replace('\'', "\\'")
+            .replace('"', "\\\"")
+            .replace('\0', "\\0")
+            .replace('\n', "\\n")
+            .replace('\r', "\\r")
     }
 
     fn placeholder_style(&self) -> PlaceholderStyle {
@@ -3046,22 +3051,22 @@ fn value_to_mysql_literal(value: &Value) -> String {
                 f.to_string()
             }
         }
-        Value::Decimal(s) => format!("'{}'", mysql_escape_string(s)),
-        Value::Text(s) => format!("'{}'", mysql_escape_string(s)),
-        Value::Json(s) => format!("'{}'", mysql_escape_string(s)),
+        Value::Decimal(s) => mysql_text_literal(s),
+        Value::Text(s) => mysql_text_literal(s),
+        Value::Json(s) => mysql_text_literal(s),
         Value::Bytes(b) => format!("X'{}'", hex::encode(b)),
         Value::DateTime(dt) => format!("'{}'", dt.format("%Y-%m-%d %H:%M:%S")),
         Value::Date(d) => format!("'{}'", d.format("%Y-%m-%d")),
         Value::Time(t) => format!("'{}'", t.format("%H:%M:%S")),
-        Value::ObjectId(id) => format!("'{}'", mysql_escape_string(id)),
+        Value::ObjectId(id) => mysql_text_literal(id),
         Value::Unsupported(_) => "NULL".to_string(),
         Value::Array(arr) => {
             let json = serde_json::to_string(arr).unwrap_or_else(|_| "[]".to_string());
-            format!("'{}'", mysql_escape_string(&json))
+            mysql_text_literal(&json)
         }
         Value::Document(doc) => {
             let json = serde_json::to_string(doc).unwrap_or_else(|_| "{}".to_string());
-            format!("'{}'", mysql_escape_string(&json))
+            mysql_text_literal(&json)
         }
     }
 }
@@ -3110,14 +3115,26 @@ fn mysql_qualified_name(schema: Option<&str>, name: &str) -> String {
     }
 }
 
-/// Escape a string for use inside a MySQL single-quoted literal.
-fn mysql_escape_string(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('\'', "\\'")
-        .replace('"', "\\\"")
-        .replace('\0', "\\0")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
+/// Renders a MySQL string literal that is safe under ALL `sql_mode` settings,
+/// including `NO_BACKSLASH_ESCAPES`.
+///
+/// If the value contains a single quote, a backslash, or any control character
+/// (which includes NUL), it is emitted as a hex string literal `X'<hex>'` — a form
+/// MySQL interprets identically regardless of `sql_mode`. Otherwise the value has no
+/// characters needing escaping and is emitted verbatim inside single quotes, keeping
+/// the common case human-readable.
+///
+/// Backslash-escaping (`\'`) is deliberately NOT used: under `NO_BACKSLASH_ESCAPES`
+/// the server treats `\` as literal, turning `\'` into a string terminator and
+/// reopening injection. Quote-doubling-without-backslash is also rejected: under the
+/// DEFAULT mode a trailing backslash would escape the doubled closing quote. Conditional
+/// hex is the only form correct under BOTH modes.
+fn mysql_text_literal(s: &str) -> String {
+    if s.chars().any(|c| c == '\'' || c == '\\' || c.is_control()) {
+        format!("X'{}'", hex::encode(s.as_bytes()))
+    } else {
+        format!("'{}'", s)
+    }
 }
 
 fn fetch_tables_shallow(conn: &mut Conn, database: &str) -> Result<Vec<TableInfo>, DbError> {
@@ -3703,7 +3720,7 @@ pub fn fetch_dependents(
 mod tests {
     use super::{
         MysqlDialect, MysqlDriver, inject_password_into_mysql_uri, mysql_routine_type_to_kind,
-        normalize_mysql_tcp_host, plan_mysql_semantic_request,
+        mysql_text_literal, normalize_mysql_tcp_host, plan_mysql_semantic_request,
     };
     use dbflux_core::{
         DatabaseCategory, DbConfig, DbDriver, DbError, DbKind, FormValues, MutationRequest,
@@ -4014,5 +4031,41 @@ mod tests {
             "skeleton must not contain the password: {skeleton}"
         );
         assert_eq!(secret.expose_secret(), "s3cr3t");
+    }
+
+    // --- SEC2-5: mode-independent MySQL string literals ---
+
+    #[test]
+    fn mysql_literal_no_backslash_escapes_injection_guard() {
+        let lit = mysql_text_literal("it's a test");
+        assert!(
+            !lit.contains("\\'"),
+            "literal must not contain backslash-quote (unsafe under NO_BACKSLASH_ESCAPES): {lit}"
+        );
+        assert!(
+            lit.starts_with("X'"),
+            "literal containing a single quote must be hex-encoded: {lit}"
+        );
+    }
+
+    #[test]
+    fn mysql_literal_default_mode_trailing_backslash_guard() {
+        let input = "abc\\";
+        let lit = mysql_text_literal(input);
+        assert_eq!(
+            lit,
+            format!("X'{}'", hex::encode(input.as_bytes())),
+            "trailing backslash must be hex-encoded, not quote-escaped"
+        );
+        assert!(
+            !lit.ends_with("\\'"),
+            "literal must not end with backslash-quote: {lit}"
+        );
+    }
+
+    #[test]
+    fn mysql_literal_plain_value_stays_readable() {
+        let lit = mysql_text_literal("plain value 123");
+        assert_eq!(lit, "'plain value 123'");
     }
 }

--- a/crates/dbflux_lua/src/api/dbflux.rs
+++ b/crates/dbflux_lua/src/api/dbflux.rs
@@ -134,6 +134,8 @@ fn run_process(lua: &Lua, state: &LuaRuntimeState, options: Table) -> LuaResult<
 
     ensure_program_allowed(&program, &allowlist)?;
 
+    let resolved = resolve_program_in_path(&program);
+
     if !detached && timeout.is_none() && state.hook_timeout.is_none() {
         return Err(mlua::Error::RuntimeError(
             "dbflux.process.run requires a timeout_ms when no hook-level timeout is set"
@@ -141,7 +143,11 @@ fn run_process(lua: &Lua, state: &LuaRuntimeState, options: Table) -> LuaResult<
         ));
     }
 
-    let mut command = Command::new(&program);
+    let exec_target = resolved
+        .as_deref()
+        .map(|p| p.as_os_str())
+        .unwrap_or_else(|| program.as_ref());
+    let mut command = Command::new(exec_target);
     command.args(&args);
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
@@ -154,12 +160,18 @@ fn run_process(lua: &Lua, state: &LuaRuntimeState, options: Table) -> LuaResult<
         command.current_dir(cwd);
     }
 
+    let resolved_display = resolved
+        .as_deref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<unresolved>".to_string());
+
     append_log(
         state,
         OutputStreamKind::Log,
         format!(
-            "[PROCESS/{allowlist}] {}{}",
+            "[PROCESS/{allowlist}] {} -> {}{}",
             program,
+            resolved_display,
             if args.is_empty() {
                 String::new()
             } else {
@@ -256,6 +268,36 @@ fn format_process_description(program: &str, args: &[String]) -> String {
     }
 }
 
+/// Resolves a bare program name to an absolute executable path by walking `$PATH`.
+///
+/// First match wins. On Unix a candidate must be a file with an executable bit set;
+/// on other platforms `is_file()` is sufficient. Returns `None` when `PATH` is unset
+/// or no candidate matches. Best-effort only: the allowlist already gated the name —
+/// this exists to make the executed binary visible in the run trail, not to enforce trust.
+fn resolve_program_in_path(program: &str) -> Option<std::path::PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(program);
+        if is_executable_file(&candidate) {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &std::path::Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::metadata(path)
+        .map(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &std::path::Path) -> bool {
+    path.is_file()
+}
+
 /// Checks whether a program name is path-qualified (contains a path separator or leading `~`).
 ///
 /// This is a footgun guard: it prevents accidental execution of path-qualified names like
@@ -271,10 +313,12 @@ fn is_path_qualified(program: &str) -> bool {
 
 /// Validates that `program` is a bare command name on the named allowlist.
 ///
-/// The allowlist is an ergonomics/footgun guard that prevents typos and unintended
-/// execution of programs not expected by the hook author. It is NOT a security
-/// isolation boundary: a user controlling PATH can still substitute a different
-/// binary under the same name.
+/// The allowlist is an ergonomics/footgun guard: it prevents typos and unintended
+/// execution of programs the hook author did not expect, and it forbids path-qualified
+/// names. It is NOT a security isolation boundary — a user who controls `$PATH` can
+/// still substitute a different binary under the same name. To make the substitution
+/// auditable, [`run_process`] resolves the name against `$PATH` and records the resolved
+/// absolute path (or `<unresolved>`) in the run trail.
 fn ensure_program_allowed(program: &str, allowlist: &str) -> LuaResult<()> {
     if is_path_qualified(program) {
         return Err(mlua::Error::RuntimeError(format!(
@@ -671,5 +715,88 @@ mod tests {
             .unwrap();
         unsafe { std::env::remove_var("DBFLUX_TEST_SAFE_VAR_12345") };
         assert_eq!(value.as_deref(), Some("visible"));
+    }
+
+    // --- SEC2-3: PATH resolution helper ---
+    // All PATH-mutating sub-cases are in one test fn to avoid cross-test races.
+
+    #[test]
+    fn resolve_program_in_path_cases() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+        static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+        fn tmp_dir(label: &str) -> std::path::PathBuf {
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            std::env::temp_dir().join(format!(
+                "dbflux_lua_path_test_{}_{}_{}",
+                std::process::id(),
+                n,
+                label
+            ))
+        }
+
+        let saved_path = std::env::var_os("PATH");
+
+        // Sub-case: returns None when program is absent
+        {
+            let empty = tmp_dir("empty");
+            std::fs::create_dir_all(&empty).unwrap();
+            unsafe { std::env::set_var("PATH", std::env::join_paths([&empty]).unwrap()) };
+
+            let result = resolve_program_in_path("definitely-not-here-xyz");
+            assert!(result.is_none(), "absent program must return None");
+
+            let _ = std::fs::remove_dir_all(&empty);
+        }
+
+        // Unix-only sub-cases: exec-bit detection
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            // Sub-case: finds a bare name when on PATH with exec bit
+            {
+                let dir = tmp_dir("exec");
+                std::fs::create_dir_all(&dir).unwrap();
+                let prog = dir.join("fakeprog");
+                std::fs::write(&prog, b"#!/bin/sh").unwrap();
+                let mut perms = std::fs::metadata(&prog).unwrap().permissions();
+                perms.set_mode(0o755);
+                std::fs::set_permissions(&prog, perms).unwrap();
+
+                unsafe { std::env::set_var("PATH", std::env::join_paths([&dir]).unwrap()) };
+                let result = resolve_program_in_path("fakeprog");
+                assert_eq!(
+                    result.as_deref(),
+                    Some(prog.as_path()),
+                    "exec binary must be found"
+                );
+
+                let _ = std::fs::remove_dir_all(&dir);
+            }
+
+            // Sub-case: skips non-executable file (no exec bit)
+            {
+                let dir = tmp_dir("noexec");
+                std::fs::create_dir_all(&dir).unwrap();
+                let prog = dir.join("fakeprog");
+                std::fs::write(&prog, b"#!/bin/sh").unwrap();
+                let mut perms = std::fs::metadata(&prog).unwrap().permissions();
+                perms.set_mode(0o644);
+                std::fs::set_permissions(&prog, perms).unwrap();
+
+                unsafe { std::env::set_var("PATH", std::env::join_paths([&dir]).unwrap()) };
+                let result = resolve_program_in_path("fakeprog");
+                assert!(result.is_none(), "non-executable file must not be returned");
+
+                let _ = std::fs::remove_dir_all(&dir);
+            }
+        }
+
+        // Restore PATH
+        match saved_path {
+            Some(p) => unsafe { std::env::set_var("PATH", p) },
+            None => unsafe { std::env::remove_var("PATH") },
+        }
     }
 }

--- a/crates/dbflux_storage/src/artifacts.rs
+++ b/crates/dbflux_storage/src/artifacts.rs
@@ -36,10 +36,7 @@ impl ArtifactStore {
     pub fn new() -> Result<Self, StorageError> {
         let data_dir = paths::data_dir()?;
         let root = data_dir.join(SESSIONS_SUBDIR);
-        std::fs::create_dir_all(&root).map_err(|source| StorageError::Io {
-            path: root.clone(),
-            source,
-        })?;
+        paths::ensure_private_dir(&root)?;
         Ok(Self { root })
     }
 
@@ -47,10 +44,7 @@ impl ArtifactStore {
     ///
     /// Useful for tests or alternate data roots.
     pub fn for_root(root: PathBuf) -> Result<Self, StorageError> {
-        std::fs::create_dir_all(&root).map_err(|source| StorageError::Io {
-            path: root.clone(),
-            source,
-        })?;
+        paths::ensure_private_dir(&root)?;
         Ok(Self { root })
     }
 
@@ -84,6 +78,8 @@ impl ArtifactStore {
     }
 
     /// Writes content to a file, creating parent directories if needed.
+    ///
+    /// On Unix, the file is narrowed to `0o600` after the write succeeds.
     pub fn write_content(&self, path: &Path, content: &str) -> Result<(), StorageError> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|source| StorageError::Io {
@@ -94,7 +90,9 @@ impl ArtifactStore {
         std::fs::write(path, content).map_err(|source| StorageError::Io {
             path: path.to_path_buf(),
             source,
-        })
+        })?;
+        paths::secure_file_permissions(path)?;
+        Ok(())
     }
 
     /// Deletes a file at the given path, silently ignoring absence.

--- a/crates/dbflux_storage/src/bootstrap.rs
+++ b/crates/dbflux_storage/src/bootstrap.rs
@@ -70,6 +70,9 @@ impl StorageRuntime {
         registry.run_all(&dbflux_conn)?;
         crate::sqlite::set_foreign_keys(&dbflux_conn, true)?;
 
+        // Sidecars created lazily on the first migration write; secure them now.
+        paths::secure_db_sidecars(&dbflux_db_path)?;
+
         info!("Unified database ready at {}", dbflux_db_path.display());
 
         // Initialize the artifact store using the parent directory of dbflux.db as data root.

--- a/crates/dbflux_storage/src/paths.rs
+++ b/crates/dbflux_storage/src/paths.rs
@@ -1,19 +1,77 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::error::StorageError;
 
-/// Returns `~/.config/dbflux/`, creating it if necessary.
+/// Creates `path` (and parents) and, on Unix, restricts it to owner-only (`0o700`).
+///
+/// On non-Unix platforms the chmod is skipped; directory ACLs are managed by the OS.
+/// Mirrors the owner-private creation pattern in `dbflux_ipc::auth`.
+pub(crate) fn ensure_private_dir(path: &Path) -> Result<(), StorageError> {
+    std::fs::create_dir_all(path).map_err(|source| StorageError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    secure_dir_permissions(path)
+}
+
+/// On Unix, restricts an existing directory to `0o700`. No-op elsewhere.
+#[cfg(unix)]
+pub(crate) fn secure_dir_permissions(path: &Path) -> Result<(), StorageError> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut permissions = std::fs::metadata(path)
+        .map_err(|source| StorageError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?
+        .permissions();
+    permissions.set_mode(0o700);
+    std::fs::set_permissions(path, permissions).map_err(|source| StorageError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(not(unix))]
+pub(crate) fn secure_dir_permissions(_path: &Path) -> Result<(), StorageError> {
+    Ok(())
+}
+
+/// On Unix, restricts an existing file to owner read/write only (`0o600`). No-op elsewhere.
+///
+/// Idempotent and safe to call right after the file is created/opened. There is a
+/// brief open-then-chmod window (TOCTOU) where the file exists at the process umask
+/// before narrowing; this is an accepted tradeoff, identical to `dbflux_ipc::auth`,
+/// because rusqlite/`File::create` do not expose pre-creation mode.
+pub fn secure_file_permissions(path: &Path) -> Result<(), StorageError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = std::fs::metadata(path)
+            .map_err(|source| StorageError::Io {
+                path: path.to_path_buf(),
+                source,
+            })?
+            .permissions();
+        permissions.set_mode(0o600);
+        std::fs::set_permissions(path, permissions).map_err(|source| StorageError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+/// Returns `~/.config/dbflux/`, creating it if necessary with owner-only permissions.
 pub fn config_data_dir() -> Result<PathBuf, StorageError> {
     let base = dirs::config_dir().ok_or(StorageError::ConfigDirUnavailable)?;
     let dir = base.join("dbflux");
-    std::fs::create_dir_all(&dir).map_err(|source| StorageError::Io {
-        path: dir.clone(),
-        source,
-    })?;
+    ensure_private_dir(&dir)?;
     Ok(dir)
 }
 
-/// Returns `~/.local/share/dbflux/`, creating it if necessary.
+/// Returns `~/.local/share/dbflux/`, creating it if necessary with owner-only permissions.
 ///
 /// This directory is used for:
 /// - The unified `dbflux.db` database
@@ -21,10 +79,7 @@ pub fn config_data_dir() -> Result<PathBuf, StorageError> {
 pub fn data_dir() -> Result<PathBuf, StorageError> {
     let base = dirs::data_dir().ok_or(StorageError::DataDirUnavailable)?;
     let dir = base.join("dbflux");
-    std::fs::create_dir_all(&dir).map_err(|source| StorageError::Io {
-        path: dir.clone(),
-        source,
-    })?;
+    ensure_private_dir(&dir)?;
     Ok(dir)
 }
 
@@ -64,6 +119,7 @@ pub fn set_nightly_shares_stable_db(enabled: bool) -> Result<(), StorageError> {
             path: path.clone(),
             source,
         })?;
+        secure_file_permissions(&path)?;
     } else if path.exists() {
         std::fs::remove_file(&path).map_err(|source| StorageError::Io {
             path: path.clone(),
@@ -87,4 +143,70 @@ pub fn dbflux_db_path() -> Result<PathBuf, StorageError> {
         dbflux_core::ReleaseChannel::current().db_file_name()
     };
     Ok(data_dir()?.join(file_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn unique_tmp_path(prefix: &str) -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "dbflux_paths_test_{}_{}_{}",
+            std::process::id(),
+            n,
+            prefix
+        ))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_private_dir_sets_0o700() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = unique_tmp_path("dir");
+        let _ = std::fs::remove_dir_all(&path);
+
+        ensure_private_dir(&path).expect("ensure_private_dir should succeed");
+
+        let mode = std::fs::metadata(&path)
+            .expect("metadata readable")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o700,
+            "directory should be 0o700, got {:o}",
+            mode & 0o777
+        );
+
+        let _ = std::fs::remove_dir_all(&path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secure_file_permissions_sets_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = unique_tmp_path("file");
+        std::fs::write(&path, b"test").expect("write temp file");
+
+        secure_file_permissions(&path).expect("secure_file_permissions should succeed");
+
+        let mode = std::fs::metadata(&path)
+            .expect("metadata readable")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "file should be 0o600, got {:o}",
+            mode & 0o777
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
 }

--- a/crates/dbflux_storage/src/paths.rs
+++ b/crates/dbflux_storage/src/paths.rs
@@ -63,6 +63,36 @@ pub fn secure_file_permissions(path: &Path) -> Result<(), StorageError> {
     Ok(())
 }
 
+/// Secures the WAL and SHM sidecar files that SQLite creates lazily alongside a database.
+///
+/// SQLite creates `<db>-wal`, `<db>-shm`, and (in rollback-journal mode) `<db>-journal`
+/// on the first write, after the database file itself has already been opened and
+/// chmod'd. This means those sidecars appear at the process umask rather than at the
+/// desired owner-only mode. This helper is called after the first write has occurred
+/// (e.g. after migrations run) to narrow each sidecar that actually exists to `0o600`.
+///
+/// Missing sidecar files are not an error — when WAL mode is not active or the
+/// database has never been written, the sidecar simply does not exist yet.
+///
+/// On non-Unix platforms this is a no-op.
+pub fn secure_db_sidecars(db_path: &Path) -> Result<(), StorageError> {
+    #[cfg(unix)]
+    {
+        let base = db_path.as_os_str();
+        for suffix in ["-wal", "-shm", "-journal"] {
+            let mut sidecar_os = base.to_owned();
+            sidecar_os.push(suffix);
+            let sidecar = Path::new(&sidecar_os);
+            if sidecar.exists() {
+                secure_file_permissions(sidecar)?;
+            }
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = db_path;
+    Ok(())
+}
+
 /// Returns `~/.config/dbflux/`, creating it if necessary with owner-only permissions.
 pub fn config_data_dir() -> Result<PathBuf, StorageError> {
     let base = dirs::config_dir().ok_or(StorageError::ConfigDirUnavailable)?;
@@ -160,6 +190,57 @@ mod tests {
             n,
             prefix
         ))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secure_db_sidecars_sets_0o600_on_existing_sidecars() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let db = unique_tmp_path("sidecars.db");
+        let wal = {
+            let mut p = db.as_os_str().to_owned();
+            p.push("-wal");
+            PathBuf::from(p)
+        };
+        let shm = {
+            let mut p = db.as_os_str().to_owned();
+            p.push("-shm");
+            PathBuf::from(p)
+        };
+
+        // Create dummy sidecars at the process umask (typically 0o644).
+        std::fs::write(&wal, b"").expect("write wal");
+        std::fs::write(&shm, b"").expect("write shm");
+
+        secure_db_sidecars(&db).expect("secure_db_sidecars should succeed");
+
+        for (label, path) in [("wal", &wal), ("shm", &shm)] {
+            let mode = std::fs::metadata(path)
+                .expect("metadata readable")
+                .permissions()
+                .mode();
+            assert_eq!(
+                mode & 0o777,
+                0o600,
+                "{} sidecar should be 0o600, got {:o}",
+                label,
+                mode & 0o777
+            );
+        }
+
+        // Missing -journal must be silently tolerated (no error).
+        let _ = std::fs::remove_file(&wal);
+        let _ = std::fs::remove_file(&shm);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn secure_db_sidecars_tolerates_missing_sidecars() {
+        let db = unique_tmp_path("no_sidecars.db");
+        // Nothing created — all sidecars absent.
+        let result = secure_db_sidecars(&db);
+        assert!(result.is_ok(), "missing sidecars should not be an error");
     }
 
     #[cfg(unix)]

--- a/crates/dbflux_storage/src/sqlite.rs
+++ b/crates/dbflux_storage/src/sqlite.rs
@@ -20,6 +20,8 @@ pub fn open_database(path: &Path) -> Result<Connection, StorageError> {
 
     apply_default_pragmas(&conn, path)?;
 
+    crate::paths::secure_db_sidecars(path)?;
+
     Ok(conn)
 }
 
@@ -78,6 +80,69 @@ mod tests {
 
     fn temp_db(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("dbflux_storage_test_{}.sqlite", name))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_database_secures_wal_shm_sidecars_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_db("sidecars");
+        let wal = PathBuf::from({
+            let mut p = path.as_os_str().to_owned();
+            p.push("-wal");
+            p
+        });
+        let shm = PathBuf::from({
+            let mut p = path.as_os_str().to_owned();
+            p.push("-shm");
+            p
+        });
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&wal);
+        let _ = std::fs::remove_file(&shm);
+
+        // Open the DB and write data so SQLite actually creates real WAL/SHM sidecars.
+        {
+            let conn = open_database(&path).expect("first open");
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS t (x INTEGER); INSERT INTO t VALUES (1);",
+            )
+            .expect("create and insert");
+        }
+
+        // After the write the sidecars should exist; widen them to simulate the
+        // process-umask exposure before the next open (the gap this task closes).
+        for sidecar in [&wal, &shm] {
+            if sidecar.exists() {
+                std::fs::set_permissions(sidecar, std::fs::Permissions::from_mode(0o644))
+                    .expect("widen sidecar permissions");
+            }
+        }
+
+        // Re-open: open_database must narrow whichever sidecars it finds.
+        open_database(&path).expect("second open");
+
+        for (label, sidecar) in [("wal", &wal), ("shm", &shm)] {
+            if sidecar.exists() {
+                let mode = std::fs::metadata(sidecar)
+                    .expect("metadata readable")
+                    .permissions()
+                    .mode();
+                assert_eq!(
+                    mode & 0o777,
+                    0o600,
+                    "{} sidecar should be 0o600 after reopen, got {:o}",
+                    label,
+                    mode & 0o777
+                );
+            }
+        }
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(&wal);
+        let _ = std::fs::remove_file(&shm);
     }
 
     #[cfg(unix)]

--- a/crates/dbflux_storage/src/sqlite.rs
+++ b/crates/dbflux_storage/src/sqlite.rs
@@ -6,11 +6,17 @@ use crate::error::StorageError;
 
 /// Opens (or creates) a SQLite database at `path` and applies the standard
 /// PRAGMA set that every internal DBFlux database should use.
+///
+/// On Unix the database file is narrowed to `0o600` immediately after opening.
+/// There is a brief TOCTOU window between `Connection::open` and the chmod; this
+/// matches the accepted pattern in `dbflux_ipc::auth`.
 pub fn open_database(path: &Path) -> Result<Connection, StorageError> {
     let conn = Connection::open(path).map_err(|source| StorageError::Sqlite {
         path: path.to_path_buf(),
         source,
     })?;
+
+    crate::paths::secure_file_permissions(path)?;
 
     apply_default_pragmas(&conn, path)?;
 
@@ -72,6 +78,34 @@ mod tests {
 
     fn temp_db(name: &str) -> PathBuf {
         std::env::temp_dir().join(format!("dbflux_storage_test_{}.sqlite", name))
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_database_secures_file_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = temp_db("secure");
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+        let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
+
+        open_database(&path).expect("open_database should succeed");
+
+        let mode = std::fs::metadata(&path)
+            .expect("metadata readable")
+            .permissions()
+            .mode();
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "db file should be 0o600, got {:o}",
+            mode & 0o777
+        );
+
+        let _ = std::fs::remove_file(&path);
+        let _ = std::fs::remove_file(path.with_extension("sqlite-wal"));
+        let _ = std::fs::remove_file(path.with_extension("sqlite-shm"));
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/audit/mod.rs
+++ b/crates/dbflux_ui_document/src/audit/mod.rs
@@ -1543,13 +1543,13 @@ impl AuditDocument {
                     format!("{}/{}", home, filename)
                 };
 
-                let message = match std::fs::write(&path, &bytes) {
-                    Ok(_) => PendingToast {
+                let message = match write_export_file(std::path::Path::new(&path), &bytes) {
+                    Ok(()) => PendingToast {
                         message: format!("Exported {} events to {}", event_count, path),
                         is_error: false,
                     },
                     Err(error) => PendingToast {
-                        message: format!("Export succeeded but failed to write file: {}", error),
+                        message: format!("Export failed to write file: {}", error),
                         is_error: true,
                     },
                 };
@@ -1581,6 +1581,19 @@ impl Focusable for AuditDocument {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
     }
+}
+
+/// Writes `bytes` to `path` and restricts the resulting file to owner read/write
+/// (`0o600`) on Unix. The caller is responsible for routing errors to the UI.
+///
+/// Extracting the write + chmod into a single helper makes it testable without
+/// any GPUI coupling and ensures the permission step cannot be accidentally
+/// dropped when the write path changes.
+fn write_export_file(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    std::fs::write(path, bytes)?;
+
+    dbflux_storage::paths::secure_file_permissions(path)
+        .map_err(|e| std::io::Error::other(e.to_string()))
 }
 
 impl EventEmitter<DocumentEvent> for AuditDocument {}
@@ -1732,5 +1745,31 @@ mod tests {
         let line = "a\nb\nc";
 
         assert_eq!(AuditDocument::event_code_rows(line, 2), 3);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_export_file_sets_mode_0o600() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!(
+            "dbflux_audit_export_test_{}.json",
+            std::process::id()
+        ));
+
+        super::write_export_file(&path, b"{}").expect("write succeeded");
+
+        let mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode();
+        let _ = std::fs::remove_file(&path);
+
+        assert_eq!(
+            mode & 0o777,
+            0o600,
+            "export file must be owner read/write only"
+        );
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/hooks.rs
+++ b/crates/dbflux_ui_windows/src/settings/hooks.rs
@@ -277,7 +277,10 @@ impl HooksSection {
 
         if hook_kind == HookKindSelection::Lua && self.hook_lua_process_run {
             warnings.push(
-                "Lua process.run is enabled: this hook can execute external programs with your user permissions"
+                "Lua process.run is enabled: this hook can execute external programs with your \
+                 user permissions. The program allowlist is a convenience filter, not a security \
+                 isolation boundary — a program earlier on $PATH can be substituted under the \
+                 same name."
                     .to_string(),
             );
         }


### PR DESCRIPTION
## Summary

Three residual P3/Medium security items from the board (SEC2 tier), one consolidated PR. All test-first, behavior-preserving except for the intended security changes, no new dependencies.

- **SEC2-5 (MySQL injection under `NO_BACKSLASH_ESCAPES`)** — The mutation executor inlines values as escaped literals. MySQL's escaper used backslash (`\'`), which does **not** escape the quote when the server runs `sql_mode = NO_BACKSLASH_ESCAPES`, opening an injection path via cell values. MySQL string literals now use a mode-independent encoding: any value containing `'`, `\`, or a control char is emitted as a hex literal `X'<hex>'`; plain values stay readable as `'value'`. Safe under **both** default mode and `NO_BACKSLASH_ESCAPES`.
- **SEC2-4 (data-at-rest permissions)** — `~/.local/share/dbflux/dbflux.db` holds connection metadata, the full audit log, governance policies, and saved queries, but nothing in the storage tree set permissions — the dir and files inherited the user umask. On Unix the data dir is now `0o700` and every sensitive file (`dbflux.db`, WAL/SHM sidecars, the `use-stable-db` marker, artifact scratch files, the audit DB, audit exports) is `0o600`, mirroring the existing IPC-token pattern. Windows is unchanged.
- **SEC2-3 (`process.run` PATH-hijack visibility)** — The Lua `process.run` allowlist matches a bare program name resolved against `$PATH`, so a binary planted earlier on `$PATH` can be substituted under an allowlisted name. There is no clean cross-platform fix (a trusted-bindir policy breaks Nix/brew/venv). This change makes the substitution **auditable**: `run_process` resolves the name to an absolute path via a manual `$PATH` walk, executes that resolved path, and records it in the process trail. The doc-comment and the Settings warning now state plainly that the allowlist is **not** a security isolation boundary.

## Changes

| Item | Crate(s) | Change |
|------|----------|--------|
| SEC2-5 | `dbflux_driver_mysql` | `mysql_text_literal` (conditional `X'<hex>'`) replaces the backslash escaper on every MySQL literal arm; `MysqlDialect::escape_string` switched to ANSI quote-doubling and documented as not-for-literals |
| SEC2-4 | `dbflux_storage`, `dbflux_audit`, `dbflux_ui_document` | `ensure_private_dir` / `secure_dir_permissions` / `secure_file_permissions` / `secure_db_sidecars` helpers applied at every storage/audit/export creation site; `dbflux_audit` redirected to `dbflux_storage::paths::data_dir()` (drops the `dirs` dep) |
| SEC2-3 | `dbflux_lua`, `dbflux_ui_windows` | `resolve_program_in_path` + `is_executable_file`; resolved absolute path executed and logged in the `[PROCESS/...]` trail; allowlist doc-comment + Settings warning state it is not an isolation boundary |

## Test plan

- New tests: MySQL — `mysql_literal_no_backslash_escapes_injection_guard`, `mysql_literal_default_mode_trailing_backslash_guard` (regression guard against a naive quote-doubling fix), `mysql_literal_plain_value_stays_readable`; storage — `ensure_private_dir_sets_0o700`, `secure_file_permissions_sets_0o600`, `open_database_secures_file_0o600`, `secure_db_sidecars_*`; audit-export — `write_export_file_sets_mode_0o600`; Lua — `resolve_program_in_path_cases`. All permission tests are `#[cfg(unix)]`.
- `cargo check --workspace` clean; `cargo nextest run` green across the touched crates (1019 passed at the largest slice); `cargo clippy -- -D warnings` clean on the touched crates; `cargo fmt --all --check` clean.
- Reviewed via independent dual adversarial review (two blind judges): both APPROVED with no CRITICAL. They exhaustively traced the SEC2-5 funnel and confirmed no production MySQL literal path can reach a backslash escaper, and that the hex form round-trips losslessly and is injection-safe under both sql_modes. The one shared real finding — WAL/SHM sidecars not chmod'd — was closed in this PR via `secure_db_sidecars`.

## Notes

- Out of scope (separate items): relocating `~/.config/dbflux` (LEG), adding a real parameterized-binding path to the `Connection` trait, and any trusted-bindir allowlist policy.
- The `X'<hex>'` form is the only encoding correct under both default and `NO_BACKSLASH_ESCAPES` modes; plain quote-doubling would reintroduce injection under default mode via a trailing backslash, which the `mysql_literal_default_mode_trailing_backslash_guard` test guards against.
