### PR TITLE
refactor: error-handling hygiene across MCP, UI, and core (CODE-3/5/6)

### DIFF
--- a/crates/dbflux_core/src/connection/manager.rs
+++ b/crates/dbflux_core/src/connection/manager.rs
@@ -1,3 +1,4 @@
+use crate::LogErr;
 use crate::{
     CollectionChildrenCache, CollectionChildrenPage, CollectionChildrenRequest, CollectionRef,
     Connection, ConnectionHooks, ConnectionProfile, CustomTypeInfo, DbDriver, DbKind, DbSchemaInfo,
@@ -690,9 +691,9 @@ impl ConnectionManager {
     pub fn disconnect(&mut self, profile_id: Uuid) {
         if let Some(connected) = self.connections.remove(&profile_id) {
             std::thread::spawn(move || {
-                let _ = connected.connection.cancel_active();
+                connected.connection.cancel_active().log_err();
                 for db_conn in connected.database_connections.values() {
-                    let _ = db_conn.connection.cancel_active();
+                    db_conn.connection.cancel_active().log_err();
                 }
                 drop(connected);
             });

--- a/crates/dbflux_core/src/core/log_err.rs
+++ b/crates/dbflux_core/src/core/log_err.rs
@@ -1,0 +1,55 @@
+//! Extension trait for logging-and-discarding fallible results.
+//!
+//! The project rule forbids `let _ =` on a fallible expression. When the
+//! caller genuinely wants to ignore an error but still leave a trace, this
+//! trait provides `.log_err()` as the sanctioned alternative: it logs the
+//! error (with the call-site location) and yields the success value as an
+//! `Option`, so the dropped error is never silent.
+
+use std::fmt::Display;
+use std::panic::Location;
+
+/// Logs the error of a `Result` before discarding it.
+///
+/// Intended for fire-and-forget call sites where propagation is not possible
+/// but a silent drop would hide a real failure. The success value is returned
+/// as `Some(_)`; an error is logged at error level and replaced with `None`.
+pub trait LogErr<T> {
+    /// Log the error (with caller location) and return the value as `Option`.
+    fn log_err(self) -> Option<T>;
+
+    /// Like [`LogErr::log_err`] but prefixes the log line with `context`.
+    fn log_err_with(self, context: &str) -> Option<T>;
+}
+
+impl<T, E: Display> LogErr<T> for Result<T, E> {
+    #[track_caller]
+    fn log_err(self) -> Option<T> {
+        match self {
+            Ok(value) => Some(value),
+            Err(error) => {
+                let location = Location::caller();
+                log::error!("{}:{}: {}", location.file(), location.line(), error);
+                None
+            }
+        }
+    }
+
+    #[track_caller]
+    fn log_err_with(self, context: &str) -> Option<T> {
+        match self {
+            Ok(value) => Some(value),
+            Err(error) => {
+                let location = Location::caller();
+                log::error!(
+                    "{}:{}: {}: {}",
+                    location.file(),
+                    location.line(),
+                    context,
+                    error
+                );
+                None
+            }
+        }
+    }
+}

--- a/crates/dbflux_core/src/core/mod.rs
+++ b/crates/dbflux_core/src/core/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod error;
 pub(crate) mod error_formatter;
+pub(crate) mod log_err;
 pub(crate) mod shutdown;
 pub(crate) mod task;
 pub(crate) mod traits;
@@ -10,6 +11,7 @@ pub use error_formatter::{
     ConnectionErrorFormatter, DefaultErrorFormatter, ErrorLocation, FormattedError,
     QueryErrorFormatter, sanitize_uri,
 };
+pub use log_err::LogErr;
 pub use shutdown::{ShutdownCoordinator, ShutdownPhase};
 pub use task::{
     CancelToken, TaskId, TaskKind, TaskManager, TaskSlot, TaskSnapshot, TaskStatus, TaskTarget,

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -87,7 +87,7 @@ pub use core::{
     CancelToken, CodeGenScope, CodeGeneratorInfo, Connection, ConnectionErrorFormatter,
     ConnectionExt, ConnectionOverrides, DbDriver, DbError, DefaultErrorFormatter,
     DocumentConnection, ErrorLocation, EventStreamTarget, FormattedError, KeyValueApi,
-    KeyValueConnection, NoopCancelHandle, QueryCancelHandle, QueryErrorFormatter,
+    KeyValueConnection, LogErr, NoopCancelHandle, QueryCancelHandle, QueryErrorFormatter,
     RelationalConnection, SchemaDropTarget, SchemaFeatures, SchemaLoadingStrategy,
     SchemaObjectKind, ShutdownCoordinator, ShutdownPhase, SourceContextSpec, SourceQueryMode,
     TaskId, TaskKind, TaskManager, TaskSlot, TaskSnapshot, TaskStatus, TaskTarget, Value,

--- a/crates/dbflux_mcp_server/src/helper.rs
+++ b/crates/dbflux_mcp_server/src/helper.rs
@@ -1,5 +1,21 @@
 use dbflux_core::{QueryResult, SqlDialect, Value};
 use rmcp::ErrorData;
+use rmcp::model::Content;
+use serde::Serialize;
+
+/// Serialize a value to pretty JSON wrapped in an MCP text `Content`.
+///
+/// Replaces the `serde_json::to_string_pretty(..).unwrap()` pattern repeated
+/// across the tool handlers. Serializing the handlers' own response DTOs is
+/// effectively infallible, but this lives on the MCP request path, so a
+/// serialization failure is surfaced as an `ErrorData` instead of a panic.
+pub fn to_json_content<T: Serialize>(value: &T) -> Result<Content, ErrorData> {
+    serde_json::to_string_pretty(value)
+        .map(Content::text)
+        .map_err(|error| {
+            ErrorData::internal_error(format!("Failed to serialize response: {error}"), None)
+        })
+}
 
 #[allow(dead_code)]
 pub fn json_to_sql_literal(value: &serde_json::Value, _dialect: &dyn SqlDialect) -> String {

--- a/crates/dbflux_mcp_server/src/tools/approval.rs
+++ b/crates/dbflux_mcp_server/src/tools/approval.rs
@@ -10,16 +10,13 @@
 use dbflux_approval::store::ExecutionPlan;
 use dbflux_policy::ExecutionClassification;
 use rmcp::{
-    ErrorData,
-    handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
-    schemars::JsonSchema,
+    ErrorData, handler::server::wrapper::Parameters, model::CallToolResult, schemars::JsonSchema,
     tool, tool_router,
 };
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::server::DbFluxServer;
+use crate::{helper::to_json_content, server::DbFluxServer};
 
 const DEFAULT_REJECTION_REASON: &str = "rejected by approver";
 
@@ -111,9 +108,7 @@ impl DbFluxServer {
                         "message": "Execution request created. Awaiting approval."
                     });
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&response).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&response)?]))
                 },
             )
             .await
