### PR TITLE
ci: fix macOS amd64 cross-compile broken by toolchain pin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -364,6 +364,14 @@ jobs:
           targets: ${{ matrix.target }}
           components: rust-src
 
+      - name: Add cross target to the pinned toolchain
+        # rust-toolchain.toml pins the toolchain cargo actually uses; the step
+        # above adds the target to `stable` instead, so the x86_64-apple-darwin
+        # std is missing on the pinned toolchain when cross-compiling amd64 on the
+        # Apple Silicon runner. Add it to the pinned toolchain. No-op for the
+        # native arm64 target.
+        run: rustup target add ${{ matrix.target }}
+
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:


### PR DESCRIPTION
## What

Adds an explicit `rustup target add ${{ matrix.target }}` to the macOS build job so the cross-compilation target's std lands on the **pinned** toolchain.

## Why

The latest nightly builds Linux (x64/arm64), macOS arm64, and the Windows installer cleanly, but **macOS amd64 fails** in ~1 min:

```
error[E0463]: can't find crate for `core`
note: the `x86_64-apple-darwin` target may not be installed
```

macOS amd64 is the only true cross-compile in the matrix (both macOS archs run on `macos-14` / Apple Silicon, so x86_64 is cross-built on arm64). #225 pinned the toolchain via `rust-toolchain.toml` (`1.95.0`), which is what cargo uses — but the `dtolnay/rust-toolchain` step adds `targets:` to `stable`, not to `1.95.0`. So the x86_64-apple-darwin std is absent on the toolchain cargo runs, and the cross-compile can't find `core`.

This was deterministic from the moment #225 merged (2026-06-22 11:01, after the last green nightly at 04:53); it was masked until now by the earlier `--locked` (#254) and Inno-installer (#255) failures that killed the build sooner.

## Fix

`rustup target add ${{ matrix.target }}` runs in the repo (where rust-toolchain.toml is active), so the target is added to the **pinned** 1.95.0 toolchain. No-op for the native arm64 target. DRY — no toolchain version duplicated into the workflow.

`build.yml` is shared by nightly and release, so this also unblocks the macOS amd64 binary in the next stable `v0.7.0`.

## Validation

CI here only confirms no Rust regression; the cross-compile path runs on nightly/release. Validated by triggering Nightly after merge.