### PR TITLE
feat(i18n): translate sidebar overlays, filters, and reconnect toasts

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -220,11 +220,37 @@ sidebar:
     connections_hint: Use + to add a new connection
     scripts_title: No scripts yet
     scripts_hint: Use + to create a new script or import an existing file
+  filter:
+    connections_placeholder: Filter connections and schema...
+    scripts_placeholder: Filter scripts...
+    stream_placeholder: Filter stream names...
+  overlay:
+    add_folder: New Folder
+    add_connection: New Connection
+    add_script_file: New File
+    add_script_folder: New Folder
+    import_file: Import File
+    child_picker:
+      title: "Event streams: %{name}"
+      column_name: Stream name
+      column_last_event: Last event
+      empty: No event streams found
+      prev: Prev
+      next: Next
+      page_label: "Page %{current}/%{total} (%{start}-%{end})"
+      page_label_empty: Page 0/0
+      unsupported: Event streams are not available for this collection
   status:
     connection_summary: "%{connected} connected · %{idle} idle"
+    profile_fallback_name: connection
   tabs:
     connections: CONNECTIONS
     scripts: SCRIPTS
+  toast:
+    edit_reconnect_updated: "'%{name}' updated"
+    edit_reconnect_body: Reconnect to apply the changes to the live session.
+    edit_reconnect_now: Reconnect now
+    edit_reconnect_later: Later
   tree:
     container:
       relational: Tables (%{count})
@@ -235,6 +261,8 @@ sidebar:
       wide_column: Tables (%{count})
       log_stream: Log Groups (%{count})
       object_storage: Buckets (%{count})
+    status:
+      loading: Loading…
 sql_preview:
   title:
     sql: SQL Preview

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -220,11 +220,37 @@ sidebar:
     connections_hint: Usa + para agregar una nueva conexión
     scripts_title: Aún no hay scripts
     scripts_hint: Usa + para crear un script nuevo o importar un archivo existente
+  filter:
+    connections_placeholder: Filtrar conexiones y esquema...
+    scripts_placeholder: Filtrar scripts...
+    stream_placeholder: Filtrar nombres de streams...
+  overlay:
+    add_folder: Nueva carpeta
+    add_connection: Nueva conexión
+    add_script_file: Nuevo archivo
+    add_script_folder: Nueva carpeta
+    import_file: Importar archivo
+    child_picker:
+      title: "Flujos de eventos: %{name}"
+      column_name: Nombre del stream
+      column_last_event: Último evento
+      empty: No se encontraron flujos de eventos
+      prev: Anterior
+      next: Siguiente
+      page_label: "Página %{current}/%{total} (%{start}-%{end})"
+      page_label_empty: Página 0/0
+      unsupported: Los flujos de eventos no están disponibles para esta colección
   status:
     connection_summary: "%{connected} conectadas · %{idle} inactivas"
+    profile_fallback_name: conexión
   tabs:
     connections: CONEXIONES
     scripts: SCRIPTS
+  toast:
+    edit_reconnect_updated: "'%{name}' actualizado"
+    edit_reconnect_body: Reconecta para aplicar los cambios a la sesión activa.
+    edit_reconnect_now: Reconectar ahora
+    edit_reconnect_later: Más tarde
   tree:
     container:
       relational: Tablas (%{count})
@@ -235,6 +261,8 @@ sidebar:
       wide_column: Tablas (%{count})
       log_stream: Log Groups (%{count})
       object_storage: Buckets (%{count})
+    status:
+      loading: Cargando…
 sql_preview:
   title:
     sql: Vista previa de SQL

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -43,6 +43,34 @@ pub(crate) fn footer_counts_label(connected: usize, idle: usize) -> String {
     )
 }
 
