### PR TITLE
refactor: split remaining CODE-4 god-files

### DIFF
--- a/crates/dbflux/tests/mcp_ui_governance_acceptance_tests.rs
+++ b/crates/dbflux/tests/mcp_ui_governance_acceptance_tests.rs
@@ -50,7 +50,7 @@ fn ui_contains_trusted_client_and_connection_policy_controls() {
 fn ui_contains_approval_and_audit_controls_with_workspace_wiring() {
     let governance_view = read_workspace_file("../dbflux_ui_document/src/governance.rs");
     let workspace_actions = read_workspace_module("../dbflux_ui/src/ui/views/workspace/actions");
-    let workspace_dispatch = read_workspace_file("../dbflux_ui/src/ui/views/workspace/dispatch.rs");
+    let workspace_dispatch = read_workspace_module("../dbflux_ui/src/ui/views/workspace/dispatch");
     let workspace_mod = read_workspace_file("../dbflux_ui/src/ui/views/workspace/mod.rs");
 
     assert!(governance_view.contains("mcp-approval-approve"));

--- a/crates/dbflux_app/src/app_state/bootstrap.rs
+++ b/crates/dbflux_app/src/app_state/bootstrap.rs
@@ -1,0 +1,19 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use dbflux_core::{
+    ConnectionHook, DbDriver, DriverKey, FormValues, GeneralSettings, GlobalOverrides,
+    ServiceConfig,
+};
+
+use crate::rpc_services::ExternalDriverDiagnostic;
+
+pub(super) struct BuiltDrivers {
+    pub(super) drivers: HashMap<String, Arc<dyn DbDriver>>,
+    pub(super) external_driver_diagnostics: HashMap<String, ExternalDriverDiagnostic>,
+    pub(super) general_settings: GeneralSettings,
+    pub(super) driver_overrides: HashMap<DriverKey, GlobalOverrides>,
+    pub(super) driver_settings: HashMap<DriverKey, FormValues>,
+    pub(super) hook_definitions: HashMap<String, ConnectionHook>,
+    pub(super) services: Vec<ServiceConfig>,
+}

--- a/crates/dbflux_app/src/app_state/mod.rs
+++ b/crates/dbflux_app/src/app_state/mod.rs
@@ -69,6 +69,8 @@ use std::sync::Arc;
 use std::sync::RwLock;
 use uuid::Uuid;
 
+mod bootstrap;
+
 use crate::auth_provider_registry::{AuthProviderRegistry, RegistryAuthProviderWrapper};
 use crate::rpc_services::external_audit::{ExternalAuditSink, NoOpContextProvider};
 use crate::rpc_services::{
@@ -84,21 +86,13 @@ use crate::rpc_services::{
 #[cfg(test)]
 use dbflux_driver_ipc::driver::IpcDriverLaunchConfig;
 
+use bootstrap::BuiltDrivers;
+
 pub use dbflux_core::{
     ConnectProfileParams, ConnectedProfile, DangerousQuerySuppressions, FetchDatabaseSchemaParams,
     FetchSchemaForeignKeysParams, FetchSchemaIndexesParams, FetchSchemaRoutinesParams,
     FetchSchemaTypesParams, FetchTableDetailsParams, SwitchDatabaseParams,
 };
-
-struct BuiltDrivers {
-    drivers: HashMap<String, Arc<dyn DbDriver>>,
-    external_driver_diagnostics: HashMap<String, ExternalDriverDiagnostic>,
-    general_settings: GeneralSettings,
-    driver_overrides: HashMap<DriverKey, GlobalOverrides>,
-    driver_settings: HashMap<DriverKey, FormValues>,
-    hook_definitions: HashMap<String, ConnectionHook>,
-    services: Vec<ServiceConfig>,
-}
 
 pub struct AppState {
     pub facade: SessionFacade,

--- a/crates/dbflux_core/src/schema/node_id/kind_flags.rs
+++ b/crates/dbflux_core/src/schema/node_id/kind_flags.rs
@@ -1,0 +1,102 @@
+use super::SchemaNodeKind;
+
+impl SchemaNodeKind {
+    pub fn needs_click_handler(&self) -> bool {
+        matches!(
+            self,
+            Self::Profile
+                | Self::DatabasesFolder
+                | Self::Database
+                | Self::Table
+                | Self::View
+                | Self::Collection
+                | Self::CollectionChild
+                | Self::CollectionChildrenMore
+                | Self::ConnectionFolder
+                | Self::Schema
+                | Self::TablesFolder
+                | Self::ViewsFolder
+                | Self::TypesFolder
+                | Self::ColumnsFolder
+                | Self::IndexesFolder
+                | Self::ForeignKeysFolder
+                | Self::ConstraintsFolder
+                | Self::SchemaIndexesFolder
+                | Self::SchemaForeignKeysFolder
+                | Self::RoutinesFolder
+                | Self::CollectionsFolder
+                | Self::CollectionFieldsFolder
+                | Self::CustomType
+                | Self::ScriptsFolder
+                | Self::ScriptFile
+                | Self::DependentsFolder
+                | Self::Routine
+                | Self::MetricsFolder
+                | Self::MetricNamespaceFolder
+                | Self::MetricLeaf
+                | Self::DashboardsFolder
+                | Self::DashboardItem
+                | Self::RemoteDashboardsFolder
+                | Self::RemoteDashboardItem
+                | Self::SavedChartsFolder
+                | Self::SavedChartItem
+                | Self::InstanceMetricsFolder
+                | Self::InstanceMetricLeaf
+                | Self::InstanceInspectorsFolder
+                | Self::InstanceInspectorLeaf
+                | Self::InstanceOverviewLeaf
+        )
+    }
+
+    pub fn is_expandable_folder(&self) -> bool {
+        matches!(
+            self,
+            Self::ConnectionFolder
+                | Self::DatabasesFolder
+                | Self::Schema
+                | Self::TablesFolder
+                | Self::ViewsFolder
+                | Self::TypesFolder
+                | Self::ColumnsFolder
+                | Self::IndexesFolder
+                | Self::ForeignKeysFolder
+                | Self::ConstraintsFolder
+                | Self::SchemaIndexesFolder
+                | Self::SchemaForeignKeysFolder
+                | Self::RoutinesFolder
+                | Self::CollectionsFolder
+                | Self::CollectionFieldsFolder
+                | Self::Database
+                | Self::CustomType
+                | Self::ScriptsFolder
+                | Self::DependentsFolder
+                | Self::MetricsFolder
+                | Self::MetricNamespaceFolder
+                | Self::DashboardsFolder
+                | Self::RemoteDashboardsFolder
+                | Self::SavedChartsFolder
+                | Self::InstanceMetricsFolder
+                | Self::InstanceInspectorsFolder
+        )
+    }
+
+    pub fn shows_pointer_cursor(&self) -> bool {
+        matches!(
+            self,
+            Self::Profile
+                | Self::Database
+                | Self::ConnectionFolder
+                | Self::CollectionChild
+                | Self::CollectionChildrenMore
+                | Self::ScriptFile
+                | Self::Routine
+                | Self::MetricLeaf
+                | Self::DashboardItem
+                | Self::RemoteDashboardItem
+                | Self::SavedChartItem
+                | Self::InstanceMetricLeaf
+                | Self::InstanceInspectorLeaf
+                | Self::InstanceOverviewLeaf
+        )
+    }
+}

--- a/crates/dbflux_core/src/schema/node_id/mod.rs
+++ b/crates/dbflux_core/src/schema/node_id/mod.rs
@@ -2,6 +2,8 @@ use std::fmt;
 use std::str::FromStr;
 use uuid::Uuid;
 
+mod kind_flags;
+
 /// Typed representation of a sidebar tree node ID.
 ///
 /// Every node in the sidebar schema tree has a string ID that encodes its type
@@ -1731,107 +1733,6 @@ impl FromStr for SchemaNodeId {
     }
 }
 
-impl SchemaNodeKind {
-    pub fn needs_click_handler(&self) -> bool {
-        matches!(
-            self,
-            Self::Profile
-                | Self::DatabasesFolder
-                | Self::Database
-                | Self::Table
-                | Self::View
-                | Self::Collection
-                | Self::CollectionChild
-                | Self::CollectionChildrenMore
-                | Self::ConnectionFolder
-                | Self::Schema
-                | Self::TablesFolder
-                | Self::ViewsFolder
-                | Self::TypesFolder
-                | Self::ColumnsFolder
-                | Self::IndexesFolder
-                | Self::ForeignKeysFolder
-                | Self::ConstraintsFolder
-                | Self::SchemaIndexesFolder
-                | Self::SchemaForeignKeysFolder
-                | Self::RoutinesFolder
-                | Self::CollectionsFolder
-                | Self::CollectionFieldsFolder
-                | Self::CustomType
-                | Self::ScriptsFolder
-                | Self::ScriptFile
-                | Self::DependentsFolder
-                | Self::Routine
-                | Self::MetricsFolder
-                | Self::MetricNamespaceFolder
-                | Self::MetricLeaf
-                | Self::DashboardsFolder
-                | Self::DashboardItem
-                | Self::RemoteDashboardsFolder
-                | Self::RemoteDashboardItem
-                | Self::SavedChartsFolder
-                | Self::SavedChartItem
-                | Self::InstanceMetricsFolder
-                | Self::InstanceMetricLeaf
-                | Self::InstanceInspectorsFolder
-                | Self::InstanceInspectorLeaf
-                | Self::InstanceOverviewLeaf
-        )
-    }
-
-    pub fn is_expandable_folder(&self) -> bool {
-        matches!(
-            self,
-            Self::ConnectionFolder
-                | Self::DatabasesFolder
-                | Self::Schema
-                | Self::TablesFolder
-                | Self::ViewsFolder
-                | Self::TypesFolder
-                | Self::ColumnsFolder
-                | Self::IndexesFolder
-                | Self::ForeignKeysFolder
-                | Self::ConstraintsFolder
-                | Self::SchemaIndexesFolder
-                | Self::SchemaForeignKeysFolder
-                | Self::RoutinesFolder
-                | Self::CollectionsFolder
-                | Self::CollectionFieldsFolder
-                | Self::Database
-                | Self::CustomType
-                | Self::ScriptsFolder
-                | Self::DependentsFolder
-                | Self::MetricsFolder
-                | Self::MetricNamespaceFolder
-                | Self::DashboardsFolder
-                | Self::RemoteDashboardsFolder
-                | Self::SavedChartsFolder
-                | Self::InstanceMetricsFolder
-                | Self::InstanceInspectorsFolder
-        )
-    }
-
-    pub fn shows_pointer_cursor(&self) -> bool {
-        matches!(
-            self,
-            Self::Profile
-                | Self::Database
-                | Self::ConnectionFolder
-                | Self::CollectionChild
-                | Self::CollectionChildrenMore
-                | Self::ScriptFile
-                | Self::Routine
-                | Self::MetricLeaf
-                | Self::DashboardItem
-                | Self::RemoteDashboardItem
-                | Self::SavedChartItem
-                | Self::InstanceMetricLeaf
-                | Self::InstanceInspectorLeaf
-                | Self::InstanceOverviewLeaf
-        )
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2137,6 +2038,35 @@ mod tests {
             name: "users".into(),
         };
         assert_eq!(id.kind(), SchemaNodeKind::Table);
+    }
+
+    #[test]
+    fn schema_node_kind_flags_remain_stable_for_representative_nodes() {
+        assert!(SchemaNodeKind::ConnectionFolder.needs_click_handler());
+        assert!(SchemaNodeKind::ConnectionFolder.is_expandable_folder());
+        assert!(SchemaNodeKind::ConnectionFolder.shows_pointer_cursor());
+
+        assert!(SchemaNodeKind::TablesFolder.needs_click_handler());
+        assert!(SchemaNodeKind::TablesFolder.is_expandable_folder());
+        assert!(!SchemaNodeKind::TablesFolder.shows_pointer_cursor());
+
+        assert!(SchemaNodeKind::ScriptFile.needs_click_handler());
+        assert!(!SchemaNodeKind::ScriptFile.is_expandable_folder());
+        assert!(SchemaNodeKind::ScriptFile.shows_pointer_cursor());
+
+        assert!(!SchemaNodeKind::Column.needs_click_handler());
+        assert!(!SchemaNodeKind::Column.is_expandable_folder());
+        assert!(!SchemaNodeKind::Column.shows_pointer_cursor());
+    }
+
+    #[test]
+    fn pipe_preserving_paths_round_trip_for_script_nodes() {
+        roundtrip(SchemaNodeId::ScriptsFolder {
+            path: Some("/tmp/dbflux|scripts|archive".into()),
+        });
+        roundtrip(SchemaNodeId::ScriptFile {
+            path: "/tmp/dbflux|scripts|query.sql".into(),
+        });
     }
 
     #[test]

--- a/crates/dbflux_ui/src/ui/views/workspace/dispatch/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/dispatch/mod.rs
@@ -1,29 +1,8 @@
 use super::*;
 
-fn sidebar_tree_command_is_blocked_by_search_focus(cmd: Command) -> bool {
-    matches!(
-        cmd,
-        Command::SelectNext
-            | Command::SelectPrev
-            | Command::SelectFirst
-            | Command::SelectLast
-            | Command::Execute
-            | Command::ExpandCollapse
-            | Command::ColumnLeft
-            | Command::ColumnRight
-            | Command::Cancel
-            | Command::Rename
-            | Command::Delete
-            | Command::CreateFolder
-            | Command::SidebarNextTab
-            | Command::OpenItemMenu
-            | Command::ExtendSelectNext
-            | Command::ExtendSelectPrev
-            | Command::ToggleSelection
-            | Command::MoveSelectedUp
-            | Command::MoveSelectedDown
-    )
-}
+mod preflight;
+
+use preflight::sidebar_tree_command_is_blocked_by_search_focus;
 
 impl CommandDispatcher for Workspace {
     fn dispatch(&mut self, cmd: Command, window: &mut Window, cx: &mut Context<Self>) -> bool {
@@ -872,40 +851,5 @@ impl CommandDispatcher for Workspace {
                 true
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::sidebar_tree_command_is_blocked_by_search_focus;
-    use crate::keymap::Command;
-
-    #[test]
-    fn sidebar_search_focus_blocks_tree_navigation_commands() {
-        assert!(sidebar_tree_command_is_blocked_by_search_focus(
-            Command::SelectNext
-        ));
-        assert!(sidebar_tree_command_is_blocked_by_search_focus(
-            Command::Execute
-        ));
-        assert!(sidebar_tree_command_is_blocked_by_search_focus(
-            Command::Delete
-        ));
-        assert!(sidebar_tree_command_is_blocked_by_search_focus(
-            Command::MoveSelectedDown
-        ));
-    }
-
-    #[test]
-    fn sidebar_search_focus_leaves_unrelated_commands_available() {
-        assert!(!sidebar_tree_command_is_blocked_by_search_focus(
-            Command::RunQuery
-        ));
-        assert!(!sidebar_tree_command_is_blocked_by_search_focus(
-            Command::ToggleSidebar
-        ));
-        assert!(!sidebar_tree_command_is_blocked_by_search_focus(
-            Command::OpenSettings
-        ));
     }
 }

--- a/crates/dbflux_ui/src/ui/views/workspace/dispatch/preflight.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/dispatch/preflight.rs
@@ -1,0 +1,61 @@
+use crate::keymap::Command;
+
+pub(super) fn sidebar_tree_command_is_blocked_by_search_focus(cmd: Command) -> bool {
+    matches!(
+        cmd,
+        Command::SelectNext
+            | Command::SelectPrev
+            | Command::SelectFirst
+            | Command::SelectLast
+            | Command::Execute
+            | Command::ExpandCollapse
+            | Command::ColumnLeft
+            | Command::ColumnRight
+            | Command::Cancel
+            | Command::Rename
+            | Command::Delete
+            | Command::CreateFolder
+            | Command::SidebarNextTab
+            | Command::OpenItemMenu
+            | Command::ExtendSelectNext
+            | Command::ExtendSelectPrev
+            | Command::ToggleSelection
+            | Command::MoveSelectedUp
+            | Command::MoveSelectedDown
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sidebar_tree_command_is_blocked_by_search_focus;
+    use crate::keymap::Command;
+
+    #[test]
+    fn sidebar_search_focus_blocks_tree_navigation_commands() {
+        assert!(sidebar_tree_command_is_blocked_by_search_focus(
+            Command::SelectNext
+        ));
+        assert!(sidebar_tree_command_is_blocked_by_search_focus(
+            Command::Execute
+        ));
+        assert!(sidebar_tree_command_is_blocked_by_search_focus(
+            Command::Delete
+        ));
+        assert!(sidebar_tree_command_is_blocked_by_search_focus(
+            Command::MoveSelectedDown
+        ));
+    }
+
+    #[test]
+    fn sidebar_search_focus_leaves_unrelated_commands_available() {
+        assert!(!sidebar_tree_command_is_blocked_by_search_focus(
+            Command::RunQuery
+        ));
+        assert!(!sidebar_tree_command_is_blocked_by_search_focus(
+            Command::ToggleSidebar
+        ));
+        assert!(!sidebar_tree_command_is_blocked_by_search_focus(
+            Command::OpenSettings
+        ));
+    }
+}

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/items.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/items.rs
@@ -1,0 +1,195 @@
+use super::ContextMenuItem;
+use dbflux_components::components::data_table::ContextMenuAction;
+use dbflux_components::icons::AppIcon;
+
+pub(super) fn build_context_menu_items(
+    is_editable: bool,
+    is_document_view: bool,
+    has_row_target: bool,
+    can_chart: bool,
+    inspect_row_enabled: bool,
+) -> Vec<ContextMenuItem> {
+    if is_document_view {
+        let mut items = Vec::new();
+
+        if has_row_target {
+            items.extend([
+                ContextMenuItem {
+                    label: "Copy",
+                    action: Some(ContextMenuAction::Copy),
+                    icon: Some(AppIcon::Layers),
+                    is_separator: false,
+                    is_danger: false,
+                },
+                ContextMenuItem {
+                    label: "View Document",
+                    action: Some(ContextMenuAction::EditInModal),
+                    icon: Some(AppIcon::Maximize2),
+                    is_separator: false,
+                    is_danger: false,
+                },
+            ]);
+        }
+
+        if is_editable {
+            if !items.is_empty() {
+                items.push(ContextMenuItem {
+                    label: "",
+                    action: None,
+                    icon: None,
+                    is_separator: true,
+                    is_danger: false,
+                });
+            }
+
+            items.push(ContextMenuItem {
+                label: "Add Document",
+                action: Some(ContextMenuAction::AddRow),
+                icon: Some(AppIcon::Plus),
+                is_separator: false,
+                is_danger: false,
+            });
+
+            if has_row_target {
+                items.extend([
+                    ContextMenuItem {
+                        label: "Duplicate Document",
+                        action: Some(ContextMenuAction::DuplicateRow),
+                        icon: Some(AppIcon::Layers),
+                        is_separator: false,
+                        is_danger: false,
+                    },
+                    ContextMenuItem {
+                        label: "Delete Document",
+                        action: Some(ContextMenuAction::DeleteRow),
+                        icon: Some(AppIcon::Delete),
+                        is_separator: false,
+                        is_danger: true,
+                    },
+                ]);
+            }
+        }
+
+        return items;
+    }
+
+    let mut items = vec![ContextMenuItem {
+        label: "Copy",
+        action: Some(ContextMenuAction::Copy),
+        icon: Some(AppIcon::Layers),
+        is_separator: false,
+        is_danger: false,
+    }];
+
+    if is_editable {
+        if has_row_target {
+            items.extend([
+                ContextMenuItem {
+                    label: "Paste",
+                    action: Some(ContextMenuAction::Paste),
+                    icon: Some(AppIcon::Download),
+                    is_separator: false,
+                    is_danger: false,
+                },
+                ContextMenuItem {
+                    label: "Edit",
+                    action: Some(ContextMenuAction::Edit),
+                    icon: Some(AppIcon::Pencil),
+                    is_separator: false,
+                    is_danger: false,
+                },
+                ContextMenuItem {
+                    label: "Edit in Modal",
+                    action: Some(ContextMenuAction::EditInModal),
+                    icon: Some(AppIcon::Maximize2),
+                    is_separator: false,
+                    is_danger: false,
+                },
+                ContextMenuItem {
+                    label: "",
+                    action: None,
+                    icon: None,
+                    is_separator: true,
+                    is_danger: false,
+                },
+                ContextMenuItem {
+                    label: "Set to Default",
+                    action: Some(ContextMenuAction::SetDefault),
+                    icon: Some(AppIcon::RotateCcw),
+                    is_separator: false,
+                    is_danger: false,
+                },
+                ContextMenuItem {
+                    label: "Set to NULL",
+                    action: Some(ContextMenuAction::SetNull),
+                    icon: Some(AppIcon::X),
+                    is_separator: false,
+                    is_danger: false,
+                },
+                ContextMenuItem {
+                    label: "",
+                    action: None,
+                    icon: None,
+                    is_separator: true,
+                    is_danger: false,
+                },
+            ]);
+        }
+
+        items.push(ContextMenuItem {
+            label: "Add Row",
+            action: Some(ContextMenuAction::AddRow),
+            icon: Some(AppIcon::Plus),
+            is_separator: false,
+            is_danger: false,
+        });
+
+        if has_row_target {
+            if inspect_row_enabled {
+                items.push(ContextMenuItem {
+                    label: "Inspect Row",
+                    action: Some(ContextMenuAction::InspectRow),
+                    icon: Some(AppIcon::Info),
+                    is_separator: false,
+                    is_danger: false,
+                });
+            }
+
+            items.extend([
+                ContextMenuItem {
+                    label: "Duplicate Row",
+                    action: Some(ContextMenuAction::DuplicateRow),
+                    icon: Some(AppIcon::Layers),
+                    is_separator: false,
+                    is_danger: false,
+                },
+                ContextMenuItem {
+                    label: "Delete Row",
+                    action: Some(ContextMenuAction::DeleteRow),
+                    icon: Some(AppIcon::Delete),
+                    is_separator: false,
+                    is_danger: true,
+                },
+            ]);
+        }
+    }
+
+    if can_chart {
+        items.push(ContextMenuItem {
+            label: "",
+            action: None,
+            icon: None,
+            is_separator: true,
+            is_danger: false,
+        });
+        items.push(ContextMenuItem {
+            label: "Chart this query",
+            action: Some(ContextMenuAction::ChartThisQuery),
+            icon: Some(AppIcon::ChartSpline),
+            is_separator: false,
+            is_danger: false,
+        });
+    }
+
+    items
+}

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
@@ -23,6 +23,8 @@ use gpui_component::ActiveTheme;
 use std::fs::File;
 use std::io::BufWriter;
 
+mod items;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum FilterBackend {
     Sql,
@@ -1128,190 +1130,13 @@ impl DataGridPanel {
         can_chart: bool,
         inspect_row_enabled: bool,
     ) -> Vec<ContextMenuItem> {
-        if is_document_view {
-            // Document view menu: Copy, View/Edit Document, CRUD operations
-            let mut items = Vec::new();
-
-            if has_row_target {
-                items.extend([
-                    ContextMenuItem {
-                        label: "Copy",
-                        action: Some(ContextMenuAction::Copy),
-                        icon: Some(AppIcon::Layers),
-                        is_separator: false,
-                        is_danger: false,
-                    },
-                    ContextMenuItem {
-                        label: "View Document",
-                        action: Some(ContextMenuAction::EditInModal),
-                        icon: Some(AppIcon::Maximize2),
-                        is_separator: false,
-                        is_danger: false,
-                    },
-                ]);
-            }
-
-            if is_editable {
-                if !items.is_empty() {
-                    items.push(ContextMenuItem {
-                        label: "",
-                        action: None,
-                        icon: None,
-                        is_separator: true,
-                        is_danger: false,
-                    });
-                }
-
-                items.push(ContextMenuItem {
-                    label: "Add Document",
-                    action: Some(ContextMenuAction::AddRow),
-                    icon: Some(AppIcon::Plus),
-                    is_separator: false,
-                    is_danger: false,
-                });
-
-                if has_row_target {
-                    items.extend([
-                        ContextMenuItem {
-                            label: "Duplicate Document",
-                            action: Some(ContextMenuAction::DuplicateRow),
-                            icon: Some(AppIcon::Layers),
-                            is_separator: false,
-                            is_danger: false,
-                        },
-                        ContextMenuItem {
-                            label: "Delete Document",
-                            action: Some(ContextMenuAction::DeleteRow),
-                            icon: Some(AppIcon::Delete),
-                            is_separator: false,
-                            is_danger: true,
-                        },
-                    ]);
-                }
-            }
-
-            return items;
-        }
-
-        // Table view menu
-        let mut items = vec![ContextMenuItem {
-            label: "Copy",
-            action: Some(ContextMenuAction::Copy),
-            icon: Some(AppIcon::Layers),
-            is_separator: false,
-            is_danger: false,
-        }];
-
-        if is_editable {
-            if has_row_target {
-                items.extend([
-                    ContextMenuItem {
-                        label: "Paste",
-                        action: Some(ContextMenuAction::Paste),
-                        icon: Some(AppIcon::Download),
-                        is_separator: false,
-                        is_danger: false,
-                    },
-                    ContextMenuItem {
-                        label: "Edit",
-                        action: Some(ContextMenuAction::Edit),
-                        icon: Some(AppIcon::Pencil),
-                        is_separator: false,
-                        is_danger: false,
-                    },
-                    ContextMenuItem {
-                        label: "Edit in Modal",
-                        action: Some(ContextMenuAction::EditInModal),
-                        icon: Some(AppIcon::Maximize2),
-                        is_separator: false,
-                        is_danger: false,
-                    },
-                    ContextMenuItem {
-                        label: "",
-                        action: None,
-                        icon: None,
-                        is_separator: true,
-                        is_danger: false,
-                    },
-                    ContextMenuItem {
-                        label: "Set to Default",
-                        action: Some(ContextMenuAction::SetDefault),
-                        icon: Some(AppIcon::RotateCcw),
-                        is_separator: false,
-                        is_danger: false,
-                    },
-                    ContextMenuItem {
-                        label: "Set to NULL",
-                        action: Some(ContextMenuAction::SetNull),
-                        icon: Some(AppIcon::X),
-                        is_separator: false,
-                        is_danger: false,
-                    },
-                    ContextMenuItem {
-                        label: "",
-                        action: None,
-                        icon: None,
-                        is_separator: true,
-                        is_danger: false,
-                    },
-                ]);
-            }
-
-            items.push(ContextMenuItem {
-                label: "Add Row",
-                action: Some(ContextMenuAction::AddRow),
-                icon: Some(AppIcon::Plus),
-                is_separator: false,
-                is_danger: false,
-            });
-
-            if has_row_target {
-                if inspect_row_enabled {
-                    items.push(ContextMenuItem {
-                        label: "Inspect Row",
-                        action: Some(ContextMenuAction::InspectRow),
-                        icon: Some(AppIcon::Info),
-                        is_separator: false,
-                        is_danger: false,
-                    });
-                }
-                items.extend([
-                    ContextMenuItem {
-                        label: "Duplicate Row",
-                        action: Some(ContextMenuAction::DuplicateRow),
-                        icon: Some(AppIcon::Layers),
-                        is_separator: false,
-                        is_danger: false,
-                    },
-                    ContextMenuItem {
-                        label: "Delete Row",
-                        action: Some(ContextMenuAction::DeleteRow),
-                        icon: Some(AppIcon::Delete),
-                        is_separator: false,
-                        is_danger: true,
-                    },
-                ]);
-            }
-        }
-
-        if can_chart {
-            items.push(ContextMenuItem {
-                label: "",
-                action: None,
-                icon: None,
-                is_separator: true,
-                is_danger: false,
-            });
-            items.push(ContextMenuItem {
-                label: "Chart this query",
-                action: Some(ContextMenuAction::ChartThisQuery),
-                icon: Some(AppIcon::ChartSpline),
-                is_separator: false,
-                is_danger: false,
-            });
-        }
-
-        items
+        items::build_context_menu_items(
+            is_editable,
+            is_document_view,
+            has_row_target,
+            can_chart,
+            inspect_row_enabled,
+        )
     }
 
     /// Returns the total number of navigable items in the context menu.


### PR DESCRIPTION
## Summary
- Completes the remaining non-driver CODE-4/DBF-149 god-file split scope after PR #277.
- Moves the remaining parent modules to directory modules with focused helper modules, preserving public module paths and behavior.
- Updates the governance acceptance test to read the new `workspace/dispatch/` module directory.

## Review notes
- This is intentionally a single PR by request, with a recorded size exception from the SDD review-workload guard.
- The change is mechanical and behavior-preserving: no new dependencies, no public API redesign, and no new driver-specific UI/app branching.
- The main review path is the extracted helpers:
  - `crates/dbflux_app/src/app_state/bootstrap.rs`
  - `crates/dbflux_core/src/schema/node_id/kind_flags.rs`
  - `crates/dbflux_ui/src/ui/views/workspace/dispatch/preflight.rs`
  - `crates/dbflux_ui_document/src/data_grid_panel/context_menu/items.rs`

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

SDD verify result: PASS WITH WARNINGS. One unrelated transient `dbflux_lua` controlled-process test failure was observed during verification, then the targeted rerun and final full workspace rerun passed.