@@ -155,9 +150,7 @@ impl DbFluxServer {
                         "count": filtered.len()
                     });
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&response).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&response)?]))
                 },
             )
             .await
@@ -191,9 +184,9 @@ impl DbFluxServer {
                     };
 
                     match pending {
-                        Some(pending) => Ok(CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&pending).unwrap(),
-                        )])),
+                        Some(pending) => {
+                            Ok(CallToolResult::success(vec![to_json_content(&pending)?]))
+                        }
                         None => Err(ErrorData::invalid_params(
                             format!("Pending execution not found: {}", pending_id),
                             None,
@@ -270,9 +263,7 @@ impl DbFluxServer {
                         )
                     });
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&response).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&response)?]))
                 },
             )
             .await
@@ -314,9 +305,7 @@ impl DbFluxServer {
                         "reason": rejection_reason
                     });
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&response).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&response)?]))
                 },
             )
             .await

--- a/crates/dbflux_mcp_server/src/tools/audit.rs
+++ b/crates/dbflux_mcp_server/src/tools/audit.rs
@@ -16,7 +16,10 @@ use rmcp::{
 };
 use serde::Deserialize;
 
-use crate::{helper::IntoErrorData, server::DbFluxServer};
+use crate::{
+    helper::{IntoErrorData, to_json_content},
+    server::DbFluxServer,
+};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct QueryAuditLogsParams {
@@ -219,9 +222,7 @@ impl DbFluxServer {
                         .map_err(|e| format!("Failed to query audit logs: {}", e))
                         .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&events).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&events)?]))
                 },
             )
             .await
@@ -253,9 +254,7 @@ impl DbFluxServer {
                         .map_err(|e| e.into_error_data())?;
 
                     match event {
-                        Some(entry) => Ok(CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&entry).unwrap(),
-                        )])),
+                        Some(entry) => Ok(CallToolResult::success(vec![to_json_content(&entry)?])),
                         None => {
                             Err(format!("Audit entry with ID {} not found", id).into_error_data())
                         }

--- a/crates/dbflux_mcp_server/src/tools/connection.rs
+++ b/crates/dbflux_mcp_server/src/tools/connection.rs
@@ -1,13 +1,13 @@
 use rmcp::{
-    ErrorData,
-    handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
-    schemars::JsonSchema,
+    ErrorData, handler::server::wrapper::Parameters, model::CallToolResult, schemars::JsonSchema,
     tool, tool_router,
 };
 use serde::Deserialize;
 
-use crate::{helper::IntoErrorData, server::DbFluxServer};
+use crate::{
+    helper::{IntoErrorData, to_json_content},
+    server::DbFluxServer,
+};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ConnectParams {
@@ -80,9 +80,9 @@ impl DbFluxServer {
                         .collect();
 
                     let json_output = serde_json::json!({ "connections": connections });
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&json_output).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(
+                        &json_output,
+                    )?]))
                 },
             )
             .await
