### PR TITLE
fix(ui): prevent duplicate settings windows on close

### DIFF
--- a/crates/dbflux_ui_windows/src/settings/open_window.rs
+++ b/crates/dbflux_ui_windows/src/settings/open_window.rs
@@ -56,17 +56,9 @@ pub fn open_or_focus_settings<S>(
     };
     platform::apply_window_options(&mut options, 800.0, 600.0);
 
-    let app_state_for_close = app_state.clone();
     let app_state_for_new = app_state.clone();
 
     let open_result = cx.open_window(options, move |window, cx| {
-        window.on_window_should_close(cx, move |_window, cx| {
-            app_state_for_close.update(cx, |state, _| {
-                state.settings_window = None;
-            });
-            true
-        });
-
         let settings = cx.new(|cx| match section {
             Some(section) => {
                 SettingsCoordinator::new_with_section(app_state_for_new, section, window, cx)


### PR DESCRIPTION
## Summary

Prevents a second Settings window from opening while the previous native window is still closing. The singleton handle now remains registered until GPUI reports it as invalid.

## What does this resolve?

Tracked as Atlas task **DBF-164**: Windows can open multiple Settings windows. The same lifecycle weakness can affect macOS, although it has not been reproduced there. There is no linked GitHub issue.

## How was this solved?

`open_or_focus_settings` previously cleared `AppStateEntity::settings_window` from `on_window_should_close`. That callback runs before native window destruction, creating a period where DBFlux advertises that no Settings window exists while the old window is still closing.

The pre-close mutation was removed. Existing opens still focus the registered window, and the existing `WindowHandle::update` failure path clears a genuinely stale handle before opening a replacement.

**Out of scope:** Connection Manager and its native SSO window can also open multiple instances, but the product does not currently establish that those windows should be singletons.

## Validation

- `cargo fmt --all --check` — passed.
- `cargo check -p dbflux_ui_windows` — passed.
- `git diff --check` — passed.
- No automated native-window lifecycle test exists in this crate. Runtime smoke testing on Windows and macOS remains pending.

## Where was this tested?

- [x] Local development environment
- [ ] Automated tests
- [ ] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s) — native Windows/macOS smoke testing is pending
- [ ] I added or updated tests when needed — no native window-lifecycle test seam exists
- [x] I documented follow-up work or known limitations when applicable
- [x] I supplied the user-visible changelog entry through the Conventional Commit; no manual `CHANGELOG.md` edit
- [x] I applied the appropriate labels

## Labels to apply

- `ui:bug`
- `platform:windows`
- `rust`
- `status:needs-review`