### PR TITLE
ci(DBF-166): run clippy on every shipped platform

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -20,6 +20,9 @@ concurrency:
 jobs:
   fmt:
     name: Formatting
+    # Deliberately not matrixed, unlike clippy below: rustfmt parses whole
+    # files, so it already formats cfg-gated code that never compiles here, and
+    # a Windows checkout would only add line-ending noise.
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -36,9 +39,27 @@ jobs:
         run: cargo fmt --all -- --check
 
   clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+    name: Clippy ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+
+    # GPUI and the platform seams (keyring, IPC, windowing, process spawning)
+    # carry a large amount of cfg-gated code that a Linux-only clippy run never
+    # compiles, so lint debt could accumulate there unseen until a release
+    # build. Lint every platform we ship instead.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            extra_features: ""
+          # Native arm64; vendored-openssl matches build.yml (the runner has no
+          # pkg-config-discoverable OpenSSL, so openssl-sys must build it).
+          - os: macos-14
+            extra_features: ",vendored-openssl"
+          # Native x86_64-msvc; OpenSSL is resolved on the runner as in build.yml.
+          - os: windows-latest
+            extra_features: ""
 
     steps:
       - name: Checkout repository
@@ -50,6 +71,7 @@ jobs:
           components: clippy
 
       - name: Install system dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -63,12 +85,32 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
         with:
-          shared-key: ci-clippy
+          shared-key: ci-clippy-${{ matrix.os }}
           cache-targets: true
           cache-on-failure: true
 
       - name: Run clippy
-        run: cargo clippy --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws" -- -D warnings
+        run: cargo clippy --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws${{ matrix.extra_features }}" -- -D warnings
+
+  # Aggregate gate. `Clippy` is a required status check in the repository
+  # ruleset, and a matrixed job reports one context per platform instead, so
+  # this job keeps the required name alive and fails if any platform did.
+  clippy-result:
+    name: Clippy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: clippy
+    if: always()
+
+    steps:
+      - name: Check matrix result
+        env:
+          RESULT: ${{ needs.clippy.result }}
+        run: |
+          if [ "$RESULT" != "success" ]; then
+            echo "::error::Clippy did not pass on every platform (result: $RESULT)."
+            exit 1
+          fi
 
   machete:
     name: Unused dependencies

