### PR TITLE
ci: harden release/build/nightly workflows (CI-6..CI-9)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,21 @@ jobs:
           cache-on-failure: true
 
       - name: Stamp workspace version
-        run: sed -i 's/^version = ".*"/version = "${{ inputs.version }}"/' Cargo.toml
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # The workspace version is a single line in the root Cargo.toml. Bail if
+          # zero or several lines match, so a structural change to Cargo.toml can
+          # never silently rewrite the wrong line(s). VERSION is read from env, not
+          # interpolated into the script, so a crafted tag cannot inject shell.
+          MATCHES=$(grep -c '^version = "' Cargo.toml)
+          if [ "$MATCHES" -ne 1 ]; then
+            echo "::error::Expected exactly 1 workspace version line in Cargo.toml, found $MATCHES."
+            exit 1
+          fi
+          sed -i "s|^version = \".*\"|version = \"${VERSION}\"|" Cargo.toml
+          grep -qF "version = \"${VERSION}\"" Cargo.toml \
+            || { echo "::error::Version stamp did not apply."; exit 1; }
 
       - name: Build DBFlux
         # No --locked here: the version stamp above mutates Cargo.toml, so cargo must
@@ -143,11 +157,27 @@ jobs:
           tar -czf ../dbflux-linux-${{ matrix.arch }}.tar.gz .
 
       - name: Download appimagetool
+        # Pinned to a tagged release (not the rolling `continuous`) and verified
+        # by sha256 before exec. appimagetool runs right before the AppImage is
+        # GPG-signed, so a compromised binary would be signed as ours.
+        env:
+          APPIMAGETOOL_VERSION: "1.9.1"
+          SHA256_X86_64: "ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0"
+          SHA256_AARCH64: "f0837e7448a0c1e4e650a93bb3e85802546e60654ef287576f46c71c126a9158"
         run: |
-          ARCH=$(echo "${{ matrix.arch }}" | sed 's/amd64/x86_64/' | sed 's/arm64/aarch64/')
-          curl -LO https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage
-          chmod +x appimagetool-${ARCH}.AppImage
-          echo "APPIMAGE_ARCH=$ARCH" >> $GITHUB_ENV
+          case "${{ matrix.arch }}" in
+            amd64) ARCH=x86_64;  EXPECTED="$SHA256_X86_64"  ;;
+            arm64) ARCH=aarch64; EXPECTED="$SHA256_AARCH64" ;;
+            *) echo "::error::Unsupported arch '${{ matrix.arch }}'"; exit 1 ;;
+          esac
+
+          curl -fsSL -o "appimagetool-${ARCH}.AppImage" \
+            "https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-${ARCH}.AppImage"
+
+          echo "${EXPECTED}  appimagetool-${ARCH}.AppImage" | sha256sum -c -
+
+          chmod +x "appimagetool-${ARCH}.AppImage"
+          echo "APPIMAGE_ARCH=$ARCH" >> "$GITHUB_ENV"
 
       - name: Create AppImage
         run: |
@@ -214,7 +244,8 @@ jobs:
           go-version: stable
 
       - name: Install nfpm
-        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+        # Pinned: @latest would silently pull a new nfpm into the signing job.
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.47.0
 
       - name: Generate packages
         run: |
@@ -381,7 +412,19 @@ jobs:
           cache-on-failure: true
 
       - name: Stamp workspace version
-        run: sed -i.bak 's/^version = ".*"/version = "${{ inputs.version }}"/' Cargo.toml
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          # See the Linux build job for the rationale (single-line guard + env-routed
+          # version). BSD sed needs the -i.bak form.
+          MATCHES=$(grep -c '^version = "' Cargo.toml)
+          if [ "$MATCHES" -ne 1 ]; then
+            echo "::error::Expected exactly 1 workspace version line in Cargo.toml, found $MATCHES."
+            exit 1
+          fi
+          sed -i.bak "s|^version = \".*\"|version = \"${VERSION}\"|" Cargo.toml
+          grep -qF "version = \"${VERSION}\"" Cargo.toml \
+            || { echo "::error::Version stamp did not apply."; exit 1; }
 
       - name: Build DBFlux
         # vendored-openssl makes ssh2/libssh2 compile OpenSSL from source for the
@@ -500,8 +543,23 @@ jobs:
 
       - name: Stamp workspace version
         shell: pwsh
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
-          (Get-Content Cargo.toml) -replace '^version = ".*"', 'version = "${{ inputs.version }}"' | Set-Content Cargo.toml
+          # See the Linux build job for the rationale (single-line guard + env-routed
+          # version).
+          $content = Get-Content Cargo.toml
+          $versionLines = @($content | Select-String -Pattern '^version = "').Count
+          if ($versionLines -ne 1) {
+            Write-Output "::error::Expected exactly 1 workspace version line in Cargo.toml, found $versionLines."
+            exit 1
+          }
+          $stamped = $content -replace '^version = ".*"', "version = `"$env:VERSION`""
+          $stamped | Set-Content Cargo.toml
+          if (-not (Select-String -Path Cargo.toml -Pattern ([regex]::Escape("version = `"$env:VERSION`"")))) {
+            Write-Output "::error::Version stamp did not apply."
+            exit 1
+          }
 
       - name: Build DBFlux
         # No --locked: the version stamp above mutates Cargo.toml; see the Linux build
