### PR TITLE
deps: migrate bson 2 -> 3 (mongodb bson-3 feature)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,23 +1529,22 @@ dependencies = [
 
 [[package]]
 name = "bson"
-version = "2.15.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969a9ba84b0ff843813e7249eed1678d9b6607ce5a3b8f0a47af3fcf7978e6e"
+checksum = "b3f109694c4f45353972af96bf97d8a057f82e2d6e496457f4d135b9867a518c"
 dependencies = [
  "ahash 0.8.12",
  "base64 0.22.1",
  "bitvec",
- "getrandom 0.2.17",
  "getrandom 0.3.4",
  "hex",
  "indexmap",
  "js-sys",
- "once_cell",
  "rand 0.9.4",
  "serde",
  "serde_bytes",
- "serde_json",
+ "simdutf8",
+ "thiserror 2.0.18",
  "time",
  "uuid",
 ]

--- a/crates/dbflux_driver_mongodb/Cargo.toml
+++ b/crates/dbflux_driver_mongodb/Cargo.toml
@@ -16,8 +16,8 @@ path = "src/lib.rs"
 async-trait = { workspace = true }
 dbflux_core.workspace = true
 dbflux_ssh.workspace = true
-mongodb = { version = "3", default-features = false, features = ["sync", "rustls-tls", "bson-2", "compat-3-3-0", "dns-resolver"] }
-bson = "2"
+mongodb = { version = "3", default-features = false, features = ["sync", "rustls-tls", "bson-3", "compat-3-3-0", "dns-resolver"] }
+bson = { version = "3.1", features = ["serde"] }
 log.workspace = true
 serde_json.workspace = true
 chrono = { workspace = true }

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -3161,7 +3161,7 @@ fn execute_db_operation(
                     let mut doc = Document::new();
                     doc.insert("name", spec.name);
                     doc.insert("type", format!("{:?}", spec.collection_type));
-                    if let Ok(bson) = bson::to_bson(&spec.options) {
+                    if let Ok(bson) = bson::serialize_to_bson(&spec.options) {
                         doc.insert("options", bson);
                     }
                     doc


### PR DESCRIPTION
## Summary

Resolves Dependabot #244. The PR bumped the direct `bson` dep to 3.x but left the `mongodb` crate on its `bson-2` feature, producing two incompatible bson crates that don't compile. This switches `mongodb`'s feature to `bson-3` so the whole driver speaks one bson version.

- `crates/dbflux_driver_mongodb/Cargo.toml`: mongodb feature `bson-2` → `bson-3`; `bson = { version = "3.1", features = ["serde"] }` (serde needed for `serialize_to_bson`). `compat-3-3-0` kept — mongodb 3.7 enforces it via `compile_error!`.
- `driver.rs`: `bson::to_bson` → `bson::serialize_to_bson` (bson 3 renamed it; identical semantics).

No mongodb major bump (already v3). BSON wire format is unchanged between 2.x and 3.x, so this is behavior-preserving — no serialization/data change.

## Test plan

- `cargo check`/`clippy -p dbflux_driver_mongodb` clean; `cargo nextest run -p dbflux_driver_mongodb` 127 passed / 9 skipped (live).
- Full workspace check with all drivers enabled: clean.
- CI Driver Live Integration (Dockerized MongoDB) exercises the driver end-to-end against a real server.

Closes #244