### PR TITLE
feat(i18n): translate destructive and connection modals in dbflux_components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,7 +274,7 @@ Architecture details live in `ARCHITECTURE.md`. This file only keeps the agent-f
 
 The UI layer is split into six crates (see `ARCHITECTURE.md` § Layered crate map for the full diagram):
 
-- `dbflux_components` — domain-free leaf: theme, tokens, icons, primitives, composites, controls, data_table, document_tree, result_panel, chart engine, modals. No `dbflux_app` dependency.
+- `dbflux_components` — domain-free leaf: theme, tokens, icons, primitives, composites, controls, data_table, document_tree, result_panel, chart engine, modals. No `dbflux_app` dependency. May depend on `dbflux_i18n` for translated UI copy; `dbflux_i18n` has no `dbflux_*` dependencies.
 - `dbflux_ui_base` — AppStateEntity, events, keymap helpers, toast, modal_frame, platform detection, sql_preview_modal, sso_wizard.
 - `dbflux_ui_document` — tab/pane system, all document types (CodeDocument, DataDocument, ChartDocument, KeyValueDocument, AuditDocument, BucketsTableDocument, ObjectBrowserDocument, ObjectEditorDocument), data_grid_panel, governance view.
 - `dbflux_ui_sidebar` — connections + scripts sidebar tree.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ version = "0.8.0-dev.0"
 dependencies = [
  "chrono",
  "dbflux_core",
+ "dbflux_i18n",
  "gpui",
  "gpui-component",
  "log",

--- a/crates/dbflux_components/Cargo.toml
+++ b/crates/dbflux_components/Cargo.toml
@@ -14,6 +14,7 @@ license.workspace = true
 gpui.workspace = true
 gpui-component.workspace = true
 dbflux_core.workspace = true
+dbflux_i18n.workspace = true
 thiserror.workspace = true
 log.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/dbflux_components/src/modals/active_query.rs
+++ b/crates/dbflux_components/src/modals/active_query.rs
@@ -103,6 +103,11 @@ impl ModalActiveQuery {
     }
 }
 
