### PR TITLE
feat(migrate-wizard): redesign the migration modal as a multi-phase wizard (DBF-160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ All notable changes to DBFlux will be documented in this file.
   tables in the sidebar and **Export** them to a folder (one CSV or JSON file
   per table plus a `manifest.json` that makes the bundle re-importable),
   **Import** a previously exported bundle into a connected database, or
-  **Migrate** tables directly from one connection to another. Migration orders
+  **Migrate** tables directly from one connection to another through a guided,
+  multi-phase wizard — pick the source tables and the target database from a
+  connection → database → schema → table tree, review the mapping in a
+  Source / Target / Mapping / Transform grid, and move through Options,
+  Confirm, and Run steps tracked in a phase sidebar, in a larger centered
+  modal. Migration orders
   tables by foreign-key dependencies (parents before children), with a manual
   reorder step when the graph has cycles and an optional
   disable-referential-integrity toggle during transfer. Target tables can be

--- a/crates/dbflux_app/src/app_state/mod.rs
+++ b/crates/dbflux_app/src/app_state/mod.rs
@@ -215,11 +215,12 @@ impl AppState {
         &self,
         profile_id: Uuid,
         database: &str,
+        schema: Option<&str>,
         table: &str,
     ) -> Option<&dbflux_core::TableInfo> {
         self.facade
             .connections
-            .get_table_details(profile_id, database, table)
+            .get_table_details(profile_id, database, schema, table)
     }
 
     #[allow(dead_code)]
@@ -227,31 +228,39 @@ impl AppState {
         &mut self,
         profile_id: Uuid,
         database: String,
+        schema: Option<String>,
         table: String,
         details: dbflux_core::TableInfo,
     ) {
         self.facade
             .connections
-            .set_table_details(profile_id, database, table, details);
+            .set_table_details(profile_id, database, schema, table, details);
     }
 
     pub fn set_dependents(
         &mut self,
         profile_id: Uuid,
         database: String,
+        schema: Option<String>,
         table: String,
         deps: Vec<dbflux_core::RelationRef>,
     ) {
         self.facade
             .connections
-            .set_dependents(profile_id, database, table, deps);
+            .set_dependents(profile_id, database, schema, table, deps);
     }
 
     #[allow(dead_code)]
-    pub fn needs_table_details(&self, profile_id: Uuid, database: &str, table: &str) -> bool {
+    pub fn needs_table_details(
+        &self,
+        profile_id: Uuid,
+        database: &str,
+        schema: Option<&str>,
+        table: &str,
+    ) -> bool {
         self.facade
             .connections
-            .needs_table_details(profile_id, database, table)
+            .needs_table_details(profile_id, database, schema, table)
     }
 
     #[allow(dead_code)]

--- a/crates/dbflux_components/src/components/tree_nav/mod.rs
+++ b/crates/dbflux_components/src/components/tree_nav/mod.rs
@@ -150,6 +150,23 @@ impl TreeNav {
         self.rebuild();
     }
 
+    /// Replaces the tree definition (e.g. after a lazy-loaded subtree resolves) while
+    /// preserving the current `expanded` set and restoring the cursor to the row that
+    /// carried it before the rebuild. If that row no longer exists, the cursor is only
+    /// clamped when it now falls out of bounds — it is left untouched otherwise.
+    pub fn set_nodes(&mut self, nodes: Vec<TreeNavNode>) {
+        let cursor_id = self.rows.get(self.cursor).map(|row| row.id.clone());
+
+        self.nodes = nodes;
+        self.rows = flatten_tree(&self.nodes, &self.expanded);
+
+        if let Some(pos) = cursor_id.and_then(|id| self.rows.iter().position(|row| row.id == id)) {
+            self.cursor = pos;
+        } else if self.cursor >= self.rows.len() {
+            self.cursor = self.rows.len().saturating_sub(1);
+        }
+    }
+
     #[allow(dead_code)]
     pub fn expanded(&self) -> &HashSet<SharedString> {
         &self.expanded
@@ -642,5 +659,76 @@ mod tests {
         nav.activate();
 
         assert!(nav.expanded().contains("network"));
+    }
+
+    // ── set_nodes ───────────────────────────────────────────────
+
+    #[test]
+    fn set_nodes_preserves_expanded_across_rebuild() {
+        let mut nav = TreeNav::new(make_test_tree(), all_expanded());
+        assert!(nav.expanded().contains("connection"));
+
+        nav.set_nodes(make_test_tree());
+
+        assert!(nav.expanded().contains("connection"));
+        let ids: Vec<&str> = nav.rows().iter().map(|r| r.id.as_ref()).collect();
+        assert!(ids.contains(&"hooks"));
+    }
+
+    #[test]
+    fn set_nodes_restores_cursor_by_id() {
+        let mut nav = TreeNav::new(make_test_tree(), all_expanded());
+        nav.select_by_id("hooks");
+        assert_eq!(nav.cursor_item().unwrap().id.as_ref(), "hooks");
+
+        // Reordered tree: "about" now comes first, shifting "hooks" to a different index.
+        let reordered = vec![
+            TreeNavNode::leaf("about", "About", Some(AppIcon::Info)),
+            TreeNavNode::leaf("general", "General", Some(AppIcon::Settings)),
+            TreeNavNode::leaf("keybindings", "Keybindings", Some(AppIcon::Keyboard)),
+            TreeNavNode::group(
+                "network",
+                "Network",
+                None,
+                vec![TreeNavNode::leaf(
+                    "ssh-tunnels",
+                    "SSH Tunnels",
+                    Some(AppIcon::FingerprintPattern),
+                )],
+            ),
+            TreeNavNode::group(
+                "connection",
+                "Connection",
+                None,
+                vec![
+                    TreeNavNode::leaf("services", "Services", Some(AppIcon::Plug)),
+                    TreeNavNode::leaf("hooks", "Hooks", Some(AppIcon::SquareTerminal)),
+                    TreeNavNode::leaf("drivers", "Drivers", Some(AppIcon::Database)),
+                ],
+            ),
+        ];
+
+        nav.set_nodes(reordered);
+
+        assert_eq!(nav.cursor_item().unwrap().id.as_ref(), "hooks");
+    }
+
+    #[test]
+    fn set_nodes_clamps_cursor_when_node_gone() {
+        let mut nav = TreeNav::new(make_test_tree(), all_expanded());
+        nav.select_by_id("about");
+        let last_index = nav.rows().len() - 1;
+        assert_eq!(nav.cursor(), last_index);
+
+        // New tree drops "about" and is shorter than the previous cursor index.
+        let shorter = vec![
+            TreeNavNode::leaf("general", "General", Some(AppIcon::Settings)),
+            TreeNavNode::leaf("keybindings", "Keybindings", Some(AppIcon::Keyboard)),
+        ];
+
+        nav.set_nodes(shorter);
+
+        assert_eq!(nav.cursor(), nav.rows().len() - 1);
+        assert!(nav.cursor() < nav.rows().len());
     }
 }

--- a/crates/dbflux_components/src/composites/modal_frame.rs
+++ b/crates/dbflux_components/src/composites/modal_frame.rs
@@ -10,9 +10,27 @@ use crate::tokens::{ChromeEdgeRole, Heights, Spacing};
 
 type CloseHandler = Arc<dyn Fn(&mut Window, &mut App) + Send + Sync>;
 
+#[derive(Clone, Copy, Debug, PartialEq)]
 enum ModalHeight {
     Fixed(Pixels),
     Max(Pixels),
+    Fraction(f32),
+}
+
+/// Whether the modal overlay anchors its container near the top (the default for
+/// every existing modal) or centers it vertically (opt-in via `center_vertically()`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum OverlayVerticalPlacement {
+    TopAnchored,
+    Centered,
+}
+
+fn overlay_vertical_placement(center_vertically: bool) -> OverlayVerticalPlacement {
+    if center_vertically {
+        OverlayVerticalPlacement::Centered
+    } else {
+        OverlayVerticalPlacement::TopAnchored
+    }
 }
 
 enum ModalFrameCloseAffordance {
@@ -28,6 +46,7 @@ pub struct ModalFrame {
     width: Pixels,
     height: ModalHeight,
     top_offset: Pixels,
+    center_vertically: bool,
     on_close: CloseHandler,
     header_leading: Option<gpui::AnyElement>,
     header_extra: Option<gpui::AnyElement>,
@@ -50,6 +69,7 @@ impl ModalFrame {
             width: px(900.0),
             height: ModalHeight::Fixed(px(600.0)),
             top_offset: px(80.0),
+            center_vertically: false,
             on_close: Arc::new(on_close),
             header_leading: None,
             header_extra: None,
@@ -86,6 +106,20 @@ impl ModalFrame {
 
     pub fn top_offset(mut self, offset: Pixels) -> Self {
         self.top_offset = offset;
+        self
+    }
+
+    /// Opt-in: vertically centers the overlay instead of anchoring it near the top.
+    /// Every other modal keeps the default top-anchored behavior unless it calls this.
+    pub fn center_vertically(mut self) -> Self {
+        self.center_vertically = true;
+        self
+    }
+
+    /// Opt-in: sizes the container as a fraction of the viewport height (e.g. `0.8` = 80%).
+    /// Every other modal keeps its default fixed/max height unless it calls this.
+    pub fn height_fraction(mut self, fraction: f32) -> Self {
+        self.height = ModalHeight::Fraction(fraction);
         self
     }
 
@@ -137,6 +171,7 @@ impl ModalFrame {
         match self.height {
             ModalHeight::Fixed(height) => container = container.h(height),
             ModalHeight::Max(height) => container = container.max_h(height),
+            ModalHeight::Fraction(fraction) => container = container.h(gpui::relative(fraction)),
         };
 
         let mut header_left = div().flex().items_center().gap(Spacing::SM);
@@ -196,9 +231,14 @@ impl ModalFrame {
             .inset_0()
             .bg(crate::primitives::overlay_bg(theme))
             .flex()
-            .justify_center()
-            .items_start()
-            .pt(self.top_offset)
+            .justify_center();
+
+        overlay = match overlay_vertical_placement(self.center_vertically) {
+            OverlayVerticalPlacement::Centered => overlay.items_center(),
+            OverlayVerticalPlacement::TopAnchored => overlay.items_start().pt(self.top_offset),
+        };
+
+        let mut overlay = overlay
             .on_mouse_down(MouseButton::Left, move |_, window, cx| {
                 (close_for_overlay)(window, cx);
             })
@@ -330,10 +370,14 @@ pub fn modal_frame_with_header_extra(
 
 #[cfg(test)]
 mod tests {
-    use super::{ModalFrameVariant, inspect_modal_frame};
+    use super::{
+        ModalFrame, ModalFrameVariant, ModalHeight, OverlayVerticalPlacement, inspect_modal_frame,
+        overlay_vertical_placement,
+    };
     use crate::primitives::{SurfaceRole, TextVariant};
     use crate::tokens::ChromeEdgeRole;
     use crate::tokens::Spacing;
+    use gpui::{TestAppContext, px};
 
     #[test]
     fn modal_frame_keeps_scrim_container_and_title_contracts_centralized() {
@@ -359,5 +403,46 @@ mod tests {
 
         let with_extra = inspect_modal_frame(ModalFrameVariant::Dialog, true);
         assert!(with_extra.has_header_extra);
+    }
+
+    // ── overlay_vertical_placement (pure) ──────────────────────
+
+    #[test]
+    fn overlay_vertical_placement_defaults_to_top_anchored() {
+        assert_eq!(
+            overlay_vertical_placement(false),
+            OverlayVerticalPlacement::TopAnchored
+        );
+    }
+
+    #[test]
+    fn overlay_vertical_placement_centers_when_opted_in() {
+        assert_eq!(
+            overlay_vertical_placement(true),
+            OverlayVerticalPlacement::Centered
+        );
+    }
+
+    // ── ModalFrame builder state (regression guard for R6) ─────
+
+    #[gpui::test]
+    fn default_modal_frame_stays_top_anchored_with_fixed_height(cx: &mut TestAppContext) {
+        let focus_handle = cx.update(|cx| cx.focus_handle());
+        let frame = ModalFrame::new("regression-modal", &focus_handle, |_, _| {});
+
+        assert!(!frame.center_vertically);
+        assert_eq!(frame.top_offset, px(80.0));
+        assert_eq!(frame.height, ModalHeight::Fixed(px(600.0)));
+    }
+
+    #[gpui::test]
+    fn center_vertically_and_height_fraction_opt_into_centered_layout(cx: &mut TestAppContext) {
+        let focus_handle = cx.update(|cx| cx.focus_handle());
+        let frame = ModalFrame::new("wizard-modal", &focus_handle, |_, _| {})
+            .center_vertically()
+            .height_fraction(0.8);
+
+        assert!(frame.center_vertically);
+        assert_eq!(frame.height, ModalHeight::Fraction(0.8));
     }
 }

--- a/crates/dbflux_core/src/connection/manager.rs
+++ b/crates/dbflux_core/src/connection/manager.rs
@@ -1,10 +1,10 @@
 use crate::LogErr;
 use crate::{
     CollectionChildrenCache, CollectionChildrenPage, CollectionChildrenRequest, CollectionRef,
-    Connection, ConnectionHooks, ConnectionProfile, CustomTypeInfo, DbDriver, DbKind, DbSchemaInfo,
-    HookContext, ProxyProfile, RelationRef, RoutineInfo, SchemaForeignKeyInfo, SchemaIndexInfo,
-    SchemaLoadingStrategy, SchemaSnapshot, SecretStore, ShutdownCoordinator, ShutdownPhase,
-    SshTunnelProfile, TableInfo, TaskTarget,
+    Connection, ConnectionHooks, ConnectionProfile, CustomTypeInfo, DbDriver, DbError, DbKind,
+    DbSchemaInfo, HookContext, ProxyProfile, RelationRef, RoutineInfo, SchemaForeignKeyInfo,
+    SchemaIndexInfo, SchemaLoadingStrategy, SchemaSnapshot, SecretStore, ShutdownCoordinator,
+    ShutdownPhase, SshTunnelProfile, TableInfo, TaskTarget,
 };
 use log::{error, info};
 use secrecy::SecretString;
@@ -26,6 +26,7 @@ pub enum CacheKey {
     },
     TableDetails {
         database: String,
+        schema: Option<String>,
         table: String,
     },
     CollectionChildren {
@@ -57,9 +58,14 @@ impl CacheKey {
         }
     }
 
-    pub fn table_details(database: impl Into<String>, table: impl Into<String>) -> Self {
+    pub fn table_details(
+        database: impl Into<String>,
+        schema: Option<impl Into<String>>,
+        table: impl Into<String>,
+    ) -> Self {
         Self::TableDetails {
             database: database.into(),
+            schema: schema.map(|s| s.into()),
             table: table.into(),
         }
     }
@@ -123,6 +129,7 @@ pub enum OwnedCacheEntry {
     },
     TableDetails {
         database: String,
+        schema: Option<String>,
         table: String,
         details: TableInfo,
     },
@@ -325,14 +332,18 @@ pub struct ConnectedProfile {
     pub mutation_policy: MutationPolicy,
     /// Lazy-loaded schemas per database (MySQL/MariaDB).
     pub database_schemas: HashMap<String, DbSchemaInfo>,
-    pub table_details: HashMap<(String, String), TableInfo>,
+    /// Table details keyed by `(database, schema, table)` — the schema is part
+    /// of the key so same-named tables in different schemas cache independently.
+    pub table_details: HashMap<(String, Option<String>, String), TableInfo>,
     pub collection_children: HashMap<(String, String), CollectionChildrenCache>,
     pub schema_types: HashMap<SchemaCacheKey, Vec<CustomTypeInfo>>,
     pub schema_indexes: HashMap<SchemaCacheKey, Vec<SchemaIndexInfo>>,
     pub schema_foreign_keys: HashMap<SchemaCacheKey, Vec<SchemaForeignKeyInfo>>,
     pub schema_routines: HashMap<SchemaCacheKey, Vec<RoutineInfo>>,
-    /// Dependent objects (views, FK children, triggers) per table, keyed by `(database, table)`.
-    pub dependents_cache: HashMap<(String, String), Vec<RelationRef>>,
+    /// Dependent objects (views, FK children, triggers) per table, keyed by
+    /// `(database, schema, table)` — the schema is part of the key so
+    /// same-named tables in different schemas keep independent dependents.
+    pub dependents_cache: HashMap<(String, Option<String>, String), Vec<RelationRef>>,
     /// Active database for query context (MySQL/MariaDB USE).
     pub active_database: Option<String>,
     pub redis_key_cache: RedisKeyCache,
@@ -354,9 +365,13 @@ impl ConnectedProfile {
                 .get(database.as_str())
                 .map(CacheEntry::DatabaseSchema),
 
-            CacheKey::TableDetails { database, table } => self
+            CacheKey::TableDetails {
+                database,
+                schema,
+                table,
+            } => self
                 .table_details
-                .get(&(database.clone(), table.clone()))
+                .get(&(database.clone(), schema.clone(), table.clone()))
                 .map(CacheEntry::TableDetails),
 
             CacheKey::CollectionChildren {
@@ -407,10 +422,12 @@ impl ConnectedProfile {
 
             OwnedCacheEntry::TableDetails {
                 database,
+                schema,
                 table,
                 details,
             } => {
-                self.table_details.insert((database, table), details);
+                self.table_details
+                    .insert((database, schema, table), details);
             }
 
             OwnedCacheEntry::CollectionChildren {
@@ -488,26 +505,36 @@ impl ConnectedProfile {
             .unwrap_or_else(|| self.connection.clone())
     }
 
-    /// Return all cached dependents for the given `(database, table)` pair.
+    /// Return all cached dependents for the given `(database, schema, table)`.
     ///
     /// Returns an empty `Vec` when nothing has been populated yet, which is
     /// correct for drivers that have not called `populate_dependents`.
-    pub fn dependents(&self, database: &str, table: &str) -> Vec<RelationRef> {
+    pub fn dependents(
+        &self,
+        database: &str,
+        schema: Option<&str>,
+        table: &str,
+    ) -> Vec<RelationRef> {
         self.dependents_cache
-            .get(&(database.to_string(), table.to_string()))
+            .get(&(
+                database.to_string(),
+                schema.map(String::from),
+                table.to_string(),
+            ))
             .cloned()
             .unwrap_or_default()
     }
 
-    /// Store the dependent objects for a specific `(database, table)` pair.
+    /// Store the dependent objects for a specific `(database, schema, table)`.
     pub fn populate_dependents(
         &mut self,
         database: impl Into<String>,
+        schema: Option<String>,
         table: impl Into<String>,
         deps: Vec<RelationRef>,
     ) {
         self.dependents_cache
-            .insert((database.into(), table.into()), deps);
+            .insert((database.into(), schema, table.into()), deps);
     }
 
     /// Resolve the effective connection for query execution.
@@ -744,11 +771,15 @@ impl ConnectionManager {
         &self,
         profile_id: Uuid,
         database: &str,
+        schema: Option<&str>,
         table: &str,
     ) -> Option<&TableInfo> {
         self.connections.get(&profile_id).and_then(|c| {
-            c.table_details
-                .get(&(database.to_string(), table.to_string()))
+            c.table_details.get(&(
+                database.to_string(),
+                schema.map(String::from),
+                table.to_string(),
+            ))
         })
     }
 
@@ -756,12 +787,14 @@ impl ConnectionManager {
         &mut self,
         profile_id: Uuid,
         database: String,
+        schema: Option<String>,
         table: String,
         details: TableInfo,
     ) {
         if let Some(connected) = self.connections.get_mut(&profile_id) {
             connected.cache_set(OwnedCacheEntry::TableDetails {
                 database,
+                schema,
                 table,
                 details,
             });
@@ -772,16 +805,23 @@ impl ConnectionManager {
         &mut self,
         profile_id: Uuid,
         database: String,
+        schema: Option<String>,
         table: String,
         deps: Vec<RelationRef>,
     ) {
         if let Some(connected) = self.connections.get_mut(&profile_id) {
-            connected.populate_dependents(database, table, deps);
+            connected.populate_dependents(database, schema, table, deps);
         }
     }
 
-    pub fn needs_table_details(&self, profile_id: Uuid, database: &str, table: &str) -> bool {
-        let key = CacheKey::table_details(database, table);
+    pub fn needs_table_details(
+        &self,
+        profile_id: Uuid,
+        database: &str,
+        schema: Option<&str>,
+        table: &str,
+    ) -> bool {
+        let key = CacheKey::table_details(database, schema, table);
         self.connections
             .get(&profile_id)
             .is_some_and(|c| !c.cache_contains(&key))
@@ -1347,7 +1387,11 @@ impl ConnectionManager {
             .get(&profile_id)
             .ok_or_else(|| "Profile not connected".to_string())?;
 
-        let cache_key = (database.to_string(), table.to_string());
+        let cache_key = (
+            database.to_string(),
+            schema.map(String::from),
+            table.to_string(),
+        );
         if let Some(details) = connected.table_details.get(&cache_key)
             && (details.columns.is_some() || details.sample_fields.is_some())
         {
@@ -1762,11 +1806,13 @@ pub struct FetchTableDetailsParams {
 
 #[allow(dead_code)]
 impl FetchTableDetailsParams {
-    pub fn execute(self) -> Result<FetchTableDetailsResult, String> {
-        let details = self
-            .connection
-            .table_details(&self.database, self.schema.as_deref(), &self.table)
-            .map_err(|e| e.to_string())?;
+    /// Errors keep the typed [`DbError`] so callers can distinguish a genuine
+    /// "object does not exist" (`DbError::ObjectNotFound`) from a real fetch
+    /// failure instead of collapsing both into a string.
+    pub fn execute(self) -> Result<FetchTableDetailsResult, DbError> {
+        let details =
+            self.connection
+                .table_details(&self.database, self.schema.as_deref(), &self.table)?;
 
         let dependents = self
             .connection
@@ -1776,6 +1822,7 @@ impl FetchTableDetailsParams {
         Ok(FetchTableDetailsResult {
             profile_id: self.profile_id,
             database: self.database,
+            schema: self.schema,
             table: self.table,
             details,
             dependents,
@@ -1787,6 +1834,8 @@ impl FetchTableDetailsParams {
 pub struct FetchTableDetailsResult {
     pub profile_id: Uuid,
     pub database: String,
+    /// The schema the details were fetched for — part of the cache key.
+    pub schema: Option<String>,
     pub table: String,
     pub details: TableInfo,
     /// Dependent objects fetched alongside the table details (views, FK children, triggers).
@@ -2638,6 +2687,105 @@ mod tests {
     }
 
     #[test]
+    fn connection_for_database_prefers_the_per_database_connection_over_the_primary() {
+        let profile = ConnectionProfile::new("pg", DbConfig::default_postgres());
+        let primary = make_connection(
+            DbKind::Postgres,
+            SchemaLoadingStrategy::ConnectionPerDatabase,
+        );
+        let reports = make_connection(
+            DbKind::Postgres,
+            SchemaLoadingStrategy::ConnectionPerDatabase,
+        );
+
+        let mut db_connections = HashMap::new();
+        db_connections.insert(
+            "reports".to_string(),
+            DatabaseConnection {
+                connection: reports.clone(),
+                schema: Some(relational_schema_with_current_database("reports")),
+            },
+        );
+
+        let schema = relational_schema_with_current_database("main_db");
+        let connected = connected_profile(profile, primary.clone(), Some(schema), db_connections);
+
+        assert!(Arc::ptr_eq(
+            &connected.connection_for_database("reports"),
+            &reports
+        ));
+        assert!(Arc::ptr_eq(
+            &connected.connection_for_database("main_db"),
+            &primary
+        ));
+    }
+
+    #[test]
+    fn table_details_cache_keeps_same_named_tables_in_different_schemas_distinct() {
+        use crate::ColumnInfo;
+
+        fn table_with_column(schema: &str, column: &str) -> TableInfo {
+            TableInfo {
+                name: "users".to_string(),
+                schema: Some(schema.to_string()),
+                columns: Some(vec![ColumnInfo {
+                    name: column.to_string(),
+                    type_name: "text".to_string(),
+                    nullable: true,
+                    is_primary_key: false,
+                    default_value: None,
+                    enum_values: None,
+                }]),
+                indexes: None,
+                foreign_keys: None,
+                constraints: None,
+                sample_fields: None,
+                presentation: Default::default(),
+                child_items: None,
+            }
+        }
+
+        let profile = ConnectionProfile::new("pg", DbConfig::default_postgres());
+        let connection = make_connection(
+            DbKind::Postgres,
+            SchemaLoadingStrategy::ConnectionPerDatabase,
+        );
+        let mut connected = connected_profile(profile, connection, None, HashMap::new());
+
+        connected.cache_set(OwnedCacheEntry::TableDetails {
+            database: "app".to_string(),
+            schema: Some("public".to_string()),
+            table: "users".to_string(),
+            details: table_with_column("public", "email"),
+        });
+        connected.cache_set(OwnedCacheEntry::TableDetails {
+            database: "app".to_string(),
+            schema: Some("audit".to_string()),
+            table: "users".to_string(),
+            details: table_with_column("audit", "changed_at"),
+        });
+
+        let column_for = |schema: &str| -> String {
+            let key = CacheKey::table_details("app", Some(schema), "users");
+            match connected.cache_get(&key) {
+                Some(CacheEntry::TableDetails(info)) => {
+                    info.columns.as_ref().unwrap()[0].name.clone()
+                }
+                _ => panic!("expected cached table details for schema {schema}"),
+            }
+        };
+
+        assert_eq!(column_for("public"), "email");
+        assert_eq!(column_for("audit"), "changed_at");
+
+        let unqualified = CacheKey::table_details("app", None::<String>, "users");
+        assert!(
+            connected.cache_get(&unqualified).is_none(),
+            "schema-less key must not alias a schema-qualified entry"
+        );
+    }
+
+    #[test]
     fn dependents_roundtrip_returns_stored_relations() {
         use crate::{RelationKind, RelationRef};
 
@@ -2659,9 +2807,9 @@ mod tests {
             },
         ];
 
-        connected.populate_dependents("mydb", "users", deps.clone());
+        connected.populate_dependents("mydb", Some("public".to_string()), "users", deps.clone());
 
-        let retrieved = connected.dependents("mydb", "users");
+        let retrieved = connected.dependents("mydb", Some("public"), "users");
         assert_eq!(retrieved, deps);
     }
 
@@ -2678,6 +2826,7 @@ mod tests {
 
         connected.populate_dependents(
             "mydb",
+            Some("public".to_string()),
             "users",
             vec![RelationRef {
                 kind: RelationKind::Trigger,
@@ -2685,11 +2834,54 @@ mod tests {
             }],
         );
 
-        let retrieved = connected.dependents("mydb", "orders");
+        let retrieved = connected.dependents("mydb", Some("public"), "orders");
         assert!(
             retrieved.is_empty(),
             "expected empty for unknown table, got {:?}",
             retrieved
+        );
+    }
+
+    #[test]
+    fn dependents_cache_keeps_same_named_tables_in_different_schemas_distinct() {
+        use crate::{RelationKind, RelationRef};
+
+        let profile = ConnectionProfile::new("pg", DbConfig::default_postgres());
+        let connection = make_connection(
+            DbKind::Postgres,
+            SchemaLoadingStrategy::ConnectionPerDatabase,
+        );
+        let mut connected = connected_profile(profile, connection, None, HashMap::new());
+
+        let public_deps = vec![RelationRef {
+            kind: RelationKind::View,
+            qualified_name: "public.audit".to_string(),
+        }];
+        let sales_deps = vec![RelationRef {
+            kind: RelationKind::ForeignKeyChild,
+            qualified_name: "sales.line_items".to_string(),
+        }];
+
+        connected.populate_dependents(
+            "app",
+            Some("public".to_string()),
+            "orders",
+            public_deps.clone(),
+        );
+        connected.populate_dependents(
+            "app",
+            Some("sales".to_string()),
+            "orders",
+            sales_deps.clone(),
+        );
+
+        assert_eq!(
+            connected.dependents("app", Some("public"), "orders"),
+            public_deps
+        );
+        assert_eq!(
+            connected.dependents("app", Some("sales"), "orders"),
+            sales_deps
         );
     }
 

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -188,7 +188,7 @@ pub use schema::{
     RelationalSchema, RelationshipTypeInfo, RetentionPolicyInfo, RoutineInfo, RoutineKind,
     SchemaChange, SchemaDiff, SchemaDriftDetected, SchemaFingerprint, SchemaForeignKeyBuilder,
     SchemaForeignKeyInfo, SchemaIndexBuilder, SchemaIndexInfo, SchemaNodeId, SchemaNodeKind,
-    SchemaSnapshot, SearchIndexInfo, SearchMappingInfo, SearchSchema, TableInfo,
+    SchemaSnapshot, SearchIndexInfo, SearchMappingInfo, SearchSchema, TableInfo, TableKey,
     TimeSeriesFieldInfo, TimeSeriesSchema, VectorCollectionInfo, VectorMetadataField, VectorMetric,
     VectorSchema, ViewInfo, WideColumnInfo, WideColumnKeyspaceInfo, WideColumnSchema,
     check_drift_sync, check_schema_drift, diff_table_info, extract_referenced_tables,

--- a/crates/dbflux_core/src/schema/drift_check.rs
+++ b/crates/dbflux_core/src/schema/drift_check.rs
@@ -7,8 +7,9 @@ use crate::schema::{
     query_parser::QueryTableRef,
 };
 
-/// Key used to address an entry in `ConnectedProfile::table_details`.
-pub type TableKey = (String, String);
+/// Key used to address an entry in `ConnectedProfile::table_details`:
+/// `(database, schema, table)`.
+pub type TableKey = (String, Option<String>, String);
 
 /// Outcome returned by [`check_schema_drift`].
 pub enum DriftOutcome {
@@ -45,6 +46,50 @@ pub fn check_drift_sync(
     }
 
     Some(diff_table_info(cached, fresh))
+}
+
+/// Locates the cached entry for a referenced table. An explicit query
+/// qualifier addresses exactly one schema slot; an unqualified reference
+/// prefers the caller's default schema, then a schema-less entry, then falls
+/// back to the (deterministically smallest) schema that has the table cached —
+/// preserving the pre-schema-keyed behavior where a lone entry was found
+/// regardless of which schema populated it.
+fn find_cached_entry<'a>(
+    table_details: &'a std::collections::HashMap<TableKey, TableInfo>,
+    database: &str,
+    explicit_schema: Option<&str>,
+    table: &str,
+    default_schema: Option<&str>,
+) -> Option<(&'a TableKey, &'a TableInfo)> {
+    if let Some(schema) = explicit_schema {
+        let key: TableKey = (
+            database.to_string(),
+            Some(schema.to_string()),
+            table.to_string(),
+        );
+        return table_details.get_key_value(&key);
+    }
+
+    if let Some(schema) = default_schema {
+        let key: TableKey = (
+            database.to_string(),
+            Some(schema.to_string()),
+            table.to_string(),
+        );
+        if let Some(entry) = table_details.get_key_value(&key) {
+            return Some(entry);
+        }
+    }
+
+    let schemaless: TableKey = (database.to_string(), None, table.to_string());
+    if let Some(entry) = table_details.get_key_value(&schemaless) {
+        return Some(entry);
+    }
+
+    table_details
+        .iter()
+        .filter(|(key, _)| key.0 == database && key.2 == table)
+        .min_by(|(a, _), (b, _)| a.1.cmp(&b.1))
 }
 
 /// Check whether any tables referenced by `query` have drifted since they were
@@ -90,7 +135,7 @@ pub fn check_drift_sync(
 ///   "Continue with stale", NOT updating the cache.
 pub fn check_schema_drift(
     connection: &Arc<dyn Connection>,
-    table_details: &std::collections::HashMap<(String, String), TableInfo>,
+    table_details: &std::collections::HashMap<TableKey, TableInfo>,
     query: &str,
     database: &str,
     default_schema: Option<&str>,
@@ -106,8 +151,15 @@ pub fn check_schema_drift(
     for table_ref in &table_refs {
         let table_name = &table_ref.table;
         let effective_db = table_ref.database.as_deref().unwrap_or(database);
-        let cache_key: TableKey = (effective_db.to_string(), table_name.clone());
-        let cached = table_details.get(&cache_key);
+
+        let cached_entry = find_cached_entry(
+            table_details,
+            effective_db,
+            table_ref.schema.as_deref(),
+            table_name,
+            default_schema,
+        );
+        let cached = cached_entry.map(|(_, info)| info);
 
         let schema = table_ref
             .schema
@@ -139,16 +191,28 @@ pub fn check_schema_drift(
             continue;
         }
 
+        // Refresh writes go back under the exact key the entry was found at,
+        // so the update lands in the same slot; a first encounter is keyed by
+        // the schema the fresh fetch actually resolved to.
+        let refresh_key: TableKey = match cached_entry {
+            Some((key, _)) => key.clone(),
+            None => (
+                effective_db.to_string(),
+                fresh.schema.clone().or_else(|| Some(schema.to_string())),
+                table_name.clone(),
+            ),
+        };
+
         match cached {
             None => {
                 // First encounter — populate cache silently, no drift to report.
-                refreshes.push((cache_key, fresh));
+                refreshes.push((refresh_key, fresh));
             }
 
             Some(cached) => match check_drift_sync(cached, &fresh) {
                 None => {
                     // No drift — schedule transparent cache refresh.
-                    refreshes.push((cache_key, fresh));
+                    refreshes.push((refresh_key, fresh));
                 }
 
                 Some(changes) => {
@@ -445,10 +509,14 @@ mod tests {
             vec![col("id", "integer", false, true)],
         );
 
-        let mut cache: std::collections::HashMap<(String, String), TableInfo> =
+        let mut cache: std::collections::HashMap<TableKey, TableInfo> =
             std::collections::HashMap::new();
         cache.insert(
-            ("app_db".to_string(), "events".to_string()),
+            (
+                "app_db".to_string(),
+                Some("analytics".to_string()),
+                "events".to_string(),
+            ),
             table_in_analytics.clone(),
         );
 
@@ -486,7 +554,7 @@ mod tests {
     /// to the caller-supplied default schema (the editor's toolbar selection).
     #[test]
     fn default_schema_used_when_cache_is_empty_and_query_unqualified() {
-        let cache: std::collections::HashMap<(String, String), TableInfo> =
+        let cache: std::collections::HashMap<TableKey, TableInfo> =
             std::collections::HashMap::new();
 
         let table = make_table_in(
@@ -541,10 +609,10 @@ mod tests {
         );
         cached_without_schema.schema = None;
 
-        let mut cache: std::collections::HashMap<(String, String), TableInfo> =
+        let mut cache: std::collections::HashMap<TableKey, TableInfo> =
             std::collections::HashMap::new();
         cache.insert(
-            ("db".to_string(), "tbl_v".to_string()),
+            ("db".to_string(), None, "tbl_v".to_string()),
             cached_without_schema,
         );
 
@@ -576,7 +644,7 @@ mod tests {
     /// columns" and stop trying to fetch real data.
     #[test]
     fn empty_fresh_columns_skipped_on_first_encounter() {
-        let cache: std::collections::HashMap<(String, String), TableInfo> =
+        let cache: std::collections::HashMap<TableKey, TableInfo> =
             std::collections::HashMap::new();
 
         let driver: Arc<dyn Connection> = Arc::new(MockDriver::new(vec![QueryTableRef {
@@ -617,10 +685,14 @@ mod tests {
         let table_in_public =
             make_table_in("public", "tbl_v", vec![col("id", "bigint", false, true)]);
 
-        let mut cache: std::collections::HashMap<(String, String), TableInfo> =
+        let mut cache: std::collections::HashMap<TableKey, TableInfo> =
             std::collections::HashMap::new();
         cache.insert(
-            ("db".to_string(), "tbl_v".to_string()),
+            (
+                "db".to_string(),
+                Some("analytics".to_string()),
+                "tbl_v".to_string(),
+            ),
             table_in_analytics.clone(),
         );
 

--- a/crates/dbflux_core/src/schema/mod.rs
+++ b/crates/dbflux_core/src/schema/mod.rs
@@ -11,7 +11,7 @@ pub(crate) mod types;
 pub use builder::{ForeignKeyBuilder, IndexBuilder, SchemaForeignKeyBuilder, SchemaIndexBuilder};
 pub use dependency_order::{OrderResult, topological_order};
 pub use dependents::{RelationKind, RelationRef};
-pub use drift_check::{DriftOutcome, check_drift_sync, check_schema_drift};
+pub use drift_check::{DriftOutcome, TableKey, check_drift_sync, check_schema_drift};
 pub use fingerprint::SchemaFingerprint;
 pub use node_id::{ParseSchemaNodeIdError, SchemaNodeId, SchemaNodeKind};
 pub use query_parser::{QueryTableRef, extract_referenced_tables};

--- a/crates/dbflux_core/src/schema/schema_drift.rs
+++ b/crates/dbflux_core/src/schema/schema_drift.rs
@@ -55,9 +55,9 @@ pub struct SchemaDiff {
 pub struct SchemaDriftDetected {
     pub diffs: Vec<SchemaDiff>,
     /// Unchanged tables whose fresh `TableInfo` should be written into the
-    /// cache transparently, keyed by `(database, table)`. Provided so that
-    /// the "Refresh & re-run" handler can update all tables in one pass.
-    pub refreshes: Vec<((String, String), crate::TableInfo)>,
+    /// cache transparently, keyed by `(database, schema, table)`. Provided so
+    /// that the "Refresh & re-run" handler can update all tables in one pass.
+    pub refreshes: Vec<(crate::schema::TableKey, crate::TableInfo)>,
 }
 
 /// Compute the list of schema changes between `before` and `after` for one table.

--- a/crates/dbflux_ui_base/src/modal_frame.rs
+++ b/crates/dbflux_ui_base/src/modal_frame.rs
@@ -61,6 +61,16 @@ impl ModalFrame {
         self
     }
 
+    pub fn height_fraction(mut self, fraction: f32) -> Self {
+        self.inner = self.inner.height_fraction(fraction);
+        self
+    }
+
+    pub fn center_vertically(mut self) -> Self {
+        self.inner = self.inner.center_vertically();
+        self
+    }
+
     pub fn top_offset(mut self, offset: Pixels) -> Self {
         self.inner = self.inner.top_offset(offset);
         self

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -454,42 +454,31 @@ impl CodeDocument {
 
                     DriftOutcome::Refresh(entries) => {
                         // No drift — schedule transparent cache update then execute.
-                        let cache_updates = entries
-                            .into_iter()
-                            .map(|((db, tbl), info)| (db, tbl, info))
-                            .collect();
-
                         doc.pending.drift_query = Some(PendingDriftQuery {
                             query: query_capture,
                             in_new_tab,
                             action: DriftAction::ExecuteNow,
-                            cache_updates,
+                            cache_updates: entries,
                         });
                     }
 
                     DriftOutcome::Drift(detected) => {
-                        // Build cache updates from unchanged tables.
-                        let cache_updates_for_refresh: Vec<(
-                            String,
-                            String,
-                            dbflux_core::TableInfo,
-                        )> = detected
-                            .refreshes
-                            .iter()
-                            .map(|((db, tbl), info)| (db.clone(), tbl.clone(), info.clone()))
-                            .collect();
-
-                        // Also collect per-diff fresh infos so "Refresh & re-run" updates them.
-                        let mut all_updates = cache_updates_for_refresh;
+                        // Build cache updates from unchanged tables, then add
+                        // per-diff fresh infos so "Refresh & re-run" updates them.
+                        let mut all_updates = detected.refreshes.clone();
                         for diff in &detected.diffs {
                             let effective_db = diff
                                 .table
                                 .database
                                 .clone()
                                 .unwrap_or_else(|| "default".to_string());
+                            let schema = diff
+                                .table
+                                .schema
+                                .clone()
+                                .or_else(|| diff.fresh.schema.clone());
                             all_updates.push((
-                                effective_db,
-                                diff.table.table.clone(),
+                                (effective_db, schema, diff.table.table.clone()),
                                 diff.fresh.clone(),
                             ));
                         }
@@ -1807,10 +1796,8 @@ impl CodeDocument {
         if !pending.cache_updates.is_empty() {
             self.app_state.update(cx, |state, _cx| {
                 if let Some(connected) = state.connections_mut().get_mut(&conn_id) {
-                    for (db, table, info) in &pending.cache_updates {
-                        connected
-                            .table_details
-                            .insert((db.clone(), table.clone()), info.clone());
+                    for (key, info) in &pending.cache_updates {
+                        connected.table_details.insert(key.clone(), info.clone());
                     }
                 }
             });
@@ -1870,10 +1857,8 @@ impl CodeDocument {
                 {
                     self.app_state.update(cx, |state, _cx| {
                         if let Some(connected) = state.connections_mut().get_mut(&conn_id) {
-                            for (db, table, info) in &pending.cache_updates {
-                                connected
-                                    .table_details
-                                    .insert((db.clone(), table.clone()), info.clone());
+                            for (key, info) in &pending.cache_updates {
+                                connected.table_details.insert(key.clone(), info.clone());
                             }
                         }
                     });

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -430,7 +430,8 @@ struct PendingDriftQuery {
     in_new_tab: bool,
     action: DriftAction,
     /// Cache updates to apply before execution when action is `ExecuteNow` or
-    /// after "Refresh & re-run". Each entry is `(database, table, TableInfo)`.
+    /// after "Refresh & re-run". Each entry is `(TableKey, TableInfo)`, where
+    /// `TableKey` is `(database, schema, table)`.
     cache_updates: Vec<(dbflux_core::TableKey, dbflux_core::TableInfo)>,
 }
 

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -431,7 +431,7 @@ struct PendingDriftQuery {
     action: DriftAction,
     /// Cache updates to apply before execution when action is `ExecuteNow` or
     /// after "Refresh & re-run". Each entry is `(database, table, TableInfo)`.
-    cache_updates: Vec<(String, String, dbflux_core::TableInfo)>,
+    cache_updates: Vec<(dbflux_core::TableKey, dbflux_core::TableInfo)>,
 }
 
 /// Record of a query execution.

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
@@ -1627,7 +1627,11 @@ impl DataGridPanel {
             None => return Vec::new(),
         };
         let database = connected.active_database.as_deref().unwrap_or("default");
-        let cache_key = (database.to_string(), table_ref.name.clone());
+        let cache_key = (
+            database.to_string(),
+            table_ref.schema.clone(),
+            table_ref.name.clone(),
+        );
         let table_info = match connected.table_details.get(&cache_key) {
             Some(t) => t,
             None => return Vec::new(),
@@ -2970,7 +2974,11 @@ impl DataGridPanel {
         };
 
         let database = connected.active_database.as_deref().unwrap_or("default");
-        let cache_key = (database.to_string(), table_ref.name.clone());
+        let cache_key = (
+            database.to_string(),
+            table_ref.schema.clone(),
+            table_ref.name.clone(),
+        );
         let table_info = connected.table_details.get(&cache_key);
         let columns_info = table_info.and_then(|t| t.columns.as_deref());
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -753,12 +753,14 @@ impl DataGridPanel {
                     state.set_table_details(
                         fetch_result.profile_id,
                         fetch_result.database.clone(),
+                        fetch_result.schema.clone(),
                         fetch_result.table.clone(),
                         fetch_result.details,
                     );
                     state.set_dependents(
                         fetch_result.profile_id,
                         fetch_result.database,
+                        fetch_result.schema,
                         fetch_result.table,
                         fetch_result.dependents,
                     );
@@ -861,7 +863,7 @@ impl DataGridPanel {
                             .or_else(|| table.schema.clone())
                             .unwrap_or_else(|| "default".to_string());
                         conn.table_details
-                            .get(&(db, table.name.clone()))
+                            .get(&(db, table.schema.clone(), table.name.clone()))
                             .and_then(|info| info.columns.clone())
                     })
                     .unwrap_or_default()
@@ -2193,7 +2195,11 @@ impl DataGridPanel {
         let database = connected.active_database.as_deref().unwrap_or("default");
 
         // Check table_details cache first (populated when table is expanded)
-        let cache_key = (database.to_string(), table.name.clone());
+        let cache_key = (
+            database.to_string(),
+            table.schema.clone(),
+            table.name.clone(),
+        );
         if let Some(table_info) = connected.table_details.get(&cache_key) {
             let columns = table_info.columns.as_deref().unwrap_or(&[]);
             return columns
@@ -2697,7 +2703,7 @@ impl DataGridPanel {
         let db = db.to_string();
 
         spec.compute_editable_binding(|source| {
-            let cache_key = (db.clone(), source.table.clone());
+            let cache_key = (db.clone(), source.schema.clone(), source.table.clone());
             if let Some(table_info) = connected.table_details.get(&cache_key) {
                 let cols = table_info.columns.as_deref().unwrap_or(&[]);
                 let pk_names: Vec<String> = cols
@@ -3262,6 +3268,7 @@ impl DataGridPanel {
                                     state.set_table_details(
                                         profile_id,
                                         database_for_finish.clone(),
+                                        table_for_finish.schema.clone(),
                                         table_for_finish.name.clone(),
                                         details,
                                     );
@@ -6414,6 +6421,7 @@ mod tests {
                 app.set_table_details(
                     profile_id,
                     "app".to_string(),
+                    Some("public".to_string()),
                     "users".to_string(),
                     TableInfo {
                         name: "users".to_string(),

--- a/crates/dbflux_ui_document/src/data_grid_panel/utils.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/utils.rs
@@ -58,7 +58,11 @@ impl DataGridPanel {
         let state = self.app_state.read(cx);
         let connected = state.connections().get(&profile_id)?;
         let database = connected.active_database.as_deref().unwrap_or("default");
-        let cache_key = (database.to_string(), table_ref.name.clone());
+        let cache_key = (
+            database.to_string(),
+            table_ref.schema.clone(),
+            table_ref.name.clone(),
+        );
         let table_info = connected.table_details.get(&cache_key)?;
         let columns = table_info.columns.as_deref()?;
 
@@ -84,7 +88,11 @@ impl DataGridPanel {
         let state = self.app_state.read(cx);
         let connected = state.connections().get(&profile_id)?;
         let database = connected.active_database.as_deref().unwrap_or("default");
-        let cache_key = (database.to_string(), table_ref.name.clone());
+        let cache_key = (
+            database.to_string(),
+            table_ref.schema.clone(),
+            table_ref.name.clone(),
+        );
         let table_info = connected.table_details.get(&cache_key)?;
 
         table_info.columns.clone()
@@ -111,7 +119,11 @@ impl DataGridPanel {
         };
 
         let database = connected.active_database.as_deref().unwrap_or("default");
-        let cache_key = (database.to_string(), table_ref.name.clone());
+        let cache_key = (
+            database.to_string(),
+            table_ref.schema.clone(),
+            table_ref.name.clone(),
+        );
         let table_info = match connected.table_details.get(&cache_key) {
             Some(t) => t,
             None => return std::collections::HashSet::new(),
@@ -146,7 +158,11 @@ impl DataGridPanel {
         };
 
         let database = connected.active_database.as_deref().unwrap_or("default");
-        let cache_key = (database.to_string(), table_ref.name.clone());
+        let cache_key = (
+            database.to_string(),
+            table_ref.schema.clone(),
+            table_ref.name.clone(),
+        );
         let table_info = match connected.table_details.get(&cache_key) {
             Some(t) => t,
             None => return vec![None; self.result.columns.len()],

--- a/crates/dbflux_ui_document/src/migrate_wizard/column_mapping.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/column_mapping.rs
@@ -39,6 +39,7 @@ pub fn default_mapping_mode(target_exists: bool) -> TableMappingMode {
 
 /// One selected table's target location, mapping mode, and adjustable column
 /// bindings (index into `source_columns`, per `target_columns` slot).
+#[derive(Clone)]
 pub struct TableMigrationConfig {
     pub source_table: TableRef,
     pub source_columns: Vec<TransferColumn>,

--- a/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
@@ -710,9 +710,15 @@ impl ConfirmRunPhase {
                 )
             })
             .child(
-                Button::new("migrate-confirm-start", "Start Migration")
-                    .disabled(!start_enabled)
-                    .on_click(cx.listener(|this, _event, _window, cx| this.on_start_migration(cx))),
+                div().flex().justify_end().child(
+                    Button::new("migrate-confirm-start", "Start Migration")
+                        .small()
+                        .primary()
+                        .disabled(!start_enabled)
+                        .on_click(
+                            cx.listener(|this, _event, _window, cx| this.on_start_migration(cx)),
+                        ),
+                ),
             )
             .into_any_element()
     }
@@ -775,8 +781,12 @@ impl ConfirmRunPhase {
             )
             .children(rows)
             .child(
-                Button::new("migrate-reorder-accept", "Use this order")
-                    .on_click(cx.listener(|this, _event, _window, cx| this.accept_reorder(cx))),
+                div().flex().justify_end().child(
+                    Button::new("migrate-reorder-accept", "Use this order")
+                        .small()
+                        .primary()
+                        .on_click(cx.listener(|this, _event, _window, cx| this.accept_reorder(cx))),
+                ),
             )
             .into_any_element()
     }

--- a/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
@@ -16,9 +16,11 @@
 //! background run always surfaces to the foreground through `report_error`.
 
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use dbflux_components::controls::{Button, Checkbox};
-use dbflux_components::primitives::Text;
+use dbflux_components::icons::AppIcon;
+use dbflux_components::primitives::{Icon, Text};
 use dbflux_components::tokens::Spacing;
 use dbflux_core::{
     CancelToken, Connection, OrderResult, TableRef, TaskId, TaskKind, TaskStatus, TaskTarget,
@@ -153,6 +155,18 @@ pub enum ConfirmRunEvent {
     CloseRequested,
 }
 
+/// Live counters for the running migration, shared between the run task's
+/// progress callback and the render thread. `table_index` is the position in
+/// the resolved (post-ordering) load sequence of the table currently being
+/// transferred, so it maps into [`ConfirmRunPhase::final_order`] for a
+/// per-table live status list.
+#[derive(Clone, Copy, Default)]
+struct RunProgress {
+    table_index: usize,
+    rows_done: u64,
+    estimated_total: Option<u64>,
+}
+
 /// Confirm + Run phase entity: renders the plan summary, the optional reorder
 /// interrupt, and the live run (progress + cancel), and owns the migration run
 /// itself. Mounted by the wizard once `Options` is complete.
@@ -180,7 +194,13 @@ pub struct ConfirmRunPhase {
     destructive_ack: bool,
 
     run_state: RunState,
-    progress: Arc<Mutex<(u64, Option<u64>)>>,
+    progress: Arc<Mutex<RunProgress>>,
+    /// Wall-clock start of the live run, for the elapsed-time readout; cleared
+    /// until a run begins.
+    run_started_at: Option<Instant>,
+    /// Frozen total run duration, captured when the run reaches `Done`, so the
+    /// completed screen keeps showing how long the migration took.
+    run_elapsed: Option<Duration>,
     cancel_token: Option<CancelToken>,
     result_summary: Option<String>,
     result_warnings: Vec<String>,
@@ -219,7 +239,9 @@ impl ConfirmRunPhase {
             confirmed_destructive: false,
             destructive_ack: false,
             run_state: RunState::Idle,
-            progress: Arc::new(Mutex::new((0, None))),
+            progress: Arc::new(Mutex::new(RunProgress::default())),
+            run_started_at: None,
+            run_elapsed: None,
             cancel_token: None,
             result_summary: None,
             result_warnings: Vec::new(),
@@ -281,7 +303,9 @@ impl ConfirmRunPhase {
         self.run_state = RunState::Running;
         self.result_summary = None;
         self.result_warnings.clear();
-        *self.progress.lock().unwrap_or_else(|p| p.into_inner()) = (0, None);
+        self.run_started_at = Some(Instant::now());
+        self.run_elapsed = None;
+        *self.progress.lock().unwrap_or_else(|p| p.into_inner()) = RunProgress::default();
 
         let description = format!("Migrate {} table(s)", plans.len());
         let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
@@ -323,7 +347,7 @@ impl ConfirmRunPhase {
         let ticker_app_state = self.app_state.clone();
         let ticker_progress = Arc::clone(&self.progress);
 
-        cx.spawn(async move |_this, cx| {
+        cx.spawn(async move |this, cx| {
             loop {
                 cx.background_executor()
                     .timer(std::time::Duration::from_millis(150))
@@ -339,13 +363,14 @@ impl ConfirmRunPhase {
                                 return false;
                             }
 
-                            let (rows_done, estimated_total) = *ticker_progress
+                            let progress = *ticker_progress
                                 .lock()
                                 .unwrap_or_else(|poisoned| poisoned.into_inner());
-                            if let Some(total) = estimated_total
+                            if let Some(total) = progress.estimated_total
                                 && total > 0
                             {
-                                let fraction = (rows_done as f32 / total as f32).clamp(0.0, 1.0);
+                                let fraction =
+                                    (progress.rows_done as f32 / total as f32).clamp(0.0, 1.0);
                                 state.tasks_mut().update_progress(task_id, fraction);
                                 cx.notify();
                             }
@@ -358,6 +383,12 @@ impl ConfirmRunPhase {
                 if !still_running {
                     break;
                 }
+
+                // Re-render the phase every tick so the elapsed timer, the
+                // progress bar, and the per-table live status advance while the
+                // run is in flight (the app-state notify above only refreshes
+                // the tasks panel, not this modal).
+                this.update(cx, |_this, cx| cx.notify()).ok();
             }
         })
         .detach();
@@ -399,9 +430,13 @@ impl ConfirmRunPhase {
                         &plans,
                         &options,
                         &cancel_token,
-                        move |_index, rows_done, estimated_total| {
+                        move |index, rows_done, estimated_total| {
                             if let Ok(mut guard) = progress.lock() {
-                                *guard = (rows_done, estimated_total);
+                                *guard = RunProgress {
+                                    table_index: index,
+                                    rows_done,
+                                    estimated_total,
+                                };
                             }
                         },
                     )
@@ -450,6 +485,7 @@ impl ConfirmRunPhase {
             // already been finalized above.
             this.update(cx, |this, cx| {
                 this.run_state = RunState::Done;
+                this.run_elapsed = this.run_started_at.map(|started| started.elapsed());
                 this.cancel_token = None;
                 this.result_summary = Some(summary);
                 this.result_warnings = warnings;
@@ -745,35 +781,167 @@ impl ConfirmRunPhase {
             .into_any_element()
     }
 
+    /// The tables in their resolved load order, for the live run status list.
+    /// Falls back to the summary's source names if the order was never
+    /// resolved (which cannot happen once a run has started, but keeps the
+    /// renderer total).
+    fn ordered_table_names(&self) -> Vec<String> {
+        match &self.final_order {
+            Some(order) => order.iter().map(|table| table.qualified_name()).collect(),
+            None => self
+                .summary
+                .rows
+                .iter()
+                .map(|row| row.source.clone())
+                .collect(),
+        }
+    }
+
     fn render_running(&self, cx: &mut Context<Self>) -> AnyElement {
-        let (rows_done, estimated_total) = *self.progress.lock().unwrap_or_else(|p| p.into_inner());
-        let label = match estimated_total {
-            Some(total) if total > 0 => format!("{rows_done} / {total} rows"),
-            _ => format!("{rows_done} rows"),
+        let theme = cx.theme();
+        let color_done = theme.success;
+        let color_current = theme.primary;
+        let color_foreground = theme.foreground;
+        let color_pending = theme.muted_foreground;
+        let color_track = theme.muted;
+        let color_fill = theme.primary;
+
+        let progress = *self.progress.lock().unwrap_or_else(|p| p.into_inner());
+
+        let names = self.ordered_table_names();
+        let total_tables = names.len();
+        let current_index = progress.table_index.min(total_tables.saturating_sub(1));
+
+        let rows_label = match progress.estimated_total {
+            Some(total) if total > 0 => format!("{} / {} rows", progress.rows_done, total),
+            _ => format!("{} rows", progress.rows_done),
         };
+        let determinate = matches!(progress.estimated_total, Some(total) if total > 0);
+        let fraction = match progress.estimated_total {
+            Some(total) if total > 0 => (progress.rows_done as f32 / total as f32).clamp(0.0, 1.0),
+            _ => 0.0,
+        };
+
+        let elapsed = self
+            .run_started_at
+            .map(|started| started.elapsed())
+            .unwrap_or_default();
+
+        let current_table = names.get(current_index).cloned().unwrap_or_default();
+        let position_label = if total_tables > 0 {
+            format!("Table {} of {}", current_index + 1, total_tables)
+        } else {
+            "Preparing".to_string()
+        };
+
+        let steps_rows_label = rows_label.clone();
+        let steps = names.iter().enumerate().map(move |(index, name)| {
+            let (marker, label_color) = if index < current_index {
+                (
+                    Icon::new(AppIcon::CircleCheck)
+                        .size(px(14.0))
+                        .color(color_done)
+                        .into_any_element(),
+                    color_foreground,
+                )
+            } else if index == current_index {
+                (
+                    Icon::new(AppIcon::Loader)
+                        .size(px(14.0))
+                        .color(color_current)
+                        .into_any_element(),
+                    color_foreground,
+                )
+            } else {
+                (
+                    div()
+                        .size(px(8.0)) // guardrail-allow: decorative pending status-dot diameter
+                        .rounded_full()
+                        .bg(color_pending)
+                        .into_any_element(),
+                    color_pending,
+                )
+            };
+
+            div()
+                .flex()
+                .items_center()
+                .gap(Spacing::SM)
+                .py(px(2.0))
+                .child(
+                    div()
+                        .w(px(16.0)) // guardrail-allow: fixed marker gutter for label alignment
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .child(marker),
+                )
+                .child(Text::body(name.clone()).color(label_color))
+                .when(index == current_index, |el| {
+                    el.child(Text::caption(steps_rows_label.clone()).muted_foreground())
+                })
+                .into_any_element()
+        });
 
         div()
             .flex()
             .flex_col()
             .gap(Spacing::MD)
-            .child(Text::body("Migrating…"))
-            .child(Text::caption(label))
+            .size_full()
             .child(
-                Button::new("migrate-run-cancel", "Cancel")
-                    .ghost()
-                    .on_click(cx.listener(|this, _event, _window, cx| this.cancel_run(cx))),
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .child(Text::label("Migrating…"))
+                    .child(Text::caption(format_elapsed(elapsed)).muted_foreground()),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .justify_between()
+                    .gap(Spacing::SM)
+                    .child(Text::caption(format!("{position_label}: {current_table}")))
+                    .child(Text::caption(rows_label.clone()).muted_foreground()),
+            )
+            .when(determinate, |el| {
+                el.child(
+                    div()
+                        .w_full()
+                        .h(px(6.0)) // guardrail-allow: progress-bar track height
+                        .rounded_full()
+                        .bg(color_track)
+                        .child(
+                            div()
+                                .h_full()
+                                .w(relative(fraction))
+                                .rounded_full()
+                                .bg(color_fill),
+                        ),
+                )
+            })
+            .child(
+                div()
+                    .id("migrate-run-steps")
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .overflow_y_scroll()
+                    .flex()
+                    .flex_col()
+                    .children(steps),
             )
             .into_any_element()
     }
 
-    fn cancel_run(&mut self, cx: &mut Context<Self>) {
+    pub fn cancel_run(&mut self, cx: &mut Context<Self>) {
         if let Some(token) = &self.cancel_token {
             token.cancel();
         }
         cx.notify();
     }
 
-    fn render_done(&self, cx: &mut Context<Self>) -> AnyElement {
+    fn render_done(&self, _cx: &mut Context<Self>) -> AnyElement {
         div()
             .flex()
             .flex_col()
@@ -781,14 +949,26 @@ impl ConfirmRunPhase {
             .when_some(self.result_summary.clone(), |el, summary| {
                 el.child(Text::body(summary))
             })
+            .when_some(self.run_elapsed, |el, elapsed| {
+                el.child(
+                    Text::caption(format!("Completed in {}", format_elapsed(elapsed)))
+                        .muted_foreground(),
+                )
+            })
             .when(!self.result_warnings.is_empty(), |el| {
                 el.child(Text::caption(self.result_warnings.join("; ")))
             })
-            .child(Button::new("migrate-run-close", "Close").on_click(
-                cx.listener(|_this, _event, _window, cx| cx.emit(ConfirmRunEvent::CloseRequested)),
-            ))
             .into_any_element()
     }
+}
+
+/// Formats an elapsed run duration as `M:SS` for the live timer and the
+/// completed-run readout.
+fn format_elapsed(elapsed: Duration) -> String {
+    let total_seconds = elapsed.as_secs();
+    let minutes = total_seconds / 60;
+    let seconds = total_seconds % 60;
+    format!("{minutes}:{seconds:02}")
 }
 
 #[cfg(test)]

--- a/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
@@ -17,7 +17,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use dbflux_components::controls::Button;
+use dbflux_components::controls::{Button, Checkbox};
 use dbflux_components::primitives::Text;
 use dbflux_components::tokens::Spacing;
 use dbflux_core::{
@@ -138,6 +138,10 @@ pub struct ConfirmRunInputs {
     pub disable_referential_integrity: bool,
     pub order: OrderDecision,
     pub configs: Vec<TableMigrationConfig>,
+    /// Non-blocking warnings computed on the `Options` → `Confirm` transition
+    /// (e.g. a non-destructive same-container source-as-target write), shown on
+    /// the Confirm screen so the user sees them before starting the run.
+    pub pre_run_warnings: Vec<String>,
 }
 
 /// Emitted to the host wizard so it can flip the rail's current phase to `Run`
@@ -166,14 +170,17 @@ pub struct ConfirmRunPhase {
 
     configs: Vec<TableMigrationConfig>,
     summary: PlanSummary,
+    pre_run_warnings: Vec<String>,
 
     reorder: Option<ReorderState>,
     final_order: Option<Vec<TableRef>>,
     confirmed_destructive: bool,
+    /// Explicit user acknowledgment required before a destructive plan can be
+    /// started; unused (and irrelevant) for non-destructive plans.
+    destructive_ack: bool,
 
     run_state: RunState,
     progress: Arc<Mutex<(u64, Option<u64>)>>,
-    active_task_id: Option<TaskId>,
     cancel_token: Option<CancelToken>,
     result_summary: Option<String>,
     result_warnings: Vec<String>,
@@ -206,12 +213,13 @@ impl ConfirmRunPhase {
             disable_referential_integrity: inputs.disable_referential_integrity,
             configs: inputs.configs,
             summary,
+            pre_run_warnings: inputs.pre_run_warnings,
             reorder,
             final_order,
             confirmed_destructive: false,
+            destructive_ack: false,
             run_state: RunState::Idle,
             progress: Arc::new(Mutex::new((0, None))),
-            active_task_id: None,
             cancel_token: None,
             result_summary: None,
             result_warnings: Vec::new(),
@@ -244,7 +252,17 @@ impl ConfirmRunPhase {
     }
 
     fn on_start_migration(&mut self, cx: &mut Context<Self>) {
-        self.confirmed_destructive = true;
+        // Never start a second concurrent run from the same phase.
+        if self.run_state == RunState::Running {
+            return;
+        }
+
+        // The engine's destructive backstop is satisfied only for a plan that
+        // actually contains destructive operations — and only then after the
+        // user's explicit acknowledgment (which gates this button). A
+        // non-destructive plan leaves the flag `false` and needs no ack.
+        self.confirmed_destructive = self.summary.has_destructive();
+
         cx.emit(ConfirmRunEvent::RunStarted);
         self.start_migration(cx);
     }
@@ -278,7 +296,6 @@ impl ConfirmRunPhase {
             cx.emit(AppStateChanged);
             pair
         });
-        self.active_task_id = Some(task_id);
         self.cancel_token = Some(cancel_token.clone());
 
         self.spawn_progress_ticker(task_id, cx);
@@ -391,89 +408,136 @@ impl ConfirmRunPhase {
                 })
                 .await;
 
+            let RunResolution {
+                task_action,
+                report,
+                toast_success,
+                summary,
+                warnings,
+            } = resolve_run_outcome(migration_result);
+
+            // The run's task MUST reach a terminal state and any failure MUST
+            // reach the foreground even if the phase entity was dropped (modal
+            // closed/reopened, rail-back attempt) — so finalize the task and
+            // report through the app directly, never gated on `this` being
+            // alive. `cx.update` only fails if the whole app is gone.
+            cx.update(|cx| {
+                app_state.update(cx, |state, cx| {
+                    match &task_action {
+                        RunTaskAction::Complete => {
+                            state.complete_task(task_id);
+                        }
+                        RunTaskAction::Cancel => {
+                            state.tasks_mut().cancel(task_id);
+                        }
+                        RunTaskAction::Fail(message) => {
+                            state.fail_task(task_id, message.clone());
+                        }
+                    }
+                    cx.emit(AppStateChanged);
+                });
+
+                if let Some(message) = &report {
+                    report_error(UserFacingError::new(ErrorKind::Driver, message.clone()), cx);
+                }
+                if toast_success {
+                    Toast::success("Migration completed").push(cx);
+                }
+            })
+            .ok();
+
+            // Best-effort UI reflection: if the phase is gone the run has
+            // already been finalized above.
             this.update(cx, |this, cx| {
                 this.run_state = RunState::Done;
                 this.cancel_token = None;
-                this.apply_run_outcome(migration_result, task_id, &app_state, cx);
+                this.result_summary = Some(summary);
+                this.result_warnings = warnings;
                 cx.notify();
             })
             .ok();
         })
         .detach();
     }
+}
 
-    fn apply_run_outcome(
-        &mut self,
-        result: Result<MigrationOutcome, dbflux_transfer::TransferError>,
-        task_id: TaskId,
-        app_state: &Entity<AppStateEntity>,
-        cx: &mut Context<Self>,
-    ) {
-        match result {
-            Ok(MigrationOutcome::Completed(outcome)) if outcome.cancelled => {
-                app_state.update(cx, |state, cx| {
-                    state.tasks_mut().cancel(task_id);
-                    cx.emit(AppStateChanged);
-                });
-                self.result_summary = Some("Migration cancelled".to_string());
-            }
-            Ok(MigrationOutcome::Completed(outcome)) => {
-                let failed_table = outcome.tables.iter().find_map(|t| match &t.status {
-                    TableTransferStatus::Failed { error } => {
-                        Some((t.source_table.clone(), error.clone()))
-                    }
-                    _ => None,
-                });
+/// The terminal action to apply to the run's task registry entry.
+enum RunTaskAction {
+    Complete,
+    Cancel,
+    Fail(String),
+}
 
-                if let Some((table, error)) = &failed_table {
-                    app_state.update(cx, |state, cx| {
-                        state.fail_task(task_id, format!("{table}: {error}"));
-                        cx.emit(AppStateChanged);
-                    });
-                    report_error(
-                        UserFacingError::new(
-                            ErrorKind::Driver,
-                            format!("Migration failed on table '{table}': {error}"),
-                        ),
-                        cx,
-                    );
-                } else {
-                    app_state.update(cx, |state, cx| {
-                        state.complete_task(task_id);
-                        cx.emit(AppStateChanged);
-                    });
-                    Toast::success("Migration completed").push(cx);
+/// The fully-resolved outcome of a migration run: the task action, an optional
+/// user-facing error to report, whether to toast success, and the summary /
+/// per-table lines for the Done screen. Computed once so the task-finalization
+/// path and the UI-reflection path stay consistent even if the phase entity is
+/// dropped between them.
+struct RunResolution {
+    task_action: RunTaskAction,
+    report: Option<String>,
+    toast_success: bool,
+    summary: String,
+    warnings: Vec<String>,
+}
+
+fn resolve_run_outcome(
+    result: Result<MigrationOutcome, dbflux_transfer::TransferError>,
+) -> RunResolution {
+    match result {
+        Ok(MigrationOutcome::Completed(outcome)) if outcome.cancelled => RunResolution {
+            task_action: RunTaskAction::Cancel,
+            report: None,
+            toast_success: false,
+            summary: "Migration cancelled".to_string(),
+            warnings: Vec::new(),
+        },
+        Ok(MigrationOutcome::Completed(outcome)) => {
+            let failed_table = outcome.tables.iter().find_map(|t| match &t.status {
+                TableTransferStatus::Failed { error } => {
+                    Some((t.source_table.clone(), error.clone()))
                 }
+                _ => None,
+            });
 
-                self.result_summary = Some(MigrateWizard::summarize(&outcome));
-                self.result_warnings =
-                    MigrateWizard::itemized_status_lines(&outcome.tables, &outcome.warnings);
+            let summary = MigrateWizard::summarize(&outcome);
+            let warnings = MigrateWizard::itemized_status_lines(&outcome.tables, &outcome.warnings);
+
+            match failed_table {
+                Some((table, error)) => RunResolution {
+                    task_action: RunTaskAction::Fail(format!("{table}: {error}")),
+                    report: Some(format!("Migration failed on table '{table}': {error}")),
+                    toast_success: false,
+                    summary,
+                    warnings,
+                },
+                None => RunResolution {
+                    task_action: RunTaskAction::Complete,
+                    report: None,
+                    toast_success: true,
+                    summary,
+                    warnings,
+                },
             }
-            Ok(MigrationOutcome::CyclicOrderRequired { .. }) => {
-                app_state.update(cx, |state, cx| {
-                    state.fail_task(task_id, "FK order became cyclic mid-run".to_string());
-                    cx.emit(AppStateChanged);
-                });
-                report_error(
-                    UserFacingError::new(
-                        ErrorKind::Driver,
-                        "Migration failed: FK order became cyclic mid-run".to_string(),
-                    ),
-                    cx,
-                );
-                self.result_summary =
-                    Some("Migration failed: FK order became cyclic mid-run".to_string());
+        }
+        Ok(MigrationOutcome::CyclicOrderRequired { .. }) => {
+            let message = "Migration failed: FK order became cyclic mid-run".to_string();
+            RunResolution {
+                task_action: RunTaskAction::Fail("FK order became cyclic mid-run".to_string()),
+                report: Some(message.clone()),
+                toast_success: false,
+                summary: message,
+                warnings: Vec::new(),
             }
-            Err(e) => {
-                app_state.update(cx, |state, cx| {
-                    state.fail_task(task_id, e.to_string());
-                    cx.emit(AppStateChanged);
-                });
-                report_error(
-                    UserFacingError::new(ErrorKind::Driver, format!("Migration failed: {e}")),
-                    cx,
-                );
-                self.result_summary = Some(format!("Migration failed: {e}"));
+        }
+        Err(e) => {
+            let message = format!("Migration failed: {e}");
+            RunResolution {
+                task_action: RunTaskAction::Fail(e.to_string()),
+                report: Some(message.clone()),
+                toast_success: false,
+                summary: message,
+                warnings: Vec::new(),
             }
         }
     }
@@ -532,12 +596,23 @@ impl ConfirmRunPhase {
             false => self.render_start_action(cx),
         };
 
+        let warnings = self.pre_run_warnings.clone();
+
         div()
             .flex()
             .flex_col()
             .gap(Spacing::MD)
             .size_full()
             .child(summary)
+            .when(!warnings.is_empty(), |parent| {
+                parent.child(
+                    div().flex().flex_col().gap(px(2.0)).children(
+                        warnings
+                            .into_iter()
+                            .map(|warning| Text::caption(warning).warning().into_any_element()),
+                    ),
+                )
+            })
             .child(action)
             .into_any_element()
     }
@@ -578,10 +653,29 @@ impl ConfirmRunPhase {
     }
 
     fn render_start_action(&self, cx: &mut Context<Self>) -> AnyElement {
+        let has_destructive = self.summary.has_destructive();
+        let start_enabled = !has_destructive || self.destructive_ack;
+
         div()
             .flex()
+            .flex_col()
+            .gap(Spacing::SM)
+            .when(has_destructive, |parent| {
+                parent.child(
+                    Checkbox::new("migrate-confirm-destructive-ack")
+                        .checked(self.destructive_ack)
+                        .label(
+                            "I understand this plan will drop or empty existing data in the target.",
+                        )
+                        .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                            this.destructive_ack = *checked;
+                            cx.notify();
+                        })),
+                )
+            })
             .child(
                 Button::new("migrate-confirm-start", "Start Migration")
+                    .disabled(!start_enabled)
                     .on_click(cx.listener(|this, _event, _window, cx| this.on_start_migration(cx))),
             )
             .into_any_element()

--- a/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
@@ -1,0 +1,811 @@
+//! Confirm and Run phases of the migration wizard, plus the FK-cycle reorder
+//! interrupt that can sit in front of the run.
+//!
+//! The Confirm phase shows the assembled plan — source/target containers and
+//! one row per table (source name, target name, mapping mode, destructive
+//! flag) — and is where the destructive-confirm gate is finally set. When
+//! `topological_order` reported a cycle among the selected tables, an inline
+//! reorder panel (not a listed rail phase, see design ADR #1) appears first so
+//! the user fixes the load order before the run can start.
+//!
+//! The Run phase reuses the wizard's existing progress/task wiring verbatim:
+//! `start_task_for_target(TaskKind::Migrate, …)`, the shared cancel token, the
+//! 150 ms progress ticker, and the same `run_migration` invocation and outcome
+//! handling (`summarize` / `itemized_status_lines`) as the pre-redesign wizard,
+//! so the produced plan and options stay semantically identical (R9). A failed
+//! background run always surfaces to the foreground through `report_error`.
+
+use std::sync::{Arc, Mutex};
+
+use dbflux_components::controls::Button;
+use dbflux_components::primitives::Text;
+use dbflux_components::tokens::Spacing;
+use dbflux_core::{
+    CancelToken, Connection, OrderResult, TableRef, TaskId, TaskKind, TaskStatus, TaskTarget,
+};
+use dbflux_transfer::TableMappingMode;
+use dbflux_transfer::TableTransferStatus;
+use dbflux_transfer::migration::{MigrationOutcome, MigrationTablePlan, run_migration};
+use dbflux_ui_base::app_state_entity::{AppStateChanged, AppStateEntity};
+use dbflux_ui_base::toast::Toast;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::ActiveTheme;
+use uuid::Uuid;
+
+use crate::migrate_wizard::MigrateWizard;
+use crate::migrate_wizard::column_mapping::TableMigrationConfig;
+use crate::migrate_wizard::phases::{ReorderState, RunState};
+use crate::migrate_wizard::{build_migration_options, build_migration_table_plans};
+
+/// Outcome of resolving the FK load order on the `Options` → `Confirm`
+/// transition: either a full order is ready to run, or the selected tables
+/// form a cycle and the user must reorder the cyclic subset first.
+pub enum OrderDecision {
+    Ready(Vec<TableRef>),
+    NeedsReorder(ReorderState),
+}
+
+/// Maps a raw [`OrderResult`] (computed off-thread by `topological_order`)
+/// into the wizard's [`OrderDecision`]: an acyclic graph yields a ready order,
+/// a cyclic one seeds the reorder interrupt with the fixed prefix and the
+/// cyclic remainder. Pure so the branch is unit-testable without a live run.
+pub fn decide_order(result: OrderResult) -> OrderDecision {
+    match result {
+        OrderResult::Ordered(order) => OrderDecision::Ready(order),
+        OrderResult::Cyclic {
+            ordered_prefix,
+            cycle,
+        } => OrderDecision::NeedsReorder(ReorderState::new(ordered_prefix, cycle)),
+    }
+}
+
+/// The human-readable mode label shown in the Confirm summary — the same
+/// wording used by the mapping grid's mode picker, kept as a small pure map so
+/// the summary never has to reach back into the dropdown's option list.
+pub fn mapping_mode_label(mode: TableMappingMode) -> &'static str {
+    match mode {
+        TableMappingMode::Create => "Create",
+        TableMappingMode::Existing => "Existing",
+        TableMappingMode::Recreate => "Recreate",
+        TableMappingMode::Skip => "Skip",
+        TableMappingMode::Truncate => "Truncate",
+    }
+}
+
+/// One row of the Confirm plan summary: what will happen to a single table.
+pub struct PlanSummaryRow {
+    pub source: String,
+    pub target: String,
+    pub mode_label: &'static str,
+    pub destructive: bool,
+}
+
+/// The Confirm phase's read-only view of the assembled plan: the two ends of
+/// the transfer and one row per table. Built purely from the mapping configs
+/// so it can be asserted without rendering.
+pub struct PlanSummary {
+    pub source_container: String,
+    pub target_container: String,
+    pub rows: Vec<PlanSummaryRow>,
+}
+
+impl PlanSummary {
+    pub fn has_destructive(&self) -> bool {
+        self.rows.iter().any(|row| row.destructive)
+    }
+}
+
+/// Assembles the Confirm summary from the mapping configs — the same
+/// per-table `is_destructive()` classification the engine's destructive gate
+/// uses, so what the user confirms matches what will run.
+pub fn build_plan_summary<'a>(
+    source_container: String,
+    target_container: String,
+    configs: impl IntoIterator<Item = &'a TableMigrationConfig>,
+) -> PlanSummary {
+    let rows = configs
+        .into_iter()
+        .map(|config| PlanSummaryRow {
+            source: config.source_table.qualified_name(),
+            target: config.target_table.clone(),
+            mode_label: mapping_mode_label(config.mapping_mode),
+            destructive: config.is_destructive(),
+        })
+        .collect();
+
+    PlanSummary {
+        source_container,
+        target_container,
+        rows,
+    }
+}
+
+/// Everything the Confirm/Run phase needs to render the plan and drive the
+/// migration, handed over by the wizard once the earlier phases have resolved
+/// the connections, databases, mapping configs, run options, and FK order.
+pub struct ConfirmRunInputs {
+    pub app_state: Entity<AppStateEntity>,
+    pub source_connection: Arc<dyn Connection>,
+    pub target_connection: Arc<dyn Connection>,
+    pub source_database: String,
+    pub target_database: String,
+    pub target_profile_id: Uuid,
+    pub source_container_label: String,
+    pub target_container_label: String,
+    pub segment_size: u32,
+    pub disable_referential_integrity: bool,
+    pub order: OrderDecision,
+    pub configs: Vec<TableMigrationConfig>,
+}
+
+/// Emitted to the host wizard so it can flip the rail's current phase to `Run`
+/// when the migration starts, and close the modal when the user dismisses the
+/// finished run.
+#[derive(Debug, Clone, Copy)]
+pub enum ConfirmRunEvent {
+    RunStarted,
+    CloseRequested,
+}
+
+/// Confirm + Run phase entity: renders the plan summary, the optional reorder
+/// interrupt, and the live run (progress + cancel), and owns the migration run
+/// itself. Mounted by the wizard once `Options` is complete.
+pub struct ConfirmRunPhase {
+    app_state: Entity<AppStateEntity>,
+    focus_handle: FocusHandle,
+
+    source_connection: Arc<dyn Connection>,
+    target_connection: Arc<dyn Connection>,
+    source_database: String,
+    target_database: String,
+    target_profile_id: Uuid,
+    segment_size: u32,
+    disable_referential_integrity: bool,
+
+    configs: Vec<TableMigrationConfig>,
+    summary: PlanSummary,
+
+    reorder: Option<ReorderState>,
+    final_order: Option<Vec<TableRef>>,
+    confirmed_destructive: bool,
+
+    run_state: RunState,
+    progress: Arc<Mutex<(u64, Option<u64>)>>,
+    active_task_id: Option<TaskId>,
+    cancel_token: Option<CancelToken>,
+    result_summary: Option<String>,
+    result_warnings: Vec<String>,
+}
+
+impl EventEmitter<ConfirmRunEvent> for ConfirmRunPhase {}
+
+impl ConfirmRunPhase {
+    pub fn new(inputs: ConfirmRunInputs, cx: &mut Context<Self>) -> Self {
+        let summary = build_plan_summary(
+            inputs.source_container_label,
+            inputs.target_container_label,
+            inputs.configs.iter(),
+        );
+
+        let (reorder, final_order) = match inputs.order {
+            OrderDecision::Ready(order) => (None, Some(order)),
+            OrderDecision::NeedsReorder(state) => (Some(state), None),
+        };
+
+        Self {
+            app_state: inputs.app_state,
+            focus_handle: cx.focus_handle(),
+            source_connection: inputs.source_connection,
+            target_connection: inputs.target_connection,
+            source_database: inputs.source_database,
+            target_database: inputs.target_database,
+            target_profile_id: inputs.target_profile_id,
+            segment_size: inputs.segment_size,
+            disable_referential_integrity: inputs.disable_referential_integrity,
+            configs: inputs.configs,
+            summary,
+            reorder,
+            final_order,
+            confirmed_destructive: false,
+            run_state: RunState::Idle,
+            progress: Arc::new(Mutex::new((0, None))),
+            active_task_id: None,
+            cancel_token: None,
+            result_summary: None,
+            result_warnings: Vec::new(),
+        }
+    }
+
+    pub fn focus_handle(&self) -> &FocusHandle {
+        &self.focus_handle
+    }
+
+    pub fn run_state(&self) -> RunState {
+        self.run_state
+    }
+
+    fn move_reorder_row(&mut self, index: usize, delta: isize, cx: &mut Context<Self>) {
+        if let Some(reorder) = &mut self.reorder {
+            reorder.move_row(index, delta);
+            cx.notify();
+        }
+    }
+
+    /// Accepts the current reorder arrangement: the fixed prefix followed by
+    /// the user-ordered cyclic remainder becomes the final load order, and the
+    /// interrupt clears so the Confirm summary can offer "Start Migration".
+    fn accept_reorder(&mut self, cx: &mut Context<Self>) {
+        if let Some(reorder) = self.reorder.take() {
+            self.final_order = Some(reorder.resolved_order());
+        }
+        cx.notify();
+    }
+
+    fn on_start_migration(&mut self, cx: &mut Context<Self>) {
+        self.confirmed_destructive = true;
+        cx.emit(ConfirmRunEvent::RunStarted);
+        self.start_migration(cx);
+    }
+
+    fn start_migration(&mut self, cx: &mut Context<Self>) {
+        let source_connection = Arc::clone(&self.source_connection);
+        let target_connection = Arc::clone(&self.target_connection);
+        let source_database = self.source_database.clone();
+        let target_database = self.target_database.clone();
+        let manual_order = self.final_order.clone();
+        let plans = build_migration_table_plans(self.configs.iter());
+        let destructive_confirmed = self.confirmed_destructive;
+        let disable_referential_integrity = self.disable_referential_integrity;
+        let segment_size = self.segment_size;
+
+        self.run_state = RunState::Running;
+        self.result_summary = None;
+        self.result_warnings.clear();
+        *self.progress.lock().unwrap_or_else(|p| p.into_inner()) = (0, None);
+
+        let description = format!("Migrate {} table(s)", plans.len());
+        let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
+            let pair = state.start_task_for_target(
+                TaskKind::Migrate,
+                description,
+                Some(TaskTarget {
+                    profile_id: self.target_profile_id,
+                    database: Some(target_database.clone()),
+                }),
+            );
+            cx.emit(AppStateChanged);
+            pair
+        });
+        self.active_task_id = Some(task_id);
+        self.cancel_token = Some(cancel_token.clone());
+
+        self.spawn_progress_ticker(task_id, cx);
+        self.spawn_run(
+            RunTaskContext {
+                source_connection,
+                target_connection,
+                source_database,
+                target_database,
+                plans,
+                segment_size,
+                destructive_confirmed,
+                disable_referential_integrity,
+                manual_order,
+                cancel_token,
+            },
+            task_id,
+            cx,
+        );
+
+        cx.notify();
+    }
+
+    fn spawn_progress_ticker(&self, task_id: TaskId, cx: &mut Context<Self>) {
+        let ticker_app_state = self.app_state.clone();
+        let ticker_progress = Arc::clone(&self.progress);
+
+        cx.spawn(async move |_this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(std::time::Duration::from_millis(150))
+                    .await;
+
+                let still_running = cx
+                    .update(|cx| {
+                        ticker_app_state.update(cx, |state, cx| {
+                            let Some(snapshot) = state.tasks().get(task_id) else {
+                                return false;
+                            };
+                            if snapshot.status != TaskStatus::Running {
+                                return false;
+                            }
+
+                            let (rows_done, estimated_total) = *ticker_progress
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner());
+                            if let Some(total) = estimated_total
+                                && total > 0
+                            {
+                                let fraction = (rows_done as f32 / total as f32).clamp(0.0, 1.0);
+                                state.tasks_mut().update_progress(task_id, fraction);
+                                cx.notify();
+                            }
+
+                            true
+                        })
+                    })
+                    .unwrap_or(false);
+
+                if !still_running {
+                    break;
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn spawn_run(&self, run: RunTaskContext, task_id: TaskId, cx: &mut Context<Self>) {
+        let app_state = self.app_state.clone();
+        let progress = Arc::clone(&self.progress);
+
+        cx.spawn(async move |this, cx| {
+            let RunTaskContext {
+                source_connection,
+                target_connection,
+                source_database,
+                target_database,
+                plans,
+                segment_size,
+                destructive_confirmed,
+                disable_referential_integrity,
+                manual_order,
+                cancel_token,
+            } = run;
+
+            let migration_result = cx
+                .background_executor()
+                .spawn(async move {
+                    let options = build_migration_options(
+                        segment_size,
+                        source_database,
+                        target_database,
+                        destructive_confirmed,
+                        disable_referential_integrity,
+                        manual_order,
+                    );
+
+                    run_migration(
+                        &source_connection,
+                        &target_connection,
+                        &plans,
+                        &options,
+                        &cancel_token,
+                        move |_index, rows_done, estimated_total| {
+                            if let Ok(mut guard) = progress.lock() {
+                                *guard = (rows_done, estimated_total);
+                            }
+                        },
+                    )
+                })
+                .await;
+
+            this.update(cx, |this, cx| {
+                this.run_state = RunState::Done;
+                this.cancel_token = None;
+                this.apply_run_outcome(migration_result, task_id, &app_state, cx);
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn apply_run_outcome(
+        &mut self,
+        result: Result<MigrationOutcome, dbflux_transfer::TransferError>,
+        task_id: TaskId,
+        app_state: &Entity<AppStateEntity>,
+        cx: &mut Context<Self>,
+    ) {
+        match result {
+            Ok(MigrationOutcome::Completed(outcome)) if outcome.cancelled => {
+                app_state.update(cx, |state, cx| {
+                    state.tasks_mut().cancel(task_id);
+                    cx.emit(AppStateChanged);
+                });
+                self.result_summary = Some("Migration cancelled".to_string());
+            }
+            Ok(MigrationOutcome::Completed(outcome)) => {
+                let failed_table = outcome.tables.iter().find_map(|t| match &t.status {
+                    TableTransferStatus::Failed { error } => {
+                        Some((t.source_table.clone(), error.clone()))
+                    }
+                    _ => None,
+                });
+
+                if let Some((table, error)) = &failed_table {
+                    app_state.update(cx, |state, cx| {
+                        state.fail_task(task_id, format!("{table}: {error}"));
+                        cx.emit(AppStateChanged);
+                    });
+                    report_error(
+                        UserFacingError::new(
+                            ErrorKind::Driver,
+                            format!("Migration failed on table '{table}': {error}"),
+                        ),
+                        cx,
+                    );
+                } else {
+                    app_state.update(cx, |state, cx| {
+                        state.complete_task(task_id);
+                        cx.emit(AppStateChanged);
+                    });
+                    Toast::success("Migration completed").push(cx);
+                }
+
+                self.result_summary = Some(MigrateWizard::summarize(&outcome));
+                self.result_warnings =
+                    MigrateWizard::itemized_status_lines(&outcome.tables, &outcome.warnings);
+            }
+            Ok(MigrationOutcome::CyclicOrderRequired { .. }) => {
+                app_state.update(cx, |state, cx| {
+                    state.fail_task(task_id, "FK order became cyclic mid-run".to_string());
+                    cx.emit(AppStateChanged);
+                });
+                self.result_summary =
+                    Some("Migration failed: FK order became cyclic mid-run".to_string());
+            }
+            Err(e) => {
+                app_state.update(cx, |state, cx| {
+                    state.fail_task(task_id, e.to_string());
+                    cx.emit(AppStateChanged);
+                });
+                report_error(
+                    UserFacingError::new(ErrorKind::Driver, format!("Migration failed: {e}")),
+                    cx,
+                );
+                self.result_summary = Some(format!("Migration failed: {e}"));
+            }
+        }
+    }
+}
+
+/// The owned inputs handed to the off-thread run task, bundled so
+/// `start_migration` stays under the readable-length limit.
+struct RunTaskContext {
+    source_connection: Arc<dyn Connection>,
+    target_connection: Arc<dyn Connection>,
+    source_database: String,
+    target_database: String,
+    plans: Vec<MigrationTablePlan>,
+    segment_size: u32,
+    destructive_confirmed: bool,
+    disable_referential_integrity: bool,
+    manual_order: Option<Vec<TableRef>>,
+    cancel_token: CancelToken,
+}
+
+impl Render for ConfirmRunPhase {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let body = match self.run_state {
+            RunState::Idle => self.render_confirm(cx),
+            RunState::Running => self.render_running(cx),
+            RunState::Done => self.render_done(cx),
+        };
+
+        div()
+            .track_focus(&self.focus_handle)
+            .key_context("MigrateConfirmRun")
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .p(Spacing::MD)
+            .size_full()
+            .child(body)
+    }
+}
+
+impl ConfirmRunPhase {
+    fn render_confirm(&self, cx: &mut Context<Self>) -> AnyElement {
+        let summary = div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::XS)
+            .child(Text::label("Review migration plan"))
+            .child(Text::caption(format!(
+                "{} → {}",
+                self.summary.source_container, self.summary.target_container
+            )))
+            .child(self.render_summary_rows(cx));
+
+        let action = match self.reorder.is_some() {
+            true => self.render_reorder_interrupt(cx),
+            false => self.render_start_action(cx),
+        };
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .size_full()
+            .child(summary)
+            .child(action)
+            .into_any_element()
+    }
+
+    fn render_summary_rows(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme().clone();
+
+        let rows = self.summary.rows.iter().map(move |row| {
+            let mut container = div()
+                .flex()
+                .items_center()
+                .gap(Spacing::SM)
+                .py(Spacing::XS)
+                .px(Spacing::SM)
+                .border_b_1()
+                .border_color(theme.border);
+
+            if row.destructive {
+                container = container.border_1().border_color(theme.danger);
+            }
+
+            container
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w(px(0.0))
+                        .overflow_hidden()
+                        .child(Text::body(format!("{} → {}", row.source, row.target))),
+                )
+                .child(Text::caption(row.mode_label))
+                .when(row.destructive, |el| {
+                    el.child(Text::caption("destructive").danger())
+                })
+                .into_any_element()
+        });
+
+        div().flex().flex_col().gap(Spacing::XS).children(rows)
+    }
+
+    fn render_start_action(&self, cx: &mut Context<Self>) -> AnyElement {
+        div()
+            .flex()
+            .child(
+                Button::new("migrate-confirm-start", "Start Migration")
+                    .on_click(cx.listener(|this, _event, _window, cx| this.on_start_migration(cx))),
+            )
+            .into_any_element()
+    }
+
+    fn render_reorder_interrupt(&self, cx: &mut Context<Self>) -> AnyElement {
+        let Some(reorder) = self.reorder.as_ref() else {
+            return div().into_any_element();
+        };
+
+        let rows = reorder.list.iter().enumerate().map(|(index, table)| {
+            let is_last = index + 1 == reorder.list.len();
+            div()
+                .flex()
+                .items_center()
+                .gap(Spacing::SM)
+                .py(Spacing::XS)
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w(px(0.0))
+                        .child(Text::body(table.qualified_name())),
+                )
+                .child(
+                    Button::new(
+                        SharedString::from(format!("migrate-reorder-up-{index}")),
+                        "Up",
+                    )
+                    .small()
+                    .ghost()
+                    .disabled(index == 0)
+                    .on_click(cx.listener(move |this, _event, _window, cx| {
+                        this.move_reorder_row(index, -1, cx);
+                    })),
+                )
+                .child(
+                    Button::new(
+                        SharedString::from(format!("migrate-reorder-down-{index}")),
+                        "Down",
+                    )
+                    .small()
+                    .ghost()
+                    .disabled(is_last)
+                    .on_click(cx.listener(move |this, _event, _window, cx| {
+                        this.move_reorder_row(index, 1, cx);
+                    })),
+                )
+                .into_any_element()
+        });
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::SM)
+            .child(
+                Text::caption(
+                    "These tables reference each other in a cycle and cannot be ordered \
+                     automatically. Choose the load order before starting:",
+                )
+                .warning(),
+            )
+            .children(rows)
+            .child(
+                Button::new("migrate-reorder-accept", "Use this order")
+                    .on_click(cx.listener(|this, _event, _window, cx| this.accept_reorder(cx))),
+            )
+            .into_any_element()
+    }
+
+    fn render_running(&self, cx: &mut Context<Self>) -> AnyElement {
+        let (rows_done, estimated_total) = *self.progress.lock().unwrap_or_else(|p| p.into_inner());
+        let label = match estimated_total {
+            Some(total) if total > 0 => format!("{rows_done} / {total} rows"),
+            _ => format!("{rows_done} rows"),
+        };
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .child(Text::body("Migrating…"))
+            .child(Text::caption(label))
+            .child(
+                Button::new("migrate-run-cancel", "Cancel")
+                    .ghost()
+                    .on_click(cx.listener(|this, _event, _window, cx| this.cancel_run(cx))),
+            )
+            .into_any_element()
+    }
+
+    fn cancel_run(&mut self, cx: &mut Context<Self>) {
+        if let Some(token) = &self.cancel_token {
+            token.cancel();
+        }
+        cx.notify();
+    }
+
+    fn render_done(&self, cx: &mut Context<Self>) -> AnyElement {
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .when_some(self.result_summary.clone(), |el, summary| {
+                el.child(Text::body(summary))
+            })
+            .when(!self.result_warnings.is_empty(), |el| {
+                el.child(Text::caption(self.result_warnings.join("; ")))
+            })
+            .child(Button::new("migrate-run-close", "Close").on_click(
+                cx.listener(|_this, _event, _window, cx| cx.emit(ConfirmRunEvent::CloseRequested)),
+            ))
+            .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{OrderDecision, PlanSummary, build_plan_summary, decide_order, mapping_mode_label};
+    use crate::migrate_wizard::column_mapping::TableMigrationConfig;
+    use dbflux_core::{OrderResult, TableRef, TransferColumn};
+    use dbflux_transfer::TableMappingMode;
+
+    fn column(name: &str) -> TransferColumn {
+        TransferColumn {
+            name: name.to_string(),
+            type_name: Some("text".to_string()),
+            nullable: true,
+            is_primary_key: false,
+        }
+    }
+
+    fn config(name: &str, mode: TableMappingMode) -> TableMigrationConfig {
+        let mut config = TableMigrationConfig::new(
+            TableRef::new(name),
+            vec![column("id")],
+            true,
+            vec![column("id")],
+        );
+        config.mapping_mode = mode;
+        config
+    }
+
+    #[test]
+    fn decide_order_ready_when_topological_order_is_acyclic() {
+        let order = vec![TableRef::new("parent"), TableRef::new("child")];
+        let decision = decide_order(OrderResult::Ordered(order.clone()));
+
+        match decision {
+            OrderDecision::Ready(resolved) => assert_eq!(resolved, order),
+            OrderDecision::NeedsReorder(_) => panic!("acyclic order must be Ready"),
+        }
+    }
+
+    #[test]
+    fn decide_order_needs_reorder_seeds_prefix_and_cyclic_list() {
+        let result = OrderResult::Cyclic {
+            ordered_prefix: vec![TableRef::new("a")],
+            cycle: vec![TableRef::new("b"), TableRef::new("c")],
+        };
+
+        match decide_order(result) {
+            OrderDecision::NeedsReorder(state) => {
+                assert_eq!(state.prefix, vec![TableRef::new("a")]);
+                assert_eq!(state.list, vec![TableRef::new("b"), TableRef::new("c")]);
+            }
+            OrderDecision::Ready(_) => panic!("cyclic order must need reorder"),
+        }
+    }
+
+    #[test]
+    fn accepting_a_reorder_yields_prefix_then_user_order() {
+        let result = OrderResult::Cyclic {
+            ordered_prefix: vec![TableRef::new("a")],
+            cycle: vec![TableRef::new("b"), TableRef::new("c")],
+        };
+
+        let OrderDecision::NeedsReorder(mut state) = decide_order(result) else {
+            panic!("expected reorder");
+        };
+
+        state.move_row(0, 1);
+        let resolved: Vec<String> = state.resolved_order().into_iter().map(|t| t.name).collect();
+
+        assert_eq!(resolved, vec!["a", "c", "b"]);
+    }
+
+    #[test]
+    fn mapping_mode_label_covers_every_mode() {
+        assert_eq!(mapping_mode_label(TableMappingMode::Create), "Create");
+        assert_eq!(mapping_mode_label(TableMappingMode::Existing), "Existing");
+        assert_eq!(mapping_mode_label(TableMappingMode::Recreate), "Recreate");
+        assert_eq!(mapping_mode_label(TableMappingMode::Skip), "Skip");
+        assert_eq!(mapping_mode_label(TableMappingMode::Truncate), "Truncate");
+    }
+
+    #[test]
+    fn build_plan_summary_maps_each_config_to_a_row_with_destructive_flag() {
+        let configs = [
+            config("users", TableMappingMode::Existing),
+            config("orders", TableMappingMode::Recreate),
+        ];
+
+        let summary: PlanSummary = build_plan_summary(
+            "prod / app".to_string(),
+            "staging / app".to_string(),
+            configs.iter(),
+        );
+
+        assert_eq!(summary.source_container, "prod / app");
+        assert_eq!(summary.target_container, "staging / app");
+        assert_eq!(summary.rows.len(), 2);
+
+        assert_eq!(summary.rows[0].target, "users");
+        assert_eq!(summary.rows[0].mode_label, "Existing");
+        assert!(!summary.rows[0].destructive);
+
+        assert_eq!(summary.rows[1].mode_label, "Recreate");
+        assert!(summary.rows[1].destructive);
+
+        assert!(summary.has_destructive());
+    }
+
+    #[test]
+    fn build_plan_summary_has_no_destructive_when_all_modes_are_safe() {
+        let configs = [
+            config("users", TableMappingMode::Existing),
+            config("orders", TableMappingMode::Skip),
+        ];
+
+        let summary = build_plan_summary("a".to_string(), "b".to_string(), configs.iter());
+
+        assert!(!summary.has_destructive());
+    }
+}

--- a/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
@@ -454,6 +454,13 @@ impl ConfirmRunPhase {
                     state.fail_task(task_id, "FK order became cyclic mid-run".to_string());
                     cx.emit(AppStateChanged);
                 });
+                report_error(
+                    UserFacingError::new(
+                        ErrorKind::Driver,
+                        "Migration failed: FK order became cyclic mid-run".to_string(),
+                    ),
+                    cx,
+                );
                 self.result_summary =
                     Some("Migration failed: FK order became cyclic mid-run".to_string());
             }

--- a/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
@@ -331,6 +331,17 @@ impl MappingPhase {
             .await;
 
             this.update(cx, |this, cx| {
+                // Drop a stale result: if the row's target changed while this
+                // fetch was in flight, a newer reseed owns the row and
+                // applying this schema would clobber the current state.
+                let still_current = this.rows.get(row_index).is_some_and(|row| {
+                    row.config.target_schema == table_ref.schema
+                        && row.config.target_table == table_ref.name
+                });
+                if !still_current {
+                    return;
+                }
+
                 if let Some(row) = this.rows.get_mut(row_index) {
                     match result {
                         Ok(super::TableDetailsFetch::Found(info)) => {

--- a/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
@@ -1,0 +1,845 @@
+//! Tables Mapping phase of the migration wizard: a wizard-local flex grid
+//! with one row per checked source table and columns
+//! **Source / Target / Mapping mode / Transform**. Each row wraps the pure
+//! [`TableMigrationConfig`] (the unchanged binding contract) with the live
+//! `Input` (target table name) and `Dropdown` (mapping mode) controls the user
+//! adjusts it through, plus a per-table column drill-in that edits the
+//! source→target column bindings.
+//!
+//! Typing a target-table name that already exists in the chosen container sets
+//! the row to [`TableMappingMode::Existing`] and reseeds its column bindings
+//! from the real target schema (fetched through the shared metadata seam);
+//! typing an unknown name sets [`TableMappingMode::Create`] and mirrors the
+//! source columns as the to-be-created target columns. The column drill-in
+//! drives `TableMigrationConfig::set_binding`, so the assembled plan still
+//! flows through `to_overrides()` verbatim.
+//!
+//! `data_table::DataTable` is deliberately not reused here — it is a
+//! virtualized text grid that cannot host a `Dropdown`/`Input` entity per cell
+//! (design ADR #6). The grid is shaped as its own module so a future review
+//! surface (e.g. a deferred Import review) can lift it without a premature
+//! `dbflux_components` abstraction.
+
+use dbflux_components::controls::{
+    Button, Dropdown, DropdownItem, DropdownSelectionChanged, GpuiInput as Input, InputEvent,
+    InputState,
+};
+use dbflux_components::icons::AppIcon;
+use dbflux_components::primitives::{Icon, Text};
+use dbflux_components::tokens::{Heights, Spacing};
+use dbflux_core::{TableRef, TransferColumn};
+use dbflux_transfer::TableMappingMode;
+use dbflux_ui_base::app_state_entity::AppStateEntity;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::{ActiveTheme, Sizable};
+use uuid::Uuid;
+
+use crate::migrate_wizard::column_mapping::{
+    TableMigrationConfig, default_mapping_mode, mapping_mode_options,
+};
+use crate::migrate_wizard::phases::MappingRowReadiness;
+use crate::migrate_wizard::tree_model::NodeLoad;
+
+const TARGET_COL_W: Pixels = px(220.0);
+const MODE_COL_W: Pixels = px(200.0);
+const TRANSFORM_COL_W: Pixels = px(160.0);
+const UNSET_LABEL: &str = "(unset)";
+
+/// Whether a typed target-table name refers to a table that already exists in
+/// the chosen target container (⇒ [`TargetResolution::Existing`]) or a new one
+/// the engine will create (⇒ [`TargetResolution::Create`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetResolution {
+    Create,
+    Existing,
+}
+
+/// Classifies a typed target-table name against the set of tables known to
+/// already exist in the container. Exact match after trimming — an empty name
+/// is treated as a not-yet-existing (Create) target so the advance guard, not
+/// this classifier, is what blocks on a blank name.
+pub fn resolve_target_name(name: &str, existing_tables: &[String]) -> TargetResolution {
+    let trimmed = name.trim();
+
+    if !trimmed.is_empty() && existing_tables.iter().any(|table| table == trimmed) {
+        TargetResolution::Existing
+    } else {
+        TargetResolution::Create
+    }
+}
+
+/// Applies a typed target-table name to a row's config: records the trimmed
+/// name, sets the mapping mode from whether the target already exists
+/// (Existing vs Create), and returns the resolution so the caller can decide
+/// how to reseed the column bindings (a background schema fetch for an
+/// existing table, or the source columns for a to-be-created one).
+pub fn apply_target_name(
+    config: &mut TableMigrationConfig,
+    name: &str,
+    existing_tables: &[String],
+) -> TargetResolution {
+    let resolution = resolve_target_name(name, existing_tables);
+
+    config.target_table = name.trim().to_string();
+    config.target_exists = resolution == TargetResolution::Existing;
+    config.mapping_mode = default_mapping_mode(config.target_exists);
+
+    resolution
+}
+
+/// Reseeds a config's target columns and re-runs the name-based auto-map while
+/// preserving the user's chosen target table name, target schema, and mapping
+/// mode. Reuses [`TableMigrationConfig::new`]'s auto-mapping rather than
+/// reimplementing the binding model: for an existing table the fetched target
+/// schema is passed in; for a Create target the source columns are mirrored.
+pub fn reseed_target_columns(
+    config: &mut TableMigrationConfig,
+    target_columns: Vec<TransferColumn>,
+) {
+    let target_table = config.target_table.clone();
+    let target_schema = config.target_schema.clone();
+    let mapping_mode = config.mapping_mode;
+
+    let mut rebuilt = TableMigrationConfig::new(
+        config.source_table.clone(),
+        config.source_columns.clone(),
+        config.target_exists,
+        target_columns,
+    );
+
+    rebuilt.target_table = target_table;
+    rebuilt.target_schema = target_schema;
+    rebuilt.mapping_mode = mapping_mode;
+
+    *config = rebuilt;
+}
+
+/// Emitted whenever a row's target name, mapping mode, or column binding
+/// changes, so the host can re-evaluate the `TablesMapping` advance guard.
+#[derive(Debug, Clone)]
+pub struct MappingChanged;
+
+/// One grid row: the pure [`TableMigrationConfig`] plus the live controls the
+/// user edits it through and the load state of its target-existence lookup.
+struct MappingRow {
+    config: TableMigrationConfig,
+    target_input: Entity<InputState>,
+    mode_dropdown: Entity<Dropdown>,
+    target_lookup: NodeLoad,
+}
+
+/// The open column drill-in: which row it edits and one source-column
+/// `Dropdown` per target column (index 0 = `(unset)` = NULL).
+struct BindingEditor {
+    row_index: usize,
+    dropdowns: Vec<Entity<Dropdown>>,
+}
+
+pub struct MappingPhase {
+    app_state: Entity<AppStateEntity>,
+    focus_handle: FocusHandle,
+    target_profile_id: Uuid,
+    target_database: String,
+    existing_target_tables: Vec<String>,
+    supports_truncate: bool,
+    rows: Vec<MappingRow>,
+    editor: Option<BindingEditor>,
+    _subscriptions: Vec<Subscription>,
+    _editor_subscriptions: Vec<Subscription>,
+}
+
+impl EventEmitter<MappingChanged> for MappingPhase {}
+
+impl MappingPhase {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        app_state: Entity<AppStateEntity>,
+        target_profile_id: Uuid,
+        target_database: String,
+        existing_target_tables: Vec<String>,
+        supports_truncate: bool,
+        configs: Vec<TableMigrationConfig>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let mut phase = Self {
+            app_state,
+            focus_handle: cx.focus_handle(),
+            target_profile_id,
+            target_database,
+            existing_target_tables,
+            supports_truncate,
+            rows: Vec::new(),
+            editor: None,
+            _subscriptions: Vec::new(),
+            _editor_subscriptions: Vec::new(),
+        };
+
+        phase.build_rows(configs, window, cx);
+        phase
+    }
+
+    pub fn focus_handle(&self) -> &FocusHandle {
+        &self.focus_handle
+    }
+
+    /// The assembled configs, in row order, for the host to feed into
+    /// `build_migration_table_plans` — the binding contract is untouched.
+    pub fn configs(&self) -> impl Iterator<Item = &TableMigrationConfig> {
+        self.rows.iter().map(|row| &row.config)
+    }
+
+    /// Per-row readiness for the `TablesMapping` → `Options` guard.
+    pub fn readiness(&self) -> Vec<MappingRowReadiness<'_>> {
+        self.rows
+            .iter()
+            .map(|row| MappingRowReadiness {
+                target_name: row.config.target_table.as_str(),
+                target_lookup: row.target_lookup.clone(),
+            })
+            .collect()
+    }
+
+    fn build_rows(
+        &mut self,
+        configs: Vec<TableMigrationConfig>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.rows.clear();
+        self._subscriptions.clear();
+        self.editor = None;
+        self._editor_subscriptions.clear();
+
+        let supports_truncate = self.supports_truncate;
+
+        for (row_index, config) in configs.into_iter().enumerate() {
+            let target_input = cx.new(|cx| {
+                InputState::new(window, cx)
+                    .default_value(config.target_table.clone())
+                    .placeholder("Target table")
+            });
+
+            let mode_options = mapping_mode_options(supports_truncate);
+            let selected_mode = mode_options
+                .iter()
+                .position(|(_, mode)| *mode == config.mapping_mode);
+            let mode_items: Vec<DropdownItem> = mode_options
+                .iter()
+                .map(|(label, _)| DropdownItem::new(*label))
+                .collect();
+            let mode_dropdown = cx.new(|_cx| {
+                Dropdown::new(SharedString::from(format!("migrate-mode-{row_index}")))
+                    .items(mode_items)
+                    .selected_index(selected_mode)
+                    .placeholder("Mode")
+            });
+
+            let input_sub = cx.subscribe_in(
+                &target_input,
+                window,
+                move |this, _entity, event: &InputEvent, window, cx| {
+                    if let InputEvent::Change = event {
+                        this.on_target_name_changed(row_index, window, cx);
+                    }
+                },
+            );
+            let mode_sub = cx.subscribe(
+                &mode_dropdown,
+                move |this, _entity, event: &DropdownSelectionChanged, cx| {
+                    this.on_mode_changed(row_index, event.index, cx);
+                },
+            );
+
+            self.rows.push(MappingRow {
+                config,
+                target_input,
+                mode_dropdown,
+                target_lookup: NodeLoad::Loaded,
+            });
+            self._subscriptions.push(input_sub);
+            self._subscriptions.push(mode_sub);
+        }
+    }
+
+    fn on_target_name_changed(
+        &mut self,
+        row_index: usize,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let existing = self.existing_target_tables.clone();
+        let Some(row) = self.rows.get_mut(row_index) else {
+            return;
+        };
+
+        let typed = row.target_input.read(cx).value().to_string();
+        let resolution = apply_target_name(&mut row.config, &typed, &existing);
+
+        match resolution {
+            TargetResolution::Create => {
+                let source_columns = row.config.source_columns.clone();
+                reseed_target_columns(&mut row.config, source_columns);
+                row.target_lookup = NodeLoad::Loaded;
+                self.sync_editor_after_reseed(row_index, cx);
+                cx.emit(MappingChanged);
+                cx.notify();
+            }
+            TargetResolution::Existing => {
+                row.target_lookup = NodeLoad::Loading;
+                cx.emit(MappingChanged);
+                cx.notify();
+                self.reseed_existing(row_index, cx);
+            }
+        }
+    }
+
+    fn on_mode_changed(&mut self, row_index: usize, index: usize, cx: &mut Context<Self>) {
+        let mode_options = mapping_mode_options(self.supports_truncate);
+        let Some((_, mode)) = mode_options.get(index).copied() else {
+            return;
+        };
+        if let Some(row) = self.rows.get_mut(row_index) {
+            row.config.mapping_mode = mode;
+            cx.emit(MappingChanged);
+            cx.notify();
+        }
+    }
+
+    /// Fetches the existing target table's real schema through the shared
+    /// metadata seam on the background executor and reseeds the row's column
+    /// bindings against it (design "existing ⇒ bg target-column fetch").
+    fn reseed_existing(&mut self, row_index: usize, cx: &mut Context<Self>) {
+        let Some(row) = self.rows.get(row_index) else {
+            return;
+        };
+        let table_ref = TableRef {
+            schema: row.config.target_schema.clone(),
+            name: row.config.target_table.clone(),
+        };
+
+        let app_state = self.app_state.clone();
+        let profile_id = self.target_profile_id;
+        let database = self.target_database.clone();
+
+        cx.spawn(async move |this, cx| {
+            let result = super::fetch_table_details_via_seam(
+                &app_state, profile_id, &database, &table_ref, cx,
+            )
+            .await;
+
+            this.update(cx, |this, cx| {
+                if let Some(row) = this.rows.get_mut(row_index) {
+                    match result {
+                        Ok(super::TableDetailsFetch::Found(info)) => {
+                            let columns =
+                                super::to_transfer_columns(info.columns.unwrap_or_default());
+                            reseed_target_columns(&mut row.config, columns);
+                            row.target_lookup = NodeLoad::Loaded;
+                        }
+                        Ok(super::TableDetailsFetch::NotFound(error)) | Err(error) => {
+                            row.target_lookup = NodeLoad::Failed(error.clone());
+                            report_error(
+                                UserFacingError::new(
+                                    ErrorKind::Driver,
+                                    format!("Could not read target table schema: {error}"),
+                                ),
+                                cx,
+                            );
+                        }
+                    }
+                }
+                this.sync_editor_after_reseed(row_index, cx);
+                cx.emit(MappingChanged);
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn sync_editor_after_reseed(&mut self, row_index: usize, cx: &mut Context<Self>) {
+        if self
+            .editor
+            .as_ref()
+            .is_some_and(|editor| editor.row_index == row_index)
+        {
+            self.open_drilldown(row_index, cx);
+        }
+    }
+
+    /// Opens (or rebuilds) the column drill-in for `row_index`, creating one
+    /// source-column `Dropdown` per target column seeded from the current
+    /// bindings and wiring each back to `TableMigrationConfig::set_binding`.
+    fn open_drilldown(&mut self, row_index: usize, cx: &mut Context<Self>) {
+        self._editor_subscriptions.clear();
+
+        let Some(row) = self.rows.get(row_index) else {
+            self.editor = None;
+            return;
+        };
+
+        let source_names: Vec<SharedString> = row
+            .config
+            .source_columns
+            .iter()
+            .map(|column| SharedString::from(column.name.clone()))
+            .collect();
+
+        let mut dropdowns = Vec::with_capacity(row.config.target_columns.len());
+        let mut subscriptions = Vec::new();
+
+        for (target_index, binding) in row.config.bindings.iter().enumerate() {
+            let mut items = vec![DropdownItem::new(UNSET_LABEL)];
+            items.extend(source_names.iter().cloned().map(DropdownItem::new));
+
+            let selected = binding.map(|source_index| source_index + 1).or(Some(0));
+            let dropdown = cx.new(|_cx| {
+                Dropdown::new(SharedString::from(format!(
+                    "migrate-bind-{row_index}-{target_index}"
+                )))
+                .items(items)
+                .selected_index(selected)
+            });
+
+            let subscription = cx.subscribe(
+                &dropdown,
+                move |this, _entity, event: &DropdownSelectionChanged, cx| {
+                    this.on_binding_changed(row_index, target_index, event.index, cx);
+                },
+            );
+
+            dropdowns.push(dropdown);
+            subscriptions.push(subscription);
+        }
+
+        self.editor = Some(BindingEditor {
+            row_index,
+            dropdowns,
+        });
+        self._editor_subscriptions = subscriptions;
+        cx.notify();
+    }
+
+    fn close_drilldown(&mut self, cx: &mut Context<Self>) {
+        self.editor = None;
+        self._editor_subscriptions.clear();
+        cx.notify();
+    }
+
+    fn on_binding_changed(
+        &mut self,
+        row_index: usize,
+        target_index: usize,
+        item_index: usize,
+        cx: &mut Context<Self>,
+    ) {
+        let source_index = item_index.checked_sub(1);
+        if let Some(row) = self.rows.get_mut(row_index) {
+            row.config.set_binding(target_index, source_index);
+            cx.emit(MappingChanged);
+            cx.notify();
+        }
+    }
+
+    fn set_all_modes(&mut self, mode: TableMappingMode, cx: &mut Context<Self>) {
+        let mode_options = mapping_mode_options(self.supports_truncate);
+        let selected = mode_options.iter().position(|(_, m)| *m == mode);
+
+        for row in &mut self.rows {
+            row.config.mapping_mode = mode;
+            row.mode_dropdown
+                .update(cx, |dropdown, cx| dropdown.set_selected_index(selected, cx));
+        }
+
+        cx.emit(MappingChanged);
+        cx.notify();
+    }
+}
+
+impl Render for MappingPhase {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let body = match self.editor.as_ref().map(|editor| editor.row_index) {
+            Some(row_index) => self.render_drilldown(row_index, cx).into_any_element(),
+            None => self.render_grid(cx).into_any_element(),
+        };
+
+        div()
+            .track_focus(&self.focus_handle)
+            .key_context("MigrateTablesMapping")
+            .flex()
+            .flex_col()
+            .gap(Spacing::SM)
+            .p(Spacing::MD)
+            .size_full()
+            .child(body)
+    }
+}
+
+impl MappingPhase {
+    fn render_grid(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let rows: Vec<AnyElement> = self
+            .rows
+            .iter()
+            .enumerate()
+            .map(|(index, row)| self.render_grid_row(index, row, cx))
+            .collect();
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::XS)
+            .size_full()
+            .child(self.render_bulk_toolbar(cx))
+            .child(render_grid_header(cx))
+            .child(
+                div()
+                    .id("migrate-mapping-rows")
+                    .flex()
+                    .flex_col()
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .overflow_y_scroll()
+                    .children(rows),
+            )
+    }
+
+    fn render_bulk_toolbar(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        let supports_truncate = self.supports_truncate;
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(Spacing::SM)
+            .child(Text::caption("Set all:"))
+            .child(
+                Button::new("migrate-bulk-existing", "Existing")
+                    .small()
+                    .ghost()
+                    .on_click(cx.listener(|this, _event, _window, cx| {
+                        this.set_all_modes(TableMappingMode::Existing, cx);
+                    })),
+            )
+            .when(supports_truncate, |parent| {
+                parent.child(
+                    Button::new("migrate-bulk-truncate", "Truncate")
+                        .small()
+                        .ghost()
+                        .on_click(cx.listener(|this, _event, _window, cx| {
+                            this.set_all_modes(TableMappingMode::Truncate, cx);
+                        })),
+                )
+            })
+            .child(
+                Button::new("migrate-bulk-skip", "Skip")
+                    .small()
+                    .ghost()
+                    .on_click(cx.listener(|this, _event, _window, cx| {
+                        this.set_all_modes(TableMappingMode::Skip, cx);
+                    })),
+            )
+    }
+
+    fn render_grid_row(
+        &self,
+        row_index: usize,
+        row: &MappingRow,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let theme = cx.theme().clone();
+        let unmatched = row.config.unmatched_source_names();
+
+        let transform_cell = div()
+            .w(TRANSFORM_COL_W)
+            .flex()
+            .flex_col()
+            .gap(px(2.0))
+            .child(
+                Button::new(
+                    SharedString::from(format!("migrate-transform-{row_index}")),
+                    "Columns…",
+                )
+                .small()
+                .ghost()
+                .disabled(matches!(row.target_lookup, NodeLoad::Loading))
+                .on_click(cx.listener(move |this, _event, _window, cx| {
+                    this.open_drilldown(row_index, cx);
+                })),
+            )
+            .when(!unmatched.is_empty(), |parent| {
+                parent.child(
+                    Text::caption(SharedString::from(format!("{} unmapped", unmatched.len())))
+                        .color(theme.warning),
+                )
+            });
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(Spacing::SM)
+            .py(Spacing::XS)
+            .border_b_1()
+            .border_color(theme.border)
+            .child(
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .overflow_hidden()
+                    .child(Text::body(row.config.source_table.qualified_name())),
+            )
+            .child(
+                div()
+                    .w(TARGET_COL_W)
+                    .child(Input::new(&row.target_input).small().w_full()),
+            )
+            .child(div().w(MODE_COL_W).child(row.mode_dropdown.clone()))
+            .child(transform_cell)
+            .into_any_element()
+    }
+
+    fn render_drilldown(&self, row_index: usize, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme().clone();
+        let Some(row) = self.rows.get(row_index) else {
+            return div().into_any_element();
+        };
+        let Some(editor) = self.editor.as_ref() else {
+            return div().into_any_element();
+        };
+
+        let unmatched = row.config.unmatched_source_names();
+        let binding_rows: Vec<AnyElement> = row
+            .config
+            .target_columns
+            .iter()
+            .zip(editor.dropdowns.iter())
+            .map(|(target_column, dropdown)| {
+                render_binding_row(&target_column.name, dropdown, &theme)
+            })
+            .collect();
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::SM)
+            .size_full()
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap(Spacing::SM)
+                    .child(
+                        Button::new("migrate-drilldown-back", "Back")
+                            .small()
+                            .ghost()
+                            .icon(AppIcon::ChevronLeft)
+                            .on_click(cx.listener(|this, _event, _window, cx| {
+                                this.close_drilldown(cx);
+                            })),
+                    )
+                    .child(Text::body(SharedString::from(format!(
+                        "Column mapping — {}",
+                        row.config.source_table.qualified_name()
+                    )))),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .items_center()
+                    .gap(Spacing::SM)
+                    .child(div().w(TARGET_COL_W).child(Text::label("Target column")))
+                    .child(div().w(TARGET_COL_W).child(Text::label("Source column"))),
+            )
+            .child(
+                div()
+                    .id("migrate-binding-rows")
+                    .flex()
+                    .flex_col()
+                    .gap(Spacing::XS)
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .overflow_y_scroll()
+                    .children(binding_rows),
+            )
+            .when(!unmatched.is_empty(), |parent| {
+                parent.child(
+                    Text::caption(SharedString::from(format!(
+                        "Unmapped source columns: {}",
+                        unmatched.join(", ")
+                    )))
+                    .color(theme.warning),
+                )
+            })
+            .into_any_element()
+    }
+}
+
+fn render_grid_header(cx: &mut Context<MappingPhase>) -> impl IntoElement {
+    let theme = cx.theme().clone();
+
+    div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap(Spacing::SM)
+        .h(Heights::ROW)
+        .border_b_1()
+        .border_color(theme.border)
+        .child(div().flex_1().min_w(px(0.0)).child(Text::label("Source")))
+        .child(div().w(TARGET_COL_W).child(Text::label("Target")))
+        .child(div().w(MODE_COL_W).child(Text::label("Mapping mode")))
+        .child(div().w(TRANSFORM_COL_W).child(Text::label("Transform")))
+}
+
+fn render_binding_row(
+    target_name: &str,
+    dropdown: &Entity<Dropdown>,
+    theme: &gpui_component::Theme,
+) -> AnyElement {
+    div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap(Spacing::SM)
+        .child(
+            div()
+                .w(TARGET_COL_W)
+                .overflow_hidden()
+                .child(Text::body(target_name.to_string())),
+        )
+        .child(
+            Icon::new(AppIcon::ChevronRight)
+                .small()
+                .color(theme.muted_foreground),
+        )
+        .child(div().w(TARGET_COL_W).child(dropdown.clone()))
+        .into_any_element()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TargetResolution, apply_target_name, reseed_target_columns, resolve_target_name};
+    use crate::migrate_wizard::column_mapping::TableMigrationConfig;
+    use dbflux_core::{TableRef, TransferColumn};
+    use dbflux_transfer::TableMappingMode;
+
+    fn column(name: &str) -> TransferColumn {
+        TransferColumn {
+            name: name.to_string(),
+            type_name: Some("text".to_string()),
+            nullable: true,
+            is_primary_key: false,
+        }
+    }
+
+    fn config_for(source: &[&str]) -> TableMigrationConfig {
+        let source_columns = source.iter().map(|name| column(name)).collect();
+        TableMigrationConfig::new(TableRef::new("users"), source_columns, false, Vec::new())
+    }
+
+    #[test]
+    fn resolve_target_name_matches_existing_tables_exactly_after_trimming() {
+        let existing = vec!["users".to_string(), "orders".to_string()];
+
+        assert_eq!(
+            resolve_target_name("  users  ", &existing),
+            TargetResolution::Existing
+        );
+        assert_eq!(
+            resolve_target_name("brand_new", &existing),
+            TargetResolution::Create
+        );
+        assert_eq!(
+            resolve_target_name("   ", &existing),
+            TargetResolution::Create
+        );
+        assert_eq!(
+            resolve_target_name("Users", &existing),
+            TargetResolution::Create
+        );
+    }
+
+    #[test]
+    fn apply_target_name_with_unknown_name_sets_create_mode() {
+        let mut config = config_for(&["id", "email"]);
+        let existing = vec!["orders".to_string()];
+
+        let resolution = apply_target_name(&mut config, "t_new", &existing);
+
+        assert_eq!(resolution, TargetResolution::Create);
+        assert_eq!(config.mapping_mode, TableMappingMode::Create);
+        assert!(!config.target_exists);
+        assert_eq!(config.target_table, "t_new");
+    }
+
+    #[test]
+    fn apply_target_name_with_existing_name_sets_existing_mode_and_signals_reseed() {
+        let mut config = config_for(&["id", "email"]);
+        let existing = vec!["accounts".to_string()];
+
+        let resolution = apply_target_name(&mut config, "accounts", &existing);
+
+        assert_eq!(resolution, TargetResolution::Existing);
+        assert_eq!(config.mapping_mode, TableMappingMode::Existing);
+        assert!(config.target_exists);
+        assert_eq!(config.target_table, "accounts");
+    }
+
+    #[test]
+    fn reseed_target_columns_reautomaps_and_surfaces_unmatched_source() {
+        let mut config = config_for(&["id", "legacy_x"]);
+        apply_target_name(&mut config, "accounts", &["accounts".to_string()]);
+
+        reseed_target_columns(&mut config, vec![column("id"), column("y")]);
+
+        assert_eq!(config.target_table, "accounts");
+        assert_eq!(config.mapping_mode, TableMappingMode::Existing);
+        assert_eq!(
+            config.unmatched_source_names(),
+            vec!["legacy_x".to_string()]
+        );
+    }
+
+    #[test]
+    fn reseed_as_create_mirrors_source_columns_and_clears_unmatched() {
+        let mut config = config_for(&["id", "email"]);
+        apply_target_name(&mut config, "accounts", &["accounts".to_string()]);
+        reseed_target_columns(&mut config, vec![column("id")]);
+        assert_eq!(config.unmatched_source_names(), vec!["email".to_string()]);
+
+        apply_target_name(&mut config, "fresh_table", &["accounts".to_string()]);
+        let source_columns = config.source_columns.clone();
+        reseed_target_columns(&mut config, source_columns);
+
+        assert_eq!(config.mapping_mode, TableMappingMode::Create);
+        assert!(config.unmatched_source_names().is_empty());
+    }
+
+    #[test]
+    fn drilldown_set_binding_round_trips_through_to_overrides() {
+        let mut config = config_for(&["id", "legacy_x"]);
+        apply_target_name(&mut config, "accounts", &["accounts".to_string()]);
+        reseed_target_columns(&mut config, vec![column("id"), column("y")]);
+        assert_eq!(
+            config.unmatched_source_names(),
+            vec!["legacy_x".to_string()]
+        );
+
+        let source_index = Some(1);
+        config.set_binding(1, source_index);
+
+        assert!(config.unmatched_source_names().is_empty());
+        let overrides = config.to_overrides();
+        assert_eq!(overrides[1].target_column, "y");
+        assert_eq!(overrides[1].source_column, Some("legacy_x".to_string()));
+
+        config.set_binding(1, None);
+        let overrides = config.to_overrides();
+        assert_eq!(overrides[1].source_column, None);
+    }
+}

--- a/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
@@ -39,7 +39,10 @@ use uuid::Uuid;
 use crate::migrate_wizard::column_mapping::{
     TableMigrationConfig, default_mapping_mode, mapping_mode_options,
 };
-use crate::migrate_wizard::phases::MappingRowReadiness;
+use crate::migrate_wizard::phases::{
+    MappingRowPlan, MappingRowReadiness, can_advance_from_tables_mapping,
+    tables_mapping_blocking_errors,
+};
 use crate::migrate_wizard::tree_model::NodeLoad;
 
 const TARGET_COL_W: Pixels = px(220.0);
@@ -140,6 +143,8 @@ struct BindingEditor {
 pub struct MappingPhase {
     app_state: Entity<AppStateEntity>,
     focus_handle: FocusHandle,
+    source_profile_id: Uuid,
+    source_database: String,
     target_profile_id: Uuid,
     target_database: String,
     existing_target_tables: Vec<String>,
@@ -156,6 +161,8 @@ impl MappingPhase {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         app_state: Entity<AppStateEntity>,
+        source_profile_id: Uuid,
+        source_database: String,
         target_profile_id: Uuid,
         target_database: String,
         existing_target_tables: Vec<String>,
@@ -167,6 +174,8 @@ impl MappingPhase {
         let mut phase = Self {
             app_state,
             focus_handle: cx.focus_handle(),
+            source_profile_id,
+            source_database,
             target_profile_id,
             target_database,
             existing_target_tables,
@@ -200,6 +209,38 @@ impl MappingPhase {
                 target_lookup: row.target_lookup.clone(),
             })
             .collect()
+    }
+
+    /// Whether the source and target refer to the same container — the same
+    /// connection and database — so a target table can collide with a source
+    /// table (see [`tables_mapping_blocking_errors`]).
+    fn same_container(&self) -> bool {
+        self.source_profile_id == self.target_profile_id
+            && self.source_database == self.target_database
+    }
+
+    fn row_plans(&self) -> Vec<MappingRowPlan<'_>> {
+        self.rows
+            .iter()
+            .map(|row| MappingRowPlan {
+                source_table: row.config.source_table.name.as_str(),
+                target_schema: row.config.target_schema.as_deref(),
+                target_table: row.config.target_table.as_str(),
+                destructive: row.config.is_destructive(),
+            })
+            .collect()
+    }
+
+    /// Cross-row blocking validation errors (duplicate targets, destructive
+    /// source-as-target collisions) that must prevent advancing.
+    pub fn blocking_errors(&self) -> Vec<String> {
+        tables_mapping_blocking_errors(&self.row_plans(), self.same_container())
+    }
+
+    /// The single guard the host uses for the `TablesMapping` → `Options`
+    /// advance: every row ready AND no blocking cross-row collision.
+    pub fn can_advance(&self) -> bool {
+        can_advance_from_tables_mapping(&self.readiness()) && self.blocking_errors().is_empty()
     }
 
     fn build_rows(
@@ -271,12 +312,24 @@ impl MappingPhase {
         cx: &mut Context<Self>,
     ) {
         let existing = self.existing_target_tables.clone();
+        let supports_truncate = self.supports_truncate;
         let Some(row) = self.rows.get_mut(row_index) else {
             return;
         };
 
         let typed = row.target_input.read(cx).value().to_string();
         let resolution = apply_target_name(&mut row.config, &typed, &existing);
+
+        // `apply_target_name` may reset the mapping mode (Create vs Existing);
+        // keep the row's mode dropdown in lockstep so the grid never shows a
+        // mode different from the one that will actually run.
+        let mode_options = mapping_mode_options(supports_truncate);
+        let selected_mode = mode_options
+            .iter()
+            .position(|(_, mode)| *mode == row.config.mapping_mode);
+        row.mode_dropdown.update(cx, |dropdown, cx| {
+            dropdown.set_selected_index(selected_mode, cx)
+        });
 
         match resolution {
             TargetResolution::Create => {
@@ -498,6 +551,8 @@ impl MappingPhase {
             .map(|(index, row)| self.render_grid_row(index, row, cx))
             .collect();
 
+        let blocking_errors = self.blocking_errors();
+
         div()
             .flex()
             .flex_col()
@@ -515,6 +570,15 @@ impl MappingPhase {
                     .overflow_y_scroll()
                     .children(rows),
             )
+            .when(!blocking_errors.is_empty(), |parent| {
+                parent.child(
+                    div().flex().flex_col().gap(px(2.0)).children(
+                        blocking_errors
+                            .into_iter()
+                            .map(|error| Text::caption(error).danger().into_any_element()),
+                    ),
+                )
+            })
     }
 
     fn render_bulk_toolbar(&self, cx: &mut Context<Self>) -> impl IntoElement {

--- a/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
@@ -223,6 +223,7 @@ impl MappingPhase {
         self.rows
             .iter()
             .map(|row| MappingRowPlan {
+                source_schema: row.config.source_table.schema.as_deref(),
                 source_table: row.config.source_table.name.as_str(),
                 target_schema: row.config.target_schema.as_deref(),
                 target_table: row.config.target_table.as_str(),

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -132,14 +132,17 @@ where
     F: Fn(WizardPhase, &mut Window, &mut App) + Clone + 'static,
 {
     let theme = cx.theme();
-    let accent = theme.accent;
-    let muted = theme.muted_foreground;
+    let colors = RailColors {
+        current: theme.primary,
+        done: theme.success,
+        muted: theme.muted_foreground,
+        hover_bg: theme.secondary,
+    };
     let border = theme.border;
-    let hover_bg = theme.secondary;
 
     let entries = rail_entries(current)
         .into_iter()
-        .map(move |entry| render_rail_entry(entry, accent, muted, hover_bg, on_select.clone()));
+        .map(move |entry| render_rail_entry(entry, colors, on_select.clone()));
 
     div()
         .flex()
@@ -152,13 +155,19 @@ where
         .children(entries)
 }
 
-fn render_rail_entry<F>(
-    entry: RailEntry,
-    accent: Hsla,
+/// The rail's marker/label colors, resolved once per render from the theme.
+/// `current` and `done` use the theme's bright action/success colors (not the
+/// dark `accent`, which is a low-contrast highlight background on dark themes),
+/// so the current phase reads as the most prominent entry.
+#[derive(Clone, Copy)]
+struct RailColors {
+    current: Hsla,
+    done: Hsla,
     muted: Hsla,
     hover_bg: Hsla,
-    on_select: F,
-) -> impl IntoElement
+}
+
+fn render_rail_entry<F>(entry: RailEntry, colors: RailColors, on_select: F) -> impl IntoElement
 where
     F: Fn(WizardPhase, &mut Window, &mut App) + Clone + 'static,
 {
@@ -167,10 +176,14 @@ where
     let marker = if entry.completed {
         Icon::new(AppIcon::CircleCheck)
             .size(px(14.0))
-            .color(accent)
+            .color(colors.done)
             .into_any_element()
     } else {
-        let dot_color = if entry.current { accent } else { muted };
+        let dot_color = if entry.current {
+            colors.current
+        } else {
+            colors.muted
+        };
         div()
             .size(px(8.0)) // guardrail-allow: decorative status-dot diameter, not a spacing token
             .rounded_full()
@@ -178,12 +191,15 @@ where
             .into_any_element()
     };
 
-    // Only the current entry is accented; every other label stays at full
-    // foreground contrast (a check/dot marker already conveys completed vs.
-    // pending), so the rail reads clearly instead of as dim, low-contrast text.
+    // The current entry is the most prominent: bright action color plus a
+    // heavier weight. Every other label stays at full foreground contrast (a
+    // check/dot marker conveys completed vs. pending), so the rail reads
+    // clearly instead of as dim, low-contrast text.
     let mut label = Text::body(phase.label());
     if entry.current {
-        label = label.color(accent);
+        label = label
+            .color(colors.current)
+            .font_weight(FontWeight::SEMIBOLD);
     }
 
     div()
@@ -208,7 +224,7 @@ where
         .child(label)
         .when(entry.completed, |el| {
             el.cursor_pointer()
-                .hover(|style| style.bg(hover_bg))
+                .hover(|style| style.bg(colors.hover_bg))
                 .on_click(move |_event, window, app| on_select(phase, window, app))
         })
 }
@@ -1423,10 +1439,17 @@ impl MigrateWizard {
                 .ok();
         };
 
+        // `flex_1` (not `size_full`): the modal container is a fixed-height
+        // flex column whose first child is the header, so the body must grow
+        // into the *remaining* height. `size_full` (100% height) would instead
+        // push the body to the full container height below the header, and the
+        // container's `overflow_hidden` would then clip the footer off-screen.
         div()
             .flex()
             .flex_col()
-            .size_full()
+            .flex_1()
+            .min_h(px(0.0))
+            .w_full()
             .child(
                 div()
                     .flex()

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -10,6 +10,7 @@
 
 mod column_mapping;
 pub mod mapping;
+pub mod options;
 pub mod phases;
 pub mod source_target;
 pub mod tree_model;

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -27,8 +27,8 @@ use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Text};
 use dbflux_components::tokens::Spacing;
 use dbflux_core::{
-    ColumnInfo, Connection, DriverCapabilities, LogErr, SchemaCacheKey, SchemaForeignKeyInfo,
-    TableInfo, TableRef, TransferColumn, topological_order,
+    ColumnInfo, Connection, DbError, DriverCapabilities, LogErr, SchemaCacheKey,
+    SchemaForeignKeyInfo, TableInfo, TableRef, TransferColumn, topological_order,
 };
 use dbflux_transfer::TableTransferStatus;
 use dbflux_transfer::migration::{MigratedTable, MigrationOptions, MigrationTablePlan};
@@ -44,7 +44,9 @@ pub use column_mapping::TableMigrationConfig;
 use confirm_run::{ConfirmRunEvent, ConfirmRunInputs, ConfirmRunPhase, decide_order};
 use mapping::{MappingChanged, MappingPhase};
 use options::{OptionsChanged, OptionsPhase};
-use phases::{RailEntry, WizardPhase, can_advance_from_tables_mapping, rail_entries};
+use phases::{
+    MappingRowPlan, RailEntry, RunState, WizardPhase, rail_entries, tables_mapping_confirm_warnings,
+};
 use source_target::{SourceTargetChanged, SourceTargetPhase};
 
 /// Whether an `Err(String)` returned by one of the shared
@@ -208,12 +210,12 @@ where
 }
 
 /// Outcome of fetching one table's details through the shared
-/// `prepare_fetch_table_details` seam. `NotFound` covers both a
-/// driver-reported lookup failure (the common "target table does not exist
-/// yet" case) and any other execute-time error — the caller decides whether
-/// that is fatal (source tables must already exist) or an expected signal
-/// (target tables may not exist yet, see [`TableMigrationConfig::new`]'s
-/// `target_exists` flag).
+/// `prepare_fetch_table_details` seam. `NotFound` maps only a genuine
+/// driver-reported "object does not exist" (`DbError::ObjectNotFound`) — the
+/// expected "target table will be created" signal, see
+/// [`TableMigrationConfig::new`]'s `target_exists` flag. Any other
+/// execute-time failure is returned as a real error so a transient fetch
+/// failure is never silently classified as "will be created".
 enum TableDetailsFetch {
     Found(TableInfo),
     NotFound(String),
@@ -250,7 +252,12 @@ async fn fetch_table_details_via_seam(
                 .update(|cx| {
                     app_state
                         .read(cx)
-                        .get_table_details(profile_id, database, &table_ref.name)
+                        .get_table_details(
+                            profile_id,
+                            database,
+                            table_ref.schema.as_deref(),
+                            &table_ref.name,
+                        )
                         .cloned()
                 })
                 .map_err(|e| e.to_string())?;
@@ -277,12 +284,14 @@ async fn fetch_table_details_via_seam(
                     state.set_table_details(
                         result.profile_id,
                         result.database.clone(),
+                        result.schema.clone(),
                         result.table.clone(),
                         result.details,
                     );
                     state.set_dependents(
                         result.profile_id,
                         result.database,
+                        result.schema,
                         result.table,
                         result.dependents,
                     );
@@ -291,7 +300,10 @@ async fn fetch_table_details_via_seam(
             .map_err(|e| e.to_string())?;
             Ok(TableDetailsFetch::Found(details))
         }
-        Err(e) => Ok(TableDetailsFetch::NotFound(e)),
+        Err(error @ DbError::ObjectNotFound(_)) => {
+            Ok(TableDetailsFetch::NotFound(error.to_string()))
+        }
+        Err(error) => Err(error.to_string()),
     }
 }
 
@@ -449,6 +461,20 @@ pub struct MigrateWizard {
     error: Option<String>,
     advancing: bool,
 
+    /// Monotonic epoch bumped whenever the inputs an in-flight advance was
+    /// spawned against are invalidated (selection/mapping/options edits,
+    /// re-open). Each advance spawn captures the value at spawn time and
+    /// discards its result if the epoch moved — a stale completion must never
+    /// mount a phase built from abandoned inputs or force a phase jump.
+    generation: u64,
+
+    /// The effective Source & Target selection (checked tables + target
+    /// container) the downstream phases were last built from. Used to ignore
+    /// no-op `SourceTargetChanged` events (re-selecting the same target,
+    /// toggling a check off and back on) so mapping/options work is only
+    /// discarded on a real change.
+    built_selection: Option<(Vec<TableRef>, Uuid, String)>,
+
     /// The phase whose child tree/grid currently holds keyboard focus. Drives
     /// the render-time focus routing so the active phase receives arrow-key
     /// focus on entry without a click-in first (keyboard-first identity).
@@ -485,6 +511,8 @@ impl MigrateWizard {
             phase: WizardPhase::SourceTarget,
             error: None,
             advancing: false,
+            generation: 0,
+            built_selection: None,
             focused_phase: None,
             resolved_source_database: None,
             target_profile_id: None,
@@ -514,6 +542,18 @@ impl MigrateWizard {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // A migration already in flight owns the wizard until it terminates.
+        // Re-entering would drop the run's owner (orphaning its task and
+        // progress) and could start a second concurrent migration, so instead
+        // surface the in-progress run and ignore the new request.
+        if self.is_running(cx) {
+            self.visible = true;
+            self.phase = WizardPhase::Run;
+            self.focus_handle.focus(window);
+            cx.notify();
+            return;
+        }
+
         self.visible = true;
         self.source_profile_id = Some(source_profile_id);
         self.source_database = source_database.clone();
@@ -521,6 +561,8 @@ impl MigrateWizard {
         self.phase = WizardPhase::SourceTarget;
         self.error = None;
         self.advancing = false;
+        self.generation = self.generation.wrapping_add(1);
+        self.built_selection = None;
         self.focused_phase = None;
 
         self.resolved_source_database = None;
@@ -565,26 +607,78 @@ impl MigrateWizard {
 
     /// A changed source selection or target container invalidates every
     /// downstream phase — the mapping configs, the options' capability
-    /// gating, and the confirm/run plan all derive from it.
+    /// gating, and the confirm/run plan all derive from it. Invalidation is
+    /// deferred to the next advance (see [`Self::advance_from_source_target`])
+    /// so a no-op round trip — a check toggled off and back on, the same
+    /// target re-selected — never discards the user's mapping/options work.
+    /// A real deviation still orphans any in-flight advance immediately: its
+    /// result was spawned against inputs that no longer hold.
     fn on_source_target_changed(&mut self, cx: &mut Context<Self>) {
-        self.mapping = None;
-        self._mapping_sub = None;
-        self.options = None;
-        self._options_sub = None;
-        self.confirm_run = None;
-        self._confirm_run_sub = None;
+        // A live run owns the wizard; a late tree-fetch completion must not
+        // disturb it (and there is nothing downstream to rebuild).
+        if self.is_running(cx) {
+            return;
+        }
+        if !self.selection_matches_built(cx) {
+            self.invalidate_in_flight_advance();
+        }
         cx.notify();
+    }
+
+    /// Whether the confirm/run phase currently owns a migration in the
+    /// `Running` state. Drives the guards that keep the run's owner alive and
+    /// the rail frozen on `Run` for the duration of the run.
+    fn is_running(&self, cx: &App) -> bool {
+        self.confirm_run
+            .as_ref()
+            .is_some_and(|phase| phase.read(cx).run_state() == RunState::Running)
+    }
+
+    /// Whether the Source & Target phase's current effective selection equals
+    /// the one the downstream phases were built from.
+    fn selection_matches_built(&self, cx: &App) -> bool {
+        let Some((built_tables, built_profile_id, built_database)) = self.built_selection.as_ref()
+        else {
+            return false;
+        };
+        let Some(source_target) = self.source_target.as_ref() else {
+            return false;
+        };
+
+        let phase = source_target.read(cx);
+        phase.checked_source_tables() == *built_tables
+            && phase.target_profile_id() == Some(*built_profile_id)
+            && phase.target_database().as_deref() == Some(built_database.as_str())
+    }
+
+    /// Orphans any in-flight advance spawn: bumping the generation makes its
+    /// completion discard itself, and the footer stops showing "Loading…" for
+    /// work whose inputs no longer exist.
+    fn invalidate_in_flight_advance(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.advancing = false;
     }
 
     /// Edited mappings only invalidate the confirm/run plan and its FK order;
     /// the options phase is independent of the per-table mapping.
     fn on_mapping_changed(&mut self, cx: &mut Context<Self>) {
+        // Never drop the confirm/run phase while it owns a live run — that
+        // would orphan the migration. Edits are impossible during a run anyway
+        // (the rail is frozen on Run), but a late async reseed could still emit.
+        if self.is_running(cx) {
+            return;
+        }
+        self.invalidate_in_flight_advance();
         self.confirm_run = None;
         self._confirm_run_sub = None;
         cx.notify();
     }
 
     fn on_options_changed(&mut self, cx: &mut Context<Self>) {
+        if self.is_running(cx) {
+            return;
+        }
+        self.invalidate_in_flight_advance();
         self.confirm_run = None;
         self._confirm_run_sub = None;
         cx.notify();
@@ -612,15 +706,19 @@ impl MigrateWizard {
         })
     }
 
-    fn resolve_target_connection(&self, profile_id: Uuid, cx: &App) -> Option<Arc<dyn Connection>> {
-        Some(
-            self.app_state
-                .read(cx)
-                .connections()
-                .get(&profile_id)?
-                .connection
-                .clone(),
-        )
+    /// Resolves the target connection scoped to the chosen target database
+    /// (for `ConnectionPerDatabase` drivers), mirroring
+    /// [`Self::resolve_source_connection`] and the import wizard — the
+    /// profile's primary connection may be bound to a different database, and
+    /// the sink would silently write the migrated rows there.
+    fn resolve_target_connection(
+        &self,
+        profile_id: Uuid,
+        target_database: &str,
+        cx: &App,
+    ) -> Option<Arc<dyn Connection>> {
+        let connected = self.app_state.read(cx).connections().get(&profile_id)?;
+        Some(connected.connection_for_database(target_database))
     }
 
     /// A human-readable `profile / database` label for the Confirm summary.
@@ -643,6 +741,11 @@ impl MigrateWizard {
     /// Back-navigation from the rail: only ever returns to an already-passed
     /// phase, keeping the downstream entities intact so re-advancing is free.
     fn go_to_phase(&mut self, phase: WizardPhase, cx: &mut Context<Self>) {
+        // The rail is frozen on `Run` while a migration is live: navigating
+        // back would drop the run's owner and orphan the in-flight task.
+        if self.phase == WizardPhase::Run && self.is_running(cx) {
+            return;
+        }
         if phase < self.phase {
             self.phase = phase;
             cx.notify();
@@ -657,11 +760,11 @@ impl MigrateWizard {
             WizardPhase::SourceTarget => self
                 .source_target
                 .as_ref()
-                .is_some_and(|phase| phase.read(cx).is_ready()),
+                .is_some_and(|phase| phase.read(cx).is_ready(cx)),
             WizardPhase::TablesMapping => self
                 .mapping
                 .as_ref()
-                .is_some_and(|phase| can_advance_from_tables_mapping(&phase.read(cx).readiness())),
+                .is_some_and(|phase| phase.read(cx).can_advance()),
             WizardPhase::Options => true,
             WizardPhase::Confirm | WizardPhase::Run => false,
         }
@@ -697,7 +800,7 @@ impl MigrateWizard {
             return;
         };
         let source_target = source_target.read(cx);
-        if !source_target.is_ready() {
+        if !source_target.is_ready(cx) {
             return;
         }
 
@@ -721,7 +824,9 @@ impl MigrateWizard {
             );
             return;
         };
-        let Some(target_connection) = self.resolve_target_connection(target_profile_id, cx) else {
+        let Some(target_connection) =
+            self.resolve_target_connection(target_profile_id, &target_database, cx)
+        else {
             self.report_advance_error(
                 ErrorKind::Storage,
                 "No active connection for the target profile",
@@ -747,6 +852,20 @@ impl MigrateWizard {
         self.supports_disable_ri =
             target_connection.supports(DriverCapabilities::DISABLE_FK_CHECKS);
 
+        // Deferred invalidation of downstream phases: only a selection that
+        // actually differs from the one they were built from discards them —
+        // a no-op round trip through the trees keeps the mapping work intact.
+        let new_selection = (checked.clone(), target_profile_id, target_database.clone());
+        if self.built_selection.as_ref() != Some(&new_selection) {
+            self.mapping = None;
+            self._mapping_sub = None;
+            self.options = None;
+            self._options_sub = None;
+            self.confirm_run = None;
+            self._confirm_run_sub = None;
+        }
+        self.built_selection = Some(new_selection);
+
         if self.mapping.is_some() {
             self.phase = WizardPhase::TablesMapping;
             cx.notify();
@@ -761,6 +880,8 @@ impl MigrateWizard {
         let supports_truncate = self.supports_truncate;
         let list_connection = Arc::clone(&target_connection);
         let list_database = target_database.clone();
+        let mapping_source_database = source_database.clone();
+        let generation = self.generation;
 
         cx.spawn_in(window, async move |this, cx| {
             let configs = build_configs_via_seam(
@@ -780,6 +901,10 @@ impl MigrateWizard {
                 .await;
 
             this.update_in(cx, |this, window, cx| {
+                if this.generation != generation {
+                    return;
+                }
+
                 this.advancing = false;
                 match configs {
                     Ok(configs) => {
@@ -800,6 +925,8 @@ impl MigrateWizard {
                             configs,
                             existing_target_tables,
                             supports_truncate,
+                            source_profile_id,
+                            mapping_source_database,
                             target_profile_id,
                             target_database,
                             window,
@@ -828,6 +955,8 @@ impl MigrateWizard {
         configs: Vec<TableMigrationConfig>,
         existing_target_tables: Vec<String>,
         supports_truncate: bool,
+        source_profile_id: Uuid,
+        source_database: String,
         target_profile_id: Uuid,
         target_database: String,
         window: &mut Window,
@@ -837,6 +966,8 @@ impl MigrateWizard {
         let mapping = cx.new(|cx| {
             MappingPhase::new(
                 app_state,
+                source_profile_id,
+                source_database,
                 target_profile_id,
                 target_database,
                 existing_target_tables,
@@ -858,7 +989,7 @@ impl MigrateWizard {
         let Some(mapping) = self.mapping.as_ref() else {
             return;
         };
-        if !can_advance_from_tables_mapping(&mapping.read(cx).readiness()) {
+        if !mapping.read(cx).can_advance() {
             return;
         }
 
@@ -917,7 +1048,9 @@ impl MigrateWizard {
             );
             return;
         };
-        let Some(target_connection) = self.resolve_target_connection(target_profile_id, cx) else {
+        let Some(target_connection) =
+            self.resolve_target_connection(target_profile_id, &target_database, cx)
+        else {
             self.report_advance_error(
                 ErrorKind::Storage,
                 "No active connection for the target profile",
@@ -936,6 +1069,25 @@ impl MigrateWizard {
         let source_container_label = self.container_label(source_profile_id, &source_database, cx);
         let target_container_label = self.container_label(target_profile_id, &target_database, cx);
 
+        // A non-destructive row whose target is one of the source tables in the
+        // same container appends into a table that is also being read; that is
+        // allowed but worth flagging on the Confirm screen (the destructive
+        // variant is already blocked at the mapping step, LD-14).
+        let same_container =
+            source_profile_id == target_profile_id && source_database == target_database;
+        let pre_run_warnings = {
+            let plans: Vec<MappingRowPlan> = configs
+                .iter()
+                .map(|config| MappingRowPlan {
+                    source_table: config.source_table.name.as_str(),
+                    target_schema: config.target_schema.as_deref(),
+                    target_table: config.target_table.as_str(),
+                    destructive: config.is_destructive(),
+                })
+                .collect();
+            tables_mapping_confirm_warnings(&plans, same_container)
+        };
+
         let table_refs: Vec<TableRef> = configs.iter().map(|c| c.source_table.clone()).collect();
         let mut schemas: Vec<Option<String>> =
             table_refs.iter().map(|t| t.schema.clone()).collect();
@@ -947,6 +1099,7 @@ impl MigrateWizard {
         cx.notify();
 
         let app_state = self.app_state.clone();
+        let generation = self.generation;
 
         cx.spawn(async move |this, cx| {
             let mut foreign_keys: Vec<SchemaForeignKeyInfo> = Vec::new();
@@ -979,6 +1132,10 @@ impl MigrateWizard {
             };
 
             this.update(cx, |this, cx| {
+                if this.generation != generation {
+                    return;
+                }
+
                 this.advancing = false;
                 match order_result {
                     Ok(order) => {
@@ -995,6 +1152,7 @@ impl MigrateWizard {
                             disable_referential_integrity,
                             order: decide_order(order),
                             configs,
+                            pre_run_warnings,
                         };
                         this.mount_confirm_run(inputs, cx);
                         this.phase = WizardPhase::Confirm;

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -21,8 +21,8 @@ use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::Text;
 use dbflux_components::tokens::Spacing;
 use dbflux_core::{
-    Connection, DriverCapabilities, SchemaForeignKeyInfo, TableRef, TaskId, TaskKind, TaskStatus,
-    TaskTarget, TransferColumn, topological_order,
+    ColumnInfo, Connection, DriverCapabilities, SchemaCacheKey, SchemaForeignKeyInfo, TableInfo,
+    TableRef, TaskId, TaskKind, TaskStatus, TaskTarget, TransferColumn, topological_order,
 };
 use dbflux_transfer::TableTransferStatus;
 use dbflux_transfer::migration::{
@@ -38,6 +38,226 @@ use uuid::Uuid;
 
 pub use column_mapping::TableMigrationConfig;
 use column_mapping::mapping_mode_options;
+
+/// Whether an `Err(String)` returned by one of the shared
+/// `AppStateEntity::prepare_fetch_*` seams means "the data is already cached"
+/// rather than a real failure — mirrors the sidebar's `spawn_fetch_*`
+/// handling (`crates/dbflux_ui_sidebar/src/table_loading.rs`), where the same
+/// sentinel strings gate whether to report an error or simply proceed with
+/// what is already cached.
+fn is_already_cached_sentinel(error: &str) -> bool {
+    matches!(
+        error,
+        "Table details already cached" | "Schema foreign keys already cached"
+    )
+}
+
+/// Converts driver-reported column metadata into the transfer engine's
+/// column shape — identical to the wizard's original inline conversion.
+fn to_transfer_columns(columns: Vec<ColumnInfo>) -> Vec<TransferColumn> {
+    columns
+        .into_iter()
+        .map(|c| TransferColumn {
+            name: c.name,
+            type_name: Some(c.type_name),
+            nullable: c.nullable,
+            is_primary_key: c.is_primary_key,
+        })
+        .collect()
+}
+
+/// Assembles the engine's per-table migration plans from the wizard's
+/// adjustable [`TableMigrationConfig`] rows — the same field mapping the
+/// wizard previously built inline in `start_migration`, extracted here so
+/// it is unit-testable without a live wizard entity or GPUI context.
+fn build_migration_table_plans<'a>(
+    configs: impl IntoIterator<Item = &'a TableMigrationConfig>,
+) -> Vec<MigrationTablePlan> {
+    configs
+        .into_iter()
+        .map(|config| MigrationTablePlan {
+            source_table: config.source_table.clone(),
+            source_columns: config.source_columns.clone(),
+            target_schema: config.target_schema.clone(),
+            target_table: config.target_table.clone(),
+            mapping_mode: config.mapping_mode,
+            column_overrides: Some(config.to_overrides()),
+            estimated_total: None,
+        })
+        .collect()
+}
+
+/// Assembles [`MigrationOptions`] from the wizard's resolved run settings.
+/// `target_database` is taken as an explicit parameter (rather than
+/// re-derived from a live connection here) so a future target-container
+/// picker can feed it directly without this function changing shape.
+#[allow(clippy::too_many_arguments)]
+fn build_migration_options(
+    segment_size: u32,
+    source_database: String,
+    target_database: String,
+    destructive_confirmed: bool,
+    disable_referential_integrity: bool,
+    manual_order: Option<Vec<TableRef>>,
+) -> MigrationOptions {
+    MigrationOptions {
+        segment_size,
+        source_database,
+        target_database,
+        destructive_confirmed,
+        disable_referential_integrity,
+        manual_order,
+    }
+}
+
+/// Outcome of fetching one table's details through the shared
+/// `prepare_fetch_table_details` seam. `NotFound` covers both a
+/// driver-reported lookup failure (the common "target table does not exist
+/// yet" case) and any other execute-time error — the caller decides whether
+/// that is fatal (source tables must already exist) or an expected signal
+/// (target tables may not exist yet, see [`TableMigrationConfig::new`]'s
+/// `target_exists` flag).
+enum TableDetailsFetch {
+    Found(TableInfo),
+    NotFound(String),
+}
+
+/// Reads (or fetches, on the background executor) one table's details
+/// through the shared `AppStateEntity::prepare_fetch_table_details` seam,
+/// treating the "already cached" sentinel as success by reading the already
+/// populated `ConnectedProfile` cache instead of re-fetching — mirrors the
+/// sidebar's `spawn_fetch_table_details` (Reuse Audit: replaces the wizard's
+/// former bespoke `Connection::table_details` closure).
+async fn fetch_table_details_via_seam(
+    app_state: &Entity<AppStateEntity>,
+    profile_id: Uuid,
+    database: &str,
+    table_ref: &TableRef,
+    cx: &mut AsyncApp,
+) -> Result<TableDetailsFetch, String> {
+    let prepared = cx
+        .update(|cx| {
+            app_state.read(cx).prepare_fetch_table_details(
+                profile_id,
+                database,
+                table_ref.schema.as_deref(),
+                &table_ref.name,
+            )
+        })
+        .map_err(|e| e.to_string())?;
+
+    let params = match prepared {
+        Ok(params) => params,
+        Err(e) if is_already_cached_sentinel(&e) => {
+            let cached = cx
+                .update(|cx| {
+                    app_state
+                        .read(cx)
+                        .get_table_details(profile_id, database, &table_ref.name)
+                        .cloned()
+                })
+                .map_err(|e| e.to_string())?;
+            return Ok(match cached {
+                Some(info) => TableDetailsFetch::Found(info),
+                None => TableDetailsFetch::NotFound(
+                    "Table details reported as cached but the cache was empty".to_string(),
+                ),
+            });
+        }
+        Err(e) => return Err(e),
+    };
+
+    let execute_result = cx
+        .background_executor()
+        .spawn(async move { params.execute() })
+        .await;
+
+    match execute_result {
+        Ok(result) => {
+            let details = result.details.clone();
+            cx.update(|cx| {
+                app_state.update(cx, |state, _| {
+                    state.set_table_details(
+                        result.profile_id,
+                        result.database.clone(),
+                        result.table.clone(),
+                        result.details,
+                    );
+                    state.set_dependents(
+                        result.profile_id,
+                        result.database,
+                        result.table,
+                        result.dependents,
+                    );
+                });
+            })
+            .map_err(|e| e.to_string())?;
+            Ok(TableDetailsFetch::Found(details))
+        }
+        Err(e) => Ok(TableDetailsFetch::NotFound(e)),
+    }
+}
+
+/// Reads (or fetches, on the background executor) one schema's foreign keys
+/// through the shared `AppStateEntity::prepare_fetch_schema_foreign_keys`
+/// seam, treating the "already cached" sentinel as success by reading the
+/// already populated `ConnectedProfile` cache — mirrors
+/// [`fetch_table_details_via_seam`]. Replaces the wizard's former
+/// synchronous foreground `Connection::schema_foreign_keys` call.
+async fn fetch_schema_foreign_keys_via_seam(
+    app_state: &Entity<AppStateEntity>,
+    profile_id: Uuid,
+    database: &str,
+    schema: Option<&str>,
+    cx: &mut AsyncApp,
+) -> Result<Vec<SchemaForeignKeyInfo>, String> {
+    let prepared = cx
+        .update(|cx| {
+            app_state
+                .read(cx)
+                .prepare_fetch_schema_foreign_keys(profile_id, database, schema)
+        })
+        .map_err(|e| e.to_string())?;
+
+    let params = match prepared {
+        Ok(params) => params,
+        Err(e) if is_already_cached_sentinel(&e) => {
+            let key = SchemaCacheKey::new(database, schema.map(str::to_string));
+            return cx
+                .update(|cx| {
+                    app_state
+                        .read(cx)
+                        .connections()
+                        .get(&profile_id)
+                        .and_then(|connected| connected.schema_foreign_keys.get(&key))
+                        .cloned()
+                        .unwrap_or_default()
+                })
+                .map_err(|e| e.to_string());
+        }
+        Err(e) => return Err(e),
+    };
+
+    let execute_result = cx
+        .background_executor()
+        .spawn(async move { params.execute() })
+        .await?;
+
+    let foreign_keys = execute_result.foreign_keys.clone();
+    cx.update(|cx| {
+        app_state.update(cx, |state, _| {
+            state.set_schema_foreign_keys(
+                execute_result.profile_id,
+                execute_result.database,
+                execute_result.schema,
+                execute_result.foreign_keys,
+            );
+        });
+    })
+    .map_err(|e| e.to_string())?;
+
+    Ok(foreign_keys)
+}
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum WizardStep {
@@ -254,6 +474,11 @@ impl MigrateWizard {
             cx.notify();
             return;
         };
+        let Some(source_profile_id) = self.source_profile_id else {
+            self.error = Some("No active connection for the source profile".to_string());
+            cx.notify();
+            return;
+        };
         let Some(source_connection) = self.resolve_source_connection(cx) else {
             self.error = Some("No active connection for the source profile".to_string());
             cx.notify();
@@ -279,71 +504,67 @@ impl MigrateWizard {
         self.error = None;
         cx.notify();
 
+        let app_state = self.app_state.clone();
+
         cx.spawn(async move |this, cx| {
-            let build_result = cx
-                .background_executor()
-                .spawn(async move {
-                    let mut configs = Vec::with_capacity(source_tables.len());
-                    for table_ref in &source_tables {
-                        let source_columns: Vec<TransferColumn> = source_connection
-                            .table_details(
-                                &source_database,
-                                table_ref.schema.as_deref(),
-                                &table_ref.name,
-                            )
-                            .map_err(|e| format!("{}: {e}", table_ref.qualified_name()))?
-                            .columns
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(|c| TransferColumn {
-                                name: c.name,
-                                type_name: Some(c.type_name),
-                                nullable: c.nullable,
-                                is_primary_key: c.is_primary_key,
-                            })
-                            .collect();
+            let mut configs = Vec::with_capacity(source_tables.len());
+            let mut build_error: Option<String> = None;
 
-                        let target_lookup = target_connection.table_details(
-                            &target_database,
-                            table_ref.schema.as_deref(),
-                            &table_ref.name,
-                        );
-                        let target_exists = target_lookup.is_ok();
-                        let target_columns = target_lookup
-                            .ok()
-                            .and_then(|info| info.columns)
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(|c| TransferColumn {
-                                name: c.name,
-                                type_name: Some(c.type_name),
-                                nullable: c.nullable,
-                                is_primary_key: c.is_primary_key,
-                            })
-                            .collect::<Vec<_>>();
-
-                        configs.push(TableMigrationConfig::new(
-                            table_ref.clone(),
-                            source_columns,
-                            target_exists,
-                            target_columns,
-                        ));
-                    }
-
-                    Ok::<Vec<TableMigrationConfig>, String>(configs)
-                })
+            for table_ref in &source_tables {
+                let source_details = fetch_table_details_via_seam(
+                    &app_state,
+                    source_profile_id,
+                    &source_database,
+                    table_ref,
+                    cx,
+                )
                 .await;
+                let source_info = match source_details {
+                    Ok(TableDetailsFetch::Found(info)) => info,
+                    Ok(TableDetailsFetch::NotFound(e)) | Err(e) => {
+                        build_error = Some(format!("{}: {e}", table_ref.qualified_name()));
+                        break;
+                    }
+                };
+                let source_columns = to_transfer_columns(source_info.columns.unwrap_or_default());
+
+                let target_details = fetch_table_details_via_seam(
+                    &app_state,
+                    target_profile_id,
+                    &target_database,
+                    table_ref,
+                    cx,
+                )
+                .await;
+                let (target_exists, target_columns) = match target_details {
+                    Ok(TableDetailsFetch::Found(info)) => {
+                        (true, to_transfer_columns(info.columns.unwrap_or_default()))
+                    }
+                    Ok(TableDetailsFetch::NotFound(_)) => (false, Vec::new()),
+                    Err(e) => {
+                        build_error = Some(format!("{}: {e}", table_ref.qualified_name()));
+                        break;
+                    }
+                };
+
+                configs.push(TableMigrationConfig::new(
+                    table_ref.clone(),
+                    source_columns,
+                    target_exists,
+                    target_columns,
+                ));
+            }
 
             this.update(cx, |this, cx| {
                 this.loading = false;
-                match build_result {
-                    Ok(configs) => {
+                match build_error {
+                    None => {
                         this.supports_truncate = supports_truncate;
                         this.supports_disable_ri = supports_disable_ri;
                         this.build_rows(configs, cx);
                         this.step = WizardStep::Configure;
                     }
-                    Err(e) => {
+                    Some(e) => {
                         this.error = Some(format!("Could not read table schema: {e}"));
                     }
                 }
@@ -467,6 +688,11 @@ impl MigrateWizard {
     /// transitions to `ReorderCycle` instead of proceeding — the caller must
     /// never guess an order across a cyclic FK graph (R6).
     fn continue_from_configure(&mut self, cx: &mut Context<Self>) {
+        let Some(source_profile_id) = self.source_profile_id else {
+            self.error = Some("No active connection for the source profile".to_string());
+            cx.notify();
+            return;
+        };
         let Some(source_connection) = self.resolve_source_connection(cx) else {
             self.error = Some("No active connection for the source profile".to_string());
             cx.notify();
@@ -489,33 +715,63 @@ impl MigrateWizard {
         schemas.sort();
         schemas.dedup();
 
-        let mut fks: Vec<SchemaForeignKeyInfo> = Vec::new();
-        for schema in schemas {
-            match source_connection.schema_foreign_keys(&source_database, schema.as_deref()) {
-                Ok(batch) => fks.extend(batch),
-                Err(e) => {
-                    self.error = Some(format!("Could not read foreign keys: {e}"));
-                    cx.notify();
-                    return;
+        self.error = None;
+        cx.notify();
+
+        let app_state = self.app_state.clone();
+
+        cx.spawn(async move |this, cx| {
+            let mut fks: Vec<SchemaForeignKeyInfo> = Vec::new();
+            let mut fetch_error: Option<String> = None;
+
+            for schema in &schemas {
+                match fetch_schema_foreign_keys_via_seam(
+                    &app_state,
+                    source_profile_id,
+                    &source_database,
+                    schema.as_deref(),
+                    cx,
+                )
+                .await
+                {
+                    Ok(batch) => fks.extend(batch),
+                    Err(e) => {
+                        fetch_error = Some(e);
+                        break;
+                    }
                 }
             }
-        }
 
-        match topological_order(&table_refs, &fks) {
-            dbflux_core::OrderResult::Ordered(order) => {
-                self.final_order = Some(order);
-                self.advance_past_ordering(cx);
-            }
-            dbflux_core::OrderResult::Cyclic {
-                ordered_prefix,
-                cycle,
-            } => {
-                self.cyclic_prefix = ordered_prefix;
-                self.reorder_list = cycle;
-                self.step = WizardStep::ReorderCycle;
-                cx.notify();
-            }
-        }
+            let order_result = match fetch_error {
+                Some(e) => Err(e),
+                None => Ok(cx
+                    .background_executor()
+                    .spawn(async move { topological_order(&table_refs, &fks) })
+                    .await),
+            };
+
+            this.update(cx, |this, cx| match order_result {
+                Ok(dbflux_core::OrderResult::Ordered(order)) => {
+                    this.final_order = Some(order);
+                    this.advance_past_ordering(cx);
+                }
+                Ok(dbflux_core::OrderResult::Cyclic {
+                    ordered_prefix,
+                    cycle,
+                }) => {
+                    this.cyclic_prefix = ordered_prefix;
+                    this.reorder_list = cycle;
+                    this.step = WizardStep::ReorderCycle;
+                    cx.notify();
+                }
+                Err(e) => {
+                    this.error = Some(format!("Could not read foreign keys: {e}"));
+                    cx.notify();
+                }
+            })
+            .ok();
+        })
+        .detach();
     }
 
     fn move_reorder_row(&mut self, index: usize, delta: isize, cx: &mut Context<Self>) {
@@ -586,19 +842,7 @@ impl MigrateWizard {
         let target_database = target_connection.active_database().unwrap_or_default();
         let manual_order = self.final_order.clone();
 
-        let plans: Vec<MigrationTablePlan> = self
-            .rows
-            .iter()
-            .map(|row| MigrationTablePlan {
-                source_table: row.config.source_table.clone(),
-                source_columns: row.config.source_columns.clone(),
-                target_schema: row.config.target_schema.clone(),
-                target_table: row.config.target_table.clone(),
-                mapping_mode: row.config.mapping_mode,
-                column_overrides: Some(row.config.to_overrides()),
-                estimated_total: None,
-            })
-            .collect();
+        let plans = build_migration_table_plans(self.rows.iter().map(|row| &row.config));
         let destructive_confirmed = self.confirmed_destructive;
         let disable_referential_integrity = self.disable_ri && self.supports_disable_ri;
 
@@ -670,14 +914,14 @@ impl MigrateWizard {
             let migration_result = cx
                 .background_executor()
                 .spawn(async move {
-                    let options = MigrationOptions {
-                        segment_size: 500,
+                    let options = build_migration_options(
+                        500,
                         source_database,
                         target_database,
                         destructive_confirmed,
                         disable_referential_integrity,
                         manual_order,
-                    };
+                    );
 
                     run_migration(
                         &source_connection,
@@ -1097,5 +1341,114 @@ impl MigrateWizard {
                     .on_click(cx.listener(|this, _, _, cx| this.close(cx))),
             )
             .into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        TableMigrationConfig, build_migration_options, build_migration_table_plans,
+        is_already_cached_sentinel,
+    };
+    use dbflux_core::{TableRef, TransferColumn};
+
+    fn transfer_column(name: &str) -> TransferColumn {
+        TransferColumn {
+            name: name.to_string(),
+            type_name: Some("text".to_string()),
+            nullable: true,
+            is_primary_key: false,
+        }
+    }
+
+    #[test]
+    fn is_already_cached_sentinel_matches_only_the_known_sentinel_strings() {
+        assert!(is_already_cached_sentinel("Table details already cached"));
+        assert!(is_already_cached_sentinel(
+            "Schema foreign keys already cached"
+        ));
+        assert!(!is_already_cached_sentinel("Profile not connected"));
+        assert!(!is_already_cached_sentinel(""));
+    }
+
+    #[test]
+    fn build_migration_table_plans_maps_every_config_field_and_defaults_estimate_to_none() {
+        let source_columns = vec![transfer_column("id"), transfer_column("legacy_x")];
+        let target_columns = vec![transfer_column("id"), transfer_column("y")];
+        let mut config = TableMigrationConfig::new(
+            TableRef::new("users"),
+            source_columns.clone(),
+            true,
+            target_columns,
+        );
+        config.target_schema = Some("public".to_string());
+        config.set_binding(1, Some(1));
+        let expected_overrides = config.to_overrides();
+
+        let plans = build_migration_table_plans(std::slice::from_ref(&config));
+
+        assert_eq!(plans.len(), 1);
+        let plan = &plans[0];
+        assert_eq!(plan.source_table, config.source_table);
+        assert_eq!(plan.source_columns, source_columns);
+        assert_eq!(plan.target_schema, Some("public".to_string()));
+        assert_eq!(plan.target_table, config.target_table);
+        assert_eq!(plan.mapping_mode, config.mapping_mode);
+        assert_eq!(plan.column_overrides, Some(expected_overrides));
+        assert_eq!(plan.estimated_total, None);
+    }
+
+    #[test]
+    fn build_migration_table_plans_assembles_one_plan_per_config_in_order() {
+        let users = TableMigrationConfig::new(
+            TableRef::new("users"),
+            vec![transfer_column("id")],
+            true,
+            vec![transfer_column("id")],
+        );
+        let orders = TableMigrationConfig::new(
+            TableRef::new("orders"),
+            vec![transfer_column("id")],
+            false,
+            Vec::new(),
+        );
+        let configs = vec![users, orders];
+
+        let plans = build_migration_table_plans(&configs);
+
+        assert_eq!(plans.len(), 2);
+        assert_eq!(plans[0].target_table, "users");
+        assert_eq!(plans[1].target_table, "orders");
+    }
+
+    #[test]
+    fn build_migration_options_maps_every_field_including_target_database() {
+        let options = build_migration_options(
+            500,
+            "source_db".to_string(),
+            "target_db".to_string(),
+            true,
+            false,
+            Some(vec![TableRef::new("a"), TableRef::new("b")]),
+        );
+
+        assert_eq!(options.segment_size, 500);
+        assert_eq!(options.source_database, "source_db");
+        assert_eq!(options.target_database, "target_db");
+        assert!(options.destructive_confirmed);
+        assert!(!options.disable_referential_integrity);
+        assert_eq!(
+            options.manual_order,
+            Some(vec![TableRef::new("a"), TableRef::new("b")])
+        );
+    }
+
+    #[test]
+    fn build_migration_options_with_no_manual_order_leaves_it_none() {
+        let options =
+            build_migration_options(250, "src".to_string(), "dst".to_string(), false, true, None);
+
+        assert_eq!(options.manual_order, None);
+        assert!(options.disable_referential_integrity);
     }
 }

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -1,12 +1,16 @@
-//! T27 — Migrate wizard: pick a connected, transfer-compatible target
-//! connection, review/adjust each table's target-table handling and column
-//! mapping (mirroring the Import wizard's T22 review step), resolve FK load
-//! order (R6) — surfacing a manual-reorder step on a cycle instead of
-//! guessing — confirm any destructive plan, then run the migration via
-//! `dbflux_transfer::migration::run_migration`.
+//! Migrate wizard: a five-phase flow (Source & Target → Tables Mapping →
+//! Options → Confirm → Run) rendered inside a large, vertically centered
+//! modal with a left phase rail. Each phase is a self-contained child
+//! entity; this module owns the [`WizardPhase`] state machine that mounts
+//! them, resolves the source/target connections and metadata between phases
+//! (via the shared `prepare_fetch_*` seam), pre-computes the FK load order on
+//! the `Options` → `Confirm` transition, and drives forward/back navigation.
 //!
-//! Reached from the sidebar's multi-select "Migrate…" action (T28), which
+//! Reached from the sidebar's multi-select "Migrate…" action, which
 //! pre-populates `source_profile_id` / `source_database` / `source_tables`.
+//! Engine contracts are preserved verbatim: `TableMigrationConfig::to_overrides()`,
+//! the `open(profile_id, database, tables, …)` signature, and `run_migration`
+//! semantics (the run itself lives in [`confirm_run`]).
 
 mod column_mapping;
 pub mod confirm_run;
@@ -16,25 +20,20 @@ pub mod phases;
 pub mod source_target;
 pub mod tree_model;
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use dbflux_components::controls::{
-    Button, Checkbox, Dropdown, DropdownItem, DropdownSelectionChanged,
-};
+use dbflux_components::controls::Button;
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Text};
 use dbflux_components::tokens::Spacing;
 use dbflux_core::{
     ColumnInfo, Connection, DriverCapabilities, SchemaCacheKey, SchemaForeignKeyInfo, TableInfo,
-    TableRef, TaskId, TaskKind, TaskStatus, TaskTarget, TransferColumn, topological_order,
+    TableRef, TransferColumn, topological_order,
 };
 use dbflux_transfer::TableTransferStatus;
-use dbflux_transfer::migration::{
-    MigratedTable, MigrationOptions, MigrationOutcome, MigrationTablePlan, run_migration,
-};
-use dbflux_ui_base::app_state_entity::{AppStateChanged, AppStateEntity};
+use dbflux_transfer::migration::{MigratedTable, MigrationOptions, MigrationTablePlan};
+use dbflux_ui_base::app_state_entity::AppStateEntity;
 use dbflux_ui_base::modal_frame::ModalFrame;
-use dbflux_ui_base::toast::Toast;
 use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use gpui::prelude::FluentBuilder;
 use gpui::*;
@@ -42,8 +41,11 @@ use gpui_component::ActiveTheme;
 use uuid::Uuid;
 
 pub use column_mapping::TableMigrationConfig;
-use column_mapping::mapping_mode_options;
-use phases::{RailEntry, WizardPhase, rail_entries};
+use confirm_run::{ConfirmRunEvent, ConfirmRunInputs, ConfirmRunPhase, decide_order};
+use mapping::{MappingChanged, MappingPhase};
+use options::{OptionsChanged, OptionsPhase};
+use phases::{RailEntry, WizardPhase, can_advance_from_tables_mapping, rail_entries};
+use source_target::{SourceTargetChanged, SourceTargetPhase};
 
 /// Whether an `Err(String)` returned by one of the shared
 /// `AppStateEntity::prepare_fetch_*` seams means "the data is already cached"
@@ -354,73 +356,120 @@ async fn fetch_schema_foreign_keys_via_seam(
     Ok(foreign_keys)
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum WizardStep {
-    PickTarget,
-    Configure,
-    ReorderCycle,
-    Confirm,
-    Running,
-    Done,
+/// Builds one [`TableMigrationConfig`] per checked source table by fetching
+/// the source and target table schemas through the shared metadata seam: the
+/// source columns must exist (a failure here is fatal), while a missing target
+/// table is the expected "will be created" signal rather than an error. The
+/// same field mapping the pre-redesign wizard produced inline, extracted so
+/// the `Source & Target` → `Tables Mapping` transition stays readable.
+async fn build_configs_via_seam(
+    app_state: &Entity<AppStateEntity>,
+    source_profile_id: Uuid,
+    source_database: &str,
+    target_profile_id: Uuid,
+    target_database: &str,
+    tables: &[TableRef],
+    cx: &mut AsyncApp,
+) -> Result<Vec<TableMigrationConfig>, String> {
+    let mut configs = Vec::with_capacity(tables.len());
+
+    for table_ref in tables {
+        let source_info = match fetch_table_details_via_seam(
+            app_state,
+            source_profile_id,
+            source_database,
+            table_ref,
+            cx,
+        )
+        .await
+        {
+            Ok(TableDetailsFetch::Found(info)) => info,
+            Ok(TableDetailsFetch::NotFound(e)) | Err(e) => {
+                return Err(format!("{}: {e}", table_ref.qualified_name()));
+            }
+        };
+        let source_columns = to_transfer_columns(source_info.columns.unwrap_or_default());
+
+        let (target_exists, target_columns) = match fetch_table_details_via_seam(
+            app_state,
+            target_profile_id,
+            target_database,
+            table_ref,
+            cx,
+        )
+        .await
+        {
+            Ok(TableDetailsFetch::Found(info)) => {
+                (true, to_transfer_columns(info.columns.unwrap_or_default()))
+            }
+            Ok(TableDetailsFetch::NotFound(_)) => (false, Vec::new()),
+            Err(e) => return Err(format!("{}: {e}", table_ref.qualified_name())),
+        };
+
+        configs.push(TableMigrationConfig::new(
+            table_ref.clone(),
+            source_columns,
+            target_exists,
+            target_columns,
+        ));
+    }
+
+    Ok(configs)
 }
 
-/// One table row's live controls, wrapping the pure [`TableMigrationConfig`]
-/// with the `Dropdown` entities the user adjusts it through — same shape as
-/// the Import wizard's `TableImportRow`.
-struct TableMigrationRow {
-    config: TableMigrationConfig,
-    mapping_mode_dropdown: Entity<Dropdown>,
-    rebind_target_dropdown: Entity<Dropdown>,
-    rebind_source_dropdown: Entity<Dropdown>,
+/// The phase reached by pressing the footer's Continue button from `phase`,
+/// or `None` for phases whose forward action lives elsewhere: `Confirm` starts
+/// the run through the Confirm/Run phase's own "Start Migration" button, and
+/// `Run` has no forward step. Pure so the footer's button visibility and the
+/// dispatch in [`MigrateWizard::advance`] agree by construction.
+fn next_phase(phase: WizardPhase) -> Option<WizardPhase> {
+    match phase {
+        WizardPhase::SourceTarget => Some(WizardPhase::TablesMapping),
+        WizardPhase::TablesMapping => Some(WizardPhase::Options),
+        WizardPhase::Options => Some(WizardPhase::Confirm),
+        WizardPhase::Confirm | WizardPhase::Run => None,
+    }
 }
 
+/// The migration wizard modal: owns the current [`WizardPhase`] plus the four
+/// child phase entities it mounts as the user advances. Downstream phases are
+/// invalidated (dropped) whenever an upstream phase reports a change, so a
+/// re-advance rebuilds them against fresh inputs; navigating back and forward
+/// without changes reuses the already-built entities.
 pub struct MigrateWizard {
     app_state: Entity<AppStateEntity>,
     focus_handle: FocusHandle,
     visible: bool,
+
     source_profile_id: Option<Uuid>,
     source_database: Option<String>,
     source_tables: Vec<TableRef>,
-    step: WizardStep,
+
+    phase: WizardPhase,
     error: Option<String>,
-    target_dropdown: Entity<Dropdown>,
-    /// Profile ids of connected, transfer-compatible targets, parallel to
-    /// `target_dropdown`'s items — rebuilt once per `open()` call.
-    target_candidates: Vec<Uuid>,
+    advancing: bool,
+
+    /// Resolved once the `Source & Target` phase is left, then fed to the
+    /// downstream phases and the run without re-deriving them.
+    resolved_source_database: Option<String>,
     target_profile_id: Option<Uuid>,
-    rows: Vec<TableMigrationRow>,
+    target_database: Option<String>,
     supports_truncate: bool,
     supports_disable_ri: bool,
-    disable_ri: bool,
-    /// The FK-ordered prefix that resolved cleanly (fixed, not reorderable)
-    /// when a cycle was detected among the remaining tables.
-    cyclic_prefix: Vec<TableRef>,
-    /// The unresolved cyclic subset, in the user's current (reorderable)
-    /// order — seeded from `topological_order`'s `cycle`.
-    reorder_list: Vec<TableRef>,
-    /// The final load order once resolved (auto or user-reordered),
-    /// consumed verbatim by `run_migration`.
-    final_order: Option<Vec<TableRef>>,
-    /// Set only by the Confirm step's "Yes, proceed" handler — never derived
-    /// from "is any plan destructive" — so the engine's destructive-confirm
-    /// gate stays a real backstop against a state-machine bypass, not merely
-    /// a restatement of the plan's own classification.
-    confirmed_destructive: bool,
-    loading: bool,
-    running: bool,
-    progress: Arc<Mutex<(u64, Option<u64>)>>,
-    active_task_id: Option<TaskId>,
-    result_summary: Option<String>,
-    result_warnings: Vec<String>,
-    _row_subscriptions: Vec<Subscription>,
-    _target_subscription: Option<Subscription>,
+
+    source_target: Option<Entity<SourceTargetPhase>>,
+    mapping: Option<Entity<MappingPhase>>,
+    options: Option<Entity<OptionsPhase>>,
+    confirm_run: Option<Entity<ConfirmRunPhase>>,
+
+    _source_target_sub: Option<Subscription>,
+    _mapping_sub: Option<Subscription>,
+    _options_sub: Option<Subscription>,
+    _confirm_run_sub: Option<Subscription>,
 }
 
 impl MigrateWizard {
     pub fn new(app_state: Entity<AppStateEntity>, cx: &mut Context<Self>) -> Self {
-        let target_dropdown =
-            cx.new(|_cx| Dropdown::new("migrate-target").placeholder("Target connection"));
-
         Self {
             app_state,
             focus_handle: cx.focus_handle(),
@@ -428,27 +477,22 @@ impl MigrateWizard {
             source_profile_id: None,
             source_database: None,
             source_tables: Vec::new(),
-            step: WizardStep::PickTarget,
+            phase: WizardPhase::SourceTarget,
             error: None,
-            target_dropdown,
-            target_candidates: Vec::new(),
+            advancing: false,
+            resolved_source_database: None,
             target_profile_id: None,
-            rows: Vec::new(),
+            target_database: None,
             supports_truncate: false,
             supports_disable_ri: false,
-            disable_ri: false,
-            cyclic_prefix: Vec::new(),
-            reorder_list: Vec::new(),
-            final_order: None,
-            confirmed_destructive: false,
-            loading: false,
-            running: false,
-            progress: Arc::new(Mutex::new((0, None))),
-            active_task_id: None,
-            result_summary: None,
-            result_warnings: Vec::new(),
-            _row_subscriptions: Vec::new(),
-            _target_subscription: None,
+            source_target: None,
+            mapping: None,
+            options: None,
+            confirm_run: None,
+            _source_target_sub: None,
+            _mapping_sub: None,
+            _options_sub: None,
+            _confirm_run_sub: None,
         }
     }
 
@@ -466,23 +510,43 @@ impl MigrateWizard {
     ) {
         self.visible = true;
         self.source_profile_id = Some(source_profile_id);
-        self.source_database = source_database;
-        self.step = WizardStep::PickTarget;
+        self.source_database = source_database.clone();
+        self.source_tables = source_tables.clone();
+        self.phase = WizardPhase::SourceTarget;
         self.error = None;
-        self.rows.clear();
-        self._row_subscriptions.clear();
-        self.cyclic_prefix.clear();
-        self.reorder_list.clear();
-        self.final_order = None;
-        self.confirmed_destructive = false;
-        self.disable_ri = false;
-        self.loading = false;
-        self.running = false;
-        self.active_task_id = None;
-        self.result_summary = None;
-        self.result_warnings.clear();
+        self.advancing = false;
 
-        self.build_target_candidates(source_tables, cx);
+        self.resolved_source_database = None;
+        self.target_profile_id = None;
+        self.target_database = None;
+        self.supports_truncate = false;
+        self.supports_disable_ri = false;
+
+        self.mapping = None;
+        self.options = None;
+        self.confirm_run = None;
+        self._mapping_sub = None;
+        self._options_sub = None;
+        self._confirm_run_sub = None;
+
+        let app_state = self.app_state.clone();
+        let source_target = cx.new(|cx| {
+            SourceTargetPhase::new(
+                app_state,
+                source_profile_id,
+                source_database,
+                source_tables,
+                cx,
+            )
+        });
+        self._source_target_sub = Some(cx.subscribe(
+            &source_target,
+            |this, _entity, _event: &SourceTargetChanged, cx| {
+                this.on_source_target_changed(cx);
+            },
+        ));
+        self.source_target = Some(source_target);
+
         self.focus_handle.focus(window);
         cx.notify();
     }
@@ -492,49 +556,41 @@ impl MigrateWizard {
         cx.notify();
     }
 
-    fn build_target_candidates(&mut self, source_tables: Vec<TableRef>, cx: &mut Context<Self>) {
-        self.source_tables = source_tables;
+    /// A changed source selection or target container invalidates every
+    /// downstream phase — the mapping configs, the options' capability
+    /// gating, and the confirm/run plan all derive from it.
+    fn on_source_target_changed(&mut self, cx: &mut Context<Self>) {
+        self.mapping = None;
+        self._mapping_sub = None;
+        self.options = None;
+        self._options_sub = None;
+        self.confirm_run = None;
+        self._confirm_run_sub = None;
+        cx.notify();
+    }
 
-        let state = self.app_state.read(cx);
-        let Some(source_profile_id) = self.source_profile_id else {
-            return;
-        };
-        let Some(source_connected) = state.connections().get(&source_profile_id) else {
-            self.error = Some("No active connection for the selected tables".to_string());
-            return;
-        };
-        let source_metadata = source_connected.connection.metadata();
+    /// Edited mappings only invalidate the confirm/run plan and its FK order;
+    /// the options phase is independent of the per-table mapping.
+    fn on_mapping_changed(&mut self, cx: &mut Context<Self>) {
+        self.confirm_run = None;
+        self._confirm_run_sub = None;
+        cx.notify();
+    }
 
-        let mut candidates: Vec<(Uuid, String)> = state
-            .connections()
-            .iter()
-            .filter(|(_, connected)| {
-                dbflux_core::transfer_compatible(source_metadata, connected.connection.metadata())
-            })
-            .map(|(profile_id, connected)| (*profile_id, connected.profile.name.clone()))
-            .collect();
-        candidates.sort_by(|a, b| a.1.cmp(&b.1));
+    fn on_options_changed(&mut self, cx: &mut Context<Self>) {
+        self.confirm_run = None;
+        self._confirm_run_sub = None;
+        cx.notify();
+    }
 
-        self.target_candidates = candidates.iter().map(|(id, _)| *id).collect();
-        let items: Vec<DropdownItem> = candidates
-            .iter()
-            .map(|(_, name)| DropdownItem::new(name.clone()))
-            .collect();
-
-        let target_dropdown = cx.new(|_cx| {
-            Dropdown::new("migrate-target")
-                .items(items)
-                .placeholder("Target connection")
-        });
-        let subscription = cx.subscribe(
-            &target_dropdown,
-            |this, _entity, event: &DropdownSelectionChanged, cx| {
-                this.target_profile_id = this.target_candidates.get(event.index).copied();
+    fn on_confirm_run_event(&mut self, event: &ConfirmRunEvent, cx: &mut Context<Self>) {
+        match event {
+            ConfirmRunEvent::RunStarted => {
+                self.phase = WizardPhase::Run;
                 cx.notify();
-            },
-        );
-        self.target_dropdown = target_dropdown;
-        self._target_subscription = Some(subscription);
+            }
+            ConfirmRunEvent::CloseRequested => self.close(cx),
+        }
     }
 
     /// Resolves the source connection, honoring the specific database the
@@ -549,9 +605,6 @@ impl MigrateWizard {
         })
     }
 
-    /// Resolves a candidate target connection by profile id, using its own
-    /// primary connection — Migration does not offer a separate
-    /// target-database sub-picker in this slice (T27 explicit scope).
     fn resolve_target_connection(&self, profile_id: Uuid, cx: &App) -> Option<Arc<dyn Connection>> {
         Some(
             self.app_state
@@ -563,25 +616,109 @@ impl MigrateWizard {
         )
     }
 
-    fn continue_from_pick_target(&mut self, cx: &mut Context<Self>) {
-        let Some(target_profile_id) = self.target_profile_id else {
-            self.error = Some("Choose a target connection".to_string());
+    /// A human-readable `profile / database` label for the Confirm summary.
+    fn container_label(&self, profile_id: Uuid, database: &str, cx: &App) -> String {
+        let name = self
+            .app_state
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .map(|connected| connected.profile.name.clone())
+            .unwrap_or_default();
+
+        if database.is_empty() {
+            name
+        } else {
+            format!("{name} / {database}")
+        }
+    }
+
+    /// Back-navigation from the rail: only ever returns to an already-passed
+    /// phase, keeping the downstream entities intact so re-advancing is free.
+    fn go_to_phase(&mut self, phase: WizardPhase, cx: &mut Context<Self>) {
+        if phase < self.phase {
+            self.phase = phase;
             cx.notify();
+        }
+    }
+
+    /// Whether the footer's Continue button is enabled for the current phase:
+    /// the `Source & Target` and `Tables Mapping` guards compose their child's
+    /// readiness; `Options` always has a usable value.
+    fn continue_enabled(&self, cx: &App) -> bool {
+        match self.phase {
+            WizardPhase::SourceTarget => self
+                .source_target
+                .as_ref()
+                .is_some_and(|phase| phase.read(cx).is_ready()),
+            WizardPhase::TablesMapping => self
+                .mapping
+                .as_ref()
+                .is_some_and(|phase| can_advance_from_tables_mapping(&phase.read(cx).readiness())),
+            WizardPhase::Options => true,
+            WizardPhase::Confirm | WizardPhase::Run => false,
+        }
+    }
+
+    fn advance(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.phase {
+            WizardPhase::SourceTarget => self.advance_from_source_target(window, cx),
+            WizardPhase::TablesMapping => self.advance_from_tables_mapping(window, cx),
+            WizardPhase::Options => self.advance_from_options(cx),
+            WizardPhase::Confirm | WizardPhase::Run => {}
+        }
+    }
+
+    fn report_advance_error(
+        &mut self,
+        kind: ErrorKind,
+        message: impl Into<String>,
+        cx: &mut Context<Self>,
+    ) {
+        let message = message.into();
+        self.advancing = false;
+        self.error = Some(message.clone());
+        report_error(UserFacingError::new(kind, message), cx);
+        cx.notify();
+    }
+
+    /// `Source & Target` → `Tables Mapping`: resolves the chosen connections,
+    /// then (re)builds the mapping grid off-thread from the checked tables'
+    /// schemas and the target container's existing tables.
+    fn advance_from_source_target(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(source_target) = self.source_target.as_ref() else {
+            return;
+        };
+        let source_target = source_target.read(cx);
+        if !source_target.is_ready() {
+            return;
+        }
+
+        let checked = source_target.checked_source_tables();
+        let Some(target_profile_id) = source_target.target_profile_id() else {
+            return;
+        };
+        let Some(target_database) = source_target.target_database() else {
             return;
         };
         let Some(source_profile_id) = self.source_profile_id else {
-            self.error = Some("No active connection for the source profile".to_string());
-            cx.notify();
             return;
         };
+
         let Some(source_connection) = self.resolve_source_connection(cx) else {
-            self.error = Some("No active connection for the source profile".to_string());
-            cx.notify();
+            self.report_advance_error(
+                ErrorKind::Storage,
+                "No active connection for the source profile",
+                cx,
+            );
             return;
         };
         let Some(target_connection) = self.resolve_target_connection(target_profile_id, cx) else {
-            self.error = Some("No active connection for the target profile".to_string());
-            cx.notify();
+            self.report_advance_error(
+                ErrorKind::Storage,
+                "No active connection for the target profile",
+                cx,
+            );
             return;
         };
 
@@ -590,233 +727,208 @@ impl MigrateWizard {
             .clone()
             .or_else(|| source_connection.active_database())
             .unwrap_or_default();
-        let target_database = target_connection.active_database().unwrap_or_default();
-        let source_tables = self.source_tables.clone();
-        let supports_truncate = target_connection.supports(DriverCapabilities::TRUNCATE_TABLE);
-        let supports_disable_ri = target_connection.supports(DriverCapabilities::DISABLE_FK_CHECKS);
 
-        self.loading = true;
+        self.resolved_source_database = Some(source_database.clone());
+        self.target_profile_id = Some(target_profile_id);
+        self.target_database = Some(target_database.clone());
+        self.supports_truncate = target_connection.supports(DriverCapabilities::TRUNCATE_TABLE);
+        self.supports_disable_ri =
+            target_connection.supports(DriverCapabilities::DISABLE_FK_CHECKS);
+
+        if self.mapping.is_some() {
+            self.phase = WizardPhase::TablesMapping;
+            cx.notify();
+            return;
+        }
+
+        self.advancing = true;
         self.error = None;
         cx.notify();
 
         let app_state = self.app_state.clone();
+        let supports_truncate = self.supports_truncate;
+        let list_connection = Arc::clone(&target_connection);
+        let list_database = target_database.clone();
 
-        cx.spawn(async move |this, cx| {
-            let mut configs = Vec::with_capacity(source_tables.len());
-            let mut build_error: Option<String> = None;
+        cx.spawn_in(window, async move |this, cx| {
+            let configs = build_configs_via_seam(
+                &app_state,
+                source_profile_id,
+                &source_database,
+                target_profile_id,
+                &target_database,
+                &checked,
+                cx,
+            )
+            .await;
 
-            for table_ref in &source_tables {
-                let source_details = fetch_table_details_via_seam(
-                    &app_state,
-                    source_profile_id,
-                    &source_database,
-                    table_ref,
-                    cx,
-                )
+            let existing = cx
+                .background_executor()
+                .spawn(async move { list_connection.schema_for_database(&list_database) })
                 .await;
-                let source_info = match source_details {
-                    Ok(TableDetailsFetch::Found(info)) => info,
-                    Ok(TableDetailsFetch::NotFound(e)) | Err(e) => {
-                        build_error = Some(format!("{}: {e}", table_ref.qualified_name()));
-                        break;
-                    }
-                };
-                let source_columns = to_transfer_columns(source_info.columns.unwrap_or_default());
 
-                let target_details = fetch_table_details_via_seam(
-                    &app_state,
-                    target_profile_id,
-                    &target_database,
-                    table_ref,
-                    cx,
-                )
-                .await;
-                let (target_exists, target_columns) = match target_details {
-                    Ok(TableDetailsFetch::Found(info)) => {
-                        (true, to_transfer_columns(info.columns.unwrap_or_default()))
+            this.update_in(cx, |this, window, cx| {
+                this.advancing = false;
+                match configs {
+                    Ok(configs) => {
+                        let existing_target_tables = match existing {
+                            Ok(info) => info.tables.into_iter().map(|table| table.name).collect(),
+                            Err(_) => Vec::new(),
+                        };
+                        this.mount_mapping(
+                            configs,
+                            existing_target_tables,
+                            supports_truncate,
+                            target_profile_id,
+                            target_database,
+                            window,
+                            cx,
+                        );
+                        this.phase = WizardPhase::TablesMapping;
+                        cx.notify();
                     }
-                    Ok(TableDetailsFetch::NotFound(_)) => (false, Vec::new()),
                     Err(e) => {
-                        build_error = Some(format!("{}: {e}", table_ref.qualified_name()));
-                        break;
-                    }
-                };
-
-                configs.push(TableMigrationConfig::new(
-                    table_ref.clone(),
-                    source_columns,
-                    target_exists,
-                    target_columns,
-                ));
-            }
-
-            this.update(cx, |this, cx| {
-                this.loading = false;
-                match build_error {
-                    None => {
-                        this.supports_truncate = supports_truncate;
-                        this.supports_disable_ri = supports_disable_ri;
-                        this.build_rows(configs, cx);
-                        this.step = WizardStep::Configure;
-                    }
-                    Some(e) => {
-                        this.error = Some(format!("Could not read table schema: {e}"));
+                        this.report_advance_error(
+                            ErrorKind::Driver,
+                            format!("Could not read table schema: {e}"),
+                            cx,
+                        );
                     }
                 }
-                cx.notify();
             })
             .ok();
         })
         .detach();
     }
 
-    fn build_rows(&mut self, configs: Vec<TableMigrationConfig>, cx: &mut Context<Self>) {
-        self.rows.clear();
-        self._row_subscriptions.clear();
-        let supports_truncate = self.supports_truncate;
-
-        for (table_index, config) in configs.into_iter().enumerate() {
-            let mode_options = mapping_mode_options(supports_truncate);
-            let selected_mode_index = mode_options
-                .iter()
-                .position(|(_, mode)| *mode == config.mapping_mode);
-            let mode_items: Vec<DropdownItem> = mode_options
-                .iter()
-                .map(|(label, _)| DropdownItem::new(*label))
-                .collect();
-
-            let mapping_mode_dropdown = cx.new(|_cx| {
-                Dropdown::new(SharedString::from(format!("migrate-mode-{table_index}")))
-                    .items(mode_items)
-                    .selected_index(selected_mode_index)
-                    .placeholder("Mode")
-            });
-
-            let target_items: Vec<DropdownItem> = config
-                .target_columns
-                .iter()
-                .map(|c| DropdownItem::new(c.name.clone()))
-                .collect();
-            let rebind_target_dropdown = cx.new(|_cx| {
-                Dropdown::new(SharedString::from(format!(
-                    "migrate-target-col-{table_index}"
-                )))
-                .items(target_items)
-                .placeholder("Target column")
-            });
-
-            let mut source_items = vec![DropdownItem::new("(unset)")];
-            source_items.extend(
-                config
-                    .source_columns
-                    .iter()
-                    .map(|c| DropdownItem::new(c.name.clone())),
-            );
-            let rebind_source_dropdown = cx.new(|_cx| {
-                Dropdown::new(SharedString::from(format!(
-                    "migrate-source-col-{table_index}"
-                )))
-                .items(source_items)
-                .placeholder("Source column")
-            });
-
-            let mode_sub = cx.subscribe(
-                &mapping_mode_dropdown,
-                move |this, _entity, event: &DropdownSelectionChanged, cx| {
-                    let mode_options = mapping_mode_options(this.supports_truncate);
-                    if let Some((_, mode)) = mode_options.get(event.index)
-                        && let Some(row) = this.rows.get_mut(table_index)
-                    {
-                        row.config.mapping_mode = *mode;
-                        cx.notify();
-                    }
-                },
-            );
-
-            self.rows.push(TableMigrationRow {
-                config,
-                mapping_mode_dropdown,
-                rebind_target_dropdown,
-                rebind_source_dropdown,
-            });
-            self._row_subscriptions.push(mode_sub);
-        }
+    #[allow(clippy::too_many_arguments)]
+    fn mount_mapping(
+        &mut self,
+        configs: Vec<TableMigrationConfig>,
+        existing_target_tables: Vec<String>,
+        supports_truncate: bool,
+        target_profile_id: Uuid,
+        target_database: String,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let app_state = self.app_state.clone();
+        let mapping = cx.new(|cx| {
+            MappingPhase::new(
+                app_state,
+                target_profile_id,
+                target_database,
+                existing_target_tables,
+                supports_truncate,
+                configs,
+                window,
+                cx,
+            )
+        });
+        self._mapping_sub = Some(
+            cx.subscribe(&mapping, |this, _entity, _event: &MappingChanged, cx| {
+                this.on_mapping_changed(cx)
+            }),
+        );
+        self.mapping = Some(mapping);
     }
 
-    fn apply_rebind(&mut self, table_index: usize, cx: &mut Context<Self>) {
-        let Some(row) = self.rows.get(table_index) else {
+    fn advance_from_tables_mapping(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(mapping) = self.mapping.as_ref() else {
             return;
         };
-
-        let Some(target_index) = row
-            .rebind_target_dropdown
-            .read(cx)
-            .selected_value()
-            .and_then(|value| {
-                row.config
-                    .target_columns
-                    .iter()
-                    .position(|c| c.name.as_str() == value.as_ref())
-            })
-        else {
+        if !can_advance_from_tables_mapping(&mapping.read(cx).readiness()) {
             return;
-        };
-
-        let source_index = row
-            .rebind_source_dropdown
-            .read(cx)
-            .selected_value()
-            .and_then(|value| {
-                row.config
-                    .source_columns
-                    .iter()
-                    .position(|c| c.name.as_str() == value.as_ref())
-            });
-
-        if let Some(row) = self.rows.get_mut(table_index) {
-            row.config.set_binding(target_index, source_index);
         }
+
+        if self.options.is_none() {
+            let supports_disable_ri = self.supports_disable_ri;
+            let options = cx.new(|cx| OptionsPhase::new(supports_disable_ri, window, cx));
+            self._options_sub = Some(
+                cx.subscribe(&options, |this, _entity, _event: &OptionsChanged, cx| {
+                    this.on_options_changed(cx)
+                }),
+            );
+            self.options = Some(options);
+        }
+
+        self.phase = WizardPhase::Options;
+        self.error = None;
         cx.notify();
     }
 
-    /// Resolves the FK load order over the selected tables. On a cycle,
-    /// transitions to `ReorderCycle` instead of proceeding — the caller must
-    /// never guess an order across a cyclic FK graph (R6).
-    fn continue_from_configure(&mut self, cx: &mut Context<Self>) {
+    /// `Options` → `Confirm`: fetches the selected tables' foreign keys through
+    /// the shared seam and computes the load order off-thread, surfacing a
+    /// reorder interrupt on a cycle (via [`decide_order`]) before mounting the
+    /// Confirm/Run phase.
+    fn advance_from_options(&mut self, cx: &mut Context<Self>) {
+        if self.confirm_run.is_some() {
+            self.phase = WizardPhase::Confirm;
+            cx.notify();
+            return;
+        }
+
+        let Some(mapping) = self.mapping.as_ref() else {
+            return;
+        };
+        let Some(options) = self.options.as_ref() else {
+            return;
+        };
+        let Some(target_profile_id) = self.target_profile_id else {
+            return;
+        };
+        let Some(target_database) = self.target_database.clone() else {
+            return;
+        };
         let Some(source_profile_id) = self.source_profile_id else {
-            self.error = Some("No active connection for the source profile".to_string());
-            cx.notify();
             return;
         };
+
+        let configs: Vec<TableMigrationConfig> = mapping.read(cx).configs().cloned().collect();
+        let segment_size = options.read(cx).segment_size();
+        let disable_referential_integrity = options.read(cx).disable_referential_integrity();
+
         let Some(source_connection) = self.resolve_source_connection(cx) else {
-            self.error = Some("No active connection for the source profile".to_string());
-            cx.notify();
+            self.report_advance_error(
+                ErrorKind::Storage,
+                "No active connection for the source profile",
+                cx,
+            );
             return;
         };
+        let Some(target_connection) = self.resolve_target_connection(target_profile_id, cx) else {
+            self.report_advance_error(
+                ErrorKind::Storage,
+                "No active connection for the target profile",
+                cx,
+            );
+            return;
+        };
+
         let source_database = self
-            .source_database
+            .resolved_source_database
             .clone()
+            .or_else(|| self.source_database.clone())
             .or_else(|| source_connection.active_database())
             .unwrap_or_default();
 
-        let table_refs: Vec<TableRef> = self
-            .rows
-            .iter()
-            .map(|row| row.config.source_table.clone())
-            .collect();
+        let source_container_label = self.container_label(source_profile_id, &source_database, cx);
+        let target_container_label = self.container_label(target_profile_id, &target_database, cx);
 
+        let table_refs: Vec<TableRef> = configs.iter().map(|c| c.source_table.clone()).collect();
         let mut schemas: Vec<Option<String>> =
             table_refs.iter().map(|t| t.schema.clone()).collect();
         schemas.sort();
         schemas.dedup();
 
+        self.advancing = true;
         self.error = None;
         cx.notify();
 
         let app_state = self.app_state.clone();
 
         cx.spawn(async move |this, cx| {
-            let mut fks: Vec<SchemaForeignKeyInfo> = Vec::new();
+            let mut foreign_keys: Vec<SchemaForeignKeyInfo> = Vec::new();
             let mut fetch_error: Option<String> = None;
 
             for schema in &schemas {
@@ -829,7 +941,7 @@ impl MigrateWizard {
                 )
                 .await
                 {
-                    Ok(batch) => fks.extend(batch),
+                    Ok(batch) => foreign_keys.extend(batch),
                     Err(e) => {
                         fetch_error = Some(e);
                         break;
@@ -841,276 +953,53 @@ impl MigrateWizard {
                 Some(e) => Err(e),
                 None => Ok(cx
                     .background_executor()
-                    .spawn(async move { topological_order(&table_refs, &fks) })
+                    .spawn(async move { topological_order(&table_refs, &foreign_keys) })
                     .await),
             };
 
-            this.update(cx, |this, cx| match order_result {
-                Ok(dbflux_core::OrderResult::Ordered(order)) => {
-                    this.final_order = Some(order);
-                    this.advance_past_ordering(cx);
-                }
-                Ok(dbflux_core::OrderResult::Cyclic {
-                    ordered_prefix,
-                    cycle,
-                }) => {
-                    this.cyclic_prefix = ordered_prefix;
-                    this.reorder_list = cycle;
-                    this.step = WizardStep::ReorderCycle;
-                    cx.notify();
-                }
-                Err(e) => {
-                    this.error = Some(format!("Could not read foreign keys: {e}"));
-                    cx.notify();
-                }
-            })
-            .ok();
-        })
-        .detach();
-    }
-
-    fn move_reorder_row(&mut self, index: usize, delta: isize, cx: &mut Context<Self>) {
-        let Some(new_index) = index.checked_add_signed(delta) else {
-            return;
-        };
-        if new_index >= self.reorder_list.len() {
-            return;
-        }
-        self.reorder_list.swap(index, new_index);
-        cx.notify();
-    }
-
-    fn continue_from_reorder(&mut self, cx: &mut Context<Self>) {
-        let mut order = self.cyclic_prefix.clone();
-        order.extend(self.reorder_list.clone());
-        self.final_order = Some(order);
-        self.advance_past_ordering(cx);
-    }
-
-    fn advance_past_ordering(&mut self, cx: &mut Context<Self>) {
-        let has_destructive = self.rows.iter().any(|row| row.config.is_destructive());
-        self.step = if has_destructive {
-            WizardStep::Confirm
-        } else {
-            self.start_migration(cx);
-            WizardStep::Running
-        };
-        cx.notify();
-    }
-
-    fn confirm_destructive_and_run(&mut self, cx: &mut Context<Self>) {
-        self.confirmed_destructive = true;
-        self.start_migration(cx);
-        self.step = WizardStep::Running;
-        cx.notify();
-    }
-
-    fn start_migration(&mut self, cx: &mut Context<Self>) {
-        let Some(target_profile_id) = self.target_profile_id else {
-            return;
-        };
-        let Some(source_connection) = self.resolve_source_connection(cx) else {
-            report_error(
-                UserFacingError::new(
-                    ErrorKind::Storage,
-                    "No active connection for this migration",
-                ),
-                cx,
-            );
-            return;
-        };
-        let Some(target_connection) = self.resolve_target_connection(target_profile_id, cx) else {
-            report_error(
-                UserFacingError::new(
-                    ErrorKind::Storage,
-                    "No active connection for this migration",
-                ),
-                cx,
-            );
-            return;
-        };
-        let source_database = self
-            .source_database
-            .clone()
-            .or_else(|| source_connection.active_database())
-            .unwrap_or_default();
-        let target_database = target_connection.active_database().unwrap_or_default();
-        let manual_order = self.final_order.clone();
-
-        let plans = build_migration_table_plans(self.rows.iter().map(|row| &row.config));
-        let destructive_confirmed = self.confirmed_destructive;
-        let disable_referential_integrity = self.disable_ri && self.supports_disable_ri;
-
-        self.running = true;
-        self.result_summary = None;
-        self.result_warnings.clear();
-        *self.progress.lock().unwrap_or_else(|p| p.into_inner()) = (0, None);
-
-        let description = format!("Migrate {} table(s)", plans.len());
-        let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
-            let pair = state.start_task_for_target(
-                TaskKind::Migrate,
-                description,
-                Some(TaskTarget {
-                    profile_id: target_profile_id,
-                    database: Some(target_database.clone()),
-                }),
-            );
-            cx.emit(AppStateChanged);
-            pair
-        });
-        self.active_task_id = Some(task_id);
-
-        let app_state = self.app_state.clone();
-        let progress = Arc::clone(&self.progress);
-        let ticker_progress = Arc::clone(&self.progress);
-        let ticker_app_state = app_state.clone();
-
-        cx.spawn(async move |_this, cx| {
-            loop {
-                cx.background_executor()
-                    .timer(std::time::Duration::from_millis(150))
-                    .await;
-
-                let still_running = cx
-                    .update(|cx| {
-                        ticker_app_state.update(cx, |state, cx| {
-                            let Some(snapshot) = state.tasks().get(task_id) else {
-                                return false;
-                            };
-                            if snapshot.status != TaskStatus::Running {
-                                return false;
-                            }
-
-                            let (rows_done, estimated_total) = *ticker_progress
-                                .lock()
-                                .unwrap_or_else(|poisoned| poisoned.into_inner());
-                            if let Some(total) = estimated_total
-                                && total > 0
-                            {
-                                let fraction = (rows_done as f32 / total as f32).clamp(0.0, 1.0);
-                                state.tasks_mut().update_progress(task_id, fraction);
-                                cx.notify();
-                            }
-
-                            true
-                        })
-                    })
-                    .unwrap_or(false);
-
-                if !still_running {
-                    break;
-                }
-            }
-        })
-        .detach();
-
-        cx.spawn(async move |this, cx| {
-            let migration_result = cx
-                .background_executor()
-                .spawn(async move {
-                    let options = build_migration_options(
-                        500,
-                        source_database,
-                        target_database,
-                        destructive_confirmed,
-                        disable_referential_integrity,
-                        manual_order,
-                    );
-
-                    run_migration(
-                        &source_connection,
-                        &target_connection,
-                        &plans,
-                        &options,
-                        &cancel_token,
-                        move |_index, rows_done, estimated_total| {
-                            if let Ok(mut guard) = progress.lock() {
-                                *guard = (rows_done, estimated_total);
-                            }
-                        },
-                    )
-                })
-                .await;
-
             this.update(cx, |this, cx| {
-                this.running = false;
-                this.step = WizardStep::Done;
-
-                match migration_result {
-                    Ok(MigrationOutcome::Completed(outcome)) if outcome.cancelled => {
-                        app_state.update(cx, |state, cx| {
-                            state.tasks_mut().cancel(task_id);
-                            cx.emit(AppStateChanged);
-                        });
-                        this.result_summary = Some("Migration cancelled".to_string());
-                    }
-                    Ok(MigrationOutcome::Completed(outcome)) => {
-                        let failed_table = outcome.tables.iter().find_map(|t| match &t.status {
-                            TableTransferStatus::Failed { error } => {
-                                Some((t.source_table.clone(), error.clone()))
-                            }
-                            _ => None,
-                        });
-
-                        if let Some((table, error)) = &failed_table {
-                            app_state.update(cx, |state, cx| {
-                                state.fail_task(task_id, format!("{table}: {error}"));
-                                cx.emit(AppStateChanged);
-                            });
-                            report_error(
-                                UserFacingError::new(
-                                    ErrorKind::Driver,
-                                    format!("Migration failed on table '{table}': {error}"),
-                                ),
-                                cx,
-                            );
-                        } else {
-                            app_state.update(cx, |state, cx| {
-                                state.complete_task(task_id);
-                                cx.emit(AppStateChanged);
-                            });
-                            Toast::success("Migration completed").push(cx);
-                        }
-
-                        this.result_summary = Some(Self::summarize(&outcome));
-                        this.result_warnings =
-                            Self::itemized_status_lines(&outcome.tables, &outcome.warnings);
-                    }
-                    Ok(MigrationOutcome::CyclicOrderRequired { .. }) => {
-                        // The wizard always resolves ordering (auto or
-                        // manual) before calling `run_migration`, so this
-                        // branch is unreachable in practice; treat it the
-                        // same as any other failure to run rather than
-                        // panicking on an engine invariant.
-                        app_state.update(cx, |state, cx| {
-                            state.fail_task(task_id, "FK order became cyclic mid-run".to_string());
-                            cx.emit(AppStateChanged);
-                        });
-                        this.result_summary =
-                            Some("Migration failed: FK order became cyclic mid-run".to_string());
+                this.advancing = false;
+                match order_result {
+                    Ok(order) => {
+                        let inputs = ConfirmRunInputs {
+                            app_state: this.app_state.clone(),
+                            source_connection,
+                            target_connection,
+                            source_database,
+                            target_database,
+                            target_profile_id,
+                            source_container_label,
+                            target_container_label,
+                            segment_size,
+                            disable_referential_integrity,
+                            order: decide_order(order),
+                            configs,
+                        };
+                        this.mount_confirm_run(inputs, cx);
+                        this.phase = WizardPhase::Confirm;
+                        cx.notify();
                     }
                     Err(e) => {
-                        app_state.update(cx, |state, cx| {
-                            state.fail_task(task_id, e.to_string());
-                            cx.emit(AppStateChanged);
-                        });
-                        report_error(
-                            UserFacingError::new(
-                                ErrorKind::Driver,
-                                format!("Migration failed: {e}"),
-                            ),
+                        this.report_advance_error(
+                            ErrorKind::Driver,
+                            format!("Could not read foreign keys: {e}"),
                             cx,
                         );
-                        this.result_summary = Some(format!("Migration failed: {e}"));
                     }
                 }
-
-                cx.notify();
             })
             .ok();
         })
         .detach();
+    }
+
+    fn mount_confirm_run(&mut self, inputs: ConfirmRunInputs, cx: &mut Context<Self>) {
+        let confirm_run = cx.new(|cx| ConfirmRunPhase::new(inputs, cx));
+        self._confirm_run_sub = Some(cx.subscribe(
+            &confirm_run,
+            |this, _entity, event: &ConfirmRunEvent, cx| this.on_confirm_run_event(event, cx),
+        ));
+        self.confirm_run = Some(confirm_run);
     }
 
     fn summarize(outcome: &dbflux_transfer::migration::MigrationRunOutcome) -> String {
@@ -1195,246 +1084,110 @@ impl Render for MigrateWizard {
             close_entity.update(cx, |this, cx| this.close(cx)).ok();
         };
 
-        let mut frame = ModalFrame::new("migrate-wizard", &self.focus_handle, close)
+        let frame = ModalFrame::new("migrate-wizard", &self.focus_handle, close)
             .title("Migrate Data")
             .icon(AppIcon::ArrowUpDown)
-            .width(px(720.0))
-            .max_height(px(640.0));
+            .width(px(1000.0))
+            .height_fraction(0.8)
+            .center_vertically()
+            .child(self.render_body(cx));
 
-        let body = match self.step {
-            WizardStep::PickTarget => self.render_pick_target(cx),
-            WizardStep::Configure => self.render_configure(cx),
-            WizardStep::ReorderCycle => self.render_reorder_cycle(cx),
-            WizardStep::Confirm => self.render_confirm(cx),
-            WizardStep::Running => self.render_running(),
-            WizardStep::Done => self.render_done(cx),
-        };
-
-        frame = frame.child(body);
         frame.render(cx).into_any_element()
     }
 }
 
 impl MigrateWizard {
-    fn render_pick_target(&self, cx: &mut Context<Self>) -> AnyElement {
-        div()
-            .flex()
-            .flex_col()
-            .gap(Spacing::MD)
-            .p(Spacing::MD)
-            .child(Text::body(format!(
-                "Choose a connected, compatible target for {} table(s).",
-                self.source_tables.len()
-            )))
-            .when_some(self.error.clone(), |d, error| d.child(Text::caption(error)))
-            .child(self.target_dropdown.clone())
-            .child(
-                Button::new(
-                    "migrate-wizard-continue-target",
-                    if self.loading {
-                        "Loading..."
-                    } else {
-                        "Continue"
-                    },
-                )
-                .disabled(self.loading)
-                .on_click(cx.listener(|this, _, _, cx| this.continue_from_pick_target(cx))),
-            )
-            .into_any_element()
-    }
-
-    fn render_configure(&self, cx: &mut Context<Self>) -> AnyElement {
-        let rows = self.rows.iter().enumerate().map(|(table_index, row)| {
-            let unmatched = row.config.unmatched_source_names();
-
-            div()
-                .flex()
-                .flex_col()
-                .gap(Spacing::XS)
-                .p(Spacing::SM)
-                .border_1()
-                .child(Text::body(format!(
-                    "{} → {}",
-                    row.config.source_table.qualified_name(),
-                    row.config.target_table
-                )))
-                .child(
-                    div()
-                        .flex()
-                        .gap(Spacing::SM)
-                        .child(row.mapping_mode_dropdown.clone())
-                        .child(row.rebind_target_dropdown.clone())
-                        .child(row.rebind_source_dropdown.clone())
-                        .child(
-                            Button::new(
-                                SharedString::from(format!("migrate-apply-mapping-{table_index}")),
-                                "Apply Mapping",
-                            )
-                            .ghost()
-                            .on_click(cx.listener(
-                                move |this, _, _, cx| {
-                                    this.apply_rebind(table_index, cx);
-                                },
-                            )),
-                        ),
-                )
-                .when(!unmatched.is_empty(), |d| {
-                    d.child(Text::caption(format!(
-                        "Unmatched source column(s), will be skipped unless remapped: {}",
-                        unmatched.join(", ")
-                    )))
-                })
-                .into_any_element()
-        });
-
-        div()
-            .flex()
-            .flex_col()
-            .gap(Spacing::MD)
-            .p(Spacing::MD)
-            .children(rows)
-            .when(self.supports_disable_ri, |d| {
-                d.child(
-                    Checkbox::new("migrate-disable-ri")
-                        .checked(self.disable_ri)
-                        .label("Disable referential integrity during migration")
-                        .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                            this.disable_ri = *checked;
-                            cx.notify();
-                        })),
-                )
-            })
-            .when_some(self.error.clone(), |d, error| d.child(Text::caption(error)))
-            .child(
-                Button::new("migrate-wizard-continue-configure", "Continue")
-                    .on_click(cx.listener(|this, _, _, cx| this.continue_from_configure(cx))),
-            )
-            .into_any_element()
-    }
-
-    fn render_reorder_cycle(&self, cx: &mut Context<Self>) -> AnyElement {
-        let rows = self.reorder_list.iter().enumerate().map(|(index, table)| {
-            div()
-                .flex()
-                .items_center()
-                .gap(Spacing::SM)
-                .p(Spacing::SM)
-                .border_1()
-                .child(Text::body(table.qualified_name()))
-                .child(
-                    Button::new(
-                        SharedString::from(format!("migrate-reorder-up-{index}")),
-                        "Up",
-                    )
-                    .ghost()
-                    .disabled(index == 0)
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.move_reorder_row(index, -1, cx);
-                    })),
-                )
-                .child(
-                    Button::new(
-                        SharedString::from(format!("migrate-reorder-down-{index}")),
-                        "Down",
-                    )
-                    .ghost()
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.move_reorder_row(index, 1, cx);
-                    })),
-                )
-                .into_any_element()
-        });
-
-        div()
-            .flex()
-            .flex_col()
-            .gap(Spacing::MD)
-            .p(Spacing::MD)
-            .child(Text::body(
-                "These tables have a circular foreign-key relationship and could not be \
-                 ordered automatically. Choose a manual load order:",
-            ))
-            .children(rows)
-            .child(
-                Button::new("migrate-wizard-continue-reorder", "Continue")
-                    .on_click(cx.listener(|this, _, _, cx| this.continue_from_reorder(cx))),
-            )
-            .into_any_element()
-    }
-
-    fn render_confirm(&self, cx: &mut Context<Self>) -> AnyElement {
-        let destructive_tables: Vec<String> = self
-            .rows
-            .iter()
-            .filter(|row| row.config.is_destructive())
-            .map(|row| row.config.target_table.clone())
-            .collect();
-
-        div()
-            .flex()
-            .flex_col()
-            .gap(Spacing::MD)
-            .p(Spacing::MD)
-            .child(Text::body(format!(
-                "This will drop-and-recreate or truncate the following table(s) before loading data: {}",
-                destructive_tables.join(", ")
-            )))
-            .child(Text::caption("This cannot be undone. Confirm to proceed."))
-            .child(
-                div()
-                    .flex()
-                    .gap(Spacing::SM)
-                    .child(
-                        Button::new("migrate-wizard-cancel-confirm", "Back")
-                            .ghost()
-                            .on_click(cx.listener(|this, _, _, cx| {
-                                this.step = WizardStep::Configure;
-                                this.confirmed_destructive = false;
-                                cx.notify();
-                            })),
-                    )
-                    .child(
-                        Button::new("migrate-wizard-confirm-destructive", "Yes, proceed").on_click(
-                            cx.listener(|this, _, _, cx| this.confirm_destructive_and_run(cx)),
-                        ),
-                    ),
-            )
-            .into_any_element()
-    }
-
-    fn render_running(&self) -> AnyElement {
-        let (rows_done, estimated_total) = *self.progress.lock().unwrap_or_else(|p| p.into_inner());
-        let label = match estimated_total {
-            Some(total) if total > 0 => format!("{rows_done} / {total} rows"),
-            _ => format!("{rows_done} rows"),
+    fn render_body(&self, cx: &mut Context<Self>) -> AnyElement {
+        let rail_entity = cx.entity().downgrade();
+        let on_select = move |phase: WizardPhase, _window: &mut Window, app: &mut App| {
+            rail_entity
+                .update(app, |this, cx| this.go_to_phase(phase, cx))
+                .ok();
         };
 
         div()
             .flex()
             .flex_col()
-            .gap(Spacing::MD)
-            .p(Spacing::MD)
-            .child(Text::body("Migrating..."))
-            .child(Text::caption(label))
+            .size_full()
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .child(render_phase_rail(self.phase, on_select, cx))
+                    .child(self.render_phase_area()),
+            )
+            .child(self.render_footer(cx))
             .into_any_element()
     }
 
-    fn render_done(&self, cx: &mut Context<Self>) -> AnyElement {
+    fn render_phase_area(&self) -> AnyElement {
+        let content = match self.phase {
+            WizardPhase::SourceTarget => self
+                .source_target
+                .as_ref()
+                .map(|entity| entity.clone().into_any_element()),
+            WizardPhase::TablesMapping => self
+                .mapping
+                .as_ref()
+                .map(|entity| entity.clone().into_any_element()),
+            WizardPhase::Options => self
+                .options
+                .as_ref()
+                .map(|entity| entity.clone().into_any_element()),
+            WizardPhase::Confirm | WizardPhase::Run => self
+                .confirm_run
+                .as_ref()
+                .map(|entity| entity.clone().into_any_element()),
+        };
+
         div()
+            .flex_1()
+            .min_w(px(0.0))
             .flex()
             .flex_col()
-            .gap(Spacing::MD)
-            .p(Spacing::MD)
-            .when_some(self.result_summary.clone(), |d, summary| {
-                d.child(Text::body(summary))
-            })
-            .when(!self.result_warnings.is_empty(), |d| {
-                d.child(Text::caption(self.result_warnings.join("; ")))
-            })
+            .when_some(content, |parent, element| parent.child(element))
+            .into_any_element()
+    }
+
+    fn render_footer(&self, cx: &mut Context<Self>) -> AnyElement {
+        let theme = cx.theme();
+        let border = theme.border;
+
+        let shows_continue = next_phase(self.phase).is_some();
+        let continue_enabled = !self.advancing && self.continue_enabled(cx);
+        let label = if self.advancing {
+            "Loading…"
+        } else {
+            "Continue"
+        };
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_between()
+            .gap(Spacing::SM)
+            .px(Spacing::MD)
+            .py(Spacing::SM)
+            .border_t_1()
+            .border_color(border)
             .child(
-                Button::new("migrate-wizard-close", "Close")
-                    .on_click(cx.listener(|this, _, _, cx| this.close(cx))),
+                div()
+                    .flex_1()
+                    .min_w(px(0.0))
+                    .when_some(self.error.clone(), |parent, error| {
+                        parent.child(Text::caption(error).danger())
+                    }),
             )
+            .when(shows_continue, |parent| {
+                parent.child(
+                    Button::new("migrate-wizard-continue", label)
+                        .disabled(!continue_enabled)
+                        .on_click(cx.listener(|this, _event, window, cx| this.advance(window, cx))),
+                )
+            })
             .into_any_element()
     }
 }
@@ -1442,8 +1195,8 @@ impl MigrateWizard {
 #[cfg(test)]
 mod tests {
     use super::{
-        TableMigrationConfig, build_migration_options, build_migration_table_plans,
-        is_already_cached_sentinel,
+        TableMigrationConfig, WizardPhase, build_migration_options, build_migration_table_plans,
+        is_already_cached_sentinel, next_phase,
     };
     use dbflux_core::{TableRef, TransferColumn};
 
@@ -1464,6 +1217,21 @@ mod tests {
         ));
         assert!(!is_already_cached_sentinel("Profile not connected"));
         assert!(!is_already_cached_sentinel(""));
+    }
+
+    #[test]
+    fn next_phase_advances_through_the_forward_flow_and_stops_at_confirm() {
+        assert_eq!(
+            next_phase(WizardPhase::SourceTarget),
+            Some(WizardPhase::TablesMapping)
+        );
+        assert_eq!(
+            next_phase(WizardPhase::TablesMapping),
+            Some(WizardPhase::Options)
+        );
+        assert_eq!(next_phase(WizardPhase::Options), Some(WizardPhase::Confirm));
+        assert_eq!(next_phase(WizardPhase::Confirm), None);
+        assert_eq!(next_phase(WizardPhase::Run), None);
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -9,6 +9,7 @@
 //! pre-populates `source_profile_id` / `source_database` / `source_tables`.
 
 mod column_mapping;
+pub mod mapping;
 pub mod phases;
 pub mod source_target;
 pub mod tree_model;

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -1520,6 +1520,7 @@ impl MigrateWizard {
             .when(shows_back, |parent| {
                 parent.child(
                     Button::new("migrate-wizard-back", "Back")
+                        .small()
                         .ghost()
                         .disabled(self.advancing)
                         .on_click(cx.listener(|this, _event, _window, cx| this.go_back(cx))),
@@ -1528,6 +1529,8 @@ impl MigrateWizard {
             .when(shows_continue, |parent| {
                 parent.child(
                     Button::new("migrate-wizard-continue", continue_label)
+                        .small()
+                        .primary()
                         .disabled(!continue_enabled)
                         .on_click(cx.listener(|this, _event, window, cx| this.advance(window, cx))),
                 )
@@ -1544,6 +1547,7 @@ impl MigrateWizard {
                 parent.child(
                     Button::new("migrate-wizard-close", "Close")
                         .small()
+                        .primary()
                         .on_click(cx.listener(|this, _event, _window, cx| this.request_close(cx))),
                 )
             });

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -27,8 +27,8 @@ use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Text};
 use dbflux_components::tokens::Spacing;
 use dbflux_core::{
-    ColumnInfo, Connection, DriverCapabilities, SchemaCacheKey, SchemaForeignKeyInfo, TableInfo,
-    TableRef, TransferColumn, topological_order,
+    ColumnInfo, Connection, DriverCapabilities, LogErr, SchemaCacheKey, SchemaForeignKeyInfo,
+    TableInfo, TableRef, TransferColumn, topological_order,
 };
 use dbflux_transfer::TableTransferStatus;
 use dbflux_transfer::migration::{MigratedTable, MigrationOptions, MigrationTablePlan};
@@ -449,6 +449,11 @@ pub struct MigrateWizard {
     error: Option<String>,
     advancing: bool,
 
+    /// The phase whose child tree/grid currently holds keyboard focus. Drives
+    /// the render-time focus routing so the active phase receives arrow-key
+    /// focus on entry without a click-in first (keyboard-first identity).
+    focused_phase: Option<WizardPhase>,
+
     /// Resolved once the `Source & Target` phase is left, then fed to the
     /// downstream phases and the run without re-deriving them.
     resolved_source_database: Option<String>,
@@ -480,6 +485,7 @@ impl MigrateWizard {
             phase: WizardPhase::SourceTarget,
             error: None,
             advancing: false,
+            focused_phase: None,
             resolved_source_database: None,
             target_profile_id: None,
             target_database: None,
@@ -515,6 +521,7 @@ impl MigrateWizard {
         self.phase = WizardPhase::SourceTarget;
         self.error = None;
         self.advancing = false;
+        self.focused_phase = None;
 
         self.resolved_source_database = None;
         self.target_profile_id = None;
@@ -695,6 +702,7 @@ impl MigrateWizard {
         }
 
         let checked = source_target.checked_source_tables();
+        let resolved_source_database = source_target.source_database().to_string();
         let Some(target_profile_id) = source_target.target_profile_id() else {
             return;
         };
@@ -722,11 +730,15 @@ impl MigrateWizard {
             return;
         };
 
-        let source_database = self
-            .source_database
-            .clone()
-            .or_else(|| source_connection.active_database())
-            .unwrap_or_default();
+        // Bind the plan's source database to exactly the database the phase
+        // resolved the checked tables against, so every checked table lines up
+        // with the single source the engine reads from. Fall back to the
+        // live connection only when the phase could not resolve one.
+        let source_database = if resolved_source_database.is_empty() {
+            source_connection.active_database().unwrap_or_default()
+        } else {
+            resolved_source_database
+        };
 
         self.resolved_source_database = Some(source_database.clone());
         self.target_profile_id = Some(target_profile_id);
@@ -771,10 +783,19 @@ impl MigrateWizard {
                 this.advancing = false;
                 match configs {
                     Ok(configs) => {
-                        let existing_target_tables = match existing {
-                            Ok(info) => info.tables.into_iter().map(|table| table.name).collect(),
-                            Err(_) => Vec::new(),
-                        };
+                        // A failed listing only affects Create/Existing
+                        // classification while the user types a new name, so
+                        // the empty-list fallback is safe — but the error is
+                        // traced rather than silently dropped.
+                        let existing_target_tables = existing
+                            .map(|info| {
+                                info.tables
+                                    .into_iter()
+                                    .map(|table| table.name)
+                                    .collect::<Vec<_>>()
+                            })
+                            .log_err_with("Could not list existing target tables for mapping")
+                            .unwrap_or_default();
                         this.mount_mapping(
                             configs,
                             existing_target_tables,
@@ -993,6 +1014,44 @@ impl MigrateWizard {
         .detach();
     }
 
+    /// The focus handle of the child entity backing the current phase, so the
+    /// wizard can route keyboard focus into the active tree/grid on entry.
+    /// `Confirm` and `Run` share the confirm/run child.
+    fn active_phase_focus_handle(&self, cx: &App) -> Option<FocusHandle> {
+        match self.phase {
+            WizardPhase::SourceTarget => self
+                .source_target
+                .as_ref()
+                .map(|entity| entity.read(cx).focus_handle().clone()),
+            WizardPhase::TablesMapping => self
+                .mapping
+                .as_ref()
+                .map(|entity| entity.read(cx).focus_handle().clone()),
+            WizardPhase::Options => self
+                .options
+                .as_ref()
+                .map(|entity| entity.read(cx).focus_handle().clone()),
+            WizardPhase::Confirm | WizardPhase::Run => self
+                .confirm_run
+                .as_ref()
+                .map(|entity| entity.read(cx).focus_handle().clone()),
+        }
+    }
+
+    /// Moves keyboard focus into the active phase's child once per phase
+    /// change, so arrow-key navigation works without clicking into the tree
+    /// first. Focus stays put across re-renders of the same phase, so tabbing
+    /// to the footer button is never stolen back.
+    fn focus_active_phase_on_entry(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.focused_phase == Some(self.phase) {
+            return;
+        }
+        if let Some(handle) = self.active_phase_focus_handle(cx) {
+            handle.focus(window);
+            self.focused_phase = Some(self.phase);
+        }
+    }
+
     fn mount_confirm_run(&mut self, inputs: ConfirmRunInputs, cx: &mut Context<Self>) {
         let confirm_run = cx.new(|cx| ConfirmRunPhase::new(inputs, cx));
         self._confirm_run_sub = Some(cx.subscribe(
@@ -1074,10 +1133,12 @@ impl MigrateWizard {
 }
 
 impl Render for MigrateWizard {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         if !self.visible {
             return div().into_any_element();
         }
+
+        self.focus_active_phase_on_entry(window, cx);
 
         let close_entity = cx.entity().downgrade();
         let close = move |_window: &mut Window, cx: &mut App| {

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -368,6 +368,17 @@ async fn fetch_schema_foreign_keys_via_seam(
     Ok(foreign_keys)
 }
 
+/// Whether a successfully fetched target `table_details` proves the target
+/// relation already exists. An existing relation always projects at least one
+/// column, so a `None`/empty column set is treated as "does not exist" — some
+/// drivers (Postgres/MySQL) return `Ok(TableInfo)` with no columns for a
+/// missing relation instead of `DbError::ObjectNotFound`, and that Ok-but-empty
+/// result must classify the row as `Create` (mirror the source columns), never
+/// `Existing`.
+fn target_columns_prove_existing(columns: Option<&[ColumnInfo]>) -> bool {
+    columns.is_some_and(|columns| !columns.is_empty())
+}
+
 /// Builds one [`TableMigrationConfig`] per checked source table by fetching
 /// the source and target table schemas through the shared metadata seam: the
 /// source columns must exist (a failure here is fatal), while a missing target
@@ -402,7 +413,7 @@ async fn build_configs_via_seam(
         };
         let source_columns = to_transfer_columns(source_info.columns.unwrap_or_default());
 
-        let (target_exists, target_columns) = match fetch_table_details_via_seam(
+        let target_fetch = match fetch_table_details_via_seam(
             app_state,
             target_profile_id,
             target_database,
@@ -411,11 +422,21 @@ async fn build_configs_via_seam(
         )
         .await
         {
-            Ok(TableDetailsFetch::Found(info)) => {
+            Ok(fetch) => fetch,
+            Err(e) => return Err(format!("{}: {e}", table_ref.qualified_name())),
+        };
+
+        // An Ok fetch that carries no columns means the target relation does
+        // not exist (Postgres/MySQL report a missing table this way instead of
+        // ObjectNotFound), so it is treated the same as NotFound: the row is a
+        // Create that mirrors the source columns, not an Existing target.
+        let (target_exists, target_columns) = match target_fetch {
+            TableDetailsFetch::Found(info)
+                if target_columns_prove_existing(info.columns.as_deref()) =>
+            {
                 (true, to_transfer_columns(info.columns.unwrap_or_default()))
             }
-            Ok(TableDetailsFetch::NotFound(_)) => (false, Vec::new()),
-            Err(e) => return Err(format!("{}: {e}", table_ref.qualified_name())),
+            _ => (false, Vec::new()),
         };
 
         configs.push(TableMigrationConfig::new(
@@ -475,6 +496,14 @@ pub struct MigrateWizard {
     /// discarded on a real change.
     built_selection: Option<(Vec<TableRef>, Uuid, String)>,
 
+    /// The effective selection captured when the currently in-flight
+    /// `Source & Target` advance was spawned. While an advance is in flight it
+    /// is judged against this snapshot — not [`Self::built_selection`] — so a
+    /// completing background tree fetch that re-emits `SourceTargetChanged`
+    /// without changing the selection (a no-op) does not cancel the advance the
+    /// user already triggered. `None` when no advance is in flight.
+    advance_selection: Option<(Vec<TableRef>, Uuid, String)>,
+
     /// The phase whose child tree/grid currently holds keyboard focus. Drives
     /// the render-time focus routing so the active phase receives arrow-key
     /// focus on entry without a click-in first (keyboard-first identity).
@@ -513,6 +542,7 @@ impl MigrateWizard {
             advancing: false,
             generation: 0,
             built_selection: None,
+            advance_selection: None,
             focused_phase: None,
             resolved_source_database: None,
             target_profile_id: None,
@@ -563,6 +593,7 @@ impl MigrateWizard {
         self.advancing = false;
         self.generation = self.generation.wrapping_add(1);
         self.built_selection = None;
+        self.advance_selection = None;
         self.focused_phase = None;
 
         self.resolved_source_database = None;
@@ -619,7 +650,21 @@ impl MigrateWizard {
         if self.is_running(cx) {
             return;
         }
-        if !self.selection_matches_built(cx) {
+
+        // While a Source & Target advance is in flight, judge the event against
+        // the selection that advance was spawned with — not the built selection
+        // — so a completing background tree fetch that re-emits
+        // `SourceTargetChanged` without changing the selection does not cancel
+        // the advance the user already triggered. A genuine change still
+        // differs and cancels. With no such advance in flight
+        // (`advance_selection` is `None`, including during the later
+        // `Options → Confirm` advance) the built selection is the reference.
+        let reference = if self.advance_selection.is_some() {
+            &self.advance_selection
+        } else {
+            &self.built_selection
+        };
+        if !self.selection_matches(reference, cx) {
             self.invalidate_in_flight_advance();
         }
         cx.notify();
@@ -634,11 +679,16 @@ impl MigrateWizard {
             .is_some_and(|phase| phase.read(cx).run_state() == RunState::Running)
     }
 
-    /// Whether the Source & Target phase's current effective selection equals
-    /// the one the downstream phases were built from.
-    fn selection_matches_built(&self, cx: &App) -> bool {
-        let Some((built_tables, built_profile_id, built_database)) = self.built_selection.as_ref()
-        else {
+    /// Whether the Source & Target phase's current effective selection equals a
+    /// previously captured one (the built selection, or the selection an
+    /// in-flight advance was spawned with). `None` — no captured selection —
+    /// never matches, so the caller treats it as a change.
+    fn selection_matches(
+        &self,
+        captured: &Option<(Vec<TableRef>, Uuid, String)>,
+        cx: &App,
+    ) -> bool {
+        let Some((tables, profile_id, database)) = captured.as_ref() else {
             return false;
         };
         let Some(source_target) = self.source_target.as_ref() else {
@@ -646,9 +696,9 @@ impl MigrateWizard {
         };
 
         let phase = source_target.read(cx);
-        phase.checked_source_tables() == *built_tables
-            && phase.target_profile_id() == Some(*built_profile_id)
-            && phase.target_database().as_deref() == Some(built_database.as_str())
+        phase.checked_source_tables() == *tables
+            && phase.target_profile_id() == Some(*profile_id)
+            && phase.target_database().as_deref() == Some(database.as_str())
     }
 
     /// Orphans any in-flight advance spawn: bumping the generation makes its
@@ -657,6 +707,7 @@ impl MigrateWizard {
     fn invalidate_in_flight_advance(&mut self) {
         self.generation = self.generation.wrapping_add(1);
         self.advancing = false;
+        self.advance_selection = None;
     }
 
     /// Edited mappings only invalidate the confirm/run plan and its FK order;
@@ -873,6 +924,7 @@ impl MigrateWizard {
         }
 
         self.advancing = true;
+        self.advance_selection = self.built_selection.clone();
         self.error = None;
         cx.notify();
 
@@ -906,6 +958,7 @@ impl MigrateWizard {
                 }
 
                 this.advancing = false;
+                this.advance_selection = None;
                 match configs {
                     Ok(configs) => {
                         // A failed listing only affects Create/Existing
@@ -1079,6 +1132,7 @@ impl MigrateWizard {
             let plans: Vec<MappingRowPlan> = configs
                 .iter()
                 .map(|config| MappingRowPlan {
+                    source_schema: config.source_table.schema.as_deref(),
                     source_table: config.source_table.name.as_str(),
                     target_schema: config.target_schema.as_deref(),
                     target_table: config.target_table.as_str(),
@@ -1415,9 +1469,9 @@ impl MigrateWizard {
 mod tests {
     use super::{
         TableMigrationConfig, WizardPhase, build_migration_options, build_migration_table_plans,
-        is_already_cached_sentinel, next_phase,
+        is_already_cached_sentinel, next_phase, target_columns_prove_existing,
     };
-    use dbflux_core::{TableRef, TransferColumn};
+    use dbflux_core::{ColumnInfo, TableRef, TransferColumn};
 
     fn transfer_column(name: &str) -> TransferColumn {
         TransferColumn {
@@ -1426,6 +1480,29 @@ mod tests {
             nullable: true,
             is_primary_key: false,
         }
+    }
+
+    fn column_info(name: &str) -> ColumnInfo {
+        ColumnInfo {
+            name: name.to_string(),
+            type_name: "text".to_string(),
+            nullable: true,
+            is_primary_key: false,
+            default_value: None,
+            enum_values: None,
+        }
+    }
+
+    #[test]
+    fn target_columns_prove_existing_only_for_a_non_empty_column_set() {
+        // A real, existing relation always projects at least one column.
+        let columns = vec![column_info("id")];
+        assert!(target_columns_prove_existing(Some(&columns)));
+
+        // Ok-but-empty columns (Postgres/MySQL "table absent" signal) and a
+        // never-loaded column set both mean the target must be created.
+        assert!(!target_columns_prove_existing(Some(&[])));
+        assert!(!target_columns_prove_existing(None));
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -9,6 +9,8 @@
 //! pre-populates `source_profile_id` / `source_database` / `source_tables`.
 
 mod column_mapping;
+pub mod phases;
+pub mod tree_model;
 
 use std::sync::{Arc, Mutex};
 

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -10,6 +10,7 @@
 
 mod column_mapping;
 pub mod phases;
+pub mod source_target;
 pub mod tree_model;
 
 use std::sync::{Arc, Mutex};

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -135,10 +135,11 @@ where
     let accent = theme.accent;
     let muted = theme.muted_foreground;
     let border = theme.border;
+    let hover_bg = theme.secondary;
 
     let entries = rail_entries(current)
         .into_iter()
-        .map(move |entry| render_rail_entry(entry, accent, muted, on_select.clone()));
+        .map(move |entry| render_rail_entry(entry, accent, muted, hover_bg, on_select.clone()));
 
     div()
         .flex()
@@ -155,6 +156,7 @@ fn render_rail_entry<F>(
     entry: RailEntry,
     accent: Hsla,
     muted: Hsla,
+    hover_bg: Hsla,
     on_select: F,
 ) -> impl IntoElement
 where
@@ -176,11 +178,12 @@ where
             .into_any_element()
     };
 
+    // Only the current entry is accented; every other label stays at full
+    // foreground contrast (a check/dot marker already conveys completed vs.
+    // pending), so the rail reads clearly instead of as dim, low-contrast text.
     let mut label = Text::body(phase.label());
     if entry.current {
         label = label.color(accent);
-    } else if !entry.completed {
-        label = label.muted_foreground();
     }
 
     div()
@@ -205,6 +208,7 @@ where
         .child(label)
         .when(entry.completed, |el| {
             el.cursor_pointer()
+                .hover(|style| style.bg(hover_bg))
                 .on_click(move |_event, window, app| on_select(phase, window, app))
         })
 }
@@ -461,6 +465,18 @@ fn next_phase(phase: WizardPhase) -> Option<WizardPhase> {
         WizardPhase::TablesMapping => Some(WizardPhase::Options),
         WizardPhase::Options => Some(WizardPhase::Confirm),
         WizardPhase::Confirm | WizardPhase::Run => None,
+    }
+}
+
+/// The phase reached by pressing the footer's Back button from `phase`, or
+/// `None` for the first phase and for `Run` (whose back-navigation is frozen —
+/// leaving a live or finished run behind is handled by Cancel/Close, not Back).
+fn prev_phase(phase: WizardPhase) -> Option<WizardPhase> {
+    match phase {
+        WizardPhase::SourceTarget | WizardPhase::Run => None,
+        WizardPhase::TablesMapping => Some(WizardPhase::SourceTarget),
+        WizardPhase::Options => Some(WizardPhase::TablesMapping),
+        WizardPhase::Confirm => Some(WizardPhase::Options),
     }
 }
 
@@ -786,6 +802,35 @@ impl MigrateWizard {
             name
         } else {
             format!("{name} / {database}")
+        }
+    }
+
+    /// Footer Back button: steps one phase backwards through the linear flow.
+    /// Shares [`Self::go_to_phase`]'s running guard, so it is inert during a
+    /// live run.
+    fn go_back(&mut self, cx: &mut Context<Self>) {
+        if let Some(previous) = prev_phase(self.phase) {
+            self.go_to_phase(previous, cx);
+        }
+    }
+
+    /// Footer Cancel button: signals the confirm/run phase's cancel token so
+    /// the in-flight migration stops at the next chunk boundary.
+    fn cancel_run(&mut self, cx: &mut Context<Self>) {
+        if let Some(phase) = self.confirm_run.clone() {
+            phase.update(cx, |phase, cx| phase.cancel_run(cx));
+        }
+    }
+
+    /// Footer Close button (shown once the run is `Done`): routes through the
+    /// confirm/run phase's existing `CloseRequested` event so the single close
+    /// path in the wizard's subscription stays the only way the modal dismisses.
+    fn request_close(&mut self, cx: &mut Context<Self>) {
+        match self.confirm_run.clone() {
+            Some(phase) => {
+                phase.update(cx, |_phase, cx| cx.emit(ConfirmRunEvent::CloseRequested));
+            }
+            None => self.close(cx),
         }
     }
 
@@ -1428,13 +1473,57 @@ impl MigrateWizard {
         let theme = cx.theme();
         let border = theme.border;
 
+        let run_state = self
+            .confirm_run
+            .as_ref()
+            .map(|phase| phase.read(cx).run_state());
+        let running = run_state == Some(RunState::Running);
+        let done = run_state == Some(RunState::Done);
+
+        let shows_back = prev_phase(self.phase).is_some() && !running && !done;
         let shows_continue = next_phase(self.phase).is_some();
         let continue_enabled = !self.advancing && self.continue_enabled(cx);
-        let label = if self.advancing {
+        let continue_label = if self.advancing {
             "Loading…"
         } else {
             "Continue"
         };
+
+        let actions = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(Spacing::SM)
+            .when(shows_back, |parent| {
+                parent.child(
+                    Button::new("migrate-wizard-back", "Back")
+                        .ghost()
+                        .disabled(self.advancing)
+                        .on_click(cx.listener(|this, _event, _window, cx| this.go_back(cx))),
+                )
+            })
+            .when(shows_continue, |parent| {
+                parent.child(
+                    Button::new("migrate-wizard-continue", continue_label)
+                        .disabled(!continue_enabled)
+                        .on_click(cx.listener(|this, _event, window, cx| this.advance(window, cx))),
+                )
+            })
+            .when(running, |parent| {
+                parent.child(
+                    Button::new("migrate-wizard-cancel", "Cancel")
+                        .small()
+                        .ghost()
+                        .on_click(cx.listener(|this, _event, _window, cx| this.cancel_run(cx))),
+                )
+            })
+            .when(done, |parent| {
+                parent.child(
+                    Button::new("migrate-wizard-close", "Close")
+                        .small()
+                        .on_click(cx.listener(|this, _event, _window, cx| this.request_close(cx))),
+                )
+            });
 
         div()
             .flex()
@@ -1454,13 +1543,7 @@ impl MigrateWizard {
                         parent.child(Text::caption(error).danger())
                     }),
             )
-            .when(shows_continue, |parent| {
-                parent.child(
-                    Button::new("migrate-wizard-continue", label)
-                        .disabled(!continue_enabled)
-                        .on_click(cx.listener(|this, _event, window, cx| this.advance(window, cx))),
-                )
-            })
+            .child(actions)
             .into_any_element()
     }
 }

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -9,6 +9,7 @@
 //! pre-populates `source_profile_id` / `source_database` / `source_tables`.
 
 mod column_mapping;
+pub mod confirm_run;
 pub mod mapping;
 pub mod options;
 pub mod phases;
@@ -21,7 +22,7 @@ use dbflux_components::controls::{
     Button, Checkbox, Dropdown, DropdownItem, DropdownSelectionChanged,
 };
 use dbflux_components::icons::AppIcon;
-use dbflux_components::primitives::Text;
+use dbflux_components::primitives::{Icon, Text};
 use dbflux_components::tokens::Spacing;
 use dbflux_core::{
     ColumnInfo, Connection, DriverCapabilities, SchemaCacheKey, SchemaForeignKeyInfo, TableInfo,
@@ -37,10 +38,12 @@ use dbflux_ui_base::toast::Toast;
 use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 use gpui::prelude::FluentBuilder;
 use gpui::*;
+use gpui_component::ActiveTheme;
 use uuid::Uuid;
 
 pub use column_mapping::TableMigrationConfig;
 use column_mapping::mapping_mode_options;
+use phases::{RailEntry, WizardPhase, rail_entries};
 
 /// Whether an `Err(String)` returned by one of the shared
 /// `AppStateEntity::prepare_fetch_*` seams means "the data is already cached"
@@ -111,6 +114,95 @@ fn build_migration_options(
         disable_referential_integrity,
         manual_order,
     }
+}
+
+/// Renders the wizard's left phase rail: the five fixed [`WizardPhase`]
+/// entries in order, a checkmark on every completed phase, a highlight on the
+/// current one, and click-to-return back-navigation on completed entries.
+/// `on_select` is invoked with the clicked phase; only completed (already
+/// passed) entries are interactive, so the caller cannot jump ahead. The FK
+/// reorder interrupt is deliberately absent — it is a conditional overlay
+/// inside `Confirm`, never a listed rail phase.
+pub fn render_phase_rail<F>(current: WizardPhase, on_select: F, cx: &App) -> impl IntoElement
+where
+    F: Fn(WizardPhase, &mut Window, &mut App) + Clone + 'static,
+{
+    let theme = cx.theme();
+    let accent = theme.accent;
+    let muted = theme.muted_foreground;
+    let border = theme.border;
+
+    let entries = rail_entries(current)
+        .into_iter()
+        .map(move |entry| render_rail_entry(entry, accent, muted, on_select.clone()));
+
+    div()
+        .flex()
+        .flex_col()
+        .gap(Spacing::XS)
+        .p(Spacing::MD)
+        .min_w(px(180.0))
+        .border_r_1()
+        .border_color(border)
+        .children(entries)
+}
+
+fn render_rail_entry<F>(
+    entry: RailEntry,
+    accent: Hsla,
+    muted: Hsla,
+    on_select: F,
+) -> impl IntoElement
+where
+    F: Fn(WizardPhase, &mut Window, &mut App) + Clone + 'static,
+{
+    let phase = entry.phase;
+
+    let marker = if entry.completed {
+        Icon::new(AppIcon::CircleCheck)
+            .size(px(14.0))
+            .color(accent)
+            .into_any_element()
+    } else {
+        let dot_color = if entry.current { accent } else { muted };
+        div()
+            .size(px(8.0)) // guardrail-allow: decorative status-dot diameter, not a spacing token
+            .rounded_full()
+            .bg(dot_color)
+            .into_any_element()
+    };
+
+    let mut label = Text::body(phase.label());
+    if entry.current {
+        label = label.color(accent);
+    } else if !entry.completed {
+        label = label.muted_foreground();
+    }
+
+    div()
+        .id(SharedString::from(format!(
+            "migrate-rail-{}",
+            phase.label()
+        )))
+        .flex()
+        .items_center()
+        .gap(Spacing::SM)
+        .px(Spacing::SM)
+        .py(Spacing::XS)
+        .rounded_md()
+        .child(
+            div()
+                .w(px(16.0)) // guardrail-allow: fixed rail marker gutter width for label alignment
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(marker),
+        )
+        .child(label)
+        .when(entry.completed, |el| {
+            el.cursor_pointer()
+                .on_click(move |_event, window, app| on_select(phase, window, app))
+        })
 }
 
 /// Outcome of fetching one table's details through the shared

--- a/crates/dbflux_ui_document/src/migrate_wizard/options.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/options.rs
@@ -1,0 +1,233 @@
+//! Options phase of the migration wizard: exactly two engine-backed controls,
+//! nothing decorative. **Segment/commit size** feeds
+//! `MigrationOptions::segment_size` (default 500, minimum 1) and **disable
+//! referential integrity** feeds `MigrationOptions::disable_referential_integrity`,
+//! rendered only when the target driver advertises
+//! `DriverCapabilities::DISABLE_FK_CHECKS` (R7) — an unsupported target simply
+//! never sees the control, it is not an error state. Per-table mapping mode
+//! lives in the Tables Mapping grid (`mapping.rs`), not here.
+
+use dbflux_components::controls::{Checkbox, GpuiInput as Input, InputEvent, InputState};
+use dbflux_components::primitives::Text;
+use dbflux_components::tokens::Spacing;
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::Sizable;
+
+const DEFAULT_SEGMENT_SIZE: u32 = 500;
+const SEGMENT_SIZE_INPUT_WIDTH: Pixels = px(160.0);
+
+/// Parses a typed segment/commit-size value, rejecting non-numeric text and
+/// non-positive values — the engine commits at least one row per segment, so
+/// zero (and anything that does not parse as a whole number) is invalid.
+pub fn parse_segment_size(text: &str) -> Option<u32> {
+    match text.trim().parse::<u32>() {
+        Ok(0) | Err(_) => None,
+        Ok(value) => Some(value),
+    }
+}
+
+/// Whether a disable-referential-integrity request is actually honored: only
+/// when the target driver advertises `DriverCapabilities::DISABLE_FK_CHECKS`
+/// (R7). The wizard never asks the engine to disable a toggle the target
+/// cannot support — the gating happens here, before `MigrationOptions` is
+/// built, not as a silent no-op inside `run_migration`.
+pub fn resolved_disable_referential_integrity(
+    requested: bool,
+    target_supports_disable_fk_checks: bool,
+) -> bool {
+    requested && target_supports_disable_fk_checks
+}
+
+/// Emitted whenever the segment size or the disable-RI request changes, so
+/// the host can re-evaluate any downstream state that depends on this
+/// phase's values.
+#[derive(Debug, Clone)]
+pub struct OptionsChanged;
+
+pub struct OptionsPhase {
+    focus_handle: FocusHandle,
+    segment_size: u32,
+    segment_size_input: Entity<InputState>,
+    segment_size_invalid: bool,
+    supports_disable_ri: bool,
+    disable_referential_integrity_requested: bool,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl EventEmitter<OptionsChanged> for OptionsPhase {}
+
+impl OptionsPhase {
+    /// `supports_disable_ri` reflects the chosen target's
+    /// `DriverCapabilities::DISABLE_FK_CHECKS` and is fixed for the phase's
+    /// lifetime — the target container is chosen earlier, in Source & Target.
+    pub fn new(supports_disable_ri: bool, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let segment_size_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .default_value(DEFAULT_SEGMENT_SIZE.to_string())
+                .placeholder("Segment / commit size")
+        });
+
+        let mut phase = Self {
+            focus_handle: cx.focus_handle(),
+            segment_size: DEFAULT_SEGMENT_SIZE,
+            segment_size_input,
+            segment_size_invalid: false,
+            supports_disable_ri,
+            disable_referential_integrity_requested: false,
+            _subscriptions: Vec::new(),
+        };
+
+        let subscription = cx.subscribe_in(
+            &phase.segment_size_input,
+            window,
+            |this, _entity, event: &InputEvent, window, cx| {
+                if let InputEvent::Change = event {
+                    this.on_segment_size_changed(window, cx);
+                }
+            },
+        );
+        phase._subscriptions.push(subscription);
+
+        phase
+    }
+
+    pub fn focus_handle(&self) -> &FocusHandle {
+        &self.focus_handle
+    }
+
+    /// The last valid segment/commit size, feeding
+    /// `MigrationOptions::segment_size` directly — an in-progress invalid
+    /// edit never overwrites it, so the run always has a usable value.
+    pub fn segment_size(&self) -> u32 {
+        self.segment_size
+    }
+
+    /// Feeds `MigrationOptions::disable_referential_integrity` directly,
+    /// already gated on the target's capability.
+    pub fn disable_referential_integrity(&self) -> bool {
+        resolved_disable_referential_integrity(
+            self.disable_referential_integrity_requested,
+            self.supports_disable_ri,
+        )
+    }
+
+    fn on_segment_size_changed(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        let typed = self.segment_size_input.read(cx).value().to_string();
+
+        match parse_segment_size(&typed) {
+            Some(value) => {
+                self.segment_size = value;
+                self.segment_size_invalid = false;
+            }
+            None => {
+                self.segment_size_invalid = true;
+            }
+        }
+
+        cx.emit(OptionsChanged);
+        cx.notify();
+    }
+
+    fn on_disable_ri_toggled(&mut self, checked: bool, cx: &mut Context<Self>) {
+        self.disable_referential_integrity_requested = checked;
+        cx.emit(OptionsChanged);
+        cx.notify();
+    }
+}
+
+impl Render for OptionsPhase {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .track_focus(&self.focus_handle)
+            .key_context("MigrateOptions")
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .p(Spacing::MD)
+            .size_full()
+            .child(self.render_segment_size())
+            .when(self.supports_disable_ri, |parent| {
+                parent.child(self.render_disable_ri(cx))
+            })
+    }
+}
+
+impl OptionsPhase {
+    fn render_segment_size(&self) -> impl IntoElement {
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::XS)
+            .child(Text::label("Segment / commit size"))
+            .child(
+                div()
+                    .w(SEGMENT_SIZE_INPUT_WIDTH)
+                    .child(Input::new(&self.segment_size_input).small().w_full()),
+            )
+            .when(self.segment_size_invalid, |parent| {
+                parent.child(
+                    Text::caption("Must be a whole number of 1 or more; kept the previous value.")
+                        .danger(),
+                )
+            })
+    }
+
+    fn render_disable_ri(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        Checkbox::new("migrate-options-disable-ri")
+            .checked(self.disable_referential_integrity_requested)
+            .label("Disable referential integrity during migration")
+            .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                this.on_disable_ri_toggled(*checked, cx);
+            }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_segment_size, resolved_disable_referential_integrity};
+    use crate::migrate_wizard::build_migration_options;
+    use dbflux_core::TableRef;
+
+    #[test]
+    fn parse_segment_size_accepts_positive_whole_numbers() {
+        assert_eq!(parse_segment_size("500"), Some(500));
+        assert_eq!(parse_segment_size("1"), Some(1));
+        assert_eq!(parse_segment_size("  250  "), Some(250));
+    }
+
+    #[test]
+    fn parse_segment_size_rejects_zero_and_non_numeric_input() {
+        assert_eq!(parse_segment_size("0"), None);
+        assert_eq!(parse_segment_size(""), None);
+        assert_eq!(parse_segment_size("abc"), None);
+        assert_eq!(parse_segment_size("-5"), None);
+        assert_eq!(parse_segment_size("12.5"), None);
+    }
+
+    #[test]
+    fn resolved_disable_referential_integrity_requires_both_request_and_capability() {
+        assert!(!resolved_disable_referential_integrity(false, false));
+        assert!(!resolved_disable_referential_integrity(false, true));
+        assert!(!resolved_disable_referential_integrity(true, false));
+        assert!(resolved_disable_referential_integrity(true, true));
+    }
+
+    #[test]
+    fn options_phase_values_feed_migration_options_verbatim() {
+        let segment_size = parse_segment_size("750").expect("valid segment size");
+        let disable_referential_integrity = resolved_disable_referential_integrity(true, true);
+
+        let options = build_migration_options(
+            segment_size,
+            "source_db".to_string(),
+            "target_db".to_string(),
+            false,
+            disable_referential_integrity,
+            Some(vec![TableRef::new("a")]),
+        );
+
+        assert_eq!(options.segment_size, 750);
+        assert!(options.disable_referential_integrity);
+    }
+}

--- a/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
@@ -6,7 +6,7 @@
 //! `topological_order` result) live in `mod.rs`; this module owns only the
 //! state shapes and the guards that do not require live metadata.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use dbflux_core::TableRef;
 
@@ -110,6 +110,7 @@ pub fn can_advance_from_tables_mapping(rows: &[MappingRowReadiness]) -> bool {
 /// [`MappingRowReadiness`] cannot express (they compare rows against each
 /// other and against the shared source container).
 pub struct MappingRowPlan<'a> {
+    pub source_schema: Option<&'a str>,
     pub source_table: &'a str,
     pub target_schema: Option<&'a str>,
     pub target_table: &'a str,
@@ -120,6 +121,35 @@ fn target_label(schema: Option<&str>, table: &str) -> String {
     match schema {
         Some(schema) if !schema.is_empty() => format!("{schema}.{table}"),
         _ => table.to_string(),
+    }
+}
+
+/// Normalizes an optional schema so an empty schema string is treated as
+/// "unqualified" (`None`), matching how [`target_label`] renders it — a bare
+/// `Some("")` must never be a distinct identity from `None`.
+fn normalized_schema(schema: Option<&str>) -> Option<&str> {
+    schema.filter(|s| !s.is_empty())
+}
+
+/// Whether a destructive row's target refers to the same relation as a source
+/// table in the same container. Table names must match; schemas are compared
+/// only when the target schema is known — an unqualified target (`None`) is a
+/// potential collision with any same-named source table, since the server
+/// resolves it against the active schema at run time (the safe direction for a
+/// destructive self-target). A qualified target with a *different* schema (e.g.
+/// `archive.orders` vs source `public.orders`) is therefore not a collision.
+fn is_same_relation(
+    source_schema: Option<&str>,
+    source_table: &str,
+    target_schema: Option<&str>,
+    target_table: &str,
+) -> bool {
+    if source_table != target_table {
+        return false;
+    }
+    match normalized_schema(target_schema) {
+        Some(target_schema) => normalized_schema(source_schema) == Some(target_schema),
+        None => true,
     }
 }
 
@@ -153,17 +183,28 @@ pub fn tables_mapping_blocking_errors(
     }
 
     if same_container {
-        let source_names: HashSet<&str> = rows.iter().map(|row| row.source_table).collect();
-        let mut collided: HashSet<&str> = HashSet::new();
+        let mut collided: HashSet<(Option<&str>, &str)> = HashSet::new();
         for row in rows {
-            if row.destructive
-                && source_names.contains(row.target_table)
-                && collided.insert(row.target_table)
-            {
+            if !row.destructive {
+                continue;
+            }
+
+            let collides = rows.iter().any(|source| {
+                is_same_relation(
+                    source.source_schema,
+                    source.source_table,
+                    row.target_schema,
+                    row.target_table,
+                )
+            });
+            let target_key = (normalized_schema(row.target_schema), row.target_table);
+
+            if collides && collided.insert(target_key) {
                 errors.push(format!(
                     "'{}' uses a destructive mode but its target is source table '{}' in the \
                      same connection — it would be dropped or emptied before it is read.",
-                    row.source_table, row.target_table
+                    row.source_table,
+                    target_label(row.target_schema, row.target_table)
                 ));
             }
         }
@@ -172,33 +213,89 @@ pub fn tables_mapping_blocking_errors(
     errors
 }
 
-/// Non-blocking, cross-row warnings surfaced on the Confirm screen: a
-/// non-destructive row whose target is one of the source tables in the same
-/// container appends rows into a table that is also being read. Destructive
-/// same-container collisions are blocked earlier by
-/// [`tables_mapping_blocking_errors`].
+/// Non-blocking, cross-row warnings surfaced on the Confirm screen:
+/// - **Case-only target collisions**: two rows whose targets differ only in
+///   letter case (e.g. `Users` and `users`). On a case-sensitive database they
+///   are distinct tables (so this is not the blocking exact-duplicate error),
+///   but on a case-insensitive collation they resolve to one table — worth a
+///   warning, not a hard block. Independent of the source/target container.
+/// - **Same-container append**: a non-destructive row whose target is one of the
+///   source tables in the same container appends rows into a table that is also
+///   being read. Destructive same-container collisions are blocked earlier by
+///   [`tables_mapping_blocking_errors`].
 pub fn tables_mapping_confirm_warnings(
     rows: &[MappingRowPlan],
     same_container: bool,
 ) -> Vec<String> {
-    if !same_container {
-        return Vec::new();
+    let mut warnings = case_insensitive_duplicate_target_warnings(rows);
+
+    if same_container {
+        warnings.extend(same_container_append_warnings(rows));
     }
 
-    let source_names: HashSet<&str> = rows.iter().map(|row| row.source_table).collect();
-    let mut warned: HashSet<&str> = HashSet::new();
+    warnings
+}
+
+/// Warns when two target rows share the same identifier under a case-insensitive
+/// comparison but differ in exact spelling. Exact duplicates are the blocking
+/// error in [`tables_mapping_blocking_errors`], so a group that is a single
+/// exact spelling is left alone here.
+fn case_insensitive_duplicate_target_warnings(rows: &[MappingRowPlan]) -> Vec<String> {
+    let mut folded: BTreeMap<(Option<String>, String), BTreeSet<String>> = BTreeMap::new();
+
+    for row in rows {
+        let key = (
+            normalized_schema(row.target_schema).map(str::to_lowercase),
+            row.target_table.to_lowercase(),
+        );
+        folded
+            .entry(key)
+            .or_default()
+            .insert(target_label(row.target_schema, row.target_table));
+    }
+
+    folded
+        .into_values()
+        .filter(|spellings| spellings.len() > 1)
+        .map(|spellings| {
+            let labels: Vec<String> = spellings.into_iter().collect();
+            format!(
+                "Targets {} differ only in letter case; on a case-insensitive database they \
+                 resolve to the same table.",
+                labels.join(", ")
+            )
+        })
+        .collect()
+}
+
+/// The same-container append warnings: a non-destructive row writing into one of
+/// the source tables in the same container.
+fn same_container_append_warnings(rows: &[MappingRowPlan]) -> Vec<String> {
+    let mut warned: HashSet<(Option<&str>, &str)> = HashSet::new();
 
     rows.iter()
         .filter(|row| {
-            !row.destructive
-                && source_names.contains(row.target_table)
-                && warned.insert(row.target_table)
+            if row.destructive {
+                return false;
+            }
+
+            let collides = rows.iter().any(|source| {
+                is_same_relation(
+                    source.source_schema,
+                    source.source_table,
+                    row.target_schema,
+                    row.target_table,
+                )
+            });
+
+            collides && warned.insert((normalized_schema(row.target_schema), row.target_table))
         })
         .map(|row| {
             format!(
                 "'{}' writes into source table '{}' in the same connection; rows are appended to \
                  a table you are also reading.",
-                row.source_table, row.target_table
+                row.source_table,
+                target_label(row.target_schema, row.target_table)
             )
         })
         .collect()
@@ -327,8 +424,25 @@ mod tests {
 
     fn plan<'a>(source: &'a str, target: &'a str, destructive: bool) -> MappingRowPlan<'a> {
         MappingRowPlan {
+            source_schema: None,
             source_table: source,
             target_schema: None,
+            target_table: target,
+            destructive,
+        }
+    }
+
+    fn qualified_plan<'a>(
+        source_schema: Option<&'a str>,
+        source: &'a str,
+        target_schema: Option<&'a str>,
+        target: &'a str,
+        destructive: bool,
+    ) -> MappingRowPlan<'a> {
+        MappingRowPlan {
+            source_schema,
+            source_table: source,
+            target_schema,
             target_table: target,
             destructive,
         }
@@ -363,6 +477,33 @@ mod tests {
     }
 
     #[test]
+    fn tables_mapping_blocking_errors_compares_qualified_identity_for_source_as_target() {
+        // A destructive row targeting `archive.orders` must NOT be blocked by a
+        // source `public.orders` in the same connection — different schemas are
+        // different relations.
+        let different_schema = vec![qualified_plan(
+            Some("public"),
+            "orders",
+            Some("archive"),
+            "orders",
+            true,
+        )];
+        assert!(tables_mapping_blocking_errors(&different_schema, true).is_empty());
+
+        // A genuine same-(schema, table) destructive self-target still blocks.
+        let same_schema = vec![qualified_plan(
+            Some("public"),
+            "orders",
+            Some("public"),
+            "orders",
+            true,
+        )];
+        let errors = tables_mapping_blocking_errors(&same_schema, true);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("orders"));
+    }
+
+    #[test]
     fn tables_mapping_confirm_warnings_flags_non_destructive_same_container_collision() {
         let rows = vec![plan("orders", "orders", false)];
 
@@ -371,6 +512,28 @@ mod tests {
         let warnings = tables_mapping_confirm_warnings(&rows, true);
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("orders"));
+    }
+
+    #[test]
+    fn tables_mapping_confirm_warnings_flags_case_only_target_collisions() {
+        // `Users` and `users` are distinct on a case-sensitive database (so no
+        // blocking exact-duplicate error) but collide on a case-insensitive
+        // collation — a non-blocking warning, independent of the container.
+        let rows = vec![plan("a", "Users", false), plan("b", "users", false)];
+
+        assert!(tables_mapping_blocking_errors(&rows, false).is_empty());
+
+        let warnings = tables_mapping_confirm_warnings(&rows, false);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("Users"));
+        assert!(warnings[0].contains("users"));
+    }
+
+    #[test]
+    fn tables_mapping_confirm_warnings_ignores_exact_duplicate_targets() {
+        // Exact duplicates are the blocking error, not a case-only warning.
+        let rows = vec![plan("a", "users", false), plan("b", "users", false)];
+        assert!(tables_mapping_confirm_warnings(&rows, false).is_empty());
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
@@ -3,8 +3,8 @@
 //! reorder interrupt overlay, and run-state tracking. No GPUI — unit
 //! testable without a wizard entity. Rendering (`render_phase_rail`) and the
 //! metadata-dependent transitions (`Options` → `Confirm`, which needs a real
-//! `topological_order` result) are built in later slices; this module only
-//! owns the state shapes and the guards that do not require live metadata.
+//! `topological_order` result) live in `mod.rs`; this module owns only the
+//! state shapes and the guards that do not require live metadata.
 
 use dbflux_core::TableRef;
 
@@ -88,7 +88,7 @@ pub fn can_advance_from_source_target(
 }
 
 /// One mapping-grid row's readiness to advance past `TablesMapping`,
-/// decoupled from the grid's full row type (built in a later slice).
+/// decoupled from the grid's full row type in `mapping.rs`.
 pub struct MappingRowReadiness<'a> {
     pub target_name: &'a str,
     pub target_lookup: NodeLoad,

--- a/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
@@ -24,6 +24,19 @@ pub enum WizardPhase {
     Run,
 }
 
+impl WizardPhase {
+    /// The rail's display label for this phase.
+    pub fn label(self) -> &'static str {
+        match self {
+            WizardPhase::SourceTarget => "Source & Target",
+            WizardPhase::TablesMapping => "Tables Mapping",
+            WizardPhase::Options => "Options",
+            WizardPhase::Confirm => "Confirm",
+            WizardPhase::Run => "Run",
+        }
+    }
+}
+
 /// All rail entries in display order, for `render_phase_rail` to iterate.
 pub const RAIL_PHASES: [WizardPhase; 5] = [
     WizardPhase::SourceTarget,
@@ -37,6 +50,30 @@ pub const RAIL_PHASES: [WizardPhase; 5] = [
 /// on `current` — an already-passed rail entry.
 pub fn is_completed(entry: WizardPhase, current: WizardPhase) -> bool {
     entry < current
+}
+
+/// One rail row's presentation state: a completed entry shows a checkmark and
+/// is clickable for back-navigation; the current entry is highlighted. Derived
+/// purely from the linear phase ordering so `render_phase_rail` stays a thin
+/// view over this model.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RailEntry {
+    pub phase: WizardPhase,
+    pub completed: bool,
+    pub current: bool,
+}
+
+/// The rail's five entries with their completion/current flags resolved
+/// against `current` — the single source of truth the renderer iterates.
+pub fn rail_entries(current: WizardPhase) -> Vec<RailEntry> {
+    RAIL_PHASES
+        .iter()
+        .map(|&phase| RailEntry {
+            phase,
+            completed: is_completed(phase, current),
+            current: phase == current,
+        })
+        .collect()
 }
 
 /// Guard for `SourceTarget` → `TablesMapping`: at least one source table is
@@ -224,5 +261,51 @@ mod tests {
     #[test]
     fn run_state_defaults_to_idle() {
         assert_eq!(RunState::default(), RunState::Idle);
+    }
+
+    #[test]
+    fn phase_labels_cover_every_rail_entry() {
+        assert_eq!(WizardPhase::SourceTarget.label(), "Source & Target");
+        assert_eq!(WizardPhase::TablesMapping.label(), "Tables Mapping");
+        assert_eq!(WizardPhase::Options.label(), "Options");
+        assert_eq!(WizardPhase::Confirm.label(), "Confirm");
+        assert_eq!(WizardPhase::Run.label(), "Run");
+    }
+
+    #[test]
+    fn rail_entries_mark_passed_phases_completed_and_only_current_as_current() {
+        let entries = rail_entries(WizardPhase::Options);
+
+        assert_eq!(entries.len(), RAIL_PHASES.len());
+
+        let completed: Vec<WizardPhase> = entries
+            .iter()
+            .filter(|entry| entry.completed)
+            .map(|entry| entry.phase)
+            .collect();
+        assert_eq!(
+            completed,
+            vec![WizardPhase::SourceTarget, WizardPhase::TablesMapping]
+        );
+
+        let current: Vec<WizardPhase> = entries
+            .iter()
+            .filter(|entry| entry.current)
+            .map(|entry| entry.phase)
+            .collect();
+        assert_eq!(current, vec![WizardPhase::Options]);
+
+        assert!(
+            entries
+                .iter()
+                .all(|entry| !(entry.completed && entry.current))
+        );
+    }
+
+    #[test]
+    fn rail_entries_on_first_phase_have_no_completed_entries() {
+        let entries = rail_entries(WizardPhase::SourceTarget);
+        assert!(entries.iter().all(|entry| !entry.completed));
+        assert!(entries[0].current);
     }
 }

--- a/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
@@ -1,0 +1,228 @@
+//! Pure phase state machine for the migration wizard: the fixed rail
+//! ordering, the guards that gate each forward transition, the FK-cycle
+//! reorder interrupt overlay, and run-state tracking. No GPUI — unit
+//! testable without a wizard entity. Rendering (`render_phase_rail`) and the
+//! metadata-dependent transitions (`Options` → `Confirm`, which needs a real
+//! `topological_order` result) are built in later slices; this module only
+//! owns the state shapes and the guards that do not require live metadata.
+
+use dbflux_core::TableRef;
+
+use crate::migrate_wizard::tree_model::NodeLoad;
+
+/// The five fixed rail entries. Declaration order doubles as the `Ord`
+/// used by the rail to decide which entries are already completed
+/// (`entry < current_phase`) — see design ADR #1. A cyclic FK graph is a
+/// conditional interrupt surfaced inside `Confirm` (see [`ReorderState`]),
+/// never a sixth listed phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum WizardPhase {
+    SourceTarget,
+    TablesMapping,
+    Options,
+    Confirm,
+    Run,
+}
+
+/// All rail entries in display order, for `render_phase_rail` to iterate.
+pub const RAIL_PHASES: [WizardPhase; 5] = [
+    WizardPhase::SourceTarget,
+    WizardPhase::TablesMapping,
+    WizardPhase::Options,
+    WizardPhase::Confirm,
+    WizardPhase::Run,
+];
+
+/// Whether `entry` should render a checkmark given the wizard is currently
+/// on `current` — an already-passed rail entry.
+pub fn is_completed(entry: WizardPhase, current: WizardPhase) -> bool {
+    entry < current
+}
+
+/// Guard for `SourceTarget` → `TablesMapping`: at least one source table is
+/// checked, a target container has been chosen, and the source/target
+/// drivers are transfer-compatible.
+pub fn can_advance_from_source_target(
+    checked_table_count: usize,
+    target_container_chosen: bool,
+    transfer_compatible: bool,
+) -> bool {
+    checked_table_count > 0 && target_container_chosen && transfer_compatible
+}
+
+/// One mapping-grid row's readiness to advance past `TablesMapping`,
+/// decoupled from the grid's full row type (built in a later slice).
+pub struct MappingRowReadiness<'a> {
+    pub target_name: &'a str,
+    pub target_lookup: NodeLoad,
+}
+
+/// Guard for `TablesMapping` → `Options`: every row has a non-empty target
+/// table name and its target-existence lookup has finished (neither
+/// `Loading` nor `Failed`).
+pub fn can_advance_from_tables_mapping(rows: &[MappingRowReadiness]) -> bool {
+    rows.iter().all(|row| {
+        !row.target_name.trim().is_empty()
+            && !matches!(row.target_lookup, NodeLoad::Loading | NodeLoad::Failed(_))
+    })
+}
+
+/// The FK-cycle reorder interrupt shown inside `Confirm` when
+/// `topological_order` reports a cycle among the selected tables — not a
+/// listed rail phase (design ADR #1). `prefix` is the fixed, already-ordered
+/// portion; `list` is the cyclic remainder the user reorders with Up/Down.
+pub struct ReorderState {
+    pub prefix: Vec<TableRef>,
+    pub list: Vec<TableRef>,
+}
+
+impl ReorderState {
+    pub fn new(prefix: Vec<TableRef>, list: Vec<TableRef>) -> Self {
+        Self { prefix, list }
+    }
+
+    /// Swaps `index` with `index + delta`, ignoring the move if it would
+    /// fall outside `list`'s bounds (the reorderable cyclic subset).
+    pub fn move_row(&mut self, index: usize, delta: isize) {
+        let Some(new_index) = index.checked_add_signed(delta) else {
+            return;
+        };
+        if index >= self.list.len() || new_index >= self.list.len() {
+            return;
+        }
+        self.list.swap(index, new_index);
+    }
+
+    /// The final load order once the user accepts the current arrangement:
+    /// the fixed prefix followed by the user-ordered cyclic remainder.
+    pub fn resolved_order(&self) -> Vec<TableRef> {
+        let mut order = self.prefix.clone();
+        order.extend(self.list.clone());
+        order
+    }
+}
+
+/// Tracks the migration run itself, separate from `WizardPhase` so `Run`
+/// can stay a single rail entry while progress/completion vary underneath.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RunState {
+    #[default]
+    Idle,
+    Running,
+    Done,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_ordering_matches_rail_declaration_order() {
+        assert!(WizardPhase::SourceTarget < WizardPhase::TablesMapping);
+        assert!(WizardPhase::TablesMapping < WizardPhase::Options);
+        assert!(WizardPhase::Options < WizardPhase::Confirm);
+        assert!(WizardPhase::Confirm < WizardPhase::Run);
+        assert!(WizardPhase::Run >= WizardPhase::SourceTarget);
+    }
+
+    #[test]
+    fn is_completed_is_true_only_for_entries_before_current() {
+        assert!(is_completed(
+            WizardPhase::SourceTarget,
+            WizardPhase::TablesMapping
+        ));
+        assert!(!is_completed(
+            WizardPhase::TablesMapping,
+            WizardPhase::TablesMapping
+        ));
+        assert!(!is_completed(
+            WizardPhase::Confirm,
+            WizardPhase::TablesMapping
+        ));
+    }
+
+    #[test]
+    fn can_advance_from_source_target_requires_checked_table_target_and_compatibility() {
+        assert!(!can_advance_from_source_target(0, true, true));
+        assert!(!can_advance_from_source_target(1, false, true));
+        assert!(!can_advance_from_source_target(1, true, false));
+        assert!(can_advance_from_source_target(1, true, true));
+    }
+
+    #[test]
+    fn can_advance_from_tables_mapping_requires_every_row_named_and_lookup_resolved() {
+        let ready = vec![
+            MappingRowReadiness {
+                target_name: "users",
+                target_lookup: NodeLoad::Loaded,
+            },
+            MappingRowReadiness {
+                target_name: "orders",
+                target_lookup: NodeLoad::NotLoaded,
+            },
+        ];
+        assert!(can_advance_from_tables_mapping(&ready));
+
+        let empty_name = vec![MappingRowReadiness {
+            target_name: "",
+            target_lookup: NodeLoad::Loaded,
+        }];
+        assert!(!can_advance_from_tables_mapping(&empty_name));
+
+        let blank_name = vec![MappingRowReadiness {
+            target_name: "   ",
+            target_lookup: NodeLoad::Loaded,
+        }];
+        assert!(!can_advance_from_tables_mapping(&blank_name));
+
+        let still_loading = vec![MappingRowReadiness {
+            target_name: "users",
+            target_lookup: NodeLoad::Loading,
+        }];
+        assert!(!can_advance_from_tables_mapping(&still_loading));
+
+        let lookup_failed = vec![MappingRowReadiness {
+            target_name: "users",
+            target_lookup: NodeLoad::Failed("boom".to_string()),
+        }];
+        assert!(!can_advance_from_tables_mapping(&lookup_failed));
+    }
+
+    #[test]
+    fn reorder_state_move_row_swaps_within_bounds_and_ignores_out_of_range_moves() {
+        let mut reorder = ReorderState::new(
+            vec![TableRef::new("a")],
+            vec![TableRef::new("b"), TableRef::new("c")],
+        );
+
+        reorder.move_row(0, 1);
+        assert_eq!(reorder.list[0].name, "c");
+        assert_eq!(reorder.list[1].name, "b");
+
+        reorder.move_row(0, -1);
+        assert_eq!(reorder.list[0].name, "c");
+
+        reorder.move_row(1, 1);
+        assert_eq!(reorder.list[1].name, "b");
+    }
+
+    #[test]
+    fn reorder_state_resolved_order_is_prefix_then_reordered_list() {
+        let reorder = ReorderState::new(
+            vec![TableRef::new("a")],
+            vec![TableRef::new("c"), TableRef::new("b")],
+        );
+
+        let names: Vec<String> = reorder
+            .resolved_order()
+            .into_iter()
+            .map(|t| t.name)
+            .collect();
+        assert_eq!(names, vec!["a", "c", "b"]);
+    }
+
+    #[test]
+    fn run_state_defaults_to_idle() {
+        assert_eq!(RunState::default(), RunState::Idle);
+    }
+}

--- a/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
@@ -6,6 +6,8 @@
 //! `topological_order` result) live in `mod.rs`; this module owns only the
 //! state shapes and the guards that do not require live metadata.
 
+use std::collections::HashSet;
+
 use dbflux_core::TableRef;
 
 use crate::migrate_wizard::tree_model::NodeLoad;
@@ -102,6 +104,104 @@ pub fn can_advance_from_tables_mapping(rows: &[MappingRowReadiness]) -> bool {
         !row.target_name.trim().is_empty()
             && !matches!(row.target_lookup, NodeLoad::Loading | NodeLoad::Failed(_))
     })
+}
+
+/// Cross-row view of one mapping row, for the collision checks that
+/// [`MappingRowReadiness`] cannot express (they compare rows against each
+/// other and against the shared source container).
+pub struct MappingRowPlan<'a> {
+    pub source_table: &'a str,
+    pub target_schema: Option<&'a str>,
+    pub target_table: &'a str,
+    pub destructive: bool,
+}
+
+fn target_label(schema: Option<&str>, table: &str) -> String {
+    match schema {
+        Some(schema) if !schema.is_empty() => format!("{schema}.{table}"),
+        _ => table.to_string(),
+    }
+}
+
+/// Blocking, cross-row validations for `TablesMapping` → `Options` beyond
+/// per-row readiness:
+/// - **Duplicate targets**: two rows writing the same `(schema, table)` would
+///   silently have the second clobber the first.
+/// - **Source-as-target destructive collision**: when source and target are the
+///   same container, a destructive row (Recreate/Truncate) whose target is one
+///   of the source tables would drop or empty that table before it is read.
+///
+/// Each returned string is a user-facing error; a non-empty result must block
+/// advancing. Non-destructive same-container collisions are intentionally not
+/// blocked here — they surface as a warning on the Confirm screen instead.
+pub fn tables_mapping_blocking_errors(
+    rows: &[MappingRowPlan],
+    same_container: bool,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    let mut seen: HashSet<(Option<&str>, &str)> = HashSet::new();
+    let mut reported: HashSet<(Option<&str>, &str)> = HashSet::new();
+    for row in rows {
+        let key = (row.target_schema, row.target_table);
+        if !seen.insert(key) && reported.insert(key) {
+            errors.push(format!(
+                "Two source tables map to the same target '{}'. Give each a unique target name.",
+                target_label(row.target_schema, row.target_table)
+            ));
+        }
+    }
+
+    if same_container {
+        let source_names: HashSet<&str> = rows.iter().map(|row| row.source_table).collect();
+        let mut collided: HashSet<&str> = HashSet::new();
+        for row in rows {
+            if row.destructive
+                && source_names.contains(row.target_table)
+                && collided.insert(row.target_table)
+            {
+                errors.push(format!(
+                    "'{}' uses a destructive mode but its target is source table '{}' in the \
+                     same connection — it would be dropped or emptied before it is read.",
+                    row.source_table, row.target_table
+                ));
+            }
+        }
+    }
+
+    errors
+}
+
+/// Non-blocking, cross-row warnings surfaced on the Confirm screen: a
+/// non-destructive row whose target is one of the source tables in the same
+/// container appends rows into a table that is also being read. Destructive
+/// same-container collisions are blocked earlier by
+/// [`tables_mapping_blocking_errors`].
+pub fn tables_mapping_confirm_warnings(
+    rows: &[MappingRowPlan],
+    same_container: bool,
+) -> Vec<String> {
+    if !same_container {
+        return Vec::new();
+    }
+
+    let source_names: HashSet<&str> = rows.iter().map(|row| row.source_table).collect();
+    let mut warned: HashSet<&str> = HashSet::new();
+
+    rows.iter()
+        .filter(|row| {
+            !row.destructive
+                && source_names.contains(row.target_table)
+                && warned.insert(row.target_table)
+        })
+        .map(|row| {
+            format!(
+                "'{}' writes into source table '{}' in the same connection; rows are appended to \
+                 a table you are also reading.",
+                row.source_table, row.target_table
+            )
+        })
+        .collect()
 }
 
 /// The FK-cycle reorder interrupt shown inside `Confirm` when
@@ -223,6 +323,54 @@ mod tests {
             target_lookup: NodeLoad::Failed("boom".to_string()),
         }];
         assert!(!can_advance_from_tables_mapping(&lookup_failed));
+    }
+
+    fn plan<'a>(source: &'a str, target: &'a str, destructive: bool) -> MappingRowPlan<'a> {
+        MappingRowPlan {
+            source_table: source,
+            target_schema: None,
+            target_table: target,
+            destructive,
+        }
+    }
+
+    #[test]
+    fn tables_mapping_blocking_errors_flags_duplicate_targets() {
+        let rows = vec![
+            plan("users", "accounts", false),
+            plan("members", "accounts", false),
+        ];
+        let errors = tables_mapping_blocking_errors(&rows, false);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("accounts"));
+    }
+
+    #[test]
+    fn tables_mapping_blocking_errors_flags_destructive_source_as_target_only_in_same_container() {
+        let rows = vec![plan("orders", "orders", true)];
+
+        assert!(tables_mapping_blocking_errors(&rows, false).is_empty());
+
+        let errors = tables_mapping_blocking_errors(&rows, true);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("orders"));
+    }
+
+    #[test]
+    fn tables_mapping_blocking_errors_ignores_non_destructive_source_as_target() {
+        let rows = vec![plan("orders", "orders", false)];
+        assert!(tables_mapping_blocking_errors(&rows, true).is_empty());
+    }
+
+    #[test]
+    fn tables_mapping_confirm_warnings_flags_non_destructive_same_container_collision() {
+        let rows = vec![plan("orders", "orders", false)];
+
+        assert!(tables_mapping_confirm_warnings(&rows, false).is_empty());
+
+        let warnings = tables_mapping_confirm_warnings(&rows, true);
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("orders"));
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/migrate_wizard/source_target.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/source_target.rs
@@ -14,8 +14,7 @@
 //! checkbox glyph is drawn here over `TreeModel::is_checked`, and an
 //! unexpanded/loading/failed branch surfaces a synthetic child row
 //! (`Loading…` / `Retry`) so the branch stays expandable and its state is
-//! visible. This phase is a self-contained entity so it compiles and is
-//! reviewable on its own; the wizard entity rewrite mounts it later.
+//! visible. The wizard entity mounts this phase as the first step of the flow.
 
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
@@ -289,6 +288,34 @@ fn split_tables_by_schema(tables: Vec<TableEntry>) -> (Vec<TableEntry>, Vec<Sche
     (schemaless, schemas)
 }
 
+/// Whether a source-side node may be checked: a migration reads from exactly
+/// one database, so only a table leaf that lives in `source_database` is
+/// selectable. Gating both the checkbox and the toggle on this makes it
+/// impossible to check a same-named table in another browsed database — which
+/// would otherwise be silently migrated in place of the intended one.
+fn is_source_table_checkable(payload: Option<&TreePayload>, source_database: &str) -> bool {
+    matches!(
+        payload,
+        Some(TreePayload::Table { database, .. }) if database == source_database
+    )
+}
+
+/// Resolves the wizard-owned checked set to `TableRef`s, keeping only tables
+/// that live in `source_database`. Any stray check from another browsed
+/// database is dropped, so the returned tables always resolve against the
+/// single source the plan is built for.
+fn checked_tables_in_database(model: &TreeModel, source_database: &str) -> Vec<TableRef> {
+    model
+        .checked_ids()
+        .filter_map(|id| match model.payload(id) {
+            Some(TreePayload::Table {
+                database, table, ..
+            }) if database == source_database => Some(table.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
 /// Per-side runtime state: the known structure, the payload/load/checked
 /// model, and the `TreeNav` nav state built from them.
 struct SideState {
@@ -301,6 +328,11 @@ pub struct SourceTargetPhase {
     app_state: Entity<AppStateEntity>,
     focus_handle: FocusHandle,
     source_profile_id: Uuid,
+    /// The single database the migration reads from. A migration has exactly
+    /// one source database, so only tables that live in it are checkable —
+    /// checking a same-named table in another browsed database would silently
+    /// migrate the wrong table (the plan resolves one source database only).
+    source_database: String,
     source: SideState,
     target: SideState,
     active_side: TreeSide,
@@ -342,6 +374,7 @@ impl SourceTargetPhase {
             app_state,
             focus_handle: cx.focus_handle(),
             source_profile_id,
+            source_database: resolved_database,
             source: SideState {
                 roots: source_roots,
                 model: source_model,
@@ -364,15 +397,19 @@ impl SourceTargetPhase {
 
     /// The tables the user has checked in the source tree, resolved from the
     /// wizard-owned checked set back to `TableRef`s via the payload map.
+    /// Constrained to the single [`source_database`](Self::source_database):
+    /// a migration reads from exactly one database, so a stray check in
+    /// another browsed database is never returned as a source table.
     pub fn checked_source_tables(&self) -> Vec<TableRef> {
-        self.source
-            .model
-            .checked_ids()
-            .filter_map(|id| match self.source.model.payload(id) {
-                Some(TreePayload::Table { table, .. }) => Some(table.clone()),
-                _ => None,
-            })
-            .collect()
+        checked_tables_in_database(&self.source.model, &self.source_database)
+    }
+
+    /// The single database this migration reads from. Downstream plan
+    /// assembly must use exactly this database so that every table from
+    /// [`checked_source_tables`](Self::checked_source_tables) resolves against
+    /// the same source — see the cross-database check guard in `on_select`.
+    pub fn source_database(&self) -> &str {
+        &self.source_database
     }
 
     pub fn target_profile_id(&self) -> Option<Uuid> {
@@ -520,10 +557,20 @@ impl SourceTargetPhase {
         }
 
         match self.side(side).model.payload(&id).cloned() {
-            Some(TreePayload::Table { .. }) if side == TreeSide::Source => {
-                self.source.model.toggle_checked(&id);
-                cx.emit(SourceTargetChanged);
-                cx.notify();
+            Some(TreePayload::Table { database, .. }) if side == TreeSide::Source => {
+                if database == self.source_database {
+                    self.source.model.toggle_checked(&id);
+                    self.error = None;
+                    cx.emit(SourceTargetChanged);
+                    cx.notify();
+                } else {
+                    self.error = Some(format!(
+                        "A migration has a single source database. Only tables in \
+                         '{}' can be selected — tables in '{database}' can't be mixed in.",
+                        self.source_database
+                    ));
+                    cx.notify();
+                }
             }
             Some(TreePayload::Database {
                 profile_id,
@@ -923,9 +970,9 @@ impl SourceTargetPhase {
         let row_id = row.id.clone();
         let synthetic = is_status_id(&row_id) || is_retry_id(&row_id);
         let is_checkable = side == TreeSide::Source
-            && matches!(
+            && is_source_table_checkable(
                 self.side(side).model.payload(&row_id),
-                Some(TreePayload::Table { .. })
+                &self.source_database,
             );
         let is_checked = is_checkable && self.side(side).model.is_checked(&row_id);
         let is_target_selected = side == TreeSide::Target
@@ -1065,13 +1112,15 @@ fn current_database_node(database: &str, relational: &dbflux_core::RelationalSch
 #[cfg(test)]
 mod tests {
     use super::{
-        ConnRoot, DbNode, SchemaNode, TableEntry, TreeSide, build_side_nodes, is_retry_id,
-        is_status_id, parent_of_synthetic, split_tables_by_schema,
+        ConnRoot, DbNode, SchemaNode, TableEntry, TreeSide, build_side_nodes,
+        checked_tables_in_database, is_retry_id, is_source_table_checkable, is_status_id,
+        parent_of_synthetic, split_tables_by_schema,
     };
     use crate::migrate_wizard::tree_model::{
         NodeLoad, TreeModel, TreePayload, connection_node_id, database_node_id, schema_node_id,
         table_node_id,
     };
+    use dbflux_core::TableRef;
     use uuid::Uuid;
 
     fn uuid(seed: u8) -> Uuid {
@@ -1226,6 +1275,74 @@ mod tests {
         assert_eq!(public.tables.len(), 2);
         let audit = schemas.iter().find(|s| s.name == "audit").unwrap();
         assert_eq!(audit.tables.len(), 1);
+    }
+
+    fn table_payload(
+        profile_id: Uuid,
+        database: &str,
+        schema: Option<&str>,
+        name: &str,
+    ) -> TreePayload {
+        TreePayload::Table {
+            profile_id,
+            database: database.to_string(),
+            schema: schema.map(str::to_string),
+            table: TableRef {
+                schema: schema.map(str::to_string),
+                name: name.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn checked_source_tables_never_cross_the_resolved_source_database() {
+        let profile_id = uuid(9);
+        let mut model = TreeModel::new();
+
+        // Same table name in two different databases — the exact silent
+        // cross-database mismatch W1 guards against.
+        let active_users = table_node_id(profile_id, "app", Some("public"), "users");
+        let other_users = table_node_id(profile_id, "archive", Some("public"), "users");
+        let other_orders = table_node_id(profile_id, "archive", Some("public"), "orders");
+
+        model.insert_payload(
+            active_users.clone(),
+            table_payload(profile_id, "app", Some("public"), "users"),
+        );
+        model.insert_payload(
+            other_users.clone(),
+            table_payload(profile_id, "archive", Some("public"), "users"),
+        );
+        model.insert_payload(
+            other_orders.clone(),
+            table_payload(profile_id, "archive", Some("public"), "orders"),
+        );
+
+        model.toggle_checked(&active_users);
+        model.toggle_checked(&other_users);
+        model.toggle_checked(&other_orders);
+        assert_eq!(model.checked_count(), 3);
+
+        let resolved = checked_tables_in_database(&model, "app");
+
+        // Only the table in the active source database survives — the
+        // same-named "users" and the "orders" in "archive" are dropped, so a
+        // cross-database source table can never reach the plan.
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "users");
+
+        assert!(is_source_table_checkable(
+            model.payload(&active_users),
+            "app"
+        ));
+        assert!(!is_source_table_checkable(
+            model.payload(&other_users),
+            "app"
+        ));
+        assert!(!is_source_table_checkable(
+            model.payload(&other_orders),
+            "app"
+        ));
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/migrate_wizard/source_target.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/source_target.rs
@@ -1,0 +1,1237 @@
+//! Source & Target phase of the migration wizard: two lazy-loaded object-tree
+//! pickers side by side. The left tree browses the source connection
+//! (connection → database → schema → table) with checkable table leaves — it
+//! opens pre-checked with the tables the sidebar passed and stays fully
+//! editable (uncheck, check others, browse other databases). The right tree
+//! lists only connected, transfer-compatible targets (connection → database)
+//! and captures which target *container* the migration loads into; the
+//! per-table target name/mode is chosen later in the mapping grid, not here
+//! (design ADR #5).
+//!
+//! `TreeNav` is reused as the pure nav model (rows / expand / cursor). The
+//! checkbox state and per-node lazy-load state live in the wizard-owned
+//! [`TreeModel`] (design ADR #3/#4) — `TreeNav` renders nothing itself, so the
+//! checkbox glyph is drawn here over `TreeModel::is_checked`, and an
+//! unexpanded/loading/failed branch surfaces a synthetic child row
+//! (`Loading…` / `Retry`) so the branch stays expandable and its state is
+//! visible. This phase is a self-contained entity so it compiles and is
+//! reviewable on its own; the wizard entity rewrite mounts it later.
+
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+
+use dbflux_components::components::tree_nav::{
+    TreeNav, TreeNavAction, TreeNavNode, render_gutter, tree_line_color,
+};
+use dbflux_components::icons::AppIcon;
+use dbflux_components::primitives::{Icon, Text};
+use dbflux_components::tokens::{Heights, Spacing};
+use dbflux_core::{Connection, TableRef, transfer_compatible};
+use dbflux_ui_base::app_state_entity::AppStateEntity;
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::ActiveTheme;
+use uuid::Uuid;
+
+use crate::migrate_wizard::tree_model::{
+    NodeLoad, TreeModel, TreePayload, connection_node_id, database_node_id, schema_node_id,
+    table_node_id,
+};
+
+const ROW_HEIGHT: Pixels = Heights::ROW_COMPACT;
+const INDENT_PX: f32 = 14.0;
+
+/// Which of the two trees an operation targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TreeSide {
+    Source,
+    Target,
+}
+
+/// Emitted whenever the checked source tables or the chosen target container
+/// change, so the host can re-evaluate the phase-advance guard.
+#[derive(Debug, Clone)]
+pub struct SourceTargetChanged;
+
+/// The container the migration loads into: a connected, transfer-compatible
+/// profile plus the specific database. Feeds `MigrationOptions::target_database`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetSelection {
+    pub profile_id: Uuid,
+    pub database: String,
+}
+
+/// One table under a database/schema, decoupled from `TableInfo` so tree
+/// construction is pure and testable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableEntry {
+    pub schema: Option<String>,
+    pub name: String,
+}
+
+/// A schema group holding its tables (schema-based drivers).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaNode {
+    pub name: String,
+    pub tables: Vec<TableEntry>,
+}
+
+/// A database node. `schemas` is used by schema-based drivers; `tables` holds
+/// schemaless tables directly under the database. Both empty means the node's
+/// contents have not been loaded yet (or the database is genuinely empty).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DbNode {
+    pub name: String,
+    pub schemas: Vec<SchemaNode>,
+    pub tables: Vec<TableEntry>,
+}
+
+/// A connection root and the databases known under it so far.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConnRoot {
+    pub profile_id: Uuid,
+    pub label: String,
+    pub databases: Vec<DbNode>,
+}
+
+fn status_child_id(parent: &SharedString) -> SharedString {
+    SharedString::from(format!("{parent}::__status"))
+}
+
+fn retry_child_id(parent: &SharedString) -> SharedString {
+    SharedString::from(format!("{parent}::__retry"))
+}
+
+fn is_status_id(id: &str) -> bool {
+    id.ends_with("::__status")
+}
+
+fn is_retry_id(id: &str) -> bool {
+    id.ends_with("::__retry")
+}
+
+/// The real node id an on-screen `Loading…`/`Retry` child stands in for.
+fn parent_of_synthetic(id: &str) -> Option<&str> {
+    id.strip_suffix("::__retry")
+        .or_else(|| id.strip_suffix("::__status"))
+}
+
+/// The synthetic child rendered under an expandable branch whose contents are
+/// not yet available, so the branch stays expandable (a childless `TreeNav`
+/// group is not) and its load state is visible. `Loaded` needs no placeholder.
+fn status_child(parent: &SharedString, load: &NodeLoad) -> Option<TreeNavNode> {
+    match load {
+        NodeLoad::Loaded => None,
+        NodeLoad::NotLoaded | NodeLoad::Loading => {
+            let mut node =
+                TreeNavNode::leaf(status_child_id(parent), "Loading…", Some(AppIcon::Loader));
+            node.selectable = false;
+            Some(node)
+        }
+        NodeLoad::Failed(error) => {
+            let mut node = TreeNavNode::leaf(
+                retry_child_id(parent),
+                SharedString::from(format!("Retry — {error}")),
+                Some(AppIcon::RotateCcw),
+            );
+            node.selectable = true;
+            Some(node)
+        }
+    }
+}
+
+/// Builds the full `TreeNav` node list for one side from the known structure
+/// and the load/payload state, registering every real node's payload so click
+/// and key handlers can act on ids without parsing them. Pure over its inputs.
+pub fn build_side_nodes(
+    side: TreeSide,
+    roots: &[ConnRoot],
+    model: &mut TreeModel,
+) -> Vec<TreeNavNode> {
+    roots
+        .iter()
+        .map(|root| build_connection_node(side, root, model))
+        .collect()
+}
+
+fn build_connection_node(side: TreeSide, root: &ConnRoot, model: &mut TreeModel) -> TreeNavNode {
+    let id = connection_node_id(root.profile_id);
+    model.insert_payload(id.clone(), TreePayload::Connection(root.profile_id));
+
+    let mut children: Vec<TreeNavNode> = root
+        .databases
+        .iter()
+        .map(|db| build_database_node(side, root.profile_id, db, model))
+        .collect();
+
+    if children.is_empty() {
+        children.extend(status_child(&id, &model.load(&id)));
+    }
+
+    TreeNavNode::group(id, root.label.clone(), Some(AppIcon::Server), children)
+}
+
+fn build_database_node(
+    side: TreeSide,
+    profile_id: Uuid,
+    db: &DbNode,
+    model: &mut TreeModel,
+) -> TreeNavNode {
+    let id = database_node_id(profile_id, &db.name);
+    model.insert_payload(
+        id.clone(),
+        TreePayload::Database {
+            profile_id,
+            database: db.name.clone(),
+        },
+    );
+
+    if side == TreeSide::Target {
+        // The target tree stops at the database — that is the container the
+        // migration loads into; per-table mapping is the grid's job.
+        return TreeNavNode::leaf(id, db.name.clone(), Some(AppIcon::Database));
+    }
+
+    let mut children = build_database_children(profile_id, db, model);
+    if children.is_empty() {
+        children.extend(status_child(&id, &model.load(&id)));
+    }
+
+    TreeNavNode::group(id, db.name.clone(), Some(AppIcon::Database), children)
+}
+
+fn build_database_children(
+    profile_id: Uuid,
+    db: &DbNode,
+    model: &mut TreeModel,
+) -> Vec<TreeNavNode> {
+    if !db.schemas.is_empty() {
+        return db
+            .schemas
+            .iter()
+            .map(|schema| build_schema_node(profile_id, &db.name, schema, model))
+            .collect();
+    }
+
+    db.tables
+        .iter()
+        .map(|table| build_table_leaf(profile_id, &db.name, table, model))
+        .collect()
+}
+
+fn build_schema_node(
+    profile_id: Uuid,
+    database: &str,
+    schema: &SchemaNode,
+    model: &mut TreeModel,
+) -> TreeNavNode {
+    let id = schema_node_id(profile_id, database, &schema.name);
+    model.insert_payload(
+        id.clone(),
+        TreePayload::Schema {
+            profile_id,
+            database: database.to_string(),
+            schema: schema.name.clone(),
+        },
+    );
+
+    let children: Vec<TreeNavNode> = schema
+        .tables
+        .iter()
+        .map(|table| build_table_leaf(profile_id, database, table, model))
+        .collect();
+
+    TreeNavNode::group(id, schema.name.clone(), Some(AppIcon::Folder), children)
+}
+
+fn build_table_leaf(
+    profile_id: Uuid,
+    database: &str,
+    table: &TableEntry,
+    model: &mut TreeModel,
+) -> TreeNavNode {
+    let id = table_node_id(profile_id, database, table.schema.as_deref(), &table.name);
+    model.insert_payload(
+        id.clone(),
+        TreePayload::Table {
+            profile_id,
+            database: database.to_string(),
+            schema: table.schema.clone(),
+            table: TableRef {
+                schema: table.schema.clone(),
+                name: table.name.clone(),
+            },
+        },
+    );
+
+    TreeNavNode::leaf(id, table.name.clone(), Some(AppIcon::Table))
+}
+
+/// Groups a database's tables into schemaless (`None` key) and per-schema
+/// buckets, preserving encounter order within each bucket — the pure core of
+/// turning a freshly fetched table list into [`DbNode`] children.
+fn split_tables_by_schema(tables: Vec<TableEntry>) -> (Vec<TableEntry>, Vec<SchemaNode>) {
+    let mut schemaless = Vec::new();
+    let mut by_schema: BTreeMap<String, Vec<TableEntry>> = BTreeMap::new();
+
+    for table in tables {
+        match table.schema.clone() {
+            None => schemaless.push(table),
+            Some(schema) => by_schema.entry(schema).or_default().push(table),
+        }
+    }
+
+    let schemas = by_schema
+        .into_iter()
+        .map(|(name, tables)| SchemaNode { name, tables })
+        .collect();
+
+    (schemaless, schemas)
+}
+
+/// Per-side runtime state: the known structure, the payload/load/checked
+/// model, and the `TreeNav` nav state built from them.
+struct SideState {
+    roots: Vec<ConnRoot>,
+    model: TreeModel,
+    tree: TreeNav,
+}
+
+pub struct SourceTargetPhase {
+    app_state: Entity<AppStateEntity>,
+    focus_handle: FocusHandle,
+    source_profile_id: Uuid,
+    source: SideState,
+    target: SideState,
+    active_side: TreeSide,
+    target_selection: Option<TargetSelection>,
+    error: Option<String>,
+}
+
+impl EventEmitter<SourceTargetChanged> for SourceTargetPhase {}
+
+impl SourceTargetPhase {
+    pub fn new(
+        app_state: Entity<AppStateEntity>,
+        source_profile_id: Uuid,
+        source_database: Option<String>,
+        source_tables: Vec<TableRef>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let (source_roots, resolved_database) =
+            Self::source_roots_from_state(&app_state, source_profile_id, source_database, cx);
+        let target_roots = Self::target_roots_from_state(&app_state, source_profile_id, cx);
+
+        let mut source_model = TreeModel::new();
+        let seed = source_model.seed_source_selection(
+            source_profile_id,
+            &resolved_database,
+            &source_tables,
+        );
+        let source_nodes = build_side_nodes(TreeSide::Source, &source_roots, &mut source_model);
+        let mut source_tree = TreeNav::new(source_nodes, seed.expand);
+        if let Some(cursor) = seed.cursor {
+            source_tree.select_by_id(&cursor);
+        }
+
+        let mut target_model = TreeModel::new();
+        let target_nodes = build_side_nodes(TreeSide::Target, &target_roots, &mut target_model);
+        let target_tree = TreeNav::new(target_nodes, HashSet::new());
+
+        Self {
+            app_state,
+            focus_handle: cx.focus_handle(),
+            source_profile_id,
+            source: SideState {
+                roots: source_roots,
+                model: source_model,
+                tree: source_tree,
+            },
+            target: SideState {
+                roots: target_roots,
+                model: target_model,
+                tree: target_tree,
+            },
+            active_side: TreeSide::Source,
+            target_selection: None,
+            error: None,
+        }
+    }
+
+    pub fn focus_handle(&self) -> &FocusHandle {
+        &self.focus_handle
+    }
+
+    /// The tables the user has checked in the source tree, resolved from the
+    /// wizard-owned checked set back to `TableRef`s via the payload map.
+    pub fn checked_source_tables(&self) -> Vec<TableRef> {
+        self.source
+            .model
+            .checked_ids()
+            .filter_map(|id| match self.source.model.payload(id) {
+                Some(TreePayload::Table { table, .. }) => Some(table.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub fn target_profile_id(&self) -> Option<Uuid> {
+        self.target_selection.as_ref().map(|t| t.profile_id)
+    }
+
+    pub fn target_database(&self) -> Option<String> {
+        self.target_selection.as_ref().map(|t| t.database.clone())
+    }
+
+    /// Whether the phase's advance guard is satisfied: at least one checked
+    /// source table and a chosen target container. Transfer compatibility is
+    /// already guaranteed — only compatible targets appear in the tree.
+    pub fn is_ready(&self) -> bool {
+        self.source.model.checked_count() > 0 && self.target_selection.is_some()
+    }
+
+    fn source_roots_from_state(
+        app_state: &Entity<AppStateEntity>,
+        source_profile_id: Uuid,
+        source_database: Option<String>,
+        cx: &App,
+    ) -> (Vec<ConnRoot>, String) {
+        let state = app_state.read(cx);
+        let Some(connected) = state.connections().get(&source_profile_id) else {
+            return (Vec::new(), source_database.unwrap_or_default());
+        };
+
+        let relational = connected.schema.as_ref().and_then(relational_schema);
+        let current_database = source_database
+            .or_else(|| relational.and_then(|r| r.current_database.clone()))
+            .or_else(|| connected.connection.active_database())
+            .unwrap_or_default();
+
+        let mut databases = Vec::new();
+        if let Some(relational) = relational {
+            databases.push(current_database_node(&current_database, relational));
+
+            for database in &relational.databases {
+                if database.name != current_database {
+                    databases.push(DbNode {
+                        name: database.name.clone(),
+                        ..Default::default()
+                    });
+                }
+            }
+        } else if !current_database.is_empty() {
+            databases.push(DbNode {
+                name: current_database.clone(),
+                ..Default::default()
+            });
+        }
+
+        let root = ConnRoot {
+            profile_id: source_profile_id,
+            label: connected.profile.name.clone(),
+            databases,
+        };
+        (vec![root], current_database)
+    }
+
+    fn target_roots_from_state(
+        app_state: &Entity<AppStateEntity>,
+        source_profile_id: Uuid,
+        cx: &App,
+    ) -> Vec<ConnRoot> {
+        let state = app_state.read(cx);
+        let Some(source_connected) = state.connections().get(&source_profile_id) else {
+            return Vec::new();
+        };
+        let source_metadata = source_connected.connection.metadata();
+
+        let mut roots: Vec<ConnRoot> = state
+            .connections()
+            .iter()
+            .filter(|(_, connected)| {
+                transfer_compatible(source_metadata, connected.connection.metadata())
+            })
+            .map(|(profile_id, connected)| {
+                let databases = connected
+                    .schema
+                    .as_ref()
+                    .and_then(relational_schema)
+                    .map(|relational| {
+                        relational
+                            .databases
+                            .iter()
+                            .map(|database| DbNode {
+                                name: database.name.clone(),
+                                ..Default::default()
+                            })
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default();
+
+                ConnRoot {
+                    profile_id: *profile_id,
+                    label: connected.profile.name.clone(),
+                    databases,
+                }
+            })
+            .collect();
+
+        roots.sort_by(|a, b| a.label.cmp(&b.label));
+        roots
+    }
+
+    fn side(&self, side: TreeSide) -> &SideState {
+        match side {
+            TreeSide::Source => &self.source,
+            TreeSide::Target => &self.target,
+        }
+    }
+
+    fn side_mut(&mut self, side: TreeSide) -> &mut SideState {
+        match side {
+            TreeSide::Source => &mut self.source,
+            TreeSide::Target => &mut self.target,
+        }
+    }
+
+    fn rebuild_side(&mut self, side: TreeSide) {
+        let state = self.side_mut(side);
+        let nodes = build_side_nodes(side, &state.roots, &mut state.model);
+        state.tree.set_nodes(nodes);
+    }
+
+    fn activate_current(&mut self, side: TreeSide, cx: &mut Context<Self>) {
+        let action = self.side_mut(side).tree.activate();
+        self.handle_action(side, action, cx);
+    }
+
+    fn handle_action(&mut self, side: TreeSide, action: TreeNavAction, cx: &mut Context<Self>) {
+        match action {
+            TreeNavAction::Selected(id) => self.on_select(side, id, cx),
+            TreeNavAction::Toggled { id, expanded } => self.on_toggle(side, id, expanded, cx),
+            TreeNavAction::None => {}
+        }
+    }
+
+    fn on_select(&mut self, side: TreeSide, id: SharedString, cx: &mut Context<Self>) {
+        if is_retry_id(&id) {
+            self.retry(side, &id, cx);
+            return;
+        }
+
+        match self.side(side).model.payload(&id).cloned() {
+            Some(TreePayload::Table { .. }) if side == TreeSide::Source => {
+                self.source.model.toggle_checked(&id);
+                cx.emit(SourceTargetChanged);
+                cx.notify();
+            }
+            Some(TreePayload::Database {
+                profile_id,
+                database,
+            }) if side == TreeSide::Target => {
+                self.target_selection = Some(TargetSelection {
+                    profile_id,
+                    database,
+                });
+                cx.emit(SourceTargetChanged);
+                cx.notify();
+            }
+            _ => {}
+        }
+    }
+
+    fn on_toggle(
+        &mut self,
+        side: TreeSide,
+        id: SharedString,
+        expanded: bool,
+        cx: &mut Context<Self>,
+    ) {
+        if expanded && self.side(side).model.load(&id) == NodeLoad::NotLoaded {
+            self.start_fetch_for(side, &id, cx);
+        }
+        cx.notify();
+    }
+
+    fn retry(&mut self, side: TreeSide, retry_id: &str, cx: &mut Context<Self>) {
+        let Some(parent) = parent_of_synthetic(retry_id) else {
+            return;
+        };
+        let parent = SharedString::from(parent.to_string());
+        self.start_fetch_for(side, &parent, cx);
+    }
+
+    /// Dispatches the correct lazy fetch for a branch based on its payload:
+    /// a source database loads its schemas/tables; a target connection loads
+    /// its databases. Other payloads are already fully materialized.
+    fn start_fetch_for(&mut self, side: TreeSide, id: &SharedString, cx: &mut Context<Self>) {
+        match self.side(side).model.payload(id).cloned() {
+            Some(TreePayload::Database { database, .. }) if side == TreeSide::Source => {
+                self.fetch_source_database(id.clone(), database, cx);
+            }
+            Some(TreePayload::Connection(profile_id)) if side == TreeSide::Target => {
+                self.fetch_target_databases(id.clone(), profile_id, cx);
+            }
+            _ => {}
+        }
+    }
+
+    fn fetch_source_database(
+        &mut self,
+        node_id: SharedString,
+        database: String,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(connection) = self.resolve_source_connection(&database, cx) else {
+            self.source.model.set_load(
+                node_id,
+                NodeLoad::Failed("Source connection is gone".to_string()),
+            );
+            self.rebuild_side(TreeSide::Source);
+            cx.notify();
+            return;
+        };
+
+        self.source
+            .model
+            .set_load(node_id.clone(), NodeLoad::Loading);
+        self.rebuild_side(TreeSide::Source);
+        cx.notify();
+
+        let fetch_database = database.clone();
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { connection.schema_for_database(&fetch_database) })
+                .await;
+
+            this.update(cx, |this, cx| {
+                match result {
+                    Ok(info) => {
+                        let tables = info
+                            .tables
+                            .into_iter()
+                            .map(|table| TableEntry {
+                                schema: table.schema,
+                                name: table.name,
+                            })
+                            .collect();
+                        this.populate_source_database(&database, tables);
+                        this.source
+                            .model
+                            .set_load(node_id.clone(), NodeLoad::Loaded);
+                    }
+                    Err(error) => {
+                        this.source
+                            .model
+                            .set_load(node_id.clone(), NodeLoad::Failed(error.to_string()));
+                    }
+                }
+                this.rebuild_side(TreeSide::Source);
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn fetch_target_databases(
+        &mut self,
+        node_id: SharedString,
+        profile_id: Uuid,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(connection) = self.resolve_target_connection(profile_id, cx) else {
+            self.target.model.set_load(
+                node_id,
+                NodeLoad::Failed("Target connection is gone".to_string()),
+            );
+            self.rebuild_side(TreeSide::Target);
+            cx.notify();
+            return;
+        };
+
+        self.target
+            .model
+            .set_load(node_id.clone(), NodeLoad::Loading);
+        self.rebuild_side(TreeSide::Target);
+        cx.notify();
+
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { connection.list_databases() })
+                .await;
+
+            this.update(cx, |this, cx| {
+                match result {
+                    Ok(databases) => {
+                        let names = databases
+                            .into_iter()
+                            .map(|database| database.name)
+                            .collect();
+                        this.populate_target_databases(profile_id, names);
+                        this.target
+                            .model
+                            .set_load(node_id.clone(), NodeLoad::Loaded);
+                    }
+                    Err(error) => {
+                        this.target
+                            .model
+                            .set_load(node_id.clone(), NodeLoad::Failed(error.to_string()));
+                    }
+                }
+                this.rebuild_side(TreeSide::Target);
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn populate_source_database(&mut self, database: &str, tables: Vec<TableEntry>) {
+        let Some(root) = self
+            .source
+            .roots
+            .iter_mut()
+            .find(|root| root.profile_id == self.source_profile_id)
+        else {
+            return;
+        };
+        let Some(db) = root.databases.iter_mut().find(|db| db.name == database) else {
+            return;
+        };
+
+        let (schemaless, schemas) = split_tables_by_schema(tables);
+        db.tables = schemaless;
+        db.schemas = schemas;
+    }
+
+    fn populate_target_databases(&mut self, profile_id: Uuid, names: Vec<String>) {
+        let Some(root) = self
+            .target
+            .roots
+            .iter_mut()
+            .find(|root| root.profile_id == profile_id)
+        else {
+            return;
+        };
+
+        root.databases = names
+            .into_iter()
+            .map(|name| DbNode {
+                name,
+                ..Default::default()
+            })
+            .collect();
+    }
+
+    fn resolve_source_connection(&self, database: &str, cx: &App) -> Option<Arc<dyn Connection>> {
+        let connected = self
+            .app_state
+            .read(cx)
+            .connections()
+            .get(&self.source_profile_id)?;
+        Some(connected.connection_for_database(database))
+    }
+
+    fn resolve_target_connection(&self, profile_id: Uuid, cx: &App) -> Option<Arc<dyn Connection>> {
+        Some(
+            self.app_state
+                .read(cx)
+                .connections()
+                .get(&profile_id)?
+                .connection
+                .clone(),
+        )
+    }
+
+    fn handle_key_down(
+        &mut self,
+        event: &KeyDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if event.keystroke.modifiers != Modifiers::none() {
+            return;
+        }
+
+        let side = self.active_side;
+        match event.keystroke.key.as_str() {
+            "down" | "j" => {
+                self.side_mut(side).tree.move_next();
+                cx.notify();
+            }
+            "up" | "k" => {
+                self.side_mut(side).tree.move_prev();
+                cx.notify();
+            }
+            "left" => self.collapse_cursor(side, cx),
+            "right" => self.expand_cursor(side, cx),
+            "enter" | "space" => self.activate_current(side, cx),
+            "tab" => {
+                self.active_side = match side {
+                    TreeSide::Source => TreeSide::Target,
+                    TreeSide::Target => TreeSide::Source,
+                };
+                cx.notify();
+            }
+            _ => {}
+        }
+    }
+
+    fn collapse_cursor(&mut self, side: TreeSide, cx: &mut Context<Self>) {
+        let should = self
+            .side(side)
+            .tree
+            .cursor_item()
+            .is_some_and(|row| row.has_children && !row.selectable && row.expanded);
+        if should {
+            self.activate_current(side, cx);
+        }
+    }
+
+    fn expand_cursor(&mut self, side: TreeSide, cx: &mut Context<Self>) {
+        let should = self
+            .side(side)
+            .tree
+            .cursor_item()
+            .is_some_and(|row| row.has_children && !row.selectable && !row.expanded);
+        if should {
+            self.activate_current(side, cx);
+        }
+    }
+}
+
+impl Render for SourceTargetPhase {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .track_focus(&self.focus_handle)
+            .key_context("MigrateSourceTarget")
+            .on_key_down(cx.listener(|this, event: &KeyDownEvent, window, cx| {
+                this.handle_key_down(event, window, cx);
+            }))
+            .flex()
+            .flex_col()
+            .gap(Spacing::SM)
+            .p(Spacing::MD)
+            .size_full()
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .gap(Spacing::MD)
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .child(self.render_tree_panel(TreeSide::Source, "Source", cx))
+                    .child(self.render_tree_panel(TreeSide::Target, "Target", cx)),
+            )
+            .when_some(self.error.clone(), |parent, error| {
+                parent.child(Text::caption(error))
+            })
+    }
+}
+
+impl SourceTargetPhase {
+    fn render_tree_panel(
+        &self,
+        side: TreeSide,
+        title: &str,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let theme = cx.theme().clone();
+        let subtitle = match side {
+            TreeSide::Source => format!("{} checked", self.source.model.checked_count()),
+            TreeSide::Target => self
+                .target_selection
+                .as_ref()
+                .map(|selection| selection.database.clone())
+                .unwrap_or_else(|| "No target selected".to_string()),
+        };
+
+        div()
+            .flex_1()
+            .flex()
+            .flex_col()
+            .min_w(px(0.0))
+            .border_1()
+            .border_color(theme.border)
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(px(2.0))
+                    .px(Spacing::SM)
+                    .py(Spacing::XS)
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .child(Text::body(title.to_string()))
+                    .child(Text::caption(subtitle)),
+            )
+            .child(
+                div()
+                    .id(SharedString::from(format!("migrate-tree-{title}")))
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .overflow_y_scroll()
+                    .p(Spacing::XS)
+                    .children(self.render_rows(side, &theme, cx)),
+            )
+    }
+
+    fn render_rows(
+        &self,
+        side: TreeSide,
+        theme: &gpui_component::Theme,
+        cx: &mut Context<Self>,
+    ) -> Vec<AnyElement> {
+        let state = self.side(side);
+        let cursor = state.tree.cursor();
+        let active = self.active_side == side;
+        let line_color = tree_line_color(theme);
+
+        state
+            .tree
+            .rows()
+            .iter()
+            .enumerate()
+            .map(|(index, row)| {
+                let is_cursor = active && index == cursor;
+                let gutter = render_gutter(
+                    row.depth,
+                    row.is_last,
+                    &row.ancestors_continue,
+                    INDENT_PX,
+                    ROW_HEIGHT,
+                    line_color,
+                    false,
+                );
+                self.render_row(side, row, is_cursor, gutter, theme, cx)
+            })
+            .collect()
+    }
+
+    fn render_row(
+        &self,
+        side: TreeSide,
+        row: &dbflux_components::components::tree_nav::FlatRow,
+        is_cursor: bool,
+        gutter: AnyElement,
+        theme: &gpui_component::Theme,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let row_id = row.id.clone();
+        let synthetic = is_status_id(&row_id) || is_retry_id(&row_id);
+        let is_checkable = side == TreeSide::Source
+            && matches!(
+                self.side(side).model.payload(&row_id),
+                Some(TreePayload::Table { .. })
+            );
+        let is_checked = is_checkable && self.side(side).model.is_checked(&row_id);
+        let is_target_selected = side == TreeSide::Target
+            && self
+                .target_selection
+                .as_ref()
+                .zip(self.side(side).model.payload(&row_id))
+                .is_some_and(|(selection, payload)| match payload {
+                    TreePayload::Database {
+                        profile_id,
+                        database,
+                    } => selection.profile_id == *profile_id && &selection.database == database,
+                    _ => false,
+                });
+
+        let text_color = if synthetic {
+            theme.muted_foreground
+        } else {
+            theme.foreground
+        };
+        let icon_color = if is_target_selected || is_checked {
+            theme.primary
+        } else {
+            theme.muted_foreground
+        };
+
+        let mut content = div()
+            .flex()
+            .items_center()
+            .gap(Spacing::XXS)
+            .flex_1()
+            .min_w(px(0.0))
+            .when(is_checkable, |parent| {
+                parent.child(checkbox_glyph(is_checked, theme))
+            })
+            .when_some(row.icon, |parent, icon| {
+                parent.child(Icon::new(icon).small().color(icon_color))
+            })
+            .child(Text::body(row.label.to_string()).color(text_color));
+
+        if is_target_selected {
+            content = content
+                .child(div().flex_1())
+                .child(Icon::new(AppIcon::Check).small().color(theme.primary));
+        }
+
+        div()
+            .id(row_id.clone())
+            .flex()
+            .items_center()
+            .h(ROW_HEIGHT)
+            .px(px(2.0))
+            .cursor_pointer()
+            .when(is_cursor, |parent| parent.bg(theme.accent))
+            .child(gutter)
+            .child(content)
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(move |this, _event, _window, cx| {
+                    this.active_side = side;
+                    this.side_mut(side).tree.select_by_id(&row_id);
+                    this.activate_current(side, cx);
+                }),
+            )
+            .into_any_element()
+    }
+}
+
+/// A small bordered checkbox glyph drawn over the wizard-owned checked set —
+/// `TreeNav` holds no checkbox state, so the wizard renders its own.
+fn checkbox_glyph(checked: bool, theme: &gpui_component::Theme) -> impl IntoElement {
+    div()
+        .size(px(14.0))
+        .flex()
+        .items_center()
+        .justify_center()
+        .border_1()
+        .rounded(px(3.0))
+        .border_color(if checked { theme.primary } else { theme.border })
+        .when(checked, |parent| parent.bg(theme.primary))
+        .when(checked, |parent| {
+            parent.child(
+                Icon::new(AppIcon::Check)
+                    .small()
+                    .color(theme.primary_foreground),
+            )
+        })
+}
+
+/// The relational view of a schema snapshot, or `None` for non-relational
+/// paradigms (which are not transfer-compatible migration targets anyway).
+fn relational_schema(
+    snapshot: &dbflux_core::SchemaSnapshot,
+) -> Option<&dbflux_core::RelationalSchema> {
+    match &snapshot.structure {
+        dbflux_core::DataStructure::Relational(relational) => Some(relational),
+        _ => None,
+    }
+}
+
+/// Builds the pre-loaded current-database node from the connection's live
+/// schema snapshot (schemas for schema-based drivers, top-level tables for
+/// schemaless ones) so the pre-checked source tables are visible immediately.
+fn current_database_node(database: &str, relational: &dbflux_core::RelationalSchema) -> DbNode {
+    let schemas = relational
+        .schemas
+        .iter()
+        .map(|schema| SchemaNode {
+            name: schema.name.clone(),
+            tables: schema
+                .tables
+                .iter()
+                .map(|table| TableEntry {
+                    schema: table.schema.clone(),
+                    name: table.name.clone(),
+                })
+                .collect(),
+        })
+        .collect();
+
+    let tables = relational
+        .tables
+        .iter()
+        .map(|table| TableEntry {
+            schema: table.schema.clone(),
+            name: table.name.clone(),
+        })
+        .collect();
+
+    DbNode {
+        name: database.to_string(),
+        schemas,
+        tables,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ConnRoot, DbNode, SchemaNode, TableEntry, TreeSide, build_side_nodes, is_retry_id,
+        is_status_id, parent_of_synthetic, split_tables_by_schema,
+    };
+    use crate::migrate_wizard::tree_model::{
+        NodeLoad, TreeModel, TreePayload, connection_node_id, database_node_id, schema_node_id,
+        table_node_id,
+    };
+    use uuid::Uuid;
+
+    fn uuid(seed: u8) -> Uuid {
+        Uuid::from_bytes([seed; 16])
+    }
+
+    fn table(schema: Option<&str>, name: &str) -> TableEntry {
+        TableEntry {
+            schema: schema.map(str::to_string),
+            name: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn source_side_builds_connection_database_schema_table_hierarchy_with_payloads() {
+        let profile_id = uuid(1);
+        let roots = vec![ConnRoot {
+            profile_id,
+            label: "Prod".to_string(),
+            databases: vec![DbNode {
+                name: "app".to_string(),
+                schemas: vec![SchemaNode {
+                    name: "public".to_string(),
+                    tables: vec![
+                        table(Some("public"), "users"),
+                        table(Some("public"), "orders"),
+                    ],
+                }],
+                tables: Vec::new(),
+            }],
+        }];
+
+        let mut model = TreeModel::new();
+        let nodes = build_side_nodes(TreeSide::Source, &roots, &mut model);
+
+        assert_eq!(nodes.len(), 1);
+        let connection = &nodes[0];
+        assert_eq!(connection.id, connection_node_id(profile_id));
+        assert!(!connection.selectable);
+
+        let database = &connection.children[0];
+        assert_eq!(database.id, database_node_id(profile_id, "app"));
+        assert!(!database.selectable);
+
+        let schema = &database.children[0];
+        assert_eq!(schema.id, schema_node_id(profile_id, "app", "public"));
+
+        let user_leaf = &schema.children[0];
+        assert_eq!(
+            user_leaf.id,
+            table_node_id(profile_id, "app", Some("public"), "users")
+        );
+        assert!(user_leaf.selectable);
+
+        assert_eq!(
+            model.payload(&connection_node_id(profile_id)),
+            Some(&TreePayload::Connection(profile_id))
+        );
+        assert!(matches!(
+            model.payload(&table_node_id(profile_id, "app", Some("public"), "users")),
+            Some(TreePayload::Table { .. })
+        ));
+    }
+
+    #[test]
+    fn unloaded_source_database_gets_a_status_child_so_it_stays_expandable() {
+        let profile_id = uuid(2);
+        let roots = vec![ConnRoot {
+            profile_id,
+            label: "Prod".to_string(),
+            databases: vec![DbNode {
+                name: "other".to_string(),
+                ..Default::default()
+            }],
+        }];
+
+        let mut model = TreeModel::new();
+        let nodes = build_side_nodes(TreeSide::Source, &roots, &mut model);
+
+        let database = &nodes[0].children[0];
+        assert_eq!(database.children.len(), 1);
+        assert!(is_status_id(&database.children[0].id));
+        assert!(!database.children[0].selectable);
+    }
+
+    #[test]
+    fn failed_source_database_gets_a_selectable_retry_child() {
+        let profile_id = uuid(3);
+        let roots = vec![ConnRoot {
+            profile_id,
+            label: "Prod".to_string(),
+            databases: vec![DbNode {
+                name: "other".to_string(),
+                ..Default::default()
+            }],
+        }];
+
+        let mut model = TreeModel::new();
+        model.set_load(
+            database_node_id(profile_id, "other"),
+            NodeLoad::Failed("boom".to_string()),
+        );
+        let nodes = build_side_nodes(TreeSide::Source, &roots, &mut model);
+
+        let retry = &nodes[0].children[0].children[0];
+        assert!(is_retry_id(&retry.id));
+        assert!(retry.selectable);
+        assert!(retry.label.contains("boom"));
+    }
+
+    #[test]
+    fn target_side_stops_at_selectable_database_leaves() {
+        let profile_id = uuid(4);
+        let roots = vec![ConnRoot {
+            profile_id,
+            label: "Warehouse".to_string(),
+            databases: vec![DbNode {
+                name: "analytics".to_string(),
+                ..Default::default()
+            }],
+        }];
+
+        let mut model = TreeModel::new();
+        let nodes = build_side_nodes(TreeSide::Target, &roots, &mut model);
+
+        let database = &nodes[0].children[0];
+        assert_eq!(database.id, database_node_id(profile_id, "analytics"));
+        assert!(database.selectable);
+        assert!(database.children.is_empty());
+        assert!(matches!(
+            model.payload(&database_node_id(profile_id, "analytics")),
+            Some(TreePayload::Database { .. })
+        ));
+    }
+
+    #[test]
+    fn split_tables_by_schema_separates_schemaless_from_grouped() {
+        let tables = vec![
+            table(None, "loose"),
+            table(Some("public"), "users"),
+            table(Some("public"), "orders"),
+            table(Some("audit"), "log"),
+        ];
+
+        let (schemaless, schemas) = split_tables_by_schema(tables);
+
+        assert_eq!(schemaless.len(), 1);
+        assert_eq!(schemaless[0].name, "loose");
+
+        assert_eq!(schemas.len(), 2);
+        let public = schemas.iter().find(|s| s.name == "public").unwrap();
+        assert_eq!(public.tables.len(), 2);
+        let audit = schemas.iter().find(|s| s.name == "audit").unwrap();
+        assert_eq!(audit.tables.len(), 1);
+    }
+
+    #[test]
+    fn parent_of_synthetic_recovers_the_real_node_id() {
+        assert_eq!(parent_of_synthetic("db:1:app::__status"), Some("db:1:app"));
+        assert_eq!(parent_of_synthetic("conn:1::__retry"), Some("conn:1"));
+        assert_eq!(parent_of_synthetic("db:1:app"), None);
+    }
+}

--- a/crates/dbflux_ui_document/src/migrate_wizard/source_target.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/source_target.rs
@@ -32,6 +32,7 @@ use gpui::*;
 use gpui_component::ActiveTheme;
 use uuid::Uuid;
 
+use crate::migrate_wizard::phases::can_advance_from_source_target;
 use crate::migrate_wizard::tree_model::{
     NodeLoad, TreeModel, TreePayload, connection_node_id, database_node_id, schema_node_id,
     table_node_id,
@@ -39,6 +40,23 @@ use crate::migrate_wizard::tree_model::{
 
 const ROW_HEIGHT: Pixels = Heights::ROW_COMPACT;
 const INDENT_PX: f32 = 14.0;
+
+/// Display label for the implicit, empty-named database of a single-database
+/// driver (e.g. SQLite, whose one database is conventionally called `main`), so
+/// its tree row is never blank. Keyed off an empty database name, not a driver
+/// id, so it stays driver-agnostic.
+const IMPLICIT_DATABASE_LABEL: &str = "main";
+
+/// The label shown for a database node. Falls back to [`IMPLICIT_DATABASE_LABEL`]
+/// for the empty-named implicit database so the row is readable; the node's
+/// payload keeps the real (possibly empty) database identity untouched.
+fn database_display_label(name: &str) -> SharedString {
+    if name.trim().is_empty() {
+        SharedString::from(IMPLICIT_DATABASE_LABEL)
+    } else {
+        SharedString::from(name.to_string())
+    }
+}
 
 /// Which of the two trees an operation targets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -185,10 +203,12 @@ fn build_database_node(
         },
     );
 
+    let label = database_display_label(&db.name);
+
     if side == TreeSide::Target {
         // The target tree stops at the database — that is the container the
         // migration loads into; per-table mapping is the grid's job.
-        return TreeNavNode::leaf(id, db.name.clone(), Some(AppIcon::Database));
+        return TreeNavNode::leaf(id, label, Some(AppIcon::Database));
     }
 
     let mut children = build_database_children(profile_id, db, model);
@@ -196,7 +216,7 @@ fn build_database_node(
         children.extend(status_child(&id, &model.load(&id)));
     }
 
-    TreeNavNode::group(id, db.name.clone(), Some(AppIcon::Database), children)
+    TreeNavNode::group(id, label, Some(AppIcon::Database), children)
 }
 
 fn build_database_children(
@@ -303,9 +323,11 @@ fn is_source_table_checkable(payload: Option<&TreePayload>, source_database: &st
 /// Resolves the wizard-owned checked set to `TableRef`s, keeping only tables
 /// that live in `source_database`. Any stray check from another browsed
 /// database is dropped, so the returned tables always resolve against the
-/// single source the plan is built for.
+/// single source the plan is built for. Sorted by qualified name — the
+/// checked set is a `HashSet`, and grid rows, Confirm rows, and the
+/// FK-independent run order must be deterministic across openings.
 fn checked_tables_in_database(model: &TreeModel, source_database: &str) -> Vec<TableRef> {
-    model
+    let mut tables: Vec<TableRef> = model
         .checked_ids()
         .filter_map(|id| match model.payload(id) {
             Some(TreePayload::Table {
@@ -313,7 +335,10 @@ fn checked_tables_in_database(model: &TreeModel, source_database: &str) -> Vec<T
             }) if database == source_database => Some(table.clone()),
             _ => None,
         })
-        .collect()
+        .collect();
+
+    tables.sort_by_key(|table| table.qualified_name());
+    tables
 }
 
 /// Per-side runtime state: the known structure, the payload/load/checked
@@ -370,7 +395,7 @@ impl SourceTargetPhase {
         let target_nodes = build_side_nodes(TreeSide::Target, &target_roots, &mut target_model);
         let target_tree = TreeNav::new(target_nodes, HashSet::new());
 
-        Self {
+        let mut phase = Self {
             app_state,
             focus_handle: cx.focus_handle(),
             source_profile_id,
@@ -388,7 +413,37 @@ impl SourceTargetPhase {
             active_side: TreeSide::Source,
             target_selection: None,
             error: None,
+        };
+
+        phase.ensure_resolved_database_loaded(cx);
+        phase
+    }
+
+    /// Kicks the lazy fetch for the resolved source database when no local
+    /// data describes it (sidebar multi-select on a non-current database):
+    /// the node arrives pre-expanded with pre-checked tables, so without an
+    /// immediate fetch the seeded checks would stay unresolvable ghosts and
+    /// the placeholder row would read "Loading…" with nothing in flight.
+    fn ensure_resolved_database_loaded(&mut self, cx: &mut Context<Self>) {
+        if self.source_database.is_empty() {
+            return;
         }
+
+        let populated = self.source.roots.iter().any(|root| {
+            root.databases.iter().any(|db| {
+                db.name == self.source_database && (!db.schemas.is_empty() || !db.tables.is_empty())
+            })
+        });
+        if populated {
+            return;
+        }
+
+        let node_id = database_node_id(self.source_profile_id, &self.source_database);
+        if self.source.model.load(&node_id) != NodeLoad::NotLoaded {
+            return;
+        }
+
+        self.fetch_source_database(node_id, self.source_database.clone(), cx);
     }
 
     pub fn focus_handle(&self) -> &FocusHandle {
@@ -420,11 +475,39 @@ impl SourceTargetPhase {
         self.target_selection.as_ref().map(|t| t.database.clone())
     }
 
-    /// Whether the phase's advance guard is satisfied: at least one checked
-    /// source table and a chosen target container. Transfer compatibility is
-    /// already guaranteed — only compatible targets appear in the tree.
-    pub fn is_ready(&self) -> bool {
-        self.source.model.checked_count() > 0 && self.target_selection.is_some()
+    /// Whether the phase's advance guard is satisfied, via the tested pure
+    /// guard [`can_advance_from_source_target`]: at least one checked source
+    /// table that actually resolves to a real table payload in the source
+    /// database (a raw checked count would let ghost checks enable Continue
+    /// for a "migrate 0 tables" run), a chosen target container, and live
+    /// transfer compatibility between the two connections.
+    pub fn is_ready(&self, cx: &App) -> bool {
+        can_advance_from_source_target(
+            self.checked_source_tables().len(),
+            self.target_selection.is_some(),
+            self.target_is_transfer_compatible(cx),
+        )
+    }
+
+    /// Re-verifies transfer compatibility against the live connections. The
+    /// target tree only lists compatible profiles, but either side can
+    /// disconnect while the phase is open.
+    fn target_is_transfer_compatible(&self, cx: &App) -> bool {
+        let Some(selection) = self.target_selection.as_ref() else {
+            return false;
+        };
+
+        let state = self.app_state.read(cx);
+        let connections = state.connections();
+        match (
+            connections.get(&self.source_profile_id),
+            connections.get(&selection.profile_id),
+        ) {
+            (Some(source), Some(target)) => {
+                transfer_compatible(source.connection.metadata(), target.connection.metadata())
+            }
+            _ => false,
+        }
     }
 
     fn source_roots_from_state(
@@ -439,36 +522,43 @@ impl SourceTargetPhase {
         };
 
         let relational = connected.schema.as_ref().and_then(relational_schema);
-        let current_database = source_database
-            .or_else(|| relational.and_then(|r| r.current_database.clone()))
-            .or_else(|| connected.connection.active_database())
+        let connection_database = relational
+            .and_then(|r| r.current_database.clone())
+            .or_else(|| connected.connection.active_database());
+        let resolved_database = source_database
+            .or_else(|| connection_database.clone())
             .unwrap_or_default();
 
-        let mut databases = Vec::new();
+        let mut names: Vec<String> = Vec::new();
+        if !resolved_database.is_empty() {
+            names.push(resolved_database.clone());
+        }
         if let Some(relational) = relational {
-            databases.push(current_database_node(&current_database, relational));
-
             for database in &relational.databases {
-                if database.name != current_database {
-                    databases.push(DbNode {
-                        name: database.name.clone(),
-                        ..Default::default()
-                    });
+                if !names.contains(&database.name) {
+                    names.push(database.name.clone());
                 }
             }
-        } else if !current_database.is_empty() {
-            databases.push(DbNode {
-                name: current_database.clone(),
-                ..Default::default()
-            });
         }
+        if let Some(connection_database) = &connection_database
+            && !names.contains(connection_database)
+        {
+            names.push(connection_database.clone());
+        }
+
+        let databases = names
+            .into_iter()
+            .map(|name| {
+                source_database_node(name, connected, relational, connection_database.as_deref())
+            })
+            .collect();
 
         let root = ConnRoot {
             profile_id: source_profile_id,
             label: connected.profile.name.clone(),
             databases,
         };
-        (vec![root], current_database)
+        (vec![root], resolved_database)
     }
 
     fn target_roots_from_state(
@@ -489,7 +579,7 @@ impl SourceTargetPhase {
                 transfer_compatible(source_metadata, connected.connection.metadata())
             })
             .map(|(profile_id, connected)| {
-                let databases = connected
+                let listed = connected
                     .schema
                     .as_ref()
                     .and_then(relational_schema)
@@ -497,18 +587,17 @@ impl SourceTargetPhase {
                         relational
                             .databases
                             .iter()
-                            .map(|database| DbNode {
-                                name: database.name.clone(),
-                                ..Default::default()
-                            })
+                            .map(|database| database.name.clone())
                             .collect::<Vec<_>>()
                     })
                     .unwrap_or_default();
 
+                let implicit = connected.connection.active_database().unwrap_or_default();
+
                 ConnRoot {
                     profile_id: *profile_id,
                     label: connected.profile.name.clone(),
-                    databases,
+                    databases: target_database_nodes(listed, implicit),
                 }
             })
             .collect();
@@ -576,11 +665,17 @@ impl SourceTargetPhase {
                 profile_id,
                 database,
             }) if side == TreeSide::Target => {
-                self.target_selection = Some(TargetSelection {
+                let selection = TargetSelection {
                     profile_id,
                     database,
-                });
-                cx.emit(SourceTargetChanged);
+                };
+
+                // Re-selecting the already-chosen target is a no-op: emitting
+                // would make the host discard downstream mapping work.
+                if self.target_selection.as_ref() != Some(&selection) {
+                    self.target_selection = Some(selection);
+                    cx.emit(SourceTargetChanged);
+                }
                 cx.notify();
             }
             _ => {}
@@ -667,6 +762,11 @@ impl SourceTargetPhase {
                         this.source
                             .model
                             .set_load(node_id.clone(), NodeLoad::Loaded);
+
+                        // Freshly inserted payloads can turn seeded checks
+                        // into resolvable tables (or reveal ghosts), so the
+                        // host must re-evaluate its advance guard.
+                        cx.emit(SourceTargetChanged);
                     }
                     Err(error) => {
                         this.source
@@ -717,7 +817,7 @@ impl SourceTargetPhase {
                             .into_iter()
                             .map(|database| database.name)
                             .collect();
-                        this.populate_target_databases(profile_id, names);
+                        this.populate_target_databases(profile_id, names, cx);
                         this.target
                             .model
                             .set_load(node_id.clone(), NodeLoad::Loaded);
@@ -754,7 +854,15 @@ impl SourceTargetPhase {
         db.schemas = schemas;
     }
 
-    fn populate_target_databases(&mut self, profile_id: Uuid, names: Vec<String>) {
+    fn populate_target_databases(&mut self, profile_id: Uuid, names: Vec<String>, cx: &App) {
+        let implicit = self
+            .app_state
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .and_then(|connected| connected.connection.active_database())
+            .unwrap_or_default();
+
         let Some(root) = self
             .target
             .roots
@@ -764,13 +872,7 @@ impl SourceTargetPhase {
             return;
         };
 
-        root.databases = names
-            .into_iter()
-            .map(|name| DbNode {
-                name,
-                ..Default::default()
-            })
-            .collect();
+        root.databases = target_database_nodes(names, implicit);
     }
 
     fn resolve_source_connection(&self, database: &str, cx: &App) -> Option<Arc<dyn Connection>> {
@@ -799,7 +901,21 @@ impl SourceTargetPhase {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if event.keystroke.modifiers != Modifiers::none() {
+        let modifiers = event.keystroke.modifiers;
+
+        // Shift+Tab switches the active tree; plain Tab is deliberately left
+        // unhandled so it can move focus onward to the footer's Continue button
+        // (keyboard-first — the wizard must never trap Tab on this phase).
+        if modifiers.shift && event.keystroke.key == "tab" {
+            self.active_side = match self.active_side {
+                TreeSide::Source => TreeSide::Target,
+                TreeSide::Target => TreeSide::Source,
+            };
+            cx.notify();
+            return;
+        }
+
+        if modifiers != Modifiers::none() {
             return;
         }
 
@@ -816,13 +932,6 @@ impl SourceTargetPhase {
             "left" => self.collapse_cursor(side, cx),
             "right" => self.expand_cursor(side, cx),
             "enter" | "space" => self.activate_current(side, cx),
-            "tab" => {
-                self.active_side = match side {
-                    TreeSide::Source => TreeSide::Target,
-                    TreeSide::Target => TreeSide::Source,
-                };
-                cx.notify();
-            }
             _ => {}
         }
     }
@@ -874,7 +983,7 @@ impl Render for SourceTargetPhase {
                     .child(self.render_tree_panel(TreeSide::Target, "Target", cx)),
             )
             .when_some(self.error.clone(), |parent, error| {
-                parent.child(Text::caption(error))
+                parent.child(Text::caption(error).danger())
             })
     }
 }
@@ -1062,6 +1171,29 @@ fn checkbox_glyph(checked: bool, theme: &gpui_component::Theme) -> impl IntoElem
         })
 }
 
+/// The target tree's database nodes for one connection: the listed databases,
+/// or — when the driver exposes no database list (a single implicit database,
+/// e.g. SQLite) — one node for the implicit database so it can still be chosen
+/// as a migration target. Keyed off "empty list", not a driver id, so it stays
+/// driver-agnostic; the implicit database's (possibly empty) identity is
+/// preserved in the node while [`database_display_label`] handles the label.
+fn target_database_nodes(listed: Vec<String>, implicit_database: String) -> Vec<DbNode> {
+    if listed.is_empty() {
+        return vec![DbNode {
+            name: implicit_database,
+            ..Default::default()
+        }];
+    }
+
+    listed
+        .into_iter()
+        .map(|name| DbNode {
+            name,
+            ..Default::default()
+        })
+        .collect()
+}
+
 /// The relational view of a schema snapshot, or `None` for non-relational
 /// paradigms (which are not transfer-compatible migration targets anyway).
 fn relational_schema(
@@ -1070,6 +1202,57 @@ fn relational_schema(
     match &snapshot.structure {
         dbflux_core::DataStructure::Relational(relational) => Some(relational),
         _ => None,
+    }
+}
+
+/// Populates one source database node from whichever local data actually
+/// describes that database: the connection's live snapshot describes only its
+/// current database, per-database connections carry their own snapshot, and
+/// lazy-per-database drivers cache a `DbSchemaInfo` per browsed database. A
+/// database with no local data stays empty and lazy-loads on expand — it must
+/// never be pre-populated with the current database's tables, which describe
+/// a different container.
+fn source_database_node(
+    name: String,
+    connected: &dbflux_core::ConnectedProfile,
+    relational: Option<&dbflux_core::RelationalSchema>,
+    connection_database: Option<&str>,
+) -> DbNode {
+    if connection_database == Some(name.as_str())
+        && let Some(relational) = relational
+    {
+        return current_database_node(&name, relational);
+    }
+
+    if let Some(snapshot) = connected
+        .database_connection(&name)
+        .and_then(|db_connection| db_connection.schema.as_ref())
+        && let Some(relational) = relational_schema(snapshot)
+    {
+        return current_database_node(&name, relational);
+    }
+
+    if let Some(db_schema) = connected.database_schemas.get(&name) {
+        let tables = db_schema
+            .tables
+            .iter()
+            .map(|table| TableEntry {
+                schema: table.schema.clone(),
+                name: table.name.clone(),
+            })
+            .collect();
+
+        let (schemaless, schemas) = split_tables_by_schema(tables);
+        return DbNode {
+            name,
+            schemas,
+            tables: schemaless,
+        };
+    }
+
+    DbNode {
+        name,
+        ..Default::default()
     }
 }
 
@@ -1113,8 +1296,8 @@ fn current_database_node(database: &str, relational: &dbflux_core::RelationalSch
 mod tests {
     use super::{
         ConnRoot, DbNode, SchemaNode, TableEntry, TreeSide, build_side_nodes,
-        checked_tables_in_database, is_retry_id, is_source_table_checkable, is_status_id,
-        parent_of_synthetic, split_tables_by_schema,
+        checked_tables_in_database, database_display_label, is_retry_id, is_source_table_checkable,
+        is_status_id, parent_of_synthetic, split_tables_by_schema, target_database_nodes,
     };
     use crate::migrate_wizard::tree_model::{
         NodeLoad, TreeModel, TreePayload, connection_node_id, database_node_id, schema_node_id,
@@ -1343,6 +1526,34 @@ mod tests {
             model.payload(&other_orders),
             "app"
         ));
+    }
+
+    #[test]
+    fn target_database_nodes_falls_back_to_a_single_implicit_database_when_list_is_empty() {
+        let nodes = target_database_nodes(Vec::new(), "main".to_string());
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(nodes[0].name, "main");
+
+        let empty_identity = target_database_nodes(Vec::new(), String::new());
+        assert_eq!(empty_identity.len(), 1);
+        assert_eq!(empty_identity[0].name, "");
+    }
+
+    #[test]
+    fn target_database_nodes_uses_the_listed_databases_when_present() {
+        let nodes = target_database_nodes(
+            vec!["app".to_string(), "warehouse".to_string()],
+            String::new(),
+        );
+        let names: Vec<&str> = nodes.iter().map(|n| n.name.as_str()).collect();
+        assert_eq!(names, vec!["app", "warehouse"]);
+    }
+
+    #[test]
+    fn database_display_label_falls_back_for_the_empty_named_implicit_database() {
+        assert_eq!(database_display_label(""), "main");
+        assert_eq!(database_display_label("   "), "main");
+        assert_eq!(database_display_label("app"), "app");
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/migrate_wizard/tree_model.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/tree_model.rs
@@ -1,0 +1,347 @@
+//! Wizard-owned tree selection model backing the source/target table
+//! pickers: deterministic node ids over connection/database/schema/table
+//! payloads (looked up by id — never parsed back out of the id string),
+//! per-node lazy-load state, and the wizard's own checked-table
+//! multi-select. `TreeNav` itself is a pure nav model that renders nothing,
+//! so checkbox state has no business living there (design ADR #3) — it
+//! lives here instead. Pure data, no GPUI, unit testable without a wizard
+//! entity. A later slice turns live metadata into `TreeNavNode`s keyed by
+//! these same ids and hands them to `TreeNav::set_nodes`.
+
+use std::collections::{HashMap, HashSet};
+
+use dbflux_core::TableRef;
+use gpui::SharedString;
+use uuid::Uuid;
+
+/// What a tree node id refers to, looked up in [`TreeModel::payload`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TreePayload {
+    Connection(Uuid),
+    Database {
+        profile_id: Uuid,
+        database: String,
+    },
+    Schema {
+        profile_id: Uuid,
+        database: String,
+        schema: String,
+    },
+    Table {
+        profile_id: Uuid,
+        database: String,
+        schema: Option<String>,
+        table: TableRef,
+    },
+}
+
+/// Per-node lazy-load state. Reused by the Tables Mapping grid (a later
+/// slice) for its own target-table-existence lookup, so `Loaded` carries no
+/// payload here — the grid reads the result from its own row state.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum NodeLoad {
+    #[default]
+    NotLoaded,
+    Loading,
+    Loaded,
+    Failed(String),
+}
+
+pub fn connection_node_id(profile_id: Uuid) -> SharedString {
+    SharedString::from(format!("conn:{profile_id}"))
+}
+
+pub fn database_node_id(profile_id: Uuid, database: &str) -> SharedString {
+    SharedString::from(format!("db:{profile_id}:{database}"))
+}
+
+pub fn schema_node_id(profile_id: Uuid, database: &str, schema: &str) -> SharedString {
+    SharedString::from(format!("schema:{profile_id}:{database}:{schema}"))
+}
+
+pub fn table_node_id(
+    profile_id: Uuid,
+    database: &str,
+    schema: Option<&str>,
+    table: &str,
+) -> SharedString {
+    match schema {
+        Some(schema) => {
+            SharedString::from(format!("table:{profile_id}:{database}:{schema}:{table}"))
+        }
+        None => SharedString::from(format!("table:{profile_id}:{database}::{table}")),
+    }
+}
+
+/// The ids a caller should hand to `TreeNav` after seeding pre-selection:
+/// which ancestor group ids to expand, and which table row to move the
+/// cursor to via `TreeNav::select_by_id`.
+pub struct SeedResult {
+    pub expand: HashSet<SharedString>,
+    pub cursor: Option<SharedString>,
+}
+
+#[derive(Default)]
+pub struct TreeModel {
+    node_payloads: HashMap<SharedString, TreePayload>,
+    node_load: HashMap<SharedString, NodeLoad>,
+    checked: HashSet<SharedString>,
+}
+
+impl TreeModel {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert_payload(&mut self, id: SharedString, payload: TreePayload) {
+        self.node_payloads.insert(id, payload);
+    }
+
+    pub fn payload(&self, id: &str) -> Option<&TreePayload> {
+        self.node_payloads.get(id)
+    }
+
+    pub fn set_load(&mut self, id: SharedString, load: NodeLoad) {
+        self.node_load.insert(id, load);
+    }
+
+    pub fn load(&self, id: &str) -> NodeLoad {
+        self.node_load.get(id).cloned().unwrap_or_default()
+    }
+
+    /// Flips `id`'s checked state and returns the new state — mirrors the
+    /// table-leaf `Selected(id)` toggle action (Space/Enter/click) the
+    /// caller wires from `TreeNav::activate`.
+    pub fn toggle_checked(&mut self, id: &SharedString) -> bool {
+        if self.checked.remove(id) {
+            false
+        } else {
+            self.checked.insert(id.clone());
+            true
+        }
+    }
+
+    pub fn is_checked(&self, id: &str) -> bool {
+        self.checked.contains(id)
+    }
+
+    pub fn checked_count(&self) -> usize {
+        self.checked.len()
+    }
+
+    pub fn checked_ids(&self) -> impl Iterator<Item = &SharedString> {
+        self.checked.iter()
+    }
+
+    pub fn clear_checked(&mut self) {
+        self.checked.clear();
+    }
+
+    /// Seeds pre-selection from `MigrateWizard::open`'s `source_tables`:
+    /// every table becomes checked, and the returned [`SeedResult`] carries
+    /// the ancestor ids (schema, if any, database, connection) to expand and
+    /// the first table's id to move the cursor to, so the caller's
+    /// `TreeNav` shows the pre-checked tables already visible and selected.
+    pub fn seed_source_selection(
+        &mut self,
+        profile_id: Uuid,
+        database: &str,
+        source_tables: &[TableRef],
+    ) -> SeedResult {
+        let mut expand = HashSet::new();
+        expand.insert(connection_node_id(profile_id));
+        expand.insert(database_node_id(profile_id, database));
+
+        let mut cursor = None;
+        for table in source_tables {
+            if let Some(schema) = table.schema.as_deref() {
+                expand.insert(schema_node_id(profile_id, database, schema));
+            }
+            let id = table_node_id(profile_id, database, table.schema.as_deref(), &table.name);
+            self.checked.insert(id.clone());
+            if cursor.is_none() {
+                cursor = Some(id);
+            }
+        }
+
+        SeedResult { expand, cursor }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn uuid(seed: u8) -> Uuid {
+        Uuid::from_bytes([seed; 16])
+    }
+
+    #[test]
+    fn payload_variants_round_trip_through_the_model() {
+        let mut model = TreeModel::new();
+        let profile_id = uuid(1);
+
+        model.insert_payload(
+            connection_node_id(profile_id),
+            TreePayload::Connection(profile_id),
+        );
+        model.insert_payload(
+            database_node_id(profile_id, "app"),
+            TreePayload::Database {
+                profile_id,
+                database: "app".to_string(),
+            },
+        );
+        model.insert_payload(
+            schema_node_id(profile_id, "app", "public"),
+            TreePayload::Schema {
+                profile_id,
+                database: "app".to_string(),
+                schema: "public".to_string(),
+            },
+        );
+        model.insert_payload(
+            table_node_id(profile_id, "app", Some("public"), "users"),
+            TreePayload::Table {
+                profile_id,
+                database: "app".to_string(),
+                schema: Some("public".to_string()),
+                table: TableRef {
+                    schema: Some("public".to_string()),
+                    name: "users".to_string(),
+                },
+            },
+        );
+
+        assert_eq!(
+            model.payload(&connection_node_id(profile_id)),
+            Some(&TreePayload::Connection(profile_id))
+        );
+        assert_eq!(
+            model.payload(&database_node_id(profile_id, "app")),
+            Some(&TreePayload::Database {
+                profile_id,
+                database: "app".to_string(),
+            })
+        );
+        assert_eq!(
+            model.payload(&schema_node_id(profile_id, "app", "public")),
+            Some(&TreePayload::Schema {
+                profile_id,
+                database: "app".to_string(),
+                schema: "public".to_string(),
+            })
+        );
+        assert_eq!(
+            model.payload(&table_node_id(profile_id, "app", Some("public"), "users")),
+            Some(&TreePayload::Table {
+                profile_id,
+                database: "app".to_string(),
+                schema: Some("public".to_string()),
+                table: TableRef {
+                    schema: Some("public".to_string()),
+                    name: "users".to_string(),
+                },
+            })
+        );
+        assert_eq!(model.payload("missing"), None);
+    }
+
+    #[test]
+    fn node_load_transitions_not_loaded_loading_loaded_or_failed() {
+        let mut model = TreeModel::new();
+        let id = SharedString::from("schema:x");
+
+        assert_eq!(model.load(&id), NodeLoad::NotLoaded);
+
+        model.set_load(id.clone(), NodeLoad::Loading);
+        assert_eq!(model.load(&id), NodeLoad::Loading);
+
+        model.set_load(id.clone(), NodeLoad::Loaded);
+        assert_eq!(model.load(&id), NodeLoad::Loaded);
+
+        let failing_id = SharedString::from("schema:y");
+        model.set_load(failing_id.clone(), NodeLoad::Loading);
+        model.set_load(failing_id.clone(), NodeLoad::Failed("boom".to_string()));
+        assert_eq!(
+            model.load(&failing_id),
+            NodeLoad::Failed("boom".to_string())
+        );
+    }
+
+    #[test]
+    fn toggle_checked_flips_state_and_reports_the_new_value() {
+        let mut model = TreeModel::new();
+        let id = SharedString::from("table:1");
+
+        assert!(!model.is_checked(&id));
+        assert!(model.toggle_checked(&id));
+        assert!(model.is_checked(&id));
+        assert_eq!(model.checked_count(), 1);
+
+        assert!(!model.toggle_checked(&id));
+        assert!(!model.is_checked(&id));
+        assert_eq!(model.checked_count(), 0);
+    }
+
+    #[test]
+    fn clear_checked_empties_the_set() {
+        let mut model = TreeModel::new();
+        model.toggle_checked(&SharedString::from("a"));
+        model.toggle_checked(&SharedString::from("b"));
+        assert_eq!(model.checked_count(), 2);
+
+        model.clear_checked();
+        assert_eq!(model.checked_count(), 0);
+    }
+
+    #[test]
+    fn seed_source_selection_checks_every_table_and_expands_its_ancestor_path() {
+        let mut model = TreeModel::new();
+        let profile_id = uuid(2);
+        let source_tables = vec![
+            TableRef {
+                schema: Some("public".to_string()),
+                name: "users".to_string(),
+            },
+            TableRef {
+                schema: Some("public".to_string()),
+                name: "orders".to_string(),
+            },
+            TableRef {
+                schema: None,
+                name: "no_schema_table".to_string(),
+            },
+        ];
+
+        let seed = model.seed_source_selection(profile_id, "app", &source_tables);
+
+        assert!(model.is_checked(&table_node_id(profile_id, "app", Some("public"), "users")));
+        assert!(model.is_checked(&table_node_id(profile_id, "app", Some("public"), "orders")));
+        assert!(model.is_checked(&table_node_id(profile_id, "app", None, "no_schema_table")));
+        assert_eq!(model.checked_count(), 3);
+
+        assert!(seed.expand.contains(&connection_node_id(profile_id)));
+        assert!(seed.expand.contains(&database_node_id(profile_id, "app")));
+        assert!(
+            seed.expand
+                .contains(&schema_node_id(profile_id, "app", "public"))
+        );
+        assert_eq!(
+            seed.cursor,
+            Some(table_node_id(profile_id, "app", Some("public"), "users"))
+        );
+    }
+
+    #[test]
+    fn seed_source_selection_with_no_tables_expands_only_the_connection_and_database() {
+        let mut model = TreeModel::new();
+        let profile_id = uuid(3);
+
+        let seed = model.seed_source_selection(profile_id, "app", &[]);
+
+        assert_eq!(model.checked_count(), 0);
+        assert_eq!(seed.expand.len(), 2);
+        assert!(seed.cursor.is_none());
+    }
+}

--- a/crates/dbflux_ui_document/src/migrate_wizard/tree_model.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/tree_model.rs
@@ -5,7 +5,7 @@
 //! multi-select. `TreeNav` itself is a pure nav model that renders nothing,
 //! so checkbox state has no business living there (design ADR #3) — it
 //! lives here instead. Pure data, no GPUI, unit testable without a wizard
-//! entity. A later slice turns live metadata into `TreeNavNode`s keyed by
+//! entity. `source_target` turns live metadata into `TreeNavNode`s keyed by
 //! these same ids and hands them to `TreeNav::set_nodes`.
 
 use std::collections::{HashMap, HashSet};
@@ -35,9 +35,9 @@ pub enum TreePayload {
     },
 }
 
-/// Per-node lazy-load state. Reused by the Tables Mapping grid (a later
-/// slice) for its own target-table-existence lookup, so `Loaded` carries no
-/// payload here — the grid reads the result from its own row state.
+/// Per-node lazy-load state. Reused by the Tables Mapping grid for its own
+/// target-table-existence lookup, so `Loaded` carries no payload here — the
+/// grid reads the result from its own row state.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum NodeLoad {
     #[default]

--- a/crates/dbflux_ui_document/src/query_builder/panel/mod.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel/mod.rs
@@ -622,10 +622,10 @@ impl QueryBuilderPanel {
                     let db_name = conn
                         .active_database
                         .clone()
-                        .or(source_schema)
+                        .or_else(|| source_schema.clone())
                         .unwrap_or_else(|| "default".to_string());
                     conn.table_details
-                        .get(&(db_name, source_table_name))
+                        .get(&(db_name, source_schema, source_table_name))
                         .and_then(|info| info.columns.clone())
                 })
                 .unwrap_or_default()

--- a/crates/dbflux_ui_sidebar/src/code_generation.rs
+++ b/crates/dbflux_ui_sidebar/src/code_generation.rs
@@ -233,7 +233,11 @@ impl Sidebar {
             };
 
             let cache_db = parts.cache_database();
-            let cache_key = (cache_db.to_string(), parts.object_name.clone());
+            let cache_key = (
+                cache_db.to_string(),
+                Some(parts.schema_name.clone()),
+                parts.object_name.clone(),
+            );
 
             if let Some(table) = conn.table_details.get(&cache_key) {
                 Some(table.clone())

--- a/crates/dbflux_ui_sidebar/src/context_menu.rs
+++ b/crates/dbflux_ui_sidebar/src/context_menu.rs
@@ -1108,7 +1108,7 @@ impl Sidebar {
 
         let state = self.app_state.read(cx);
         let conn = state.connections().get(&profile_id)?;
-        let cache_key = (database.clone(), name.clone());
+        let cache_key = (database.clone(), Some(database.clone()), name.clone());
 
         if let Some(details) = conn.table_details.get(&cache_key) {
             return Some(details.clone());

--- a/crates/dbflux_ui_sidebar/src/deletion.rs
+++ b/crates/dbflux_ui_sidebar/src/deletion.rs
@@ -222,7 +222,7 @@ impl Sidebar {
                     .read(cx)
                     .connections()
                     .get(profile_id)
-                    .map(|conn| conn.dependents(&effective_db, name))
+                    .map(|conn| conn.dependents(&effective_db, Some(schema.as_str()), name))
                     .unwrap_or_default();
 
                 let schema_name = Some(schema.clone());

--- a/crates/dbflux_ui_sidebar/src/expansion.rs
+++ b/crates/dbflux_ui_sidebar/src/expansion.rs
@@ -851,7 +851,7 @@ impl Sidebar {
         self.app_state.update(cx, |state, _cx| {
             if let Some(conn) = state.connections_mut().get_mut(&profile_id) {
                 conn.database_schemas.remove(db_name);
-                conn.table_details.retain(|(db, _), _| db != db_name);
+                conn.table_details.retain(|(db, _, _), _| db != db_name);
                 conn.collection_children.retain(|(db, _), _| db != db_name);
                 conn.schema_types.retain(|key, _| key.database != db_name);
                 conn.schema_indexes.retain(|key, _| key.database != db_name);
@@ -877,9 +877,13 @@ impl Sidebar {
     ) {
         self.app_state.update(cx, |state, _cx| {
             if let Some(conn) = state.connections_mut().get_mut(&profile_id) {
-                let key = (cache_db.to_string(), target.name.clone());
-                conn.table_details.remove(&key);
-                conn.collection_children.remove(&key);
+                // Drop every schema slot for the object name: a drop target
+                // may or may not carry a schema, and stale details under any
+                // schema must not survive the invalidation.
+                conn.table_details
+                    .retain(|(db, _, table), _| db != cache_db || table != &target.name);
+                conn.collection_children
+                    .remove(&(cache_db.to_string(), target.name.clone()));
 
                 if target.kind == SchemaObjectKind::Table {
                     let target_schema = target.schema.as_deref();

--- a/crates/dbflux_ui_sidebar/src/operations/dnd.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/dnd.rs
@@ -264,7 +264,9 @@ impl Sidebar {
     ) {
         if let Some(connected) = state.connections_mut().get_mut(&profile_id) {
             connected.database_schemas.remove(database);
-            connected.table_details.retain(|(db, _), _| db != database);
+            connected
+                .table_details
+                .retain(|(db, _, _), _| db != database);
 
             if connected.active_database.as_deref() == Some(database) {
                 connected.active_database = None;

--- a/crates/dbflux_ui_sidebar/src/operations/tree_ops.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/tree_ops.rs
@@ -12,7 +12,7 @@ struct HeldSidebarDatabaseRefreshState {
     database: String,
     primary_schema: Option<SchemaSnapshot>,
     cached_schema: Option<DbSchemaInfo>,
-    table_details: HashMap<(String, String), TableInfo>,
+    table_details: HashMap<(String, Option<String>, String), TableInfo>,
     schema_types: HashMap<SchemaCacheKey, Vec<CustomTypeInfo>>,
     schema_indexes: HashMap<SchemaCacheKey, Vec<SchemaIndexInfo>>,
     schema_foreign_keys: HashMap<SchemaCacheKey, Vec<SchemaForeignKeyInfo>>,
@@ -54,6 +54,7 @@ enum SchemaObjectRefreshResult {
 struct HeldSidebarObjectRefreshState {
     profile_id: Uuid,
     cache_database: String,
+    schema_name: String,
     object_name: String,
     previous_details: Option<TableInfo>,
 }
@@ -176,7 +177,7 @@ impl Sidebar {
                 let existing = std::mem::take(&mut connected.table_details);
                 let (removed, kept): (Vec<_>, Vec<_>) = existing
                     .into_iter()
-                    .partition(|((cache_db, _), _)| cache_db == database);
+                    .partition(|((cache_db, _, _), _)| cache_db == database);
                 connected.table_details = kept.into_iter().collect();
                 removed.into_iter().collect()
             };
@@ -1190,15 +1191,18 @@ impl Sidebar {
                 .connections_mut()
                 .get_mut(&parts.profile_id)
                 .and_then(|connected| {
-                    connected
-                        .table_details
-                        .remove(&(cache_db.clone(), parts.object_name.clone()))
+                    connected.table_details.remove(&(
+                        cache_db.clone(),
+                        Some(parts.schema_name.clone()),
+                        parts.object_name.clone(),
+                    ))
                 })
         });
 
         let held_state = HeldSidebarObjectRefreshState {
             profile_id: parts.profile_id,
             cache_database: cache_db.clone(),
+            schema_name: parts.schema_name.clone(),
             object_name: parts.object_name.clone(),
             previous_details,
         };
@@ -1243,6 +1247,7 @@ impl Sidebar {
                     state.set_table_details(
                         held_state.profile_id,
                         held_state.cache_database.clone(),
+                        Some(held_state.schema_name.clone()),
                         held_state.object_name.clone(),
                         previous_details,
                     );
@@ -1284,6 +1289,7 @@ impl Sidebar {
                             params
                                 .execute()
                                 .map(|r| SchemaObjectRefreshResult::TableDetails(Box::new(r)))
+                                .map_err(|e| e.to_string())
                         })
                         .await
                 }
@@ -1327,6 +1333,7 @@ impl Sidebar {
                                 state.set_table_details(
                                     held_state.profile_id,
                                     held_state.cache_database.clone(),
+                                    Some(held_state.schema_name.clone()),
                                     held_state.object_name.clone(),
                                     previous_details,
                                 );
@@ -1344,12 +1351,14 @@ impl Sidebar {
                                 state.set_table_details(
                                     result.profile_id,
                                     result.database.clone(),
+                                    result.schema.clone(),
                                     result.table.clone(),
                                     result.details,
                                 );
                                 state.set_dependents(
                                     result.profile_id,
                                     result.database,
+                                    result.schema,
                                     result.table,
                                     result.dependents,
                                 );
@@ -1417,6 +1426,7 @@ impl Sidebar {
                                     state.set_table_details(
                                         held_state.profile_id,
                                         held_state.cache_database.clone(),
+                                        Some(held_state.schema_name.clone()),
                                         held_state.object_name.clone(),
                                         previous_details,
                                     );

--- a/crates/dbflux_ui_sidebar/src/table_loading.rs
+++ b/crates/dbflux_ui_sidebar/src/table_loading.rs
@@ -66,7 +66,11 @@ impl Sidebar {
         };
 
         let cache_db = parts.cache_database();
-        let cache_key = (cache_db.to_string(), parts.object_name.clone());
+        let cache_key = (
+            cache_db.to_string(),
+            Some(parts.schema_name.clone()),
+            parts.object_name.clone(),
+        );
 
         if let Some(details) = conn.table_details.get(&cache_key)
             && (details.columns.is_some() || details.sample_fields.is_some())
@@ -348,7 +352,7 @@ impl Sidebar {
 
         let task = cx
             .background_executor()
-            .spawn(async move { params.execute() });
+            .spawn(async move { params.execute().map_err(|e| e.to_string()) });
 
         self.spawn_fetch_with_result(
             pending_action,
@@ -361,10 +365,17 @@ impl Sidebar {
                     state.set_table_details(
                         res.profile_id,
                         res.database.clone(),
+                        res.schema.clone(),
                         res.table.clone(),
                         res.details,
                     );
-                    state.set_dependents(res.profile_id, res.database, res.table, res.dependents);
+                    state.set_dependents(
+                        res.profile_id,
+                        res.database,
+                        res.schema,
+                        res.table,
+                        res.dependents,
+                    );
                     cx.emit(AppStateChanged);
                 });
             },

--- a/crates/dbflux_ui_sidebar/src/tree_builder.rs
+++ b/crates/dbflux_ui_sidebar/src/tree_builder.rs
@@ -788,13 +788,13 @@ impl Sidebar {
         database_name: &str,
         target_database: Option<&str>,
         snapshot: &dbflux_core::SchemaSnapshot,
-        table_details: &HashMap<(String, String), TableInfo>,
+        table_details: &HashMap<(String, Option<String>, String), TableInfo>,
         schema_types: &HashMap<SchemaCacheKey, Vec<CustomTypeInfo>>,
         schema_indexes: &HashMap<SchemaCacheKey, Vec<SchemaIndexInfo>>,
         schema_foreign_keys: &HashMap<SchemaCacheKey, Vec<SchemaForeignKeyInfo>>,
         schema_routines: &HashMap<SchemaCacheKey, Vec<RoutineInfo>>,
         supports_routines: bool,
-        dependents_cache: &HashMap<(String, String), Vec<RelationRef>>,
+        dependents_cache: &HashMap<(String, Option<String>, String), Vec<RelationRef>>,
     ) -> Vec<TreeItem> {
         let mut children = Vec::new();
 
@@ -835,7 +835,7 @@ impl Sidebar {
         profile_id: Uuid,
         database_name: &str,
         db_schema: &dbflux_core::DbSchemaInfo,
-        table_details: &HashMap<(String, String), TableInfo>,
+        table_details: &HashMap<(String, Option<String>, String), TableInfo>,
         collection_children_cache: &HashMap<(String, String), dbflux_core::CollectionChildrenCache>,
         capabilities: DriverCapabilities,
         category: dbflux_core::DatabaseCategory,
@@ -1054,13 +1054,20 @@ impl Sidebar {
         profile_id: Uuid,
         database_name: &str,
         collection: &dbflux_core::TableInfo,
-        table_details: &HashMap<(String, String), TableInfo>,
+        table_details: &HashMap<(String, Option<String>, String), TableInfo>,
         collection_children_cache: &HashMap<(String, String), dbflux_core::CollectionChildrenCache>,
     ) -> TreeItem {
         let coll_name = &collection.name;
-        let cache_key = (database_name.to_string(), coll_name.clone());
-        let effective = table_details.get(&cache_key).unwrap_or(collection);
-        let paged_children = collection_children_cache.get(&cache_key);
+        // Collections carry their database as the schema key component —
+        // mirrors `ItemIdParts::from_node_id` for `SchemaNodeId::Collection`.
+        let details_key = (
+            database_name.to_string(),
+            Some(database_name.to_string()),
+            coll_name.clone(),
+        );
+        let effective = table_details.get(&details_key).unwrap_or(collection);
+        let children_key = (database_name.to_string(), coll_name.clone());
+        let paged_children = collection_children_cache.get(&children_key);
         let child_items = paged_children
             .map(|cache| cache.items.clone())
             .or_else(|| effective.child_items.clone());
@@ -1187,13 +1194,13 @@ impl Sidebar {
         database_name: &str,
         target_database: Option<&str>,
         db_schema: &dbflux_core::DbSchemaInfo,
-        table_details: &HashMap<(String, String), TableInfo>,
+        table_details: &HashMap<(String, Option<String>, String), TableInfo>,
         schema_types: &HashMap<SchemaCacheKey, Vec<CustomTypeInfo>>,
         schema_indexes: &HashMap<SchemaCacheKey, Vec<SchemaIndexInfo>>,
         schema_foreign_keys: &HashMap<SchemaCacheKey, Vec<SchemaForeignKeyInfo>>,
         schema_routines: &HashMap<SchemaCacheKey, Vec<RoutineInfo>>,
         supports_routines: bool,
-        dependents_cache: &HashMap<(String, String), Vec<RelationRef>>,
+        dependents_cache: &HashMap<(String, Option<String>, String), Vec<RelationRef>>,
     ) -> Vec<TreeItem> {
         let mut content = Vec::new();
         let schema_name = &db_schema.name;
@@ -1323,12 +1330,16 @@ impl Sidebar {
         target_database: Option<&str>,
         schema_name: &str,
         table: &dbflux_core::TableInfo,
-        table_details: &HashMap<(String, String), TableInfo>,
-        dependents_cache: &HashMap<(String, String), Vec<RelationRef>>,
+        table_details: &HashMap<(String, Option<String>, String), TableInfo>,
+        dependents_cache: &HashMap<(String, Option<String>, String), Vec<RelationRef>>,
     ) -> TreeItem {
         // Must match the key used by cache_database().
         let cache_db = target_database.unwrap_or(schema_name);
-        let cache_key = (cache_db.to_string(), table.name.clone());
+        let cache_key = (
+            cache_db.to_string(),
+            Some(schema_name.to_string()),
+            table.name.clone(),
+        );
         let effective_table = table_details.get(&cache_key).unwrap_or(table);
         let details_loaded = effective_table.columns.is_some();
 
@@ -1371,9 +1382,10 @@ impl Sidebar {
         };
 
         // Lookup key must match the cache write path in populate_dependents.
-        // The cache key mirrors `table_details`: (database-or-schema, table).
+        // The cache key mirrors `table_details`: (database-or-schema, schema, table).
         let dep_key = (
             target_database.unwrap_or(schema_name).to_string(),
+            Some(schema_name.to_string()),
             table.name.clone(),
         );
         let deps = dependents_cache
@@ -1792,7 +1804,7 @@ fn build_collections_folder(
     database_name: &str,
     category: dbflux_core::DatabaseCategory,
     db_schema: &dbflux_core::DbSchemaInfo,
-    table_details: &HashMap<(String, String), TableInfo>,
+    table_details: &HashMap<(String, Option<String>, String), TableInfo>,
     collection_children_cache: &HashMap<(String, String), dbflux_core::CollectionChildrenCache>,
 ) -> Option<TreeItem> {
     if db_schema.tables.is_empty() {
@@ -2183,8 +2195,8 @@ fn build_schema_tables_folder(
     schema_name: &str,
     target_database: Option<&str>,
     tables: &[TableInfo],
-    table_details: &HashMap<(String, String), TableInfo>,
-    dependents_cache: &HashMap<(String, String), Vec<RelationRef>>,
+    table_details: &HashMap<(String, Option<String>, String), TableInfo>,
+    dependents_cache: &HashMap<(String, Option<String>, String), Vec<RelationRef>>,
 ) -> Option<TreeItem> {
     if tables.is_empty() {
         return None;


### PR DESCRIPTION
## Summary

- Redesigns the "Migrate Data" modal into a guided, multi-phase wizard (Source & Target → Tables Mapping → Options → Confirm → Run) with a phase sidebar, in a larger centered modal.
- Replaces the old target-connection dropdown with a `connection → database → schema → table` tree for both source and target, adds in-wizard table and target-database selection, and renders column mapping as a Source / Target / Mapping / Transform grid.
- UI-only: no changes to the `dbflux_transfer` engine or the sidebar; existing `run_migration` semantics are preserved.

## What does this resolve?

Tracked as Atlas task **DBF-160** — *[bug] Modal de Migración* (there is no GitHub issue; DBFlux tracks work in Atlas). It fixes every point raised there against the modal that shipped with the transfer engine (#286):

| # | Reported problem | Resolution |
|---|------------------|------------|
| 1 | Target dropdown box huge, options tiny | Dropdown removed; replaced by a tree picker |
| 2 | Could not select the target database, only the connection | Target tree selects connection → database → schema; `target_database` now flows into `MigrationOptions` |
| 3 | Could not select tables in the modal | Source tree with multi-select checkboxes |
| 4 | Wanted a tree like the sidebar, not a dropdown | `TreeNav`-based source/target trees, lazy-loaded on expand |
| 5 | The second screen was confusing | It is the column mapping — now a labeled phase with a Source/Target/Mapping/Transform grid and a per-table column drill-in |
| 6 | Wanted to see the phases (like DBeaver) | Left phase rail with completion checkmarks and back-navigation |
| 7 | Wanted tables-mapping as a table | Rendered as a grid |
| 8 | Continue button too large | Normal-sized primary button in the footer |
| 9 | Modal too small and top-anchored | ~1000px, ~80% viewport, vertically centered |

## How was this solved?

A five-phase wizard entity mounts four self-contained phase entities and drives a `WizardPhase` state machine with per-phase advance guards. The FK-dependency cycle case is a conditional reorder interrupt before Run, not a fixed phase.

**Reuse-first** (repo directive): reuses `TreeNav` (only `set_nodes` added) as the tree nav model and the existing shared `AppStateEntity::prepare_fetch_*` metadata seam — deleting the wizard's previous bespoke `Connection::table_details` fetch path (which also removes a synchronous foreground `schema_foreign_keys` call). Larger/centered geometry is two **opt-in** `ModalFrame` builders (`center_vertically`, `height_fraction`); every other modal's default render path is byte-identical.

Only engine-backed options are surfaced (per-table mapping mode in the grid; segment size and a capability-gated disable-referential-integrity toggle in Options) — no decorative controls.

**Reviewing:** the 9 commits are ordered as reviewable work units — start at `9fa310ff` (shared component additions + tests), then the wizard logic (`8cc21a3d`, `7b349622`), then the UI phases (`32ea964a`, `fb9149a7`, `9af2fa6a`, `d7ea82f2`), the integrating rewrite that removes the old wizard (`9b742742`), and the review-finding fixes (`69ccf910`).

**Out of scope (deliberate):** import/export-to-file unification; DBeaver-parity extraction/data-load performance panels (would require engine work — no mockups); unifying the sidebar's bespoke tree with the wizard picker (follow-up).

## Validation

```
cargo nextest run --workspace        → 4229 passed, 0 failed, 189 skipped
cargo clippy --workspace -- -D warnings → clean
cargo fmt --all -- --check           → clean
cargo test --doc --workspace         → ok
cargo build -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws → builds with the live wizard
```

Extractable logic is unit-tested (phase machine, plan/options assembly, tree selection, mapping `to_overrides()` round-trip, FK-order decision, `TreeNav::set_nodes`, and a `ModalFrame` default-geometry regression guard). A dedicated invariant test locks the correctness fix that source-table selection can never cross the resolved source database.

**Not yet done:** the interactive SQLite→SQLite GUI smoke (FK-cycle reorder, cancel-mid-run, destructive-confirm, and keyboard arrow-nav landing in the tree on open) has not been exercised in a live window — pending manual verification.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s) — automated only; live GUI smoke pending
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels

## Labels to apply

`ui:feature`, `kind:sql`, `size:exception`
