### PR TITLE
fix(ui): anchor context submenu to its owning row height

### DIFF
--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -786,12 +786,28 @@ impl Render for Workspace {
                 let menu_width = px(160.0);
                 let menu_gap = Spacing::XS;
                 let menu_item_height = Heights::ROW_COMPACT;
+                let separator_height = px(1.0) + Spacing::XS * 2.0;
                 let menu_container_padding = px(4.0);
 
                 let parent_entry = menu.parent_stack.last();
 
-                let submenu_y_offset = if let Some((_, parent_selected)) = parent_entry {
-                    menu_container_padding + (menu_item_height * (*parent_selected as f32))
+                // Anchor the submenu to its owning row by summing the actual
+                // rendered height of every preceding row. Separators are ~9px,
+                // not a full ROW_COMPACT, so a flat `height * index` over-counts
+                // and pushes the submenu too far down.
+                let submenu_y_offset = if let Some((parent_items, parent_selected)) = parent_entry {
+                    let rows_above = parent_items.iter().take(*parent_selected).fold(
+                        px(0.0),
+                        |acc, item| {
+                            acc + if item.is_separator {
+                                separator_height
+                            } else {
+                                menu_item_height
+                            }
+                        },
+                    );
+
+                    menu_container_padding + rows_above
                 } else {
                     px(0.0)
                 };

--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -796,16 +796,17 @@ impl Render for Workspace {
                 // not a full ROW_COMPACT, so a flat `height * index` over-counts
                 // and pushes the submenu too far down.
                 let submenu_y_offset = if let Some((parent_items, parent_selected)) = parent_entry {
-                    let rows_above = parent_items.iter().take(*parent_selected).fold(
-                        px(0.0),
-                        |acc, item| {
-                            acc + if item.is_separator {
-                                separator_height
-                            } else {
-                                menu_item_height
-                            }
-                        },
-                    );
+                    let rows_above =
+                        parent_items
+                            .iter()
+                            .take(*parent_selected)
+                            .fold(px(0.0), |acc, item| {
+                                acc + if item.is_separator {
+                                    separator_height
+                                } else {
+                                    menu_item_height
+                                }
+                            });
 
                     menu_container_padding + rows_above
                 } else {


### PR DESCRIPTION
## Summary

The cascading context-menu submenu (e.g. **Generate SQL ›**, **Export Table ›**) opened noticeably below its parent row instead of anchoring next to it. This fixes the vertical offset so the submenu lines up with the item that owns it.

## What does this resolve?

A submenu positioning regression in the sidebar context menu: the further down a submenu-owning item sits (past several separator-delimited sections), the more the submenu drifted downward — most visible on **Export Table…**, **Generate SQL**, and **Migrate Table…**.

## How was this solved?

The submenu's `y` position was computed as `ROW_COMPACT * owner_index` — assuming every preceding row is a full 24px menu item. But separators (`ContextMenuItem::separator()`) render at only ~9px (`1px` line + `2×4px` vertical margin), so each separator above the owning item over-counted the offset by ~15px.

The offset now sums the *actual* rendered height of each preceding row — 24px for items, 9px for separators — so the submenu anchors to its owning row regardless of how many separators precede it.

- `crates/dbflux_ui/src/ui/views/workspace/render.rs` — replace the flat `height × index` offset with a per-row height sum that accounts for separator rows.

This is a follow-up to #288 (DBF-159), which anchored the submenu to the item instead of the cursor; the remaining error was the separator-height miscalculation in that anchor.

## Validation

- `cargo check -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws` — passes.
- The fix is deterministic geometry (summing known row heights). It was **not** visually confirmed in a running session, since reproducing the cascade needs a live GUI + connection; reviewer visual confirmation on the affected flow is welcome.

## Where was this tested?

- [x] Local development environment (type-check)
- [ ] Automated tests
- [ ] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s) — type-checked only; visual confirmation pending
- [ ] I added or updated tests when needed — offset is inline render math with no seam to unit-test without extracting a pure helper
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible — N/A: fixes alignment of context submenus that are themselves unreleased UI (transfer engine #286 / submenu anchor #288), so no released behavior changes

## Labels to apply

- `ui:bug`
