### PR TITLE
fix(web): point the canonical at a page that exists

### DIFF
--- a/web/src/layouts/DocsLayout.astro
+++ b/web/src/layouts/DocsLayout.astro
@@ -5,6 +5,7 @@ import VersionPicker from '../components/VersionPicker.astro';
 import { docTitle } from '../data/nav';
 import type { DocsVersion } from '../data/versions';
 import { CURRENT, versionHome, versionLabel } from '../data/versions';
+import { docsUrl } from '../data/site';
 
 interface Heading {
   depth: number;
@@ -41,7 +42,7 @@ const suffix = isCurrent ? '' : ` (${versionLabel(version)})`;
  * Older and unreleased versions point at the current release, so a search engine
  * ranks the version most readers are running rather than whichever it crawled.
  */
-const canonicalPath = isCurrent ? undefined : currentPath ? `/docs/${currentPath}/` : '/docs/';
+const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '');
 ---
 
 <Base


### PR DESCRIPTION
## Summary

Older and unreleased documentation pages declare a canonical that 404s on the
documentation host.

Live right now:

```
docs.dbflux.dev/nightly/usage/  canonical -> docs.dbflux.dev/docs/usage/   404
docs.dbflux.dev/v0.6/usage/     canonical -> docs.dbflux.dev/docs/usage/   404
```

## What does this resolve?

A miss in #344. Every documentation link moved to `docsUrl()`; this one path was
still written by hand:

```js
const canonicalPath = isCurrent ? undefined : currentPath ? `/docs/${currentPath}/` : '/docs/';
```

`/docs/` exists only while the documentation shares the site's origin. On its own
host it does not, so the canonical points nowhere. Pointing search engines at a
missing page is worse than having no canonical at all: the signal that says "rank
the current release instead of this one" is the one that broke.

## How was this solved?

The canonical is built by the same helper as every other documentation link, so
it follows the deployment rather than restating it.

## Validation

- `docs` mode — `/v0.6/usage/` and `/nightly/usage/` both canonical to
  `https://docs.dbflux.dev/usage/`, which is a page that exists in that build.
- `embedded` mode — canonical to `https://dbflux.dev/docs/usage/`, unchanged.
- `pnpm check` clean, 95 pages, every internal link resolves.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels

## Follow-up worth considering

The link checker only sees same-origin links inside one build, so it could not
catch this. A check that resolves declared canonicals against the pages the build
emits would have.