### PR TITLE
chore(ci): silence unfixable transitive security advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,17 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    ignore:
+      # Transitive crates whose advisory fix is unreachable without bumping a
+      # parent we do not control directly. Dependabot's security updater fails
+      # these on every run (security_update_not_possible); ignore them until the
+      # parents ship a compatible release, then remove the matching entry.
+      #   lru           pulled by the `mysql` crate; fix needs lru >= 0.16.3
+      #   grid          pulled by taffy -> gpui; fix needs grid >= 1.0.1
+      #   rustls-webpki pulled by the rustls/TLS stack (tracked by DEP-5); fix needs >= 0.103.13
+      - dependency-name: "lru"
+      - dependency-name: "grid"
+      - dependency-name: "rustls-webpki"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## What

Adds `ignore` conditions to the cargo block of `dependabot.yml` for three crates: `lru`, `grid`, `rustls-webpki`.

## Why

Dependabot's **security** updater runs on each scan and fails all three with `security_update_not_possible`. They are **transitive** dependencies whose patched version is unreachable without bumping a parent crate we do not control directly:

| Crate | Have (max resolvable) | Advisory needs | Parent that pins it |
|---|---|---|---|
| `lru` | 0.12.5 | 0.16.3 | the `mysql` crate (`dbflux_driver_mysql`) |
| `grid` | 0.18.0 | 1.0.1 | `taffy` → `gpui` |
| `rustls-webpki` | 0.101.7 | 0.103.13 | the `rustls`/TLS stack (tracked by DEP-5) |

Dependabot cannot open a PR for any of them, so the jobs sit perpetually red in the Dependabot tab with no actionable fix. These are non-blocking already (cargo-deny advisories run `continue-on-error`), so nothing in CI gates on them.

## Scope

This silences the **recurring updater failures**, not the advisories themselves. Each ignore entry documents the parent and the version the fix requires; the entry is removed once that parent ships a compatible release. `rustls-webpki` resolves as part of the deferred DEP-5 TLS-stack migration.

Optional follow-up (not in this PR): add the matching RUSTSEC IDs to `deny.toml` `[advisories].ignore` to also quiet the non-blocking cargo-deny warnings.