### PR TITLE
feat(i18n): translate the SSO wizard and SQL preview modal in dbflux_ui_base

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -110,6 +110,55 @@ settings:
       button: Save
       error: "Failed to save general settings: %{error}"
       success: Settings saved. Some changes apply on next startup.
+sql_preview:
+  title:
+    sql: SQL Preview
+    query: Query Preview
+  options:
+    label: Options
+    fully_qualified: Fully qualified names
+    compact: Compact SQL
+  action:
+    refresh: Refresh
+    copy: Copy
+    close: Close
+sso_wizard:
+  title: AWS SSO Wizard
+  step:
+    start: "Step 1: Start URL"
+    account: "Step 2: Account"
+    role: "Step 3: Role"
+    confirm: "Step 4: Confirm"
+  account:
+    hint: Use account ID from AWS SSO account discovery
+    discovering: Discovering accounts...
+    discover_button: Login + Discover Accounts
+    no_matches: No matching accounts for current filter
+  role:
+    hint: Use role name from AWS SSO role listing
+    discovering: Discovering roles...
+    discover_button: Discover Roles for Selected Account
+    no_matches: No matching roles for current filter
+  confirm:
+    profile: "Profile: %{value}"
+    start_url: "Start URL: %{value}"
+    region: "Region: %{value}"
+    account: "Account: %{value}"
+    role: "Role: %{value}"
+  back: Back
+  next: Next
+  save: Save
+  status:
+    missing_required: Profile name, start URL, and region are required
+    fill_before_account_discovery: Fill profile name, start URL, and region before discovery
+    discovering_accounts: Logging in and fetching SSO accounts...
+    accounts_discovered: SSO account discovery completed
+    accounts_failed: "Failed to discover accounts: %{error}"
+    fill_before_role_discovery: Fill profile/region/start URL and select an account first
+    discovering_roles: Fetching SSO roles...
+    roles_discovered: SSO role discovery completed
+    roles_failed: "Failed to discover roles: %{error}"
+    profile_created: Created AWS SSO auth profile
 toast:
   action:
     copy: Copy

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -110,6 +110,55 @@ settings:
       button: Guardar
       error: "No se pudo guardar la configuración general: %{error}"
       success: Configuración guardada. Algunos cambios se aplican al reiniciar.
+sql_preview:
+  title:
+    sql: Vista previa de SQL
+    query: Vista previa de consulta
+  options:
+    label: Opciones
+    fully_qualified: Nombres completamente calificados
+    compact: SQL compacto
+  action:
+    refresh: Actualizar
+    copy: Copiar
+    close: Cerrar
+sso_wizard:
+  title: Asistente de AWS SSO
+  step:
+    start: "Paso 1: URL de inicio"
+    account: "Paso 2: Cuenta"
+    role: "Paso 3: Rol"
+    confirm: "Paso 4: Confirmar"
+  account:
+    hint: Usa el ID de cuenta obtenido con el descubrimiento de cuentas de AWS SSO
+    discovering: Descubriendo cuentas...
+    discover_button: Iniciar sesión y descubrir cuentas
+    no_matches: No hay cuentas que coincidan con el filtro actual
+  role:
+    hint: Usa el nombre de rol del listado de roles de AWS SSO
+    discovering: Descubriendo roles...
+    discover_button: Descubrir roles para la cuenta seleccionada
+    no_matches: No hay roles que coincidan con el filtro actual
+  confirm:
+    profile: "Perfil: %{value}"
+    start_url: "URL de inicio: %{value}"
+    region: "Región: %{value}"
+    account: "Cuenta: %{value}"
+    role: "Rol: %{value}"
+  back: Atrás
+  next: Siguiente
+  save: Guardar
+  status:
+    missing_required: El nombre de perfil, la URL de inicio y la región son obligatorios
+    fill_before_account_discovery: Completa el nombre de perfil, la URL de inicio y la región antes de descubrir
+    discovering_accounts: Iniciando sesión y obteniendo cuentas de SSO...
+    accounts_discovered: Descubrimiento de cuentas de SSO completado
+    accounts_failed: "Error al descubrir cuentas: %{error}"
+    fill_before_role_discovery: Completa perfil, región y URL de inicio, y selecciona una cuenta primero
+    discovering_roles: Obteniendo roles de SSO...
+    roles_discovered: Descubrimiento de roles de SSO completado
+    roles_failed: "Error al descubrir roles: %{error}"
+    profile_created: Perfil de autenticación de AWS SSO creado
 toast:
   action:
     copy: Copiar

