### PR TITLE
feat(i18n): UI language setting with English and Spanish catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to DBFlux will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+* **UI language setting (#360)** — Settings → General gains a Language
+  control with System, English, and Spanish. System follows the OS locale
+  and falls back to English when that locale is not supported; the choice
+  is persisted and applied on the next start, and the control shows a
+  permanent note saying so. This release translates the General section
+  only; the rest of the interface stays in English and is converted crate
+  by crate in follow-up changes. Database terms (query, schema, WHERE, …)
+  stay in English inside Spanish text. The catalogs live in
+  `crates/dbflux_i18n/locales/{en,es}.yml`, one file per locale, so a
+  translation platform can consume them later.
+
 ## [0.7.0] - 2026-07-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3315,6 +3315,7 @@ dependencies = [
  "dbflux_app",
  "dbflux_components",
  "dbflux_core",
+ "dbflux_i18n",
  "dbflux_mcp",
  "dbflux_policy",
  "dbflux_portability",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,6 +2609,7 @@ dependencies = [
  "dbflux_audit",
  "dbflux_core",
  "dbflux_driver_ipc",
+ "dbflux_i18n",
  "dbflux_ipc",
  "dbflux_ssh",
  "dbflux_test_support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2999,6 +2999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbflux_i18n"
+version = "0.8.0-dev.0"
+dependencies = [
+ "rust-i18n",
+ "serde_yaml",
+ "sys-locale",
+]
+
+[[package]]
 name = "dbflux_ipc"
 version = "0.8.0-dev.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "crates/dbflux_driver_influxdb",
     "crates/dbflux_portability",
     "crates/dbflux_driver_s3",
+    "crates/dbflux_i18n",
 ]
 default-members = ["crates/dbflux"]
 # The website is not a crate. Excluding it keeps cargo from descending into it
@@ -97,6 +98,7 @@ dbflux_ui_windows = { path = "crates/dbflux_ui_windows" }
 dbflux_ui_sidebar = { path = "crates/dbflux_ui_sidebar" }
 dbflux_ui = { path = "crates/dbflux_ui" }
 dbflux_transfer = { path = "crates/dbflux_transfer" }
+dbflux_i18n = { path = "crates/dbflux_i18n" }
 mysql = "28"
 
 gpui = "0.2.2"
@@ -149,6 +151,9 @@ sha2 = "0.11"
 interprocess = "2.4"
 mlua = "0.11"
 indexmap = "2"
+rust-i18n = "3.1"
+sys-locale = "0.3"
+serde_yaml = "0.9"
 
 [workspace.lints.rust]
 unsafe_code = "warn"

--- a/crates/dbflux/Cargo.toml
+++ b/crates/dbflux/Cargo.toml
@@ -18,6 +18,7 @@ gpui-component.workspace = true
 dbflux_app.workspace = true
 dbflux_ui = { workspace = true }
 dbflux_core = { workspace = true, features = ["tracing-bridge"] }
+dbflux_i18n.workspace = true
 dbflux_ipc.workspace = true
 dbflux_driver_ipc.workspace = true
 dbflux_audit.workspace = true

--- a/crates/dbflux/src/main.rs
+++ b/crates/dbflux/src/main.rs
@@ -388,6 +388,12 @@ fn run_gui() {
         let theme_setting = general_settings.theme;
         let style_setting = general_settings.style;
 
+        let language = dbflux_i18n::resolve(
+            Some(general_settings.language.as_str()),
+            dbflux_i18n::detect_system_locale().as_deref(),
+        );
+        dbflux_i18n::set_locale(language);
+
         // Set up the density global and apply the persisted theme+style so
         // radius tokens are correct from the very first frame.
         dbflux_ui::theme::init_with_settings(theme_setting, style_setting, cx);

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -89,6 +89,7 @@ pub fn save_general_settings(
         },
         schema_snapshot_retention: settings.schema_snapshot_retention as i64,
         object_preview_size_limit_mib: settings.object_preview_size_limit_mib as i64,
+        language: settings.language.clone(),
         updated_at: String::new(),
     };
     repo.upsert(&dto)?;
@@ -1063,6 +1064,7 @@ fn load_general_settings(
         workspace_inspector_width_px: None,
         schema_snapshot_retention: dto.schema_snapshot_retention as usize,
         object_preview_size_limit_mib: dto.object_preview_size_limit_mib as u64,
+        language: language_setting_from_storage(&dto.language),
     }
 }
 
@@ -1079,6 +1081,20 @@ fn theme_setting_from_storage(theme: &str) -> dbflux_core::ThemeSetting {
         "light" => dbflux_core::ThemeSetting::Light,
         "mirage" => dbflux_core::ThemeSetting::Mirage,
         _ => dbflux_core::ThemeSetting::Dark,
+    }
+}
+
+/// Maps a storage `language` string to a `GeneralSettings::language` value.
+///
+/// Mirrors the supported set of `dbflux_i18n::Language` storage identifiers
+/// without depending on `dbflux_i18n` from this app/core layer. Any value
+/// other than the empty string or a currently supported language falls back
+/// to the empty string, which `dbflux_i18n::resolve` treats as "follow the
+/// system locale" (`LanguagePreference::System`).
+fn language_setting_from_storage(language: &str) -> String {
+    match language {
+        "en" | "es" => language.to_string(),
+        _ => String::new(),
     }
 }
 
@@ -2390,6 +2406,7 @@ mod tests {
             style: "default".to_string(),
             schema_snapshot_retention: 10,
             object_preview_size_limit_mib: 10,
+            language: String::new(),
             updated_at: String::new(),
         };
 
@@ -2421,6 +2438,77 @@ mod tests {
         assert!(!loaded.general_settings.confirm_dangerous_queries);
         assert!(!loaded.general_settings.dangerous_requires_where);
         assert!(loaded.general_settings.dangerous_requires_preview);
+    }
+
+    #[test]
+    fn invalid_language_storage_value_falls_back_to_empty_string() {
+        let runtime = StorageRuntime::in_memory().expect("in-memory storage runtime");
+
+        let mut dto = GeneralSettingsDto {
+            id: 1,
+            theme: "dark".to_string(),
+            restore_session_on_startup: 1,
+            reopen_last_connections: 0,
+            default_focus_on_startup: "sidebar".to_string(),
+            max_history_entries: 1000,
+            auto_save_interval_ms: 2000,
+            default_refresh_policy: "manual".to_string(),
+            default_refresh_interval_secs: 5,
+            max_concurrent_background_tasks: 8,
+            auto_refresh_pause_on_error: 1,
+            auto_refresh_only_if_visible: 0,
+            confirm_dangerous_queries: 1,
+            dangerous_requires_where: 1,
+            dangerous_requires_preview: 0,
+            style: "default".to_string(),
+            schema_snapshot_retention: 10,
+            object_preview_size_limit_mib: 10,
+            language: "de".to_string(),
+            updated_at: String::new(),
+        };
+        runtime
+            .general_settings()
+            .upsert(&dto)
+            .expect("save general settings dto");
+
+        let loaded = load_config(&runtime).expect("load configuration");
+        assert_eq!(
+            loaded.general_settings.language, "",
+            "unsupported language storage value must fall back to empty string (System)"
+        );
+
+        dto.language = "es".to_string();
+        runtime
+            .general_settings()
+            .upsert(&dto)
+            .expect("save general settings dto");
+
+        let loaded = load_config(&runtime).expect("load configuration");
+        assert_eq!(
+            loaded.general_settings.language, "es",
+            "supported language storage value must load through unchanged"
+        );
+    }
+
+    #[test]
+    fn language_round_trips_through_save_and_load() {
+        let settings = GeneralSettings {
+            language: "es".to_string(),
+            ..Default::default()
+        };
+
+        let runtime = StorageRuntime::in_memory().expect("in-memory storage runtime");
+        super::save_general_settings(&runtime, &settings).expect("save general settings");
+
+        let dto = runtime
+            .general_settings()
+            .get()
+            .expect("load saved dto")
+            .expect("general settings row");
+        assert_eq!(dto.language, "es");
+
+        let loaded = load_config(&runtime).expect("load configuration");
+        assert_eq!(loaded.general_settings.language, "es");
     }
 
     #[test]
