### PR TITLE
fix(ui): S3 browsing and editor UX fixes

### DIFF
--- a/crates/dbflux_ui/src/keymap/actions.rs
+++ b/crates/dbflux_ui/src/keymap/actions.rs
@@ -114,6 +114,10 @@ pub fn workspace_keybindings() -> Vec<KeyBinding> {
 /// `ctrl-enter` elsewhere) rather than the abstract `secondary-` form so the
 /// macOS Ctrl+Enter stays free for editor interrupt semantics and matches the
 /// Cmd convention used by `results_layer` for ResultsCopyCell.
+///
+/// On Linux/Windows this also adds Ctrl+Shift+Z as redo: `gpui-component`
+/// only binds Ctrl+Y there (macOS already has Cmd+Shift+Z), and Ctrl+Shift+Z
+/// is the redo chord most editors pair with Ctrl+Z.
 pub fn input_context_keybindings() -> Vec<KeyBinding> {
     let ctx = Some("Input");
     #[cfg(target_os = "macos")]
@@ -128,6 +132,7 @@ pub fn input_context_keybindings() -> Vec<KeyBinding> {
         vec![
             KeyBinding::new("ctrl-enter", RunQuery, ctx),
             KeyBinding::new("ctrl-shift-enter", RunQueryInNewTab, ctx),
+            KeyBinding::new("ctrl-shift-z", gpui_component::input::Redo, ctx),
         ]
     }
 }
@@ -145,7 +150,6 @@ mod tests {
     #[test]
     fn input_context_keybindings_shape() {
         let bindings = input_context_keybindings();
-        assert_eq!(bindings.len(), 2);
 
         #[cfg(target_os = "macos")]
         let (run, run_new) = (
@@ -166,6 +170,23 @@ mod tests {
             bindings[1].match_keystrokes(&[run_new]) == Some(false)
                 && bindings[1].action().partial_eq(&RunQueryInNewTab),
         );
+
+        // Linux/Windows additionally rebind Ctrl+Shift+Z as redo, which macOS
+        // already gets from `gpui-component`'s own Cmd+Shift+Z default.
+        #[cfg(target_os = "macos")]
+        assert_eq!(bindings.len(), 2);
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert_eq!(bindings.len(), 3);
+
+            let redo = Keystroke::parse("ctrl-shift-z").unwrap();
+            assert!(
+                bindings[2].match_keystrokes(&[redo]) == Some(false)
+                    && bindings[2]
+                        .action()
+                        .partial_eq(&gpui_component::input::Redo),
+            );
+        }
     }
 
     // Regression test for the GPUI shift-digit normalization bug (GitHub #65):

--- a/crates/dbflux_ui_base/src/keymap.rs
+++ b/crates/dbflux_ui_base/src/keymap.rs
@@ -641,6 +641,15 @@ fn text_input_layer() -> KeymapLayer {
         Command::NewQueryTab,
     );
 
+    // Save must keep working while a text buffer owns the keyboard: the S3
+    // object editors report `ContextId::TextInput`, which has no parent
+    // layer, so without these bindings Ctrl/Cmd+S is silently dropped.
+    layer.bind(KeyChord::new("s", Modifiers::primary()), Command::SaveQuery);
+    layer.bind(
+        KeyChord::new("s", Modifiers::primary_shift()),
+        Command::SaveFileAs,
+    );
+
     // Escape exits text input mode
     layer.bind(KeyChord::new("escape", Modifiers::none()), Command::Cancel);
 
@@ -1016,5 +1025,28 @@ mod tests {
             assert_eq!(keymap.resolve(ContextId::TextInput, &chord), None);
             assert_eq!(keymap.resolve(ContextId::Editor, &chord), None);
         }
+    }
+
+    /// Save must resolve while a text buffer owns the keyboard — the S3
+    /// object editors report `ContextId::TextInput`, which inherits from no
+    /// parent layer.
+    #[test]
+    fn text_input_layer_binds_save() {
+        let keymap = default_keymap();
+
+        assert_eq!(
+            keymap.resolve(
+                ContextId::TextInput,
+                &KeyChord::new("s", Modifiers::primary())
+            ),
+            Some(Command::SaveQuery),
+        );
+        assert_eq!(
+            keymap.resolve(
+                ContextId::TextInput,
+                &KeyChord::new("s", Modifiers::primary_shift())
+            ),
+            Some(Command::SaveFileAs),
+        );
     }
 }

