### PR TITLE
test(lua): drop redundant flaky run_process streaming test

### DIFF
--- a/crates/dbflux_lua/src/api/dbflux.rs
+++ b/crates/dbflux_lua/src/api/dbflux.rs
@@ -493,40 +493,11 @@ mod tests {
         assert_eq!(event.text, "hello-log\n");
     }
 
-    #[test]
-    fn run_process_streams_stdout_and_stderr() {
-        let lua = Lua::new();
-        let (sender, receiver) = dbflux_core::output_channel();
-        let state = test_state(None, Instant::now(), Some(sender));
-        let options = process_options(&lua, python_program()).unwrap();
-        let args = lua.create_table().unwrap();
-
-        args.set(1, "-c").unwrap();
-        args.set(
-            2,
-            "import sys; sys.stdout.write('out\\n'); sys.stdout.flush(); sys.stderr.write('err\\n'); sys.stderr.flush()",
-        )
-        .unwrap();
-        options.set("args", args).unwrap();
-        options.set("stream", true).unwrap();
-        options.set("timeout_ms", 30000_i64).unwrap();
-
-        // The process writes to both streams and exits normally, so run_process drains
-        // and joins both output readers before returning — every byte is delivered with
-        // no kill race to observe. Verifying streaming under cancellation instead would
-        // be inherently racy: a killed process can lose still-buffered output.
-        run_process(&lua, &state, options).unwrap();
-
-        let events: Vec<_> = receiver.try_iter().collect();
-
-        assert!(events.iter().any(|event| {
-            event.stream == OutputStreamKind::Stdout && event.text.contains("out")
-        }));
-        assert!(events.iter().any(|event| {
-            event.stream == OutputStreamKind::Stderr && event.text.contains("err")
-        }));
-    }
-
+    // Streaming of a child's stdout/stderr is covered directly in dbflux_core by
+    // `process_executor_emits_streaming_output_events`, `execute_captures_stderr`, and
+    // `execute_streaming_process_emits_partial_line_output_before_newline`. A
+    // run_process-level variant added nothing but a real `python3` spawn, which is
+    // flaky under CI process pressure, so it is intentionally not duplicated here.
     #[test]
     fn run_process_cancellation_returns_cancelled_error() {
         let lua = Lua::new();


### PR DESCRIPTION
## Summary

`run_process_streams_stdout_and_stderr` (added in #251) spawned a real `python3` child to verify stdout/stderr streaming. Under the heavy parallel CI suite on a 2-core runner, spawning the python interpreter intermittently failed (EAGAIN), so `run_process` returned a spawn error and the test's `.unwrap()` panicked — a new flaky path.

The streaming behavior it checked is already covered directly in `dbflux_core`:
- `process_executor_emits_streaming_output_events`
- `execute_captures_stderr`
- `execute_streaming_process_emits_partial_line_output_before_newline`

Those use a lightweight `sh`/`cmd` child (not behind the Lua program allowlist, which is why they can't be reused verbatim at the dbflux_lua level). Removing the duplicate eliminates the last flaky path. `run_process`'s cancellation contract remains covered by the deterministic `run_process_cancellation_returns_cancelled_error` (pre-set token, no spawn).

This is the final piece of the flake cleanup — the underlying product bug (cancellation outcome masked by a cleanup error) and the deterministic cancellation test landed in #251.

## Test plan

- `cargo clippy -p dbflux_lua -- -D warnings`: clean (no unused imports).
- `cargo nextest run -p dbflux_lua`: 39 pass.