### PR TITLE
fix(ui): keep sidebar context menu on-screen near window edges

### DIFF
--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -811,24 +811,30 @@ impl Render for Workspace {
                         let sidebar_click = sidebar_entity.clone();
                         let sidebar_hover = sidebar_entity.clone();
 
-                        d.child(div().absolute().top(menu_y).left(menu_x).child(
-                            ctx::render_menu_container(
-                                "parent-menu",
-                                &shared_items,
-                                Some(*parent_selected),
-                                move |idx, cx| {
-                                    sidebar_click.update(cx, |s, cx| {
-                                        s.context_menu_parent_execute_at(idx, cx);
-                                    });
-                                },
-                                move |idx, cx| {
-                                    sidebar_hover.update(cx, |s, cx| {
-                                        s.context_menu_parent_hover_at(idx, cx);
-                                    });
-                                },
-                                cx,
-                            ),
-                        ))
+                        d.child(
+                            deferred(
+                                anchored()
+                                    .position(point(menu_x, menu_y))
+                                    .snap_to_window()
+                                    .child(ctx::render_menu_container(
+                                        "parent-menu",
+                                        &shared_items,
+                                        Some(*parent_selected),
+                                        move |idx, cx| {
+                                            sidebar_click.update(cx, |s, cx| {
+                                                s.context_menu_parent_execute_at(idx, cx);
+                                            });
+                                        },
+                                        move |idx, cx| {
+                                            sidebar_hover.update(cx, |s, cx| {
+                                                s.context_menu_parent_hover_at(idx, cx);
+                                            });
+                                        },
+                                        cx,
+                                    )),
+                            )
+                            .with_priority(1),
+                        )
                     })
                     // Current menu (submenu to the right of parent, or main menu at click position)
                     .child({
@@ -836,30 +842,35 @@ impl Render for Workspace {
                         let sidebar_click = sidebar_entity.clone();
                         let sidebar_hover = sidebar_entity.clone();
 
-                        div()
-                            .absolute()
-                            .top(menu_y + submenu_y_offset)
-                            .left(if in_submenu {
-                                menu_x + menu_width + menu_gap
-                            } else {
-                                menu_x
-                            })
-                            .child(ctx::render_menu_container(
-                                "context-menu",
-                                &shared_items,
-                                Some(menu.selected_index),
-                                move |idx, cx| {
-                                    sidebar_click.update(cx, |s, cx| {
-                                        s.context_menu_execute_at(idx, cx);
-                                    });
-                                },
-                                move |idx, cx| {
-                                    sidebar_hover.update(cx, |s, cx| {
-                                        s.context_menu_hover_at(idx, cx);
-                                    });
-                                },
-                                cx,
-                            ))
+                        let menu_left = if in_submenu {
+                            menu_x + menu_width + menu_gap
+                        } else {
+                            menu_x
+                        };
+                        let menu_top = menu_y + submenu_y_offset;
+
+                        deferred(
+                            anchored()
+                                .position(point(menu_left, menu_top))
+                                .snap_to_window()
+                                .child(ctx::render_menu_container(
+                                    "context-menu",
+                                    &shared_items,
+                                    Some(menu.selected_index),
+                                    move |idx, cx| {
+                                        sidebar_click.update(cx, |s, cx| {
+                                            s.context_menu_execute_at(idx, cx);
+                                        });
+                                    },
+                                    move |idx, cx| {
+                                        sidebar_hover.update(cx, |s, cx| {
+                                            s.context_menu_hover_at(idx, cx);
+                                        });
+                                    },
+                                    cx,
+                                )),
+                        )
+                        .with_priority(1)
                     })
             })
             // Tab context menu rendered at workspace level for proper positioning


### PR DESCRIPTION
## Summary

- Fixes DBF-157: the sidebar table context menu (and its "Generate SQL" submenu) got clipped by the window's bottom edge when opened low in the window.
- Root cause: the menu and submenu were positioned with raw `div().absolute().top()/.left()` from the click point, with no viewport awareness, so anything taller than the space below the click was drawn past the bottom edge.

## Changes

| File | Change |
|------|--------|
| `crates/dbflux_ui/src/ui/views/workspace/render.rs` | Wrap the parent menu and the current/submenu containers in `deferred(anchored().position(..).snap_to_window())` instead of a raw absolute `div`. |

`anchored()` clamps the element inside the viewport (and flips near an edge), so a menu opened near the bottom slides up and stays fully visible. This is the same pattern already used by `dropdown.rs` and `multi_select.rs`.

## Test plan

- `cargo check -p dbflux_ui` — clean
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dbflux_ui -- -D warnings` — no warnings
- Manual: right-click a table near the bottom of the window and hover "Generate SQL"; the submenu now stays within the window instead of being cut off.

## Notes

- The tab context menu (same file, just below) uses the same raw-absolute pattern but anchors at the top of the window, so it is not affected by this bug and was left unchanged to keep the diff focused.