### PR TITLE
feat(web): lead the version selector with nightly, and show the build

### DIFF
--- a/web/scripts/fetch-docs.mjs
+++ b/web/scripts/fetch-docs.mjs
@@ -65,6 +65,19 @@ function workspaceVersion(ref) {
 }
 
 /**
+ * What the documentation was built from.
+ *
+ * The version number alone does not identify a moving target: nightly reports
+ * the same `-dev` number for months, and a release branch keeps its number
+ * across cherry-picked fixes.
+ */
+function buildOf(ref) {
+  const [commit, date] = git(['show', '-s', '--format=%h%n%cs', ref]).trim().split('\n');
+
+  return { commit, date };
+}
+
+/**
  * @param {ReadonlyArray<{ id: string, ref: string }>} versions
  * @returns {Array<{ id: string, ref: string, version: string }>} what was materialised
  */
@@ -90,9 +103,10 @@ export function fetchDocs(versions) {
     }
 
     const version = workspaceVersion(ref);
+    const { commit, date } = buildOf(ref);
 
-    console.log(`  docs: ${id} <- ${ref} @ ${version} (${files.length} files)`);
-    done.push({ id, ref, version });
+    console.log(`  docs: ${id} <- ${ref} @ ${version} (${commit}, ${files.length} files)`);
+    done.push({ id, ref, version, commit, date });
   }
 
   writeFileSync(join(VERSIONS_DIR, 'manifest.json'), JSON.stringify(done, null, 2));

--- a/web/src/components/VersionPicker.astro
+++ b/web/src/components/VersionPicker.astro
@@ -2,7 +2,14 @@
 import { getCollection } from 'astro:content';
 import { pathsForVersion } from '../data/docs';
 import type { DocsVersion } from '../data/versions';
