### PR TITLE
feat(clickhouse): add HTTP driver support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
         required: true
 
 env:
-  FEATURES: "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws"
+  FEATURES: "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,clickhouse,aws"
 
 permissions:
   contents: read

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -90,7 +90,7 @@ jobs:
           cache-on-failure: true
 
       - name: Run clippy
-        run: cargo clippy --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws${{ matrix.extra_features }}" -- -D warnings
+        run: cargo clippy --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,clickhouse,aws${{ matrix.extra_features }}" -- -D warnings
 
   # Aggregate gate. `Clippy` is a required status check in the repository
   # ruleset, and a matrixed job reports one context per platform instead, so

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
           cache-on-failure: true
 
       - name: Run deterministic workspace tests
-        run: cargo test --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws"
+        run: cargo test --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,clickhouse,aws"
 
   driver-live-integration:
     name: Driver Live Integration
@@ -105,9 +105,9 @@ jobs:
       - name: Run SQLite live integration tests
         run: cargo test -p dbflux_driver_sqlite --locked --test live_integration
 
-      # MSSQL and InfluxDB spin up one container per test (the SQL Server image
-      # is ~2 GB), so these suites run single-threaded to avoid exhausting the
-      # runner with concurrent containers.
+      # MSSQL, InfluxDB, and ClickHouse spin up one container per test (the SQL
+      # Server image is ~2 GB), so these suites run single-threaded to avoid
+      # exhausting the runner with concurrent containers.
       - name: Run MSSQL live integration tests
         run: cargo test -p dbflux_driver_mssql --locked --test live_integration -- --ignored --test-threads=1
 
@@ -119,6 +119,9 @@ jobs:
 
       - name: Run InfluxDB live integration tests
         run: cargo test -p dbflux_driver_influxdb --locked --test live_integration -- --ignored --test-threads=1
+
+      - name: Run ClickHouse live integration tests
+        run: cargo test -p dbflux_driver_clickhouse --locked --test live_integration -- --ignored --test-threads=1
 
   cross-platform-check:
     name: Cross-platform check ${{ matrix.os }}
@@ -158,4 +161,4 @@ jobs:
           cache-on-failure: true
 
       - name: Cargo check
-        run: cargo check --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,aws${{ matrix.extra_features }}"
+        run: cargo check --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,clickhouse,aws${{ matrix.extra_features }}"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ flowchart TB
     end
 
     subgraph Drivers["Driver implementations"]
-        drv["postgres · mysql · sqlite · mssql<br/>mongodb · redis · dynamodb<br/>influxdb · cloudwatch · ipc (RPC)"]
+        drv["postgres · mysql · sqlite · mssql · clickhouse<br/>mongodb · redis · dynamodb<br/>influxdb · cloudwatch · ipc (RPC)"]
     end
 
     subgraph Support["Supporting libraries"]
@@ -108,7 +108,7 @@ flowchart TB
 
 - Language: Rust 2024 edition (crates/dbflux/Cargo.toml).
 - UI: `gpui`, `gpui-component` (Cargo.toml).
-- Databases: `tokio-postgres` (PostgreSQL), `rusqlite` (SQLite), `mysql` (MySQL/MariaDB), `mongodb` (MongoDB), `redis` (Redis), `aws-sdk-dynamodb` (DynamoDB) (Cargo.toml).
+- Databases: `tokio-postgres` (PostgreSQL), `rusqlite` (SQLite), `mysql` (MySQL/MariaDB), `mongodb` (MongoDB), `redis` (Redis), `aws-sdk-dynamodb` (DynamoDB), and HTTP via `reqwest` (ClickHouse) (Cargo.toml).
 - AWS auth/integration: `aws-config`, `aws-sdk-sso`, `aws-sdk-ssooidc`, `aws-sdk-sts`, `aws-sdk-secretsmanager`, `aws-sdk-ssm` (`dbflux_aws`).
 - IPC/RPC: `interprocess` local sockets + `bincode` message framing (`dbflux_ipc`, `dbflux_driver_ipc`, `dbflux_driver_host`).
 - SSH: `ssh2` via `dbflux_ssh` (crates/dbflux_ssh/src/lib.rs).
@@ -458,6 +458,11 @@ crates/
   dbflux_driver_influxdb/   # InfluxDB driver (v1 + v2)
     src/driver.rs           # Connection, bucket/measurement discovery, query execution
     src/query_generator.rs  # InfluxQL (v1) and Flux (v2) query/template generation
+  dbflux_driver_clickhouse/ # ClickHouse HTTP(S) relational driver
+    src/driver.rs           # Metadata, connection form, and connection construction
+    src/connection.rs       # Query execution and system-catalog discovery
+    src/types.rs            # ClickHouse type parsing and value decoding
+    src/dialect.rs          # SQL generation dialect
   dbflux_driver_cloudwatch/ # AWS CloudWatch Logs driver (DatabaseCategory::LogStream)
     src/driver.rs           # Log group/stream discovery, EventStreamTarget, CollectionPresentation::EventStream
   dbflux_driver_s3/         # AWS S3 object-storage driver (DatabaseCategory::ObjectStorage)
