### PR TITLE
chore(nix): point release-info at v0.7.3

### DIFF
--- a/nix/release-info.nix
+++ b/nix/release-info.nix
@@ -1,5 +1,5 @@
 {
-  version = "0.7.2";
+  version = "0.7.3";
 
   # SHA256 SRI hashes of each prebuilt artifact published in the matching
   # GitHub Release. This file is a per-branch channel pointer: on `main` it
@@ -21,12 +21,12 @@
   # Then update `version`, the two `url`s, and the two `hash`es below.
   artifacts = {
     "x86_64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.2/dbflux-linux-amd64.tar.gz";
-      hash = "sha256-Ma9Aw7tsfWXcMDHj/nLxfMSMA2qLFy0cMUDHNs2xkpw=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.3/dbflux-linux-amd64.tar.gz";
+      hash = "sha256-sYwcfG0QtNwc3Di/HQefj4XSKtJfgc4RKaRY5QDeLvs=";
     };
     "aarch64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.2/dbflux-linux-arm64.tar.gz";
-      hash = "sha256-/kM0Zv3jalgB9vEQW5C6OFaMRnjiRaz0UaYxqct3LYw=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.3/dbflux-linux-arm64.tar.gz";
+      hash = "sha256-BDPG/VGpA+PaaPj6OgGsP1NqAUO+2AAniihLAZ3r6cQ=";
     };
   };
 }


### PR DESCRIPTION
## What

Advances `main`'s Nix channel pointer to the newly published `v0.7.3` stable release: `version`, both prebuilt tarball URLs, and both SRI hashes.

## Why

`nix/release-info.nix` is a per-branch channel pointer that must be refreshed on every branch whose channel a new tag advances (see `docs/RELEASE.md` § Nix). The same commit already landed on `release/v0.7` as `8135393d`; this is the `main` half.

## Testing

- Hashes derived from the release's own `.sha256` files via `nix-hash --to-sri`.
- `nix build .#dbflux-bin --no-link` succeeds against the new pins (verified on `release/v0.7`, identical file).