### PR TITLE
chore(nix): point release-info at v0.7.5

### DIFF
--- a/nix/release-info.nix
+++ b/nix/release-info.nix
@@ -1,5 +1,5 @@
 {
-  version = "0.7.4";
+  version = "0.7.5";
 
   # SHA256 SRI hashes of each prebuilt artifact published in the matching
   # GitHub Release. This file is a per-branch channel pointer: on `main` it
@@ -21,12 +21,12 @@
   # Then update `version`, the two `url`s, and the two `hash`es below.
   artifacts = {
     "x86_64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.4/dbflux-linux-amd64.tar.gz";
-      hash = "sha256-xv0pdPZIwivTSFJVh15wWHSASDOmzDZY2xx9tnZCGbc=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.5/dbflux-linux-amd64.tar.gz";
+      hash = "sha256-QltB3Euk50ZaxzBSHVDAsyEkCtKEloDEBzABJ5VwE0c=";
     };
     "aarch64-linux" = {
-      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.4/dbflux-linux-arm64.tar.gz";
-      hash = "sha256-SP4WCQGHD3W/2im19l9MbcrKq5IqwcLCy0C6TJlKoWs=";
+      url = "https://github.com/0xErwin1/dbflux/releases/download/v0.7.5/dbflux-linux-arm64.tar.gz";
+      hash = "sha256-/RjHalMeMJVtCD75zcMyg/eQSSavEq6eFoMZh3UCEiA=";
     };
   };
 }


### PR DESCRIPTION
## What

Advances `main`'s Nix channel pointer to the newly published `v0.7.5` stable release: `version`, both prebuilt tarball URLs, and both SRI hashes.

## Why

`nix/release-info.nix` is a per-branch channel pointer that must be refreshed on every branch whose channel a new tag advances (see `docs/RELEASE.md` § Nix). The same commit already landed on `release/v0.7` as `51160be7`; this is the `main` half.

## Testing

- Hashes derived from the release's own `.sha256` files via `nix-hash --to-sri`.
- `nix build .#dbflux-bin --no-link` succeeds against the new pins (verified on `release/v0.7`, identical file).