### PR TITLE
deps: migrate mlua 0.10 -> 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,12 +3559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_home"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
-
-[[package]]
 name = "env_logger"
 version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6024,21 +6018,21 @@ dependencies = [
 
 [[package]]
 name = "lua-src"
-version = "547.0.0"
+version = "550.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edaf29e3517b49b8b746701e5648ccb5785cde1c119062cbabbc5d5cd115e42"
+checksum = "e836dc8ae16806c9bdcf42003a88da27d163433e3f9684c52f0301258004a4fb"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "luajit-src"
-version = "210.5.12+a4f56a4"
+version = "210.6.6+707c12b"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3a8e7962a5368d5f264d045a5a255e90f9aa3fc1941ae15a8d2940d42cac671"
+checksum = "a86cc925d4053d0526ae7f5bc765dbd0d7a5d1a63d43974f4966cb349ca63295"
 dependencies = [
  "cc",
- "which 7.0.3",
+ "which 8.0.4",
 ]
 
 [[package]]
@@ -6330,12 +6324,13 @@ dependencies = [
 
 [[package]]
 name = "mlua"
-version = "0.10.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1f5f8fbebc7db5f671671134b9321c4b9aa9adeafccfd9a8c020ae45c6a35d0"
+checksum = "ccd36acfa49ce6ee56d1307a061dd302c564eee757e6e4cd67eb4f7204846fab"
 dependencies = [
  "bstr",
  "either",
+ "libc",
  "mlua-sys",
  "num-traits",
  "parking_lot",
@@ -6345,12 +6340,13 @@ dependencies = [
 
 [[package]]
 name = "mlua-sys"
-version = "0.6.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380c1f7e2099cafcf40e51d3a9f20a346977587aa4d012eae1f043149a728a93"
+checksum = "0f1c3a7fc7580227ece249fd90aa2fa3b39eb2b49d3aec5e103b3e85f2c3dfc8"
 dependencies = [
  "cc",
  "cfg-if",
+ "libc",
  "lua-src",
  "luajit-src",
  "pkg-config",
@@ -11333,14 +11329,11 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "7.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
 dependencies = [
- "either",
- "env_home",
- "rustix 1.1.4",
- "winsafe",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ base64 = "0.22"
 hex = "0.4"
 sha2 = "0.11"
 interprocess = "2.4"
-mlua = "0.10"
+mlua = "0.11"
 indexmap = "2"
 
 [workspace.lints.rust]

--- a/crates/dbflux_lua/src/executor.rs
+++ b/crates/dbflux_lua/src/executor.rs
@@ -67,20 +67,24 @@ impl HookExecutor for LuaExecutor {
         let cancel = cancel_token.clone();
         let parent = parent_cancel_token.cloned();
 
-        vm.lua.set_hook(
-            HookTriggers::new().every_nth_instruction(1_000),
-            move |_, _| {
-                if cancel.is_cancelled() || parent.as_ref().is_some_and(CancelToken::is_cancelled) {
-                    return Err(LuaError::RuntimeError("Lua hook cancelled".to_string()));
-                }
+        vm.lua
+            .set_hook(
+                HookTriggers::new().every_nth_instruction(1_000),
+                move |_, _| {
+                    if cancel.is_cancelled()
+                        || parent.as_ref().is_some_and(CancelToken::is_cancelled)
+                    {
+                        return Err(LuaError::RuntimeError("Lua hook cancelled".to_string()));
+                    }
 
-                if timeout.is_some_and(|max| start.elapsed() > max) {
-                    return Err(LuaError::RuntimeError("Lua hook timed out".to_string()));
-                }
+                    if timeout.is_some_and(|max| start.elapsed() > max) {
+                        return Err(LuaError::RuntimeError("Lua hook timed out".to_string()));
+                    }
 
-                Ok(VmState::Continue)
-            },
-        );
+                    Ok(VmState::Continue)
+                },
+            )
+            .map_err(|e| format!("Failed to install Lua hook: {e}"))?;
 
         let exec_result = vm.lua.load(&script_content).exec();
         vm.lua.remove_hook();


### PR DESCRIPTION
## Summary

Resolves Dependabot #236. mlua 0.11 has exactly one breaking change that affects DBFlux: `Lua::set_hook` now returns `Result<()>` instead of `()`. Under CI's `clippy -- -D warnings`, the dropped `Result` was a hard error (`unused_must_use`) — the reason the Dependabot PR failed.

- Root `Cargo.toml`: `mlua = "0.10"` → `"0.11"` (resolves to 0.11.6).
- `crates/dbflux_lua/src/executor.rs`: propagate `set_hook`'s `Result` via `.map_err(|e| format!("Failed to install Lua hook: {e}"))?`, matching the function's existing `Result<_, String>` return.

Runtime behavior is unchanged: the instruction-count hook installs and runs identically; an install failure (e.g. OOM) is now surfaced as an error instead of being silently dropped — a strict improvement. The `lua54`/`send`/`vendored` feature combo and every other mlua API in use are unchanged in 0.11.

## Test plan

- `cargo clippy -p dbflux_lua -- -D warnings` and `cargo clippy --workspace --features "<all drivers>" -- -D warnings`: zero warnings (the gate Dependabot failed).
- `cargo nextest run -p dbflux_lua`: 39/39 pass, including the recently de-flaked `run_process_cancellation_streams_partial_stdout_and_stderr`.
- Full workspace check with all drivers: clean.

Closes #236