### PR TITLE
chore(build): tune release profile, pin toolchain, prune + unify dependencies (DEP-1/2/3/4)

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -60,3 +60,20 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --workspace -- -D warnings
+
+  machete:
+    name: Unused dependencies
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-machete
+        run: cargo install cargo-machete --locked
+
+      - name: Check for unused dependencies
+        run: cargo machete

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2507,9 +2507,6 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 name = "dbflux"
 version = "0.7.0-dev.0"
 dependencies = [
- "anyhow",
- "async-trait",
- "bincode",
  "dbflux_app",
  "dbflux_audit",
  "dbflux_core",
@@ -2518,20 +2515,12 @@ dependencies = [
  "dbflux_ssh",
  "dbflux_test_support",
  "dbflux_ui",
- "dirs 5.0.1",
- "fuzzy-matcher",
  "gpui",
  "gpui-component",
- "indexmap",
  "interprocess",
  "libc",
  "log",
- "lsp-types",
- "open",
- "rfd",
- "serde_json",
  "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -2606,16 +2595,14 @@ dependencies = [
  "aws-sdk-secretsmanager",
  "aws-sdk-ssm",
  "aws-sdk-sso",
- "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "chrono",
  "dbflux_core",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "filetime",
  "futures-lite 2.6.1",
  "log",
  "secrecy",
- "serde",
  "serde_json",
  "sha1",
  "sha2 0.10.9",
@@ -2649,7 +2636,7 @@ dependencies = [
  "chrono",
  "dbflux_policy",
  "dbflux_test_support",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "futures",
  "keyring",
  "log",
@@ -2709,7 +2696,6 @@ dependencies = [
  "dbflux_ipc",
  "interprocess",
  "log",
- "serde",
  "serde_json",
  "uuid",
 ]
@@ -2726,7 +2712,6 @@ dependencies = [
  "log",
  "regex",
  "reqwest",
- "serde",
  "serde_json",
  "thiserror 2.0.18",
  "urlencoding",
@@ -2736,13 +2721,11 @@ dependencies = [
 name = "dbflux_driver_ipc"
 version = "0.7.0-dev.0"
 dependencies = [
- "bincode",
  "dbflux_core",
  "dbflux_ipc",
  "dbflux_test_support",
  "interprocess",
  "log",
- "serde",
  "serde_json",
  "thiserror 2.0.18",
  "uuid",
@@ -2785,7 +2768,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "urlencoding",
- "uuid",
 ]
 
 [[package]]
@@ -2802,7 +2784,6 @@ dependencies = [
  "mysql",
  "serde_json",
  "urlencoding",
- "uuid",
 ]
 
 [[package]]
@@ -2832,7 +2813,6 @@ dependencies = [
  "dbflux_core",
  "dbflux_ssh",
  "dbflux_test_support",
- "log",
  "redis",
  "serde_json",
  "urlencoding",
@@ -2911,7 +2891,6 @@ version = "0.7.0-dev.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.22.1",
  "chrono",
  "dbflux_approval",
  "dbflux_audit",
@@ -2948,7 +2927,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "uuid",
 ]
 
 [[package]]
@@ -3003,7 +2981,6 @@ name = "dbflux_ssm"
 version = "0.7.0-dev.0"
 dependencies = [
  "dbflux_core",
- "dbflux_tunnel_core",
  "env_logger",
  "log",
 ]
@@ -3016,13 +2993,11 @@ dependencies = [
  "dbflux_approval",
  "dbflux_core",
  "dbflux_policy",
- "dirs 5.0.1",
- "hex",
+ "dirs 6.0.0",
  "log",
  "rusqlite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "uuid",
@@ -3045,7 +3020,6 @@ dependencies = [
  "dbflux_ipc",
  "interprocess",
  "reqwest",
- "serde_json",
  "testcontainers",
 ]
 
@@ -3061,38 +3035,26 @@ dependencies = [
 name = "dbflux_ui"
 version = "0.7.0-dev.0"
 dependencies = [
- "anyhow",
- "async-trait",
- "bincode",
  "chrono",
  "dbflux_app",
- "dbflux_audit",
  "dbflux_components",
  "dbflux_core",
- "dbflux_driver_ipc",
- "dbflux_export",
  "dbflux_ipc",
- "dbflux_proxy",
  "dbflux_ssh",
  "dbflux_storage",
  "dbflux_ui_base",
  "dbflux_ui_document",
  "dbflux_ui_sidebar",
  "dbflux_ui_windows",
- "dirs 5.0.1",
- "env_logger",
  "fuzzy-matcher",
  "gpui",
  "gpui-component",
- "indexmap",
  "interprocess",
  "libc",
  "log",
- "lsp-types",
  "open",
  "rfd",
  "serde_json",
- "tokio",
  "uuid",
 ]
 
@@ -3153,7 +3115,7 @@ dependencies = [
  "dbflux_ssh",
  "dbflux_storage",
  "dbflux_ui_base",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "gpui",
  "gpui-component",
  "log",
@@ -3176,7 +3138,7 @@ dependencies = [
  "dbflux_ssh",
  "dbflux_storage",
  "dbflux_ui_base",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "gpui",
  "gpui-component",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
+rust-version = "1.85"
 version = "0.7.0-dev.0"
 authors = ["Ignacio Perez <ignacio@feuer.me>"]
 description = "A fast, keyboard-first database client"
@@ -94,12 +95,16 @@ rfd = "0.17"
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+async-trait = "0.1"
+anyhow = "1"
+bincode = "1"
+lsp-types = "0.97"
 toml = "1"
 uuid = { version = "1", features = ["v4", "v5", "v7", "serde"] }
 thiserror = "2"
 secrecy = "0.10"
 age = { version = "0.11", features = ["armor"] }
-dirs = "5"
+dirs = "6"
 rusqlite = { version = "0.32", features = ["bundled"] }
 tokio-postgres = "0.7"
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
@@ -148,3 +153,12 @@ debug = "line-tables-only"
 # large reduction in target/ size and link-time memory.
 [profile.dev.package."*"]
 debug = false
+
+# Release build profile tuned for binary size and runtime speed.
+# `panic` is intentionally left at the default `unwind`: switching to `abort` is a
+# separate decision that loses `catch_unwind` and may break GPUI internals that
+# rely on unwinding, so it is not changed here.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "symbols"

--- a/crates/dbflux/Cargo.toml
+++ b/crates/dbflux/Cargo.toml
@@ -22,19 +22,8 @@ dbflux_ipc.workspace = true
 dbflux_driver_ipc.workspace = true
 dbflux_audit.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
-uuid.workspace = true
 log.workspace = true
-serde_json.workspace = true
-dirs.workspace = true
-rfd.workspace = true
-fuzzy-matcher.workspace = true
-async-trait = "0.1"
-anyhow = "1"
-lsp-types = "0.97"
-bincode = "1"
 interprocess.workspace = true
-open = "5"
-indexmap.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -71,3 +60,11 @@ vendored-openssl = ["dbflux_ssh/vendored-openssl"]
 
 [dev-dependencies]
 dbflux_test_support.workspace = true
+
+[package.metadata.cargo-machete]
+# tokio is declared to pin the rt-multi-thread+time features for the MCP runtime;
+# no direct tokio:: calls appear in this crate's source because the runtime is
+# driven through dbflux_app/dbflux_mcp_server.
+# dbflux_ssh is an optional dep forwarded only to enable the vendored-openssl
+# feature on the ssh crate; no source-level use of dbflux_ssh is needed.
+ignored = ["tokio", "dbflux_ssh"]

--- a/crates/dbflux_app/Cargo.toml
+++ b/crates/dbflux_app/Cargo.toml
@@ -41,7 +41,7 @@ tokio.workspace = true
 uuid.workspace = true
 log.workspace = true
 indexmap.workspace = true
-async-trait = "0.1"
+async-trait = { workspace = true }
 
 [features]
 default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "mssql"]

--- a/crates/dbflux_aws/Cargo.toml
+++ b/crates/dbflux_aws/Cargo.toml
@@ -16,24 +16,22 @@ path = "src/lib.rs"
 dbflux_core = { path = "../dbflux_core" }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-sso = "1"
-aws-sdk-ssooidc = "1"
 aws-sdk-sts = "1"
 aws-sdk-secretsmanager = "1"
 aws-sdk-ssm = "1"
-async-trait = "0.1"
+async-trait = { workspace = true }
 log = "0.4"
 secrecy = "0.10"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "time", "process", "fs"] }
-uuid = { version = "1", features = ["v4", "serde"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-chrono = { version = "0.4", features = ["serde"] }
-dirs = "5"
+tokio = { workspace = true, features = ["rt", "net", "time", "process", "fs"] }
+uuid = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+dirs = { workspace = true }
 sha1 = "0.10"
 sha2 = "0.10"
 futures-lite = "2"
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros"] }
 tempfile = "3"
 filetime = "0.2"

--- a/crates/dbflux_core/Cargo.toml
+++ b/crates/dbflux_core/Cargo.toml
@@ -10,21 +10,21 @@ homepage.workspace = true
 license.workspace = true
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-uuid = { version = "1", features = ["v4", "v5", "serde"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
 thiserror = "2"
-dirs = "5"
+dirs = { workspace = true }
 log = "0.4"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 bitflags = "2.10.0"
 tree-sitter = "0.25"
 tree-sitter-sequel = "0.3"
 urlencoding = "2"
 tempfile = "3"
 secrecy = "0.10"
-async-trait = "0.1"
-tokio = { version = "1", features = ["sync", "time"] }
+async-trait = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 futures = "0.3"
 dbflux_policy.workspace = true
 tracing = { workspace = true, optional = true }
@@ -43,8 +43,8 @@ tracing-bridge = [
 
 [dev-dependencies]
 dbflux_test_support.workspace = true
-tokio = { version = "1", features = ["rt", "macros", "sync", "time"] }
-rusqlite = { version = "0.32", features = ["bundled"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
+rusqlite = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service"] }

--- a/crates/dbflux_driver_cloudwatch/Cargo.toml
+++ b/crates/dbflux_driver_cloudwatch/Cargo.toml
@@ -20,6 +20,6 @@ dbflux_core.workspace = true
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-cloudwatchlogs = "1"
 aws-sdk-cloudwatch = "1"
-tokio = { version = "1", features = ["rt-multi-thread", "time"] }
-serde_json = "1"
+tokio = { workspace = true, features = ["time"] }
+serde_json = { workspace = true }
 log = "0.4"

--- a/crates/dbflux_driver_dynamodb/Cargo.toml
+++ b/crates/dbflux_driver_dynamodb/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/lib.rs"
 dbflux_core.workspace = true
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-dynamodb = "1"
-tokio = { version = "1", features = ["rt-multi-thread"] }
-serde_json = "1"
+tokio = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 dbflux_test_support.workspace = true

--- a/crates/dbflux_driver_host/Cargo.toml
+++ b/crates/dbflux_driver_host/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/main.rs"
 dbflux_core = { path = "../dbflux_core", features = ["tracing-bridge"] }
 dbflux_ipc = { path = "../dbflux_ipc" }
 interprocess.workspace = true
-serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
 log.workspace = true

--- a/crates/dbflux_driver_influxdb/Cargo.toml
+++ b/crates/dbflux_driver_influxdb/Cargo.toml
@@ -17,7 +17,6 @@ dbflux_core.workspace = true
 reqwest = { workspace = true, default-features = false, features = ["blocking", "rustls-tls", "gzip"] }
 csv = { workspace = true }
 serde_json.workspace = true
-serde.workspace = true
 chrono = { workspace = true }
 urlencoding = { workspace = true }
 thiserror.workspace = true

--- a/crates/dbflux_driver_ipc/Cargo.toml
+++ b/crates/dbflux_driver_ipc/Cargo.toml
@@ -12,10 +12,8 @@ license.workspace = true
 dbflux_core = { path = "../dbflux_core" }
 dbflux_ipc = { path = "../dbflux_ipc" }
 interprocess.workspace = true
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-bincode = "1.3"
-uuid = { version = "1.0", features = ["v4", "serde"] }
+serde_json = { workspace = true }
+uuid = { workspace = true }
 log = "0.4"
 thiserror = "2.0"
 
@@ -25,3 +23,8 @@ dbflux_test_support.workspace = true
 [lib]
 name = "dbflux_driver_ipc"
 path = "src/lib.rs"
+
+[package.metadata.cargo-machete]
+# uuid::Uuid is used directly in src/transport.rs (line 15: `use uuid::Uuid`);
+# machete misses it because the import comes from the workspace re-export path.
+ignored = ["uuid"]

--- a/crates/dbflux_driver_mongodb/Cargo.toml
+++ b/crates/dbflux_driver_mongodb/Cargo.toml
@@ -13,15 +13,15 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 dbflux_core.workspace = true
 dbflux_ssh.workspace = true
 mongodb = { version = "3", default-features = false, features = ["sync", "rustls-tls", "bson-2", "compat-3-3-0", "dns-resolver"] }
 bson = "2"
 log.workspace = true
 serde_json.workspace = true
-chrono = { version = "0.4", features = ["serde"] }
-tokio = { version = "1", features = ["rt-multi-thread"] }
+chrono = { workspace = true }
+tokio = { workspace = true }
 base64 = "0.22"
 urlencoding = "2"
 uuid.workspace = true
@@ -31,3 +31,8 @@ dbflux_test_support.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-machete]
+# tokio is declared to ensure the rt-multi-thread runtime feature is active for
+# the mongodb async client; the driver itself does not call tokio:: directly.
+ignored = ["tokio"]

--- a/crates/dbflux_driver_mssql/Cargo.toml
+++ b/crates/dbflux_driver_mssql/Cargo.toml
@@ -13,20 +13,19 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 dbflux_core = { path = "../dbflux_core" }
 dbflux_ssh = { path = "../dbflux_ssh" }
-chrono = "0.4"
+chrono = { workspace = true }
 hex.workspace = true
 indexmap.workspace = true
 log = "0.4"
-serde_json = "1"
+serde_json = { workspace = true }
 sha2.workspace = true
 tiberius = { version = "0.12", default-features = false, features = ["chrono", "tds73", "rustls", "sql-browser-tokio"] }
-tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "sync", "time", "macros"] }
+tokio = { workspace = true, features = ["net", "io-util", "time", "macros"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 urlencoding = "2"
-uuid.workspace = true
 
 [dev-dependencies]
 dbflux_test_support.workspace = true

--- a/crates/dbflux_driver_mysql/Cargo.toml
+++ b/crates/dbflux_driver_mysql/Cargo.toml
@@ -13,16 +13,15 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1"
-chrono = "0.4"
+async-trait = { workspace = true }
+chrono = { workspace = true }
 dbflux_core.workspace = true
 dbflux_ssh.workspace = true
 hex.workspace = true
 log.workspace = true
 mysql.workspace = true
-serde_json = "1"
+serde_json = { workspace = true }
 urlencoding = "2"
-uuid.workspace = true
 
 [dev-dependencies]
 dbflux_test_support.workspace = true

--- a/crates/dbflux_driver_postgres/Cargo.toml
+++ b/crates/dbflux_driver_postgres/Cargo.toml
@@ -12,16 +12,16 @@ license.workspace = true
 [dependencies]
 dbflux_core = { path = "../dbflux_core" }
 dbflux_ssh = { path = "../dbflux_ssh" }
-async-trait = "0.1"
-chrono = "0.4"
+async-trait = { workspace = true }
+chrono = { workspace = true }
 hex = "0.4"
 log = "0.4"
 native-tls = "0.2"
 postgres = { version = "0.19", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 postgres-native-tls = "0.5"
-serde_json = "1"
+serde_json = { workspace = true }
 urlencoding = "2"
-uuid = { version = "1", features = ["v4"] }
+uuid = { workspace = true }
 
 [dev-dependencies]
 dbflux_test_support.workspace = true

--- a/crates/dbflux_driver_redis/Cargo.toml
+++ b/crates/dbflux_driver_redis/Cargo.toml
@@ -13,10 +13,9 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }
 dbflux_core.workspace = true
 dbflux_ssh.workspace = true
-log.workspace = true
 redis = { version = "0.27", features = ["tls-rustls"] }
 serde_json.workspace = true
 urlencoding = "2"

--- a/crates/dbflux_driver_sqlite/Cargo.toml
+++ b/crates/dbflux_driver_sqlite/Cargo.toml
@@ -13,8 +13,8 @@ license.workspace = true
 dbflux_core = { path = "../dbflux_core" }
 hex.workspace = true
 log = "0.4"
-rusqlite = { version = "0.32", features = ["bundled", "column_decltype"] }
-serde_json = "1"
+rusqlite = { workspace = true, features = ["column_decltype"] }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 dbflux_test_support.workspace = true

--- a/crates/dbflux_export/Cargo.toml
+++ b/crates/dbflux_export/Cargo.toml
@@ -17,7 +17,7 @@ dbflux_core = { path = "../dbflux_core" }
 base64 = "0.22"
 csv = "1.3"
 hex = "0.4"
-serde_json = "1"
+serde_json = { workspace = true }
 thiserror = "2"
 
 [dev-dependencies]

--- a/crates/dbflux_ipc/Cargo.toml
+++ b/crates/dbflux_ipc/Cargo.toml
@@ -10,12 +10,12 @@ license.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
-bincode = "1"
+bincode = { workspace = true }
 interprocess.workspace = true
 dbflux_core.workspace = true
 dbflux_storage.workspace = true
 uuid.workspace = true
 serde_json.workspace = true
 secrecy = "0.10"
-async-trait = "0.1"
+async-trait = { workspace = true }
 log.workspace = true

--- a/crates/dbflux_mcp_server/Cargo.toml
+++ b/crates/dbflux_mcp_server/Cargo.toml
@@ -54,10 +54,9 @@ tokio = { workspace = true, features = ["rt-multi-thread", "io-util", "sync", "m
 
 # Utilities
 uuid = { workspace = true }
-anyhow = "1"
-base64 = "0.22"
-chrono = { version = "0.4", features = ["serde"] }
-async-trait = "0.1"
+anyhow = { workspace = true }
+chrono = { workspace = true }
+async-trait = { workspace = true }
 rusqlite.workspace = true
 
 log.workspace = true

--- a/crates/dbflux_policy/Cargo.toml
+++ b/crates/dbflux_policy/Cargo.toml
@@ -15,7 +15,6 @@ path = "src/lib.rs"
 [dependencies]
 serde.workspace = true
 thiserror.workspace = true
-uuid.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/crates/dbflux_ssh/Cargo.toml
+++ b/crates/dbflux_ssh/Cargo.toml
@@ -17,7 +17,7 @@ dbflux_core = { path = "../dbflux_core" }
 dbflux_tunnel_core = { path = "../dbflux_tunnel_core" }
 dbflux_storage = { path = "../dbflux_storage" }
 base64 = { workspace = true }
-dirs = "6"
+dirs = { workspace = true }
 log = "0.4"
 sha2 = { workspace = true }
 ssh2 = "0.9"

--- a/crates/dbflux_ssm/Cargo.toml
+++ b/crates/dbflux_ssm/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/lib.rs"
 
 [dependencies]
 dbflux_core = { path = "../dbflux_core" }
-dbflux_tunnel_core = { path = "../dbflux_tunnel_core" }
 log = "0.4"
 
 [dev-dependencies]

--- a/crates/dbflux_storage/Cargo.toml
+++ b/crates/dbflux_storage/Cargo.toml
@@ -22,11 +22,8 @@ log.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 uuid.workspace = true
-sha2.workspace = true
-hex.workspace = true
 
-# For timestamp formatting in state repositories (without pulling full chrono from workspace)
-chrono = "0.4"
+chrono = { workspace = true }
 
 [dev-dependencies]
 dbflux_policy.workspace = true
@@ -34,5 +31,5 @@ tempfile = "3"
 uuid.workspace = true
 
 [dev-dependencies.rusqlite]
-version = "0.32"
-features = ["bundled", "trace"]
+workspace = true
+features = ["trace"]

--- a/crates/dbflux_test_support/Cargo.toml
+++ b/crates/dbflux_test_support/Cargo.toml
@@ -24,7 +24,6 @@ dbflux_driver_mysql.workspace = true
 dbflux_driver_postgres.workspace = true
 dbflux_driver_redis.workspace = true
 dbflux_driver_sqlite.workspace = true
-serde_json.workspace = true
 testcontainers = "0.15"
 interprocess.workspace = true
 reqwest = { workspace = true, default-features = false, features = ["blocking", "rustls-tls"] }

--- a/crates/dbflux_ui/Cargo.toml
+++ b/crates/dbflux_ui/Cargo.toml
@@ -21,28 +21,16 @@ dbflux_ui_sidebar.workspace = true
 dbflux_core.workspace = true
 dbflux_storage.workspace = true
 dbflux_app.workspace = true
-dbflux_export.workspace = true
-dbflux_ssh.workspace = true
-dbflux_proxy.workspace = true
 dbflux_ipc.workspace = true
-dbflux_driver_ipc.workspace = true
-dbflux_audit.workspace = true
-tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
+dbflux_ssh.workspace = true
 uuid.workspace = true
 chrono.workspace = true
 log.workspace = true
-env_logger.workspace = true
 serde_json.workspace = true
-dirs.workspace = true
 rfd.workspace = true
 fuzzy-matcher.workspace = true
-async-trait = "0.1"
-anyhow = "1"
-lsp-types = "0.97"
-bincode = "1"
 interprocess.workspace = true
 open = "5"
-indexmap = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -59,3 +47,8 @@ vendored-openssl = ["dbflux_ssh/vendored-openssl"]
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }
+
+[package.metadata.cargo-machete]
+# dbflux_ssh is used only via the vendored-openssl feature passthrough
+# (no direct source usage needed — the dep only forwards the feature).
+ignored = ["dbflux_ssh"]

--- a/crates/dbflux_ui_base/Cargo.toml
+++ b/crates/dbflux_ui_base/Cargo.toml
@@ -22,7 +22,7 @@ dbflux_aws = { workspace = true, optional = true }
 tracing.workspace = true
 uuid.workspace = true
 log.workspace = true
-anyhow = "1"
+anyhow = { workspace = true }
 chrono.workspace = true
 
 [dev-dependencies]

--- a/crates/dbflux_ui_document/Cargo.toml
+++ b/crates/dbflux_ui_document/Cargo.toml
@@ -23,8 +23,8 @@ dbflux_export.workspace = true
 uuid.workspace = true
 log.workspace = true
 serde_json.workspace = true
-lsp-types = "0.97"
-anyhow = "1"
+lsp-types = { workspace = true }
+anyhow = { workspace = true }
 rfd.workspace = true
 dbflux_mcp = { workspace = true, optional = true }
 dbflux_policy = { workspace = true, optional = true }

--- a/examples/custom_auth_provider/Cargo.toml
+++ b/examples/custom_auth_provider/Cargo.toml
@@ -14,7 +14,5 @@ path = "src/main.rs"
 dbflux_core = { path = "../../crates/dbflux_core" }
 dbflux_ipc = { path = "../../crates/dbflux_ipc" }
 interprocess = "2.4"
-serde_json = "1"
-uuid = { version = "1", features = ["v4"] }
 log = "0.4"
 env_logger = "0.11"

--- a/examples/custom_driver/Cargo.toml
+++ b/examples/custom_driver/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/main.rs"
 dbflux_core = { path = "../../crates/dbflux_core" }
 dbflux_ipc = { path = "../../crates/dbflux_ipc" }
 interprocess = "2.4"
-serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 log = "0.4"

--- a/flake.nix
+++ b/flake.nix
@@ -36,12 +36,7 @@
             overlays = [ (import rust-overlay) ];
           };
 
-          rustToolchain = pkgs.pkgsBuildHost.rust-bin.stable.latest.default.override {
-            extensions = [
-              "rust-src"
-              "rust-analyzer"
-            ];
-          };
+          rustToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
           craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
 
@@ -91,6 +86,8 @@
               # Run with `cargo nextest run` (doctests still need `cargo test --doc`).
               # mold is inherited from dbflux.nativeBuildInputs (see default.nix).
               pkgs.cargo-nextest
+              # Detects unused dependency declarations (DEP-2 regression guard).
+              pkgs.cargo-machete
             ];
 
             buildInputs = dbflux.buildInputs;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]


### PR DESCRIPTION
## Summary

Build and dependency hardening across the workspace (DEP-1/2/3/4), one consolidated PR. Config-only — no Rust logic changes.

- **DEP-1** — Add a tuned `[profile.release]` (`lto = "thin"`, `codegen-units = 1`, `strip = "symbols"`). `panic` stays at the default `unwind` (switching to `abort` is a separate decision that loses `catch_unwind` and may break GPUI internals).
- **DEP-2** — Remove confirmed-dead dependencies and add `cargo-machete` as a regression guard (dev shell + a CI job). To make `cargo machete` pass workspace-wide before gating on it, genuinely-unused deps were pruned from more crates than just the two originally flagged; legitimate machete false-positives (feature-only `tokio`, the `vendored-openssl` passthrough on `dbflux_ssh`, `uuid` reached via a re-export) carry `[package.metadata.cargo-machete] ignored` annotations.
- **DEP-3** — Pin the toolchain: a `rust-toolchain.toml` (1.95.0) read by `flake.nix` via `fromRustupToolchainFile`, plus `rust-version = "1.85"` (the edition-2024 floor) in `[workspace.package]`. CI, Nix, and local builds now agree.
- **DEP-4** — Unify shared dependencies into `[workspace.dependencies]` (`{ workspace = true }`), preserving every member's extra features. This also resolves a real bug: `dirs` was split (workspace `"5"` vs `dbflux_ssh` inline `"6"`), pulling two majors into the tree for our own code — all our crates are now on `dirs = "6"`.

DEP-5 (postgres TLS migration) is intentionally out of scope — it's a driver TLS-implementation change that needs its own evaluation.

## Changes

| Item | Files | Change |
|------|-------|--------|
| DEP-1 | root `Cargo.toml` | `[profile.release]` block |
| DEP-2 | `crates/*/Cargo.toml`, `flake.nix`, `.github/workflows/style.yml` | dead-dep removal; `cargo-machete` in dev shell + CI gate; justified ignore annotations |
| DEP-3 | `rust-toolchain.toml` (new), `flake.nix`, root `Cargo.toml` | toolchain pin + MSRV |
| DEP-4 | root `Cargo.toml` + ~20 member `Cargo.toml` | workspace-deps unification + `dirs` → 6 |

## Test plan

- `cargo check --workspace` clean; `cargo check -p dbflux` with the full driver feature set clean (exercises every gated path); `cargo nextest run --workspace` **3906 passed / 184 skipped**; `cargo test --doc --workspace` green; `cargo clippy --workspace -- -D warnings` clean; `cargo fmt --all --check` clean; `cargo machete` reports zero unused deps workspace-wide.
- Release build with the tuned profile succeeds; stripped binary is 117 MB.
- Toolchain: `rustc --version` resolves to the pinned 1.95.0 via the flake.
- Reviewed via spec verification + independent dual adversarial review: all three confirmed the decisive feature-preservation check dep-by-dep (every member's `tokio`/`rusqlite`/`uuid`/`chrono`/`serde` feature set is a superset of before — no feature dropped), that every removed dep is genuinely unused at the source level, that each machete-ignore is a true false-positive, and that the new CI job genuinely gates on machete's exit code.

## Notes

- The lockfile still carries `dirs` 4.0.0 and 5.0.1 alongside 6.0.0 — these are **transitive through the gpui fork** (`gpui_util` → dirs 4; `zed-font-kit` → gpui → dirs 5) and not reachable from our direct declarations, so they can't be collapsed without changing gpui. All of our crates are on `dirs = "6"`.
- LTO + `codegen-units = 1` makes the release build notably slower (~12 min for the full-feature binary); acceptable for a desktop app that doesn't rebuild frequently.
- The pinned toolchain will require contributors on an older rustc to update.
