### PR TITLE
ci: SHA-pin actions, add dep monitoring, --locked, feature coverage, concurrency (CI-1..5, CI-9)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,16 @@ on:
         required: true
 
 env:
-  FEATURES: "sqlite,postgres,mysql,mongodb,redis,influxdb"
+  FEATURES: "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws"
+
+permissions:
+  contents: read
 
 jobs:
   build-linux:
     name: Build Linux ${{ matrix.arch }}
     runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -47,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Resolve channel identity
         run: |
@@ -67,7 +71,7 @@ jobs:
           echo "BRAND_DIR=$BRAND_DIR" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: ${{ matrix.target }}
           components: rust-src
@@ -92,7 +96,7 @@ jobs:
           sudo apt-get install -y gettext imagemagick
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           prefix-key: "v0-rust"
           shared-key: linux-${{ matrix.arch }}
@@ -103,7 +107,7 @@ jobs:
         run: sed -i 's/^version = ".*"/version = "${{ inputs.version }}"/' Cargo.toml
 
       - name: Build DBFlux
-        run: cargo build --release --features "$FEATURES" --target ${{ matrix.target }}
+        run: cargo build --release --locked --features "$FEATURES" --target ${{ matrix.target }}
 
       - name: Create package
         run: |
@@ -201,7 +205,7 @@ jobs:
           convert "$BRAND_DIR/mark-small.svg" -resize 16x16 packaging/icons/16x16/apps/dbflux.png
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:
           go-version: stable
 
@@ -229,7 +233,7 @@ jobs:
         run: sudo apt-get install -y rpm debsigs
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec  # v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -251,9 +255,11 @@ jobs:
           } > ~/.rpmmacros
 
       - name: Sign .rpm packages
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         run: |
           for rpm in *.rpm; do
-            rpm --addsign "$rpm" 3< <(echo "${{ secrets.GPG_PASSPHRASE }}")
+            rpm --addsign "$rpm" 3< <(printf '%s' "$GPG_PASSPHRASE")
           done
 
       - name: Sign artifacts
@@ -272,7 +278,7 @@ jobs:
 
       - name: Upload artifacts
         if: env.ACT != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: linux-${{ matrix.arch }}
           path: |
@@ -310,6 +316,7 @@ jobs:
   build-macos:
     name: Build macOS ${{ matrix.arch }}
     runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -328,7 +335,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Resolve channel identity
         run: |
@@ -348,13 +355,13 @@ jobs:
           echo "BRAND_DIR=$BRAND_DIR" >> "$GITHUB_ENV"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: ${{ matrix.target }}
           components: rust-src
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           prefix-key: "v0-rust"
           shared-key: macos-${{ matrix.arch }}
@@ -369,7 +376,7 @@ jobs:
         # target instead of linking the runner's system OpenSSL. Required to
         # cross-compile x86_64 on the Apple Silicon runner (no x86_64 OpenSSL is
         # present), and keeps both macOS binaries self-contained at runtime.
-        run: cargo build --release --features "$FEATURES,vendored-openssl" --target ${{ matrix.target }}
+        run: cargo build --release --locked --features "$FEATURES,vendored-openssl" --target ${{ matrix.target }}
 
       - name: Create app bundle
         run: |
@@ -412,7 +419,7 @@ jobs:
             "$APP_BUNDLE"
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec  # v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -426,7 +433,7 @@ jobs:
 
       - name: Upload artifacts
         if: env.ACT != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: macos-${{ matrix.arch }}
           path: |
@@ -446,10 +453,11 @@ jobs:
   build-windows:
     name: Build Windows amd64
     runs-on: windows-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Resolve channel identity
         shell: pwsh
@@ -463,13 +471,13 @@ jobs:
           }
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           targets: x86_64-pc-windows-msvc
           components: rust-src
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           prefix-key: "v0-rust"
           shared-key: windows-amd64