-import { CURRENT, VERSIONS, docsHref, versionHome, versionLabel } from '../data/versions';
+import {
+  CURRENT,
+  VERSIONS,
+  buildInfo,
+  docsHref,
+  versionHome,
+  versionLabel,
+} from '../data/versions';
 
 interface Props {
   version: DocsVersion;
@@ -13,6 +20,7 @@ interface Props {
 const { version, currentPath } = Astro.props;
 
 const entries = await getCollection('docs');
+const build = buildInfo(version.id);
 
 /**
  * Switching version keeps the reader on the same page where that page exists,
@@ -57,6 +65,14 @@ const targets = VERSIONS.map((candidate) => {
       <path d="M5 9l7 7 7-7"></path>
     </svg>
   </button>
+
+  <p class="picker__build">
+    <span>{build.version}</span>
+    <span aria-hidden="true">&middot;</span>
+    <code>{build.commit}</code>
+    <span aria-hidden="true">&middot;</span>
+    <time datetime={build.date}>{build.date}</time>
+  </p>
 
   <ul class="picker__menu" id="version-menu" hidden>
     {
@@ -129,6 +145,20 @@ const targets = VERSIONS.map((candidate) => {
 
   .picker__button[aria-expanded='true'] svg {
     transform: rotate(180deg);
+  }
+
+  .picker__build {
+    display: flex;
+    gap: var(--s-2);
+    margin: var(--s-2) 0 0;
+    font-family: var(--font-mono);
+    font-size: var(--fs-label);
+    color: var(--text-muted);
+  }
+
+  .picker__build code {
+    font-size: inherit;
+    color: var(--text);
   }
 
   .picker__menu {

--- a/web/src/data/versions.ts
+++ b/web/src/data/versions.ts
@@ -16,6 +16,14 @@ export interface DocsVersion {
   readonly ref: string;
   /** Excluded from search engines. Nightly documents behaviour nobody is running yet. */
   readonly noindex?: boolean;
+  /**
+   * The release served unprefixed at `/docs/`.
+   *
+   * Separate from list order on purpose: the list is what the selector shows,
+   * newest first, and nightly leads it. Making position decide which release is
+   * current would have put unreleased documentation at `/docs/`.
+   */
+  readonly current?: boolean;
 }
 
 /**
@@ -25,9 +33,11 @@ export interface DocsVersion {
  * cherry-picked fixes only, so a documentation change between two patches is a
  * correction — someone on X.Y.7 should read it, not be pinned to the wrong text.
  *
- * The first entry is the current release. It is served unprefixed at `/docs/`,
- * so a link to `/docs/usage/` always means "whatever is current". Every other
- * entry is served under its id and keeps that URL for good.
+ * Order is what the version selector shows, newest first. Which entry is the
+ * current release is the `current` flag, not the position: that release is
+ * served unprefixed at `/docs/`, so a link to `/docs/usage/` always means
+ * "whatever is current". Every other entry is served under its id and keeps
+ * that URL for good.
  *
  * Note what is *not* here: the product version. It is read from each ref's
  * Cargo.toml at build time, because a number typed here is a number that goes
@@ -35,15 +45,41 @@ export interface DocsVersion {
  */
 export const VERSIONS: readonly DocsVersion[] = registry;
 
-export const CURRENT = VERSIONS[0];
+export const CURRENT = VERSIONS.find((version) => version.current) ?? VERSIONS[0];
 
-/** The product version a documentation set describes, from its own Cargo.toml. */
-export function productVersion(id: string): string {
-  const entry = manifest.find((candidate) => candidate.id === id);
+/** One record written by `scripts/fetch-docs.mjs` while it pulls that ref. */
+interface ManifestEntry {
+  id: string;
+  ref: string;
+  version: string;
+  commit: string;
+  date: string;
+}
+
+function entryFor(id: string): ManifestEntry {
+  const entry = (manifest as ManifestEntry[]).find((candidate) => candidate.id === id);
 
   if (!entry) throw new Error(`No materialised documentation for version "${id}"`);
 
-  return entry.version;
+  return entry;
+}
+
+/** The product version a documentation set describes, from its own Cargo.toml. */
+export function productVersion(id: string): string {
+  return entryFor(id).version;
+}
+
+/**
+ * What exactly this documentation was built from.
+ *
+ * A version number is not enough to identify a moving target: nightly reports
+ * `0.8.0-dev.0` for months, and a release branch keeps its number across
+ * cherry-picked fixes. The commit says which one you are reading.
+ */
+export function buildInfo(id: string): { version: string; commit: string; date: string } {
+  const entry = entryFor(id);
+
+  return { version: entry.version, commit: entry.commit, date: entry.date };
 }
 
 /** What the version selector and page titles show. */

--- a/web/versions.json
+++ b/web/versions.json
@@ -1,5 +1,5 @@
 [
-  { "id": "v0.7", "ref": "release/v0.7" },
   { "id": "nightly", "ref": "main", "noindex": true },
+  { "id": "v0.7", "ref": "release/v0.7", "current": true },
   { "id": "v0.6", "ref": "release/v0.6" }
 ]


### PR DESCRIPTION
## Summary

Two changes to the documentation version selector.

**Nightly leads the list.** It is the most current documentation, so it belongs
first.

**Each version shows what it was built from**: version, short commit, and date.

## What does this resolve?

Reported directly: the selector should read nightly, 0.7, 0.6.

## How was this solved?

The list order and the default release were the same thing — `VERSIONS[0]` was
both the first menu entry and the release served unprefixed at `/docs/`.
Reordering alone would have published nightly's documentation as the site's
default, which is the opposite of what anyone wants. They are separate now: the
array is display order, and a `current` flag names the default.

The build line comes from the fetch step, which already visits every ref. It
records the short commit and commit date beside the version it was already
reading from `Cargo.toml`.

## Validation

- `pnpm check` — 0 errors, 0 warnings, 0 hints.
- `pnpm format:check` — clean.
- `pnpm build` — 94 pages; `/docs/` still renders 0.7, `/nightly/docs/` and
  `/v0.6/docs/` unchanged.
- `node scripts/check-links.mjs` — every internal link resolves.
- Verified in the browser: the menu reads nightly, 0.7 (marked default), 0.6,
  and the rail shows `0.7.7 · 6f775938 · 2026-08-18`.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland