### PR TITLE
fix(ui): preserve inline table text input

### DIFF
--- a/crates/dbflux_components/src/components/data_table/state.rs
+++ b/crates/dbflux_components/src/components/data_table/state.rs
@@ -561,6 +561,10 @@ impl DataTableState {
         self.editing_cell.is_some()
     }
 
+    pub fn is_editing_text_input(&self) -> bool {
+        self.cell_input.is_some()
+    }
+
     /// Get the currently editing cell, if any.
     pub fn editing_cell(&self) -> Option<CellCoord> {
         self.editing_cell

--- a/crates/dbflux_components/src/components/data_table/table.rs
+++ b/crates/dbflux_components/src/components/data_table/table.rs
@@ -78,32 +78,38 @@ actions!(
     ]
 );
 
-/// Key context for DataTable - matches ContextId::Results.as_gpui_context()
+/// Key context for DataTable - matches ContextId::Results.as_gpui_context().
 const CONTEXT: &str = "Results";
+/// Key binding context for DataTable actions when no nested input is focused.
+const CONTEXT_WITHOUT_INPUT: &str = "Results && !Input";
 
 pub fn init(cx: &mut App) {
     cx.bind_keys([
         // Navigation
-        KeyBinding::new("up", MoveUp, Some(CONTEXT)),
-        KeyBinding::new("down", MoveDown, Some(CONTEXT)),
-        KeyBinding::new("left", MoveLeft, Some(CONTEXT)),
-        KeyBinding::new("right", MoveRight, Some(CONTEXT)),
-        KeyBinding::new("k", MoveUp, Some(CONTEXT)),
-        KeyBinding::new("j", MoveDown, Some(CONTEXT)),
-        KeyBinding::new("h", MoveLeft, Some(CONTEXT)),
-        KeyBinding::new("l", MoveRight, Some(CONTEXT)),
-        KeyBinding::new("shift-up", SelectUp, Some(CONTEXT)),
-        KeyBinding::new("shift-down", SelectDown, Some(CONTEXT)),
-        KeyBinding::new("shift-left", SelectLeft, Some(CONTEXT)),
-        KeyBinding::new("shift-right", SelectRight, Some(CONTEXT)),
-        KeyBinding::new("home", MoveToLineStart, Some(CONTEXT)),
-        KeyBinding::new("end", MoveToLineEnd, Some(CONTEXT)),
-        KeyBinding::new("ctrl-home", MoveToTop, Some(CONTEXT)),
-        KeyBinding::new("ctrl-end", MoveToBottom, Some(CONTEXT)),
-        KeyBinding::new("shift-home", SelectToLineStart, Some(CONTEXT)),
-        KeyBinding::new("shift-end", SelectToLineEnd, Some(CONTEXT)),
-        KeyBinding::new("ctrl-shift-home", SelectToTop, Some(CONTEXT)),
-        KeyBinding::new("ctrl-shift-end", SelectToBottom, Some(CONTEXT)),
+        KeyBinding::new("up", MoveUp, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("down", MoveDown, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("left", MoveLeft, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("right", MoveRight, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("k", MoveUp, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("j", MoveDown, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("h", MoveLeft, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("l", MoveRight, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("shift-up", SelectUp, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("shift-down", SelectDown, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("shift-left", SelectLeft, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("shift-right", SelectRight, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("home", MoveToLineStart, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("end", MoveToLineEnd, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("ctrl-home", MoveToTop, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("ctrl-end", MoveToBottom, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("shift-home", SelectToLineStart, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("shift-end", SelectToLineEnd, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("ctrl-shift-home", SelectToTop, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new(
+            "ctrl-shift-end",
+            SelectToBottom,
+            Some(CONTEXT_WITHOUT_INPUT),
+        ),
         // `secondary-*` is GPUI's platform-aware modifier: Cmd on macOS,
         // Ctrl elsewhere. Use it for the system-standard commands so macOS
         // gets the expected Cmd shortcut without binding the literal Ctrl
@@ -112,31 +118,31 @@ pub fn init(cx: &mut App) {
         // Scope this to "table without an active Input" so that ctrl-a /
         // cmd-a inside an inline cell editor (or any other Input nested in
         // the table) selects the input's text instead of all rows.
-        KeyBinding::new("secondary-a", SelectAll, Some("Results && !Input")),
-        KeyBinding::new("escape", ClearSelection, Some(CONTEXT)),
+        KeyBinding::new("secondary-a", SelectAll, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("escape", ClearSelection, Some(CONTEXT_WITHOUT_INPUT)),
         // Copy
-        KeyBinding::new("secondary-c", Copy, Some(CONTEXT)),
-        KeyBinding::new("y y", Copy, Some(CONTEXT)),
-        KeyBinding::new("shift-y shift-y", CopyRow, Some(CONTEXT)),
+        KeyBinding::new("secondary-c", Copy, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("y y", Copy, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("shift-y shift-y", CopyRow, Some(CONTEXT_WITHOUT_INPUT)),
         // Edit mode
-        KeyBinding::new("enter", StartEdit, Some(CONTEXT)),
-        KeyBinding::new("f2", StartEdit, Some(CONTEXT)),
-        KeyBinding::new("secondary-enter", SaveRow, Some(CONTEXT)),
+        KeyBinding::new("enter", StartEdit, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("f2", StartEdit, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("secondary-enter", SaveRow, Some(CONTEXT_WITHOUT_INPUT)),
         // Row operations (vim-style)
-        KeyBinding::new("d d", DeleteRow, Some(CONTEXT)),
-        KeyBinding::new("delete", DeleteRow, Some(CONTEXT)),
-        KeyBinding::new("a a", AddRow, Some(CONTEXT)),
-        KeyBinding::new("shift-a shift-a", DuplicateRow, Some(CONTEXT)),
+        KeyBinding::new("d d", DeleteRow, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("delete", DeleteRow, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("a a", AddRow, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("shift-a shift-a", DuplicateRow, Some(CONTEXT_WITHOUT_INPUT)),
         // SetNull — local mnemonic ("N" for NULL). Kept as literal Ctrl on
         // every platform; this isn't a system-standard shortcut and reusing
         // Cmd+N on macOS would clash with NewQueryTab.
-        KeyBinding::new("ctrl-n", SetNull, Some(CONTEXT)),
+        KeyBinding::new("ctrl-n", SetNull, Some(CONTEXT_WITHOUT_INPUT)),
         // Undo/Redo: standard Cmd/Ctrl variants via `secondary-`, plus
         // vim-style `u` / `ctrl-r` kept literal as familiar editor aliases.
-        KeyBinding::new("u", Undo, Some(CONTEXT)),
-        KeyBinding::new("secondary-z", Undo, Some(CONTEXT)),
-        KeyBinding::new("ctrl-r", Redo, Some(CONTEXT)),
-        KeyBinding::new("secondary-shift-z", Redo, Some(CONTEXT)),
+        KeyBinding::new("u", Undo, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("secondary-z", Undo, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("ctrl-r", Redo, Some(CONTEXT_WITHOUT_INPUT)),
+        KeyBinding::new("secondary-shift-z", Redo, Some(CONTEXT_WITHOUT_INPUT)),
     ]);
 }
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu.rs
@@ -544,17 +544,16 @@ impl DataGridPanel {
             return ContextId::TextInput;
         }
 
-        if self.context_menu.is_some() {
-            ContextId::ContextMenu
-        } else if self
+        let inline_text_input_active = self
             .grid_table
             .table_state
             .as_ref()
             .map(|ts| ts.read(cx).is_editing_text_input())
-            .unwrap_or(false)
-        {
-            ContextId::TextInput
-        } else if self.focus.edit_state == EditState::Editing {
+            .unwrap_or(false);
+
+        if self.context_menu.is_some() {
+            ContextId::ContextMenu
+        } else if inline_text_input_active || self.focus.edit_state == EditState::Editing {
             ContextId::TextInput
         } else {
             ContextId::Results

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu.rs
@@ -532,7 +532,6 @@ impl DataGridPanel {
             .unwrap_or(false)
     }
 
-    /// Returns true if the context menu is currently open.
     /// Returns the active context for keyboard handling.
     pub fn active_context(&self, cx: &App) -> ContextId {
         if self.document_view.cell_editor.read(cx).is_visible()
@@ -547,6 +546,14 @@ impl DataGridPanel {
 
         if self.context_menu.is_some() {
             ContextId::ContextMenu
+        } else if self
+            .grid_table
+            .table_state
+            .as_ref()
+            .map(|ts| ts.read(cx).is_editing_text_input())
+            .unwrap_or(false)
+        {
+            ContextId::TextInput
         } else if self.focus.edit_state == EditState::Editing {
             ContextId::TextInput
         } else {


### PR DESCRIPTION
## Summary
- Prevent DataTable and Results keymaps from handling keystrokes while an inline table cell text input is focused.
- Expose a small DataTable state signal so the grid panel reports `TextInput` context during inline text editing.
- Preserve table shortcuts outside nested inputs by scoping DataTable action bindings to `Results && !Input`.

## Changes
| Area | Change |
| --- | --- |
| `DataTableState` | Adds `is_editing_text_input()` to distinguish text input editing from enum/dropdown/modal editing. |
| DataTable keybindings | Scopes table action bindings away from nested GPUI `Input` focus. |
| DataGridPanel context | Prioritizes modals, context menus, and inline text input before falling back to `Results`. |

## Test plan
- `cargo fmt --all -- --check`
- `cargo check -p dbflux_ui_document -p dbflux_components`
- `cargo test -p dbflux_components data_table`
- `cargo test -p dbflux_ui_document data_grid_panel::context_menu`
- `git diff --check`

## Manual validation recommended
- Edit a table cell and type `d`, `h`, `j`, `k`, `l`, `u`, and `y`; confirm they insert text.
- Exit edit mode and confirm the same table shortcuts still work in Results context.