@@ -482,7 +490,7 @@ jobs:
           (Get-Content Cargo.toml) -replace '^version = ".*"', 'version = "${{ inputs.version }}"' | Set-Content Cargo.toml
 
       - name: Build DBFlux
-        run: cargo build --release --features "$env:FEATURES" --target x86_64-pc-windows-msvc
+        run: cargo build --release --locked --features "$env:FEATURES" --target x86_64-pc-windows-msvc
 
       - name: Install ImageMagick
         run: choco install imagemagick -y
@@ -517,7 +525,7 @@ jobs:
           Copy-Item LICENSE-APACHE installer/LICENSE-APACHE
 
       - name: Build installer
-        uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
+        uses: Minionguyjpro/Inno-Setup-Action@b8e8eb5936437c243592fda645c96dfc6488c275  # v1.2.2
         with:
           path: installer/installer.iss
           options: /DMyAppVersion=${{ inputs.version }} /DMyAppName="${{ env.APP_NAME }}" /DMyAppId="${{ env.MY_APP_ID }}"
@@ -526,7 +534,7 @@ jobs:
         run: Move-Item installer/output/dbflux-windows-amd64-setup.exe dbflux-windows-amd64-setup.exe -Force
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec  # v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -546,7 +554,7 @@ jobs:
 
       - name: Upload artifacts
         if: env.ACT != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: windows-amd64
           path: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,18 +7,23 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: nightly
+  cancel-in-progress: false
 
 jobs:
   guard:
     name: Guard — canonical repo and new commits
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       proceed: ${{ steps.guard.outputs.proceed }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -63,12 +68,13 @@ jobs:
     needs: guard
     if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.nightly.outputs.version }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Compute version string
         id: nightly