@@ -817,6 +822,10 @@ The channel/branding model is a runtime seam: UI and app code read `ReleaseChann
   - v1 speaks InfluxQL; v2 exposes Flux in addition to InfluxQL (`QueryGenerator` emits Flux only when `version == V2`)
   - Bucket/database and measurement discovery mapped to the schema model, with pagination and CSV/JSON export
   - Read-oriented: no transactions; mutation generation is limited compared with the relational drivers
+- **ClickHouse**: `crates/dbflux_driver_clickhouse/` — `DatabaseCategory::Relational` and `QueryLanguage::Sql` driver for self-hosted ClickHouse and ClickHouse Cloud:
+  - Uses ClickHouse's HTTP(S) interface and dynamic JSON result decoding for arbitrary schemas
+  - Discovers databases, tables, views, columns, and engine metadata without representing databases as schemas
+  - Supports read-oriented SQL and visual SELECT generation; structured mutations, DDL, transactions, SSH tunneling, and generic query parameters are not exposed
 - **CloudWatch Logs**: `crates/dbflux_driver_cloudwatch/` — `DatabaseCategory::LogStream` driver for AWS CloudWatch Logs:
   - Log group/stream discovery exposed as collections; log groups open as event streams via `CollectionPresentation::EventStream` and a generic `EventStreamTarget`, consumed by the `AuditDocument`/log-stream viewer without any driver-specific UI branch
   - Query modes (Logs Insights QL, OpenSearch PPL/SQL) are surfaced through `SourceContextSpec`; `DriverMetadata.query_language` defaults to `Sql` for editor behavior
@@ -930,6 +939,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 - MongoDB: `mongodb` async driver with BSON handling, query parser for `db.collection.method()` syntax, collection/index discovery, document CRUD, shell query generation, and collection description support for MCP/UI metadata workflows (crates/dbflux_driver_mongodb/src/driver.rs).
 - Redis: `redis` driver with key-value API for all Redis types, variadic commands, keyspace support, key scanning, and command generation (crates/dbflux_driver_redis/src/driver.rs).
 - DynamoDB: `aws-sdk-dynamodb` driver with AWS profile/region support for remote DynamoDB, plus optional endpoint override for local emulators and tests (crates/dbflux_driver_dynamodb/src/driver.rs).
+- ClickHouse: HTTP(S) driver using `reqwest` with dynamic JSON decoding, database/table discovery, and read-oriented SQL support for self-hosted ClickHouse and ClickHouse Cloud (crates/dbflux_driver_clickhouse/src/driver.rs).
 - Amazon S3: `aws-sdk-s3` driver with AWS profile/SSO or static credentials, endpoint override and path-style addressing for S3-compatible endpoints (Cloudflare R2, MinIO), bucket/object CRUD, presigned URLs, and copy/versions support (crates/dbflux_driver_s3/src/driver.rs).
 - AWS auth stack: `dbflux_aws` provides AWS SSO/shared/static auth providers, SSO login orchestration, account/role discovery, and `~/.aws/config` profile write-back for newly saved auth profiles.
 - Local IPC/RPC: `interprocess` sockets + versioned envelopes for app control and RPC service communication (`crates/dbflux_ipc/`, `crates/dbflux_driver_ipc/`, `crates/dbflux_driver_host/`). `dbflux_app::rpc_services` discovers persisted service descriptors, adapts `RpcServiceKind::Driver` into runtime `DbDriver`s, and wires `RpcServiceKind::AuthProvider` into `RpcAuthProvider` (which implements `DynAuthProvider`). Preserves `rpc:<socket_id>` compatibility. Auth-provider IPC protocol is at v1.2: adds `FetchDynamicOptions` / `DynamicOptions` variants and the `secret_dependency_opt_in` manifest flag. Auth tokens are managed by `dbflux_ipc/src/auth.rs`.
@@ -941,7 +951,7 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 ## Configuration
 
 - Workspace settings: `Cargo.toml` defines workspace members and shared dependencies.
-- App features: `crates/dbflux/Cargo.toml` gates `sqlite`, `postgres`, `mysql`, `mongodb`, `redis`, `dynamodb`, `cloudwatch`, `influxdb`, `mssql`, `lua`, `aws`, and `mcp` (enabled by default in this branch).
+- App features: `crates/dbflux/Cargo.toml` gates `sqlite`, `postgres`, `mysql`, `mongodb`, `redis`, `dynamodb`, `cloudwatch`, `influxdb`, `mssql`, `redshift`, `clickhouse`, `s3`, `lua`, `aws`, and `mcp` (enabled by default in this branch).
 - Runtime data: All runtime configuration is stored in `~/.local/share/dbflux/dbflux.db` (single SQLite file).
   - `cfg_connection_profiles` + child tables (auth, proxy, SSH bindings)
   - `cfg_auth_profiles` (provider-agnostic auth profile storage)
@@ -969,8 +979,8 @@ DBFlux supports the Model Context Protocol (MCP) for AI client integration with 
 
 ## Build & Deploy
 
-- Build: `cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws` or `--release` (AGENTS.md).
-- Run: `cargo run -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,aws` (AGENTS.md).
+- Build: `cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,clickhouse,aws` or `--release` (AGENTS.md).
+- Run: `cargo run -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,clickhouse,aws` (AGENTS.md).
 - Test: `cargo test --workspace` (AGENTS.md).
 - Lint/format: `cargo clippy --workspace -- -D warnings`, `cargo fmt --all` (AGENTS.md).
 - Nix: `nix build` or `nix run` using flake.nix; `nix develop` for dev shell.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,6 +2632,7 @@ dependencies = [
  "dbflux_audit",
  "dbflux_aws",
  "dbflux_core",
+ "dbflux_driver_clickhouse",
  "dbflux_driver_cloudwatch",
  "dbflux_driver_dynamodb",
  "dbflux_driver_influxdb",
@@ -2759,6 +2760,21 @@ dependencies = [
  "tree-sitter-sequel",
  "urlencoding",
  "uuid",
+]
+
+[[package]]
+name = "dbflux_driver_clickhouse"
+version = "0.8.0-dev.0"
+dependencies = [
+ "chrono",
+ "dbflux_core",
+ "dbflux_test_support",
+ "hex",
+ "log",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3035,6 +3051,7 @@ dependencies = [
  "dbflux_audit",
  "dbflux_aws",
  "dbflux_core",
+ "dbflux_driver_clickhouse",
  "dbflux_driver_dynamodb",
  "dbflux_driver_mongodb",
  "dbflux_driver_mysql",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/dbflux_driver_cloudwatch",
     "crates/dbflux_driver_mssql",
     "crates/dbflux_driver_redshift",
+    "crates/dbflux_driver_clickhouse",
     "crates/dbflux_ssh",
     "crates/dbflux_proxy",
     "crates/dbflux_tunnel_core",
@@ -67,6 +68,7 @@ dbflux_driver_dynamodb = { path = "crates/dbflux_driver_dynamodb" }
 dbflux_driver_cloudwatch = { path = "crates/dbflux_driver_cloudwatch" }
 dbflux_driver_mssql = { path = "crates/dbflux_driver_mssql" }
 dbflux_driver_redshift = { path = "crates/dbflux_driver_redshift" }
+dbflux_driver_clickhouse = { path = "crates/dbflux_driver_clickhouse" }
 dbflux_ssh = { path = "crates/dbflux_ssh" }
 dbflux_proxy = { path = "crates/dbflux_proxy" }
 dbflux_export = { path = "crates/dbflux_export" }

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ git clone https://github.com/0xErwin1/dbflux.git
 cd dbflux
 
 # Recommended: build with the full default feature set
-cargo build --release --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,lua,aws,mcp
+cargo build --release --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,clickhouse,lua,aws,mcp
 
 # Minimal build (relational drivers only, no AI/MCP, no Lua)
 cargo build --release --no-default-features --features sqlite,postgres,mysql
@@ -248,6 +248,7 @@ curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/uninst
 - **Redis** with key browsing for all types (String, Hash, List, Set, Sorted Set, Stream)
 - **DynamoDB** with table browsing, item CRUD, and AWS authentication
 - **InfluxDB** v1 and v2 (InfluxQL on v1, InfluxQL + Flux on v2)
+- **ClickHouse** and ClickHouse Cloud over HTTP(S), with database/table discovery, visual SELECTs, and explicit raw SQL execution
 - **CloudWatch Logs** with log group/stream browsing and event streaming
 - **Amazon S3** with bucket browsing, object preview/editing, full CRUD, and presigned URLs, including S3-compatible endpoints (Cloudflare R2, MinIO)
 - **External drivers over RPC** (register out-of-process drivers via the [Driver RPC Protocol](docs/DRIVER_RPC_PROTOCOL.md))

--- a/crates/dbflux/Cargo.toml
+++ b/crates/dbflux/Cargo.toml
@@ -44,7 +44,7 @@ workspace = true
 optional = true
 
 [features]
-default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "influxdb", "mssql", "redshift", "s3", "lua", "aws", "mcp"]
+default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "influxdb", "mssql", "redshift", "clickhouse", "s3", "lua", "aws", "mcp"]
 # dbflux_ui is driver-agnostic, so driver features only drive dbflux_app (which
 # registers the drivers and relays to the MCP server). The binary does not need
 # to declare driver/runtime crates as direct optional deps — `dbflux_app/<feat>`
@@ -59,6 +59,7 @@ cloudwatch = ["dbflux_app/cloudwatch"]
 influxdb = ["dbflux_app/influxdb"]
 mssql = ["dbflux_app/mssql"]
 redshift = ["dbflux_app/redshift"]
+clickhouse = ["dbflux_app/clickhouse"]
 s3 = ["dbflux_app/s3"]
 lua = ["dbflux_app/lua", "dbflux_ui/lua"]
 aws = ["dbflux_app/aws", "dbflux_ui/aws"]

--- a/crates/dbflux_app/Cargo.toml
+++ b/crates/dbflux_app/Cargo.toml
@@ -28,6 +28,7 @@ dbflux_driver_cloudwatch = { workspace = true, optional = true }
 dbflux_driver_influxdb = { workspace = true, optional = true }
 dbflux_driver_mssql = { workspace = true, optional = true }
 dbflux_driver_redshift = { workspace = true, optional = true }
+dbflux_driver_clickhouse = { workspace = true, optional = true }
 dbflux_driver_s3 = { workspace = true, optional = true }
 dbflux_portability.workspace = true
 dbflux_lua = { workspace = true, optional = true }
@@ -61,6 +62,7 @@ cloudwatch = ["dbflux_driver_cloudwatch"]
 influxdb = ["dep:dbflux_driver_influxdb"]
 mssql = ["dep:dbflux_driver_mssql"]
 redshift = ["dbflux_driver_redshift", "dbflux_mcp_server?/redshift"]
+clickhouse = ["dbflux_driver_clickhouse", "dbflux_mcp_server?/clickhouse"]
 s3 = ["dep:dbflux_driver_s3"]
 lua = ["dbflux_lua"]
 aws = ["dbflux_aws", "dbflux_ssm", "dbflux_mcp_server?/aws"]

--- a/crates/dbflux_app/src/app_state/bootstrap.rs
+++ b/crates/dbflux_app/src/app_state/bootstrap.rs
@@ -58,6 +58,9 @@ use dbflux_driver_mssql::MssqlDriver;
 #[cfg(feature = "redshift")]
 use dbflux_driver_redshift::RedshiftDriver;
 
+#[cfg(feature = "clickhouse")]
+use dbflux_driver_clickhouse::ClickHouseDriver;
+
 #[cfg(feature = "s3")]
 use dbflux_driver_s3::S3Driver;
 
@@ -1141,6 +1144,11 @@ impl AppState {
         #[cfg(feature = "redshift")]
         {
             drivers.insert("redshift".to_string(), Arc::new(RedshiftDriver::new()));
+        }
+
+        #[cfg(feature = "clickhouse")]
+        {
+            drivers.insert("clickhouse".to_string(), Arc::new(ClickHouseDriver::new()));
         }
 
         #[cfg(feature = "s3")]

--- a/crates/dbflux_app/src/app_state/mod.rs
+++ b/crates/dbflux_app/src/app_state/mod.rs
@@ -3342,6 +3342,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "clickhouse")]
+    fn clickhouse_registration_present_when_feature_enabled() {
+        let drivers = AppState::build_builtin_drivers();
+        assert!(
+            drivers.contains_key("clickhouse"),
+            "driver map must contain the 'clickhouse' key when the clickhouse feature is enabled"
+        );
+
+        let driver = drivers
+            .get("clickhouse")
+            .expect("clickhouse driver must be registered");
+        assert_eq!(driver.driver_key(), "builtin:clickhouse");
+    }
+
+    #[test]
     fn appstate_new_with_storage_runtime_returns_result_and_propagates_viz_failure() {
         // Uses a directory as the DB path. open_dbflux_db will succeed (migrations
         // ran during StorageRuntime construction on the real path), but viz_connection()

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -467,6 +467,7 @@ fn db_kind_to_str(kind: DbKind) -> String {
         DbKind::SqlServer => "SqlServer",
         DbKind::Redshift => "Redshift",
         DbKind::S3 => "S3",
+        DbKind::ClickHouse => "ClickHouse",
     }
     .to_string()
 }
@@ -485,6 +486,7 @@ fn str_to_db_kind(s: &str) -> Option<DbKind> {
         "SqlServer" => Some(DbKind::SqlServer),
         "Redshift" => Some(DbKind::Redshift),
         "S3" => Some(DbKind::S3),
+        "ClickHouse" => Some(DbKind::ClickHouse),
         _ => None,
     }
 }
@@ -502,6 +504,7 @@ fn default_db_config_for_kind(kind: DbKind) -> dbflux_core::DbConfig {
         DbKind::SqlServer => dbflux_core::DbConfig::default_sqlserver(),
         DbKind::Redshift => dbflux_core::DbConfig::default_redshift(),
         DbKind::S3 => dbflux_core::DbConfig::default_s3(),
+        DbKind::ClickHouse => dbflux_core::DbConfig::default_clickhouse(),
     }
 }
 
@@ -1798,9 +1801,9 @@ fn load_ssh_tunnels(
 #[cfg(test)]
 mod tests {
     use super::{
-        HookDefinitionSave, default_db_config_for_kind, general_settings_theme_to_storage,
-        load_config, save_hook_definitions, save_profiles, save_services, save_ssh_tunnels,
-        theme_setting_from_storage,
+        HookDefinitionSave, db_kind_to_str, default_db_config_for_kind,
+        general_settings_theme_to_storage, load_config, save_hook_definitions, save_profiles,
+        save_services, save_ssh_tunnels, str_to_db_kind, theme_setting_from_storage,
     };
     use dbflux_core::{
         AccessKind, ConnectionHook, ConnectionHookBindings, ConnectionHooks, ConnectionProfile,
@@ -2328,6 +2331,21 @@ mod tests {
         assert!(matches!(
             default_db_config_for_kind(DbKind::InfluxDB),
             DbConfig::InfluxDB { .. }
+        ));
+    }
+
+    #[test]
+    fn clickhouse_kind_and_default_config_use_canonical_storage_name() {
+        assert_eq!(db_kind_to_str(DbKind::ClickHouse), "ClickHouse");
+        assert_eq!(str_to_db_kind("ClickHouse"), Some(DbKind::ClickHouse));
+        assert!(matches!(
+            default_db_config_for_kind(DbKind::ClickHouse),
+            DbConfig::ClickHouse {
+                ref url,
+                ref user,
+                ref database,
+                request_timeout_seconds: None,
+            } if url == "http://localhost:8123" && user == "default" && database == "default"
         ));
     }
 

--- a/crates/dbflux_components/src/icons/mod.rs
+++ b/crates/dbflux_components/src/icons/mod.rs
@@ -118,6 +118,7 @@ pub enum AppIcon {
     BrandSqlite,
     BrandMongodb,
     BrandRedis,
+    BrandClickhouse,
 
     // Language brands (for script file icons)
     BrandLua,
@@ -220,6 +221,7 @@ impl AppIcon {
             Self::BrandSqlite => "icons/brand/sqlite.svg",
             Self::BrandMongodb => "icons/brand/mongodb.svg",
             Self::BrandRedis => "icons/brand/redis.svg",
+            Self::BrandClickhouse => "icons/brand/clickhouse.svg",
             Self::BrandLua => "icons/brand/lua.svg",
             Self::BrandPython => "icons/brand/python.svg",
             Self::BrandBash => "icons/brand/gnubash.svg",
@@ -285,6 +287,7 @@ impl AppIcon {
             Icon::Dynamodb => Self::Braces,
             Icon::Redshift => Self::ChartNoAxesColumn,
             Icon::S3 => Self::Boxes,
+            Icon::Clickhouse => Self::BrandClickhouse,
             Icon::Influxdb => Self::BrandInfluxDb,
             Icon::Logs => Self::Logs,
             Icon::Database => match category {
@@ -335,6 +338,10 @@ mod tests {
         assert_eq!(
             AppIcon::for_driver(Icon::S3, DatabaseCategory::ObjectStorage),
             AppIcon::Boxes
+        );
+        assert_eq!(
+            AppIcon::for_driver(Icon::Clickhouse, DatabaseCategory::Relational),
+            AppIcon::BrandClickhouse
         );
     }
 

--- a/crates/dbflux_core/src/connection/hook.rs
+++ b/crates/dbflux_core/src/connection/hook.rs
@@ -515,6 +515,9 @@ fn profile_config_context(config: &DbConfig) -> (Option<String>, Option<u16>, Op
             default_bucket,
             ..
         } => (Some(url.clone()), None, default_bucket.clone()),
+        DbConfig::ClickHouse { url, database, .. } => {
+            (credential_free_authority(url), None, Some(database.clone()))
+        }
         DbConfig::SqlServer {
             host,
             port,
@@ -543,6 +546,27 @@ fn profile_config_context(config: &DbConfig) -> (Option<String>, Option<u16>, Op
             (host, port, database)
         }
     }
+}
+
+fn credential_free_authority(url: &str) -> Option<String> {
+    let (scheme, remainder) = url.split_once("://")?;
+    if scheme.is_empty()
+        || !scheme.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.')
+        })
+    {
+        return None;
+    }
+
+    let authority = remainder.split(['/', '?', '#']).next()?;
+    let authority = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if authority.is_empty() {
+        return None;
+    }
+
+    Some(format!("{scheme}://{authority}"))
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1774,6 +1798,38 @@ mod tests {
         assert!(ctx.host.is_none());
         assert!(ctx.port.is_none());
         assert_eq!(ctx.database.as_deref(), Some("/data/app.db"));
+    }
+
+    #[test]
+    fn hook_context_from_clickhouse_profile() {
+        let profile = ConnectionProfile::new("clickhouse", DbConfig::default_clickhouse());
+
+        let ctx = HookContext::from_profile(&profile);
+
+        assert_eq!(ctx.host.as_deref(), Some("http://localhost:8123"));
+        assert_eq!(ctx.port, None);
+        assert_eq!(ctx.database.as_deref(), Some("default"));
+    }
+
+    #[test]
+    fn hook_context_removes_url_credentials() {
+        let profile = ConnectionProfile::new(
+            "clickhouse",
+            DbConfig::ClickHouse {
+                url: "https://alice:secret@clickhouse.example.com:8443/query".to_string(),
+                user: "alice".to_string(),
+                database: "default".to_string(),
+                request_timeout_seconds: None,
+            },
+        );
+
+        let context = HookContext::from_profile(&profile);
+
+        assert_eq!(
+            context.host.as_deref(),
+            Some("https://clickhouse.example.com:8443")
+        );
+        assert!(!format!("{context:?}").contains("secret"));
     }
 
     #[test]

--- a/crates/dbflux_core/src/connection/profile.rs
+++ b/crates/dbflux_core/src/connection/profile.rs
@@ -25,6 +25,7 @@ pub enum DbKind {
     SqlServer,
     Redshift,
     S3,
+    ClickHouse,
 }
 
 impl DbKind {
@@ -42,6 +43,7 @@ impl DbKind {
             DbKind::SqlServer => "SQL Server",
             DbKind::Redshift => "Amazon Redshift",
             DbKind::S3 => "Amazon S3",
+            DbKind::ClickHouse => "ClickHouse",
         }
     }
 }
@@ -579,6 +581,13 @@ pub enum DbConfig {
         #[serde(default)]
         path_style: bool,
     },
+    ClickHouse {
+        url: String,
+        user: String,
+        database: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        request_timeout_seconds: Option<u64>,
+    },
     /// Generic config for external RPC drivers.
     External {
         kind: DbKind,
@@ -605,6 +614,7 @@ impl DbConfig {
             DbConfig::SqlServer { .. } => DbKind::SqlServer,
             DbConfig::Redshift { .. } => DbKind::Redshift,
             DbConfig::S3 { .. } => DbKind::S3,
+            DbConfig::ClickHouse { .. } => DbKind::ClickHouse,
             DbConfig::External { kind, .. } => *kind,
         }
     }
@@ -759,6 +769,15 @@ impl DbConfig {
         }
     }
 
+    pub fn default_clickhouse() -> Self {
+        DbConfig::ClickHouse {
+            url: "http://localhost:8123".to_string(),
+            user: "default".to_string(),
+            database: "default".to_string(),
+            request_timeout_seconds: None,
+        }
+    }
+
     pub fn ssh_tunnel(&self) -> Option<&SshTunnelConfig> {
         match self {
             DbConfig::Postgres { ssh_tunnel, .. }
@@ -772,6 +791,7 @@ impl DbConfig {
             | DbConfig::CloudWatchLogs { .. }
             | DbConfig::InfluxDB { .. }
             | DbConfig::S3 { .. }
+            | DbConfig::ClickHouse { .. }
             | DbConfig::External { .. } => None,
         }
     }
@@ -808,6 +828,7 @@ impl DbConfig {
             | DbConfig::CloudWatchLogs { .. }
             | DbConfig::InfluxDB { .. }
             | DbConfig::S3 { .. }
+            | DbConfig::ClickHouse { .. }
             | DbConfig::External { .. } => None,
         }
     }
@@ -850,6 +871,7 @@ impl DbConfig {
             | DbConfig::CloudWatchLogs { .. }
             | DbConfig::InfluxDB { .. }
             | DbConfig::S3 { .. }
+            | DbConfig::ClickHouse { .. }
             | DbConfig::External { .. } => false,
         }
     }
@@ -868,6 +890,7 @@ impl DbConfig {
             | DbConfig::CloudWatchLogs { .. }
             | DbConfig::InfluxDB { .. }
             | DbConfig::S3 { .. }
+            | DbConfig::ClickHouse { .. }
             | DbConfig::External { .. } => None,
         }
     }
@@ -920,6 +943,7 @@ impl DbConfig {
             | DbConfig::CloudWatchLogs { .. }
             | DbConfig::InfluxDB { .. }
             | DbConfig::S3 { .. }
+            | DbConfig::ClickHouse { .. }
             | DbConfig::External { .. } => {}
         }
     }
@@ -929,6 +953,17 @@ impl DbConfig {
     /// Returns the extracted password when one was present and updates the
     /// stored URI in-place to a sanitized form without the password.
     pub fn strip_uri_password(&mut self) -> Option<String> {
+        if let DbConfig::ClickHouse { url, user, .. } = self {
+            let (sanitized_uri, extracted_password) = strip_password_from_uri(url);
+            if extracted_password.is_some() {
+                if let Some(username) = uri_username(url) {
+                    *user = username;
+                }
+                *url = strip_uri_userinfo(&sanitized_uri);
+            }
+            return extracted_password;
+        }
+
         let (use_uri, uri) = match self {
             DbConfig::Postgres { use_uri, uri, .. }
             | DbConfig::MySQL { use_uri, uri, .. }
@@ -941,6 +976,7 @@ impl DbConfig {
             | DbConfig::CloudWatchLogs { .. }
             | DbConfig::InfluxDB { .. }
             | DbConfig::S3 { .. }
+            | DbConfig::ClickHouse { .. }
             | DbConfig::External { .. } => {
                 return None;
             }
@@ -974,6 +1010,7 @@ impl DbConfig {
             DbConfig::SQLite { .. } => Some("main".to_string()),
             DbConfig::DynamoDB { .. } | DbConfig::CloudWatchLogs { .. } => None,
             DbConfig::InfluxDB { default_bucket, .. } => default_bucket.clone(),
+            DbConfig::ClickHouse { database, .. } => Some(database.clone()),
             DbConfig::S3 { .. } => None,
             DbConfig::External { .. } => None,
         }
@@ -1166,9 +1203,42 @@ impl DbConfig {
                 ssh_tunnel,
                 ssh_tunnel_profile_id,
             }),
+            DbConfig::ClickHouse {
+                url,
+                user,
+                request_timeout_seconds,
+                ..
+            } => Ok(DbConfig::ClickHouse {
+                url,
+                user,
+                database: database.to_string(),
+                request_timeout_seconds,
+            }),
             _ => Err("Changing database is not supported for this database type".to_string()),
         }
     }
+}
+
+fn uri_username(uri: &str) -> Option<String> {
+    let authority = uri.split_once("://")?.1.split(['/', '?', '#']).next()?;
+    let userinfo = authority.rsplit_once('@')?.0;
+    let username = userinfo.split_once(':')?.0;
+    urlencoding::decode(username)
+        .map(|username| username.into_owned())
+        .ok()
+}
+
+fn strip_uri_userinfo(uri: &str) -> String {
+    let Some((scheme, remainder)) = uri.split_once("://") else {
+        return uri.to_string();
+    };
+    let authority_end = remainder.find(['/', '?', '#']).unwrap_or(remainder.len());
+    let authority = &remainder[..authority_end];
+    let suffix = &remainder[authority_end..];
+    let host = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    format!("{scheme}://{host}{suffix}")
 }
 
 /// Removes an embedded password from a connection URI.
@@ -1465,6 +1535,7 @@ impl ConnectionProfile {
             DbKind::SqlServer => "mssql",
             DbKind::Redshift => "redshift",
             DbKind::S3 => "s3",
+            DbKind::ClickHouse => "clickhouse",
         }
     }
 
@@ -1626,6 +1697,34 @@ mod tests {
         assert_eq!(
             ConnectionProfile::builtin_driver_id_for_kind(DbKind::Redshift),
             "redshift"
+        );
+    }
+
+    #[test]
+    fn default_clickhouse_uses_http_defaults_without_ssh() {
+        let config = DbConfig::default_clickhouse();
+
+        let DbConfig::ClickHouse {
+            url,
+            user,
+            database,
+            request_timeout_seconds,
+        } = &config
+        else {
+            panic!("expected DbConfig::ClickHouse");
+        };
+
+        assert_eq!(url, "http://localhost:8123");
+        assert_eq!(user, "default");
+        assert_eq!(database, "default");
+        assert_eq!(*request_timeout_seconds, None);
+        assert_eq!(config.kind(), DbKind::ClickHouse);
+        assert!(!config.has_ssh_tunnel());
+        assert_eq!(config.host_port(), None);
+        assert_eq!(config.database().as_deref(), Some("default"));
+        assert_eq!(
+            ConnectionProfile::builtin_driver_id_for_kind(DbKind::ClickHouse),
+            "clickhouse"
         );
     }
 
@@ -2009,6 +2108,25 @@ mod tests {
             DbConfig::Redis {
                 uri: Some(ref uri), ..
             } if uri == "redis://localhost:6379/0"
+        ));
+    }
+
+    #[test]
+    fn strip_uri_password_moves_clickhouse_credentials_out_of_url() {
+        let mut config = DbConfig::ClickHouse {
+            url: "https://alice:p%40ss@clickhouse.example.com:8443".to_string(),
+            user: "default".to_string(),
+            database: "default".to_string(),
+            request_timeout_seconds: None,
+        };
+
+        let extracted = config.strip_uri_password();
+
+        assert_eq!(extracted.as_deref(), Some("p@ss"));
+        assert!(matches!(
+            config,
+            DbConfig::ClickHouse { ref url, ref user, .. }
+                if url == "https://clickhouse.example.com:8443" && user == "alice"
         ));
     }
 

--- a/crates/dbflux_core/src/driver/capabilities.rs
+++ b/crates/dbflux_core/src/driver/capabilities.rs
@@ -137,6 +137,7 @@ pub enum Icon {
     Dynamodb,
     Redshift,
     S3,
+    Clickhouse,
 
     // Time-series brands
     Influxdb,
@@ -2959,6 +2960,7 @@ mod tests {
         assert!(matches!(Icon::Redis, Icon::Redis));
         assert!(matches!(Icon::Dynamodb, Icon::Dynamodb));
         assert!(matches!(Icon::Redshift, Icon::Redshift));
+        assert!(matches!(Icon::Clickhouse, Icon::Clickhouse));
         assert!(matches!(Icon::Database, Icon::Database));
     }
 

--- a/crates/dbflux_core/src/pipeline/resolve.rs
+++ b/crates/dbflux_core/src/pipeline/resolve.rs
@@ -201,6 +201,23 @@ fn patch_config_field(config: &mut DbConfig, field: &str, value: &ResolvedValue)
             _ => {}
         },
 
+        DbConfig::ClickHouse {
+            url,
+            user,
+            database,
+            request_timeout_seconds,
+        } => match field {
+            "url" => *url = val.to_string(),
+            "user" => *user = val.to_string(),
+            "database" => *database = val.to_string(),
+            "request_timeout_seconds" => {
+                if let Ok(timeout) = val.parse() {
+                    *request_timeout_seconds = Some(timeout);
+                }
+            }
+            _ => {}
+        },
+
         DbConfig::SqlServer {
             host,
             port,
@@ -363,6 +380,52 @@ mod tests {
             DbConfig::Postgres { port, .. } => assert_eq!(*port, 5433),
             _ => panic!("expected Postgres"),
         }
+    }
+
+    #[tokio::test]
+    async fn resolve_clickhouse_fields_and_password() {
+        let mut refs = HashMap::new();
+        refs.insert(
+            "url".to_string(),
+            ValueRef::literal("https://ch.example.com"),
+        );
+        refs.insert("user".to_string(), ValueRef::literal("analytics"));
+        refs.insert("database".to_string(), ValueRef::literal("events"));
+        refs.insert(
+            "request_timeout_seconds".to_string(),
+            ValueRef::literal("45"),
+        );
+        refs.insert(
+            "password".to_string(),
+            ValueRef::secret("stub", "clickhouse-pass", None),
+        );
+
+        let mut profile = ConnectionProfile::new("clickhouse", DbConfig::default_clickhouse());
+        profile.value_refs = refs;
+        let resolver = test_resolver();
+        let ctx = ResolveContext::default();
+
+        let (patched, password) = resolve_profile_values(&profile, &resolver, &ctx)
+            .await
+            .unwrap();
+
+        let DbConfig::ClickHouse {
+            url,
+            user,
+            database,
+            request_timeout_seconds,
+        } = patched.config
+        else {
+            panic!("expected ClickHouse");
+        };
+        assert_eq!(url, "https://ch.example.com");
+        assert_eq!(user, "analytics");
+        assert_eq!(database, "events");
+        assert_eq!(request_timeout_seconds, Some(45));
+        assert_eq!(
+            password.unwrap().expose_secret(),
+            "resolved-clickhouse-pass"
+        );
     }
 
     #[tokio::test]

--- a/crates/dbflux_core/src/query/safety.rs
+++ b/crates/dbflux_core/src/query/safety.rs
@@ -36,10 +36,7 @@ pub fn classify_sql_execution(sql: &str) -> ExecutionClassification {
         }
         "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "REPLACE" => ExecutionClassification::Write,
         "TRUNCATE" | "DROP" | "ALTER" => ExecutionClassification::Destructive,
-        "GRANT" | "REVOKE" | "CREATE" | "SET" | "SYSTEM" | "KILL" | "ATTACH" | "DETACH"
-        | "OPTIMIZE" | "RENAME" | "EXCHANGE" | "BACKUP" | "RESTORE" | "UNDROP" | "MOVE" => {
-            ExecutionClassification::Admin
-        }
+        "GRANT" | "REVOKE" | "CREATE" | "SET" => ExecutionClassification::Admin,
         _ => ExecutionClassification::Write,
     }
 }
@@ -295,28 +292,5 @@ mod tests {
             classify_query_for_governance(&QueryLanguage::Sql, "VACUUM users"),
             ExecutionClassification::Write
         );
-    }
-
-    #[test]
-    fn database_administration_queries_require_admin_governance() {
-        for query in [
-            "SYSTEM SHUTDOWN",
-            "KILL QUERY WHERE query_id = 'abc'",
-            "OPTIMIZE TABLE events FINAL",
-            "ATTACH TABLE events",
-            "DETACH TABLE events",
-            "RENAME TABLE old TO new",
-            "EXCHANGE TABLES old AND new",
-            "UNDROP TABLE events",
-            "MOVE USER alice TO another_access_storage",
-            "BACKUP DATABASE analytics TO Disk('backups', 'analytics.zip')",
-            "RESTORE DATABASE analytics FROM Disk('backups', 'analytics.zip')",
-        ] {
-            assert_eq!(
-                classify_sql_execution(query),
-                ExecutionClassification::Admin,
-                "query must require admin governance: {query}"
-            );
-        }
     }
 }

--- a/crates/dbflux_core/src/query/safety.rs
+++ b/crates/dbflux_core/src/query/safety.rs
@@ -36,7 +36,10 @@ pub fn classify_sql_execution(sql: &str) -> ExecutionClassification {
         }
         "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "REPLACE" => ExecutionClassification::Write,
         "TRUNCATE" | "DROP" | "ALTER" => ExecutionClassification::Destructive,
-        "GRANT" | "REVOKE" | "CREATE" | "SET" => ExecutionClassification::Admin,
+        "GRANT" | "REVOKE" | "CREATE" | "SET" | "SYSTEM" | "KILL" | "ATTACH" | "DETACH"
+        | "OPTIMIZE" | "RENAME" | "EXCHANGE" | "BACKUP" | "RESTORE" | "UNDROP" | "MOVE" => {
+            ExecutionClassification::Admin
+        }
         _ => ExecutionClassification::Write,
     }
 }
@@ -292,5 +295,28 @@ mod tests {
             classify_query_for_governance(&QueryLanguage::Sql, "VACUUM users"),
             ExecutionClassification::Write
         );
+    }
+
+    #[test]
+    fn database_administration_queries_require_admin_governance() {
+        for query in [
+            "SYSTEM SHUTDOWN",
+            "KILL QUERY WHERE query_id = 'abc'",
+            "OPTIMIZE TABLE events FINAL",
+            "ATTACH TABLE events",
+            "DETACH TABLE events",
+            "RENAME TABLE old TO new",
+            "EXCHANGE TABLES old AND new",
+            "UNDROP TABLE events",
+            "MOVE USER alice TO another_access_storage",
+            "BACKUP DATABASE analytics TO Disk('backups', 'analytics.zip')",
+            "RESTORE DATABASE analytics FROM Disk('backups', 'analytics.zip')",
+        ] {
+            assert_eq!(
+                classify_sql_execution(query),
+                ExecutionClassification::Admin,
+                "query must require admin governance: {query}"
+            );
+        }
     }
 }

--- a/crates/dbflux_core/src/query/tx_vocab.rs
+++ b/crates/dbflux_core/src/query/tx_vocab.rs
@@ -119,7 +119,8 @@ impl TransactionVocab {
             | DbKind::CloudWatchLogs
             | DbKind::InfluxDB
             | DbKind::Redshift
-            | DbKind::S3 => None,
+            | DbKind::S3
+            | DbKind::ClickHouse => None,
         }
     }
 

--- a/crates/dbflux_core/src/storage/secret_manager.rs
+++ b/crates/dbflux_core/src/storage/secret_manager.rs
@@ -314,6 +314,7 @@ impl SecretManager {
             | DbConfig::CloudWatchLogs { .. }
             | DbConfig::InfluxDB { .. }
             | DbConfig::S3 { .. }
+            | DbConfig::ClickHouse { .. }
             | DbConfig::External { .. } => {
                 return None;
             }

--- a/crates/dbflux_driver_clickhouse/Cargo.toml
+++ b/crates/dbflux_driver_clickhouse/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "dbflux_driver_clickhouse"
+version.workspace = true
+edition.workspace = true
+publish = false
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+chrono.workspace = true
+dbflux_core = { path = "../dbflux_core" }
+hex.workspace = true
+log.workspace = true
+reqwest = { workspace = true, default-features = false, features = ["blocking", "rustls-tls", "gzip"] }
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+dbflux_test_support.workspace = true
+
+[lints]
+workspace = true

--- a/crates/dbflux_driver_clickhouse/README.md
+++ b/crates/dbflux_driver_clickhouse/README.md
@@ -1,0 +1,20 @@
+# ClickHouse Driver
+
+## Features
+
+- Blocking HTTP(S) transport using rustls and HTTP Basic authentication
+- Arbitrary single-statement SQL with forced `JSONCompact` responses
+- Database, table, view, column, engine, key, size, and compression introspection
+- Lazy schema loading per ClickHouse database
+- Recursive decoding for nullable, low-cardinality, array, tuple, map, decimal, integer, date/time, and JSON-like types
+- Read-only visual SELECT generation and ClickHouse identifier/literal syntax
+- Local chart authoring from query results
+
+## Limitations
+
+- No SSH tunnels
+- No transactions, prepared statements, or query cancellation
+- No structured INSERT, UPDATE, DELETE, DDL, or data transfer support; write SQL can only be entered explicitly
+- One SQL statement per request
+- HTTP response bodies are capped at 128 MiB
+- Named ClickHouse time zones are not interpreted client-side; ISO timestamps with offsets are handled accurately, while offset-free timestamps are treated as UTC

--- a/crates/dbflux_driver_clickhouse/src/connection.rs
+++ b/crates/dbflux_driver_clickhouse/src/connection.rs
@@ -4,10 +4,9 @@ use std::time::{Duration, Instant};
 
 use dbflux_core::{
     ColumnMeta, Connection, ConnectionExt, DatabaseInfo, DbError, DbKind, DbSchemaInfo,
-    DocumentConnection, DriverMetadata, ExecutionClassification, KeyValueConnection,
-    QueryCancelHandle, QueryGenerator, QueryHandle, QueryRequest, QueryResult,
-    RelationalConnection, RelationalSchema, Row, SchemaLoadingStrategy, SchemaSnapshot, SqlDialect,
-    TableInfo, Value, classify_sql_execution,
+    DocumentConnection, DriverMetadata, KeyValueConnection, QueryCancelHandle, QueryGenerator,
+    QueryHandle, QueryRequest, QueryResult, RelationalConnection, RelationalSchema, Row,
+    SchemaLoadingStrategy, SchemaSnapshot, SqlDialect, TableInfo, Value,
 };
 use serde::Deserialize;
 
@@ -36,7 +35,7 @@ impl ClickHouseConnection {
 
     pub(crate) fn validate_connection(&self) -> Result<(), DbError> {
         self.client
-            .execute("SELECT 1", None, None)
+            .execute("SELECT 1", None, None, None, None)
             .map(|_| ())
             .map_err(|error| ClickHouseErrorFormatter::into_connection_error(&error))
     }
@@ -49,11 +48,10 @@ impl ClickHouseConnection {
         row_limit: Option<u32>,
         row_offset: Option<u32>,
     ) -> Result<QueryResult, DbError> {
-        let sql = paginate_sql(sql, row_limit, row_offset)?;
         let started = Instant::now();
         let response = self
             .client
-            .execute(&sql, database, timeout)
+            .execute(sql, database, timeout, row_limit, row_offset)
             .map_err(|error| {
                 ClickHouseErrorFormatter::format_http_error(&error).into_query_error()
             })?;
@@ -279,27 +277,9 @@ fn parse_response(
     Ok(QueryResult::table(columns, rows, None, execution_time))
 }
 
-fn paginate_sql(sql: &str, limit: Option<u32>, offset: Option<u32>) -> Result<String, DbError> {
-    if limit.is_none() && offset.is_none() {
-        return Ok(sql.to_string());
-    }
-    if classify_sql_execution(sql) != ExecutionClassification::Read {
-        return Err(DbError::NotSupported(
-            "ClickHouse LIMIT/OFFSET request fields require a single read query".to_string(),
-        ));
-    }
-
-    let inner = sql.trim().trim_end_matches(';').trim_end();
-    let limit = limit.unwrap_or(u32::MAX);
-    let offset = offset.unwrap_or(0);
-    Ok(format!(
-        "SELECT * FROM ({inner}) AS `dbflux_page` LIMIT {limit} OFFSET {offset}"
-    ))
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{paginate_sql, parse_response};
+    use super::parse_response;
     use crate::http::HttpResponse;
     use dbflux_core::{ColumnKind, Value};
     use reqwest::header::HeaderMap;
@@ -319,14 +299,5 @@ mod tests {
             Value::Decimal("18446744073709551615".to_string())
         );
         assert_eq!(result.affected_rows, None);
-    }
-
-    #[test]
-    fn pagination_wraps_read_queries_for_server_side_execution() {
-        assert_eq!(
-            paginate_sql("SELECT number FROM numbers(10);", Some(2), Some(3)).expect("read query"),
-            "SELECT * FROM (SELECT number FROM numbers(10)) AS `dbflux_page` LIMIT 2 OFFSET 3"
-        );
-        assert!(paginate_sql("DROP TABLE events", Some(2), None).is_err());
     }
 }

--- a/crates/dbflux_driver_clickhouse/src/connection.rs
+++ b/crates/dbflux_driver_clickhouse/src/connection.rs
@@ -1,0 +1,332 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
+
+use dbflux_core::{
+    ColumnMeta, Connection, ConnectionExt, DatabaseInfo, DbError, DbKind, DbSchemaInfo,
+    DocumentConnection, DriverMetadata, ExecutionClassification, KeyValueConnection,
+    QueryCancelHandle, QueryGenerator, QueryHandle, QueryRequest, QueryResult,
+    RelationalConnection, RelationalSchema, Row, SchemaLoadingStrategy, SchemaSnapshot, SqlDialect,
+    TableInfo, Value, classify_sql_execution,
+};
+use serde::Deserialize;
+
+use crate::dialect::CLICKHOUSE_DIALECT;
+use crate::driver::{METADATA, READ_ONLY_GENERATOR};
+use crate::error_formatter::ClickHouseErrorFormatter;
+use crate::http::{ClickHouseHttpClient, HttpResponse};
+use crate::introspection;
+use crate::types::{
+    clickhouse_type_is_nullable, clickhouse_type_to_column_kind, json_to_value,
+    parse_clickhouse_type,
+};
+
+pub struct ClickHouseConnection {
+    client: ClickHouseHttpClient,
+    active_database: RwLock<String>,
+}
+
+impl ClickHouseConnection {
+    pub(crate) fn new(client: ClickHouseHttpClient, database: String) -> Self {
+        Self {
+            client,
+            active_database: RwLock::new(database),
+        }
+    }
+
+    pub(crate) fn validate_connection(&self) -> Result<(), DbError> {
+        self.client
+            .execute("SELECT 1", None, None)
+            .map(|_| ())
+            .map_err(|error| ClickHouseErrorFormatter::into_connection_error(&error))
+    }
+
+    pub(crate) fn execute_sql(
+        &self,
+        sql: &str,
+        database: Option<&str>,
+        timeout: Option<Duration>,
+        row_limit: Option<u32>,
+        row_offset: Option<u32>,
+    ) -> Result<QueryResult, DbError> {
+        let sql = paginate_sql(sql, row_limit, row_offset)?;
+        let started = Instant::now();
+        let response = self
+            .client
+            .execute(&sql, database, timeout)
+            .map_err(|error| {
+                ClickHouseErrorFormatter::format_http_error(&error).into_query_error()
+            })?;
+        parse_response(response, started.elapsed())
+    }
+
+    fn current_database(&self) -> Result<String, DbError> {
+        self.active_database
+            .read()
+            .map(|database| database.clone())
+            .map_err(|error| {
+                DbError::QueryFailed(format!("ClickHouse database lock failed: {error}").into())
+            })
+    }
+}
+
+impl Connection for ClickHouseConnection {
+    fn metadata(&self) -> &DriverMetadata {
+        &METADATA
+    }
+
+    fn ping(&self) -> Result<(), DbError> {
+        self.execute_sql("SELECT 1", None, None, Some(1), None)
+            .map(|_| ())
+    }
+
+    fn close(&mut self) -> Result<(), DbError> {
+        Ok(())
+    }
+
+    fn execute(&self, request: &QueryRequest) -> Result<QueryResult, DbError> {
+        if !request.params.is_empty() {
+            return Err(DbError::NotSupported(
+                "ClickHouse HTTP queries do not support QueryRequest parameters".to_string(),
+            ));
+        }
+        let active_database = self.current_database()?;
+        let database = request.database.as_deref().unwrap_or(&active_database);
+        self.execute_sql(
+            &request.sql,
+            Some(database),
+            request.statement_timeout,
+            request.limit,
+            request.offset,
+        )
+    }
+
+    fn cancel(&self, _handle: &QueryHandle) -> Result<(), DbError> {
+        Err(DbError::NotSupported(
+            "ClickHouse HTTP query cancellation is not supported".to_string(),
+        ))
+    }
+
+    fn cancel_handle(&self) -> Arc<dyn QueryCancelHandle> {
+        Arc::new(dbflux_core::NoopCancelHandle)
+    }
+
+    fn schema(&self) -> Result<SchemaSnapshot, DbError> {
+        let databases = introspection::list_databases(self)?;
+        Ok(SchemaSnapshot::relational(RelationalSchema {
+            databases,
+            current_database: Some(self.current_database()?),
+            schemas: Vec::new(),
+            tables: Vec::new(),
+            views: Vec::new(),
+        }))
+    }
+
+    fn list_databases(&self) -> Result<Vec<DatabaseInfo>, DbError> {
+        introspection::list_databases(self)
+    }
+
+    fn schema_for_database(&self, database: &str) -> Result<DbSchemaInfo, DbError> {
+        introspection::schema_for_database(self, database)
+    }
+
+    fn table_details(
+        &self,
+        database: &str,
+        _schema: Option<&str>,
+        table: &str,
+    ) -> Result<TableInfo, DbError> {
+        introspection::table_details(self, database, table)
+    }
+
+    fn set_active_database(&self, database: Option<&str>) -> Result<(), DbError> {
+        let Some(database) = database else {
+            return Ok(());
+        };
+        let mut active = self.active_database.write().map_err(|error| {
+            DbError::QueryFailed(format!("ClickHouse database lock failed: {error}").into())
+        })?;
+        *active = database.to_string();
+        Ok(())
+    }
+
+    fn active_database(&self) -> Option<String> {
+        self.active_database
+            .read()
+            .ok()
+            .map(|database| database.clone())
+    }
+
+    fn kind(&self) -> DbKind {
+        DbKind::ClickHouse
+    }
+
+    fn schema_loading_strategy(&self) -> SchemaLoadingStrategy {
+        SchemaLoadingStrategy::LazyPerDatabase
+    }
+
+    fn dialect(&self) -> &dyn SqlDialect {
+        &CLICKHOUSE_DIALECT
+    }
+
+    fn query_generator(&self) -> Option<&dyn QueryGenerator> {
+        Some(&READ_ONLY_GENERATOR)
+    }
+}
+
+impl RelationalConnection for ClickHouseConnection {}
+
+impl ConnectionExt for ClickHouseConnection {
+    fn as_relational(&self) -> Option<&dyn RelationalConnection> {
+        Some(self)
+    }
+
+    fn as_document(&self) -> Option<&dyn DocumentConnection> {
+        None
+    }
+
+    fn as_keyvalue(&self) -> Option<&dyn KeyValueConnection> {
+        None
+    }
+}
+
+#[derive(Deserialize)]
+struct CompactResponse {
+    #[serde(default)]
+    meta: Vec<CompactColumn>,
+    #[serde(default)]
+    data: Vec<Vec<serde_json::Value>>,
+}
+
+#[derive(Deserialize)]
+struct CompactColumn {
+    name: String,
+    #[serde(rename = "type")]
+    type_name: String,
+}
+
+fn parse_response(
+    response: HttpResponse,
+    execution_time: Duration,
+) -> Result<QueryResult, DbError> {
+    if response.body.iter().all(u8::is_ascii_whitespace) {
+        let affected_rows = response
+            .headers
+            .get("X-ClickHouse-Summary")
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| serde_json::from_str::<HashMap<String, String>>(value).ok())
+            .and_then(|summary| {
+                summary
+                    .get("written_rows")
+                    .and_then(|value| value.parse().ok())
+            });
+        return Ok(QueryResult::table(
+            Vec::new(),
+            Vec::new(),
+            affected_rows,
+            execution_time,
+        ));
+    }
+
+    let compact: CompactResponse = serde_json::from_slice(&response.body).map_err(|error| {
+        DbError::QueryFailed(
+            format!("Invalid JSONCompact response from ClickHouse: {error}").into(),
+        )
+    })?;
+    let parsed_types = compact
+        .meta
+        .iter()
+        .map(|column| parse_clickhouse_type(&column.type_name))
+        .collect::<Vec<_>>();
+    let columns = compact
+        .meta
+        .iter()
+        .zip(&parsed_types)
+        .map(|(column, data_type)| ColumnMeta {
+            name: column.name.clone(),
+            type_name: column.type_name.clone(),
+            kind: clickhouse_type_to_column_kind(data_type),
+            nullable: clickhouse_type_is_nullable(data_type),
+            is_primary_key: false,
+        })
+        .collect::<Vec<_>>();
+    let rows = compact
+        .data
+        .iter()
+        .map(|row| {
+            if row.len() != parsed_types.len() {
+                return Err(DbError::QueryFailed(
+                    format!(
+                        "Invalid JSONCompact row width from ClickHouse: expected {}, received {}",
+                        parsed_types.len(),
+                        row.len()
+                    )
+                    .into(),
+                ));
+            }
+            let values = parsed_types
+                .iter()
+                .enumerate()
+                .map(|(index, data_type)| {
+                    row.get(index)
+                        .map(|value| json_to_value(value, data_type))
+                        .unwrap_or(Value::Null)
+                })
+                .collect::<Row>();
+            Ok(values)
+        })
+        .collect::<Result<Vec<_>, DbError>>()?;
+    Ok(QueryResult::table(columns, rows, None, execution_time))
+}
+
+fn paginate_sql(sql: &str, limit: Option<u32>, offset: Option<u32>) -> Result<String, DbError> {
+    if limit.is_none() && offset.is_none() {
+        return Ok(sql.to_string());
+    }
+    if classify_sql_execution(sql) != ExecutionClassification::Read {
+        return Err(DbError::NotSupported(
+            "ClickHouse LIMIT/OFFSET request fields require a single read query".to_string(),
+        ));
+    }
+
+    let inner = sql.trim().trim_end_matches(';').trim_end();
+    let limit = limit.unwrap_or(u32::MAX);
+    let offset = offset.unwrap_or(0);
+    Ok(format!(
+        "SELECT * FROM ({inner}) AS `dbflux_page` LIMIT {limit} OFFSET {offset}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{paginate_sql, parse_response};
+    use crate::http::HttpResponse;
+    use dbflux_core::{ColumnKind, Value};
+    use reqwest::header::HeaderMap;
+    use std::time::Duration;
+
+    #[test]
+    fn parses_json_compact_metadata_and_values() {
+        let response = HttpResponse {
+            body: br#"{"meta":[{"name":"id","type":"UInt64"},{"name":"ts","type":"DateTime64(3, 'UTC')"}],"data":[["18446744073709551615","2026-08-17T12:00:00.000Z"]],"rows":1}"#.to_vec(),
+            headers: HeaderMap::new(),
+        };
+        let result = parse_response(response, Duration::ZERO).expect("valid response");
+        assert_eq!(result.columns[0].kind, ColumnKind::Integer);
+        assert_eq!(result.columns[1].kind, ColumnKind::Timestamp);
+        assert_eq!(
+            result.rows[0][0],
+            Value::Decimal("18446744073709551615".to_string())
+        );
+        assert_eq!(result.affected_rows, None);
+    }
+
+    #[test]
+    fn pagination_wraps_read_queries_for_server_side_execution() {
+        assert_eq!(
+            paginate_sql("SELECT number FROM numbers(10);", Some(2), Some(3)).expect("read query"),
+            "SELECT * FROM (SELECT number FROM numbers(10)) AS `dbflux_page` LIMIT 2 OFFSET 3"
+        );
+        assert!(paginate_sql("DROP TABLE events", Some(2), None).is_err());
+    }
+}

--- a/crates/dbflux_driver_clickhouse/src/dialect.rs
+++ b/crates/dbflux_driver_clickhouse/src/dialect.rs
@@ -1,0 +1,101 @@
+use dbflux_core::{PlaceholderStyle, SqlDialect, Value};
+
+pub struct ClickHouseDialect;
+
+impl SqlDialect for ClickHouseDialect {
+    fn quote_identifier(&self, name: &str) -> String {
+        format!("`{}`", name.replace('\\', "\\\\").replace('`', "\\`"))
+    }
+
+    fn qualified_table(&self, database: Option<&str>, table: &str) -> String {
+        match database {
+            Some(database) => format!(
+                "{}.{}",
+                self.quote_identifier(database),
+                self.quote_identifier(table)
+            ),
+            None => self.quote_identifier(table),
+        }
+    }
+
+    fn value_to_literal(&self, value: &Value) -> String {
+        match value {
+            Value::Null => "NULL".to_string(),
+            Value::Bool(value) => if *value { "true" } else { "false" }.to_string(),
+            Value::Int(value) => value.to_string(),
+            Value::Float(value) if value.is_finite() => value.to_string(),
+            Value::Float(value) if value.is_nan() => "nan".to_string(),
+            Value::Float(value) if value.is_sign_positive() => "inf".to_string(),
+            Value::Float(_) => "-inf".to_string(),
+            Value::Decimal(value) => value.clone(),
+            Value::Text(value) | Value::Json(value) | Value::ObjectId(value) => {
+                format!("'{}'", self.escape_string(value))
+            }
+            Value::Bytes(value) => format!("unhex('{}')", hex::encode(value)),
+            Value::DateTime(value) => format!("'{}'", value.to_rfc3339()),
+            Value::Date(value) => format!("'{}'", value.format("%Y-%m-%d")),
+            Value::Time(value) => format!("'{}'", value.format("%H:%M:%S%.f")),
+            Value::Array(values) => format!(
+                "[{}]",
+                values
+                    .iter()
+                    .map(|value| self.value_to_literal(value))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            Value::Document(value) => {
+                let json = serde_json::to_string(value).unwrap_or_else(|error| {
+                    log::warn!("Failed to serialize ClickHouse object literal: {error}");
+                    "{}".to_string()
+                });
+                format!("'{}'", self.escape_string(&json))
+            }
+            Value::Unsupported(_) => "NULL".to_string(),
+        }
+    }
+
+    fn escape_string(&self, value: &str) -> String {
+        value.replace('\\', "\\\\").replace('\'', "\\'")
+    }
+
+    fn placeholder_style(&self) -> PlaceholderStyle {
+        PlaceholderStyle::QuestionMark
+    }
+
+    fn normalize_identifier<'a>(&self, name: &'a str) -> std::borrow::Cow<'a, str> {
+        std::borrow::Cow::Borrowed(name)
+    }
+}
+
+pub static CLICKHOUSE_DIALECT: ClickHouseDialect = ClickHouseDialect;
+
+#[cfg(test)]
+mod tests {
+    use super::CLICKHOUSE_DIALECT;
+    use dbflux_core::{PlaceholderStyle, SqlDialect, Value};
+
+    #[test]
+    fn quotes_clickhouse_identifiers() {
+        assert_eq!(CLICKHOUSE_DIALECT.quote_identifier("events"), "`events`");
+        assert_eq!(
+            CLICKHOUSE_DIALECT.quote_identifier("odd\\`name"),
+            "`odd\\\\\\`name`"
+        );
+        assert_eq!(
+            CLICKHOUSE_DIALECT.qualified_table(Some("analytics"), "events"),
+            "`analytics`.`events`"
+        );
+    }
+
+    #[test]
+    fn escapes_clickhouse_string_literals() {
+        assert_eq!(
+            CLICKHOUSE_DIALECT.value_to_literal(&Value::Text("a'b\\c".to_string())),
+            "'a\\'b\\\\c'"
+        );
+        assert_eq!(
+            CLICKHOUSE_DIALECT.placeholder_style(),
+            PlaceholderStyle::QuestionMark
+        );
+    }
+}

