### PR TITLE
feat: cross-driver query tooling — core seams + DynamoDB/MongoDB read generation (1/2)

### DIFF
--- a/crates/dbflux_core/src/connection/manager.rs
+++ b/crates/dbflux_core/src/connection/manager.rs
@@ -1986,6 +1986,7 @@ mod tests {
                     classification_override: None,
                     default_chunk_size: None,
                     supports_lock_timeout: false,
+                    editor_profile: None,
                 },
             }
         }
@@ -2369,6 +2370,7 @@ mod tests {
                     classification_override: None,
                     default_chunk_size: None,
                     supports_lock_timeout: false,
+                    editor_profile: None,
                 },
                 form: &TEST_FORM,
             })
@@ -2572,6 +2574,7 @@ mod tests {
                     classification_override: None,
                     default_chunk_size: None,
                     supports_lock_timeout: false,
+                    editor_profile: None,
                 });
                 &META
             }

--- a/crates/dbflux_core/src/driver/capabilities.rs
+++ b/crates/dbflux_core/src/driver/capabilities.rs
@@ -981,6 +981,41 @@ impl QueryLanguage {
     }
 }
 
+/// How a driver's query editor should present and behave, independent of the
+/// raw [`QueryLanguage`] enum.
+///
+/// Defaults derive from the language (see [`EditorLanguageProfile::from_language`])
+/// so existing drivers need no change; a driver with a bespoke editor surface
+/// overrides individual fields via [`DriverMetadata::editor_profile`]. The UI reads
+/// presentation from this profile rather than matching on a concrete driver.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EditorLanguageProfile {
+    /// Syntax-highlighting mode id (e.g. `"sql"`, `"javascript"`, `"plaintext"`).
+    pub editor_mode: String,
+
+    /// Whether the connection-aware completion provider engages.
+    pub supports_connection_context: bool,
+
+    /// Editor placeholder text.
+    pub placeholder: String,
+
+    /// Line-comment prefix.
+    pub comment_prefix: String,
+}
+
+impl EditorLanguageProfile {
+    /// Default profile derived entirely from the driver's [`QueryLanguage`],
+    /// reproducing the language accessors byte-for-byte.
+    pub fn from_language(language: &QueryLanguage) -> Self {
+        Self {
+            editor_mode: language.editor_mode().to_string(),
+            supports_connection_context: language.supports_connection_context(),
+            placeholder: language.placeholder().to_string(),
+            comment_prefix: language.comment_prefix().to_string(),
+        }
+    }
+}
+
 /// `;`-delimited SQL statement splitter that is aware of strings, identifiers,
 /// comments, and dollar-quoted bodies. See [`QueryLanguage::split_statements`].
 fn split_sql_statements(text: &str) -> Vec<String> {
@@ -1211,6 +1246,24 @@ impl Default for SyntaxInfo {
 // Query Capabilities
 // ============================================================================
 
+/// How a driver allows result ordering, beyond the boolean `supports_order_by`.
+///
+/// Lets a store advertise a constrained ordering surface (e.g. DynamoDB orders
+/// only on the sort key, by direction) so the query builder never offers an
+/// ordering the driver cannot execute.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum OrderByMode {
+    /// No ordering support; the builder hides the order-by section.
+    None,
+
+    /// Ordering on any projected column, in any direction (relational default).
+    #[default]
+    AnyColumns,
+
+    /// Ordering only on the sort key, expressed as a single direction toggle.
+    SortKeyOnly,
+}
+
 /// Query-related capabilities supported by a driver.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryCapabilities {
@@ -1225,6 +1278,13 @@ pub struct QueryCapabilities {
 
     /// Whether the driver supports ORDER BY.
     pub supports_order_by: bool,
+
+    /// Granular ordering surface offered by the driver.
+    ///
+    /// Defaults to [`OrderByMode::AnyColumns`] so existing relational drivers
+    /// keep the multi-column sort UI unchanged.
+    #[serde(default)]
+    pub order_by_mode: OrderByMode,
 
     /// Maximum number of ORDER BY columns (0 = unlimited).
     pub max_order_by_columns: u32,
@@ -1294,6 +1354,7 @@ impl Default for QueryCapabilities {
             ],
             max_query_parameters: 0,
             supports_order_by: true,
+            order_by_mode: OrderByMode::AnyColumns,
             max_order_by_columns: 0,
             supports_group_by: true,
             max_group_by_columns: 0,
@@ -1695,6 +1756,15 @@ pub struct DriverMetadata {
     /// SQLite does not.
     #[serde(default)]
     pub supports_lock_timeout: bool,
+
+    /// Editor presentation override for drivers whose surface diverges from the
+    /// defaults derived from `query_language`.
+    ///
+    /// `None` (the common case) means the editor presentation is derived from
+    /// `query_language` via [`DriverMetadata::editor_profile`]. A driver with a
+    /// bespoke surface sets `Some(...)`.
+    #[serde(default)]
+    pub editor_profile: Option<EditorLanguageProfile>,
 }
 
 impl Debug for DriverMetadata {
@@ -1721,6 +1791,7 @@ impl Debug for DriverMetadata {
             .field("classification_override", &"...")
             .field("default_chunk_size", &self.default_chunk_size)
             .field("supports_lock_timeout", &self.supports_lock_timeout)
+            .field("editor_profile", &self.editor_profile)
             .finish()
     }
 }
@@ -1751,6 +1822,7 @@ impl Clone for DriverMetadata {
             classification_override: None,
             default_chunk_size: self.default_chunk_size,
             supports_lock_timeout: self.supports_lock_timeout,
+            editor_profile: self.editor_profile.clone(),
         }
     }
 }
@@ -1779,6 +1851,17 @@ impl DriverMetadata {
     /// Check if this is a log-stream service (e.g. CloudWatch Logs).
     pub fn is_log_stream(&self) -> bool {
         self.category == DatabaseCategory::LogStream
+    }
+
+    /// Editor presentation profile for this driver.
+    ///
+    /// Returns the driver's `editor_profile` override when set, otherwise a
+    /// profile derived from `query_language` (the behavior every existing
+    /// driver had before this field existed).
+    pub fn editor_profile(&self) -> EditorLanguageProfile {
+        self.editor_profile
+            .clone()
+            .unwrap_or_else(|| EditorLanguageProfile::from_language(&self.query_language))
     }
 }
 
@@ -1839,6 +1922,7 @@ pub struct DriverMetadataBuilder {
     classification_override: Option<Box<dyn OperationClassifier>>,
     default_chunk_size: Option<usize>,
     supports_lock_timeout: bool,
+    editor_profile: Option<EditorLanguageProfile>,
 }
 
 impl DriverMetadataBuilder {
@@ -1871,6 +1955,7 @@ impl DriverMetadataBuilder {
             classification_override: None,
             default_chunk_size: None,
             supports_lock_timeout: false,
+            editor_profile: None,
         }
     }
 
@@ -1994,6 +2079,7 @@ impl DriverMetadataBuilder {
             classification_override: self.classification_override,
             default_chunk_size: self.default_chunk_size,
             supports_lock_timeout: self.supports_lock_timeout,
+            editor_profile: self.editor_profile,
         }
     }
 
