### PR TITLE
fix(ssh): restore key-authenticated tunnels on Windows

### DIFF
--- a/crates/dbflux_driver_postgres/tests/live_integration.rs
+++ b/crates/dbflux_driver_postgres/tests/live_integration.rs
@@ -6,15 +6,18 @@
     clippy::result_large_err
 )]
 
+use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
     CollectionRef, ColumnAssignment, ConnectionProfile, DbConfig, DbDriver, DbError,
     DescribeRequest, ExplainRequest, MutationRequest, OrderByColumn, Pagination, QueryRequest,
     RecordIdentity, RowDelete, RowInsert, RowPatch, SchemaLoadingStrategy, SemanticFilter,
-    SemanticRequest, SqlUpdateRequest, SqlUpsertRequest, TableBrowseRequest, TableCountRequest,
-    TableRef, Value, WhereOperator,
+    SemanticRequest, SqlUpdateRequest, SqlUpsertRequest, SshAuthMethod, SshTunnelConfig,
+    TableBrowseRequest, TableCountRequest, TableRef, Value, WhereOperator,
 };
 use dbflux_driver_postgres::PostgresDriver;
 use dbflux_test_support::containers;
+use std::env;
+use std::path::PathBuf;
 use std::time::Duration;
 
 fn connect_postgres(
@@ -74,6 +77,69 @@ fn assert_text_array_matches_server_text(decoded: &Value, server_text: &Value) {
 // ---------------------------------------------------------------------------
 // Basic connectivity
 // ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires SSH and PostgreSQL test services"]
+fn postgres_live_connects_through_ssh_with_private_key() -> Result<(), DbError> {
+    let required_env = |name: &str| {
+        env::var(name).unwrap_or_else(|_| panic!("{name} must be set for the SSH live test"))
+    };
+    let database_port = env::var("DBFLUX_TEST_DB_PORT")
+        .unwrap_or_else(|_| "5432".to_string())
+        .parse::<u16>()
+        .map_err(|error| {
+            DbError::InvalidProfile(format!("DBFLUX_TEST_DB_PORT must be a valid port: {error}"))
+        })?;
+    let ssh_port = required_env("DBFLUX_TEST_SSH_PORT")
+        .parse::<u16>()
+        .map_err(|error| {
+            DbError::InvalidProfile(format!(
+                "DBFLUX_TEST_SSH_PORT must be a valid port: {error}"
+            ))
+        })?;
+
+    let profile = ConnectionProfile::new(
+        "live-postgres-ssh",
+        DbConfig::Postgres {
+            use_uri: false,
+            uri: None,
+            host: required_env("DBFLUX_TEST_DB_HOST"),
+            port: database_port,
+            user: required_env("DBFLUX_TEST_DB_USER"),
+            database: required_env("DBFLUX_TEST_DB_NAME"),
+            ssl_mode: Some("disable".to_string()),
+            ssl_root_cert_path: None,
+            ssl_client_cert_path: None,
+            ssl_client_key_path: None,
+            ssh_tunnel: Some(SshTunnelConfig {
+                host: env::var("DBFLUX_TEST_SSH_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
+                port: ssh_port,
+                user: required_env("DBFLUX_TEST_SSH_USER"),
+                auth_method: SshAuthMethod::PrivateKey {
+                    key_path: Some(PathBuf::from(required_env("DBFLUX_TEST_SSH_KEY_PATH"))),
+                },
+            }),
+            ssh_tunnel_profile_id: None,
+        },
+    );
+
+    let database_password = SecretString::from(required_env("DBFLUX_TEST_DB_PASSWORD"));
+    let ssh_passphrase = env::var("DBFLUX_TEST_SSH_PASSPHRASE")
+        .ok()
+        .map(SecretString::from);
+
+    let connection = PostgresDriver::new().connect_with_secrets(
+        &profile,
+        Some(&database_password),
+        ssh_passphrase.as_ref(),
+    )?;
+
+    connection.ping()?;
+    let result = connection.execute(&QueryRequest::new("SELECT 42::bigint AS answer"))?;
+    assert_eq!(result.rows, vec![vec![Value::Int(42)]]);
+
+    Ok(())
+}
 
 #[test]
 #[ignore = "requires Docker daemon"]

--- a/crates/dbflux_driver_postgres/tests/live_integration.rs
+++ b/crates/dbflux_driver_postgres/tests/live_integration.rs
@@ -6,18 +6,15 @@
     clippy::result_large_err
 )]
 
-use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
     CollectionRef, ColumnAssignment, ConnectionProfile, DbConfig, DbDriver, DbError,
     DescribeRequest, ExplainRequest, MutationRequest, OrderByColumn, Pagination, QueryRequest,
     RecordIdentity, RowDelete, RowInsert, RowPatch, SchemaLoadingStrategy, SemanticFilter,
-    SemanticRequest, SqlUpdateRequest, SqlUpsertRequest, SshAuthMethod, SshTunnelConfig,
-    TableBrowseRequest, TableCountRequest, TableRef, Value, WhereOperator,
+    SemanticRequest, SqlUpdateRequest, SqlUpsertRequest, TableBrowseRequest, TableCountRequest,
+    TableRef, Value, WhereOperator,
 };
 use dbflux_driver_postgres::PostgresDriver;
 use dbflux_test_support::containers;
