### PR TITLE
deps: migrate rusqlite 0.32 -> 0.40

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3886,6 +3886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "font-types"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4803,9 +4809,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
-]
 
 [[package]]
 name = "hashbrown"
@@ -4815,7 +4818,16 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -4823,14 +4835,17 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -5907,9 +5922,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
  "pkg-config",
@@ -8318,10 +8333,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
+name = "rsqlite-vfs"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
 dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator 0.3.0",
@@ -8329,6 +8354,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -9280,6 +9306,18 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ thiserror = "2"
 secrecy = "0.10"
 age = { version = "0.11", features = ["armor"] }
 dirs = "6"
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.40", features = ["bundled"] }
 tokio-postgres = "0.7"
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 log = "0.4"

--- a/crates/dbflux_storage/src/repositories/audit.rs
+++ b/crates/dbflux_storage/src/repositories/audit.rs
@@ -599,7 +599,7 @@ impl AuditRepository {
 
         let deleted = conn.execute(
             "DELETE FROM aud_audit_events WHERE created_at_epoch_ms < ?1 LIMIT ?2",
-            rusqlite::params![cutoff_ms, limit],
+            rusqlite::params![cutoff_ms, limit as i64],
         )?;
 
         Ok(deleted as i64)


### PR DESCRIPTION
## Summary

Resolves Dependabot #241 (an 8-minor-version jump that failed to compile). Despite the version span, DBFlux's usage hits exactly one breaking change: rusqlite 0.38 stopped implementing `ToSql` for `usize` by default, so the audit purge's `LIMIT ?2` bind (a `usize` batch size) no longer compiled.

- Root `Cargo.toml`: `rusqlite` `0.32` → `0.40` (bundled). `cargo update` moves libsqlite3-sys 0.30 → 0.38.
- `crates/dbflux_storage/src/repositories/audit.rs`: cast `limit as i64` at the bind site (`delete_older_than`'s public `usize` signature is unchanged).

Every other feared breakage across 0.33–0.40 (scalar-function `Fn` bound, multi-statement `prepare`/`execute`, optional statement cache, `ValueRef` error type, named-param `BindIndex`, VTab macro) does not apply — DBFlux uses none of those. The `column_decltype` (sqlite driver) and `trace` (storage dev) features remain supported. Bundled SQLite moves 3.45 → 3.51; wire format and standard SQL are unchanged.

## Test plan

- `cargo clippy -p dbflux_storage -p dbflux_driver_sqlite -- -D warnings`: clean.
- `cargo nextest run -p dbflux_storage`: 217 pass; `-p dbflux_driver_sqlite`: 43 pass.
- Full workspace check with all drivers: clean.

Closes #241