### PR TITLE
refactor(ipc): replace unmaintained bincode with postcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,15 +1262,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,6 +1745,15 @@ name = "cmov"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cocoa"
@@ -2709,11 +2718,11 @@ name = "dbflux_ipc"
 version = "0.7.0-dev.0"
 dependencies = [
  "async-trait",
- "bincode",
  "dbflux_core",
  "dbflux_storage",
  "interprocess",
  "log",
+ "postcard",
  "secrecy",
  "serde",
  "serde_json",
@@ -3353,6 +3362,18 @@ dependencies = [
  "vswhom",
  "winreg",
 ]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encoding_rs"
@@ -4602,6 +4623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4641,6 +4671,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5081f264ed7adee96ea4b4778b6bb9da0a7228b084587aa3bd3ff05da7c5a3b"
 dependencies = [
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -7285,6 +7329,19 @@ dependencies = [
  "pollster 0.2.5",
  "static_assertions",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
 anyhow = "1"
-bincode = "1"
+postcard = { version = "1", features = ["use-std"] }
 lsp-types = "0.97"
 toml = "1"
 uuid = { version = "1", features = ["v4", "v5", "v7", "serde"] }

--- a/crates/dbflux_ipc/Cargo.toml
+++ b/crates/dbflux_ipc/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
-bincode = { workspace = true }
+postcard = { workspace = true }
 interprocess.workspace = true
 dbflux_core.workspace = true
 dbflux_storage.workspace = true

--- a/crates/dbflux_ipc/src/framing.rs
+++ b/crates/dbflux_ipc/src/framing.rs
@@ -5,7 +5,7 @@ use std::io::{self, Read, Write};
 const MAX_MSG_SIZE: u32 = 16 * 1024 * 1024;
 
 pub fn send_msg<W: Write, T: Serialize>(mut writer: W, msg: &T) -> io::Result<()> {
-    let bytes = bincode::serialize(msg).map_err(io::Error::other)?;
+    let bytes = postcard::to_allocvec(msg).map_err(io::Error::other)?;
     let len = bytes.len() as u32;
 
     if len > MAX_MSG_SIZE {
@@ -36,7 +36,7 @@ pub fn recv_msg<R: Read, T: DeserializeOwned>(mut reader: R) -> io::Result<T> {
         ));
     }
 
-    bincode::deserialize(&buf).map_err(io::Error::other)
+    postcard::from_bytes(&buf).map_err(io::Error::other)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Replaces `bincode` with `postcard` for the IPC framing in `dbflux_ipc` (`send_msg`/`recv_msg`).

## Why

Dependabot proposed bincode 1.3.3 → 3.0.0 (#264), but on inspection:
- **bincode is unmaintained** (maintainer stepped back).
- **bincode 3.0.0 fails to build on docs.rs** and ships an empty feature set — **no `serde` feature**, which our framing depends on (it serializes arbitrary serde `T`). Adopting it would require rewriting every IPC message type to bincode-native `Encode`/`Decode` derives.
- bincode 1.3.3 has no security advisory, but the crate is a dead end.

`postcard` is a maintained, serde-based binary format. The migration is a drop-in for our usage:
- `bincode::serialize` → `postcard::to_allocvec`
- `bincode::deserialize` → `postcard::from_bytes`

The 4-byte LE length prefix, 16 MiB size cap, and short-body `UnexpectedEof` handling are unchanged.

## Wire-format change

This is the transport encoding between the host and external RPC driver/auth-provider subprocesses. The host and all in-tree drivers move together. Third-party external drivers built against the old bincode framing must rebuild against this protocol — acceptable during `0.7.0-dev`. Example driver lockfiles regenerate on their next build.

## Validation

`cargo clippy -p dbflux_ipc --all-targets -- -D warnings` clean; `cargo test -p dbflux_ipc framing` passes, including the 4 MiB send/recv round-trip that exercises the new encoder end-to-end. `Cargo.lock` is `--locked`-consistent with bincode removed.

Closes #264.