@@ -108,13 +108,12 @@ impl DbFluxServer {
                         .await
                         .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&serde_json::json!({
+                    Ok(CallToolResult::success(vec![to_json_content(
+                        &serde_json::json!({
                             "success": true,
                             "message": format!("Connected to {}", connection_id)
-                        }))
-                        .unwrap(),
-                    )]))
+                        }),
+                    )?]))
                 },
             )
             .await
@@ -141,13 +140,12 @@ impl DbFluxServer {
                         cache.remove_connection_variants(&connection_id);
                     }
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&serde_json::json!({
+                    Ok(CallToolResult::success(vec![to_json_content(
+                        &serde_json::json!({
                             "success": true,
                             "message": format!("Disconnected from {}", connection_id)
-                        }))
-                        .unwrap(),
-                    )]))
+                        }),
+                    )?]))
                 },
             )
             .await
@@ -230,9 +228,7 @@ impl DbFluxServer {
                         info["current_database"] = serde_json::Value::String(db);
                     }
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&info).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&info)?]))
                 },
             )
             .await

--- a/crates/dbflux_mcp_server/src/tools/ddl.rs
+++ b/crates/dbflux_mcp_server/src/tools/ddl.rs
@@ -22,7 +22,7 @@ use dbflux_core::{
 };
 use rmcp::{
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content, ErrorData},
+    model::{CallToolResult, ErrorData},
     schemars::JsonSchema,
     tool, tool_router,
 };
@@ -992,9 +992,7 @@ impl DbFluxServer {
                     .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails {
                             query: non_empty(sql),
                         },
@@ -1031,9 +1029,7 @@ impl DbFluxServer {
                             .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails {
                             query: non_empty(sql),
                         },
@@ -1079,9 +1075,7 @@ impl DbFluxServer {
                     .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails {
                             query: non_empty(sql),
                         },
@@ -1123,9 +1117,7 @@ impl DbFluxServer {
                     .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails {
                             query: non_empty(sql),
                         },
@@ -1168,9 +1160,7 @@ impl DbFluxServer {
                         .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails {
                             query: non_empty(sql),
                         },

--- a/crates/dbflux_mcp_server/src/tools/destructive.rs
+++ b/crates/dbflux_mcp_server/src/tools/destructive.rs
@@ -15,10 +15,7 @@ use dbflux_core::{
     SemanticRequest, SqlDeleteRequest, TableRef, parse_semantic_filter_json,
 };
 use rmcp::{
-    ErrorData,
-    handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
-    schemars::JsonSchema,
+    ErrorData, handler::server::wrapper::Parameters, model::CallToolResult, schemars::JsonSchema,
     tool, tool_router,
 };
 use serde::Deserialize;
@@ -112,9 +109,7 @@ impl DbFluxServer {
                     .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails { query: sql_text },
                     ))
                 },
@@ -150,9 +145,7 @@ impl DbFluxServer {
                         .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails { query: Some(sql) },
                     ))
                 },
@@ -191,9 +184,7 @@ impl DbFluxServer {
                             .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails { query: Some(sql) },
                     ))
                 },
@@ -231,9 +222,7 @@ impl DbFluxServer {
                             .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails { query: Some(sql) },
                     ))
                 },

--- a/crates/dbflux_mcp_server/src/tools/query.rs
+++ b/crates/dbflux_mcp_server/src/tools/query.rs
@@ -4,10 +4,7 @@ use dbflux_core::{
     Connection, ExplainRequest, SemanticRequest, TableRef, classify_query_for_governance,
 };
 use rmcp::{
-    ErrorData,
-    handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
-    schemars::JsonSchema,
+    ErrorData, handler::server::wrapper::Parameters, model::CallToolResult, schemars::JsonSchema,
     tool, tool_router,
 };
 use serde::Deserialize;
@@ -81,9 +78,7 @@ impl DbFluxServer {
                     .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails { query: audit_sql },
                     ))
                 },
@@ -122,9 +117,7 @@ impl DbFluxServer {
                     .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails {
                             query: Some(audit_sql),
                         },

--- a/crates/dbflux_mcp_server/src/tools/read.rs
+++ b/crates/dbflux_mcp_server/src/tools/read.rs
@@ -14,16 +14,13 @@ use dbflux_core::{
     TableBrowseRequest, TableCountRequest, TableRef, parse_semantic_filter_json,
 };
 use rmcp::{
-    ErrorData,
-    handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
-    schemars::JsonSchema,
+    ErrorData, handler::server::wrapper::Parameters, model::CallToolResult, schemars::JsonSchema,
     tool, tool_router,
 };
 use serde::Deserialize;
 
 use crate::{
-    helper::{IntoErrorData, serialize_query_result},
+    helper::{IntoErrorData, serialize_query_result, to_json_content},
     server::DbFluxServer,
     state::ServerState,
 };
@@ -200,9 +197,7 @@ impl DbFluxServer {
                     .await
                     .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await
@@ -237,10 +232,9 @@ impl DbFluxServer {
                     .await
                     .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&serde_json::json!({ "count": count }))
-                            .unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(
+                        &serde_json::json!({ "count": count }),
+                    )?]))
                 },
             )
             .await