--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -33,6 +33,7 @@ use interprocess::local_socket::{
 use log::info;
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
+#[cfg(unix)]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};

--- a/crates/dbflux_proxy/src/lib.rs
+++ b/crates/dbflux_proxy/src/lib.rs
@@ -31,7 +31,9 @@ pub enum ProxyProtocol {
 
 enum ProxiedStream {
     Plain(TcpStream),
-    Tls(TlsStream<TcpStream>),
+    // Boxed because a schannel-backed TlsStream is far larger than a bare
+    // TcpStream, which makes every ProxiedStream pay the TLS size on Windows.
+    Tls(Box<TlsStream<TcpStream>>),
 }
 
 impl ProxiedStream {
@@ -298,7 +300,7 @@ fn open_https_connect_stream(
     })?;
 
     let tls_stream = perform_connect_handshake(tls_stream, config, remote_host, remote_port)?;
-    Ok(ProxiedStream::Tls(tls_stream))
+    Ok(ProxiedStream::Tls(Box::new(tls_stream)))
 }
 
 fn perform_connect_handshake<S: Read + Write>(

--- a/crates/dbflux_ui_base/src/platform.rs
+++ b/crates/dbflux_ui_base/src/platform.rs
@@ -4,16 +4,22 @@
 /// This module provides helpers to detect the current platform and
 /// adjust window creation accordingly.
 use dbflux_components::icons::AppIcon;
+#[cfg(target_os = "linux")]
 use dbflux_components::primitives::{Icon, Text};
 #[cfg(target_os = "linux")]
 use dbflux_components::tokens::ChromeColors;
 #[cfg(target_os = "linux")]
 use dbflux_components::tokens::{Heights, Spacing};
 use gpui::{
-    App, ClickEvent, Decorations, InteractiveElement, IntoElement, ParentElement, SharedString,
-    Stateful, Styled, Window, WindowDecorations, WindowKind, WindowOptions, div, px,
+    App, IntoElement, SharedString, Stateful, Window, WindowDecorations, WindowKind, WindowOptions,
+    div, px,
 };
+// Only the CSD title bar uses these, and it is compiled on Linux alone.
+#[cfg(target_os = "linux")]
+use gpui::{ClickEvent, Decorations, InteractiveElement, ParentElement, Styled};
+#[cfg(target_os = "linux")]
 use gpui_component::ActiveTheme;
+#[cfg(target_os = "linux")]
 use gpui_component::InteractiveElementExt;
 
 /// A single breadcrumb entry for the CSD title bar.
@@ -115,8 +121,10 @@ pub fn render_csd_title_bar_with_crumbs(
     title: &str,
     crumbs: &[TitleCrumb],
 ) -> Option<Stateful<gpui::Div>> {
+    // Only the Linux CSD branch reads these; the signature stays uniform so
+    // callers do not need their own cfg.
     #[cfg(not(target_os = "linux"))]
-    let _ = crumbs;
+    let _ = (cx, title, crumbs);
 
     if !should_render_csd(window) {
         #[cfg(target_os = "linux")]


### PR DESCRIPTION
DBF-166. Clippy only ran on `ubuntu-latest`, so every `cfg(target_os = "macos")` / `cfg(windows)` branch was invisible to the lint gate. That debt was real, not hypothetical: the first matrixed run failed on both new platforms.

## Part 1: run clippy everywhere

Matrixes clippy over `ubuntu-latest`, `macos-14`, and `windows-latest`, reusing the platform setup `tests.yml` already uses for its cross-platform check (`vendored-openssl` on macOS, system deps only on Linux, per-OS cache key).

`Clippy` is a required status check in the repository ruleset. A matrixed job reports one context per platform (`Clippy macos-14`, ...), so the required `Clippy` context would never appear again and every PR would block forever. An aggregate job named `Clippy` gates on the matrix result instead, which keeps the ruleset unchanged.

`Formatting` stays on Linux only, deliberately: rustfmt parses whole files, so it already covers cfg-gated code that never compiles on this host, and a Windows checkout would only add line-ending noise.

## Part 2: clear what it found

**`dbflux_ui_base/src/platform.rs`** (6 findings, macOS and Windows). The CSD title bar is Linux-only, so the imports only it consumes (`Icon`, `Text`, `ClickEvent`, `Decorations`, `InteractiveElement`, `ParentElement`, `Styled`, `ActiveTheme`, `InteractiveElementExt`) and the `cx` / `title` parameters only it reads were dead everywhere else. The imports are now gated and the existing `crumbs` discard covers all three parameters. The signature is unchanged, so no caller needs its own `cfg`.

**`dbflux_proxy`** (Windows). `ProxiedStream::Tls` tripped `large_enum_variant`. This one is a genuine platform difference rather than lint noise: `TlsStream` is schannel-backed on Windows and dwarfs a bare `TcpStream`, so every `ProxiedStream` paid the TLS size even when `Plain`. Boxed. The enum is private and every use site reaches the stream through auto-deref.

**`dbflux/src/main.rs`** (Windows). The SIGINT/SIGTERM handling from #304 is entirely `cfg(unix)` but its `AtomicBool`/`Ordering` import was not. macOS is unix, so only the Windows lane caught it.

## Verification

All three platforms pass, and so does the aggregate `Clippy` job. Linux clippy and `cargo fmt --check` were also run locally against each commit.

---

**Correction to an earlier note in this description.** It claimed `redshift`, `s3`, `lua`, and `mcp` were unlinted because the clippy command does not name them. That is wrong: `--features` adds to default features rather than replacing them, and `default` in `crates/dbflux/Cargo.toml` already includes all four. Verified by forcing a rebuild of those crates and running clippy with the short list, which compiles and lints `dbflux_driver_s3`, `dbflux_driver_redshift`, `dbflux_lua`, `dbflux_mcp`, and `dbflux_mcp_server`. There is no coverage gap and no follow-up PR is needed.
