### PR TITLE
chore(web): add the deploy configuration for the documentation host

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,9 @@
     "sync-docs": "node scripts/fetch-docs.mjs",
     "build:site": "DOCS_MODE=site pnpm run build",
     "build:docs": "DOCS_MODE=docs pnpm run build",
-    "dev:docs": "DOCS_MODE=docs pnpm run dev"
+    "dev:docs": "DOCS_MODE=docs pnpm run dev",
+    "deploy:site": "pnpm run build:site && wrangler deploy",
+    "deploy:docs": "pnpm run build:docs && wrangler deploy --config wrangler.docs.jsonc"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.3",

--- a/web/wrangler.docs.jsonc
+++ b/web/wrangler.docs.jsonc
@@ -1,0 +1,15 @@
+{
+  // Deploy configuration for the documentation host.
+  //
+  // Identical to `wrangler.jsonc` apart from the name: two Workers cannot share
+  // one, and the deployments are independent. Pair it with `pnpm build:docs`,
+  // which puts the documentation at the root rather than under `/docs`.
+  //
+  //   wrangler deploy --config wrangler.docs.jsonc
+  "name": "dbflux-docs",
+  "compatibility_date": "2026-08-19",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "404-page",
+  },
+}

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -9,6 +9,9 @@
   // generated file derived the Worker name from the npm package name, and a
   // scoped name is rejected: Worker names are lowercase alphanumeric with
   // dashes, so `@dbflux/web` failed the deploy.
+  //
+  // `wrangler.docs.jsonc` is the same thing for the documentation host, used
+  // when DOCS_MODE splits the site across two origins.
   "name": "dbflux-web",
   "compatibility_date": "2026-08-19",
   "assets": {


### PR DESCRIPTION
## Summary

Adds `web/wrangler.docs.jsonc` and the two deploy scripts, so publishing the
documentation on its own host is dashboard configuration rather than a repository
change.

## What does this resolve?

Follow-up to #344, which added `DOCS_MODE` but left the deployment side with a
single Worker configuration. Two Workers cannot share a name, so the second
project had nothing valid to build against.

## How was this solved?

`wrangler.docs.jsonc` is `wrangler.jsonc` with `name: dbflux-docs`, paired with
`pnpm build:docs`. Two scripts spell the combinations out:

```
deploy:site   pnpm run build:site && wrangler deploy
deploy:docs   pnpm run build:docs && wrangler deploy --config wrangler.docs.jsonc
```

Nothing changes until a second project is pointed at it. The existing project
has no `DOCS_MODE` set, so it keeps building everything on one origin.

## Validation

- `pnpm build:docs` — documentation index at `/`, `/usage/` present.
- `pnpm build` (default) — 95 pages, every internal link resolves.
- Both wrangler configs parse and name different Workers against the same
  `./dist`.

Not validated: the deploy itself, which needs the second Cloudflare project.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels