### PR TITLE
chore(nix): point release-info at v0.7.1

### DIFF
--- a/nix/release-info.nix
+++ b/nix/release-info.nix
@@ -1,5 +1,5 @@
 {
-  version = "0.7.0";
+  version = "0.7.1";
 
   # SHA256 SRI hashes of each prebuilt artifact published in the matching
   # GitHub Release. This file is a per-branch channel pointer: on `main` it
@@ -21,12 +21,12 @@
   # Then update `version`, the two `url`s, and the two `hash`es below.
   artifacts = {
     "x86_64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.0/dbflux-linux-amd64.tar.gz";
-      hash = "sha256-97o+plbM2qAE+0vq7zrzIZpRFREzmQ+e5+SAFeZQUPQ=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.1/dbflux-linux-amd64.tar.gz";
+      hash = "sha256-0evYMLuW+70b4dvNNi9bCXkIbjhG4dFARon6Bzm/VDE=";
     };
     "aarch64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.0/dbflux-linux-arm64.tar.gz";
-      hash = "sha256-dYhTCj4g6XoaPQ1srdcS2FGAUNq0ykwmfqYhl7shRow=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.1/dbflux-linux-arm64.tar.gz";
+      hash = "sha256-5ESy2l7x4LrI/+TJrszt/Zr+gVj8J/A5ZvtTW4zij6I=";
     };
   };
 }


### PR DESCRIPTION
## Summary

Update the stable prebuilt-binary pointer on `main` to the published DBFlux v0.7.1 artifacts.

## What does this resolve?

Post-release follow-up for [v0.7.1](https://github.com/0xErwin1/dbflux/releases/tag/v0.7.1). No issue is linked.

## How was this solved?

- Updated the stable release version to `0.7.1`.
- Pointed the amd64 and arm64 tarball URLs at the v0.7.1 release.
- Replaced both SRI hashes with values derived from the published checksums.

## Validation

- `nix build .#dbflux-bin --no-link --print-out-paths`
- Result: `/nix/store/a42108cf0dy92kx1n533d3ckl781yswf-dbflux-0.7.1`

## Where was this tested?

- [x] Local development environment
- [x] Automated Nix build
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [x] Other: published v0.7.1 release artifacts

## Checklist

- [x] I verified the published artifact URLs and hashes
- [x] I updated the post-release channel pointer
- [x] No CHANGELOG update is required for this post-release metadata change
- [x] No additional labels apply