### PR TITLE
docs(readme): mention Weblate for translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ Choose the path that matches what you want to do.
 - [Driver Authoring](docs/DRIVER_AUTHORING.md) — choose and implement a built-in Rust or external RPC driver
 - [Architecture](ARCHITECTURE.md) — the canonical architecture and crate map, including crate boundaries and cross-crate flows
 
+### Translations
+
+DBFlux is translated on [Hosted Weblate](https://hosted.weblate.org/engage/dbflux/).
+The catalogs live in `crates/dbflux_i18n/locales/`, one YAML file per language, and
+translation updates arrive as pull requests from Weblate.
+
+[![Translation status](https://hosted.weblate.org/widget/dbflux/app/svg-badge.svg)](https://hosted.weblate.org/engage/dbflux/)
+
 ### Reference
 
 - [Charts](docs/CHARTS.md) — chart types, column kinds, and axis auto-detection


### PR DESCRIPTION
## Summary

Adds a Translations section to the README pointing at the Hosted Weblate project, with the component status badge.

## What does this resolve?

- Refs #360. Hosted Weblate's libre hosting requires the project README to mention Weblate; this is the only change needed to request approval.

## How was this solved?

- New `### Translations` subsection under Documentation → Contributors: where the catalogs live (`crates/dbflux_i18n/locales/`), that updates arrive as pull requests from Weblate, and the engage link plus SVG badge.

## Validation

- Markdown only; rendered on GitHub and on the site (the README is not part of the docs build).
- Receipt-driven review: low risk, approved.

## Where was this tested?

- [x] Local development environment
- [ ] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed (not applicable)
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (README only)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