--- a/crates/dbflux_ui_document/src/object_browser/mod.rs
+++ b/crates/dbflux_ui_document/src/object_browser/mod.rs
@@ -166,6 +166,9 @@ pub struct ObjectBrowserDocument {
     /// Document origin in window coordinates, captured by a canvas on every
     /// render so a click position can be placed inside the document.
     panel_origin: Point<Pixels>,
+    /// Scroll state of the virtualized listing, shared with keyboard
+    /// navigation so the selected row is scrolled into view.
+    pub(super) listing_scroll: UniformListScrollHandle,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -240,6 +243,7 @@ impl ObjectBrowserDocument {
             context_menu: None,
             pending_open_object_editor: None,
             panel_origin: Point::default(),
+            listing_scroll: UniformListScrollHandle::new(),
             _subscriptions: vec![filter_subscription],
         };
 
@@ -533,6 +537,7 @@ impl ObjectBrowserDocument {
 
         self.tree.select(visible.get(next).cloned());
         self.focus_mode = ObjectBrowserFocusMode::Listing;
+        self.scroll_selected_into_view();
         cx.notify();
     }
 
@@ -545,7 +550,26 @@ impl ObjectBrowserDocument {
             visible.first().cloned()
         });
         self.focus_mode = ObjectBrowserFocusMode::Listing;
+        self.scroll_selected_into_view();
         cx.notify();
+    }
+
+    /// Scrolls the virtualized listing the minimum amount needed to bring the
+    /// selected row into view (a no-op when it is already fully visible).
+    fn scroll_selected_into_view(&self) {
+        let Some(selected) = self.tree.selected.as_ref() else {
+            return;
+        };
+
+        let index = self.visible_rows().iter().position(|row| match row {
+            ListingRow::Entry(visible) => &visible.entry.node_id() == selected,
+            ListingRow::LoadMore { .. } => false,
+        });
+
+        if let Some(index) = index {
+            self.listing_scroll
+                .scroll_to_item(index, ScrollStrategy::Top);
+        }
     }
 
     // -- Navigation ------------------------------------------------------

--- a/crates/dbflux_ui_document/src/object_browser/render.rs
+++ b/crates/dbflux_ui_document/src/object_browser/render.rs
@@ -20,7 +20,6 @@ use dbflux_core::chrono::{DateTime, Utc};
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::ActiveTheme;
-use gpui_component::scroll::ScrollableElement;
 
 /// Column widths. `Key` takes the remaining space; the rest are fixed so the
 /// size column stays right-aligned against a stable edge.
@@ -786,33 +785,52 @@ impl Render for ObjectBrowserDocument {
             _ => None,
         };
 
