### PR TITLE
chore(ci): patch+minor monthly dependabot policy with cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,20 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      # Batch routine minor/patch bumps into a single PR to avoid a flood of
+      # individual PRs. Majors stay ungrouped so each compile-breaking bump is
+      # reviewed and migrated on its own.
+      cargo-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     ignore:
       # Transitive crates whose advisory fix is unreachable without bumping a
       # parent we do not control directly. Dependabot's security updater fails
       # these on every run (security_update_not_possible); ignore them until the
       # parents ship a compatible release, then remove the matching entry.
-      #   lru           pulled by the `mysql` crate; fix needs lru >= 0.16.3
       #   grid          pulled by taffy -> gpui; fix needs grid >= 1.0.1
       #   rustls-webpki pulled by the rustls/TLS stack (tracked by DEP-5); fix needs >= 0.103.13
-      - dependency-name: "lru"
       - dependency-name: "grid"
       - dependency-name: "rustls-webpki"
   - package-ecosystem: github-actions
@@ -21,3 +26,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      github-actions-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,17 +6,20 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
-      # Batch routine minor/patch bumps into a single PR to avoid a flood of
-      # individual PRs. Majors stay ungrouped so each compile-breaking bump is
-      # reviewed and migrated on its own.
-      cargo-minor-patch:
+      # Batch the patch bumps into a single PR per run instead of one PR each.
+      cargo-patches:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
+        update-types: ["patch"]
     ignore:
+      # Patch-only policy: hold all major and minor version updates to cut update
+      # churn. Security updates still fire regardless of this filter.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
       # Transitive crates whose advisory fix is unreachable without bumping a
-      # parent we do not control directly. Dependabot's security updater fails
-      # these on every run (security_update_not_possible); ignore them until the
-      # parents ship a compatible release, then remove the matching entry.
+      # parent we do not control directly; remove the entry once the parent ships
+      # a compatible release.
       #   grid          pulled by taffy -> gpui; fix needs grid >= 1.0.1
       #   rustls-webpki pulled by the rustls/TLS stack (tracked by DEP-5); fix needs >= 0.103.13
       - dependency-name: "grid"
@@ -27,6 +30,13 @@ updates:
       interval: weekly
     open-pull-requests-limit: 10
     groups:
-      github-actions-minor-patch:
+      github-actions-patches:
         patterns: ["*"]
-        update-types: ["minor", "patch"]
+        update-types: ["patch"]
+    ignore:
+      # Patch-only policy for actions too: hold major/minor bumps (a major action
+      # bump broke the nightly Windows installer once); take only patches.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,20 +3,24 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
+      interval: monthly
+    open-pull-requests-limit: 5
+    cooldown:
+      # Wait at least two weeks after a release before opening a PR, so a
+      # malicious or broken version that gets yanked shortly after publish is
+      # never picked up (supply-chain mitigation). Does not apply to security
+      # updates, which must land immediately.
+      default-days: 14
     groups:
-      # Batch the patch bumps into a single PR per run instead of one PR each.
-      cargo-patches:
+      # One grouped PR per run for routine patch + minor bumps.
+      cargo-updates:
         patterns: ["*"]
-        update-types: ["patch"]
+        update-types: ["minor", "patch"]
     ignore:
-      # Patch-only policy: hold all major and minor version updates to cut update
-      # churn. Security updates still fire regardless of this filter.
+      # Majors are opt-in: bump them deliberately in-repo, not via a Dependabot PR.
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-          - "version-update:semver-minor"
       # Transitive crates whose advisory fix is unreachable without bumping a
       # parent we do not control directly; remove the entry once the parent ships
       # a compatible release.
@@ -27,16 +31,15 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
+      interval: monthly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
     groups:
-      github-actions-patches:
+      github-actions-updates:
         patterns: ["*"]
-        update-types: ["patch"]
+        update-types: ["minor", "patch"]
     ignore:
-      # Patch-only policy for actions too: hold major/minor bumps (a major action
-      # bump broke the nightly Windows installer once); take only patches.
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
-          - "version-update:semver-minor"


### PR DESCRIPTION
## What

Reworks the Dependabot config to a low-noise, supply-chain-aware policy and drops the now-fixed `lru` ignore.

## Policy

- **patch + minor only**, grouped into one PR per ecosystem per run. **Majors are ignored** — bumped deliberately in-repo when wanted (as we did for sha1/mysql/bincode/testcontainers), not via a reactive PR for each.
- **monthly** schedule + `open-pull-requests-limit: 5` → at most one small grouped PR per ecosystem per month.
- **14-day cooldown**: a release must age two weeks before a PR is opened, so a malicious or broken version that is yanked shortly after publish is never adopted. Cooldown does **not** apply to security updates — those land immediately (the vulnerable version is the old one).
- `Cargo.toml` requirements stay caret (`^`); the exact, reproducible pin is the committed `Cargo.lock` enforced by `--locked` in CI, so nothing drifts silently. Switching to `=` exact requirements is intentionally avoided — it breaks resolver unification across the workspace's shared transitive deps and adds nothing over the lockfile.

## lru

`lru` was ignored in #256 because its advisory fix was unreachable. mysql 25→28 (#258) pulls `lru` **0.16.4** (≥ the advisory's 0.16.3), so it is resolved and the ignore is removed. `grid` and `rustls-webpki` remain ignored (still gated by taffy/gpui and the rustls/TLS stack).