### PR TITLE
fix(driver): MySQL/MariaDB TLS panic on SSL connect (#291)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,6 +2516,7 @@ dependencies = [
  "interprocess",
  "libc",
  "log",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -6591,9 +6592,13 @@ dependencies = [
  "named_pipe",
  "pem",
  "percent-encoding",
+ "rustls 0.23.40",
+ "rustls-pemfile 2.2.0",
  "socket2 0.6.3",
  "twox-hash",
  "url",
+ "webpki",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -11545,6 +11550,16 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]

--- a/crates/dbflux/Cargo.toml
+++ b/crates/dbflux/Cargo.toml
@@ -24,6 +24,11 @@ dbflux_audit.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "time"] }
 log.workspace = true
 interprocess.workspace = true
+# rustls 0.23 refuses to auto-select a crypto provider when more than one
+# backend is linked. This workspace links several (the AWS SDK pulls `ring`,
+# reqwest and the TLS drivers pull `aws-lc-rs`), so the binary installs a
+# process-wide default in `main`. Declared here to reach `rustls::crypto`.
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -147,8 +147,27 @@ fn emit_system_shutdown(audit_service: &AuditService) {
     }
 }
 
+/// Installs a process-wide rustls crypto provider.
+///
+/// rustls 0.23 only auto-selects a provider when exactly one backend is
+/// compiled in. Several are linked here (the AWS SDK enables `ring`, reqwest
+/// and the TLS drivers enable `aws-lc-rs`), so any consumer that builds a
+/// rustls client via the auto path — notably the `mysql` driver — would panic
+/// with "Could not automatically determine the process-level CryptoProvider".
+/// Installing one explicitly, before any handshake, resolves that for every
+/// consumer that relies on the process default.
+fn install_default_crypto_provider() {
+    if rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .is_err()
+    {
+        log::debug!("rustls crypto provider was already installed");
+    }
+}
+
 fn main() {
     install_panic_hook();
+    install_default_crypto_provider();
 
     let args: Vec<String> = std::env::args().collect();
 

--- a/crates/dbflux_driver_mysql/Cargo.toml
+++ b/crates/dbflux_driver_mysql/Cargo.toml
@@ -19,7 +19,7 @@ dbflux_core.workspace = true
 dbflux_ssh.workspace = true
 hex.workspace = true
 log.workspace = true
-mysql.workspace = true
+mysql = { workspace = true, features = ["rustls-tls"] }
 serde_json = { workspace = true }
 urlencoding = "2"
 

--- a/crates/dbflux_driver_mysql/README.md
+++ b/crates/dbflux_driver_mysql/README.md
@@ -4,7 +4,8 @@
 
 - MySQL and MariaDB relational driver implementations in one crate.
 - Supports SQL execution, schema discovery, indexes, foreign keys, check constraints, and unique constraints.
-- Supports authentication, SSL, SSH tunneling, and URI/manual connection modes.
+- Supports authentication, SSH tunneling, and URI/manual connection modes.
+- TLS with the five native SSL modes (`DISABLED`, `PREFERRED`, `REQUIRED`, `VERIFY_CA`, `VERIFY_IDENTITY`): `VERIFY_CA` verifies the server chain while skipping hostname validation and `VERIFY_IDENTITY` verifies both. A custom root CA replaces the system trust store for the verifying modes, and a client certificate + key enables mutual TLS. Uses the `rustls`/`aws-lc-rs` backend.
 - Supports query cancellation through a dedicated cancel path (`KILL QUERY` flow).
 - Includes SQL/code generation for CRUD, indexes, foreign keys, and table DDL operations.
 - Routine discovery: lists stored procedures and user-defined functions from `information_schema.ROUTINES` including parameter types and return type hints (Functions only).

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -1248,8 +1248,9 @@ impl MysqlDriver {
                         "[SSL] SSL connection failed ({}), falling back to non-SSL",
                         ssl_err
                     );
-                    let no_ssl_opts =
-                        build_mysql_opts(host, port, user, database, password, "DISABLED", ssl_paths);
+                    let no_ssl_opts = build_mysql_opts(
+                        host, port, user, database, password, "DISABLED", ssl_paths,
+                    );
                     let c = Conn::new(no_ssl_opts.clone())
                         .map_err(|e| format_mysql_error(&e, host, port))?;
                     (no_ssl_opts, c)

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -29,7 +30,7 @@ use dbflux_core::{
 };
 use dbflux_ssh::SshTunnel;
 use mysql::prelude::*;
-use mysql::{Conn, Opts, OptsBuilder, SslOpts};
+use mysql::{ClientIdentity, Conn, Opts, OptsBuilder, SslOpts};
 
 /// MySQL driver metadata.
 pub static MYSQL_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -668,6 +669,7 @@ impl DbDriver for MysqlDriver {
                 config.database.as_deref(),
                 password,
                 &config.ssl_mode,
+                &config.ssl_paths,
             )
         } else {
             self.connect_direct(
@@ -677,6 +679,7 @@ impl DbDriver for MysqlDriver {
                 config.database.as_deref(),
                 password,
                 &config.ssl_mode,
+                &config.ssl_paths,
             )
         }
     }
