### PR TITLE
fix(postgres): display pgvector values and report unsupported types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,6 +2879,7 @@ dependencies = [
  "native-tls",
  "postgres",
  "postgres-native-tls",
+ "ryu",
  "serde_json",
  "urlencoding",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2873,6 +2873,7 @@ dependencies = [
  "dbflux_core",
  "dbflux_ssh",
  "dbflux_test_support",
+ "half",
  "hex",
  "log",
  "native-tls",

--- a/crates/dbflux_components/src/components/data_table/clipboard.rs
+++ b/crates/dbflux_components/src/components/data_table/clipboard.rs
@@ -74,6 +74,23 @@ mod tests {
     }
 
     #[test]
+    fn long_text_keeps_full_value_for_editing_and_clipboard_while_display_is_capped() {
+        let full_text = format!("[{}]", "1,".repeat(150));
+        assert!(full_text.len() > 200);
+
+        let cell = CellValue::text(&full_text);
+
+        assert!(matches!(&cell.kind, CellKind::Text(text) if text.as_ref() == full_text));
+        assert_eq!(cell.edit_text(), full_text);
+        assert_eq!(format_cell(&cell), full_text);
+
+        let display = cell.display_text();
+        assert_eq!(display.chars().count(), 201);
+        assert!(display.ends_with('…'));
+        assert_eq!(display.as_ref(), format!("{}…", &full_text[..200]));
+    }
+
+    #[test]
     fn test_escape_tsv() {
         assert_eq!(escape_tsv("hello\tworld"), "hello world");
         assert_eq!(escape_tsv("line1\nline2"), "line1 line2");

--- a/crates/dbflux_core/src/data/crud.rs
+++ b/crates/dbflux_core/src/data/crud.rs
@@ -868,6 +868,9 @@ pub struct CrudResult {
     /// The updated row data (from RETURNING clause or re-query).
     /// None if the operation doesn't return row data.
     pub returning_row: Option<Row>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata_extra: Option<std::collections::HashMap<String, serde_json::Value>>,
 }
 
 impl CrudResult {
@@ -875,6 +878,7 @@ impl CrudResult {
         Self {
             affected_rows,
             returning_row,
+            metadata_extra: None,
         }
     }
 
@@ -882,6 +886,7 @@ impl CrudResult {
         Self {
             affected_rows: 1,
             returning_row: Some(returning_row),
+            metadata_extra: None,
         }
     }
 
@@ -889,7 +894,30 @@ impl CrudResult {
         Self {
             affected_rows: 0,
             returning_row: None,
+            metadata_extra: None,
         }
+    }
+
+    pub fn set_unsupported_types(&mut self, type_names: impl IntoIterator<Item = String>) {
+        crate::query::types::encode_unsupported_types(&mut self.metadata_extra, type_names);
+    }
+
+    pub fn take_unsupported_types(&mut self) -> Vec<String> {
+        crate::query::types::take_unsupported_types(&mut self.metadata_extra)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CrudResult;
+
+    #[test]
+    fn crud_result_unsupported_types_round_trip() {
+        let mut result = CrudResult::empty();
+        result.set_unsupported_types(["bit".to_string(), "halfvec".to_string(), "bit".to_string()]);
+
+        assert_eq!(result.take_unsupported_types(), vec!["bit", "halfvec"]);
+        assert!(result.take_unsupported_types().is_empty());
     }
 }
 

--- a/crates/dbflux_core/src/query/types.rs
+++ b/crates/dbflux_core/src/query/types.rs
@@ -1,7 +1,57 @@
 use crate::{ExecutionContext, QueryLanguage, Value};
 use serde::{Deserialize, Serialize};
+use std::collections::{BTreeSet, HashMap};
 use std::time::Duration;
 use uuid::Uuid;
+
+pub const UNSUPPORTED_TYPES_METADATA_KEY: &str = "unsupported_types";
+
+pub(crate) fn encode_unsupported_types(
+    metadata: &mut Option<HashMap<String, serde_json::Value>>,
+    type_names: impl IntoIterator<Item = String>,
+) {
+    let type_names = type_names
+        .into_iter()
+        .filter(|type_name| !type_name.is_empty())
+        .collect::<BTreeSet<_>>();
+
+    if type_names.is_empty() {
+        return;
+    }
+
+    metadata.get_or_insert_with(HashMap::new).insert(
+        UNSUPPORTED_TYPES_METADATA_KEY.to_string(),
+        serde_json::Value::Array(
+            type_names
+                .into_iter()
+                .map(serde_json::Value::String)
+                .collect(),
+        ),
+    );
+}
+
+pub(crate) fn take_unsupported_types(
+    metadata: &mut Option<HashMap<String, serde_json::Value>>,
+) -> Vec<String> {
+    let value = metadata
+        .as_mut()
+        .and_then(|metadata| metadata.remove(UNSUPPORTED_TYPES_METADATA_KEY));
+
+    if metadata.as_ref().is_some_and(HashMap::is_empty) {
+        *metadata = None;
+    }
+
+    match value {
+        Some(serde_json::Value::Array(values)) => values
+            .into_iter()
+            .filter_map(|value| value.as_str().map(ToOwned::to_owned))
+            .filter(|type_name| !type_name.is_empty())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect(),
+        _ => Vec::new(),
+    }
+}
 
 // -- Query Result Shape --
 
@@ -298,6 +348,14 @@ impl QueryResult {
         }
     }
 
+    pub fn set_unsupported_types(&mut self, type_names: impl IntoIterator<Item = String>) {
+        encode_unsupported_types(&mut self.metadata_extra, type_names);
+    }
+
+    pub fn take_unsupported_types(&mut self) -> Vec<String> {
+        take_unsupported_types(&mut self.metadata_extra)
+    }
+
     pub fn row_count(&self) -> usize {
         self.rows.len()
     }
@@ -478,5 +536,39 @@ mod tests {
             .map(|r| r.columns[0].name.clone())
             .collect();
         assert_eq!(labels, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn unsupported_types_are_sorted_and_deduplicated() {
+        let mut result = QueryResult::empty();
+        result.set_unsupported_types([
+            "varbit".to_string(),
+            "vector".to_string(),
+            "varbit".to_string(),
+            String::new(),
+        ]);
+
+        assert_eq!(result.take_unsupported_types(), vec!["varbit", "vector"]);
+    }
+
+    #[test]
+    fn unsupported_types_remove_malformed_metadata_without_reporting() {
+        let mut result = QueryResult::empty();
+        result.metadata_extra = Some(HashMap::from([(
+            UNSUPPORTED_TYPES_METADATA_KEY.to_string(),
+            serde_json::json!({ "type": "vector" }),
+        )]));
+
+        assert!(result.take_unsupported_types().is_empty());
+        assert!(result.metadata_extra.is_none());
+    }
+
+    #[test]
+    fn taking_unsupported_types_is_idempotent() {
+        let mut result = QueryResult::empty();
+        result.set_unsupported_types(["vector".to_string()]);
+
+        assert_eq!(result.take_unsupported_types(), vec!["vector"]);
+        assert!(result.take_unsupported_types().is_empty());
     }
 }

--- a/crates/dbflux_driver_postgres/Cargo.toml
+++ b/crates/dbflux_driver_postgres/Cargo.toml
@@ -20,6 +20,7 @@ log = "0.4"
 native-tls = "0.2"
 postgres = { version = "0.19", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 postgres-native-tls = "0.5"
+ryu = "1"
 serde_json = { workspace = true }
 urlencoding = "2"
 uuid = { workspace = true }

--- a/crates/dbflux_driver_postgres/Cargo.toml
+++ b/crates/dbflux_driver_postgres/Cargo.toml
@@ -15,6 +15,7 @@ dbflux_ssh = { path = "../dbflux_ssh" }
 async-trait = { workspace = true }
 chrono = { workspace = true }
 hex = "0.4"
+half = "2"
 log = "0.4"
 native-tls = "0.2"
 postgres = { version = "0.19", features = ["with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }

--- a/crates/dbflux_driver_postgres/README.md
+++ b/crates/dbflux_driver_postgres/README.md
@@ -10,6 +10,7 @@
 - Includes PostgreSQL-specific SQL/code generation for CRUD, indexes, reindex, foreign keys, and type operations.
 - Multi-statement scripts (several `;`-separated statements) run as a batch via the simple query protocol, returning one result set per statement.
 - Data-transfer engine: native multi-row `INSERT` bulk-load (`BULK_INSERT`), driver-native `CREATE TABLE` DDL from a source table's columns, `TRUNCATE TABLE` support, and a referential-integrity toggle (`SET session_replication_role`) for FK-safe migrations.
+- Displays `pgvector` `vector`, `halfvec`, and `sparsevec` values, including verified one-dimensional arrays, as textual results.
 
 ### Instance Metrics
 

--- a/crates/dbflux_driver_postgres/src/driver.rs
+++ b/crates/dbflux_driver_postgres/src/driver.rs
@@ -3420,7 +3420,7 @@ fn decode_pgvector_dense(
 fn decode_pgvector_vector(
     raw: &[u8],
 ) -> Result<PgVectorText, Box<dyn std::error::Error + Sync + Send>> {
-    decode_pgvector_dense(raw, 4, |raw, offset| read_pgvector_f32(raw, offset))
+    decode_pgvector_dense(raw, 4, read_pgvector_f32)
 }
 
 fn decode_pgvector_halfvec(
@@ -3511,12 +3511,94 @@ fn decode_pgvector(
     }
 }
 
+fn format_pgvector_float4(value: f32) -> String {
+    let mut buffer = ryu::Buffer::new();
+    let shortest = buffer.format_finite(value);
+
+    let (sign, number) = shortest
+        .strip_prefix('-')
+        .map_or_else(|| ("", shortest), |number| ("-", number));
+    let (coefficient, exponent) =
+        number
+            .split_once('e')
+            .map_or((number, 0), |(coefficient, exponent)| {
+                (
+                    coefficient,
+                    parse_pgvector_exponent(exponent).unwrap_or_default(),
+                )
+            });
+    let integer_digits = coefficient.find('.').unwrap_or(coefficient.len());
+    let digits: String = coefficient.chars().filter(char::is_ascii_digit).collect();
+    let Some(first_digit) = digits.find(|digit| digit != '0') else {
+        return format!("{sign}0");
+    };
+
+    let exponent = exponent + integer_digits as i32 - first_digit as i32 - 1;
+    let digits = digits[first_digit..].trim_end_matches('0');
+
+    if (-4..6).contains(&exponent) {
+        format_pgvector_fixed(sign, digits, exponent)
+    } else {
+        format_pgvector_scientific(sign, digits, exponent)
+    }
+}
+
+fn parse_pgvector_exponent(exponent: &str) -> Option<i32> {
+    let (sign, digits) = exponent.strip_prefix('-').map_or_else(
+        || (1, exponent.strip_prefix('+').unwrap_or(exponent)),
+        |digits| (-1, digits),
+    );
+
+    if digits.is_empty() {
+        return None;
+    }
+
+    let value = digits.chars().try_fold(0_i32, |value, digit| {
+        let digit = i32::try_from(digit.to_digit(10)?).ok()?;
+        value.checked_mul(10)?.checked_add(digit)
+    })?;
+
+    value.checked_mul(sign)
+}
+
+fn format_pgvector_fixed(sign: &str, digits: &str, exponent: i32) -> String {
+    let integer_digits = usize::try_from(exponent + 1).unwrap_or_default();
+
+    if integer_digits >= digits.len() {
+        format!(
+            "{sign}{digits}{}",
+            "0".repeat(integer_digits - digits.len())
+        )
+    } else if integer_digits == 0 {
+        format!("{sign}0.{}{digits}", "0".repeat((-exponent - 1) as usize))
+    } else {
+        format!(
+            "{sign}{}.{}",
+            &digits[..integer_digits],
+            &digits[integer_digits..]
+        )
+    }
+}
+
+fn format_pgvector_scientific(sign: &str, digits: &str, exponent: i32) -> String {
+    let digits = digits.trim_end_matches('0');
+    let mantissa = if digits.len() == 1 {
+        digits.to_string()
+    } else {
+        format!("{}.{}", &digits[..1], &digits[1..])
+    };
+    let exponent_sign = if exponent < 0 { '-' } else { '+' };
+    let exponent = exponent.unsigned_abs();
+
+    format!("{sign}{mantissa}e{exponent_sign}{exponent:02}")
+}
+
 fn format_pgvector_dense(values: &[f32]) -> String {
     format!(
         "[{}]",
         values
             .iter()
-            .map(ToString::to_string)
+            .map(|value| format_pgvector_float4(*value))
             .collect::<Vec<_>>()
             .join(",")
     )
@@ -3525,7 +3607,7 @@ fn format_pgvector_dense(values: &[f32]) -> String {
 fn format_pgvector_sparse(entries: &[(usize, f32)], dimension: usize) -> String {
     let entries = entries
         .iter()
-        .map(|(index, value)| format!("{index}:{value}"))
+        .map(|(index, value)| format!("{index}:{}", format_pgvector_float4(*value)))
         .collect::<Vec<_>>()
         .join(",");
 
@@ -3561,6 +3643,15 @@ fn pgvector_array_values_to_value(values: Option<Vec<Option<PgVectorText>>>) -> 
     }
 }
 
+fn pgvector_array_decode_to_value<E>(
+    type_name: &str,
+    decoded: Result<Option<Vec<Option<PgVectorText>>>, E>,
+) -> Value {
+    decoded
+        .map(pgvector_array_values_to_value)
+        .unwrap_or_else(|_| Value::Unsupported(type_name.to_string()))
+}
+
 fn postgres_pgvector_array_to_value(
     row: &postgres::Row,
     idx: usize,
@@ -3570,9 +3661,10 @@ fn postgres_pgvector_array_to_value(
         return None;
     }
 
-    row.try_get::<_, Option<Vec<Option<PgVectorText>>>>(idx)
-        .ok()
-        .map(pgvector_array_values_to_value)
+    Some(pgvector_array_decode_to_value(
+        type_name,
+        row.try_get::<_, Option<Vec<Option<PgVectorText>>>>(idx),
+    ))
 }
 
 fn postgres_array_to_value(row: &postgres::Row, idx: usize, type_name: &str) -> Option<Value> {
@@ -4667,8 +4759,10 @@ mod tests {
     use super::{
         POSTGRES_DIALECT, PgUriSslMode, PgVectorText, PostgresCodeGenerator, PostgresDialect,
         PostgresDriver, decode_pgvector_halfvec, decode_pgvector_sparsevec, decode_pgvector_vector,
-        inject_password_into_pg_uri, parse_pg_uri_sslmode, pgvector_array_values_to_value,
-        plan_postgres_semantic_request, prokind_to_routine_kind, unsupported_type_names,
+        format_pgvector_dense, format_pgvector_float4, format_pgvector_sparse,
+        inject_password_into_pg_uri, parse_pg_uri_sslmode, pgvector_array_decode_to_value,
+        pgvector_array_values_to_value, plan_postgres_semantic_request, prokind_to_routine_kind,
+        unsupported_type_names,
     };
     use dbflux_core::{
         AddColumnRequest, AlterColumnRequest, CodeGenerator, ColumnAssignment, CreateTableSpec,
@@ -4677,6 +4771,7 @@ mod tests {
         SemanticRequest, SqlDialect, SqlMutationGenerator, SqlQueryBuilder, TableBrowseRequest,
         TableRef, TransferFamily, TypeAttributeDefinition, TypeDefinition, Value, WhereOperator,
     };
+    use postgres::types::{FromSql, Kind, Type};
 
     fn sparsevec_payload(dimension: i32, indices: &[i32], values: &[f32]) -> Vec<u8> {
         assert_eq!(indices.len(), values.len());
@@ -4730,6 +4825,41 @@ mod tests {
     }
 
     #[test]
+    fn pgvector_float4_formatter_matches_postgres_shortest_decimal_boundaries() {
+        let cases = [
+            (1e-6_f32, "1e-06"),
+            (1e-5_f32, "1e-05"),
+            (1e-4_f32, "0.0001"),
+            (999_999_f32, "999999"),
+            (1e6_f32, "1e+06"),
+            (1e20_f32, "1e+20"),
+            (-1e-6_f32, "-1e-06"),
+            (-1e5_f32, "-100000"),
+            (-1e20_f32, "-1e+20"),
+            (f32::MIN_POSITIVE, "1.1754944e-38"),
+            (f32::MAX, "3.4028235e+38"),
+            (0.0_f32, "0"),
+            (-0.0_f32, "-0"),
+        ];
+
+        for (value, expected) in cases {
+            assert_eq!(format_pgvector_float4(value), expected, "value: {value:?}");
+        }
+    }
+
+    #[test]
+    fn pgvector_dense_and_sparse_formatters_share_float4_formatting() {
+        assert_eq!(
+            format_pgvector_dense(&[1e-6, 1e20, -0.0]),
+            "[1e-06,1e+20,-0]"
+        );
+        assert_eq!(
+            format_pgvector_sparse(&[(1, 1e-6), (4, -1e20)], 4),
+            "{1:1e-06,4:-1e+20}/4"
+        );
+    }
+
+    #[test]
     fn pgvector_decoders_reject_malformed_and_non_finite_payloads() {
         let malformed = [0, 1, 0, 0];
         assert!(decode_pgvector_vector(&malformed).is_err());
@@ -4769,6 +4899,36 @@ mod tests {
             ])
         );
         assert_eq!(pgvector_array_values_to_value(None), Value::Null);
+    }
+
+    #[test]
+    fn malformed_pgvector_array_element_is_unsupported_and_warning_eligible() {
+        let vector_type = Type::new("vector".to_string(), 0, Kind::Simple, "public".to_string());
+        let vector_array_type = Type::new(
+            "_vector".to_string(),
+            0,
+            Kind::Array(vector_type),
+            "public".to_string(),
+        );
+        let malformed_element = [0, 1, 0, 0];
+        let mut array = Vec::new();
+        array.extend_from_slice(&1i32.to_be_bytes());
+        array.extend_from_slice(&0i32.to_be_bytes());
+        array.extend_from_slice(&0i32.to_be_bytes());
+        array.extend_from_slice(&1i32.to_be_bytes());
+        array.extend_from_slice(&1i32.to_be_bytes());
+        array.extend_from_slice(&(malformed_element.len() as i32).to_be_bytes());
+        array.extend_from_slice(&malformed_element);
+
+        let decoded = Vec::<Option<PgVectorText>>::from_sql(&vector_array_type, &array).map(Some);
+
+        let value = pgvector_array_decode_to_value("_vector", decoded);
+
+        assert_eq!(value, Value::Unsupported("_vector".to_string()));
+        assert_eq!(
+            unsupported_type_names(&[vec![value]]),
+            ["_vector".to_string()].into()
+        );
     }
 
     #[test]

--- a/crates/dbflux_driver_postgres/src/driver.rs
+++ b/crates/dbflux_driver_postgres/src/driver.rs
@@ -3467,7 +3467,7 @@ fn decode_pgvector_sparsevec(
     let dimension = usize::try_from(dimension)
         .map_err(|_| pgvector_decode_error("invalid pgvector sparse dimension"))?;
     let values_offset = 12 + non_zero_count * 4;
-    let mut previous_index = 0usize;
+    let mut previous_index = None;
     let mut entries = Vec::with_capacity(non_zero_count);
 
     for position in 0..non_zero_count {
@@ -3475,15 +3475,25 @@ fn decode_pgvector_sparsevec(
         let index = usize::try_from(index)
             .map_err(|_| pgvector_decode_error("invalid pgvector sparse index"))?;
 
-        if index == 0 || index > dimension || index <= previous_index {
+        if index >= dimension {
+            return Err(pgvector_decode_error("invalid pgvector sparse index"));
+        }
+
+        if previous_index.is_some_and(|previous_index| index <= previous_index) {
             return Err(pgvector_decode_error(
                 "invalid pgvector sparse index ordering",
             ));
         }
 
         let value = read_pgvector_f32(raw, values_offset + position * 4)?;
-        entries.push((index, value));
-        previous_index = index;
+        if value == 0.0 {
+            return Err(pgvector_decode_error(
+                "pgvector sparse values must be non-zero",
+            ));
+        }
+
+        entries.push((index + 1, value));
+        previous_index = Some(index);
     }
 
     Ok(PgVectorText(format_pgvector_sparse(&entries, dimension)))
@@ -4668,6 +4678,25 @@ mod tests {
         TableRef, TransferFamily, TypeAttributeDefinition, TypeDefinition, Value, WhereOperator,
     };
 
+    fn sparsevec_payload(dimension: i32, indices: &[i32], values: &[f32]) -> Vec<u8> {
+        assert_eq!(indices.len(), values.len());
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&dimension.to_be_bytes());
+        payload.extend_from_slice(&(indices.len() as i32).to_be_bytes());
+        payload.extend_from_slice(&0i32.to_be_bytes());
+
+        for index in indices {
+            payload.extend_from_slice(&index.to_be_bytes());
+        }
+
+        for value in values {
+            payload.extend_from_slice(&value.to_be_bytes());
+        }
+
+        payload
+    }
+
     #[test]
     fn pgvector_scalar_decoders_render_canonical_text() {
         let mut vector = Vec::new();
@@ -4682,14 +4711,7 @@ mod tests {
         halfvec.extend_from_slice(&half::f16::from_f32(1.5).to_bits().to_be_bytes());
         halfvec.extend_from_slice(&half::f16::from_f32(-2.25).to_bits().to_be_bytes());
 
-        let mut sparsevec = Vec::new();
-        sparsevec.extend_from_slice(&4i32.to_be_bytes());
-        sparsevec.extend_from_slice(&2i32.to_be_bytes());
-        sparsevec.extend_from_slice(&0i32.to_be_bytes());
-        sparsevec.extend_from_slice(&1i32.to_be_bytes());
-        sparsevec.extend_from_slice(&4i32.to_be_bytes());
-        sparsevec.extend_from_slice(&1.5f32.to_be_bytes());
-        sparsevec.extend_from_slice(&(-2.25f32).to_be_bytes());
+        let sparsevec = sparsevec_payload(4, &[0, 3], &[1.5, -2.25]);
 
         assert_eq!(
             decode_pgvector_vector(&vector).expect("valid vector").0,
@@ -4720,9 +4742,20 @@ mod tests {
     }
 
     #[test]
+    fn pgvector_sparsevec_rejects_invalid_indices_and_zero_values() {
+        assert!(decode_pgvector_sparsevec(&sparsevec_payload(4, &[4], &[1.5])).is_err());
+        assert!(decode_pgvector_sparsevec(&sparsevec_payload(4, &[1, 1], &[1.5, -2.25])).is_err());
+        assert!(decode_pgvector_sparsevec(&sparsevec_payload(4, &[2, 1], &[1.5, -2.25])).is_err());
+        assert!(decode_pgvector_sparsevec(&sparsevec_payload(4, &[0], &[0.0])).is_err());
+        assert!(decode_pgvector_sparsevec(&sparsevec_payload(4, &[3], &[-0.0])).is_err());
+    }
+
+    #[test]
     fn pgvector_array_values_preserve_element_nulls() {
+        let sparsevec = decode_pgvector_sparsevec(&sparsevec_payload(4, &[0, 3], &[1.5, -2.25]))
+            .expect("valid sparsevec");
         let value = pgvector_array_values_to_value(Some(vec![
-            Some(PgVectorText("[1,2]".to_string())),
+            Some(sparsevec),
             None,
             Some(PgVectorText("[3,4]".to_string())),
         ]));
@@ -4730,7 +4763,7 @@ mod tests {
         assert_eq!(
             value,
             Value::Array(vec![
-                Value::Text("[1,2]".to_string()),
+                Value::Text("{1:1.5,4:-2.25}/4".to_string()),
                 Value::Null,
                 Value::Text("[3,4]".to_string()),
             ])

--- a/crates/dbflux_driver_postgres/src/driver.rs
+++ b/crates/dbflux_driver_postgres/src/driver.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::net::IpAddr;
 use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -33,6 +33,7 @@ use dbflux_core::{
     when_unchecked, with_default, with_help,
 };
 use dbflux_ssh::SshTunnel;
+use half::f16;
 use native_tls::TlsConnector;
 use postgres::types::{FromSql, Kind, Type};
 use postgres::{CancelToken as PgCancelToken, Client, NoTls, SimpleQueryMessage};
@@ -1712,7 +1713,10 @@ impl Connection for PostgresConnection {
             columns.len()
         );
 
-        Ok(QueryResult::table(columns, result_rows, None, total_time))
+        let mut result = QueryResult::table(columns, result_rows, None, total_time);
+        result.set_unsupported_types(unsupported_type_names(&result.rows));
+
+        Ok(result)
     }
 
     fn cancel(&self, handle: &QueryHandle) -> Result<(), DbError> {
@@ -2186,7 +2190,7 @@ impl Connection for PostgresConnection {
             .map(|i| postgres_value_to_value(row, i))
             .collect();
 
-        Ok(CrudResult::success(returning_row))
+        Ok(crud_result_with_unsupported_types(returning_row))
     }
 
     fn insert_row(&self, insert: &RowInsert) -> Result<CrudResult, DbError> {
@@ -2223,7 +2227,7 @@ impl Connection for PostgresConnection {
             .map(|i| postgres_value_to_value(row, i))
             .collect();
 
-        Ok(CrudResult::success(returning_row))
+        Ok(crud_result_with_unsupported_types(returning_row))
     }
 
     fn delete_row(&self, delete: &RowDelete) -> Result<CrudResult, DbError> {
@@ -2262,7 +2266,7 @@ impl Connection for PostgresConnection {
             .map(|i| postgres_value_to_value(row, i))
             .collect();
 
-        Ok(CrudResult::success(returning_row))
+        Ok(crud_result_with_unsupported_types(returning_row))
     }
 
     fn explain(&self, request: &ExplainRequest) -> Result<QueryResult, DbError> {
@@ -3328,6 +3332,239 @@ impl<'a> FromSql<'a> for PgText {
     }
 }
 
+struct PgVectorText(String);
+
+fn pgvector_decode_error(message: &'static str) -> Box<dyn std::error::Error + Sync + Send> {
+    Box::new(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        message,
+    ))
+}
+
+fn read_pgvector_u16(
+    raw: &[u8],
+    offset: usize,
+) -> Result<u16, Box<dyn std::error::Error + Sync + Send>> {
+    let bytes = raw
+        .get(offset..offset + 2)
+        .ok_or_else(|| pgvector_decode_error("pgvector payload ended unexpectedly"))?
+        .try_into()
+        .map_err(|_| pgvector_decode_error("invalid pgvector u16 payload"))?;
+
+    Ok(u16::from_be_bytes(bytes))
+}
+
+fn read_pgvector_i32(
+    raw: &[u8],
+    offset: usize,
+) -> Result<i32, Box<dyn std::error::Error + Sync + Send>> {
+    let bytes = raw
+        .get(offset..offset + 4)
+        .ok_or_else(|| pgvector_decode_error("pgvector payload ended unexpectedly"))?
+        .try_into()
+        .map_err(|_| pgvector_decode_error("invalid pgvector i32 payload"))?;
+
+    Ok(i32::from_be_bytes(bytes))
+}
+
+fn read_pgvector_f32(
+    raw: &[u8],
+    offset: usize,
+) -> Result<f32, Box<dyn std::error::Error + Sync + Send>> {
+    let bytes = raw
+        .get(offset..offset + 4)
+        .ok_or_else(|| pgvector_decode_error("pgvector payload ended unexpectedly"))?
+        .try_into()
+        .map_err(|_| pgvector_decode_error("invalid pgvector float payload"))?;
+    let value = f32::from_be_bytes(bytes);
+
+    if !value.is_finite() {
+        return Err(pgvector_decode_error("pgvector values must be finite"));
+    }
+
+    Ok(value)
+}
+
+fn decode_pgvector_dense(
+    raw: &[u8],
+    element_size: usize,
+    decode_element: impl Fn(&[u8], usize) -> Result<f32, Box<dyn std::error::Error + Sync + Send>>,
+) -> Result<PgVectorText, Box<dyn std::error::Error + Sync + Send>> {
+    let dimension = usize::from(read_pgvector_u16(raw, 0)?);
+    let reserved = read_pgvector_u16(raw, 2)?;
+
+    if dimension == 0 || reserved != 0 {
+        return Err(pgvector_decode_error("invalid pgvector dense header"));
+    }
+
+    let payload_size = dimension
+        .checked_mul(element_size)
+        .ok_or_else(|| pgvector_decode_error("pgvector dimension is too large"))?;
+    let expected_length = 4usize
+        .checked_add(payload_size)
+        .ok_or_else(|| pgvector_decode_error("pgvector payload is too large"))?;
+
+    if raw.len() != expected_length {
+        return Err(pgvector_decode_error(
+            "invalid pgvector dense payload length",
+        ));
+    }
+
+    let values = (0..dimension)
+        .map(|index| decode_element(raw, 4 + index * element_size))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(PgVectorText(format_pgvector_dense(&values)))
+}
+
+fn decode_pgvector_vector(
+    raw: &[u8],
+) -> Result<PgVectorText, Box<dyn std::error::Error + Sync + Send>> {
+    decode_pgvector_dense(raw, 4, |raw, offset| read_pgvector_f32(raw, offset))
+}
+
+fn decode_pgvector_halfvec(
+    raw: &[u8],
+) -> Result<PgVectorText, Box<dyn std::error::Error + Sync + Send>> {
+    decode_pgvector_dense(raw, 2, |raw, offset| {
+        let bits = read_pgvector_u16(raw, offset)?;
+        let value = f16::from_bits(bits).to_f32();
+
+        if !value.is_finite() {
+            return Err(pgvector_decode_error("pgvector values must be finite"));
+        }
+
+        Ok(value)
+    })
+}
+
+fn decode_pgvector_sparsevec(
+    raw: &[u8],
+) -> Result<PgVectorText, Box<dyn std::error::Error + Sync + Send>> {
+    let dimension = read_pgvector_i32(raw, 0)?;
+    let non_zero_count = read_pgvector_i32(raw, 4)?;
+    let reserved = read_pgvector_i32(raw, 8)?;
+
+    if dimension <= 0 || non_zero_count < 0 || non_zero_count > dimension || reserved != 0 {
+        return Err(pgvector_decode_error("invalid pgvector sparse header"));
+    }
+
+    let non_zero_count = usize::try_from(non_zero_count)
+        .map_err(|_| pgvector_decode_error("invalid pgvector sparse count"))?;
+    let values_size = non_zero_count
+        .checked_mul(8)
+        .ok_or_else(|| pgvector_decode_error("pgvector payload is too large"))?;
+    let expected_length = 12usize
+        .checked_add(values_size)
+        .ok_or_else(|| pgvector_decode_error("pgvector payload is too large"))?;
+
+    if raw.len() != expected_length {
+        return Err(pgvector_decode_error(
+            "invalid pgvector sparse payload length",
+        ));
+    }
+
+    let dimension = usize::try_from(dimension)
+        .map_err(|_| pgvector_decode_error("invalid pgvector sparse dimension"))?;
+    let values_offset = 12 + non_zero_count * 4;
+    let mut previous_index = 0usize;
+    let mut entries = Vec::with_capacity(non_zero_count);
+
+    for position in 0..non_zero_count {
+        let index = read_pgvector_i32(raw, 12 + position * 4)?;
+        let index = usize::try_from(index)
+            .map_err(|_| pgvector_decode_error("invalid pgvector sparse index"))?;
+
+        if index == 0 || index > dimension || index <= previous_index {
+            return Err(pgvector_decode_error(
+                "invalid pgvector sparse index ordering",
+            ));
+        }
+
+        let value = read_pgvector_f32(raw, values_offset + position * 4)?;
+        entries.push((index, value));
+        previous_index = index;
+    }
+
+    Ok(PgVectorText(format_pgvector_sparse(&entries, dimension)))
+}
+
+fn decode_pgvector(
+    type_name: &str,
+    raw: &[u8],
+) -> Result<PgVectorText, Box<dyn std::error::Error + Sync + Send>> {
+    match type_name {
+        "vector" => decode_pgvector_vector(raw),
+        "halfvec" => decode_pgvector_halfvec(raw),
+        "sparsevec" => decode_pgvector_sparsevec(raw),
+        _ => Err(pgvector_decode_error("unsupported pgvector type")),
+    }
+}
+
+fn format_pgvector_dense(values: &[f32]) -> String {
+    format!(
+        "[{}]",
+        values
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",")
+    )
+}
+
+fn format_pgvector_sparse(entries: &[(usize, f32)], dimension: usize) -> String {
+    let entries = entries
+        .iter()
+        .map(|(index, value)| format!("{index}:{value}"))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    format!("{{{entries}}}/{dimension}")
+}
+
+impl<'a> FromSql<'a> for PgVectorText {
+    fn from_sql(
+        ty: &Type,
+        raw: &'a [u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        decode_pgvector(ty.name(), raw)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        matches!(ty.name(), "vector" | "halfvec" | "sparsevec")
+    }
+}
+
+fn pgvector_array_values_to_value(values: Option<Vec<Option<PgVectorText>>>) -> Value {
+    match values {
+        Some(values) => Value::Array(
+            values
+                .into_iter()
+                .map(|value| {
+                    value
+                        .map(|PgVectorText(text)| Value::Text(text))
+                        .unwrap_or(Value::Null)
+                })
+                .collect(),
+        ),
+        None => Value::Null,
+    }
+}
+
+fn postgres_pgvector_array_to_value(
+    row: &postgres::Row,
+    idx: usize,
+    type_name: &str,
+) -> Option<Value> {
+    if !matches!(type_name, "_vector" | "_halfvec" | "_sparsevec") {
+        return None;
+    }
+
+    row.try_get::<_, Option<Vec<Option<PgVectorText>>>>(idx)
+        .ok()
+        .map(pgvector_array_values_to_value)
+}
+
 fn postgres_array_to_value(row: &postgres::Row, idx: usize, type_name: &str) -> Option<Value> {
     match type_name {
         "_bool" => match row.try_get::<_, Option<Vec<bool>>>(idx) {
@@ -3452,6 +3689,10 @@ fn postgres_value_to_value(row: &postgres::Row, idx: usize) -> Value {
         return array_value;
     }
 
+    if let Some(array_value) = postgres_pgvector_array_to_value(row, idx, type_name) {
+        return array_value;
+    }
+
     match type_name {
         "bool" => row
             .try_get::<_, Option<bool>>(idx)
@@ -3500,6 +3741,15 @@ fn postgres_value_to_value(row: &postgres::Row, idx: usize) -> Value {
                     .unwrap_or(Value::Null)
             })
             .unwrap_or(Value::Null),
+
+        "vector" | "halfvec" | "sparsevec" => row
+            .try_get::<_, Option<PgVectorText>>(idx)
+            .map(|value| {
+                value
+                    .map(|PgVectorText(text)| Value::Text(text))
+                    .unwrap_or(Value::Null)
+            })
+            .unwrap_or_else(|_| Value::Unsupported(type_name.to_string())),
 
         "uuid" => row
             .try_get::<_, Option<Uuid>>(idx)
@@ -3563,34 +3813,14 @@ fn postgres_value_to_value(row: &postgres::Row, idx: usize) -> Value {
             Kind::Enum(_) => match row.try_get::<_, Option<PgText>>(idx) {
                 Ok(Some(PgText(s))) => Value::Text(s),
                 Ok(None) => Value::Null,
-                Err(e) => {
-                    let col_name = row.columns()[idx].name();
-                    log::info!(
-                        "Unsupported PostgreSQL type '{}' (kind: {:?}) for column '{}': {}",
-                        type_name,
-                        col_type.kind(),
-                        col_name,
-                        e
-                    );
-                    Value::Unsupported(type_name.to_string())
-                }
+                Err(_) => Value::Unsupported(type_name.to_string()),
             },
 
             Kind::Domain(inner) if is_textual_pg_type(inner) => {
                 match row.try_get::<_, Option<PgText>>(idx) {
                     Ok(Some(PgText(s))) => Value::Text(s),
                     Ok(None) => Value::Null,
-                    Err(e) => {
-                        let col_name = row.columns()[idx].name();
-                        log::info!(
-                            "Unsupported PostgreSQL type '{}' (kind: {:?}) for column '{}': {}",
-                            type_name,
-                            col_type.kind(),
-                            col_name,
-                            e
-                        );
-                        Value::Unsupported(type_name.to_string())
-                    }
+                    Err(_) => Value::Unsupported(type_name.to_string()),
                 }
             }
 
@@ -3600,31 +3830,31 @@ fn postgres_value_to_value(row: &postgres::Row, idx: usize) -> Value {
                         Value::Array(arr.into_iter().map(|PgText(s)| Value::Text(s)).collect())
                     }
                     Ok(None) => Value::Null,
-                    Err(e) => {
-                        let col_name = row.columns()[idx].name();
-                        log::info!(
-                            "Unsupported PostgreSQL array type '{}' for column '{}': {}",
-                            type_name,
-                            col_name,
-                            e
-                        );
-                        Value::Unsupported(type_name.to_string())
-                    }
+                    Err(_) => Value::Unsupported(type_name.to_string()),
                 }
             }
 
-            _ => {
-                let col_name = row.columns()[idx].name();
-                log::info!(
-                    "Unsupported PostgreSQL type '{}' (kind: {:?}) for column '{}': fallback decode disabled",
-                    type_name,
-                    col_type.kind(),
-                    col_name
-                );
-                Value::Unsupported(type_name.to_string())
-            }
+            _ => Value::Unsupported(type_name.to_string()),
         },
     }
+}
+
+fn unsupported_type_names(rows: &[Row]) -> BTreeSet<String> {
+    rows.iter()
+        .flatten()
+        .filter_map(|value| match value {
+            Value::Unsupported(type_name) => Some(type_name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn crud_result_with_unsupported_types(returning_row: Row) -> CrudResult {
+    let mut result = CrudResult::success(returning_row);
+    let type_names = unsupported_type_names(result.returning_row.as_slice());
+    result.set_unsupported_types(type_names);
+
+    result
 }
 
 pub struct PostgresErrorFormatter;
@@ -4425,9 +4655,10 @@ fn get_schema_routines(
 #[cfg(test)]
 mod tests {
     use super::{
-        POSTGRES_DIALECT, PgUriSslMode, PostgresCodeGenerator, PostgresDialect, PostgresDriver,
-        inject_password_into_pg_uri, parse_pg_uri_sslmode, plan_postgres_semantic_request,
-        prokind_to_routine_kind,
+        POSTGRES_DIALECT, PgUriSslMode, PgVectorText, PostgresCodeGenerator, PostgresDialect,
+        PostgresDriver, decode_pgvector_halfvec, decode_pgvector_sparsevec, decode_pgvector_vector,
+        inject_password_into_pg_uri, parse_pg_uri_sslmode, pgvector_array_values_to_value,
+        plan_postgres_semantic_request, prokind_to_routine_kind, unsupported_type_names,
     };
     use dbflux_core::{
         AddColumnRequest, AlterColumnRequest, CodeGenerator, ColumnAssignment, CreateTableSpec,
@@ -4436,6 +4667,97 @@ mod tests {
         SemanticRequest, SqlDialect, SqlMutationGenerator, SqlQueryBuilder, TableBrowseRequest,
         TableRef, TransferFamily, TypeAttributeDefinition, TypeDefinition, Value, WhereOperator,
     };
+
+    #[test]
+    fn pgvector_scalar_decoders_render_canonical_text() {
+        let mut vector = Vec::new();
+        vector.extend_from_slice(&2u16.to_be_bytes());
+        vector.extend_from_slice(&0u16.to_be_bytes());
+        vector.extend_from_slice(&1.5f32.to_be_bytes());
+        vector.extend_from_slice(&(-2.25f32).to_be_bytes());
+
+        let mut halfvec = Vec::new();
+        halfvec.extend_from_slice(&2u16.to_be_bytes());
+        halfvec.extend_from_slice(&0u16.to_be_bytes());
+        halfvec.extend_from_slice(&half::f16::from_f32(1.5).to_bits().to_be_bytes());
+        halfvec.extend_from_slice(&half::f16::from_f32(-2.25).to_bits().to_be_bytes());
+
+        let mut sparsevec = Vec::new();
+        sparsevec.extend_from_slice(&4i32.to_be_bytes());
+        sparsevec.extend_from_slice(&2i32.to_be_bytes());
+        sparsevec.extend_from_slice(&0i32.to_be_bytes());
+        sparsevec.extend_from_slice(&1i32.to_be_bytes());
+        sparsevec.extend_from_slice(&4i32.to_be_bytes());
+        sparsevec.extend_from_slice(&1.5f32.to_be_bytes());
+        sparsevec.extend_from_slice(&(-2.25f32).to_be_bytes());
+
+        assert_eq!(
+            decode_pgvector_vector(&vector).expect("valid vector").0,
+            "[1.5,-2.25]"
+        );
+        assert_eq!(
+            decode_pgvector_halfvec(&halfvec).expect("valid halfvec").0,
+            "[1.5,-2.25]"
+        );
+        assert_eq!(
+            decode_pgvector_sparsevec(&sparsevec)
+                .expect("valid sparsevec")
+                .0,
+            "{1:1.5,4:-2.25}/4"
+        );
+    }
+
+    #[test]
+    fn pgvector_decoders_reject_malformed_and_non_finite_payloads() {
+        let malformed = [0, 1, 0, 0];
+        assert!(decode_pgvector_vector(&malformed).is_err());
+
+        let mut non_finite = Vec::new();
+        non_finite.extend_from_slice(&1u16.to_be_bytes());
+        non_finite.extend_from_slice(&0u16.to_be_bytes());
+        non_finite.extend_from_slice(&f32::NAN.to_be_bytes());
+        assert!(decode_pgvector_vector(&non_finite).is_err());
+    }
+
+    #[test]
+    fn pgvector_array_values_preserve_element_nulls() {
+        let value = pgvector_array_values_to_value(Some(vec![
+            Some(PgVectorText("[1,2]".to_string())),
+            None,
+            Some(PgVectorText("[3,4]".to_string())),
+        ]));
+
+        assert_eq!(
+            value,
+            Value::Array(vec![
+                Value::Text("[1,2]".to_string()),
+                Value::Null,
+                Value::Text("[3,4]".to_string()),
+            ])
+        );
+        assert_eq!(pgvector_array_values_to_value(None), Value::Null);
+    }
+
+    #[test]
+    fn unsupported_type_aggregation_is_deduplicated() {
+        let rows = vec![
+            vec![
+                Value::Unsupported("vector".to_string()),
+                Value::Unsupported("bit".to_string()),
+            ],
+            vec![
+                Value::Unsupported("vector".to_string()),
+                Value::Unsupported("varbit".to_string()),
+            ],
+        ];
+
+        assert_eq!(
+            unsupported_type_names(&rows)
+                .into_iter()
+                .collect::<Vec<_>>(),
+            vec!["bit", "varbit", "vector"]
+        );
+    }
 
     #[test]
     fn build_uri_encodes_user_and_password() {

--- a/crates/dbflux_driver_postgres/tests/live_integration.rs
+++ b/crates/dbflux_driver_postgres/tests/live_integration.rs
@@ -49,6 +49,28 @@ fn connect_postgres(
     Ok((connection, driver))
 }
 
+fn assert_pgvector_array_matches_server_text(decoded: &Value, server_text: &Value) {
+    let Value::Array(values) = decoded else {
+        panic!("expected decoded pgvector array, got {decoded:?}");
+    };
+    let Value::Text(server_text) = server_text else {
+        panic!("expected server canonical array text, got {server_text:?}");
+    };
+
+    let decoded_text: Vec<Option<String>> = values
+        .iter()
+        .map(|value| match value {
+            Value::Text(text) => Some(text.clone()),
+            Value::Null => None,
+            other => panic!("expected pgvector array text or NULL, got {other:?}"),
+        })
+        .collect();
+    let canonical_text: Vec<Option<String>> =
+        serde_json::from_str(server_text).expect("server pgvector array text must be JSON");
+
+    assert_eq!(decoded_text, canonical_text);
+}
+
 // ---------------------------------------------------------------------------
 // Basic connectivity
 // ---------------------------------------------------------------------------
@@ -248,6 +270,112 @@ fn postgres_crud_operations() -> Result<(), DbError> {
             .execute(&QueryRequest::new("SELECT * FROM crud_test"))?
             .rows;
         assert!(rows.is_empty());
+
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon and the pinned pgvector PostgreSQL 16 image"]
+fn postgres_pgvector_text_matches_server_output_and_crud_returning() -> Result<(), DbError> {
+    containers::with_pgvector_postgres_16_url(|uri| {
+        let (connection, _) = connect_postgres(uri)?;
+
+        connection.execute(&QueryRequest::new("CREATE EXTENSION vector"))?;
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE pgvector_display (
+                id INTEGER PRIMARY KEY,
+                vector_value vector,
+                halfvec_value halfvec,
+                sparsevec_value sparsevec,
+                vector_values vector[],
+                halfvec_values halfvec[],
+                sparsevec_values sparsevec[]
+            )",
+        ))?;
+        connection.execute(&QueryRequest::new(
+            "INSERT INTO pgvector_display VALUES (
+                1,
+                '[1e-6,1e20,-1e-6,-1e20]',
+                '[1.5,-2.25]',
+                '{1:1e-6,4:-1e20}/4',
+                ARRAY['[1e-6,1e20,-1e-6,-1e20]'::vector, NULL, '[2,3]'::vector],
+                ARRAY['[1.5,-2.25]'::halfvec, NULL, '[3,4]'::halfvec],
+                ARRAY['{1:1e-6,4:-1e20}/4'::sparsevec, NULL, '{2:3}/4'::sparsevec]
+            )",
+        ))?;
+
+        let result = connection.execute(&QueryRequest::new(
+            "SELECT
+                vector_value, vector_value::text,
+                halfvec_value, halfvec_value::text,
+                sparsevec_value, sparsevec_value::text,
+                vector_values, array_to_json(vector_values)::text,
+                halfvec_values, array_to_json(halfvec_values)::text,
+                sparsevec_values, array_to_json(sparsevec_values)::text,
+                NULL::vector, NULL::vector[]
+             FROM pgvector_display",
+        ))?;
+        let row = &result.rows[0];
+
+        for (value_index, text_index) in [(0, 1), (2, 3), (4, 5)] {
+            assert_eq!(row[value_index], row[text_index]);
+        }
+        assert_pgvector_array_matches_server_text(&row[6], &row[7]);
+        assert_pgvector_array_matches_server_text(&row[8], &row[9]);
+        assert_pgvector_array_matches_server_text(&row[10], &row[11]);
+        assert_eq!(row[12], Value::Null);
+        assert_eq!(row[13], Value::Null);
+
+        let inserted = connection.insert_row(&RowInsert::with_typed_assignments(
+            "pgvector_display".to_string(),
+            Some("public".to_string()),
+            vec![
+                ColumnAssignment::new("id", Value::Int(2)),
+                ColumnAssignment::typed(
+                    "vector_value",
+                    Value::Text("[1e-6,1e20,-1e-6,-1e20]".to_string()),
+                    "vector",
+                ),
+            ],
+        ))?;
+        let inserted_value = inserted.returning_row.as_ref().and_then(|row| row.get(1));
+        let server_value = connection
+            .execute(&QueryRequest::new(
+                "SELECT vector_value::text FROM pgvector_display WHERE id = 2",
+            ))?
+            .rows[0][0]
+            .clone();
+        assert_eq!(inserted_value, Some(&server_value));
+
+        let updated = connection.update_row(&RowPatch::with_typed_changes(
+            RecordIdentity::composite(vec!["id".to_string()], vec![Value::Int(2)]),
+            "pgvector_display".to_string(),
+            Some("public".to_string()),
+            vec![ColumnAssignment::typed(
+                "vector_value",
+                Value::Text("[2,3]".to_string()),
+                "vector",
+            )],
+        ))?;
+        let updated_value = updated.returning_row.as_ref().and_then(|row| row.get(1));
+        let server_value = connection
+            .execute(&QueryRequest::new(
+                "SELECT vector_value::text FROM pgvector_display WHERE id = 2",
+            ))?
+            .rows[0][0]
+            .clone();
+        assert_eq!(updated_value, Some(&server_value));
+
+        let deleted = connection.delete_row(&RowDelete::new(
+            RecordIdentity::composite(vec!["id".to_string()], vec![Value::Int(2)]),
+            "pgvector_display".to_string(),
+            Some("public".to_string()),
+        ))?;
+        assert_eq!(
+            deleted.returning_row.as_ref().and_then(|row| row.get(1)),
+            Some(&server_value)
+        );
 
         Ok(())
     })

--- a/crates/dbflux_test_support/src/containers.rs
+++ b/crates/dbflux_test_support/src/containers.rs
@@ -25,6 +25,30 @@ where
     run(url)
 }
 
+pub fn with_pgvector_postgres_16_url<T, E, F>(run: F) -> Result<T, E>
+where
+    F: FnOnce(String) -> Result<T, E>,
+{
+    let image = GenericImage::new("pgvector/pgvector", "0.8.0-pg16")
+        .with_exposed_port(ContainerPort::Tcp(5432))
+        .with_wait_for(WaitFor::message_on_stdout(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_USER", "postgres")
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .with_env_var("POSTGRES_DB", "postgres");
+
+    let container = image
+        .start()
+        .expect("failed to start pgvector postgres container");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .expect("failed to get pgvector postgres host port");
+    let url = format!("postgres://postgres:postgres@127.0.0.1:{port}/postgres");
+
+    run(url)
+}
+
 pub fn with_mysql_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -998,11 +998,7 @@ impl CodeDocument {
             Ok(mut qr) => {
                 self.runner.complete_primary(pending.task_id, cx);
 
-                crate::result_warnings::consume_query_result_warnings(
-                    &mut qr,
-                    crate::result_warnings::ResultWarningContext::Query,
-                    cx,
-                );
+                crate::result_warnings::consume_sql_editor_result_warnings(&mut qr, cx);
 
                 // Use affected_rows when available (INSERT/UPDATE/DELETE), otherwise rows.len() (SELECT)
                 let affected_rows = qr.affected_rows;

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -637,7 +637,13 @@ impl CodeDocument {
         });
 
         cx.spawn(async move |this, cx| {
-            let result = task.await;
+            let mut result = task.await;
+
+            if let Ok(query_result) = result.as_mut() {
+                crate::result_warnings::handoff_sql_editor_result(query_result, |warning| {
+                    dbflux_ui_base::user_error::report_error_async(warning, cx)
+                });
+            }
 
             if cancel_token.is_cancelled() {
                 log::info!("Query was cancelled, discarding result");
@@ -995,10 +1001,8 @@ impl CodeDocument {
         let is_script = pending.is_script;
 
         match pending.result {
-            Ok(mut qr) => {
+            Ok(qr) => {
                 self.runner.complete_primary(pending.task_id, cx);
-
-                crate::result_warnings::consume_sql_editor_result_warnings(&mut qr, cx);
 
                 // Use affected_rows when available (INSERT/UPDATE/DELETE), otherwise rows.len() (SELECT)
                 let affected_rows = qr.affected_rows;

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -995,8 +995,14 @@ impl CodeDocument {
         let is_script = pending.is_script;
 
         match pending.result {
-            Ok(qr) => {
+            Ok(mut qr) => {
                 self.runner.complete_primary(pending.task_id, cx);
+
+                crate::result_warnings::consume_query_result_warnings(
+                    &mut qr,
+                    crate::result_warnings::ResultWarningContext::Query,
+                    cx,
+                );
 
                 // Use affected_rows when available (INSERT/UPDATE/DELETE), otherwise rows.len() (SELECT)
                 let affected_rows = qr.affected_rows;

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
@@ -2161,10 +2161,9 @@ impl DataGridPanel {
                     entity.update(cx, |panel, cx| {
                         match result {
                             Ok(mut crud_result) => {
-                                crate::result_warnings::consume_crud_result_warnings(
+                                crate::result_warnings::handoff_crud_returning_result(
                                     &mut crud_result,
-                                    crate::result_warnings::ResultWarningContext::CrudReturning,
-                                    cx,
+                                    |warning| dbflux_ui_base::user_error::report_error(warning, cx),
                                 );
                                 panel.pending.toast = Some(PendingToast {
                                     message: "Document inserted".to_string(),
@@ -2281,10 +2280,9 @@ impl DataGridPanel {
                 entity.update(cx, |panel, cx| {
                     match result {
                         Ok(mut crud_result) => {
-                            crate::result_warnings::consume_crud_result_warnings(
+                            crate::result_warnings::handoff_crud_returning_result(
                                 &mut crud_result,
-                                crate::result_warnings::ResultWarningContext::CrudReturning,
-                                cx,
+                                |warning| dbflux_ui_base::user_error::report_error(warning, cx),
                             );
                             panel.pending.toast = Some(PendingToast {
                                 message: "Document updated".to_string(),

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
@@ -2160,7 +2160,12 @@ impl DataGridPanel {
                 cx.update(|cx| {
                     entity.update(cx, |panel, cx| {
                         match result {
-                            Ok(_) => {
+                            Ok(mut crud_result) => {
+                                crate::result_warnings::consume_crud_result_warnings(
+                                    &mut crud_result,
+                                    crate::result_warnings::ResultWarningContext::CrudReturning,
+                                    cx,
+                                );
                                 panel.pending.toast = Some(PendingToast {
                                     message: "Document inserted".to_string(),
                                     is_error: false,
@@ -2275,7 +2280,12 @@ impl DataGridPanel {
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
                     match result {
-                        Ok(_) => {
+                        Ok(mut crud_result) => {
+                            crate::result_warnings::consume_crud_result_warnings(
+                                &mut crud_result,
+                                crate::result_warnings::ResultWarningContext::CrudReturning,
+                                cx,
+                            );
                             panel.pending.toast = Some(PendingToast {
                                 message: "Document updated".to_string(),
                                 is_error: false,

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -3758,7 +3758,11 @@ impl DataGridPanel {
 
         // Fetch sample rows synchronously on background thread (2s deadline).
         let (sample_columns, sample_rows) =
-            crate::data_grid_panel::mutation_confirm::fetch_sample_rows(connection, &spec);
+            crate::data_grid_panel::mutation_confirm::fetch_sample_rows(
+                connection,
+                &spec,
+                |warning| dbflux_ui_base::user_error::report_error(warning, cx),
+            );
 
         let sample_rows_opt = if sample_rows.is_empty() {
             None

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutation_confirm.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutation_confirm.rs
@@ -5,6 +5,7 @@ use dbflux_components::modals::{MutationConfirmHardRequest, MutationConfirmReque
 use dbflux_core::{
     Connection, FilterNode, QueryRequest, Value, VisualMutationSpec, render_filter_node_sql,
 };
+use dbflux_ui_base::user_error::UserFacingError;
 
 /// Controls which mutation confirmation modal opens, and carries its request payload.
 ///
@@ -29,6 +30,7 @@ pub enum PendingMutationModal {
 pub fn fetch_sample_rows(
     connection: Arc<dyn Connection>,
     spec: &VisualMutationSpec,
+    report: impl FnMut(UserFacingError),
 ) -> (Vec<String>, Vec<Vec<String>>) {
     let dialect = connection.dialect();
     let qualified_table = dialect.qualified_table(spec.from.schema.as_deref(), &spec.from.name);
@@ -49,28 +51,40 @@ pub fn fetch_sample_rows(
         _ => format!("SELECT * FROM {} ORDER BY 1 {}", qualified_table, limit),
     };
 
-    let (tx, rx) = std::sync::mpsc::channel::<Option<(Vec<String>, Vec<Vec<String>>)>>();
+    let (tx, rx) = std::sync::mpsc::channel();
 
     std::thread::spawn(move || {
         let mut request = QueryRequest::new(sql);
         request.params = params;
-        let result = connection.execute(&request).ok().map(|qr| {
-            let col_names: Vec<String> = qr.columns.iter().map(|c| c.name.clone()).collect();
-            let rows: Vec<Vec<String>> = qr
-                .rows
-                .iter()
-                .map(|row| row.iter().map(|v| format!("{}", v)).collect())
-                .collect();
-            (col_names, rows)
-        });
+        let result = connection.execute(&request).ok();
         // The receiver may have already timed out and been dropped; drop the send error.
         let _drop_send = tx.send(result);
     });
 
     match rx.recv_timeout(Duration::from_secs(2)) {
-        Ok(Some(data)) => data,
+        Ok(Some(mut result)) => sample_rows_from_result(&mut result, report),
         _ => (Vec::new(), Vec::new()),
     }
+}
+
+fn sample_rows_from_result(
+    result: &mut dbflux_core::QueryResult,
+    report: impl FnMut(UserFacingError),
+) -> (Vec<String>, Vec<Vec<String>>) {
+    crate::result_warnings::handoff_mutation_preview_result(result, report);
+
+    let columns = result
+        .columns
+        .iter()
+        .map(|column| column.name.clone())
+        .collect();
+    let rows = result
+        .rows
+        .iter()
+        .map(|row| row.iter().map(|value| format!("{value}")).collect())
+        .collect();
+
+    (columns, rows)
 }
 
 /// Returns `true` when the filter uniquely identifies a single row by primary key.
@@ -214,9 +228,11 @@ pub fn format_value(value: &Value) -> String {
 
 #[cfg(test)]
 mod tests {
-    use dbflux_core::{BoolOp, Comparator, FilterNode, LiteralValue, Predicate, PredicateValue};
+    use dbflux_core::{
+        BoolOp, Comparator, FilterNode, LiteralValue, Predicate, PredicateValue, QueryResult,
+    };
 
-    use super::filter_is_pk_unique;
+    use super::{filter_is_pk_unique, sample_rows_from_result};
 
     fn pred_eq(col: &str) -> FilterNode {
         FilterNode::Predicate(Predicate {
@@ -310,6 +326,21 @@ mod tests {
     fn empty_pk_cols_is_not_pk_unique() {
         let filter = Some(pred_eq("id"));
         assert!(!filter_is_pk_unique(&filter, &[]));
+    }
+
+    #[test]
+    fn mutation_preview_handoff_reports_and_drains_warning_metadata() {
+        let mut result = QueryResult::empty();
+        result.set_unsupported_types(["bit".to_string(), "bit".to_string()]);
+
+        let mut summaries = Vec::new();
+        let _ = sample_rows_from_result(&mut result, |warning| summaries.push(warning.summary));
+
+        assert_eq!(
+            summaries,
+            ["Unsupported database type 'bit' in mutation preview result"]
+        );
+        assert!(result.take_unsupported_types().is_empty());
     }
 
     // AND group where one child is a non-Eq predicate → false (mixed group rejected).
@@ -600,7 +631,7 @@ mod tests {
             let conn_ref = Arc::clone(&conn);
             let spec = delete_spec("orders");
 
-            fetch_sample_rows(conn as Arc<dyn dbflux_core::Connection>, &spec);
+            fetch_sample_rows(conn as Arc<dyn dbflux_core::Connection>, &spec, |_| {});
 
             let calls = conn_ref.recorded_calls();
             assert_eq!(calls.len(), 1, "expected exactly one SELECT call");
@@ -633,7 +664,7 @@ mod tests {
             let conn_ref = Arc::clone(&conn);
             let spec = delete_spec("orders");
 
-            fetch_sample_rows(conn as Arc<dyn dbflux_core::Connection>, &spec);
+            fetch_sample_rows(conn as Arc<dyn dbflux_core::Connection>, &spec, |_| {});
 
             let calls = conn_ref.recorded_calls();
             assert_eq!(calls.len(), 1, "expected exactly one SELECT call");

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
@@ -712,7 +712,13 @@ impl DataGridPanel {
         };
 
         match result {
-            Ok(crud_result) => {
+            Ok(mut crud_result) => {
+                crate::result_warnings::consume_crud_result_warnings(
+                    &mut crud_result,
+                    crate::result_warnings::ResultWarningContext::CrudReturning,
+                    cx,
+                );
+
                 table_state.update(cx, |state, cx| {
                     if let Some(returning_row) = crud_result.returning_row {
                         state.apply_returning_row(row_idx, &returning_row);

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
@@ -309,7 +309,12 @@ impl DataGridPanel {
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
                     match result {
-                        Ok(_) => {
+                        Ok(mut crud_result) => {
+                            crate::result_warnings::consume_crud_result_warnings(
+                                &mut crud_result,
+                                crate::result_warnings::ResultWarningContext::CrudReturning,
+                                cx,
+                            );
                             panel.runner.complete_mutation(task_id, cx);
                             panel.apply_inline_value_to_result(&node_id, &inline_value);
 
@@ -854,7 +859,12 @@ impl DataGridPanel {
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
                     match result {
-                        Ok(_) => {
+                        Ok(mut crud_result) => {
+                            crate::result_warnings::consume_crud_result_warnings(
+                                &mut crud_result,
+                                crate::result_warnings::ResultWarningContext::CrudReturning,
+                                cx,
+                            );
                             panel.runner.complete_mutation(task_id, cx);
 
                             table_state_clone.update(cx, |state, cx| {
@@ -993,7 +1003,12 @@ impl DataGridPanel {
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
                     match result {
-                        Ok(_) => {
+                        Ok(mut crud_result) => {
+                            crate::result_warnings::consume_crud_result_warnings(
+                                &mut crud_result,
+                                crate::result_warnings::ResultWarningContext::CrudReturning,
+                                cx,
+                            );
                             panel.runner.complete_mutation(task_id, cx);
 
                             table_state_clone.update(cx, |state, cx| {
@@ -1202,7 +1217,12 @@ impl DataGridPanel {
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
                     match result {
-                        Ok(_) => {
+                        Ok(mut crud_result) => {
+                            crate::result_warnings::consume_crud_result_warnings(
+                                &mut crud_result,
+                                crate::result_warnings::ResultWarningContext::CrudReturning,
+                                cx,
+                            );
                             panel.runner.complete_mutation(task_id, cx);
 
                             table_state_clone.update(cx, |state, cx| {
@@ -1336,7 +1356,12 @@ impl DataGridPanel {
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
                     match result {
-                        Ok(_) => {
+                        Ok(mut crud_result) => {
+                            crate::result_warnings::consume_crud_result_warnings(
+                                &mut crud_result,
+                                crate::result_warnings::ResultWarningContext::CrudReturning,
+                                cx,
+                            );
                             panel.runner.complete_mutation(task_id, cx);
 
                             table_state_clone.update(cx, |state, cx| {
@@ -1577,7 +1602,7 @@ impl DataGridPanel {
                 return;
             };
 
-            let mut success_count = 0usize;
+            let mut successful_results = Vec::new();
             let mut last_error: Option<dbflux_core::DbError> = None;
 
             for (_row_idx, identity) in &identities {
@@ -1591,8 +1616,8 @@ impl DataGridPanel {
                     .await;
 
                 match result {
-                    Ok(_) => {
-                        success_count += 1;
+                    Ok(crud_result) => {
+                        successful_results.push(crud_result);
                     }
                     Err(e) => {
                         last_error = Some(e);
@@ -1604,6 +1629,15 @@ impl DataGridPanel {
 
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
+                    for crud_result in &mut successful_results {
+                        crate::result_warnings::consume_crud_result_warnings(
+                            crud_result,
+                            crate::result_warnings::ResultWarningContext::CrudReturning,
+                            cx,
+                        );
+                    }
+
+                    let success_count = successful_results.len();
                     if let Some(e) = last_error {
                         panel.runner.fail_mutation(task_id, e.to_string(), cx);
                         report_error(
@@ -1756,7 +1790,7 @@ impl DataGridPanel {
                 return;
             };
 
-            let mut success_count = 0usize;
+            let mut successful_results = Vec::new();
             let mut last_error: Option<dbflux_core::DbError> = None;
 
             for (_row_idx, filter) in &filters {
@@ -1771,8 +1805,8 @@ impl DataGridPanel {
                     .await;
 
                 match result {
-                    Ok(_) => {
-                        success_count += 1;
+                    Ok(crud_result) => {
+                        successful_results.push(crud_result);
                     }
                     Err(e) => {
                         last_error = Some(e);
@@ -1783,6 +1817,15 @@ impl DataGridPanel {
 
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
+                    for crud_result in &mut successful_results {
+                        crate::result_warnings::consume_crud_result_warnings(
+                            crud_result,
+                            crate::result_warnings::ResultWarningContext::CrudReturning,
+                            cx,
+                        );
+                    }
+
+                    let success_count = successful_results.len();
                     if let Some(e) = last_error {
                         panel.runner.fail_mutation(task_id, e.to_string(), cx);
                         report_error(

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
@@ -310,10 +310,9 @@ impl DataGridPanel {
                 entity.update(cx, |panel, cx| {
                     match result {
                         Ok(mut crud_result) => {
-                            crate::result_warnings::consume_crud_result_warnings(
+                            crate::result_warnings::handoff_crud_returning_result(
                                 &mut crud_result,
-                                crate::result_warnings::ResultWarningContext::CrudReturning,
-                                cx,
+                                |warning| report_error(warning, cx),
                             );
                             panel.runner.complete_mutation(task_id, cx);
                             panel.apply_inline_value_to_result(&node_id, &inline_value);
@@ -718,10 +717,9 @@ impl DataGridPanel {
 
         match result {
             Ok(mut crud_result) => {
-                crate::result_warnings::consume_crud_result_warnings(
+                crate::result_warnings::handoff_crud_returning_result(
                     &mut crud_result,
-                    crate::result_warnings::ResultWarningContext::CrudReturning,
-                    cx,
+                    |warning| report_error(warning, cx),
                 );
 
                 table_state.update(cx, |state, cx| {
@@ -860,10 +858,9 @@ impl DataGridPanel {
                 entity.update(cx, |panel, cx| {
                     match result {
                         Ok(mut crud_result) => {
-                            crate::result_warnings::consume_crud_result_warnings(
+                            crate::result_warnings::handoff_crud_returning_result(
                                 &mut crud_result,
-                                crate::result_warnings::ResultWarningContext::CrudReturning,
-                                cx,
+                                |warning| report_error(warning, cx),
                             );
                             panel.runner.complete_mutation(task_id, cx);
 
@@ -1004,10 +1001,9 @@ impl DataGridPanel {
                 entity.update(cx, |panel, cx| {
                     match result {
                         Ok(mut crud_result) => {
-                            crate::result_warnings::consume_crud_result_warnings(
+                            crate::result_warnings::handoff_crud_returning_result(
                                 &mut crud_result,
-                                crate::result_warnings::ResultWarningContext::CrudReturning,
-                                cx,
+                                |warning| report_error(warning, cx),
                             );
                             panel.runner.complete_mutation(task_id, cx);
 
@@ -1218,10 +1214,9 @@ impl DataGridPanel {
                 entity.update(cx, |panel, cx| {
                     match result {
                         Ok(mut crud_result) => {
-                            crate::result_warnings::consume_crud_result_warnings(
+                            crate::result_warnings::handoff_crud_returning_result(
                                 &mut crud_result,
-                                crate::result_warnings::ResultWarningContext::CrudReturning,
-                                cx,
+                                |warning| report_error(warning, cx),
                             );
                             panel.runner.complete_mutation(task_id, cx);
 
@@ -1357,10 +1352,9 @@ impl DataGridPanel {
                 entity.update(cx, |panel, cx| {
                     match result {
                         Ok(mut crud_result) => {
-                            crate::result_warnings::consume_crud_result_warnings(
+                            crate::result_warnings::handoff_crud_returning_result(
                                 &mut crud_result,
-                                crate::result_warnings::ResultWarningContext::CrudReturning,
-                                cx,
+                                |warning| report_error(warning, cx),
                             );
                             panel.runner.complete_mutation(task_id, cx);
 
@@ -1629,13 +1623,10 @@ impl DataGridPanel {
 
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
-                    for crud_result in &mut successful_results {
-                        crate::result_warnings::consume_crud_result_warnings(
-                            crud_result,
-                            crate::result_warnings::ResultWarningContext::CrudReturning,
-                            cx,
-                        );
-                    }
+                    crate::result_warnings::handoff_bulk_crud_returning_results(
+                        &mut successful_results,
+                        |warning| report_error(warning, cx),
+                    );
 
                     let success_count = successful_results.len();
                     if let Some(e) = last_error {
@@ -1817,13 +1808,10 @@ impl DataGridPanel {
 
             cx.update(|cx| {
                 entity.update(cx, |panel, cx| {
-                    for crud_result in &mut successful_results {
-                        crate::result_warnings::consume_crud_result_warnings(
-                            crud_result,
-                            crate::result_warnings::ResultWarningContext::CrudReturning,
-                            cx,
-                        );
-                    }
+                    crate::result_warnings::handoff_bulk_crud_returning_results(
+                        &mut successful_results,
+                        |warning| report_error(warning, cx),
+                    );
 
                     let success_count = successful_results.len();
                     if let Some(e) = last_error {

--- a/crates/dbflux_ui_document/src/data_grid_panel/query.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/query.rs
@@ -256,9 +256,8 @@ impl DataGridPanel {
 
                         entity.update(cx, |panel, cx| {
                             panel.runner.complete_primary(task_id, cx);
-                            crate::result_warnings::consume_query_result_warnings(
+                            crate::result_warnings::consume_table_browse_result_warnings(
                                 &mut query_result,
-                                crate::result_warnings::ResultWarningContext::TableBrowse,
                                 cx,
                             );
                             panel.apply_table_result(
@@ -402,9 +401,8 @@ impl DataGridPanel {
 
                         entity.update(cx, |panel, cx| {
                             panel.runner.complete_primary(task_id, cx);
-                            crate::result_warnings::consume_query_result_warnings(
+                            crate::result_warnings::consume_visual_query_result_warnings(
                                 &mut query_result,
-                                crate::result_warnings::ResultWarningContext::VisualQuery,
                                 cx,
                             );
                             panel.builder.current_visual_spec = committed_spec.clone();
@@ -580,9 +578,8 @@ impl DataGridPanel {
 
                         entity.update(cx, |panel, cx| {
                             panel.runner.complete_primary(task_id, cx);
-                            crate::result_warnings::consume_query_result_warnings(
+                            crate::result_warnings::consume_collection_browse_result_warnings(
                                 &mut query_result,
-                                crate::result_warnings::ResultWarningContext::CollectionBrowse,
                                 cx,
                             );
                             panel.apply_collection_result(

--- a/crates/dbflux_ui_document/src/data_grid_panel/query.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/query.rs
@@ -235,7 +235,13 @@ impl DataGridPanel {
             .spawn(async move { conn.browse_table(&browse_request) });
 
         cx.spawn(async move |_this, cx| {
-            let result = task.await;
+            let mut result = task.await;
+
+            if let Ok(query_result) = result.as_mut() {
+                crate::result_warnings::handoff_table_browse_result(query_result, |warning| {
+                    dbflux_ui_base::user_error::report_error_async(warning, cx)
+                });
+            }
 
             if let Err(error) = cx.update(|cx| {
                 if cancel_token.is_cancelled() {
@@ -247,7 +253,7 @@ impl DataGridPanel {
                 }
 
                 match result {
-                    Ok(mut query_result) => {
+                    Ok(query_result) => {
                         info!(
                             "Query returned {} rows in {:?}",
                             query_result.row_count(),
@@ -256,10 +262,6 @@ impl DataGridPanel {
 
                         entity.update(cx, |panel, cx| {
                             panel.runner.complete_primary(task_id, cx);
-                            crate::result_warnings::consume_table_browse_result_warnings(
-                                &mut query_result,
-                                cx,
-                            );
                             panel.apply_table_result(
                                 profile_id,
                                 table_for_spawn,
@@ -376,7 +378,13 @@ impl DataGridPanel {
             .spawn(async move { conn.execute(&request) });
 
         cx.spawn(async move |_this, cx| {
-            let result = task.await;
+            let mut result = task.await;
+
+            if let Ok(query_result) = result.as_mut() {
+                crate::result_warnings::handoff_visual_query_result(query_result, |warning| {
+                    dbflux_ui_base::user_error::report_error_async(warning, cx)
+                });
+            }
 
             if let Err(error) = cx.update(|cx| {
                 if cancel_token.is_cancelled() {
@@ -401,10 +409,6 @@ impl DataGridPanel {
 
                         entity.update(cx, |panel, cx| {
                             panel.runner.complete_primary(task_id, cx);
-                            crate::result_warnings::consume_visual_query_result_warnings(
-                                &mut query_result,
-                                cx,
-                            );
                             panel.builder.current_visual_spec = committed_spec.clone();
                             panel.result = query_result;
                             panel.refresh.state = GridState::Ready;
@@ -557,7 +561,13 @@ impl DataGridPanel {
             .spawn(async move { conn.browse_collection(&browse_request) });
 
         cx.spawn(async move |_this, cx| {
-            let result = task.await;
+            let mut result = task.await;
+
+            if let Ok(query_result) = result.as_mut() {
+                crate::result_warnings::handoff_collection_browse_result(query_result, |warning| {
+                    dbflux_ui_base::user_error::report_error_async(warning, cx)
+                });
+            }
 
             if let Err(error) = cx.update(|cx| {
                 if cancel_token.is_cancelled() {
@@ -569,7 +579,7 @@ impl DataGridPanel {
                 }
 
                 match result {
-                    Ok(mut query_result) => {
+                    Ok(query_result) => {
                         info!(
                             "Collection query returned {} documents in {:?}",
                             query_result.row_count(),
@@ -578,10 +588,6 @@ impl DataGridPanel {
 
                         entity.update(cx, |panel, cx| {
                             panel.runner.complete_primary(task_id, cx);
-                            crate::result_warnings::consume_collection_browse_result_warnings(
-                                &mut query_result,
-                                cx,
-                            );
                             panel.apply_collection_result(
                                 profile_id,
                                 collection_for_spawn,

--- a/crates/dbflux_ui_document/src/data_grid_panel/query.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/query.rs
@@ -246,8 +246,8 @@ impl DataGridPanel {
                     return;
                 }
 
-                match &result {
-                    Ok(query_result) => {
+                match result {
+                    Ok(mut query_result) => {
                         info!(
                             "Query returned {} rows in {:?}",
                             query_result.row_count(),
@@ -256,13 +256,18 @@ impl DataGridPanel {
 
                         entity.update(cx, |panel, cx| {
                             panel.runner.complete_primary(task_id, cx);
+                            crate::result_warnings::consume_query_result_warnings(
+                                &mut query_result,
+                                crate::result_warnings::ResultWarningContext::TableBrowse,
+                                cx,
+                            );
                             panel.apply_table_result(
                                 profile_id,
                                 table_for_spawn,
                                 pagination_for_spawn,
                                 order_by_for_spawn,
                                 total_rows,
-                                query_result.clone(),
+                                query_result,
                                 cx,
                             );
                         });
@@ -397,6 +402,11 @@ impl DataGridPanel {
 
                         entity.update(cx, |panel, cx| {
                             panel.runner.complete_primary(task_id, cx);
+                            crate::result_warnings::consume_query_result_warnings(
+                                &mut query_result,
+                                crate::result_warnings::ResultWarningContext::VisualQuery,
+                                cx,
+                            );
                             panel.builder.current_visual_spec = committed_spec.clone();
                             panel.result = query_result;
                             panel.refresh.state = GridState::Ready;
@@ -560,8 +570,8 @@ impl DataGridPanel {
                     return;
                 }
 
-                match &result {
-                    Ok(query_result) => {
+                match result {
+                    Ok(mut query_result) => {
                         info!(
                             "Collection query returned {} documents in {:?}",
                             query_result.row_count(),
@@ -570,12 +580,17 @@ impl DataGridPanel {
 
                         entity.update(cx, |panel, cx| {
                             panel.runner.complete_primary(task_id, cx);
+                            crate::result_warnings::consume_query_result_warnings(
+                                &mut query_result,
+                                crate::result_warnings::ResultWarningContext::CollectionBrowse,
+                                cx,
+                            );
                             panel.apply_collection_result(
                                 profile_id,
                                 collection_for_spawn,
                                 pagination_for_spawn,
                                 total_docs,
-                                query_result.clone(),
+                                query_result,
                                 cx,
                             );
                         });

--- a/crates/dbflux_ui_document/src/lib.rs
+++ b/crates/dbflux_ui_document/src/lib.rs
@@ -36,6 +36,7 @@ pub mod object_text;
 pub mod pane;
 pub mod refresh;
 mod result_view;
+mod result_warnings;
 pub mod tab_bar;
 mod tab_manager;
 mod task_runner;

--- a/crates/dbflux_ui_document/src/result_warnings.rs
+++ b/crates/dbflux_ui_document/src/result_warnings.rs
@@ -30,7 +30,7 @@ pub(crate) fn consume_query_result_warnings(
     context: ResultWarningContext,
     cx: &mut App,
 ) {
-    report_unsupported_type_warnings(take_query_result_warning_types(result), context, cx);
+    consume_query_result_warnings_with(result, context, |warning| report_error(warning, cx));
 }
 
 pub(crate) fn consume_crud_result_warnings(
@@ -38,7 +38,23 @@ pub(crate) fn consume_crud_result_warnings(
     context: ResultWarningContext,
     cx: &mut App,
 ) {
-    report_unsupported_type_warnings(take_crud_result_warning_types(result), context, cx);
+    consume_crud_result_warnings_with(result, context, |warning| report_error(warning, cx));
+}
+
+fn consume_query_result_warnings_with(
+    result: &mut QueryResult,
+    context: ResultWarningContext,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_warning_types_with(take_query_result_warning_types(result), context, report);
+}
+
+fn consume_crud_result_warnings_with(
+    result: &mut CrudResult,
+    context: ResultWarningContext,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_warning_types_with(take_crud_result_warning_types(result), context, report);
 }
 
 fn take_query_result_warning_types(result: &mut QueryResult) -> Vec<String> {
@@ -55,14 +71,14 @@ fn take_crud_result_warning_types(result: &mut CrudResult) -> Vec<String> {
     result.take_unsupported_types()
 }
 
-fn report_unsupported_type_warnings(
+fn consume_warning_types_with(
     type_names: Vec<String>,
     context: ResultWarningContext,
-    cx: &mut App,
+    report: impl FnMut(UserFacingError),
 ) {
-    for warning in unsupported_type_warnings(type_names, context) {
-        report_error(warning, cx);
-    }
+    unsupported_type_warnings(type_names, context)
+        .into_iter()
+        .for_each(report);
 }
 
 fn unsupported_type_warnings(
@@ -94,8 +110,9 @@ fn unsupported_type_warnings(
 #[cfg(test)]
 mod tests {
     use super::{
-        ResultWarningContext, take_crud_result_warning_types, take_query_result_warning_types,
-        unsupported_type_warnings,
+        ResultWarningContext, consume_crud_result_warnings_with,
+        consume_query_result_warnings_with, take_crud_result_warning_types,
+        take_query_result_warning_types, unsupported_type_warnings,
     };
     use dbflux_core::observability::EventSeverity;
     use dbflux_core::{CrudResult, QueryResult};
@@ -168,5 +185,92 @@ mod tests {
 
         assert_eq!(take_crud_result_warning_types(&mut result), vec!["halfvec"]);
         assert!(take_crud_result_warning_types(&mut result).is_empty());
+    }
+
+    #[test]
+    fn sql_editor_history_handoff_reports_once_before_replay() {
+        let mut result = QueryResult::empty();
+        result.set_unsupported_types(["bit".to_string(), "bit".to_string()]);
+
+        let mut additional_result = QueryResult::empty();
+        additional_result.set_unsupported_types(["varbit".to_string()]);
+        result.additional_results.push(additional_result);
+
+        let mut summaries = Vec::new();
+        consume_query_result_warnings_with(&mut result, ResultWarningContext::Query, |warning| {
+            summaries.push(warning.summary);
+        });
+        consume_query_result_warnings_with(&mut result, ResultWarningContext::Query, |warning| {
+            summaries.push(warning.summary);
+        });
+
+        assert_eq!(
+            summaries,
+            [
+                "Unsupported database type 'bit' in query result",
+                "Unsupported database type 'varbit' in query result",
+            ]
+        );
+    }
+
+    #[test]
+    fn browse_refresh_and_visual_query_handoffs_report_once_per_result() {
+        let cases = [
+            (ResultWarningContext::TableBrowse, "table browse result"),
+            (ResultWarningContext::VisualQuery, "visual query result"),
+            (
+                ResultWarningContext::CollectionBrowse,
+                "collection browse result",
+            ),
+        ];
+
+        for (context, label) in cases {
+            let mut result = QueryResult::empty();
+            result.set_unsupported_types(["bit".to_string(), "varbit".to_string()]);
+
+            let mut summaries = Vec::new();
+            consume_query_result_warnings_with(&mut result, context, |warning| {
+                summaries.push(warning.summary);
+            });
+            consume_query_result_warnings_with(&mut result, context, |warning| {
+                summaries.push(warning.summary);
+            });
+
+            assert_eq!(
+                summaries,
+                [
+                    format!("Unsupported database type 'bit' in {label}"),
+                    format!("Unsupported database type 'varbit' in {label}"),
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn crud_handoffs_report_once_before_returning_application_or_discard() {
+        for _operation in ["insert", "update", "delete", "bulk delete"] {
+            let mut result = CrudResult::empty();
+            result.set_unsupported_types(["bit".to_string(), "varbit".to_string()]);
+
+            let mut summaries = Vec::new();
+            consume_crud_result_warnings_with(
+                &mut result,
+                ResultWarningContext::CrudReturning,
+                |warning| summaries.push(warning.summary),
+            );
+            consume_crud_result_warnings_with(
+                &mut result,
+                ResultWarningContext::CrudReturning,
+                |warning| summaries.push(warning.summary),
+            );
+
+            assert_eq!(
+                summaries,
+                [
+                    "Unsupported database type 'bit' in mutation RETURNING result",
+                    "Unsupported database type 'varbit' in mutation RETURNING result",
+                ]
+            );
+        }
     }
 }

--- a/crates/dbflux_ui_document/src/result_warnings.rs
+++ b/crates/dbflux_ui_document/src/result_warnings.rs
@@ -25,12 +25,20 @@ impl ResultWarningContext {
     }
 }
 
-pub(crate) fn consume_query_result_warnings(
-    result: &mut QueryResult,
-    context: ResultWarningContext,
-    cx: &mut App,
-) {
-    consume_query_result_warnings_with(result, context, |warning| report_error(warning, cx));
+pub(crate) fn consume_sql_editor_result_warnings(result: &mut QueryResult, cx: &mut App) {
+    consume_sql_editor_result_warnings_with(result, |warning| report_error(warning, cx));
+}
+
+pub(crate) fn consume_table_browse_result_warnings(result: &mut QueryResult, cx: &mut App) {
+    consume_table_browse_result_warnings_with(result, |warning| report_error(warning, cx));
+}
+
+pub(crate) fn consume_visual_query_result_warnings(result: &mut QueryResult, cx: &mut App) {
+    consume_visual_query_result_warnings_with(result, |warning| report_error(warning, cx));
+}
+
+pub(crate) fn consume_collection_browse_result_warnings(result: &mut QueryResult, cx: &mut App) {
+    consume_collection_browse_result_warnings_with(result, |warning| report_error(warning, cx));
 }
 
 pub(crate) fn consume_crud_result_warnings(
@@ -47,6 +55,34 @@ fn consume_query_result_warnings_with(
     report: impl FnMut(UserFacingError),
 ) {
     consume_warning_types_with(take_query_result_warning_types(result), context, report);
+}
+
+fn consume_sql_editor_result_warnings_with(
+    result: &mut QueryResult,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_query_result_warnings_with(result, ResultWarningContext::Query, report);
+}
+
+fn consume_table_browse_result_warnings_with(
+    result: &mut QueryResult,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_query_result_warnings_with(result, ResultWarningContext::TableBrowse, report);
+}
+
+fn consume_visual_query_result_warnings_with(
+    result: &mut QueryResult,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_query_result_warnings_with(result, ResultWarningContext::VisualQuery, report);
+}
+
+fn consume_collection_browse_result_warnings_with(
+    result: &mut QueryResult,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_query_result_warnings_with(result, ResultWarningContext::CollectionBrowse, report);
 }
 
 fn consume_crud_result_warnings_with(
@@ -110,12 +146,14 @@ fn unsupported_type_warnings(
 #[cfg(test)]
 mod tests {
     use super::{
-        ResultWarningContext, consume_crud_result_warnings_with,
-        consume_query_result_warnings_with, take_crud_result_warning_types,
-        take_query_result_warning_types, unsupported_type_warnings,
+        ResultWarningContext, consume_collection_browse_result_warnings_with,
+        consume_crud_result_warnings_with, consume_sql_editor_result_warnings_with,
+        consume_table_browse_result_warnings_with, consume_visual_query_result_warnings_with,
+        take_crud_result_warning_types, take_query_result_warning_types, unsupported_type_warnings,
     };
     use dbflux_core::observability::EventSeverity;
     use dbflux_core::{CrudResult, QueryResult};
+    use dbflux_ui_base::user_error::UserFacingError;
 
     #[test]
     fn builds_one_warning_per_distinct_type() {
@@ -197,10 +235,10 @@ mod tests {
         result.additional_results.push(additional_result);
 
         let mut summaries = Vec::new();
-        consume_query_result_warnings_with(&mut result, ResultWarningContext::Query, |warning| {
+        consume_sql_editor_result_warnings_with(&mut result, |warning| {
             summaries.push(warning.summary);
         });
-        consume_query_result_warnings_with(&mut result, ResultWarningContext::Query, |warning| {
+        consume_sql_editor_result_warnings_with(&mut result, |warning| {
             summaries.push(warning.summary);
         });
 
@@ -214,63 +252,110 @@ mod tests {
     }
 
     #[test]
-    fn browse_refresh_and_visual_query_handoffs_report_once_per_result() {
-        let cases = [
-            (ResultWarningContext::TableBrowse, "table browse result"),
-            (ResultWarningContext::VisualQuery, "visual query result"),
-            (
-                ResultWarningContext::CollectionBrowse,
-                "collection browse result",
-            ),
-        ];
-
-        for (context, label) in cases {
-            let mut result = QueryResult::empty();
-            result.set_unsupported_types(["bit".to_string(), "varbit".to_string()]);
-
-            let mut summaries = Vec::new();
-            consume_query_result_warnings_with(&mut result, context, |warning| {
-                summaries.push(warning.summary);
-            });
-            consume_query_result_warnings_with(&mut result, context, |warning| {
-                summaries.push(warning.summary);
-            });
-
-            assert_eq!(
-                summaries,
-                [
-                    format!("Unsupported database type 'bit' in {label}"),
-                    format!("Unsupported database type 'varbit' in {label}"),
-                ]
-            );
-        }
+    fn table_browse_refresh_handoff_reports_once_before_replay() {
+        assert_query_handoff_reports_once("table browse result", |result, report| {
+            consume_table_browse_result_warnings_with(result, report)
+        });
     }
 
     #[test]
-    fn crud_handoffs_report_once_before_returning_application_or_discard() {
-        for _operation in ["insert", "update", "delete", "bulk delete"] {
-            let mut result = CrudResult::empty();
-            result.set_unsupported_types(["bit".to_string(), "varbit".to_string()]);
+    fn visual_query_handoff_reports_once_before_replay() {
+        assert_query_handoff_reports_once("visual query result", |result, report| {
+            consume_visual_query_result_warnings_with(result, report)
+        });
+    }
 
-            let mut summaries = Vec::new();
-            consume_crud_result_warnings_with(
-                &mut result,
-                ResultWarningContext::CrudReturning,
-                |warning| summaries.push(warning.summary),
-            );
-            consume_crud_result_warnings_with(
-                &mut result,
-                ResultWarningContext::CrudReturning,
-                |warning| summaries.push(warning.summary),
-            );
+    #[test]
+    fn collection_browse_handoff_reports_once_before_replay() {
+        assert_query_handoff_reports_once("collection browse result", |result, report| {
+            consume_collection_browse_result_warnings_with(result, report)
+        });
+    }
 
-            assert_eq!(
-                summaries,
-                [
-                    "Unsupported database type 'bit' in mutation RETURNING result",
-                    "Unsupported database type 'varbit' in mutation RETURNING result",
-                ]
-            );
-        }
+    #[test]
+    fn crud_returning_handoff_reports_once_before_apply_or_discard() {
+        let mut result = CrudResult::empty();
+        result.set_unsupported_types(["bit".to_string(), "varbit".to_string()]);
+
+        let mut summaries = Vec::new();
+        consume_crud_result_warnings_with(
+            &mut result,
+            ResultWarningContext::CrudReturning,
+            |warning| summaries.push(warning.summary),
+        );
+        consume_crud_result_warnings_with(
+            &mut result,
+            ResultWarningContext::CrudReturning,
+            |warning| summaries.push(warning.summary),
+        );
+
+        assert_eq!(
+            summaries,
+            [
+                "Unsupported database type 'bit' in mutation RETURNING result",
+                "Unsupported database type 'varbit' in mutation RETURNING result",
+            ]
+        );
+    }
+
+    #[test]
+    fn production_handoffs_invoke_the_destructive_consumers_once() {
+        let execution = include_str!("code/execution.rs");
+        let query = include_str!("data_grid_panel/query.rs");
+        let mutations = include_str!("data_grid_panel/mutations.rs");
+        let context_menu = include_str!("data_grid_panel/context_menu/mod.rs");
+
+        assert_eq!(
+            execution
+                .matches("consume_sql_editor_result_warnings(")
+                .count(),
+            1
+        );
+        assert_eq!(
+            query
+                .matches("consume_table_browse_result_warnings(")
+                .count(),
+            1
+        );
+        assert_eq!(
+            query
+                .matches("consume_visual_query_result_warnings(")
+                .count(),
+            1
+        );
+        assert_eq!(
+            query
+                .matches("consume_collection_browse_result_warnings(")
+                .count(),
+            1
+        );
+        assert_eq!(
+            mutations.matches("consume_crud_result_warnings(").count()
+                + context_menu
+                    .matches("consume_crud_result_warnings(")
+                    .count(),
+            10
+        );
+    }
+
+    fn assert_query_handoff_reports_once(
+        label: &str,
+        consume: impl Fn(&mut QueryResult, &mut dyn FnMut(UserFacingError)),
+    ) {
+        let mut result = QueryResult::empty();
+        result.set_unsupported_types(["bit".to_string(), "varbit".to_string()]);
+
+        let mut summaries = Vec::new();
+        let mut report = |warning: UserFacingError| summaries.push(warning.summary);
+        consume(&mut result, &mut report);
+        consume(&mut result, &mut report);
+
+        assert_eq!(
+            summaries,
+            [
+                format!("Unsupported database type 'bit' in {label}"),
+                format!("Unsupported database type 'varbit' in {label}"),
+            ]
+        );
     }
 }

--- a/crates/dbflux_ui_document/src/result_warnings.rs
+++ b/crates/dbflux_ui_document/src/result_warnings.rs
@@ -1,0 +1,172 @@
+use dbflux_core::observability::EventSeverity;
+use dbflux_core::{CrudResult, QueryResult};
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
+use gpui::App;
+use std::collections::BTreeSet;
+
+#[derive(Clone, Copy)]
+pub(crate) enum ResultWarningContext {
+    Query,
+    TableBrowse,
+    VisualQuery,
+    CollectionBrowse,
+    CrudReturning,
+}
+
+impl ResultWarningContext {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Query => "query result",
+            Self::TableBrowse => "table browse result",
+            Self::VisualQuery => "visual query result",
+            Self::CollectionBrowse => "collection browse result",
+            Self::CrudReturning => "mutation RETURNING result",
+        }
+    }
+}
+
+pub(crate) fn consume_query_result_warnings(
+    result: &mut QueryResult,
+    context: ResultWarningContext,
+    cx: &mut App,
+) {
+    report_unsupported_type_warnings(take_query_result_warning_types(result), context, cx);
+}
+
+pub(crate) fn consume_crud_result_warnings(
+    result: &mut CrudResult,
+    context: ResultWarningContext,
+    cx: &mut App,
+) {
+    report_unsupported_type_warnings(take_crud_result_warning_types(result), context, cx);
+}
+
+fn take_query_result_warning_types(result: &mut QueryResult) -> Vec<String> {
+    let mut type_names = result.take_unsupported_types();
+
+    for additional_result in &mut result.additional_results {
+        type_names.extend(additional_result.take_unsupported_types());
+    }
+
+    type_names
+}
+
+fn take_crud_result_warning_types(result: &mut CrudResult) -> Vec<String> {
+    result.take_unsupported_types()
+}
+
+fn report_unsupported_type_warnings(
+    type_names: Vec<String>,
+    context: ResultWarningContext,
+    cx: &mut App,
+) {
+    for warning in unsupported_type_warnings(type_names, context) {
+        report_error(warning, cx);
+    }
+}
+
+fn unsupported_type_warnings(
+    type_names: Vec<String>,
+    context: ResultWarningContext,
+) -> Vec<UserFacingError> {
+    type_names
+        .into_iter()
+        .filter(|type_name| !type_name.is_empty())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .map(|type_name| {
+            UserFacingError::new(
+                ErrorKind::Driver,
+                format!(
+                    "Unsupported database type '{type_name}' in {}",
+                    context.label()
+                ),
+            )
+            .with_cause(format!(
+                "The {} contains values of unsupported type '{type_name}'.",
+                context.label()
+            ))
+            .with_severity(EventSeverity::Warn)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ResultWarningContext, take_crud_result_warning_types, take_query_result_warning_types,
+        unsupported_type_warnings,
+    };
+    use dbflux_core::observability::EventSeverity;
+    use dbflux_core::{CrudResult, QueryResult};
+
+    #[test]
+    fn builds_one_warning_per_distinct_type() {
+        let warnings = unsupported_type_warnings(
+            vec![
+                "varbit".to_string(),
+                "bit".to_string(),
+                "varbit".to_string(),
+            ],
+            ResultWarningContext::Query,
+        );
+
+        assert_eq!(warnings.len(), 2);
+        assert_eq!(warnings[0].severity, EventSeverity::Warn);
+        assert_eq!(
+            warnings[0].summary,
+            "Unsupported database type 'bit' in query result"
+        );
+        assert_eq!(
+            warnings[1].summary,
+            "Unsupported database type 'varbit' in query result"
+        );
+    }
+
+    #[test]
+    fn warning_text_contains_only_type_and_safe_context() {
+        let warnings = unsupported_type_warnings(
+            vec!["vector".to_string()],
+            ResultWarningContext::CrudReturning,
+        );
+
+        let warning = &warnings[0];
+        assert_eq!(
+            warning.summary,
+            "Unsupported database type 'vector' in mutation RETURNING result"
+        );
+        assert_eq!(
+            warning.cause.as_deref(),
+            Some("The mutation RETURNING result contains values of unsupported type 'vector'.")
+        );
+    }
+
+    #[test]
+    fn query_warning_metadata_is_consumed_once_before_result_storage() {
+        let mut result = QueryResult::empty();
+        result.set_unsupported_types(["bit".to_string()]);
+
+        let mut additional_result = QueryResult::empty();
+        additional_result.set_unsupported_types(["bit".to_string(), "varbit".to_string()]);
+        result.additional_results.push(additional_result);
+
+        assert_eq!(
+            unsupported_type_warnings(
+                take_query_result_warning_types(&mut result),
+                ResultWarningContext::Query,
+            )
+            .len(),
+            2
+        );
+        assert!(take_query_result_warning_types(&mut result).is_empty());
+    }
+
+    #[test]
+    fn crud_warning_metadata_is_consumed_once_before_returning_application() {
+        let mut result = CrudResult::empty();
+        result.set_unsupported_types(["halfvec".to_string()]);
+
+        assert_eq!(take_crud_result_warning_types(&mut result), vec!["halfvec"]);
+        assert!(take_crud_result_warning_types(&mut result).is_empty());
+    }
+}

--- a/crates/dbflux_ui_document/src/result_warnings.rs
+++ b/crates/dbflux_ui_document/src/result_warnings.rs
@@ -1,7 +1,6 @@
 use dbflux_core::observability::EventSeverity;
 use dbflux_core::{CrudResult, QueryResult};
-use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
-use gpui::App;
+use dbflux_ui_base::user_error::{ErrorKind, UserFacingError};
 use std::collections::BTreeSet;
 
 #[derive(Clone, Copy)]
@@ -11,6 +10,7 @@ pub(crate) enum ResultWarningContext {
     VisualQuery,
     CollectionBrowse,
     CrudReturning,
+    MutationPreview,
 }
 
 impl ResultWarningContext {
@@ -21,35 +21,61 @@ impl ResultWarningContext {
             Self::VisualQuery => "visual query result",
             Self::CollectionBrowse => "collection browse result",
             Self::CrudReturning => "mutation RETURNING result",
+            Self::MutationPreview => "mutation preview result",
         }
     }
 }
 
-pub(crate) fn consume_sql_editor_result_warnings(result: &mut QueryResult, cx: &mut App) {
-    consume_sql_editor_result_warnings_with(result, |warning| report_error(warning, cx));
-}
-
-pub(crate) fn consume_table_browse_result_warnings(result: &mut QueryResult, cx: &mut App) {
-    consume_table_browse_result_warnings_with(result, |warning| report_error(warning, cx));
-}
-
-pub(crate) fn consume_visual_query_result_warnings(result: &mut QueryResult, cx: &mut App) {
-    consume_visual_query_result_warnings_with(result, |warning| report_error(warning, cx));
-}
-
-pub(crate) fn consume_collection_browse_result_warnings(result: &mut QueryResult, cx: &mut App) {
-    consume_collection_browse_result_warnings_with(result, |warning| report_error(warning, cx));
-}
-
-pub(crate) fn consume_crud_result_warnings(
+pub(crate) fn handoff_crud_returning_result(
     result: &mut CrudResult,
-    context: ResultWarningContext,
-    cx: &mut App,
+    report: impl FnMut(UserFacingError),
 ) {
-    consume_crud_result_warnings_with(result, context, |warning| report_error(warning, cx));
+    consume_crud_result_warnings(result, ResultWarningContext::CrudReturning, report);
 }
 
-fn consume_query_result_warnings_with(
+pub(crate) fn handoff_bulk_crud_returning_results(
+    results: &mut [CrudResult],
+    report: impl FnMut(UserFacingError),
+) {
+    consume_bulk_crud_result_warnings(results, report);
+}
+
+pub(crate) fn handoff_sql_editor_result(
+    result: &mut QueryResult,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_query_result_warnings(result, ResultWarningContext::Query, report);
+}
+
+pub(crate) fn handoff_table_browse_result(
+    result: &mut QueryResult,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_query_result_warnings(result, ResultWarningContext::TableBrowse, report);
+}
+
+pub(crate) fn handoff_visual_query_result(
+    result: &mut QueryResult,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_query_result_warnings(result, ResultWarningContext::VisualQuery, report);
+}
+
+pub(crate) fn handoff_collection_browse_result(
+    result: &mut QueryResult,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_query_result_warnings(result, ResultWarningContext::CollectionBrowse, report);
+}
+
+pub(crate) fn handoff_mutation_preview_result(
+    result: &mut QueryResult,
+    report: impl FnMut(UserFacingError),
+) {
+    consume_query_result_warnings(result, ResultWarningContext::MutationPreview, report);
+}
+
+fn consume_query_result_warnings(
     result: &mut QueryResult,
     context: ResultWarningContext,
     report: impl FnMut(UserFacingError),
@@ -57,40 +83,24 @@ fn consume_query_result_warnings_with(
     consume_warning_types_with(take_query_result_warning_types(result), context, report);
 }
 
-fn consume_sql_editor_result_warnings_with(
-    result: &mut QueryResult,
-    report: impl FnMut(UserFacingError),
-) {
-    consume_query_result_warnings_with(result, ResultWarningContext::Query, report);
-}
-
-fn consume_table_browse_result_warnings_with(
-    result: &mut QueryResult,
-    report: impl FnMut(UserFacingError),
-) {
-    consume_query_result_warnings_with(result, ResultWarningContext::TableBrowse, report);
-}
-
-fn consume_visual_query_result_warnings_with(
-    result: &mut QueryResult,
-    report: impl FnMut(UserFacingError),
-) {
-    consume_query_result_warnings_with(result, ResultWarningContext::VisualQuery, report);
-}
-
-fn consume_collection_browse_result_warnings_with(
-    result: &mut QueryResult,
-    report: impl FnMut(UserFacingError),
-) {
-    consume_query_result_warnings_with(result, ResultWarningContext::CollectionBrowse, report);
-}
-
-fn consume_crud_result_warnings_with(
+fn consume_crud_result_warnings(
     result: &mut CrudResult,
     context: ResultWarningContext,
     report: impl FnMut(UserFacingError),
 ) {
     consume_warning_types_with(take_crud_result_warning_types(result), context, report);
+}
+
+fn consume_bulk_crud_result_warnings(
+    results: &mut [CrudResult],
+    report: impl FnMut(UserFacingError),
+) {
+    let type_names = results
+        .iter_mut()
+        .flat_map(take_crud_result_warning_types)
+        .collect();
+
+    consume_warning_types_with(type_names, ResultWarningContext::CrudReturning, report);
 }
 
 fn take_query_result_warning_types(result: &mut QueryResult) -> Vec<String> {
@@ -146,10 +156,10 @@ fn unsupported_type_warnings(
 #[cfg(test)]
 mod tests {
     use super::{
-        ResultWarningContext, consume_collection_browse_result_warnings_with,
-        consume_crud_result_warnings_with, consume_sql_editor_result_warnings_with,
-        consume_table_browse_result_warnings_with, consume_visual_query_result_warnings_with,
-        take_crud_result_warning_types, take_query_result_warning_types, unsupported_type_warnings,
+        ResultWarningContext, handoff_bulk_crud_returning_results,
+        handoff_collection_browse_result, handoff_crud_returning_result, handoff_sql_editor_result,
+        handoff_table_browse_result, handoff_visual_query_result, take_crud_result_warning_types,
+        take_query_result_warning_types, unsupported_type_warnings,
     };
     use dbflux_core::observability::EventSeverity;
     use dbflux_core::{CrudResult, QueryResult};
@@ -235,10 +245,10 @@ mod tests {
         result.additional_results.push(additional_result);
 
         let mut summaries = Vec::new();
-        consume_sql_editor_result_warnings_with(&mut result, |warning| {
+        handoff_sql_editor_result(&mut result, |warning| {
             summaries.push(warning.summary);
         });
-        consume_sql_editor_result_warnings_with(&mut result, |warning| {
+        handoff_sql_editor_result(&mut result, |warning| {
             summaries.push(warning.summary);
         });
 
@@ -254,21 +264,21 @@ mod tests {
     #[test]
     fn table_browse_refresh_handoff_reports_once_before_replay() {
         assert_query_handoff_reports_once("table browse result", |result, report| {
-            consume_table_browse_result_warnings_with(result, report)
+            handoff_table_browse_result(result, report)
         });
     }
 
     #[test]
     fn visual_query_handoff_reports_once_before_replay() {
         assert_query_handoff_reports_once("visual query result", |result, report| {
-            consume_visual_query_result_warnings_with(result, report)
+            handoff_visual_query_result(result, report)
         });
     }
 
     #[test]
     fn collection_browse_handoff_reports_once_before_replay() {
         assert_query_handoff_reports_once("collection browse result", |result, report| {
-            consume_collection_browse_result_warnings_with(result, report)
+            handoff_collection_browse_result(result, report)
         });
     }
 
@@ -278,16 +288,8 @@ mod tests {
         result.set_unsupported_types(["bit".to_string(), "varbit".to_string()]);
 
         let mut summaries = Vec::new();
-        consume_crud_result_warnings_with(
-            &mut result,
-            ResultWarningContext::CrudReturning,
-            |warning| summaries.push(warning.summary),
-        );
-        consume_crud_result_warnings_with(
-            &mut result,
-            ResultWarningContext::CrudReturning,
-            |warning| summaries.push(warning.summary),
-        );
+        handoff_crud_returning_result(&mut result, |warning| summaries.push(warning.summary));
+        handoff_crud_returning_result(&mut result, |warning| summaries.push(warning.summary));
 
         assert_eq!(
             summaries,
@@ -299,42 +301,29 @@ mod tests {
     }
 
     #[test]
-    fn production_handoffs_invoke_the_destructive_consumers_once() {
-        let execution = include_str!("code/execution.rs");
-        let query = include_str!("data_grid_panel/query.rs");
-        let mutations = include_str!("data_grid_panel/mutations.rs");
-        let context_menu = include_str!("data_grid_panel/context_menu/mod.rs");
+    fn bulk_crud_handoff_deduplicates_partial_successes_before_reporting() {
+        let mut first = CrudResult::empty();
+        first.set_unsupported_types(["bit".to_string(), "varbit".to_string()]);
+        let mut second = CrudResult::empty();
+        second.set_unsupported_types(["bit".to_string()]);
+        let mut results = vec![first, second];
+
+        let mut summaries = Vec::new();
+        handoff_bulk_crud_returning_results(&mut results, |warning| {
+            summaries.push(warning.summary);
+        });
 
         assert_eq!(
-            execution
-                .matches("consume_sql_editor_result_warnings(")
-                .count(),
-            1
+            summaries,
+            [
+                "Unsupported database type 'bit' in mutation RETURNING result",
+                "Unsupported database type 'varbit' in mutation RETURNING result",
+            ]
         );
-        assert_eq!(
-            query
-                .matches("consume_table_browse_result_warnings(")
-                .count(),
-            1
-        );
-        assert_eq!(
-            query
-                .matches("consume_visual_query_result_warnings(")
-                .count(),
-            1
-        );
-        assert_eq!(
-            query
-                .matches("consume_collection_browse_result_warnings(")
-                .count(),
-            1
-        );
-        assert_eq!(
-            mutations.matches("consume_crud_result_warnings(").count()
-                + context_menu
-                    .matches("consume_crud_result_warnings(")
-                    .count(),
-            10
+        assert!(
+            results
+                .iter_mut()
+                .all(|result| take_crud_result_warning_types(result).is_empty())
         );
     }
 


### PR DESCRIPTION
## Summary

- Decode PostgreSQL `vector`, `halfvec`, and `sparsevec` values, including verified one-dimensional arrays, instead of rendering them as `NULL` or unsupported placeholders.
- Report genuinely unsupported result types once per logical result through the shared warning seam, producing a warning toast, correlated audit event, and log entry.
- Preserve full vector text for editing and clipboard while keeping the existing 200-character grid preview.

## What does this resolve?

Resolves the reported PostgreSQL vector-display regression. No GitHub issue was linked to the original report.

## How was this solved?

- Added validated binary decoders and PostgreSQL-compatible float4 text formatting for pgvector types.
- Added result-level unsupported-type metadata with destructive, production-owned handoffs across editor, grid, refresh, preview, cancellation, and CRUD paths.
- Deduplicated warnings across logical bulk operations to prevent toast, audit, and log storms.
- Added a pinned PostgreSQL 16 + pgvector 0.8 live fixture and regression coverage for scalars, arrays, NULL values, sparse indices, and CRUD `RETURNING`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo nextest run --workspace` (4,834 passed, 208 skipped)
- `DOCKER_HOST=unix://$XDG_RUNTIME_DIR/podman/podman.sock cargo nextest run -p dbflux_driver_postgres --run-ignored all postgres_pgvector_text_matches_server_output_and_crud_returning` (1 passed)
- Dual Judgment Day review: approved by both judges
- Final SDD verification: PASS, 8/8 tasks and 9/9 scenarios

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [x] Other: rootless Podman with `pgvector/pgvector:0.8.0-pg16`

## Checklist

- [x] I verified the change against the affected user flows
- [x] I added or updated tests when needed
- [x] I documented the supported PostgreSQL pgvector behavior
- [x] User-visible release notes are derived from the Conventional Commit history; `CHANGELOG.md` was not edited per repository policy
- [x] I applied the appropriate labels

## Labels to apply

`driver:bug`, `driver:postgres`, `driver`, `ui:bug`, `kind:sql`, `rust`, `size:exception`