### PR TITLE
ci: fix Windows installer broken by Inno-Setup-Action v1.2.8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -534,9 +534,12 @@ jobs:
 
       - name: Build installer
         uses: Minionguyjpro/Inno-Setup-Action@202dd0c4950ef315b6ba13359998fe120179b147  # v1.2.8
+        env:
+          DBFLUX_APP_NAME: ${{ env.APP_NAME }}
+          DBFLUX_APP_ID: ${{ env.MY_APP_ID }}
+          DBFLUX_APP_VERSION: ${{ inputs.version }}
         with:
           path: installer/installer.iss
-          options: /DMyAppVersion=${{ inputs.version }} /DMyAppName="${{ env.APP_NAME }}" /DMyAppId="${{ env.MY_APP_ID }}"
 
       - name: Move installer
         run: Move-Item installer/output/dbflux-windows-amd64-setup.exe dbflux-windows-amd64-setup.exe -Force

--- a/resources/windows/installer.iss
+++ b/resources/windows/installer.iss
@@ -1,11 +1,27 @@
+; Values are read from the environment so the build workflow does not pass them
+; through the Inno-Setup-Action `options` input. Forwarding /D defines whose
+; values contain spaces (e.g. "DBFlux Nightly") breaks under the action's
+; argument splitting, making ISCC mistake the rest for a second script filename.
 #ifndef MyAppName
+#define MyAppName GetEnv("DBFLUX_APP_NAME")
+#if MyAppName == ""
+#undef MyAppName
 #define MyAppName "DBFlux"
 #endif
+#endif
 #ifndef MyAppId
+#define MyAppId GetEnv("DBFLUX_APP_ID")
+#if MyAppId == ""
+#undef MyAppId
 #define MyAppId "{{D8A3E981-6A8D-4B8F-9E09-86D8DEB7A6F1}"
 #endif
+#endif
 #ifndef MyAppVersion
+#define MyAppVersion GetEnv("DBFLUX_APP_VERSION")
+#if MyAppVersion == ""
+#undef MyAppVersion
 #define MyAppVersion "0.7.0-dev.0"
+#endif
 #endif
 #define MyAppPublisher "Ignacio Perez"
 #define MyAppURL "https://github.com/0xErwin1/dbflux"


### PR DESCRIPTION
## What

The nightly Windows job now fails at the installer step:

```
Execution failed: You may not specify more than one script filename.
```

## Why

The `Inno-Setup-Action` bump 1.2.2 → 1.2.8 (#230) rewrote the action into an ES module that re-splits the `options` input on spaces. We pass `/DMyAppName="${{ env.APP_NAME }}"`, and on the **nightly** channel `APP_NAME` is `DBFlux Nightly` — the space splits the argument, so ISCC reads `Nightly` as a second script filename and aborts.

Stable releases were unaffected (their app name is `DBFlux`, no space), which is why only nightly broke.

This surfaced only after #254 fixed the earlier `--locked` failure that was killing the build before it ever reached the installer step. Linux and macOS already build, package, sign, and upload cleanly on the latest nightly.

## Fix

Read `MyAppName` / `MyAppId` / `MyAppVersion` from the environment via Inno's `GetEnv` in `installer.iss`, and pass them as step `env:` instead of through `options`. This sidesteps the action's argument splitting entirely and is independent of the action version.

Kept v1.2.8 (rather than reverting to v1.2.2) because v1.2.7+ self-installs Inno Setup, which matters now that newer `windows-latest` images no longer ship it preinstalled.

## Validation

ISCC only runs on Windows, so this is validated by the nightly Windows build after merge (manual `workflow_dispatch`). The `.iss` still falls back to the previous literals when the env vars are unset, so local/default behavior is unchanged.