@@ -2117,6 +2203,69 @@ mod tests {
     fn split_statements_empty_is_zero() {
         assert_eq!(QueryLanguage::Sql.statement_count("   \n  "), 0);
         assert_eq!(QueryLanguage::MongoQuery.statement_count(""), 0);
+    }
+
+    #[test]
+    fn editor_profile_from_language_matches_accessors() {
+        let variants = [
+            QueryLanguage::Sql,
+            QueryLanguage::CloudWatchLogsInsightsQl,
+            QueryLanguage::OpenSearchPpl,
+            QueryLanguage::OpenSearchSql,
+            QueryLanguage::MongoQuery,
+            QueryLanguage::RedisCommands,
+            QueryLanguage::Cypher,
+            QueryLanguage::InfluxQuery,
+            QueryLanguage::Flux,
+            QueryLanguage::Cql,
+            QueryLanguage::Lua,
+            QueryLanguage::Python,
+            QueryLanguage::Bash,
+            QueryLanguage::Custom("DynamoDB".to_string()),
+        ];
+
+        for language in &variants {
+            let profile = EditorLanguageProfile::from_language(language);
+
+            assert_eq!(
+                profile.editor_mode,
+                language.editor_mode(),
+                "editor_mode mismatch for {language:?}"
+            );
+            assert_eq!(
+                profile.supports_connection_context,
+                language.supports_connection_context(),
+                "supports_connection_context mismatch for {language:?}"
+            );
+            assert_eq!(
+                profile.placeholder,
+                language.placeholder(),
+                "placeholder mismatch for {language:?}"
+            );
+            assert_eq!(
+                profile.comment_prefix,
+                language.comment_prefix(),
+                "comment_prefix mismatch for {language:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn editor_profile_defaults_when_metadata_has_no_override() {
+        let derived = EditorLanguageProfile::from_language(&QueryLanguage::MongoQuery);
+
+        assert_eq!(derived.editor_mode, "javascript");
+        assert!(derived.supports_connection_context);
+        assert_eq!(derived.comment_prefix, "//");
+    }
+
+    #[test]
+    fn order_by_mode_default_is_any_columns() {
+        assert_eq!(OrderByMode::default(), OrderByMode::AnyColumns);
+        assert_eq!(
+            QueryCapabilities::default().order_by_mode,
+            OrderByMode::AnyColumns
+        );
     }
 
     #[test]

--- a/crates/dbflux_core/src/driver/mod.rs
+++ b/crates/dbflux_core/src/driver/mod.rs
@@ -3,9 +3,10 @@ pub(crate) mod form;
 
 pub use capabilities::{
     DatabaseCategory, DdlCapabilities, DeploymentClass, DriverCapabilities, DriverLimits,
-    DriverMetadata, DriverMetadataBuilder, ExecutionClassification, Icon, IsolationLevel,
-    MutationCapabilities, OperationClassifier, PaginationStyle, QueryCapabilities, QueryLanguage,
-    SslCertFields, SslModeOption, SyntaxInfo, TransactionCapabilities, WhereOperator,
+    DriverMetadata, DriverMetadataBuilder, EditorLanguageProfile, ExecutionClassification, Icon,
+    IsolationLevel, MutationCapabilities, OperationClassifier, OrderByMode, PaginationStyle,
+    QueryCapabilities, QueryLanguage, SslCertFields, SslModeOption, SyntaxInfo,
+    TransactionCapabilities, WhereOperator,
 };
 pub use form::{
     DriverFormDef, ExportFieldHint, FieldExportTransform, FormFieldDef, FormFieldKind, FormSection,

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -108,10 +108,11 @@ pub use data::{
 
 pub use driver::{
     DatabaseCategory, DdlCapabilities, DeploymentClass, DriverCapabilities, DriverFormDef,
-    DriverLimits, DriverMetadata, DriverMetadataBuilder, ExecutionClassification, ExportFieldHint,
-    FieldExportTransform, FormFieldDef, FormFieldKind, FormSection, FormTab, FormValues, Icon,
-    IsolationLevel, MutationCapabilities, OperationClassifier, PaginationStyle, QueryCapabilities,
-    QueryLanguage, RefreshTrigger, SelectOption, SslCertFields, SslModeOption, SyntaxInfo,
+    DriverLimits, DriverMetadata, DriverMetadataBuilder, EditorLanguageProfile,
+    ExecutionClassification, ExportFieldHint, FieldExportTransform, FormFieldDef, FormFieldKind,
+    FormSection, FormTab, FormValues, Icon, IsolationLevel, MutationCapabilities,
+    OperationClassifier, OrderByMode, PaginationStyle, QueryCapabilities, QueryLanguage,
+    RefreshTrigger, SelectOption, SslCertFields, SslModeOption, SyntaxInfo,
     TransactionCapabilities, WhereOperator, field, field_file_path, field_password, field_required,
     field_use_uri, ssh_tab, when_checked, when_unchecked, with_default, with_help,
 };
@@ -135,11 +136,12 @@ pub use query::{
     SqlLanguageService, SqlMutationGenerator, TableBrowseRequest, TableCountRequest, TableRef,
     TextPosition, TextPositionRange, TextRange, TransactionVocab, ValidationResult,
     VisualAggregateSpec, VisualMutationSpec, VisualQuerySpec, VisualSortDirection,
-    classify_query_for_governance, classify_query_for_language, classify_sql_execution,
-    classify_visual_mutation, contains_time_macros, detect_dangerous_query, detect_dangerous_sql,
-    infer_column_kind, inline_params, is_safe_read_query, lower_keyset_predicate,
-    parse_semantic_filter_json, project_aggregate_kinds, render_filter_node_sql,
-    render_semantic_filter_sql, strip_leading_comments, substitute_time_macros,
+    classify_query_for_governance, classify_query_for_language,
+    classify_query_for_language_with_service, classify_sql_execution, classify_visual_mutation,
+    contains_time_macros, detect_dangerous_query, detect_dangerous_sql, infer_column_kind,
+    inline_params, is_safe_read_query, lower_keyset_predicate, parse_semantic_filter_json,
+    project_aggregate_kinds, render_filter_node_sql, render_semantic_filter_sql,
+    strip_leading_comments, substitute_time_macros,
 };
 
 pub use query::relational_filter::{

--- a/crates/dbflux_core/src/query/generator.rs
+++ b/crates/dbflux_core/src/query/generator.rs
@@ -28,7 +28,7 @@ impl MutationRequest {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GeneratedQuery {
     pub language: QueryLanguage,
     pub text: String,
@@ -324,6 +324,20 @@ pub trait QueryGenerator: Send + Sync {
         &self,
         _spec: &VisualQuerySpec,
     ) -> Result<Option<SelectQuery>, QueryGenError> {
+        Ok(None)
+    }
+
+    /// Render a structured read spec to a driver-native, non-SQL read query.
+    ///
+    /// Returns a generic [`GeneratedQuery`] whose `text` is the executable
+    /// query (non-SQL stores carry no positional parameters). The default
+    /// returns `Ok(None)` meaning "this generator emits no non-SQL read text",
+    /// so relational drivers keep using [`QueryGenerator::generate_select`].
+    /// Document drivers (MongoDB, DynamoDB) override this.
+    fn generate_read_from_spec(
+        &self,
+        _spec: &VisualQuerySpec,
+    ) -> Result<Option<GeneratedQuery>, QueryGenError> {
         Ok(None)
     }
 
@@ -2068,6 +2082,31 @@ mod tests {
             limit: Some(100),
             offset: 0,
         }
+    }
+
+    #[test]
+    fn generate_read_from_spec_default_is_unsupported() {
+        struct NoReadGenerator;
+        impl QueryGenerator for NoReadGenerator {
+            fn supported_categories(&self) -> &'static [MutationCategory] {
+                &[]
+            }
+            fn generate_mutation(
+                &self,
+                _mutation: &crate::MutationRequest,
+            ) -> Option<GeneratedQuery> {
+                None
+            }
+        }
+
+        let result = NoReadGenerator.generate_read_from_spec(&users_spec());
+        assert_eq!(result, Ok(None));
+    }
+
+    #[test]
+    fn sql_generator_does_not_emit_non_sql_read_text() {
+        let result = SqlMutationGenerator::new(&DIALECT).generate_read_from_spec(&users_spec());
+        assert_eq!(result, Ok(None));
     }
 
     // -------------------------------------------------------------------------

--- a/crates/dbflux_core/src/query/language_service.rs
+++ b/crates/dbflux_core/src/query/language_service.rs
@@ -238,6 +238,23 @@ pub fn classify_query_for_language(
     query_language: &QueryLanguage,
     query: &str,
 ) -> ExecutionClassification {
+    classify_query_for_language_with_service(query_language, query, None)
+}
+
+/// Classify a query's execution impact, optionally delegating a `Custom`
+/// language to the driver's own [`LanguageService`].
+///
+/// For the built-in languages the classification is keyed off the language. For
+/// a `Custom(_)` language the classifier consults `service` (when present) so a
+/// driver-defined surface (e.g. PartiQL) is classified by the driver rather than
+/// dead-ending at a conservative `Write`. With no service it falls back to
+/// `Write`, preserving the previous conservative default for non-connection
+/// callers.
+pub fn classify_query_for_language_with_service(
+    query_language: &QueryLanguage,
+    query: &str,
+    service: Option<&dyn LanguageService>,
+) -> ExecutionClassification {
     match query_language {
         QueryLanguage::Sql => classify_sql_execution(query),
         QueryLanguage::CloudWatchLogsInsightsQl
@@ -245,6 +262,9 @@ pub fn classify_query_for_language(
         | QueryLanguage::OpenSearchSql => ExecutionClassification::Read,
         QueryLanguage::MongoQuery => classify_mongo_query(query),
         QueryLanguage::RedisCommands => classify_redis_query(query),
+        QueryLanguage::Custom(_) => service
+            .and_then(|service| service.classify_execution(query))
+            .unwrap_or(ExecutionClassification::Write),
         _ => ExecutionClassification::Write,
     }
 }
@@ -375,6 +395,17 @@ pub trait LanguageService: Send + Sync {
     /// frequent text changes to provide live feedback as the user types.
     fn editor_diagnostics(&self, _query: &str) -> Vec<EditorDiagnostic> {
         vec![]
+    }
+
+    /// Classify a query's execution impact for governance.
+    ///
+    /// Returns `None` (the default) when the driver does not provide a bespoke
+    /// classifier, letting the core fall back to its language-keyed
+    /// classification. A driver whose `QueryLanguage` is `Custom(_)` (e.g. a
+    /// PartiQL surface) overrides this so its statements are classified by the
+    /// driver rather than dead-ending at a conservative `Write`.
+    fn classify_execution(&self, _query: &str) -> Option<ExecutionClassification> {
+        None
     }
 }
 
@@ -1261,6 +1292,67 @@ END $$;"#;
         assert_eq!(
             classify_query_for_language(&QueryLanguage::RedisCommands, "CONFIG SET a b"),
             ExecutionClassification::Admin
+        );
+    }
+
+    #[test]
+    fn custom_language_without_service_falls_back_to_write() {
+        let language = QueryLanguage::Custom("DynamoDB".to_string());
+
+        assert_eq!(
+            classify_query_for_language(&language, "SELECT * FROM \"t\""),
+            ExecutionClassification::Write
+        );
+        assert_eq!(
+            classify_query_for_language_with_service(&language, "SELECT * FROM \"t\"", None),
+            ExecutionClassification::Write
+        );
+    }
+
+    #[test]
+    fn custom_language_routes_classification_through_service() {
+        struct PartiqlService;
+        impl LanguageService for PartiqlService {
+            fn validate(&self, _query: &str) -> ValidationResult {
+                ValidationResult::Valid
+            }
+            fn detect_dangerous(&self, _query: &str) -> Option<DangerousQueryKind> {
+                None
+            }
+            fn classify_execution(&self, query: &str) -> Option<ExecutionClassification> {
+                let normalized = query.trim_start().to_ascii_uppercase();
+                if normalized.starts_with("SELECT") {
+                    Some(ExecutionClassification::Read)
+                } else if normalized.starts_with("DELETE") {
+                    Some(ExecutionClassification::Destructive)
+                } else {
+                    None
+                }
+            }
+        }
+
+        let language = QueryLanguage::Custom("DynamoDB".to_string());
+        let service = PartiqlService;
+
+        assert_eq!(
+            classify_query_for_language_with_service(
+                &language,
+                "SELECT * FROM \"t\"",
+                Some(&service),
+            ),
+            ExecutionClassification::Read
+        );
+        assert_eq!(
+            classify_query_for_language_with_service(
+                &language,
+                "DELETE FROM \"t\" WHERE pk = 'a'",
+                Some(&service),
+            ),
+            ExecutionClassification::Destructive
+        );
+        assert_eq!(
+            classify_query_for_language_with_service(&language, "weird", Some(&service)),
+            ExecutionClassification::Write
         );
     }
 

--- a/crates/dbflux_core/src/query/mod.rs
+++ b/crates/dbflux_core/src/query/mod.rs
@@ -22,8 +22,8 @@ pub use keyset::lower_keyset_predicate;
 pub use language_service::{
     ClassifiedMutation, DangerousQueryKind, Diagnostic, DiagnosticSeverity, EditorDiagnostic,
     LanguageService, SqlLanguageService, TextPosition, TextPositionRange, TextRange,
-    ValidationResult, classify_query_for_language, classify_visual_mutation,
-    detect_dangerous_query, detect_dangerous_sql, strip_leading_comments,
+    ValidationResult, classify_query_for_language, classify_query_for_language_with_service,
+    classify_visual_mutation, detect_dangerous_query, detect_dangerous_sql, strip_leading_comments,
 };
 pub use safety::{classify_query_for_governance, classify_sql_execution, is_safe_read_query};
 pub use semantic::{

--- a/crates/dbflux_core/src/schema/drift_check.rs
+++ b/crates/dbflux_core/src/schema/drift_check.rs
@@ -313,6 +313,7 @@ mod tests {
             classification_override: None,
             default_chunk_size: None,
             supports_lock_timeout: false,
+            editor_profile: None,
         }
     }
 

--- a/crates/dbflux_core/tests/connection_contract.rs
+++ b/crates/dbflux_core/tests/connection_contract.rs
@@ -274,6 +274,7 @@ impl dbflux_core::Connection for PlannedExecutionConnection {
                 classification_override: None,
                 default_chunk_size: None,
                 supports_lock_timeout: false,
+                editor_profile: None,
             });
 
         &METADATA

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -55,6 +55,7 @@ pub static CLOUDWATCH_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driv
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 pub static CLOUDWATCH_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef {

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -312,6 +312,7 @@ pub static DYNAMODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driver
             WhereOperator::Not,
         ],
         supports_order_by: true,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         supports_group_by: false,
         supports_having: false,
         supports_distinct: false,
@@ -387,6 +388,7 @@ pub static DYNAMODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driver
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 pub const DYNAMODB_MVP_SUPPORTED_FLOWS: &[&str] = &[

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -8,6 +8,7 @@ use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemError;
 use aws_sdk_dynamodb::operation::delete_item::DeleteItemError;
 use aws_sdk_dynamodb::operation::delete_table::DeleteTableError;
 use aws_sdk_dynamodb::operation::describe_table::DescribeTableError;
+use aws_sdk_dynamodb::operation::execute_statement::ExecuteStatementError;
 use aws_sdk_dynamodb::operation::list_tables::ListTablesError;
 use aws_sdk_dynamodb::operation::put_item::PutItemError;
 use aws_sdk_dynamodb::operation::query::QueryError;
@@ -23,16 +24,17 @@ use dbflux_core::{
     CollectionBrowseRequest, CollectionCountRequest, CollectionIndexInfo, CollectionInfo,
     CollectionRef, ColumnKind, ColumnMeta, Connection, ConnectionErrorFormatter, ConnectionExt,
     ConnectionProfile, DangerousQueryKind, DatabaseCategory, DatabaseInfo, DbConfig, DbDriver,
-    DbError, DbKind, DbSchemaInfo, DdlCapabilities, DeploymentClass, DocumentConnection,
-    DocumentDelete, DocumentInsert, DocumentSchema, DocumentUpdate, DriverCapabilities,
-    DriverFormDef, DriverLimits, DriverMetadata, FieldInfo, FormFieldKind, FormSection, FormTab,
+    DbError, DbKind, DbSchemaInfo, DdlCapabilities, DeploymentClass, DiagnosticSeverity,
+    DocumentConnection, DocumentDelete, DocumentInsert, DocumentSchema, DocumentUpdate,
+    DriverCapabilities, DriverFormDef, DriverLimits, DriverMetadata, EditorDiagnostic,
+    EditorLanguageProfile, ExecutionClassification, FieldInfo, FormFieldKind, FormSection, FormTab,
     FormValues, FormattedError, Icon, IndexData, IndexDirection, KeyValueConnection,
     LanguageService, MutationCapabilities, OrderByColumn, Pagination, PaginationStyle,
     QueryCapabilities, QueryErrorFormatter, QueryGenerator, QueryLanguage, QueryRequest,
     QueryResult, RelationalConnection, SchemaDropTarget, SchemaLoadingStrategy, SchemaObjectKind,
     SchemaSnapshot, SemanticFieldRef, SemanticFilter, SemanticPlan, SemanticPlanKind,
-    SemanticRequest, SqlDialect, TableInfo, TransactionCapabilities, ValidationResult, Value,
-    WhereOperator, field, field_required,
+    SemanticRequest, SqlDialect, TableInfo, TextPosition, TextPositionRange,
+    TransactionCapabilities, ValidationResult, Value, WhereOperator, field, field_required,
 };
 
 use crate::query_generator::DynamoQueryGenerator;
@@ -312,7 +314,7 @@ pub static DYNAMODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driver
             WhereOperator::Not,
         ],
         supports_order_by: true,
-        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
+        order_by_mode: dbflux_core::OrderByMode::SortKeyOnly,
         supports_group_by: false,
         supports_having: false,
         supports_distinct: false,
@@ -388,7 +390,12 @@ pub static DYNAMODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driver
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
-    editor_profile: None,
+    editor_profile: Some(EditorLanguageProfile {
+        editor_mode: "sql".to_string(),
+        supports_connection_context: true,
+        placeholder: "-- SELECT * FROM \"table\" WHERE pk = '...'".to_string(),
+        comment_prefix: "--".to_string(),
+    }),
 });
 
 pub const DYNAMODB_MVP_SUPPORTED_FLOWS: &[&str] = &[
@@ -559,6 +566,13 @@ impl Connection for DynamoConnection {
 
     fn execute(&self, req: &QueryRequest) -> Result<QueryResult, DbError> {
         let started = std::time::Instant::now();
+
+        if partiql_verb(&req.sql).is_some() {
+            let mut result = self.execute_partiql(req)?;
+            result.execution_time = started.elapsed();
+            return Ok(result);
+        }
+
         let envelope = parse_command_envelope(&req.sql)?;
 
         let mut result = match envelope {
@@ -1222,6 +1236,51 @@ impl ConnectionExt for DynamoConnection {
 }
 
 impl DynamoConnection {
+    /// Execute a single PartiQL statement through the DynamoDB
+    /// `ExecuteStatement` API.
+    ///
+    /// `SELECT` statements map their returned items into a `QueryResult` (the
+    /// SDK pagination token is carried as `next_page_token`); write statements
+    /// (`INSERT`/`UPDATE`/`DELETE`) report an affected-row count. Row limiting
+    /// rides on the SDK `set_limit` argument because PartiQL has no `LIMIT`
+    /// keyword. Only single statements are supported here; the JSON command
+    /// envelope remains the escape hatch for everything PartiQL cannot express.
+    fn execute_partiql(&self, req: &QueryRequest) -> Result<QueryResult, DbError> {
+        let config = DynamoProfileConfig {
+            region: self.default_region.clone(),
+            profile: None,
+            endpoint: None,
+            table: self.default_table.clone(),
+        };
+
+        let runtime = runtime();
+
+        let request = self
+            .client
+            .execute_statement()
+            .statement(req.sql.trim())
+            .set_limit(req.limit.map(|limit| limit as i32));
+
+        let output = runtime.block_on(request.send()).map_err(|error| {
+            let formatted = DYNAMO_ERROR_FORMATTER.format_execute_statement_error(&error, &config);
+            classify_query_error(formatted)
+        })?;
+
+        if partiql_verb(&req.sql) == Some(PartiqlVerb::Select) {
+            let next_page_token = output.next_token().map(|token| token.to_string());
+            Ok(partiql_items_to_query_result(
+                output.items(),
+                next_page_token,
+            ))
+        } else {
+            // ExecuteStatement returns no affected-row count for writes; a
+            // successful single-statement write affects one item.
+            Ok(crud_result_to_query_result(crud_result_with_affected_rows(
+                1,
+            )))
+        }
+    }
+
     fn browse_collection_with_read_options(
         &self,
         request: &CollectionBrowseRequest,
@@ -2247,6 +2306,7 @@ struct DynamoScanPlan {
 struct DynamoQueryPlan {
     index_name: Option<String>,
     consistent_read: bool,
+    scan_index_forward: Option<bool>,
     key_condition_expression: String,
     key_expression_attribute_names: HashMap<String, String>,
     key_expression_attribute_values: HashMap<String, AttributeValue>,
@@ -2436,6 +2496,7 @@ fn decide_read_strategy(
         return Ok(DynamoReadStrategy::Query(DynamoQueryPlan {
             index_name: read_options.index_name.clone(),
             consistent_read: read_options.consistent_read,
+            scan_index_forward: read_options.scan_index_forward,
             key_condition_expression,
             key_expression_attribute_names,
             key_expression_attribute_values,
@@ -2874,6 +2935,7 @@ fn fetch_read_page(
                 .table_name(table)
                 .set_index_name(plan.index_name.clone())
                 .consistent_read(plan.consistent_read)
+                .set_scan_index_forward(plan.scan_index_forward)
                 .key_condition_expression(&plan.key_condition_expression)
                 .set_expression_attribute_names(Some(expression_attribute_names))
                 .set_expression_attribute_values(Some(expression_attribute_values))
@@ -3043,6 +3105,61 @@ fn items_to_query_result(
                 nullable: true,
                 is_primary_key,
             }
+        })
+        .collect();
+
+    let rows = items
+        .iter()
+        .map(|item| {
+            field_names
+                .iter()
+                .map(|field| {
+                    item.get(field)
+                        .map(attribute_value_to_value)
+                        .unwrap_or(Value::Null)
+                })
+                .collect()
+        })
+        .collect();
+
+    let mut result = QueryResult::json(columns, rows, std::time::Duration::ZERO);
+    result.next_page_token = next_page_token;
+    result
+}
+
+/// Build a `QueryResult` from PartiQL `ExecuteStatement` items.
+///
+/// Unlike `items_to_query_result`, no table key schema is available for a
+/// free-form PartiQL `SELECT`, so column order is derived purely from the
+/// sampled items and no column is marked as a primary key. Column kinds are
+/// still inferred from the sampled values (CLAUDE.md rule 10) so the chart
+/// engine can use them.
+fn partiql_items_to_query_result(
+    items: &[HashMap<String, AttributeValue>],
+    next_page_token: Option<String>,
+) -> QueryResult {
+    let mut field_names: Vec<String> = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+
+    for item in items {
+        let mut keys: Vec<&String> = item.keys().collect();
+        keys.sort();
+
+        for key in keys {
+            if seen.insert(key.clone()) {
+                field_names.push(key.clone());
+            }
+        }
+    }
+
+    let columns = field_names
+        .iter()
+        .map(|name| ColumnMeta {
+            name: name.clone(),
+            type_name: infer_field_type_label(items, name),
+            kind: infer_field_kind(items, name),
+            nullable: true,
+            is_primary_key: false,
         })
         .collect();
 
@@ -4048,6 +4165,20 @@ impl DynamoErrorFormatter {
         self.format_sdk_message(&error.to_string(), config)
     }
 
+    fn format_execute_statement_error(
+        &self,
+        error: &aws_sdk_dynamodb::error::SdkError<ExecuteStatementError>,
+        config: &DynamoProfileConfig,
+    ) -> FormattedError {
+        if let Some(service_error) = error.as_service_error() {
+            let code = service_error.code();
+            let message = service_error.message().unwrap_or("DynamoDB service error");
+            return self.format_from_code(code, message, config);
+        }
+
+        self.format_sdk_message(&error.to_string(), config)
+    }
+
     fn format_put_error(
         &self,
         error: &aws_sdk_dynamodb::error::SdkError<PutItemError>,
@@ -4149,30 +4280,60 @@ static DYNAMO_ERROR_FORMATTER: DynamoErrorFormatter = DynamoErrorFormatter;
 
 struct DynamoLanguageService;
 
+/// The leading PartiQL verb of a statement, when the text starts with one.
+///
+/// DynamoDB's query surface has two shapes: a JSON command envelope and PartiQL
+/// statements (`SELECT`/`INSERT`/`UPDATE`/`DELETE`). This recognizes the latter
+/// so validation, danger detection, and governance classification can treat
+/// PartiQL distinctly from the envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PartiqlVerb {
+    Select,
+    Insert,
+    Update,
+    Delete,
+}
+
+fn partiql_verb(query: &str) -> Option<PartiqlVerb> {
+    let lower = query.trim_start().to_ascii_lowercase();
+
+    if lower.starts_with("select ") || lower.starts_with("select\n") {
+        Some(PartiqlVerb::Select)
+    } else if lower.starts_with("insert ") || lower.starts_with("insert\n") {
+        Some(PartiqlVerb::Insert)
+    } else if lower.starts_with("update ") || lower.starts_with("update\n") {
+        Some(PartiqlVerb::Update)
+    } else if lower.starts_with("delete ") || lower.starts_with("delete\n") {
+        Some(PartiqlVerb::Delete)
+    } else {
+        None
+    }
+}
+
+/// Whether a PartiQL statement carries a `WHERE` clause.
+fn partiql_has_where(query: &str) -> bool {
+    let lower = query.to_ascii_lowercase();
+    lower.contains(" where ") || lower.contains("\nwhere ") || lower.ends_with(" where")
+}
+
 impl LanguageService for DynamoLanguageService {
-    fn validate(&self, query: &str) -> ValidationResult {
-        let trimmed = query.trim();
-        if trimmed.is_empty() {
-            return ValidationResult::Valid;
-        }
-
-        let lower = trimmed.to_ascii_lowercase();
-        if lower.starts_with("select ")
-            || lower.starts_with("insert ")
-            || lower.starts_with("update ")
-            || lower.starts_with("delete ")
-        {
-            return ValidationResult::WrongLanguage {
-                expected: QueryLanguage::Custom("DynamoDB".to_string()),
-                message: "SQL syntax not supported for DynamoDB. Use DynamoDB command envelopes or mutation tools."
-                    .to_string(),
-            };
-        }
-
+    fn validate(&self, _query: &str) -> ValidationResult {
         ValidationResult::Valid
     }
 
     fn detect_dangerous(&self, query: &str) -> Option<DangerousQueryKind> {
+        if let Some(verb) = partiql_verb(query) {
+            return match verb {
+                PartiqlVerb::Delete if !partiql_has_where(query) => {
+                    Some(DangerousQueryKind::DeleteNoWhere)
+                }
+                PartiqlVerb::Update if !partiql_has_where(query) => {
+                    Some(DangerousQueryKind::UpdateNoWhere)
+                }
+                _ => None,
+            };
+        }
+
         let normalized = query.trim().to_ascii_lowercase();
 
         if normalized.contains("\"op\":\"delete\"") {
@@ -4185,9 +4346,68 @@ impl LanguageService for DynamoLanguageService {
 
         None
     }
+
+    fn editor_diagnostics(&self, query: &str) -> Vec<EditorDiagnostic> {
+        let trimmed = query.trim();
+
+        if trimmed.is_empty() || partiql_verb(query).is_some() {
+            return Vec::new();
+        }
+
+        if !trimmed.starts_with('{') {
+            return Vec::new();
+        }
+
+        match parse_command_envelope(query) {
+            Ok(_) => Vec::new(),
+            Err(error) => vec![EditorDiagnostic {
+                severity: DiagnosticSeverity::Error,
+                message: error.to_string(),
+                range: dynamo_full_query_range(query),
+            }],
+        }
+    }
+
+    fn classify_execution(&self, query: &str) -> Option<ExecutionClassification> {
+        if let Some(verb) = partiql_verb(query) {
+            return Some(match verb {
+                PartiqlVerb::Select => ExecutionClassification::Read,
+                PartiqlVerb::Insert | PartiqlVerb::Update => ExecutionClassification::Write,
+                PartiqlVerb::Delete => ExecutionClassification::Destructive,
+            });
+        }
+
+        let normalized = query.trim().to_ascii_lowercase();
+
+        if normalized.contains("\"op\":\"scan\"") || normalized.contains("\"op\":\"query\"") {
+            return Some(ExecutionClassification::Read);
+        }
+
+        if normalized.contains("\"op\":\"delete\"") {
+            return Some(ExecutionClassification::Destructive);
+        }
+
+        Some(ExecutionClassification::Write)
+    }
 }
 
 static DYNAMO_LANGUAGE_SERVICE: DynamoLanguageService = DynamoLanguageService;
+
+/// A diagnostic range spanning the whole query text (single-position editors
+/// for the JSON envelope have no finer-grained span available).
+fn dynamo_full_query_range(query: &str) -> TextPositionRange {
+    let last_line = query.lines().count().saturating_sub(1) as u32;
+    let last_column = query
+        .lines()
+        .last()
+        .map(|line| line.chars().count())
+        .unwrap_or(0) as u32;
+
+    TextPositionRange::new(
+        TextPosition::new(0, 0),
+        TextPosition::new(last_line, last_column.max(1)),
+    )
+}
 
 fn classify_connection_error(formatted: FormattedError) -> DbError {
     match formatted.code.as_deref() {
@@ -4270,9 +4490,9 @@ mod tests {
     use dbflux_core::{
         CollectionBrowseRequest, CollectionCountRequest, CollectionRef, ColumnKind,
         ConnectionProfile, DangerousQueryKind, DatabaseCategory, DbConfig, DbDriver, DbError,
-        DocumentFilter, DocumentUpdate, DriverCapabilities, FormFieldKind, FormValues, IndexData,
-        LanguageService, QueryLanguage, SemanticFilter, SemanticPlanKind, SemanticRequest, Value,
-        WhereOperator,
+        DocumentFilter, DocumentUpdate, DriverCapabilities, ExecutionClassification, FormFieldKind,
+        FormValues, IndexData, LanguageService, QueryLanguage, SemanticFilter, SemanticPlanKind,
+        SemanticRequest, Value, WhereOperator,
     };
     use serde_json::json;
     use std::collections::HashMap;
@@ -4778,6 +4998,7 @@ mod tests {
             index_name: Some("gsi_users_by_status".to_string()),
             consistent_read: true,
             filter_fallback: DynamoFilterFallback::Reject,
+            scan_index_forward: None,
         };
 
         let strategy =
@@ -4812,6 +5033,7 @@ mod tests {
             index_name: Some("gsi_users_by_status".to_string()),
             consistent_read: false,
             filter_fallback: DynamoFilterFallback::Reject,
+            scan_index_forward: None,
         };
 
         let strategy = decide_read_strategy(
@@ -4875,6 +5097,7 @@ mod tests {
             index_name: None,
             consistent_read: false,
             filter_fallback: DynamoFilterFallback::Reject,
+            scan_index_forward: None,
         };
 
         let error = decide_read_strategy(
@@ -4936,6 +5159,7 @@ mod tests {
             index_name: Some("missing_index".to_string()),
             consistent_read: false,
             filter_fallback: DynamoFilterFallback::ClientSide,
+            scan_index_forward: None,
         };
 
         let error = validate_read_options("users", &key_schema, &read_options)
@@ -4959,6 +5183,7 @@ mod tests {
             index_name: Some("gsi_users_by_status".to_string()),
             consistent_read: true,
             filter_fallback: DynamoFilterFallback::ClientSide,
+            scan_index_forward: None,
         };
 
         let error = validate_read_options("users", &key_schema, &read_options)
@@ -5322,6 +5547,90 @@ mod tests {
         assert_eq!(delete, Some(DangerousQueryKind::DeleteNoWhere));
         assert_eq!(update, Some(DangerousQueryKind::UpdateNoWhere));
         assert_eq!(put, None);
+    }
+
+    #[test]
+    fn dangerous_detection_flags_no_where_partiql_delete_and_update() {
+        let service = DynamoLanguageService;
+
+        assert_eq!(
+            service.detect_dangerous("DELETE FROM \"users\""),
+            Some(DangerousQueryKind::DeleteNoWhere)
+        );
+        assert_eq!(
+            service.detect_dangerous("  delete from \"users\"  "),
+            Some(DangerousQueryKind::DeleteNoWhere)
+        );
+        assert_eq!(
+            service.detect_dangerous("UPDATE \"users\" SET name = 'A'"),
+            Some(DangerousQueryKind::UpdateNoWhere)
+        );
+    }
+
+    #[test]
+    fn dangerous_detection_ignores_partiql_with_where() {
+        let service = DynamoLanguageService;
+
+        assert_eq!(
+            service.detect_dangerous("DELETE FROM \"users\" WHERE pk = '1'"),
+            None
+        );
+        assert_eq!(
+            service.detect_dangerous("UPDATE \"users\" SET name = 'A' WHERE pk = '1'"),
+            None
+        );
+        assert_eq!(
+            service.detect_dangerous("SELECT * FROM \"users\" WHERE pk = '1'"),
+            None
+        );
+    }
+
+    #[test]
+    fn classify_execution_distinguishes_partiql_reads_and_writes() {
+        let service = DynamoLanguageService;
+
+        assert_eq!(
+            service.classify_execution("SELECT * FROM \"users\" WHERE pk = '1'"),
+            Some(ExecutionClassification::Read)
+        );
+        assert_eq!(
+            service.classify_execution("INSERT INTO \"users\" VALUE {'pk': '1'}"),
+            Some(ExecutionClassification::Write)
+        );
+        assert_eq!(
+            service.classify_execution("UPDATE \"users\" SET name = 'A' WHERE pk = '1'"),
+            Some(ExecutionClassification::Write)
+        );
+        assert_eq!(
+            service.classify_execution("DELETE FROM \"users\" WHERE pk = '1'"),
+            Some(ExecutionClassification::Destructive)
+        );
+    }
+
+    #[test]
+    fn classify_execution_handles_command_envelopes() {
+        let service = DynamoLanguageService;
+
+        assert_eq!(
+            service.classify_execution(r#"{"op":"scan","table":"users"}"#),
+            Some(ExecutionClassification::Read)
+        );
+        assert_eq!(
+            service.classify_execution(r#"{"op":"query","table":"users"}"#),
+            Some(ExecutionClassification::Read)
+        );
+        assert_eq!(
+            service.classify_execution(r#"{"op":"put","table":"users","item":{"pk":"1"}}"#),
+            Some(ExecutionClassification::Write)
+        );
+        assert_eq!(
+            service.classify_execution(r#"{"op":"update","table":"users","key":{"pk":"1"}}"#),
+            Some(ExecutionClassification::Write)
+        );
+        assert_eq!(
+            service.classify_execution(r#"{"op":"delete","table":"users","key":{"pk":"1"}}"#),
+            Some(ExecutionClassification::Destructive)
+        );
     }
 
     #[test]

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -330,7 +330,7 @@ pub static DYNAMODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driver
         supports_ctes: false,
         supports_explain: false,
         max_query_parameters: 0,
-        max_order_by_columns: 0,
+        max_order_by_columns: 1,
         max_group_by_columns: 0,
     }),
     mutation: Some(MutationCapabilities {
@@ -1255,11 +1255,17 @@ impl DynamoConnection {
 
         let runtime = runtime();
 
+        // limitation: PartiQL pagination beyond page 1 needs an inbound page-token
+        // seam on QueryRequest (deferred to the UI batch); only the first page is
+        // returned and next_page_token is surfaced but cannot yet be fed back in.
         let request = self
             .client
             .execute_statement()
             .statement(req.sql.trim())
-            .set_limit(req.limit.map(|limit| limit as i32));
+            .set_limit(
+                req.limit
+                    .map(|limit| i32::try_from(limit).unwrap_or(i32::MAX)),
+            );
 
         let output = runtime.block_on(request.send()).map_err(|error| {
             let formatted = DYNAMO_ERROR_FORMATTER.format_execute_statement_error(&error, &config);
@@ -1273,11 +1279,12 @@ impl DynamoConnection {
                 next_page_token,
             ))
         } else {
-            // ExecuteStatement returns no affected-row count for writes; a
-            // successful single-statement write affects one item.
-            Ok(crud_result_to_query_result(crud_result_with_affected_rows(
-                1,
-            )))
+            // ExecuteStatement returns no affected-row count for writes, so the
+            // affected count is reported as unknown rather than fabricated.
+            let mut query_result =
+                QueryResult::json(Vec::new(), Vec::new(), std::time::Duration::ZERO);
+            query_result.affected_rows = None;
+            Ok(query_result)
         }
     }
 
@@ -4294,26 +4301,59 @@ enum PartiqlVerb {
     Delete,
 }
 
-fn partiql_verb(query: &str) -> Option<PartiqlVerb> {
-    let lower = query.trim_start().to_ascii_lowercase();
+/// Strip leading `--` line comments and surrounding whitespace from a PartiQL
+/// statement so verb detection sees the first real keyword. The editor
+/// placeholder itself is a `--` comment, so a comment-led statement must still
+/// classify by its underlying verb.
+fn strip_partiql_leading_comments(query: &str) -> &str {
+    let mut rest = query.trim_start();
 
-    if lower.starts_with("select ") || lower.starts_with("select\n") {
-        Some(PartiqlVerb::Select)
-    } else if lower.starts_with("insert ") || lower.starts_with("insert\n") {
-        Some(PartiqlVerb::Insert)
-    } else if lower.starts_with("update ") || lower.starts_with("update\n") {
-        Some(PartiqlVerb::Update)
-    } else if lower.starts_with("delete ") || lower.starts_with("delete\n") {
-        Some(PartiqlVerb::Delete)
-    } else {
-        None
+    while let Some(after) = rest.strip_prefix("--") {
+        match after.find('\n') {
+            Some(newline) => rest = after[newline + 1..].trim_start(),
+            None => return "",
+        }
+    }
+
+    rest
+}
+
+fn partiql_verb(query: &str) -> Option<PartiqlVerb> {
+    let stripped = strip_partiql_leading_comments(query);
+
+    let verb_end = stripped
+        .char_indices()
+        .find(|(_, character)| character.is_ascii_whitespace())
+        .map(|(index, _)| index)?;
+
+    match stripped[..verb_end].to_ascii_lowercase().as_str() {
+        "select" => Some(PartiqlVerb::Select),
+        "insert" => Some(PartiqlVerb::Insert),
+        "update" => Some(PartiqlVerb::Update),
+        "delete" => Some(PartiqlVerb::Delete),
+        _ => None,
     }
 }
 
-/// Whether a PartiQL statement carries a `WHERE` clause.
+/// Whether a PartiQL statement carries a `WHERE` clause. `WHERE` is matched as a
+/// case-insensitive token bounded by ASCII whitespace on both sides, so a clause
+/// whose keyword is followed by a newline or tab is still recognized.
 fn partiql_has_where(query: &str) -> bool {
     let lower = query.to_ascii_lowercase();
-    lower.contains(" where ") || lower.contains("\nwhere ") || lower.ends_with(" where")
+    let bytes = lower.as_bytes();
+
+    lower.match_indices("where").any(|(index, _)| {
+        let before_ok = index
+            .checked_sub(1)
+            .is_none_or(|previous| bytes.get(previous).is_some_and(u8::is_ascii_whitespace));
+
+        let after = index + "where".len();
+        let after_ok = bytes
+            .get(after)
+            .is_none_or(|byte| byte.is_ascii_whitespace());
+
+        before_ok && after_ok
+    })
 }
 
 impl LanguageService for DynamoLanguageService {
@@ -5582,6 +5622,42 @@ mod tests {
         assert_eq!(
             service.detect_dangerous("SELECT * FROM \"users\" WHERE pk = '1'"),
             None
+        );
+    }
+
+    #[test]
+    fn dangerous_detection_recognizes_where_followed_by_newline_or_tab() {
+        let service = DynamoLanguageService;
+
+        assert_eq!(
+            service.detect_dangerous("DELETE FROM \"users\" WHERE\n pk = '1'"),
+            None
+        );
+        assert_eq!(
+            service.detect_dangerous("DELETE FROM \"users\" WHERE\tpk = '1'"),
+            None
+        );
+        assert_eq!(
+            service.detect_dangerous("UPDATE \"users\" SET name = 'A' WHERE\n pk = '1'"),
+            None
+        );
+    }
+
+    #[test]
+    fn verb_detection_handles_leading_comments_and_tab_delimited_verbs() {
+        let service = DynamoLanguageService;
+
+        assert_eq!(
+            service.classify_execution("-- note\nSELECT * FROM \"users\" WHERE pk = '1'"),
+            Some(ExecutionClassification::Read)
+        );
+        assert_eq!(
+            service.classify_execution("SELECT\t* FROM \"users\" WHERE pk = '1'"),
+            Some(ExecutionClassification::Read)
+        );
+        assert_eq!(
+            service.classify_execution("DELETE\tFROM \"users\" WHERE pk = '1'"),
+            Some(ExecutionClassification::Destructive)
         );
     }
 

--- a/crates/dbflux_driver_dynamodb/src/query_generator.rs
+++ b/crates/dbflux_driver_dynamodb/src/query_generator.rs
@@ -1,7 +1,7 @@
 use dbflux_core::{
     Comparator, DocumentDelete, DocumentInsert, DocumentUpdate, FilterNode, GeneratedQuery,
     LiteralValue, MutationCategory, MutationRequest, Predicate, PredicateValue, QueryGenError,
-    QueryGenerator, QueryLanguage, VisualQuerySpec,
+    QueryGenerator, QueryLanguage, VisualQuerySpec, VisualSortDirection,
 };
 
 fn json_text(value: &serde_json::Value) -> Option<String> {
@@ -181,12 +181,11 @@ fn partiql_filter(node: &FilterNode) -> Result<Option<String>, QueryGenError> {
 
 /// Build the PartiQL `SELECT` text for a visual read spec.
 ///
-/// DynamoDB PartiQL has no `LIMIT` or `ORDER BY` keyword: row limiting travels
-/// out-of-band as the `execute_statement` limit argument, and sort-key direction
-/// as the query envelope's `scan_index_forward`. This generator therefore emits
-/// only the `SELECT ... FROM ... [WHERE ...]` shape; `spec.limit`, `spec.offset`,
-/// and `spec.sort` are intentionally not encoded into the text and are carried by
-/// the execution path instead.
+/// DynamoDB PartiQL has no `LIMIT` keyword: row limiting travels out-of-band as
+/// the `execute_statement` limit argument, so `spec.limit` and `spec.offset` are
+/// not encoded into the text. PartiQL does support `ORDER BY` on key attributes,
+/// so a chosen sort-key direction (`OrderByMode::SortKeyOnly`) is emitted in-band
+/// as `ORDER BY "<sortkey>" ASC|DESC` to reach the executed path.
 fn generate_partiql_read(spec: &VisualQuerySpec) -> Result<GeneratedQuery, QueryGenError> {
     if spec.source.table.trim().is_empty() {
         return Err(QueryGenError::InvalidSpec(
@@ -214,6 +213,17 @@ fn generate_partiql_read(spec: &VisualQuerySpec) -> Result<GeneratedQuery, Query
     {
         text.push_str(" WHERE ");
         text.push_str(&where_clause);
+    }
+
+    if let Some(sort) = spec.sort.first() {
+        let direction = match sort.direction {
+            VisualSortDirection::Asc => "ASC",
+            VisualSortDirection::Desc => "DESC",
+        };
+        text.push_str(" ORDER BY ");
+        text.push_str(&quote_partiql_identifier(&sort.column));
+        text.push(' ');
+        text.push_str(direction);
     }
 
     Ok(GeneratedQuery {
@@ -356,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn generate_read_from_spec_omits_limit_and_sort_from_text() {
+    fn generate_read_from_spec_omits_limit_but_emits_sort_direction() {
         let generator = DynamoQueryGenerator;
         let mut spec = read_spec("users", None);
         spec.limit = Some(25);
@@ -371,9 +381,39 @@ mod tests {
             .expect("read generation should succeed")
             .expect("DynamoDB generator should emit a read");
 
-        assert_eq!(generated.text, "SELECT * FROM \"users\"");
+        assert_eq!(
+            generated.text,
+            "SELECT * FROM \"users\" ORDER BY \"sk\" DESC"
+        );
         assert!(!generated.text.to_ascii_uppercase().contains("LIMIT"));
-        assert!(!generated.text.to_ascii_uppercase().contains("ORDER BY"));
+    }
+
+    #[test]
+    fn generate_read_from_spec_emits_ascending_order_by_after_where() {
+        let generator = DynamoQueryGenerator;
+        let filter = FilterNode::Group {
+            op: BoolOp::And,
+            children: vec![FilterNode::Predicate(eq_predicate(
+                "pk",
+                LiteralValue::Text("U#1".to_string()),
+            ))],
+        };
+        let mut spec = read_spec("users", Some(filter));
+        spec.sort = vec![SortEntry {
+            source_alias: "t".to_string(),
+            column: "sk".to_string(),
+            direction: VisualSortDirection::Asc,
+        }];
+
+        let generated = generator
+            .generate_read_from_spec(&spec)
+            .expect("read generation should succeed")
+            .expect("DynamoDB generator should emit a read");
+
+        assert_eq!(
+            generated.text,
+            "SELECT * FROM \"users\" WHERE \"pk\" = 'U#1' ORDER BY \"sk\" ASC"
+        );
     }
 
     #[test]

--- a/crates/dbflux_driver_dynamodb/src/query_generator.rs
+++ b/crates/dbflux_driver_dynamodb/src/query_generator.rs
@@ -1,6 +1,7 @@
 use dbflux_core::{
-    DocumentDelete, DocumentInsert, DocumentUpdate, GeneratedQuery, MutationCategory,
-    MutationRequest, QueryGenerator, QueryLanguage,
+    Comparator, DocumentDelete, DocumentInsert, DocumentUpdate, FilterNode, GeneratedQuery,
+    LiteralValue, MutationCategory, MutationRequest, Predicate, PredicateValue, QueryGenError,
+    QueryGenerator, QueryLanguage, VisualQuerySpec,
 };
 
 fn json_text(value: &serde_json::Value) -> Option<String> {
@@ -89,6 +90,138 @@ fn generate_delete(delete: &DocumentDelete) -> Option<String> {
     json_text(&serde_json::Value::Object(envelope))
 }
 
+/// Quote a PartiQL identifier (table or attribute name) with double quotes,
+/// escaping embedded double quotes by doubling them.
+fn quote_partiql_identifier(name: &str) -> String {
+    format!("\"{}\"", name.replace('"', "\"\""))
+}
+
+/// Render a PartiQL scalar literal. Text and timestamp values are single-quoted
+/// (single quotes doubled); numbers and booleans are emitted bare; null becomes
+/// the `NULL` keyword.
+fn partiql_literal(value: &LiteralValue) -> String {
+    match value {
+        LiteralValue::Text(text) | LiteralValue::Timestamp(text) => {
+            format!("'{}'", text.replace('\'', "''"))
+        }
+        LiteralValue::Integer(value) => value.to_string(),
+        LiteralValue::Float(value) => value.to_string(),
+        LiteralValue::Bool(value) => value.to_string(),
+        LiteralValue::Null => "NULL".to_string(),
+    }
+}
+
+/// Render a single filter predicate as a PartiQL boolean expression.
+fn partiql_predicate(predicate: &Predicate) -> Result<String, QueryGenError> {
+    let column = quote_partiql_identifier(&predicate.column);
+
+    let render_binary = |symbol: &str, value: &PredicateValue| match value {
+        PredicateValue::Single(literal) => {
+            Ok(format!("{column} {symbol} {}", partiql_literal(literal)))
+        }
+        _ => Err(QueryGenError::InvalidSpec(format!(
+            "operator {symbol} requires a single value"
+        ))),
+    };
+
+    match predicate.comparator {
+        Comparator::Eq => render_binary("=", &predicate.value),
+        Comparator::Neq => render_binary("<>", &predicate.value),
+        Comparator::Gt => render_binary(">", &predicate.value),
+        Comparator::Lt => render_binary("<", &predicate.value),
+        Comparator::Gte => render_binary(">=", &predicate.value),
+        Comparator::Lte => render_binary("<=", &predicate.value),
+        Comparator::In => match &predicate.value {
+            PredicateValue::List(values) if !values.is_empty() => {
+                let rendered: Vec<String> = values.iter().map(partiql_literal).collect();
+                Ok(format!("{column} IN [{}]", rendered.join(", ")))
+            }
+            _ => Err(QueryGenError::InvalidSpec(
+                "IN requires a non-empty value list".to_string(),
+            )),
+        },
+        Comparator::IsNull => Ok(format!("{column} IS NULL")),
+        Comparator::IsNotNull => Ok(format!("{column} IS NOT NULL")),
+        Comparator::Like | Comparator::ILike => Err(QueryGenError::InvalidSpec(
+            "DynamoDB PartiQL does not support LIKE/ILIKE in the visual builder".to_string(),
+        )),
+    }
+}
+
+/// Render a filter tree as a PartiQL boolean expression. Groups are parenthesized
+/// and joined by their boolean operator.
+fn partiql_filter(node: &FilterNode) -> Result<Option<String>, QueryGenError> {
+    match node {
+        FilterNode::Predicate(predicate) => Ok(Some(partiql_predicate(predicate)?)),
+        FilterNode::Group { op, children } => {
+            let mut rendered = Vec::new();
+            for child in children {
+                if let Some(expression) = partiql_filter(child)? {
+                    rendered.push(expression);
+                }
+            }
+
+            if rendered.is_empty() {
+                return Ok(None);
+            }
+
+            let joiner = match op {
+                dbflux_core::BoolOp::And => " AND ",
+                dbflux_core::BoolOp::Or => " OR ",
+            };
+
+            if rendered.len() == 1 {
+                Ok(rendered.into_iter().next())
+            } else {
+                Ok(Some(format!("({})", rendered.join(joiner))))
+            }
+        }
+    }
+}
+
+/// Build the PartiQL `SELECT` text for a visual read spec.
+///
+/// DynamoDB PartiQL has no `LIMIT` or `ORDER BY` keyword: row limiting travels
+/// out-of-band as the `execute_statement` limit argument, and sort-key direction
+/// as the query envelope's `scan_index_forward`. This generator therefore emits
+/// only the `SELECT ... FROM ... [WHERE ...]` shape; `spec.limit`, `spec.offset`,
+/// and `spec.sort` are intentionally not encoded into the text and are carried by
+/// the execution path instead.
+fn generate_partiql_read(spec: &VisualQuerySpec) -> Result<GeneratedQuery, QueryGenError> {
+    if spec.source.table.trim().is_empty() {
+        return Err(QueryGenError::InvalidSpec(
+            "source table must not be empty".to_string(),
+        ));
+    }
+
+    if !spec.joins.is_empty() {
+        return Err(QueryGenError::InvalidSpec(
+            "DynamoDB PartiQL reads do not support joins".to_string(),
+        ));
+    }
+
+    if spec.is_grouped() {
+        return Err(QueryGenError::InvalidSpec(
+            "DynamoDB PartiQL reads do not support GROUP BY or aggregates".to_string(),
+        ));
+    }
+
+    let table = quote_partiql_identifier(&spec.source.table);
+    let mut text = format!("SELECT * FROM {table}");
+
+    if let Some(filter) = spec.filter.as_ref()
+        && let Some(where_clause) = partiql_filter(filter)?
+    {
+        text.push_str(" WHERE ");
+        text.push_str(&where_clause);
+    }
+
+    Ok(GeneratedQuery {
+        language: QueryLanguage::Custom("DynamoDB".to_string()),
+        text,
+    })
+}
+
 pub struct DynamoQueryGenerator;
 
 impl QueryGenerator for DynamoQueryGenerator {
@@ -109,6 +242,13 @@ impl QueryGenerator for DynamoQueryGenerator {
             text,
         })
     }
+
+    fn generate_read_from_spec(
+        &self,
+        spec: &VisualQuerySpec,
+    ) -> Result<Option<GeneratedQuery>, QueryGenError> {
+        generate_partiql_read(spec).map(Some)
+    }
 }
 
 #[cfg(test)]
@@ -116,10 +256,142 @@ mod tests {
     use super::DynamoQueryGenerator;
     use crate::query_parser::parse_command_envelope;
     use dbflux_core::{
-        DocumentDelete, DocumentFilter, DocumentInsert, DocumentUpdate, MutationRequest,
-        QueryGenerator,
+        BoolOp, Comparator, DocumentDelete, DocumentFilter, DocumentInsert, DocumentUpdate,
+        FilterNode, LiteralValue, MutationRequest, Predicate, PredicateValue, Projection,
+        QueryGenError, QueryGenerator, QueryLanguage, SortEntry, SourceTable, VisualAggregateSpec,
+        VisualQuerySpec, VisualSortDirection,
     };
     use serde_json::json;
+
+    fn read_spec(table: &str, filter: Option<FilterNode>) -> VisualQuerySpec {
+        VisualQuerySpec {
+            source: SourceTable {
+                schema: None,
+                table: table.to_string(),
+                alias: table.to_string(),
+            },
+            projection: Projection::All,
+            joins: Vec::new(),
+            filter,
+            group_by: Vec::new(),
+            aggregates: Vec::new(),
+            having: None,
+            sort: Vec::new(),
+            limit: None,
+            offset: 0,
+        }
+    }
+
+    fn eq_predicate(column: &str, value: LiteralValue) -> Predicate {
+        Predicate {
+            source_alias: "t".to_string(),
+            column: column.to_string(),
+            comparator: Comparator::Eq,
+            value: PredicateValue::Single(value),
+            node_id: 0,
+        }
+    }
+
+    #[test]
+    fn generate_read_from_spec_emits_partiql_select_without_filter() {
+        let generator = DynamoQueryGenerator;
+        let spec = read_spec("users", None);
+
+        let generated = generator
+            .generate_read_from_spec(&spec)
+            .expect("read generation should succeed")
+            .expect("DynamoDB generator should emit a read");
+
+        assert_eq!(generated.text, "SELECT * FROM \"users\"");
+        assert_eq!(
+            generated.language,
+            QueryLanguage::Custom("DynamoDB".to_string())
+        );
+    }
+
+    #[test]
+    fn generate_read_from_spec_emits_where_for_single_predicate() {
+        let generator = DynamoQueryGenerator;
+        let filter = FilterNode::Group {
+            op: BoolOp::And,
+            children: vec![FilterNode::Predicate(eq_predicate(
+                "pk",
+                LiteralValue::Text("U#1".to_string()),
+            ))],
+        };
+        let spec = read_spec("users", Some(filter));
+
+        let generated = generator
+            .generate_read_from_spec(&spec)
+            .expect("read generation should succeed")
+            .expect("DynamoDB generator should emit a read");
+
+        assert_eq!(
+            generated.text,
+            "SELECT * FROM \"users\" WHERE \"pk\" = 'U#1'"
+        );
+    }
+
+    #[test]
+    fn generate_read_from_spec_joins_group_with_boolean_operator() {
+        let generator = DynamoQueryGenerator;
+        let filter = FilterNode::Group {
+            op: BoolOp::And,
+            children: vec![
+                FilterNode::Predicate(eq_predicate("pk", LiteralValue::Text("U#1".to_string()))),
+                FilterNode::Predicate(eq_predicate("score", LiteralValue::Integer(10))),
+            ],
+        };
+        let spec = read_spec("users", Some(filter));
+
+        let generated = generator
+            .generate_read_from_spec(&spec)
+            .expect("read generation should succeed")
+            .expect("DynamoDB generator should emit a read");
+
+        assert_eq!(
+            generated.text,
+            "SELECT * FROM \"users\" WHERE (\"pk\" = 'U#1' AND \"score\" = 10)"
+        );
+    }
+
+    #[test]
+    fn generate_read_from_spec_omits_limit_and_sort_from_text() {
+        let generator = DynamoQueryGenerator;
+        let mut spec = read_spec("users", None);
+        spec.limit = Some(25);
+        spec.sort = vec![SortEntry {
+            source_alias: "t".to_string(),
+            column: "sk".to_string(),
+            direction: VisualSortDirection::Desc,
+        }];
+
+        let generated = generator
+            .generate_read_from_spec(&spec)
+            .expect("read generation should succeed")
+            .expect("DynamoDB generator should emit a read");
+
+        assert_eq!(generated.text, "SELECT * FROM \"users\"");
+        assert!(!generated.text.to_ascii_uppercase().contains("LIMIT"));
+        assert!(!generated.text.to_ascii_uppercase().contains("ORDER BY"));
+    }
+
+    #[test]
+    fn generate_read_from_spec_rejects_joins_and_grouping() {
+        let generator = DynamoQueryGenerator;
+        let mut spec = read_spec("users", None);
+        spec.aggregates = vec![VisualAggregateSpec {
+            function: dbflux_core::AggFn::CountStar,
+            source_alias: None,
+            column: None,
+            alias: "count".to_string(),
+        }];
+
+        let error = generator
+            .generate_read_from_spec(&spec)
+            .expect_err("grouped spec must be rejected");
+        assert!(matches!(error, QueryGenError::InvalidSpec(_)));
+    }
 
     #[test]
     fn generated_insert_update_delete_envelopes_are_parseable() {

--- a/crates/dbflux_driver_dynamodb/src/query_parser.rs
+++ b/crates/dbflux_driver_dynamodb/src/query_parser.rs
@@ -52,6 +52,10 @@ pub struct DynamoReadOptions {
     pub index_name: Option<String>,
     pub consistent_read: bool,
     pub filter_fallback: DynamoFilterFallback,
+    /// Sort-key scan direction. `Some(true)` = ascending (DynamoDB default),
+    /// `Some(false)` = descending, `None` = leave the API default. Only affects
+    /// `Query` reads; `Scan` does not order by the sort key.
+    pub scan_index_forward: Option<bool>,
 }
 
 impl Default for DynamoReadOptions {
@@ -60,6 +64,7 @@ impl Default for DynamoReadOptions {
             index_name: None,
             consistent_read: false,
             filter_fallback: DynamoFilterFallback::ClientSide,
+            scan_index_forward: None,
         }
     }
 }
@@ -106,6 +111,7 @@ pub fn parse_command_envelope(input: &str) -> Result<DynamoCommandEnvelope, DbEr
                     "consistent_read",
                     "allow_filter_fallback",
                     "require_server_filter",
+                    "scan_index_forward",
                 ],
             )?;
 
@@ -135,6 +141,7 @@ pub fn parse_command_envelope(input: &str) -> Result<DynamoCommandEnvelope, DbEr
                     "consistent_read",
                     "allow_filter_fallback",
                     "require_server_filter",
+                    "scan_index_forward",
                 ],
             )?;
 
@@ -368,6 +375,7 @@ fn parse_read_options(
     let consistent_read = optional_bool(object, "consistent_read")?.unwrap_or(false);
     let allow_filter_fallback = optional_bool(object, "allow_filter_fallback")?.unwrap_or(true);
     let require_server_filter = optional_bool(object, "require_server_filter")?.unwrap_or(false);
+    let scan_index_forward = optional_bool(object, "scan_index_forward")?;
 
     if allow_filter_fallback && require_server_filter {
         return Err(DbError::query_failed(format!(
@@ -391,6 +399,7 @@ fn parse_read_options(
         index_name,
         consistent_read,
         filter_fallback,
+        scan_index_forward,
     })
 }
 
@@ -582,6 +591,37 @@ mod tests {
             }
             other => panic!("expected query envelope, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_query_envelope_with_scan_index_forward() {
+        let descending = parse_command_envelope(
+            r#"{"op":"query","table":"users","filter":{"pk":"A"},"scan_index_forward":false}"#,
+        )
+        .expect("query envelope with scan_index_forward should parse");
+
+        match descending {
+            DynamoCommandEnvelope::Query { read_options, .. } => {
+                assert_eq!(read_options.scan_index_forward, Some(false));
+            }
+            other => panic!("expected query envelope, got {other:?}"),
+        }
+
+        let default =
+            parse_command_envelope(r#"{"op":"query","table":"users","filter":{"pk":"A"}}"#)
+                .expect("query envelope without scan_index_forward should parse");
+
+        match default {
+            DynamoCommandEnvelope::Query { read_options, .. } => {
+                assert_eq!(read_options.scan_index_forward, None);
+            }
+            other => panic!("expected query envelope, got {other:?}"),
+        }
+
+        let non_bool =
+            parse_command_envelope(r#"{"op":"query","table":"users","scan_index_forward":"asc"}"#)
+                .expect_err("non-bool scan_index_forward must fail");
+        assert!(matches!(non_bool, DbError::QueryFailed(_)));
     }
 
     #[test]

--- a/crates/dbflux_driver_influxdb/src/driver.rs
+++ b/crates/dbflux_driver_influxdb/src/driver.rs
@@ -49,6 +49,7 @@ pub static INFLUXDB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driver
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 pub static INFLUXDB_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef {

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -134,6 +134,7 @@ pub static MONGODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverM
             WhereOperator::Not,
         ],
         supports_order_by: true,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         supports_group_by: true,
         supports_having: true,
         supports_distinct: false,
@@ -223,6 +224,7 @@ pub static MONGODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverM
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 pub struct MongoDriver;

--- a/crates/dbflux_driver_mongodb/src/query_generator.rs
+++ b/crates/dbflux_driver_mongodb/src/query_generator.rs
@@ -1,6 +1,9 @@
 use dbflux_core::{
-    GeneratedQuery, MutationCategory, MutationRequest, QueryGenerator, QueryLanguage,
+    Comparator, FilterNode, GeneratedQuery, LiteralValue, MutationCategory, MutationRequest,
+    Predicate, PredicateValue, Projection, QueryGenError, QueryGenerator, QueryLanguage, SortEntry,
+    VisualQuerySpec, VisualSortDirection,
 };
+use serde_json::{Value, json};
 
 pub struct MongoShellGenerator;
 
@@ -21,6 +24,260 @@ impl QueryGenerator for MongoShellGenerator {
             language: QueryLanguage::MongoQuery,
             text,
         })
+    }
+
+    fn generate_read_from_spec(
+        &self,
+        spec: &VisualQuerySpec,
+    ) -> Result<Option<GeneratedQuery>, QueryGenError> {
+        let text = generate_find(spec)?;
+
+        Ok(Some(GeneratedQuery {
+            language: QueryLanguage::MongoQuery,
+            text,
+        }))
+    }
+}
+
+/// Renders a `VisualQuerySpec` into a MongoDB shell `find(...)` read.
+///
+/// The shape is `db.<collection>.find(<filter>, <projection?>).sort(<doc>)
+/// .limit(N).skip(M)`, where the `.sort`/`.limit`/`.skip` segments are emitted
+/// only when the spec carries the corresponding data. SQL-only constructs
+/// (joins, GROUP BY, HAVING, aggregates) have no MongoDB `find` equivalent and
+/// are rejected as `InvalidSpec` rather than silently dropped.
+fn generate_find(spec: &VisualQuerySpec) -> Result<String, QueryGenError> {
+    if !spec.joins.is_empty() {
+        return Err(QueryGenError::InvalidSpec(
+            "MongoDB find() does not support joins".to_string(),
+        ));
+    }
+    if !spec.group_by.is_empty() || !spec.aggregates.is_empty() || spec.having.is_some() {
+        return Err(QueryGenError::InvalidSpec(
+            "MongoDB find() does not support GROUP BY / HAVING / aggregates".to_string(),
+        ));
+    }
+
+    let collection = &spec.source.table;
+    let filter = render_filter(spec.filter.as_ref());
+    let projection = render_projection(&spec.projection);
+
+    let mut text = match projection {
+        Some(proj) => format!("db.{collection}.find({filter}, {proj})"),
+        None => format!("db.{collection}.find({filter})"),
+    };
+
+    if let Some(sort_doc) = render_sort(&spec.sort) {
+        text.push_str(&format!(".sort({sort_doc})"));
+    }
+
+    if let Some(limit) = spec.limit {
+        text.push_str(&format!(".limit({limit})"));
+    }
+
+    if spec.offset > 0 {
+        text.push_str(&format!(".skip({})", spec.offset));
+    }
+
+    Ok(text)
+}
+
+/// An order-preserving MongoDB document (object).
+///
+/// `serde_json::Map` is backed by a `BTreeMap` in this build (no `preserve_order`
+/// feature), so it reorders keys alphabetically — which would scramble the
+/// authored order of a generated query (e.g. `$options` ahead of `$regex`).
+/// The generated text is read by humans, so the document is rendered from an
+/// ordered list of entries instead, while leaf values keep `serde_json`'s
+/// correct escaping and number formatting.
+enum MongoValue {
+    Document(Vec<(String, MongoValue)>),
+    Array(Vec<MongoValue>),
+    Leaf(Value),
+}
+
+impl MongoValue {
+    fn render(&self) -> String {
+        match self {
+            MongoValue::Leaf(value) => value.to_string(),
+            MongoValue::Array(items) => {
+                let rendered: Vec<String> = items.iter().map(MongoValue::render).collect();
+                format!("[{}]", rendered.join(","))
+            }
+            MongoValue::Document(entries) => {
+                let rendered: Vec<String> = entries
+                    .iter()
+                    .map(|(key, value)| {
+                        format!("{}:{}", Value::String(key.clone()), value.render())
+                    })
+                    .collect();
+                format!("{{{}}}", rendered.join(","))
+            }
+        }
+    }
+}
+
+/// Renders the filter tree as a compact MongoDB query document.
+///
+/// `None` (or a tree that produces no predicates) renders as the empty document
+/// `{}`, matching the shell convention for "match everything".
+fn render_filter(filter: Option<&FilterNode>) -> String {
+    filter
+        .and_then(filter_node_to_value)
+        .unwrap_or_else(|| MongoValue::Document(Vec::new()))
+        .render()
+}
+
+fn filter_node_to_value(node: &FilterNode) -> Option<MongoValue> {
+    use dbflux_core::BoolOp;
+
+    match node {
+        FilterNode::Predicate(pred) => predicate_to_value(pred),
+        FilterNode::Group { op, children } => {
+            let parts: Vec<MongoValue> = children.iter().filter_map(filter_node_to_value).collect();
+
+            match parts.len() {
+                0 => None,
+                1 => parts.into_iter().next(),
+                _ => {
+                    let key = match op {
+                        BoolOp::And => "$and",
+                        BoolOp::Or => "$or",
+                    };
+                    Some(MongoValue::Document(vec![(
+                        key.to_string(),
+                        MongoValue::Array(parts),
+                    )]))
+                }
+            }
+        }
+    }
+}
+
+/// Maps a single predicate to a `{ field: <condition> }` document.
+///
+/// Predicates whose column is empty (still being authored in the UI) are
+/// skipped, mirroring the SQL builder's tolerance for partially-edited rows.
+fn predicate_to_value(pred: &Predicate) -> Option<MongoValue> {
+    let field = pred.column.trim();
+    if field.is_empty() {
+        return None;
+    }
+
+    let condition = match pred.comparator {
+        Comparator::Eq => MongoValue::Leaf(predicate_scalar(&pred.value)),
+        Comparator::Neq => op_document("$ne", predicate_scalar(&pred.value)),
+        Comparator::Gt => op_document("$gt", predicate_scalar(&pred.value)),
+        Comparator::Lt => op_document("$lt", predicate_scalar(&pred.value)),
+        Comparator::Gte => op_document("$gte", predicate_scalar(&pred.value)),
+        Comparator::Lte => op_document("$lte", predicate_scalar(&pred.value)),
+        Comparator::In => op_document("$in", predicate_list(&pred.value)),
+        Comparator::IsNull => op_document("$eq", Value::Null),
+        Comparator::IsNotNull => op_document("$ne", Value::Null),
+        Comparator::Like => op_document("$regex", regex_text(&pred.value)),
+        Comparator::ILike => MongoValue::Document(vec![
+            (
+                "$regex".to_string(),
+                MongoValue::Leaf(regex_text(&pred.value)),
+            ),
+            (
+                "$options".to_string(),
+                MongoValue::Leaf(Value::String("i".to_string())),
+            ),
+        ]),
+    };
+
+    Some(MongoValue::Document(vec![(field.to_string(), condition)]))
+}
+
+fn op_document(operator: &str, value: Value) -> MongoValue {
+    MongoValue::Document(vec![(operator.to_string(), MongoValue::Leaf(value))])
+}
+
+fn predicate_scalar(value: &PredicateValue) -> Value {
+    match value {
+        PredicateValue::Single(literal) => literal_to_value(literal),
+        PredicateValue::None => Value::Null,
+        PredicateValue::List(items) => Value::Array(items.iter().map(literal_to_value).collect()),
+    }
+}
+
+fn predicate_list(value: &PredicateValue) -> Value {
+    match value {
+        PredicateValue::List(items) => Value::Array(items.iter().map(literal_to_value).collect()),
+        PredicateValue::Single(literal) => Value::Array(vec![literal_to_value(literal)]),
+        PredicateValue::None => Value::Array(Vec::new()),
+    }
+}
+
+fn regex_text(value: &PredicateValue) -> Value {
+    match value {
+        PredicateValue::Single(LiteralValue::Text(text)) => Value::String(text.clone()),
+        other => predicate_scalar(other),
+    }
+}
+
+fn literal_to_value(literal: &LiteralValue) -> Value {
+    match literal {
+        LiteralValue::Text(text) => Value::String(text.clone()),
+        LiteralValue::Integer(n) => json!(n),
+        LiteralValue::Float(f) => json!(f),
+        LiteralValue::Bool(b) => Value::Bool(*b),
+        LiteralValue::Timestamp(text) => Value::String(text.clone()),
+        LiteralValue::Null => Value::Null,
+    }
+}
+
+/// Renders the projection document, or `None` for `Projection::All` (no second
+/// `find` argument). Explicit columns map to `{ "col": 1, ... }`; an explicit
+/// projection with no usable columns also collapses to `None`.
+fn render_projection(projection: &Projection) -> Option<String> {
+    match projection {
+        Projection::All => None,
+        Projection::Explicit(columns) => {
+            let mut entries: Vec<(String, MongoValue)> = Vec::new();
+            for column in columns {
+                let key = column
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| column.column.clone());
+                if !key.trim().is_empty() {
+                    entries.push((key, MongoValue::Leaf(json!(1))));
+                }
+            }
+
+            if entries.is_empty() {
+                None
+            } else {
+                Some(MongoValue::Document(entries).render())
+            }
+        }
+    }
+}
+
+/// Renders the sort document `{ "field": 1|-1, ... }`, where ascending is `1`
+/// and descending is `-1`. Returns `None` when there is nothing to sort by.
+fn render_sort(sort: &[SortEntry]) -> Option<String> {
+    if sort.is_empty() {
+        return None;
+    }
+
+    let mut entries: Vec<(String, MongoValue)> = Vec::new();
+    for entry in sort {
+        if entry.column.trim().is_empty() {
+            continue;
+        }
+        let direction = match entry.direction {
+            VisualSortDirection::Asc => 1,
+            VisualSortDirection::Desc => -1,
+        };
+        entries.push((entry.column.clone(), MongoValue::Leaf(json!(direction))));
+    }
+
+    if entries.is_empty() {
+        None
+    } else {
+        Some(MongoValue::Document(entries).render())
     }
 }
 
@@ -153,6 +410,201 @@ mod tests {
 
         let result = MongoShellGenerator.generate_mutation(&mutation).unwrap();
         assert!(result.text.contains("deleteMany"));
+    }
+
+    // =========================================================================
+    // generate_read_from_spec — VisualQuerySpec -> find().sort().limit().skip()
+    // =========================================================================
+
+    use dbflux_core::{BoolOp, ProjectedColumn, SourceTable, VisualSortDirection};
+
+    fn source(table: &str) -> SourceTable {
+        SourceTable {
+            schema: None,
+            table: table.to_string(),
+            alias: table.to_string(),
+        }
+    }
+
+    fn read_spec(table: &str) -> VisualQuerySpec {
+        VisualQuerySpec {
+            source: source(table),
+            projection: Projection::All,
+            joins: vec![],
+            filter: None,
+            group_by: vec![],
+            aggregates: vec![],
+            having: None,
+            sort: vec![],
+            limit: None,
+            offset: 0,
+        }
+    }
+
+    fn eq_predicate(column: &str, value: LiteralValue) -> FilterNode {
+        FilterNode::Predicate(Predicate {
+            source_alias: String::new(),
+            column: column.to_string(),
+            comparator: Comparator::Eq,
+            value: PredicateValue::Single(value),
+            node_id: 0,
+        })
+    }
+
+    fn sort_entry(column: &str, direction: VisualSortDirection) -> SortEntry {
+        SortEntry {
+            source_alias: String::new(),
+            column: column.to_string(),
+            direction,
+        }
+    }
+
+    #[test]
+    fn read_spec_filter_sort_limit_skip() {
+        let mut spec = read_spec("users");
+        spec.filter = Some(FilterNode::Group {
+            op: BoolOp::And,
+            children: vec![
+                eq_predicate("status", LiteralValue::Text("active".to_string())),
+                FilterNode::Predicate(Predicate {
+                    source_alias: String::new(),
+                    column: "age".to_string(),
+                    comparator: Comparator::Gt,
+                    value: PredicateValue::Single(LiteralValue::Integer(18)),
+                    node_id: 0,
+                }),
+            ],
+        });
+        spec.sort = vec![
+            sort_entry("created_at", VisualSortDirection::Desc),
+            sort_entry("name", VisualSortDirection::Asc),
+        ];
+        spec.limit = Some(25);
+        spec.offset = 10;
+
+        let result = MongoShellGenerator
+            .generate_read_from_spec(&spec)
+            .expect("read spec must generate")
+            .expect("MongoDB generator emits read text");
+
+        assert_eq!(result.language, QueryLanguage::MongoQuery);
+        assert_eq!(
+            result.text,
+            r#"db.users.find({"$and":[{"status":"active"},{"age":{"$gt":18}}]}).sort({"created_at":-1,"name":1}).limit(25).skip(10)"#
+        );
+    }
+
+    #[test]
+    fn read_spec_empty_filter_renders_empty_document() {
+        let spec = read_spec("events");
+
+        let result = MongoShellGenerator
+            .generate_read_from_spec(&spec)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.text, "db.events.find({})");
+    }
+
+    #[test]
+    fn read_spec_explicit_projection_emits_projection_argument() {
+        let mut spec = read_spec("users");
+        spec.projection = Projection::Explicit(vec![
+            ProjectedColumn {
+                source_alias: "users".to_string(),
+                column: "name".to_string(),
+                alias: None,
+            },
+            ProjectedColumn {
+                source_alias: "users".to_string(),
+                column: "email".to_string(),
+                alias: Some("contact".to_string()),
+            },
+        ]);
+        spec.filter = Some(eq_predicate("active", LiteralValue::Bool(true)));
+
+        let result = MongoShellGenerator
+            .generate_read_from_spec(&spec)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            result.text,
+            r#"db.users.find({"active":true}, {"name":1,"contact":1})"#
+        );
+    }
+
+    #[test]
+    fn read_spec_in_and_regex_operators() {
+        let mut spec = read_spec("users");
+        spec.filter = Some(FilterNode::Group {
+            op: BoolOp::Or,
+            children: vec![
+                FilterNode::Predicate(Predicate {
+                    source_alias: String::new(),
+                    column: "role".to_string(),
+                    comparator: Comparator::In,
+                    value: PredicateValue::List(vec![
+                        LiteralValue::Text("admin".to_string()),
+                        LiteralValue::Text("staff".to_string()),
+                    ]),
+                    node_id: 0,
+                }),
+                FilterNode::Predicate(Predicate {
+                    source_alias: String::new(),
+                    column: "name".to_string(),
+                    comparator: Comparator::ILike,
+                    value: PredicateValue::Single(LiteralValue::Text("al".to_string())),
+                    node_id: 0,
+                }),
+            ],
+        });
+
+        let result = MongoShellGenerator
+            .generate_read_from_spec(&spec)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            result.text,
+            r#"db.users.find({"$or":[{"role":{"$in":["admin","staff"]}},{"name":{"$regex":"al","$options":"i"}}]})"#
+        );
+    }
+
+    #[test]
+    fn read_spec_rejects_joins() {
+        use dbflux_core::{JoinKind, JoinOn, JoinStep};
+
+        let mut spec = read_spec("orders");
+        spec.joins = vec![JoinStep {
+            kind: JoinKind::Inner,
+            from_alias: "orders".to_string(),
+            to_schema: None,
+            to_table: "users".to_string(),
+            to_alias: "users".to_string(),
+            on: JoinOn::RawExpression("orders.user_id = users.id".to_string()),
+        }];
+
+        let err = MongoShellGenerator
+            .generate_read_from_spec(&spec)
+            .expect_err("joins are not expressible in find()");
+        assert!(matches!(err, QueryGenError::InvalidSpec(_)));
+    }
+
+    #[test]
+    fn read_spec_rejects_grouping() {
+        use dbflux_core::GroupByEntry;
+
+        let mut spec = read_spec("orders");
+        spec.group_by = vec![GroupByEntry {
+            source_alias: "orders".to_string(),
+            column: "status".to_string(),
+        }];
+
+        let err = MongoShellGenerator
+            .generate_read_from_spec(&spec)
+            .expect_err("grouping is not expressible in find()");
+        assert!(matches!(err, QueryGenError::InvalidSpec(_)));
     }
 
     #[test]

--- a/crates/dbflux_driver_mongodb/src/query_generator.rs
+++ b/crates/dbflux_driver_mongodb/src/query_generator.rs
@@ -57,14 +57,19 @@ fn generate_find(spec: &VisualQuerySpec) -> Result<String, QueryGenError> {
             "MongoDB find() does not support GROUP BY / HAVING / aggregates".to_string(),
         ));
     }
+    if spec.source.table.trim().is_empty() {
+        return Err(QueryGenError::InvalidSpec(
+            "MongoDB find() requires a collection name".to_string(),
+        ));
+    }
 
-    let collection = &spec.source.table;
+    let collection = collection_accessor(&spec.source.table);
     let filter = render_filter(spec.filter.as_ref());
     let projection = render_projection(&spec.projection);
 
     let mut text = match projection {
-        Some(proj) => format!("db.{collection}.find({filter}, {proj})"),
-        None => format!("db.{collection}.find({filter})"),
+        Some(proj) => format!("{collection}.find({filter}, {proj})"),
+        None => format!("{collection}.find({filter})"),
     };
 
     if let Some(sort_doc) = render_sort(&spec.sort) {
@@ -80,6 +85,28 @@ fn generate_find(spec: &VisualQuerySpec) -> Result<String, QueryGenError> {
     }
 
     Ok(text)
+}
+
+/// Render the collection accessor for the MongoDB shell. A simple identifier
+/// uses dot access (`db.<name>`); any other name (containing `.`, quotes,
+/// whitespace, parentheses, etc.) is JSON-escaped and rendered via bracket
+/// access (`db["<escaped>"]`) so the generated text stays valid.
+fn collection_accessor(name: &str) -> String {
+    let is_simple_identifier = !name.is_empty()
+        && name
+            .chars()
+            .enumerate()
+            .all(|(index, character)| match character {
+                'A'..='Z' | 'a'..='z' | '_' => true,
+                '0'..='9' => index > 0,
+                _ => false,
+            });
+
+    if is_simple_identifier {
+        format!("db.{name}")
+    } else {
+        format!("db[{}]", Value::String(name.to_string()))
+    }
 }
 
 /// An order-preserving MongoDB document (object).
@@ -504,6 +531,18 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.text, "db.events.find({})");
+    }
+
+    #[test]
+    fn read_spec_non_identifier_collection_uses_bracket_access() {
+        let spec = read_spec("orders.2024");
+
+        let result = MongoShellGenerator
+            .generate_read_from_spec(&spec)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(result.text, r#"db["orders.2024"].find({})"#);
     }
 
     #[test]

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -168,6 +168,7 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
             WhereOperator::Not,
         ],
         supports_order_by: true,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         supports_group_by: true,
         supports_having: true,
         supports_distinct: true,
@@ -263,6 +264,7 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 // =============================================================================

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -84,6 +84,7 @@ pub static MYSQL_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMet
             WhereOperator::Not,
         ],
         supports_order_by: true,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         supports_group_by: true,
         supports_having: true,
         supports_distinct: true,
@@ -185,6 +186,7 @@ pub static MYSQL_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMet
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 /// MariaDB driver metadata.
@@ -240,6 +242,7 @@ pub static MARIADB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverM
             WhereOperator::Not,
         ],
         supports_order_by: true,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         supports_group_by: true,
         supports_having: true,
         supports_distinct: true,
@@ -342,6 +345,7 @@ pub static MARIADB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverM
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 /// MySQL/MariaDB SQL dialect implementation.

--- a/crates/dbflux_driver_postgres/src/driver.rs
+++ b/crates/dbflux_driver_postgres/src/driver.rs
@@ -100,6 +100,7 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
             WhereOperator::Not,
         ],
         supports_order_by: true,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         supports_group_by: true,
         supports_having: true,
         supports_distinct: true,
@@ -205,6 +206,7 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 /// PostgreSQL SQL dialect implementation.

--- a/crates/dbflux_driver_redis/src/driver.rs
+++ b/crates/dbflux_driver_redis/src/driver.rs
@@ -147,6 +147,7 @@ pub static REDIS_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMet
         pagination: vec![PaginationStyle::Cursor],
         where_operators: vec![],
         supports_order_by: false,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         supports_group_by: false,
         supports_having: false,
         supports_distinct: false,
@@ -236,6 +237,7 @@ pub static REDIS_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMet
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 pub struct RedisDriver;

--- a/crates/dbflux_driver_redis/src/driver.rs
+++ b/crates/dbflux_driver_redis/src/driver.rs
@@ -147,7 +147,7 @@ pub static REDIS_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMet
         pagination: vec![PaginationStyle::Cursor],
         where_operators: vec![],
         supports_order_by: false,
-        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
+        order_by_mode: dbflux_core::OrderByMode::None,
         supports_group_by: false,
         supports_having: false,
         supports_distinct: false,

--- a/crates/dbflux_driver_sqlite/src/driver.rs
+++ b/crates/dbflux_driver_sqlite/src/driver.rs
@@ -100,6 +100,7 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
             WhereOperator::Not,
         ],
         supports_order_by: true,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         supports_group_by: true,
         supports_having: true,
         supports_distinct: true,
@@ -173,6 +174,7 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 /// SQLite SQL dialect implementation.

--- a/crates/dbflux_mcp/tests/capability_routing_tests.rs
+++ b/crates/dbflux_mcp/tests/capability_routing_tests.rs
@@ -54,6 +54,7 @@ fn postgresql_metadata() -> ConnectionMetadata {
         supports_ctes: true,
         supports_explain: true,
         max_query_parameters: 32767,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         max_order_by_columns: 0,
         max_group_by_columns: 0,
     };
@@ -112,6 +113,7 @@ fn mongodb_metadata() -> ConnectionMetadata {
         supports_ctes: false,
         supports_explain: false,
         max_query_parameters: 0,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
         max_order_by_columns: 0,
         max_group_by_columns: 0,
     };

--- a/crates/dbflux_mcp_server/src/tools/query.rs
+++ b/crates/dbflux_mcp_server/src/tools/query.rs
@@ -302,6 +302,7 @@ mod tests {
         classification_override: None,
         default_chunk_size: None,
         supports_lock_timeout: false,
+        editor_profile: None,
     });
 
     struct TestConnection {

--- a/crates/dbflux_mcp_server/src/tools/read.rs
+++ b/crates/dbflux_mcp_server/src/tools/read.rs
@@ -775,6 +775,7 @@ mod tests {
         classification_override: None,
         default_chunk_size: None,
         supports_lock_timeout: false,
+        editor_profile: None,
     });
 
     struct UnsupportedAggregateConnection;

--- a/crates/dbflux_test_support/src/fake_driver.rs
+++ b/crates/dbflux_test_support/src/fake_driver.rs
@@ -720,6 +720,7 @@ static FAKE_POSTGRES_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Drive
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 static FAKE_SQLITE_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -778,6 +779,7 @@ static FAKE_SQLITE_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverM
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 static FAKE_MYSQL_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -820,6 +822,7 @@ static FAKE_MYSQL_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMe
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 static FAKE_MARIADB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -862,6 +865,7 @@ static FAKE_MARIADB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driver
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 static FAKE_MONGODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -918,6 +922,7 @@ static FAKE_MONGODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Driver
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 static FAKE_REDIS_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -969,6 +974,7 @@ static FAKE_REDIS_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMe
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 static FAKE_DYNAMODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -1001,6 +1007,7 @@ static FAKE_DYNAMODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Drive
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 static FAKE_CLOUDWATCH_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -1033,6 +1040,7 @@ static FAKE_CLOUDWATCH_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Dri
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 static FAKE_INFLUXDB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -1065,6 +1073,7 @@ static FAKE_INFLUXDB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Drive
     classification_override: None,
     default_chunk_size: None,
     supports_lock_timeout: false,
+    editor_profile: None,
 });
 
 #[cfg(test)]

--- a/crates/dbflux_ui/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions.rs
@@ -4994,6 +4994,7 @@ mod tests {
             classification_override: None,
             default_chunk_size: None,
             supports_lock_timeout: false,
+            editor_profile: None,
         }
     }
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -4931,6 +4931,7 @@ mod tests {
                     classification_override: None,
                     default_chunk_size: None,
                     supports_lock_timeout: false,
+                    editor_profile: None,
                 })
             }
 
@@ -5592,6 +5593,7 @@ mod tests {
                     classification_override: None,
                     default_chunk_size: None,
                     supports_lock_timeout: false,
+                    editor_profile: None,
                 })
             }
 
@@ -6031,6 +6033,7 @@ mod tests {
                                     classification_override: None,
                                     default_chunk_size: None,
                                     supports_lock_timeout: false,
+                                    editor_profile: None,
                                 })
                             }
                             fn kind(&self) -> DbKind {

--- a/crates/dbflux_ui_sidebar/src/tree_builder.rs
+++ b/crates/dbflux_ui_sidebar/src/tree_builder.rs
@@ -3426,6 +3426,7 @@ mod tests {
                     classification_override: None,
                     default_chunk_size: None,
                     supports_lock_timeout: false,
+                    editor_profile: None,
                 },
             }
         }


### PR DESCRIPTION
## What

**PR 1 of 2** of the cross-driver query-tooling work. This PR lands the **driver-agnostic core seams and the per-driver read generation** for Document databases (MongoDB + DynamoDB), including a **PartiQL** surface for DynamoDB. **No UI changes** — the visual-builder ungating, editor call-site migration, and PartiQL editor polish land in PR 2.

Planned via SDD (proposal → spec → design → tasks); this PR is Batches 1-3 of 5.

## Why

Non-SQL Document drivers had no query-composition or editor-assistance parity with SQL, and DynamoDB was fully orphaned in the editor because it declares `QueryLanguage::Custom("DynamoDB")`. Rather than special-case drivers in the UI (which the codebase forbids), this PR adds the capability seams so the UI can stay driver-agnostic, then implements them per driver.

## Architectural invariant

Everything is keyed off `DatabaseCategory` / `QueryLanguage` / `QueryCapabilities` — **never a driver id**. The DynamoDB-specific knowledge lives entirely in `dbflux_driver_dynamodb`; `dbflux_core` contains no driver-name branch. Verified: `git diff main..HEAD` touches zero `dbflux_ui*` / `dbflux_app` files.

## Changes

### Batch 1 — Foundational core (`dbflux_core`, additive + defaulted)
- `EditorLanguageProfile` + `DriverMetadata::editor_profile()` with a `from_language()` default that reproduces the existing `QueryLanguage` presentation accessors (`editor_mode` / `placeholder` / `comment_prefix` / `supports_connection_context`) **byte-for-byte**. This replaces the original plan of hardcoding a `"DynamoDB"` match in core: presentation now flows from driver metadata, so a driver overrides it in its own crate.
- `OrderByMode { None, AnyColumns, SortKeyOnly }` on `QueryCapabilities` (default `AnyColumns`) — a truthful sort capability instead of a bare `supports_order_by` bool.
- Defaulted `QueryGenerator::generate_read_from_spec(&VisualQuerySpec) -> ...` (default `Ok(None)`), so relational drivers keep `generate_select` untouched.
- A generic `Custom`-language classification seam that routes through the driver's `LanguageService` (no driver-name branch in core).

> Adding non-defaultable fields to `DriverMetadata` / `QueryCapabilities` required mechanical `editor_profile: None` / `order_by_mode: AnyColumns` initializers across every driver crate and test fixture (these structs are built with exhaustive literals; same precedent as `supports_lock_timeout`). `None` / `AnyColumns` preserve current behavior exactly.

### Batch 2 — DynamoDB (`dbflux_driver_dynamodb`)
- `editor_profile` override (SQL editor mode + connection context + PartiQL placeholder); `query_language` stays `Custom("DynamoDB")`.
- `DynamoLanguageService` extended to flag no-WHERE PartiQL `DELETE` / `UPDATE` as the existing `DangerousQueryKind::DeleteNoWhere` / `UpdateNoWhere`, routed through the core Custom classification seam — so governed writes reuse the same confirm flow as every other driver.
- `OrderByMode::SortKeyOnly` + `ScanIndexForward` (asc/desc) threaded into the command envelope and query path.
- **PartiQL** `execute_statement` path (aws-sdk-dynamodb v1.115.0): reads (`SELECT`) and governed writes (`INSERT`/`UPDATE`/`DELETE`). The JSON command envelope remains as the advanced escape hatch.
- `generate_read_from_spec` emits a PartiQL `SELECT`; limit/sort travel out-of-band (PartiQL has no `LIMIT`/`ORDER BY` keyword).

### Batch 3 — MongoDB (`dbflux_driver_mongodb`)
- `generate_read_from_spec` emits `db.<coll>.find(<filter>,<projection?>).sort(<doc>).limit(N).skip(M)` from a `VisualQuerySpec`, with an order-preserving renderer (workspace `serde_json` has no `preserve_order`, so a plain `Map` would scramble authored key order).

## Verification

- `cargo check --workspace`, `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check` — all clean.
- `cargo nextest run -p dbflux_core -p dbflux_driver_dynamodb -p dbflux_driver_mongodb` — **1191 passed, 0 failed**.
- Test-first for the testable units: `from_language` equality across all 14 `QueryLanguage` variants; DynamoDB dangerous-classification and PartiQL `SELECT` generation; MongoDB read generation.

## Notes

- Size is past the usual budget (mostly additive code + tests, zero UI); intended as the foundation half of a deliberately split delivery — `size:exception`.
- DynamoDB's JSON envelope now renders under SQL highlighting (escape-hatch mode) — an accepted minor visual delta, revisited in PR 2 if warranted.

## Next (PR 2)

Batch 4 (UI generalization: capability-driven `can_open_builder`, migrate the editor call sites to `editor_profile()`, remove the SQL-only diagnostics gate, builder section visibility + sort UX) and Batch 5 (PartiQL editor polish).