-use std::env;
-use std::path::PathBuf;
 use std::time::Duration;
 
 fn connect_postgres(
@@ -77,69 +74,6 @@ fn assert_text_array_matches_server_text(decoded: &Value, server_text: &Value) {
 // ---------------------------------------------------------------------------
 // Basic connectivity
 // ---------------------------------------------------------------------------
-
-#[test]
-#[ignore = "requires SSH and PostgreSQL test services"]
-fn postgres_live_connects_through_ssh_with_private_key() -> Result<(), DbError> {
-    let required_env = |name: &str| {
-        env::var(name).unwrap_or_else(|_| panic!("{name} must be set for the SSH live test"))
-    };
-    let database_port = env::var("DBFLUX_TEST_DB_PORT")
-        .unwrap_or_else(|_| "5432".to_string())
-        .parse::<u16>()
-        .map_err(|error| {
-            DbError::InvalidProfile(format!("DBFLUX_TEST_DB_PORT must be a valid port: {error}"))
-        })?;
-    let ssh_port = required_env("DBFLUX_TEST_SSH_PORT")
-        .parse::<u16>()
-        .map_err(|error| {
-            DbError::InvalidProfile(format!(
-                "DBFLUX_TEST_SSH_PORT must be a valid port: {error}"
-            ))
-        })?;
-
-    let profile = ConnectionProfile::new(
-        "live-postgres-ssh",
-        DbConfig::Postgres {
-            use_uri: false,
-            uri: None,
-            host: required_env("DBFLUX_TEST_DB_HOST"),
-            port: database_port,
-            user: required_env("DBFLUX_TEST_DB_USER"),
-            database: required_env("DBFLUX_TEST_DB_NAME"),
-            ssl_mode: Some("disable".to_string()),
-            ssl_root_cert_path: None,
-            ssl_client_cert_path: None,
-            ssl_client_key_path: None,
-            ssh_tunnel: Some(SshTunnelConfig {
-                host: env::var("DBFLUX_TEST_SSH_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-                port: ssh_port,
-                user: required_env("DBFLUX_TEST_SSH_USER"),
-                auth_method: SshAuthMethod::PrivateKey {
-                    key_path: Some(PathBuf::from(required_env("DBFLUX_TEST_SSH_KEY_PATH"))),
-                },
-            }),
-            ssh_tunnel_profile_id: None,
-        },
-    );
-
-    let database_password = SecretString::from(required_env("DBFLUX_TEST_DB_PASSWORD"));
-    let ssh_passphrase = env::var("DBFLUX_TEST_SSH_PASSPHRASE")
-        .ok()
-        .map(SecretString::from);
-
-    let connection = PostgresDriver::new().connect_with_secrets(
-        &profile,
-        Some(&database_password),
-        ssh_passphrase.as_ref(),
-    )?;
-
-    connection.ping()?;
-    let result = connection.execute(&QueryRequest::new("SELECT 42::bigint AS answer"))?;
-    assert_eq!(result.rows, vec![vec![Value::Int(42)]]);
-
-    Ok(())
-}
 
 #[test]
 #[ignore = "requires Docker daemon"]

--- a/crates/dbflux_driver_postgres/tests/ssh_live_integration.rs
+++ b/crates/dbflux_driver_postgres/tests/ssh_live_integration.rs
@@ -1,0 +1,75 @@
+#![allow(clippy::result_large_err)]
+
+use dbflux_core::secrecy::SecretString;
+use dbflux_core::{
+    ConnectionProfile, DbConfig, DbDriver, DbError, QueryRequest, SshAuthMethod, SshTunnelConfig,
+    Value,
+};
+use dbflux_driver_postgres::PostgresDriver;
+use std::env;
+use std::path::PathBuf;
+
+fn required_env(name: &str) -> Result<String, DbError> {
+    env::var(name)
+        .map_err(|_| DbError::InvalidProfile(format!("{name} must be set for the SSH live test")))
+}
+
+#[test]
+#[ignore = "requires SSH and PostgreSQL test services"]
+fn postgres_live_connects_through_ssh_with_private_key() -> Result<(), DbError> {
+    let database_port = env::var("DBFLUX_TEST_DB_PORT")
+        .unwrap_or_else(|_| "5432".to_string())
+        .parse::<u16>()
+        .map_err(|error| {
+            DbError::InvalidProfile(format!("DBFLUX_TEST_DB_PORT must be a valid port: {error}"))
+        })?;
+    let ssh_port = required_env("DBFLUX_TEST_SSH_PORT")?
+        .parse::<u16>()
+        .map_err(|error| {
+            DbError::InvalidProfile(format!(
+                "DBFLUX_TEST_SSH_PORT must be a valid port: {error}"
+            ))
+        })?;
+
+    let profile = ConnectionProfile::new(
+        "live-postgres-ssh",
+        DbConfig::Postgres {
+            use_uri: false,
+            uri: None,
+            host: required_env("DBFLUX_TEST_DB_HOST")?,
+            port: database_port,
+            user: required_env("DBFLUX_TEST_DB_USER")?,
+            database: required_env("DBFLUX_TEST_DB_NAME")?,
+            ssl_mode: Some("disable".to_string()),
+            ssl_root_cert_path: None,
+            ssl_client_cert_path: None,
+            ssl_client_key_path: None,
+            ssh_tunnel: Some(SshTunnelConfig {
+                host: env::var("DBFLUX_TEST_SSH_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
+                port: ssh_port,
+                user: required_env("DBFLUX_TEST_SSH_USER")?,
+                auth_method: SshAuthMethod::PrivateKey {
+                    key_path: Some(PathBuf::from(required_env("DBFLUX_TEST_SSH_KEY_PATH")?)),
+                },
+            }),
+            ssh_tunnel_profile_id: None,
+        },
+    );
+
+    let database_password = SecretString::from(required_env("DBFLUX_TEST_DB_PASSWORD")?);
+    let ssh_passphrase = env::var("DBFLUX_TEST_SSH_PASSPHRASE")
+        .ok()
+        .map(SecretString::from);
+
+    let connection = PostgresDriver::new().connect_with_secrets(
+        &profile,
+        Some(&database_password),
+        ssh_passphrase.as_ref(),
+    )?;
+
+    connection.ping()?;
+    let result = connection.execute(&QueryRequest::new("SELECT 42::bigint AS answer"))?;
+    assert_eq!(result.rows, vec![vec![Value::Int(42)]]);
+
+    Ok(())
+}

--- a/crates/dbflux_ssh/Cargo.toml
+++ b/crates/dbflux_ssh/Cargo.toml
@@ -20,8 +20,16 @@ base64 = { workspace = true }
 dirs = { workspace = true }
 log = "0.4"
 sha2 = { workspace = true }
-ssh2 = "0.9"
 uuid = { workspace = true }
+
+[target.'cfg(not(windows))'.dependencies]
+ssh2 = "0.9"
+
+# libssh2's WinCNG backend offers only legacy Diffie-Hellman KEX methods,
+# which current OpenSSH servers reject. The OpenSSL backend provides the
+# Curve25519/ECDH methods needed for a modern SSH handshake.
+[target.'cfg(windows)'.dependencies]
+ssh2 = { version = "0.9", features = ["openssl-on-win32", "vendored-openssl"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dbflux_ssh/src/lib.rs
+++ b/crates/dbflux_ssh/src/lib.rs
@@ -14,6 +14,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD_NO_PAD;
+#[cfg(windows)]
+use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use dbflux_core::{DbError, SshAuthMethod, SshTunnelConfig};
 use dbflux_tunnel_core::{ForwardingConnection, Tunnel, TunnelConnector, adaptive_sleep};
 use sha2::{Digest, Sha256};
@@ -582,7 +584,7 @@ fn authenticate_with_key(
             if passphrase.is_some() { "yes" } else { "no" }
         );
 
-        let result = session.userauth_pubkey_file(user, None, path, passphrase);
+        let result = authenticate_with_key_file(session, user, path, passphrase);
 
         match result {
             Ok(()) if session.authenticated() => {
@@ -596,10 +598,9 @@ fn authenticate_with_key(
                 );
                 last_error = Some(format!("Key {} not accepted by server", path.display()));
             }
-            Err(e) => {
-                let err_msg = format!("{}", e);
-                log::info!("[SSH] Key {} failed: {}", path.display(), err_msg);
-                last_error = Some(err_msg);
+            Err(error) => {
+                log::info!("[SSH] Key {} failed: {}", path.display(), error);
+                last_error = Some(error);
             }
         }
     }
@@ -609,6 +610,38 @@ fn authenticate_with_key(
         "SSH key authentication failed: {}",
         error_detail
     )))
+}
+
+#[cfg(windows)]
+fn authenticate_with_key_file(
+    session: &Session,
+    user: &str,
+    path: &Path,
+    passphrase: Option<&str>,
+) -> Result<(), String> {
+    let private_key = SecretString::from(std::fs::read_to_string(path).map_err(|error| {
+        format!(
+            "Failed to read SSH private key {}: {}",
+            path.display(),
+            error
+        )
+    })?);
+
+    session
+        .userauth_pubkey_memory(user, None, private_key.expose_secret(), passphrase)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(not(windows))]
+fn authenticate_with_key_file(
+    session: &Session,
+    user: &str,
+    path: &Path,
+    passphrase: Option<&str>,
+) -> Result<(), String> {
+    session
+        .userauth_pubkey_file(user, None, path, passphrase)
+        .map_err(|error| error.to_string())
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Restore key-authenticated SSH tunnels on Windows when connecting through modern OpenSSH servers.

## What does this resolve?

Windows builds used libssh2's WinCNG backend, which offered only legacy Diffie-Hellman key exchange methods that do not overlap with current OpenSSH defaults. After switching the backend, private-key authentication could still fail because libssh2's C file API could not reliably open valid Windows key paths.

- No linked issue.

## How was this solved?

- Use libssh2's OpenSSL backend on Windows so Curve25519/ECDH key exchanges are available, while leaving non-Windows dependency behavior unchanged.
- On Windows, read the private key through Rust into a zeroizing `SecretString` and authenticate with `userauth_pubkey_memory`, avoiding the failing C file-path boundary.
- Keep `userauth_pubkey_file` on non-Windows platforms.
- Add an ignored, environment-driven PostgreSQL live test that verifies the complete key-authenticated SSH tunnel path, including ping and query execution.

The Windows backend uses vendored OpenSSL. This adds work to the first cold build and requires Perl at build time, but it adds no runtime dependency. GitHub's Windows runner already includes Perl, and the existing Rust target cache retains dependency build artifacts for later runs.

## Validation

- `cargo clippy --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws" -- -D warnings`
- `cargo check -p dbflux --no-default-features --features postgres`
- `cargo test -p dbflux_ssh` — 13 passed
- `cargo test -p dbflux_driver_postgres --lib` — 82 passed, 1 pre-existing live test ignored
- `cargo test -p dbflux_driver_postgres --locked --test live_integration -- --ignored` — 14 passed after isolating the opt-in SSH environment test in its own test target
- Targeted `rustfmt --check` for both changed Rust files and `git diff --check`
- Windows Docker E2E with PostgreSQL 17 reachable only through SSH `direct-tcpip`; `ping` and `SELECT 42` passed with:
  - RSA 3072 PEM key
  - Ed25519 OpenSSH key
  - Encrypted Ed25519 OpenSSH key with passphrase
- A full Windows workspace test run was also attempted. It reached `dbflux_components`, where 323/325 tests passed; two pre-existing style guardrail tests failed on unchanged `chart/engine.rs`. The SSH and PostgreSQL test suites were green.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [ ] Linux
- [ ] macOS
- [x] Windows
- [ ] X11
- [ ] Wayland
- [x] Other: Docker Desktop Linux containers (OpenSSH and PostgreSQL 17)

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I did not edit `CHANGELOG.md`; the current contribution guide generates user-visible entries from the `fix` commit
- [ ] I applied the appropriate labels — requested below; fork contributors cannot assign labels in upstream

## Labels to apply

- `ssh:bug`
- `ssh`
- `platform:windows`