### PR TITLE
feat(i18n): translate the mutation-confirm and schema-drift modals in dbflux_components

### DIFF
--- a/crates/dbflux_components/src/modals/mutation_confirm.rs
+++ b/crates/dbflux_components/src/modals/mutation_confirm.rs
@@ -151,7 +151,9 @@ impl Render for ModalMutationConfirm {
                     div()
                         .text_size(FontSizes::XS)
                         .text_color(theme.muted_foreground)
-                        .child("Sample preview unavailable"),
+                        .child(dbflux_i18n::t!(
+                            "modals.mutation_confirm.sample_unavailable"
+                        )),
                 );
             }
         }
@@ -162,26 +164,32 @@ impl Render for ModalMutationConfirm {
             .gap_2()
             .justify_end()
             .child(
-                Button::new("mutation-confirm-cancel", "Cancel")
-                    .variant(ButtonVariant::Default)
-                    .on_click(cx.listener(|this, _event, _window, cx| {
-                        this.visible = false;
-                        cx.emit(MutationConfirmOutcome::Cancelled);
-                        cx.notify();
-                    })),
+                Button::new(
+                    "mutation-confirm-cancel",
+                    dbflux_i18n::t!("modals.mutation_confirm.cancel"),
+                )
+                .variant(ButtonVariant::Default)
+                .on_click(cx.listener(|this, _event, _window, cx| {
+                    this.visible = false;
+                    cx.emit(MutationConfirmOutcome::Cancelled);
+                    cx.notify();
+                })),
             )
             .child(
-                Button::new("mutation-confirm-ok", "Confirm")
-                    .variant(ButtonVariant::Primary)
-                    .on_click(cx.listener(|this, _event, _window, cx| {
-                        this.visible = false;
-                        cx.emit(MutationConfirmOutcome::Confirmed);
-                        cx.notify();
-                    })),
+                Button::new(
+                    "mutation-confirm-ok",
+                    dbflux_i18n::t!("modals.mutation_confirm.confirm"),
+                )
+                .variant(ButtonVariant::Primary)
+                .on_click(cx.listener(|this, _event, _window, cx| {
+                    this.visible = false;
+                    cx.emit(MutationConfirmOutcome::Confirmed);
+                    cx.notify();
+                })),
             );
 
         ModalShell::new(
-            "Confirm mutation",
+            dbflux_i18n::t!("modals.mutation_confirm.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
@@ -231,8 +239,11 @@ pub struct ModalMutationConfirmHard {
 
 impl ModalMutationConfirmHard {
     pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let confirm_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Type table name to confirm"));
+        let confirm_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "modals.mutation_confirm.type_to_confirm_placeholder"
+            ))
+        });
         Self {
             request: None,
             visible: false,
@@ -392,7 +403,9 @@ impl Render for ModalMutationConfirmHard {
                     div()
                         .text_size(FontSizes::XS)
                         .text_color(theme.muted_foreground)
-                        .child("Sample preview unavailable"),
+                        .child(dbflux_i18n::t!(
+                            "modals.mutation_confirm.sample_unavailable"
+                        )),
                 );
             }
         }
@@ -407,7 +420,9 @@ impl Render for ModalMutationConfirmHard {
                     div()
                         .text_size(FontSizes::XS)
                         .text_color(theme.muted_foreground)
-                        .child("Type the table name to confirm:"),
+                        .child(dbflux_i18n::t!(
+                            "modals.mutation_confirm.type_to_confirm_label"
+                        )),
                 )
                 .child(crate::controls::Input::new(&self.confirm_input)),
         );