-        // The scrollable ancestor needs its own `id`, `min_h_0`, and
-        // `overflow_y_scrollbar` — without `min_h_0` a flex child never
-        // shrinks below its content size, so a long listing pushed the
-        // footer off-screen instead of scrolling.
+        // The listing is virtualized: a large bucket page (up to 1000 keys per
+        // ListObjectsV2 call, more with expanded tree nodes) built as plain
+        // `.children(...)` lays out every row on every frame and makes the
+        // document lag. `uniform_list` only builds the rows in the viewport;
+        // `min_h_0` is still required so the flex child shrinks instead of
+        // pushing the footer off-screen.
         let listing = if entry_rows.is_empty() {
             self.render_empty_state(is_loading)
         } else {
+            let entity = cx.entity().clone();
+            let list_rows = rows.clone();
+            let list_selected = selected.clone();
+
             div()
-                .id("object-browser-listing")
                 .flex_1()
                 .min_h_0()
-                .overflow_y_scrollbar()
-                .children(rows.iter().map(|row| {
-                    match row {
-                        ListingRow::Entry(visible) => {
-                            let is_selected = selected.as_ref() == Some(&visible.entry.node_id());
-                            self.render_row(visible, is_selected, cx)
-                        }
-                        ListingRow::LoadMore {
-                            depth,
-                            prefix,
-                            loading,
-                        } => self
-                            .render_load_more(*depth, prefix, *loading, cx)
-                            .into_any_element(),
-                    }
-                }))
+                .overflow_hidden()
+                .child(
+                    uniform_list(
+                        "object-browser-listing",
+                        list_rows.len(),
+                        move |range, _window, cx| {
+                            entity.update(cx, |this, cx| {
+                                range
+                                    .filter_map(|index| list_rows.get(index))
+                                    .map(|row| match row {
+                                        ListingRow::Entry(visible) => {
+                                            let is_selected = list_selected.as_ref()
+                                                == Some(&visible.entry.node_id());
+                                            this.render_row(visible, is_selected, cx)
+                                        }
+                                        ListingRow::LoadMore {
+                                            depth,
+                                            prefix,
+                                            loading,
+                                        } => this
+                                            .render_load_more(*depth, prefix, *loading, cx)
+                                            .into_any_element(),
+                                    })
+                                    .collect()
+                            })
+                        },
+                    )
+                    .size_full()
+                    .track_scroll(self.listing_scroll.clone()),
+                )
                 .into_any_element()
         };
 

