### PR TITLE
feat(i18n): translate the import, preview, and cell-editor modals in dbflux_components

### DIFF
--- a/crates/dbflux_components/src/components/json_editor_view.rs
+++ b/crates/dbflux_components/src/components/json_editor_view.rs
@@ -27,7 +27,7 @@ pub fn validate_json(s: &str, allow_empty: bool) -> Result<(), String> {
         return if allow_empty {
             Ok(())
         } else {
-            Err("Document cannot be empty".to_string())
+            Err(dbflux_i18n::t!("components.json_editor.empty_error"))
         };
     }
 
@@ -139,7 +139,7 @@ impl JsonEditorView {
             if let Some(on_format) = self.on_format {
                 left_buttons = left_buttons.child(
                     Button::new(SharedString::from(format!("{}-format", prefix)))
-                        .label("Format")
+                        .label(dbflux_i18n::t!("components.json_editor.format"))
                         .small()
                         .with_variant(ButtonVariant::Ghost)
                         .on_click(on_format),
@@ -148,7 +148,7 @@ impl JsonEditorView {
             if let Some(on_compact) = self.on_compact {
                 left_buttons = left_buttons.child(
                     Button::new(SharedString::from(format!("{}-compact", prefix)))
-                        .label("Compact")
+                        .label(dbflux_i18n::t!("components.json_editor.compact"))
                         .small()
                         .with_variant(ButtonVariant::Ghost)
                         .on_click(on_compact),
@@ -162,14 +162,14 @@ impl JsonEditorView {
             .gap(Spacing::SM)
             .child(
                 Button::new(SharedString::from(format!("{}-cancel", prefix)))
-                    .label("Cancel")
+                    .label(dbflux_i18n::t!("components.json_editor.cancel"))
                     .small()
                     .with_variant(ButtonVariant::Ghost)
                     .on_click(self.on_cancel),
             )
             .child(
                 Button::new(SharedString::from(format!("{}-save", prefix)))
-                    .label("Save")
+                    .label(dbflux_i18n::t!("components.json_editor.save"))
                     .small()
                     .with_variant(ButtonVariant::Primary)
                     .on_click(self.on_save),
@@ -189,5 +189,44 @@ impl JsonEditorView {
         );
 
         el.into_any_element()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_json;
+
+    #[test]
+    fn validate_json_empty_error_matches_translated_catalog() {
+        let error = validate_json("", false).unwrap_err();
+        assert_eq!(
+            error,
+            dbflux_i18n::t!("components.json_editor.empty_error", locale = "en")
+        );
+    }
+
+    #[test]
+    fn validate_json_empty_error_diverges_between_locales() {
+        let en = dbflux_i18n::t!("components.json_editor.empty_error", locale = "en");
+        let es = dbflux_i18n::t!("components.json_editor.empty_error", locale = "es");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn json_editor_keys_resolve_in_both_locales() {
+        let keys = [
+            "components.json_editor.empty_error",
+            "components.json_editor.format",
+            "components.json_editor.compact",
+            "components.json_editor.cancel",
+            "components.json_editor.save",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
     }
 }

--- a/crates/dbflux_components/src/modals/cell_editor.rs
+++ b/crates/dbflux_components/src/modals/cell_editor.rs
@@ -174,10 +174,39 @@ impl Render for CellEditorModal {
             .key_context(ContextId::SqlPreviewModal.as_gpui_context())
             .close_icon(IconSource::Svg(AppIcon::X.path().into()))
             .header_leading(Icon::new(AppIcon::Pencil).size(Heights::ICON_SM).primary())
-            .title(if is_json { "Edit JSON" } else { "Edit Text" })
+            .title(if is_json {
+                dbflux_i18n::t!("modals.cell_editor.title_json")
+            } else {
+                dbflux_i18n::t!("modals.cell_editor.title_text")
+            })
             .width(px(900.0))
             .height(px(600.0))
             .child(editor.render(cx))
             .render(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn cell_editor_keys_resolve_in_both_locales() {
+        let keys = [
+            "modals.cell_editor.title_json",
+            "modals.cell_editor.title_text",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn cell_editor_title_json_diverges_between_locales() {
+        let en = dbflux_i18n::t!("modals.cell_editor.title_json", locale = "en");
+        let es = dbflux_i18n::t!("modals.cell_editor.title_json", locale = "es");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_components/src/modals/document_preview.rs
+++ b/crates/dbflux_components/src/modals/document_preview.rs
@@ -159,12 +159,34 @@ impl Render for DocumentPreviewModal {
             .key_context(ContextId::SqlPreviewModal.as_gpui_context())
             .close_icon(IconSource::Svg(AppIcon::X.path().into()))
             .header_leading(Icon::new(AppIcon::Braces).size(Heights::ICON_SM).primary())
-            .title("Document Preview")
+            .title(dbflux_i18n::t!("modals.document_preview.title"))
             .width(px(1000.0))
             .height(px(700.0))
             .top_offset(px(60.0))
             .block_scroll()
             .child(editor.render(cx))
             .render(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn document_preview_keys_resolve_in_both_locales() {
+        let keys = ["modals.document_preview.title"];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn document_preview_title_diverges_between_locales() {
+        let en = dbflux_i18n::t!("modals.document_preview.title", locale = "en");
+        let es = dbflux_i18n::t!("modals.document_preview.title", locale = "es");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_components/src/modals/import_dashboard.rs
+++ b/crates/dbflux_components/src/modals/import_dashboard.rs
@@ -49,10 +49,13 @@ impl ModalImportDashboard {
                 .code_editor("json")
                 .line_number(true)
                 .soft_wrap(true)
-                .placeholder("Paste dashboard JSON here…")
+                .placeholder(dbflux_i18n::t!("modals.import_dashboard.json_placeholder"))
         });
 
-        let name_input = cx.new(|cx| InputState::new(window, cx).placeholder("Dashboard name"));
+        let name_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("modals.import_dashboard.name_placeholder"))
+        });
 
         Self {
             visible: false,
@@ -128,7 +131,7 @@ impl ModalImportDashboard {
 
         let name = self.name_input.read(cx).value().trim().to_string();
         if name.is_empty() {
-            self.name_error = Some("Name cannot be empty".to_string());
+            self.name_error = Some(dbflux_i18n::t!("modals.import_dashboard.name_error"));
             cx.notify();
             return;
         }
@@ -144,7 +147,7 @@ impl ModalImportDashboard {
         };
 
         if final_name.trim().is_empty() {
-            self.name_error = Some("Name cannot be empty".to_string());
+            self.name_error = Some(dbflux_i18n::t!("modals.import_dashboard.name_error"));
             cx.notify();
             return;
         }
@@ -213,7 +216,9 @@ impl Render for ModalImportDashboard {
             .flex()
             .flex_col()
             .gap(Spacing::XS)
-            .child(Text::label("Dashboard name"))
+            .child(Text::label(dbflux_i18n::t!(
+                "modals.import_dashboard.name_label"
+            )))
             .child(Input::new(&self.name_input))
             .when_some(name_error, |el, err| {
                 el.child(
@@ -229,7 +234,9 @@ impl Render for ModalImportDashboard {
             .flex()
             .flex_col()
             .gap(Spacing::XS)
-            .child(Text::label("Dashboard JSON"))
+            .child(Text::label(dbflux_i18n::t!(
+                "modals.import_dashboard.json_label"
+            )))
             .child(
                 div()
                     .border_1()
@@ -301,14 +308,14 @@ impl Render for ModalImportDashboard {
                     .gap(Spacing::SM)
                     .child(
                         Button::new("import-dashboard-format")
-                            .label("Format")
+                            .label(dbflux_i18n::t!("modals.import_dashboard.format"))
                             .small()
                             .with_variant(ButtonVariant::Ghost)
                             .on_click(on_format),
                     )
                     .child(
                         Button::new("import-dashboard-compact")
-                            .label("Compact")
+                            .label(dbflux_i18n::t!("modals.import_dashboard.compact"))
                             .small()
                             .with_variant(ButtonVariant::Ghost)
                             .on_click(on_compact),
@@ -321,19 +328,19 @@ impl Render for ModalImportDashboard {
                     .gap(Spacing::SM)
                     .child(
                         Button::new("import-dashboard-cancel")
-                            .label("Cancel")
+                            .label(dbflux_i18n::t!("modals.import_dashboard.cancel"))
                             .on_click(on_cancel),
                     )
                     .child(
                         Button::new("import-dashboard-save")
-                            .label("Import")
+                            .label(dbflux_i18n::t!("modals.import_dashboard.confirm"))
                             .with_variant(ButtonVariant::Primary)
                             .on_click(on_save),
                     ),
             );
 
         ModalShell::new(
-            "Import Dashboard from JSON",
+            dbflux_i18n::t!("modals.import_dashboard.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
@@ -381,9 +388,34 @@ mod tests {
     }
 
     #[test]
-    fn modal_title_contains_no_cloudwatch_substring() {
-        let title = "Import Dashboard from JSON";
-        assert!(!title.contains("CloudWatch"));
-        assert!(title.contains("Import Dashboard from JSON"));
+    fn modal_title_matches_translated_catalog_and_diverges_by_locale() {
+        let en = dbflux_i18n::t!("modals.import_dashboard.title", locale = "en");
+        let es = dbflux_i18n::t!("modals.import_dashboard.title", locale = "es");
+        assert!(!en.contains("CloudWatch"));
+        assert_eq!(en, "Import Dashboard from JSON");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn import_dashboard_keys_resolve_in_both_locales() {
+        let keys = [
+            "modals.import_dashboard.title",
+            "modals.import_dashboard.name_label",
+            "modals.import_dashboard.name_placeholder",
+            "modals.import_dashboard.json_label",
+            "modals.import_dashboard.json_placeholder",
+            "modals.import_dashboard.name_error",
+            "modals.import_dashboard.format",
+            "modals.import_dashboard.compact",
+            "modals.import_dashboard.cancel",
+            "modals.import_dashboard.confirm",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
     }
 }

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1,3 +1,10 @@
+components:
+  json_editor:
+    empty_error: Document cannot be empty
+    format: Format
+    compact: Compact
+    cancel: Cancel
+    save: Save
 errors:
   action:
     view_in_audit: View in Audit
@@ -52,6 +59,9 @@ modals:
       no_metrics: No metrics in this namespace.
       no_metrics_filtered: No metrics match the filter.
     cancel: Cancel
+  cell_editor:
+    title_json: Edit JSON
+    title_text: Edit Text
   create_dashboard:
     name_label: Dashboard name
     title: New dashboard
@@ -77,6 +87,8 @@ modals:
     documents_closed: Any open documents using this connection will be closed.
     cancel: Cancel
     confirm: Delete
+  document_preview:
+    title: Document Preview
   drop_table:
     title: Drop table
     confirm: Drop table
@@ -85,6 +97,17 @@ modals:
     confirm_prompt: 'Type "%{table}" to confirm'
     cascade_warning: "Dependent objects will also be dropped (CASCADE):"
     delete_warning: This will permanently delete the table and any dependent objects.
+  import_dashboard:
+    title: Import Dashboard from JSON
+    name_label: Dashboard name
+    name_placeholder: Dashboard name
+    json_label: Dashboard JSON
+    json_placeholder: "Paste dashboard JSON here…"
+    name_error: Name cannot be empty
+    format: Format
+    compact: Compact
+    cancel: Cancel
+    confirm: Import
   rename:
     placeholder: Enter a name
     title:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1,3 +1,10 @@
+components:
+  json_editor:
+    empty_error: El documento no puede estar vacío
+    format: Formatear
+    compact: Compactar
+    cancel: Cancelar
+    save: Guardar
 errors:
   action:
     view_in_audit: Ver en auditoría
@@ -52,6 +59,9 @@ modals:
       no_metrics: No hay métricas en este espacio de nombres.
       no_metrics_filtered: Ninguna métrica coincide con el filtro.
     cancel: Cancelar
+  cell_editor:
+    title_json: Editar JSON
+    title_text: Editar texto
   create_dashboard:
     name_label: Nombre del dashboard
     title: Nuevo dashboard
@@ -77,6 +87,8 @@ modals:
     documents_closed: Se cerrarán los documentos abiertos que usen esta conexión.
     cancel: Cancelar
     confirm: Eliminar
+  document_preview:
+    title: Vista previa del documento
   drop_table:
     title: Eliminar tabla
     confirm: Eliminar tabla
@@ -85,6 +97,17 @@ modals:
     confirm_prompt: 'Escribe "%{table}" para confirmar'
     cascade_warning: "También se eliminarán los objetos dependientes (CASCADE):"
     delete_warning: Esto eliminará de forma permanente la tabla y cualquier objeto dependiente.
+  import_dashboard:
+    title: Importar dashboard desde JSON
+    name_label: Nombre del dashboard
+    name_placeholder: Nombre del dashboard
+    json_label: JSON del dashboard
+    json_placeholder: "Pega aquí el JSON del dashboard…"
+    name_error: El nombre no puede estar vacío
+    format: Formatear
+    compact: Compactar
+    cancel: Cancelar
+    confirm: Importar
   rename:
     placeholder: Escribe un nombre
     title:


### PR DESCRIPTION
## Summary

Second `dbflux_components` i18n slice: the import-dashboard, document-preview and cell-editor modals and the JSON editor view render through `dbflux_i18n::t!`. 20 keys (`modals.import_dashboard.*`, `modals.document_preview.title`, `modals.cell_editor.*`, `components.json_editor.*`), English and Spanish together.

## What does this resolve?

- Refs #360 (follows #366; next: mutation-confirm + schema-drift modals, tree/chart/controls)

## How was this solved?

- Same mechanism; no signature changes. `DEFAULT_IMPORT_NAME` ("Imported Dashboard") stays an English constant: it is persisted data and a sentinel compared in code, not chrome.
- The import-dashboard literal test now asserts against the catalog in both locales and that they differ.

## Validation

- `cargo nextest run -p dbflux_components -p dbflux_i18n` → 379 passed (after rebase on `main`); clippy clean; fmt clean. Workspace-wide gates run in CI.
- Receipt-driven review (one lens): approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish: import a dashboard from JSON, open a document preview, edit a JSON cell)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
