### PR TITLE
fix(web): give static assets a cache lifetime

### DIFF
--- a/web/public/_headers
+++ b/web/public/_headers
@@ -1,0 +1,29 @@
+# Cache lifetimes for both hosts.
+#
+# Workers Static Assets serves everything with `max-age=0, must-revalidate` by
+# default, so a returning reader revalidates every stylesheet, script and font
+# on every visit. The zone's Browser Cache TTL does not fix this: no zone-level
+# cache configuration applies to a Worker's responses, which makes this file the
+# only place the lifetimes can be set.
+#
+# HTML is deliberately absent. It keeps the revalidating default so a deploy is
+# visible immediately.
+
+# Astro puts a content hash in these filenames, so a changed file is a changed
+# URL and the old one is never asked for again.
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Self-hosted font files. Their names carry no hash, so `immutable` is a promise
+# this repository has to keep: replacing a face means giving the file a new name,
+# not overwriting it.
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Brand and screenshots. Unhashed and genuinely replaceable — the social card and
+# the hero are edited in place — so these get a day rather than a year.
+/brand/*
+  Cache-Control: public, max-age=86400
+
+/img/*
+  Cache-Control: public, max-age=86400


### PR DESCRIPTION
## What

Every asset on both hosts is served with `max-age=0, must-revalidate`:

```
$ curl -sSI https://dbflux.dev/_astro/Base.CSAPicRD.css | grep cache-control
cache-control: public, max-age=0, must-revalidate

$ curl -sSI https://dbflux.dev/fonts/ibm-plex-sans-latin-400-normal.woff2 | grep cache-control
cache-control: public, max-age=0, must-revalidate
```

That is the Workers Static Assets default, and it means a returning reader revalidates every stylesheet, script and font on each visit — including `Base.CSAPicRD.css`, whose filename already contains a content hash and therefore can never change under that URL. It is the `Use efficient cache lifetimes` item in the Lighthouse run.

The zone's Browser Cache TTL (4 hours) does not correct it: [no zone-level cache configuration applies to a Worker's responses](https://developers.cloudflare.com/workers/cache/), which leaves `_headers` as the only place these lifetimes can be set.

## Choices

| Path | Lifetime | Why |
|---|---|---|
| `/_astro/*` | 1 year, `immutable` | Astro puts a content hash in the filename. A changed file is a changed URL. |
| `/fonts/*` | 1 year, `immutable` | Effectively frozen — but the names carry no hash, so `immutable` is a promise this repo has to keep: replacing a face means renaming the file, not overwriting it. That is written in the file. |
| `/brand/*`, `/img/*` | 1 day | The social card and the hero screenshot are genuinely edited in place under a stable name. |
| HTML | unchanged | Deliberately absent, so a deploy is visible immediately. |

## Verified

`pnpm build` emits `dist/_headers` intact (Astro copies `public/` verbatim, underscore prefix included), and `pnpm format:check` is clean. The headers themselves can only be confirmed once deployed — same as `_redirects` in #348 — so I will check the live responses after merge.