+/// Translated page indicator for the collection child picker, e.g.
+/// `"Page 1/3 (1-50)"`. `page` and `pages` are 1-based, `from`/`to` are the
+/// 1-based inclusive row range shown on the current page.
+pub(crate) fn page_label(page: usize, pages: usize, from: usize, to: usize) -> String {
+    if pages == 0 {
+        return dbflux_i18n::t!("sidebar.overlay.child_picker.page_label_empty");
+    }
+
+    dbflux_i18n::t!(
+        "sidebar.overlay.child_picker.page_label",
+        current = page,
+        total = pages,
+        start = from,
+        end = to
+    )
+}
+
+/// Translated child-picker modal title, e.g. `"Event streams: orders"`.
+pub(crate) fn child_picker_title(collection: &str) -> String {
+    dbflux_i18n::t!("sidebar.overlay.child_picker.title", name = collection)
+}
+
+/// Translated toast headline reporting a connection profile was updated,
+/// e.g. `"'prod-db' updated"`.
+pub(crate) fn profile_updated_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.edit_reconnect_updated", name = name)
+}
+
 #[cfg(test)]
 mod tests {
     use dbflux_core::DatabaseCategory;
@@ -80,6 +108,32 @@ mod tests {
         "sidebar.status.connection_summary",
         "sidebar.tree.container.relational",
         "sidebar.tree.container.log_stream",
+    ];
+
+    const OVERLAY_KEYS: [&str; 23] = [
+        "sidebar.filter.connections_placeholder",
+        "sidebar.filter.scripts_placeholder",
+        "sidebar.filter.stream_placeholder",
+        "sidebar.overlay.add_folder",
+        "sidebar.overlay.add_connection",
+        "sidebar.overlay.add_script_file",
+        "sidebar.overlay.add_script_folder",
+        "sidebar.overlay.import_file",
+        "sidebar.overlay.child_picker.title",
+        "sidebar.overlay.child_picker.column_name",
+        "sidebar.overlay.child_picker.column_last_event",
+        "sidebar.overlay.child_picker.empty",
+        "sidebar.overlay.child_picker.prev",
+        "sidebar.overlay.child_picker.next",
+        "sidebar.overlay.child_picker.page_label",
+        "sidebar.overlay.child_picker.page_label_empty",
+        "sidebar.overlay.child_picker.unsupported",
+        "sidebar.toast.edit_reconnect_updated",
+        "sidebar.toast.edit_reconnect_body",
+        "sidebar.toast.edit_reconnect_now",
+        "sidebar.toast.edit_reconnect_later",
+        "sidebar.status.profile_fallback_name",
+        "sidebar.tree.status.loading",
     ];
 
     #[test]
@@ -152,5 +206,82 @@ mod tests {
 
             assert_eq!(expected, translated);
         }
+    }
+
+    #[test]
+    fn overlay_keys_resolve_in_both_locales() {
+        for key in OVERLAY_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn overlay_prev_differs_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.overlay.child_picker.prev", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.overlay.child_picker.prev", locale = "es");
+
+        assert_eq!(english, "Prev");
+        assert_eq!(spanish, "Anterior");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn page_label_reports_current_page_and_visible_range() {
+        let label = super::page_label(1, 3, 1, 50);
+
+        assert!(label.contains('1'));
+        assert!(label.contains('3'));
+        assert!(label.contains("50"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!(
+                "sidebar.overlay.child_picker.page_label",
+                current = 1,
+                total = 3,
+                start = 1,
+                end = 50
+            )
+        );
+    }
+
+    #[test]
+    fn page_label_falls_back_to_empty_variant_when_there_are_no_pages() {
+        let label = super::page_label(0, 0, 0, 0);
+
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.overlay.child_picker.page_label_empty")
+        );
+    }
+
+    #[test]
+    fn child_picker_title_includes_the_collection_name() {
+        let title = super::child_picker_title("orders");
+
+        assert!(title.contains("orders"));
+        assert_eq!(
+            title,
+            dbflux_i18n::t!("sidebar.overlay.child_picker.title", name = "orders")
+        );
+    }
+
+    #[test]
+    fn profile_updated_label_includes_the_profile_name() {
+        let label = super::profile_updated_label("prod-db");
+
+        assert!(label.contains("prod-db"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.toast.edit_reconnect_updated", name = "prod-db")
+        );
     }
 }

--- a/crates/dbflux_ui_sidebar/src/lib.rs
+++ b/crates/dbflux_ui_sidebar/src/lib.rs
@@ -1006,14 +1006,18 @@ impl Sidebar {
         let visible_entry_count = Self::count_visible_entries(&items);
         let gutter_metadata = compute_gutter_map(&items);
         let tree_state = cx.new(|cx| TreeState::new(cx).items(items));
-        let connections_search_input = cx
-            .new(|cx| InputState::new(window, cx).placeholder("Filter connections and schema..."));
+        let connections_search_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("sidebar.filter.connections_placeholder"))
+        });
 
         let scripts_items = Self::build_initial_scripts_tree(app_state.read(cx));
         let scripts_gutter_metadata = compute_gutter_map(&scripts_items);
         let scripts_tree_state = cx.new(|cx| TreeState::new(cx).items(scripts_items));
-        let scripts_search_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Filter scripts..."));
+        let scripts_search_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("sidebar.filter.scripts_placeholder"))
+        });
 
         let rename_input = cx.new(|cx| InputState::new(window, cx));
 
