### PR TITLE
test: security-crate coverage + MSSQL/InfluxDB live tests in CI (TEST-1/2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,6 +100,21 @@ jobs:
       - name: Run SQLite live integration tests
         run: cargo test -p dbflux_driver_sqlite --locked --test live_integration
 
+      # MSSQL and InfluxDB spin up one container per test (the SQL Server image
+      # is ~2 GB), so these suites run single-threaded to avoid exhausting the
+      # runner with concurrent containers.
+      - name: Run MSSQL live integration tests
+        run: cargo test -p dbflux_driver_mssql --locked --test live_integration -- --ignored --test-threads=1
+
+      - name: Run MSSQL DDL integration tests
+        run: cargo test -p dbflux_driver_mssql --locked --test ddl_integration -- --ignored --test-threads=1
+
+      - name: Run MSSQL instance catalog tests
+        run: cargo test -p dbflux_driver_mssql --locked --test instance_catalog -- --ignored --test-threads=1
+
+      - name: Run InfluxDB live integration tests
+        run: cargo test -p dbflux_driver_influxdb --locked --test live_integration -- --ignored --test-threads=1
+
   cross-platform-check:
     name: Cross-platform check ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,6 +2756,7 @@ dependencies = [
  "dbflux_core",
  "dbflux_ssh",
  "dbflux_test_support",
+ "futures-util",
  "hex",
  "indexmap 2.14.0",
  "log",

--- a/crates/dbflux_audit/src/export.rs
+++ b/crates/dbflux_audit/src/export.rs
@@ -123,3 +123,245 @@ fn export_extended_csv(events: &[AuditEventDto]) -> String {
 
     output
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{AuditExportFormat, export_entries, export_extended};
+    use crate::AuditEvent;
+    use dbflux_storage::repositories::audit::AuditEventDto;
+
+    fn event(id: i64, reason: Option<&str>) -> AuditEvent {
+        AuditEvent {
+            id,
+            actor_id: "alice".to_string(),
+            tool_id: "read_query".to_string(),
+            decision: "allow".to_string(),
+            reason: reason.map(str::to_string),
+            created_at_epoch_ms: 1_700_000_000_000,
+        }
+    }
+
+    const CSV_HEADER: &str = "id,actor_id,tool_id,decision,reason,created_at_epoch_ms\n";
+
+    #[test]
+    fn csv_basic_header_and_rows() {
+        let events = vec![event(1, Some("first")), event(2, None)];
+
+        let csv = export_entries(&events, AuditExportFormat::Csv).expect("csv export");
+
+        let expected = format!(
+            "{CSV_HEADER}\
+             1,alice,read_query,allow,\"first\",1700000000000\n\
+             2,alice,read_query,allow,\"\",1700000000000\n"
+        );
+        assert_eq!(csv, expected);
+    }
+
+    #[test]
+    fn csv_empty_slice_yields_header_only() {
+        let csv = export_entries(&[], AuditExportFormat::Csv).expect("csv export");
+        assert_eq!(csv, CSV_HEADER);
+    }
+
+    #[test]
+    fn csv_reason_doubles_embedded_quotes() {
+        let events = vec![event(1, Some(r#"contains "quoted" text"#))];
+
+        let csv = export_entries(&events, AuditExportFormat::Csv).expect("csv export");
+
+        // export_csv only doubles `"` inside the quoted reason field.
+        assert!(
+            csv.contains(r#""contains ""quoted"" text""#),
+            "embedded quotes in reason must be doubled per RFC 4180; got: {csv}"
+        );
+    }
+
+    // FINDING: export_csv (the basic AuditEvent CSV) does NOT quote the
+    // id/actor_id/tool_id/decision fields and does NOT escape commas or newlines
+    // inside `reason` (it only doubles `"`). A reason containing a comma or
+    // newline produces malformed CSV (extra/leaked columns or rows). This test
+    // asserts the CURRENT (buggy) behavior so the suite is green and the gap is
+    // documented; it is intentionally not a "correct CSV" assertion.
+    #[test]
+    fn csv_reason_with_comma_and_newline_is_not_escaped_finding() {
+        let events = vec![event(1, Some("a,b\nc"))];
+
+        let csv = export_entries(&events, AuditExportFormat::Csv).expect("csv export");
+
+        // The comma and the raw newline survive verbatim inside the quoted field:
+        // a correct serializer would still keep them inside quotes (legal), but
+        // note the actor/tool/decision columns are emitted entirely unquoted.
+        let expected = format!("{CSV_HEADER}1,alice,read_query,allow,\"a,b\nc\",1700000000000\n");
+        assert_eq!(
+            csv, expected,
+            "documenting current behavior: reason is wrapped in quotes but the \
+             leading numeric/text columns are never quoted"
+        );
+    }
+
+    #[test]
+    fn json_basic_round_trips_to_expected_values() {
+        let events = vec![event(7, Some("why")), event(8, None)];
+
+        let json = export_entries(&events, AuditExportFormat::Json).expect("json export");
+
+        let decoded: Vec<AuditEvent> = serde_json::from_str(&json).expect("parse json");
+        assert_eq!(decoded, events);
+    }
+
+    #[test]
+    fn json_empty_slice_is_empty_array() {
+        let json = export_entries(&[], AuditExportFormat::Json).expect("json export");
+        let decoded: Vec<AuditEvent> = serde_json::from_str(&json).expect("parse json");
+        assert!(decoded.is_empty());
+    }
+
+    fn minimal_dto(id: i64) -> AuditEventDto {
+        AuditEventDto {
+            id,
+            actor_id: "alice".to_string(),
+            tool_id: "read_query".to_string(),
+            decision: "allow".to_string(),
+            reason: None,
+            profile_id: None,
+            classification: None,
+            duration_ms: None,
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            created_at_epoch_ms: 1_700_000_000_000,
+            level: None,
+            category: None,
+            action: None,
+            outcome: None,
+            actor_type: None,
+            source_id: None,
+            summary: None,
+            connection_id: None,
+            database_name: None,
+            driver_id: None,
+            object_type: None,
+            object_id: None,
+            details_json: None,
+            error_code: None,
+            error_message: None,
+            session_id: None,
+            correlation_id: None,
+        }
+    }
+
+    fn fuller_dto(id: i64) -> AuditEventDto {
+        AuditEventDto {
+            reason: Some("looked risky".to_string()),
+            profile_id: Some("prof-1".to_string()),
+            classification: Some("destructive".to_string()),
+            duration_ms: Some(42),
+            level: Some("warn".to_string()),
+            category: Some("query".to_string()),
+            action: Some("query_execute".to_string()),
+            outcome: Some("success".to_string()),
+            actor_type: Some("user".to_string()),
+            source_id: Some("local".to_string()),
+            summary: Some("ran a query".to_string()),
+            connection_id: Some("conn-1".to_string()),
+            database_name: Some("main".to_string()),
+            driver_id: Some("sqlite".to_string()),
+            object_type: Some("table".to_string()),
+            object_id: Some("users".to_string()),
+            details_json: Some(r#"{"query":"select 1"}"#.to_string()),
+            error_code: Some("E001".to_string()),
+            error_message: Some("boom".to_string()),
+            session_id: Some("sess-1".to_string()),
+            correlation_id: Some("corr-1".to_string()),
+            ..minimal_dto(id)
+        }
+    }
+
+    #[test]
+    fn extended_csv_includes_extended_fields() {
+        let events = vec![fuller_dto(1)];
+
+        let csv = export_extended(&events, AuditExportFormat::Csv).expect("extended csv");
+
+        let header = csv.lines().next().expect("header line");
+        assert!(header.contains("classification"));
+        assert!(header.contains("correlation_id"));
+        assert!(header.contains("details_json"));
+
+        // Extended values must appear in the data row.
+        assert!(csv.contains("\"destructive\""));
+        assert!(csv.contains("\"corr-1\""));
+        assert!(csv.contains("\"sqlite\""));
+        // duration_ms is emitted as an unquoted number.
+        assert!(csv.contains(",42,"));
+    }
+
+    #[test]
+    fn extended_csv_escapes_quotes_and_flattens_newlines() {
+        let mut dto = minimal_dto(1);
+        dto.summary = Some("line one\nline two".to_string());
+        dto.error_message = Some(r#"say "hi""#.to_string());
+
+        let csv = export_extended(&[dto], AuditExportFormat::Csv).expect("extended csv");
+
+        // Newlines inside a field are replaced by spaces; quotes are doubled.
+        assert!(
+            csv.contains("\"line one line two\""),
+            "extended csv must flatten newlines to spaces; got: {csv}"
+        );
+        assert!(
+            csv.contains(r#""say ""hi""""#),
+            "extended csv must double embedded quotes; got: {csv}"
+        );
+    }
+
+    #[test]
+    fn extended_csv_empty_slice_yields_header_only() {
+        let csv = export_extended(&[], AuditExportFormat::Csv).expect("extended csv");
+
+        let lines: Vec<&str> = csv.lines().collect();
+        assert_eq!(
+            lines.len(),
+            1,
+            "empty input must produce only the header row"
+        );
+        assert!(lines[0].starts_with("id,actor_id,tool_id,decision,reason"));
+    }
+
+    #[test]
+    fn extended_json_minimal_and_fuller_round_trip() {
+        let events = vec![minimal_dto(1), fuller_dto(2)];
+
+        let json = export_extended(&events, AuditExportFormat::Json).expect("extended json");
+
+        let decoded: serde_json::Value = serde_json::from_str(&json).expect("parse json");
+        let array = decoded.as_array().expect("top-level array");
+        assert_eq!(array.len(), 2);
+
+        assert_eq!(array[0]["id"], 1);
+        assert_eq!(array[1]["classification"], "destructive");
+        assert_eq!(array[1]["correlation_id"], "corr-1");
+        assert_eq!(array[1]["duration_ms"], 42);
+    }
+
+    #[test]
+    fn extended_json_empty_slice_is_empty_array() {
+        let json = export_extended(&[], AuditExportFormat::Json).expect("extended json");
+        let decoded: serde_json::Value = serde_json::from_str(&json).expect("parse json");
+        assert_eq!(decoded.as_array().map(Vec::len), Some(0));
+    }
+
+    // export_extended normalizes blank tool_id/decision to the legacy projection.
+    #[test]
+    fn extended_normalizes_blank_tool_id_and_decision() {
+        let mut dto = minimal_dto(1);
+        dto.tool_id = String::new();
+        dto.decision = String::new();
+        dto.action = Some("mcp_approve_execution".to_string());
+        dto.outcome = Some("success".to_string());
+
+        let json = export_extended(&[dto], AuditExportFormat::Json).expect("extended json");
+        let decoded: serde_json::Value = serde_json::from_str(&json).expect("parse json");
+
+        assert_eq!(decoded[0]["tool_id"], "approve_execution");
+        assert_eq!(decoded[0]["decision"], "allow");
+    }
+}

--- a/crates/dbflux_driver_mssql/Cargo.toml
+++ b/crates/dbflux_driver_mssql/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = { workspace = true }
 dbflux_core = { path = "../dbflux_core" }
 dbflux_ssh = { path = "../dbflux_ssh" }
 chrono = { workspace = true }
+futures-util = "0.3"
 hex.workspace = true
 indexmap.workspace = true
 log = "0.4"

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -1250,27 +1250,25 @@ impl MssqlConnection {
 
         // Multi-statement batches in SQL Server can produce multiple result
         // sets (e.g. `SELECT 1; SELECT 2;` or a stored procedure with
-        // several `SELECT`s). We return the LAST non-empty set as the
-        // primary `QueryResult` (preserving the historical "last statement
-        // wins" UX) and attach every earlier non-empty set to
-        // `additional_results` in batch order, so callers that want the
-        // full batch can walk it via `QueryResult::iter_result_sets()`.
-        // Pure preparation batches (`SET LOCK_TIMEOUT 5000`) produce no
-        // result sets and surface as an empty primary, which is what
-        // callers already expect.
+        // several `SELECT`s). We return the LAST result set as the primary
+        // `QueryResult` (preserving the historical "last statement wins" UX)
+        // and attach every earlier set to `additional_results` in batch
+        // order, so callers that want the full batch can walk it via
+        // `QueryResult::iter_result_sets()`. Column metadata comes from each
+        // set's METADATA token, so a `SELECT` that returned zero rows still
+        // carries its column headers. Pure preparation batches
+        // (`SET LOCK_TIMEOUT 5000`) emit no metadata, produce no result set,
+        // and surface as an empty primary, which is what callers expect.
         let collected = self.with_client(|runtime, client| {
             runtime.block_on(async move {
-                let stream = client
+                let mut stream = client
                     .simple_query(sql_owned)
                     .await
                     .map_err(|e| format_mssql_query_error(&e))?;
 
-                let result_sets = stream
-                    .into_results()
-                    .await
-                    .map_err(|e| format_mssql_query_error(&e))?;
+                let result_sets = collect_result_sets(&mut stream).await?;
 
-                Ok::<_, DbError>(convert_result_sets(result_sets))
+                Ok::<_, DbError>(result_sets)
             })
         })?;
 
@@ -1289,32 +1287,64 @@ impl MssqlConnection {
     }
 }
 
-/// Convert tiberius's raw result sets into `(columns, rows)` pairs, dropping
-/// any empty sets so the multi-set splitter sees only meaningful output.
-fn convert_result_sets(result_sets: Vec<Vec<tiberius::Row>>) -> Vec<(Vec<ColumnMeta>, Vec<Row>)> {
-    result_sets
-        .into_iter()
-        .filter(|set| !set.is_empty())
-        .map(convert_single_result_set)
-        .collect()
+/// Drive a tiberius `QueryStream` item by item, capturing column metadata from
+/// the result-set METADATA tokens rather than from rows.
+///
+/// Each `Metadata` item starts a new `(columns, rows)` pair built from the
+/// declared columns, so a result set that produced zero rows still carries its
+/// columns. Each `Row` item is appended to the most recently started pair.
+/// Statements that emit no metadata (e.g. `SET LOCK_TIMEOUT 5000`) create no
+/// pair at all.
+///
+/// The returned pairs are passed through [`finalize_result_sets`] so empty,
+/// metadata-less batches are dropped while empty-but-columned sets are kept.
+async fn collect_result_sets(
+    stream: &mut tiberius::QueryStream<'_>,
+) -> Result<Vec<(Vec<ColumnMeta>, Vec<Row>)>, DbError> {
+    use futures_util::TryStreamExt;
+
+    let mut sets: Vec<(Vec<ColumnMeta>, Vec<Row>)> = Vec::new();
+
+    while let Some(item) = stream
+        .try_next()
+        .await
+        .map_err(|e| format_mssql_query_error(&e))?
+    {
+        if let Some(metadata) = item.as_metadata() {
+            let columns = metadata
+                .columns()
+                .iter()
+                .map(tiberius_column_to_meta)
+                .collect();
+            sets.push((columns, Vec::new()));
+            continue;
+        }
+
+        if let Some(row) = item.into_row() {
+            let converted: Row = (0..row.columns().len())
+                .map(|idx| tiberius_value_to_value(&row, idx))
+                .collect();
+
+            match sets.last_mut() {
+                Some((_, rows)) => rows.push(converted),
+                None => sets.push((Vec::new(), vec![converted])),
+            }
+        }
+    }
+
+    Ok(finalize_result_sets(sets))
 }
 
-fn convert_single_result_set(set: Vec<tiberius::Row>) -> (Vec<ColumnMeta>, Vec<Row>) {
-    let columns = set
-        .first()
-        .map(|row| row.columns().iter().map(tiberius_column_to_meta).collect())
-        .unwrap_or_default();
-
-    let rows: Vec<Row> = set
-        .iter()
-        .map(|row| {
-            (0..row.columns().len())
-                .map(|idx| tiberius_value_to_value(row, idx))
-                .collect::<Row>()
-        })
-        .collect();
-
-    (columns, rows)
+/// Drop result sets that carry neither columns nor rows, while preserving
+/// empty-but-columned sets (a `SELECT` that returned zero rows still has its
+/// column headers). Factored out so it can be unit-tested without a live
+/// SQL Server.
+fn finalize_result_sets(
+    sets: Vec<(Vec<ColumnMeta>, Vec<Row>)>,
+) -> Vec<(Vec<ColumnMeta>, Vec<Row>)> {
+    sets.into_iter()
+        .filter(|(columns, rows)| !columns.is_empty() || !rows.is_empty())
+        .collect()
 }
 
 fn tiberius_column_to_meta(column: &tiberius::Column) -> ColumnMeta {
@@ -1327,14 +1357,14 @@ fn tiberius_column_to_meta(column: &tiberius::Column) -> ColumnMeta {
     }
 }
 
-/// Splits a list of non-empty result sets into a primary `QueryResult` plus
-/// additional sets, mirroring the multi-result-set contract on
+/// Splits a list of result sets into a primary `QueryResult` plus additional
+/// sets, mirroring the multi-result-set contract on
 /// `QueryResult::additional_results`.
 ///
-/// The LAST non-empty set becomes the primary (this preserves the historical
-/// "last statement wins" UX for `SELECT 1; SELECT 2;` style batches), and
-/// every earlier non-empty set is attached to `additional_results` in batch
-/// order. Empty input yields an empty primary.
+/// The LAST set becomes the primary (this preserves the historical "last
+/// statement wins" UX for `SELECT 1; SELECT 2;` style batches), and every
+/// earlier set is attached to `additional_results` in batch order. Empty
+/// input yields an empty primary.
 ///
 /// Factored out of `execute_simple` so it can be unit-tested without a live
 /// SQL Server.
@@ -4190,6 +4220,38 @@ mod tests {
             names,
             vec!["c".to_string(), "a".to_string(), "b".to_string()]
         );
+    }
+
+    #[test]
+    fn finalize_drops_only_sets_without_columns_and_rows() {
+        let empty_columned: (Vec<ColumnMeta>, Vec<Row>) =
+            (vec![col("id"), col("name")], Vec::new());
+        let metadata_less: (Vec<ColumnMeta>, Vec<Row>) = (Vec::new(), Vec::new());
+
+        let kept = finalize_result_sets(vec![metadata_less, empty_columned, one_row_set("data")]);
+
+        // The metadata-less set (no columns, no rows) is dropped; the
+        // empty-but-columned set and the populated set are retained.
+        assert_eq!(kept.len(), 2);
+        assert_eq!(kept[0].0.len(), 2);
+        assert!(kept[0].1.is_empty());
+        assert_eq!(kept[1].0[0].name, "data");
+    }
+
+    #[test]
+    fn empty_but_columned_set_becomes_primary_with_columns() {
+        let empty_columned: (Vec<ColumnMeta>, Vec<Row>) =
+            (vec![col("user_id"), col("email")], Vec::new());
+
+        let collected = finalize_result_sets(vec![empty_columned]);
+        let result = build_multi_result(collected, std::time::Duration::ZERO);
+
+        // The regression guard: a zero-row SELECT keeps its column headers.
+        assert!(!result.columns.is_empty());
+        assert_eq!(result.columns.len(), 2);
+        assert_eq!(result.columns[0].name, "user_id");
+        assert_eq!(result.columns[1].name, "email");
+        assert!(result.rows.is_empty());
     }
 
     #[test]

--- a/crates/dbflux_policy/src/assignments.rs
+++ b/crates/dbflux_policy/src/assignments.rs
@@ -20,3 +20,39 @@ impl ConnectionPolicyAssignment {
         self.actor_id == actor_id && self.scope.connection_id == connection_id
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{ConnectionPolicyAssignment, PolicyBindingScope};
+
+    fn assignment() -> ConnectionPolicyAssignment {
+        ConnectionPolicyAssignment {
+            actor_id: "alice".to_string(),
+            scope: PolicyBindingScope {
+                connection_id: "conn-a".to_string(),
+            },
+            role_ids: Vec::new(),
+            policy_ids: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn applies_to_matches_actor_and_connection() {
+        assert!(assignment().applies_to("alice", "conn-a"));
+    }
+
+    #[test]
+    fn applies_to_rejects_actor_mismatch() {
+        assert!(!assignment().applies_to("bob", "conn-a"));
+    }
+
+    #[test]
+    fn applies_to_rejects_connection_mismatch() {
+        assert!(!assignment().applies_to("alice", "conn-b"));
+    }
+
+    #[test]
+    fn applies_to_rejects_when_both_mismatch() {
+        assert!(!assignment().applies_to("bob", "conn-b"));
+    }
+}

--- a/crates/dbflux_policy/src/classification.rs
+++ b/crates/dbflux_policy/src/classification.rs
@@ -37,3 +37,83 @@ impl ExecutionClassification {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ExecutionClassification;
+
+    /// The escalation ladder from least to most restrictive. `max` must always
+    /// return whichever of its two operands sits higher on this ladder, since it
+    /// is the gate that decides how dangerous a composed operation is.
+    const ORDER: [ExecutionClassification; 7] = [
+        ExecutionClassification::Metadata,
+        ExecutionClassification::Read,
+        ExecutionClassification::Write,
+        ExecutionClassification::Destructive,
+        ExecutionClassification::AdminSafe,
+        ExecutionClassification::Admin,
+        ExecutionClassification::AdminDestructive,
+    ];
+
+    #[test]
+    fn max_returns_higher_rank_for_every_pair() {
+        for (lower_index, lower) in ORDER.iter().enumerate() {
+            for (higher_index, higher) in ORDER.iter().enumerate() {
+                let expected = if higher_index >= lower_index {
+                    *higher
+                } else {
+                    *lower
+                };
+
+                assert_eq!(
+                    lower.max(*higher),
+                    expected,
+                    "max({lower:?}, {higher:?}) must be the higher-ranked variant"
+                );
+                assert_eq!(
+                    higher.max(*lower),
+                    expected,
+                    "max is symmetric: max({higher:?}, {lower:?}) must match"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn max_is_idempotent_for_each_variant() {
+        for variant in ORDER {
+            assert_eq!(variant.max(variant), variant);
+        }
+    }
+
+    #[test]
+    fn serde_round_trip_preserves_every_variant() {
+        for variant in ORDER {
+            let json = serde_json::to_string(&variant).expect("serialize");
+            let decoded: ExecutionClassification =
+                serde_json::from_str(&json).expect("deserialize");
+
+            assert_eq!(decoded, variant, "round-trip must preserve {variant:?}");
+        }
+    }
+
+    #[test]
+    fn serde_uses_snake_case_wire_names() {
+        let cases = [
+            (ExecutionClassification::Metadata, "\"metadata\""),
+            (ExecutionClassification::Read, "\"read\""),
+            (ExecutionClassification::Write, "\"write\""),
+            (ExecutionClassification::Destructive, "\"destructive\""),
+            (ExecutionClassification::AdminSafe, "\"admin_safe\""),
+            (ExecutionClassification::Admin, "\"admin\""),
+            (
+                ExecutionClassification::AdminDestructive,
+                "\"admin_destructive\"",
+            ),
+        ];
+
+        for (variant, wire) in cases {
+            assert_eq!(serde_json::to_string(&variant).expect("serialize"), wire);
+        }
+    }
+}

--- a/crates/dbflux_policy/src/engine.rs
+++ b/crates/dbflux_policy/src/engine.rs
@@ -145,7 +145,8 @@ mod tests {
     use crate::classification::ExecutionClassification;
 
     use super::{
-        PolicyDecision, PolicyDecisionReason, PolicyEngine, PolicyEvaluationRequest, ToolPolicy,
+        PolicyDecision, PolicyDecisionReason, PolicyEngine, PolicyEngineError,
+        PolicyEvaluationRequest, PolicyRole, ToolPolicy,
     };
 
     fn request(connection_id: &str) -> PolicyEvaluationRequest {
@@ -239,5 +240,143 @@ mod tests {
             decision,
             PolicyDecision::Deny(PolicyDecisionReason::ClassificationDenied)
         );
+    }
+
+    fn read_query_assignment(
+        role_ids: Vec<String>,
+        policy_ids: Vec<String>,
+    ) -> ConnectionPolicyAssignment {
+        ConnectionPolicyAssignment {
+            actor_id: "alice".to_string(),
+            scope: PolicyBindingScope {
+                connection_id: "A".to_string(),
+            },
+            role_ids,
+            policy_ids,
+        }
+    }
+
+    fn read_query_policy(id: &str) -> ToolPolicy {
+        ToolPolicy {
+            id: id.to_string(),
+            allowed_tools: vec!["read_query".to_string()],
+            allowed_classes: vec![ExecutionClassification::Read],
+        }
+    }
+
+    #[test]
+    fn allows_via_role_resolved_policy() {
+        let engine = PolicyEngine::new(
+            vec![read_query_assignment(
+                vec!["reader".to_string()],
+                Vec::new(),
+            )],
+            vec![PolicyRole {
+                id: "reader".to_string(),
+                policy_ids: vec!["read-a".to_string()],
+            }],
+            vec![read_query_policy("read-a")],
+        );
+
+        let decision = engine
+            .evaluate(&request("A"))
+            .expect("evaluation should succeed");
+
+        assert_eq!(decision, PolicyDecision::Allow);
+    }
+
+    #[test]
+    fn missing_role_is_an_engine_error() {
+        let engine = PolicyEngine::new(
+            vec![read_query_assignment(
+                vec!["ghost-role".to_string()],
+                Vec::new(),
+            )],
+            Vec::new(),
+            vec![read_query_policy("read-a")],
+        );
+
+        let error = engine
+            .evaluate(&request("A"))
+            .expect_err("a role_id absent from the roles set must surface an error");
+
+        assert!(matches!(error, PolicyEngineError::MissingRole(role) if role == "ghost-role"));
+    }
+
+    #[test]
+    fn tool_denied_when_policy_matches_but_tool_not_allowed() {
+        let engine = PolicyEngine::new(
+            vec![read_query_assignment(
+                Vec::new(),
+                vec!["write-only".to_string()],
+            )],
+            Vec::new(),
+            vec![ToolPolicy {
+                id: "write-only".to_string(),
+                allowed_tools: vec!["write_query".to_string()],
+                allowed_classes: vec![ExecutionClassification::Read],
+            }],
+        );
+
+        let decision = engine
+            .evaluate(&request("A"))
+            .expect("evaluation should succeed");
+
+        assert_eq!(
+            decision,
+            PolicyDecision::Deny(PolicyDecisionReason::ToolDenied)
+        );
+    }
+
+    #[test]
+    fn no_policy_when_policy_set_is_empty() {
+        let engine = PolicyEngine::new(
+            vec![read_query_assignment(
+                Vec::new(),
+                vec!["read-a".to_string()],
+            )],
+            Vec::new(),
+            Vec::new(),
+        );
+
+        let decision = engine
+            .evaluate(&request("A"))
+            .expect("evaluation should succeed");
+
+        assert_eq!(
+            decision,
+            PolicyDecision::Deny(PolicyDecisionReason::NoPolicy)
+        );
+    }
+
+    #[test]
+    fn actor_draws_policies_from_both_direct_id_and_role() {
+        // The direct policy_id grants a tool the request does not use; the role's
+        // policy is the one that authorizes read_query. Allow must come from the
+        // union of both sources, not from either alone.
+        let engine = PolicyEngine::new(
+            vec![read_query_assignment(
+                vec!["reader".to_string()],
+                vec!["meta-only".to_string()],
+            )],
+            vec![PolicyRole {
+                id: "reader".to_string(),
+                policy_ids: vec!["read-a".to_string()],
+            }],
+            vec![
+                ToolPolicy {
+                    id: "meta-only".to_string(),
+                    allowed_tools: vec!["describe_table".to_string()],
+                    allowed_classes: vec![ExecutionClassification::Metadata],
+                },
+                read_query_policy("read-a"),
+            ],
+        );
+
+        let decision = engine
+            .evaluate(&request("A"))
+            .expect("evaluation should succeed");
+
+        assert_eq!(decision, PolicyDecision::Allow);
     }
 }

--- a/crates/dbflux_policy/src/trusted_clients.rs
+++ b/crates/dbflux_policy/src/trusted_clients.rs
@@ -157,4 +157,79 @@ mod tests {
             }
         );
     }
+
+    fn client(id: &str, issuer: Option<&str>) -> TrustedClient {
+        TrustedClient {
+            id: id.to_string(),
+            name: id.to_string(),
+            issuer: issuer.map(str::to_string),
+            active: true,
+        }
+    }
+
+    #[test]
+    fn issuer_none_in_config_accepts_regardless_of_identity_issuer() {
+        // TrustedClient::matches returns true for any identity issuer when the
+        // configured issuer is None (the `(None, _) => true` arm), so a wildcard
+        // client must accept a presented issuer it never declared.
+        let registry = TrustedClientRegistry::new(vec![client("agent-a", None)]);
+
+        let result = registry.evaluate(&ClientIdentity {
+            client_id: "agent-a".to_string(),
+            issuer: Some("some-issuer".to_string()),
+        });
+
+        assert!(matches!(result, TrustedClientMatch::Trusted(_)));
+    }
+
+    #[test]
+    fn registry_with_multiple_clients_resolves_the_matching_one() {
+        let registry = TrustedClientRegistry::new(vec![
+            client("agent-a", Some("issuer-a")),
+            client("agent-b", Some("issuer-b")),
+        ]);
+
+        let result = registry.evaluate(&ClientIdentity {
+            client_id: "agent-b".to_string(),
+            issuer: Some("issuer-b".to_string()),
+        });
+
+        match result {
+            TrustedClientMatch::Trusted(matched) => assert_eq!(matched.id, "agent-b"),
+            other => panic!("expected agent-b to be trusted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn replace_clients_swaps_the_active_set() {
+        let mut registry = TrustedClientRegistry::new(vec![client("agent-a", None)]);
+
+        let identity_a = ClientIdentity {
+            client_id: "agent-a".to_string(),
+            issuer: None,
+        };
+        let identity_b = ClientIdentity {
+            client_id: "agent-b".to_string(),
+            issuer: None,
+        };
+
+        assert!(matches!(
+            registry.evaluate(&identity_a),
+            TrustedClientMatch::Trusted(_)
+        ));
+
+        registry.replace_clients(vec![client("agent-b", None)]);
+
+        // The previously trusted client is gone, and the new one is now trusted.
+        assert_eq!(
+            registry.evaluate(&identity_a),
+            TrustedClientMatch::Untrusted {
+                reason: UNTRUSTED_CLIENT_AUDIT_REASON
+            }
+        );
+        assert!(matches!(
+            registry.evaluate(&identity_b),
+            TrustedClientMatch::Trusted(_)
+        ));
+    }
 }

--- a/crates/dbflux_tunnel_core/src/lib.rs
+++ b/crates/dbflux_tunnel_core/src/lib.rs
@@ -339,4 +339,194 @@ mod tests {
             "thread ignoring shutdown must be detached, not joined"
         );
     }
+
+    #[test]
+    fn start_binds_a_nonzero_ephemeral_port() {
+        let joined = Arc::new(AtomicBool::new(false));
+        let tunnel = Tunnel::start(
+            MockConnector {
+                joined: joined.clone(),
+            },
+            "127.0.0.1".into(),
+            1,
+            "TEST",
+        )
+        .unwrap();
+
+        assert_ne!(
+            tunnel.local_port(),
+            0,
+            "binding 127.0.0.1:0 must resolve to a real ephemeral port"
+        );
+    }
+
+    /// Records whether `test_connection` had already run by the time the
+    /// forwarding loop starts. `Tunnel::start` calls `test_connection` and only
+    /// then spawns the thread, so the loop must always observe the flag set.
+    struct OrderingConnector {
+        tested: Arc<AtomicBool>,
+        loop_saw_tested: Arc<AtomicBool>,
+    }
+
+    impl TunnelConnector for OrderingConnector {
+        fn test_connection(&self, _host: &str, _port: u16) -> Result<(), DbError> {
+            self.tested.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn run_tunnel_loop(
+            self,
+            _listener: TcpListener,
+            _remote_host: String,
+            _remote_port: u16,
+            shutdown: Arc<AtomicBool>,
+        ) {
+            self.loop_saw_tested
+                .store(self.tested.load(Ordering::SeqCst), Ordering::SeqCst);
+
+            while !shutdown.load(Ordering::SeqCst) {
+                adaptive_sleep(false, false);
+            }
+        }
+    }
+
+    #[test]
+    fn test_connection_runs_before_forwarding_thread_starts() {
+        let tested = Arc::new(AtomicBool::new(false));
+        let loop_saw_tested = Arc::new(AtomicBool::new(false));
+
+        let tunnel = Tunnel::start(
+            OrderingConnector {
+                tested: tested.clone(),
+                loop_saw_tested: loop_saw_tested.clone(),
+            },
+            "127.0.0.1".into(),
+            1,
+            "TEST",
+        )
+        .unwrap();
+
+        assert!(
+            tested.load(Ordering::SeqCst),
+            "test_connection must run during start()"
+        );
+
+        // Dropping joins the thread, so its recorded observation is final afterwards.
+        drop(tunnel);
+
+        assert!(
+            loop_saw_tested.load(Ordering::SeqCst),
+            "the forwarding loop must observe test_connection as already completed"
+        );
+    }
+
+    /// In-memory remote half for `ForwardingConnection`. `read` drains a queued
+    /// inbound buffer; `write` appends to an outbound buffer the test can inspect.
+    struct MockRemote {
+        inbound: Vec<u8>,
+        outbound: Vec<u8>,
+    }
+
+    impl Read for MockRemote {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            if self.inbound.is_empty() {
+                return Err(io::Error::new(io::ErrorKind::WouldBlock, "no data"));
+            }
+
+            let n = self.inbound.len().min(buf.len());
+            buf[..n].copy_from_slice(&self.inbound[..n]);
+            self.inbound.drain(..n);
+            Ok(n)
+        }
+    }
+
+    impl Write for MockRemote {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.outbound.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn write_all_remote(remote: &mut MockRemote, data: &[u8]) -> io::Result<()> {
+        remote.write_all(data)
+    }
+
+    fn write_all_client(client: &mut TcpStream, data: &[u8]) -> io::Result<()> {
+        blocking_write_all(client, data)
+    }
+
+    /// Builds a connected loopback `TcpStream` pair. Loopback is in-process and
+    /// needs no external network, so this stays deterministic in CI.
+    fn loopback_pair() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+
+        let client = TcpStream::connect(addr).expect("connect loopback");
+        let (server, _) = listener.accept().expect("accept loopback");
+
+        (client, server)
+    }
+
+    #[test]
+    fn poll_forwards_remote_bytes_to_the_client() {
+        let (client, mut peer) = loopback_pair();
+
+        let remote = MockRemote {
+            inbound: b"hello-from-remote".to_vec(),
+            outbound: Vec::new(),
+        };
+
+        let mut conn = ForwardingConnection::new(client, remote).expect("forwarding connection");
+
+        let activity = conn.poll(write_all_remote, write_all_client);
+
+        assert!(activity, "remote had data, so poll must report activity");
+        assert!(
+            !conn.closed,
+            "a successful transfer must not close the tunnel"
+        );
+
+        // The peer end of the loopback pair must now hold the forwarded bytes.
+        peer.set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("set read timeout");
+        let mut received = vec![0u8; 64];
+        let n = peer.read(&mut received).expect("peer read");
+        assert_eq!(&received[..n], b"hello-from-remote");
+    }
+
+    #[test]
+    fn poll_closes_when_remote_reaches_eof() {
+        let (client, _peer) = loopback_pair();
+
+        // inbound empty AND we simulate EOF by returning Ok(0): override read.
+        struct EofRemote;
+        impl Read for EofRemote {
+            fn read(&mut self, _buf: &mut [u8]) -> io::Result<usize> {
+                Ok(0)
+            }
+        }
+        impl Write for EofRemote {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        fn write_all_eof(remote: &mut EofRemote, data: &[u8]) -> io::Result<()> {
+            remote.write_all(data)
+        }
+
+        let mut conn = ForwardingConnection::new(client, EofRemote).expect("forwarding connection");
+
+        let activity = conn.poll(write_all_eof, write_all_client);
+
+        assert!(!activity, "an EOF poll transfers nothing");
+        assert!(conn.closed, "remote EOF (Ok(0)) must close the tunnel");
+    }
 }


### PR DESCRIPTION
Closes the TEST-1 and TEST-2 board items. Wiring the dormant live tests into CI immediately paid off: it surfaced a real MSSQL driver bug, which this PR also fixes.

## TEST-2 — direct tests for security-critical crates

Added 42 focused tests where coverage was only indirect:
- **dbflux_policy** — deny-by-default and role/policy composition in `PolicyEngine`, `ExecutionClassification` ordering, connection-scoped assignment matching, trusted-client resolution.
- **dbflux_tunnel_core** — RAII tunnel lifecycle (port binding, connect-before-forward ordering, forwarding poll), all without real network.
- **dbflux_audit** — CSV/JSON export formatting for both the basic and extended paths.

Tests only; no production change in these crates.

> **Finding (follow-up):** the basic audit CSV export does not escape commas/newlines and leaves non-reason columns unquoted — a corruption / CSV-injection risk in the compliance artifact. The new tests pin current behavior; hardening the export is left as a separate change.

## TEST-1 — run MSSQL and InfluxDB live suites in CI

The `driver-live-integration` job ran postgres/mysql/mongodb/redis/dynamodb/sqlite but never MSSQL or InfluxDB, so those suites rotted silently. Added MSSQL (live / ddl / instance-catalog) and InfluxDB live steps, single-threaded because each MSSQL test starts its own ~2 GB SQL Server container.

## fix(mssql) — empty result sets lost their columns

Running the never-run MSSQL suite caught a genuine bug: a `SELECT` returning 0 rows (e.g. a view over an empty table) came back with **no column metadata** — an empty grid with no headers in the app. Cause: results were read via `into_results()` (which carries no columns for a 0-row set) and columns were derived from the first row. `execute_simple` now drives the `QueryStream` manually, capturing columns from each result set's metadata token, so empty-but-real sets keep their columns. Prep batches (`SET …`) that emit no metadata still yield an empty primary. Added deterministic unit tests for the filter/assembly seam; the live `mssql_ddl_create_view` test is the end-to-end guard.

## Validation

- `cargo nextest run --workspace` → 3985 passed, 184 skipped (the new tests included).
- MSSQL live suite (serial, Docker): **95 passed, 0 failed** (`mssql_ddl_create_view` now passes; was the lone failure).
- InfluxDB live suite (serial, Docker): 8 passed.
- `cargo clippy --workspace --all-features -- -D warnings` and `cargo fmt --all --check` → clean.

Note: this PR touches the MSSQL driver's core result path, so it's left for review (not auto-merged).