--- a/crates/dbflux_ui_base/src/sql_preview_modal.rs
+++ b/crates/dbflux_ui_base/src/sql_preview_modal.rs
@@ -500,9 +500,9 @@ impl Render for SqlPreviewModal {
         // -- Title & badge --
 
         let title = if is_generic {
-            "Query Preview"
+            dbflux_i18n::t!("sql_preview.title.query")
         } else {
-            "SQL Preview"
+            dbflux_i18n::t!("sql_preview.title.sql")
         };
 
         let badge_text: SharedString = if let Some(label) = &self.badge_label {
@@ -554,7 +554,10 @@ impl Render for SqlPreviewModal {
                     .flex()
                     .items_center()
                     .gap(Spacing::LG)
-                    .child(Text::label_sm("Options").muted_foreground())
+                    .child(
+                        Text::label_sm(dbflux_i18n::t!("sql_preview.options.label"))
+                            .muted_foreground(),
+                    )
                     .child(
                         div()
                             .flex()
@@ -568,7 +571,9 @@ impl Render for SqlPreviewModal {
                                         this.toggle_fully_qualified(window, cx);
                                     })),
                             )
-                            .child(Text::body("Fully qualified names")),
+                            .child(Text::body(dbflux_i18n::t!(
+                                "sql_preview.options.fully_qualified"
+                            ))),
                     )
                     .child(
                         div()
@@ -583,7 +588,7 @@ impl Render for SqlPreviewModal {
                                         this.toggle_compact(window, cx);
                                     })),
                             )
-                            .child(Text::body("Compact SQL")),
+                            .child(Text::body(dbflux_i18n::t!("sql_preview.options.compact"))),
                     ),
             );
         }
@@ -621,7 +626,10 @@ impl Render for SqlPreviewModal {
                             .size(Heights::ICON_SM)
                             .muted(),
                     )
-                    .child(Text::body("Refresh").font_size(FontSizes::SM)),
+                    .child(
+                        Text::body(dbflux_i18n::t!("sql_preview.action.refresh"))
+                            .font_size(FontSizes::SM),
+                    ),
             );
         }
 
@@ -648,7 +656,10 @@ impl Render for SqlPreviewModal {
                             .size(Heights::ICON_SM)
                             .color(theme.primary_foreground),
                     )
