### PR TITLE
docs: document platform concepts and driver authoring

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture
 
+For the conceptual model and contract boundaries, begin with [Key Concepts](docs/CONCEPTS.md). This document remains canonical for crate boundaries and key files.
+
 ## Overview
 
 - DBFlux is a keyboard-first database client built with Rust and GPUI, focused on fast workflows and a clean desktop UI (README.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thanks for considering a contribution. This guide explains how to file issues, o
 ## Quick Links
 
 - [Architecture overview](ARCHITECTURE.md)
+- [Driver authoring guide](docs/DRIVER_AUTHORING.md)
 - [Release process and branching model](docs/RELEASE.md)
 - [Audit event schema](docs/AUDIT.md)
 - [Driver RPC protocol](docs/DRIVER_RPC_PROTOCOL.md)

--- a/README.md
+++ b/README.md
@@ -1,38 +1,50 @@
 # DBFlux
 
-A fast, keyboard-first database client built with Rust and GPUI.
+An extensible, keyboard-first data platform delivered as a Rust + GPUI desktop client.
 
 ## Overview
 
-DBFlux is an open-source database client written in Rust, built with GPUI (Zed's UI framework). It focuses on performance, a clean UX, and keyboard-first workflows.
+DBFlux is an open-source desktop client with built-in drivers for relational and non-relational databases. Its core contracts are driver-neutral, and external drivers can integrate over RPC.
 
-The long-term goal is to provide a fully open-source alternative to DBeaver, supporting both relational and non-relational databases.
+The client focuses on performance, a clean UX, and keyboard-first workflows. The long-term goal is to provide a fully open-source alternative to DBeaver.
 
 ![DBFlux](resources/dbflux.png)
 
 ## Documentation
 
-### User guides
+Choose the path that matches what you want to do.
 
-- [Usage Guide](docs/USAGE.md) — getting started: connect, query, chart, export
-- [Connecting — Advanced Setup](docs/CONNECTIONS.md) — SSH tunnels, proxies, AWS SSO auth profiles, value sources
-- [Settings & Hooks](docs/SETTINGS.md) — every Settings section and connection hooks
-- [Data & Privacy](docs/DATA_AND_PRIVACY.md) — where your data and secrets live, backup and reset
-- [Dashboards & Audit — User Guide](docs/DASHBOARDS_AND_AUDIT.md) — charts, dashboards, instance metrics, audit viewer
-- [Drivers Overview](docs/DRIVERS.md) — supported databases, capabilities, limitations
+### Start here
+
+| Goal | Guide |
+|------|-------|
+| Create a connection | Start with the [Usage Guide](docs/USAGE.md#1-first-launch-and-creating-a-connection). For SSH tunnels, proxies, AWS SSO, and value sources, use [Connecting — Advanced Setup](docs/CONNECTIONS.md). |
+| Run queries and follow common workflows | Follow the [Usage Guide](docs/USAGE.md) for querying, browsing results, charting, exporting, and keyboard navigation. |
+| View audit events | Open the audit viewer with the [Dashboards & Audit User Guide](docs/DASHBOARDS_AND_AUDIT.md#audit-viewer). |
+| Use MCP | Follow the [AI + MCP Integration Guide](docs/MCP_AI_INTEGRATION.md). |
+| Check driver support and limitations | Use [Drivers Overview](docs/DRIVERS.md), the canonical capability and limitations overview. |
+
+### More user guides
+
+- [Settings & Hooks](docs/SETTINGS.md) — settings, connection hooks, and access profiles
+- [Data & Privacy](docs/DATA_AND_PRIVACY.md) — data and secret storage, backup, and reset
 - [Lua Scripting](docs/LUA.md) — the embedded Lua runtime for hooks
 
-### Reference & internals
+### Contributors
 
-- [Architecture](ARCHITECTURE.md) — layered diagrams, query/connection flow, crate map
-- [Charts](docs/CHARTS.md) — chart types, column kinds, axis auto-detection
-- [Dashboards](docs/DASHBOARDS.md) — dashboards, saved charts, instance metrics and inspectors
+- [Contributing](CONTRIBUTING.md) — setup, checks, and contribution workflow
+- [Key Concepts](docs/CONCEPTS.md) — the short mental model for contracts and subsystem boundaries
+- [Driver Authoring](docs/DRIVER_AUTHORING.md) — choose and implement a built-in Rust or external RPC driver
+- [Architecture](ARCHITECTURE.md) — the canonical architecture and crate map, including crate boundaries and cross-crate flows
+
+### Reference
+
+- [Charts](docs/CHARTS.md) — chart types, column kinds, and axis auto-detection
+- [Dashboards](docs/DASHBOARDS.md) — dashboards, saved charts, instance metrics, and inspectors
 - [Audit](docs/AUDIT.md) — audit event schema and redaction
-- [AI + MCP Integration Guide](docs/MCP_AI_INTEGRATION.md)
 - [Driver RPC Protocol](docs/DRIVER_RPC_PROTOCOL.md)
 - [RPC Services Config](docs/RPC_SERVICES_CONFIG.md)
 - [Release Process](docs/RELEASE.md)
-- [Contributing](CONTRIBUTING.md)
 - [Code Style](CODE_STYLE.md)
 - [Agent Instructions](AGENTS.md)
 - [Claude Instructions](CLAUDE.md)
@@ -228,6 +240,7 @@ curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/uninst
 ### Database Support
 
 - **PostgreSQL** with SSL/TLS modes (Disable, Prefer, Require)
+- **Amazon Redshift** with read-only SQL over the PostgreSQL wire protocol, SSH tunneling, and TLS/client certificates
 - **MySQL** / MariaDB
 - **SQLite** for local database files
 - **Microsoft SQL Server** (TDS) with TLS, SQL Browser named-instance routing, and multi-schema introspection

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -1,0 +1,131 @@
+# Key Concepts
+
+This guide is the short mental model for contributors and advanced users.
+It describes the contracts between subsystems; [Architecture](../ARCHITECTURE.md) remains the
+canonical, exhaustive map of crate boundaries and key files.
+
+## Mental model
+
+```text
+UI document
+  -> app orchestration (profiles, connections, policy, lifecycle)
+    -> dbflux_core contracts (metadata, capabilities, requests, values)
+      -> built-in driver or RPC-adapted driver
+        -> QueryResult -> generic result views
+        -> EventRecord -> audit sink
+```
+
+The important direction is inward: presentation and workflows depend on contracts, while
+driver-specific behavior stays behind those contracts. Audit observes work across the flow rather
+than forming a separate execution path.
+
+## Concept map
+
+| Concept | What it is | Why it matters | Go deeper |
+|---|---|---|---|
+| Drivers | Implementations of the `DbDriver` and `Connection` contracts. | Built-in and external databases enter the app through the same boundary. | [Core traits](../crates/dbflux_core/src/core/traits.rs), [Driver Authoring](DRIVER_AUTHORING.md) |
+| `DriverMetadata` | A driver's declarative identity, category, language, forms, and detailed feature descriptors. | Generic workflows can select presentation and behavior without identifying a concrete driver. | [Metadata definition](../crates/dbflux_core/src/driver/capabilities.rs) |
+| `DriverCapabilities` | Feature flags declared by a driver and exposed by a connection. | The UI enables only supported operations instead of guessing from database names. | [Capability flags](../crates/dbflux_core/src/driver/capabilities.rs) |
+| Documents | Type-erased panes managed as tabs, with identity and event contracts. | New document types can participate without extending a closed document enum. | [`PaneHandle`](../crates/dbflux_ui_document/src/pane.rs), [`TabManager`](../crates/dbflux_ui_document/src/tab_manager.rs) |
+| Query results | Structured shapes, columns, rows, and values returned by connections. | Generic tables, trees, text views, exports, and charts consume one result model. | [Result types](../crates/dbflux_core/src/query/types.rs), [`Value`](../crates/dbflux_core/src/core/value.rs) |
+| MCP governance | Trusted-client, connection, classification, policy, approval, and audit enforcement around AI tools. | Agent access is explicit, scoped, reviewable, and observable. | [AI + MCP Integration](MCP_AI_INTEGRATION.md) |
+| Audit | The cross-cutting `EventRecord`/`EventSink` observability seam. | Queries, lifecycle work, hooks, governance, and external services share a correlated trail. | [Audit reference](AUDIT.md), [`EventSink`](../crates/dbflux_core/src/observability/source.rs) |
+| Hooks | Commands, scripts, or Lua attached to connection lifecycle phases. | Environment setup and cleanup remain outside driver implementations, with explicit failure behavior. | [Hook contracts](../crates/dbflux_core/src/connection/hook.rs), [Settings & Hooks](SETTINGS.md#connection-hooks) |
+| RPC services | Persisted descriptors adapted at startup into drivers or auth providers. | Out-of-process integrations join the runtime without becoming UI special cases. | [RPC config](RPC_SERVICES_CONFIG.md), [protocol](DRIVER_RPC_PROTOCOL.md) |
+
+## Drivers are contracts, not UI cases
+
+`DbDriver` creates and describes a database integration; `Connection` exposes operations on an
+active connection. Their current contracts live in
+[`core/traits.rs`](../crates/dbflux_core/src/core/traits.rs). Built-in crates implement them directly,
+while external drivers are adapted over RPC.
+
+The decoupling rule is strict: UI and app workflow code adapt through generic metadata,
+capabilities, and contracts, never concrete driver IDs. If a feature requires
+`if driver == "postgres"` in presentation or workflow code, the missing abstraction belongs in
+metadata, a capability, or a core contract.
+
+### Metadata and capabilities
+
+[`DriverMetadata`](../crates/dbflux_core/src/driver/capabilities.rs) describes what a driver is:
+display identity, `DatabaseCategory`, query language, syntax and operation descriptors, limits, and
+other generic presentation inputs. `DriverCapabilities` declares which broad features it supports.
+A connection exposes the same metadata and capabilities so callers do not need its originating
+driver object.
+
+Use metadata to choose a generic mode and capabilities to gate an operation. Do not infer support
+from a driver key, icon, native type-name string, or a list maintained in the UI.
+
+## Documents are open polymorphism
+
+[`PaneHandle`](../crates/dbflux_ui_document/src/pane.rs) is the document polymorphism seam. It
+type-erases each concrete GPUI entity behind closures for rendering, focus, commands, metadata,
+lifecycle behavior, deduplication, and subscription. The workspace therefore does not model
+documents as a closed enum of concrete document types.
+
+[`DocumentKey`](../crates/dbflux_ui_document/src/dedup.rs) expresses open-document identity. Each
+pane decides whether it matches a key, and
+[`TabManager`](../crates/dbflux_ui_document/src/tab_manager.rs) uses that contract to focus an
+existing tab instead of opening a duplicate.
+
+Documents emit [`DocumentEvent`](../crates/dbflux_ui_document/src/handle.rs). The tab manager and
+workspace translate those events into cross-document actions without reaching into a concrete
+document implementation. Add a pane behavior at this seam rather than adding concrete-type
+matching to workspace code.
+
+## Query results are structured data
+
+The current result boundary is [`QueryResult`](../crates/dbflux_core/src/query/types.rs): a declared
+`QueryResultShape`, `ColumnMeta` entries, rows of core `Value`, optional text or bytes, execution
+timing, and possible additional result sets. [`Value`](../crates/dbflux_core/src/core/value.rs)
+preserves relational and document values without reducing everything to JSON or display strings.
+
+Structured result values and column metadata feed generic views. In particular, `ColumnMeta.kind`
+carries semantic type information such as timestamp, float, integer, text, or unknown. Charts and
+other consumers use that semantic kind; they must not sniff `ColumnMeta.type_name` or branch on
+driver identity.
+
+## MCP governance wraps execution
+
+The MCP process authorizes requests through trusted-client identity, the per-connection MCP gate, execution classification, assigned roles and policies, and approval where required. Decisions and executions are audited. See the [governance model](MCP_AI_INTEGRATION.md#3-governance-model-core-concepts), [`dbflux_mcp` authorization](../crates/dbflux_mcp/src/server/authorization.rs), the [policy engine](../crates/dbflux_policy/src/engine.rs), and the [approval service](../crates/dbflux_approval/src/service.rs).
+
+Safety properties are part of the boundary:
+
+- `preview_mutation` is read-governed and produces a read-only plan; it does not execute the mutation. The implementation rejects any driver-generated preview query that is not metadata/read classified ([query tool](../crates/dbflux_mcp_server/src/tools/query.rs)).
+- `select_data` currently rejects requested joins instead of silently ignoring them ([read tool](../crates/dbflux_mcp_server/src/tools/read.rs)).
+- Mutation preview is not a DDL-preview surface. DDL operations are separate governed tools; no DDL preview tool is exposed in the current [tool catalog](../crates/dbflux_mcp/src/tool_catalog.rs).
+
+Keep classification, policy, approval, and audit decisions at the governance boundary. A handler must not weaken them because an underlying driver can perform the operation.
+
+## Audit is the observability seam
+
+Services emit canonical [`EventRecord`](../crates/dbflux_core/src/observability/types.rs) values through [`EventSink`](../crates/dbflux_core/src/observability/source.rs). The record carries actor, source, category, outcome, target context, details, and correlation fields; the sink owns validation and storage behavior.
+
+This makes audit cross-cutting: query execution, connection lifecycle, hooks, MCP decisions, configuration, and external RPC services can be observed without coupling their domain logic to the SQLite implementation. Use the [Audit reference](AUDIT.md) for schema, validation, redaction, retention, and tracing-bridge details.
+
+## Hooks surround connection lifecycle
+
+[`ConnectionHook`](../crates/dbflux_core/src/connection/hook.rs) defines command, script, or Lua work at `PreConnect`, `PostConnect`, `PreDisconnect`, and `PostDisconnect`. Hooks belong to orchestration around a connection, not to the database driver's query contract.
+
+Failure policy is explicit: `Disconnect` aborts the phase, `Warn` continues with a surfaced warning, and `Ignore` continues while logging the failure. Execution can be blocking or detached, with timeout, environment, and ready-signal controls. See [Settings & Connection Hooks](SETTINGS.md#connection-hooks) for configuration and safety details.
+
+## RPC services are runtime descriptors
+
+RPC services are persisted launch and compatibility descriptors classified as `Driver` or `AuthProvider`. At startup, [`dbflux_app::rpc_services`](../crates/dbflux_app/src/rpc_services/) discovers descriptors, validates and probes the appropriate protocol, then adapts successful services into the driver or auth-provider registry. One service family failing does not redefine the other.
+
+External driver registry keys remain `rpc:<socket_id>`. Auth providers use their provider identity and never appear as database drivers. Runtime metadata for an external driver comes from its handshake, not from UI conditionals. See [RPC Services Config](RPC_SERVICES_CONFIG.md) for persistence and [Driver RPC Protocol](DRIVER_RPC_PROTOCOL.md) for transport, negotiation, lifecycle, and audit emission.
+
+## Where to make a change
+
+| You need to change… | Start at… | Recognition rule |
+|---|---|---|
+| A database operation available to every integration | [`DbDriver`/`Connection`](../crates/dbflux_core/src/core/traits.rs) | Define a generic contract before implementing drivers. |
+| Whether a generic feature is shown or allowed | [Metadata and capabilities](../crates/dbflux_core/src/driver/capabilities.rs) | Declare support; never identify the driver in UI/workflow code. |
+| Result rendering or semantic type behavior | [Query result types](../crates/dbflux_core/src/query/types.rs) | Consume shape, values, and `ColumnMeta.kind`. |
+| A new workspace document | [`PaneHandle`](../crates/dbflux_ui_document/src/pane.rs) and [`DocumentEvent`](../crates/dbflux_ui_document/src/handle.rs) | Implement the open pane seam and a dedup key; do not extend a concrete document union. |
+| An AI tool or execution rule | [MCP integration](MCP_AI_INTEGRATION.md) and [authorization](../crates/dbflux_mcp/src/server/authorization.rs) | Preserve classification, policy, approval, and audit ordering. |
+| An observable domain action | [`EventRecord` and `EventSink`](../crates/dbflux_core/src/observability/types.rs) | Emit through the seam; keep storage details out of domain code. |
+| Connection setup or cleanup automation | [Hook contract](../crates/dbflux_core/src/connection/hook.rs) | Choose a lifecycle phase and explicit failure mode. |
+| An out-of-process driver or auth provider | [RPC services](RPC_SERVICES_CONFIG.md) | Persist a descriptor and adapt through `dbflux_app::rpc_services`. |
+
+Continue with [Architecture](../ARCHITECTURE.md) for canonical crate boundaries and key files, or [Driver Authoring](DRIVER_AUTHORING.md) to implement a built-in or external driver.

--- a/docs/DRIVERS.md
+++ b/docs/DRIVERS.md
@@ -4,7 +4,8 @@ This document is a comparative overview of the database drivers shipped with
 DBFlux. For per-driver details, follow the link to each driver crate's
 `README.md`. For the internal driver architecture (traits, registration, the
 `DbDriver`/`Connection` seam), see the **Driver System** section of
-[`ARCHITECTURE.md`](../ARCHITECTURE.md).
+[`ARCHITECTURE.md`](../ARCHITECTURE.md). Contributors implementing a driver
+should start with the [Driver Authoring Guide](DRIVER_AUTHORING.md).
 
 ## How drivers are abstracted
 
@@ -32,6 +33,7 @@ The capability flags listed below are exactly the ones each driver's
 | Driver | Category | Query language | Key capabilities | Notes / limitations |
 | --- | --- | --- | --- | --- |
 | PostgreSQL | Relational | SQL | Relational base + schemas, SSH tunnel, SSL, auth, foreign keys, check/unique constraints, custom types, `RETURNING`, transactional DDL, routines, multi-statement | Full SQL driver; routine viewer is read-only; transactional DDL except `CREATE INDEX CONCURRENTLY`. |
+| Amazon Redshift | Relational | SQL | Multiple databases, schemas, views, SSH tunnel, SSL/client certificates, auth, query cancellation, prepared statements, pagination, sorting, filtering, CSV/JSON export | Read-only over the PostgreSQL wire protocol; single-statement; exposes Redshift storage hints; no writes/DDL, IAM/SSO, or indexes. |
 | MySQL | Relational | SQL | Relational base + SSH tunnel, SSL, auth, foreign keys, check/unique constraints, routines, multi-statement | DDL is non-transactional; multi-statement scripts split text-based and run sequentially; routine listing covers FUNCTION/PROCEDURE only. |
 | MariaDB | Relational | SQL | Same crate and capabilities as MySQL | Registered as a separate `mariadb` metadata sharing the MySQL implementation. |
 | SQLite | Relational | SQL | Views, indexes, foreign keys, check/unique constraints, prepared statements, insert/update/delete, pagination, sorting, filtering, CSV/JSON export, query cancellation, transactional DDL, multi-statement | Embedded file driver: no network, SSH tunnel, or TLS; no multi-schema namespace. |
@@ -51,6 +53,15 @@ SSH tunneling, query cancellation via cancel tokens, transactional DDL, and
 PostgreSQL-specific code generation. Multi-statement scripts run as a batch via
 the simple query protocol. See
 [`crates/dbflux_driver_postgres/README.md`](../crates/dbflux_driver_postgres/README.md).
+
+### Amazon Redshift
+
+Read-only relational SQL driver using the PostgreSQL wire protocol. It supports
+schema, table, view, and column introspection; SSH tunneling; TLS and client
+certificates; query cancellation; and Redshift distribution/sort-key storage
+hints. It does not support writes or DDL, IAM/SSO authentication,
+multi-statement queries, or indexes. See
+[`crates/dbflux_driver_redshift/README.md`](../crates/dbflux_driver_redshift/README.md).
 
 ### MySQL / MariaDB
 

--- a/docs/DRIVER_AUTHORING.md
+++ b/docs/DRIVER_AUTHORING.md
@@ -1,0 +1,124 @@
+# Driver Authoring Guide
+
+Use this guide to choose and implement a DBFlux database-driver integration. It covers the contributor path without repeating the broader architecture or RPC protocol references.
+
+## Choose an integration path
+
+| Choose | Built-in Rust driver | External RPC driver |
+| --- | --- | --- |
+| Best fit | The driver should ship in the DBFlux workspace and process | The driver should run out of process or be developed and deployed independently |
+| Implementation | A `crates/dbflux_driver_<name>/` crate implementing core Rust contracts | A service implementing the driver RPC protocol |
+| Registration | Compile-time feature wiring and `AppState::build_builtin_drivers()` | Settings -> RPC Services with `kind=driver` and a `socket_id` |
+| Stable key | `builtin:<name>` | `rpc:<socket_id>` |
+| Configuration | Driver-owned `DriverFormDef` converted to a built-in `DbConfig` variant | Form data supplied by the handshake and stored as `DbConfig::External` |
+
+## Built-in driver: happy path
+
+1. Copy the structure of the closest existing `crates/dbflux_driver_*/` crate.
+2. Implement `DbDriver` and `Connection`, including metadata, form/config conversion, connection behavior, errors, and typed result columns.
+3. Declare only capabilities backed by working implementations; add optional seams only when the driver supports them.
+4. Wire the crate and feature through the workspace, app, and binary, then register it in `build_builtin_drivers()`.
+5. Add focused tests, a crate README, and update the driver support matrix.
+
+The [detailed built-in checklist](#built-in-driver-checklist) expands each step.
+
+## External RPC driver: happy path
+
+1. Implement the canonical [Driver RPC Protocol](DRIVER_RPC_PROTOCOL.md), using the [custom driver example](../examples/custom_driver/README.md) as a starting point.
+2. Build and run the service, either independently or with a managed command.
+3. Add it under Settings -> RPC Services with `kind=driver`, a stable `socket_id`, and the optional managed command.
+4. Restart DBFlux and verify that the handshake-provided metadata and form appear in the connection manager.
+
+See the [RPC Services configuration reference](RPC_SERVICES_CONFIG.md) for current configuration behavior. Do not copy launch flags from this guide; the protocol, configuration reference, and example are authoritative.
+
+## Core contracts and decoupling rule
+
+The primary contract is [`DbDriver` plus `Connection`](../crates/dbflux_core/src/core/traits.rs):
+
+- `DbDriver` supplies driver metadata, its connection form definition, config construction and extraction, connection construction, and a stable `DriverKey`.
+- `Connection` supplies runtime query, schema, mutation, and optional capability-specific behavior. Defaults exist for many unsupported operations; required methods and advertised capabilities must still agree.
+- Built-in `driver_key()` values use `builtin:<name>`. External drivers use `rpc:<socket_id>`.
+
+Metadata and adaptation are defined by [`DriverMetadata`, `DatabaseCategory`, `QueryLanguage`, and `DriverCapabilities`](../crates/dbflux_core/src/driver/capabilities.rs), including generic editor-presentation metadata. Runtime source and presentation behavior is exposed through generic seams on `Connection` in [`traits.rs`](../crates/dbflux_core/src/core/traits.rs).
+
+**Strict rule:** UI and app workflow code must not branch on concrete driver IDs. Adapt from metadata, category, query language, capability flags, form definitions, and generic source/presentation seams. If a new UI distinction is necessary, add a generic core contract that another driver could implement.
+
+For result data, populate [`ColumnMeta.kind` with `ColumnKind`](../crates/dbflux_core/src/query/types.rs). Charts and other consumers use this semantic kind; they do not infer it from a driver ID or `type_name`.
+
+## Built-in driver checklist
+
+### 1. Crate and contracts
+
+- [ ] Add `crates/dbflux_driver_<name>/Cargo.toml`, `src/lib.rs`, implementation modules, and tests. Follow the closest driver rather than assuming every driver has identical modules.
+- [ ] Implement `DbDriver` and a thread-safe `Connection` from [`crates/dbflux_core/src/core/traits.rs`](../crates/dbflux_core/src/core/traits.rs).
+- [ ] Return a stable `DriverKey` in the form `builtin:<name>`.
+- [ ] Keep database-client types and driver-specific behavior inside the driver crate; expose behavior through core contracts.
+
+### 2. Metadata and capabilities
+
+- [ ] Define factual `DriverMetadata`: identity, display fields, `DatabaseCategory`, `QueryLanguage`, `DriverCapabilities`, connection defaults, and applicable generic capability structures.
+- [ ] Use metadata and generic presentation/source seams for UI adaptation. Do not add driver-ID conditionals to UI or app workflows.
+- [ ] Advertise a capability only when the corresponding operation or optional seam works. Confirm negative claims as well as supported behavior.
+
+### 3. Forms and configuration
+
+- [ ] Define and own the crate's `DriverFormDef`; the connection UI renders it generically.
+- [ ] Implement `build_config()` validation and `extract_values()` editing round trips.
+- [ ] Keep secrets on the established secret paths rather than embedding them in persisted form values.
+- [ ] Implement URI parsing/building or export-field overrides only when applicable.
+
+### 4. Connections, errors, and results
+
+- [ ] Construct and test the connection through the `DbDriver` methods, including required secret handling and connection tests.
+- [ ] Implement structured query and connection error formatting through [`QueryErrorFormatter` and `ConnectionErrorFormatter`](../crates/dbflux_core/src/core/error_formatter.rs). Preserve useful database context without exposing secrets.
+- [ ] Return schema and query data through core types, including `ColumnMeta.kind` for every result column using the correct `ColumnKind`.
+- [ ] Test type mapping directly. Do not rely on consumers to derive semantics from raw `type_name` strings.
+
+### 5. Optional seams
+
+Implement these only when the database supports them, and keep capability flags synchronized with the implementation:
+
+- [ ] A non-default `LanguageService` for language-specific validation and mutation classification.
+- [ ] SQL dialect, code generator, query generator, or semantic planner behavior as applicable.
+- [ ] Source context, metric catalog, dashboard importer, or dashboard source behavior as applicable.
+- [ ] An instance catalog for metrics or inspectors as applicable.
+- [ ] Other schema, CRUD, cancellation, transfer, or key-value seams represented by the core traits and capability flags.
+
+### 6. Feature wiring and registration
+
+- [ ] Add workspace membership and a workspace dependency in the root [`Cargo.toml`](../Cargo.toml).
+- [ ] Add an optional dependency and feature relay in [`crates/dbflux_app/Cargo.toml`](../crates/dbflux_app/Cargo.toml).
+- [ ] Forward the binary feature in [`crates/dbflux/Cargo.toml`](../crates/dbflux/Cargo.toml).
+- [ ] Add feature-gated imports and registration in [`AppState::build_builtin_drivers()`](../crates/dbflux_app/src/app_state/bootstrap.rs).
+- [ ] Verify both the enabled feature and a representative feature-disabled build so registration remains properly gated.
+
+### 7. Tests and documentation
+
+- [ ] Test metadata, capability declarations, form/config round trips, errors, connection behavior, schema mapping, query results, and every advertised optional seam.
+- [ ] Add integration tests where behavior crosses the driver/core boundary; keep live service tests ignored or gated according to existing crate conventions.
+- [ ] Add `crates/dbflux_driver_<name>/README.md` with clear **Features** and **Limitations** sections.
+- [ ] Update [`docs/DRIVERS.md`](DRIVERS.md) and keep its capability claims aligned with the crate README and implementation.
+
+## External RPC driver checklist
+
+- [ ] Implement handshake, form, session, query, and supported optional operations against the [Driver RPC Protocol](DRIVER_RPC_PROTOCOL.md).
+- [ ] Supply metadata, capabilities, and the form definition through the protocol handshake; keep every capability claim aligned with implemented RPC operations.
+- [ ] Configure the service under Settings -> RPC Services as `kind=driver` with a stable `socket_id`; add a managed command only when DBFlux should own the process lifecycle.
+- [ ] Expect the runtime key `rpc:<socket_id>` and generic configuration storage through `DbConfig::External`.
+- [ ] Follow [RPC Services Config](RPC_SERVICES_CONFIG.md) for persisted configuration and lifecycle semantics.
+- [ ] Build and smoke-test from the [custom driver example](../examples/custom_driver/README.md), then test restart, handshake failure, unsupported operations, and connection-form round trips.
+
+External RPC drivers do not use the built-in Cargo feature wiring or `build_builtin_drivers()` registration path.
+
+## Review checklist
+
+Before opening a PR, confirm:
+
+- [ ] The selected built-in or RPC path is used consistently; the two registration paths are not mixed.
+- [ ] No UI or app workflow branches on a concrete driver ID.
+- [ ] Metadata, capability flags, optional seams, tests, crate README, and `docs/DRIVERS.md` make the same claims.
+- [ ] Form/config editing round trips work and secrets are not persisted or logged unexpectedly.
+- [ ] Query results populate `ColumnMeta.kind` correctly.
+- [ ] Connection and query failures produce structured, useful, secret-safe errors.
+- [ ] Built-in feature-disabled and feature-enabled builds pass, or the RPC service completes its handshake and restart smoke test.
+- [ ] The repository checks in [CONTRIBUTING.md](../CONTRIBUTING.md) pass.

--- a/docs/DRIVER_RPC_PROTOCOL.md
+++ b/docs/DRIVER_RPC_PROTOCOL.md
@@ -63,7 +63,6 @@ Notes:
 
 - `socket_id` is required.
 - `kind` supports `driver` and `auth_provider`.
-- `kind` supports `driver` and `auth_provider`.
 - `command` is optional.
   - If `command` is omitted and `args` is empty, DBFlux expects the service to already be running.
   - For `driver`, if `command` is omitted and `args` is non-empty, DBFlux launches `dbflux-driver-host`.


### PR DESCRIPTION
## Summary

- Reframes DBFlux documentation around an extensible data platform and adds goal-based navigation for common user workflows.
- Adds concise key-concepts and driver-authoring guides without duplicating the canonical architecture map.
- Corrects documentation drift by adding the shipping Redshift driver and removing duplicated RPC configuration guidance.

## What does this resolve?

Resolves **DBF-27** — “Documentation: architecture, key concepts, driver contribution guide” (Atlas task; no GitHub issue number).

## How was this solved?

- Added `docs/CONCEPTS.md` as the short mental model for drivers, metadata/capabilities, documents, query results, MCP governance, audit, hooks, and RPC services.
- Added `docs/DRIVER_AUTHORING.md` with separate built-in Rust and external RPC paths, implementation checklists, generic extension rules, and review guidance.
- Updated `README.md`, `CONTRIBUTING.md`, and `ARCHITECTURE.md` to provide progressive navigation while keeping `ARCHITECTURE.md` canonical for crate boundaries and key files.
- Updated `docs/DRIVERS.md` with missing Redshift coverage and a contributor path to the authoring guide.
- Removed a duplicated service-kind bullet from `docs/DRIVER_RPC_PROTOCOL.md` without changing its launch semantics.

The authored diff is 317 changed lines, below the repository's chained-PR threshold.

## Validation

All commands passed:

```text
cargo fmt --all -- --check
cargo clippy --workspace -- -D warnings
cargo test --workspace
git diff --check
```

Additionally, a repository-relative link check confirmed that all local links resolve across the seven changed Markdown files.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed — documentation-only change; no new tests were required
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible — not applicable; `docs` commits are excluded from generated release notes
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

`documentation`
