### PR TITLE
fix(s3): stretch listing rows to the full listing width

### DIFF
--- a/crates/dbflux_ui_document/src/object_browser/render.rs
+++ b/crates/dbflux_ui_document/src/object_browser/render.rs
@@ -486,6 +486,10 @@ impl ObjectBrowserDocument {
 
         div()
             .id(row_id)
+            // `uniform_list` sizes each item from its own content instead of
+            // stretching it like a flex column child, so the row needs an
+            // explicit full width to line up with the header columns.
+            .w_full()
             .flex()
             .items_center()
             .gap(Spacing::MD)
@@ -591,6 +595,7 @@ impl ObjectBrowserDocument {
 
         div()
             .id(row_id)
+            .w_full()
             .flex()
             .items_center()
             .justify_center()


### PR DESCRIPTION
## What

Entry and load-more rows in the S3 object listing now take the full listing width.

## Why

Regression from the `uniform_list` virtualization in #325. As plain flex-column children the rows stretched via `align-items: stretch`; `uniform_list` sizes each item from its own content instead, so rows rendered only as wide as their text. The visible symptoms were a selection highlight and bottom border that stopped short of the columns, and rows that no longer lined up with the header.

## Testing

- `cargo clippy -p dbflux_ui_document` clean, 859 tests passing.
- Layout change only, verified by reading the element tree against the header row (which is outside the list and already spans full width). Needs a visual confirmation in the running app.