### PR TITLE
chore(nix): point release-info at v0.7.0

### DIFF
--- a/nix/release-info.nix
+++ b/nix/release-info.nix
@@ -1,5 +1,5 @@
 {
-  version = "0.6.0";
+  version = "0.7.0";
 
   # SHA256 SRI hashes of each prebuilt artifact published in the matching
   # GitHub Release. This file is a per-branch channel pointer: on `main` it
@@ -21,12 +21,12 @@
   # Then update `version`, the two `url`s, and the two `hash`es below.
   artifacts = {
     "x86_64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0/dbflux-linux-amd64.tar.gz";
-      hash = "sha256-QbyKIjbIPbudb8IwS86UcN25Y7LcHgi2cjwP/BzCd/A=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.0/dbflux-linux-amd64.tar.gz";
+      hash = "sha256-97o+plbM2qAE+0vq7zrzIZpRFREzmQ+e5+SAFeZQUPQ=";
     };
     "aarch64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.6.0/dbflux-linux-arm64.tar.gz";
-      hash = "sha256-E1FFudu+kdYyVHPajxTuvnDP63/JhemDiMkaxGrc1VQ=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.0/dbflux-linux-arm64.tar.gz";
+      hash = "sha256-dYhTCj4g6XoaPQ1srdcS2FGAUNq0ykwmfqYhl7shRow=";
     };
   };
 }


### PR DESCRIPTION
Post-release step for v0.7.0: the flake's prebuilt-binary package (`dbflux-bin`, the default) still pointed at the v0.6.0 tarballs, so `nix run github:0xErwin1/dbflux` installed the previous release.

Bumps `version`, both artifact URLs, and both SRI hashes. The hashes were computed from the downloaded tarballs and match the published `.sha256` files. Verified with `nix build .#dbflux-bin`, which produces `dbflux-0.7.0`.

Cherry-picked from `release/v0.7` (`3513b77b`), per the post-release step in `docs/RELEASE.md` that refreshes both the release branch and `main`.