@@ -885,7 +888,20 @@ struct ExtractedMysqlConfig {
     database: Option<String>,
     /// MySQL native ssl-mode identifier (e.g. `"PREFERRED"`, `"VERIFY_CA"`). Defaults to `"PREFERRED"` when absent.
     ssl_mode: String,
+    ssl_paths: MysqlSslPaths,
     ssh_tunnel: Option<SshTunnelConfig>,
+}
+
+/// Filesystem paths for TLS certificate material, populated by the generic
+/// connection-manager SSL section (see `SslCertFields` in the driver metadata).
+///
+/// `root_cert` verifies the server chain for the `VERIFY_CA` / `VERIFY_IDENTITY`
+/// modes; `client_cert` + `client_key` present a client identity for mutual TLS.
+#[derive(Clone, Default)]
+struct MysqlSslPaths {
+    root_cert: Option<String>,
+    client_cert: Option<String>,
+    client_key: Option<String>,
 }
 
 /// Map a MySQL column to a canonical SQL type label (e.g. `VARCHAR`,
@@ -1030,6 +1046,9 @@ fn extract_mysql_config(config: &DbConfig) -> Result<ExtractedMysqlConfig, DbErr
             user,
             database,
             ssl_mode,
+            ssl_root_cert_path,
+            ssl_client_cert_path,
+            ssl_client_key_path,
             ssh_tunnel,
             ..
         } => Ok(ExtractedMysqlConfig {
@@ -1040,6 +1059,11 @@ fn extract_mysql_config(config: &DbConfig) -> Result<ExtractedMysqlConfig, DbErr
             user: user.clone(),
             database: database.clone(),
             ssl_mode: ssl_mode.clone().unwrap_or_else(|| "PREFERRED".to_string()),
+            ssl_paths: MysqlSslPaths {
+                root_cert: ssl_root_cert_path.clone(),
+                client_cert: ssl_client_cert_path.clone(),
+                client_key: ssl_client_key_path.clone(),
+            },
             ssh_tunnel: ssh_tunnel.clone(),
         }),
         _ => Err(DbError::InvalidProfile(
@@ -1052,9 +1076,15 @@ fn extract_mysql_config(config: &DbConfig) -> Result<ExtractedMysqlConfig, DbErr
 ///
 /// Maps MySQL native ssl-mode identifiers to the appropriate `SslOpts`:
 /// - `"DISABLED"` — no TLS
-/// - `"PREFERRED"` — TLS preferred, accept self-signed certs (fall back handled by the mysql crate)
-/// - `"REQUIRED"` — TLS required, self-signed certs accepted
-/// - `"VERIFY_CA"` / `"VERIFY_IDENTITY"` — TLS with full certificate validation
+/// - `"PREFERRED"` — TLS preferred, server cert not verified (crate may fall back to plain)
+/// - `"REQUIRED"` — TLS required, server cert not verified
+/// - `"VERIFY_CA"` — TLS required, verify the server chain but skip hostname validation
+/// - `"VERIFY_IDENTITY"` — TLS required, verify both the server chain and the hostname
+///
+/// For every TLS mode a client identity (mutual TLS) is attached when both a
+/// client cert and key are configured. For the verifying modes a custom root
+/// certificate replaces the system trust store when one is configured.
+#[allow(clippy::too_many_arguments)]
 fn build_mysql_opts(
     host: &str,
     port: u16,
@@ -1062,6 +1092,7 @@ fn build_mysql_opts(
     database: Option<&str>,
     password: Option<&str>,
     ssl_mode: &str,
+    ssl_paths: &MysqlSslPaths,
 ) -> Opts {
     let host = normalize_mysql_tcp_host(host);
 
@@ -1080,29 +1111,56 @@ fn build_mysql_opts(
         "DISABLED" => {
             // No SSL — leave ssl_opts unset.
         }
-        "PREFERRED" => {
-            // TLS preferred; accept self-signed certs so the crate can fall back to plain.
+        "PREFERRED" | "REQUIRED" => {
+            // TLS without server verification; still present a client identity
+            // for mutual TLS when one is configured.
             let ssl_opts = SslOpts::default().with_danger_accept_invalid_certs(true);
-            builder = builder.ssl_opts(ssl_opts);
+            builder = builder.ssl_opts(apply_client_identity(ssl_opts, ssl_paths));
         }
-        "REQUIRED" => {
-            // TLS required; accept self-signed certs.
-            let ssl_opts = SslOpts::default().with_danger_accept_invalid_certs(true);
-            builder = builder.ssl_opts(ssl_opts);
+        "VERIFY_CA" => {
+            // Verify the server chain against the (optionally custom) CA, but do
+            // not require the hostname to match the certificate.
+            let ssl_opts = SslOpts::default().with_danger_skip_domain_validation(true);
+            let ssl_opts = apply_root_cert(ssl_opts, ssl_paths);
+            builder = builder.ssl_opts(apply_client_identity(ssl_opts, ssl_paths));
         }
-        "VERIFY_CA" | "VERIFY_IDENTITY" => {
-            // TLS required with full certificate validation.
-            let ssl_opts = SslOpts::default();
-            builder = builder.ssl_opts(ssl_opts);
+        "VERIFY_IDENTITY" => {
+            // Full validation: verify the server chain and the hostname.
+            let ssl_opts = apply_root_cert(SslOpts::default(), ssl_paths);
+            builder = builder.ssl_opts(apply_client_identity(ssl_opts, ssl_paths));
         }
         _ => {
             // Unknown mode — treat as PREFERRED (accept-invalid, allow fallback).
             let ssl_opts = SslOpts::default().with_danger_accept_invalid_certs(true);
-            builder = builder.ssl_opts(ssl_opts);
+            builder = builder.ssl_opts(apply_client_identity(ssl_opts, ssl_paths));
         }
     }
 
     builder.into()
+}
+
+/// Attaches a custom root certificate to `ssl_opts` when one is configured,
+/// so the verifying SSL modes trust a private CA instead of the system store.
+fn apply_root_cert(ssl_opts: SslOpts, ssl_paths: &MysqlSslPaths) -> SslOpts {
+    match ssl_paths.root_cert.as_deref().filter(|p| !p.is_empty()) {
+        Some(path) => ssl_opts.with_root_cert_path(Some(PathBuf::from(path))),
+        None => ssl_opts,
+    }
+}
+
+/// Attaches a client identity (cert chain + private key) for mutual TLS when
+/// both paths are configured; otherwise leaves `ssl_opts` unchanged.
+fn apply_client_identity(ssl_opts: SslOpts, ssl_paths: &MysqlSslPaths) -> SslOpts {
+    match (
+        ssl_paths.client_cert.as_deref().filter(|p| !p.is_empty()),
+        ssl_paths.client_key.as_deref().filter(|p| !p.is_empty()),
+    ) {
+        (Some(cert), Some(key)) => ssl_opts.with_client_identity(Some(ClientIdentity::new(
+            PathBuf::from(cert),
+            PathBuf::from(key),
+        ))),
+        _ => ssl_opts,
+    }
 }
 
 fn normalize_mysql_tcp_host(host: &str) -> &str {
@@ -1156,6 +1214,7 @@ impl MysqlDriver {
         }))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn connect_direct(
         &self,
         host: &str,
@@ -1164,6 +1223,7 @@ impl MysqlDriver {
         database: Option<&str>,
         password: Option<&str>,
         ssl_mode: &str,
+        ssl_paths: &MysqlSslPaths,
     ) -> Result<Box<dyn Connection>, DbError> {
         log::info!(
             "Connecting directly to MySQL at {}:{} as {} (database: {:?}, ssl: {})",
@@ -1176,7 +1236,8 @@ impl MysqlDriver {
 
         // For PREFERRED mode: attempt SSL first, fall back to plain on failure.
         let (opts, catalog_conn) = if ssl_mode == "PREFERRED" {
-            let ssl_opts = build_mysql_opts(host, port, user, database, password, "PREFERRED");
+            let ssl_opts =
+                build_mysql_opts(host, port, user, database, password, "PREFERRED", ssl_paths);
             match Conn::new(ssl_opts.clone()) {
                 Ok(c) => {
                     log::info!("[SSL] Catalog connection established with SSL (PREFERRED mode)");
@@ -1188,14 +1249,14 @@ impl MysqlDriver {
                         ssl_err
                     );
                     let no_ssl_opts =
-                        build_mysql_opts(host, port, user, database, password, "DISABLED");
+                        build_mysql_opts(host, port, user, database, password, "DISABLED", ssl_paths);
                     let c = Conn::new(no_ssl_opts.clone())
                         .map_err(|e| format_mysql_error(&e, host, port))?;
                     (no_ssl_opts, c)
                 }
             }
         } else {
-            let opts = build_mysql_opts(host, port, user, database, password, ssl_mode);
+            let opts = build_mysql_opts(host, port, user, database, password, ssl_mode, ssl_paths);
             let c = Conn::new(opts.clone()).map_err(|e| format_mysql_error(&e, host, port))?;
             (opts, c)
         };
@@ -1243,6 +1304,7 @@ impl MysqlDriver {
         database: Option<&str>,
         db_password: Option<&str>,
         ssl_mode: &str,
+        ssl_paths: &MysqlSslPaths,
     ) -> Result<Box<dyn Connection>, DbError> {
         let total_start = Instant::now();
 
@@ -1273,6 +1335,7 @@ impl MysqlDriver {
                 database,
                 db_password,
                 "PREFERRED",
+                ssl_paths,
             );
             match Conn::new(ssl_opts) {
                 Ok(c) => {
@@ -1288,6 +1351,7 @@ impl MysqlDriver {
                         database,
                         db_password,
                         "DISABLED",
+                        ssl_paths,
                     );
                     let c = Conn::new(no_ssl_opts)
                         .map_err(|e| format_mysql_error(&e, "127.0.0.1", local_port1))?;
@@ -1302,6 +1366,7 @@ impl MysqlDriver {
                 database,
                 db_password,
                 ssl_mode,
+                ssl_paths,
             );
             let c =
                 Conn::new(opts).map_err(|e| format_mysql_error(&e, "127.0.0.1", local_port1))?;
@@ -1325,6 +1390,7 @@ impl MysqlDriver {
             database,
             db_password,
             working_ssl_mode,
+            ssl_paths,
         );
         let mut query_conn = Conn::new(query_opts.clone())
             .map_err(|e| format_mysql_error(&e, "127.0.0.1", local_port2))?;


### PR DESCRIPTION
## Summary

- Fixes #291: MySQL/MariaDB connections with SSL enabled panicked the worker thread instead of connecting.
- Roots out two stacked failures and completes the previously dead SSL certificate wiring.

## Root cause

The panic had two layers, and fixing the first exposed the second:

1. **No TLS backend.** The `mysql` 25 → 28 bump moved TLS out of the crate's `default` features, so any SSL handshake hit `"Client had asked for TLS connection but TLS support is disabled"`. (v0.6 is unaffected: it uses `mysql = "25"`, which still ships `native-tls` by default.)
2. **Ambiguous rustls crypto provider.** Enabling a rustls backend surfaced a second panic: `rustls` 0.23 links **both** providers in this workspace (the AWS SDK forces `ring`, reqwest/mongodb force `aws-lc-rs`), so the process-level provider cannot be auto-selected. The `mysql` client builds its rustls config via the auto path and panicked. This cannot be resolved by picking a driver feature; both providers are structurally present. The fix is the canonical rustls remedy (the same one Zed applies, hence its `zed-reqwest` `-no-provider` variant): install one process-wide default at startup.

## Changes

| File | Change |
|------|--------|
| `crates/dbflux_driver_mysql/Cargo.toml` | Enable the `rustls-tls` (aws-lc-rs) feature on `mysql`, matching the dominant provider on rustls 0.23. |
| `crates/dbflux/Cargo.toml` | Add `rustls` (aws-lc-rs) as a direct dep so `main` can install the provider. |
| `crates/dbflux/src/main.rs` | `install_default_crypto_provider()` at the top of `main()` (covers GUI, MCP, and CLI, before any handshake). |
| `crates/dbflux_driver_mysql/src/driver.rs` | Thread the SSL cert paths into `build_mysql_opts` and apply them (see below). |
| `crates/dbflux_driver_mysql/README.md` | Document the SSL modes, custom CA, and mutual TLS. |

### SSL certificate wiring

`DbConfig::MySQL` already carried `ssl_root_cert_path` / `ssl_client_cert_path` / `ssl_client_key_path` (populated by the generic connection-manager SSL section), but the driver ignored them and `VERIFY_CA` / `VERIFY_IDENTITY` were identical. Now:

- `VERIFY_CA` verifies the server chain but skips hostname validation; `VERIFY_IDENTITY` verifies both.
- A custom root CA replaces the system trust store for the verifying modes.
- A client cert + key attaches a client identity for mutual TLS in any TLS mode.

## Test plan

- `cargo clippy -p dbflux_driver_mysql -- -D warnings` — clean.
- `cargo nextest run -p dbflux_driver_mysql` — 44 passed.
- `cargo check -p dbflux --no-default-features --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws` — builds.
- **Not yet exercised end-to-end** against a live MySQL/MariaDB with TLS (handshake, `VERIFY_CA` with a private CA, mutual TLS). The fix targets the exact panic path, but a runtime check against a TLS-enabled server is still worth doing before release.

Closes #291