--- a/crates/dbflux_driver_clickhouse/src/driver.rs
+++ b/crates/dbflux_driver_clickhouse/src/driver.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::time::Duration;
 
-use dbflux_core::secrecy::{ExposeSecret, SecretString};
+use dbflux_core::secrecy::SecretString;
 use dbflux_core::{
     DatabaseCategory, DbConfig, DbDriver, DbError, DbKind, DeploymentClass, DriverCapabilities,
     DriverFormDef, DriverKey, DriverMetadata, FormFieldKind, FormSection, FormTab, FormValues,
@@ -261,10 +261,7 @@ impl DbDriver for ClickHouseDriver {
         let client = ClickHouseHttpClient::new(
             url,
             user.clone(),
-            password
-                .map(ExposeSecret::expose_secret)
-                .unwrap_or_default()
-                .to_string(),
+            password.cloned(),
             database.clone(),
             Duration::from_secs(timeout),
         )

--- a/crates/dbflux_driver_clickhouse/src/driver.rs
+++ b/crates/dbflux_driver_clickhouse/src/driver.rs
@@ -41,7 +41,7 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
     ),
     default_port: Some(8123),
     uri_scheme: "http".to_string(),
-    icon: Icon::Database,
+    icon: Icon::Clickhouse,
     syntax: Some(SyntaxInfo {
         identifier_quote: '`',
         string_quote: '\'',

--- a/crates/dbflux_driver_clickhouse/src/driver.rs
+++ b/crates/dbflux_driver_clickhouse/src/driver.rs
@@ -1,0 +1,470 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use dbflux_core::secrecy::{ExposeSecret, SecretString};
+use dbflux_core::{
+    DatabaseCategory, DbConfig, DbDriver, DbError, DbKind, DeploymentClass, DriverCapabilities,
+    DriverFormDef, DriverKey, DriverMetadata, FormFieldKind, FormSection, FormTab, FormValues,
+    Icon, MutationRequest, OrderByMode, PaginationStyle, PlaceholderStyle, QueryCapabilities,
+    QueryGenError, QueryGenerator, QueryLanguage, ReadTemplateRequest, SelectQuery,
+    SqlMutationGenerator, SyntaxInfo, TransferFamily, VisualQuerySpec, WhereOperator, field,
+    field_password, field_required, with_default, with_help,
+};
+
+use crate::connection::ClickHouseConnection;
+use crate::dialect::CLICKHOUSE_DIALECT;
+use crate::http::ClickHouseHttpClient;
+
+const DEFAULT_REQUEST_TIMEOUT_SECONDS: u64 = 30;
+const MAX_REQUEST_TIMEOUT_SECONDS: u64 = i32::MAX as u64;
+
+pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
+    id: "clickhouse".to_string(),
+    display_name: "ClickHouse".to_string(),
+    description: "Column-oriented analytical database over HTTP".to_string(),
+    category: DatabaseCategory::Relational,
+    transfer_family: TransferFamily::Incompatible,
+    deployment_class: Some(DeploymentClass::SelfHosted),
+    query_language: QueryLanguage::Sql,
+    capabilities: DriverCapabilities::from_bits_truncate(
+        DriverCapabilities::MULTIPLE_DATABASES.bits()
+            | DriverCapabilities::SSL.bits()
+            | DriverCapabilities::AUTHENTICATION.bits()
+            | DriverCapabilities::VIEWS.bits()
+            | DriverCapabilities::PAGINATION.bits()
+            | DriverCapabilities::SORTING.bits()
+            | DriverCapabilities::FILTERING.bits()
+            | DriverCapabilities::CHART_AUTHORING.bits()
+            | DriverCapabilities::EXPORT_CSV.bits()
+            | DriverCapabilities::EXPORT_JSON.bits(),
+    ),
+    default_port: Some(8123),
+    uri_scheme: "http".to_string(),
+    icon: Icon::Database,
+    syntax: Some(SyntaxInfo {
+        identifier_quote: '`',
+        string_quote: '\'',
+        placeholder_style: PlaceholderStyle::QuestionMark,
+        supports_schemas: false,
+        default_schema: None,
+        case_sensitive_identifiers: true,
+    }),
+    query: Some(QueryCapabilities {
+        pagination: vec![PaginationStyle::Offset],
+        where_operators: vec![
+            WhereOperator::Eq,
+            WhereOperator::Ne,
+            WhereOperator::Gt,
+            WhereOperator::Gte,
+            WhereOperator::Lt,
+            WhereOperator::Lte,
+            WhereOperator::Like,
+            WhereOperator::Null,
+            WhereOperator::In,
+            WhereOperator::NotIn,
+            WhereOperator::And,
+            WhereOperator::Or,
+            WhereOperator::Not,
+        ],
+        supports_order_by: true,
+        order_by_mode: OrderByMode::AnyColumns,
+        supports_group_by: true,
+        supports_having: true,
+        supports_distinct: true,
+        supports_limit: true,
+        supports_offset: true,
+        supports_joins: true,
+        supports_subqueries: true,
+        supports_union: true,
+        supports_intersect: true,
+        supports_except: true,
+        supports_case_expressions: true,
+        supports_window_functions: true,
+        supports_ctes: true,
+        supports_explain: true,
+        max_query_parameters: 0,
+        max_order_by_columns: 0,
+        max_group_by_columns: 0,
+    }),
+    mutation: None,
+    ddl: None,
+    transactions: None,
+    limits: None,
+    ssl_modes: None,
+    ssl_cert_fields: None,
+    classification_override: None,
+    default_chunk_size: None,
+    supports_lock_timeout: false,
+    editor_profile: None,
+});
+
+pub static CLICKHOUSE_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef {
+    tabs: vec![FormTab {
+        id: "main".to_string(),
+        label: "Main".to_string(),
+        sections: vec![
+            FormSection {
+                title: "Server".to_string(),
+                fields: vec![
+                    with_default(
+                        field_required(
+                            "url",
+                            "HTTP URL",
+                            FormFieldKind::Text,
+                            "http://localhost:8123",
+                        ),
+                        "http://localhost:8123",
+                    ),
+                    with_default(
+                        field_required("database", "Database", FormFieldKind::Text, "default"),
+                        "default",
+                    ),
+                    with_default(
+                        field(
+                            "request_timeout_seconds",
+                            "Request Timeout (seconds)",
+                            FormFieldKind::Number,
+                            "30",
+                        ),
+                        "30",
+                    ),
+                ],
+            },
+            FormSection {
+                title: "Authentication".to_string(),
+                fields: vec![
+                    with_default(
+                        field_required("user", "User", FormFieldKind::Text, "default"),
+                        "default",
+                    ),
+                    with_help(
+                        field_password(),
+                        "Stored securely; sent using HTTP Basic Auth",
+                    ),
+                ],
+            },
+        ],
+    }],
+});
+
+pub struct ClickHouseDriver;
+
+impl ClickHouseDriver {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ClickHouseDriver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DbDriver for ClickHouseDriver {
+    fn kind(&self) -> DbKind {
+        DbKind::ClickHouse
+    }
+
+    fn metadata(&self) -> &DriverMetadata {
+        &METADATA
+    }
+
+    fn form_definition(&self) -> &DriverFormDef {
+        &CLICKHOUSE_FORM
+    }
+
+    fn driver_key(&self) -> DriverKey {
+        "builtin:clickhouse".into()
+    }
+
+    fn build_config(&self, values: &FormValues) -> Result<DbConfig, DbError> {
+        let url = required_value(values, "url", "HTTP URL")?;
+        ClickHouseHttpClient::validate_endpoint(&url)
+            .map_err(|error| DbError::InvalidProfile(error.to_string()))?;
+        let user = required_value(values, "user", "User")?;
+        let database = required_value(values, "database", "Database")?;
+        let request_timeout_seconds = values
+            .get("request_timeout_seconds")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(|value| {
+                value.parse::<u64>().map_err(|_| {
+                    DbError::InvalidProfile("Request timeout must be a whole number".to_string())
+                })
+            })
+            .transpose()?;
+        if request_timeout_seconds == Some(0) {
+            return Err(DbError::InvalidProfile(
+                "Request timeout must be greater than zero".to_string(),
+            ));
+        }
+        if request_timeout_seconds.is_some_and(|timeout| timeout > MAX_REQUEST_TIMEOUT_SECONDS) {
+            return Err(DbError::InvalidProfile(format!(
+                "Request timeout must not exceed {MAX_REQUEST_TIMEOUT_SECONDS} seconds"
+            )));
+        }
+        Ok(DbConfig::ClickHouse {
+            url,
+            user,
+            database,
+            request_timeout_seconds,
+        })
+    }
+
+    fn extract_values(&self, config: &DbConfig) -> FormValues {
+        let mut values = HashMap::new();
+        if let DbConfig::ClickHouse {
+            url,
+            user,
+            database,
+            request_timeout_seconds,
+        } = config
+        {
+            values.insert("url".to_string(), url.clone());
+            values.insert("user".to_string(), user.clone());
+            values.insert("database".to_string(), database.clone());
+            values.insert(
+                "request_timeout_seconds".to_string(),
+                request_timeout_seconds
+                    .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECONDS)
+                    .to_string(),
+            );
+        }
+        values
+    }
+
+    fn connect_with_secrets(
+        &self,
+        profile: &dbflux_core::ConnectionProfile,
+        password: Option<&SecretString>,
+        _ssh_secret: Option<&SecretString>,
+    ) -> Result<Box<dyn dbflux_core::Connection>, DbError> {
+        let DbConfig::ClickHouse {
+            url,
+            user,
+            database,
+            request_timeout_seconds,
+        } = &profile.config
+        else {
+            return Err(DbError::InvalidProfile(
+                "Expected ClickHouse configuration".to_string(),
+            ));
+        };
+        let timeout = request_timeout_seconds.unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECONDS);
+        if timeout == 0 || timeout > MAX_REQUEST_TIMEOUT_SECONDS {
+            return Err(DbError::InvalidProfile(format!(
+                "Request timeout must be between 1 and {MAX_REQUEST_TIMEOUT_SECONDS} seconds"
+            )));
+        }
+        let client = ClickHouseHttpClient::new(
+            url,
+            user.clone(),
+            password
+                .map(ExposeSecret::expose_secret)
+                .unwrap_or_default()
+                .to_string(),
+            database.clone(),
+            Duration::from_secs(timeout),
+        )
+        .map_err(|error| {
+            crate::error_formatter::ClickHouseErrorFormatter::into_connection_error(&error)
+        })?;
+        let connection = ClickHouseConnection::new(client, database.clone());
+        connection.validate_connection()?;
+        Ok(Box::new(connection))
+    }
+
+    fn test_connection(&self, profile: &dbflux_core::ConnectionProfile) -> Result<(), DbError> {
+        self.connect(profile).map(|_| ())
+    }
+}
+
+fn required_value(values: &FormValues, key: &str, label: &str) -> Result<String, DbError> {
+    values
+        .get(key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| DbError::InvalidProfile(format!("{label} is required")))
+}
+
+pub(crate) struct ReadOnlyClickHouseGenerator {
+    inner: SqlMutationGenerator,
+}
+
+impl ReadOnlyClickHouseGenerator {
+    const fn new() -> Self {
+        Self {
+            inner: SqlMutationGenerator::new(&CLICKHOUSE_DIALECT),
+        }
+    }
+}
+
+impl QueryGenerator for ReadOnlyClickHouseGenerator {
+    fn supported_categories(&self) -> &'static [dbflux_core::MutationCategory] {
+        &[]
+    }
+
+    fn generate_mutation(
+        &self,
+        _mutation: &MutationRequest,
+    ) -> Option<dbflux_core::GeneratedQuery> {
+        None
+    }
+
+    fn generate_read_template(
+        &self,
+        request: &ReadTemplateRequest<'_>,
+    ) -> Option<dbflux_core::GeneratedQuery> {
+        self.inner.generate_read_template(request)
+    }
+
+    fn generate_select(
+        &self,
+        spec: &VisualQuerySpec,
+    ) -> Result<Option<SelectQuery>, QueryGenError> {
+        self.inner.generate_select(spec).map(|query| {
+            query.map(|query| SelectQuery {
+                sql: query.materialize_for_editor(&CLICKHOUSE_DIALECT),
+                params: Vec::new(),
+            })
+        })
+    }
+
+    fn materialize_select_for_editor(&self, query: &SelectQuery) -> String {
+        query.sql.clone()
+    }
+}
+
+pub(crate) static READ_ONLY_GENERATOR: ReadOnlyClickHouseGenerator =
+    ReadOnlyClickHouseGenerator::new();
+
+#[cfg(test)]
+mod tests {
+    use super::{ClickHouseDriver, MAX_REQUEST_TIMEOUT_SECONDS, METADATA, READ_ONLY_GENERATOR};
+    use dbflux_core::{
+        Comparator, DbConfig, DbDriver, DriverCapabilities, FilterNode, FormValues, LiteralValue,
+        Predicate, PredicateValue, Projection, QueryGenerator, SourceTable, VisualQuerySpec,
+    };
+
+    #[test]
+    fn metadata_is_conservative_and_has_no_mutation_contract() {
+        for capability in [
+            DriverCapabilities::INSERT,
+            DriverCapabilities::UPDATE,
+            DriverCapabilities::DELETE,
+            DriverCapabilities::TRANSACTIONS,
+            DriverCapabilities::PREPARED_STATEMENTS,
+            DriverCapabilities::QUERY_CANCELLATION,
+            DriverCapabilities::MULTI_STATEMENT,
+        ] {
+            assert!(!METADATA.capabilities.contains(capability));
+        }
+        assert!(METADATA.mutation.is_none());
+        assert!(METADATA.transactions.is_none());
+        assert!(
+            METADATA
+                .capabilities
+                .contains(DriverCapabilities::CHART_AUTHORING)
+        );
+    }
+
+    #[test]
+    fn config_round_trips_without_password() {
+        let driver = ClickHouseDriver::new();
+        let values = FormValues::from([
+            ("url".to_string(), "https://ch.example.com".to_string()),
+            ("user".to_string(), "analytics".to_string()),
+            ("database".to_string(), "events".to_string()),
+            ("request_timeout_seconds".to_string(), "45".to_string()),
+        ]);
+        let config = driver.build_config(&values).expect("valid config");
+        let DbConfig::ClickHouse {
+            request_timeout_seconds,
+            ..
+        } = &config
+        else {
+            panic!("expected ClickHouse config");
+        };
+        assert_eq!(*request_timeout_seconds, Some(45));
+        let extracted = driver.extract_values(&config);
+        assert!(!extracted.contains_key("password"));
+        assert_eq!(
+            extracted.get("database").map(String::as_str),
+            Some("events")
+        );
+    }
+
+    #[test]
+    fn rejects_zero_timeout() {
+        let driver = ClickHouseDriver::new();
+        let values = FormValues::from([
+            ("url".to_string(), "http://localhost:8123".to_string()),
+            ("user".to_string(), "default".to_string()),
+            ("database".to_string(), "default".to_string()),
+            ("request_timeout_seconds".to_string(), "0".to_string()),
+        ]);
+        assert!(driver.build_config(&values).is_err());
+    }
+
+    #[test]
+    fn rejects_unsafe_endpoint_and_unpersistable_timeout() {
+        let driver = ClickHouseDriver::new();
+        let mut values = FormValues::from([
+            (
+                "url".to_string(),
+                "https://user:secret@clickhouse.example.com".to_string(),
+            ),
+            ("user".to_string(), "default".to_string()),
+            ("database".to_string(), "default".to_string()),
+            ("request_timeout_seconds".to_string(), "30".to_string()),
+        ]);
+        assert!(driver.build_config(&values).is_err());
+
+        values.insert(
+            "url".to_string(),
+            "https://clickhouse.example.com".to_string(),
+        );
+        values.insert(
+            "request_timeout_seconds".to_string(),
+            (MAX_REQUEST_TIMEOUT_SECONDS + 1).to_string(),
+        );
+        assert!(driver.build_config(&values).is_err());
+    }
+
+    #[test]
+    fn visual_select_inlines_escaped_values_without_params() {
+        let spec = VisualQuerySpec {
+            source: SourceTable {
+                schema: Some("analytics".to_string()),
+                table: "events".to_string(),
+                alias: "events".to_string(),
+            },
+            projection: Projection::All,
+            joins: Vec::new(),
+            filter: Some(FilterNode::Predicate(Predicate {
+                source_alias: "events".to_string(),
+                column: "name".to_string(),
+                comparator: Comparator::Eq,
+                value: PredicateValue::Single(LiteralValue::Text("O'Reilly\\docs".to_string())),
+                node_id: 0,
+            })),
+            group_by: Vec::new(),
+            aggregates: Vec::new(),
+            having: None,
+            sort: Vec::new(),
+            limit: Some(10),
+            offset: 0,
+        };
+
+        let query = READ_ONLY_GENERATOR
+            .generate_select(&spec)
+            .expect("valid spec")
+            .expect("SELECT supported");
+        assert!(query.params.is_empty());
+        assert!(query.sql.contains("'O\\'Reilly\\\\docs'"));
+        assert!(!query.sql.contains('?'));
+    }
+}

