### PR TITLE
fix(app): run graceful shutdown on SIGINT and SIGTERM

### DIFF
--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -33,6 +33,7 @@ use interprocess::local_socket::{
 use log::info;
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -54,6 +55,60 @@ const TASK_CANCEL_TIMEOUT: Duration = Duration::from_millis(2000);
 const CONNECTION_CLOSE_TIMEOUT: Duration = Duration::from_millis(3000);
 const TOTAL_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(10000);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Cadence for observing `SHUTDOWN_SIGNAL_RECEIVED`. Deliberately coarser than
+/// `POLL_INTERVAL`: this timer lives for the whole process lifetime, so it is
+/// traded against idle wakeups. The added latency is imperceptible to a user
+/// pressing Ctrl+C.
+#[cfg(unix)]
+const SIGNAL_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Set by `handle_shutdown_signal` when SIGINT or SIGTERM arrives; polled on
+/// the GPUI foreground thread so the same graceful-shutdown path used by
+/// window close also runs for terminal signals.
+#[cfg(unix)]
+static SHUTDOWN_SIGNAL_RECEIVED: AtomicBool = AtomicBool::new(false);
+
+/// Signal handler for SIGINT and SIGTERM.
+///
+/// This runs in an async-signal-unsafe context (arbitrary interrupted code,
+/// possibly mid-allocation or mid-lock), so it must only perform
+/// async-signal-safe operations. Setting an `AtomicBool` is safe; anything
+/// else (logging, allocating, taking locks) is not. The actual shutdown work
+/// happens later, on the GPUI foreground thread, once the flag is observed.
+#[cfg(unix)]
+extern "C" fn handle_shutdown_signal(_signum: std::ffi::c_int) {
+    SHUTDOWN_SIGNAL_RECEIVED.store(true, Ordering::SeqCst);
+}
+
+/// Registers `handle_shutdown_signal` for SIGINT and SIGTERM via `sigaction`.
+///
+/// `SA_RESTART` is required: without it, installing these handlers would make
+/// blocking syscalls elsewhere in the process (IPC accept/read, driver I/O)
+/// fail with `EINTR` on every delivery.
+#[cfg(unix)]
+fn install_shutdown_signal_handlers() {
+    let mut action: libc::sigaction = unsafe { std::mem::zeroed() };
+    action.sa_sigaction = handle_shutdown_signal as *const () as usize;
+    action.sa_flags = libc::SA_RESTART;
+    unsafe {
+        libc::sigemptyset(&mut action.sa_mask);
+    }
+
+    for (signum, name) in [(libc::SIGINT, "SIGINT"), (libc::SIGTERM, "SIGTERM")] {
+        let result = unsafe { libc::sigaction(signum, &action, std::ptr::null_mut()) };
+
+        if result != 0 {
+            log::warn!(
+                "Failed to install {name} handler, graceful shutdown on {name} unavailable: {}",
+                io::Error::last_os_error()
+            );
+        }
+    }
+}
+
+#[cfg(not(unix))]
+fn install_shutdown_signal_handlers() {}
 
 /// Installs a chained best-effort panic hook that:
 /// 1. Attempts to record the panic via AuditService::record_panic_best_effort
@@ -384,20 +439,7 @@ fn run_gui() {
                         return false;
                     }
 
-                    info!("Starting graceful shutdown...");
-                    let initiated_shutdown =
-                        app_state_for_close.update(cx, |state, _| state.begin_shutdown());
-
-                    if initiated_shutdown {
-                        let audit_service = app_state_for_close.read(cx).audit_service().clone();
-                        emit_system_shutdown(&audit_service);
-
-                        let app_state_shutdown = app_state_for_close.clone();
-                        cx.spawn(async move |cx| {
-                            run_shutdown_sequence(app_state_shutdown, cx).await;
-                        })
-                        .detach();
-                    }
+                    initiate_graceful_shutdown(&app_state_for_close, cx);
 
                     false
                 });
@@ -405,7 +447,53 @@ fn run_gui() {
             .unwrap_or_else(|error| {
                 log::warn!("Failed to install window close handler: {:?}", error);
             });
+
+        install_shutdown_signal_handlers();
+
+        #[cfg(unix)]
+        {
+            let app_state_for_signal = app_state.clone();
+            cx.spawn(async move |cx| {
+                loop {
+                    cx.background_executor().timer(SIGNAL_POLL_INTERVAL).await;
+
+                    if !SHUTDOWN_SIGNAL_RECEIVED.load(Ordering::SeqCst) {
+                        continue;
+                    }
+
+                    info!("Received shutdown signal from terminal");
+
+                    if let Err(error) = cx.update(|cx| {
+                        initiate_graceful_shutdown(&app_state_for_signal, cx);
+                    }) {
+                        log::warn!("Failed to start shutdown from signal: {:?}", error);
+                    }
+
+                    break;
+                }
+            })
+            .detach();
+        }
     });
