### PR TITLE
fix(governance): classify SQL administration operations

### DIFF
--- a/crates/dbflux_core/src/query/safety.rs
+++ b/crates/dbflux_core/src/query/safety.rs
@@ -36,7 +36,9 @@ pub fn classify_sql_execution(sql: &str) -> ExecutionClassification {
         }
         "INSERT" | "UPDATE" | "DELETE" | "MERGE" | "REPLACE" => ExecutionClassification::Write,
         "TRUNCATE" | "DROP" | "ALTER" => ExecutionClassification::Destructive,
-        "GRANT" | "REVOKE" | "CREATE" | "SET" => ExecutionClassification::Admin,
+        "GRANT" | "REVOKE" | "CREATE" | "SET" | "SYSTEM" | "KILL" | "ATTACH" | "OPTIMIZE"
+        | "BACKUP" | "RESTORE" | "UNDROP" | "MOVE" => ExecutionClassification::Admin,
+        "DETACH" | "RENAME" | "EXCHANGE" => ExecutionClassification::Destructive,
         _ => ExecutionClassification::Write,
     }
 }
@@ -292,5 +294,40 @@ mod tests {
             classify_query_for_governance(&QueryLanguage::Sql, "VACUUM users"),
             ExecutionClassification::Write
         );
+    }
+
+    #[test]
+    fn database_administration_queries_require_admin_governance() {
+        for query in [
+            "SYSTEM SHUTDOWN",
+            "KILL QUERY WHERE query_id = 'abc'",
+            "OPTIMIZE TABLE events FINAL",
+            "ATTACH TABLE events",
+            "UNDROP TABLE events",
+            "MOVE USER alice TO another_access_storage",
+            "BACKUP DATABASE analytics TO Disk('backups', 'analytics.zip')",
+            "RESTORE DATABASE analytics FROM Disk('backups', 'analytics.zip')",
+        ] {
+            assert_eq!(
+                classify_sql_execution(query),
+                ExecutionClassification::Admin,
+                "query must require admin governance: {query}"
+            );
+        }
+    }
+
+    #[test]
+    fn disruptive_administration_queries_require_destructive_governance() {
+        for query in [
+            "DETACH TABLE events",
+            "RENAME TABLE old TO new",
+            "EXCHANGE TABLES old AND new",
+        ] {
+            assert_eq!(
+                classify_sql_execution(query),
+                ExecutionClassification::Destructive,
+                "query must require destructive governance: {query}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Ensures administrative and disruptive SQL operations receive appropriate governance instead of falling back to generic write policies.

Administrative operations such as `SYSTEM`, `KILL`, `OPTIMIZE`, backup, and restore now require admin governance. Disruptive metadata operations such as `DETACH`, `RENAME`, and `EXCHANGE` require destructive governance.

Extracted from the review of #334 so the policy change can be evaluated independently across all SQL drivers.

## Validation

- `cargo test -p dbflux_core query::safety`
- `cargo test --workspace` (4,858 passed, 220 ignored)
- `cargo clippy --workspace -- -D warnings`
- `cargo fmt --all -- --check`

## Checklist

- [x] I added or updated tests when needed
- [x] The change is limited to generic SQL governance
- [x] `CHANGELOG.md` was not edited per repository policy