@@ -97,10 +103,13 @@ jobs:
     name: Publish rolling nightly release
     needs: [compute-version, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
           # The `nightly` tag (and its pin commit) is needed to scope the
@@ -108,16 +117,17 @@ jobs:
           fetch-tags: true
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: artifacts
           pattern: "*"
           merge-multiple: false
 
       - name: Install git-cliff
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9  # v2
         with:
           tool: git-cliff
+          version: 2.13.1
 
       - name: Generate changelog for nightly body
         run: |
@@ -229,7 +239,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish rolling nightly release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           tag_name: nightly
           name: DBFlux Nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,11 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   tests:
@@ -26,6 +30,7 @@ jobs:
   classify:
     name: Classify release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       version: ${{ steps.version.outputs.version }}
       channel: ${{ steps.classify.outputs.channel }}
@@ -80,16 +85,19 @@ jobs:
     name: Create Release
     needs: [classify, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Download all artifacts
         if: env.ACT != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: artifacts
           pattern: "*"
@@ -103,9 +111,10 @@ jobs:
           ls -R artifacts
 
       - name: Install git-cliff
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@9e1e5806d4a4822de933115878265be9aaa786d9  # v2
         with:
           tool: git-cliff
+          version: 2.13.1
 
       - name: Generate changelog for release body
         id: cliff
@@ -159,7 +168,7 @@ jobs:
           fi
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65  # v2
         with:
           tag_name: v${{ needs.classify.outputs.version }}
           name: DBFlux v${{ needs.classify.outputs.version }}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -10,17 +10,25 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     name: Formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: rustfmt
 
@@ -30,13 +38,14 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
         with:
           components: clippy
 
@@ -52,28 +61,46 @@ jobs:
             libxkbcommon-x11-dev
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           shared-key: ci-clippy
           cache-targets: true
           cache-on-failure: true
 
       - name: Run clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws" -- -D warnings
 
   machete:
     name: Unused dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install cargo-machete
         run: cargo install cargo-machete --locked
 
       - name: Check for unused dependencies
         run: cargo machete
+
+  cargo-deny:
+    name: Supply-chain advisories
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe  # v2
+        with:
+          command: check advisories licenses bans sources

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -91,7 +91,6 @@ jobs:
   cargo-deny:
     name: Supply-chain advisories
     runs-on: ubuntu-latest
-    continue-on-error: true
     timeout-minutes: 15
     permissions:
       contents: read
@@ -100,7 +99,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
+      # Non-blocking: advisory/license findings surface as annotations but never
+      # gate a PR. Promote to gating by removing continue-on-error once the
+      # advisory backlog is triaged.
       - name: Run cargo-deny
+        continue-on-error: true
         uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe  # v2
         with:
           command: check advisories licenses bans sources

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,17 +10,25 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deterministic-tests:
     name: Deterministic Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install system dependencies
         run: |
@@ -34,26 +42,27 @@ jobs:
             libxkbcommon-x11-dev
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           shared-key: ci-deterministic
           cache-targets: true
           cache-on-failure: true
 
       - name: Run deterministic workspace tests
-        run: cargo test --workspace
+        run: cargo test --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws"
 
   driver-live-integration:
     name: Driver Live Integration
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     needs: deterministic-tests
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
       - name: Install system dependencies
         run: |
@@ -67,26 +76,26 @@ jobs:
             libxkbcommon-x11-dev
 
       - name: Setup Rust cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
           shared-key: ci-live-integration
           cache-targets: true
           cache-on-failure: true
 
       - name: Run PostgreSQL live integration tests
-        run: cargo test -p dbflux_driver_postgres --test live_integration -- --ignored
+        run: cargo test -p dbflux_driver_postgres --locked --test live_integration -- --ignored
 
       - name: Run MySQL live integration tests
-        run: cargo test -p dbflux_driver_mysql --test live_integration -- --ignored
+        run: cargo test -p dbflux_driver_mysql --locked --test live_integration -- --ignored
 
       - name: Run MongoDB live integration tests
-        run: cargo test -p dbflux_driver_mongodb --test live_integration -- --ignored
+        run: cargo test -p dbflux_driver_mongodb --locked --test live_integration -- --ignored
 
       - name: Run Redis live integration tests
-        run: cargo test -p dbflux_driver_redis --test live_integration -- --ignored
+        run: cargo test -p dbflux_driver_redis --locked --test live_integration -- --ignored
 
       - name: DynamoDB live integration
-        run: cargo test -p dbflux_driver_dynamodb --test live_integration -- --ignored
+        run: cargo test -p dbflux_driver_dynamodb --locked --test live_integration -- --ignored
 
       - name: Run SQLite live integration tests
-        run: cargo test -p dbflux_driver_sqlite --test live_integration
+        run: cargo test -p dbflux_driver_sqlite --locked --test live_integration

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,46 @@
+# cargo-deny configuration. Under `version = 2` advisory findings (vulnerabilities,
+# unmaintained crates) are reported as errors and the old per-type warn keys no
+# longer exist, so they are NOT softened here. The CI job stays non-blocking via
+# `continue-on-error: true` in style.yml — a freshly published RUSTSEC advisory
+# surfaces without blocking unrelated PRs. Dropping that once advisories are
+# triaged is a deliberate later decision.
+[advisories]
+version = 2
+yanked = "warn"
+
+[licenses]
+version = 2
+# Verify against the real graph at apply time:
+#   nix develop --command cargo deny check licenses
+# Add any license cargo-deny reports as rejected here; do NOT remove entries.
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-3.0",
+  "Unicode-DFS-2016",
+  "Zlib",
+  "MPL-2.0",
+  "CC0-1.0",
+  "OpenSSL",
+  "0BSD",
+  "BlueOak-1.0.0",
+  "CDLA-Permissive-2.0",
+  "NCSA",
+]
+confidence-threshold = 0.8
+
+[[licenses.clarify]]
+crate = "dbflux_lua"
+expression = "MIT OR Apache-2.0"
+license-files = []
+
+[bans]
+multiple-versions = "warn"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"


### PR DESCRIPTION
## Summary

CI/CD supply-chain hardening (board items **CI-1..5** and the core of **CI-9**), one consolidated config-only PR. No Rust source changes — only the five workflows plus two new config files.

- **CI-1** — SHA-pin every third-party GitHub Action (40-hex commit + trailing `# tag` comment); no mutable `@vN`/`@stable` refs remain. The highest-value pin is `crazy-max/ghaction-import-gpg`, which handles the signing key.
- **CI-2** — add dependency monitoring: `.github/dependabot.yml` (cargo + github-actions, weekly), `deny.toml`, and a **non-blocking** `Supply-chain advisories` cargo-deny job in `style.yml` (`continue-on-error: true`).
- **CI-3** — add `--locked` to every `cargo build`/`test`/`clippy` in CI (not `cargo fmt`), so CI fails loudly on a stale `Cargo.lock` instead of silently resolving.
- **CI-4** — expand the build feature set to the full 10-driver canonical list and pass `--features` to the workspace test (`tests.yml`) and clippy (`style.yml`), so `#[cfg(feature = …)]` driver code is actually compiled and linted.
- **CI-5** — `concurrency` groups (cancel-in-progress on push/PR workflows, serial on nightly/release) and `timeout-minutes` on every non-reusable job.
- **CI-9 (core)** — least-privilege `permissions` (workflow-level `read`; `write` only on publish jobs), move the RPM-signing passphrase out of `${{ }}` shell interpolation into `env:` + `printf '%s'`, and pin the `git-cliff` version.

## Deferred to follow-up PRs (out of scope here)

These are release-tag-only or require a deliberate decision, so they cannot be validated by this PR's push and are intentionally split out:

- **CI-6** — enforce the tag → `release/vX.Y` branch invariant (release-trigger-only; a logic bug would block a real release tag).
- **CI-7** — pin/verify release tooling (`nfpm@latest`, `appimagetool@continuous`) (`workflow_call`-only).
- **CI-8** — compile macOS/Windows on PR (runner-cost decision).
- **CI-9 provenance** — SLSA build-provenance attestations (needs `id-token` infra + SLSA-level decision).

## Changes

| Item | Files | Change |
|------|-------|--------|
| CI-1 | 5 workflows | SHA-pin 11 distinct actions across all `uses:` sites |
| CI-2 | `.github/dependabot.yml` (new), `deny.toml` (new), `style.yml` | dependency monitoring + non-blocking advisory job |
| CI-3 | `tests.yml`, `style.yml`, `build.yml` | `--locked` on cargo build/test/clippy |
| CI-4 | `build.yml`, `tests.yml`, `style.yml` | full feature set compiled/linted in CI |
| CI-5 | all 5 workflows | concurrency groups + per-job timeouts |
| CI-9 | `build.yml`, `nightly.yml`, `release.yml`, `style.yml` | least-privilege permissions, GPG passphrase via `env:`, git-cliff pin |

## Test plan

- Required status-check job names unchanged (`Formatting`, `Clippy`, `Deterministic Tests`, `Driver Live Integration`, `Unused dependencies`); the new cargo-deny job has a distinct name and nothing depends on it.
- All 11 action SHAs cross-checked against `gh api repos/<repo>/commits/<tag>` — every pinned SHA resolves to its tag.
- `deny.toml` valid; `cargo deny check licenses bans sources` → ok. Advisories run non-blocking via `continue-on-error: true` (several existing RUSTSEC advisories surface as findings without gating PRs; remediation tracked separately).
- `cargo metadata --locked` succeeds, so the `--locked` additions are satisfiable; the full `--features` set resolves against the workspace.
- `actionlint` reports zero workflow-syntax errors; all YAML and `deny.toml` parse.
- Reviewed via spec verification (0 CRITICAL) + dual blind adversarial review (both APPROVE), each re-resolving SHAs and re-running cargo-deny independently.

## Notes

- The CI-9 edits live in `workflow_call`/tag-triggered files, so they are not exercised by this PR's push — first live run is the next nightly. Acceptance here is structural.
- SHA pins don't auto-update; the new `github-actions` Dependabot ecosystem keeps them current.