+/// Label for the elapsed-time hint, with the elapsed seconds interpolated.
+fn elapsed_label(seconds: u64) -> String {
+    dbflux_i18n::t!("modals.active_query.elapsed", seconds = seconds)
+}
+
 impl EventEmitter<ActiveQueryOutcome> for ModalActiveQuery {}
 
 impl Render for ModalActiveQuery {
@@ -119,18 +124,13 @@ impl Render for ModalActiveQuery {
         let sql = request.sql.clone();
         let trigger = request.trigger;
         let elapsed = self.elapsed_secs;
-        let elapsed_label = format!("Running for {}s", elapsed);
+        let elapsed_label = elapsed_label(elapsed);
 
         let body = div()
             .flex()
             .flex_col()
             .gap(Spacing::MD)
-            .child(
-                Text::body(
-                    "A query is still running on this connection. What would you like to do?",
-                )
-                .into_any_element(),
-            )
+            .child(Text::body(dbflux_i18n::t!("modals.active_query.prompt")).into_any_element())
             .child(
                 surface_raised(cx)
                     .w_full()
@@ -169,8 +169,10 @@ impl Render for ModalActiveQuery {
         });
 
         let force_btn_label = match trigger {
-            ActiveQueryTrigger::Disconnect => "Disconnect anyway",
-            ActiveQueryTrigger::Shutdown => "Quit anyway",
+            ActiveQueryTrigger::Disconnect => {
+                dbflux_i18n::t!("modals.active_query.disconnect_anyway")
+            }
+            ActiveQueryTrigger::Shutdown => dbflux_i18n::t!("modals.active_query.quit_anyway"),
         };
 
         let footer = div()
@@ -186,23 +188,86 @@ impl Render for ModalActiveQuery {
             .child(div().flex_1())
             .child(
                 Button::new("active-keep-waiting")
-                    .label("Keep waiting")
+                    .label(dbflux_i18n::t!("modals.active_query.keep_waiting"))
                     .on_click(on_keep_waiting),
             )
             .child(
                 Button::new("active-cancel-query")
-                    .label("Cancel query")
+                    .label(dbflux_i18n::t!("modals.active_query.cancel_query"))
                     .danger()
                     .on_click(on_cancel_query),
             );
 
         ModalShell::new(
-            "Active query running",
+            dbflux_i18n::t!("modals.active_query.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
         .variant(ModalVariant::Default)
         .width(px(520.0))
         .into_any_element()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — translation key resolution and elapsed label formatting
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_query_keys_resolve_in_both_locales() {
+        let keys = [
+            "modals.active_query.title",
+            "modals.active_query.prompt",
+            "modals.active_query.elapsed",
+            "modals.active_query.disconnect_anyway",
+            "modals.active_query.quit_anyway",
+            "modals.active_query.keep_waiting",
+            "modals.active_query.cancel_query",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn active_query_keep_waiting_diverges_between_locales() {
+        let en = dbflux_i18n::t!("modals.active_query.keep_waiting", locale = "en");
+        let es = dbflux_i18n::t!("modals.active_query.keep_waiting", locale = "es");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn elapsed_label_contains_seconds_for_zero_and_one() {
+        let zero = elapsed_label(0);
+        assert!(zero.contains('0'));
+        assert_eq!(
+            zero,
+            dbflux_i18n::t!("modals.active_query.elapsed", seconds = 0)
+        );
+
+        let one = elapsed_label(1);
+        assert!(one.contains('1'));
+        assert_eq!(
+            one,
+            dbflux_i18n::t!("modals.active_query.elapsed", seconds = 1)
+        );
+    }
+
+    #[test]
+    fn elapsed_label_contains_seconds_for_larger_value() {
+        let label = elapsed_label(42);
+        assert!(label.contains("42"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("modals.active_query.elapsed", seconds = 42)
+        );
     }
 }

--- a/crates/dbflux_components/src/modals/delete_connection.rs
+++ b/crates/dbflux_components/src/modals/delete_connection.rs
@@ -85,20 +85,19 @@ impl Render for ModalDeleteConnection {
                     .flex()
                     .items_start()
                     .gap(Spacing::SM)
-                    .child(Icon::new(AppIcon::TriangleAlert).size(Heights::ICON_SM).color(theme.danger))
+                    .child(
+                        Icon::new(AppIcon::TriangleAlert)
+                            .size(Heights::ICON_SM)
+                            .color(theme.danger),
+                    )
                     .child(
                         // flex_1 + min_w_0 lets the description wrap to the
                         // modal's width instead of overflowing past the
                         // card edge (same pattern as the toast/banner fix).
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .child(
-                                Text::body(
-                                    "You're about to delete the following connection. This can't be undone.",
-                                )
+                        div().flex_1().min_w_0().child(
+                            Text::body(dbflux_i18n::t!("modals.delete_connection.warning"))
                                 .into_any_element(),
-                            ),
+                        ),
                     ),
             )
             .child(
@@ -119,7 +118,7 @@ impl Render for ModalDeleteConnection {
                     div()
                         .text_size(FontSizes::SM)
                         .text_color(theme.muted_foreground)
-                        .child("Any open documents using this connection will be closed."),
+                        .child(dbflux_i18n::t!("modals.delete_connection.documents_closed")),
                 )
             });
 
@@ -139,23 +138,55 @@ impl Render for ModalDeleteConnection {
             .gap(Spacing::SM)
             .child(
                 Button::new("delete-conn-cancel")
-                    .label("Cancel")
+                    .label(dbflux_i18n::t!("modals.delete_connection.cancel"))
                     .on_click(on_cancel),
             )
             .child(
                 Button::new("delete-conn-confirm")
-                    .label("Delete")
+                    .label(dbflux_i18n::t!("modals.delete_connection.confirm"))
                     .danger()
                     .on_click(on_confirm),
             );
 
         ModalShell::new(
-            "Delete connection",
+            dbflux_i18n::t!("modals.delete_connection.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
         .variant(ModalVariant::Danger)
         .width(px(460.0))
         .into_any_element()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — translation key resolution
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn delete_connection_keys_resolve_in_both_locales() {
+        let keys = [
+            "modals.delete_connection.title",
+            "modals.delete_connection.warning",
+            "modals.delete_connection.documents_closed",
+            "modals.delete_connection.cancel",
+            "modals.delete_connection.confirm",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn delete_connection_confirm_diverges_between_locales() {
+        let en = dbflux_i18n::t!("modals.delete_connection.confirm", locale = "en");
+        let es = dbflux_i18n::t!("modals.delete_connection.confirm", locale = "es");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_components/src/modals/drop_table.rs
+++ b/crates/dbflux_components/src/modals/drop_table.rs
@@ -61,6 +61,12 @@ fn relation_kind_label(kind: &RelationKind) -> &'static str {
     }
 }
 
+/// Confirmation hint shown while the typed table name does not yet match,
+/// with the expected table name interpolated into the translated prompt.
+fn confirm_hint(table: &str) -> String {
+    dbflux_i18n::t!("modals.drop_table.confirm_prompt", table = table)
+}
+
 /// Modal entity for "drop table" with TypeToConfirm gate.
 ///
 /// Uses `ModalShell::Danger` (560 px). The "Drop table" button is disabled
@@ -77,8 +83,10 @@ pub struct ModalDropTable {
 
 impl ModalDropTable {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let confirm_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Type table name to confirm"));
+        let confirm_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("modals.drop_table.confirm_placeholder"))
+        });
         Self {
             request: None,
             visible: false,
@@ -172,7 +180,7 @@ impl Render for ModalDropTable {
                     .text_size(FontSizes::XS)
                     .font_weight(gpui::FontWeight::SEMIBOLD)
                     .text_color(theme.muted_foreground)
-                    .child("Dependent objects will also be dropped (CASCADE):"),
+                    .child(dbflux_i18n::t!("modals.drop_table.cascade_warning")),
             );
 
             for dep in &dependents {
@@ -226,7 +234,7 @@ impl Render for ModalDropTable {
                 div()
                     .text_size(FontSizes::XS)
                     .text_color(theme.muted_foreground)
-                    .child(format!("Type \"{}\" to confirm", table_name))
+                    .child(confirm_hint(&table_name))
                     .into_any_element(),
             )
         } else {
@@ -238,8 +246,7 @@ impl Render for ModalDropTable {
             .flex_col()
             .gap(Spacing::MD)
             .child(
-                Text::body("This will permanently delete the table and any dependent objects.")
-                    .into_any_element(),
+                Text::body(dbflux_i18n::t!("modals.drop_table.delete_warning")).into_any_element(),
             )
             .child(name_badge)
             .when(has_deps, |el| el.child(dependents_section))
@@ -263,12 +270,12 @@ impl Render for ModalDropTable {
             .gap(Spacing::SM)
             .child(
                 Button::new("drop-table-cancel")
-                    .label("Cancel")
+                    .label(dbflux_i18n::t!("modals.drop_table.cancel"))
                     .on_click(on_cancel),
             )
             .child(if drop_enabled {
                 Button::new("drop-table-confirm")
-                    .label("Drop table")
+                    .label(dbflux_i18n::t!("modals.drop_table.confirm"))
                     .danger()
                     .on_click(on_drop)
                     .into_any_element()
@@ -286,13 +293,13 @@ impl Render for ModalDropTable {
                         div()
                             .text_size(FontSizes::SM)
                             .text_color(theme.background)
-                            .child("Drop table"),
+                            .child(dbflux_i18n::t!("modals.drop_table.confirm")),
                     )
                     .into_any_element()
             });
 
         ModalShell::new(
-            "Drop table",
+            dbflux_i18n::t!("modals.drop_table.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
@@ -354,5 +361,42 @@ mod tests {
     fn sql_preview_no_schema_with_deps() {
         let r = request("orders", None, vec![view_dep("public.order_view")]);
         assert_eq!(r.sql_preview(), "DROP TABLE \"orders\"\n  CASCADE;");
+    }
+
+    #[test]
+    fn drop_table_keys_resolve_in_both_locales() {
+        let keys = [
+            "modals.drop_table.title",
+            "modals.drop_table.confirm",
+            "modals.drop_table.cancel",
+            "modals.drop_table.confirm_placeholder",
+            "modals.drop_table.confirm_prompt",
+            "modals.drop_table.cascade_warning",
+            "modals.drop_table.delete_warning",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn drop_table_title_diverges_between_locales() {
+        let en = dbflux_i18n::t!("modals.drop_table.title", locale = "en");
+        let es = dbflux_i18n::t!("modals.drop_table.title", locale = "es");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn confirm_hint_interpolates_table_name() {
+        let hint = confirm_hint("orders");
+        assert!(hint.contains("orders"));
+        assert_eq!(
+            hint,
+            dbflux_i18n::t!("modals.drop_table.confirm_prompt", table = "orders")
+        );
     }
 }

--- a/crates/dbflux_components/src/modals/tunnel_auth.rs
+++ b/crates/dbflux_components/src/modals/tunnel_auth.rs
@@ -50,6 +50,23 @@ impl TunnelAuthRequest {
     }
 }
 
+/// "Host: host:port · User: user" pre-block text, with connection details
+/// interpolated into the translated template.
+fn connection_detail(host: &str, port: u16, user: &str) -> String {
+    dbflux_i18n::t!(
+        "modals.tunnel_auth.connection_detail",
+        host = host,
+        port = port,
+        user = user
+    )
+}
+
+/// Prompt text asking for the passphrase, with the tunnel name interpolated
+/// into the translated template.
+fn prompt(tunnel_name: &str) -> String {
+    dbflux_i18n::t!("modals.tunnel_auth.prompt", tunnel = tunnel_name)
+}
+
 /// Modal entity for SSH passphrase prompt.
 ///
 /// Uses `ModalShell::Default` (480 px). The parent opens it via
@@ -66,7 +83,7 @@ impl ModalTunnelAuth {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let passphrase_input = cx.new(|cx| {
             InputState::new(window, cx)
-                .placeholder("Enter passphrase")
+                .placeholder(dbflux_i18n::t!("modals.tunnel_auth.placeholder"))
                 .masked(true)
         });
         Self {
@@ -134,15 +151,18 @@ impl Render for ModalTunnelAuth {
         // Error banner shown when a previous attempt with the same modal was rejected.
         let error_banner = if last_attempt_failed {
             Some(
-                BannerBlock::new(BannerVariant::Danger, "Incorrect passphrase. Try again.")
-                    .into_any_element(),
+                BannerBlock::new(
+                    BannerVariant::Danger,
+                    dbflux_i18n::t!("modals.tunnel_auth.incorrect"),
+                )
+                .into_any_element(),
             )
         } else {
             None
         };
 
         // Connection details pre-block: "Host: host:port · User: user"
-        let connection_detail = format!("Host: {}:{} · User: {}", host, port, user);
+        let connection_detail_text = connection_detail(&host, port, &user);
 
         let body = div()
             .flex()
@@ -153,10 +173,7 @@ impl Render for ModalTunnelAuth {
                 div()
                     .text_size(FontSizes::SM)
                     .text_color(theme.muted_foreground)
-                    .child(format!(
-                        "Enter the passphrase for tunnel \"{}\"",
-                        tunnel_name
-                    )),
+                    .child(prompt(&tunnel_name)),
             )
             .child(
                 surface_raised(cx)
@@ -168,20 +185,20 @@ impl Render for ModalTunnelAuth {
                             .text_size(FontSizes::SM)
                             .font_family(AppFonts::MONO)
                             .text_color(theme.muted_foreground)
-                            .child(connection_detail),
+                            .child(connection_detail_text),
                     ),
             )
             .child(
                 div().w_full().child(
                     Input::new(&self.passphrase_input)
                         .w_full()
-                        .placeholder("Enter passphrase"),
+                        .placeholder(dbflux_i18n::t!("modals.tunnel_auth.placeholder")),
                 ),
             )
             .child(
                 Checkbox::new("tunnel-auth-remember")
                     .checked(remember)
-                    .label("Remember for this session")
+                    .label(dbflux_i18n::t!("modals.tunnel_auth.remember"))
                     .on_click(cx.listener(|this, checked: &bool, _, cx| {
                         this.remember = *checked;
                         cx.notify();
@@ -212,19 +229,19 @@ impl Render for ModalTunnelAuth {
             .gap(Spacing::SM)
             .child(
                 Button::new("tunnel-auth-cancel")
-                    .label("Cancel")
+                    .label(dbflux_i18n::t!("modals.tunnel_auth.cancel"))
                     .on_click(on_cancel),
             )
             .child(
                 Button::new("tunnel-auth-connect")
-                    .label("Connect")
+                    .label(dbflux_i18n::t!("modals.tunnel_auth.connect"))
                     .primary()
                     .disabled(!connect_enabled)
                     .on_click(on_connect),
             );
 
         ModalShell::new(
-            "SSH passphrase required",
+            dbflux_i18n::t!("modals.tunnel_auth.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
@@ -251,5 +268,61 @@ mod tests {
     fn non_empty_passphrase_passes_validation() {
         assert!(TunnelAuthRequest::validate_passphrase("hunter2").is_ok());
         assert!(TunnelAuthRequest::validate_passphrase(" ").is_ok());
+    }
+
+    #[test]
+    fn tunnel_auth_keys_resolve_in_both_locales() {
+        let keys = [
+            "modals.tunnel_auth.title",
+            "modals.tunnel_auth.prompt",
+            "modals.tunnel_auth.connection_detail",
+            "modals.tunnel_auth.placeholder",
+            "modals.tunnel_auth.incorrect",
+            "modals.tunnel_auth.empty_error",
+            "modals.tunnel_auth.remember",
+            "modals.tunnel_auth.cancel",
+            "modals.tunnel_auth.connect",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn tunnel_auth_connect_diverges_between_locales() {
+        let en = dbflux_i18n::t!("modals.tunnel_auth.connect", locale = "en");
+        let es = dbflux_i18n::t!("modals.tunnel_auth.connect", locale = "es");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn connection_detail_contains_host_port_and_user() {
+        let detail = connection_detail("db.internal", 2222, "deploy");
+        assert!(detail.contains("db.internal"));
+        assert!(detail.contains("2222"));
+        assert!(detail.contains("deploy"));
+        assert_eq!(
+            detail,
+            dbflux_i18n::t!(
+                "modals.tunnel_auth.connection_detail",
+                host = "db.internal",
+                port = 2222,
+                user = "deploy"
+            )
+        );
+    }
+
+    #[test]
+    fn prompt_contains_tunnel_name() {
+        let text = prompt("prod-tunnel");
+        assert!(text.contains("prod-tunnel"));
+        assert_eq!(
+            text,
+            dbflux_i18n::t!("modals.tunnel_auth.prompt", tunnel = "prod-tunnel")
+        );
     }
 }

--- a/crates/dbflux_components/src/modals/unsaved_changes.rs
+++ b/crates/dbflux_components/src/modals/unsaved_changes.rs
@@ -88,6 +88,18 @@ impl ModalUnsavedChanges {
     }
 }
 
+/// Label for the "Save selected" button, with the selected count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one selected document;
+/// every other count, including zero, uses the plural bucket.
+fn save_selected_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("modals.unsaved_changes.save_selected.one", count = count)
+    } else {
+        dbflux_i18n::t!("modals.unsaved_changes.save_selected.many", count = count)
+    }
+}
+
 impl EventEmitter<UnsavedChangesOutcome> for ModalUnsavedChanges {}
 
 impl Render for ModalUnsavedChanges {
@@ -174,12 +186,7 @@ impl Render for ModalUnsavedChanges {
             .flex()
             .flex_col()
             .gap(Spacing::MD)
-            .child(
-                Text::body(
-                    "You have unsaved changes in the following documents. What would you like to do?",
-                )
-                .into_any_element(),
-            )
+            .child(Text::body(dbflux_i18n::t!("modals.unsaved_changes.prompt")).into_any_element())
             .child(rows);
 
         let on_discard = cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
@@ -192,7 +199,7 @@ impl Render for ModalUnsavedChanges {
             this.close(cx);
         });
 
-        let save_label = format!("Save selected ({})", selected_count);
+        let save_label = save_selected_label(selected_count);
         let save_disabled = selected_count == 0;
 
         let on_save = cx.listener(move |this, _: &gpui::ClickEvent, _, cx| {
@@ -207,14 +214,14 @@ impl Render for ModalUnsavedChanges {
             .gap(Spacing::SM)
             .child(
                 Button::new("unsaved-discard")
-                    .label("Don't save")
+                    .label(dbflux_i18n::t!("modals.unsaved_changes.dont_save"))
                     .ghost()
                     .on_click(on_discard),
             )
             .child(div().flex_1())
             .child(
                 Button::new("unsaved-cancel")
-                    .label("Cancel")
+                    .label(dbflux_i18n::t!("modals.unsaved_changes.cancel"))
                     .on_click(on_cancel),
             )
             .child(if save_disabled {
@@ -242,7 +249,7 @@ impl Render for ModalUnsavedChanges {
             });
 
         ModalShell::new(
-            "Unsaved changes",
+            dbflux_i18n::t!("modals.unsaved_changes.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
@@ -330,5 +337,58 @@ mod tests {
         assert!(!modal.selected[&a]);
         *modal.selected.entry(a).or_insert(false) ^= true;
         assert!(modal.selected[&a]);
+    }
+
+    #[test]
+    fn unsaved_changes_keys_resolve_in_both_locales() {
+        let keys = [
+            "modals.unsaved_changes.title",
+            "modals.unsaved_changes.prompt",
+            "modals.unsaved_changes.save_selected.one",
+            "modals.unsaved_changes.save_selected.many",
+            "modals.unsaved_changes.dont_save",
+            "modals.unsaved_changes.cancel",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn unsaved_changes_dont_save_diverges_between_locales() {
+        let en = dbflux_i18n::t!("modals.unsaved_changes.dont_save", locale = "en");
+        let es = dbflux_i18n::t!("modals.unsaved_changes.dont_save", locale = "es");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn save_selected_label_uses_singular_bucket_for_one() {
+        let label = save_selected_label(1);
+        assert!(label.contains('1'));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("modals.unsaved_changes.save_selected.one", count = 1)
+        );
+    }
+
+    #[test]
+    fn save_selected_label_uses_plural_bucket_for_zero_and_many() {
+        let zero = save_selected_label(0);
+        assert!(zero.contains('0'));
+        assert_eq!(
+            zero,
+            dbflux_i18n::t!("modals.unsaved_changes.save_selected.many", count = 0)
+        );
+
+        let many = save_selected_label(2);
+        assert!(many.contains('2'));
+        assert_eq!(
+            many,
+            dbflux_i18n::t!("modals.unsaved_changes.save_selected.many", count = 2)
+        );
     }
 }

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -5,6 +5,14 @@ errors:
     detail: "Correlation: %{id}"
     clipboard: "%{summary}\nCorrelation: %{id}"
 modals:
+  active_query:
+    title: Active query running
+    prompt: A query is still running on this connection. What would you like to do?
+    elapsed: "Running for %{seconds}s"
+    disconnect_anyway: Disconnect anyway
+    quit_anyway: Quit anyway
+    keep_waiting: Keep waiting
+    cancel_query: Cancel query
   add_panel_picker:
     title: Add panels
     submit:
@@ -44,15 +52,6 @@ modals:
       no_metrics: No metrics in this namespace.
       no_metrics_filtered: No metrics match the filter.
     cancel: Cancel
-  rename:
-    placeholder: Enter a name
-    title:
-      dashboard: Rename dashboard
-      saved_chart: Rename saved chart
-    validation:
-      empty_name: Name cannot be empty
-    cancel: Cancel
-    confirm: Rename
   create_dashboard:
     name_label: Dashboard name
     title: New dashboard
@@ -72,6 +71,47 @@ modals:
         many: "This chart is used in %{count} dashboards: %{names}. Panels that reference it will show broken placeholders."
     cancel: Cancel
     confirm: Delete
+  delete_connection:
+    title: Delete connection
+    warning: "You're about to delete the following connection. This can't be undone."
+    documents_closed: Any open documents using this connection will be closed.
+    cancel: Cancel
+    confirm: Delete
+  drop_table:
+    title: Drop table
+    confirm: Drop table
+    cancel: Cancel
+    confirm_placeholder: Type table name to confirm
+    confirm_prompt: 'Type "%{table}" to confirm'
+    cascade_warning: "Dependent objects will also be dropped (CASCADE):"
+    delete_warning: This will permanently delete the table and any dependent objects.
+  rename:
+    placeholder: Enter a name
+    title:
+      dashboard: Rename dashboard
+      saved_chart: Rename saved chart
+    validation:
+      empty_name: Name cannot be empty
+    cancel: Cancel
+    confirm: Rename
+  tunnel_auth:
+    title: SSH passphrase required
+    prompt: 'Enter the passphrase for tunnel "%{tunnel}"'
+    connection_detail: "Host: %{host}:%{port} · User: %{user}"
+    placeholder: Enter passphrase
+    incorrect: Incorrect passphrase. Try again.
+    empty_error: Passphrase cannot be empty
+    remember: Remember for this session
+    cancel: Cancel
+    connect: Connect
+  unsaved_changes:
+    title: Unsaved changes
+    prompt: You have unsaved changes in the following documents. What would you like to do?
+    save_selected:
+      one: "Save selected (%{count})"
+      many: "Save selected (%{count})"
+    dont_save: Don't save
+    cancel: Cancel
 settings:
   general:
     header:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -5,6 +5,14 @@ errors:
     detail: "Correlación: %{id}"
     clipboard: "%{summary}\nCorrelación: %{id}"
 modals:
+  active_query:
+    title: Consulta en ejecución
+    prompt: Todavía hay una consulta ejecutándose en esta conexión. ¿Qué quieres hacer?
+    elapsed: "En ejecución desde hace %{seconds} s"
+    disconnect_anyway: Desconectar de todos modos
+    quit_anyway: Salir de todos modos
+    keep_waiting: Seguir esperando
+    cancel_query: Cancelar consulta
   add_panel_picker:
     title: Agregar paneles
     submit:
@@ -44,15 +52,6 @@ modals:
       no_metrics: No hay métricas en este espacio de nombres.
       no_metrics_filtered: Ninguna métrica coincide con el filtro.
     cancel: Cancelar
-  rename:
-    placeholder: Escribe un nombre
-    title:
-      dashboard: Renombrar dashboard
-      saved_chart: Renombrar gráfico guardado
-    validation:
-      empty_name: El nombre no puede estar vacío
-    cancel: Cancelar
-    confirm: Renombrar
   create_dashboard:
     name_label: Nombre del dashboard
     title: Nuevo dashboard
@@ -72,6 +71,47 @@ modals:
         many: "Este gráfico se usa en %{count} dashboards: %{names}. Los paneles que lo referencian mostrarán marcadores rotos."
     cancel: Cancelar
     confirm: Eliminar
+  delete_connection:
+    title: Eliminar conexión
+    warning: "Vas a eliminar la siguiente conexión. Esta acción no se puede deshacer."
+    documents_closed: Se cerrarán los documentos abiertos que usen esta conexión.
+    cancel: Cancelar
+    confirm: Eliminar
+  drop_table:
+    title: Eliminar tabla
+    confirm: Eliminar tabla
+    cancel: Cancelar
+    confirm_placeholder: Escribe el nombre de la tabla para confirmar
+    confirm_prompt: 'Escribe "%{table}" para confirmar'
+    cascade_warning: "También se eliminarán los objetos dependientes (CASCADE):"
+    delete_warning: Esto eliminará de forma permanente la tabla y cualquier objeto dependiente.
+  rename:
+    placeholder: Escribe un nombre
+    title:
+      dashboard: Renombrar dashboard
+      saved_chart: Renombrar gráfico guardado
+    validation:
+      empty_name: El nombre no puede estar vacío
+    cancel: Cancelar
+    confirm: Renombrar
+  tunnel_auth:
+    title: Se requiere la frase de contraseña SSH
+    prompt: 'Introduce la frase de contraseña del túnel "%{tunnel}"'
+    connection_detail: "Host: %{host}:%{port} · Usuario: %{user}"
+    placeholder: Introduce la frase de contraseña
+    incorrect: Frase de contraseña incorrecta. Inténtalo de nuevo.
+    empty_error: La frase de contraseña no puede estar vacía
+    remember: Recordar durante esta sesión
+    cancel: Cancelar
+    connect: Conectar
+  unsaved_changes:
+    title: Cambios sin guardar
+    prompt: Tienes cambios sin guardar en los siguientes documentos. ¿Qué quieres hacer?
+    save_selected:
+      one: "Guardar seleccionado (%{count})"
+      many: "Guardar seleccionados (%{count})"
+    dont_save: No guardar
+    cancel: Cancelar
 settings:
   general:
     header:


### PR DESCRIPTION
## Summary

First `dbflux_components` i18n slice: the destructive and connection modals (drop table, delete connection, unsaved changes, active query, SSH tunnel passphrase) render through `dbflux_i18n::t!`. `dbflux_components` now depends on `dbflux_i18n`; `CLAUDE.md` records that the domain-free leaf may depend on it because `dbflux_i18n` itself has no `dbflux_*` dependencies.

## What does this resolve?

- Refs #360 (follows #361, #363, #364, #365; next: the remaining `dbflux_components` modals, tree, chart and controls, then the sidebar)

## How was this solved?

- Same mechanism as the previous slices; no public signature changes. Interpolated and plural text lives in private helpers (`confirm_hint`, `save_selected_label`, `elapsed_label`, `connection_detail`, `prompt`) so the tests exercise production code. The tunnel detail line is one templated key (`Host: %{host}:%{port} · User: %{user}`), not concatenated fragments.
- Untouched by design: relation-kind badges (View / MatView / FK / Trigger — DB terms), `validate_passphrase`'s internal error (never rendered; its catalog key is reserved and will be wired or dropped in the last slice), SQL preview text, logs.

## Validation

- `cargo nextest run --workspace` → 4937 passed; `cargo clippy --workspace -- -D warnings` → clean; `cargo fmt --all -- --check` → clean; doctests ok.
- 18 new tests: per-module catalog resolution in `en` and `es`, divergence checks, helper behavior (plural buckets 0/1/2, elapsed seconds, host/port/user, tunnel name, table name).
- Receipt-driven review (four lenses, high risk because the change touches the tunnel auth modal): approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish: drop table with CASCADE, delete connection, close with unsaved changes (1 and 2 docs), disconnect with an active query, SSH tunnel passphrase prompt)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Known limitations

- 511 changed lines (`size:exception`): roughly half is catalog YAML and tests.
- The dependents list in the drop-table modal shows the relation kind in English next to a translated heading; that is the terminology rule at work, not an omission.
