### PR TITLE
feat(ui): rail-based export wizard + shared wizard rail

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,7 +3128,6 @@ dependencies = [
  "dbflux_core",
  "dbflux_ssh",
  "dbflux_storage",
- "dbflux_transfer",
  "dbflux_ui_base",
  "dirs 6.0.0",
  "gpui",

--- a/crates/dbflux_components/src/composites/mod.rs
+++ b/crates/dbflux_components/src/composites/mod.rs
@@ -9,6 +9,7 @@ mod refresh_split_button;
 mod section_header;
 mod split_toolbar_action;
 mod tab_strip;
+mod wizard_rail;
 
 pub(crate) use control_shell::control_shell_with_padding;
 
@@ -37,3 +38,4 @@ pub use section_header::{
 };
 pub use split_toolbar_action::split_toolbar_action;
 pub use tab_strip::tab_strip;
+pub use wizard_rail::{RailItem, render_wizard_rail};

--- a/crates/dbflux_components/src/composites/wizard_rail.rs
+++ b/crates/dbflux_components/src/composites/wizard_rail.rs
@@ -1,0 +1,133 @@
+//! Generic left phase rail shared by the wizard family (Migrate, Export,
+//! Import): a vertical list of entries with a checkmark on completed steps, a
+//! highlight on the current one, and optional click-to-return navigation.
+//! Domain-free — callers supply their own phase enum's labels and completion
+//! state via [`RailItem`]; this module only renders.
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::ActiveTheme;
+
+use crate::icons::AppIcon;
+use crate::primitives::{Icon, Text};
+use crate::tokens::Spacing;
+
+/// One rail row's presentation state: a completed entry shows a checkmark and
+/// (when `on_select` is provided) is clickable for back-navigation; the
+/// current entry is highlighted. Callers derive this from their own phase
+/// ordering.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RailItem {
+    pub label: SharedString,
+    pub completed: bool,
+    pub current: bool,
+}
+
+/// The rail's marker/label colors, resolved once per render from the theme.
+/// `current` and `done` use the theme's bright action/success colors (not the
+/// dark `accent`, which is a low-contrast highlight background on dark
+/// themes), so the current phase reads as the most prominent entry.
+#[derive(Clone, Copy)]
+struct RailColors {
+    current: Hsla,
+    done: Hsla,
+    muted: Hsla,
+    hover_bg: Hsla,
+}
+
+/// Renders a wizard's left phase rail from `items` in order. `on_select`, when
+/// `Some`, is invoked with the clicked entry's index and makes completed
+/// entries clickable for back-navigation; `None` (or a caller that never
+/// marks entries completed) renders a display-only progress rail with no
+/// hover/click affordance.
+pub fn render_wizard_rail<F>(items: &[RailItem], on_select: Option<F>, cx: &App) -> impl IntoElement
+where
+    F: Fn(usize, &mut Window, &mut App) + Clone + 'static,
+{
+    let theme = cx.theme();
+    let colors = RailColors {
+        current: theme.primary,
+        done: theme.success,
+        muted: theme.muted_foreground,
+        hover_bg: theme.secondary,
+    };
+    let border = theme.border;
+
+    let entries = items
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(move |(index, item)| render_rail_entry(index, item, colors, on_select.clone()));
+
+    div()
+        .flex()
+        .flex_col()
+        .gap(Spacing::XS)
+        .p(Spacing::MD)
+        .min_w(px(180.0))
+        .border_r_1()
+        .border_color(border)
+        .children(entries)
+}
+
+fn render_rail_entry<F>(
+    index: usize,
+    item: RailItem,
+    colors: RailColors,
+    on_select: Option<F>,
+) -> impl IntoElement
+where
+    F: Fn(usize, &mut Window, &mut App) + Clone + 'static,
+{
+    let marker = if item.completed {
+        Icon::new(AppIcon::CircleCheck)
+            .size(px(14.0))
+            .color(colors.done)
+            .into_any_element()
+    } else {
+        let dot_color = if item.current {
+            colors.current
+        } else {
+            colors.muted
+        };
+        div()
+            .size(px(8.0)) // guardrail-allow: decorative status-dot diameter, not a spacing token
+            .rounded_full()
+            .bg(dot_color)
+            .into_any_element()
+    };
+
+    // The current entry is the most prominent: bright action color plus a
+    // heavier weight. Every other label stays at full foreground contrast (a
+    // check/dot marker conveys completed vs. pending), so the rail reads
+    // clearly instead of as dim, low-contrast text.
+    let mut label = Text::body(item.label.clone());
+    if item.current {
+        label = label
+            .color(colors.current)
+            .font_weight(FontWeight::SEMIBOLD);
+    }
+
+    div()
+        .id(SharedString::from(format!("wizard-rail-{index}")))
+        .flex()
+        .items_center()
+        .gap(Spacing::SM)
+        .px(Spacing::SM)
+        .py(Spacing::XS)
+        .rounded_md()
+        .child(
+            div()
+                .w(px(16.0)) // guardrail-allow: fixed rail marker gutter width for label alignment
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(marker),
+        )
+        .child(label)
+        .when_some(on_select.filter(|_| item.completed), |el, on_select| {
+            el.cursor_pointer()
+                .hover(|style| style.bg(colors.hover_bg))
+                .on_click(move |_event, window, app| on_select(index, window, app))
+        })
+}

--- a/crates/dbflux_transfer/src/file_sink.rs
+++ b/crates/dbflux_transfer/src/file_sink.rs
@@ -23,10 +23,21 @@ pub enum FileFormat {
 }
 
 impl FileFormat {
+    /// All formats the export UI can offer, in display order.
+    pub const ALL: [FileFormat; 2] = [Self::Csv, Self::Json];
+
     pub fn extension(self) -> &'static str {
         match self {
             Self::Csv => "csv",
             Self::Json => "json",
+        }
+    }
+
+    /// Human-readable label for format pickers.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Csv => "CSV",
+            Self::Json => "JSON",
         }
     }
 
@@ -257,6 +268,13 @@ mod tests {
         assert_eq!(FileFormat::from_extension("csv"), Some(FileFormat::Csv));
         assert_eq!(FileFormat::from_extension("json"), Some(FileFormat::Json));
         assert_eq!(FileFormat::from_extension("xml"), None);
+    }
+
+    #[test]
+    fn all_lists_every_format_with_a_label() {
+        assert_eq!(FileFormat::ALL, [FileFormat::Csv, FileFormat::Json]);
+        assert_eq!(FileFormat::Csv.label(), "CSV");
+        assert_eq!(FileFormat::Json.label(), "JSON");
     }
 
     #[test]

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -300,6 +300,9 @@ pub struct Workspace {
     /// Migrate wizard (table -> table, cross-connection), pre-populated from
     /// the sidebar's multi-select Migrate action.
     migrate_wizard: Entity<dbflux_ui_document::migrate_wizard::MigrateWizard>,
+    /// Export wizard (table -> file bundle), pre-populated from the
+    /// sidebar's multi-select Export action.
+    export_wizard: Entity<dbflux_ui_document::export_wizard::ExportWizard>,
 
     tasks_state: PanelState,
     pending_command: Option<&'static str>,
@@ -396,6 +399,9 @@ impl Workspace {
             .new(|cx| dbflux_ui_document::import_wizard::ImportWizard::new(app_state.clone(), cx));
         let migrate_wizard = cx.new(|cx| {
             dbflux_ui_document::migrate_wizard::MigrateWizard::new(app_state.clone(), cx)
+        });
+        let export_wizard = cx.new(|cx| {
+            dbflux_ui_document::export_wizard::ExportWizard::new(app_state.clone(), window, cx)
         });
 
         // Subscribe: ModalDeleteConnection — on Confirmed, execute the pending delete.
@@ -1033,6 +1039,18 @@ impl Workspace {
                         wizard.open(profile_id, database, tables, window, cx);
                     });
                 }
+                SidebarEvent::RequestExportWizard {
+                    profile_id,
+                    database,
+                    tables,
+                } => {
+                    let profile_id = *profile_id;
+                    let database = database.clone();
+                    let tables = tables.clone();
+                    this.export_wizard.update(cx, |wizard, cx| {
+                        wizard.open(profile_id, database, tables, window, cx);
+                    });
+                }
                 SidebarEvent::RequestOpenSettings => {
                     this.open_settings(cx);
                 }