@@ -509,7 +567,9 @@ jobs:
         run: cargo build --release --features "$env:FEATURES" --target x86_64-pc-windows-msvc
 
       - name: Install ImageMagick
-        run: choco install imagemagick -y
+        # Pinned: an unversioned choco install pulls whatever the feed serves into
+        # the icon-generation step.
+        run: choco install imagemagick --version=7.1.2.2500 -y
 
       - name: Create ICO from SVG
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -106,6 +106,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
+      id-token: write      # OIDC token for build-provenance attestation
+      attestations: write  # write the provenance attestation
 
     steps:
       - name: Checkout repository
@@ -143,16 +145,21 @@ jobs:
           # tag is an ancestor of main (stable/rc tags live on release/vX.Y and
           # are never merged back), so that range is pinned at the last legacy
           # stable and grows without bound. See docs/RELEASE.md.
+          # A git-cliff failure must not silently produce empty release notes
+          # (e.g. a cliff.toml regression). Surface it as a warning and fall back
+          # to a placeholder below, but never swallow it entirely.
           if PREV_NIGHTLY="$(git rev-parse --verify --quiet nightly^)"; then
             git-cliff --config cliff.toml "${PREV_NIGHTLY}..HEAD" \
               --strip header \
-              -o cliff_notes.md 2>/dev/null || true
+              -o cliff_notes.md \
+              || echo "::warning::git-cliff failed to generate nightly notes; the body may be incomplete."
           else
             # First nightly, or the tag is missing: fall back to the unreleased
             # range so the body is never empty on the initial run.
             git-cliff --config cliff.toml --unreleased \
               --strip header \
-              -o cliff_notes.md 2>/dev/null || true
+              -o cliff_notes.md \
+              || echo "::warning::git-cliff failed to generate nightly notes; the body may be incomplete."
           fi
 
           if [ ! -s cliff_notes.md ]; then
@@ -269,3 +276,15 @@ jobs:
             artifacts/windows-*/*-setup.exe.asc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-path: |
+            artifacts/linux-*/*.tar.gz
+            artifacts/linux-*/*.AppImage
+            artifacts/linux-*/*.deb
+            artifacts/linux-*/*.rpm
+            artifacts/macos-*/*.dmg
+            artifacts/windows-*/*.zip
+            artifacts/windows-*/*-setup.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,37 +38,70 @@ jobs:
       prerelease: ${{ steps.classify.outputs.prerelease }}
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+
       - name: Resolve version
         id: version
+        env:
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            RAW="${{ github.event.inputs.version }}"
+            RAW="$DISPATCH_VERSION"
           else
             RAW="${GITHUB_REF_NAME}"
           fi
-          echo "version=${RAW#v}" >> $GITHUB_OUTPUT
+          echo "version=${RAW#v}" >> "$GITHUB_OUTPUT"
 
       - name: Classify channel
         id: classify
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "channel=stable"    >> $GITHUB_OUTPUT
-            echo "draft=false"       >> $GITHUB_OUTPUT
-            echo "prerelease=false"  >> $GITHUB_OUTPUT
+            echo "channel=stable"    >> "$GITHUB_OUTPUT"
+            echo "draft=false"       >> "$GITHUB_OUTPUT"
+            echo "prerelease=false"  >> "$GITHUB_OUTPUT"
           elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
-            echo "channel=rc"        >> $GITHUB_OUTPUT
-            echo "draft=false"       >> $GITHUB_OUTPUT
-            echo "prerelease=true"   >> $GITHUB_OUTPUT
+            echo "channel=rc"        >> "$GITHUB_OUTPUT"
+            echo "draft=false"       >> "$GITHUB_OUTPUT"
+            echo "prerelease=true"   >> "$GITHUB_OUTPUT"
           elif [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-dev\.[0-9]+$ ]]; then
             # -dev.N is deprecated; kept for back-compat until old tags are gone.
-            echo "channel=rc"        >> $GITHUB_OUTPUT
-            echo "draft=false"       >> $GITHUB_OUTPUT
-            echo "prerelease=true"   >> $GITHUB_OUTPUT
+            echo "channel=rc"        >> "$GITHUB_OUTPUT"
+            echo "draft=false"       >> "$GITHUB_OUTPUT"
+            echo "prerelease=true"   >> "$GITHUB_OUTPUT"
           else
-            echo "channel=stable"    >> $GITHUB_OUTPUT
-            echo "draft=true"        >> $GITHUB_OUTPUT
-            echo "prerelease=false"  >> $GITHUB_OUTPUT
+            echo "channel=stable"    >> "$GITHUB_OUTPUT"
+            echo "draft=true"        >> "$GITHUB_OUTPUT"
+            echo "prerelease=false"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enforce release-branch ancestry
+        # docs/RELEASE.md requires rc/stable tags to originate from a
+        # release/vX.Y branch; tagging from main is an anti-pattern. The classify
+        # steps above key only off the tag name, so an accidental tag pushed from
+        # main would otherwise publish a full release. Verify the built commit is
+        # an ancestor of the matching release branch and fail loudly otherwise.
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          CHANNEL: ${{ steps.classify.outputs.channel }}
+        run: |
+          MINOR="$(echo "$VERSION" | cut -d. -f1,2)"
+          BRANCH="release/v${MINOR}"
+
+          if ! git fetch --quiet origin "$BRANCH" 2>/dev/null; then
+            echo "::error::Release branch '$BRANCH' does not exist on origin. A $CHANNEL release must be cut from its release branch (see docs/RELEASE.md)."
+            exit 1
+          fi
+
+          if git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "Commit $GITHUB_SHA is an ancestor of $BRANCH — ancestry OK."
+          else
+            echo "::error::Commit $GITHUB_SHA is not an ancestor of '$BRANCH'. Refusing to publish a $CHANNEL release tagged outside its release branch (see docs/RELEASE.md)."
+            exit 1
           fi
 
   build:
@@ -88,6 +121,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
+      id-token: write      # OIDC token for build-provenance attestation
+      attestations: write  # write the provenance attestation
 
     steps:
       - name: Checkout repository
@@ -118,20 +153,27 @@ jobs:
 
       - name: Generate changelog for release body
         id: cliff
+        env:
+          RAW_VERSION: ${{ needs.classify.outputs.version }}
+          CHANNEL: ${{ needs.classify.outputs.channel }}
         run: |
-          VERSION="v${{ needs.classify.outputs.version }}"
-          CHANNEL="${{ needs.classify.outputs.channel }}"
+          VERSION="v${RAW_VERSION}"
 
+          # A git-cliff failure must not silently produce empty release notes
+          # (e.g. a cliff.toml regression). Surface it as a warning and fall back
+          # to a placeholder below, but never swallow it entirely.
           if [ "$CHANNEL" = "stable" ]; then
             # Stable: notes for exactly this tag (range since previous stable tag).
             git-cliff --config cliff.toml --current --tag "$VERSION" \
               --strip header \
-              -o cliff_notes.md 2>/dev/null || true
+              -o cliff_notes.md \
+              || echo "::warning::git-cliff failed to generate release notes; the release body may be incomplete."
           else
             # RC / pre-release: unreleased range since last stable tag.
             git-cliff --config cliff.toml --unreleased --tag "$VERSION" \
               --strip header \
-              -o cliff_notes.md 2>/dev/null || true
+              -o cliff_notes.md \
+              || echo "::warning::git-cliff failed to generate release notes; the release body may be incomplete."
           fi
 
           if [ ! -s cliff_notes.md ]; then
@@ -139,10 +181,12 @@ jobs:
           fi
 
       - name: Compose release body
+        env:
+          RAW_VERSION: ${{ needs.classify.outputs.version }}
+          CHANNEL: ${{ needs.classify.outputs.channel }}
         run: |
-          VERSION="v${{ needs.classify.outputs.version }}"
+          VERSION="v${RAW_VERSION}"
           REPO="${{ github.repository }}"
-          CHANNEL="${{ needs.classify.outputs.channel }}"
 
           : > release_body.md
 