@@ -2505,6 +2593,7 @@ mod tests {
             style: "ultracompact".to_string(), // unknown value
             schema_snapshot_retention: 10,
             object_preview_size_limit_mib: 10,
+            language: String::new(),
             updated_at: String::new(),
         };
         runtime

--- a/crates/dbflux_core/src/config/app.rs
+++ b/crates/dbflux_core/src/config/app.rs
@@ -299,6 +299,12 @@ pub struct GeneralSettings {
     #[serde(default)]
     pub style: AppStyle,
 
+    /// The user's language preference: a `dbflux_i18n::Language` storage
+    /// identifier (for example `"en"`, `"es"`), or an empty string to follow
+    /// the system locale.
+    #[serde(default)]
+    pub language: String,
+
     // -- Startup & Session --
     #[serde(default = "default_true")]
     pub restore_session_on_startup: bool,
@@ -365,6 +371,7 @@ impl Default for GeneralSettings {
         Self {
             theme: ThemeSetting::Dark,
             style: AppStyle::Default,
+            language: String::new(),
             restore_session_on_startup: true,
             reopen_last_connections: false,
             default_focus_on_startup: StartupFocus::Sidebar,

--- a/crates/dbflux_i18n/Cargo.toml
+++ b/crates/dbflux_i18n/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "dbflux_i18n"
+edition.workspace = true
+publish = false
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+homepage.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+rust-i18n = { workspace = true }
+sys-locale = { workspace = true }
+
+[dev-dependencies]
+serde_yaml = { workspace = true }

--- a/crates/dbflux_i18n/build.rs
+++ b/crates/dbflux_i18n/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=locales");
+}

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1,11 +1,77 @@
 settings:
   general:
+    header:
+      title: General
+      subtitle: Configure startup, session, refresh, and safety behavior
+    appearance:
+      group: Appearance
+    startup:
+      group: Startup & Session
+    refresh:
+      group: Refresh & Background
+    safety:
+      group: Execution Safety
+    object_storage:
+      group: Object Storage
+    storage:
+      group: Storage
+    theme:
+      label: Theme
+    style:
+      label: Style
     language:
+      label: Language
       option:
         system: System
         english: English
         spanish: Spanish
       notice: Language changes apply after restarting DBFlux.
+    restore_session:
+      label: Restore session on startup
+    reopen_connections:
+      label: Reopen last connections
+    default_focus:
+      label: Default focus
+      option:
+        sidebar: Sidebar
+        last_tab: Last Tab
+    max_history:
+      label: Max history entries
+      error: Max history entries must be a number >= 10
+    auto_save_interval:
+      label: Auto-save interval (ms)
+      error: Auto-save interval must be >= 500 ms
+    refresh_policy:
+      label: Default refresh policy
+      option:
+        manual: Manual
+        interval: Interval
+    refresh_interval:
+      label: Default refresh interval (seconds)
+      error: Refresh interval must be >= 1 second
+    max_background_tasks:
+      label: Max concurrent background tasks
+      error: Max background tasks must be >= 1
+    pause_refresh_on_error:
+      label: Pause auto-refresh on error
+    refresh_only_if_visible:
+      label: Auto-refresh only if tab is visible
+    confirm_dangerous:
+      label: Confirm dangerous queries
+    requires_where:
+      label: Require WHERE for DELETE/UPDATE
+    requires_preview:
+      label: Always require preview (ignore suppressions)
+    object_preview_limit:
+      label: Object preview size limit (MiB)
+      error: Object preview size limit must be >= 1 MiB
+    object_preview_hint:
+      label: "Objects larger than this are never downloaded for preview; the browser shows their metadata only."
+    share_stable_db:
+      label: Use the stable database
+      error: Failed to update the shared-database setting
+      hint: "Applied on next launch. Shares the stable database (dbflux.db) instead of this nightly build's dbflux-nightly.db."
     save:
       button: Save
       error: "Failed to save general settings: %{error}"
+      success: Settings saved. Some changes apply on next startup.

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1,0 +1,11 @@
+settings:
+  general:
+    language:
+      option:
+        system: System
+        english: English
+        spanish: Spanish
+      notice: Language changes apply after restarting DBFlux.
+    save:
+      button: Save
+      error: "Failed to save general settings: %{error}"

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1,11 +1,77 @@
 settings:
   general:
+    header:
+      title: General
+      subtitle: Configura el inicio, la sesión, la actualización y el comportamiento de seguridad
+    appearance:
+      group: Apariencia
+    startup:
+      group: Inicio y sesión
+    refresh:
+      group: Actualización y tareas en segundo plano
+    safety:
+      group: Seguridad de ejecución
+    object_storage:
+      group: Almacenamiento de objetos
+    storage:
+      group: Almacenamiento
+    theme:
+      label: Tema
+    style:
+      label: Estilo
     language:
+      label: Idioma
       option:
         system: Sistema
         english: Inglés
         spanish: Español
       notice: Los cambios de idioma se aplican al reiniciar DBFlux.
+    restore_session:
+      label: Restaurar la sesión al iniciar
+    reopen_connections:
+      label: Reabrir las últimas conexiones
+    default_focus:
+      label: Foco predeterminado
+      option:
+        sidebar: Barra lateral
+        last_tab: Última pestaña
+    max_history:
+      label: Máximo de entradas de historial
+      error: El máximo de entradas de historial debe ser un número >= 10
+    auto_save_interval:
+      label: Intervalo de guardado automático (ms)
+      error: El intervalo de guardado automático debe ser >= 500 ms
+    refresh_policy:
+      label: Política de actualización predeterminada
+      option:
+        manual: Manual
+        interval: Intervalo
+    refresh_interval:
+      label: Intervalo de actualización predeterminado (segundos)
+      error: El intervalo de actualización debe ser >= 1 segundo
+    max_background_tasks:
+      label: Máximo de tareas en segundo plano simultáneas
+      error: El máximo de tareas en segundo plano debe ser >= 1
+    pause_refresh_on_error:
+      label: Pausar la actualización automática ante un error
+    refresh_only_if_visible:
+      label: Actualizar automáticamente solo si la pestaña está visible
+    confirm_dangerous:
+      label: Confirmar queries peligrosas
+    requires_where:
+      label: Exigir WHERE en DELETE/UPDATE
+    requires_preview:
+      label: Exigir siempre la vista previa (ignorar supresiones)
+    object_preview_limit:
+      label: Límite de tamaño para la vista previa de objetos (MiB)
+      error: El límite de tamaño para la vista previa de objetos debe ser >= 1 MiB
+    object_preview_hint:
+      label: "Los objetos más grandes que este límite nunca se descargan para la vista previa; el navegador solo muestra sus metadatos."
+    share_stable_db:
+      label: Usar la base de datos estable
+      error: No se pudo actualizar la configuración de base de datos compartida
+      hint: "Se aplica en el próximo inicio. Comparte la base de datos estable (dbflux.db) en lugar de la dbflux-nightly.db de esta compilación nightly."
     save:
       button: Guardar
       error: "No se pudo guardar la configuración general: %{error}"
+      success: Configuración guardada. Algunos cambios se aplican al reiniciar.

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1,0 +1,11 @@
+settings:
+  general:
+    language:
+      option:
+        system: Sistema
+        english: Inglés
+        spanish: Español
+      notice: Los cambios de idioma se aplican al reiniciar DBFlux.
+    save:
+      button: Guardar
+      error: "No se pudo guardar la configuración general: %{error}"

--- a/crates/dbflux_i18n/src/lib.rs
+++ b/crates/dbflux_i18n/src/lib.rs
@@ -1,0 +1,324 @@
+rust_i18n::i18n!("locales", fallback = "en");
+
+/// A language DBFlux ships a translation catalog for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Language {
+    English,
+    Spanish,
+}
+
+impl Language {
+    /// The stable identifier persisted to settings storage.
+    pub fn as_storage_str(self) -> &'static str {
+        match self {
+            Language::English => "en",
+            Language::Spanish => "es",
+        }
+    }
+
+    /// Parses a persisted storage identifier back into a `Language`.
+    ///
+    /// Returns `None` for anything other than the exact stored identifiers,
+    /// including unsupported languages and locale strings with region tags.
+    pub fn from_storage_str(value: &str) -> Option<Language> {
+        match value {
+            "en" => Some(Language::English),
+            "es" => Some(Language::Spanish),
+            _ => None,
+        }
+    }
+
+    /// The `rust-i18n` locale code, currently identical to the storage string.
+    pub fn locale_code(self) -> &'static str {
+        self.as_storage_str()
+    }
+}
+
+/// The user's language choice: either follow the OS locale, or pin an
+/// explicit `Language` regardless of what the OS reports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguagePreference {
+    System,
+    Explicit(Language),
+}
+
+impl LanguagePreference {
+    /// The stable identifier persisted to settings storage. `System` is the
+    /// empty string so an unset/legacy field defaults to following the OS.
+    pub fn as_storage_str(self) -> &'static str {
+        match self {
+            LanguagePreference::System => "",
+            LanguagePreference::Explicit(language) => language.as_storage_str(),
+        }
+    }
+
+    /// Parses a persisted storage identifier back into a `LanguagePreference`.
+    ///
+    /// Any value that is not a recognized `Language` storage string
+    /// (including an unset field) resolves to `System`.
+    pub fn from_storage_str(value: &str) -> LanguagePreference {
+        match Language::from_storage_str(value) {
+            Some(language) => LanguagePreference::Explicit(language),
+            None => LanguagePreference::System,
+        }
+    }
+}
+
+/// Resolves the effective UI `Language` from a persisted preference and the
+/// detected system locale.
+///
+/// Precedence: a valid persisted `Language` wins outright. Otherwise, the
+/// system locale's primary subtag (the part before `-` or `_`) is matched
+/// case-insensitively against the supported languages. If neither source
+/// yields a supported language, English is the default.
+pub fn resolve(persisted: Option<&str>, system: Option<&str>) -> Language {
+    if let Some(persisted) = persisted
+        && let Some(language) = Language::from_storage_str(persisted)
+    {
+        return language;
+    }
+
+    if let Some(system) = system {
+        let primary_subtag = system
+            .split(['-', '_'])
+            .next()
+            .unwrap_or(system)
+            .to_ascii_lowercase();
+
+        if let Some(language) = Language::from_storage_str(&primary_subtag) {
+            return language;
+        }
+    }
+
+    Language::English
+}
+
+/// Detects the OS-reported locale (for example `"en-US"` or `"es-ES"`).
+///
+/// Returns `None` when the platform cannot report a locale.
+pub fn detect_system_locale() -> Option<String> {
+    sys_locale::get_locale()
+}
+
+/// Sets the process-wide active locale used by [`translate`] and [`t!`].
+///
+/// `rust-i18n` stores the active locale in a process-global, so this is
+/// intended to run once at startup after resolving the effective
+/// [`Language`], not on every translation lookup.
+pub fn set_locale(language: Language) {
+    rust_i18n::set_locale(language.locale_code());
+}
+
+/// Translates `key` using the process-wide active locale set by [`set_locale`].
+///
+/// Falls back to the configured fallback locale, then to the key itself,
+/// when no translation is found.
+pub fn translate(key: &str) -> String {
+    use std::ops::Deref;
+
+    crate::_rust_i18n_translate(rust_i18n::locale().deref(), key).into_owned()
+}
+
+/// Translates `key` for an explicit `locale`, ignoring the process-wide
+/// active locale.
+pub fn translate_in(locale: &str, key: &str) -> String {
+    crate::_rust_i18n_translate(locale, key).into_owned()
+}
+
+/// Translates a catalog key, optionally against an explicit locale or with
+/// `%{name}` placeholder interpolation.
+///
+/// `rust-i18n`'s own `t!` expands to a crate-local `_rust_i18n_t!` alias that
+/// cannot be re-exported from this crate, so `dbflux_i18n` defines its own
+/// macro on top of [`translate`] / [`translate_in`].
+#[macro_export]
+macro_rules! t {
+    ($key:expr) => {
+        $crate::translate($key)
+    };
+    ($key:expr, locale = $locale:expr) => {
+        $crate::translate_in($locale, $key)
+    };
+    ($key:expr, $($name:ident = $value:expr),+ $(,)?) => {{
+        let mut out = $crate::translate($key);
+        $(
+            out = out.replace(concat!("%{", stringify!($name), "}"), &$value.to_string());
+        )+
+        out
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_prefers_valid_persisted_language() {
+        assert_eq!(resolve(Some("es"), Some("en-US")), Language::Spanish);
+    }
+
+    #[test]
+    fn resolve_empty_persisted_falls_back_to_system() {
+        assert_eq!(resolve(Some(""), Some("es-ES")), Language::Spanish);
+    }
+
+    #[test]
+    fn resolve_invalid_persisted_falls_back_to_system() {
+        assert_eq!(resolve(Some("de"), Some("es-419")), Language::Spanish);
+        assert_eq!(resolve(Some("de"), Some("fr-FR")), Language::English);
+    }
+
+    #[test]
+    fn resolve_unsupported_system_subtag_falls_back_to_english() {
+        assert_eq!(resolve(None, Some("fr-FR")), Language::English);
+        assert_eq!(resolve(None, None), Language::English);
+    }
+
+    #[test]
+    fn resolve_es419_maps_to_spanish() {
+        assert_eq!(resolve(None, Some("es-419")), Language::Spanish);
+    }
+
+    #[test]
+    fn explicit_locale_translate_differs_from_default() {
+        let english = t!("settings.general.save.button", locale = "en");
+        let spanish = t!("settings.general.save.button", locale = "es");
+
+        assert_eq!(english, "Save");
+        assert_eq!(spanish, "Guardar");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn t_macro_interpolates_named_placeholders() {
+        // Relies on the process-wide default locale ("en"); no test in this
+        // suite calls `set_locale`, so the default is stable across tests.
+        let message = t!("settings.general.save.error", error = "disk full");
+
+        assert_eq!(message, "Failed to save general settings: disk full");
+    }
+
+    #[test]
+    fn language_preference_storage_str_roundtrip_including_system() {
+        assert_eq!(LanguagePreference::System.as_storage_str(), "");
+        assert_eq!(
+            LanguagePreference::from_storage_str(""),
+            LanguagePreference::System
+        );
+
+        assert_eq!(
+            LanguagePreference::Explicit(Language::English).as_storage_str(),
+            "en"
+        );
+        assert_eq!(
+            LanguagePreference::from_storage_str("en"),
+            LanguagePreference::Explicit(Language::English)
+        );
+
+        assert_eq!(
+            LanguagePreference::Explicit(Language::Spanish).as_storage_str(),
+            "es"
+        );
+        assert_eq!(
+            LanguagePreference::from_storage_str("es"),
+            LanguagePreference::Explicit(Language::Spanish)
+        );
+    }
+
+    fn flatten_catalog_keys(value: &serde_yaml::Value, prefix: String, out: &mut Vec<String>) {
+        match value {
+            serde_yaml::Value::Mapping(mapping) => {
+                for (key, nested) in mapping {
+                    let key = key.as_str().expect("catalog keys must be strings");
+                    let path = if prefix.is_empty() {
+                        key.to_string()
+                    } else {
+                        format!("{prefix}.{key}")
+                    };
+                    flatten_catalog_keys(nested, path, out);
+                }
+            }
+            _ => out.push(prefix),
+        }
+    }
+
+    fn flatten_catalog_values(
+        value: &serde_yaml::Value,
+        out: &mut Vec<(String, serde_yaml::Value)>,
+    ) {
+        flatten_catalog_values_with_prefix(value, String::new(), out);
+    }
+
+    fn flatten_catalog_values_with_prefix(
+        value: &serde_yaml::Value,
+        prefix: String,
+        out: &mut Vec<(String, serde_yaml::Value)>,
+    ) {
+        match value {
+            serde_yaml::Value::Mapping(mapping) => {
+                for (key, nested) in mapping {
+                    let key = key.as_str().expect("catalog keys must be strings");
+                    let path = if prefix.is_empty() {
+                        key.to_string()
+                    } else {
+                        format!("{prefix}.{key}")
+                    };
+                    flatten_catalog_values_with_prefix(nested, path, out);
+                }
+            }
+            other => out.push((prefix, other.clone())),
+        }
+    }
+
+    #[test]
+    fn catalog_keys_match_between_en_and_es() {
+        let en: serde_yaml::Value =
+            serde_yaml::from_str(include_str!("../locales/en.yml")).expect("valid en.yml");
+        let es: serde_yaml::Value =
+            serde_yaml::from_str(include_str!("../locales/es.yml")).expect("valid es.yml");
+
+        let mut en_keys = Vec::new();
+        flatten_catalog_keys(&en, String::new(), &mut en_keys);
+        let mut es_keys = Vec::new();
+        flatten_catalog_keys(&es, String::new(), &mut es_keys);
+
+        let en_set: std::collections::BTreeSet<_> = en_keys.into_iter().collect();
+        let es_set: std::collections::BTreeSet<_> = es_keys.into_iter().collect();
+
+        let missing_in_es: Vec<_> = en_set.difference(&es_set).cloned().collect();
+        let missing_in_en: Vec<_> = es_set.difference(&en_set).cloned().collect();
+
+        assert!(
+            missing_in_es.is_empty() && missing_in_en.is_empty(),
+            "catalog key mismatch — missing in es.yml: {missing_in_es:?}, missing in en.yml: {missing_in_en:?}"
+        );
+    }
+
+    #[test]
+    fn catalog_has_no_empty_values() {
+        let en: serde_yaml::Value =
+            serde_yaml::from_str(include_str!("../locales/en.yml")).expect("valid en.yml");
+        let es: serde_yaml::Value =
+            serde_yaml::from_str(include_str!("../locales/es.yml")).expect("valid es.yml");
+
+        let mut entries = Vec::new();
+        flatten_catalog_values(&en, &mut entries);
+        flatten_catalog_values(&es, &mut entries);
+
+        let empty_keys: Vec<_> = entries
+            .iter()
+            .filter(|(_, value)| {
+                value
+                    .as_str()
+                    .map(|text| text.trim().is_empty())
+                    .unwrap_or(true)
+            })
+            .map(|(key, _)| key.clone())
+            .collect();
+
+        assert!(
+            empty_keys.is_empty(),
+            "catalog has empty or non-string values for keys: {empty_keys:?}"
+        );
+    }
+}

--- a/crates/dbflux_storage/src/migrations/mod.rs
+++ b/crates/dbflux_storage/src/migrations/mod.rs
@@ -168,6 +168,7 @@ impl MigrationRegistry {
         registry.register(mod_023_profile_hook_interpreter::MigrationImpl);
         registry.register(mod_024_s3_config_columns::MigrationImpl);
         registry.register(mod_025_general_settings_object_preview_limit::MigrationImpl);
+        registry.register(mod_026_general_settings_language::MigrationImpl);
         registry
     }
 
@@ -376,6 +377,7 @@ mod mod_022_hook_kind_json;
 mod mod_023_profile_hook_interpreter;
 mod mod_024_s3_config_columns;
 mod mod_025_general_settings_object_preview_limit;
+mod mod_026_general_settings_language;
 
 pub use mod_001_initial::MigrationImpl;
 pub use mod_002_audit_extended::MigrationImpl as MigrationImplAuditExtended;
@@ -1026,6 +1028,7 @@ mod tests {
             "023_profile_hook_interpreter",
             "024_s3_config_columns",
             "025_general_settings_object_preview_limit",
+            "026_general_settings_language",
         ];
 
         let pending = registry.get_pending(&conn).unwrap();

--- a/crates/dbflux_storage/src/migrations/mod_026_general_settings_language.rs
+++ b/crates/dbflux_storage/src/migrations/mod_026_general_settings_language.rs
@@ -1,0 +1,57 @@
+//! Migration 026: Add `language` column to `cfg_general_settings`.
+//!
+//! Persists the user's language preference. An empty string means "follow
+//! the system locale" (`LanguagePreference::System`); anything else is a
+//! `dbflux_i18n::Language` storage identifier (for example `"en"`, `"es"`).
+
+use rusqlite::Transaction;
+
+use crate::migrations::{Migration, MigrationError};
+
+pub struct MigrationImpl;
+
+impl Migration for MigrationImpl {
+    fn name(&self) -> &str {
+        "026_general_settings_language"
+    }
+
+    fn run(&self, tx: &Transaction) -> Result<(), MigrationError> {
+        let table_exists: bool = tx
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='cfg_general_settings'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .map_err(sqlite_err)?;
+
+        if !table_exists {
+            return Ok(());
+        }
+
+        let column_exists: bool = tx
+            .query_row(
+                "SELECT COUNT(*) FROM pragma_table_info('cfg_general_settings') WHERE name = 'language'",
+                [],
+                |row| row.get::<_, i64>(0),
+            )
+            .map(|n| n > 0)
+            .map_err(sqlite_err)?;
+
+        if !column_exists {
+            tx.execute_batch(
+                "ALTER TABLE cfg_general_settings ADD COLUMN language TEXT NOT NULL DEFAULT '';",
+            )
+            .map_err(sqlite_err)?;
+        }
+
+        Ok(())
+    }
+}
+
+fn sqlite_err(source: rusqlite::Error) -> MigrationError {
+    MigrationError::Sqlite {
+        path: std::path::PathBuf::from("<unknown>"),
+        source,
+    }
+}

--- a/crates/dbflux_storage/src/repositories/general_settings.rs
+++ b/crates/dbflux_storage/src/repositories/general_settings.rs
@@ -38,7 +38,7 @@ impl GeneralSettingsRepository {
                        auto_refresh_only_if_visible, confirm_dangerous_queries,
                        dangerous_requires_where, dangerous_requires_preview,
                        style, schema_snapshot_retention,
-                       object_preview_size_limit_mib, updated_at
+                       object_preview_size_limit_mib, language, updated_at
                 FROM cfg_general_settings WHERE id = 1
                 "#,
             )
@@ -67,7 +67,8 @@ impl GeneralSettingsRepository {
                 style: row.get(15)?,
                 schema_snapshot_retention: row.get(16)?,
                 object_preview_size_limit_mib: row.get(17)?,
-                updated_at: row.get(18)?,
+                language: row.get(18)?,
+                updated_at: row.get(19)?,
             })
         });
 
