### PR TITLE
fix(web): make the Cloudflare deploy work

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dbflux/web",
+  "name": "dbflux-web",
   "type": "module",
   "private": true,
   "scripts": {

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -1,0 +1,74 @@
+---
+import Base from '../layouts/Base.astro';
+import { CURRENT, VERSIONS } from '../data/versions';
+
+/**
+ * Versions come and go, so a link that worked against one release can land here
+ * against another. Offer the documentation of every published version rather
+ * than a dead end.
+ */
+const versions = VERSIONS;
+---
+
+<Base title="Page not found — DBFlux" description="That page does not exist." noindex>
+  <section class="miss">
+    <p class="eyebrow">404</p>
+    <h1>That page does not exist.</h1>
+    <p class="miss__lede">
+      It may have been renamed, or it may belong to a version of DBFlux other than the one you were
+      reading.
+    </p>
+
+    <div class="miss__actions">
+      <a class="btn btn--primary" href="/docs/">Documentation</a>
+      <a class="btn btn--secondary" href="/">Home</a>
+    </div>
+
+    <p class="miss__versions">
+      Documentation by version:
+      {
+        versions.map((version, index) => (
+          <>
+            {index > 0 && <span aria-hidden="true"> &middot; </span>}
+            <a href={version.id === CURRENT.id ? '/docs/' : `/${version.id}/docs/`}>
+              {version.label}
+            </a>
+          </>
+        ))
+      }
+    </p>
+  </section>
+</Base>
+
+<style>
+  .miss {
+    max-width: 640px;
+    margin-inline: auto;
+    padding: var(--s-9) var(--s-8);
+    display: flex;
+    flex-direction: column;
+    gap: var(--s-5);
+  }
+
+  h1 {
+    font-size: var(--fs-h1);
+  }
+
+  .miss__lede {
+    margin: 0;
+  }
+
+  .miss__actions {
+    display: flex;
+    gap: var(--s-4);
+    flex-wrap: wrap;
+    padding-block: var(--s-4);
+  }
+
+  .miss__versions {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: var(--fs-small);
+    color: var(--text-muted);
+  }
+</style>

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -25,7 +25,7 @@ const versions = VERSIONS;
     </div>
 
     <p class="miss__versions">
-      Documentation by version:
+      Documentation by version:{' '}
       {
         versions.map((version, index) => (
           <>

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -1,0 +1,18 @@
+{
+  // Deploy configuration for Cloudflare.
+  //
+  // The site is fully static, so this serves `dist/` as Workers Static Assets
+  // and declares no entry script: there is nothing to run per request, and the
+  // Astro Cloudflare adapter is not needed.
+  //
+  // Committing this stops Cloudflare generating one during the build. The
+  // generated file derived the Worker name from the npm package name, and a
+  // scoped name is rejected: Worker names are lowercase alphanumeric with
+  // dashes, so `@dbflux/web` failed the deploy.
+  "name": "dbflux-web",
+  "compatibility_date": "2026-08-19",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "404-page",
+  },
+}


### PR DESCRIPTION
## Summary

The Cloudflare deploy fails before it reaches the site. Two causes, one root:
the npm package was named `@dbflux/web`.

Cloudflare generates a `wrangler.jsonc` during the build and derives the Worker
name from the package name. A scoped name is rejected — Worker names are
lowercase alphanumeric with dashes:

    Expected "name" to be of type string, alphanumeric and lowercase with
    dashes only but got "@dbflux/web".

The same name also broke the build command it wrote, `pnpm --filter
@dbflux/web... run build`, which resolved to no project from that directory.

## What does this resolve?

Blocks the first deployment. No issue was filed; it surfaced while setting the
project up.

## How was this solved?

- The package becomes `dbflux-web`. It is private and nothing depends on the
  name.
- The deploy configuration is committed rather than generated, so Cloudflare
  stops inventing one. The site is fully static, so it serves `dist/` as Workers
  Static Assets with no entry script and no Cloudflare adapter.
- Adds the 404 page that configuration points at. The site did not have one, and
  links rot across versions: a path that exists in nightly may not exist in the
  release someone is reading. It offers the documentation of every published
  version rather than a dead end.

## Validation

- `pnpm check` — 0 errors, 0 warnings, 0 hints.
- `pnpm format:check` — clean.
- `pnpm build` — 94 pages, `dist/404.html` present.
- `node scripts/check-links.mjs` — every internal link resolves.

Not validated: the deploy itself, which needs the Cloudflare project.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels

## Dashboard settings this expects

Root directory `web`, build command `pnpm build`, output `dist`, production
branch `main`. If the project is set up as Workers rather than Pages, the deploy
command is `npx wrangler deploy` from the same directory.