-                    .child(Text::caption("Copy").color(theme.primary_foreground)),
+                    .child(
+                        Text::caption(dbflux_i18n::t!("sql_preview.action.copy"))
+                            .color(theme.primary_foreground),
+                    ),
             )
             .child(
                 div()
@@ -665,7 +676,10 @@ impl Render for SqlPreviewModal {
                     .on_click(cx.listener(|this, _, _, cx| {
                         this.close(cx);
                     }))
-                    .child(Text::body("Close").font_size(FontSizes::SM)),
+                    .child(
+                        Text::body(dbflux_i18n::t!("sql_preview.action.close"))
+                            .font_size(FontSizes::SM),
+                    ),
             );
 
         frame = frame.child(footer);
@@ -675,3 +689,38 @@ impl Render for SqlPreviewModal {
 }
 
 impl EventEmitter<()> for SqlPreviewModal {}
+
+#[cfg(test)]
+mod tests {
+    const SQL_PREVIEW_KEYS: &[&str] = &[
+        "sql_preview.title.sql",
+        "sql_preview.title.query",
+        "sql_preview.options.label",
+        "sql_preview.options.fully_qualified",
+        "sql_preview.options.compact",
+        "sql_preview.action.refresh",
+        "sql_preview.action.copy",
+        "sql_preview.action.close",
+    ];
+
+    #[test]
+    fn sql_preview_catalog_keys_resolve() {
+        for key in SQL_PREVIEW_KEYS.iter().copied() {
+            let english = dbflux_i18n::t!(key);
+            let spanish = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert_ne!(english, key, "missing English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(spanish, key, "missing Spanish translation for {key}");
+        }
+    }
+
+    #[test]
+    fn sql_preview_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("sql_preview.title.sql");
+        let spanish = dbflux_i18n::t!("sql_preview.title.sql", locale = "es");
+
+        assert_ne!(english, spanish);
+    }
+}

--- a/crates/dbflux_ui_base/src/sso_wizard.rs
+++ b/crates/dbflux_ui_base/src/sso_wizard.rs
@@ -126,7 +126,7 @@ impl SsoWizard {
         let role_name = self.input_role_name.read(cx).value().trim().to_string();
 
         if profile_name.is_empty() || start_url.is_empty() || region.is_empty() {
-            self.status = Some("Profile name, start URL, and region are required".to_string());
+            self.status = Some(dbflux_i18n::t!("sso_wizard.status.missing_required"));
             cx.notify();
             return;
         }
@@ -162,7 +162,7 @@ impl SsoWizard {
 
         cx.emit(SsoWizardEvent::ProfileCreated { profile_id });
 
-        self.status = Some("Created AWS SSO auth profile".to_string());
+        self.status = Some(dbflux_i18n::t!("sso_wizard.status.profile_created"));
         self.visible = false;
         cx.notify();
     }
@@ -178,14 +178,15 @@ impl SsoWizard {
         let region = self.input_region.read(cx).value().trim().to_string();
 
         if profile_name.is_empty() || start_url.is_empty() || region.is_empty() {
-            self.status =
-                Some("Fill profile name, start URL, and region before discovery".to_string());
+            self.status = Some(dbflux_i18n::t!(
+                "sso_wizard.status.fill_before_account_discovery"
+            ));
             cx.notify();
             return;
         }
 
         self.accounts_loading = true;
-        self.status = Some("Logging in and fetching SSO accounts...".to_string());
+        self.status = Some(dbflux_i18n::t!("sso_wizard.status.discovering_accounts"));
         cx.notify();
 
         let this = cx.entity().clone();
@@ -202,11 +203,15 @@ impl SsoWizard {
                     match result {
                         Ok(accounts) => {
                             this.discovered_accounts = accounts;
-                            this.status = Some("SSO account discovery completed".to_string());
+                            this.status =
+                                Some(dbflux_i18n::t!("sso_wizard.status.accounts_discovered"));
                         }
                         Err(error) => {
                             this.discovered_accounts.clear();
-                            this.status = Some(format!("Failed to discover accounts: {}", error));
+                            this.status = Some(dbflux_i18n::t!(
+                                "sso_wizard.status.accounts_failed",
+                                error = error
+                            ));
                         }
                     }
                     cx.notify();
@@ -232,14 +237,15 @@ impl SsoWizard {
             || region.is_empty()
             || account_id.is_empty()
         {
-            self.status =
-                Some("Fill profile/region/start URL and select an account first".to_string());
+            self.status = Some(dbflux_i18n::t!(
+                "sso_wizard.status.fill_before_role_discovery"
+            ));
             cx.notify();
             return;
         }
 
         self.roles_loading = true;
-        self.status = Some("Fetching SSO roles...".to_string());
+        self.status = Some(dbflux_i18n::t!("sso_wizard.status.discovering_roles"));
         cx.notify();
 
         let this = cx.entity().clone();
@@ -255,11 +261,15 @@ impl SsoWizard {
                     match result {
                         Ok(roles) => {
                             this.discovered_roles = roles;
-                            this.status = Some("SSO role discovery completed".to_string());
+                            this.status =
+                                Some(dbflux_i18n::t!("sso_wizard.status.roles_discovered"));
                         }
                         Err(error) => {
                             this.discovered_roles.clear();
-                            this.status = Some(format!("Failed to discover roles: {}", error));
+                            this.status = Some(dbflux_i18n::t!(
+                                "sso_wizard.status.roles_failed",
+                                error = error
+                            ));
                         }
                     }
                     cx.notify();
@@ -274,7 +284,8 @@ impl EventEmitter<SsoWizardEvent> for SsoWizard {}
 
 impl Render for SsoWizard {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let csd_title_bar = platform::render_csd_title_bar(_window, cx, "AWS SSO Wizard");
+        let title_text = dbflux_i18n::t!("sso_wizard.title");
+        let csd_title_bar = platform::render_csd_title_bar(_window, cx, &title_text);
 
         let content = if !self.visible {
             div().into_any_element()
@@ -298,15 +309,15 @@ impl SsoWizard {
         };
 
         let mut frame = ModalFrame::new("sso-wizard", &self.focus_handle, close)
-            .title("AWS SSO Wizard")
+            .title(dbflux_i18n::t!("sso_wizard.title"))
             .icon(AppIcon::Lock)
             .width(px(680.0));
 
         let step_title = match self.step {
-            WizardStep::Start => "Step 1: Start URL",
-            WizardStep::Account => "Step 2: Account",
-            WizardStep::Role => "Step 3: Role",
-            WizardStep::Confirm => "Step 4: Confirm",
+            WizardStep::Start => dbflux_i18n::t!("sso_wizard.step.start"),
+            WizardStep::Account => dbflux_i18n::t!("sso_wizard.step.account"),
+            WizardStep::Role => dbflux_i18n::t!("sso_wizard.step.role"),
+            WizardStep::Confirm => dbflux_i18n::t!("sso_wizard.step.confirm"),
         };
 
         let body = div()
@@ -331,9 +342,7 @@ impl SsoWizard {
                         .flex_col()
                         .gap(Spacing::SM)
                         .child(Input::new(&self.input_account_id))
-                        .child(Text::caption(
-                            "Use account ID from AWS SSO account discovery",
-                        ));
+                        .child(Text::caption(dbflux_i18n::t!("sso_wizard.account.hint")));
 
                     #[cfg(feature = "aws")]
                     {
@@ -354,9 +363,9 @@ impl SsoWizard {
                             .collect::<Vec<_>>();
 
                         let discover_label = if self.accounts_loading {
-                            "Discovering accounts..."
+                            dbflux_i18n::t!("sso_wizard.account.discovering")
                         } else {
-                            "Login + Discover Accounts"
+                            dbflux_i18n::t!("sso_wizard.account.discover_button")
                         };
 
                         account_step = account_step
@@ -373,9 +382,9 @@ impl SsoWizard {
                                     && !self.discovered_accounts.is_empty()
                                     && filtered_accounts.is_empty(),
                                 |d| {
-                                    d.child(Text::caption(
-                                        "No matching accounts for current filter",
-                                    ))
+                                    d.child(Text::caption(dbflux_i18n::t!(
+                                        "sso_wizard.account.no_matches"
+                                    )))
                                 },
                             )
                             .child(div().flex().flex_col().gap_1().children(
@@ -416,7 +425,7 @@ impl SsoWizard {
                         .flex_col()
                         .gap(Spacing::SM)
                         .child(Input::new(&self.input_role_name))
-                        .child(Text::caption("Use role name from AWS SSO role listing"));
+                        .child(Text::caption(dbflux_i18n::t!("sso_wizard.role.hint")));
 
                     #[cfg(feature = "aws")]
                     {
@@ -436,9 +445,9 @@ impl SsoWizard {
                             .collect::<Vec<_>>();
 
                         let discover_label = if self.roles_loading {
-                            "Discovering roles..."
+                            dbflux_i18n::t!("sso_wizard.role.discovering")
                         } else {
-                            "Discover Roles for Selected Account"
+                            dbflux_i18n::t!("sso_wizard.role.discover_button")
                         };
 
                         role_step = role_step
@@ -454,7 +463,11 @@ impl SsoWizard {
                                 !self.roles_loading
                                     && !self.discovered_roles.is_empty()
                                     && filtered_roles.is_empty(),
-                                |d| d.child(Text::caption("No matching roles for current filter")),
+                                |d| {
+                                    d.child(Text::caption(dbflux_i18n::t!(
+                                        "sso_wizard.role.no_matches"
+                                    )))
+                                },
                             )
                             .child(div().flex().flex_col().gap_1().children(
                                 filtered_roles.iter().map(|role| {
@@ -487,25 +500,25 @@ impl SsoWizard {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Text::body(format!(
-                        "Profile: {}",
-                        self.input_profile_name.read(cx).value()
+                    .child(Text::body(dbflux_i18n::t!(
+                        "sso_wizard.confirm.profile",
+                        value = self.input_profile_name.read(cx).value()
                     )))
-                    .child(Text::body(format!(
-                        "Start URL: {}",
-                        self.input_start_url.read(cx).value()
+                    .child(Text::body(dbflux_i18n::t!(
+                        "sso_wizard.confirm.start_url",
+                        value = self.input_start_url.read(cx).value()
                     )))
-                    .child(Text::body(format!(
-                        "Region: {}",
-                        self.input_region.read(cx).value()
+                    .child(Text::body(dbflux_i18n::t!(
+                        "sso_wizard.confirm.region",
+                        value = self.input_region.read(cx).value()
                     )))
-                    .child(Text::body(format!(
-                        "Account: {}",
-                        self.input_account_id.read(cx).value()
+                    .child(Text::body(dbflux_i18n::t!(
+                        "sso_wizard.confirm.account",
+                        value = self.input_account_id.read(cx).value()
                     )))
-                    .child(Text::body(format!(
-                        "Role: {}",
-                        self.input_role_name.read(cx).value()
+                    .child(Text::body(dbflux_i18n::t!(
+                        "sso_wizard.confirm.role",
+                        value = self.input_role_name.read(cx).value()
                     )))
                     .into_any_element(),
             })
@@ -518,7 +531,7 @@ impl SsoWizard {
                     .justify_end()
                     .gap(Spacing::SM)
                     .child(
-                        Button::new("sso-wizard-back", "Back")
+                        Button::new("sso-wizard-back", dbflux_i18n::t!("sso_wizard.back"))
                             .ghost()
                             .disabled(matches!(self.step, WizardStep::Start))
                             .on_click(cx.listener(|this, _, _, cx| {
@@ -527,9 +540,9 @@ impl SsoWizard {
                     )
                     .child({
                         let next_label = if matches!(self.step, WizardStep::Confirm) {
-                            "Save"
+                            dbflux_i18n::t!("sso_wizard.save")
                         } else {
-                            "Next"
+                            dbflux_i18n::t!("sso_wizard.next")
                         };
                         Button::new("sso-wizard-next", next_label)
                             .ghost()
@@ -545,5 +558,63 @@ impl SsoWizard {
 
         frame = frame.child(body);
         frame.render(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const SSO_WIZARD_KEYS: &[&str] = &[
+        "sso_wizard.title",
+        "sso_wizard.step.start",
+        "sso_wizard.step.account",
+        "sso_wizard.step.role",
+        "sso_wizard.step.confirm",
+        "sso_wizard.account.hint",
+        "sso_wizard.account.discovering",
+        "sso_wizard.account.discover_button",
+        "sso_wizard.account.no_matches",
+        "sso_wizard.role.hint",
+        "sso_wizard.role.discovering",
+        "sso_wizard.role.discover_button",
+        "sso_wizard.role.no_matches",
+        "sso_wizard.confirm.profile",
+        "sso_wizard.confirm.start_url",
+        "sso_wizard.confirm.region",
+        "sso_wizard.confirm.account",
+        "sso_wizard.confirm.role",
+        "sso_wizard.back",
+        "sso_wizard.next",
+        "sso_wizard.save",
+        "sso_wizard.status.missing_required",
+        "sso_wizard.status.fill_before_account_discovery",
+        "sso_wizard.status.discovering_accounts",
+        "sso_wizard.status.accounts_discovered",
+        "sso_wizard.status.accounts_failed",
+        "sso_wizard.status.fill_before_role_discovery",
+        "sso_wizard.status.discovering_roles",
+        "sso_wizard.status.roles_discovered",
+        "sso_wizard.status.roles_failed",
+        "sso_wizard.status.profile_created",
+    ];
+
+    #[test]
+    fn sso_wizard_catalog_keys_resolve() {
+        for key in SSO_WIZARD_KEYS.iter().copied() {
+            let english = dbflux_i18n::t!(key);
+            let spanish = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert_ne!(english, key, "missing English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(spanish, key, "missing Spanish translation for {key}");
+        }
+    }
+
+    #[test]
+    fn sso_wizard_step_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("sso_wizard.step.start");
+        let spanish = dbflux_i18n::t!("sso_wizard.step.start", locale = "es");
+
+        assert_ne!(english, spanish);
     }
 }


### PR DESCRIPTION
## Summary

Third i18n slice (PR B of `dbflux_ui_base`): the AWS SSO wizard and the SQL preview modal render through `dbflux_i18n::t!`. 39 keys (31 `sso_wizard.*`, 8 `sql_preview.*`), English and Spanish shipped together.

## What does this resolve?

- Refs #360 (follows #361 and #363; next: add-panel picker, then `dbflux_components`)

## How was this solved?

- Same mechanism as #363: fully qualified `dbflux_i18n::t!` at the call sites, no signature changes, named-argument interpolation for the confirm lines (`%{value}`) and the two discovery failures (`%{error}`).
- Untouched by design: SSO input placeholders (sample values), `provider_id`, form field keys, the generated `-- ...` SQL comment strings in the preview (editor content, copied verbatim), log lines. "AWS SSO" / "SSO" / "SQL" stay as-is inside Spanish text.

## Validation

- `cargo nextest run -p dbflux_ui_base -p dbflux_i18n` → 136 passed
- `cargo clippy --workspace -- -D warnings` → clean; `cargo fmt --all -- --check` → clean; `cargo test --doc --workspace` → 0 failed
- Workspace nextest run hit one pre-existing timing-sensitive test (`dbflux_core connection::hook::tests::execute_streaming_process_emits_partial_line_output_before_newline`) under heavy local load; no `dbflux_core` file is touched here. CI is the arbiter.
- New tests: catalog key resolution in `en` and `es` for both modules, locale divergence on the step title and the preview title; crate parity tests cover the catalogs.
- Receipt-driven review (one lens): approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish: walk the 4 SSO wizard steps incl. a failed discovery, open the SQL/query preview)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (covered by the #361 entry; consolidated when the crate completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
