### PR TITLE
fix(web): accessibility defects from the Lighthouse run, and a security.txt

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Report privately through GitHub Security Advisories:
+
+**https://github.com/0xErwin1/dbflux/security/advisories/new**
+
+Please do not open a public issue for a suspected vulnerability. A report is more
+useful with the DBFlux version, the platform, the driver involved when there is
+one, and the smallest set of steps that reproduces it.
+
+Machine-readable contact details are published at
+[`/.well-known/security.txt`](https://dbflux.dev/.well-known/security.txt).
+
+## Supported versions
+
+Fixes land on the current release branch. DBFlux develops on `main` and cuts a
+`release/vX.Y` branch per minor, which receives cherry-picked fixes until it
+reaches end of life; older minors do not. See [the release
+process](docs/RELEASE.md) for how the branches and channels work.
+
+If you are running an older minor, the answer to a security report will be to
+upgrade to the current one.
+
+## Known limitations, by design
+
+These are documented behaviours rather than vulnerabilities. A report about them
+is welcome as a design discussion, but they are not treated as an undisclosed
+risk.
+
+- **MCP authentication is process identity only.** Presenting `--client-id` is
+  the sole authentication signal, so any local process that knows the client id
+  can connect. It is not a cryptographic guarantee, and the MCP server should not
+  be exposed beyond localhost without an additional authentication layer. See
+  [AI + MCP integration](docs/MCP_AI_INTEGRATION.md).
+- **Connection hooks and Lua scripts run code you configured.** They execute with
+  the privileges of the DBFlux process by design; that is what a hook is. See
+  [Settings and hooks](docs/SETTINGS.md) and [Lua scripting](docs/LUA.md).
+- **The audit log is local.** It records what happened on that machine and is
+  readable by anything that can read your data directory. See [data and
+  privacy](docs/DATA_AND_PRIVACY.md).
+
+## Where secrets live
+
+Credentials are held in the operating system keyring, never in a connection
+profile file, and the audit log stores a fingerprint of query text rather than
+the text itself. [Data and privacy](docs/DATA_AND_PRIVACY.md) describes what is
+written where, and how to inspect or remove it.

--- a/web/public/.well-known/security.txt
+++ b/web/public/.well-known/security.txt
@@ -1,0 +1,9 @@
+# Reporting a security problem in DBFlux.
+# https://www.rfc-editor.org/rfc/rfc9116
+
+Contact: https://github.com/0xErwin1/dbflux/security/advisories/new
+Expires: 2027-08-19T00:00:00.000Z
+Preferred-Languages: en, es
+Canonical: https://dbflux.dev/.well-known/security.txt
+Canonical: https://docs.dbflux.dev/.well-known/security.txt
+Policy: https://github.com/0xErwin1/dbflux/blob/main/SECURITY.md

--- a/web/src/components/DocsTree.astro
+++ b/web/src/components/DocsTree.astro
@@ -158,10 +158,12 @@ const sections = sectionsFor(available).sections.map((section) => ({
     color: var(--text-strong);
   }
 
+  /* This is a count, not an ornament: it has to be readable. --border is a
+     separator colour at 1.25:1 and was never a text colour. */
   .tree__count {
     font-family: var(--font-mono);
     font-size: var(--fs-label);
-    color: var(--border);
+    color: var(--text-muted);
   }
 
   @keyframes unfurl {

--- a/web/src/components/InstallTabs.astro
+++ b/web/src/components/InstallTabs.astro
@@ -93,20 +93,22 @@ const PLATFORMS = [
 ---
 
 <div class="install" data-install>
-  <div class="install__platforms" role="tablist" aria-label="Platform">
-    {
-      PLATFORMS.map((platform, index) => (
-        <button
-          type="button"
-          role="tab"
-          aria-selected={index === 0 ? 'true' : 'false'}
-          tabindex={index === 0 ? 0 : -1}
-          data-platform-tab={platform.id}
-        >
-          {platform.label}
-        </button>
-      ))
-    }
+  <div class="install__head">
+    <div class="install__platforms" role="tablist" aria-label="Platform">
+      {
+        PLATFORMS.map((platform, index) => (
+          <button
+            type="button"
+            role="tab"
+            aria-selected={index === 0 ? 'true' : 'false'}
+            tabindex={index === 0 ? 0 : -1}
+            data-platform-tab={platform.id}
+          >
+            {platform.label}
+          </button>
+        ))
+      }
+    </div>
     <a class="install__releases" href={RELEASES} rel="noopener">All downloads &rarr;</a>
   </div>
 
@@ -160,15 +162,21 @@ const PLATFORMS = [
     border: var(--bw) solid var(--border);
   }
 
+  .install__head {
+    display: flex;
+    align-items: stretch;
+    background: var(--bg);
+    border-bottom: var(--bw) solid var(--border);
+  }
+
   .install__platforms,
   .install__methods {
     display: flex;
-    border-bottom: var(--bw) solid var(--border);
     overflow-x: auto;
   }
 
-  .install__platforms {
-    background: var(--bg);
+  .install__methods {
+    border-bottom: var(--bw) solid var(--border);
   }
 
   .install__platforms button,

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -43,6 +43,19 @@ a:hover {
   text-decoration: underline;
 }
 
+/*
+ * A link sitting inside a run of text is underlined from the start. Colour alone
+ * does not identify it for a reader who cannot separate the two hues, and every
+ * link in prose or in a breadcrumb is exactly that case. Links that are their
+ * own block — navigation items, cards, buttons — are identifiable by position
+ * and are left alone.
+ */
+.prose a,
+.crumbs a {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
 img {
   max-width: 100%;
   display: block;


### PR DESCRIPTION
## Summary

Fixes the three accessibility defects the Lighthouse run found that are actually
ours, and adds `/.well-known/security.txt` with the policy it points at.

Scores from the run: dbflux.dev 69 / 95 / 77 / 100, docs.dbflux.dev 81 / 92 / 77
/ 100 (performance / accessibility / best practices / SEO).

## What does this resolve?

A Lighthouse audit of both hosts.

## How was this solved?

**Contrast, on the documentation rail.** The group counts were `--border`, which
measures 1.25:1 against the page. That token is a separator colour and was never
a text colour; a count is information, not an ornament. Now `--text-muted`, 5.75:1.

**A tablist containing something that is not a tab.** The "All downloads" link
sat inside `role="tablist"` on the install strip, which breaks the accessibility
tree — a tablist may only contain tabs. It moves to a header row beside the tab
list, which is where it already appeared to be.

**Links identified by colour alone.** A link inside a run of text was blue and
nothing else, so a reader who cannot separate the two hues cannot find it. Links
in prose and in the breadcrumb are underlined from the start. Links that are
their own block — navigation, cards, buttons — are left alone, because position
already identifies them.

**security.txt.** RFC 9116, at `/.well-known/security.txt` on both hosts, with a
`SECURITY.md` behind its `Policy` field rather than a link to a page that does
not exist. The policy names where reports go, which versions receive fixes under
the existing release model, and three behaviours that are design decisions
rather than undisclosed risk — chiefly that MCP authentication is process
identity only, which `CLAUDE.md` already states and which a researcher would
otherwise report as a finding.

## What was not fixed, and why

Both hosts score 77 on best practices for two audits, and neither is our code:

- The logged console error is `static.cloudflareinsights.com/beacon.min.js`
  failing with `ERR_BLOCKED_BY_CLIENT` — Cloudflare's analytics beacon, injected
  by the platform and blocked by an extension in the browser that ran the audit.
- The deprecated API is `StorageType.persistent` inside
  `/cdn-cgi/challenge-platform/scripts/jsd/main.js`, Cloudflare's bot detection.

Turning off Web Analytics in the dashboard removes the first. The second is not
removable while the platform serves the site.

## Performance, for a later pass

Left alone here because it is a different kind of work and needs measurement
rather than guesses:

- `Use efficient cache lifetimes` is a Cloudflare headers question, not a build
  one. The font files have stable names, so they want a long lifetime and a
  rename on change.
- `Reduce unused JavaScript` and `Minify JavaScript` want checking against the
  bundle before touching anything; mermaid is the obvious suspect on
  documentation pages and is already loaded only where a diagram exists.

## Validation

- `pnpm check`, `pnpm format:check` clean; 95 pages; every internal link
  resolves.
- Built in `docs` mode as well: `security.txt` is served from both hosts.
- Contrast recomputed: 1.25:1 → 5.75:1.

Not validated: a fresh Lighthouse run, which needs the deploy.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels

## One maintenance note

`security.txt` carries `Expires: 2027-08-19`. The RFC requires the field and
clients are expected to distrust the file past that date, so it needs renewing
within the year.