@@ -289,9 +283,7 @@ impl DbFluxServer {
                     .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails { query: sql_text },
                     ))
                 },

--- a/crates/dbflux_mcp_server/src/tools/schema.rs
+++ b/crates/dbflux_mcp_server/src/tools/schema.rs
@@ -2,10 +2,7 @@ use std::sync::Arc;
 
 use dbflux_core::{Connection, DataStructure, DescribeRequest, TableRef};
 use rmcp::{
-    ErrorData,
-    handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
-    schemars::JsonSchema,
+    ErrorData, handler::server::wrapper::Parameters, model::CallToolResult, schemars::JsonSchema,
     tool, tool_router,
 };
 use serde::Deserialize;
@@ -81,9 +78,7 @@ impl DbFluxServer {
                         .await
                         .map_err(|e| e.into_error_data())?;
 
-                    let json_str = serde_json::to_string_pretty(&result)
-                        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
-                    Ok(CallToolResult::success(vec![Content::text(json_str)]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await
@@ -111,9 +106,7 @@ impl DbFluxServer {
                             .await
                             .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await
@@ -146,9 +139,7 @@ impl DbFluxServer {
                     .await
                     .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await
@@ -195,9 +186,7 @@ impl DbFluxServer {
                     .await
                     .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await

--- a/crates/dbflux_mcp_server/src/tools/scripts.rs
+++ b/crates/dbflux_mcp_server/src/tools/scripts.rs
@@ -5,7 +5,11 @@
 //!
 //! All tools use `ScriptsDirectory` from `dbflux_core` to manage file operations.
 
-use crate::{DbFluxServer, helper::IntoErrorData, state::ServerState};
+use crate::{
+    DbFluxServer,
+    helper::{IntoErrorData, to_json_content},
+    state::ServerState,
+};
 use dbflux_core::{QueryLanguage, QueryRequest};
 use rmcp::{
     ErrorData,
@@ -143,9 +147,7 @@ impl DbFluxServer {
                         .await
                         .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await
@@ -171,9 +173,7 @@ impl DbFluxServer {
                         .await
                         .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await
@@ -208,9 +208,7 @@ impl DbFluxServer {
                     .await
                     .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await
@@ -237,9 +235,7 @@ impl DbFluxServer {
                         .await
                         .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await
@@ -306,9 +302,7 @@ impl DbFluxServer {
                             .await
                             .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await

--- a/crates/dbflux_mcp_server/src/tools/write.rs
+++ b/crates/dbflux_mcp_server/src/tools/write.rs
@@ -14,10 +14,7 @@ use dbflux_core::{
     Value, parse_semantic_filter_json,
 };
 use rmcp::{
-    ErrorData,
-    handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
-    schemars::JsonSchema,
+    ErrorData, handler::server::wrapper::Parameters, model::CallToolResult, schemars::JsonSchema,
     tool, tool_router,
 };
 use serde::Deserialize;
@@ -133,9 +130,7 @@ impl DbFluxServer {
                     .await
                     .map_err(|e| e.into_error_data())?;
 
-                    Ok(CallToolResult::success(vec![Content::text(
-                        serde_json::to_string_pretty(&result).unwrap(),
-                    )]))
+                    Ok(CallToolResult::success(vec![to_json_content(&result)?]))
                 },
             )
             .await
@@ -180,9 +175,7 @@ impl DbFluxServer {
                     .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails { query: sql_text },
                     ))
                 },
@@ -224,9 +217,7 @@ impl DbFluxServer {
                     .map_err(|e| e.into_error_data())?;
 
                     Ok((
-                        CallToolResult::success(vec![Content::text(
-                            serde_json::to_string_pretty(&result).unwrap(),
-                        )]),
+                        CallToolResult::success(vec![to_json_content(&result)?]),
                         AuditDetails { query: sql_text },
                     ))
                 },

--- a/crates/dbflux_storage/src/artifacts.rs
+++ b/crates/dbflux_storage/src/artifacts.rs
@@ -9,6 +9,7 @@
 //! source for scratch/shadow path ownership. Callers should never hardcode
 //! `sessions/` paths directly.
 
+use dbflux_core::LogErr;
 use log::info;
 use std::path::{Path, PathBuf};
 
@@ -97,7 +98,11 @@ impl ArtifactStore {
 
     /// Deletes a file at the given path, silently ignoring absence.
     pub fn delete_file(&self, path: &Path) {
-        let _ = std::fs::remove_file(path);
+        if let Err(error) = std::fs::remove_file(path)
+            && error.kind() != std::io::ErrorKind::NotFound
+        {
+            log::error!("failed to delete file {}: {error}", path.display());
+        }
     }
 
     /// Returns the modification time of a file, if readable.
@@ -130,8 +135,7 @@ impl ArtifactStore {
                 continue;
             }
 
-            if !referenced.contains(&path) {
-                let _ = std::fs::remove_file(&path);
+            if !referenced.contains(&path) && std::fs::remove_file(&path).log_err().is_some() {
                 info!("Cleaned up orphan artifact: {}", path.display());
             }
         }

--- a/crates/dbflux_ui/src/ui/views/workspace/actions.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions.rs
@@ -1860,7 +1860,7 @@ impl Workspace {
     }
 
     /// Write the current tab state to the session manifest (dbflux.db-backed).
-    pub(super) fn write_session_manifest(&self, cx: &App) {
+    pub(super) fn write_session_manifest(&self, cx: &mut App) {
         use dbflux_core::SessionTab;
 
         let runtime = self.app_state.read(cx).storage_runtime();
@@ -1902,7 +1902,11 @@ impl Workspace {
         };
 
         if let Err(e) = repo.save_workspace_session(&manifest) {
-            log::error!("Failed to save session manifest: {}", e);
+            report_error(
+                UserFacingError::new(ErrorKind::Storage, "Failed to save session manifest")
+                    .with_cause(format!("{e}")),
+                cx,
+            );
         }
     }
 

--- a/crates/dbflux_ui_document/src/code/context_bar.rs
+++ b/crates/dbflux_ui_document/src/code/context_bar.rs
@@ -3,6 +3,7 @@ use crate::result_view::ResultViewMode;
 use dbflux_components::composites::control_shell;
 use dbflux_components::primitives::{Icon, Text, focus_frame};
 use dbflux_ui_base::AsyncUpdateResultExt;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 
 fn context_dropdown_min_width(index: usize) -> Pixels {
     match index {
@@ -826,7 +827,14 @@ impl CodeDocument {
         {
             Ok(p) => p,
             Err(e) => {
-                log::warn!("Cannot connect to database {}: {}", database, e);
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Network,
+                        format!("Cannot connect to database '{database}'"),
+                    )
+                    .with_cause(e),
+                    cx,
+                );
                 self.revert_database_selection(prev_database, prev_schema, cx);
                 return;
             }

--- a/crates/dbflux_ui_document/src/code/file_ops.rs
+++ b/crates/dbflux_ui_document/src/code/file_ops.rs
@@ -235,7 +235,14 @@ impl CodeDocument {
                     .ok();
                 }
                 Err(e) => {
-                    log::error!("Auto-save failed for {}: {}", target.display(), e);
+                    report_error_async(
+                        UserFacingError::new(
+                            ErrorKind::Storage,
+                            format!("Auto-save failed for {}", target.display()),
+                        )
+                        .with_cause(format!("{e}")),
+                        cx,
+                    );
                 }
             }
         }));

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
@@ -238,7 +238,13 @@ impl DataGridPanel {
                 }
                 Value::Text(value) => DocumentFilter::new(serde_json::json!({"_id": value})),
                 _ => {
-                    log::error!("[SAVE] Invalid _id value for document inline edit");
+                    report_error(
+                        UserFacingError::new(
+                            ErrorKind::User,
+                            "Cannot update document field: the document has an unsupported _id value",
+                        ),
+                        cx,
+                    );
                     return;
                 }
             }
@@ -448,7 +454,13 @@ impl DataGridPanel {
         }
 
         if pk_columns.len() != pk_indices.len() || pk_values.len() != pk_indices.len() {
-            log::error!("[SAVE] Failed to build row identity");
+            report_error(
+                UserFacingError::new(
+                    ErrorKind::User,
+                    "Cannot save row: failed to build row identity from primary key columns",
+                ),
+                cx,
+            );
             return;
         }
 
@@ -588,7 +600,13 @@ impl DataGridPanel {
                 }
                 Value::Text(s) => DocumentFilter::new(serde_json::json!({"_id": s})),
                 _ => {
-                    log::error!("[SAVE] Invalid _id value for document");
+                    report_error(
+                        UserFacingError::new(
+                            ErrorKind::User,
+                            "Cannot save document: it has an unsupported _id value",
+                        ),
+                        cx,
+                    );
                     return;
                 }
             }
@@ -1114,7 +1132,13 @@ impl DataGridPanel {
                 }
                 Value::Text(s) => dbflux_core::DocumentFilter::new(serde_json::json!({"_id": s})),
                 _ => {
-                    log::error!("[DELETE] Invalid _id value for document");
+                    report_error(
+                        UserFacingError::new(
+                            ErrorKind::User,
+                            "Cannot delete document: it has an unsupported _id value",
+                        ),
+                        cx,
+                    );
                     return;
                 }
             }

--- a/crates/dbflux_ui_sidebar/src/table_loading.rs
+++ b/crates/dbflux_ui_sidebar/src/table_loading.rs
@@ -1,6 +1,7 @@
 use super::*;
 use dbflux_core::TaskKind;
 use dbflux_ui_base::AsyncUpdateResultExt;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 
 const COLLECTION_CHILDREN_PAGE_SIZE: u32 = 50;
 
@@ -394,7 +395,11 @@ impl Sidebar {
             Ok(p) => p,
             Err(e) => {
                 if e != "Schema types already cached" {
-                    log::warn!("Cannot fetch schema types: {}", e);
+                    report_error(
+                        UserFacingError::new(ErrorKind::Network, "Cannot load schema types")
+                            .with_cause(e),
+                        cx,
+                    );
                 }
                 return false;
             }
@@ -438,7 +443,11 @@ impl Sidebar {
             Ok(p) => p,
             Err(e) => {
                 if e != "Schema indexes already cached" {
-                    log::warn!("Cannot fetch schema indexes: {}", e);
+                    report_error(
+                        UserFacingError::new(ErrorKind::Network, "Cannot load schema indexes")
+                            .with_cause(e),
+                        cx,
+                    );
                 }
                 return false;
             }
@@ -482,7 +491,11 @@ impl Sidebar {
             Ok(p) => p,
             Err(e) => {
                 if e != "Schema foreign keys already cached" {
-                    log::warn!("Cannot fetch schema foreign keys: {}", e);
+                    report_error(
+                        UserFacingError::new(ErrorKind::Network, "Cannot load schema foreign keys")
+                            .with_cause(e),
+                        cx,
+                    );
                 }
                 return false;
             }
@@ -530,7 +543,11 @@ impl Sidebar {
             Ok(p) => p,
             Err(e) => {
                 if e != "Schema routines already cached" {
-                    log::warn!("Cannot fetch schema routines: {}", e);
+                    report_error(
+                        UserFacingError::new(ErrorKind::Network, "Cannot load schema routines")
+                            .with_cause(e),
+                        cx,
+                    );
                 }
                 return false;
             }

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -27,6 +27,7 @@ use dbflux_core::{
 };
 use dbflux_ui_base::platform;
 use dbflux_ui_base::sso_wizard::SsoWizard;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use dbflux_ui_base::{AppStateEntity, AuthProfileCreated};
 use gpui::*;
 use gpui_component::Root;
@@ -1201,37 +1202,37 @@ impl ConnectionManagerWindow {
         self.form
             .host_value_source_selector
             .update(cx, |selector, cx| {
-                let _ = selector.set_value_ref(None, window, cx);
+                let _previous = selector.set_value_ref(None, window, cx);
             });
         self.access
             .ssm_instance_id_value_source_selector
             .update(cx, |selector, cx| {
-                let _ = selector.set_value_ref(None, window, cx);
+                let _previous = selector.set_value_ref(None, window, cx);
             });
         self.access
             .ssm_region_value_source_selector
             .update(cx, |selector, cx| {
-                let _ = selector.set_value_ref(None, window, cx);
+                let _previous = selector.set_value_ref(None, window, cx);
             });
         self.access
             .ssm_remote_port_value_source_selector
             .update(cx, |selector, cx| {
-                let _ = selector.set_value_ref(None, window, cx);
+                let _previous = selector.set_value_ref(None, window, cx);
             });
         self.form
             .database_value_source_selector
             .update(cx, |selector, cx| {
-                let _ = selector.set_value_ref(None, window, cx);
+                let _previous = selector.set_value_ref(None, window, cx);
             });
         self.form
             .user_value_source_selector
             .update(cx, |selector, cx| {
-                let _ = selector.set_value_ref(None, window, cx);
+                let _previous = selector.set_value_ref(None, window, cx);
             });
         self.form
             .password_value_source_selector
             .update(cx, |selector, cx| {
-                let _ = selector.set_value_ref(None, window, cx);
+                let _previous = selector.set_value_ref(None, window, cx);
             });
     }
 
@@ -2560,14 +2561,20 @@ impl ConnectionManagerWindow {
         };
         platform::apply_window_options(&mut options, 600.0, 500.0);
 
-        let _ = cx.open_window(options, move |window, cx| {
+        if let Err(error) = cx.open_window(options, move |window, cx| {
             let wizard = cx.new(|cx| {
                 let mut wizard = SsoWizard::new(app_state.clone(), window, cx);
                 wizard.open(window, cx);
                 wizard
             });
             cx.new(|cx| Root::new(wizard, window, cx))
-        });
+        }) {
+            report_error(
+                UserFacingError::new(ErrorKind::User, "Failed to open AWS SSO wizard window")
+                    .with_cause(format!("{error}")),
+                cx,
+            );
+        }
     }
 
     fn handle_app_state_changed(&mut self, cx: &mut Context<Self>) {

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -15,7 +15,7 @@ use dbflux_components::tokens::{Heights, Radii, Spacing};
 use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use dbflux_core::{
     AccessKind, AuthEditCapabilities, AuthEditSnapshot, AuthProfile, AuthSaveOutcome,
-    DanglingMessage, FetchOptionsError, FetchOptionsRequest, FormFieldKind, RefreshTrigger,
+    DanglingMessage, FetchOptionsError, FetchOptionsRequest, FormFieldKind, LogErr, RefreshTrigger,
 };
 use dbflux_ui_base::keymap::key_chord_from_gpui;
 use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
@@ -1732,7 +1732,7 @@ impl AuthProfilesSection {
         // of when the login future resolves.
         let (url_tx, url_rx) = std::sync::mpsc::sync_channel::<Option<String>>(1);
         let url_callback: dbflux_core::auth::UrlCallback = Box::new(move |url| {
-            let _ = url_tx.try_send(url);
+            url_tx.try_send(url).log_err();
         });
 
         // URL-forwarding task: poll the channel and push the verification URL
@@ -1979,7 +1979,7 @@ impl AuthProfilesSection {
                                 if let Some(profile) = this.current_form_profile(cx)
                                     && let Some(provider) = this.selected_provider(cx)
                                 {
-                                    let _ = provider.abort_login(&profile);
+                                    let _aborted = provider.abort_login(&profile);
                                 }
                                 this.active_login_url = None;
                                 this.provider_login_status = Some((

--- a/crates/dbflux_ui_windows/src/settings/general.rs
+++ b/crates/dbflux_ui_windows/src/settings/general.rs
@@ -89,12 +89,20 @@ impl GeneralSection {
 
     /// Toggles whether this nightly build shares the stable database. The change
     /// is persisted to the pre-database marker immediately and applies on the
-    /// next launch; a write failure is logged and leaves the toggle unchanged.
-    fn set_share_stable_db(&mut self, value: bool) {
+    /// next launch; a write failure is surfaced to the user and leaves the toggle
+    /// unchanged.
+    fn set_share_stable_db(&mut self, value: bool, cx: &mut Context<Self>) {
         match dbflux_storage::paths::set_nightly_shares_stable_db(value) {
             Ok(()) => self.gen_share_stable_db = value,
             Err(error) => {
-                log::error!("Failed to update the shared-database setting: {error}")
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Config,
+                        "Failed to update the shared-database setting",
+                    )
+                    .with_cause(format!("{error}")),
+                    cx,
+                );
             }
         }
     }
@@ -186,7 +194,7 @@ impl GeneralSection {
                 cx.notify();
             }
             Some(GeneralFormRow::ShareStableDb) => {
-                self.set_share_stable_db(!self.gen_share_stable_db);
+                self.set_share_stable_db(!self.gen_share_stable_db, cx);
                 cx.notify();
             }
             Some(GeneralFormRow::MaxHistory)
@@ -506,7 +514,7 @@ impl GeneralSection {
                     self.gen_settings.restore_session_on_startup,
                     is_at(GeneralFormRow::RestoreSession),
                     GeneralFormRow::RestoreSession,
-                    |this, value| this.gen_settings.restore_session_on_startup = value,
+                    |this, value, _cx| this.gen_settings.restore_session_on_startup = value,
                     cx,
                 ))
                 .child(self.render_gen_checkbox(
@@ -515,7 +523,7 @@ impl GeneralSection {
                     self.gen_settings.reopen_last_connections,
                     is_at(GeneralFormRow::ReopenConnections),
                     GeneralFormRow::ReopenConnections,
-                    |this, value| this.gen_settings.reopen_last_connections = value,
+                    |this, value, _cx| this.gen_settings.reopen_last_connections = value,
                     cx,
                 ))
                 .child(self.render_gen_dropdown(
@@ -573,7 +581,7 @@ impl GeneralSection {
                     self.gen_settings.auto_refresh_pause_on_error,
                     is_at(GeneralFormRow::PauseRefreshOnError),
                     GeneralFormRow::PauseRefreshOnError,
-                    |this, value| this.gen_settings.auto_refresh_pause_on_error = value,
+                    |this, value, _cx| this.gen_settings.auto_refresh_pause_on_error = value,
                     cx,
                 ))
                 .child(self.render_gen_checkbox(
@@ -582,7 +590,7 @@ impl GeneralSection {
                     self.gen_settings.auto_refresh_only_if_visible,
                     is_at(GeneralFormRow::RefreshOnlyIfVisible),
                     GeneralFormRow::RefreshOnlyIfVisible,
-                    |this, value| this.gen_settings.auto_refresh_only_if_visible = value,
+                    |this, value, _cx| this.gen_settings.auto_refresh_only_if_visible = value,
                     cx,
                 ))
                 .child(self.render_gen_group_header("Execution Safety", border, muted_fg))
@@ -592,7 +600,7 @@ impl GeneralSection {
                     self.gen_settings.confirm_dangerous_queries,
                     is_at(GeneralFormRow::ConfirmDangerous),
                     GeneralFormRow::ConfirmDangerous,
-                    |this, value| this.gen_settings.confirm_dangerous_queries = value,
+                    |this, value, _cx| this.gen_settings.confirm_dangerous_queries = value,
                     cx,
                 ))
                 .child(self.render_gen_checkbox(
@@ -601,7 +609,7 @@ impl GeneralSection {
                     self.gen_settings.dangerous_requires_where,
                     is_at(GeneralFormRow::RequiresWhere),
                     GeneralFormRow::RequiresWhere,
-                    |this, value| this.gen_settings.dangerous_requires_where = value,
+                    |this, value, _cx| this.gen_settings.dangerous_requires_where = value,
                     cx,
                 ))
                 .child(self.render_gen_checkbox(
@@ -610,7 +618,7 @@ impl GeneralSection {
                     self.gen_settings.dangerous_requires_preview,
                     is_at(GeneralFormRow::RequiresPreview),
                     GeneralFormRow::RequiresPreview,
-                    |this, value| this.gen_settings.dangerous_requires_preview = value,
+                    |this, value, _cx| this.gen_settings.dangerous_requires_preview = value,
                     cx,
                 ))
                 .when(Self::is_nightly(), |column| {
@@ -622,7 +630,7 @@ impl GeneralSection {
                             self.gen_share_stable_db,
                             is_at(GeneralFormRow::ShareStableDb),
                             GeneralFormRow::ShareStableDb,
-                            |this, value| this.set_share_stable_db(value),
+                            |this, value, cx| this.set_share_stable_db(value, cx),
                             cx,
                         ))
                         .child(
@@ -690,7 +698,7 @@ impl GeneralSection {
         checked: bool,
         is_focused: bool,
         row: GeneralFormRow,
-        setter: fn(&mut Self, bool),
+        setter: fn(&mut Self, bool, &mut Context<Self>),
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let primary = cx.theme().primary;
@@ -724,7 +732,7 @@ impl GeneralSection {
             )
             .child(Checkbox::new(id).checked(checked).on_click(cx.listener(
                 move |this, value: &bool, _, cx| {
-                    setter(this, *value);
+                    setter(this, *value, cx);
                     cx.notify();
                 },
             )))


### PR DESCRIPTION
Clears the CODE-3/5/6 cluster from the audit board: three error-handling hygiene items that share a theme of not silently dropping failures.

## What changed

**CODE-3 — MCP unwrap cluster.** Replaced the workspace's largest `unwrap()` cluster (37 sites of `serde_json::to_string_pretty(..).unwrap()`) in `dbflux_mcp_server` tool handlers with a single helper, `to_json_content`. Serializing the handlers' own response DTOs is effectively infallible, but it sits on the MCP request path, so a failure now surfaces as `ErrorData` instead of panicking.

**CODE-5 — user-error seam migration.** Routed genuinely swallowed, user-triggered failures through `dbflux_ui_base::user_error` (`report_error` / `report_error_async`) so each gets a correlation id, an audit row, and the status-bar error badge. 10 first-catch sites migrated (auto-save, data-grid mutation guards, schema sub-fetches on tree expansion, session-manifest save, shared-DB setting). Sites already surfaced via the Tasks panel or a pending toast were deliberately left as `log::error!` to avoid double-reporting (the seam has no runtime dedup).

**CODE-6 — `let _ =` on fallible expressions.** Added the `LogErr` extension trait (`.log_err()`) to `dbflux_core` — the convention CLAUDE.md already documents but that did not exist in the tree — and used it to fix the silent discards (`cancel_active`, SSO `try_send`, artifact cleanup). Genuine value drops (`set_value_ref` → `String`, `abort_login` → `bool`) were renamed to `_name` rather than logged. The SSO-wizard window-open failure now reports to the user. `delete_file` keeps its documented silent-on-absence contract but logs real I/O errors.

## Why

`unwrap()` on the MCP path is a panic waiting to happen; swallowed UI failures leave users with no feedback and no audit trail; `let _ =` on a `Result` hides real errors. Each item removes a class of silent failure. `LogErr` also makes a documented-but-missing convention real, so future code has the sanctioned alternative to `let _ =`.

## Review notes

- No `dbflux_core` → UI dependency: `manager.rs` uses `.log_err()`, not the seam.
- Foreground vs background reporting was checked per site (`report_error` panics from background; `report_error_async` is the background variant).
- Reviewed by dual blind adversarial judges: 0 critical, the one confirmed warning (spurious error logs for the common absent-file path in `delete_file`) is fixed in this PR.

## Test plan

- `cargo nextest run --workspace` → 3951 passed, 184 skipped (live `#[ignore]`).
- `cargo clippy --workspace --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws -- -D warnings` → clean.
- `cargo fmt --all --check` → clean.