### PR TITLE
fix(drivers): truncate query previews at UTF-8 char boundaries

### DIFF
--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -262,3 +262,56 @@ pub fn truncate_string_safe(s: &str, max_len: usize) -> String {
 
     format!("{}...", &s[..safe_end])
 }
+
+#[cfg(test)]
+mod truncate_tests {
+    use super::truncate_string_safe;
+
+    #[test]
+    fn keeps_short_strings_verbatim() {
+        assert_eq!(truncate_string_safe("SELECT 1;", 80), "SELECT 1;");
+    }
+
+    #[test]
+    fn truncates_ascii_with_ellipsis() {
+        let long = "a".repeat(200);
+        let truncated = truncate_string_safe(&long, 80);
+        assert_eq!(truncated, format!("{}...", "a".repeat(77)));
+    }
+
+    #[test]
+    fn truncates_inside_multibyte_codepoint_without_panicking() {
+        let digits: String = "1234567890".chars().cycle().take(76).collect();
+        let sql = format!("-- {digits}中\nSELECT 1;");
+        assert!(!sql.is_char_boundary(80), "byte 80 must split 中");
+
+        assert_eq!(
+            truncate_string_safe(&sql, 80),
+            format!("-- {}...", &digits[..74])
+        );
+    }
+
+    #[test]
+    fn truncates_between_every_byte_of_a_multibyte_run() {
+        // 4-byte emoji, 3-byte CJK and 2-byte latin-1 mixed, so every possible
+        // cut index lands somewhere inside a codepoint for some `max_len`.
+        let text = "🚀中ä".repeat(40);
+        for max_len in 0..text.len() {
+            let truncated = truncate_string_safe(&text, max_len);
+            assert!(
+                text.starts_with(truncated.trim_end_matches('.')),
+                "max_len {max_len} produced a non-prefix truncation"
+            );
+        }
+    }
+
+    #[test]
+    fn never_splits_a_codepoint_at_the_exact_limit() {
+        // "中" occupies bytes 77..80, so max_len 80 cuts at byte 77.
+        let sql = format!("{}中tail", "x".repeat(77));
+        assert_eq!(
+            truncate_string_safe(&sql, 80),
+            format!("{}...", "x".repeat(77))
+        );
+    }
+}

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -1854,11 +1854,7 @@ impl Connection for MongoConnection {
 
         let start = Instant::now();
 
-        let sql_preview = if req.sql.len() > 80 {
-            format!("{}...", &req.sql[..80])
-        } else {
-            req.sql.clone()
-        };
+        let sql_preview = dbflux_core::truncate_string_safe(&req.sql, 80);
         log::debug!(
             "[QUERY] Executing (id={}): {}",
             query_id,

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -2056,11 +2056,7 @@ impl Connection for MysqlConnection {
 
         let start = Instant::now();
 
-        let sql_preview = if req.sql.len() > 80 {
-            format!("{}...", &req.sql[..80])
-        } else {
-            req.sql.clone()
-        };
+        let sql_preview = dbflux_core::truncate_string_safe(&req.sql, 80);
         log::debug!("[QUERY] Executing: {}", sql_preview.replace('\n', " "));
 
         let mut state = match self.query_conn.lock() {

--- a/crates/dbflux_driver_postgres/src/driver.rs
+++ b/crates/dbflux_driver_postgres/src/driver.rs
@@ -1625,11 +1625,7 @@ impl Connection for PostgresConnection {
         let query_id = Uuid::new_v4();
         let _active_query_guard = ActiveQueryGuard::activate(&self.active_query, query_id)?;
 
-        let sql_preview = if req.sql.len() > 80 {
-            format!("{}...", &req.sql[..80])
-        } else {
-            req.sql.clone()
-        };
+        let sql_preview = dbflux_core::truncate_string_safe(&req.sql, 80);
         log::debug!(
             "[QUERY] Executing (id={}): {}",
             query_id,


### PR DESCRIPTION
## Summary

The query preview in the debug log was sliced at a fixed byte offset (`&req.sql[..80]`), which panics if byte 80 lands inside a multi-byte character. A query with a CJK char at the wrong spot killed the app.

Reported for MySQL, but Postgres and MongoDB had the same slice and crashed on the same query. mssql already cut on a char boundary.

## What does this resolve?

- Resolves #331

## How was this solved?

All three drivers now use `truncate_string_safe` from core, which we already use for history and saved-query previews. Nothing new, just three hand-rolled copies less.
Left mssql alone since it was already correct.

## Validation

Added tests for `truncate_string_safe` (ASCII, the query from the issue, a cut landing exactly on a char boundary, plus a brute-force pass over every length with mixed 2/3/4-byte chars). Checked they actually fail against the old slicing logic first.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [ ] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [ ] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

driver:bug, driver, driver:mysql/mariadb, driver:postgres, driver:mongodb
<!--
Pick the labels that match this PR. Maintainers may adjust during review.
Full guide: CONTRIBUTING.md#label-guide

- Kind (required, choose at least one): `*:bug` or `*:feature` for the affected area
  (e.g. `ui:feature`, `driver:bug`, `mcp:feature`, `query:bug`, `rpc:feature`, …)
- Driver (if driver-specific): `driver:postgres`, `driver:mongodb`, `driver:sqlite`,
  `driver:mysql/mariadb`, `driver:dynamodb`, `driver:redis`
- Subsystem flags: `aws`, `proxy`, `ssh`, `query`, `driver`, `mcp`
- Data model: `kind:sql`, `kind:document`, `kind:kv`, `kind:log`
- Platform (if platform-specific): `platform:linux`, `platform:macos`, `platform:windows`
- Arch (if arch-specific): `arch:amd64`, `arch:arm64`
- RPC subtype: `rpc:auth`, `rpc:driver`
-->

