### PR TITLE
feat(i18n): add the sidebar catalog foundation and translate the sidebar chrome

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3298,6 +3298,7 @@ dependencies = [
  "dbflux_app",
  "dbflux_components",
  "dbflux_core",
+ "dbflux_i18n",
  "dbflux_ssh",
  "dbflux_storage",
  "dbflux_ui_base",

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -189,6 +189,29 @@ settings:
       button: Save
       error: "Failed to save general settings: %{error}"
       success: Settings saved. Some changes apply on next startup.
+sidebar:
+  confirm:
+    delete_hint: Press x to confirm delete, ESC to cancel
+  empty:
+    connections_title: No connections yet
+    connections_hint: Use + to add a new connection
+    scripts_title: No scripts yet
+    scripts_hint: Use + to create a new script or import an existing file
+  status:
+    connection_summary: "%{connected} connected · %{idle} idle"
+  tabs:
+    connections: CONNECTIONS
+    scripts: SCRIPTS
+  tree:
+    container:
+      relational: Tables (%{count})
+      document: Collections (%{count})
+      key_value: Keys (%{count})
+      graph: Nodes (%{count})
+      time_series: Measurements (%{count})
+      wide_column: Tables (%{count})
+      log_stream: Log Groups (%{count})
+      object_storage: Buckets (%{count})
 sql_preview:
   title:
     sql: SQL Preview

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -189,6 +189,29 @@ settings:
       button: Guardar
       error: "No se pudo guardar la configuración general: %{error}"
       success: Configuración guardada. Algunos cambios se aplican al reiniciar.
+sidebar:
+  confirm:
+    delete_hint: Presiona x para confirmar la eliminación, ESC para cancelar
+  empty:
+    connections_title: Aún no hay conexiones
+    connections_hint: Usa + para agregar una nueva conexión
+    scripts_title: Aún no hay scripts
+    scripts_hint: Usa + para crear un script nuevo o importar un archivo existente
+  status:
+    connection_summary: "%{connected} conectadas · %{idle} inactivas"
+  tabs:
+    connections: CONEXIONES
+    scripts: SCRIPTS
+  tree:
+    container:
+      relational: Tablas (%{count})
+      document: Colecciones (%{count})
+      key_value: Claves (%{count})
+      graph: Nodos (%{count})
+      time_series: Mediciones (%{count})
+      wide_column: Tablas (%{count})
+      log_stream: Log Groups (%{count})
+      object_storage: Buckets (%{count})
 sql_preview:
   title:
     sql: Vista previa de SQL

--- a/crates/dbflux_ui_sidebar/Cargo.toml
+++ b/crates/dbflux_ui_sidebar/Cargo.toml
@@ -16,6 +16,7 @@ gpui-component.workspace = true
 dbflux_ui_base.workspace = true
 dbflux_components.workspace = true
 dbflux_core.workspace = true
+dbflux_i18n.workspace = true
 dbflux_app.workspace = true
 dbflux_ssh.workspace = true
 uuid.workspace = true

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -1,0 +1,156 @@
+//! Translated label helpers for sidebar chrome (tabs, footer, tree folders).
+
+use dbflux_core::DatabaseCategory;
+
+/// Translated label for a schema-tree container folder, e.g. `"Tables (12)"`.
+///
+/// Not yet wired into `tree_builder.rs` — that lands in a follow-up slice.
+#[allow(dead_code)]
+pub(crate) fn container_folder_label(category: DatabaseCategory, count: usize) -> String {
+    match category {
+        DatabaseCategory::Relational => {
+            dbflux_i18n::t!("sidebar.tree.container.relational", count = count)
+        }
+        DatabaseCategory::Document => {
+            dbflux_i18n::t!("sidebar.tree.container.document", count = count)
+        }
+        DatabaseCategory::KeyValue => {
+            dbflux_i18n::t!("sidebar.tree.container.key_value", count = count)
+        }
+        DatabaseCategory::Graph => dbflux_i18n::t!("sidebar.tree.container.graph", count = count),
+        DatabaseCategory::TimeSeries => {
+            dbflux_i18n::t!("sidebar.tree.container.time_series", count = count)
+        }
+        DatabaseCategory::WideColumn => {
+            dbflux_i18n::t!("sidebar.tree.container.wide_column", count = count)
+        }
+        DatabaseCategory::LogStream => {
+            dbflux_i18n::t!("sidebar.tree.container.log_stream", count = count)
+        }
+        DatabaseCategory::ObjectStorage => {
+            dbflux_i18n::t!("sidebar.tree.container.object_storage", count = count)
+        }
+    }
+}
+
+/// Translated footer summary of connected vs. idle connections, e.g.
+/// `"2 connected · 5 idle"`.
+pub(crate) fn footer_counts_label(connected: usize, idle: usize) -> String {
+    dbflux_i18n::t!(
+        "sidebar.status.connection_summary",
+        connected = connected,
+        idle = idle
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use dbflux_core::DatabaseCategory;
+
+    const ALL_CATEGORIES: [DatabaseCategory; 8] = [
+        DatabaseCategory::Relational,
+        DatabaseCategory::Document,
+        DatabaseCategory::KeyValue,
+        DatabaseCategory::Graph,
+        DatabaseCategory::TimeSeries,
+        DatabaseCategory::WideColumn,
+        DatabaseCategory::LogStream,
+        DatabaseCategory::ObjectStorage,
+    ];
+
+    const CONTAINER_KEYS: [&str; 8] = [
+        "sidebar.tree.container.relational",
+        "sidebar.tree.container.document",
+        "sidebar.tree.container.key_value",
+        "sidebar.tree.container.graph",
+        "sidebar.tree.container.time_series",
+        "sidebar.tree.container.wide_column",
+        "sidebar.tree.container.log_stream",
+        "sidebar.tree.container.object_storage",
+    ];
+
+    const SLICE_KEYS: [&str; 10] = [
+        "sidebar.tabs.connections",
+        "sidebar.tabs.scripts",
+        "sidebar.confirm.delete_hint",
+        "sidebar.empty.connections_title",
+        "sidebar.empty.connections_hint",
+        "sidebar.empty.scripts_title",
+        "sidebar.empty.scripts_hint",
+        "sidebar.status.connection_summary",
+        "sidebar.tree.container.relational",
+        "sidebar.tree.container.log_stream",
+    ];
+
+    #[test]
+    fn container_folder_label_matches_container_name_for_every_category() {
+        for category in ALL_CATEGORIES {
+            let label = super::container_folder_label(category, 3);
+            assert_eq!(label, format!("{} (3)", category.container_name()));
+        }
+    }
+
+    #[test]
+    fn container_folder_label_uses_the_given_count() {
+        let label = super::container_folder_label(DatabaseCategory::Document, 7);
+        assert_eq!(label, "Collections (7)");
+    }
+
+    #[test]
+    fn footer_counts_label_reports_connected_and_idle_counts() {
+        let label = super::footer_counts_label(2, 5);
+        assert!(label.contains("2 connected"));
+        assert!(label.contains("5 idle"));
+    }
+
+    #[test]
+    fn footer_counts_label_reports_zero_counts() {
+        let label = super::footer_counts_label(0, 0);
+        assert!(label.contains("0 connected"));
+        assert!(label.contains("0 idle"));
+    }
+
+    #[test]
+    fn slice_translation_keys_resolve_in_every_shipped_locale() {
+        for key in SLICE_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sidebar_tabs_connections_diverges_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.tabs.connections", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.tabs.connections", locale = "es");
+
+        assert_eq!(english, "CONNECTIONS");
+        assert_eq!(spanish, "CONEXIONES");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn sidebar_tree_container_relational_diverges_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.tree.container.relational", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.tree.container.relational", locale = "es");
+
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn container_keys_cover_every_database_category() {
+        for (category, key) in ALL_CATEGORIES.iter().zip(CONTAINER_KEYS.iter()) {
+            let expected = super::container_folder_label(*category, 1);
+            let translated = dbflux_i18n::t!(key, count = 1);
+
+            assert_eq!(expected, translated);
+        }
+    }
+}

--- a/crates/dbflux_ui_sidebar/src/lib.rs
+++ b/crates/dbflux_ui_sidebar/src/lib.rs
@@ -3,6 +3,7 @@ mod context_menu;
 mod deletion;
 mod drag_drop;
 mod expansion;
+mod labels;
 pub mod operations;
 mod render;
 mod render_footer;

--- a/crates/dbflux_ui_sidebar/src/render.rs
+++ b/crates/dbflux_ui_sidebar/src/render.rs
@@ -5,7 +5,12 @@ use dbflux_components::tokens::SyntaxColors;
 use dbflux_components::typography::{Body, MonoCaption};
 use gpui::FontWeight;
 
-fn sidebar_tab_text(label: &'static str, active: bool, focused: bool, color: Hsla) -> MonoCaption {
+fn sidebar_tab_text(
+    label: impl Into<SharedString>,
+    active: bool,
+    focused: bool,
+    color: Hsla,
+) -> MonoCaption {
     let weight = if active && focused {
         FontWeight::BOLD
     } else if active {
@@ -79,7 +84,7 @@ impl Sidebar {
                                 });
                             })
                             .child(sidebar_tab_text(
-                                "CONNECTIONS",
+                                dbflux_i18n::t!("sidebar.tabs.connections"),
                                 active_tab == SidebarTab::Connections,
                                 focused,
                                 tab_text_color(active_tab == SidebarTab::Connections),
@@ -100,7 +105,7 @@ impl Sidebar {
                                 });
                             })
                             .child(sidebar_tab_text(
-                                "SCRIPTS",
+                                dbflux_i18n::t!("sidebar.tabs.scripts"),
                                 active_tab == SidebarTab::Scripts,
                                 focused,
                                 tab_text_color(active_tab == SidebarTab::Scripts),
@@ -146,7 +151,7 @@ impl Sidebar {
                         .items_center()
                         .justify_center()
                         .child(
-                            Text::body("Press x to confirm delete, ESC to cancel")
+                            Text::body(dbflux_i18n::t!("sidebar.confirm.delete_hint"))
                                 .font_size(FontSizes::SM),
                         ),
                 )
@@ -228,8 +233,12 @@ impl Sidebar {
                         .justify_center()
                         .gap(Spacing::SM)
                         .px(Spacing::MD)
-                        .child(Body::new("No connections yet").muted(cx))
-                        .child(Body::new("Use + to add a new connection").muted(cx)),
+                        .child(
+                            Body::new(dbflux_i18n::t!("sidebar.empty.connections_title")).muted(cx),
+                        )
+                        .child(
+                            Body::new(dbflux_i18n::t!("sidebar.empty.connections_hint")).muted(cx),
+                        ),
                 )
             })
     }
