### PR TITLE
feat(i18n): translate toasts, user errors, and dashboard modals in dbflux_ui_base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3250,6 +3250,7 @@ dependencies = [
  "dbflux_aws",
  "dbflux_components",
  "dbflux_core",
+ "dbflux_i18n",
  "dbflux_mcp",
  "dbflux_storage",
  "gpui",

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1,3 +1,38 @@
+errors:
+  action:
+    view_in_audit: View in Audit
+  correlation:
+    detail: "Correlation: %{id}"
+    clipboard: "%{summary}\nCorrelation: %{id}"
+modals:
+  rename:
+    placeholder: Enter a name
+    title:
+      dashboard: Rename dashboard
+      saved_chart: Rename saved chart
+    validation:
+      empty_name: Name cannot be empty
+    cancel: Cancel
+    confirm: Rename
+  create_dashboard:
+    name_label: Dashboard name
+    title: New dashboard
+    validation:
+      empty_name: Name cannot be empty
+    cancel: Cancel
+    confirm: Create
+  delete_confirm:
+    dashboard:
+      title: Delete dashboard
+      body: 'Delete dashboard "%{name}"? This cannot be undone.'
+    saved_chart:
+      title: Delete saved chart
+      body: 'Delete saved chart "%{name}"? This cannot be undone.'
+      orphan_warning:
+        one: "This chart is used in 1 dashboard: %{names}. Panels that reference it will show broken placeholders."
+        many: "This chart is used in %{count} dashboards: %{names}. Panels that reference it will show broken placeholders."
+    cancel: Cancel
+    confirm: Delete
 settings:
   general:
     header:
@@ -75,3 +110,8 @@ settings:
       button: Save
       error: "Failed to save general settings: %{error}"
       success: Settings saved. Some changes apply on next startup.
+toast:
+  action:
+    copy: Copy
+    show_details: Show details
+    hide_details: Hide details

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1,3 +1,38 @@
+errors:
+  action:
+    view_in_audit: Ver en auditoría
+  correlation:
+    detail: "Correlación: %{id}"
+    clipboard: "%{summary}\nCorrelación: %{id}"
+modals:
+  rename:
+    placeholder: Escribe un nombre
+    title:
+      dashboard: Renombrar dashboard
+      saved_chart: Renombrar gráfico guardado
+    validation:
+      empty_name: El nombre no puede estar vacío
+    cancel: Cancelar
+    confirm: Renombrar
+  create_dashboard:
+    name_label: Nombre del dashboard
+    title: Nuevo dashboard
+    validation:
+      empty_name: El nombre no puede estar vacío
+    cancel: Cancelar
+    confirm: Crear
+  delete_confirm:
+    dashboard:
+      title: Eliminar dashboard
+      body: '¿Eliminar el dashboard "%{name}"? Esta acción no se puede deshacer.'
+    saved_chart:
+      title: Eliminar gráfico guardado
+      body: '¿Eliminar el gráfico guardado "%{name}"? Esta acción no se puede deshacer.'
+      orphan_warning:
+        one: "Este gráfico se usa en 1 dashboard: %{names}. Los paneles que lo referencian mostrarán marcadores rotos."
+        many: "Este gráfico se usa en %{count} dashboards: %{names}. Los paneles que lo referencian mostrarán marcadores rotos."
+    cancel: Cancelar
+    confirm: Eliminar
 settings:
   general:
     header:
@@ -75,3 +110,8 @@ settings:
       button: Guardar
       error: "No se pudo guardar la configuración general: %{error}"
       success: Configuración guardada. Algunos cambios se aplican al reiniciar.
+toast:
+  action:
+    copy: Copiar
+    show_details: Mostrar detalles
+    hide_details: Ocultar detalles

--- a/crates/dbflux_ui_base/Cargo.toml
+++ b/crates/dbflux_ui_base/Cargo.toml
@@ -17,6 +17,7 @@ dbflux_app.workspace = true
 dbflux_storage.workspace = true
 dbflux_components.workspace = true
 dbflux_core.workspace = true
+dbflux_i18n.workspace = true
 dbflux_mcp = { workspace = true, optional = true }
 dbflux_aws = { workspace = true, optional = true }
 tracing.workspace = true

--- a/crates/dbflux_ui_base/src/modals/create_dashboard.rs
+++ b/crates/dbflux_ui_base/src/modals/create_dashboard.rs
@@ -39,7 +39,10 @@ pub struct ModalCreateDashboard {
 
 impl ModalCreateDashboard {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let name_input = cx.new(|cx| InputState::new(window, cx).placeholder("Dashboard name"));
+        let name_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("modals.create_dashboard.name_label"))
+        });
 
         Self {
             request: None,
@@ -97,7 +100,9 @@ impl ModalCreateDashboard {
         let name = self.name_input.read(cx).value().trim().to_string();
 
         if name.is_empty() {
-            self.validation_error = Some("Name cannot be empty".to_string());
+            self.validation_error = Some(dbflux_i18n::t!(
+                "modals.create_dashboard.validation.empty_name"
+            ));
             cx.notify();
             return;
         }
@@ -129,7 +134,10 @@ impl Render for ModalCreateDashboard {
             .flex()
             .flex_col()
             .gap(Spacing::SM)
-            .child(Text::label("Dashboard name").into_any_element())
+            .child(
+                Text::label(dbflux_i18n::t!("modals.create_dashboard.name_label"))
+                    .into_any_element(),
+            )
             .child(Input::new(&self.name_input))
             .when_some(validation_error, |el, err| {
                 el.child(div().text_sm().child(Text::body(err).into_any_element()))
@@ -147,15 +155,24 @@ impl Render for ModalCreateDashboard {
             .flex()
             .items_center()
             .gap(Spacing::SM)
-            .child(Button::new("create-dashboard-cancel", "Cancel").on_click(on_cancel))
             .child(
-                Button::new("create-dashboard-confirm", "Create")
-                    .primary()
-                    .on_click(on_confirm),
+                Button::new(
+                    "create-dashboard-cancel",
+                    dbflux_i18n::t!("modals.create_dashboard.cancel"),
+                )
+                .on_click(on_cancel),
+            )
+            .child(
+                Button::new(
+                    "create-dashboard-confirm",
+                    dbflux_i18n::t!("modals.create_dashboard.confirm"),
+                )
+                .primary()
+                .on_click(on_confirm),
             );
 
         ModalShell::new(
-            "New dashboard",
+            dbflux_i18n::t!("modals.create_dashboard.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
@@ -218,5 +235,36 @@ mod tests {
             }
             _ => panic!("Expected Confirmed variant"),
         }
+    }
+
+    const CREATE_DASHBOARD_KEYS: &[&str] = &[
+        "modals.create_dashboard.name_label",
+        "modals.create_dashboard.title",
+        "modals.create_dashboard.validation.empty_name",
+        "modals.create_dashboard.cancel",
+        "modals.create_dashboard.confirm",
+    ];
+
+    #[test]
+    fn create_dashboard_catalog_keys_resolve() {
+        for key in CREATE_DASHBOARD_KEYS {
+            let english = dbflux_i18n::t!(key);
+            let spanish = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert_ne!(english, *key, "missing English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(spanish, *key, "missing Spanish translation for {key}");
+        }
+    }
+
+    #[test]
+    fn create_dashboard_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("modals.create_dashboard.title", locale = "en");
+        let spanish = dbflux_i18n::t!("modals.create_dashboard.title", locale = "es");
+
+        assert_eq!(english, "New dashboard");
+        assert_eq!(spanish, "Nuevo dashboard");
+        assert_ne!(english, spanish);
     }
 }

--- a/crates/dbflux_ui_base/src/modals/delete_confirm.rs
+++ b/crates/dbflux_ui_base/src/modals/delete_confirm.rs
@@ -9,6 +9,37 @@ use gpui::*;
 use gpui_component::ActiveTheme;
 use uuid::Uuid;
 
+/// Confirmation body text for deleting a dashboard, with the dashboard name
+/// interpolated into the translated template.
+pub fn delete_dashboard_body_text(name: &str) -> String {
+    dbflux_i18n::t!("modals.delete_confirm.dashboard.body", name = name)
+}
+
+/// Confirmation body text for deleting a saved chart, with the chart name
+/// interpolated into the translated template.
+pub fn delete_saved_chart_body_text(name: &str) -> String {
+    dbflux_i18n::t!("modals.delete_confirm.saved_chart.body", name = name)
+}
+
+/// Orphan-warning text shown when a saved chart is still referenced by
+/// dashboards. Uses the singular catalog bucket only for exactly one
+/// referencing dashboard; every other count, including zero, uses the
+/// plural bucket.
+pub fn orphan_warning_text(count: usize, names: &str) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "modals.delete_confirm.saved_chart.orphan_warning.one",
+            names = names
+        )
+    } else {
+        dbflux_i18n::t!(
+            "modals.delete_confirm.saved_chart.orphan_warning.many",
+            count = count,
+            names = names
+        )
+    }
+}
+
 // --- Dashboard delete confirm ---
 
 /// Outcome emitted when the user resolves the dashboard delete modal.
@@ -88,14 +119,9 @@ impl Render for ModalDeleteDashboardConfirm {
                             .size(Heights::ICON_SM)
                             .color(theme.danger),
                     )
-                    .child(
-                        div().flex_1().min_w_0().child(
-                            Text::body(format!(
-                                "Delete dashboard \"{dashboard_name}\"? This cannot be undone."
-                            ))
-                            .into_any_element(),
-                        ),
-                    ),
+                    .child(div().flex_1().min_w_0().child(
+                        Text::body(delete_dashboard_body_text(&dashboard_name)).into_any_element(),
+                    )),
             )
             .child(
                 surface_raised(cx)
@@ -125,15 +151,24 @@ impl Render for ModalDeleteDashboardConfirm {
             .flex()
             .items_center()
             .gap(Spacing::SM)
-            .child(Button::new("delete-dashboard-cancel", "Cancel").on_click(on_cancel))
             .child(
-                Button::new("delete-dashboard-confirm", "Delete")
-                    .danger()
-                    .on_click(on_confirm),
+                Button::new(
+                    "delete-dashboard-cancel",
+                    dbflux_i18n::t!("modals.delete_confirm.cancel"),
+                )
+                .on_click(on_cancel),
+            )
+            .child(
+                Button::new(
+                    "delete-dashboard-confirm",
+                    dbflux_i18n::t!("modals.delete_confirm.confirm"),
+                )
+                .danger()
+                .on_click(on_confirm),
             );
 
         ModalShell::new(
-            "Delete dashboard",
+            dbflux_i18n::t!("modals.delete_confirm.dashboard.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
@@ -231,14 +266,9 @@ impl Render for ModalDeleteSavedChartConfirm {
                             .size(Heights::ICON_SM)
                             .color(theme.danger),
                     )
-                    .child(
-                        div().flex_1().min_w_0().child(
-                            Text::body(format!(
-                                "Delete saved chart \"{chart_name}\"? This cannot be undone."
-                            ))
-                            .into_any_element(),
-                        ),
-                    ),
+                    .child(div().flex_1().min_w_0().child(
+                        Text::body(delete_saved_chart_body_text(&chart_name)).into_any_element(),
+                    )),
             )
             // Orphan-warning block: shown only when the chart is referenced by dashboards.
             .when(has_refs, |el| {
@@ -246,14 +276,14 @@ impl Render for ModalDeleteSavedChartConfirm {
                     referencing.iter().map(|(_, name)| name.clone()).collect();
                 let names_list = dashboard_names.join(", ");
 
-                el.child(div().flex().flex_col().gap(Spacing::XS).child(
-                    div().text_sm().text_color(theme.warning).child(format!(
-                        "This chart is used in {count} dashboard{s}: {names_list}. \
-                                     Panels that reference it will show broken placeholders.",
-                        count = referencing.len(),
-                        s = if referencing.len() == 1 { "" } else { "s" },
-                    )),
-                ))
+                el.child(
+                    div().flex().flex_col().gap(Spacing::XS).child(
+                        div()
+                            .text_sm()
+                            .text_color(theme.warning)
+                            .child(orphan_warning_text(referencing.len(), &names_list)),
+                    ),
+                )
             });
 
         let on_cancel = cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
@@ -270,15 +300,24 @@ impl Render for ModalDeleteSavedChartConfirm {
             .flex()
             .items_center()
             .gap(Spacing::SM)
-            .child(Button::new("delete-chart-cancel", "Cancel").on_click(on_cancel))
             .child(
-                Button::new("delete-chart-confirm", "Delete")
-                    .danger()
-                    .on_click(on_confirm),
+                Button::new(
+                    "delete-chart-cancel",
+                    dbflux_i18n::t!("modals.delete_confirm.cancel"),
+                )
+                .on_click(on_cancel),
+            )
+            .child(
+                Button::new(
+                    "delete-chart-confirm",
+                    dbflux_i18n::t!("modals.delete_confirm.confirm"),
+                )
+                .danger()
+                .on_click(on_confirm),
             );
 
         ModalShell::new(
-            "Delete saved chart",
+            dbflux_i18n::t!("modals.delete_confirm.saved_chart.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
@@ -301,17 +340,17 @@ mod tests {
 
     #[test]
     fn modal_delete_dashboard_confirm_body_text_contains_name_and_cannot_be_undone() {
-        let req = DeleteDashboardRequest {
-            dashboard_id: test_uuid(),
-            dashboard_name: "My Dashboard".to_string(),
-        };
+        let body_text = super::delete_dashboard_body_text("My Dashboard");
 
-        let body_text = format!(
-            "Delete dashboard \"{}\"? This cannot be undone.",
-            req.dashboard_name
-        );
         assert!(body_text.contains("My Dashboard"));
         assert!(body_text.contains("This cannot be undone."));
+        assert_eq!(
+            body_text,
+            dbflux_i18n::t!(
+                "modals.delete_confirm.dashboard.body",
+                name = "My Dashboard"
+            )
+        );
     }
 
     #[test]
@@ -379,15 +418,86 @@ mod tests {
 
     #[test]
     fn orphan_warning_text_contains_broken_placeholders() {
-        let warning = format!(
-            "This chart is used in {count} dashboard{s}: {names}. \
-             Panels that reference it will show broken placeholders.",
-            count = 2,
-            s = "s",
-            names = "Dashboard A, Dashboard B",
-        );
+        let warning = super::orphan_warning_text(2, "Dashboard A, Dashboard B");
+
         assert!(warning.contains("broken placeholders"));
         assert!(warning.contains("Dashboard A"));
         assert!(warning.contains("Dashboard B"));
+    }
+
+    #[test]
+    fn orphan_warning_text_uses_singular_bucket_for_one() {
+        let warning = super::orphan_warning_text(1, "A");
+
+        assert_eq!(
+            warning,
+            dbflux_i18n::t!(
+                "modals.delete_confirm.saved_chart.orphan_warning.one",
+                names = "A"
+            )
+        );
+        assert_ne!(
+            warning,
+            dbflux_i18n::t!(
+                "modals.delete_confirm.saved_chart.orphan_warning.many",
+                count = 1,
+                names = "A"
+            )
+        );
+    }
+
+    #[test]
+    fn orphan_warning_text_uses_plural_bucket_for_many() {
+        let warning = super::orphan_warning_text(2, "A, B");
+
+        assert!(warning.contains('2'));
+        assert!(warning.contains('A'));
+        assert!(warning.contains('B'));
+        assert_eq!(
+            warning,
+            dbflux_i18n::t!(
+                "modals.delete_confirm.saved_chart.orphan_warning.many",
+                count = 2,
+                names = "A, B"
+            )
+        );
+    }
+
+    #[test]
+    fn orphan_warning_text_zero_uses_plural_bucket() {
+        let warning = super::orphan_warning_text(0, "A");
+
+        assert_eq!(
+            warning,
+            dbflux_i18n::t!(
+                "modals.delete_confirm.saved_chart.orphan_warning.many",
+                count = 0,
+                names = "A"
+            )
+        );
+    }
+
+    const DELETE_CONFIRM_KEYS: &[&str] = &[
+        "modals.delete_confirm.dashboard.title",
+        "modals.delete_confirm.dashboard.body",
+        "modals.delete_confirm.saved_chart.title",
+        "modals.delete_confirm.saved_chart.body",
+        "modals.delete_confirm.saved_chart.orphan_warning.one",
+        "modals.delete_confirm.saved_chart.orphan_warning.many",
+        "modals.delete_confirm.cancel",
+        "modals.delete_confirm.confirm",
+    ];
+
+    #[test]
+    fn delete_confirm_catalog_keys_resolve() {
+        for key in DELETE_CONFIRM_KEYS {
+            let english = dbflux_i18n::t!(key);
+            let spanish = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert_ne!(english, *key, "missing English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(spanish, *key, "missing Spanish translation for {key}");
+        }
     }
 }

--- a/crates/dbflux_ui_base/src/modals/rename_item.rs
+++ b/crates/dbflux_ui_base/src/modals/rename_item.rs
@@ -47,7 +47,9 @@ pub struct ModalRenameItem {
 
 impl ModalRenameItem {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let input = cx.new(|cx| InputState::new(window, cx).placeholder("Enter a name"));
+        let input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!("modals.rename.placeholder"))
+        });
 
         Self {
             request: None,
@@ -102,7 +104,7 @@ impl ModalRenameItem {
         let name = self.input.read(cx).value().trim().to_string();
 
         if name.is_empty() {
-            self.validation_error = Some("Name cannot be empty".to_string());
+            self.validation_error = Some(dbflux_i18n::t!("modals.rename.validation.empty_name"));
             cx.notify();
             return;
         }
@@ -133,8 +135,8 @@ impl Render for ModalRenameItem {
         };
 
         let title = match &request.target {
-            RenameTarget::Dashboard { .. } => "Rename dashboard",
-            RenameTarget::SavedChart { .. } => "Rename saved chart",
+            RenameTarget::Dashboard { .. } => dbflux_i18n::t!("modals.rename.title.dashboard"),
+            RenameTarget::SavedChart { .. } => dbflux_i18n::t!("modals.rename.title.saved_chart"),
         };
 
         let validation_error = self.validation_error.clone();
@@ -160,11 +162,20 @@ impl Render for ModalRenameItem {
             .flex()
             .items_center()
             .gap(Spacing::SM)
-            .child(Button::new("rename-item-cancel", "Cancel").on_click(on_cancel))
             .child(
-                Button::new("rename-item-confirm", "Rename")
-                    .primary()
-                    .on_click(on_confirm),
+                Button::new(
+                    "rename-item-cancel",
+                    dbflux_i18n::t!("modals.rename.cancel"),
+                )
+                .on_click(on_cancel),
+            )
+            .child(
+                Button::new(
+                    "rename-item-confirm",
+                    dbflux_i18n::t!("modals.rename.confirm"),
+                )
+                .primary()
+                .on_click(on_confirm),
             );
 
         ModalShell::new(title, body.into_any_element(), footer.into_any_element())
@@ -256,5 +267,37 @@ mod tests {
             }
             _ => panic!("Expected Confirmed variant"),
         }
+    }
+
+    const RENAME_MODAL_KEYS: &[&str] = &[
+        "modals.rename.placeholder",
+        "modals.rename.title.dashboard",
+        "modals.rename.title.saved_chart",
+        "modals.rename.validation.empty_name",
+        "modals.rename.cancel",
+        "modals.rename.confirm",
+    ];
+
+    #[test]
+    fn rename_modal_catalog_keys_resolve() {
+        for key in RENAME_MODAL_KEYS {
+            let english = dbflux_i18n::t!(key);
+            let spanish = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert_ne!(english, *key, "missing English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(spanish, *key, "missing Spanish translation for {key}");
+        }
+    }
+
+    #[test]
+    fn rename_modal_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("modals.rename.title.dashboard", locale = "en");
+        let spanish = dbflux_i18n::t!("modals.rename.title.dashboard", locale = "es");
+
+        assert_eq!(english, "Rename dashboard");
+        assert_eq!(spanish, "Renombrar dashboard");
+        assert_ne!(english, spanish);
     }
 }

--- a/crates/dbflux_ui_base/src/toast.rs
+++ b/crates/dbflux_ui_base/src/toast.rs
@@ -30,9 +30,11 @@ pub fn now_hms() -> String {
 /// what the user saw, even if the toast is later dismissed.
 pub fn copy_action(payload: impl Into<String>) -> ToastAction {
     let payload = payload.into();
-    ToastAction::new("copy-error", "Copy").on_click(move |cx: &mut App| {
-        cx.write_to_clipboard(gpui::ClipboardItem::new_string(payload.clone()));
-    })
+    ToastAction::new("copy-error", dbflux_i18n::t!("toast.action.copy")).on_click(
+        move |cx: &mut App| {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string(payload.clone()));
+        },
+    )
 }
 
 /// Toast visual variant. Drives icon, accent stripe, banner colors, and the
@@ -382,6 +384,38 @@ impl Default for ToastHost {
 }
 
 #[cfg(test)]
+mod i18n_tests {
+    const TOAST_ACTION_KEYS: &[&str] = &[
+        "toast.action.copy",
+        "toast.action.show_details",
+        "toast.action.hide_details",
+    ];
+
+    #[test]
+    fn toast_catalog_keys_resolve() {
+        for key in TOAST_ACTION_KEYS {
+            let english = dbflux_i18n::t!(key);
+            let spanish = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert_ne!(english, *key, "missing English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(spanish, *key, "missing Spanish translation for {key}");
+        }
+    }
+
+    #[test]
+    fn toast_copy_label_differs_between_locales() {
+        let english = dbflux_i18n::t!("toast.action.copy", locale = "en");
+        let spanish = dbflux_i18n::t!("toast.action.copy", locale = "es");
+
+        assert_eq!(english, "Copy");
+        assert_eq!(spanish, "Copiar");
+        assert_ne!(english, spanish);
+    }
+}
+
+#[cfg(test)]
 impl ToastHost {
     /// Returns the number of currently-visible toasts. For use in tests only.
     pub fn toast_count(&self) -> usize {
@@ -584,10 +618,10 @@ impl ToastHost {
         }
 
         if can_collapse {
-            let label: SharedString = if is_collapsed {
-                "Show details".into()
+            let label: String = if is_collapsed {
+                dbflux_i18n::t!("toast.action.show_details")
             } else {
-                "Hide details".into()
+                dbflux_i18n::t!("toast.action.hide_details")
             };
             let toggle = gpui::div()
                 .id(("toast-toggle", toast_id))
@@ -653,9 +687,11 @@ pub fn flush_pending_toast<T>(
         Toast::error(toast.message)
             .meta_right(now_hms())
             .action(
-                ToastAction::new("copy-error", "Copy").on_click(move |cx: &mut App| {
-                    cx.write_to_clipboard(gpui::ClipboardItem::new_string(payload.clone()));
-                }),
+                ToastAction::new("copy-error", dbflux_i18n::t!("toast.action.copy")).on_click(
+                    move |cx: &mut App| {
+                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(payload.clone()));
+                    },
+                ),
             )
             .push(cx);
     } else {

--- a/crates/dbflux_ui_base/src/user_error/mod.rs
+++ b/crates/dbflux_ui_base/src/user_error/mod.rs
@@ -160,18 +160,25 @@ pub fn report_error(err: UserFacingError, cx: &mut App) {
     }
 
     let id_for_action = err.correlation_id;
-    let view_in_audit =
-        ToastAction::new("view-in-audit", "View in Audit").on_click(move |cx: &mut App| {
-            if let Some(g) = cx.try_global::<AppStateGlobal>() {
-                let entity = g.entity.clone();
-                entity.update(cx, |s, cx| s.request_open_audit(Some(id_for_action), cx));
-            }
-        });
+    let view_in_audit = ToastAction::new(
+        "view-in-audit",
+        dbflux_i18n::t!("errors.action.view_in_audit"),
+    )
+    .on_click(move |cx: &mut App| {
+        if let Some(g) = cx.try_global::<AppStateGlobal>() {
+            let entity = g.entity.clone();
+            entity.update(cx, |s, cx| s.request_open_audit(Some(id_for_action), cx));
+        }
+    });
 
     toast = toast
         .meta_right(now_hms())
-        .details(format!("Correlation: {id_str}"))
-        .action(copy_action(format!("{summary}\nCorrelation: {id_str}")))
+        .details(dbflux_i18n::t!("errors.correlation.detail", id = id_str))
+        .action(copy_action(dbflux_i18n::t!(
+            "errors.correlation.clipboard",
+            summary = summary,
+            id = id_str
+        )))
         .action(view_in_audit);
 
     toast.push(cx);
@@ -263,5 +270,37 @@ mod tests {
         assert_eq!(ErrorKind::Driver.as_str(), "driver");
         assert_eq!(ErrorKind::User.as_str(), "user");
         assert_eq!(ErrorKind::Config.as_str(), "config");
+    }
+}
+
+#[cfg(test)]
+mod i18n_tests {
+    const USER_ERROR_KEYS: &[&str] = &[
+        "errors.action.view_in_audit",
+        "errors.correlation.detail",
+        "errors.correlation.clipboard",
+    ];
+
+    #[test]
+    fn user_error_catalog_keys_resolve() {
+        for key in USER_ERROR_KEYS {
+            let english = dbflux_i18n::t!(key);
+            let spanish = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert_ne!(english, *key, "missing English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(spanish, *key, "missing Spanish translation for {key}");
+        }
+    }
+
+    #[test]
+    fn correlation_clipboard_ends_with_correlation_detail() {
+        let clipboard =
+            dbflux_i18n::t!("errors.correlation.clipboard", summary = "boom", id = "ID");
+        let detail = dbflux_i18n::t!("errors.correlation.detail", id = "ID");
+
+        assert!(clipboard.starts_with("boom\n"));
+        assert!(clipboard.ends_with(&detail));
     }
 }


### PR DESCRIPTION
## Summary

Second i18n slice: the shared UI chrome in `dbflux_ui_base` now renders through `dbflux_i18n::t!` — toast actions, the user-error toast (View in Audit, correlation line and clipboard payload), and the rename / create-dashboard / delete-confirm modals. English and Spanish catalogs ship together; the rest of the crate (SSO wizard, SQL preview, add-panel picker) follows in the next two PRs.

## What does this resolve?

- Refs #360 (slice 2 of the app translation; follows #361)

## How was this solved?

- `dbflux_ui_base` depends on `dbflux_i18n`; every literal in the five files is a fully qualified `dbflux_i18n::t!(...)` call. No public signature changed: every sink already accepts `impl Into<SharedString>`.
- Interpolation only through named placeholders (`%{id}`, `%{name}`, `%{count}`, `%{names}`); the clipboard payload for user errors uses its own composition key so no translated fragment is ever concatenated with `format!`.
- Plural forms use per-bucket keys selected in code (`orphan_warning.one` / `.many`), no macro change.
- Three pure helpers in `delete_confirm.rs` (`delete_dashboard_body_text`, `delete_saved_chart_body_text`, `orphan_warning_text`) so the body/plural tests exercise production code; the previous tests rebuilt the English string inside the test and proved nothing.
- Spanish keeps "dashboard" and database terms in English per the terminology rule.

## Validation

- `cargo nextest run --workspace` → 4920 passed, 214 skipped
- `cargo test --doc --workspace` → 0 failed
- `cargo clippy --workspace -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- New tests: per-module catalog key resolution in `en` and `es`, locale-divergence checks on non-interpolated keys, clipboard drift guard, plural bucket selection (1 / many / 0), rewritten body-text tests against the helpers.
- Receipt-driven review (gentle-ai, one lens): approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual GPUI smoke in Spanish listed below)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (the Unreleased entry from #361 already describes the incremental translation; a consolidated entry lands when the crate is complete)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Known limitations / follow-ups

- `t!` cannot combine `locale =` with named arguments, so Spanish interpolation is covered by the catalog parity test, not by a rendering test.
- Next: PR B (`sso_wizard.rs`, `sql_preview_modal.rs`), PR C (`add_panel_picker.rs`), then `dbflux_components`.
- Manual smoke in `es`: toast Copy / Show details; a failing operation's toast (View in Audit, copied text); rename, create and delete dashboard/saved-chart modals incl. the orphan warning with 1 and 2 dashboards.
- 524 changed lines (`size:exception`): about half is catalog YAML and tests; `cargo fmt` expands the chained builder calls.