--- a/crates/dbflux_driver_clickhouse/src/error_formatter.rs
+++ b/crates/dbflux_driver_clickhouse/src/error_formatter.rs
@@ -1,0 +1,158 @@
+use dbflux_core::{ConnectionErrorFormatter, FormattedError, QueryErrorFormatter};
+
+use crate::http::ClickHouseHttpError;
+
+pub struct ClickHouseErrorFormatter;
+
+impl ClickHouseErrorFormatter {
+    pub(crate) fn format_http_error(error: &ClickHouseHttpError) -> FormattedError {
+        match error {
+            ClickHouseHttpError::Server { status, code, body } => {
+                let (body_code, message) = parse_server_error(body);
+                let mut formatted = FormattedError::new(message);
+                if let Some(code) = code.clone().or(body_code) {
+                    formatted = formatted.with_code(code);
+                }
+                if *status == 429 {
+                    formatted = formatted.with_retriable(true);
+                }
+                formatted
+            }
+            ClickHouseHttpError::Transport(message) => {
+                FormattedError::new(format!("ClickHouse request failed: {message}"))
+                    .with_retriable(true)
+            }
+            other => FormattedError::new(other.to_string()),
+        }
+    }
+
+    pub(crate) fn into_connection_error(error: &ClickHouseHttpError) -> dbflux_core::DbError {
+        let formatted = Self::format_http_error(error);
+        match error {
+            ClickHouseHttpError::Server { status, body, .. }
+                if matches!(status, 401 | 403)
+                    || body.contains("AUTHENTICATION_FAILED")
+                    || body.contains("REQUIRED_PASSWORD") =>
+            {
+                dbflux_core::DbError::AuthFailed(formatted)
+            }
+            _ => formatted.into_connection_error(),
+        }
+    }
+}
+
+impl QueryErrorFormatter for ClickHouseErrorFormatter {
+    fn format_query_error(&self, error: &(dyn std::error::Error + 'static)) -> FormattedError {
+        error
+            .downcast_ref::<ClickHouseHttpError>()
+            .map(Self::format_http_error)
+            .unwrap_or_else(|| FormattedError::new(error.to_string()))
+    }
+}
+
+impl ConnectionErrorFormatter for ClickHouseErrorFormatter {
+    fn format_connection_error(
+        &self,
+        error: &(dyn std::error::Error + 'static),
+        host: &str,
+        port: u16,
+    ) -> FormattedError {
+        let message = error.to_string();
+        if message.contains("401") || message.contains("authentication") {
+            FormattedError::new("ClickHouse authentication failed. Check the user and password.")
+        } else {
+            FormattedError::new(format!(
+                "Could not connect to ClickHouse at {host}:{port}: {message}"
+            ))
+        }
+    }
+
+    fn format_uri_error(
+        &self,
+        error: &(dyn std::error::Error + 'static),
+        sanitized_uri: &str,
+    ) -> FormattedError {
+        let formatted = error
+            .downcast_ref::<ClickHouseHttpError>()
+            .map(Self::format_http_error)
+            .unwrap_or_else(|| FormattedError::new(error.to_string()));
+        FormattedError::new(format!(
+            "ClickHouse connection to {sanitized_uri} failed: {}",
+            formatted.message
+        ))
+        .with_retriable(formatted.retriable)
+    }
+}
+
+fn parse_server_error(body: &str) -> (Option<String>, String) {
+    let trimmed = body.trim().trim_start_matches("__exception__").trim();
+    let code = trimmed
+        .find("Code: ")
+        .map(|position| &trimmed[position + "Code: ".len()..])
+        .and_then(|rest| rest.split_once('.'))
+        .map(|(code, _)| code.trim().to_string());
+    let message = trimmed
+        .split_once("DB::Exception:")
+        .map(|(_, message)| message.trim())
+        .unwrap_or(trimmed)
+        .lines()
+        .next()
+        .unwrap_or("ClickHouse query failed")
+        .trim()
+        .to_string();
+    (code, message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClickHouseErrorFormatter, parse_server_error};
+    use crate::http::ClickHouseHttpError;
+
+    #[test]
+    fn extracts_clickhouse_code_and_message() {
+        let (code, message) = parse_server_error(
+            "Code: 60. DB::Exception: Table default.missing does not exist. (UNKNOWN_TABLE)",
+        );
+        assert_eq!(code.as_deref(), Some("60"));
+        assert_eq!(
+            message,
+            "Table default.missing does not exist. (UNKNOWN_TABLE)"
+        );
+
+        let (code, message) =
+            parse_server_error("__exception__Code: 241. DB::Exception: memory limit exceeded");
+        assert_eq!(code.as_deref(), Some("241"));
+        assert_eq!(message, "memory limit exceeded");
+    }
+
+    #[test]
+    fn does_not_mark_generic_server_failures_retriable() {
+        let formatted = ClickHouseErrorFormatter::format_http_error(&ClickHouseHttpError::Server {
+            status: 500,
+            code: None,
+            body: "temporarily unavailable".to_string(),
+        });
+        assert!(!formatted.retriable);
+
+        let throttled = ClickHouseErrorFormatter::format_http_error(&ClickHouseHttpError::Server {
+            status: 429,
+            code: None,
+            body: "too many requests".to_string(),
+        });
+        assert!(throttled.retriable);
+    }
+
+    #[test]
+    fn authentication_failure_maps_to_auth_error() {
+        let error = ClickHouseHttpError::Server {
+            status: 403,
+            code: Some("516".to_string()),
+            body: "Code: 516. DB::Exception: Authentication failed. (AUTHENTICATION_FAILED)"
+                .to_string(),
+        };
+        assert!(matches!(
+            ClickHouseErrorFormatter::into_connection_error(&error),
+            dbflux_core::DbError::AuthFailed(_)
+        ));
+    }
+}

--- a/crates/dbflux_driver_clickhouse/src/http.rs
+++ b/crates/dbflux_driver_clickhouse/src/http.rs
@@ -1,6 +1,7 @@
 use std::io::Read;
 use std::time::Duration;
 
+use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use reqwest::blocking::{Client, Response};
 use reqwest::header::{CONTENT_LENGTH, HeaderMap};
 use reqwest::{Url, redirect::Policy};
@@ -36,7 +37,7 @@ pub(crate) struct ClickHouseHttpClient {
     client: Client,
     endpoint: Url,
     user: String,
-    password: String,
+    password: Option<SecretString>,
     default_database: String,
     default_timeout: Duration,
 }
@@ -49,12 +50,15 @@ impl ClickHouseHttpClient {
     pub(crate) fn new(
         endpoint: &str,
         user: String,
-        password: String,
+        password: Option<SecretString>,
         default_database: String,
         timeout: Duration,
     ) -> Result<Self, ClickHouseHttpError> {
         let mut endpoint = parse_endpoint(endpoint)?;
-        if endpoint.scheme() == "http" && !password.is_empty() && !is_loopback_endpoint(&endpoint) {
+        let has_password = password
+            .as_ref()
+            .is_some_and(|password| !password.expose_secret().is_empty());
+        if endpoint.scheme() == "http" && has_password && !is_loopback_endpoint(&endpoint) {
             return Err(ClickHouseHttpError::InvalidEndpoint(
                 "non-empty passwords require HTTPS for non-loopback endpoints".to_string(),
             ));
@@ -85,6 +89,8 @@ impl ClickHouseHttpClient {
         sql: &str,
         database: Option<&str>,
         timeout: Option<Duration>,
+        limit: Option<u32>,
+        offset: Option<u32>,
     ) -> Result<HttpResponse, ClickHouseHttpError> {
         let effective_timeout = timeout.unwrap_or(self.default_timeout);
         let max_execution_time = effective_timeout
@@ -97,7 +103,10 @@ impl ClickHouseHttpClient {
         let mut request = self
             .client
             .post(self.endpoint.clone())
-            .basic_auth(&self.user, Some(&self.password))
+            .basic_auth(
+                &self.user,
+                self.password.as_ref().map(ExposeSecret::expose_secret),
+            )
             .header("X-ClickHouse-Format", "JSONCompact")
             .query(&[
                 ("database", database),
@@ -114,6 +123,13 @@ impl ClickHouseHttpClient {
                 ("max_execution_time", max_execution_time.as_str()),
             ])
             .body(sql.to_string());
+
+        if let Some(limit) = limit {
+            request = request.query(&[("limit", limit)]);
+        }
+        if let Some(offset) = offset {
+            request = request.query(&[("offset", offset)]);
+        }
 
         request = request.timeout(effective_timeout);
 
@@ -246,6 +262,7 @@ fn content_length(headers: &HeaderMap) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::{ClickHouseHttpClient, ClickHouseHttpError, success_exception};
+    use dbflux_core::secrecy::SecretString;
     use reqwest::header::{HeaderMap, HeaderValue};
     use std::time::Duration;
 
@@ -253,7 +270,7 @@ mod tests {
         ClickHouseHttpClient::new(
             url,
             "default".to_string(),
-            "secret".to_string(),
+            Some(SecretString::from("secret".to_string())),
             "default".to_string(),
             Duration::from_secs(1),
         )
@@ -294,6 +311,18 @@ mod tests {
         ));
         assert!(client("http://127.0.0.1:8123").is_ok());
         assert!(client("http://[::1]:8123").is_ok());
+    }
+
+    #[test]
+    fn accepts_empty_password_over_remote_http() {
+        let result = ClickHouseHttpClient::new(
+            "http://clickhouse.example.com",
+            "default".to_string(),
+            Some(SecretString::from(String::new())),
+            "default".to_string(),
+            Duration::from_secs(1),
+        );
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/dbflux_driver_clickhouse/src/http.rs
+++ b/crates/dbflux_driver_clickhouse/src/http.rs
@@ -1,0 +1,330 @@
+use std::io::Read;
+use std::time::Duration;
+
+use reqwest::blocking::{Client, Response};
+use reqwest::header::{CONTENT_LENGTH, HeaderMap};
+use reqwest::{Url, redirect::Policy};
+use thiserror::Error;
+
+const MAX_RESPONSE_BYTES: u64 = 128 * 1024 * 1024;
+const MAX_ERROR_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Error)]
+pub(crate) enum ClickHouseHttpError {
+    #[error("invalid ClickHouse endpoint: {0}")]
+    InvalidEndpoint(String),
+    #[error("ClickHouse HTTP request failed: {0}")]
+    Transport(String),
+    #[error("ClickHouse returned HTTP {status}: {body}")]
+    Server {
+        status: u16,
+        code: Option<String>,
+        body: String,
+    },
+    #[error("ClickHouse response exceeds the {limit} byte safety limit")]
+    ResponseTooLarge { limit: u64 },
+    #[error("failed to read ClickHouse response: {0}")]
+    Body(String),
+}
+
+pub(crate) struct HttpResponse {
+    pub body: Vec<u8>,
+    pub headers: HeaderMap,
+}
+
+pub(crate) struct ClickHouseHttpClient {
+    client: Client,
+    endpoint: Url,
+    user: String,
+    password: String,
+    default_database: String,
+    default_timeout: Duration,
+}
+
+impl ClickHouseHttpClient {
+    pub(crate) fn validate_endpoint(endpoint: &str) -> Result<(), ClickHouseHttpError> {
+        parse_endpoint(endpoint).map(|_| ())
+    }
+
+    pub(crate) fn new(
+        endpoint: &str,
+        user: String,
+        password: String,
+        default_database: String,
+        timeout: Duration,
+    ) -> Result<Self, ClickHouseHttpError> {
+        let mut endpoint = parse_endpoint(endpoint)?;
+        if endpoint.scheme() == "http" && !password.is_empty() && !is_loopback_endpoint(&endpoint) {
+            return Err(ClickHouseHttpError::InvalidEndpoint(
+                "non-empty passwords require HTTPS for non-loopback endpoints".to_string(),
+            ));
+        }
+        endpoint.set_query(None);
+
+        let client = Client::builder()
+            .timeout(timeout)
+            .gzip(true)
+            .tcp_nodelay(true)
+            .use_rustls_tls()
+            .redirect(Policy::none())
+            .build()
+            .map_err(|error| ClickHouseHttpError::Transport(error.to_string()))?;
+
+        Ok(Self {
+            client,
+            endpoint,
+            user,
+            password,
+            default_database,
+            default_timeout: timeout,
+        })
+    }
+
+    pub(crate) fn execute(
+        &self,
+        sql: &str,
+        database: Option<&str>,
+        timeout: Option<Duration>,
+    ) -> Result<HttpResponse, ClickHouseHttpError> {
+        let effective_timeout = timeout.unwrap_or(self.default_timeout);
+        let max_execution_time = effective_timeout
+            .as_secs()
+            .saturating_add(u64::from(effective_timeout.subsec_nanos() != 0))
+            .max(1)
+            .to_string();
+        let max_result_bytes = MAX_RESPONSE_BYTES.to_string();
+        let database = database.unwrap_or(&self.default_database);
+        let mut request = self
+            .client
+            .post(self.endpoint.clone())
+            .basic_auth(&self.user, Some(&self.password))
+            .header("X-ClickHouse-Format", "JSONCompact")
+            .query(&[
+                ("database", database),
+                ("wait_end_of_query", "1"),
+                ("date_time_output_format", "iso"),
+                ("output_format_json_quote_64bit_integers", "1"),
+                ("output_format_json_quote_64bit_floats", "1"),
+                ("output_format_json_quote_decimals", "1"),
+                ("output_format_json_quote_denormals", "1"),
+                ("output_format_json_named_tuples_as_objects", "0"),
+                ("output_format_json_validate_utf8", "1"),
+                ("result_overflow_mode", "throw"),
+                ("max_result_bytes", max_result_bytes.as_str()),
+                ("max_execution_time", max_execution_time.as_str()),
+            ])
+            .body(sql.to_string());
+
+        request = request.timeout(effective_timeout);
+
+        let response = request
+            .send()
+            .map_err(|error| ClickHouseHttpError::Transport(error.to_string()))?;
+        self.read_response(response)
+    }
+
+    fn read_response(&self, response: Response) -> Result<HttpResponse, ClickHouseHttpError> {
+        let status = response.status();
+        let headers = response.headers().clone();
+        let limit = if status.is_success() {
+            MAX_RESPONSE_BYTES
+        } else {
+            MAX_ERROR_BYTES
+        };
+
+        if content_length(&headers).is_some_and(|length| length > limit) {
+            return Err(ClickHouseHttpError::ResponseTooLarge { limit });
+        }
+
+        let mut body = Vec::new();
+        response
+            .take(limit + 1)
+            .read_to_end(&mut body)
+            .map_err(|error| ClickHouseHttpError::Body(error.to_string()))?;
+        if body.len() as u64 > limit {
+            return Err(ClickHouseHttpError::ResponseTooLarge { limit });
+        }
+
+        if !status.is_success() {
+            return Err(ClickHouseHttpError::Server {
+                status: status.as_u16(),
+                code: exception_code(&headers),
+                body: error_excerpt(&body, 0),
+            });
+        }
+
+        if let Some((code, offset)) = success_exception(&headers, &body) {
+            return Err(ClickHouseHttpError::Server {
+                status: status.as_u16(),
+                code,
+                body: error_excerpt(&body, offset),
+            });
+        }
+
+        Ok(HttpResponse { body, headers })
+    }
+}
+
+fn parse_endpoint(endpoint: &str) -> Result<Url, ClickHouseHttpError> {
+    let endpoint = Url::parse(endpoint)
+        .map_err(|_| ClickHouseHttpError::InvalidEndpoint("URL is not valid".to_string()))?;
+    if !matches!(endpoint.scheme(), "http" | "https") {
+        return Err(ClickHouseHttpError::InvalidEndpoint(
+            "URL scheme must be http or https".to_string(),
+        ));
+    }
+    if endpoint.host_str().is_none() {
+        return Err(ClickHouseHttpError::InvalidEndpoint(
+            "URL must include a host".to_string(),
+        ));
+    }
+    if !endpoint.username().is_empty() || endpoint.password().is_some() {
+        return Err(ClickHouseHttpError::InvalidEndpoint(
+            "credentials must be supplied through the user and password fields".to_string(),
+        ));
+    }
+    if endpoint.query().is_some() || endpoint.fragment().is_some() {
+        return Err(ClickHouseHttpError::InvalidEndpoint(
+            "URL query parameters and fragments are not supported".to_string(),
+        ));
+    }
+    Ok(endpoint)
+}
+
+fn is_loopback_endpoint(endpoint: &Url) -> bool {
+    let Some(host) = endpoint.host_str() else {
+        return false;
+    };
+    host.trim_matches(['[', ']'])
+        .parse::<std::net::IpAddr>()
+        .is_ok_and(|address| address.is_loopback())
+        || host.eq_ignore_ascii_case("localhost")
+        || host.ends_with(".localhost")
+}
+
+fn exception_code(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("X-ClickHouse-Exception-Code")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn success_exception(headers: &HeaderMap, body: &[u8]) -> Option<(Option<String>, usize)> {
+    if let Some(code) = exception_code(headers) {
+        return Some((Some(code), 0));
+    }
+    [
+        b"\r\n__exception__\r\n".as_slice(),
+        b"\n__exception__\n".as_slice(),
+    ]
+    .into_iter()
+    .find_map(|marker| {
+        body.windows(marker.len())
+            .position(|window| window == marker)
+            .map(|offset| (None, offset))
+    })
+}
+
+fn error_excerpt(body: &[u8], offset: usize) -> String {
+    let end = offset
+        .saturating_add(MAX_ERROR_BYTES as usize)
+        .min(body.len());
+    String::from_utf8_lossy(body.get(offset..end).unwrap_or_default())
+        .trim()
+        .to_string()
+}
+
+fn content_length(headers: &HeaderMap) -> Option<u64> {
+    headers
+        .get(CONTENT_LENGTH)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ClickHouseHttpClient, ClickHouseHttpError, success_exception};
+    use reqwest::header::{HeaderMap, HeaderValue};
+    use std::time::Duration;
+
+    fn client(url: &str) -> Result<ClickHouseHttpClient, ClickHouseHttpError> {
+        ClickHouseHttpClient::new(
+            url,
+            "default".to_string(),
+            "secret".to_string(),
+            "default".to_string(),
+            Duration::from_secs(1),
+        )
+    }
+
+    #[test]
+    fn accepts_http_and_https_endpoints() {
+        assert!(client("http://localhost:8123").is_ok());
+        assert!(client("https://clickhouse.example.com").is_ok());
+    }
+
+    #[test]
+    fn rejects_credentials_in_endpoint() {
+        let result = client("https://default:secret@clickhouse.example.com");
+        assert!(matches!(
+            result,
+            Err(ClickHouseHttpError::InvalidEndpoint(_))
+        ));
+        let Err(error) = result else {
+            panic!("endpoint credentials must be rejected");
+        };
+        assert!(!error.to_string().contains("default:secret@"));
+    }
+
+    #[test]
+    fn rejects_endpoint_query_parameters() {
+        assert!(matches!(
+            client("http://localhost:8123?password=secret"),
+            Err(ClickHouseHttpError::InvalidEndpoint(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_password_over_remote_http() {
+        assert!(matches!(
+            client("http://clickhouse.example.com"),
+            Err(ClickHouseHttpError::InvalidEndpoint(_))
+        ));
+        assert!(client("http://127.0.0.1:8123").is_ok());
+        assert!(client("http://[::1]:8123").is_ok());
+    }
+
+    #[test]
+    fn detects_exception_header_and_embedded_exception() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-ClickHouse-Exception-Code",
+            HeaderValue::from_static("60"),
+        );
+        assert_eq!(
+            success_exception(&headers, br#"{"data":[]}"#),
+            Some((Some("60".to_string()), 0))
+        );
+
+        assert_eq!(
+            success_exception(
+                &HeaderMap::new(),
+                b"{\"data\":[]}\n__exception__\nCode: 241. DB::Exception",
+            ),
+            Some((None, 11))
+        );
+        assert_eq!(
+            success_exception(
+                &HeaderMap::new(),
+                b"{\"data\":[]}\r\n__exception__\r\nCode: 241. DB::Exception",
+            ),
+            Some((None, 11))
+        );
+        assert_eq!(
+            success_exception(&HeaderMap::new(), br#"{"data":[["__exception__"]]}"#),
+            None
+        );
+    }
+}

--- a/crates/dbflux_driver_clickhouse/src/introspection.rs
+++ b/crates/dbflux_driver_clickhouse/src/introspection.rs
@@ -1,0 +1,269 @@
+use dbflux_core::{
+    CollectionPresentation, ColumnInfo, Connection, DatabaseInfo, DbError, DbSchemaInfo, TableInfo,
+    TableStorageHint, Value, ViewInfo,
+};
+
+use crate::connection::ClickHouseConnection;
+use crate::dialect::CLICKHOUSE_DIALECT;
+use crate::types::{clickhouse_type_is_nullable, parse_clickhouse_type};
+use dbflux_core::SqlDialect;
+
+const DATABASES_SQL: &str = "SELECT name FROM system.databases ORDER BY name";
+
+pub(crate) fn list_databases(
+    connection: &ClickHouseConnection,
+) -> Result<Vec<DatabaseInfo>, DbError> {
+    let current = connection.active_database();
+    let result = connection.execute_sql(DATABASES_SQL, Some("system"), None, None, None)?;
+    Ok(result
+        .rows
+        .iter()
+        .filter_map(|row| text_at(row, 0))
+        .map(|name| DatabaseInfo {
+            is_current: current.as_deref() == Some(name),
+            name: name.to_string(),
+        })
+        .collect())
+}
+
+pub(crate) fn schema_for_database(
+    connection: &ClickHouseConnection,
+    database: &str,
+) -> Result<DbSchemaInfo, DbError> {
+    let database_literal = CLICKHOUSE_DIALECT.value_to_literal(&Value::Text(database.to_string()));
+    let sql = format!(
+        "SELECT name, engine FROM system.tables WHERE database = {database_literal} ORDER BY name"
+    );
+    let result = connection.execute_sql(&sql, Some("system"), None, None, None)?;
+    let mut tables = Vec::new();
+    let mut views = Vec::new();
+    for row in &result.rows {
+        let (Some(name), Some(engine)) = (text_at(row, 0), text_at(row, 1)) else {
+            continue;
+        };
+        if is_view_engine(engine) {
+            views.push(ViewInfo {
+                name: name.to_string(),
+                schema: Some(database.to_string()),
+            });
+        } else {
+            tables.push(shallow_table(database, name));
+        }
+    }
+    Ok(DbSchemaInfo {
+        name: database.to_string(),
+        tables,
+        views,
+        custom_types: None,
+    })
+}
+
+pub(crate) fn table_details(
+    connection: &ClickHouseConnection,
+    database: &str,
+    table: &str,
+) -> Result<TableInfo, DbError> {
+    let database_literal = CLICKHOUSE_DIALECT.value_to_literal(&Value::Text(database.to_string()));
+    let table_literal = CLICKHOUSE_DIALECT.value_to_literal(&Value::Text(table.to_string()));
+    let columns_sql = format!(
+        "SELECT name, type, default_kind, default_expression, is_in_primary_key, is_in_sorting_key, \
+         is_in_partition_key, is_in_sampling_key, compression_codec \
+         FROM system.columns WHERE database = {database_literal} AND table = {table_literal} \
+         ORDER BY position"
+    );
+    let table_sql = format!(
+        "SELECT engine, partition_key, sorting_key, primary_key, sampling_key, total_rows, total_bytes \
+         FROM system.tables WHERE database = {database_literal} AND name = {table_literal} LIMIT 1"
+    );
+
+    let column_result = connection.execute_sql(&columns_sql, Some("system"), None, None, None)?;
+    let table_result = connection.execute_sql(&table_sql, Some("system"), None, Some(1), None)?;
+    if column_result.rows.is_empty() && table_result.rows.is_empty() {
+        return Err(DbError::ObjectNotFound(
+            format!("ClickHouse table {database}.{table} was not found").into(),
+        ));
+    }
+
+    let columns = column_result
+        .rows
+        .iter()
+        .filter_map(|row| column_info(row))
+        .collect();
+    let storage_hints = table_result
+        .rows
+        .first()
+        .map(|row| build_storage_hints(row, &column_result.rows))
+        .unwrap_or_default();
+
+    Ok(TableInfo {
+        name: table.to_string(),
+        schema: Some(database.to_string()),
+        columns: Some(columns),
+        indexes: None,
+        foreign_keys: None,
+        constraints: None,
+        sample_fields: None,
+        presentation: CollectionPresentation::DataGrid,
+        child_items: None,
+        storage_hints: Some(storage_hints),
+    })
+}
+
+fn column_info(row: &[Value]) -> Option<ColumnInfo> {
+    let name = text_at(row, 0)?;
+    let type_name = text_at(row, 1)?;
+    let data_type = parse_clickhouse_type(type_name);
+    Some(ColumnInfo {
+        name: name.to_string(),
+        type_name: type_name.to_string(),
+        nullable: clickhouse_type_is_nullable(&data_type),
+        is_primary_key: false,
+        default_value: (text_at(row, 2) == Some("DEFAULT"))
+            .then(|| text_at(row, 3))
+            .flatten()
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        enum_values: None,
+    })
+}
+
+fn shallow_table(database: &str, name: &str) -> TableInfo {
+    TableInfo {
+        name: name.to_string(),
+        schema: Some(database.to_string()),
+        columns: None,
+        indexes: None,
+        foreign_keys: None,
+        constraints: None,
+        sample_fields: None,
+        presentation: CollectionPresentation::DataGrid,
+        child_items: None,
+        storage_hints: None,
+    }
+}
+
+fn is_view_engine(engine: &str) -> bool {
+    matches!(
+        engine,
+        "View" | "MaterializedView" | "LiveView" | "WindowView"
+    )
+}
+
+fn build_storage_hints(row: &[Value], column_rows: &[Vec<Value>]) -> Vec<TableStorageHint> {
+    let mut hints = Vec::new();
+    push_detail_hint(&mut hints, "Engine", text_at(row, 0));
+    push_detail_hint(&mut hints, "Partition Key", text_at(row, 1));
+    push_detail_hint(&mut hints, "Sorting Key", text_at(row, 2));
+    push_detail_hint(&mut hints, "Primary Key", text_at(row, 3));
+    push_detail_hint(&mut hints, "Sampling Key", text_at(row, 4));
+
+    let total_rows = integer_text_at(row, 5);
+    let total_bytes = integer_text_at(row, 6);
+    if total_rows.is_some() || total_bytes.is_some() {
+        hints.push(TableStorageHint {
+            label: "Stored Data".to_string(),
+            columns: Vec::new(),
+            detail: Some(format!(
+                "{} rows, {} bytes",
+                total_rows.as_deref().unwrap_or("unknown"),
+                total_bytes.as_deref().unwrap_or("unknown")
+            )),
+        });
+    }
+
+    let codec_columns = column_rows
+        .iter()
+        .filter_map(|row| {
+            let column = text_at(row, 0)?;
+            let codec = text_at(row, 8)?;
+            (!codec.is_empty()).then(|| format!("{column}: {codec}"))
+        })
+        .collect::<Vec<_>>();
+    if !codec_columns.is_empty() {
+        hints.push(TableStorageHint {
+            label: "Compression".to_string(),
+            columns: Vec::new(),
+            detail: Some(codec_columns.join(", ")),
+        });
+    }
+    hints
+}
+
+fn push_detail_hint(hints: &mut Vec<TableStorageHint>, label: &str, detail: Option<&str>) {
+    if let Some(detail) = detail.filter(|detail| !detail.is_empty()) {
+        hints.push(TableStorageHint {
+            label: label.to_string(),
+            columns: Vec::new(),
+            detail: Some(detail.to_string()),
+        });
+    }
+}
+
+fn text_at(row: &[Value], index: usize) -> Option<&str> {
+    match row.get(index) {
+        Some(Value::Text(value) | Value::Json(value) | Value::Decimal(value)) => Some(value),
+        _ => None,
+    }
+}
+
+fn integer_text_at(row: &[Value], index: usize) -> Option<String> {
+    match row.get(index) {
+        Some(Value::Int(value)) => Some(value.to_string()),
+        Some(Value::Decimal(value)) => Some(value.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_storage_hints, column_info, is_view_engine};
+    use dbflux_core::Value;
+
+    #[test]
+    fn recognizes_clickhouse_view_engines() {
+        assert!(is_view_engine("View"));
+        assert!(is_view_engine("MaterializedView"));
+        assert!(!is_view_engine("MergeTree"));
+    }
+
+    #[test]
+    fn storage_hints_include_engine_keys_and_size() {
+        let row = vec![
+            Value::Text("MergeTree".to_string()),
+            Value::Text("toYYYYMM(ts)".to_string()),
+            Value::Text("(ts, id)".to_string()),
+            Value::Text("id".to_string()),
+            Value::Text(String::new()),
+            Value::Int(10),
+            Value::Int(1024),
+        ];
+        let hints = build_storage_hints(&row, &[]);
+        assert!(hints.iter().any(|hint| hint.label == "Engine"));
+        assert!(hints.iter().any(|hint| hint.label == "Partition Key"));
+        assert!(hints.iter().any(|hint| hint.label == "Stored Data"));
+    }
+
+    #[test]
+    fn column_metadata_is_non_editable_and_only_uses_default_kind() {
+        let default_column = column_info(&[
+            Value::Text("id".to_string()),
+            Value::Text("LowCardinality(Nullable(UInt64))".to_string()),
+            Value::Text("DEFAULT".to_string()),
+            Value::Text("42".to_string()),
+            Value::Int(1),
+        ])
+        .expect("valid column");
+        assert!(default_column.nullable);
+        assert!(!default_column.is_primary_key);
+        assert_eq!(default_column.default_value.as_deref(), Some("42"));
+
+        let alias_column = column_info(&[
+            Value::Text("derived".to_string()),
+            Value::Text("UInt64".to_string()),
+            Value::Text("ALIAS".to_string()),
+            Value::Text("id + 1".to_string()),
+        ])
+        .expect("valid column");
+        assert_eq!(alias_column.default_value, None);
+    }
+}

--- a/crates/dbflux_driver_clickhouse/src/lib.rs
+++ b/crates/dbflux_driver_clickhouse/src/lib.rs
@@ -1,0 +1,27 @@
+#![allow(clippy::result_large_err)]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing
+    )
+)]
+
+mod connection;
+pub mod dialect;
+pub mod driver;
+pub mod error_formatter;
+mod http;
+mod introspection;
+pub mod types;
+
+pub use connection::ClickHouseConnection;
+pub use dialect::ClickHouseDialect;
+pub use driver::{CLICKHOUSE_FORM, ClickHouseDriver, METADATA};
+pub use error_formatter::ClickHouseErrorFormatter;
+pub use types::{
+    ClickHouseType, clickhouse_type_is_nullable, clickhouse_type_to_column_kind,
+    parse_clickhouse_type,
+};

--- a/crates/dbflux_driver_clickhouse/src/types.rs
+++ b/crates/dbflux_driver_clickhouse/src/types.rs
@@ -1,0 +1,489 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+use dbflux_core::{ColumnKind, Value};
+use serde_json::Value as JsonValue;
+
+const MAX_TYPE_INPUT_BYTES: usize = 4096;
+const MAX_TYPE_DEPTH: usize = 64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClickHouseType {
+    pub name: String,
+    pub arguments: Vec<ClickHouseTypeArgument>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ClickHouseTypeArgument {
+    Type(ClickHouseType),
+    Literal(String),
+}
+
+impl ClickHouseType {
+    fn wrapped_type(&self) -> Option<&ClickHouseType> {
+        self.arguments.first().and_then(|argument| match argument {
+            ClickHouseTypeArgument::Type(value) => Some(value),
+            ClickHouseTypeArgument::Literal(_) => None,
+        })
+    }
+
+    fn effective(&self) -> &ClickHouseType {
+        if matches!(self.name.as_str(), "Nullable" | "LowCardinality") {
+            self.wrapped_type()
+                .map(ClickHouseType::effective)
+                .unwrap_or(self)
+        } else {
+            self
+        }
+    }
+}
+
+pub fn parse_clickhouse_type(input: &str) -> ClickHouseType {
+    if input.len() > MAX_TYPE_INPUT_BYTES {
+        return invalid_type();
+    }
+    TypeParser::new(input)
+        .parse_type(0)
+        .unwrap_or_else(|| ClickHouseType {
+            name: input.trim().to_string(),
+            arguments: Vec::new(),
+        })
+}
+
+fn invalid_type() -> ClickHouseType {
+    ClickHouseType {
+        name: "Unknown".to_string(),
+        arguments: Vec::new(),
+    }
+}
+
+pub fn clickhouse_type_is_nullable(data_type: &ClickHouseType) -> bool {
+    match data_type.name.as_str() {
+        "Nullable" => true,
+        "LowCardinality" => data_type
+            .wrapped_type()
+            .is_some_and(clickhouse_type_is_nullable),
+        _ => false,
+    }
+}
+
+pub fn clickhouse_type_to_column_kind(data_type: &ClickHouseType) -> ColumnKind {
+    match data_type.effective().name.as_str() {
+        "Int8" | "Int16" | "Int32" | "Int64" | "Int128" | "Int256" | "UInt8" | "UInt16"
+        | "UInt32" | "UInt64" | "UInt128" | "UInt256" => ColumnKind::Integer,
+        "Float32" | "Float64" | "BFloat16" | "Decimal" | "Decimal32" | "Decimal64"
+        | "Decimal128" | "Decimal256" => ColumnKind::Float,
+        "Date" | "Date32" | "DateTime" | "DateTime64" => ColumnKind::Timestamp,
+        "String" | "FixedString" | "UUID" | "IPv4" | "IPv6" | "Enum8" | "Enum16" => {
+            ColumnKind::Text
+        }
+        _ => ColumnKind::Unknown,
+    }
+}
+
+pub(crate) fn json_to_value(value: &JsonValue, data_type: &ClickHouseType) -> Value {
+    if value.is_null() {
+        return Value::Null;
+    }
+
+    let effective = data_type.effective();
+    match effective.name.as_str() {
+        "Bool" => parse_bool(value),
+        "Int8" | "Int16" | "Int32" | "Int64" => parse_i64(value),
+        "UInt8" | "UInt16" | "UInt32" | "UInt64" => parse_u64(value),
+        "Int128" | "Int256" | "UInt128" | "UInt256" | "Decimal" | "Decimal32" | "Decimal64"
+        | "Decimal128" | "Decimal256" => parse_decimal(value),
+        "Float32" | "Float64" | "BFloat16" => parse_float(value),
+        "Date" | "Date32" => parse_date(value),
+        "DateTime" | "DateTime64" => parse_datetime(value),
+        "Array" => parse_array(value, effective.wrapped_type()),
+        "Tuple" => parse_tuple(value, effective),
+        "Map" => parse_map(value, effective),
+        "JSON" | "Object" | "Nested" => Value::Json(value.to_string()),
+        "Nothing" => Value::Null,
+        _ => match value {
+            JsonValue::String(text) => Value::Text(text.clone()),
+            JsonValue::Bool(boolean) => Value::Bool(*boolean),
+            JsonValue::Number(number) => number
+                .as_i64()
+                .map(Value::Int)
+                .or_else(|| number.as_f64().map(Value::Float))
+                .unwrap_or_else(|| Value::Text(number.to_string())),
+            JsonValue::Array(_) | JsonValue::Object(_) => Value::Json(value.to_string()),
+            JsonValue::Null => Value::Null,
+        },
+    }
+}
+
+fn parse_bool(value: &JsonValue) -> Value {
+    match value {
+        JsonValue::Bool(value) => Value::Bool(*value),
+        JsonValue::Number(value) => Value::Bool(value.as_u64().is_some_and(|value| value != 0)),
+        JsonValue::String(value) => Value::Bool(value == "1" || value.eq_ignore_ascii_case("true")),
+        _ => Value::Text(value.to_string()),
+    }
+}
+
+fn parse_i64(value: &JsonValue) -> Value {
+    value
+        .as_i64()
+        .or_else(|| value.as_str().and_then(|text| text.parse().ok()))
+        .map(Value::Int)
+        .unwrap_or_else(|| Value::Decimal(json_scalar_text(value)))
+}
+
+fn parse_u64(value: &JsonValue) -> Value {
+    let parsed = value
+        .as_u64()
+        .or_else(|| value.as_str().and_then(|text| text.parse().ok()));
+    match parsed {
+        Some(value) if value <= i64::MAX as u64 => Value::Int(value as i64),
+        Some(value) => Value::Decimal(value.to_string()),
+        None => Value::Decimal(json_scalar_text(value)),
+    }
+}
+
+fn parse_decimal(value: &JsonValue) -> Value {
+    Value::Decimal(json_scalar_text(value))
+}
+
+fn parse_float(value: &JsonValue) -> Value {
+    value
+        .as_f64()
+        .or_else(|| value.as_str().and_then(|text| text.parse().ok()))
+        .filter(|value| value.is_finite())
+        .map(Value::Float)
+        .unwrap_or_else(|| Value::Text(json_scalar_text(value)))
+}
+
+fn parse_date(value: &JsonValue) -> Value {
+    value
+        .as_str()
+        .and_then(|text| NaiveDate::parse_from_str(text, "%Y-%m-%d").ok())
+        .map(Value::Date)
+        .unwrap_or_else(|| Value::Text(json_scalar_text(value)))
+}
+
+fn parse_datetime(value: &JsonValue) -> Value {
+    let Some(text) = value.as_str() else {
+        return Value::Text(json_scalar_text(value));
+    };
+    if let Ok(value) = DateTime::parse_from_rfc3339(text) {
+        return Value::DateTime(value.with_timezone(&Utc));
+    }
+    for format in ["%Y-%m-%d %H:%M:%S%.f", "%Y-%m-%dT%H:%M:%S%.f"] {
+        if let Ok(value) = NaiveDateTime::parse_from_str(text, format) {
+            return Value::DateTime(DateTime::from_naive_utc_and_offset(value, Utc));
+        }
+    }
+    if let Ok(value) = NaiveTime::parse_from_str(text, "%H:%M:%S%.f") {
+        return Value::Time(value);
+    }
+    Value::Text(text.to_string())
+}
+
+fn parse_array(value: &JsonValue, element_type: Option<&ClickHouseType>) -> Value {
+    match value.as_array() {
+        Some(values) => Value::Array(
+            values
+                .iter()
+                .map(|value| match element_type {
+                    Some(data_type) => json_to_value(value, data_type),
+                    None => Value::Json(value.to_string()),
+                })
+                .collect(),
+        ),
+        None => Value::Json(value.to_string()),
+    }
+}
+
+fn parse_tuple(value: &JsonValue, data_type: &ClickHouseType) -> Value {
+    let Some(values) = value.as_array() else {
+        return Value::Json(value.to_string());
+    };
+    Value::Array(
+        values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                data_type
+                    .arguments
+                    .get(index)
+                    .and_then(|argument| match argument {
+                        ClickHouseTypeArgument::Type(data_type) => Some(data_type),
+                        ClickHouseTypeArgument::Literal(_) => None,
+                    })
+                    .map(|data_type| json_to_value(value, data_type))
+                    .unwrap_or_else(|| Value::Json(value.to_string()))
+            })
+            .collect(),
+    )
+}
+
+fn parse_map(value: &JsonValue, data_type: &ClickHouseType) -> Value {
+    let value_type = data_type
+        .arguments
+        .get(1)
+        .and_then(|argument| match argument {
+            ClickHouseTypeArgument::Type(data_type) => Some(data_type),
+            ClickHouseTypeArgument::Literal(_) => None,
+        });
+    match value.as_object() {
+        Some(object) => Value::Document(
+            object
+                .iter()
+                .map(|(key, value)| {
+                    let value = value_type
+                        .map(|data_type| json_to_value(value, data_type))
+                        .unwrap_or_else(|| Value::Json(value.to_string()));
+                    (key.clone(), value)
+                })
+                .collect::<BTreeMap<_, _>>(),
+        ),
+        None => Value::Json(value.to_string()),
+    }
+}
+
+fn json_scalar_text(value: &JsonValue) -> String {
+    value
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| value.to_string())
+}
+
+struct TypeParser<'a> {
+    input: &'a str,
+    position: usize,
+}
+
+impl<'a> TypeParser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self { input, position: 0 }
+    }
+
+    fn parse_type(&mut self, depth: usize) -> Option<ClickHouseType> {
+        if depth >= MAX_TYPE_DEPTH {
+            return None;
+        }
+        self.skip_space();
+        let name = self.parse_identifier()?;
+        self.skip_space();
+        let mut arguments = Vec::new();
+        if self.consume('(') {
+            loop {
+                self.skip_space();
+                if self.consume(')') {
+                    break;
+                }
+                arguments.push(self.parse_argument(depth)?);
+                self.skip_space();
+                if self.consume(')') {
+                    break;
+                }
+                if !self.consume(',') {
+                    return None;
+                }
+            }
+        }
+        Some(ClickHouseType { name, arguments })
+    }
+
+    fn parse_argument(&mut self, depth: usize) -> Option<ClickHouseTypeArgument> {
+        self.skip_space();
+        let start = self.position;
+        if self.peek().is_some_and(|value| value.is_ascii_uppercase()) {
+            if let Some(data_type) = self.parse_type(depth + 1) {
+                return Some(ClickHouseTypeArgument::Type(data_type));
+            }
+            self.position = start;
+        } else if self.peek().is_some_and(|value| value.is_ascii_lowercase()) {
+            let field_start = self.position;
+            let field_name = self.parse_identifier()?;
+            let had_space = self
+                .peek()
+                .is_some_and(char::is_whitespace)
+                .then(|| self.skip_space())
+                .is_some();
+            if had_space
+                && self.peek().is_some_and(|value| value.is_ascii_uppercase())
+                && let Some(data_type) = self.parse_type(depth + 1)
+            {
+                return Some(ClickHouseTypeArgument::Type(data_type));
+            }
+            self.position = field_start;
+            if field_name.is_empty() {
+                return None;
+            }
+        }
+        self.position = start;
+        let literal = self.parse_literal_argument().trim().to_string();
+        (!literal.is_empty()).then_some(ClickHouseTypeArgument::Literal(literal))
+    }
+
+    fn parse_identifier(&mut self) -> Option<String> {
+        let start = self.position;
+        while self
+            .peek()
+            .is_some_and(|value| value.is_ascii_alphanumeric() || value == '_')
+        {
+            self.advance();
+        }
+        (self.position > start).then(|| self.input[start..self.position].to_string())
+    }
+
+    fn parse_literal_argument(&mut self) -> &str {
+        let start = self.position;
+        let mut quote = None;
+        let mut escaped = false;
+        let mut depth = 0_u32;
+        while let Some(value) = self.peek() {
+            if let Some(active_quote) = quote {
+                self.advance();
+                if escaped {
+                    escaped = false;
+                } else if value == '\\' {
+                    escaped = true;
+                } else if value == active_quote {
+                    quote = None;
+                }
+                continue;
+            }
+            if matches!(value, '\'' | '"') {
+                quote = Some(value);
+                self.advance();
+                continue;
+            }
+            if value == '(' {
+                depth += 1;
+            } else if value == ')' {
+                if depth == 0 {
+                    break;
+                }
+                depth -= 1;
+            } else if value == ',' && depth == 0 {
+                break;
+            }
+            self.advance();
+        }
+        &self.input[start..self.position]
+    }
+
+    fn skip_space(&mut self) {
+        while self.peek().is_some_and(char::is_whitespace) {
+            self.advance();
+        }
+    }
+
+    fn consume(&mut self, expected: char) -> bool {
+        if self.peek() == Some(expected) {
+            self.advance();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.input.get(self.position..)?.chars().next()
+    }
+
+    fn advance(&mut self) {
+        if let Some(value) = self.peek() {
+            self.position += value.len_utf8();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_nested_types_and_literal_arguments() {
+        let parsed = parse_clickhouse_type("LowCardinality(Nullable(Array(Decimal(18, 4))))");
+        assert_eq!(parsed.name, "LowCardinality");
+        assert_eq!(clickhouse_type_to_column_kind(&parsed), ColumnKind::Unknown);
+
+        let datetime = parse_clickhouse_type("DateTime64(6, 'UTC')");
+        assert_eq!(datetime.name, "DateTime64");
+        assert_eq!(datetime.arguments.len(), 2);
+        assert_eq!(
+            clickhouse_type_to_column_kind(&datetime),
+            ColumnKind::Timestamp
+        );
+
+        let enumeration = parse_clickhouse_type("Enum8('ready' = 1, 'done' = 2)");
+        assert_eq!(enumeration.name, "Enum8");
+        assert_eq!(enumeration.arguments.len(), 2);
+        assert_eq!(
+            clickhouse_type_to_column_kind(&enumeration),
+            ColumnKind::Text
+        );
+
+        let named_tuple = parse_clickhouse_type("Tuple(id UInt64, label String)");
+        assert_eq!(named_tuple.name, "Tuple");
+        assert_eq!(named_tuple.arguments.len(), 2);
+    }
+
+    #[test]
+    fn nullable_integer_is_classified_and_decoded() {
+        let data_type = parse_clickhouse_type("Nullable(UInt64)");
+        assert_eq!(
+            clickhouse_type_to_column_kind(&data_type),
+            ColumnKind::Integer
+        );
+        assert_eq!(
+            json_to_value(&serde_json::json!(42), &data_type),
+            Value::Int(42)
+        );
+        assert_eq!(json_to_value(&JsonValue::Null, &data_type), Value::Null);
+        assert!(clickhouse_type_is_nullable(&data_type));
+        assert!(clickhouse_type_is_nullable(&parse_clickhouse_type(
+            "LowCardinality(Nullable(String))"
+        )));
+        assert!(!clickhouse_type_is_nullable(&parse_clickhouse_type(
+            "Array(Nullable(String))"
+        )));
+    }
+
+    #[test]
+    fn large_unsigned_integer_preserves_precision() {
+        let data_type = parse_clickhouse_type("UInt64");
+        assert_eq!(
+            json_to_value(&serde_json::json!("18446744073709551615"), &data_type),
+            Value::Decimal("18446744073709551615".to_string())
+        );
+    }
+
+    #[test]
+    fn arrays_decode_recursively() {
+        let data_type = parse_clickhouse_type("Array(Nullable(Int32))");
+        assert_eq!(
+            json_to_value(&serde_json::json!([1, null, 3]), &data_type),
+            Value::Array(vec![Value::Int(1), Value::Null, Value::Int(3)])
+        );
+    }
+
+    #[test]
+    fn malformed_type_degrades_to_unknown() {
+        let parsed = parse_clickhouse_type("Tuple(String");
+        assert_eq!(parsed.name, "Tuple(String");
+        assert_eq!(clickhouse_type_to_column_kind(&parsed), ColumnKind::Unknown);
+    }
+
+    #[test]
+    fn type_parser_limits_input_and_recursion_depth() {
+        let oversized = "X".repeat(MAX_TYPE_INPUT_BYTES + 1);
+        assert_eq!(parse_clickhouse_type(&oversized), invalid_type());
+
+        let deeply_nested = format!(
+            "{}UInt8{}",
+            "Nullable(".repeat(MAX_TYPE_DEPTH + 1),
+            ")".repeat(MAX_TYPE_DEPTH + 1)
+        );
+        assert_eq!(
+            clickhouse_type_to_column_kind(&parse_clickhouse_type(&deeply_nested)),
+            ColumnKind::Unknown
+        );
+    }
+}

--- a/crates/dbflux_driver_clickhouse/tests/live_integration.rs
+++ b/crates/dbflux_driver_clickhouse/tests/live_integration.rs
@@ -1,0 +1,164 @@
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::result_large_err
+)]
+
+//! Docker-backed ClickHouse tests. Each test starts an isolated server through
+//! testcontainers. Run them with:
+//!
+//! ```text
+//! cargo test --manifest-path crates/dbflux_driver_clickhouse/Cargo.toml --test live_integration -- --ignored
+//! ```
+
+use dbflux_core::secrecy::SecretString;
+use dbflux_core::{ColumnKind, Connection, ConnectionProfile, DbConfig, DbDriver, DbError};
+use dbflux_core::{QueryRequest, Value};
+use dbflux_driver_clickhouse::ClickHouseDriver;
+use dbflux_test_support::containers::{self, ClickHouseConfig};
+use std::time::Duration;
+
+fn connect(config: &ClickHouseConfig) -> Result<Box<dyn Connection>, DbError> {
+    let profile = ConnectionProfile::new(
+        "live-clickhouse",
+        DbConfig::ClickHouse {
+            url: config.endpoint.clone(),
+            user: config.user.clone(),
+            database: config.database.clone(),
+            request_timeout_seconds: Some(30),
+        },
+    );
+    let password = SecretString::from(config.password.clone());
+
+    containers::retry_db_operation(Duration::from_secs(30), || {
+        let connection =
+            ClickHouseDriver::new().connect_with_secrets(&profile, Some(&password), None)?;
+        connection.ping()?;
+        Ok(connection)
+    })
+}
+
+struct TableCleanup<'a> {
+    connection: &'a dyn Connection,
+    table: &'static str,
+}
+
+impl Drop for TableCleanup<'_> {
+    fn drop(&mut self) {
+        if let Err(error) = self.connection.execute(&QueryRequest::new(format!(
+            "DROP TABLE IF EXISTS {}",
+            self.table
+        ))) {
+            eprintln!(
+                "failed to clean up ClickHouse table {}: {error}",
+                self.table
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn clickhouse_connects_and_decodes_types() -> Result<(), DbError> {
+    containers::with_clickhouse(|config| {
+        let connection = connect(&config)?;
+        let result = connection.execute(&QueryRequest::new(
+            "SELECT toUInt64(42) AS id, toDateTime64('2026-08-17 12:34:56.789', 3, 'UTC') AS ts, [toInt32(1), 2, 3] AS values, CAST(NULL, 'Nullable(String)') AS note",
+        ))?;
+
+        assert_eq!(result.rows.len(), 1);
+        assert_eq!(result.columns.len(), 4);
+        assert_eq!(result.columns[0].name, "id");
+        assert_eq!(result.columns[0].type_name, "UInt64");
+        assert_eq!(result.columns[0].kind, ColumnKind::Integer);
+        assert_eq!(result.columns[1].kind, ColumnKind::Timestamp);
+        assert_eq!(result.columns[2].kind, ColumnKind::Unknown);
+        assert_eq!(result.columns[3].kind, ColumnKind::Text);
+        assert!(result.columns[3].nullable);
+        assert_eq!(result.rows[0][0], Value::Int(42));
+        assert_eq!(
+            result.rows[0][1],
+            Value::DateTime("2026-08-17T12:34:56.789Z".parse().expect("valid timestamp"))
+        );
+        assert_eq!(
+            result.rows[0][2],
+            Value::Array(vec![Value::Int(1), Value::Int(2), Value::Int(3)])
+        );
+        assert_eq!(result.rows[0][3], Value::Null);
+
+        let page = connection.execute(
+            &QueryRequest::new("SELECT number FROM numbers(6) ORDER BY number")
+                .with_limit(2)
+                .with_offset(2),
+        )?;
+        assert_eq!(page.rows, vec![vec![Value::Int(2)], vec![Value::Int(3)]]);
+        assert_eq!(page.columns[0].name, "number");
+        assert_eq!(page.columns[0].kind, ColumnKind::Integer);
+
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn clickhouse_introspects_table_details_and_storage_hints() -> Result<(), DbError> {
+    containers::with_clickhouse(|config| {
+        let connection = connect(&config)?;
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE dbflux_live_test (id UInt64, ts DateTime64(3, 'UTC')) ENGINE = MergeTree ORDER BY (ts, id)",
+        ))?;
+        let _cleanup = TableCleanup {
+            connection: &*connection,
+            table: "dbflux_live_test",
+        };
+
+        let details = connection.table_details(&config.database, None, "dbflux_live_test")?;
+        let columns = details.columns.expect("columns should be loaded");
+        assert_eq!(details.name, "dbflux_live_test");
+        assert_eq!(columns.len(), 2);
+        assert_eq!(columns[0].name, "id");
+        assert_eq!(columns[0].type_name, "UInt64");
+        assert_eq!(columns[1].name, "ts");
+        assert_eq!(columns[1].type_name, "DateTime64(3, 'UTC')");
+        assert!(
+            details
+                .storage_hints
+                .expect("storage hints should be loaded")
+                .iter()
+                .any(|hint| hint.label == "Engine" && hint.detail.as_deref() == Some("MergeTree"))
+        );
+
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn clickhouse_rejects_query_parameters_and_multiple_statements() -> Result<(), DbError> {
+    containers::with_clickhouse(|config| {
+        let connection = connect(&config)?;
+        let mut parameterized = QueryRequest::new("SELECT ?");
+        parameterized.params.push(Value::Int(1));
+        let parameter_error = connection
+            .execute(&parameterized)
+            .expect_err("QueryRequest parameters must be rejected");
+        assert!(matches!(
+            parameter_error,
+            DbError::NotSupported(ref message)
+                if message == "ClickHouse HTTP queries do not support QueryRequest parameters"
+        ));
+
+        let statement_error = connection
+            .execute(&QueryRequest::new("SELECT 1; SELECT 2"))
+            .expect_err("multiple statements must be rejected");
+        assert!(matches!(
+            statement_error,
+            DbError::QueryFailed(ref formatted)
+                if formatted.message.to_ascii_lowercase().contains("multi-statements")
+        ));
+
+        Ok(())
+    })
+}

--- a/crates/dbflux_driver_clickhouse/tests/live_integration.rs
+++ b/crates/dbflux_driver_clickhouse/tests/live_integration.rs
@@ -103,6 +103,36 @@ fn clickhouse_connects_and_decodes_types() -> Result<(), DbError> {
 
 #[test]
 #[ignore = "requires Docker daemon"]
+fn clickhouse_paginates_ordered_views() -> Result<(), DbError> {
+    containers::with_clickhouse(|config| {
+        let connection = connect(&config)?;
+        connection.execute(&QueryRequest::new(
+            "CREATE VIEW dbflux_live_pagination_view AS SELECT intDiv(number, 10) AS tens, max(number) AS maximum FROM numbers(500) GROUP BY tens",
+        ))?;
+
+        let page = connection.execute(
+            &QueryRequest::new(
+                "SELECT * FROM dbflux_live_pagination_view ORDER BY tens ASC LIMIT 100",
+            )
+            .with_limit(6)
+            .with_offset(5),
+        )?;
+
+        assert_eq!(page.rows.len(), 6);
+        assert_eq!(
+            page.rows
+                .iter()
+                .map(|row| row[0].clone())
+                .collect::<Vec<_>>(),
+            (5..=10).map(Value::Int).collect::<Vec<_>>()
+        );
+        connection.execute(&QueryRequest::new("DROP VIEW dbflux_live_pagination_view"))?;
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
 fn clickhouse_introspects_table_details_and_storage_hints() -> Result<(), DbError> {
     containers::with_clickhouse(|config| {
         let connection = connect(&config)?;

--- a/crates/dbflux_mcp_server/Cargo.toml
+++ b/crates/dbflux_mcp_server/Cargo.toml
@@ -20,6 +20,7 @@ mongodb = ["dbflux_driver_mongodb"]
 redis = ["dbflux_driver_redis"]
 dynamodb = ["dbflux_driver_dynamodb"]
 redshift = ["dbflux_driver_redshift"]
+clickhouse = ["dbflux_driver_clickhouse"]
 aws = ["dbflux_aws", "dbflux_ssm"]
 
 [dependencies]
@@ -40,6 +41,7 @@ dbflux_driver_mongodb = { workspace = true, optional = true }
 dbflux_driver_redis = { workspace = true, optional = true }
 dbflux_driver_dynamodb = { workspace = true, optional = true }
 dbflux_driver_redshift = { workspace = true, optional = true }
+dbflux_driver_clickhouse = { workspace = true, optional = true }
 dbflux_aws = { workspace = true, optional = true }
 dbflux_ssm = { workspace = true, optional = true }
 

--- a/crates/dbflux_mcp_server/src/state.rs
+++ b/crates/dbflux_mcp_server/src/state.rs
@@ -587,6 +587,7 @@ fn str_to_db_kind(value: &str) -> Option<dbflux_core::DbKind> {
         "InfluxDB" => Some(dbflux_core::DbKind::InfluxDB),
         "SqlServer" => Some(dbflux_core::DbKind::SqlServer),
         "Redshift" => Some(dbflux_core::DbKind::Redshift),
+        "ClickHouse" => Some(dbflux_core::DbKind::ClickHouse),
         "S3" => Some(dbflux_core::DbKind::S3),
         _ => None,
     }
@@ -605,6 +606,7 @@ fn default_db_config_for_kind(kind: dbflux_core::DbKind) -> dbflux_core::DbConfi
         dbflux_core::DbKind::InfluxDB => dbflux_core::DbConfig::default_influxdb(),
         dbflux_core::DbKind::SqlServer => dbflux_core::DbConfig::default_sqlserver(),
         dbflux_core::DbKind::Redshift => dbflux_core::DbConfig::default_redshift(),
+        dbflux_core::DbKind::ClickHouse => dbflux_core::DbConfig::default_clickhouse(),
         dbflux_core::DbKind::S3 => dbflux_core::DbConfig::default_s3(),
     }
 }
@@ -862,6 +864,14 @@ fn build_driver_registry() -> HashMap<String, Arc<dyn DbDriver>> {
         );
     }
 
+    #[cfg(feature = "clickhouse")]
+    {
+        registry.insert(
+            "clickhouse".to_string(),
+            Arc::new(dbflux_driver_clickhouse::ClickHouseDriver::new()),
+        );
+    }
+
     registry
 }
 
@@ -986,6 +996,21 @@ mod tests {
     use dbflux_test_support::{
         FakeAuthProviderRpcConfig, FakeAuthProviderRpcServer, FakeAuthRpcResult,
     };
+
+    #[test]
+    #[cfg(feature = "clickhouse")]
+    fn clickhouse_is_available_to_mcp_when_feature_enabled() {
+        assert_eq!(
+            str_to_db_kind("ClickHouse"),
+            Some(dbflux_core::DbKind::ClickHouse)
+        );
+
+        let registry = build_driver_registry();
+        let driver = registry
+            .get("clickhouse")
+            .expect("clickhouse driver must be registered");
+        assert_eq!(driver.driver_key(), "builtin:clickhouse");
+    }
 
     fn temp_runtime() -> (tempfile::TempDir, StorageRuntime) {
         let temp_dir = tempfile::tempdir().expect("tempdir");

--- a/crates/dbflux_portability/src/import.rs
+++ b/crates/dbflux_portability/src/import.rs
@@ -2028,6 +2028,9 @@ encryption = "none"
             (DbKind::CloudWatchLogs, "CloudWatchLogs", "cloudwatch"),
             (DbKind::InfluxDB, "InfluxDB", "influxdb"),
             (DbKind::SqlServer, "SqlServer", "mssql"),
+            (DbKind::Redshift, "Redshift", "redshift"),
+            (DbKind::S3, "S3", "s3"),
+            (DbKind::ClickHouse, "ClickHouse", "clickhouse"),
         ];
 
         for (expected, kind_str, driver_id) in variants {

--- a/crates/dbflux_storage/src/repositories/connection_driver_configs.rs
+++ b/crates/dbflux_storage/src/repositories/connection_driver_configs.rs
@@ -351,6 +351,17 @@ impl ConnectionDriverConfigDto {
                 dto.s3_access_key_id = access_key_id.clone();
                 dto.s3_path_style = *path_style;
             }
+            DbConfig::ClickHouse {
+                url,
+                user,
+                database,
+                request_timeout_seconds,
+            } => {
+                dto.uri = Some(url.clone());
+                dto.user = Some(user.clone());
+                dto.database_name = Some(database.clone());
+                dto.connect_timeout_secs = persist_timeout_seconds(*request_timeout_seconds);
+            }
             DbConfig::External { kind, values } => {
                 dto.external_kind = Some(db_kind_to_str(*kind));
                 dto.external_values_json = Some(serde_json::to_string(values).unwrap_or_default());
@@ -560,6 +571,20 @@ impl ConnectionDriverConfigDto {
                 endpoint: self.dynamo_endpoint.clone(),
                 path_style: self.s3_path_style,
             }),
+            DbKind::ClickHouse => Some(DbConfig::ClickHouse {
+                url: self
+                    .uri
+                    .clone()
+                    .unwrap_or_else(|| "http://localhost:8123".to_string()),
+                user: self.user.clone().unwrap_or_else(|| "default".to_string()),
+                database: self
+                    .database_name
+                    .clone()
+                    .unwrap_or_else(|| "default".to_string()),
+                request_timeout_seconds: self
+                    .connect_timeout_secs
+                    .and_then(|timeout| u64::try_from(timeout).ok()),
+            }),
         }
     }
 }
@@ -582,6 +607,7 @@ fn db_kind_to_str(kind: DbKind) -> String {
         DbKind::SqlServer => "SqlServer",
         DbKind::Redshift => "Redshift",
         DbKind::S3 => "S3",
+        DbKind::ClickHouse => "ClickHouse",
     }
     .to_string()
 }
@@ -600,8 +626,15 @@ fn str_to_db_kind(s: &str) -> Option<DbKind> {
         "SqlServer" => Some(DbKind::SqlServer),
         "Redshift" => Some(DbKind::Redshift),
         "S3" => Some(DbKind::S3),
+        "ClickHouse" => Some(DbKind::ClickHouse),
         _ => None,
     }
+}
+
+/// The persistence column is a signed 32-bit integer; larger timeouts retain
+/// the maximum representable value instead of being silently stored as absent.
+fn persist_timeout_seconds(timeout: Option<u64>) -> Option<i32> {
+    timeout.map(|timeout| timeout.min(i32::MAX as u64) as i32)
 }
 
 /// Converts an `Option<String>` ssl_mode to the string stored in the DTO column.
@@ -1053,6 +1086,83 @@ mod tests {
                 assert_eq!(profile.as_deref(), Some("dev"));
                 assert_eq!(endpoint.as_deref(), Some("http://localhost:4566"));
             }
+            other => panic!("unexpected config: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clickhouse_driver_config_roundtrips_through_repository() {
+        let (_temp_dir, repo) = temp_repo();
+        let profile_id = uuid::Uuid::new_v4().to_string();
+
+        repo.conn()
+            .execute(
+                r#"
+                INSERT INTO cfg_connection_profiles (
+                    id, name, driver_id, kind, created_at, updated_at
+                ) VALUES (?1, 'ClickHouse', 'clickhouse', 'ClickHouse', datetime('now'), datetime('now'))
+                "#,
+                params![profile_id],
+            )
+            .expect("insert profile");
+
+        let config = DbConfig::ClickHouse {
+            url: "https://clickhouse.example.com:8443".to_string(),
+            user: "analytics".to_string(),
+            database: "events".to_string(),
+            request_timeout_seconds: Some(45),
+        };
+
+        let dto = ConnectionDriverConfigDto::from_db_config(profile_id.clone(), &config);
+        repo.insert(&dto).expect("insert config");
+
+        let restored = repo
+            .get_for_profile(&profile_id)
+            .expect("load config")
+            .expect("stored config");
+
+        match restored.to_db_config().expect("db config") {
+            DbConfig::ClickHouse {
+                url,
+                user,
+                database,
+                request_timeout_seconds,
+            } => {
+                assert_eq!(url, "https://clickhouse.example.com:8443");
+                assert_eq!(user, "analytics");
+                assert_eq!(database, "events");
+                assert_eq!(request_timeout_seconds, Some(45));
+            }
+            other => panic!("unexpected config: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn clickhouse_timeout_clamps_to_persistence_limit() {
+        assert_eq!(
+            persist_timeout_seconds(Some(i32::MAX as u64)),
+            Some(i32::MAX)
+        );
+        assert_eq!(
+            persist_timeout_seconds(Some(i32::MAX as u64 + 1)),
+            Some(i32::MAX)
+        );
+
+        let config = DbConfig::ClickHouse {
+            url: "http://localhost:8123".to_string(),
+            user: "default".to_string(),
+            database: "default".to_string(),
+            request_timeout_seconds: Some(i32::MAX as u64 + 1),
+        };
+
+        let dto = ConnectionDriverConfigDto::from_db_config("profile".to_string(), &config);
+
+        assert_eq!(dto.connect_timeout_secs, Some(i32::MAX));
+        match dto.to_db_config().expect("db config") {
+            DbConfig::ClickHouse {
+                request_timeout_seconds,
+                ..
+            } => assert_eq!(request_timeout_seconds, Some(i32::MAX as u64)),
             other => panic!("unexpected config: {other:?}"),
         }
     }

--- a/crates/dbflux_test_support/src/containers.rs
+++ b/crates/dbflux_test_support/src/containers.rs
@@ -102,6 +102,69 @@ where
     run(url)
 }
 
+/// Connection parameters for a ClickHouse test container.
+pub struct ClickHouseConfig {
+    pub endpoint: String,
+    pub user: String,
+    pub password: String,
+    pub database: String,
+}
+
+/// Spin up a ClickHouse 25.8 LTS container and wait for its HTTP API.
+pub fn with_clickhouse<T, E, F>(run: F) -> Result<T, E>
+where
+    E: From<dbflux_core::DbError>,
+    F: FnOnce(ClickHouseConfig) -> Result<T, E>,
+{
+    let user = "dbflux";
+    let password = "dbflux";
+    let database = "dbflux_test";
+    let image = GenericImage::new("clickhouse/clickhouse-server", "25.8.30.16")
+        .with_exposed_port(ContainerPort::Tcp(8123))
+        .with_wait_for(WaitFor::seconds(1))
+        .with_env_var("CLICKHOUSE_USER", user)
+        .with_env_var("CLICKHOUSE_PASSWORD", password)
+        .with_env_var("CLICKHOUSE_DB", database)
+        .with_env_var("CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT", "1");
+
+    let container = image.start().expect("failed to start clickhouse container");
+    let port = container
+        .get_host_port_ipv4(8123)
+        .expect("failed to get clickhouse HTTP host port");
+    let endpoint = format!("http://127.0.0.1:{port}");
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|error| dbflux_core::DbError::connection_failed(error.to_string()))
+        .map_err(E::from)?;
+
+    retry_db_operation(Duration::from_secs(60), || {
+        client
+            .get(format!("{endpoint}/ping"))
+            .basic_auth(user, Some(password))
+            .send()
+            .map_err(|error| dbflux_core::DbError::connection_failed(error.to_string()))
+            .map_err(E::from)
+            .and_then(|response| {
+                if response.status().is_success() {
+                    Ok(())
+                } else {
+                    Err(E::from(dbflux_core::DbError::connection_failed(format!(
+                        "ClickHouse ping returned {}",
+                        response.status()
+                    ))))
+                }
+            })
+    })?;
+
+    run(ClickHouseConfig {
+        endpoint,
+        user: user.to_string(),
+        password: password.to_string(),
+        database: database.to_string(),
+    })
+}
+
 /// Password used when launching the SQL Server test container.
 ///
 /// SQL Server requires a "strong" SA password: at least 8 characters with

--- a/crates/dbflux_test_support/src/fake_driver.rs
+++ b/crates/dbflux_test_support/src/fake_driver.rs
@@ -305,6 +305,14 @@ impl DbDriver for FakeDriver {
                 endpoint: get_optional_string(values, "endpoint"),
                 path_style: false,
             },
+            DbKind::ClickHouse => DbConfig::ClickHouse {
+                url: get_string(values, "url", "http://localhost:8123"),
+                user: get_string(values, "user", "default"),
+                database: get_string(values, "database", "default"),
+                request_timeout_seconds: values
+                    .get("request_timeout_seconds")
+                    .and_then(|value| value.parse().ok()),
+            },
         };
 
         Ok(config)
@@ -451,6 +459,22 @@ impl DbDriver for FakeDriver {
                     access_key_id.clone().unwrap_or_default(),
                 );
                 values.insert("endpoint".to_string(), endpoint.clone().unwrap_or_default());
+            }
+            DbConfig::ClickHouse {
+                url,
+                user,
+                database,
+                request_timeout_seconds,
+            } => {
+                values.insert("url".to_string(), url.clone());
+                values.insert("user".to_string(), user.clone());
+                values.insert("database".to_string(), database.clone());
+                values.insert(
+                    "request_timeout_seconds".to_string(),
+                    request_timeout_seconds
+                        .map(|timeout| timeout.to_string())
+                        .unwrap_or_default(),
+                );
             }
             DbConfig::External { values: vals, .. } => {
                 values.extend(vals.clone());
@@ -599,6 +623,7 @@ impl Connection for FakeConnection {
             DbKind::DynamoDB | DbKind::CloudWatchLogs | DbKind::InfluxDB | DbKind::S3 => {
                 SchemaLoadingStrategy::SingleDatabase
             }
+            DbKind::ClickHouse => SchemaLoadingStrategy::LazyPerDatabase,
         }
     }
 
@@ -642,6 +667,7 @@ fn active_database_from_profile(profile: &ConnectionProfile) -> Option<String> {
         DbConfig::SqlServer { database, .. } => database.clone(),
         DbConfig::Redshift { database, .. } => Some(database.clone()),
         DbConfig::S3 { .. } => None,
+        DbConfig::ClickHouse { database, .. } => Some(database.clone()),
         DbConfig::External { values, .. } => values.get("database").cloned(),
     }
 }
@@ -664,6 +690,7 @@ fn metadata_for_kind(kind: DbKind) -> &'static DriverMetadata {
         // metadata instead of a hand-rolled fake.
         DbKind::Redshift => &REDSHIFT_METADATA,
         DbKind::S3 => &FAKE_S3_METADATA,
+        DbKind::ClickHouse => &FAKE_CLICKHOUSE_METADATA,
     }
 }
 
@@ -680,6 +707,7 @@ fn form_for_kind(kind: DbKind) -> &'static DriverFormDef {
         DbKind::SqlServer => &SQLSERVER_FORM,
         DbKind::Redshift => &REDSHIFT_FORM,
         DbKind::S3 => &S3_FORM,
+        DbKind::ClickHouse => &CLICKHOUSE_FORM,
     }
 }
 
@@ -781,6 +809,108 @@ static FAKE_POSTGRES_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| Drive
     default_chunk_size: None,
     supports_lock_timeout: false,
     editor_profile: None,
+});
+
+static FAKE_CLICKHOUSE_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
+    id: "fake-clickhouse".into(),
+    display_name: "Fake ClickHouse".into(),
+    description: "Deterministic fake driver for tests".into(),
+    category: DatabaseCategory::Relational,
+    transfer_family: TransferFamily::Incompatible,
+    deployment_class: None,
+    query_language: QueryLanguage::Sql,
+    capabilities: DriverCapabilities::from_bits_truncate(
+        DriverCapabilities::MULTIPLE_DATABASES.bits()
+            | DriverCapabilities::SSL.bits()
+            | DriverCapabilities::AUTHENTICATION.bits()
+            | DriverCapabilities::VIEWS.bits()
+            | DriverCapabilities::PAGINATION.bits()
+            | DriverCapabilities::SORTING.bits()
+            | DriverCapabilities::FILTERING.bits()
+            | DriverCapabilities::EXPORT_CSV.bits()
+            | DriverCapabilities::EXPORT_JSON.bits()
+            | DriverCapabilities::CHART_AUTHORING.bits(),
+    ),
+    default_port: Some(8123),
+    uri_scheme: "http".into(),
+    icon: Icon::Database,
+    syntax: Some(SyntaxInfo {
+        identifier_quote: '`',
+        string_quote: '\'',
+        placeholder_style: dbflux_core::PlaceholderStyle::QuestionMark,
+        supports_schemas: false,
+        default_schema: None,
+        case_sensitive_identifiers: true,
+    }),
+    query: Some(QueryCapabilities {
+        pagination: vec![dbflux_core::PaginationStyle::Offset],
+        where_operators: vec![
+            dbflux_core::WhereOperator::Eq,
+            dbflux_core::WhereOperator::Ne,
+            dbflux_core::WhereOperator::Gt,
+            dbflux_core::WhereOperator::Gte,
+            dbflux_core::WhereOperator::Lt,
+            dbflux_core::WhereOperator::Lte,
+            dbflux_core::WhereOperator::Like,
+            dbflux_core::WhereOperator::Null,
+            dbflux_core::WhereOperator::In,
+            dbflux_core::WhereOperator::NotIn,
+            dbflux_core::WhereOperator::And,
+            dbflux_core::WhereOperator::Or,
+            dbflux_core::WhereOperator::Not,
+        ],
+        supports_order_by: true,
+        order_by_mode: dbflux_core::OrderByMode::AnyColumns,
+        supports_group_by: true,
+        supports_having: true,
+        supports_distinct: true,
+        supports_limit: true,
+        supports_offset: true,
+        supports_joins: true,
+        supports_subqueries: true,
+        supports_union: true,
+        supports_intersect: true,
+        supports_except: true,
+        supports_case_expressions: true,
+        supports_window_functions: true,
+        supports_ctes: true,
+        supports_explain: true,
+        max_query_parameters: 0,
+        max_order_by_columns: 0,
+        max_group_by_columns: 0,
+    }),
+    mutation: None,
+    ddl: None,
+    transactions: None,
+    limits: None,
+    ssl_modes: None,
+    ssl_cert_fields: None,
+    classification_override: None,
+    default_chunk_size: None,
+    supports_lock_timeout: false,
+    editor_profile: None,
+});
+
+static CLICKHOUSE_FORM: LazyLock<DriverFormDef> = LazyLock::new(|| DriverFormDef {
+    tabs: vec![FormTab {
+        id: "main".into(),
+        label: "Main".into(),
+        sections: vec![FormSection {
+            title: "Connection".into(),
+            fields: vec![
+                field_required("url", "URL", FormFieldKind::Text, "http://localhost:8123"),
+                field_required("user", "User", FormFieldKind::Text, "default"),
+                field("password", "Password", FormFieldKind::Password, ""),
+                field_required("database", "Database", FormFieldKind::Text, "default"),
+                field(
+                    "request_timeout_seconds",
+                    "Request timeout (seconds)",
+                    FormFieldKind::Number,
+                    "optional",
+                ),
+            ],
+        }],
+    }],
 });
 
 static FAKE_SQLITE_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -1217,7 +1347,8 @@ mod tests {
     use super::{FakeDriver, FakeQueryOutcome};
     use crate::fixtures;
     use dbflux_core::{
-        ConnectionProfile, DbConfig, DbDriver, DbError, DbKind, QueryRequest, SchemaLoadingStrategy,
+        ConnectionProfile, DatabaseCategory, DbConfig, DbDriver, DbError, DbKind,
+        DriverCapabilities, QueryRequest, SchemaLoadingStrategy, TransferFamily,
     };
 
     #[test]
@@ -1226,6 +1357,30 @@ mod tests {
         let result = driver.build_config(&dbflux_core::FormValues::new());
 
         assert!(matches!(result, Err(DbError::InvalidProfile(_))));
+    }
+
+    #[test]
+    fn clickhouse_metadata_matches_read_only_contract() {
+        let driver = FakeDriver::new(DbKind::ClickHouse);
+        let metadata = driver.metadata();
+        let expected = DriverCapabilities::MULTIPLE_DATABASES
+            | DriverCapabilities::SSL
+            | DriverCapabilities::AUTHENTICATION
+            | DriverCapabilities::VIEWS
+            | DriverCapabilities::PAGINATION
+            | DriverCapabilities::SORTING
+            | DriverCapabilities::FILTERING
+            | DriverCapabilities::EXPORT_CSV
+            | DriverCapabilities::EXPORT_JSON
+            | DriverCapabilities::CHART_AUTHORING;
+
+        assert_eq!(metadata.category, DatabaseCategory::Relational);
+        assert_eq!(metadata.transfer_family, TransferFamily::Incompatible);
+        assert_eq!(metadata.capabilities, expected);
+        assert!(!metadata.syntax.as_ref().expect("syntax").supports_schemas);
+        assert!(metadata.query.is_some());
+        assert!(metadata.mutation.is_none());
+        assert!(metadata.transactions.is_none());
     }
 
     #[test]
@@ -1350,6 +1505,7 @@ mod tests {
             (DbKind::SQLite, SchemaLoadingStrategy::SingleDatabase),
             (DbKind::MongoDB, SchemaLoadingStrategy::SingleDatabase),
             (DbKind::Redis, SchemaLoadingStrategy::SingleDatabase),
+            (DbKind::ClickHouse, SchemaLoadingStrategy::LazyPerDatabase),
             (DbKind::DynamoDB, SchemaLoadingStrategy::SingleDatabase),
             (
                 DbKind::CloudWatchLogs,
@@ -1393,6 +1549,7 @@ mod tests {
                 DbKind::SqlServer => DbConfig::default_sqlserver(),
                 DbKind::Redshift => DbConfig::default_redshift(),
                 DbKind::S3 => DbConfig::default_s3(),
+                DbKind::ClickHouse => DbConfig::default_clickhouse(),
             };
 
             let profile = ConnectionProfile::new("fake", config);

--- a/crates/dbflux_ui/src/ui/icons/mod.rs
+++ b/crates/dbflux_ui/src/ui/icons/mod.rs
@@ -89,6 +89,7 @@ pub const ALL_ICONS: &[AppIcon] = &[
     AppIcon::BrandSqlite,
     AppIcon::BrandMongodb,
     AppIcon::BrandRedis,
+    AppIcon::BrandClickhouse,
     AppIcon::BrandLua,
     AppIcon::BrandPython,
     AppIcon::BrandBash,
@@ -237,6 +238,9 @@ pub(crate) fn embedded_bytes(icon: AppIcon) -> &'static [u8] {
             include_bytes!("../../../../../resources/icons/brand/mongodb.svg")
         }
         AppIcon::BrandRedis => include_bytes!("../../../../../resources/icons/brand/redis.svg"),
+        AppIcon::BrandClickhouse => {
+            include_bytes!("../../../../../resources/icons/brand/clickhouse.svg")
+        }
         AppIcon::BrandLua => include_bytes!("../../../../../resources/icons/brand/lua.svg"),
         AppIcon::BrandPython => include_bytes!("../../../../../resources/icons/brand/python.svg"),
         AppIcon::BrandBash => include_bytes!("../../../../../resources/icons/brand/gnubash.svg"),
@@ -260,7 +264,11 @@ mod tests {
 
     #[test]
     fn semantic_driver_fallback_assets_are_registered() {
-        for icon in [AppIcon::ChartNoAxesColumn, AppIcon::Boxes] {
+        for icon in [
+            AppIcon::ChartNoAxesColumn,
+            AppIcon::Boxes,
+            AppIcon::BrandClickhouse,
+        ] {
             assert!(ALL_ICONS.contains(&icon));
             assert!(embedded_bytes(icon).starts_with(b"<svg"));
         }

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -445,6 +445,7 @@ impl ConnectionManagerWindow {
             | DbConfig::CloudWatchLogs { .. }
             | DbConfig::InfluxDB { .. }
             | DbConfig::S3 { .. }
+            | DbConfig::ClickHouse { .. }
             | DbConfig::External { .. } => {}
         }
 

--- a/docs/DRIVERS.md
+++ b/docs/DRIVERS.md
@@ -43,6 +43,7 @@ The capability flags listed below are exactly the ones each driver's
 | DynamoDB | Document | Custom("DynamoDB") | Auth, pagination, filtering, insert/update/delete, nested documents, arrays | AWS-managed; native command envelope (`scan`/`query`/`put`/`update`/`delete`); no PartiQL/transactions; no query cancellation; `update many+upsert` unsupported. |
 | CloudWatch Logs | Log Stream | Sql (metadata default) | Auth | AWS-managed; executes Logs Insights QL, OpenSearch PPL, and OpenSearch SQL via editor-managed source context; no query cancellation yet. |
 | InfluxDB | Time Series | InfluxQuery | Auth, multiple databases, pagination, CSV/JSON export | v1 and v2 in one crate; InfluxQL on both, Flux on v2 only; read-only (no INSERT/UPDATE/DELETE); no transactions. |
+| ClickHouse | Relational | SQL | Multiple databases, views, auth, pagination, sorting, filtering, grouping, joins, CTEs, windows, CSV/JSON export | HTTP(S), including ClickHouse Cloud; read-oriented DBFlux integration with no structured mutations, DDL, transactions, SSH tunneling, or query parameters. |
 | Amazon S3 | Object Storage | Custom("S3") | Auth (profile/SSO or static credentials, custom endpoint), bucket browsing, paginated object navigation, preview, full CRUD, presigned URLs | S3-compatible (Cloudflare R2, MinIO); no multipart upload/transfers panel, no embedded PDF viewer, no lifecycle/ACL management or S3 Select. |
 
 ## Per-driver summary
@@ -126,6 +127,15 @@ on both versions; Flux runs on v2 only. The query API is read-only (no
 INSERT/UPDATE/DELETE, no transactions), with optional default bucket/database and
 per-query bucket routing. See
 [`crates/dbflux_driver_influxdb/README.md`](../crates/dbflux_driver_influxdb/README.md).
+
+### ClickHouse
+
+Relational SQL driver for self-hosted ClickHouse and ClickHouse Cloud over
+HTTP(S). It discovers databases, tables, views, columns, and engine metadata,
+and supports read-oriented SQL workflows with pagination and visual SELECT
+generation. Structured mutations, DDL, transactions, SSH tunneling, and generic
+query parameters are not supported in this initial scope. See
+[`crates/dbflux_driver_clickhouse/README.md`](../crates/dbflux_driver_clickhouse/README.md).
 
 ### Amazon S3
 

--- a/resources/icons/brand/clickhouse.svg
+++ b/resources/icons/brand/clickhouse.svg
@@ -1,0 +1,1 @@
+<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>ClickHouse</title><path d="M21.333 10H24v4h-2.667ZM16 1.335h2.667v21.33H16Zm-5.333 0h2.666v21.33h-2.666ZM0 22.665V1.335h2.667v21.33zm5.333-21.33H8v21.33H5.333Z"/></svg>

--- a/tests/driver-live/README.md
+++ b/tests/driver-live/README.md
@@ -1,9 +1,9 @@
 # Driver live integration tests
 
 Driver integration tests use `testcontainers` for PostgreSQL, MySQL, MongoDB,
-Redis, DynamoDB Local, and SQL Server. Each test starts an isolated container
-with a dynamic host port and tears it down automatically. SQLite integration
-uses a temporary local file.
+Redis, DynamoDB Local, SQL Server, and ClickHouse. Each test starts an isolated
+container with a dynamic host port and tears it down automatically. SQLite
+integration uses a temporary local file.
 
 ## Run live driver tests
 
@@ -14,11 +14,19 @@ cargo test -p dbflux_driver_mongodb  --test live_integration -- --ignored
 cargo test -p dbflux_driver_redis    --test live_integration -- --ignored
 cargo test -p dbflux_driver_dynamodb --test live_integration -- --ignored
 cargo test -p dbflux_driver_mssql    --test live_integration -- --ignored
+cargo test -p dbflux_driver_clickhouse --test live_integration -- --ignored
 cargo test -p dbflux_driver_sqlite   --test live_integration
 ```
 
 The ignored tests require a working Docker daemon because `testcontainers`
 talks to Docker directly.
+
+## ClickHouse specifics
+
+The ClickHouse suite pulls `clickhouse/clickhouse-server:25.8.30.16` (25.8
+LTS). Every ignored test launches its own container through `testcontainers`,
+maps HTTP port 8123 to a dynamic host port, and initializes database
+`dbflux_test` with user/password `dbflux`/`dbflux`.
 
 ## SQL Server specifics
 


### PR DESCRIPTION
## Summary

Adds built-in ClickHouse and ClickHouse Cloud support for database browsing, typed SQL results, visual SELECTs, charts, and MCP access.

The initial scope intentionally excludes structured mutations, transactions, SSH tunneling, query cancellation, and table transfer.

## What does this resolve?

- Resolves #24

## How was this solved?

Introduces a relational HTTP(S) driver with dynamic ClickHouse type decoding and lazy system-catalog discovery. Generic capability, persistence, and MCP seams keep the UI and application workflow driver-agnostic.

Pagination uses ClickHouse's native HTTP `limit` and `offset` settings so ordered queries are not wrapped or rewritten. The HTTP client retains passwords as `SecretString` until constructing Basic Auth. A branded ClickHouse icon is registered through the generic driver icon seam. SQL governance classification changes are intentionally excluded and are proposed separately in #336.

## Validation

- `cargo test --workspace --features clickhouse` (4,887 passed, 224 ignored)
- `cargo clippy --workspace --features clickhouse -- -D warnings`
- `cargo check -p dbflux --no-default-features --features clickhouse,mcp`
- `cargo test --doc --workspace --features clickhouse`
- `cargo test -p dbflux_driver_clickhouse --test live_integration --no-run`
- `cargo fmt --all -- --check`

The Docker-backed ClickHouse suite includes ordered View pagination coverage for ClickHouse/ClickHouse#33289 and is wired into CI with a pinned ClickHouse 25.8 LTS container. It was compiled locally but not executed because the local Docker daemon was unavailable.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] Changelog entries are generated from the `feat` commit; `CHANGELOG.md` was not edited per repository policy
- [ ] I applied the appropriate labels

## Labels to apply

- `driver:feature`
- `driver`
- `query`
- `mcp`
- `kind:sql`