@@ -326,11 +335,8 @@ impl Sidebar {
                         .justify_center()
                         .gap(Spacing::SM)
                         .px(Spacing::MD)
-                        .child(Body::new("No scripts yet").muted(cx))
-                        .child(
-                            Body::new("Use + to create a new script or import an existing file")
-                                .muted(cx),
-                        ),
+                        .child(Body::new(dbflux_i18n::t!("sidebar.empty.scripts_title")).muted(cx))
+                        .child(Body::new(dbflux_i18n::t!("sidebar.empty.scripts_hint")).muted(cx)),
                 )
             })
     }

--- a/crates/dbflux_ui_sidebar/src/render_footer.rs
+++ b/crates/dbflux_ui_sidebar/src/render_footer.rs
@@ -11,7 +11,7 @@ impl Sidebar {
         let total_profiles = state.profiles().len();
         let idle_count = total_profiles.saturating_sub(connected_count);
 
-        let status_text = format!("{} connected · {} idle", connected_count, idle_count);
+        let status_text = crate::labels::footer_counts_label(connected_count, idle_count);
         let dot_variant = if connected_count > 0 {
             StatusDotVariant::Success
         } else {


### PR DESCRIPTION
## Summary

First `dbflux_ui_sidebar` i18n slice: the crate depends on `dbflux_i18n`, a `sidebar:` catalog namespace exists, and the sidebar chrome (CONNECTIONS / SCRIPTS tabs, the delete-confirm hint, both empty states, the footer connection counts) renders through `dbflux_i18n::t!`. It also ships the `container_folder_label` helper that maps `DatabaseCategory` to sidebar-owned folder labels; the tree wiring lands in the tree slices.

## What does this resolve?

- Refs #360 (sidebar slice A1 of ~9; follows the `dbflux_ui_base` and `dbflux_components` slices)

## How was this solved?

- New `crates/dbflux_ui_sidebar/src/labels.rs` for helpers that pick plural buckets or interpolate several placeholders; `container_folder_label(category, count)` reproduces today's English exactly (`Tables (N)`, `Collections (N)`, ... `Log Groups (N)` and `Buckets (N)` stay English as AWS terms) without touching `dbflux_core`.
- `sidebar_tab_text` widened from `&'static str` to `impl Into<SharedString>`; no public signature changes.

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 138 passed; clippy `-D warnings` clean; fmt clean. 8 new tests (container mapping over all 8 categories, footer counts, key resolution in `en`/`es`, divergence).
- Receipt-driven review (one lens): approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish: CONEXIONES / SCRIPTS tab width at the narrowest sidebar, empty states, footer counts singular/plural)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
