### PR TITLE
chore(nix): point release-info at v0.7.2

### DIFF
--- a/nix/release-info.nix
+++ b/nix/release-info.nix
@@ -1,5 +1,5 @@
 {
-  version = "0.7.1";
+  version = "0.7.2";
 
   # SHA256 SRI hashes of each prebuilt artifact published in the matching
   # GitHub Release. This file is a per-branch channel pointer: on `main` it
@@ -21,12 +21,12 @@
   # Then update `version`, the two `url`s, and the two `hash`es below.
   artifacts = {
     "x86_64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.1/dbflux-linux-amd64.tar.gz";
-      hash = "sha256-0evYMLuW+70b4dvNNi9bCXkIbjhG4dFARon6Bzm/VDE=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.2/dbflux-linux-amd64.tar.gz";
+      hash = "sha256-Ma9Aw7tsfWXcMDHj/nLxfMSMA2qLFy0cMUDHNs2xkpw=";
     };
     "aarch64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.1/dbflux-linux-arm64.tar.gz";
-      hash = "sha256-5ESy2l7x4LrI/+TJrszt/Zr+gVj8J/A5ZvtTW4zij6I=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.2/dbflux-linux-arm64.tar.gz";
+      hash = "sha256-/kM0Zv3jalgB9vEQW5C6OFaMRnjiRaz0UaYxqct3LYw=";
     };
   };
 }


### PR DESCRIPTION
## Summary

Advances `main`'s Nix channel pointer to the newly published `v0.7.2` stable release. `main` tracks the newest published tag of any kind, so this follows the release the same way [#322](https://github.com/0xErwin1/dbflux/pull/322) did for `v0.7.1`.

The matching commit already landed on `release/v0.7` as `05c010a3`; this is the identical file.

## Changes

| File | Change |
|------|--------|
| `nix/release-info.nix` | `version` → `0.7.2`, both artifact `url`s and both `hash`es repointed |

## Verification

- Both tarball digests match the `.sha256` sidecars published with the release:
  - `dbflux-linux-amd64.tar.gz` → `31af40c3bb6c…1929c`
  - `dbflux-linux-arm64.tar.gz` → `fe433466fde3…2d8c`
- `nix build .#dbflux-bin --no-link --print-out-paths` succeeds against the new hashes → `/nix/store/p4khzkw8ysb3nfg9951mdfwk04yhpc3q-dbflux-0.7.2`