+}
+
+/// Single entry point for graceful shutdown, reached from both window close
+/// and OS signals (SIGINT/SIGTERM). Marks shutdown as begun, records the
+/// audit event, and spawns the async shutdown sequence.
+fn initiate_graceful_shutdown(app_state: &Entity<AppStateEntity>, cx: &mut App) {
+    info!("Starting graceful shutdown...");
+    let initiated_shutdown = app_state.update(cx, |state, _| state.begin_shutdown());
+
+    if initiated_shutdown {
+        let audit_service = app_state.read(cx).audit_service().clone();
+        emit_system_shutdown(&audit_service);
+
+        let app_state_shutdown = app_state.clone();
+        cx.spawn(async move |cx| {
+            run_shutdown_sequence(app_state_shutdown, cx).await;
+        })
+        .detach();
+    }
 }
 
 async fn run_shutdown_sequence(app_state: Entity<AppStateEntity>, cx: &mut AsyncApp) {


### PR DESCRIPTION
## Summary

Ctrl+C in a terminal killed DBFlux with the default SIGINT action, skipping the whole shutdown sequence. SIGTERM (`kill`, logout, service managers) had the same problem. The graceful path was only reachable from `on_window_should_close`, so signals bypassed it entirely: no `system_shutdown` audit event, in-flight audit events dropped without a bridge flush, connections killed hard, and managed RPC/auth-provider host processes left running.

Both signals now run exactly the same sequence as closing the window.

## Approach

The change is confined to `crates/dbflux/src/main.rs` and adds no dependencies (`libc` was already a `cfg(unix)` dep of the binary).

- **Single entry point** — the body of the window-close handler moves into `initiate_graceful_shutdown`, so window close and signals share one path. `on_window_should_close` keeps its existing return-value semantics.
- **Signal handler** — `sigaction` for SIGINT and SIGTERM. The handler only does an `AtomicBool` store, which is the sole async-signal-safe thing it can do; the real work happens on the GPUI foreground thread once the flag is observed. Registration failure logs a warning rather than panicking.
- **`SA_RESTART`** — set deliberately. Without it, installing these handlers would make blocking syscalls elsewhere in the process (IPC accept/read, driver I/O) fail with `EINTR` on every delivery.
- **Polling cadence** — a dedicated 250ms interval rather than the existing 50ms `POLL_INTERVAL`, because this timer lives for the whole process lifetime and is traded against idle wakeups. The latency is imperceptible when pressing Ctrl+C.

A second signal is intentionally ignored: the existing `TOTAL_SHUTDOWN_TIMEOUT` already bounds the sequence at 10s, so it cannot hang. Unix only — the binary is `windows_subsystem = "windows"` and has no console to receive Ctrl+C.

## Test plan

Manually smoke-tested against the real GUI binary on Linux/Wayland; both signals ran the full sequence and the process exited cleanly.

`kill -TERM`:
```
INFO dbflux: Received shutdown signal from terminal
INFO dbflux: Starting graceful shutdown...
INFO dbflux: Shutdown phase: Cancelling tasks...
INFO dbflux: All tasks finished
INFO dbflux: Shutdown phase: Closing connections...
INFO dbflux_core::connection::manager: Closed 0 connections during shutdown
INFO dbflux: Shutdown phase: Flushing logs...
INFO dbflux: Shutdown complete in 200.434113ms
```

`kill -INT` produced the same sequence and exited cleanly.

The audit event that the issue reported as lost is now persisted for both signals:

```
$ sqlite3 ~/.local/share/dbflux/dbflux.db "select created_at, action, outcome from aud_audit_events where action like '%shutdown%' order by created_at_epoch_ms desc limit 2;"
2026-07-17 12:57:05|system_shutdown|success   <- SIGINT
2026-07-17 12:56:35|system_shutdown|success   <- SIGTERM
```

Also run: `cargo check`, `cargo clippy -- -D warnings`, and `cargo fmt --all` on `-p dbflux` with the full driver feature set — all clean.

Closes #303