### PR TITLE
fix(ui): activate main window on IPC focus request

### DIFF
--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -339,7 +339,13 @@ fn run_gui() {
 
                 let workspace = cx.new(|cx| Workspace::new(app_state.clone(), window, cx));
 
-                IpcServer::start_with_listener(listener, workspace.clone(), auth_token, cx);
+                IpcServer::start_with_listener(
+                    listener,
+                    workspace.clone(),
+                    window.window_handle(),
+                    auth_token,
+                    cx,
+                );
                 info!("IPC server started");
 
                 cx.new(|cx| Root::new(workspace, window, cx))

--- a/crates/dbflux_ui/src/ipc_server.rs
+++ b/crates/dbflux_ui/src/ipc_server.rs
@@ -24,6 +24,7 @@ impl IpcServer {
     pub fn start_with_listener(
         listener: IpcListener,
         workspace: Entity<Workspace>,
+        window: AnyWindowHandle,
         auth_token: String,
         cx: &mut App,
     ) {
@@ -34,7 +35,7 @@ impl IpcServer {
         });
 
         cx.spawn(async move |cx| {
-            process_commands(cmd_rx, workspace, cx.clone()).await;
+            process_commands(cmd_rx, workspace, window, cx.clone()).await;
         })
         .detach();
     }
@@ -126,21 +127,30 @@ fn handle_connection(
 async fn process_commands(
     cmd_rx: Receiver<IpcCommand>,
     workspace: Entity<Workspace>,
+    window: AnyWindowHandle,
     cx: AsyncApp,
 ) {
     loop {
         match cmd_rx.try_recv() {
             Ok(cmd) => {
-                let _ = cx.update(|cx| {
-                    workspace.update(cx, |ws, cx| match cmd {
-                        IpcCommand::OpenScript { path } => {
+                let dispatch = cx.update(|cx| match cmd {
+                    IpcCommand::OpenScript { path } => {
+                        workspace.update(cx, |ws, cx| {
                             ws.open_script_from_path(path, cx);
+                        });
+                    }
+                    IpcCommand::Focus => {
+                        if let Err(e) = window.update(cx, |_root, window, _cx| {
+                            window.activate_window();
+                        }) {
+                            log::warn!("Failed to focus main window via IPC: {:?}", e);
                         }
-                        IpcCommand::Focus => {
-                            // TODO: implement window focus
-                        }
-                    });
+                    }
                 });
+
+                if let Err(e) = dispatch {
+                    log::warn!("Failed to dispatch IPC command: {:?}", e);
+                }
             }
             Err(mpsc::TryRecvError::Empty) => {
                 cx.background_executor()


### PR DESCRIPTION
## Summary
- Implements the previously stubbed `IpcCommand::Focus` handler (MISC-8 / DBF-108). Launching a second `dbflux` instance sends a `Focus` request over the single-instance IPC socket; until now the running instance received it but did nothing (`// TODO: implement window focus`), so the existing window was never raised.
- The main window's `AnyWindowHandle` is now threaded from `main.rs` into the IPC command loop, and `Focus` calls `window.activate_window()` — the same activation primitive the Settings window already uses.

## Changes
| File | Change |
|------|--------|
| `crates/dbflux/src/main.rs` | Pass `window.window_handle()` into `IpcServer::start_with_listener` |
| `crates/dbflux_ui/src/ipc_server.rs` | Thread `AnyWindowHandle` into `process_commands`; activate the window on `Focus`; replace the discarded `let _ =` on command dispatch with explicit `log::warn!` on failure |

## Verification
- `cargo check -p dbflux_ui` and `cargo check -p dbflux` (all driver features) — clean, no warnings.
- `cargo clippy -p dbflux_ui -p dbflux ... -- -D warnings` — clean.
- Runtime window-raising is inherently a windowing-system behavior and cannot be asserted headlessly; it needs a manual smoke test: with one instance running, launch `dbflux` again with no args and confirm the existing window comes to the foreground.

Refs DBF-108 (MISC-8).