@@ -417,7 +432,7 @@ impl Render for ModalMutationConfirmHard {
             body = body.child(
                 Checkbox::new("mutation-hard-opt-in")
                     .checked(opt_in_checked)
-                    .label("I understand this operation will modify data")
+                    .label(dbflux_i18n::t!("modals.mutation_confirm.opt_in_label"))
                     .on_click(cx.listener(|this, checked, _window, cx| {
                         this.opt_in_checked = *checked;
                         cx.notify();
@@ -431,35 +446,83 @@ impl Render for ModalMutationConfirmHard {
             .gap_2()
             .justify_end()
             .child(
-                Button::new("mutation-hard-cancel", "Cancel")
-                    .variant(ButtonVariant::Default)
-                    .on_click(cx.listener(|this, _event, _window, cx| {
-                        this.visible = false;
-                        cx.emit(MutationConfirmOutcome::Cancelled);
-                        cx.notify();
-                    })),
+                Button::new(
+                    "mutation-hard-cancel",
+                    dbflux_i18n::t!("modals.mutation_confirm.cancel"),
+                )
+                .variant(ButtonVariant::Default)
+                .on_click(cx.listener(|this, _event, _window, cx| {
+                    this.visible = false;
+                    cx.emit(MutationConfirmOutcome::Cancelled);
+                    cx.notify();
+                })),
             )
             .child(
-                Button::new("mutation-hard-confirm", "Confirm")
-                    .variant(ButtonVariant::Danger)
-                    .disabled(!confirm_enabled)
-                    .on_click(cx.listener(|this, _event, _window, cx| {
-                        if !this.confirm_enabled() {
-                            return;
-                        }
-                        this.visible = false;
-                        cx.emit(MutationConfirmOutcome::Confirmed);
-                        cx.notify();
-                    })),
+                Button::new(
+                    "mutation-hard-confirm",
+                    dbflux_i18n::t!("modals.mutation_confirm.confirm"),
+                )
+                .variant(ButtonVariant::Danger)
+                .disabled(!confirm_enabled)
+                .on_click(cx.listener(|this, _event, _window, cx| {
+                    if !this.confirm_enabled() {
+                        return;
+                    }
+                    this.visible = false;
+                    cx.emit(MutationConfirmOutcome::Confirmed);
+                    cx.notify();
+                })),
             );
 
         ModalShell::new(
-            "Confirm mutation",
+            dbflux_i18n::t!("modals.mutation_confirm.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
         .variant(ModalVariant::Danger)
         .width(px(560.0))
         .into_any_element()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — catalog key resolution
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn mutation_confirm_keys_resolve_in_both_locales() {
+        let keys = [
+            "modals.mutation_confirm.title",
+            "modals.mutation_confirm.sample_unavailable",
+            "modals.mutation_confirm.type_to_confirm_label",
+            "modals.mutation_confirm.type_to_confirm_placeholder",
+            "modals.mutation_confirm.opt_in_label",
+            "modals.mutation_confirm.cancel",
+            "modals.mutation_confirm.confirm",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(
+                !en.is_empty() && !en.starts_with("en."),
+                "en missing for {key}, got {en:?}"
+            );
+            assert!(
+                !es.is_empty() && !es.starts_with("es."),
+                "es missing for {key}, got {es:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn mutation_confirm_confirm_differs_between_locales() {
+        let en = dbflux_i18n::t!("modals.mutation_confirm.confirm", locale = "en");
+        let es = dbflux_i18n::t!("modals.mutation_confirm.confirm", locale = "es");
+        assert_eq!(en, "Confirm");
+        assert_eq!(es, "Confirmar");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_components/src/modals/schema_drift.rs
+++ b/crates/dbflux_components/src/modals/schema_drift.rs
@@ -119,7 +119,7 @@ impl Render for ModalSchemaDrift {
                         .text_size(FontSizes::XS)
                         .font_weight(gpui::FontWeight::BOLD)
                         .text_color(muted)
-                        .child("column"),
+                        .child(dbflux_i18n::t!("modals.schema_drift.column_header")),
                 )
                 .child(
                     div()
@@ -127,7 +127,7 @@ impl Render for ModalSchemaDrift {
                         .text_size(FontSizes::XS)
                         .font_weight(gpui::FontWeight::BOLD)
                         .text_color(muted)
-                        .child("local cache"),
+                        .child(dbflux_i18n::t!("modals.schema_drift.local_header")),
                 )
                 .child(
                     div()
@@ -135,7 +135,7 @@ impl Render for ModalSchemaDrift {
                         .text_size(FontSizes::XS)
                         .font_weight(gpui::FontWeight::BOLD)
                         .text_color(muted)
-                        .child("remote"),
+                        .child(dbflux_i18n::t!("modals.schema_drift.remote_header")),
                 );
 
             let mut diff_rows = div()
@@ -178,14 +178,14 @@ impl Render for ModalSchemaDrift {
             .gap(Spacing::SM)
             .child(
                 Button::new("drift-continue")
-                    .label("Continue with stale schema")
+                    .label(dbflux_i18n::t!("modals.schema_drift.continue_stale"))
                     .ghost()
                     .on_click(on_continue),
             )
             .child(div().flex_1())
             .child(
                 Button::new("drift-close")
-                    .label("Cancel")
+                    .label(dbflux_i18n::t!("modals.schema_drift.cancel"))
                     .on_click(on_close),
             )
             .child(if loading {
@@ -198,19 +198,19 @@ impl Render for ModalSchemaDrift {
                         div()
                             .text_size(FontSizes::SM)
                             .text_color(theme.muted_foreground)
-                            .child("Refreshing…"),
+                            .child(dbflux_i18n::t!("modals.schema_drift.refreshing")),
                     )
                     .into_any_element()
             } else {
                 Button::new("drift-refresh")
-                    .label("Refresh and re-run")
+                    .label(dbflux_i18n::t!("modals.schema_drift.refresh"))
                     .primary()
                     .on_click(on_refresh)
                     .into_any_element()
             });
 
         ModalShell::new(
-            "Schema has changed since this query was opened",
+            dbflux_i18n::t!("modals.schema_drift.title"),
             body.into_any_element(),
             footer.into_any_element(),
         )
@@ -245,7 +245,7 @@ fn render_change_row(
             "—",
             &snap.name,
             &snap_label(snap),
-            "new column",
+            &dbflux_i18n::t!("modals.schema_drift.change.new_column"),
             muted,
         ),
         SchemaChange::ColumnRemoved(snap) => drift_row(
@@ -253,7 +253,7 @@ fn render_change_row(
             &snap.name,
             &snap_label(snap),
             "—",
-            "removed",
+            &dbflux_i18n::t!("modals.schema_drift.change.removed"),
             muted,
         ),
         SchemaChange::ColumnTypeChanged { before, after } => drift_row(
@@ -261,7 +261,7 @@ fn render_change_row(
             &before.name,
             &snap_label(before),
             &snap_label(after),
-            "type changed",
+            &dbflux_i18n::t!("modals.schema_drift.change.type_changed"),
             muted,
         ),
         SchemaChange::NullabilityChanged {
@@ -276,24 +276,24 @@ fn render_change_row(
                 column,
                 before_label,
                 after_label,
-                "nullability changed",
+                &dbflux_i18n::t!("modals.schema_drift.change.nullability_changed"),
                 muted,
             )
         }
         SchemaChange::PrimaryKeyChanged { before, after } => drift_row(
             warning_bg,
-            "(primary key)",
+            &dbflux_i18n::t!("modals.schema_drift.change.primary_key"),
             &before.join(", "),
             &after.join(", "),
-            "PK changed",
+            &dbflux_i18n::t!("modals.schema_drift.change.pk_changed"),
             muted,
         ),
         SchemaChange::ForeignKeyChanged => drift_row(
             warning_bg,
-            "(foreign keys)",
-            "cached",
-            "changed",
-            "FK changed",
+            &dbflux_i18n::t!("modals.schema_drift.change.foreign_keys"),
+            &dbflux_i18n::t!("modals.schema_drift.change.cached"),
+            &dbflux_i18n::t!("modals.schema_drift.change.changed"),
+            &dbflux_i18n::t!("modals.schema_drift.change.fk_changed"),
             muted,
         ),
         SchemaChange::DefaultChanged {
@@ -305,7 +305,7 @@ fn render_change_row(
             column,
             before.as_deref().unwrap_or("—"),
             after.as_deref().unwrap_or("—"),
-            "default changed",
+            &dbflux_i18n::t!("modals.schema_drift.change.default_changed"),
             muted,
         ),
         SchemaChange::IndexAdded(snap) => drift_row(
@@ -313,7 +313,7 @@ fn render_change_row(
             &snap.name,
             "—",
             &index_label(snap),
-            "index added",
+            &dbflux_i18n::t!("modals.schema_drift.change.index_added"),
             muted,
         ),
         SchemaChange::IndexRemoved(snap) => drift_row(
@@ -321,7 +321,7 @@ fn render_change_row(
             &snap.name,
             &index_label(snap),
             "—",
-            "index removed",
+            &dbflux_i18n::t!("modals.schema_drift.change.index_removed"),
             muted,
         ),
     }
@@ -389,4 +389,60 @@ fn drift_row(
                         .child(format!("· {}", note)),
                 ),
         )
+}
+
+// ---------------------------------------------------------------------------
+// Tests — catalog key resolution
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn schema_drift_keys_resolve_in_both_locales() {
+        let keys = [
+            "modals.schema_drift.title",
+            "modals.schema_drift.column_header",
+            "modals.schema_drift.local_header",
+            "modals.schema_drift.remote_header",
+            "modals.schema_drift.change.new_column",
+            "modals.schema_drift.change.removed",
+            "modals.schema_drift.change.type_changed",
+            "modals.schema_drift.change.nullability_changed",
+            "modals.schema_drift.change.pk_changed",
+            "modals.schema_drift.change.fk_changed",
+            "modals.schema_drift.change.default_changed",
+            "modals.schema_drift.change.index_added",
+            "modals.schema_drift.change.index_removed",
+            "modals.schema_drift.change.cached",
+            "modals.schema_drift.change.changed",
+            "modals.schema_drift.change.primary_key",
+            "modals.schema_drift.change.foreign_keys",
+            "modals.schema_drift.continue_stale",
+            "modals.schema_drift.cancel",
+            "modals.schema_drift.refreshing",
+            "modals.schema_drift.refresh",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(
+                !en.is_empty() && !en.starts_with("en."),
+                "en missing for {key}, got {en:?}"
+            );
+            assert!(
+                !es.is_empty() && !es.starts_with("es."),
+                "es missing for {key}, got {es:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_drift_refresh_differs_between_locales() {
+        let en = dbflux_i18n::t!("modals.schema_drift.refresh", locale = "en");
+        let es = dbflux_i18n::t!("modals.schema_drift.refresh", locale = "es");
+        assert_eq!(en, "Refresh and re-run");
+        assert_eq!(es, "Actualizar y volver a ejecutar");
+        assert_ne!(en, es);
+    }
 }

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -108,6 +108,14 @@ modals:
     compact: Compact
     cancel: Cancel
     confirm: Import
+  mutation_confirm:
+    title: Confirm mutation
+    sample_unavailable: Sample preview unavailable
+    type_to_confirm_label: "Type the table name to confirm:"
+    type_to_confirm_placeholder: Type table name to confirm
+    opt_in_label: I understand this operation will modify data
+    cancel: Cancel
+    confirm: Confirm
   rename:
     placeholder: Enter a name
     title:
@@ -117,6 +125,29 @@ modals:
       empty_name: Name cannot be empty
     cancel: Cancel
     confirm: Rename
+  schema_drift:
+    title: Schema has changed since this query was opened
+    column_header: column
+    local_header: local cache
+    remote_header: remote
+    change:
+      new_column: new column
+      removed: removed
+      type_changed: type changed
+      nullability_changed: nullability changed
+      pk_changed: PK changed
+      fk_changed: FK changed
+      default_changed: default changed
+      index_added: index added
+      index_removed: index removed
+      cached: cached
+      changed: changed
+      primary_key: (primary key)
+      foreign_keys: (foreign keys)
+    continue_stale: Continue with stale schema
+    cancel: Cancel
+    refreshing: Refreshing…
+    refresh: Refresh and re-run
   tunnel_auth:
     title: SSH passphrase required
     prompt: 'Enter the passphrase for tunnel "%{tunnel}"'

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -108,6 +108,14 @@ modals:
     compact: Compactar
     cancel: Cancelar
     confirm: Importar
+  mutation_confirm:
+    title: Confirmar mutación
+    sample_unavailable: Vista previa de muestra no disponible
+    type_to_confirm_label: "Escribe el nombre de la tabla para confirmar:"
+    type_to_confirm_placeholder: Escribe el nombre de la tabla
+    opt_in_label: Entiendo que esta operación modificará datos
+    cancel: Cancelar
+    confirm: Confirmar
   rename:
     placeholder: Escribe un nombre
     title:
@@ -117,6 +125,29 @@ modals:
       empty_name: El nombre no puede estar vacío
     cancel: Cancelar
     confirm: Renombrar
+  schema_drift:
+    title: El esquema cambió desde que se abrió esta consulta
+    column_header: columna
+    local_header: caché local
+    remote_header: remoto
+    change:
+      new_column: columna nueva
+      removed: eliminada
+      type_changed: tipo modificado
+      nullability_changed: nulabilidad modificada
+      pk_changed: PK modificada
+      fk_changed: FK modificada
+      default_changed: valor por defecto modificado
+      index_added: índice agregado
+      index_removed: índice eliminado
+      cached: en caché
+      changed: modificado
+      primary_key: (clave primaria)
+      foreign_keys: (claves foráneas)
+    continue_stale: Continuar con el esquema desactualizado
+    cancel: Cancelar
+    refreshing: Actualizando…
+    refresh: Actualizar y volver a ejecutar
   tunnel_auth:
     title: Se requiere la frase de contraseña SSH
     prompt: 'Introduce la frase de contraseña del túnel "%{tunnel}"'


### PR DESCRIPTION
## Summary

Third `dbflux_components` i18n slice: the mutation-confirm and schema-drift modals render through `dbflux_i18n::t!`. 31 keys (`modals.mutation_confirm.*`, `modals.schema_drift.*`, including the per-change-kind labels), English and Spanish together.

## What does this resolve?

- Refs #360 (follows #368; next: document tree + chart + value-source selector, then controls/time range)

## How was this solved?

- Same mechanism; no signature changes. Schema-drift change kinds map to keys through an exhaustive match in the modal, so `dbflux_core` stays i18n-free.
- Table names, column names, types and SQL text inside both modals stay as data; only chrome is translated.
- Key tests assert both locales resolve and that at least one value differs between them.

## Validation

- `cargo nextest run -p dbflux_components -p dbflux_i18n` → all passed (after rebase on `main`); clippy clean; fmt clean. Workspace-wide gates run in CI.
- Receipt-driven review (four lenses, high risk by line count): approved; remaining findings advisory (placeholder binding style, test sentinel strength).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish: confirm a mutation from the builder, trigger a schema-drift prompt)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
