### PR TITLE
test: migrate testcontainers 0.15 -> 0.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -179,7 +179,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -307,6 +307,22 @@ dependencies = [
  "serde_repr",
  "url",
  "zbus",
+]
+
+[[package]]
+name = "astral-tokio-tar"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.2",
+ "tokio",
+ "tokio-stream",
+ "xattr 1.6.1",
 ]
 
 [[package]]
@@ -509,6 +525,28 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1180,6 +1218,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1446,13 +1527,86 @@ dependencies = [
 ]
 
 [[package]]
-name = "bollard-stubs"
-version = "1.42.0-rc.3"
+name = "bollard"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "bitflags 2.13.0",
+ "bollard-buildkit-proto",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-named-pipe",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "num",
+ "pin-project-lite",
+ "rand 0.9.4",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.8.3",
+ "rustls-pki-types",
  "serde",
- "serde_with 1.14.0",
+ "serde_derive",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-buildkit-proto"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "time",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1466,7 +1620,7 @@ dependencies = [
  "bitvec",
  "getrandom 0.3.4",
  "hex",
- "indexmap",
+ "indexmap 2.14.0",
  "js-sys",
  "rand 0.9.4",
  "serde",
@@ -1604,7 +1758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
 dependencies = [
  "heck 0.4.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "proc-macro2",
  "quote",
@@ -2281,36 +2435,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core 0.13.4",
- "darling_macro 0.13.4",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn 1.0.109",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -2322,19 +2452,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core 0.13.4",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2343,7 +2462,7 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -2410,7 +2529,7 @@ dependencies = [
  "dbflux_ssh",
  "dbflux_ssm",
  "dbflux_storage",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde_json",
  "tokio",
@@ -2618,7 +2737,7 @@ dependencies = [
  "dbflux_ssh",
  "dbflux_test_support",
  "hex",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde_json",
  "sha2 0.11.0",
@@ -2769,7 +2888,7 @@ dependencies = [
  "log",
  "rmcp",
  "rusqlite",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -3051,6 +3170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -3205,7 +3325,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3244,6 +3364,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29547a1dc60885a552306986316bc9701ba120c1a8db6769fa68691529ad373d"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3474,7 +3605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3485,6 +3616,16 @@ checksum = "fc89bf99e5dc15954a60f707c1e09d7540e5cd9af85fa75caa0b510bc08c5342"
 dependencies = [
  "euclid",
  "svg_fmt",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3584,6 +3725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ferroid"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+dependencies = [
+ "portable-atomic",
+ "rand 0.10.1",
+ "web-time",
 ]
 
 [[package]]
@@ -4255,7 +4407,7 @@ dependencies = [
  "rand 0.9.4",
  "raw-window-handle",
  "resvg",
- "schemars",
+ "schemars 1.2.1",
  "seahash",
  "serde",
  "serde_json",
@@ -4312,7 +4464,7 @@ dependencies = [
  "regex",
  "ropey",
  "rust-i18n",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4383,7 +4535,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae39dc6d3d201be97e4bc08d96dbef2bc5b5c3d5734e05786e8cc3043342351c"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "rustc-hash 2.1.2",
 ]
 
@@ -4506,7 +4658,7 @@ dependencies = [
  "rand 0.9.4",
  "regex",
  "rust-embed",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_json_lenient",
@@ -4560,7 +4712,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4579,7 +4731,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4597,6 +4749,12 @@ dependencies = [
  "num-traits",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -4915,11 +5073,27 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
 ]
 
 [[package]]
@@ -4955,6 +5129,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4971,10 +5158,25 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -5025,7 +5227,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.117",
  "unic-langid",
 ]
@@ -5055,7 +5257,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5243,6 +5445,17 @@ name = "imgref"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -6022,6 +6235,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6244,12 +6463,12 @@ dependencies = [
  "rustls 0.23.40",
  "serde",
  "serde_bytes",
- "serde_with 3.20.0",
+ "serde_with",
  "sha1 0.10.6",
  "sha2 0.10.9",
  "socket2 0.6.3",
  "stringprep",
- "strsim 0.11.1",
+ "strsim",
  "take_mut",
  "thiserror 2.0.18",
  "tokio",
@@ -6311,7 +6530,7 @@ version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4db8a44120571277accfaa3f3d91e7d3989d601d817c2fc01a9391b86135666"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "heck 0.5.0",
  "manyhow",
  "num-bigint",
@@ -6364,7 +6583,7 @@ dependencies = [
  "half",
  "hashbrown 0.15.5",
  "hexf-parse",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "num-traits",
  "once_cell",
@@ -6532,7 +6751,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6987,6 +7206,31 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7480,6 +7724,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7541,7 +7817,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7578,7 +7854,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8046,7 +8322,7 @@ dependencies = [
  "pastey 0.2.3",
  "pin-project-lite",
  "rmcp-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -8061,7 +8337,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -8257,7 +8533,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8457,13 +8733,25 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "chrono",
  "dyn-clone",
- "indexmap",
+ "indexmap 2.14.0",
  "ref-cast",
  "schemars_derive",
  "serde",
@@ -8690,7 +8978,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -8704,7 +8992,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e033097bf0d2b59a62b42c18ebbb797503839b26afdda2c4e1415cb6c813540"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "ryu",
@@ -8754,34 +9042,22 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros 1.5.2",
-]
-
-[[package]]
-name = "serde_with"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
  "serde_core",
- "serde_with_macros 3.20.0",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling 0.13.4",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "serde_json",
+ "serde_with_macros",
+ "time",
 ]
 
 [[package]]
@@ -8790,7 +9066,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8802,7 +9078,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -9011,7 +9287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9093,7 +9369,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9182,15 +9458,32 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "strum"
@@ -9507,7 +9800,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9532,19 +9825,33 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.15.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d2931d7f521af5bae989f716c3fa43a6af9af7ec7a5e21b59ae40878cec00"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
 dependencies = [
- "bollard-stubs",
+ "astral-tokio-tar",
+ "async-trait",
+ "bollard",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "ferroid",
  "futures",
- "hex",
- "hmac 0.12.1",
+ "http 1.4.0",
+ "itertools 0.14.0",
  "log",
- "rand 0.8.6",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -9827,6 +10134,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9868,7 +10186,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -9901,7 +10219,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -9915,7 +10233,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.3",
@@ -9943,6 +10261,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "h2 0.4.14",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.3",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9950,11 +10308,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.14.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -10470,7 +10832,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10614,6 +10976,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10664,6 +11053,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -10920,7 +11315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -10946,7 +11341,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -11144,7 +11539,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11704,7 +12099,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -11735,7 +12130,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -11754,7 +12149,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -11844,6 +12239,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -12041,7 +12446,7 @@ dependencies = [
  "libc",
  "pin-project",
  "redox_syscall 0.2.16",
- "xattr",
+ "xattr 0.2.3",
 ]
 
 [[package]]

--- a/crates/dbflux_proxy/Cargo.toml
+++ b/crates/dbflux_proxy/Cargo.toml
@@ -20,7 +20,7 @@ socks = "0.3"
 native-tls = "0.2"
 
 [dev-dependencies]
-testcontainers = "0.27"
+testcontainers = { version = "0.27", features = ["blocking"] }
 postgres = "0.19"
 uuid.workspace = true
 env_logger.workspace = true

--- a/crates/dbflux_proxy/Cargo.toml
+++ b/crates/dbflux_proxy/Cargo.toml
@@ -20,7 +20,7 @@ socks = "0.3"
 native-tls = "0.2"
 
 [dev-dependencies]
-testcontainers = "0.15"
+testcontainers = "0.27"
 postgres = "0.19"
 uuid.workspace = true
 env_logger.workspace = true

--- a/crates/dbflux_proxy/tests/live_integration.rs
+++ b/crates/dbflux_proxy/tests/live_integration.rs
@@ -7,54 +7,58 @@ use std::net::TcpStream;
 use std::time::{Duration, Instant};
 
 use dbflux_proxy::{ProxyCredentials, ProxyProtocol, ProxyTunnel, ProxyTunnelConfig};
-use testcontainers::clients::Cli;
-use testcontainers::core::WaitFor;
-use testcontainers::{GenericImage, RunnableImage};
+use testcontainers::core::{ContainerPort, WaitFor};
+use testcontainers::runners::SyncRunner;
+use testcontainers::{GenericImage, ImageExt};
 
 /// Docker bridge gateway IP — routes from inside containers back to the host.
 const DOCKER_GATEWAY: &str = "172.17.0.1";
 
-fn start_postgres(docker: &Cli) -> (testcontainers::Container<'_, GenericImage>, u16) {
+fn start_postgres() -> (testcontainers::Container<GenericImage>, u16) {
     let image = GenericImage::new("postgres", "16")
-        .with_env_var("POSTGRES_USER", "postgres")
-        .with_env_var("POSTGRES_PASSWORD", "postgres")
-        .with_env_var("POSTGRES_DB", "postgres")
-        .with_exposed_port(5432)
+        .with_exposed_port(ContainerPort::Tcp(5432))
         .with_wait_for(WaitFor::message_on_stdout(
             "database system is ready to accept connections",
-        ));
+        ))
+        .with_env_var("POSTGRES_USER", "postgres")
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .with_env_var("POSTGRES_DB", "postgres");
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(5432);
+    let container = image.start().expect("failed to start postgres container");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .expect("failed to get postgres host port");
     (container, port)
 }
 
-fn start_socks5_proxy(docker: &Cli) -> (testcontainers::Container<'_, GenericImage>, u16) {
+fn start_socks5_proxy() -> (testcontainers::Container<GenericImage>, u16) {
     let image = GenericImage::new("serjs/go-socks5-proxy", "latest")
-        .with_env_var("REQUIRE_AUTH", "false")
-        .with_exposed_port(1080)
+        .with_exposed_port(ContainerPort::Tcp(1080))
         .with_wait_for(WaitFor::message_on_stderr(
             "Start listening proxy service on",
-        ));
+        ))
+        .with_env_var("REQUIRE_AUTH", "false");
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(1080);
+    let container = image.start().expect("failed to start socks5 proxy container");
+    let port = container
+        .get_host_port_ipv4(1080)
+        .expect("failed to get socks5 proxy host port");
     (container, port)
 }
 
-fn start_socks5_proxy_with_auth(
-    docker: &Cli,
-) -> (testcontainers::Container<'_, GenericImage>, u16) {
+fn start_socks5_proxy_with_auth() -> (testcontainers::Container<GenericImage>, u16) {
     let image = GenericImage::new("serjs/go-socks5-proxy", "latest")
+        .with_exposed_port(ContainerPort::Tcp(1080))
+        .with_wait_for(WaitFor::message_on_stderr(
+            "Start listening proxy service on",
+        ))
         .with_env_var("PROXY_USER", "testuser")
-        .with_env_var("PROXY_PASSWORD", "testpass")
-        .with_exposed_port(1080)
-        .with_wait_for(WaitFor::message_on_stderr(
-            "Start listening proxy service on",
-        ));
+        .with_env_var("PROXY_PASSWORD", "testpass");
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(1080);
+    let container = image.start().expect("failed to start socks5 proxy container");
+    let port = container
+        .get_host_port_ipv4(1080)
+        .expect("failed to get socks5 proxy host port");
     (container, port)
 }
 
@@ -91,9 +95,8 @@ fn wait_for_postgres(tunnel_port: u16, timeout: Duration) {
 fn socks5_tunnel_connects_to_postgres() {
     let _ = env_logger::try_init();
 
-    let docker = Cli::default();
-    let (_pg_container, pg_port) = start_postgres(&docker);
-    let (_proxy_container, proxy_port) = start_socks5_proxy(&docker);
+    let (_pg_container, pg_port) = start_postgres();
+    let (_proxy_container, proxy_port) = start_socks5_proxy();
 
     let config = ProxyTunnelConfig {
         protocol: ProxyProtocol::Socks5,
@@ -136,9 +139,8 @@ fn socks5_tunnel_connects_to_postgres() {
 fn socks5_tunnel_with_auth_connects_to_postgres() {
     let _ = env_logger::try_init();
 
-    let docker = Cli::default();
-    let (_pg_container, pg_port) = start_postgres(&docker);
-    let (_proxy_container, proxy_port) = start_socks5_proxy_with_auth(&docker);
+    let (_pg_container, pg_port) = start_postgres();
+    let (_proxy_container, proxy_port) = start_socks5_proxy_with_auth();
 
     let config = ProxyTunnelConfig {
         protocol: ProxyProtocol::Socks5,
@@ -178,9 +180,8 @@ fn socks5_tunnel_with_auth_connects_to_postgres() {
 fn socks5_tunnel_wrong_auth_fails() {
     let _ = env_logger::try_init();
 
-    let docker = Cli::default();
-    let (_pg_container, pg_port) = start_postgres(&docker);
-    let (_proxy_container, proxy_port) = start_socks5_proxy_with_auth(&docker);
+    let (_pg_container, pg_port) = start_postgres();
+    let (_proxy_container, proxy_port) = start_socks5_proxy_with_auth();
 
     let config = ProxyTunnelConfig {
         protocol: ProxyProtocol::Socks5,
@@ -201,8 +202,7 @@ fn socks5_tunnel_wrong_auth_fails() {
 fn socks5_tunnel_unreachable_target_fails() {
     let _ = env_logger::try_init();
 
-    let docker = Cli::default();
-    let (_proxy_container, proxy_port) = start_socks5_proxy(&docker);
+    let (_proxy_container, proxy_port) = start_socks5_proxy();
 
     let config = ProxyTunnelConfig {
         protocol: ProxyProtocol::Socks5,
@@ -221,9 +221,8 @@ fn socks5_tunnel_unreachable_target_fails() {
 fn socks5_tunnel_multiple_connections() {
     let _ = env_logger::try_init();
 
-    let docker = Cli::default();
-    let (_pg_container, pg_port) = start_postgres(&docker);
-    let (_proxy_container, proxy_port) = start_socks5_proxy(&docker);
+    let (_pg_container, pg_port) = start_postgres();
+    let (_proxy_container, proxy_port) = start_socks5_proxy();
 
     let config = ProxyTunnelConfig {
         protocol: ProxyProtocol::Socks5,
@@ -265,9 +264,8 @@ fn socks5_tunnel_multiple_connections() {
 fn socks5_tunnel_drops_cleanly() {
     let _ = env_logger::try_init();
 
-    let docker = Cli::default();
-    let (_pg_container, pg_port) = start_postgres(&docker);
-    let (_proxy_container, proxy_port) = start_socks5_proxy(&docker);
+    let (_pg_container, pg_port) = start_postgres();
+    let (_proxy_container, proxy_port) = start_socks5_proxy();
 
     let config = ProxyTunnelConfig {
         protocol: ProxyProtocol::Socks5,
@@ -300,14 +298,16 @@ fn socks5_tunnel_drops_cleanly() {
 // HTTP CONNECT tests
 // ---------------------------------------------------------------------------
 
-fn start_tinyproxy(docker: &Cli) -> (testcontainers::Container<'_, GenericImage>, u16) {
+fn start_tinyproxy() -> (testcontainers::Container<GenericImage>, u16) {
     let image = GenericImage::new("monokal/tinyproxy", "latest")
-        .with_exposed_port(8888)
-        .with_wait_for(WaitFor::message_on_stdout("Accepting connections"));
+        .with_exposed_port(ContainerPort::Tcp(8888))
+        .with_wait_for(WaitFor::message_on_stdout("Accepting connections"))
+        .with_cmd(vec!["ANY".to_string()]);
 
-    let args = vec!["ANY".to_string()];
-    let container = docker.run(RunnableImage::from((image, args)));
-    let port = container.get_host_port_ipv4(8888);
+    let container = image.start().expect("failed to start tinyproxy container");
+    let port = container
+        .get_host_port_ipv4(8888)
+        .expect("failed to get tinyproxy host port");
     (container, port)
 }
 
@@ -316,9 +316,8 @@ fn start_tinyproxy(docker: &Cli) -> (testcontainers::Container<'_, GenericImage>
 fn http_connect_tunnel_to_postgres() {
     let _ = env_logger::try_init();
 
-    let docker = Cli::default();
-    let (_pg_container, pg_port) = start_postgres(&docker);
-    let (_proxy_container, proxy_port) = start_tinyproxy(&docker);
+    let (_pg_container, pg_port) = start_postgres();
+    let (_proxy_container, proxy_port) = start_tinyproxy();
 
     let config = ProxyTunnelConfig {
         protocol: ProxyProtocol::HttpConnect,

--- a/crates/dbflux_proxy/tests/live_integration.rs
+++ b/crates/dbflux_proxy/tests/live_integration.rs
@@ -39,7 +39,9 @@ fn start_socks5_proxy() -> (testcontainers::Container<GenericImage>, u16) {
         ))
         .with_env_var("REQUIRE_AUTH", "false");
 
-    let container = image.start().expect("failed to start socks5 proxy container");
+    let container = image
+        .start()
+        .expect("failed to start socks5 proxy container");
     let port = container
         .get_host_port_ipv4(1080)
         .expect("failed to get socks5 proxy host port");
@@ -55,7 +57,9 @@ fn start_socks5_proxy_with_auth() -> (testcontainers::Container<GenericImage>, u
         .with_env_var("PROXY_USER", "testuser")
         .with_env_var("PROXY_PASSWORD", "testpass");
 
-    let container = image.start().expect("failed to start socks5 proxy container");
+    let container = image
+        .start()
+        .expect("failed to start socks5 proxy container");
     let port = container
         .get_host_port_ipv4(1080)
         .expect("failed to get socks5 proxy host port");

--- a/crates/dbflux_test_support/Cargo.toml
+++ b/crates/dbflux_test_support/Cargo.toml
@@ -24,6 +24,6 @@ dbflux_driver_mysql.workspace = true
 dbflux_driver_postgres.workspace = true
 dbflux_driver_redis.workspace = true
 dbflux_driver_sqlite.workspace = true
-testcontainers = "0.15"
+testcontainers = "0.27"
 interprocess.workspace = true
 reqwest = { workspace = true, default-features = false, features = ["blocking", "rustls-tls"] }

--- a/crates/dbflux_test_support/Cargo.toml
+++ b/crates/dbflux_test_support/Cargo.toml
@@ -24,6 +24,6 @@ dbflux_driver_mysql.workspace = true
 dbflux_driver_postgres.workspace = true
 dbflux_driver_redis.workspace = true
 dbflux_driver_sqlite.workspace = true
-testcontainers = "0.27"
+testcontainers = { version = "0.27", features = ["blocking"] }
 interprocess.workspace = true
 reqwest = { workspace = true, default-features = false, features = ["blocking", "rustls-tls"] }

--- a/crates/dbflux_test_support/src/containers.rs
+++ b/crates/dbflux_test_support/src/containers.rs
@@ -1,24 +1,25 @@
 use std::time::{Duration, Instant};
-use testcontainers::GenericImage;
-use testcontainers::clients::Cli;
-use testcontainers::core::WaitFor;
+use testcontainers::core::{ContainerPort, WaitFor};
+use testcontainers::runners::SyncRunner;
+use testcontainers::{GenericImage, ImageExt};
 
 pub fn with_postgres_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let docker = Cli::default();
     let image = GenericImage::new("postgres", "16")
-        .with_env_var("POSTGRES_USER", "postgres")
-        .with_env_var("POSTGRES_PASSWORD", "postgres")
-        .with_env_var("POSTGRES_DB", "postgres")
-        .with_exposed_port(5432)
+        .with_exposed_port(ContainerPort::Tcp(5432))
         .with_wait_for(WaitFor::message_on_stdout(
             "database system is ready to accept connections",
-        ));
+        ))
+        .with_env_var("POSTGRES_USER", "postgres")
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .with_env_var("POSTGRES_DB", "postgres");
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(5432);
+    let container = image.start().expect("failed to start postgres container");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .expect("failed to get postgres host port");
     let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
 
     run(url)
@@ -28,15 +29,16 @@ pub fn with_mysql_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let docker = Cli::default();
     let image = GenericImage::new("mysql", "8.4")
+        .with_exposed_port(ContainerPort::Tcp(3306))
+        .with_wait_for(WaitFor::message_on_stderr("ready for connections"))
         .with_env_var("MYSQL_ROOT_PASSWORD", "root")
-        .with_env_var("MYSQL_DATABASE", "testdb")
-        .with_exposed_port(3306)
-        .with_wait_for(WaitFor::message_on_stderr("ready for connections"));
+        .with_env_var("MYSQL_DATABASE", "testdb");
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(3306);
+    let container = image.start().expect("failed to start mysql container");
+    let port = container
+        .get_host_port_ipv4(3306)
+        .expect("failed to get mysql host port");
     let url = format!("mysql://root:root@127.0.0.1:{port}/testdb");
 
     run(url)
@@ -46,13 +48,14 @@ pub fn with_mongodb_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let docker = Cli::default();
     let image = GenericImage::new("mongo", "7")
-        .with_exposed_port(27017)
+        .with_exposed_port(ContainerPort::Tcp(27017))
         .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"));
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(27017);
+    let container = image.start().expect("failed to start mongo container");
+    let port = container
+        .get_host_port_ipv4(27017)
+        .expect("failed to get mongo host port");
     let url = format!("mongodb://127.0.0.1:{port}/testdb");
 
     run(url)
@@ -62,13 +65,14 @@ pub fn with_redis_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let docker = Cli::default();
     let image = GenericImage::new("redis", "7")
-        .with_exposed_port(6379)
+        .with_exposed_port(ContainerPort::Tcp(6379))
         .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"));
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(6379);
+    let container = image.start().expect("failed to start redis container");
+    let port = container
+        .get_host_port_ipv4(6379)
+        .expect("failed to get redis host port");
     let url = format!("redis://127.0.0.1:{port}/0");
 
     run(url)
@@ -89,18 +93,19 @@ where
     // `ACCEPT_EULA=Y` and the SA password via `MSSQL_SA_PASSWORD`. The image
     // is amd64-only; on arm64 hosts, run via emulation or substitute the
     // Azure SQL Edge image manually.
-    let docker = Cli::default();
     let image = GenericImage::new("mcr.microsoft.com/mssql/server", "2022-latest")
-        .with_env_var("ACCEPT_EULA", "Y")
-        .with_env_var("MSSQL_SA_PASSWORD", MSSQL_TEST_PASSWORD)
-        .with_env_var("MSSQL_PID", "Developer")
-        .with_exposed_port(1433)
+        .with_exposed_port(ContainerPort::Tcp(1433))
         .with_wait_for(WaitFor::message_on_stdout(
             "SQL Server is now ready for client connections",
-        ));
+        ))
+        .with_env_var("ACCEPT_EULA", "Y")
+        .with_env_var("MSSQL_SA_PASSWORD", MSSQL_TEST_PASSWORD)
+        .with_env_var("MSSQL_PID", "Developer");
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(1433);
+    let container = image.start().expect("failed to start mssql container");
+    let port = container
+        .get_host_port_ipv4(1433)
+        .expect("failed to get mssql host port");
     // Connect to `master` by default; tests that need a clean database
     // create `dbflux_test` themselves and `USE` it.
     let url = format!(
@@ -115,13 +120,14 @@ pub fn with_dynamodb_endpoint<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let docker = Cli::default();
     let image = GenericImage::new("amazon/dynamodb-local", "latest")
-        .with_exposed_port(8000)
+        .with_exposed_port(ContainerPort::Tcp(8000))
         .with_wait_for(WaitFor::message_on_stdout("Initializing DynamoDB Local"));
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(8000);
+    let container = image.start().expect("failed to start dynamodb container");
+    let port = container
+        .get_host_port_ipv4(8000)
+        .expect("failed to get dynamodb host port");
     let endpoint = format!("http://127.0.0.1:{port}");
 
     run(endpoint)
@@ -148,24 +154,25 @@ where
     E: From<dbflux_core::DbError>,
     F: FnOnce(InfluxV2Config) -> Result<T, E>,
 {
-    let docker = Cli::default();
     let token = "dbflux-test-token";
     let org = "dbflux-test-org";
     let bucket = "dbflux-test-bucket";
 
     // InfluxDB v2 logs to stdout; the "Listening" message signals HTTP readiness.
     let image = GenericImage::new("influxdb", "2.7")
+        .with_exposed_port(ContainerPort::Tcp(8086))
+        .with_wait_for(WaitFor::message_on_stdout("Listening"))
         .with_env_var("DOCKER_INFLUXDB_INIT_MODE", "setup")
         .with_env_var("DOCKER_INFLUXDB_INIT_USERNAME", "admin")
         .with_env_var("DOCKER_INFLUXDB_INIT_PASSWORD", "adminpassword")
         .with_env_var("DOCKER_INFLUXDB_INIT_ORG", org)
         .with_env_var("DOCKER_INFLUXDB_INIT_BUCKET", bucket)
-        .with_env_var("DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", token)
-        .with_exposed_port(8086)
-        .with_wait_for(WaitFor::message_on_stdout("Listening"));
+        .with_env_var("DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", token);
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(8086);
+    let container = image.start().expect("failed to start influxdb v2 container");
+    let port = container
+        .get_host_port_ipv4(8086)
+        .expect("failed to get influxdb v2 host port");
     let endpoint = format!("http://127.0.0.1:{port}");
 
     // Wait until the InfluxDB HTTP API is ready.
@@ -208,14 +215,15 @@ where
     E: From<dbflux_core::DbError>,
     F: FnOnce(InfluxV1Config) -> Result<T, E>,
 {
-    let docker = Cli::default();
     // InfluxDB v1 logs to stderr; the "Listening on HTTP" message signals readiness.
     let image = GenericImage::new("influxdb", "1.8")
-        .with_exposed_port(8086)
+        .with_exposed_port(ContainerPort::Tcp(8086))
         .with_wait_for(WaitFor::message_on_stderr("Listening on HTTP"));
 
-    let container = docker.run(image);
-    let port = container.get_host_port_ipv4(8086);
+    let container = image.start().expect("failed to start influxdb v1 container");
+    let port = container
+        .get_host_port_ipv4(8086)
+        .expect("failed to get influxdb v1 host port");
     let endpoint = format!("http://127.0.0.1:{port}");
 
     // Wait until HTTP is ready.

--- a/crates/dbflux_test_support/src/containers.rs
+++ b/crates/dbflux_test_support/src/containers.rs
@@ -169,7 +169,9 @@ where
         .with_env_var("DOCKER_INFLUXDB_INIT_BUCKET", bucket)
         .with_env_var("DOCKER_INFLUXDB_INIT_ADMIN_TOKEN", token);
 
-    let container = image.start().expect("failed to start influxdb v2 container");
+    let container = image
+        .start()
+        .expect("failed to start influxdb v2 container");
     let port = container
         .get_host_port_ipv4(8086)
         .expect("failed to get influxdb v2 host port");
@@ -220,7 +222,9 @@ where
         .with_exposed_port(ContainerPort::Tcp(8086))
         .with_wait_for(WaitFor::message_on_stderr("Listening on HTTP"));
 
-    let container = image.start().expect("failed to start influxdb v1 container");
+    let container = image
+        .start()
+        .expect("failed to start influxdb v1 container");
     let port = container
         .get_host_port_ipv4(8086)
         .expect("failed to get influxdb v1 host port");


### PR DESCRIPTION
## What

Bumps `testcontainers` 0.15 → 0.27 and migrates the Docker-backed test helpers to the new API. Supersedes the auto-closed Dependabot #265 (closed because the new patch-only policy #267 ignores majors).

## Why

testcontainers 0.27 is a large but mechanical API change. The migration keeps every image, tag, port, env var, wait condition, and container arg identical — only the API calls change.

## Changes

- `testcontainers = { version = "0.27", features = ["blocking"] }` in `dbflux_test_support` and `dbflux_proxy`.
- Removed `clients::Cli` and `RunnableImage` (both gone in 0.27); use the `SyncRunner` trait (`image.start()`), drop the `&Cli` params and the `Container` lifetime, and use `ContainerPort` / `ImageExt` for exposed ports, env vars, and command args.
- `crates/dbflux_test_support/src/containers.rs` (8 image factories) and `crates/dbflux_proxy/tests/live_integration.rs` (4 helpers + call sites).

## Validation

`cargo clippy -p dbflux_test_support -p dbflux_proxy --all-targets -- -D warnings` is clean. `Cargo.lock` is `--locked`-consistent. The live tests are `#[ignore]` + Docker-backed; `containers.rs` is exercised by the driver Live Integration CI job (postgres/mysql/mongo/redis/dynamodb), which validates real container startup on this branch.