--- a/crates/dbflux_ui_document/src/object_text.rs
+++ b/crates/dbflux_ui_document/src/object_text.rs
@@ -94,8 +94,20 @@ pub fn decode_text_body(bytes: Vec<u8>) -> Result<TextBody, String> {
 
 /// Highlighter language for the buffer, from the key's extension. Unknown
 /// extensions resolve to the plain highlighter inside the editor component.
+///
+/// Dotenv files (`.env`, `.env.local`, `production.env`, ...) have no
+/// registered grammar of their own, but their `KEY=value` + `#` comment shape
+/// is shell syntax, so they open with the bash highlighter.
 pub fn editor_language(key: &str) -> String {
     let name = key.rsplit_once('/').map(|(_, name)| name).unwrap_or(key);
+    let lowercase_name = name.to_lowercase();
+
+    if lowercase_name == ".env"
+        || lowercase_name.starts_with(".env.")
+        || lowercase_name.ends_with(".env")
+    {
+        return "bash".to_string();
+    }
 
     name.rsplit_once('.')
         .map(|(_, extension)| extension.to_lowercase())
@@ -313,6 +325,16 @@ mod tests {
         assert_eq!(editor_language("logs/app.JSON"), "json");
         assert_eq!(editor_language("notes.md"), "md");
         assert_eq!(editor_language("data/dump"), "text");
+    }
+
+    /// Dotenv files open with the bash highlighter in every naming shape:
+    /// bare `.env`, suffixed `.env.<stage>`, and prefixed `<stage>.env`.
+    #[test]
+    fn dotenv_files_highlight_as_bash() {
+        assert_eq!(editor_language("config/.env"), "bash");
+        assert_eq!(editor_language("config/.env.production"), "bash");
+        assert_eq!(editor_language("config/staging.env"), "bash");
+        assert_eq!(editor_language(".ENV"), "bash");
     }
 
     /// T30: the cursor readout is 1-based, like every other editor.

--- a/crates/dbflux_ui_sidebar/src/expansion.rs
+++ b/crates/dbflux_ui_sidebar/src/expansion.rs
@@ -837,6 +837,19 @@ impl Sidebar {
         self.pending_bucket_fetches.remove(&profile_id);
     }
 
+    /// Whether `profile_id`'s tree node is currently expanded: the user's
+    /// explicit collapse/expand override when there is one, otherwise the
+    /// builder's default (the active connection expands, the rest stay
+    /// collapsed).
+    fn profile_node_is_expanded(&self, profile_id: Uuid, cx: &App) -> bool {
+        let node_id = SchemaNodeId::Profile { profile_id }.to_string();
+
+        self.expansion_overrides
+            .get(&node_id)
+            .copied()
+            .unwrap_or_else(|| self.app_state.read(cx).active_connection_id() == Some(profile_id))
+    }
+
     fn collection_node_is_event_stream(
         &self,
         profile_id: Uuid,
@@ -913,6 +926,24 @@ impl Sidebar {
             .collect();
         for profile_id in stale_bucket_ids {
             self.clear_bucket_cache(profile_id);
+        }
+
+        // An object-storage connection that finishes while its profile node is
+        // already expanded (the active profile expands by default) never
+        // re-fires the expand handler, so the listing would sit on the
+        // "Loading..." placeholder until a manual collapse/expand. Kick the
+        // bucket fetch here instead; `spawn_fetch_buckets` deduplicates
+        // against the cache and in-flight fetches.
+        let expanded_object_store_ids: Vec<Uuid> = connected_profile_ids
+            .iter()
+            .filter(|id| {
+                self.profile_category(**id, cx) == Some(DatabaseCategory::ObjectStorage)
+                    && self.profile_node_is_expanded(**id, cx)
+            })
+            .copied()
+            .collect();
+        for profile_id in expanded_object_store_ids {
+            self.spawn_fetch_buckets(profile_id, cx);
         }
 
         self.cleanup_stale_overrides(cx);


### PR DESCRIPTION
## What

Five user-reported fixes around the S3 object browser and the text editors, one commit each:

| Commit | Fix |
|---|---|
| `7d0eae0c` | **Object listing lag** — the listing rendered every loaded row as plain children on every frame, so a 1000-key page lagged. It now renders through `uniform_list`, building only the rows in the viewport, and keyboard navigation scrolls the selected row into view. |
| `60ca45de` | **Sidebar stuck on "Loading..." after connecting an S3 profile** — the expand handler fired before the connection existed, so `spawn_fetch_buckets` early-returned and nothing retried. `refresh_tree` now kicks the bucket fetch for connected object-storage profiles whose node is expanded; the fetch already deduplicates against the cache and in-flight requests. |
| `04738e61` | **Ctrl+S dropped in the S3 object editors** — they report `ContextId::TextInput`, which has no parent keymap layer, so the save chord never resolved. The text-input layer now binds primary-S → `SaveQuery` and primary-Shift-S → `SaveFileAs`. |
| `d5db3863` | **Ctrl+Shift+Z redo** — `gpui-component` only binds Ctrl+Y outside macOS. Added `ctrl-shift-z` → `Redo` in the `Input` context on Linux/Windows (macOS already has Cmd+Shift+Z). |
| `9012eee5` | **Dotenv highlighting** — `.env`, `.env.<stage>`, and `<stage>.env` objects opened as plain text; they now use the bash grammar (`KEY=value` + `#` comments are shell syntax). |

## Why

All five were hit while browsing and editing objects on a real S3 connection: a laggy listing, a sidebar that needed a manual collapse/expand to show buckets, saves and redo that silently did nothing, and unhighlighted `.env` files.

## Testing

- `cargo clippy` clean; 1204 tests passing across the four touched crates (`dbflux_ui_document`, `dbflux_ui_base`, `dbflux_ui_sidebar`, `dbflux_ui`).
- New unit tests: text-input save bindings, dotenv → bash mapping, and the Ctrl+Shift+Z binding shape.
- Pending manual GPUI smoke for the virtualized listing and the connect flow (not coverable by unit tests).