### PR TITLE
feat: cross-driver query tooling — UI generalization + DynamoDB PartiQL editor (2/2)

### DIFF
--- a/crates/dbflux_core/src/connection/context.rs
+++ b/crates/dbflux_core/src/connection/context.rs
@@ -136,11 +136,22 @@ impl ExecutionContext {
         ctx
     }
 
-    /// Serialize the context as comment lines to prepend to a file.
+    /// Serialize the context as comment lines to prepend to a file, deriving the
+    /// line-comment prefix from `language`.
     ///
     /// Only set fields are emitted. Returns an empty string when nothing is set.
     pub fn to_comment_header(&self, language: QueryLanguage) -> String {
-        let prefix = language.comment_prefix();
+        self.to_comment_header_with_prefix(language.comment_prefix())
+    }
+
+    /// Serialize the context as comment lines to prepend to a file, using an
+    /// explicit line-comment prefix.
+    ///
+    /// Callers that resolve presentation through a driver's editor profile
+    /// (rather than the raw `QueryLanguage`) pass the profile's prefix here so a
+    /// driver with a bespoke surface (e.g. DynamoDB's PartiQL using `--`) gets the
+    /// correct annotation prefix. Only set fields are emitted.
+    pub fn to_comment_header_with_prefix(&self, prefix: &str) -> String {
         let mut lines = Vec::new();
 
         if let Some(id) = &self.connection_id {

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -135,8 +135,13 @@ pub static MONGODB_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverM
         ],
         supports_order_by: true,
         order_by_mode: dbflux_core::OrderByMode::AnyColumns,
-        supports_group_by: true,
-        supports_having: true,
+        // The visual builder emits `find()` reads, which have no GROUP BY / HAVING
+        // form (those belong to the aggregation pipeline the builder does not
+        // generate). Advertising them would render builder sections whose run path
+        // rejects the spec as `InvalidSpec`, so they are reported as unsupported to
+        // keep the offered sections truthful.
+        supports_group_by: false,
+        supports_having: false,
         supports_distinct: false,
         supports_limit: true,
         supports_offset: true,

--- a/crates/dbflux_ui_document/src/code/context_bar.rs
+++ b/crates/dbflux_ui_document/src/code/context_bar.rs
@@ -134,6 +134,9 @@ impl CodeDocument {
             Self::resolve_editor_profile(&self.app_state, connection_id, &query_language, cx);
         let editor_mode = editor_profile.editor_mode;
 
+        self.editor.cached_supports_connection_context = editor_profile.supports_connection_context;
+        self.editor.cached_comment_prefix = editor_profile.comment_prefix;
+
         let completion_provider: Rc<dyn CompletionProvider> = Rc::new(
             QueryCompletionProvider::new(query_language, self.app_state.clone(), connection_id),
         );
@@ -1024,7 +1027,7 @@ impl CodeDocument {
 
     /// Returns the visible context-bar slots for the current document.
     fn visible_context_bar_slots(&self, cx: &App) -> Vec<ContextBarSlot> {
-        if !self.supports_connection_context(cx) {
+        if !self.supports_connection_context() {
             return Vec::new();
         }
 
@@ -1248,7 +1251,7 @@ impl CodeDocument {
     // === Render the context bar ===
 
     pub(super) fn render_context_bar(&self, cx: &mut Context<Self>) -> AnyElement {
-        if !self.supports_connection_context(cx) {
+        if !self.supports_connection_context() {
             return div().id("exec-context-bar").into_any_element();
         }
 

--- a/crates/dbflux_ui_document/src/code/context_bar.rs
+++ b/crates/dbflux_ui_document/src/code/context_bar.rs
@@ -130,14 +130,16 @@ impl CodeDocument {
             .filter(|id| self.app_state.read(cx).connections().contains_key(id));
 
         let query_language = self.effective_query_language(cx);
-        let editor_mode = query_language.editor_mode();
+        let editor_profile =
+            Self::resolve_editor_profile(&self.app_state, connection_id, &query_language, cx);
+        let editor_mode = editor_profile.editor_mode;
 
         let completion_provider: Rc<dyn CompletionProvider> = Rc::new(
             QueryCompletionProvider::new(query_language, self.app_state.clone(), connection_id),
         );
 
         let editor_mode_changed = editor_mode != self.editor.current_editor_mode;
-        self.editor.current_editor_mode = editor_mode;
+        self.editor.current_editor_mode = editor_mode.clone();
 
         self.editor.input_state.update(cx, |state, cx| {
             state.lsp.completion_provider = Some(completion_provider);
@@ -1022,7 +1024,7 @@ impl CodeDocument {
 
     /// Returns the visible context-bar slots for the current document.
     fn visible_context_bar_slots(&self, cx: &App) -> Vec<ContextBarSlot> {
-        if !self.editor.query_language.supports_connection_context() {
+        if !self.supports_connection_context(cx) {
             return Vec::new();
         }
 
@@ -1246,7 +1248,7 @@ impl CodeDocument {
     // === Render the context bar ===
 
     pub(super) fn render_context_bar(&self, cx: &mut Context<Self>) -> AnyElement {
-        if !self.editor.query_language.supports_connection_context() {
+        if !self.supports_connection_context(cx) {
             return div().id("exec-context-bar").into_any_element();
         }
 

--- a/crates/dbflux_ui_document/src/code/diagnostics.rs
+++ b/crates/dbflux_ui_document/src/code/diagnostics.rs
@@ -40,23 +40,18 @@ impl CodeDocument {
     fn run_diagnostics(&mut self, cx: &mut Context<Self>) {
         let query_text = self.editor.input_state.read(cx).value().to_string();
 
-        // The connection's language service validates with the SQL tree-sitter
-        // grammar. Only run it when the effective query language actually uses
-        // the SQL editor mode; for Flux, Mongo, Redis, etc. the SQL parser would
-        // flag the whole query as invalid. Falling through with an empty list
-        // still clears any stale diagnostics below.
-        let language_is_sql = self.effective_query_language(cx).editor_mode() == "sql";
-
-        let diagnostics = if language_is_sql {
-            if let Some(conn_id) = self.connection_id {
-                if let Some(connected) = self.app_state.read(cx).connections().get(&conn_id) {
-                    connected
-                        .connection
-                        .language_service()
-                        .editor_diagnostics(&query_text)
-                } else {
-                    Vec::new()
-                }
+        // Live diagnostics are driven by the connected driver's `LanguageService`
+        // rather than the editor mode. Each driver's service validates its own
+        // dialect (SQL drivers use the SQL grammar; Mongo and DynamoDB validate
+        // their own surfaces), and the default service returns no diagnostics,
+        // so drivers without a real language service stay quiet. Falling through
+        // with an empty list still clears any stale diagnostics below.
+        let diagnostics = if let Some(conn_id) = self.connection_id {
+            if let Some(connected) = self.app_state.read(cx).connections().get(&conn_id) {
+                connected
+                    .connection
+                    .language_service()
+                    .editor_diagnostics(&query_text)
             } else {
                 Vec::new()
             }

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -153,7 +153,7 @@ impl CodeDocument {
         if self.read_only {
             return;
         }
-        if !self.editor.query_language.supports_connection_context() {
+        if !self.supports_connection_context(cx) {
             self.run_script(window, cx);
             return;
         }
@@ -168,7 +168,7 @@ impl CodeDocument {
             return;
         };
 
-        if !self.editor.query_language.supports_connection_context() {
+        if !self.supports_connection_context(cx) {
             self.run_script(window, cx);
             return;
         }
@@ -1409,7 +1409,7 @@ impl CodeDocument {
         if self.read_only {
             return;
         }
-        if !self.editor.query_language.supports_connection_context() {
+        if !self.supports_connection_context(cx) {
             self.run_script(window, cx);
             return;
         }
@@ -1421,7 +1421,7 @@ impl CodeDocument {
     /// Uses the selected text when a selection exists, otherwise the full buffer.
     /// The result appears in the same Results panel as a regular query.
     pub fn run_explain(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.editor.query_language.supports_connection_context() {
+        if !self.supports_connection_context(cx) {
             Toast::warning("Explain is not available for scripts")
                 .meta_right(now_hms())
                 .push(cx);

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -153,7 +153,7 @@ impl CodeDocument {
         if self.read_only {
             return;
         }
-        if !self.supports_connection_context(cx) {
+        if !self.supports_connection_context() {
             self.run_script(window, cx);
             return;
         }
@@ -168,7 +168,7 @@ impl CodeDocument {
             return;
         };
 
-        if !self.supports_connection_context(cx) {
+        if !self.supports_connection_context() {
             self.run_script(window, cx);
             return;
         }
@@ -1409,7 +1409,7 @@ impl CodeDocument {
         if self.read_only {
             return;
         }
-        if !self.supports_connection_context(cx) {
+        if !self.supports_connection_context() {
             self.run_script(window, cx);
             return;
         }
@@ -1421,7 +1421,7 @@ impl CodeDocument {
     /// Uses the selected text when a selection exists, otherwise the full buffer.
     /// The result appears in the same Results panel as a regular query.
     pub fn run_explain(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.supports_connection_context(cx) {
+        if !self.supports_connection_context() {
             Toast::warning("Explain is not available for scripts")
                 .meta_right(now_hms())
                 .push(cx);

--- a/crates/dbflux_ui_document/src/code/file_ops.rs
+++ b/crates/dbflux_ui_document/src/code/file_ops.rs
@@ -1,21 +1,30 @@
 use super::*;
 use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error_async};
 
+/// Build the file content, prepending the execution-context annotation header
+/// when the editor surface is connection-backed.
+///
+/// `supports_connection_context` and `comment_prefix` are resolved from the
+/// editor's profile (not the raw `QueryLanguage`) so a driver with a bespoke
+/// surface — e.g. a connection-backed DynamoDB editor whose `QueryLanguage` is
+/// `Custom("DynamoDB")` but whose profile reports connection support and a `--`
+/// prefix — emits the header with the correct prefix.
 fn build_file_content_for_language(
     editor_content: &str,
     exec_ctx: &ExecutionContext,
-    language: QueryLanguage,
+    supports_connection_context: bool,
+    comment_prefix: &str,
 ) -> String {
-    if !language.supports_connection_context() {
+    if !supports_connection_context {
         return editor_content.to_string();
     }
 
-    let header = exec_ctx.to_comment_header(language.clone());
+    let header = exec_ctx.to_comment_header_with_prefix(comment_prefix);
     if header.is_empty() {
         return editor_content.to_string();
     }
 
-    let body = CodeDocument::strip_existing_annotations(editor_content, language);
+    let body = CodeDocument::strip_existing_annotations(editor_content, comment_prefix);
     format!("{}\n{}", header, body)
 }
 
@@ -281,13 +290,13 @@ impl CodeDocument {
         build_file_content_for_language(
             &editor_content,
             &self.source.exec_ctx,
-            self.editor.query_language.clone(),
+            self.supports_connection_context(),
+            self.comment_prefix(),
         )
     }
 
     /// Strip existing annotation comments from the beginning of content.
-    fn strip_existing_annotations(content: &str, language: QueryLanguage) -> &str {
-        let prefix = language.comment_prefix();
+    fn strip_existing_annotations<'a>(content: &'a str, prefix: &str) -> &'a str {
         let mut last_annotation_end = 0;
 
         for line in content.lines() {
@@ -319,12 +328,11 @@ impl CodeDocument {
 #[cfg(test)]
 mod tests {
     use super::build_file_content_for_language;
-    use dbflux_core::{ExecutionContext, ExecutionSourceContext, QueryLanguage};
+    use dbflux_core::{ExecutionContext, ExecutionSourceContext};
     use uuid::Uuid;
 
-    #[test]
-    fn file_headers_remain_relational_only_when_source_window_exists() {
-        let exec_ctx = ExecutionContext {
+    fn collection_window_exec_ctx() -> ExecutionContext {
+        ExecutionContext {
             connection_id: Some(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap()),
             database: Some("logs".into()),
             schema: None,
@@ -335,14 +343,40 @@ mod tests {
                 end_ms: 20,
                 query_mode: Some("cwli".into()),
             }),
-        };
+        }
+    }
 
-        let content = build_file_content_for_language("SELECT 1;", &exec_ctx, QueryLanguage::Sql);
+    #[test]
+    fn file_headers_remain_relational_only_when_source_window_exists() {
+        let exec_ctx = collection_window_exec_ctx();
+
+        let content = build_file_content_for_language("SELECT 1;", &exec_ctx, true, "--");
 
         assert!(content.contains("-- @connection:"));
         assert!(content.contains("-- @database: logs"));
         assert!(!content.contains("log_groups"));
         assert!(!content.contains("start_ms"));
         assert!(!content.contains("end_ms"));
+    }
+
+    #[test]
+    fn connection_backed_custom_surface_emits_header_with_profile_prefix() {
+        // A connection-backed DynamoDB editor: profile reports connection support
+        // and a `--` prefix even though its raw `QueryLanguage` is `Custom`.
+        let exec_ctx = collection_window_exec_ctx();
+
+        let content = build_file_content_for_language("SELECT * FROM \"t\"", &exec_ctx, true, "--");
+
+        assert!(content.contains("-- @connection:"));
+        assert!(content.contains("-- @database: logs"));
+    }
+
+    #[test]
+    fn no_header_when_surface_is_not_connection_backed() {
+        let exec_ctx = collection_window_exec_ctx();
+
+        let content = build_file_content_for_language("print('hi')", &exec_ctx, false, "#");
+
+        assert_eq!(content, "print('hi')");
     }
 }

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -238,6 +238,14 @@ pub(super) struct EditorState {
     pub(super) original_content: String,
     pub(super) saved_query_id: Option<Uuid>,
     pub(super) current_editor_mode: String,
+    /// Cached `EditorLanguageProfile::supports_connection_context`, refreshed
+    /// whenever the effective profile changes (construction, connection change,
+    /// syntax/query-mode switch). Cached so per-render call sites do not re-resolve
+    /// and re-clone the profile every frame.
+    pub(super) cached_supports_connection_context: bool,
+    /// Cached `EditorLanguageProfile::comment_prefix`, refreshed alongside
+    /// `cached_supports_connection_context`.
+    pub(super) cached_comment_prefix: String,
     pub(super) diagnostic_request_id: u64,
     pub(super) _diagnostic_debounce: Option<Task<()>>,
     pub(super) path: Option<PathBuf>,
@@ -486,18 +494,20 @@ impl CodeDocument {
     /// Whether this document's editor is backed by a database connection
     /// (versus an in-process script such as Lua/Bash/Python).
     ///
-    /// Reads the connected driver's editor profile so drivers with a bespoke
-    /// query surface (e.g. DynamoDB) are recognized as connection-backed even
-    /// when their `QueryLanguage` is `Custom`, without the UI branching on a
-    /// driver id.
-    pub(super) fn supports_connection_context(&self, cx: &App) -> bool {
-        Self::resolve_editor_profile(
-            &self.app_state,
-            self.connection_id,
-            &self.editor.query_language,
-            cx,
-        )
-        .supports_connection_context
+    /// Returns the cached profile value (refreshed on construction and whenever
+    /// the effective language is re-bound via `sync_editor_language`) so the
+    /// render and execution paths do not re-resolve and re-clone the editor
+    /// profile every frame. Drivers with a bespoke query surface (e.g. DynamoDB)
+    /// are recognized as connection-backed even when their `QueryLanguage` is
+    /// `Custom`, without the UI branching on a driver id.
+    pub(super) fn supports_connection_context(&self) -> bool {
+        self.editor.cached_supports_connection_context
+    }
+
+    /// The cached line-comment prefix for the editor's effective profile,
+    /// refreshed alongside `cached_supports_connection_context`.
+    pub(super) fn comment_prefix(&self) -> &str {
+        &self.editor.cached_comment_prefix
     }
 
     /// Create a document with an explicit language (used when opening files).
@@ -825,6 +835,8 @@ impl CodeDocument {
                 original_content: String::new(),
                 saved_query_id: None,
                 current_editor_mode: editor_profile.editor_mode.clone(),
+                cached_supports_connection_context: editor_profile.supports_connection_context,
+                cached_comment_prefix: editor_profile.comment_prefix.clone(),
                 diagnostic_request_id: 0,
                 _diagnostic_debounce: None,
                 path: None,

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -26,10 +26,10 @@ use dbflux_core::observability::{
 };
 use dbflux_core::{
     DangerousAction, DangerousQueryKind, DbError, DiagnosticSeverity as CoreDiagnosticSeverity,
-    DriftOutcome, DriverCapabilities, EditorDiagnostic as CoreEditorDiagnostic, ExecutionContext,
-    ExecutionSourceContext, HistoryEntry, OutputReceiver, QueryLanguage, QueryRequest, QueryResult,
-    RefreshPolicy, SchemaDriftDetected, SchemaLoadingStrategy, TaskTarget, ValidationResult,
-    check_schema_drift,
+    DriftOutcome, DriverCapabilities, EditorDiagnostic as CoreEditorDiagnostic,
+    EditorLanguageProfile, ExecutionContext, ExecutionSourceContext, HistoryEntry, OutputReceiver,
+    QueryLanguage, QueryRequest, QueryResult, RefreshPolicy, SchemaDriftDetected,
+    SchemaLoadingStrategy, TaskTarget, ValidationResult, check_schema_drift,
 };
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
 use dbflux_ui_base::{AppStateChanged, AppStateEntity};
@@ -237,7 +237,7 @@ pub(super) struct EditorState {
     pub(super) _input_subscriptions: Vec<Subscription>,
     pub(super) original_content: String,
     pub(super) saved_query_id: Option<Uuid>,
-    pub(super) current_editor_mode: &'static str,
+    pub(super) current_editor_mode: String,
     pub(super) diagnostic_request_id: u64,
     pub(super) _diagnostic_debounce: Option<Task<()>>,
     pub(super) path: Option<PathBuf>,
@@ -457,6 +457,49 @@ impl CodeDocument {
         Self::new_with_language(app_state, connection_id, query_language, window, cx)
     }
 
+    /// Resolve the editor presentation profile for a document.
+    ///
+    /// Prefers the connected driver's `DriverMetadata::editor_profile()` so a
+    /// driver can override editor mode, completion engagement, placeholder, and
+    /// comment prefix (e.g. DynamoDB's PartiQL surface) without the UI branching
+    /// on a driver id. Falls back to deriving from `query_language` when the
+    /// connection is absent or its language no longer matches the document's
+    /// effective language (a source-context query-mode override).
+    pub(super) fn resolve_editor_profile(
+        app_state: &Entity<AppStateEntity>,
+        connection_id: Option<Uuid>,
+        query_language: &QueryLanguage,
+        cx: &App,
+    ) -> EditorLanguageProfile {
+        if let Some(connection_id) = connection_id
+            && let Some(connected) = app_state.read(cx).connections().get(&connection_id)
+        {
+            let metadata = connected.connection.metadata();
+            if &metadata.query_language == query_language {
+                return metadata.editor_profile();
+            }
+        }
+
+        EditorLanguageProfile::from_language(query_language)
+    }
+
+    /// Whether this document's editor is backed by a database connection
+    /// (versus an in-process script such as Lua/Bash/Python).
+    ///
+    /// Reads the connected driver's editor profile so drivers with a bespoke
+    /// query surface (e.g. DynamoDB) are recognized as connection-backed even
+    /// when their `QueryLanguage` is `Custom`, without the UI branching on a
+    /// driver id.
+    pub(super) fn supports_connection_context(&self, cx: &App) -> bool {
+        Self::resolve_editor_profile(
+            &self.app_state,
+            self.connection_id,
+            &self.editor.query_language,
+            cx,
+        )
+        .supports_connection_context
+    }
+
     /// Create a document with an explicit language (used when opening files).
     pub fn new_with_language(
         app_state: Entity<AppStateEntity>,
@@ -465,8 +508,10 @@ impl CodeDocument {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let editor_mode = query_language.editor_mode();
-        let placeholder = query_language.placeholder();
+        let editor_profile =
+            Self::resolve_editor_profile(&app_state, connection_id, &query_language, cx);
+        let editor_mode = editor_profile.editor_mode.clone();
+        let placeholder = editor_profile.placeholder.clone();
 
         let input_state = cx.new(|cx| {
             InputState::new(window, cx)
@@ -479,7 +524,7 @@ impl CodeDocument {
         let completion_provider: Rc<dyn CompletionProvider> = Rc::new(
             QueryCompletionProvider::new(query_language.clone(), app_state.clone(), connection_id),
         );
-        let supports_connection_context = query_language.supports_connection_context();
+        let supports_connection_context = editor_profile.supports_connection_context;
 
         input_state.update(cx, |state, _cx| {
             state.lsp.completion_provider =
@@ -779,7 +824,7 @@ impl CodeDocument {
                 _input_subscriptions: vec![input_change_sub],
                 original_content: String::new(),
                 saved_query_id: None,
-                current_editor_mode: editor_mode,
+                current_editor_mode: editor_profile.editor_mode.clone(),
                 diagnostic_request_id: 0,
                 _diagnostic_debounce: None,
                 path: None,

--- a/crates/dbflux_ui_document/src/code/render.rs
+++ b/crates/dbflux_ui_document/src/code/render.rs
@@ -19,7 +19,7 @@ impl CodeDocument {
         let theme = cx.theme().clone();
         let is_executing = self.state == DocumentState::Executing;
         let is_preflight = self.drift.preflight_running;
-        let is_db_language = self.editor.query_language.supports_connection_context();
+        let is_db_language = self.supports_connection_context(cx);
         let is_read_only = self.read_only;
 
         let auto_refresh_enabled = self.refresh.refresh_policy.is_auto();
@@ -161,7 +161,7 @@ impl CodeDocument {
         is_read_only: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let is_db_language = self.editor.query_language.supports_connection_context();
+        let is_db_language = self.supports_connection_context(cx);
 
         div()
             .flex()

--- a/crates/dbflux_ui_document/src/code/render.rs
+++ b/crates/dbflux_ui_document/src/code/render.rs
@@ -19,7 +19,7 @@ impl CodeDocument {
         let theme = cx.theme().clone();
         let is_executing = self.state == DocumentState::Executing;
         let is_preflight = self.drift.preflight_running;
-        let is_db_language = self.supports_connection_context(cx);
+        let is_db_language = self.supports_connection_context();
         let is_read_only = self.read_only;
 
         let auto_refresh_enabled = self.refresh.refresh_policy.is_auto();
@@ -161,7 +161,7 @@ impl CodeDocument {
         is_read_only: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let is_db_language = self.supports_connection_context(cx);
+        let is_db_language = self.supports_connection_context();
 
         div()
             .flex()

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -41,8 +41,8 @@ use dbflux_components::modals::{
     ModalMutationConfirm, ModalMutationConfirmHard, MutationConfirmOutcome,
 };
 use dbflux_core::{
-    CollectionRef, DatabaseCategory, OrderByColumn, Pagination, QueryResult, RefreshPolicy,
-    SelectQuery, SortDirection, TableRef, Value, VisualQuerySpec, WhereOperator,
+    CollectionRef, ColumnMeta, DatabaseCategory, OrderByColumn, Pagination, QueryResult,
+    RefreshPolicy, SelectQuery, SortDirection, TableRef, Value, VisualQuerySpec, WhereOperator,
 };
 use dbflux_ui_base::AppStateEntity;
 use dbflux_ui_base::AsyncUpdateResultExt;
@@ -142,6 +142,27 @@ impl DataSource {
             DataSource::QueryResult { .. } => None,
         }
     }
+}
+
+/// Resolve the single orderable key from a result's column metadata, generically.
+///
+/// Stores that order on exactly one key (e.g. DynamoDB's sort key) emit their
+/// primary-key columns partition-key first and sort-key last, so the trailing
+/// primary-key column is the orderable key. Returns `None` when there are fewer
+/// than two primary-key columns: a single primary-key column is a partition-only
+/// key with nothing to order on. The function reads only generic `ColumnMeta`
+/// and never names a driver.
+fn resolve_orderable_sort_key(columns: &[ColumnMeta]) -> Option<String> {
+    let primary_key_columns: Vec<&ColumnMeta> = columns
+        .iter()
+        .filter(|column| column.is_primary_key)
+        .collect();
+
+    if primary_key_columns.len() < 2 {
+        return None;
+    }
+
+    primary_key_columns.last().map(|column| column.name.clone())
 }
 
 /// Events emitted by DataGridPanel.
@@ -549,7 +570,7 @@ pub(crate) struct BuilderState {
 /// Used both embedded in ScriptDocument and as standalone DataDocument.
 pub struct DataGridPanel {
     source: DataSource,
-    app_state: Entity<AppStateEntity>,
+    app_state: gpui::Entity<AppStateEntity>,
     result: QueryResult,
     grid_table: GridTableState,
     filter_bar: FilterBarState,
@@ -598,7 +619,7 @@ impl DataGridPanel {
         profile_id: Uuid,
         table: TableRef,
         database: Option<String>,
-        app_state: Entity<AppStateEntity>,
+        app_state: gpui::Entity<AppStateEntity>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -633,7 +654,7 @@ impl DataGridPanel {
     pub fn new_for_collection(
         profile_id: Uuid,
         collection: CollectionRef,
-        app_state: Entity<AppStateEntity>,
+        app_state: gpui::Entity<AppStateEntity>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -794,7 +815,7 @@ impl DataGridPanel {
         result: Arc<QueryResult>,
         original_query: String,
         profile_id: Option<Uuid>,
-        app_state: Entity<AppStateEntity>,
+        app_state: gpui::Entity<AppStateEntity>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -812,7 +833,7 @@ impl DataGridPanel {
 
     fn new_internal(
         source: DataSource,
-        app_state: Entity<AppStateEntity>,
+        app_state: gpui::Entity<AppStateEntity>,
         pk_columns: Vec<String>,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -2547,7 +2568,19 @@ impl DataGridPanel {
     /// next render tick triggers `run_table_query`, which will find
     /// `visual_select` ready to use.
     pub fn apply_builder_draft_spec(&mut self, spec: VisualQuerySpec, cx: &mut Context<Self>) {
-        let select = self.build_visual_select(&spec, cx);
+        let select = match self.build_visual_select(&spec, cx) {
+            Ok(select) => select,
+            Err(message) => {
+                dbflux_ui_base::user_error::report_error(
+                    dbflux_ui_base::user_error::UserFacingError::new(
+                        dbflux_ui_base::user_error::ErrorKind::Driver,
+                        message,
+                    ),
+                    cx,
+                );
+                None
+            }
+        };
 
         self.builder.builder_draft_spec = Some(spec);
         self.builder.visual_select = select;
@@ -2565,25 +2598,38 @@ impl DataGridPanel {
     /// query text is wrapped as a parameter-less `SelectQuery` so the existing
     /// execution path runs it unchanged. Selection is by which generator method
     /// returns a query, never by a driver id.
+    ///
+    /// Returns `Ok(None)` when no generator is available or neither path emits a
+    /// query, and `Err(message)` when a generator actively rejects the spec
+    /// (e.g. `generate_read_from_spec` returns `InvalidSpec`) so the caller can
+    /// surface the failure instead of silently producing an empty read.
     fn build_visual_select(
         &self,
         spec: &VisualQuerySpec,
         cx: &App,
-    ) -> Option<dbflux_core::SelectQuery> {
-        let generator = self.connection_generator(cx)?;
+    ) -> Result<Option<dbflux_core::SelectQuery>, String> {
+        let Some(generator) = self.connection_generator(cx) else {
+            return Ok(None);
+        };
 
-        if let Some(select) = generator.generate_select(spec).ok().flatten() {
-            return Some(select);
+        match generator.generate_select(spec) {
+            Ok(Some(select)) => return Ok(Some(select)),
+            // No structured SELECT for this generator (Document drivers return the
+            // default `Ok(None)`; `Unsupported` is the same intent made explicit).
+            // Either way, fall through to `generate_read_from_spec`.
+            Ok(None) => {}
+            Err(dbflux_core::QueryGenError::Unsupported) => {}
+            Err(error) => return Err(error.to_string()),
         }
 
-        generator
-            .generate_read_from_spec(spec)
-            .ok()
-            .flatten()
-            .map(|generated| dbflux_core::SelectQuery {
+        match generator.generate_read_from_spec(spec) {
+            Ok(Some(generated)) => Ok(Some(dbflux_core::SelectQuery {
                 sql: generated.text,
                 params: Vec::new(),
-            })
+            })),
+            Ok(None) => Ok(None),
+            Err(error) => Err(error.to_string()),
+        }
     }
 
     /// Clears the visual spec and restores the raw filter-input chrome.
@@ -2705,16 +2751,18 @@ impl DataGridPanel {
 
     /// Returns whether the toolbar's "Open in Builder" button should be shown.
     ///
-    /// True only for `DataSource::Table` sources on connections whose driver
-    /// uses `QueryLanguage::Sql`.
+    /// Availability is capability-driven, never keyed off a driver id: the
+    /// source must be a relational `Table` or a document `Collection`, the
+    /// driver's `category` must be `Relational` or `Document`, and the driver
+    /// must publish at least one non-logical predicate operator. A `Collection`
+    /// is only eligible when the category is `Document` (relational drivers open
+    /// as `Table`; key-value drivers publish no predicate operators and are thus
+    /// excluded on both counts).
     pub fn can_open_builder(&self, cx: &App) -> bool {
-        if !matches!(self.source, DataSource::Table { .. }) {
-            return false;
-        }
-
-        let profile_id = match &self.source {
-            DataSource::Table { profile_id, .. } => *profile_id,
-            _ => return false,
+        let (profile_id, is_collection) = match &self.source {
+            DataSource::Table { profile_id, .. } => (*profile_id, false),
+            DataSource::Collection { profile_id, .. } => (*profile_id, true),
+            DataSource::QueryResult { .. } => return false,
         };
 
         let Some(connected) = self.app_state.read(cx).connections().get(&profile_id) else {
@@ -2727,6 +2775,12 @@ impl DataGridPanel {
             metadata.category,
             DatabaseCategory::Relational | DatabaseCategory::Document
         );
+
+        // A collection source only makes sense for a document store; a relational
+        // table source is served by `DataSource::Table`.
+        if is_collection && !matches!(metadata.category, DatabaseCategory::Document) {
+            return false;
+        }
 
         let has_predicates = metadata
             .query
@@ -2749,21 +2803,39 @@ impl DataGridPanel {
     /// Constructs the panel entity on first open, or re-hydrates it from
     /// `builder_draft_spec` when the inspector is opened again after being closed.
     pub fn open_query_builder(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let (profile_id, database, table) = match &self.source {
+        // Relational tables map their schema/name into the spec source; document
+        // collections map their database/name. Both feed the same builder; the
+        // driver's `QueryGenerator` decides which read form is emitted.
+        let (profile_id, database, source) = match &self.source {
             DataSource::Table {
                 profile_id,
                 database,
                 table,
                 ..
-            } => (*profile_id, database.clone(), table.clone()),
-            _ => return,
+            } => {
+                let source = dbflux_core::SourceTable {
+                    schema: table.schema.clone(),
+                    table: table.name.clone(),
+                    alias: table.name.clone(),
+                };
+                (*profile_id, database.clone(), source)
+            }
+            DataSource::Collection {
+                profile_id,
+                collection,
+                ..
+            } => {
+                let source = dbflux_core::SourceTable {
+                    schema: Some(collection.database.clone()),
+                    table: collection.name.clone(),
+                    alias: collection.name.clone(),
+                };
+                (*profile_id, Some(collection.database.clone()), source)
+            }
+            DataSource::QueryResult { .. } => return,
         };
 
-        let source = dbflux_core::SourceTable {
-            schema: table.schema.clone(),
-            table: table.name.clone(),
-            alias: table.name.clone(),
-        };
+        let source_schema = source.schema.clone();
 
         let initial_spec = self.builder.builder_draft_spec.clone();
 
@@ -2783,16 +2855,20 @@ impl DataGridPanel {
                         return String::new();
                     };
 
-                    if let Some(select) = generator.generate_select(spec).ok().flatten() {
-                        return select.materialize_for_editor(conn.dialect());
+                    match generator.generate_select(spec) {
+                        Ok(Some(select)) => return select.materialize_for_editor(conn.dialect()),
+                        Ok(None) => {}
+                        Err(dbflux_core::QueryGenError::Unsupported) => {}
+                        Err(error) => return format!("-- {error}"),
                     }
 
-                    generator
-                        .generate_read_from_spec(spec)
-                        .ok()
-                        .flatten()
-                        .map(|generated| generated.text)
-                        .unwrap_or_default()
+                    match generator.generate_read_from_spec(spec) {
+                        Ok(Some(generated)) => generated.text,
+                        Ok(None) => String::new(),
+                        // Surface the rejection inline so the preview is never a
+                        // silently-empty box when the generator refuses the spec.
+                        Err(error) => format!("-- {error}"),
+                    }
                 })
             } else {
                 Box::new(|_spec: &VisualQuerySpec| String::new())
@@ -2829,6 +2905,17 @@ impl DataGridPanel {
             .map(|c| (c.name.clone(), c.kind))
             .collect();
 
+        // Resolve the orderable key once, from the source's key-schema metadata as
+        // it appears in the browse result the builder opens from — not from the
+        // live result, which a later builder-generated read can replace with one
+        // that no longer carries key markers. Stores that order on a single key
+        // (e.g. DynamoDB's sort key) emit their primary-key columns partition-key
+        // first and sort-key last, so the trailing primary-key column is the
+        // orderable key — but only when more than one primary-key column exists.
+        // A single primary-key column is a partition-only key with nothing to
+        // order on, so no key is seeded and no ORDER BY is emitted.
+        let sort_key_column = resolve_orderable_sort_key(&self.result.columns);
+
         let panel = if let Some(existing) = &self.builder.builder_panel {
             existing.update(cx, |p, cx| {
                 if let Some(spec) = initial_spec.clone() {
@@ -2836,6 +2923,13 @@ impl DataGridPanel {
                 }
                 p.available_columns = available_columns.clone();
                 p.column_kinds = column_kinds.clone();
+                // Only refresh the cached key when the current result still
+                // carries one: a builder-generated read can replace the grid with
+                // a result that has no key markers, and re-opening the builder
+                // must not clobber a previously resolved sort key with None.
+                if let Some(key) = &sort_key_column {
+                    p.cached_sort_key_column = Some(key.clone());
+                }
             });
             existing.clone()
         } else {
@@ -2856,6 +2950,7 @@ impl DataGridPanel {
 
             new_panel.update(cx, |p, _| {
                 p.column_kinds = column_kinds;
+                p.cached_sort_key_column = sort_key_column;
             });
 
             let run_sub = cx.subscribe_in(
@@ -2872,7 +2967,7 @@ impl DataGridPanel {
             new_panel
         };
 
-        self.spawn_fk_fetch_for_builder(panel.clone(), profile_id, database, table.schema, cx);
+        self.spawn_fk_fetch_for_builder(panel.clone(), profile_id, database, source_schema, cx);
 
         let view: AnyView = AnyView::from(panel);
         cx.emit(DataGridEvent::OpenInspector {
@@ -3366,7 +3461,11 @@ impl DataGridPanel {
             }
 
             BuilderEvent::SpecChanged(spec) => {
-                self.builder.visual_select = self.build_visual_select(spec, cx);
+                // Live edit: cache the read for the next Run. A rejected spec is a
+                // transient editing state, so it caches `None` without a toast here;
+                // the failure is surfaced when the user actually Runs (see
+                // `apply_builder_draft_spec`), avoiding a toast on every keystroke.
+                self.builder.visual_select = self.build_visual_select(spec, cx).unwrap_or(None);
                 self.builder.builder_draft_spec = Some(*spec.clone());
             }
 
@@ -4186,6 +4285,50 @@ mod tests {
         QueryResult::table(zero_row_columns(), Vec::new(), None, Duration::ZERO)
     }
 
+    fn key_column(name: &str, is_primary_key: bool) -> ColumnMeta {
+        ColumnMeta {
+            name: name.to_string(),
+            type_name: "S".to_string(),
+            kind: ColumnKind::Text,
+            nullable: false,
+            is_primary_key,
+        }
+    }
+
+    #[test]
+    fn resolve_orderable_sort_key_returns_trailing_primary_key() {
+        // Partition key first, sort key last; both marked primary. The trailing
+        // primary-key column is the orderable sort key.
+        let columns = vec![
+            key_column("pk", true),
+            key_column("sk", true),
+            key_column("attr", false),
+        ];
+
+        assert_eq!(
+            super::resolve_orderable_sort_key(&columns),
+            Some("sk".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_orderable_sort_key_none_for_partition_only_key() {
+        // A single primary-key column is a partition-only key with nothing to
+        // order on, so no orderable key is resolved.
+        let columns = vec![key_column("pk", true), key_column("attr", false)];
+
+        assert_eq!(super::resolve_orderable_sort_key(&columns), None);
+    }
+
+    #[test]
+    fn resolve_orderable_sort_key_none_without_primary_keys() {
+        // A result with no primary-key markers (e.g. a PartiQL `SELECT *`) yields
+        // no orderable key, so no ORDER BY is seeded.
+        let columns = vec![key_column("a", false), key_column("b", false)];
+
+        assert_eq!(super::resolve_orderable_sort_key(&columns), None);
+    }
+
     fn init_test_runtime(cx: &mut TestAppContext) {
         cx.update(gpui_component::init);
         cx.update(theme::init);
@@ -4909,121 +5052,88 @@ mod tests {
         });
     }
 
-    #[gpui::test]
-    fn can_open_builder_false_for_collection_source(cx: &mut TestAppContext) {
-        init_test_runtime(cx);
-
-        let app_state = isolated_test_app_state(cx);
-        let panel_holder = Rc::new(RefCell::new(None));
-        let panel_handle = panel_holder.clone();
-
-        let (_, window) = cx.add_window_view(|window, cx| {
-            let panel = cx.new(|cx| {
-                let source = DataSource::Collection {
-                    profile_id: Uuid::nil(),
-                    collection: CollectionRef::new("db", "items"),
-                    pagination: Pagination::default(),
-                    total_docs: None,
-                };
-
-                DataGridPanel::new_internal(source, app_state.clone(), vec![], window, cx)
-            });
-
-            panel_handle.replace(Some(panel.clone()));
-            Root::new(panel, window, cx)
-        });
-
-        let panel = panel_holder
-            .borrow()
-            .clone()
-            .expect("panel should be created");
-
-        let result = window.update(|_, app| panel.read(app).can_open_builder(app));
-
-        assert!(
-            !result,
-            "can_open_builder should return false for Collection source"
-        );
+    /// Minimal `Connection` stub whose `metadata()` is driven entirely by the
+    /// category / query-language / capabilities passed at construction, so a
+    /// single stub serves every `can_open_builder` case without per-driver code.
+    struct StubBuilderConnection {
+        metadata: dbflux_core::DriverMetadata,
     }
 
-    #[gpui::test]
-    fn can_open_builder_true_for_sql_table_source(cx: &mut TestAppContext) {
-        use dbflux_core::{
-            ConnectedProfile, Connection, DatabaseCategory, DbConfig, DbError, DbKind,
-            DriverCapabilities, DriverMetadata, Icon as CoreIcon, QueryLanguage,
-            QueryResult as CoreQueryResult, SchemaLoadingStrategy, SchemaSnapshot, SqlDialect,
-        };
-        use std::path::PathBuf;
+    impl dbflux_core::Connection for StubBuilderConnection {
+        fn metadata(&self) -> &dbflux_core::DriverMetadata {
+            &self.metadata
+        }
 
+        fn kind(&self) -> dbflux_core::DbKind {
+            dbflux_core::DbKind::SQLite
+        }
+
+        fn schema_loading_strategy(&self) -> dbflux_core::SchemaLoadingStrategy {
+            dbflux_core::SchemaLoadingStrategy::SingleDatabase
+        }
+
+        fn dialect(&self) -> &dyn dbflux_core::SqlDialect {
+            unimplemented!("StubBuilderConnection::dialect not needed for this test")
+        }
+
+        fn ping(&self) -> Result<(), dbflux_core::DbError> {
+            Ok(())
+        }
+
+        fn close(&mut self) -> Result<(), dbflux_core::DbError> {
+            Ok(())
+        }
+
+        fn execute(
+            &self,
+            _req: &dbflux_core::QueryRequest,
+        ) -> Result<QueryResult, dbflux_core::DbError> {
+            Err(dbflux_core::DbError::NotSupported("stub".to_string()))
+        }
+
+        fn cancel(&self, _handle: &dbflux_core::QueryHandle) -> Result<(), dbflux_core::DbError> {
+            Ok(())
+        }
+
+        fn schema(&self) -> Result<dbflux_core::SchemaSnapshot, dbflux_core::DbError> {
+            Ok(dbflux_core::SchemaSnapshot::default())
+        }
+    }
+
+    /// Registers a `StubBuilderConnection` with the given capability metadata and
+    /// returns the app state plus the registered profile id.
+    fn register_builder_stub_connection(
+        cx: &mut TestAppContext,
+        category: dbflux_core::DatabaseCategory,
+        query_language: dbflux_core::QueryLanguage,
+        query: Option<dbflux_core::QueryCapabilities>,
+    ) -> (gpui::Entity<AppStateEntity>, Uuid) {
         init_test_runtime(cx);
 
-        struct StubSqlConnection;
-
-        impl Connection for StubSqlConnection {
-            fn metadata(&self) -> &DriverMetadata {
-                // Safety: returning a reference to a static value so the lifetime is valid.
-                static META: std::sync::OnceLock<DriverMetadata> = std::sync::OnceLock::new();
-                META.get_or_init(|| DriverMetadata {
-                    id: "stub-sql".to_string(),
-                    display_name: "Stub SQL".to_string(),
-                    description: "test stub".to_string(),
-                    category: DatabaseCategory::Relational,
-                    deployment_class: None,
-                    query_language: QueryLanguage::Sql,
-                    capabilities: DriverCapabilities::empty(),
-                    default_port: None,
-                    uri_scheme: "stub".to_string(),
-                    icon: CoreIcon::Database,
-                    syntax: None,
-                    query: Some(dbflux_core::QueryCapabilities::default()),
-                    mutation: None,
-                    ddl: None,
-                    transactions: None,
-                    limits: None,
-                    ssl_modes: None,
-                    ssl_cert_fields: None,
-                    classification_override: None,
-                    default_chunk_size: None,
-                    supports_lock_timeout: false,
-                    editor_profile: None,
-                })
-            }
-
-            fn kind(&self) -> DbKind {
-                DbKind::SQLite
-            }
-
-            fn schema_loading_strategy(&self) -> SchemaLoadingStrategy {
-                SchemaLoadingStrategy::SingleDatabase
-            }
-
-            fn dialect(&self) -> &dyn SqlDialect {
-                unimplemented!("StubSqlConnection::dialect not needed for this test")
-            }
-
-            fn ping(&self) -> Result<(), DbError> {
-                Ok(())
-            }
-
-            fn close(&mut self) -> Result<(), DbError> {
-                Ok(())
-            }
-
-            fn execute(
-                &self,
-                _req: &dbflux_core::QueryRequest,
-            ) -> Result<CoreQueryResult, DbError> {
-                Err(DbError::NotSupported("stub".to_string()))
-            }
-
-            fn cancel(&self, _handle: &dbflux_core::QueryHandle) -> Result<(), DbError> {
-                Ok(())
-            }
-
-            fn schema(&self) -> Result<SchemaSnapshot, DbError> {
-                Ok(SchemaSnapshot::default())
-            }
-        }
+        let metadata = dbflux_core::DriverMetadata {
+            id: "stub-builder".to_string(),
+            display_name: "Stub".to_string(),
+            description: "test stub".to_string(),
+            category,
+            deployment_class: None,
+            query_language,
+            capabilities: dbflux_core::DriverCapabilities::empty(),
+            default_port: None,
+            uri_scheme: "stub".to_string(),
+            icon: dbflux_core::Icon::Database,
+            syntax: None,
+            query,
+            mutation: None,
+            ddl: None,
+            transactions: None,
+            limits: None,
+            ssl_modes: None,
+            ssl_cert_fields: None,
+            classification_override: None,
+            default_chunk_size: None,
+            supports_lock_timeout: false,
+            editor_profile: None,
+        };
 
         let profile_id = Uuid::new_v4();
 
@@ -5040,14 +5150,14 @@ mod tests {
             app_state.update(cx, |app, _cx| {
                 let profile = dbflux_core::ConnectionProfile::new(
                     "test",
-                    DbConfig::SQLite {
-                        path: PathBuf::from(":memory:"),
+                    dbflux_core::DbConfig::SQLite {
+                        path: std::path::PathBuf::from(":memory:"),
                         connection_id: None,
                     },
                 );
-                let connected = ConnectedProfile {
+                let connected = dbflux_core::ConnectedProfile {
                     profile,
-                    connection: Arc::new(StubSqlConnection),
+                    connection: Arc::new(StubBuilderConnection { metadata }),
                     schema: None,
                     mutation_policy: dbflux_core::MutationPolicy::default(),
                     database_schemas: Default::default(),
@@ -5066,6 +5176,120 @@ mod tests {
                 app.connections_mut().insert(profile_id, connected);
             });
         });
+
+        (app_state, profile_id)
+    }
+
+    /// Builds a `DataGridPanel` over a `DataSource::Collection` for the given
+    /// profile and returns the panel entity.
+    fn build_panel_for_collection(
+        cx: &mut TestAppContext,
+        app_state: gpui::Entity<AppStateEntity>,
+        profile_id: Uuid,
+    ) -> gpui::Entity<DataGridPanel> {
+        let panel_holder = Rc::new(RefCell::new(None));
+        let panel_handle = panel_holder.clone();
+
+        let (_, _window) = cx.add_window_view(|window, cx| {
+            let panel = cx.new(|cx| {
+                let source = DataSource::Collection {
+                    profile_id,
+                    collection: CollectionRef::new("db", "items"),
+                    pagination: Pagination::default(),
+                    total_docs: None,
+                };
+
+                DataGridPanel::new_internal(source, app_state.clone(), vec![], window, cx)
+            });
+
+            panel_handle.replace(Some(panel.clone()));
+            Root::new(panel, window, cx)
+        });
+
+        panel_holder
+            .borrow()
+            .clone()
+            .expect("panel should be created")
+    }
+
+    #[gpui::test]
+    fn can_open_builder_true_for_document_collection_source(cx: &mut TestAppContext) {
+        let (app_state, profile_id) = register_builder_stub_connection(
+            cx,
+            dbflux_core::DatabaseCategory::Document,
+            dbflux_core::QueryLanguage::MongoQuery,
+            Some(dbflux_core::QueryCapabilities::default()),
+        );
+
+        let panel = build_panel_for_collection(cx, app_state, profile_id);
+
+        let result = cx.update(|app| panel.read(app).can_open_builder(app));
+
+        assert!(
+            result,
+            "can_open_builder should be true for a Document collection with predicate operators"
+        );
+    }
+
+    #[gpui::test]
+    fn can_open_builder_false_for_keyvalue_collection_source(cx: &mut TestAppContext) {
+        // A key-value store publishes no predicate operators, so the builder is
+        // excluded on both the category and the predicate check.
+        let no_predicate_caps = dbflux_core::QueryCapabilities {
+            where_operators: Vec::new(),
+            ..dbflux_core::QueryCapabilities::default()
+        };
+        let (app_state, profile_id) = register_builder_stub_connection(
+            cx,
+            dbflux_core::DatabaseCategory::KeyValue,
+            dbflux_core::QueryLanguage::RedisCommands,
+            Some(no_predicate_caps),
+        );
+
+        let panel = build_panel_for_collection(cx, app_state, profile_id);
+
+        let result = cx.update(|app| panel.read(app).can_open_builder(app));
+
+        assert!(
+            !result,
+            "can_open_builder should be false for a non-Document collection without predicates"
+        );
+    }
+
+    #[gpui::test]
+    fn can_open_builder_false_for_document_collection_without_predicates(cx: &mut TestAppContext) {
+        let no_predicate_caps = dbflux_core::QueryCapabilities {
+            where_operators: vec![
+                dbflux_core::WhereOperator::And,
+                dbflux_core::WhereOperator::Or,
+            ],
+            ..dbflux_core::QueryCapabilities::default()
+        };
+        let (app_state, profile_id) = register_builder_stub_connection(
+            cx,
+            dbflux_core::DatabaseCategory::Document,
+            dbflux_core::QueryLanguage::MongoQuery,
+            Some(no_predicate_caps),
+        );
+
+        let panel = build_panel_for_collection(cx, app_state, profile_id);
+
+        let result = cx.update(|app| panel.read(app).can_open_builder(app));
+
+        assert!(
+            !result,
+            "can_open_builder should be false when only logical predicate operators are published"
+        );
+    }
+
+    #[gpui::test]
+    fn can_open_builder_true_for_sql_table_source(cx: &mut TestAppContext) {
+        let (app_state, profile_id) = register_builder_stub_connection(
+            cx,
+            dbflux_core::DatabaseCategory::Relational,
+            dbflux_core::QueryLanguage::Sql,
+            Some(dbflux_core::QueryCapabilities::default()),
+        );
 
         let panel_holder = Rc::new(RefCell::new(None));
         let panel_handle = panel_holder.clone();

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -42,7 +42,7 @@ use dbflux_components::modals::{
 };
 use dbflux_core::{
     CollectionRef, DatabaseCategory, OrderByColumn, Pagination, QueryResult, RefreshPolicy,
-    SelectQuery, SortDirection, TableRef, Value, VisualQuerySpec,
+    SelectQuery, SortDirection, TableRef, Value, VisualQuerySpec, WhereOperator,
 };
 use dbflux_ui_base::AppStateEntity;
 use dbflux_ui_base::AsyncUpdateResultExt;
@@ -2547,9 +2547,7 @@ impl DataGridPanel {
     /// next render tick triggers `run_table_query`, which will find
     /// `visual_select` ready to use.
     pub fn apply_builder_draft_spec(&mut self, spec: VisualQuerySpec, cx: &mut Context<Self>) {
-        let generator = self.connection_generator(cx);
-
-        let select = generator.and_then(|qgen| qgen.generate_select(&spec).ok().flatten());
+        let select = self.build_visual_select(&spec, cx);
 
         self.builder.builder_draft_spec = Some(spec);
         self.builder.visual_select = select;
@@ -2557,6 +2555,35 @@ impl DataGridPanel {
         self.pending.refresh = true;
 
         cx.notify();
+    }
+
+    /// Produces the executable read for a builder spec.
+    ///
+    /// Relational drivers materialize a parameterized `SelectQuery` via
+    /// `generate_select`. Document drivers (whose `generate_select` yields
+    /// `None`) fall back to the generic `generate_read_from_spec`, whose opaque
+    /// query text is wrapped as a parameter-less `SelectQuery` so the existing
+    /// execution path runs it unchanged. Selection is by which generator method
+    /// returns a query, never by a driver id.
+    fn build_visual_select(
+        &self,
+        spec: &VisualQuerySpec,
+        cx: &App,
+    ) -> Option<dbflux_core::SelectQuery> {
+        let generator = self.connection_generator(cx)?;
+
+        if let Some(select) = generator.generate_select(spec).ok().flatten() {
+            return Some(select);
+        }
+
+        generator
+            .generate_read_from_spec(spec)
+            .ok()
+            .flatten()
+            .map(|generated| dbflux_core::SelectQuery {
+                sql: generated.text,
+                params: Vec::new(),
+            })
     }
 
     /// Clears the visual spec and restores the raw filter-input chrome.
@@ -2690,12 +2717,31 @@ impl DataGridPanel {
             _ => return false,
         };
 
-        self.app_state
-            .read(cx)
-            .connections()
-            .get(&profile_id)
-            .map(|c| c.connection.metadata().query_language == dbflux_core::QueryLanguage::Sql)
-            .unwrap_or(false)
+        let Some(connected) = self.app_state.read(cx).connections().get(&profile_id) else {
+            return false;
+        };
+
+        let metadata = connected.connection.metadata();
+
+        let category_ok = matches!(
+            metadata.category,
+            DatabaseCategory::Relational | DatabaseCategory::Document
+        );
+
+        let has_predicates = metadata
+            .query
+            .as_ref()
+            .map(|q| {
+                q.where_operators.iter().any(|op| {
+                    !matches!(
+                        op,
+                        WhereOperator::And | WhereOperator::Or | WhereOperator::Not
+                    )
+                })
+            })
+            .unwrap_or(false);
+
+        category_ok && has_predicates
     }
 
     /// Opens (or re-opens) the `QueryBuilderPanel` inspector for this grid.
@@ -2733,9 +2779,19 @@ impl DataGridPanel {
         let generate_preview: Box<dyn Fn(&VisualQuerySpec) -> String + Send + Sync> =
             if let Some(conn) = connection_arc.clone() {
                 Box::new(move |spec: &VisualQuerySpec| {
-                    conn.query_generator()
-                        .and_then(|qgen| qgen.generate_select(spec).ok().flatten())
-                        .map(|q| q.materialize_for_editor(conn.dialect()))
+                    let Some(generator) = conn.query_generator() else {
+                        return String::new();
+                    };
+
+                    if let Some(select) = generator.generate_select(spec).ok().flatten() {
+                        return select.materialize_for_editor(conn.dialect());
+                    }
+
+                    generator
+                        .generate_read_from_spec(spec)
+                        .ok()
+                        .flatten()
+                        .map(|generated| generated.text)
                         .unwrap_or_default()
                 })
             } else {
@@ -3310,9 +3366,7 @@ impl DataGridPanel {
             }
 
             BuilderEvent::SpecChanged(spec) => {
-                self.builder.visual_select = self
-                    .connection_generator(cx)
-                    .and_then(|qgen| qgen.generate_select(spec).ok().flatten());
+                self.builder.visual_select = self.build_visual_select(spec, cx);
                 self.builder.builder_draft_spec = Some(*spec.clone());
             }
 
@@ -4921,7 +4975,7 @@ mod tests {
                     uri_scheme: "stub".to_string(),
                     icon: CoreIcon::Database,
                     syntax: None,
-                    query: None,
+                    query: Some(dbflux_core::QueryCapabilities::default()),
                     mutation: None,
                     ddl: None,
                     transactions: None,

--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -364,6 +364,16 @@ pub struct QueryBuilderPanel {
     /// case values stay textual.
     pub(crate) column_kinds: std::collections::HashMap<String, dbflux_core::ColumnKind>,
 
+    /// The single orderable key column for a `SortKeyOnly` driver, resolved once
+    /// at panel open from the browse result's key-schema metadata. `None` when
+    /// the source exposes no orderable key (e.g. a partition-key-only table).
+    ///
+    /// Cached deliberately: a builder-generated read can replace the live result
+    /// with one that no longer carries key markers (e.g. a PartiQL `SELECT *`),
+    /// so the key is captured up front rather than re-derived from whatever the
+    /// grid currently shows.
+    pub(crate) cached_sort_key_column: Option<String>,
+
     /// Serialized `(table, filter)` signature of the last mutation row-count
     /// request. Used so the count is recomputed only when the target rows
     /// actually change, not on every render or assignment edit. `None` while in
@@ -753,6 +763,7 @@ impl QueryBuilderPanel {
             join_cond_op_dropdowns: HashMap::new(),
             available_columns,
             column_kinds: std::collections::HashMap::new(),
+            cached_sort_key_column: None,
             count_signature: None,
             _count_debounce: None,
             schema_cache,
@@ -2150,7 +2161,7 @@ impl QueryBuilderPanel {
         direction: VisualSortDirection,
         cx: &mut Context<Self>,
     ) {
-        let sort_key_column = self.sort_key_column(cx).unwrap_or_default();
+        let sort_key_column = self.sort_key_column().unwrap_or_default();
         self.apply_sort_key_direction(direction, sort_key_column);
         self.rebuild_spec_and_notify(cx);
     }
@@ -2173,6 +2184,7 @@ impl QueryBuilderPanel {
                 row.direction = direction;
                 if row.column.is_empty() {
                     row.column = sort_key_column;
+                    row.source_alias = alias;
                 }
                 self.sort_rows.truncate(1);
             }
@@ -2974,22 +2986,14 @@ impl QueryBuilderPanel {
 
     /// The name of the single orderable column for a `SortKeyOnly` driver.
     ///
-    /// Stores that can order on exactly one key (e.g. DynamoDB's sort key) expose
-    /// it generically as the trailing primary-key column of the result metadata:
-    /// drivers emit primary-key columns partition-first, sort-key-last, so the
-    /// last `is_primary_key` column is the orderable key. This keeps the builder
-    /// driver-agnostic — it never names a driver, only reads `ColumnMeta`. Returns
-    /// `None` when the source exposes no orderable key (e.g. a partition-key-only
-    /// table), in which case no sort column is seeded and no ORDER BY is emitted.
-    pub(crate) fn sort_key_column(&self, cx: &App) -> Option<String> {
-        let data_grid = self.data_grid.as_ref()?.upgrade()?;
-        let result = data_grid.read(cx).result();
-
-        result
-            .columns
-            .iter()
-            .rfind(|column| column.is_primary_key)
-            .map(|column| column.name.clone())
+    /// Returns the key resolved once at panel open from the source's key-schema
+    /// metadata (`cached_sort_key_column`), not from the live result — a builder
+    /// read can replace the grid with a result that no longer carries key markers
+    /// (e.g. a PartiQL `SELECT *`). `None` when the source has no orderable key
+    /// (e.g. a partition-key-only table), in which case no column is seeded and
+    /// no ORDER BY is emitted.
+    pub(crate) fn sort_key_column(&self) -> Option<String> {
+        self.cached_sort_key_column.clone()
     }
 
     /// Switches the panel to the given builder mode.
@@ -3954,6 +3958,7 @@ mod tests {
             join_cond_op_dropdowns: HashMap::new(),
             available_columns: Vec::new(),
             column_kinds: std::collections::HashMap::new(),
+            cached_sort_key_column: None,
             count_signature: None,
             _count_debounce: None,
             schema_cache: Rc::new(RefCell::new(SchemaCache::default())),
@@ -4557,6 +4562,15 @@ mod tests {
         assert_eq!(panel.sort_rows.len(), 1);
         assert!(panel.sort_rows[0].column.is_empty());
         assert!(panel.current_spec.sort.is_empty());
+    }
+
+    #[test]
+    fn sort_key_column_returns_cached_value() {
+        let mut panel = make_panel(make_spec(test_source()));
+        assert_eq!(panel.sort_key_column(), None);
+
+        panel.cached_sort_key_column = Some("created_at".to_string());
+        assert_eq!(panel.sort_key_column(), Some("created_at".to_string()));
     }
 
     // ---- 4.3: filter depth cap enforcement ---------------------------------

--- a/crates/dbflux_ui_document/src/query_builder/panel.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel.rs
@@ -2139,6 +2139,61 @@ impl QueryBuilderPanel {
         }
     }
 
+    /// Sets the single sort-key direction for sort-key-only drivers.
+    ///
+    /// Drivers whose `order_by_mode` is `SortKeyOnly` (e.g. DynamoDB) can order
+    /// only on the sort key by direction, never by arbitrary columns. This keeps
+    /// exactly one sort row carrying the chosen direction so the builder never
+    /// offers a multi-column ORDER BY the driver cannot execute.
+    pub fn set_sort_key_direction(
+        &mut self,
+        direction: VisualSortDirection,
+        cx: &mut Context<Self>,
+    ) {
+        let sort_key_column = self.sort_key_column(cx).unwrap_or_default();
+        self.apply_sort_key_direction(direction, sort_key_column);
+        self.rebuild_spec_and_notify(cx);
+    }
+
+    /// Updates the single sort-key row to the given direction, seeding the
+    /// orderable column name when the row carries none yet. Pure (no `cx`):
+    /// the resolved sort-key column is passed in so the seeding rule can be
+    /// unit-tested without a GPUI context.
+    fn apply_sort_key_direction(
+        &mut self,
+        direction: VisualSortDirection,
+        sort_key_column: String,
+    ) {
+        self.sort_validation_error = None;
+
+        let alias = self.current_spec.source.alias.clone();
+
+        match self.sort_rows.first_mut() {
+            Some(row) => {
+                row.direction = direction;
+                if row.column.is_empty() {
+                    row.column = sort_key_column;
+                }
+                self.sort_rows.truncate(1);
+            }
+            None => {
+                self.sort_rows.push(SortRow {
+                    source_alias: alias,
+                    column: sort_key_column,
+                    direction,
+                });
+            }
+        }
+    }
+
+    /// The currently selected sort-key direction (defaults to ascending).
+    pub(crate) fn sort_key_direction(&self) -> VisualSortDirection {
+        self.sort_rows
+            .first()
+            .map(|row| row.direction)
+            .unwrap_or(VisualSortDirection::Asc)
+    }
+
     /// Moves the sort row at `from_index` to `to_index`.
     pub fn reorder_sort(&mut self, from_index: usize, to_index: usize, cx: &mut Context<Self>) {
         if from_index < self.sort_rows.len() && to_index < self.sort_rows.len() {
@@ -2752,7 +2807,13 @@ impl QueryBuilderPanel {
         };
 
         let joins: Vec<JoinStep> = self.join_rows.iter().map(|r| r.to_join_step()).collect();
-        let sort: Vec<SortEntry> = self.sort_rows.iter().map(|r| r.to_sort_entry()).collect();
+
+        let sort: Vec<SortEntry> = self
+            .sort_rows
+            .iter()
+            .filter(|r| !r.column.is_empty())
+            .map(|r| r.to_sort_entry())
+            .collect();
 
         let group_by: Vec<GroupByEntry> = self
             .group_by_rows
@@ -2869,6 +2930,66 @@ impl QueryBuilderPanel {
             return false;
         }
         connected.connection.metadata().query_language == dbflux_core::QueryLanguage::Sql
+    }
+
+    /// Reads the connected driver's `QueryCapabilities`.
+    ///
+    /// Drives builder section visibility and sort UX so the builder stays
+    /// driver-agnostic: every section gate keys off these capability flags
+    /// rather than a driver id.
+    pub(crate) fn query_capabilities(&self, cx: &App) -> Option<dbflux_core::QueryCapabilities> {
+        let app_state = self.app_state_weak.upgrade()?;
+        let state = app_state.read(cx);
+        let connected = state.connections().get(&self.schema_profile_id)?;
+        connected.connection.metadata().query.clone()
+    }
+
+    /// Whether the builder should render the JOINS section for this driver.
+    pub(crate) fn shows_joins_section(&self, cx: &App) -> bool {
+        self.query_capabilities(cx)
+            .map(|q| q.supports_joins)
+            .unwrap_or(false)
+    }
+
+    /// Whether the builder should render the GROUP BY / aggregates section.
+    pub(crate) fn shows_group_by_section(&self, cx: &App) -> bool {
+        self.query_capabilities(cx)
+            .map(|q| q.supports_group_by)
+            .unwrap_or(false)
+    }
+
+    /// Whether the builder should render the HAVING section.
+    pub(crate) fn shows_having_section(&self, cx: &App) -> bool {
+        self.query_capabilities(cx)
+            .map(|q| q.supports_having)
+            .unwrap_or(false)
+    }
+
+    /// The driver's result-ordering mode, defaulting to multi-column ordering.
+    pub(crate) fn order_by_mode(&self, cx: &App) -> dbflux_core::OrderByMode {
+        self.query_capabilities(cx)
+            .map(|q| q.order_by_mode)
+            .unwrap_or(dbflux_core::OrderByMode::AnyColumns)
+    }
+
+    /// The name of the single orderable column for a `SortKeyOnly` driver.
+    ///
+    /// Stores that can order on exactly one key (e.g. DynamoDB's sort key) expose
+    /// it generically as the trailing primary-key column of the result metadata:
+    /// drivers emit primary-key columns partition-first, sort-key-last, so the
+    /// last `is_primary_key` column is the orderable key. This keeps the builder
+    /// driver-agnostic — it never names a driver, only reads `ColumnMeta`. Returns
+    /// `None` when the source exposes no orderable key (e.g. a partition-key-only
+    /// table), in which case no sort column is seeded and no ORDER BY is emitted.
+    pub(crate) fn sort_key_column(&self, cx: &App) -> Option<String> {
+        let data_grid = self.data_grid.as_ref()?.upgrade()?;
+        let result = data_grid.read(cx).result();
+
+        result
+            .columns
+            .iter()
+            .rfind(|column| column.is_primary_key)
+            .map(|column| column.name.clone())
     }
 
     /// Switches the panel to the given builder mode.
@@ -3971,6 +4092,23 @@ mod tests {
             }
         }
 
+        fn t_set_sort_key_direction(
+            &mut self,
+            direction: VisualSortDirection,
+            sort_key_column: &str,
+        ) {
+            self.apply_sort_key_direction(direction, sort_key_column.to_string());
+            self.rebuild_spec_pure();
+        }
+
+        fn t_push_raw_sort_row(&mut self, source_alias: &str, column: &str) {
+            self.sort_rows.push(SortRow {
+                source_alias: source_alias.to_string(),
+                column: column.to_string(),
+                direction: VisualSortDirection::Asc,
+            });
+        }
+
         fn t_add_join(&mut self, from_alias: &str) {
             self.join_rows.push(JoinRow {
                 kind: JoinKind::Inner,
@@ -4378,6 +4516,47 @@ mod tests {
 
         assert_eq!(panel.sort_rows[0].column, "created_at");
         assert_eq!(panel.sort_rows[1].column, "name");
+    }
+
+    #[test]
+    fn sort_key_only_seeds_orderable_column() {
+        let mut panel = make_panel(make_spec(test_source()));
+
+        panel.t_set_sort_key_direction(VisualSortDirection::Desc, "created_at");
+
+        assert_eq!(panel.sort_rows.len(), 1);
+        assert_eq!(panel.sort_rows[0].column, "created_at");
+        assert_eq!(panel.sort_rows[0].direction, VisualSortDirection::Desc);
+
+        assert_eq!(panel.current_spec.sort.len(), 1);
+        assert_eq!(panel.current_spec.sort[0].column, "created_at");
+        assert_eq!(
+            panel.current_spec.sort[0].direction,
+            VisualSortDirection::Desc
+        );
+    }
+
+    #[test]
+    fn rebuild_spec_filters_empty_column_sort_row() {
+        let mut panel = make_panel(make_spec(test_source()));
+
+        panel.t_push_raw_sort_row("users", "");
+        panel.t_push_raw_sort_row("users", "created_at");
+        panel.rebuild_spec_pure();
+
+        assert_eq!(panel.current_spec.sort.len(), 1);
+        assert_eq!(panel.current_spec.sort[0].column, "created_at");
+    }
+
+    #[test]
+    fn sort_key_only_without_orderable_column_emits_no_sort() {
+        let mut panel = make_panel(make_spec(test_source()));
+
+        panel.t_set_sort_key_direction(VisualSortDirection::Asc, "");
+
+        assert_eq!(panel.sort_rows.len(), 1);
+        assert!(panel.sort_rows[0].column.is_empty());
+        assert!(panel.current_spec.sort.is_empty());
     }
 
     // ---- 4.3: filter depth cap enforcement ---------------------------------

--- a/crates/dbflux_ui_document/src/query_builder/sections/sort.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/sort.rs
@@ -142,7 +142,7 @@ fn render_sort_key_only(
     };
 
     let sort_key_label = panel
-        .sort_key_column(cx)
+        .sort_key_column()
         .filter(|name| !name.is_empty())
         .map(|name| format!("Sort key order ({name})"))
         .unwrap_or_else(|| "Sort key order".to_string());

--- a/crates/dbflux_ui_document/src/query_builder/sections/sort.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/sort.rs
@@ -12,9 +12,13 @@ pub fn render_sort(
     cx: &mut Context<QueryBuilderPanel>,
 ) -> impl IntoElement {
     use dbflux_components::controls::{Button, Input, completion_input_keys_wrapper};
-    use dbflux_core::VisualSortDirection;
+    use dbflux_core::{OrderByMode, VisualSortDirection};
     use gpui::SharedString;
     use gpui::prelude::*;
+
+    if panel.order_by_mode(cx) == OrderByMode::SortKeyOnly {
+        return render_sort_key_only(panel, cx).into_any_element();
+    }
 
     let sort_count = panel.sort_rows.len();
     let sort_rows = panel.sort_rows.clone();
@@ -115,5 +119,67 @@ pub fn render_sort(
         );
     }
 
-    container
+    container.into_any_element()
+}
+
+/// Renders the sort section for drivers that can order only on the sort key
+/// (`OrderByMode::SortKeyOnly`, e.g. DynamoDB): a single ascending/descending
+/// toggle with an inline hint, instead of the multi-column sort list.
+fn render_sort_key_only(
+    panel: &mut QueryBuilderPanel,
+    cx: &mut Context<QueryBuilderPanel>,
+) -> impl IntoElement {
+    use dbflux_components::controls::Button;
+    use dbflux_core::VisualSortDirection;
+    use gpui::SharedString;
+    use gpui::prelude::*;
+    use gpui_component::ActiveTheme;
+
+    let direction = panel.sort_key_direction();
+    let dir_label = match direction {
+        VisualSortDirection::Asc => "ASC",
+        VisualSortDirection::Desc => "DESC",
+    };
+
+    let sort_key_label = panel
+        .sort_key_column(cx)
+        .filter(|name| !name.is_empty())
+        .map(|name| format!("Sort key order ({name})"))
+        .unwrap_or_else(|| "Sort key order".to_string());
+
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .child(
+            div()
+                .flex()
+                .flex_row()
+                .gap_1()
+                .items_center()
+                .child(
+                    div()
+                        .flex_1()
+                        .text_sm()
+                        .child(SharedString::from(sort_key_label)),
+                )
+                .child(
+                    Button::new("qb-sortkey-dir", dir_label)
+                        .ghost()
+                        .small()
+                        .on_click(cx.listener(move |this, _event, _window, cx| {
+                            let next = match this.sort_key_direction() {
+                                VisualSortDirection::Asc => VisualSortDirection::Desc,
+                                VisualSortDirection::Desc => VisualSortDirection::Asc,
+                            };
+                            this.set_sort_key_direction(next, cx);
+                        })),
+                ),
+        )
+        .child(
+            div()
+                .text_xs()
+                .text_color(cx.theme().muted_foreground)
+                .child("Ordering is limited to the sort key for this driver."),
+        )
 }

--- a/crates/dbflux_ui_document/src/query_builder/view.rs
+++ b/crates/dbflux_ui_document/src/query_builder/view.rs
@@ -229,6 +229,11 @@ fn render_body(
         BuilderMode::Select => {
             let is_grouped = panel.is_grouped();
 
+            let shows_joins = panel.shows_joins_section(cx);
+            let shows_group_by = panel.shows_group_by_section(cx);
+            let shows_having = panel.shows_having_section(cx);
+            let shows_sort = panel.order_by_mode(cx) != dbflux_core::OrderByMode::None;
+
             let columns_body = if is_grouped {
                 render_effective_select_preview(panel, theme).into_any_element()
             } else {
@@ -236,9 +241,10 @@ fn render_body(
             };
 
             let filters_body = filters::render_filters(panel, cx).into_any_element();
-            let joins_body = joins::render_joins(panel, cx).into_any_element();
-            let group_by_body = group_by::render_group_by(panel, cx).into_any_element();
-            let sort_body = sort::render_sort(panel, cx).into_any_element();
+            let joins_body = shows_joins.then(|| joins::render_joins(panel, cx).into_any_element());
+            let group_by_body =
+                shows_group_by.then(|| group_by::render_group_by(panel, cx).into_any_element());
+            let sort_body = shows_sort.then(|| sort::render_sort(panel, cx).into_any_element());
             let limit_body = render_limit_offset_body(panel).into_any_element();
 
             let mut body = div()
@@ -257,15 +263,19 @@ fn render_body(
                     theme,
                     filters_body,
                 ))
-                .child(section_card("JOINS", AppIcon::Layers, theme, joins_body))
-                .child(section_card(
-                    "GROUP BY / AGGREGATES",
-                    AppIcon::Layers,
-                    theme,
-                    group_by_body,
-                ));
+                .when_some(joins_body, |body, joins_body| {
+                    body.child(section_card("JOINS", AppIcon::Layers, theme, joins_body))
+                })
+                .when_some(group_by_body, |body, group_by_body| {
+                    body.child(section_card(
+                        "GROUP BY / AGGREGATES",
+                        AppIcon::Layers,
+                        theme,
+                        group_by_body,
+                    ))
+                });
 
-            if is_grouped {
+            if is_grouped && shows_having {
                 let having_body = group_by::render_having(panel, cx).into_any_element();
                 body = body.child(section_card(
                     "HAVING",
@@ -275,14 +285,16 @@ fn render_body(
                 ));
             }
 
-            body.child(section_card("SORT", AppIcon::ArrowUpDown, theme, sort_body))
-                .child(section_card(
-                    "LIMIT & OFFSET",
-                    AppIcon::Hash,
-                    theme,
-                    limit_body,
-                ))
-                .into_any_element()
+            body.when_some(sort_body, |body, sort_body| {
+                body.child(section_card("SORT", AppIcon::ArrowUpDown, theme, sort_body))
+            })
+            .child(section_card(
+                "LIMIT & OFFSET",
+                AppIcon::Hash,
+                theme,
+                limit_body,
+            ))
+            .into_any_element()
         }
         BuilderMode::Update => {
             let assignments_body = assignments::render_assignments(panel, cx).into_any_element();


### PR DESCRIPTION
## What

**PR 2 of 2** of the cross-driver query-tooling work (PR 1 was #273). This PR is the **UI generalization**: it makes the editor and visual query builder work for Document drivers (MongoDB + DynamoDB) and finishes the DynamoDB PartiQL editor surface — all keyed off `DatabaseCategory` / `QueryLanguage` / `QueryCapabilities` / `editor_profile()`, with **zero driver-id branches**.

Built on the core seams and per-driver read generation merged in #273.

## Why

PR1 added the driver-agnostic seams; the UI still gated query tooling on `QueryLanguage::Sql`, so MongoDB and DynamoDB never saw the visual builder, and DynamoDB (a `QueryLanguage::Custom`) had no editor completion/diagnostics/highlighting. This PR wires the UI to the capability seams so non-SQL Document drivers get the same assistance.

## Changes (Batch 4 + 5)

### Editor parity — metadata-driven presentation
- Migrated the editor call sites (syntax highlighting, placeholder, comment prefix, connection-context/completion gating) from the `QueryLanguage` accessors to `DriverMetadata::editor_profile()`. DynamoDB's profile (SQL editor mode + PartiQL placeholder, set in #273) now flows through, giving PartiQL **SQL highlighting + completion + its placeholder** (this is also all of **T40**).
- **Live diagnostics** now run whenever the driver exposes a `LanguageService`, instead of being gated on `editor_mode == "sql"`. MongoDB and DynamoDB get live diagnostics; the SQL path is byte-for-byte unchanged (the default `editor_diagnostics` returns empty, so no-service drivers stay quiet).

### Visual query builder — capability-driven
- `can_open_builder` now keys off capabilities: `DatabaseCategory ∈ {Relational, Document}` **and** a non-logical `where_operator`. Replaces the `QueryLanguage::Sql` gate. The SQL path stays behaviorally identical; Document drivers qualify; Redis/KeyValue (empty `where_operators`) falls out.
- Builder **section visibility** comes from `QueryCapabilities` (`supports_joins` / `supports_group_by` / `supports_having`); offered operators come from `where_operators`.
- **Sort UX** keys off `OrderByMode`: `AnyColumns` keeps the multi-column sort UI; `SortKeyOnly` (DynamoDB) shows a single sort entry with an asc/desc toggle, with the orderable key surfaced read-only.
- Non-SQL Document reads route through `QueryGenerator::generate_read_from_spec`; the SQL path keeps using `generate_select`.

### SortKeyOnly correctness fix
DynamoDB's in-band PartiQL `ORDER BY "<sortkey>"` (from #273) needs the sort-key column name, which the direction-only `SortKeyOnly` UI did not supply — it would emit `ORDER BY ""`. Fixed by seeding the sort column from the table's key metadata generically (`ColumnMeta.is_primary_key`, no driver branch) and defensively filtering empty-column sort rows (mirroring the existing group-by/aggregate filters).

## Decoupling (review-blocking invariant)

No `driver_id ==` / driver-name match and no `== QueryLanguage::Sql` gate in the changed UI code; the existing `no-driver-id-branching` guardrail test passes. The only DynamoDB-specific knowledge stays in the driver crate (from #273). One known minor visual delta: the standalone SQL-preview modal renders the DynamoDB JSON envelope under plaintext (it receives a bare `QueryLanguage` with no connection handle) — an accepted, design-noted delta, not on the live editor path.

## Verification

- `cargo clippy --workspace --features "<full>" -- -D warnings` — clean.
- `cargo nextest run --workspace` — **3936 passed, 0 failed**.
- `cargo check --workspace --all-targets`, `cargo fmt --all -- --check` — clean.
- New tests cover the capability predicate, sort-key seeding, and the empty-column filter.

## Notes

- The visual builder for non-SQL drivers composes/runs reads; inline-edit editable-binding for non-SQL results stays a non-goal (relational-only; needs PK mapping).
- PartiQL pagination beyond page 1 is deferred (documented in #273): it needs an inbound page-token seam on `QueryRequest`, out of scope here.