@@ -94,8 +95,8 @@ impl GeneralSettingsRepository {
                     auto_refresh_only_if_visible, confirm_dangerous_queries,
                     dangerous_requires_where, dangerous_requires_preview,
                     style, schema_snapshot_retention,
-                    object_preview_size_limit_mib, updated_at
-                ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, datetime('now'))
+                    object_preview_size_limit_mib, language, updated_at
+                ) VALUES (1, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, datetime('now'))
                 ON CONFLICT(id) DO UPDATE SET
                     theme = excluded.theme,
                     restore_session_on_startup = excluded.restore_session_on_startup,
@@ -114,6 +115,7 @@ impl GeneralSettingsRepository {
                     style = excluded.style,
                     schema_snapshot_retention = excluded.schema_snapshot_retention,
                     object_preview_size_limit_mib = excluded.object_preview_size_limit_mib,
+                    language = excluded.language,
                     updated_at = datetime('now')
                 "#,
                 params![
@@ -134,6 +136,7 @@ impl GeneralSettingsRepository {
                     settings.style,
                     settings.schema_snapshot_retention,
                     settings.object_preview_size_limit_mib,
+                    settings.language,
                 ],
             )
             .map_err(|source| StorageError::Sqlite {
@@ -173,6 +176,10 @@ pub struct GeneralSettingsDto {
     /// Largest object size (in MiB) whose bytes may be fetched for an in-app
     /// object-storage preview.
     pub object_preview_size_limit_mib: i64,
+    /// The user's language preference: a `dbflux_i18n::Language` storage
+    /// identifier (for example `"en"`, `"es"`), or an empty string to follow
+    /// the system locale.
+    pub language: String,
     pub updated_at: String,
 }
 
@@ -225,6 +232,7 @@ mod tests {
             style: "compact".to_string(),
             schema_snapshot_retention: 15,
             object_preview_size_limit_mib: 25,
+            language: String::new(),
             updated_at: String::new(),
         };
 
@@ -272,6 +280,7 @@ mod tests {
                 style: style_str.to_string(),
                 schema_snapshot_retention: 10,
                 object_preview_size_limit_mib: 10,
+                language: String::new(),
                 updated_at: String::new(),
             };
 
@@ -285,6 +294,70 @@ mod tests {
 
             let _ = std::fs::remove_file(&path);
         }
+    }
+
+    #[test]
+    fn migrated_row_defaults_language_to_empty_string() {
+        // Simulate a pre-migration row where 'language' column is absent (DEFAULT kicks in).
+        // After migration 026 runs, existing rows get the column with '' value, meaning
+        // "follow the system locale" per LanguagePreference::System.
+        let path = temp_db("language_column_default");
+        let conn = open_database(&path).expect("should open");
+        MigrationRegistry::new()
+            .run_all(&conn)
+            .expect("migration should run");
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let repo = GeneralSettingsRepository::new(Arc::new(conn));
+        let fetched = repo.get().expect("should get").expect("should exist");
+        assert_eq!(
+            fetched.language, "",
+            "language column default should be the empty string"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn language_round_trips_through_upsert() {
+        let path = temp_db("language_roundtrip");
+        let conn = open_database(&path).expect("should open");
+        MigrationRegistry::new()
+            .run_all(&conn)
+            .expect("migration should run");
+
+        #[allow(clippy::arc_with_non_send_sync)]
+        let repo = GeneralSettingsRepository::new(Arc::new(conn));
+
+        let dto = GeneralSettingsDto {
+            id: 1,
+            theme: "dark".to_string(),
+            restore_session_on_startup: 1,
+            reopen_last_connections: 0,
+            default_focus_on_startup: "sidebar".to_string(),
+            max_history_entries: 1000,
+            auto_save_interval_ms: 2000,
+            default_refresh_policy: "manual".to_string(),
+            default_refresh_interval_secs: 5,
+            max_concurrent_background_tasks: 8,
+            auto_refresh_pause_on_error: 1,
+            auto_refresh_only_if_visible: 0,
+            confirm_dangerous_queries: 1,
+            dangerous_requires_where: 1,
+            dangerous_requires_preview: 0,
+            style: "default".to_string(),
+            schema_snapshot_retention: 10,
+            object_preview_size_limit_mib: 10,
+            language: "es".to_string(),
+            updated_at: String::new(),
+        };
+
+        repo.upsert(&dto).expect("should upsert");
+
+        let fetched = repo.get().expect("should get").expect("should exist");
+        assert_eq!(fetched.language, "es");
+
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]

--- a/crates/dbflux_ui_windows/Cargo.toml
+++ b/crates/dbflux_ui_windows/Cargo.toml
@@ -20,6 +20,7 @@ dbflux_app.workspace = true
 dbflux_storage.workspace = true
 dbflux_portability.workspace = true
 dbflux_ssh.workspace = true
+dbflux_i18n.workspace = true
 dbflux_mcp = { workspace = true, optional = true }
 dbflux_policy = { workspace = true, optional = true }
 uuid.workspace = true

--- a/crates/dbflux_ui_windows/src/settings/general.rs
+++ b/crates/dbflux_ui_windows/src/settings/general.rs
@@ -64,6 +64,7 @@ impl GeneralSection {
         let mut rows = vec![
             GeneralFormRow::Theme,
             GeneralFormRow::Style,
+            GeneralFormRow::Language,
             GeneralFormRow::RestoreSession,
             GeneralFormRow::ReopenConnections,
             GeneralFormRow::DefaultFocus,
@@ -105,7 +106,7 @@ impl GeneralSection {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Config,
-                        "Failed to update the shared-database setting",
+                        dbflux_i18n::t!("settings.general.share_stable_db.error"),
                     )
                     .with_cause(format!("{error}")),
                     cx,
@@ -152,6 +153,11 @@ impl GeneralSection {
             }
             Some(GeneralFormRow::Style) => {
                 self.dropdown_style
+                    .update(cx, |dropdown, cx| dropdown.toggle_open(cx));
+                cx.notify();
+            }
+            Some(GeneralFormRow::Language) => {
+                self.dropdown_language
                     .update(cx, |dropdown, cx| dropdown.toggle_open(cx));
                 cx.notify();
             }
@@ -262,6 +268,7 @@ impl GeneralSection {
         match self.gen_current_row() {
             Some(GeneralFormRow::Theme) => Some(&self.dropdown_theme),
             Some(GeneralFormRow::Style) => Some(&self.dropdown_style),
+            Some(GeneralFormRow::Language) => Some(&self.dropdown_language),
             Some(GeneralFormRow::DefaultFocus) => Some(&self.dropdown_default_focus),
             Some(GeneralFormRow::DefaultRefreshPolicy) => Some(&self.dropdown_refresh_policy),
             _ => None,
@@ -393,9 +400,10 @@ impl GeneralSection {
         let max_history = match max_history_str.parse::<usize>() {
             Ok(value) if value >= 10 => value,
             _ => {
-                Toast::error("Max history entries must be a number >= 10")
+                let message = dbflux_i18n::t!("settings.general.max_history.error");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Max history entries must be a number >= 10"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -405,9 +413,10 @@ impl GeneralSection {
         let auto_save_ms = match auto_save_str.parse::<u64>() {
             Ok(value) if value >= 500 => value,
             _ => {
-                Toast::error("Auto-save interval must be >= 500 ms")
+                let message = dbflux_i18n::t!("settings.general.auto_save_interval.error");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Auto-save interval must be >= 500 ms"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -422,9 +431,10 @@ impl GeneralSection {
         let refresh_interval = match refresh_interval_str.parse::<u32>() {
             Ok(value) if value >= 1 => value,
             _ => {
-                Toast::error("Refresh interval must be >= 1 second")
+                let message = dbflux_i18n::t!("settings.general.refresh_interval.error");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Refresh interval must be >= 1 second"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -434,9 +444,10 @@ impl GeneralSection {
         let max_bg_tasks = match max_bg_str.parse::<usize>() {
             Ok(value) if value >= 1 => value,
             _ => {
-                Toast::error("Max background tasks must be >= 1")
+                let message = dbflux_i18n::t!("settings.general.max_background_tasks.error");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Max background tasks must be >= 1"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -451,9 +462,10 @@ impl GeneralSection {
         let object_preview_limit = match preview_limit_str.parse::<u64>() {
             Ok(value) if value >= 1 => value,
             _ => {
-                Toast::error("Object preview size limit must be >= 1 MiB")
+                let message = dbflux_i18n::t!("settings.general.object_preview_limit.error");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Object preview size limit must be >= 1 MiB"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -472,7 +484,7 @@ impl GeneralSection {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    format!("Failed to save general settings: {e}"),
+                    dbflux_i18n::t!("settings.general.save.error", error = e),
                 ),
                 cx,
             );
@@ -493,7 +505,7 @@ impl GeneralSection {
             cx,
         );
 
-        Toast::success("Settings saved. Some changes apply on next startup.")
+        Toast::success(dbflux_i18n::t!("settings.general.save.success"))
             .meta_right(now_hms())
             .push(cx);
     }
@@ -512,17 +524,21 @@ impl GeneralSection {
 
         layout::single_form_section_shell(
             dbflux_components::composites::section_header(
-                "General",
-                "Configure startup, session, refresh, and safety behavior",
+                dbflux_i18n::t!("settings.general.header.title"),
+                dbflux_i18n::t!("settings.general.header.subtitle"),
                 cx,
             ),
             div()
                 .flex()
                 .flex_col()
                 .gap_6()
-                .child(self.render_gen_group_header("Appearance", border, muted_fg))
+                .child(self.render_gen_group_header(
+                    dbflux_i18n::t!("settings.general.appearance.group"),
+                    border,
+                    muted_fg,
+                ))
                 .child(self.render_gen_dropdown(
-                    "Theme",
+                    dbflux_i18n::t!("settings.general.theme.label"),
                     &self.dropdown_theme,
                     is_at(GeneralFormRow::Theme),
                     primary,
@@ -530,17 +546,32 @@ impl GeneralSection {
                     cx,
                 ))
                 .child(self.render_gen_dropdown(
-                    "Style",
+                    dbflux_i18n::t!("settings.general.style.label"),
                     &self.dropdown_style,
                     is_at(GeneralFormRow::Style),
                     primary,
                     GeneralFormRow::Style,
                     cx,
                 ))
-                .child(self.render_gen_group_header("Startup & Session", border, muted_fg))
+                .child(self.render_gen_dropdown(
+                    dbflux_i18n::t!("settings.general.language.label"),
+                    &self.dropdown_language,
+                    is_at(GeneralFormRow::Language),
+                    primary,
+                    GeneralFormRow::Language,
+                    cx,
+                ))
+                .child(div().px_2().child(
+                    Body::new(dbflux_i18n::t!("settings.general.language.notice")).color(muted_fg),
+                ))
+                .child(self.render_gen_group_header(
+                    dbflux_i18n::t!("settings.general.startup.group"),
+                    border,
+                    muted_fg,
+                ))
                 .child(self.render_gen_checkbox(
                     "restore-session",
-                    "Restore session on startup",
+                    dbflux_i18n::t!("settings.general.restore_session.label"),
                     self.gen_settings.restore_session_on_startup,
                     is_at(GeneralFormRow::RestoreSession),
                     GeneralFormRow::RestoreSession,
@@ -549,7 +580,7 @@ impl GeneralSection {
                 ))
                 .child(self.render_gen_checkbox(
                     "reopen-conns",
-                    "Reopen last connections",
+                    dbflux_i18n::t!("settings.general.reopen_connections.label"),
                     self.gen_settings.reopen_last_connections,
                     is_at(GeneralFormRow::ReopenConnections),
                     GeneralFormRow::ReopenConnections,
@@ -557,7 +588,7 @@ impl GeneralSection {
                     cx,
                 ))
                 .child(self.render_gen_dropdown(
-                    "Default focus",
+                    dbflux_i18n::t!("settings.general.default_focus.label"),
                     &self.dropdown_default_focus,
                     is_at(GeneralFormRow::DefaultFocus),
                     primary,
@@ -565,7 +596,7 @@ impl GeneralSection {
                     cx,
                 ))
                 .child(self.render_gen_input_field(
-                    "Max history entries",
+                    dbflux_i18n::t!("settings.general.max_history.label"),
                     &self.input_max_history,
                     is_at(GeneralFormRow::MaxHistory),
                     primary,
@@ -573,16 +604,20 @@ impl GeneralSection {
                     cx,
                 ))
                 .child(self.render_gen_input_field(
-                    "Auto-save interval (ms)",
+                    dbflux_i18n::t!("settings.general.auto_save_interval.label"),
                     &self.input_auto_save,
                     is_at(GeneralFormRow::AutoSaveInterval),
                     primary,
                     GeneralFormRow::AutoSaveInterval,
                     cx,
                 ))
-                .child(self.render_gen_group_header("Refresh & Background", border, muted_fg))
+                .child(self.render_gen_group_header(
+                    dbflux_i18n::t!("settings.general.refresh.group"),
+                    border,
+                    muted_fg,
+                ))
                 .child(self.render_gen_dropdown(
-                    "Default refresh policy",
+                    dbflux_i18n::t!("settings.general.refresh_policy.label"),
                     &self.dropdown_refresh_policy,
                     is_at(GeneralFormRow::DefaultRefreshPolicy),
                     primary,
@@ -590,7 +625,7 @@ impl GeneralSection {
                     cx,
                 ))
                 .child(self.render_gen_input_field(
-                    "Default refresh interval (seconds)",
+                    dbflux_i18n::t!("settings.general.refresh_interval.label"),
                     &self.input_refresh_interval,
                     is_at(GeneralFormRow::DefaultRefreshInterval),
                     primary,
@@ -598,7 +633,7 @@ impl GeneralSection {
                     cx,
                 ))
                 .child(self.render_gen_input_field(
-                    "Max concurrent background tasks",
+                    dbflux_i18n::t!("settings.general.max_background_tasks.label"),
                     &self.input_max_bg_tasks,
                     is_at(GeneralFormRow::MaxBackgroundTasks),
                     primary,
@@ -607,7 +642,7 @@ impl GeneralSection {
                 ))
                 .child(self.render_gen_checkbox(
                     "pause-on-error",
-                    "Pause auto-refresh on error",
+                    dbflux_i18n::t!("settings.general.pause_refresh_on_error.label"),
                     self.gen_settings.auto_refresh_pause_on_error,
                     is_at(GeneralFormRow::PauseRefreshOnError),
                     GeneralFormRow::PauseRefreshOnError,
@@ -616,17 +651,21 @@ impl GeneralSection {
                 ))
                 .child(self.render_gen_checkbox(
                     "refresh-visible",
-                    "Auto-refresh only if tab is visible",
+                    dbflux_i18n::t!("settings.general.refresh_only_if_visible.label"),
                     self.gen_settings.auto_refresh_only_if_visible,
                     is_at(GeneralFormRow::RefreshOnlyIfVisible),
                     GeneralFormRow::RefreshOnlyIfVisible,
                     |this, value, _cx| this.gen_settings.auto_refresh_only_if_visible = value,
                     cx,
                 ))
-                .child(self.render_gen_group_header("Execution Safety", border, muted_fg))
+                .child(self.render_gen_group_header(
+                    dbflux_i18n::t!("settings.general.safety.group"),
+                    border,
+                    muted_fg,
+                ))
                 .child(self.render_gen_checkbox(
                     "confirm-dangerous",
-                    "Confirm dangerous queries",
+                    dbflux_i18n::t!("settings.general.confirm_dangerous.label"),
                     self.gen_settings.confirm_dangerous_queries,
                     is_at(GeneralFormRow::ConfirmDangerous),
                     GeneralFormRow::ConfirmDangerous,
@@ -635,7 +674,7 @@ impl GeneralSection {
                 ))
                 .child(self.render_gen_checkbox(
                     "requires-where",
-                    "Require WHERE for DELETE/UPDATE",
+                    dbflux_i18n::t!("settings.general.requires_where.label"),
                     self.gen_settings.dangerous_requires_where,
                     is_at(GeneralFormRow::RequiresWhere),
                     GeneralFormRow::RequiresWhere,
@@ -644,16 +683,20 @@ impl GeneralSection {
                 ))
                 .child(self.render_gen_checkbox(
                     "requires-preview",
-                    "Always require preview (ignore suppressions)",
+                    dbflux_i18n::t!("settings.general.requires_preview.label"),
                     self.gen_settings.dangerous_requires_preview,
                     is_at(GeneralFormRow::RequiresPreview),
                     GeneralFormRow::RequiresPreview,
                     |this, value, _cx| this.gen_settings.dangerous_requires_preview = value,
                     cx,
                 ))
-                .child(self.render_gen_group_header("Object Storage", border, muted_fg))
+                .child(self.render_gen_group_header(
+                    dbflux_i18n::t!("settings.general.object_storage.group"),
+                    border,
+                    muted_fg,
+                ))
                 .child(self.render_gen_input_field(
-                    "Object preview size limit (MiB)",
+                    dbflux_i18n::t!("settings.general.object_preview_limit.label"),
                     &self.input_object_preview_limit,
                     is_at(GeneralFormRow::ObjectPreviewLimit),
                     primary,
@@ -662,19 +705,22 @@ impl GeneralSection {
                 ))
                 .child(
                     div().px_2().child(
-                        Body::new(
-                            "Objects larger than this are never downloaded for preview; \
-                             the browser shows their metadata only.",
-                        )
+                        Body::new(dbflux_i18n::t!(
+                            "settings.general.object_preview_hint.label"
+                        ))
                         .color(muted_fg),
                     ),
                 )
                 .when(Self::is_nightly(), |column| {
                     column
-                        .child(self.render_gen_group_header("Storage", border, muted_fg))
+                        .child(self.render_gen_group_header(
+                            dbflux_i18n::t!("settings.general.storage.group"),
+                            border,
+                            muted_fg,
+                        ))
                         .child(self.render_gen_checkbox(
                             "share-stable-db",
-                            "Use the stable database",
+                            dbflux_i18n::t!("settings.general.share_stable_db.label"),
                             self.gen_share_stable_db,
                             is_at(GeneralFormRow::ShareStableDb),
                             GeneralFormRow::ShareStableDb,
@@ -683,12 +729,8 @@ impl GeneralSection {
                         ))
                         .child(
                             div().px_2().child(
-                                Body::new(
-                                    "Applied on next launch. Shares the stable database \
-                                     (dbflux.db) instead of this nightly build's \
-                                     dbflux-nightly.db.",
-                                )
-                                .color(muted_fg),
+                                Body::new(dbflux_i18n::t!("settings.general.share_stable_db.hint"))
+                                    .color(muted_fg),
                             ),
                         )
                 }),
@@ -707,26 +749,29 @@ impl GeneralSection {
             .child(layout::footer_action_frame(
                 is_save_focused,
                 cx.theme().primary,
-                FluxButton::new("save-general", "Save")
-                    .small()
-                    .primary()
-                    .w_full()
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.content_focused = true;
-                        this.gen_form_cursor = this
-                            .gen_form_rows()
-                            .iter()
-                            .position(|row| *row == GeneralFormRow::SaveButton)
-                            .unwrap_or_default();
-                        this.save_general_settings(window, cx);
-                    })),
+                FluxButton::new(
+                    "save-general",
+                    dbflux_i18n::t!("settings.general.save.button"),
+                )
+                .small()
+                .primary()
+                .w_full()
+                .on_click(cx.listener(|this, _, window, cx| {
+                    this.content_focused = true;
+                    this.gen_form_cursor = this
+                        .gen_form_rows()
+                        .iter()
+                        .position(|row| *row == GeneralFormRow::SaveButton)
+                        .unwrap_or_default();
+                    this.save_general_settings(window, cx);
+                })),
             ))
             .into_any_element()
     }
 
     fn render_gen_group_header(
         &self,
-        label: &str,
+        label: impl Into<SharedString>,
         border: Hsla,
         _muted_fg: Hsla,
     ) -> impl IntoElement {
@@ -735,14 +780,14 @@ impl GeneralSection {
             .pb_1()
             .border_b_1()
             .border_color(border)
-            .child(SubSectionLabel::new(label.to_string()))
+            .child(SubSectionLabel::new(label))
     }
 
     #[allow(clippy::too_many_arguments)]
     fn render_gen_checkbox(
         &self,
         id: &'static str,
-        label: &'static str,
+        label: impl Into<SharedString>,
         checked: bool,
         is_focused: bool,
         row: GeneralFormRow,
@@ -789,7 +834,7 @@ impl GeneralSection {
 
     fn render_gen_dropdown(
         &self,
-        label: &str,
+        label: impl Into<SharedString>,
         dropdown: &Entity<Dropdown>,
         is_focused: bool,
         primary: Hsla,
@@ -823,13 +868,13 @@ impl GeneralSection {
                     cx.notify();
                 }),
             )
-            .child(FieldLabel::new(label.to_string()))
+            .child(FieldLabel::new(label))
             .child(div().min_w(px(140.0)).child(dropdown.clone()))
     }
 
     fn render_gen_input_field(
         &self,
-        label: &str,
+        label: impl Into<SharedString>,
         input: &Entity<InputState>,
         is_focused: bool,
         primary: Hsla,
@@ -843,7 +888,7 @@ impl GeneralSection {
                 .flex()
                 .flex_col()
                 .gap_1()
-                .child(FieldLabel::new(label.to_string()))
+                .child(FieldLabel::new(label))
                 .child(
                     div()
                         .w_full()

--- a/crates/dbflux_ui_windows/src/settings/general_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/general_section.rs
@@ -12,6 +12,7 @@ use gpui::*;
 pub(super) enum GeneralFormRow {
     Theme,
     Style,
+    Language,
     RestoreSession,
     ReopenConnections,
     DefaultFocus,
@@ -40,6 +41,7 @@ pub(super) struct GeneralSection {
     pub(super) gen_share_stable_db: bool,
     pub(super) dropdown_theme: Entity<Dropdown>,
     pub(super) dropdown_style: Entity<Dropdown>,
+    pub(super) dropdown_language: Entity<Dropdown>,
     pub(super) dropdown_default_focus: Entity<Dropdown>,
     pub(super) dropdown_refresh_policy: Entity<Dropdown>,
     pub(super) input_max_history: Entity<InputState>,
@@ -63,6 +65,7 @@ impl GeneralSection {
         let settings = app_state.read(cx).general_settings().clone();
         let theme_index = Self::theme_index(settings.theme);
         let style_index = Self::style_index(settings.style);
+        let language_index = Self::language_index(&settings.language);
         let startup_focus_index = Self::startup_focus_index(settings.default_focus_on_startup);
         let refresh_policy_index = Self::refresh_policy_index(settings.default_refresh_policy);
         let max_history = settings.max_history_entries.to_string();
@@ -82,6 +85,12 @@ impl GeneralSection {
                 .placeholder("Style")
                 .items(Self::style_items())
                 .selected_index(Some(style_index))
+        });
+        let dropdown_language = cx.new(move |_cx| {
+            Dropdown::new("general-language")
+                .placeholder("Language")
+                .items(Self::language_items())
+                .selected_index(Some(language_index))
         });
         let dropdown_default_focus = cx.new(move |_cx| {
             Dropdown::new("general-default-focus")
@@ -135,6 +144,14 @@ impl GeneralSection {
             &dropdown_style,
             |this, _, event: &DropdownSelectionChanged, cx| {
                 this.gen_settings.style = Self::style_for_index(event.index);
+                cx.notify();
+            },
+        );
+
+        let language_subscription = cx.subscribe(
+            &dropdown_language,
+            |this, _, event: &DropdownSelectionChanged, cx| {
+                this.gen_settings.language = Self::language_for_index(event.index).to_string();
                 cx.notify();
             },
         );
@@ -223,6 +240,7 @@ impl GeneralSection {
             gen_share_stable_db: dbflux_storage::paths::nightly_shares_stable_db(),
             dropdown_theme,
             dropdown_style,
+            dropdown_language,
             dropdown_default_focus,
             dropdown_refresh_policy,
             input_max_history,
@@ -235,6 +253,7 @@ impl GeneralSection {
             _subscriptions: vec![
                 theme_subscription,
                 style_subscription,
+                language_subscription,
                 focus_subscription,
                 refresh_policy_subscription,
                 blur_max_history,
@@ -261,12 +280,34 @@ impl GeneralSection {
         ]
     }
 
+    fn language_items() -> Vec<DropdownItem> {
+        vec![
+            DropdownItem::new(dbflux_i18n::t!("settings.general.language.option.system")),
+            DropdownItem::new(dbflux_i18n::t!("settings.general.language.option.english")),
+            DropdownItem::new(dbflux_i18n::t!("settings.general.language.option.spanish")),
+        ]
+    }
+
     fn startup_focus_items() -> Vec<DropdownItem> {
-        vec![DropdownItem::new("Sidebar"), DropdownItem::new("Last Tab")]
+        vec![
+            DropdownItem::new(dbflux_i18n::t!(
+                "settings.general.default_focus.option.sidebar"
+            )),
+            DropdownItem::new(dbflux_i18n::t!(
+                "settings.general.default_focus.option.last_tab"
+            )),
+        ]
     }
 
     fn refresh_policy_items() -> Vec<DropdownItem> {
-        vec![DropdownItem::new("Manual"), DropdownItem::new("Interval")]
+        vec![
+            DropdownItem::new(dbflux_i18n::t!(
+                "settings.general.refresh_policy.option.manual"
+            )),
+            DropdownItem::new(dbflux_i18n::t!(
+                "settings.general.refresh_policy.option.interval"
+            )),
+        ]
     }
 
     fn theme_index(theme: ThemeSetting) -> usize {
@@ -297,6 +338,23 @@ impl GeneralSection {
             1 => AppStyle::Compact,
             _ => AppStyle::Default,
         }
+    }
+
+    fn language_index(persisted: &str) -> usize {
+        match dbflux_i18n::LanguagePreference::from_storage_str(persisted) {
+            dbflux_i18n::LanguagePreference::System => 0,
+            dbflux_i18n::LanguagePreference::Explicit(dbflux_i18n::Language::English) => 1,
+            dbflux_i18n::LanguagePreference::Explicit(dbflux_i18n::Language::Spanish) => 2,
+        }
+    }
+
+    fn language_for_index(index: usize) -> &'static str {
+        let preference = match index {
+            1 => dbflux_i18n::LanguagePreference::Explicit(dbflux_i18n::Language::English),
+            2 => dbflux_i18n::LanguagePreference::Explicit(dbflux_i18n::Language::Spanish),
+            _ => dbflux_i18n::LanguagePreference::System,
+        };
+        preference.as_storage_str()
     }
 
     fn startup_focus_index(focus: StartupFocus) -> usize {
@@ -419,5 +477,37 @@ mod tests {
         assert_eq!(GeneralSection::style_for_index(1), AppStyle::Compact);
         // Out-of-range falls back to Default
         assert_eq!(GeneralSection::style_for_index(99), AppStyle::Default);
+    }
+
+    #[test]
+    fn language_dropdown_exposes_exactly_three_labels() {
+        let labels: Vec<_> = GeneralSection::language_items()
+            .into_iter()
+            .map(|item| item.label)
+            .collect();
+
+        assert_eq!(
+            labels,
+            vec![
+                dbflux_i18n::t!("settings.general.language.option.system"),
+                dbflux_i18n::t!("settings.general.language.option.english"),
+                dbflux_i18n::t!("settings.general.language.option.spanish"),
+            ]
+        );
+    }
+
+    #[test]
+    fn language_index_and_reverse_mapping_cover_system_and_explicit_languages() {
+        assert_eq!(GeneralSection::language_index(""), 0);
+        assert_eq!(GeneralSection::language_index("en"), 1);
+        assert_eq!(GeneralSection::language_index("es"), 2);
+        // An unrecognized persisted value falls back to System.
+        assert_eq!(GeneralSection::language_index("de"), 0);
+
+        assert_eq!(GeneralSection::language_for_index(0), "");
+        assert_eq!(GeneralSection::language_for_index(1), "en");
+        assert_eq!(GeneralSection::language_for_index(2), "es");
+        // Out-of-range falls back to System.
+        assert_eq!(GeneralSection::language_for_index(99), "");
     }
 }

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -31,6 +31,13 @@ built with the `mcp` feature; see [AI + MCP Integration](MCP_AI_INTEGRATION.md).
 |---------|---------|---------|
 | **Theme** | Dark, Mirage, Light | Dark |
 | **Style** | Default, Compact | Default |
+| **Language** | System, English, Spanish | System |
+
+System follows your OS locale and falls back to English when that locale
+isn't supported. A language change takes effect after you restart DBFlux, so
+the control shows a permanent note to that effect. This release only
+translates the General section; the rest of the UI is being converted
+crate by crate and stays in English for now.
 
 ### Startup & session
 


### PR DESCRIPTION
## Summary

First slice of app internationalization. It adds the translation mechanism, a Language setting (System / English / Spanish), and translates the Settings → General section as the pilot surface. The rest of the UI stays in English and is converted crate by crate in follow-up PRs.

## What does this resolve?

- Refs #360 (foundation slice; the remaining UI crates follow in separate PRs)

## How was this solved?

- New leaf crate `dbflux_i18n` wrapping `rust-i18n` (already in the tree through `gpui-component`), with one YAML catalog per locale (`locales/en.yml`, `locales/es.yml`) so a translation platform can consume them later. It exposes `Language`, `LanguagePreference { System, Explicit }`, a pure `resolve(persisted, system)`, and its own `t!` macro (rust-i18n's `t!` expands crate-relative and cannot be re-exported).
- Locale resolution: a persisted `en`/`es` wins; otherwise the OS locale's primary subtag (`es-AR` → `es`) when supported; otherwise English. System locale comes from `sys-locale`.
- Persistence: migration 026 adds `cfg_general_settings.language TEXT NOT NULL DEFAULT ''`. The empty string means System, so existing installs keep following the OS locale instead of being pinned to English. `dbflux_core`/`dbflux_app` store the raw string and do not depend on `dbflux_i18n`.
- Startup: `run_gui` resolves and sets the locale after settings load and before the window opens. Entities capture `SharedString` at construction, so a change applies after restart; the control shows a permanent note saying so.
- Settings UI: Language dropdown in General → Appearance showing the persisted preference; `render_gen_*` label params widened to `impl Into<SharedString>`; every user-facing literal of the General surface routed through `t!`. Spanish keeps database terms (query, WHERE, DELETE, UPDATE, MiB, ms) in English.
- Guard: a key-parity test and a no-empty-values test over both catalogs run under `cargo nextest`, so a missing Spanish key fails CI naming the key.

## Validation

- `cargo nextest run --workspace` → 4908 passed, 214 skipped
- `cargo test --doc --workspace` → 0 failed
- `cargo clippy --workspace -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- New tests: locale resolution rules (persisted/system/fallback/region subtag), `LanguagePreference` storage round-trip, catalog key parity and non-empty values, `t!` per-locale rendering and interpolation, migration default and repository round-trip, config-loader fallback for unknown values, dropdown labels and index mapping.
- Receipt-driven review (gentle-ai, four lenses) approved; all remaining findings are advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual GPUI smoke in Spanish still pending, see below)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Known limitations / follow-ups

- Only the General section is translated in this PR. Next slices: `dbflux_ui_base`, `dbflux_components`, `dbflux_ui_sidebar`, `dbflux_ui_document`, rest of `dbflux_ui_windows`, `dbflux_ui`.
- Driver-owned text (connection form labels, `ErrorFormatter` output, instance-catalog metric names), MCP tool descriptions, and audit category strings stay in English by design.
- Manual smoke still to run before merge: set Language = Spanish, save, restart, check the General section renders without clipping, the dropdown (a gpui-component widget) behaves under `es`, the restart note is always visible, and System with an unsupported OS locale shows English.
- Exceeds the 400-line budget (`size:exception`): the mechanism and its first proof are not separable; about half of the diff is catalog YAML and mechanical literal replacements.