@@ -1304,6 +1322,7 @@ impl Workspace {
             export_modal,
             import_wizard,
             migrate_wizard,
+            export_wizard,
             tasks_state: PanelState::Collapsed,
             pending_command: None,
             pending_sql: None,

--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -628,6 +628,9 @@ impl Render for Workspace {
             .when(self.migrate_wizard.read(cx).is_visible(), |root| {
                 root.child(self.migrate_wizard.clone())
             })
+            .when(self.export_wizard.read(cx).is_visible(), |root| {
+                root.child(self.export_wizard.clone())
+            })
             .when(self.modal_create_dashboard.read(cx).is_visible(), |root| {
                 root.child(self.modal_create_dashboard.clone())
             })

--- a/crates/dbflux_ui_document/src/export_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/export_wizard/mod.rs
@@ -1,0 +1,660 @@
+//! Export wizard: a four-phase flow (Tables → Format & Options → Confirm →
+//! Run) rendered inside a modal with the shared phase rail, wearing the
+//! migrate/import wizard chrome. Unlike migrate, no phase needs live
+//! cross-connection metadata — the sidebar already resolved the table
+//! selection before the wizard opens — so this is a single flat entity
+//! holding its own format/folder/segment-size state, not a set of child
+//! phase entities.
+//!
+//! Reached from the sidebar's "Export Table…" action, which pre-populates
+//! `profile_id` / `database` / `tables`. The folder picker and format choice
+//! now live inside the modal (Format & Options phase) instead of firing an
+//! immediate OS dialog from the context menu. The run itself (`start_export`)
+//! reuses `dbflux_transfer::export::{run_export, ExportOptions}` unchanged —
+//! see [`run`].
+
+pub mod phases;
+mod run;
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use dbflux_components::composites::{RailItem, render_wizard_rail};
+use dbflux_components::controls::{
+    Button, Dropdown, DropdownItem, DropdownSelectionChanged, GpuiInput as Input, InputEvent,
+    InputState,
+};
+use dbflux_components::icons::AppIcon;
+use dbflux_components::primitives::Text;
+use dbflux_components::tokens::Spacing;
+use dbflux_core::{Connection, TableRef};
+use dbflux_transfer::FileFormat;
+use dbflux_ui_base::app_state_entity::AppStateEntity;
+use dbflux_ui_base::modal_frame::ModalFrame;
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::ActiveTheme;
+use gpui_component::Sizable;
+use uuid::Uuid;
+
+use phases::{ExportPhase, RailEntry, RunState, next_phase, prev_phase, rail_entries};
+use run::RunProgress;
+
+const SEGMENT_SIZE_INPUT_WIDTH: Pixels = px(160.0);
+
+fn format_items() -> Vec<DropdownItem> {
+    FileFormat::ALL
+        .iter()
+        .map(|format| DropdownItem::new(format.label()))
+        .collect()
+}
+
+/// Maps the wizard's [`RailEntry`]s to the shared rail composite's
+/// domain-free [`RailItem`]s.
+fn to_rail_items(current: ExportPhase) -> Vec<RailItem> {
+    rail_entries(current)
+        .into_iter()
+        .map(|entry: RailEntry| RailItem {
+            label: entry.phase.label().into(),
+            completed: entry.completed,
+            current: entry.current,
+        })
+        .collect()
+}
+
+pub struct ExportWizard {
+    app_state: Entity<AppStateEntity>,
+    focus_handle: FocusHandle,
+    visible: bool,
+
+    profile_id: Option<Uuid>,
+    database: Option<String>,
+    tables: Vec<TableRef>,
+
+    phase: ExportPhase,
+
+    format_dropdown: Entity<Dropdown>,
+    _format_dropdown_sub: Subscription,
+    selected_format_index: usize,
+
+    output_dir: Option<PathBuf>,
+    choosing_folder: bool,
+    folder_error: Option<String>,
+
+    segment_size_input: Entity<InputState>,
+    _segment_size_sub: Subscription,
+    segment_size: u32,
+    segment_size_invalid: bool,
+
+    run_state: RunState,
+    progress: Arc<Mutex<RunProgress>>,
+    cancel_token: Option<dbflux_core::CancelToken>,
+    result_summary: Option<String>,
+    result_warnings: Vec<String>,
+}
+
+impl ExportWizard {
+    pub fn new(
+        app_state: Entity<AppStateEntity>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let format_dropdown = cx.new(|_cx| {
+            Dropdown::new("export-wizard-format")
+                .items(format_items())
+                .selected_index(Some(0))
+                .placeholder("Format")
+        });
+        let format_dropdown_sub = cx.subscribe(
+            &format_dropdown,
+            |this, _entity, event: &DropdownSelectionChanged, cx| {
+                this.selected_format_index = event.index;
+                cx.notify();
+            },
+        );
+
+        let segment_size_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .default_value(phases::DEFAULT_SEGMENT_SIZE.to_string())
+                .placeholder("Segment / chunk size")
+        });
+        let segment_size_sub = cx.subscribe_in(
+            &segment_size_input,
+            window,
+            |this, _entity, event: &InputEvent, window, cx| {
+                if let InputEvent::Change = event {
+                    this.on_segment_size_changed(window, cx);
+                }
+            },
+        );
+
+        Self {
+            app_state,
+            focus_handle: cx.focus_handle(),
+            visible: false,
+            profile_id: None,
+            database: None,
+            tables: Vec::new(),
+            phase: ExportPhase::Tables,
+            format_dropdown,
+            _format_dropdown_sub: format_dropdown_sub,
+            selected_format_index: 0,
+            output_dir: None,
+            choosing_folder: false,
+            folder_error: None,
+            segment_size_input,
+            _segment_size_sub: segment_size_sub,
+            segment_size: phases::DEFAULT_SEGMENT_SIZE,
+            segment_size_invalid: false,
+            run_state: RunState::Idle,
+            progress: Arc::new(Mutex::new(RunProgress::default())),
+            cancel_token: None,
+            result_summary: None,
+            result_warnings: Vec::new(),
+        }
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.run_state == RunState::Running
+    }
+
+    pub fn open(
+        &mut self,
+        profile_id: Uuid,
+        database: Option<String>,
+        tables: Vec<TableRef>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // A run already in flight owns the wizard until it terminates —
+        // mirrors `MigrateWizard::open`'s re-entry guard: resurface the
+        // running wizard instead of resetting its state and orphaning the
+        // task.
+        if self.is_running() {
+            self.visible = true;
+            self.phase = ExportPhase::Run;
+            self.focus_handle.focus(window);
+            cx.notify();
+            return;
+        }
+
+        self.visible = true;
+        self.profile_id = Some(profile_id);
+        self.database = database;
+        self.tables = tables;
+        self.phase = ExportPhase::Tables;
+
+        self.selected_format_index = 0;
+        self.format_dropdown.update(cx, |dropdown, cx| {
+            dropdown.set_selected_index(Some(0), cx);
+        });
+
+        self.output_dir = None;
+        self.choosing_folder = false;
+        self.folder_error = None;
+
+        self.segment_size = phases::DEFAULT_SEGMENT_SIZE;
+        self.segment_size_invalid = false;
+        self.segment_size_input.update(cx, |input, cx| {
+            input.set_value(phases::DEFAULT_SEGMENT_SIZE.to_string(), window, cx);
+        });
+
+        self.run_state = RunState::Idle;
+        *self.progress.lock().unwrap_or_else(|p| p.into_inner()) = RunProgress::default();
+        self.cancel_token = None;
+        self.result_summary = None;
+        self.result_warnings.clear();
+
+        self.focus_handle.focus(window);
+        cx.notify();
+    }
+
+    pub fn close(&mut self, cx: &mut Context<Self>) {
+        self.visible = false;
+        cx.notify();
+    }
+
+    fn resolve_connection(&self, cx: &App) -> Option<Arc<dyn Connection>> {
+        let profile_id = self.profile_id?;
+        let connected = self.app_state.read(cx).connections().get(&profile_id)?;
+        Some(match &self.database {
+            Some(db) => connected.connection_for_database(db),
+            None => connected.connection.clone(),
+        })
+    }
+
+    /// A human-readable profile name for the run's task description.
+    fn profile_label(&self, cx: &App) -> String {
+        let Some(profile_id) = self.profile_id else {
+            return String::new();
+        };
+        self.app_state
+            .read(cx)
+            .connections()
+            .get(&profile_id)
+            .map(|connected| connected.profile.name.clone())
+            .unwrap_or_default()
+    }
+
+    fn selected_format(&self) -> FileFormat {
+        FileFormat::ALL[self.selected_format_index.min(FileFormat::ALL.len() - 1)]
+    }
+
+    fn on_segment_size_changed(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        let typed = self.segment_size_input.read(cx).value().to_string();
+
+        match phases::parse_segment_size(&typed) {
+            Some(value) => {
+                self.segment_size = value;
+                self.segment_size_invalid = false;
+            }
+            None => {
+                self.segment_size_invalid = true;
+            }
+        }
+
+        cx.notify();
+    }
+
+    /// Picks the export destination folder in-modal, replacing the
+    /// pre-redesign flow's immediate OS dialog on menu click. Same
+    /// dialog-availability probe and fallback directory as the original
+    /// sidebar action.
+    fn choose_folder(&mut self, cx: &mut Context<Self>) {
+        let dialog_available = dbflux_ui_base::file_dialog::is_native_file_dialog_available();
+
+        self.choosing_folder = true;
+        self.folder_error = None;
+        cx.notify();
+
+        cx.spawn(async move |this, cx| {
+            let picked = if dialog_available {
+                rfd::AsyncFileDialog::new()
+                    .set_title("Choose Export Folder")
+                    .pick_folder()
+                    .await
+                    .map(|handle| handle.path().to_path_buf())
+            } else {
+                match dbflux_ui_base::file_dialog::fallback_export_dir() {
+                    Ok(dir) => Some(dir),
+                    Err(err) => {
+                        this.update(cx, |this, cx| {
+                            this.choosing_folder = false;
+                            this.folder_error = Some(format!(
+                                "No folder picker available and the fallback export \
+                                 directory could not be created: {err}"
+                            ));
+                            cx.notify();
+                        })
+                        .ok();
+                        return;
+                    }
+                }
+            };
+
+            this.update(cx, |this, cx| {
+                this.choosing_folder = false;
+                if let Some(dir) = picked {
+                    this.output_dir = Some(dir);
+                    this.folder_error = None;
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn go_back(&mut self, cx: &mut Context<Self>) {
+        if let Some(previous) = prev_phase(self.phase) {
+            self.go_to_phase(previous, cx);
+        }
+    }
+
+    /// Back-navigation from the rail: only ever returns to an already-passed
+    /// phase, and is inert once a run is live (mirrors `MigrateWizard`).
+    fn go_to_phase(&mut self, phase: ExportPhase, cx: &mut Context<Self>) {
+        if self.phase == ExportPhase::Run && self.is_running() {
+            return;
+        }
+        if phase < self.phase {
+            self.phase = phase;
+            cx.notify();
+        }
+    }
+
+    /// Whether the footer's Continue button is enabled for the current
+    /// phase: `Tables` requires a non-empty selection, `Format & Options`
+    /// requires a chosen folder and a valid segment size.
+    fn continue_enabled(&self) -> bool {
+        match self.phase {
+            ExportPhase::Tables => !self.tables.is_empty(),
+            ExportPhase::FormatOptions => self.output_dir.is_some() && !self.segment_size_invalid,
+            ExportPhase::Confirm | ExportPhase::Run => false,
+        }
+    }
+
+    fn advance(&mut self, cx: &mut Context<Self>) {
+        if !self.continue_enabled() {
+            return;
+        }
+        if let Some(next) = next_phase(self.phase) {
+            self.phase = next;
+            cx.notify();
+        }
+    }
+}
+
+impl Render for ExportWizard {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !self.visible {
+            return div().into_any_element();
+        }
+
+        let close_entity = cx.entity().downgrade();
+        let close = move |_window: &mut Window, cx: &mut App| {
+            close_entity.update(cx, |this, cx| this.close(cx)).ok();
+        };
+
+        let frame = ModalFrame::new("export-wizard", &self.focus_handle, close)
+            .title("Export Data")
+            .icon(AppIcon::ArrowUp)
+            .width(px(720.0))
+            .height_fraction(0.7)
+            .center_vertically()
+            .child(self.render_body(cx));
+
+        frame.render(cx).into_any_element()
+    }
+}
+
+impl ExportWizard {
+    fn render_body(&self, cx: &mut Context<Self>) -> AnyElement {
+        // `flex_1` (not `size_full`): the modal container is a fixed-height
+        // flex column whose first child is the header, so the body must grow
+        // into the *remaining* height (see `MigrateWizard::render_body`).
+        div()
+            .flex()
+            .flex_col()
+            .flex_1()
+            .min_h(px(0.0))
+            .w_full()
+            .child(
+                div()
+                    .flex()
+                    .flex_row()
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .child(render_wizard_rail(
+                        &to_rail_items(self.phase),
+                        None::<fn(usize, &mut Window, &mut App)>,
+                        cx,
+                    ))
+                    .child(self.render_phase_area(cx)),
+            )
+            .child(self.render_footer(cx))
+            .into_any_element()
+    }
+
+    fn render_phase_area(&self, cx: &mut Context<Self>) -> AnyElement {
+        let content = match self.phase {
+            ExportPhase::Tables => self.render_tables(),
+            ExportPhase::FormatOptions => self.render_format_options(cx),
+            ExportPhase::Confirm => self.render_confirm(cx),
+            ExportPhase::Run => self.render_run(cx),
+        };
+
+        div()
+            .flex_1()
+            .min_w(px(0.0))
+            .flex()
+            .flex_col()
+            .p(Spacing::MD)
+            .child(content)
+            .into_any_element()
+    }
+
+    fn render_tables(&self) -> AnyElement {
+        let rows = self
+            .tables
+            .iter()
+            .map(|table| Text::body(table.qualified_name()).into_any_element());
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .size_full()
+            .child(Text::label(format!(
+                "{} table(s) selected for export",
+                self.tables.len()
+            )))
+            .child(
+                div()
+                    .id("export-wizard-tables")
+                    .flex_1()
+                    .min_h(px(0.0))
+                    .overflow_y_scroll()
+                    .flex()
+                    .flex_col()
+                    .gap(Spacing::XS)
+                    .children(rows),
+            )
+            .into_any_element()
+    }
+
+    fn render_format_options(&self, cx: &mut Context<Self>) -> AnyElement {
+        let folder_label = self
+            .output_dir
+            .as_ref()
+            .map(|dir| dir.display().to_string())
+            .unwrap_or_else(|| "No folder chosen".to_string());
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(Spacing::XS)
+                    .child(Text::label("Format"))
+                    .child(self.format_dropdown.clone()),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(Spacing::XS)
+                    .child(Text::label("Output folder"))
+                    .child(Text::caption(folder_label))
+                    .child(
+                        Button::new(
+                            "export-wizard-choose-folder",
+                            if self.choosing_folder {
+                                "Choosing…"
+                            } else {
+                                "Choose Folder…"
+                            },
+                        )
+                        .small()
+                        .disabled(self.choosing_folder)
+                        .on_click(cx.listener(|this, _event, _window, cx| this.choose_folder(cx))),
+                    )
+                    .when_some(self.folder_error.clone(), |parent, error| {
+                        parent.child(Text::caption(error).danger())
+                    }),
+            )
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .gap(Spacing::XS)
+                    .child(Text::label("Segment / chunk size (advanced)"))
+                    .child(
+                        div()
+                            .w(SEGMENT_SIZE_INPUT_WIDTH)
+                            .child(Input::new(&self.segment_size_input).small().w_full()),
+                    )
+                    .when(self.segment_size_invalid, |parent| {
+                        parent.child(
+                            Text::caption(
+                                "Must be a whole number of 1 or more; kept the previous value.",
+                            )
+                            .danger(),
+                        )
+                    }),
+            )
+            .into_any_element()
+    }
+
+    fn render_confirm(&self, cx: &mut Context<Self>) -> AnyElement {
+        let folder_label = self
+            .output_dir
+            .as_ref()
+            .map(|dir| dir.display().to_string())
+            .unwrap_or_default();
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .child(Text::label("Review export plan"))
+            .child(Text::caption(format!(
+                "{} table(s) as {} to {folder_label}",
+                self.tables.len(),
+                self.selected_format().label(),
+            )))
+            .child(Text::caption(format!(
+                "Segment / chunk size: {}",
+                self.segment_size
+            )))
+            .child(
+                div().flex().justify_end().child(
+                    Button::new("export-wizard-start", "Start Export")
+                        .small()
+                        .primary()
+                        .on_click(cx.listener(|this, _event, _window, cx| this.start_export(cx))),
+                ),
+            )
+            .into_any_element()
+    }
+
+    fn render_run(&self, cx: &mut Context<Self>) -> AnyElement {
+        match self.run_state {
+            RunState::Idle => div().into_any_element(),
+            RunState::Running => self.render_running(cx),
+            RunState::Done => self.render_done(),
+        }
+    }
+
+    fn render_running(&self, cx: &mut Context<Self>) -> AnyElement {
+        let progress = *self.progress.lock().unwrap_or_else(|p| p.into_inner());
+        let names: Vec<String> = self.tables.iter().map(|t| t.qualified_name()).collect();
+        let total_tables = names.len();
+        let current_index = progress.table_index.min(total_tables.saturating_sub(1));
+        let current_table = names.get(current_index).cloned().unwrap_or_default();
+
+        let rows_label = match progress.estimated_total {
+            Some(total) if total > 0 => format!("{} / {} rows", progress.rows_done, total),
+            _ => format!("{} rows", progress.rows_done),
+        };
+        let position_label = if total_tables > 0 {
+            format!("Table {} of {}", current_index + 1, total_tables)
+        } else {
+            "Preparing".to_string()
+        };
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .child(Text::label("Exporting…"))
+            .child(Text::caption(format!("{position_label}: {current_table}")))
+            .child(Text::caption(rows_label).muted_foreground())
+            .child(
+                div().flex().justify_end().child(
+                    Button::new("export-wizard-cancel", "Cancel")
+                        .small()
+                        .ghost()
+                        .on_click(cx.listener(|this, _event, _window, cx| this.cancel_run(cx))),
+                ),
+            )
+            .into_any_element()
+    }
+
+    fn render_done(&self) -> AnyElement {
+        div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::MD)
+            .when_some(self.result_summary.clone(), |el, summary| {
+                el.child(Text::body(summary))
+            })
+            .when(!self.result_warnings.is_empty(), |el| {
+                el.child(Text::caption(self.result_warnings.join("; ")))
+            })
+            .into_any_element()
+    }
+
+    fn render_footer(&self, cx: &mut Context<Self>) -> AnyElement {
+        let theme = cx.theme();
+        let border = theme.border;
+
+        let running = self.run_state == RunState::Running;
+        let done = self.run_state == RunState::Done;
+
+        let shows_back = prev_phase(self.phase).is_some() && !running && !done;
+        let shows_continue = next_phase(self.phase).is_some();
+        let continue_enabled = self.continue_enabled();
+
+        let actions = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap(Spacing::SM)
+            .when(shows_back, |parent| {
+                parent.child(
+                    Button::new("export-wizard-back", "Back")
+                        .small()
+                        .ghost()
+                        .on_click(cx.listener(|this, _event, _window, cx| this.go_back(cx))),
+                )
+            })
+            .when(shows_continue, |parent| {
+                parent.child(
+                    Button::new("export-wizard-continue", "Continue")
+                        .small()
+                        .primary()
+                        .disabled(!continue_enabled)
+                        .on_click(cx.listener(|this, _event, _window, cx| this.advance(cx))),
+                )
+            })
+            .when(done, |parent| {
+                parent.child(
+                    Button::new("export-wizard-close", "Close")
+                        .small()
+                        .primary()
+                        .on_click(cx.listener(|this, _event, _window, cx| this.close(cx))),
+                )
+            });
+
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .justify_end()
+            .gap(Spacing::SM)
+            .px(Spacing::MD)
+            .py(Spacing::SM)
+            .border_t_1()
+            .border_color(border)
+            .child(actions)
+            .into_any_element()
+    }
+}

--- a/crates/dbflux_ui_document/src/export_wizard/phases.rs
+++ b/crates/dbflux_ui_document/src/export_wizard/phases.rs
@@ -1,0 +1,220 @@
+//! Pure phase state machine for the export wizard: the fixed rail ordering,
+//! the guards that gate each forward transition, run-state tracking, and the
+//! segment-size input validation. No GPUI — unit testable without a wizard
+//! entity. Rendering and the run itself live in `mod.rs` / `run.rs`.
+//!
+//! Unlike the migrate wizard, no phase here depends on live metadata (the
+//! sidebar already resolved the table selection before the wizard opens), so
+//! the forward/back transitions are pure functions rather than living on the
+//! wizard entity.
+
+/// The four fixed rail entries. Declaration order doubles as the `Ord` used
+/// by the rail to decide which entries are already completed
+/// (`entry < current_phase`), mirroring the migrate wizard's `WizardPhase`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ExportPhase {
+    Tables,
+    FormatOptions,
+    Confirm,
+    Run,
+}
+
+impl ExportPhase {
+    /// The rail's display label for this phase.
+    pub fn label(self) -> &'static str {
+        match self {
+            ExportPhase::Tables => "Tables",
+            ExportPhase::FormatOptions => "Format & Options",
+            ExportPhase::Confirm => "Confirm",
+            ExportPhase::Run => "Run",
+        }
+    }
+}
+
+/// All rail entries in display order, for `render_wizard_rail` to iterate.
+pub const RAIL_PHASES: [ExportPhase; 4] = [
+    ExportPhase::Tables,
+    ExportPhase::FormatOptions,
+    ExportPhase::Confirm,
+    ExportPhase::Run,
+];
+
+/// Whether `entry` should render a checkmark given the wizard is currently
+/// on `current` — an already-passed rail entry.
+pub fn is_completed(entry: ExportPhase, current: ExportPhase) -> bool {
+    entry < current
+}
+
+/// One rail row's presentation state: a completed entry shows a checkmark,
+/// the current entry is highlighted. Derived purely from the linear phase
+/// ordering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RailEntry {
+    pub phase: ExportPhase,
+    pub completed: bool,
+    pub current: bool,
+}
+
+/// The rail's four entries with their completion/current flags resolved
+/// against `current` — the single source of truth the renderer iterates.
+pub fn rail_entries(current: ExportPhase) -> Vec<RailEntry> {
+    RAIL_PHASES
+        .iter()
+        .map(|&phase| RailEntry {
+            phase,
+            completed: is_completed(phase, current),
+            current: phase == current,
+        })
+        .collect()
+}
+
+/// The phase reached by pressing the footer's Continue button from `phase`,
+/// or `None` for phases whose forward action lives elsewhere: `Confirm`
+/// starts the export through its own "Start Export" button, and `Run` has no
+/// forward step.
+pub fn next_phase(phase: ExportPhase) -> Option<ExportPhase> {
+    match phase {
+        ExportPhase::Tables => Some(ExportPhase::FormatOptions),
+        ExportPhase::FormatOptions => Some(ExportPhase::Confirm),
+        ExportPhase::Confirm | ExportPhase::Run => None,
+    }
+}
+
+/// The phase reached by pressing the footer's Back button from `phase`, or
+/// `None` for the first phase and for `Run` (back-navigation is frozen while
+/// a run is live or done — Cancel/Close is the only way out from there).
+pub fn prev_phase(phase: ExportPhase) -> Option<ExportPhase> {
+    match phase {
+        ExportPhase::Tables | ExportPhase::Run => None,
+        ExportPhase::FormatOptions => Some(ExportPhase::Tables),
+        ExportPhase::Confirm => Some(ExportPhase::FormatOptions),
+    }
+}
+
+/// Tracks the export run itself, separate from `ExportPhase` so `Run` can
+/// stay a single rail entry while progress/completion vary underneath.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum RunState {
+    #[default]
+    Idle,
+    Running,
+    Done,
+}
+
+/// Default segment/chunk size offered by the Format & Options phase — the
+/// same default `ExportOptions` used before the wizard existed.
+pub const DEFAULT_SEGMENT_SIZE: u32 = 500;
+
+/// Parses a typed segment/chunk-size value, rejecting non-numeric text and
+/// non-positive values — the engine streams at least one row per segment, so
+/// zero (and anything that does not parse as a whole number) is invalid.
+pub fn parse_segment_size(text: &str) -> Option<u32> {
+    match text.trim().parse::<u32>() {
+        Ok(0) | Err(_) => None,
+        Ok(value) => Some(value),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn phase_ordering_matches_rail_declaration_order() {
+        assert!(ExportPhase::Tables < ExportPhase::FormatOptions);
+        assert!(ExportPhase::FormatOptions < ExportPhase::Confirm);
+        assert!(ExportPhase::Confirm < ExportPhase::Run);
+    }
+
+    #[test]
+    fn phase_labels_cover_every_rail_entry() {
+        assert_eq!(ExportPhase::Tables.label(), "Tables");
+        assert_eq!(ExportPhase::FormatOptions.label(), "Format & Options");
+        assert_eq!(ExportPhase::Confirm.label(), "Confirm");
+        assert_eq!(ExportPhase::Run.label(), "Run");
+    }
+
+    #[test]
+    fn rail_entries_mark_passed_phases_completed_and_only_current_as_current() {
+        let entries = rail_entries(ExportPhase::Confirm);
+        assert_eq!(entries.len(), RAIL_PHASES.len());
+
+        let completed: Vec<ExportPhase> = entries
+            .iter()
+            .filter(|entry| entry.completed)
+            .map(|entry| entry.phase)
+            .collect();
+        assert_eq!(
+            completed,
+            vec![ExportPhase::Tables, ExportPhase::FormatOptions]
+        );
+
+        let current: Vec<ExportPhase> = entries
+            .iter()
+            .filter(|entry| entry.current)
+            .map(|entry| entry.phase)
+            .collect();
+        assert_eq!(current, vec![ExportPhase::Confirm]);
+
+        assert!(
+            entries
+                .iter()
+                .all(|entry| !(entry.completed && entry.current))
+        );
+    }
+
+    #[test]
+    fn rail_entries_on_first_phase_have_no_completed_entries() {
+        let entries = rail_entries(ExportPhase::Tables);
+        assert!(entries.iter().all(|entry| !entry.completed));
+        assert!(entries[0].current);
+    }
+
+    #[test]
+    fn next_phase_advances_through_the_forward_flow_and_stops_at_confirm() {
+        assert_eq!(
+            next_phase(ExportPhase::Tables),
+            Some(ExportPhase::FormatOptions)
+        );
+        assert_eq!(
+            next_phase(ExportPhase::FormatOptions),
+            Some(ExportPhase::Confirm)
+        );
+        assert_eq!(next_phase(ExportPhase::Confirm), None);
+        assert_eq!(next_phase(ExportPhase::Run), None);
+    }
+
+    #[test]
+    fn prev_phase_steps_backwards_and_stops_at_tables_and_run() {
+        assert_eq!(prev_phase(ExportPhase::Tables), None);
+        assert_eq!(
+            prev_phase(ExportPhase::FormatOptions),
+            Some(ExportPhase::Tables)
+        );
+        assert_eq!(
+            prev_phase(ExportPhase::Confirm),
+            Some(ExportPhase::FormatOptions)
+        );
+        assert_eq!(prev_phase(ExportPhase::Run), None);
+    }
+
+    #[test]
+    fn run_state_defaults_to_idle() {
+        assert_eq!(RunState::default(), RunState::Idle);
+    }
+
+    #[test]
+    fn parse_segment_size_accepts_positive_whole_numbers() {
+        assert_eq!(parse_segment_size("500"), Some(500));
+        assert_eq!(parse_segment_size("1"), Some(1));
+        assert_eq!(parse_segment_size("  250  "), Some(250));
+    }
+
+    #[test]
+    fn parse_segment_size_rejects_zero_and_non_numeric_input() {
+        assert_eq!(parse_segment_size("0"), None);
+        assert_eq!(parse_segment_size("abc"), None);
+        assert_eq!(parse_segment_size(""), None);
+        assert_eq!(parse_segment_size("-5"), None);
+    }
+}

--- a/crates/dbflux_ui_document/src/export_wizard/run.rs
+++ b/crates/dbflux_ui_document/src/export_wizard/run.rs
@@ -1,0 +1,779 @@
+//! Export run execution: builds `ExportTable`s from the wizard's resolved
+//! table selection, registers the `TaskManager` entry, drives the streamed
+//! `run_export` call on the background executor with the same 150 ms
+//! progress ticker and cancellation wiring the sidebar's original inline
+//! export action used, and resolves the outcome into task/report/toast
+//! actions plus the Done screen's summary and per-table status lines.
+//!
+//! Reused unchanged: `dbflux_transfer::export::{run_export, ExportOptions}`
+//! and the timestamped `dbflux-export-<ts>` folder-bundle + `manifest.json`
+//! output they produce. `Connection::table_details` is still called directly
+//! per table (not routed through the metadata-cache seam the migrate wizard
+//! uses) — that mirrors the sidebar's original behavior exactly.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dbflux_core::{CancelToken, Connection, TaskId, TaskKind, TaskStatus, TaskTarget};
+use dbflux_transfer::TableTransferStatus;
+use dbflux_transfer::export::{
+    ExportOptions, ExportOutcome, ExportTable, ExportedTable, run_export,
+};
+use dbflux_transfer::{FileFormat, TransferError};
+use dbflux_ui_base::app_state_entity::AppStateChanged;
+use dbflux_ui_base::toast::Toast;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
+use gpui::*;
+
+use crate::export_wizard::ExportWizard;
+use crate::export_wizard::phases::{ExportPhase, RunState};
+
+/// Live counters for the running export: which table (by the wizard's fixed
+/// table order) is currently streaming, and its row progress — mirrors the
+/// migrate wizard's `RunProgress`.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct RunProgress {
+    pub(crate) table_index: usize,
+    pub(crate) rows_done: u64,
+    pub(crate) estimated_total: Option<u64>,
+}
+
+/// Converts driver-reported column metadata into the transfer engine's
+/// column shape — the same mapping the sidebar's original export action used.
+fn to_transfer_columns(columns: Vec<dbflux_core::ColumnInfo>) -> Vec<dbflux_core::TransferColumn> {
+    columns
+        .into_iter()
+        .map(|c| dbflux_core::TransferColumn {
+            name: c.name,
+            type_name: Some(c.type_name),
+            nullable: c.nullable,
+            is_primary_key: c.is_primary_key,
+        })
+        .collect()
+}
+
+/// A `schema.table` (or bare `table`) label for error/status messages.
+fn table_label(schema: &Option<String>, name: &str) -> String {
+    match schema {
+        Some(schema) => format!("{schema}.{name}"),
+        None => name.to_string(),
+    }
+}
+
+/// Fetches each selected table's column shape through `Connection::table_details`
+/// and assembles the engine's `ExportTable`s. Any single table's fetch
+/// failure aborts the whole build and is reported as one error naming the
+/// failing table — the same short-circuit the sidebar's original inline
+/// export action used.
+pub(crate) fn build_export_tables(
+    connection: &Arc<dyn Connection>,
+    database: Option<&str>,
+    table_specs: &[(Option<String>, String)],
+) -> Result<Vec<ExportTable>, String> {
+    let mut export_tables = Vec::with_capacity(table_specs.len());
+
+    for (schema, name) in table_specs {
+        let effective_database = database
+            .map(str::to_string)
+            .unwrap_or_else(|| schema.clone().unwrap_or_default());
+
+        match connection.table_details(&effective_database, schema.as_deref(), name) {
+            Ok(info) => {
+                let columns = to_transfer_columns(info.columns.unwrap_or_default());
+                export_tables.push(ExportTable {
+                    schema: schema.clone(),
+                    name: name.clone(),
+                    columns,
+                    // `TableSource` auto-counts via `SELECT COUNT(*)` when
+                    // this is `None`, so the run's progress fraction is real
+                    // rather than permanently stuck at 0.
+                    estimated_total: None,
+                });
+            }
+            Err(e) => {
+                return Err(format!("{}: {e}", table_label(schema, name)));
+            }
+        }
+    }
+
+    Ok(export_tables)
+}
+
+/// The owned inputs handed to the off-thread run task.
+pub(crate) struct ExportRunContext {
+    pub(crate) connection: Arc<dyn Connection>,
+    pub(crate) driver_id: String,
+    pub(crate) database: String,
+    pub(crate) export_tables: Vec<ExportTable>,
+    pub(crate) output_dir: PathBuf,
+    pub(crate) format: FileFormat,
+    pub(crate) segment_size: u32,
+    pub(crate) cancel_token: CancelToken,
+}
+
+/// The terminal action to apply to the run's task registry entry.
+enum RunTaskAction {
+    Complete,
+    Cancel,
+    Fail(String),
+}
+
+/// The fully-resolved outcome of an export run: the task action, an optional
+/// user-facing error to report, whether to toast success, and the summary /
+/// per-table lines for the Done screen. Computed once so the task-finalization
+/// path and the UI-reflection path stay consistent even if the wizard entity
+/// is dropped between them.
+struct RunResolution {
+    task_action: RunTaskAction,
+    task_action_details: Option<String>,
+    report: Option<String>,
+    toast_success: bool,
+    summary: String,
+    warnings: Vec<String>,
+}
+
+fn resolve_run_outcome(result: Result<ExportOutcome, TransferError>) -> RunResolution {
+    match result {
+        Ok(outcome) if outcome.cancelled => RunResolution {
+            task_action: RunTaskAction::Cancel,
+            task_action_details: None,
+            report: None,
+            toast_success: false,
+            summary: "Export cancelled".to_string(),
+            warnings: Vec::new(),
+        },
+        Ok(outcome) => {
+            let failed_table = outcome.tables.iter().find_map(|t| match &t.status {
+                TableTransferStatus::Failed { error } => Some((t.name.clone(), error.clone())),
+                _ => None,
+            });
+
+            let summary = summarize(&outcome);
+            let warnings = itemized_status_lines(&outcome.tables, &outcome.warnings);
+
+            match failed_table {
+                Some((table, error)) => RunResolution {
+                    task_action: RunTaskAction::Fail(format!("{table}: {error}")),
+                    task_action_details: Some(itemized_table_details(&outcome.tables)),
+                    report: Some(format!("Export failed on table '{table}': {error}")),
+                    toast_success: false,
+                    summary,
+                    warnings,
+                },
+                None => RunResolution {
+                    task_action: RunTaskAction::Complete,
+                    task_action_details: None,
+                    report: None,
+                    toast_success: true,
+                    summary,
+                    warnings,
+                },
+            }
+        }
+        Err(e) => {
+            let message = format!("Export failed: {e}");
+            RunResolution {
+                task_action: RunTaskAction::Fail(e.to_string()),
+                task_action_details: None,
+                report: Some(message.clone()),
+                toast_success: false,
+                summary: message,
+                warnings: Vec::new(),
+            }
+        }
+    }
+}
+
+fn summarize(outcome: &ExportOutcome) -> String {
+    let completed = outcome
+        .tables
+        .iter()
+        .filter(|t| matches!(t.status, TableTransferStatus::Completed { .. }))
+        .count();
+    let skipped = outcome
+        .tables
+        .iter()
+        .filter(|t| matches!(t.status, TableTransferStatus::Skipped))
+        .count();
+    let failed = outcome
+        .tables
+        .iter()
+        .filter(|t| matches!(t.status, TableTransferStatus::Failed { .. }))
+        .count();
+    let rows: u64 = outcome
+        .tables
+        .iter()
+        .map(|t| match &t.status {
+            TableTransferStatus::Completed { rows } => *rows,
+            _ => 0,
+        })
+        .sum();
+
+    if failed > 0 {
+        format!(
+            "Exported {completed} table(s), {rows} row(s) total ({skipped} skipped, {failed} failed)"
+        )
+    } else {
+        format!("Exported {completed} table(s), {rows} row(s) total ({skipped} skipped)")
+    }
+}
+
+/// Renders one status line per planned table when the run left any table
+/// `Failed` or `NotStarted`, so the user sees exactly which tables succeeded,
+/// which one failed with what error, and which were never attempted — not
+/// just the last error swallowed into a single toast (R4-002/B-007). On a
+/// fully successful/skipped run, only the engine's own warnings are shown.
+fn itemized_status_lines(tables: &[ExportedTable], engine_warnings: &[String]) -> Vec<String> {
+    let has_issue = tables.iter().any(|t| {
+        matches!(
+            t.status,
+            TableTransferStatus::Failed { .. } | TableTransferStatus::NotStarted
+        )
+    });
+
+    if !has_issue {
+        return engine_warnings.to_vec();
+    }
+
+    let mut lines: Vec<String> = tables.iter().map(table_status_line).collect();
+    lines.extend(engine_warnings.iter().cloned());
+    lines
+}
+
+fn table_status_line(table: &ExportedTable) -> String {
+    let label = table_label(&table.schema, &table.name);
+    match &table.status {
+        TableTransferStatus::Completed { rows } => format!("{label}: completed ({rows} row(s))"),
+        TableTransferStatus::Skipped => format!("{label}: skipped"),
+        TableTransferStatus::Failed { error } => format!("{label}: FAILED — {error}"),
+        TableTransferStatus::NotStarted => format!("{label}: not attempted"),
+    }
+}
+
+/// Renders the Tasks panel's expandable per-table details for a failed run.
+fn itemized_table_details(tables: &[ExportedTable]) -> String {
+    tables
+        .iter()
+        .map(table_status_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+impl ExportWizard {
+    /// Resolves the connection, fetches the selected tables' column shapes,
+    /// registers the run's `TaskManager` entry, and hands off to the
+    /// progress ticker and the background `run_export` call. Any table-schema
+    /// fetch failure fails the task immediately and never starts the run.
+    pub(crate) fn start_export(&mut self, cx: &mut Context<Self>) {
+        if self.run_state == RunState::Running {
+            return;
+        }
+
+        let Some(connection) = self.resolve_connection(cx) else {
+            report_error(
+                UserFacingError::new(ErrorKind::Storage, "No active connection for this export"),
+                cx,
+            );
+            return;
+        };
+        let Some(base_dir) = self.output_dir.clone() else {
+            return;
+        };
+
+        let profile_id = self.profile_id;
+        let database = self.database.clone();
+        let profile_label = self.profile_label(cx);
+        let driver_id = connection.metadata().id.clone();
+        let format = self.selected_format();
+        let segment_size = self.segment_size;
+        let table_specs: Vec<(Option<String>, String)> = self
+            .tables
+            .iter()
+            .map(|t| (t.schema.clone(), t.name.clone()))
+            .collect();
+
+        self.phase = ExportPhase::Run;
+        self.run_state = RunState::Running;
+        self.result_summary = None;
+        self.result_warnings.clear();
+        *self.progress.lock().unwrap_or_else(|p| p.into_inner()) = RunProgress::default();
+
+        let output_dir = base_dir.join(format!(
+            "dbflux-export-{}",
+            dbflux_core::chrono::Utc::now().format("%Y%m%d-%H%M%S%.3f")
+        ));
+        let description = format!("Export {} table(s) from {profile_label}", table_specs.len());
+
+        let app_state = self.app_state.clone();
+        let (task_id, cancel_token) = app_state.update(cx, |state, cx| {
+            let pair = state.start_task_for_target(
+                TaskKind::Export,
+                description,
+                profile_id.map(|profile_id| TaskTarget {
+                    profile_id,
+                    database: database.clone(),
+                }),
+            );
+            cx.emit(AppStateChanged);
+            pair
+        });
+        self.cancel_token = Some(cancel_token.clone());
+        cx.notify();
+
+        cx.spawn(async move |this, cx| {
+            let export_tables =
+                match build_export_tables(&connection, database.as_deref(), &table_specs) {
+                    Ok(tables) => tables,
+                    Err(err) => {
+                        cx.update(|cx| {
+                            app_state.update(cx, |state, cx| {
+                                state.fail_task(task_id, err.clone());
+                                cx.emit(AppStateChanged);
+                            });
+                            report_error(
+                                UserFacingError::new(
+                                    ErrorKind::Driver,
+                                    format!("Export failed while reading table schema: {err}"),
+                                ),
+                                cx,
+                            );
+                        })
+                        .ok();
+
+                        this.update(cx, |this, cx| {
+                            this.run_state = RunState::Done;
+                            this.cancel_token = None;
+                            this.result_summary = Some(format!("Export failed: {err}"));
+                            cx.notify();
+                        })
+                        .ok();
+                        return;
+                    }
+                };
+
+            this.update(cx, |this, cx| {
+                this.spawn_progress_ticker(task_id, cx);
+                this.spawn_run(
+                    ExportRunContext {
+                        connection,
+                        driver_id,
+                        database: database.unwrap_or_default(),
+                        export_tables,
+                        output_dir,
+                        format,
+                        segment_size,
+                        cancel_token,
+                    },
+                    task_id,
+                    cx,
+                );
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn spawn_progress_ticker(&self, task_id: TaskId, cx: &mut Context<Self>) {
+        let ticker_app_state = self.app_state.clone();
+        let ticker_progress = Arc::clone(&self.progress);
+
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(Duration::from_millis(150))
+                    .await;
+
+                let still_running = cx
+                    .update(|cx| {
+                        ticker_app_state.update(cx, |state, cx| {
+                            let Some(snapshot) = state.tasks().get(task_id) else {
+                                return false;
+                            };
+                            if snapshot.status != TaskStatus::Running {
+                                return false;
+                            }
+
+                            let progress = *ticker_progress
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner());
+                            if let Some(total) = progress.estimated_total
+                                && total > 0
+                            {
+                                let fraction =
+                                    (progress.rows_done as f32 / total as f32).clamp(0.0, 1.0);
+                                state.tasks_mut().update_progress(task_id, fraction);
+                                cx.notify();
+                            }
+
+                            true
+                        })
+                    })
+                    .unwrap_or(false);
+
+                if !still_running {
+                    break;
+                }
+
+                // Re-render the wizard every tick so the running phase's
+                // per-table position and row counters advance while the run
+                // is in flight (the app-state notify above only refreshes
+                // the tasks panel, not this modal).
+                this.update(cx, |_this, cx| cx.notify()).ok();
+            }
+        })
+        .detach();
+    }
+
+    fn spawn_run(&self, run: ExportRunContext, task_id: TaskId, cx: &mut Context<Self>) {
+        let app_state = self.app_state.clone();
+        let progress = Arc::clone(&self.progress);
+
+        cx.spawn(async move |this, cx| {
+            let ExportRunContext {
+                connection,
+                driver_id,
+                database,
+                export_tables,
+                output_dir,
+                format,
+                segment_size,
+                cancel_token,
+            } = run;
+            let output_dir_for_toast = output_dir.clone();
+
+            let export_result = cx
+                .background_executor()
+                .spawn(async move {
+                    let options = ExportOptions {
+                        driver_id: &driver_id,
+                        database: &database,
+                        format,
+                        segment_size,
+                    };
+
+                    run_export(
+                        &connection,
+                        &export_tables,
+                        &output_dir,
+                        &options,
+                        &cancel_token,
+                        move |table_index, rows_done, estimated_total| {
+                            if let Ok(mut guard) = progress.lock() {
+                                *guard = RunProgress {
+                                    table_index,
+                                    rows_done,
+                                    estimated_total,
+                                };
+                            }
+                        },
+                    )
+                })
+                .await;
+
+            let RunResolution {
+                task_action,
+                task_action_details,
+                report,
+                toast_success,
+                summary,
+                warnings,
+            } = resolve_run_outcome(export_result);
+
+            // The run's task MUST reach a terminal state and any failure MUST
+            // reach the foreground even if the wizard entity was dropped
+            // (modal closed/reopened) — so finalize the task and report
+            // through the app directly, never gated on `this` being alive.
+            cx.update(|cx| {
+                app_state.update(cx, |state, cx| {
+                    match &task_action {
+                        RunTaskAction::Complete => state.complete_task(task_id),
+                        RunTaskAction::Cancel => {
+                            state.tasks_mut().cancel(task_id);
+                        }
+                        RunTaskAction::Fail(message) => match &task_action_details {
+                            Some(details) => state.fail_task_with_details(
+                                task_id,
+                                message.clone(),
+                                details.clone(),
+                            ),
+                            None => state.fail_task(task_id, message.clone()),
+                        },
+                    }
+                    cx.emit(AppStateChanged);
+                });
+
+                if let Some(message) = &report {
+                    report_error(UserFacingError::new(ErrorKind::Driver, message.clone()), cx);
+                }
+                if toast_success {
+                    Toast::success(format!(
+                        "{summary}. Saved to {}",
+                        output_dir_for_toast.display()
+                    ))
+                    .push(cx);
+                }
+            })
+            .ok();
+
+            // Best-effort UI reflection: if the wizard is gone the run has
+            // already been finalized above.
+            this.update(cx, |this, cx| {
+                this.run_state = RunState::Done;
+                this.cancel_token = None;
+                this.result_summary = Some(summary);
+                this.result_warnings = warnings;
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    pub(crate) fn cancel_run(&mut self, cx: &mut Context<Self>) {
+        if let Some(token) = &self.cancel_token {
+            token.cancel();
+        }
+        cx.notify();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // `use super::*` would re-glob the parent module's `use gpui::*`, which
+    // blows rustc's macro recursion limit in this crate — import only what
+    // the tests need (see `import_wizard::tests` for the same constraint).
+    use super::{
+        ExportOutcome, ExportedTable, RunTaskAction, itemized_status_lines, resolve_run_outcome,
+        summarize, table_status_line,
+    };
+    use dbflux_transfer::{TableTransferStatus, TransferError};
+
+    fn exported(schema: Option<&str>, name: &str, status: TableTransferStatus) -> ExportedTable {
+        ExportedTable {
+            schema: schema.map(str::to_string),
+            name: name.to_string(),
+            status,
+        }
+    }
+
+    fn outcome(
+        tables: Vec<ExportedTable>,
+        warnings: Vec<String>,
+        cancelled: bool,
+    ) -> ExportOutcome {
+        ExportOutcome {
+            manifest: None,
+            warnings,
+            tables,
+            cancelled,
+        }
+    }
+
+    #[test]
+    fn resolve_run_outcome_cancelled_run_skips_task_error_and_toast() {
+        let result = Ok(outcome(
+            vec![exported(None, "users", TableTransferStatus::NotStarted)],
+            Vec::new(),
+            true,
+        ));
+
+        let resolution = resolve_run_outcome(result);
+
+        assert!(matches!(resolution.task_action, RunTaskAction::Cancel));
+        assert!(resolution.task_action_details.is_none());
+        assert!(resolution.report.is_none());
+        assert!(!resolution.toast_success);
+        assert_eq!(resolution.summary, "Export cancelled");
+        assert!(resolution.warnings.is_empty());
+    }
+
+    #[test]
+    fn resolve_run_outcome_all_success_completes_the_task_and_toasts() {
+        let result = Ok(outcome(
+            vec![
+                exported(None, "users", TableTransferStatus::Completed { rows: 10 }),
+                exported(
+                    Some("public"),
+                    "orders",
+                    TableTransferStatus::Completed { rows: 5 },
+                ),
+            ],
+            Vec::new(),
+            false,
+        ));
+
+        let resolution = resolve_run_outcome(result);
+
+        assert!(matches!(resolution.task_action, RunTaskAction::Complete));
+        assert!(resolution.task_action_details.is_none());
+        assert!(resolution.report.is_none());
+        assert!(resolution.toast_success);
+        assert_eq!(
+            resolution.summary,
+            "Exported 2 table(s), 15 row(s) total (0 skipped)"
+        );
+        assert!(resolution.warnings.is_empty());
+    }
+
+    #[test]
+    fn resolve_run_outcome_per_table_failure_fails_the_task_with_details_and_reports_once() {
+        let result = Ok(outcome(
+            vec![
+                exported(None, "users", TableTransferStatus::Completed { rows: 3 }),
+                exported(
+                    None,
+                    "orders",
+                    TableTransferStatus::Failed {
+                        error: "constraint violation".to_string(),
+                    },
+                ),
+                exported(None, "line_items", TableTransferStatus::NotStarted),
+            ],
+            Vec::new(),
+            false,
+        ));
+
+        let resolution = resolve_run_outcome(result);
+
+        match resolution.task_action {
+            RunTaskAction::Fail(ref message) => {
+                assert_eq!(message, "orders: constraint violation");
+            }
+            _ => panic!("a per-table failure must fail the task"),
+        }
+        assert_eq!(
+            resolution.report.as_deref(),
+            Some("Export failed on table 'orders': constraint violation")
+        );
+        assert!(!resolution.toast_success);
+        assert_eq!(
+            resolution.summary,
+            "Exported 1 table(s), 3 row(s) total (0 skipped, 1 failed)"
+        );
+
+        let details = resolution
+            .task_action_details
+            .expect("a failed run must carry itemized per-table details");
+        assert!(details.contains("users: completed (3 row(s))"));
+        assert!(details.contains("orders: FAILED — constraint violation"));
+        assert!(details.contains("line_items: not attempted"));
+        assert_eq!(resolution.warnings.len(), 3);
+    }
+
+    #[test]
+    fn resolve_run_outcome_pipeline_error_fails_the_task_and_reports_once() {
+        let result: Result<ExportOutcome, TransferError> =
+            Err(TransferError::Sink("disk full".to_string()));
+
+        let resolution = resolve_run_outcome(result);
+
+        match resolution.task_action {
+            RunTaskAction::Fail(ref message) => assert_eq!(message, "sink error: disk full"),
+            _ => panic!("a pipeline error must fail the task"),
+        }
+        assert!(resolution.task_action_details.is_none());
+        assert_eq!(
+            resolution.report.as_deref(),
+            Some("Export failed: sink error: disk full")
+        );
+        assert!(!resolution.toast_success);
+        assert_eq!(resolution.summary, "Export failed: sink error: disk full");
+        assert!(resolution.warnings.is_empty());
+    }
+
+    #[test]
+    fn summarize_reports_completed_skipped_and_failed_counts() {
+        let outcome = outcome(
+            vec![
+                exported(None, "a", TableTransferStatus::Completed { rows: 2 }),
+                exported(None, "b", TableTransferStatus::Skipped),
+                exported(
+                    None,
+                    "c",
+                    TableTransferStatus::Failed {
+                        error: "boom".to_string(),
+                    },
+                ),
+            ],
+            Vec::new(),
+            false,
+        );
+
+        assert_eq!(
+            summarize(&outcome),
+            "Exported 1 table(s), 2 row(s) total (1 skipped, 1 failed)"
+        );
+    }
+
+    #[test]
+    fn itemized_status_lines_returns_only_engine_warnings_when_every_table_finished_cleanly() {
+        let tables = vec![
+            exported(None, "a", TableTransferStatus::Completed { rows: 1 }),
+            exported(None, "b", TableTransferStatus::Skipped),
+        ];
+        let warnings = vec!["heads up".to_string()];
+
+        assert_eq!(itemized_status_lines(&tables, &warnings), warnings);
+    }
+
+    #[test]
+    fn itemized_status_lines_lists_every_table_when_any_table_failed_or_was_not_started() {
+        let tables = vec![
+            exported(
+                Some("public"),
+                "a",
+                TableTransferStatus::Completed { rows: 1 },
+            ),
+            exported(
+                None,
+                "b",
+                TableTransferStatus::Failed {
+                    error: "timeout".to_string(),
+                },
+            ),
+            exported(None, "c", TableTransferStatus::NotStarted),
+        ];
+        let warnings = vec!["engine note".to_string()];
+
+        assert_eq!(
+            itemized_status_lines(&tables, &warnings),
+            vec![
+                "public.a: completed (1 row(s))".to_string(),
+                "b: FAILED — timeout".to_string(),
+                "c: not attempted".to_string(),
+                "engine note".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn table_status_line_covers_every_status_and_qualifies_the_name_with_its_schema() {
+        assert_eq!(
+            table_status_line(&exported(
+                Some("public"),
+                "users",
+                TableTransferStatus::Completed { rows: 7 }
+            )),
+            "public.users: completed (7 row(s))"
+        );
+        assert_eq!(
+            table_status_line(&exported(None, "orders", TableTransferStatus::Skipped)),
+            "orders: skipped"
+        );
+        assert_eq!(
+            table_status_line(&exported(
+                None,
+                "line_items",
+                TableTransferStatus::Failed {
+                    error: "fk violation".to_string()
+                }
+            )),
+            "line_items: FAILED — fk violation"
+        );
+        assert_eq!(
+            table_status_line(&exported(None, "audit", TableTransferStatus::NotStarted)),
+            "audit: not attempted"
+        );
+    }
+}

--- a/crates/dbflux_ui_document/src/import_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/import_wizard/mod.rs
@@ -14,6 +14,7 @@ mod column_mapping;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
+use dbflux_components::composites::{RailItem, render_wizard_rail};
 use dbflux_components::controls::{Button, Dropdown, DropdownItem, DropdownSelectionChanged};
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::Text;
@@ -42,6 +43,43 @@ enum WizardStep {
     Confirm,
     Running,
     Done,
+}
+
+/// The rail's four fixed entries, in display order. `Confirm` stays a rail
+/// entry even on a non-destructive plan, where `continue_from_configure`
+/// skips straight from `Configure` to `Running` — it simply never becomes
+/// `current` in that flow and reads as already passed, matching a linear
+/// progress rail rather than a literal per-click history.
+const RAIL_LABELS: [&str; 4] = ["Pick Folder", "Configure", "Confirm", "Run"];
+
+/// `Running` and `Done` collapse onto the same rail index so the terminal
+/// steps of the five-variant `WizardStep` state machine share the rail's
+/// fourth "Run" entry instead of growing a fifth marker.
+fn rail_index(step: WizardStep) -> usize {
+    match step {
+        WizardStep::PickFolder => 0,
+        WizardStep::Configure => 1,
+        WizardStep::Confirm => 2,
+        WizardStep::Running | WizardStep::Done => 3,
+    }
+}
+
+/// Maps the wizard's current [`WizardStep`] to the shared rail composite's
+/// domain-free [`RailItem`]s, marking every entry before the current one as
+/// completed — see [`RAIL_LABELS`] for why `Confirm` may show completed
+/// without the user ever visiting it.
+fn import_rail_items(step: WizardStep) -> Vec<RailItem> {
+    let current_index = rail_index(step);
+
+    RAIL_LABELS
+        .iter()
+        .enumerate()
+        .map(|(index, label)| RailItem {
+            label: SharedString::from(*label),
+            completed: index < current_index,
+            current: index == current_index,
+        })
+        .collect()
 }
 
 /// One table row's live controls, wrapping the pure [`TableImportConfig`]
@@ -652,7 +690,19 @@ impl Render for ImportWizard {
             .width(px(720.0))
             .max_height(px(640.0));
 
-        let body = match self.step {
+        frame = frame.child(self.render_body(cx));
+        frame.render(cx).into_any_element()
+    }
+}
+
+impl ImportWizard {
+    /// Rail + phase-area layout shared with the migrate/export wizard chrome.
+    /// The rail is display-only (`on_select: None`) — see `import_rail_items`
+    /// — so this wrapping is purely presentational and leaves every step's
+    /// own logic and buttons (`render_pick_folder`, `render_configure`, ...)
+    /// unchanged.
+    fn render_body(&self, cx: &mut Context<Self>) -> AnyElement {
+        let phase = match self.step {
             WizardStep::PickFolder => self.render_pick_folder(cx),
             WizardStep::Configure => self.render_configure(cx),
             WizardStep::Confirm => self.render_confirm(cx),
@@ -660,8 +710,18 @@ impl Render for ImportWizard {
             WizardStep::Done => self.render_done(cx),
         };
 
-        frame = frame.child(body);
-        frame.render(cx).into_any_element()
+        div()
+            .flex()
+            .flex_row()
+            .flex_1()
+            .min_h(px(0.0))
+            .child(render_wizard_rail(
+                &import_rail_items(self.step),
+                None::<fn(usize, &mut Window, &mut App)>,
+                cx,
+            ))
+            .child(div().flex_1().min_w(px(0.0)).flex().flex_col().child(phase))
+            .into_any_element()
     }
 }
 

--- a/crates/dbflux_ui_document/src/lib.rs
+++ b/crates/dbflux_ui_document/src/lib.rs
@@ -20,6 +20,7 @@ mod style_guardrails;
 #[cfg(feature = "mcp")]
 mod governance;
 
+pub mod export_wizard;
 mod handle;
 pub mod history_modal;
 pub mod import_wizard;

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -22,9 +22,10 @@ pub mod tree_model;
 
 use std::sync::Arc;
 
+use dbflux_components::composites::{RailItem, render_wizard_rail};
 use dbflux_components::controls::Button;
 use dbflux_components::icons::AppIcon;
-use dbflux_components::primitives::{Icon, Text};
+use dbflux_components::primitives::Text;
 use dbflux_components::tokens::Spacing;
 use dbflux_core::{
     ColumnInfo, Connection, DbError, DriverCapabilities, LogErr, SchemaCacheKey,
@@ -45,7 +46,8 @@ use confirm_run::{ConfirmRunEvent, ConfirmRunInputs, ConfirmRunPhase, decide_ord
 use mapping::{MappingChanged, MappingPhase};
 use options::{OptionsChanged, OptionsPhase};
 use phases::{
-    MappingRowPlan, RailEntry, RunState, WizardPhase, rail_entries, tables_mapping_confirm_warnings,
+    MappingRowPlan, RAIL_PHASES, RailEntry, RunState, WizardPhase, rail_entries,
+    tables_mapping_confirm_warnings,
 };
 use source_target::{SourceTargetChanged, SourceTargetPhase};
 
@@ -120,113 +122,18 @@ fn build_migration_options(
     }
 }
 
-/// Renders the wizard's left phase rail: the five fixed [`WizardPhase`]
-/// entries in order, a checkmark on every completed phase, a highlight on the
-/// current one, and click-to-return back-navigation on completed entries.
-/// `on_select` is invoked with the clicked phase; only completed (already
-/// passed) entries are interactive, so the caller cannot jump ahead. The FK
-/// reorder interrupt is deliberately absent — it is a conditional overlay
-/// inside `Confirm`, never a listed rail phase.
-pub fn render_phase_rail<F>(current: WizardPhase, on_select: F, cx: &App) -> impl IntoElement
-where
-    F: Fn(WizardPhase, &mut Window, &mut App) + Clone + 'static,
-{
-    let theme = cx.theme();
-    let colors = RailColors {
-        current: theme.primary,
-        done: theme.success,
-        muted: theme.muted_foreground,
-        hover_bg: theme.secondary,
-    };
-    let border = theme.border;
-
-    let entries = rail_entries(current)
+/// Maps the wizard's [`RailEntry`]s to the shared rail composite's
+/// domain-free [`RailItem`]s, in the same fixed `RAIL_PHASES` order the
+/// caller uses to translate a clicked index back into a [`WizardPhase`].
+fn to_rail_items(current: WizardPhase) -> Vec<RailItem> {
+    rail_entries(current)
         .into_iter()
-        .map(move |entry| render_rail_entry(entry, colors, on_select.clone()));
-
-    div()
-        .flex()
-        .flex_col()
-        .gap(Spacing::XS)
-        .p(Spacing::MD)
-        .min_w(px(180.0))
-        .border_r_1()
-        .border_color(border)
-        .children(entries)
-}
-
-/// The rail's marker/label colors, resolved once per render from the theme.
-/// `current` and `done` use the theme's bright action/success colors (not the
-/// dark `accent`, which is a low-contrast highlight background on dark themes),
-/// so the current phase reads as the most prominent entry.
-#[derive(Clone, Copy)]
-struct RailColors {
-    current: Hsla,
-    done: Hsla,
-    muted: Hsla,
-    hover_bg: Hsla,
-}
-
-fn render_rail_entry<F>(entry: RailEntry, colors: RailColors, on_select: F) -> impl IntoElement
-where
-    F: Fn(WizardPhase, &mut Window, &mut App) + Clone + 'static,
-{
-    let phase = entry.phase;
-
-    let marker = if entry.completed {
-        Icon::new(AppIcon::CircleCheck)
-            .size(px(14.0))
-            .color(colors.done)
-            .into_any_element()
-    } else {
-        let dot_color = if entry.current {
-            colors.current
-        } else {
-            colors.muted
-        };
-        div()
-            .size(px(8.0)) // guardrail-allow: decorative status-dot diameter, not a spacing token
-            .rounded_full()
-            .bg(dot_color)
-            .into_any_element()
-    };
-
-    // The current entry is the most prominent: bright action color plus a
-    // heavier weight. Every other label stays at full foreground contrast (a
-    // check/dot marker conveys completed vs. pending), so the rail reads
-    // clearly instead of as dim, low-contrast text.
-    let mut label = Text::body(phase.label());
-    if entry.current {
-        label = label
-            .color(colors.current)
-            .font_weight(FontWeight::SEMIBOLD);
-    }
-
-    div()
-        .id(SharedString::from(format!(
-            "migrate-rail-{}",
-            phase.label()
-        )))
-        .flex()
-        .items_center()
-        .gap(Spacing::SM)
-        .px(Spacing::SM)
-        .py(Spacing::XS)
-        .rounded_md()
-        .child(
-            div()
-                .w(px(16.0)) // guardrail-allow: fixed rail marker gutter width for label alignment
-                .flex()
-                .items_center()
-                .justify_center()
-                .child(marker),
-        )
-        .child(label)
-        .when(entry.completed, |el| {
-            el.cursor_pointer()
-                .hover(|style| style.bg(colors.hover_bg))
-                .on_click(move |_event, window, app| on_select(phase, window, app))
+        .map(|entry: RailEntry| RailItem {
+            label: entry.phase.label().into(),
+            completed: entry.completed,
+            current: entry.current,
         })
+        .collect()
 }
 
 /// Outcome of fetching one table's details through the shared
@@ -1433,7 +1340,8 @@ impl Render for MigrateWizard {
 impl MigrateWizard {
     fn render_body(&self, cx: &mut Context<Self>) -> AnyElement {
         let rail_entity = cx.entity().downgrade();
-        let on_select = move |phase: WizardPhase, _window: &mut Window, app: &mut App| {
+        let on_select = move |index: usize, _window: &mut Window, app: &mut App| {
+            let phase = RAIL_PHASES[index];
             rail_entity
                 .update(app, |this, cx| this.go_to_phase(phase, cx))
                 .ok();
@@ -1456,7 +1364,11 @@ impl MigrateWizard {
                     .flex_row()
                     .flex_1()
                     .min_h(px(0.0))
-                    .child(render_phase_rail(self.phase, on_select, cx))
+                    .child(render_wizard_rail(
+                        &to_rail_items(self.phase),
+                        Some(on_select),
+                        cx,
+                    ))
                     .child(self.render_phase_area()),
             )
             .child(self.render_footer(cx))

--- a/crates/dbflux_ui_sidebar/Cargo.toml
+++ b/crates/dbflux_ui_sidebar/Cargo.toml
@@ -18,7 +18,6 @@ dbflux_components.workspace = true
 dbflux_core.workspace = true
 dbflux_app.workspace = true
 dbflux_ssh.workspace = true
-dbflux_transfer.workspace = true
 uuid.workspace = true
 log.workspace = true
 serde_json.workspace = true

--- a/crates/dbflux_ui_sidebar/src/context_menu.rs
+++ b/crates/dbflux_ui_sidebar/src/context_menu.rs
@@ -251,9 +251,11 @@ impl Sidebar {
                     );
                 }
 
-                // Export (Table -> folder bundle) is gated on the connection's
-                // transfer_family, never on driver id (R7). Views are excluded —
-                // this batch scopes bulk export to writable tables only.
+                // Export (Table -> folder bundle, via the Export wizard) is
+                // gated on the connection's transfer_family, never on driver
+                // id (R7). Views are excluded — this batch scopes bulk export
+                // to writable tables only. Format/folder/segment-size are
+                // chosen in the wizard, not from this menu.
                 if node_kind == SchemaNodeKind::Table && self.table_supports_transfer(item_id, cx) {
                     let count = self.export_table_selection_count(item_id);
                     let label = if count > 1 {
@@ -266,20 +268,7 @@ impl Sidebar {
                         &mut items,
                         [ContextMenuItem::item(
                             label,
-                            ContextMenuAction::Submenu(vec![
-                                ContextMenuItem::item(
-                                    "as CSV",
-                                    ContextMenuAction::ExportTablesAs(
-                                        dbflux_transfer::FileFormat::Csv,
-                                    ),
-                                ),
-                                ContextMenuItem::item(
-                                    "as JSON",
-                                    ContextMenuAction::ExportTablesAs(
-                                        dbflux_transfer::FileFormat::Json,
-                                    ),
-                                ),
-                            ]),
+                            ContextMenuAction::ExportTables,
                         )],
                     );
                 }
@@ -1407,8 +1396,8 @@ impl Sidebar {
                     cx.emit(SidebarEvent::RequestExportConnection { profile_id });
                 }
             }
-            ContextMenuAction::ExportTablesAs(format) => {
-                self.export_selected_tables(&item_id, format, cx);
+            ContextMenuAction::ExportTables => {
+                self.request_export_wizard(&item_id, cx);
             }
             ContextMenuAction::ImportTables => {
                 if let Some(SchemaNodeId::Profile { profile_id }) = parse_node_id(&item_id) {

--- a/crates/dbflux_ui_sidebar/src/lib.rs
+++ b/crates/dbflux_ui_sidebar/src/lib.rs
@@ -280,6 +280,18 @@ pub enum SidebarEvent {
         database: Option<String>,
         tables: Vec<TableRef>,
     },
+
+    /// Request to open the Export wizard, pre-populated with the resolved
+    /// table selection from the sidebar (R8). `profile_id`/`database`
+    /// identify the source connection; the wizard itself owns the format
+    /// choice, the output-folder picker, and running the export. The wizard
+    /// lives in `dbflux_ui_document`; the integrator (`dbflux_ui` Workspace)
+    /// owns opening it, mirroring `RequestMigrateWizard`'s layering.
+    RequestExportWizard {
+        profile_id: Uuid,
+        database: Option<String>,
+        tables: Vec<TableRef>,
+    },
 }
 
 /// Sentinel value for IDs that don't correspond to schema tree nodes
@@ -449,18 +461,19 @@ pub enum ContextMenuAction {
     RefreshInstanceCatalog,
     /// Copy the string ID of the selected node to the clipboard.
     CopyItemId,
-    /// Export the selected table(s) (or the right-clicked table, when it is
-    /// not part of a larger selection) to a folder bundle in the given
-    /// format. Distinct from `Export` (connection-profile export) — gated on
-    /// `TransferFamily::Sql` so it only appears for SQL-family connections.
-    ExportTablesAs(dbflux_transfer::FileFormat),
+    /// Open the Export wizard for the selected table(s) (or the right-
+    /// clicked table, when it is not part of a larger selection). Distinct
+    /// from `Export` (connection-profile export) — gated on
+    /// `TransferFamily::Sql` so it only appears for SQL-family connections,
+    /// never a driver id.
+    ExportTables,
     /// Open the Import wizard for the connected profile this menu was opened
-    /// on. Gated the same way as `ExportTablesAs` — `TransferFamily::Sql`,
+    /// on. Gated the same way as `ExportTables` — `TransferFamily::Sql`,
     /// never a driver id.
     ImportTables,
     /// Open the Migrate wizard for the selected table(s) (or the right-
     /// clicked table, when it is not part of a larger selection). Gated the
-    /// same way as `ExportTablesAs`/`ImportTables` — `TransferFamily::Sql`,
+    /// same way as `ExportTables`/`ImportTables` — `TransferFamily::Sql`,
     /// never a driver id.
     MigrateTables,
 }
@@ -549,7 +562,7 @@ impl ContextMenuAction {
             // Instance catalog actions
             Self::RefreshInstanceCatalog => Some(AppIcon::RefreshCcw),
             Self::CopyItemId => Some(AppIcon::Copy),
-            Self::ExportTablesAs(_) => Some(AppIcon::ArrowUp),
+            Self::ExportTables => Some(AppIcon::ArrowUp),
             Self::ImportTables => Some(AppIcon::Download),
             Self::MigrateTables => Some(AppIcon::ArrowUpDown),
         }

--- a/crates/dbflux_ui_sidebar/src/operations/export_tables.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/export_tables.rs
@@ -1,24 +1,21 @@
-//! Sidebar entry point for bulk table Export (R8): resolves the sidebar's
-//! current table selection into `dbflux_transfer::export::ExportTable`s and
-//! runs the export on a background thread, wiring progress and cancellation
-//! into the real `TaskManager` (carry-forward guard from Batch 1's verify
-//! report — `on_progress` must reach `TaskManager::update_progress`, and
-//! `TransferOutcome::Cancelled` must reach the real task state).
+//! Sidebar entry point for the Export wizard (R8): resolves the sidebar's
+//! current table selection into `TableRef`s and emits
+//! `SidebarEvent::RequestExportWizard` so the workspace opens the Export
+//! wizard (`dbflux_ui_document::export_wizard`) pre-populated with them.
+//! Unlike the pre-redesign action, this does no I/O and no longer picks a
+//! format from a submenu — the wizard itself owns the folder picker, the
+//! format choice, and running the export
+//! (`dbflux_ui_document::export_wizard::run`).
 
 use crate::*;
-use dbflux_core::{TaskKind, TaskStatus, TaskTarget, TransferColumn, TransferFamily};
-use dbflux_transfer::TableTransferStatus;
-use dbflux_transfer::export::{ExportOptions, ExportTable, ExportedTable, run_export};
-use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
-use std::sync::{Arc, Mutex};
+use dbflux_core::TransferFamily;
 
 /// One table selected in the sidebar for export, resolved from a
-/// `SchemaNodeId::Table` node before any async/background work starts.
+/// `SchemaNodeId::Table` node before the wizard opens.
 struct SelectedTable {
     profile_id: Uuid,
     database: Option<String>,
-    schema: String,
-    name: String,
+    table: TableRef,
 }
 
 fn table_node(item_id: &str) -> Option<SelectedTable> {
@@ -31,8 +28,10 @@ fn table_node(item_id: &str) -> Option<SelectedTable> {
         }) => Some(SelectedTable {
             profile_id,
             database,
-            schema,
-            name,
+            table: TableRef {
+                schema: Some(schema),
+                name,
+            },
         }),
         _ => None,
     }
@@ -42,7 +41,7 @@ fn table_node(item_id: &str) -> Option<SelectedTable> {
 /// will actually be exported, plus how many candidate tables were dropped
 /// because they belong to a different profile/database than the anchor —
 /// surfaced to the user as a non-blocking notice rather than silently
-/// vanishing from the export (carry-forward WARNING from Batch 2's verify).
+/// vanishing from the export.
 struct SelectedTablesResolution {
     tables: Vec<SelectedTable>,
     skipped_other_profile_or_database: usize,
@@ -50,9 +49,9 @@ struct SelectedTablesResolution {
 
 /// Resolves the tables an Export action rooted at `item_id` should cover: the
 /// active multi-selection when `item_id` is part of it, otherwise just
-/// `item_id` itself (matches `batch_delete_label`'s single-vs-batch pattern).
-/// Only tables sharing the right-clicked table's profile AND database are
-/// kept — a single `run_export` call uses one physical connection, and
+/// `item_id` itself (mirrors `select_migrate_tables`). Only tables sharing
+/// the right-clicked table's profile AND database are kept — the wizard's
+/// single `run_export` call uses one physical connection, and
 /// `ConnectionPerDatabase` drivers (MySQL/MariaDB) keep a separate connection
 /// per database. Resolves to an empty selection when `item_id` is not itself
 /// a table.
@@ -95,17 +94,12 @@ impl Sidebar {
 
     /// Number of tables an Export action rooted at `item_id` would cover —
     /// used to relabel the context-menu entry ("Export Table…" vs
-    /// "Export N Tables…"), mirroring `batch_delete_label`.
+    /// "Export N Tables…"), mirroring `migrate_table_selection_count`.
     pub(crate) fn export_table_selection_count(&self, item_id: &str) -> usize {
         self.resolve_export_table_selection(item_id).tables.len()
     }
 
-    pub(crate) fn export_selected_tables(
-        &mut self,
-        item_id: &str,
-        format: dbflux_transfer::FileFormat,
-        cx: &mut Context<Self>,
-    ) {
+    pub(crate) fn request_export_wizard(&mut self, item_id: &str, cx: &mut Context<Self>) {
         let resolution = self.resolve_export_table_selection(item_id);
         let tables = resolution.tables;
 
@@ -131,306 +125,14 @@ impl Sidebar {
             return;
         }
 
-        let connection = match &database {
-            Some(db) => connected.connection_for_database(db),
-            None => connected.connection.clone(),
-        };
-        let driver_id = connected.connection.metadata().id.clone();
-        let profile_name = connected.profile.name.clone();
+        let table_refs: Vec<TableRef> = tables.into_iter().map(|t| t.table).collect();
 
-        let table_specs: Vec<(Option<String>, String)> = tables
-            .into_iter()
-            .map(|t| (Some(t.schema), t.name))
-            .collect();
-        let dialog_available = dbflux_ui_base::file_dialog::is_native_file_dialog_available();
-        let app_state = self.app_state.clone();
-
-        cx.spawn(async move |_this, cx| {
-            let base_dir = if dialog_available {
-                match rfd::AsyncFileDialog::new()
-                    .set_title("Choose Export Folder")
-                    .pick_folder()
-                    .await
-                {
-                    Some(handle) => handle.path().to_path_buf(),
-                    None => return, // user cancelled — no toast, no audit.
-                }
-            } else {
-                match dbflux_ui_base::file_dialog::fallback_export_dir() {
-                    Ok(dir) => dir,
-                    Err(err) => {
-                        cx.update(|cx| {
-                            report_error(
-                                UserFacingError::new(
-                                    ErrorKind::Storage,
-                                    format!(
-                                        "Export failed — no folder picker available and the \
-                                         fallback export directory could not be created: {err}"
-                                    ),
-                                ),
-                                cx,
-                            );
-                        })
-                        .ok();
-                        return;
-                    }
-                }
-            };
-
-            let output_dir = base_dir.join(format!(
-                "dbflux-export-{}",
-                dbflux_core::chrono::Utc::now().format("%Y%m%d-%H%M%S%.3f")
-            ));
-
-            let description = format!("Export {} table(s) from {profile_name}", table_specs.len());
-
-            let Ok((task_id, cancel_token)) = cx.update(|cx| {
-                app_state.update(cx, |state, cx| {
-                    let pair = state.start_task_for_target(
-                        TaskKind::Export,
-                        description,
-                        Some(TaskTarget {
-                            profile_id,
-                            database: database.clone(),
-                        }),
-                    );
-                    cx.emit(AppStateChanged);
-                    pair
-                })
-            }) else {
-                return;
-            };
-
-            let mut export_tables = Vec::with_capacity(table_specs.len());
-            let mut resolve_error = None;
-
-            for (schema, name) in &table_specs {
-                let effective_db = database
-                    .clone()
-                    .unwrap_or_else(|| schema.clone().unwrap_or_default());
-                match connection.table_details(&effective_db, schema.as_deref(), name) {
-                    Ok(info) => {
-                        let columns: Vec<TransferColumn> = info
-                            .columns
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(|c| TransferColumn {
-                                name: c.name,
-                                type_name: Some(c.type_name),
-                                nullable: c.nullable,
-                                is_primary_key: c.is_primary_key,
-                            })
-                            .collect();
-
-                        export_tables.push(ExportTable {
-                            schema: schema.clone(),
-                            name: name.clone(),
-                            columns,
-                            // `TableSource` auto-counts via `SELECT COUNT(*)`
-                            // when this is `None` (falling back to
-                            // indeterminate progress if that query fails),
-                            // so the export path's progress fraction is real
-                            // rather than permanently stuck at 0.
-                            estimated_total: None,
-                        });
-                    }
-                    Err(e) => {
-                        let table_label = match schema {
-                            Some(schema) => format!("{schema}.{name}"),
-                            None => name.clone(),
-                        };
-                        resolve_error = Some(format!("{table_label}: {e}"));
-                        break;
-                    }
-                }
-            }
-
-            if let Some(err) = resolve_error {
-                cx.update(|cx| {
-                    app_state.update(cx, |state, cx| {
-                        state.fail_task(task_id, err.clone());
-                        cx.emit(AppStateChanged);
-                    });
-                    report_error(
-                        UserFacingError::new(
-                            ErrorKind::Driver,
-                            format!("Export failed while reading table schema: {err}"),
-                        ),
-                        cx,
-                    );
-                })
-                .ok();
-                return;
-            }
-
-            // Ticker: polls a shared progress cell every 150ms and pushes it
-            // into the real TaskManager. Self-terminates once the task is no
-            // longer Running (covers success, failure, and cancellation
-            // uniformly without needing a second signal).
-            let progress: Arc<Mutex<(u64, Option<u64>)>> = Arc::new(Mutex::new((0, None)));
-            let ticker_progress = Arc::clone(&progress);
-            let ticker_app_state = app_state.clone();
-            cx.spawn(async move |cx| {
-                loop {
-                    cx.background_executor()
-                        .timer(std::time::Duration::from_millis(150))
-                        .await;
-
-                    let still_running = cx
-                        .update(|cx| {
-                            ticker_app_state.update(cx, |state, cx| {
-                                let Some(snapshot) = state.tasks().get(task_id) else {
-                                    return false;
-                                };
-                                if snapshot.status != TaskStatus::Running {
-                                    return false;
-                                }
-
-                                let (rows_done, estimated_total) = *ticker_progress
-                                    .lock()
-                                    .unwrap_or_else(|poisoned| poisoned.into_inner());
-                                if let Some(total) = estimated_total
-                                    && total > 0
-                                {
-                                    let fraction =
-                                        (rows_done as f32 / total as f32).clamp(0.0, 1.0);
-                                    state.tasks_mut().update_progress(task_id, fraction);
-                                    cx.notify();
-                                }
-
-                                true
-                            })
-                        })
-                        .unwrap_or(false);
-
-                    if !still_running {
-                        break;
-                    }
-                }
-            })
-            .detach();
-
-            let database_for_options = database.clone().unwrap_or_default();
-
-            let export_result = cx
-                .background_executor()
-                .spawn({
-                    let connection = connection.clone();
-                    let cancel_token = cancel_token.clone();
-                    let progress = Arc::clone(&progress);
-                    let output_dir = output_dir.clone();
-                    async move {
-                        let options = ExportOptions {
-                            driver_id: &driver_id,
-                            database: &database_for_options,
-                            format,
-                            segment_size: 500,
-                        };
-
-                        run_export(
-                            &connection,
-                            &export_tables,
-                            &output_dir,
-                            &options,
-                            &cancel_token,
-                            move |_table_index, rows_done, estimated_total| {
-                                if let Ok(mut guard) = progress.lock() {
-                                    *guard = (rows_done, estimated_total);
-                                }
-                            },
-                        )
-                    }
-                })
-                .await;
-
-            cx.update(|cx| match export_result {
-                Ok(outcome) if outcome.cancelled => {
-                    app_state.update(cx, |state, cx| {
-                        state.tasks_mut().cancel(task_id);
-                        cx.emit(AppStateChanged);
-                    });
-                }
-                Ok(outcome) => {
-                    let failed_table = outcome.tables.iter().find_map(|t| match &t.status {
-                        TableTransferStatus::Failed { error } => {
-                            Some((t.name.clone(), error.clone()))
-                        }
-                        _ => None,
-                    });
-
-                    if let Some((table, error)) = &failed_table {
-                        app_state.update(cx, |state, cx| {
-                            state.fail_task_with_details(
-                                task_id,
-                                format!("{table}: {error}"),
-                                itemized_table_details(&outcome.tables),
-                            );
-                            cx.emit(AppStateChanged);
-                        });
-                        report_error(
-                            UserFacingError::new(
-                                ErrorKind::Driver,
-                                format!("Export failed on table '{table}': {error}"),
-                            ),
-                            cx,
-                        );
-                    } else {
-                        let completed = outcome
-                            .tables
-                            .iter()
-                            .filter(|t| matches!(t.status, TableTransferStatus::Completed { .. }))
-                            .count();
-                        app_state.update(cx, |state, cx| {
-                            state.complete_task(task_id);
-                            cx.emit(AppStateChanged);
-                        });
-                        dbflux_ui_base::toast::Toast::success(format!(
-                            "Exported {completed} table(s) to {}",
-                            output_dir.display()
-                        ))
-                        .push(cx);
-                    }
-                }
-                Err(e) => {
-                    app_state.update(cx, |state, cx| {
-                        state.fail_task(task_id, e.to_string());
-                        cx.emit(AppStateChanged);
-                    });
-                    report_error(
-                        UserFacingError::new(ErrorKind::Driver, format!("Export failed: {e}")),
-                        cx,
-                    );
-                }
-            })
-            .ok();
-        })
-        .detach();
+        cx.emit(SidebarEvent::RequestExportWizard {
+            profile_id,
+            database,
+            tables: table_refs,
+        });
     }
-}
-
-/// Renders one status line per planned table for the Tasks panel's expandable
-/// details, so a mid-run failure (R4-002/B-007) shows exactly which tables
-/// succeeded, which one failed with what error, and which were never
-/// attempted — instead of only the last error in a single toast.
-fn itemized_table_details(tables: &[ExportedTable]) -> String {
-    tables
-        .iter()
-        .map(|t| {
-            let label = match &t.schema {
-                Some(schema) => format!("{schema}.{}", t.name),
-                None => t.name.clone(),
-            };
-            match &t.status {
-                TableTransferStatus::Completed { rows } => {
-                    format!("{label}: completed ({rows} row(s))")
-                }
-                TableTransferStatus::Skipped => format!("{label}: skipped"),
-                TableTransferStatus::Failed { error } => format!("{label}: FAILED — {error}"),
-                TableTransferStatus::NotStarted => format!("{label}: not attempted"),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
 }
 
 #[cfg(test)]
@@ -465,7 +167,7 @@ mod tests {
         let resolved = select_export_tables(&item_id, &selection);
 
         assert_eq!(resolved.tables.len(), 1);
-        assert_eq!(resolved.tables[0].name, "users");
+        assert_eq!(resolved.tables[0].table.name, "users");
         assert_eq!(resolved.skipped_other_profile_or_database, 0);
     }
 
@@ -481,7 +183,11 @@ mod tests {
 
         let resolved = select_export_tables(&users, &selection);
 
-        let mut names: Vec<&str> = resolved.tables.iter().map(|t| t.name.as_str()).collect();
+        let mut names: Vec<&str> = resolved
+            .tables
+            .iter()
+            .map(|t| t.table.name.as_str())
+            .collect();
         names.sort_unstable();
         assert_eq!(names, vec!["items", "orders", "users"]);
         assert_eq!(resolved.skipped_other_profile_or_database, 0);
@@ -499,7 +205,7 @@ mod tests {
         let resolved = select_export_tables(&anchor, &selection);
 
         assert_eq!(resolved.tables.len(), 1);
-        assert_eq!(resolved.tables[0].name, "users");
+        assert_eq!(resolved.tables[0].table.name, "users");
         assert_eq!(profile_id_of(&resolved.tables[0]), profile_a);
         assert_eq!(
             resolved.skipped_other_profile_or_database, 1,
@@ -517,7 +223,7 @@ mod tests {
         let resolved = select_export_tables(&anchor, &selection);
 
         assert_eq!(resolved.tables.len(), 1);
-        assert_eq!(resolved.tables[0].name, "users");
+        assert_eq!(resolved.tables[0].table.name, "users");
         assert_eq!(resolved.skipped_other_profile_or_database, 1);
     }
 
@@ -531,7 +237,7 @@ mod tests {
         let resolved = select_export_tables(&anchor, &selection);
 
         assert_eq!(resolved.tables.len(), 1);
-        assert_eq!(resolved.tables[0].name, "users");
+        assert_eq!(resolved.tables[0].table.name, "users");
         assert_eq!(
             resolved.skipped_other_profile_or_database, 0,
             "a non-table selection member is not a data-transfer skip"


### PR DESCRIPTION
## Summary

- Replaces the immediate `Export Table… ›` submenu (**as CSV** / **as JSON**, which fired an export the moment you clicked) with a **modal wizard** where you pick the format from a list, choose the output folder, and adjust options before running — with live progress and cancellation.
- Extracts one **shared phase-rail composite** so the migrate, export, and **import** wizards render the same rail chrome instead of three copies.

Review it commit-by-commit (each is one self-contained slice):
1. `refactor(ui): extract shared wizard rail composite` — foundation, behavior-preserving.
2. `feat(ui): rail-based export wizard…` — the new wizard + sidebar/workspace wiring.
3. `feat(ui): put the import wizard on the shared phase rail` — chrome-only retrofit.

## What does this resolve?

The old export UX had two problems the user raised:

- **No control / not a real workflow.** Clicking `as CSV` immediately ran a folder-bundle export with only a native folder picker — no place to review what would be exported or tune anything. Now it opens a wizard "where you do things".
- **Format selection didn't scale.** Formats were submenu arms. They're now a **list inside the modal**, sourced from `FileFormat` so adding a format later is a one-line change.

No linked issue — raised directly by the user.

## How was this solved?

| Area | Decision |
|------|----------|
| Wizard shape | Rail-based modal (Tables → Format & Options → Confirm → Run), single-entity state machine wearing the migrate rail chrome. |
| Shared rail | New domain-free `dbflux_components::composites::wizard_rail` taking an **optional** click handler. Migrate keeps its clickable rail (`on_select: Some`); export and import are **display-only** (`on_select: None`). |
| Export engine | Reuses `dbflux_transfer::export::run_export` / `ExportOptions` **unchanged** — same streaming (segment size, now an advanced field defaulting to 500), TaskManager task, cancellation, per-table failure reporting, and timestamped folder-bundle + `manifest.json` output. Execution logic moved out of the sidebar closure into `export_wizard/run.rs`. |
| Sidebar | `Export Table… ›` submenu + `ExportTablesAs(FileFormat)` collapse to a single `ContextMenuAction::ExportTables` → new `SidebarEvent::RequestExportWizard`; the sidebar op is now emit-only, mirroring Migrate. |
| Hosting | Persistent `export_wizard` workspace field + `is_visible()` render gate + re-entry guard, mirroring `MigrateWizard`. |
| Import | Retrofitted onto the shared rail, **chrome-only** — step logic, destructive-confirm branch, and footer nav unchanged. |

**Intentionally out of scope:** no new export formats (CSV/JSON only), no changes to the transfer engine, and the rail is display-only for export/import by design (migrate stays clickable).

## Validation

All from the `feat/export-wizard` worktree:

- `cargo check -p dbflux --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws` — clean.
- `cargo nextest run -p dbflux_ui_document` — 640 passed / 3 skipped (includes migrate's rail tests, import's destructive-confirm tests, and **8 new unit tests** for the export run-outcome logic).
- `cargo nextest run -p dbflux_ui_sidebar` — 113 passed.
- `cargo clippy -p dbflux_ui_document -p dbflux_ui_sidebar -p dbflux_ui -p dbflux_components -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- Fresh-context spec verification: 0 CRITICAL; all 15 acceptance scenarios map to real code.

**Not done here (please cover in review):** a manual GPUI smoke pass — this environment has no running app harness. Suggested manual check: right-click a table → **Export Table…** → wizard opens → pick format / folder / segment size → **Run** → confirm the bundle + `manifest.json` land; and confirm the migrate / import / export rails all render.

## Where was this tested?

- [x] Local development environment (type-check + unit tests)
- [x] Automated tests (unit)
- [ ] Linux — runtime/manual pending
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s) — unit-tested + spec-verified; **runtime/manual smoke pending** (no GPUI harness here)
- [x] I added or updated tests when needed — export run-outcome unit tests; migrate/import behavior preserved and their tests kept green
- [x] I documented follow-up work or known limitations when applicable — manual smoke flagged above
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible — N/A: the SQL export/transfer UI is itself unreleased (`[Unreleased]`), so this changes no released behavior
- [x] I applied the appropriate labels

## Labels to apply

- `ui:feature`
- `size:exception` (≈1400 lines; consolidated by design — foundation + export wizard + import retrofit are one workstream, reviewable per commit)