@@ -1281,23 +1285,28 @@ impl Sidebar {
             .iter()
             .find(|profile| profile.id == profile_id)
             .map(|profile| profile.name.clone())
-            .unwrap_or_else(|| "connection".to_string());
+            .unwrap_or_else(|| dbflux_i18n::t!("sidebar.status.profile_fallback_name"));
 
         let app_state_for_action = app_state.clone();
-        let reconnect_action =
-            dbflux_ui_base::toast::ToastAction::new("edit-reconnect-now", "Reconnect now")
-                .primary()
-                .on_click(move |cx| {
-                    app_state_for_action.update(cx, |state, cx| {
-                        state.pending_reconnect_request = Some(profile_id);
-                        cx.emit(AppStateChanged);
-                    });
-                });
+        let reconnect_action = dbflux_ui_base::toast::ToastAction::new(
+            "edit-reconnect-now",
+            dbflux_i18n::t!("sidebar.toast.edit_reconnect_now"),
+        )
+        .primary()
+        .on_click(move |cx| {
+            app_state_for_action.update(cx, |state, cx| {
+                state.pending_reconnect_request = Some(profile_id);
+                cx.emit(AppStateChanged);
+            });
+        });
 
-        let later_action = dbflux_ui_base::toast::ToastAction::new("edit-reconnect-later", "Later");
+        let later_action = dbflux_ui_base::toast::ToastAction::new(
+            "edit-reconnect-later",
+            dbflux_i18n::t!("sidebar.toast.edit_reconnect_later"),
+        );
 
-        dbflux_ui_base::toast::Toast::info(format!("'{}' updated", profile_name))
-            .body("Reconnect to apply the changes to the live session.")
+        dbflux_ui_base::toast::Toast::info(labels::profile_updated_label(&profile_name))
+            .body(dbflux_i18n::t!("sidebar.toast.edit_reconnect_body"))
             .meta_right(dbflux_ui_base::toast::now_hms())
             .action(reconnect_action)
             .action(later_action)

--- a/crates/dbflux_ui_sidebar/src/render_overlays.rs
+++ b/crates/dbflux_ui_sidebar/src/render_overlays.rs
@@ -126,7 +126,7 @@ impl Sidebar {
                         .items_center()
                         .gap(Spacing::SM)
                         .child(Icon::new(AppIcon::Folder).size(Heights::ICON_SM).muted())
-                        .child("New Folder"),
+                        .child(dbflux_i18n::t!("sidebar.overlay.add_folder")),
                 ),
         )
         .child(
@@ -149,7 +149,7 @@ impl Sidebar {
                         .items_center()
                         .gap(Spacing::SM)
                         .child(Icon::new(AppIcon::Plug).size(Heights::ICON_SM).muted())
-                        .child("New Connection"),
+                        .child(dbflux_i18n::t!("sidebar.overlay.add_connection")),
                 ),
         )
     }
@@ -187,7 +187,7 @@ impl Sidebar {
                                 .size(Heights::ICON_SM)
                                 .muted(),
                         )
-                        .child("New File"),
+                        .child(dbflux_i18n::t!("sidebar.overlay.add_script_file")),
                 ),
         )
         .child(
@@ -210,7 +210,7 @@ impl Sidebar {
                         .items_center()
                         .gap(Spacing::SM)
                         .child(Icon::new(AppIcon::Folder).size(Heights::ICON_SM).muted())
-                        .child("New Folder"),
+                        .child(dbflux_i18n::t!("sidebar.overlay.add_script_folder")),
                 ),
         )
         .child(
@@ -233,7 +233,7 @@ impl Sidebar {
                         .items_center()
                         .gap(Spacing::SM)
                         .child(Icon::new(AppIcon::Download).size(Heights::ICON_SM).muted())
-                        .child("Import File"),
+                        .child(dbflux_i18n::t!("sidebar.overlay.import_file")),
                 ),
         )
     }
@@ -255,14 +255,16 @@ impl Sidebar {
 
         let Some(collection) = self.collection_info_for_item(item_id, cx) else {
             self.pending_toast = Some(PendingToast {
-                message: "Event streams are not available for this collection".to_string(),
+                message: dbflux_i18n::t!("sidebar.overlay.child_picker.unsupported"),
                 is_error: true,
             });
             return;
         };
 
-        let filter_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Filter stream names..."));
+        let filter_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("sidebar.filter.stream_placeholder"))
+        });
         let input_for_subscription = filter_input.clone();
         let filter_subscription = cx.subscribe_in(
             &input_for_subscription,
@@ -314,7 +316,7 @@ impl Sidebar {
             profile_id,
             database,
             collection: name.clone(),
-            title: format!("Event streams: {}", name),
+            title: super::labels::child_picker_title(&name),
             focus_handle: focus_handle.clone(),
             children,
             filter_input,
@@ -474,9 +476,9 @@ impl Sidebar {
         let can_prev = page > 0;
         let can_next = page + 1 < page_count;
         let page_label = if total == 0 {
-            "Page 0/0".to_string()
+            super::labels::page_label(0, 0, 0, 0)
         } else {
-            format!("Page {}/{} ({}-{})", page + 1, page_count, start + 1, end)
+            super::labels::page_label(page + 1, page_count, start + 1, end)
         };
 
         div()
@@ -526,7 +528,9 @@ impl Sidebar {
                                 });
                             })
                             .flex_1()
