### PR TITLE
fix(mcp): make dbflux mcp start and expose its tool catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ All notable changes to DBFlux will be documented in this file.
 
 ### Fixed
 
+* **Standalone MCP server failed to start and listed no tools** — The
+  governance binding role/policy repositories queried table names that did not
+  match the migrated schema, so `dbflux mcp` aborted with "no such table" for
+  any profile with a governance binding (the same mismatch also broke saving
+  these bindings in the main app). Startup then panicked on a blocking lock
+  read inside the async runtime, and `tools/list` returned an empty catalog
+  because the tool handler served an empty router instead of the combined one.
+
 * **SSH tunnel / proxy list icon vanishing on long hosts** — The globe icon in
   the Settings SSH tunnels and proxies lists could be squeezed to zero width by
   long, unbreakable hostnames (e.g. EC2 `ec2-…compute.amazonaws.com` addresses),

--- a/crates/dbflux_mcp_server/src/lib.rs
+++ b/crates/dbflux_mcp_server/src/lib.rs
@@ -51,7 +51,7 @@ pub async fn run_mcp_server(args: McpServerArgs) -> anyhow::Result<()> {
     // to the audit database.  The clone shares the underlying SQLite
     // connection with the service held by McpRuntime.
     if let Some(ref handle) = bridge_handle {
-        let audit_clone = state.runtime.blocking_read().audit_service().clone();
+        let audit_clone = state.runtime.read().await.audit_service().clone();
         if let Err(err) = handle.install_sink(Arc::new(audit_clone)) {
             log::warn!("Failed to install audit bridge sink: {err}");
         }

--- a/crates/dbflux_mcp_server/src/server.rs
+++ b/crates/dbflux_mcp_server/src/server.rs
@@ -370,7 +370,6 @@ pub(crate) struct DbFluxServer {
     pub(crate) state: ServerState,
     #[allow(dead_code)] // Used for policy evaluation
     pub(crate) governance: GovernanceMiddleware,
-    #[allow(dead_code)] // Built by the #[tool_router] macro; held to keep tool routes alive
     pub(crate) tool_router: ToolRouter<DbFluxServer>,
 }
 

--- a/crates/dbflux_mcp_server/src/server.rs
+++ b/crates/dbflux_mcp_server/src/server.rs
@@ -642,7 +642,7 @@ impl DbFluxServer {
     }
 }
 
-#[tool_handler]
+#[tool_handler(router = self.tool_router)]
 impl ServerHandler for DbFluxServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(
@@ -801,6 +801,25 @@ mod tests {
             connection_setup_lock: Arc::new(tokio::sync::Mutex::new(())),
             secret_manager: Arc::new(dbflux_core::SecretManager::new(Box::new(NoopSecretStore))),
             mcp_enabled_by_default: true,
+        }
+    }
+
+    #[tokio::test]
+    async fn server_handler_exposes_tools_from_all_sub_routers() {
+        let driver = Arc::new(FakeDriver::new(DbKind::Postgres)) as Arc<dyn DbDriver>;
+        let profile = ConnectionProfile::new("test-pg", DbConfig::default_postgres());
+        let state = test_state_with_driver("postgres", driver, profile);
+
+        let server = DbFluxServer::new(state);
+        let tools = server.tool_router.list_all();
+
+        assert!(!tools.is_empty(), "combined tool router must not be empty");
+        for tool in tools {
+            assert!(
+                ServerHandler::get_tool(&server, &tool.name).is_some(),
+                "tool '{}' must be exposed through the ServerHandler",
+                tool.name
+            );
         }
     }
 

--- a/crates/dbflux_storage/src/repositories/connection_profile_governance_binding_policies.rs
+++ b/crates/dbflux_storage/src/repositories/connection_profile_governance_binding_policies.rs
@@ -28,7 +28,7 @@ impl ConnectionProfileGovernanceBindingPoliciesRepository {
             .prepare(
                 r#"
                 SELECT id, binding_id, policy_id
-                FROM cfg_connection_profile_governance_binding_policies
+                FROM cfg_connection_profile_gov_binding_policies
                 WHERE binding_id = ?1
                 ORDER BY policy_id ASC
                 "#,
@@ -77,7 +77,7 @@ impl ConnectionProfileGovernanceBindingPoliciesRepository {
         self.conn()
             .execute(
                 r#"
-                INSERT INTO cfg_connection_profile_governance_binding_policies
+                INSERT INTO cfg_connection_profile_gov_binding_policies
                     (id, binding_id, policy_id)
                 VALUES (?1, ?2, ?3)
                 "#,
@@ -94,7 +94,7 @@ impl ConnectionProfileGovernanceBindingPoliciesRepository {
     pub fn delete_for_binding(&self, binding_id: &str) -> Result<(), StorageError> {
         self.conn()
             .execute(
-                "DELETE FROM cfg_connection_profile_governance_binding_policies WHERE binding_id = ?1",
+                "DELETE FROM cfg_connection_profile_gov_binding_policies WHERE binding_id = ?1",
                 [binding_id],
             )
             .map_err(|source| StorageError::Sqlite {

--- a/crates/dbflux_storage/src/repositories/connection_profile_governance_binding_roles.rs
+++ b/crates/dbflux_storage/src/repositories/connection_profile_governance_binding_roles.rs
@@ -28,7 +28,7 @@ impl ConnectionProfileGovernanceBindingRolesRepository {
             .prepare(
                 r#"
                 SELECT id, binding_id, role_id
-                FROM cfg_connection_profile_governance_binding_roles
+                FROM cfg_connection_profile_gov_binding_roles
                 WHERE binding_id = ?1
                 ORDER BY role_id ASC
                 "#,
@@ -77,7 +77,7 @@ impl ConnectionProfileGovernanceBindingRolesRepository {
         self.conn()
             .execute(
                 r#"
-                INSERT INTO cfg_connection_profile_governance_binding_roles (id, binding_id, role_id)
+                INSERT INTO cfg_connection_profile_gov_binding_roles (id, binding_id, role_id)
                 VALUES (?1, ?2, ?3)
                 "#,
                 params![role.id, role.binding_id, role.role_id],
@@ -93,7 +93,7 @@ impl ConnectionProfileGovernanceBindingRolesRepository {
     pub fn delete_for_binding(&self, binding_id: &str) -> Result<(), StorageError> {
         self.conn()
             .execute(
-                "DELETE FROM cfg_connection_profile_governance_binding_roles WHERE binding_id = ?1",
+                "DELETE FROM cfg_connection_profile_gov_binding_roles WHERE binding_id = ?1",
                 [binding_id],
             )
             .map_err(|source| StorageError::Sqlite {

--- a/crates/dbflux_storage/tests/governance_binding_repos.rs
+++ b/crates/dbflux_storage/tests/governance_binding_repos.rs
@@ -1,0 +1,106 @@
+/// Tests for the governance binding role/policy repositories, running the
+/// repository SQL against the fully migrated schema.
+use dbflux_storage::bootstrap::StorageRuntime;
+use dbflux_storage::repositories::connection_profile_governance_binding_policies::ConnectionProfileGovernanceBindingPolicyDto;
+use dbflux_storage::repositories::connection_profile_governance_binding_roles::ConnectionProfileGovernanceBindingRoleDto;
+use dbflux_storage::repositories::connection_profile_governance_bindings::ConnectionProfileGovernanceBindingDto;
+
+/// Builds a migrated runtime with one profile and one governance binding,
+/// returning the runtime and the binding id.
+fn runtime_with_binding() -> (StorageRuntime, String) {
+    let runtime = StorageRuntime::in_memory().expect("runtime should initialize");
+
+    let profile_id = uuid::Uuid::new_v4().to_string();
+    runtime
+        .open_dbflux_db()
+        .expect("should open dbflux.db")
+        .execute(
+            "INSERT INTO cfg_connection_profiles (id, name) VALUES (?1, 'P')",
+            [&profile_id],
+        )
+        .expect("should insert profile");
+
+    let binding = ConnectionProfileGovernanceBindingDto {
+        id: uuid::Uuid::new_v4().to_string(),
+        profile_id,
+        actor_id: "test-actor".to_string(),
+        order_index: 0,
+    };
+    runtime
+        .connection_profiles()
+        .governance_bindings()
+        .insert(&binding)
+        .expect("should insert governance binding");
+
+    (runtime, binding.id)
+}
+
+#[test]
+fn governance_binding_roles_are_persisted_and_loaded_per_binding() {
+    let (runtime, binding_id) = runtime_with_binding();
+    let roles_repo = runtime.connection_profiles().governance_binding_roles();
+
+    for role_id in ["role-b", "role-a"] {
+        roles_repo
+            .insert(&ConnectionProfileGovernanceBindingRoleDto::new(
+                binding_id.clone(),
+                role_id.to_string(),
+            ))
+            .expect("should insert binding role");
+    }
+
+    let role_ids: Vec<String> = roles_repo
+        .get_for_binding(&binding_id)
+        .expect("should load binding roles")
+        .into_iter()
+        .map(|role| role.role_id)
+        .collect();
+    assert_eq!(role_ids, ["role-a", "role-b"], "roles sorted by role_id");
+
+    roles_repo
+        .delete_for_binding(&binding_id)
+        .expect("should delete binding roles");
+    assert!(
+        roles_repo
+            .get_for_binding(&binding_id)
+            .expect("should load binding roles after delete")
+            .is_empty()
+    );
+}
+
+#[test]
+fn governance_binding_policies_are_persisted_and_loaded_per_binding() {
+    let (runtime, binding_id) = runtime_with_binding();
+    let policies_repo = runtime.connection_profiles().governance_binding_policies();
+
+    for policy_id in ["policy-b", "policy-a"] {
+        policies_repo
+            .insert(&ConnectionProfileGovernanceBindingPolicyDto::new(
+                binding_id.clone(),
+                policy_id.to_string(),
+            ))
+            .expect("should insert binding policy");
+    }
+
+    let policy_ids: Vec<String> = policies_repo
+        .get_for_binding(&binding_id)
+        .expect("should load binding policies")
+        .into_iter()
+        .map(|policy| policy.policy_id)
+        .collect();
+    assert_eq!(
+        policy_ids,
+        ["policy-a", "policy-b"],
+        "policies sorted by policy_id"
+    );
+
+    policies_repo
+        .delete_for_binding(&binding_id)
+        .expect("should delete binding policies");
+    assert!(
+        policies_repo
+            .get_for_binding(&binding_id)
+            .expect("should load binding policies after delete")
+            .is_empty()
+    );
+}


### PR DESCRIPTION
## Summary

Fixes three startup bugs that made the standalone MCP server (`dbflux mcp --client-id <id>`) unusable: a table-name
mismatch in the governance storage layer, a panic while installing the audit bridge sink, and an empty `tools/list`
response caused by an rmcp macro default change. Adds regression tests for the storage and tool-router fixes.

## What does this resolve?

No linked issue; found while setting up the MCP server locally. It failed in three stages, each fix uncovering the next:

1. Startup aborted with `no such table: cfg_connection_profile_governance_binding_roles` for any profile with a governance
binding.
2. Once past that, it panicked with `Cannot block the current thread from within a runtime` at `lib.rs:54`.
3. Once running, clients connected but `tools/list` returned an empty list.

## How was this solved?

- **Storage:** The initial migration creates the binding role/policy tables as `cfg_connection_profile_gov_binding_*`, but
the repositories queried the full-word `cfg_connection_profile_governance_binding_*` names. This did not only break MCP startup: the main app uses the same repositories, so per-profile governance binding roles and policies were silently broken there too. The repository SQL now matches the migrated schema. No data migration is needed: the mismatched tables were never writable, so they are empty everywhere.
- **Startup panic:** `run_mcp_server` is async but acquired the runtime lock via `blocking_read()`, which tokio forbids on
runtime worker threads. Replaced with `read().await`.
- **Empty tool list:** rmcp's `#[tool_handler]` macro defaults to `Self::tool_router()`, the static router of its own impl block, which has no tools. The combined router built in `DbFluxServer::new()` was never served, broken since the tool sub-router split in `3260f8b8`. The router field is now passed explicitly via `#[tool_handler(router = self.tool_router)]`.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [ ] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

`mcp:bug`, `mcp`

<!--
Pick the labels that match this PR. Maintainers may adjust during review.
Full guide: CONTRIBUTING.md#label-guide

- Kind (required, choose at least one): `*:bug` or `*:feature` for the affected area
  (e.g. `ui:feature`, `driver:bug`, `mcp:feature`, `query:bug`, `rpc:feature`, …)
- Driver (if driver-specific): `driver:postgres`, `driver:mongodb`, `driver:sqlite`,
  `driver:mysql/mariadb`, `driver:dynamodb`, `driver:redis`
- Subsystem flags: `aws`, `proxy`, `ssh`, `query`, `driver`, `mcp`
- Data model: `kind:sql`, `kind:document`, `kind:kv`, `kind:log`
- Platform (if platform-specific): `platform:linux`, `platform:macos`, `platform:windows`
- Arch (if arch-specific): `arch:amd64`, `arch:arm64`
- RPC subtype: `rpc:auth`, `rpc:driver`
-->

