### PR TITLE
ci: stop the release run cancelling itself via reusable workflows

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,8 +3,6 @@ name: Style
 on:
   push:
     branches: [main, dev]
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches: [main, dev]
   workflow_call:
@@ -13,8 +11,10 @@ on:
 permissions:
   contents: read
 
+# See the note in tests.yml: the group name must be a literal so a Release run
+# and the reusable workflows it calls never share a concurrency group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: style-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,6 @@ name: Tests
 on:
   push:
     branches: [main, dev]
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches: [main, dev]
   workflow_call:
@@ -13,8 +11,12 @@ on:
 permissions:
   contents: read
 
+# The group name must be a literal, not ${{ github.workflow }}: under
+# workflow_call that expression resolves to the *calling* workflow, so Release
+# invoking tests.yml and style.yml would put both — and the Release run itself,
+# whose group differs only by case — in one group and cancel them all.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
The `v0.7.0` tag published no release. The Release run cancelled itself, with `Canceling since a higher priority waiting request for Release-refs/tags/v0.7.0 exists` on every job.

**Cause.** `tests.yml` and `style.yml` set `concurrency.group` to `${{ github.workflow }}-${{ github.ref }}`. Under `workflow_call` that expression resolves to the *calling* workflow, not the callee. So when `release.yml` invokes both, they land in the group `Release-<ref>` with `cancel-in-progress: true`, which is the same group as the Release run itself (`release-<ref>`; group names are case-insensitive). The second reusable cancels the first, and both cancel the parent.

The regression came in with #272 (`8d1916d3`), after v0.6.0. No release tag was cut between that commit and `v0.7.0`, so it went unnoticed.

**Fix.** Give each workflow a literal group prefix (`tests-`, `style-`) so no reusable can collide with its caller. Also drop `push.tags` from both: a tag push already runs tests and style through Release, so the standalone runs were duplicate work, and after the group rename they would have collided with the reusable ones instead.

`build.yml` declares no concurrency and `nightly.yml` uses a literal group, so neither is affected.

Verification is the next `v0.7.0` tag: after this merges it gets cherry-picked onto `release/v0.7` and the tag is recreated.