### PR TITLE
ci: fix packaged builds broken by --locked + version stamp

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,7 +107,11 @@ jobs:
         run: sed -i 's/^version = ".*"/version = "${{ inputs.version }}"/' Cargo.toml
 
       - name: Build DBFlux
-        run: cargo build --release --locked --features "$FEATURES" --target ${{ matrix.target }}
+        # No --locked here: the version stamp above mutates Cargo.toml, so cargo must
+        # refresh the workspace entries in Cargo.lock. Dependency-lock integrity is
+        # already enforced by the deterministic-tests and clippy gates (--locked) on
+        # this same commit; here only the local workspace version changes.
+        run: cargo build --release --features "$FEATURES" --target ${{ matrix.target }}
 
       - name: Create package
         run: |
@@ -376,7 +380,9 @@ jobs:
         # target instead of linking the runner's system OpenSSL. Required to
         # cross-compile x86_64 on the Apple Silicon runner (no x86_64 OpenSSL is
         # present), and keeps both macOS binaries self-contained at runtime.
-        run: cargo build --release --locked --features "$FEATURES,vendored-openssl" --target ${{ matrix.target }}
+        # No --locked: the version stamp above mutates Cargo.toml; see the Linux build
+        # step for the full rationale.
+        run: cargo build --release --features "$FEATURES,vendored-openssl" --target ${{ matrix.target }}
 
       - name: Create app bundle
         run: |
@@ -490,7 +496,9 @@ jobs:
           (Get-Content Cargo.toml) -replace '^version = ".*"', 'version = "${{ inputs.version }}"' | Set-Content Cargo.toml
 
       - name: Build DBFlux
-        run: cargo build --release --locked --features "$env:FEATURES" --target x86_64-pc-windows-msvc
+        # No --locked: the version stamp above mutates Cargo.toml; see the Linux build
+        # step for the full rationale.
+        run: cargo build --release --features "$env:FEATURES" --target x86_64-pc-windows-msvc
 
       - name: Install ImageMagick
         run: choco install imagemagick -y


### PR DESCRIPTION
## What

Removes `--locked` from the three version-stamped `cargo build` steps in the reusable `build.yml` (Linux, macOS, Windows).

## Why

The nightly run failed on every platform (exit 101) with:

```
error: cannot update the lock file Cargo.lock because --locked was passed to prevent this
```

The packaged builds stamp the workspace version into `Cargo.toml` (`sed .../version = "…-nightly+<sha>"`) **before** compiling. That mutates the workspace package version, so `Cargo.lock`'s workspace entries no longer match and cargo must refresh them — which `--locked` forbids.

`--locked` was added to these steps by the CI supply-chain hardening (#226) without accounting for the pre-build version stamp. Before #226 these builds ran plain `cargo build --release` and succeeded for months.

`build.yml` is shared by **both** `nightly.yml` and `release.yml`, so this also would have broken the next stable `v0.7.0` tag, not just nightly.

## Safety

Dependency-lock integrity is still enforced: the `deterministic-tests` and `clippy` gates run `--locked` on the same commit with no version stamp. The packaged build's only extra mutation is its own workspace version — a local-only change that plain `cargo build` propagates into the lock without touching any dependency versions.

## Validation

CI here proves it compiles `--locked` on this commit. The packaged-build path itself only runs on nightly/release; this restores the exact pre-#226 behavior for those steps.