### PR TITLE
fix(web): derive versions from Cargo.toml, and point the repository at the site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -581,6 +581,52 @@ A `pub use dbflux_ui_base::platform::*` shim remains at `crates/dbflux_ui/src/pl
 - The channel-aware DB path lives in `crates/dbflux_storage/src/paths.rs` (`dbflux_db_path`); nightly can opt into the stable DB via `set_nightly_shares_stable_db` / `nightly_shares_stable_db`.
 - Brand assets live under `resources/branding/{stable,nightly}/` (served per channel in `crates/dbflux_ui/src/assets.rs`). Packaging and Nix files substitute channel placeholders. The release/nightly flow is documented in `docs/RELEASE.md`.
 
+## Website
+
+The site lives in `web/` and is an Astro static build. It is not a crate: `cargo` excludes it, and
+the Rust workflows skip changes confined to it or to markdown.
+
+**It renders the repository's own documentation.** `docs/*.md`, the driver READMEs,
+`ARCHITECTURE.md` and `CONTRIBUTING.md` are read straight out of git at build time. There is no
+second copy, so a behaviour change and the paragraph describing it belong in the same commit, and
+editing a document is all that is needed to change the site.
+
+**It publishes several versions.** `web/versions.json` lists them; each entry is a git ref, and the
+product version shown for it is read from that ref's `Cargo.toml` rather than typed. The first
+entry is the current release and is served unprefixed at `/docs/`; the rest are served under their
+id (`/v0.6/docs/`, `/nightly/docs/`) and keep those URLs. Granularity is the minor series, not the
+patch, because a release branch takes cherry-picked fixes only.
+
+Rules that matter when touching documentation:
+
+- Write markdown that reads correctly on GitHub. Relative links between documents and labels that
+  name a file are rewritten to site routes at build time, so `[Settings](SETTINGS.md)` works in
+  both places.
+- Diagrams go in ```mermaid fences. They render as diagrams on the site; ASCII art does not.
+- Adding a document to `docs/` gives it a page automatically. Its place in the reading order is
+  declared in `web/src/data/nav.ts`; unlisted documents still get a page and appear under "Not yet
+  filed" on the documentation index.
+- Never send a reader to the repository for something the site renders. Link to the page.
+
+```bash
+cd web
+pnpm install
+pnpm dev          # local server
+pnpm build        # static output in web/dist
+pnpm check        # types — this is a real gate, not decoration
+pnpm format       # prettier
+```
+
+`web/scripts/check-links.mjs` runs in CI after the build and fails on an internal link that points
+at a page which is not built. Versions differ, so a link that resolves in nightly may not resolve
+in an older release.
+
+Two caches will mislead you. Astro keeps rendered markdown in `web/.astro` **and**
+`web/node_modules/.astro`, so a change to the markdown pipeline can appear to do nothing — use
+`pnpm clean`. And `astro dev` and `astro preview` are daemons that outlive the shell and silently
+redirect to an existing instance instead of starting a new one, so a stale server can serve an old
+build long after a rebuild; use `pnpm stop`.
+
 ## Common Pitfalls
 
 1. Forgetting `cx.notify()` after state changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,6 +533,52 @@ A `pub use dbflux_ui_base::platform::*` shim remains at `crates/dbflux_ui/src/pl
 - The channel-aware DB path lives in `crates/dbflux_storage/src/paths.rs` (`dbflux_db_path`); nightly can opt into the stable DB via `set_nightly_shares_stable_db` / `nightly_shares_stable_db`.
 - Brand assets live under `resources/branding/{stable,nightly}/` (served per channel in `crates/dbflux_ui/src/assets.rs`). Packaging and Nix files substitute channel placeholders. The release/nightly flow is documented in `docs/RELEASE.md`.
 
+## Website
+
+The site lives in `web/` and is an Astro static build. It is not a crate: `cargo` excludes it, and
+the Rust workflows skip changes confined to it or to markdown.
+
+**It renders the repository's own documentation.** `docs/*.md`, the driver READMEs,
+`ARCHITECTURE.md` and `CONTRIBUTING.md` are read straight out of git at build time. There is no
+second copy, so a behaviour change and the paragraph describing it belong in the same commit, and
+editing a document is all that is needed to change the site.
+
+**It publishes several versions.** `web/versions.json` lists them; each entry is a git ref, and the
+product version shown for it is read from that ref's `Cargo.toml` rather than typed. The first
+entry is the current release and is served unprefixed at `/docs/`; the rest are served under their
+id (`/v0.6/docs/`, `/nightly/docs/`) and keep those URLs. Granularity is the minor series, not the
+patch, because a release branch takes cherry-picked fixes only.
+
+Rules that matter when touching documentation:
+
+- Write markdown that reads correctly on GitHub. Relative links between documents and labels that
+  name a file are rewritten to site routes at build time, so `[Settings](SETTINGS.md)` works in
+  both places.
+- Diagrams go in ```mermaid fences. They render as diagrams on the site; ASCII art does not.
+- Adding a document to `docs/` gives it a page automatically. Its place in the reading order is
+  declared in `web/src/data/nav.ts`; unlisted documents still get a page and appear under "Not yet
+  filed" on the documentation index.
+- Never send a reader to the repository for something the site renders. Link to the page.
+
+```bash
+cd web
+pnpm install
+pnpm dev          # local server
+pnpm build        # static output in web/dist
+pnpm check        # types — this is a real gate, not decoration
+pnpm format       # prettier
+```
+
+`web/scripts/check-links.mjs` runs in CI after the build and fails on an internal link that points
+at a page which is not built. Versions differ, so a link that resolves in nightly may not resolve
+in an older release.
+
+Two caches will mislead you. Astro keeps rendered markdown in `web/.astro` **and**
+`web/node_modules/.astro`, so a change to the markdown pipeline can appear to do nothing — use
+`pnpm clean`. And `astro dev` and `astro preview` are daemons that outlive the shell and silently
+redirect to an existing instance instead of starting a new one, so a stale server can serve an old
+build long after a rebuild; use `pnpm stop`.
+
 ## Common Pitfalls
 
 1. Forgetting `cx.notify()` after state changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ members = [
     "crates/dbflux_driver_s3",
 ]
 default-members = ["crates/dbflux"]
+# The website is not a crate. Excluding it keeps cargo from descending into it
+# when resolving paths or packaging.
+exclude = ["web"]
 resolver = "2"
 
 [workspace.package]
@@ -51,7 +54,8 @@ version = "0.8.0-dev.0"
 authors = ["Ignacio Perez <ignacio@feuer.me>"]
 description = "A fast, keyboard-first database client"
 repository = "https://github.com/0xErwin1/dbflux"
-homepage = "https://github.com/0xErwin1/dbflux"
+homepage = "https://dbflux.dev"
+documentation = "https://dbflux.dev/docs/"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An extensible, keyboard-first data platform delivered as a Rust + GPUI desktop client.
 
+**[dbflux.dev](https://dbflux.dev)** &middot; [Documentation](https://dbflux.dev/docs/) &middot; [Install](https://dbflux.dev/docs/install/)
+
 ## Overview
 
 DBFlux is an open-source desktop client with built-in drivers for relational and non-relational databases. Its core contracts are driver-neutral, and external drivers can integrate over RPC.
@@ -11,6 +13,10 @@ The client focuses on performance, a clean UX, and keyboard-first workflows. The
 ![DBFlux](resources/dbflux.png)
 
 ## Documentation
+
+Everything below is published at **[dbflux.dev/docs](https://dbflux.dev/docs/)**, rendered from
+these same files, with search and a version selector. The links here point at the source; read them
+on the site if you prefer.
 
 Choose the path that matches what you want to do.
 
@@ -236,6 +242,24 @@ Live integration tests (normally `#[ignore]`d) use a different flag under nextes
 ```bash
 cargo nextest run -p dbflux_driver_sqlite --run-ignored all
 ```
+
+### Website
+
+The site under `web/` is an Astro static build. It reads `docs/`, the driver READMEs,
+`ARCHITECTURE.md` and `CONTRIBUTING.md` out of git, one set per published version, so editing a
+document is all that is needed to change what the site shows.
+
+```bash
+cd web
+pnpm install
+pnpm dev          # local server
+pnpm build        # static output in web/dist
+pnpm check        # types
+pnpm format       # prettier
+```
+
+Which versions are published is declared in `web/versions.json`. Each entry names a git ref; the
+product version shown for it is read from that ref's `Cargo.toml`.
 
 ### Nix Development Shell
 

--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -3,25 +3,6 @@ import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import { routeForRepoPath, titleForRepoPath } from './src/data/nav';
-import { VERSIONS } from './src/data/versions';
-import { fetchDocs } from './scripts/fetch-docs.mjs';
-
-/**
- * Pull every published version's markdown out of git before anything reads it.
- *
- * Runs as an integration hook rather than a package script so dev and build take
- * the same path and the version registry stays in one place.
- */
-function docsVersions() {
-  return {
-    name: 'dbflux:docs-versions',
-    hooks: {
-      'astro:config:setup': () => {
-        fetchDocs(VERSIONS);
-      },
-    },
-  };
-}
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 
@@ -133,7 +114,7 @@ function rehypeMermaid() {
 
 export default defineConfig({
   site: 'https://dbflux.dev',
-  integrations: [docsVersions(), sitemap()],
+  integrations: [sitemap()],
   markdown: {
     rehypePlugins: [rehypeRepoLinks, rehypeMermaid],
     shikiConfig: {

--- a/web/package.json
+++ b/web/package.json
@@ -3,15 +3,16 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "astro dev",
-    "build": "astro build",
+    "dev": "pnpm run sync-docs && astro dev",
+    "build": "pnpm run sync-docs && astro build",
     "preview": "astro preview",
-    "check": "astro check",
+    "check": "pnpm run sync-docs && astro check",
     "clean": "rm -rf dist .astro node_modules/.astro node_modules/.vite",
     "rebuild": "pnpm clean && pnpm build",
     "stop": "astro dev stop; astro preview stop",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "sync-docs": "node scripts/fetch-docs.mjs"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.3",

--- a/web/scripts/fetch-docs.mjs
+++ b/web/scripts/fetch-docs.mjs
@@ -10,7 +10,7 @@
  * build: one unreachable branch should cost that version, not the whole site.
  */
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 const WEB = new URL('..', import.meta.url).pathname;
@@ -48,8 +48,25 @@ function readTree(ref) {
 }
 
 /**
+ * The product version a ref documents.
+ *
+ * `docs/RELEASE.md` names the workspace version in Cargo.toml as the source of
+ * truth and requires every other manifest to stay in lockstep, so it is the one
+ * place worth reading. Hard-coding these in the site is how the 0.6 entry ended
+ * up claiming a release that was never cut.
+ */
+function workspaceVersion(ref) {
+  const manifest = git(['show', `${ref}:Cargo.toml`]);
+  const match = manifest.match(/^version\s*=\s*"([^"]+)"/m);
+
+  if (!match) throw new Error(`No workspace version in ${ref}:Cargo.toml`);
+
+  return match[1];
+}
+
+/**
  * @param {ReadonlyArray<{ id: string, ref: string }>} versions
- * @returns {string[]} ids that were materialised
+ * @returns {Array<{ id: string, ref: string, version: string }>} what was materialised
  */
 export function fetchDocs(versions) {
   rmSync(VERSIONS_DIR, { recursive: true, force: true });
@@ -72,9 +89,13 @@ export function fetchDocs(versions) {
       writeFileSync(target, git(['show', `${ref}:${path}`]));
     }
 
-    console.log(`  docs: ${id} <- ${ref} (${files.length} files)`);
-    done.push(id);
+    const version = workspaceVersion(ref);
+
+    console.log(`  docs: ${id} <- ${ref} @ ${version} (${files.length} files)`);
+    done.push({ id, ref, version });
   }
+
+  writeFileSync(join(VERSIONS_DIR, 'manifest.json'), JSON.stringify(done, null, 2));
 
   if (done.length === 0) {
     throw new Error('No documentation version could be read. Is this a full clone?');
@@ -82,3 +103,7 @@ export function fetchDocs(versions) {
 
   return done;
 }
+
+const registry = JSON.parse(readFileSync(join(WEB, 'versions.json'), 'utf8'));
+
+fetchDocs(registry);

--- a/web/src/components/VersionPicker.astro
+++ b/web/src/components/VersionPicker.astro
@@ -2,7 +2,7 @@
 import { getCollection } from 'astro:content';
 import { pathsForVersion } from '../data/docs';
 import type { DocsVersion } from '../data/versions';
-import { CURRENT, VERSIONS, docsHref, versionHome } from '../data/versions';
+import { CURRENT, VERSIONS, docsHref, versionHome, versionLabel } from '../data/versions';
 
 interface Props {
   version: DocsVersion;
@@ -43,7 +43,7 @@ const targets = VERSIONS.map((candidate) => {
     data-version-toggle
   >
     <span class="picker__label">Version</span>
-    <span class="picker__value">{version.label}</span>
+    <span class="picker__value">{versionLabel(version)}</span>
     <svg
       width="11"
       height="11"
@@ -67,7 +67,7 @@ const targets = VERSIONS.map((candidate) => {
             aria-current={target.version.id === version.id ? 'true' : undefined}
             data-version-link={target.version.id}
           >
-            <span>{target.version.label}</span>
+            <span>{versionLabel(target.version)}</span>
             {!target.exact && target.version.id !== version.id && (
               <span class="picker__tag" title="This page does not exist in that version">
                 index

--- a/web/src/data/versions.ts
+++ b/web/src/data/versions.ts
@@ -1,8 +1,11 @@
+// Vite inlines this at build time. Reading it with `fs` instead breaks once the
+// module is bundled, because the relative path no longer points at the file.
+import registry from '../../versions.json';
+import manifest from '../../.versions/manifest.json';
+
 export interface DocsVersion {
   /** Directory name under `.versions/`, and the URL prefix for non-current versions. */
   readonly id: string;
-  /** What the selector shows. */
-  readonly label: string;
   /**
    * Git ref the documentation is read from.
    *
@@ -11,8 +14,6 @@ export interface DocsVersion {
    * a deleted branch breaks the next build.
    */
   readonly ref: string;
-  /** Product version this documents, shown on the page and in the hero. */
-  readonly version: string;
   /** Excluded from search engines. Nightly documents behaviour nobody is running yet. */
   readonly noindex?: boolean;
 }
@@ -27,14 +28,30 @@ export interface DocsVersion {
  * The first entry is the current release. It is served unprefixed at `/docs/`,
  * so a link to `/docs/usage/` always means "whatever is current". Every other
  * entry is served under its id and keeps that URL for good.
+ *
+ * Note what is *not* here: the product version. It is read from each ref's
+ * Cargo.toml at build time, because a number typed here is a number that goes
+ * quietly wrong at the next release.
  */
-export const VERSIONS: readonly DocsVersion[] = [
-  { id: 'v0.7', label: '0.7 — current', ref: 'release/v0.7', version: '0.7.7' },
-  { id: 'nightly', label: 'nightly', ref: 'main', version: 'main', noindex: true },
-  { id: 'v0.6', label: '0.6', ref: 'release/v0.6', version: '0.6.4' },
-];
+export const VERSIONS: readonly DocsVersion[] = registry;
 
 export const CURRENT = VERSIONS[0];
+
+/** The product version a documentation set describes, from its own Cargo.toml. */
+export function productVersion(id: string): string {
+  const entry = manifest.find((candidate) => candidate.id === id);
+
+  if (!entry) throw new Error(`No materialised documentation for version "${id}"`);
+
+  return entry.version;
+}
+
+/** What the version selector and page titles show. */
+export function versionLabel(version: DocsVersion): string {
+  if (version.id === 'nightly') return 'nightly';
+
+  return version.id.replace(/^v/, '');
+}
 
 export const versionById = (id: string): DocsVersion | undefined =>
   VERSIONS.find((version) => version.id === id);

--- a/web/src/layouts/DocsLayout.astro
+++ b/web/src/layouts/DocsLayout.astro
@@ -4,7 +4,7 @@ import DocsTree from '../components/DocsTree.astro';
 import VersionPicker from '../components/VersionPicker.astro';
 import { docTitle } from '../data/nav';
 import type { DocsVersion } from '../data/versions';
-import { CURRENT, versionHome } from '../data/versions';
+import { CURRENT, versionHome, versionLabel } from '../data/versions';
 
 interface Heading {
   depth: number;
@@ -35,7 +35,7 @@ const {
 const onThisPage = headings.filter((heading) => heading.depth === 2);
 
 const isCurrent = version.id === CURRENT.id;
-const suffix = isCurrent ? '' : ` (${version.label})`;
+const suffix = isCurrent ? '' : ` (${versionLabel(version)})`;
 
 /**
  * Older and unreleased versions point at the current release, so a search engine

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -1,6 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
-import { CURRENT, VERSIONS } from '../data/versions';
+import { CURRENT, VERSIONS, versionLabel } from '../data/versions';
 
 /**
  * Versions come and go, so a link that worked against one release can land here
@@ -31,7 +31,7 @@ const versions = VERSIONS;
           <>
             {index > 0 && <span aria-hidden="true"> &middot; </span>}
             <a href={version.id === CURRENT.id ? '/docs/' : `/${version.id}/docs/`}>
-              {version.label}
+              {versionLabel(version)}
             </a>
           </>
         ))

--- a/web/src/pages/[version]/docs/[...slug].astro
+++ b/web/src/pages/[version]/docs/[...slug].astro
@@ -2,7 +2,7 @@
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '../../../layouts/DocsLayout.astro';
 import { docTitle, pathsForVersion, splitId } from '../../../data/docs';
-import { CURRENT, VERSIONS, versionById } from '../../../data/versions';
+import { CURRENT, VERSIONS, versionById, versionLabel } from '../../../data/versions';
 
 export async function getStaticPaths() {
   const docs = await getCollection('docs');
@@ -32,7 +32,7 @@ const firstParagraph = doc.body
   .find((block) => block.length > 0 && !block.startsWith('#'));
 const description = firstParagraph
   ? firstParagraph.replace(/\s+/g, ' ').slice(0, 180)
-  : `${title} — DBFlux ${version.label} documentation.`;
+  : `${title} — DBFlux ${versionLabel(version)} documentation.`;
 ---
 
 <DocsLayout

--- a/web/src/pages/[version]/docs/index.astro
+++ b/web/src/pages/[version]/docs/index.astro
@@ -3,7 +3,7 @@ import { getCollection } from 'astro:content';
 import DocsLayout from '../../../layouts/DocsLayout.astro';
 import DocsIndex from '../../../components/DocsIndex.astro';
 import { pathsForVersion } from '../../../data/docs';
-import { CURRENT, VERSIONS, versionById } from '../../../data/versions';
+import { CURRENT, VERSIONS, versionById, versionLabel } from '../../../data/versions';
 
 export async function getStaticPaths() {
   return VERSIONS.filter((version) => version.id !== CURRENT.id).map((version) => ({
@@ -20,7 +20,7 @@ const available = pathsForVersion(docs, version.id);
   version={version}
   available={available}
   title="Documentation"
-  description={`DBFlux ${version.label} documentation.`}
+  description={`DBFlux ${versionLabel(version)} documentation.`}
 >
   <DocsIndex versionId={version.id} available={available} />
 </DocsLayout>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -3,7 +3,7 @@ import Base from '../layouts/Base.astro';
 import Icon from '../components/Icon.astro';
 import InstallTabs from '../components/InstallTabs.astro';
 import { REPO } from '../data/nav';
-import { CURRENT } from '../data/versions';
+import { CURRENT, productVersion } from '../data/versions';
 
 const DRIVERS = [
   'PostgreSQL',
@@ -87,7 +87,7 @@ const DOC_CARDS = [
 >
   <section class="hero shell">
     <div class="hero__copy">
-      <p class="eyebrow">Rust &middot; GPUI &middot; v{CURRENT.version}</p>
+      <p class="eyebrow">Rust &middot; GPUI &middot; v{productVersion(CURRENT.id)}</p>
       <h1>Every database you run, in one keyboard-driven window.</h1>
       <p class="hero__lede">
         An extensible, keyboard-first data platform. Twelve built-in drivers, a driver-neutral core,

--- a/web/versions.json
+++ b/web/versions.json
@@ -1,0 +1,5 @@
+[
+  { "id": "v0.7", "ref": "release/v0.7" },
+  { "id": "nightly", "ref": "main", "noindex": true },
+  { "id": "v0.6", "ref": "release/v0.6" }
+]


### PR DESCRIPTION
## Summary

The site's version registry carried product version numbers as literals, and one
was wrong from the day it was written: `0.6.4`, for a minor whose workspace
version is `0.6.0` and whose only tags are `v0.6.0-dev.*` prereleases. It never
reached a rendered page — the number is only used in the hero, for the current
release — but it was a fabricated fact sitting in the tree, and the next release
would have made the correct ones wrong too.

Also updates the repository to acknowledge the site now that it is live.

## What does this resolve?

No issue; found while answering whether the version was still hardcoded after
#340 shipped.

## How was this solved?

`docs/RELEASE.md` names the workspace version in `Cargo.toml` as the source of
truth. The fetch step already visits every published ref to pull its markdown,
so it reads that manifest while it is there and writes `.versions/manifest.json`.
The site imports it.

What is left to declare is only what is genuinely editorial:

```json
[
  { "id": "v0.7", "ref": "release/v0.7" },
  { "id": "nightly", "ref": "main", "noindex": true },
  { "id": "v0.6", "ref": "release/v0.6" }
]
```

The label is derived from the id too, so "current" is positional and cannot
disagree with which entry is actually first.

Ordering became explicit along the way. `build`, `dev` and `check` now run the
fetch themselves instead of relying on an Astro integration hook firing before
module resolution — it does not for `astro check`, which failed outright on a
clean checkout.

### Repository changes

- `Cargo.toml`: `homepage` and `documentation` point at the site, and `web` is
  excluded from the workspace since it is not a crate.
- `README.md`: leads with the site, notes that the documentation section is
  published there, and documents how to run and build it.
- `AGENTS.md` and `CLAUDE.md`: a Website section covering how documentation
  reaches the site, what markdown has to satisfy to render correctly in both
  places, where versions are declared, and the two caches and the daemon that
  will otherwise cost someone an afternoon.

## Validation

- `pnpm check` — 0 errors, 0 warnings, 0 hints, from a clean checkout with no
  `.versions/` present.
- `pnpm format:check` — clean.
- `pnpm build` — 94 pages. Reported versions: 0.7 → 0.7.7, 0.6 → 0.6.0,
  nightly → 0.8.0-dev.0, each read from its own ref.
- `node scripts/check-links.mjs` — every internal link resolves.
- `cargo metadata --no-deps` — the workspace still resolves.

`astro check` earned itself here: it caught a `REPO_ROOT` I had deleted while
restructuring, which the build did not notice because it was reusing a cached
content store and never re-ran the markdown pipeline.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels

## Follow-up

`docs/INSTALL.md` exists only on `main`, so `/docs/install/` is absent from the
current release's documentation and present in nightly. A cherry-pick to
`release/v0.7` would fix it and fits that branch's rules, but touching a release
branch is not something to do inside this PR.