### PR TITLE
feat(ui): copy connection test errors

### DIFF
--- a/crates/dbflux_components/src/controls/button.rs
+++ b/crates/dbflux_components/src/controls/button.rs
@@ -1,5 +1,5 @@
 use gpui::prelude::*;
-use gpui::{App, ClickEvent, ElementId, SharedString, Window, px};
+use gpui::{App, ClickEvent, ElementId, Hsla, SharedString, Window, px};
 use gpui_component::button::{
     Button as GpuiButton, ButtonVariant as GpuiButtonVariant, ButtonVariants,
 };
@@ -35,6 +35,7 @@ pub struct Button {
     variant: ButtonVariant,
     size: ButtonSize,
     icon: Option<Icon>,
+    text_color: Option<Hsla>,
     disabled: bool,
     w_full: bool,
     on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + Send + Sync>>,
@@ -48,6 +49,7 @@ impl Button {
             variant: ButtonVariant::Default,
             size: ButtonSize::Default,
             icon: None,
+            text_color: None,
             disabled: false,
             w_full: false,
             on_click: None,
@@ -82,6 +84,11 @@ impl Button {
 
     pub fn icon(mut self, icon: impl Into<Icon>) -> Self {
         self.icon = Some(icon.into());
+        self
+    }
+
+    pub fn text_color(mut self, color: Hsla) -> Self {
+        self.text_color = Some(color);
         self
     }
 
@@ -135,6 +142,10 @@ impl RenderOnce for Button {
 
         if let Some(icon) = self.icon {
             btn = btn.icon(icon);
+        }
+
+        if let Some(text_color) = self.text_color {
+            btn = btn.text_color(text_color);
         }
 
         if self.size == ButtonSize::Small {

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -412,12 +412,24 @@ impl ConnectionManagerWindow {
                             TestStatus::Failed => {
                                 let message =
                                     test_error.unwrap_or_else(|| "Connection failed".to_string());
+                                let message_to_copy = message.clone();
                                 BannerBlock::new(BannerVariant::Danger, "Connection failed")
                                     .with_body(message)
                                     .with_icon(
                                         AppIconElement::new(AppIcon::Info)
                                             .size(Heights::ICON_SM)
                                             .color(banners.error_fg),
+                                    )
+                                    .with_actions(
+                                        Button::new("copy-test-connection-error", "Copy")
+                                            .ghost()
+                                            .small()
+                                            .icon(Icon::new(AppIcon::Copy))
+                                            .on_click(move |_, _, cx| {
+                                                cx.write_to_clipboard(ClipboardItem::new_string(
+                                                    message_to_copy.clone(),
+                                                ));
+                                            }),
                                     )
                             }
                             TestStatus::None => unreachable!("guarded by when condition"),

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -424,6 +424,7 @@ impl ConnectionManagerWindow {
                                         Button::new("copy-test-connection-error", "Copy")
                                             .ghost()
                                             .small()
+                                            .text_color(gpui::white())
                                             .icon(Icon::new(AppIcon::Copy))
                                             .on_click(move |_, _, cx| {
                                                 cx.write_to_clipboard(ClipboardItem::new_string(


### PR DESCRIPTION
## Summary

Add a copy action to failed connection test banners so users can inspect the full error elsewhere.

## Verification

- `cargo check -p dbflux_ui_windows`
- `cargo test -p dbflux_ui_windows`

<img width="900" height="341" alt="screenshot-2026-08-18_13-41-28" src="https://github.com/user-attachments/assets/72183de1-95a5-48a1-9036-f5cfe3834a7f" />