@@ -199,3 +243,16 @@ jobs:
           prerelease: ${{ needs.classify.outputs.prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Attest build provenance
+        if: env.ACT != 'true'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        with:
+          subject-path: |
+            artifacts/linux-*/*.tar.gz
+            artifacts/linux-*/*.AppImage
+            artifacts/linux-*/*.deb
+            artifacts/linux-*/*.rpm
+            artifacts/macos-*/*.dmg
+            artifacts/windows-*/*.zip
+            artifacts/windows-*/*-setup.exe

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,3 +99,43 @@ jobs:
 
       - name: Run SQLite live integration tests
         run: cargo test -p dbflux_driver_sqlite --locked --test live_integration
+
+  cross-platform-check:
+    name: Cross-platform check ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+
+    # GPUI carries a large amount of platform-specific code; a macOS- or
+    # Windows-only break otherwise surfaces only when build.yml runs at release
+    # or nightly tag time. A lightweight `cargo check` on each platform catches
+    # it in the PR instead. Full test execution stays on Linux above.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Native arm64; vendored-openssl matches build.yml (the runner has no
+          # pkg-config-discoverable OpenSSL, so openssl-sys must build it).
+          - os: macos-14
+            extra_features: ",vendored-openssl"
+          # Native x86_64-msvc; OpenSSL is resolved on the runner as in build.yml.
+          - os: windows-latest
+            extra_features: ""
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          components: rust-src
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          shared-key: ci-cross-check-${{ matrix.os }}
+          cache-targets: true
+          cache-on-failure: true
+
+      - name: Cargo check
+        run: cargo check --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws${{ matrix.extra_features }}"


### PR DESCRIPTION
## What

Hardening pass over the `release.yml` / `build.yml` / `nightly.yml` / `tests.yml`
workflows, covering board items **CI-6, CI-7, CI-8, CI-9**. No application code
changes — workflows only.

## Why

The release pipeline classified releases purely by tag name, pulled unpinned
supply-chain tooling into the GPG-signing jobs, and only ever compiled macOS /
Windows at tag time. This closes those gaps.

## Changes

### CI-6 — Enforce release-branch ancestry (`release.yml`)
`docs/RELEASE.md` requires rc/stable tags to come from `release/vX.Y`; tagging
from `main` is documented as an anti-pattern, but the workflow never verified
it. The `classify` job now checks out with `fetch-depth: 0` and fails the
release unless the built commit is an ancestor of the matching `release/vX.Y`
branch (and unless that branch exists).

> **Behavior change:** a `release/vX.Y` branch must exist before its first
> `vX.Y.0` / `vX.Y.0-rc.N` tag, and tags pushed from `main` are now rejected.
> This matches the documented flow and the `dbflux-release` skill.

### CI-7 — Pin supply-chain tooling in the signing jobs (`build.yml`)
- **appimagetool**: pinned from the rolling `continuous` to the tagged **1.9.1**
  release, with a `sha256sum -c` check before `chmod +x`. appimagetool runs
  immediately before the AppImage is GPG-signed, so a compromised binary would
  be signed as ours. Digests taken from the 1.9.1 release assets
  (`x86_64 ed4ce8…`, `aarch64 f0837e…`).
- **nfpm**: `@latest` → `@v2.47.0`.
- **choco ImageMagick**: unversioned → `--version=7.1.2.2500`.

### CI-8 — Cross-platform compile check in PRs (`tests.yml`)
New `cross-platform-check` matrix (`macos-14`, `windows-latest`) running a
lightweight `cargo check`. GPUI carries a lot of platform-specific code; today a
macOS/Windows-only break is only discovered when `build.yml` runs at release or
nightly tag time. Full test execution stays on Linux. macOS adds
`vendored-openssl` to match `build.yml`.

### CI-9 — Minor workflow hardening
- **Injection surface**: event-derived versions (`inputs.version`,
  `github.event.inputs.version`) are routed through `env:` instead of being
  interpolated directly into `run:` scripts.
- **Version-stamp guard**: the `Cargo.toml` version stamp now asserts exactly
  one matching line and verifies the replacement applied, on all three platforms
  (GNU sed / BSD sed / pwsh).
- **git-cliff**: `… || true` replaced with a `::warning::` fallback so a
  `cliff.toml` regression can no longer silently produce empty release notes.
- **Build provenance**: `actions/attest-build-provenance` (pinned by SHA, v4.1.0)
  added to the release and nightly publish jobs, with the required
  `id-token: write` / `attestations: write` scopes. Verifiable via
  `gh attestation verify`.
- Already satisfied by earlier hardening and intentionally left as-is:
  workflow/job `permissions` are already least-privilege (`contents: read` at
  workflow level, `write` only on publish jobs), and the rpm `GPG_PASSPHRASE` is
  already passed via `env:` + process substitution rather than the command line.

## Validation

- `actionlint 1.7.12` clean on all four files (shellcheck-enabled run reports
  only pre-existing `info`/`style` findings in untouched steps).
- The macOS feature string
  (`…,aws,vendored-openssl`) resolves cleanly at the virtual workspace root
  (`cargo tree --workspace --locked --features … -e features`, rc=0) — confirms
  no "unknown feature" / "not allowed in virtual workspace" failure.

## Testability

- **CI-8** is exercised by this PR directly (the new macOS/Windows checks run on
  it).
- **CI-7** + the **CI-9** build-side changes (version-stamp guard, provenance on
  the nightly job) are exercised end-to-end by a `nightly.yml` run — can be
  triggered after merge.
- **CI-6** and the release-job provenance only run on a real `vX.Y.*` tag and
  are therefore validated at the next rc/stable cut.

Closes CI-6, CI-7, CI-8, CI-9.