-                            .child(Text::caption("Stream name")),
+                            .child(Text::caption(dbflux_i18n::t!(
+                                "sidebar.overlay.child_picker.column_name"
+                            ))),
                     )
                     .child(
                         div()
@@ -549,7 +553,9 @@ impl Sidebar {
                                 });
                             })
                             .flex_1()
-                            .child(Text::caption("Last event")),
+                            .child(Text::caption(dbflux_i18n::t!(
+                                "sidebar.overlay.child_picker.column_last_event"
+                            ))),
                     ),
             )
             .child(
@@ -560,7 +566,8 @@ impl Sidebar {
                     .when(visible_rows.is_empty(), |el| {
                         el.child(
                             div().px(Spacing::MD).py(Spacing::SM).child(
-                                Text::muted("No event streams found").font_size(FontSizes::SM),
+                                Text::muted(dbflux_i18n::t!("sidebar.overlay.child_picker.empty"))
+                                    .font_size(FontSizes::SM),
                             ),
                         )
                     })
@@ -647,13 +654,15 @@ impl Sidebar {
                                     theme.muted_foreground
                                 },
                             ))
-                            .child(Text::caption("Prev").font_size(FontSizes::XS).color(
-                                if can_prev {
-                                    theme.foreground
-                                } else {
-                                    theme.muted_foreground
-                                },
-                            )),
+                            .child(
+                                Text::caption(dbflux_i18n::t!("sidebar.overlay.child_picker.prev"))
+                                    .font_size(FontSizes::XS)
+                                    .color(if can_prev {
+                                        theme.foreground
+                                    } else {
+                                        theme.muted_foreground
+                                    }),
+                            ),
                     )
                     .child(Text::caption(page_label).font_size(FontSizes::XS))
                     .child(
@@ -682,13 +691,15 @@ impl Sidebar {
                                     })
                             })
                             .when(!can_next, |d| d.opacity(0.5))
-                            .child(Text::caption("Next").font_size(FontSizes::XS).color(
-                                if can_next {
-                                    theme.foreground
-                                } else {
-                                    theme.muted_foreground
-                                },
-                            ))
+                            .child(
+                                Text::caption(dbflux_i18n::t!("sidebar.overlay.child_picker.next"))
+                                    .font_size(FontSizes::XS)
+                                    .color(if can_next {
+                                        theme.foreground
+                                    } else {
+                                        theme.muted_foreground
+                                    }),
+                            )
                             .child(Icon::new(AppIcon::ChevronRight).size(Spacing::MD).color(
                                 if can_next {
                                     theme.foreground

--- a/crates/dbflux_ui_sidebar/src/render_tree.rs
+++ b/crates/dbflux_ui_sidebar/src/render_tree.rs
@@ -99,7 +99,10 @@ pub(super) fn render_tree_item(
                         .size(Spacing::MD)
                         .color(theme.muted_foreground),
                 )
-                .child(Text::caption("Loading…").color(theme.muted_foreground)),
+                .child(
+                    Text::caption(dbflux_i18n::t!("sidebar.tree.status.loading"))
+                        .color(theme.muted_foreground),
+                ),
         );
     }
 


### PR DESCRIPTION
## Summary

Sidebar i18n slice A2: the add-item overlays, the event-stream child picker (title, columns, empty state, pagination), the filter placeholders, the edit-then-reconnect toast and the tree's loading placeholder render through `dbflux_i18n::t!`. 23 keys under `sidebar.*`, English and Spanish together.

## What does this resolve?

- Refs #360 (follows #367; next: the context-menu slices B1-B3, then the tree slices)

## How was this solved?

- Same mechanism as A1; helpers `page_label`, `child_picker_title`, `profile_updated_label` in `labels.rs` for the interpolated strings. Driver-supplied child labels and timestamps stay untouched.

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 144 passed (after rebase on `main`); clippy clean; fmt clean. 8 new tests.
- Receipt-driven review (one lens): approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish: "+" overlay items, event-stream picker incl. pagination, filter placeholders, edit a connection and see the reconnect toast)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
