### PR TITLE
feat(i18n): translate the sidebar table, view, and collection context menus

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -255,6 +255,21 @@ sidebar:
     connections_placeholder: Filter connections and schema...
     scripts_placeholder: Filter scripts...
     stream_placeholder: Filter stream names...
+  menu:
+    open: Open
+    browse_event_streams: Browse Event Streams
+    view_schema: View Schema
+    refresh: Refresh
+    generate_sql: Generate SQL
+    export_table: Export Table…
+    export_tables_many: "Export %{count} Tables…"
+    migrate_table: Migrate Table…
+    migrate_tables_many: "Migrate %{count} Tables…"
+    drop_view: Drop View
+    drop_table: Drop Table
+    query_measurement: Query Measurement
+    generate_query: Generate Query
+    drop_collection: Drop Collection
   overlay:
     add_folder: New Folder
     add_connection: New Connection

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -255,6 +255,21 @@ sidebar:
     connections_placeholder: Filtrar conexiones y esquema...
     scripts_placeholder: Filtrar scripts...
     stream_placeholder: Filtrar nombres de streams...
+  menu:
+    open: Abrir
+    browse_event_streams: Explorar flujos de eventos
+    view_schema: Ver esquema
+    refresh: Actualizar
+    generate_sql: Generar SQL
+    export_table: Exportar tabla…
+    export_tables_many: "Exportar %{count} tablas…"
+    migrate_table: Migrar tabla…
+    migrate_tables_many: "Migrar %{count} tablas…"
+    drop_view: Eliminar vista
+    drop_table: Eliminar tabla
+    query_measurement: Consultar medición
+    generate_query: Generar consulta
+    drop_collection: Eliminar colección
   overlay:
     add_folder: Nueva carpeta
     add_connection: Nueva conexión

--- a/crates/dbflux_ui_sidebar/src/context_menu.rs
+++ b/crates/dbflux_ui_sidebar/src/context_menu.rs
@@ -269,14 +269,17 @@ impl Sidebar {
 
                 Self::append_menu_section(
                     &mut items,
-                    [ContextMenuItem::item("Open", ContextMenuAction::Open)],
+                    [ContextMenuItem::item(
+                        dbflux_i18n::t!("sidebar.menu.open"),
+                        ContextMenuAction::Open,
+                    )],
                 );
 
                 if self.collection_supports_child_picker(item_id, cx) {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Browse Event Streams",
+                            dbflux_i18n::t!("sidebar.menu.browse_event_streams"),
                             ContextMenuAction::OpenChildPicker,
                         )],
                     );
@@ -285,8 +288,14 @@ impl Sidebar {
                 Self::append_menu_section(
                     &mut items,
                     [
-                        ContextMenuItem::item("View Schema", ContextMenuAction::ViewSchema),
-                        ContextMenuItem::item("Refresh", ContextMenuAction::RefreshObject),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.view_schema"),
+                            ContextMenuAction::ViewSchema,
+                        ),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.refresh"),
+                            ContextMenuAction::RefreshObject,
+                        ),
                     ],
                 );
 
@@ -296,7 +305,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Generate SQL",
+                            dbflux_i18n::t!("sidebar.menu.generate_sql"),
                             ContextMenuAction::Submenu(generators),
                         )
                         .with_icon(AppIcon::Code)],
@@ -310,11 +319,7 @@ impl Sidebar {
                 // chosen in the wizard, not from this menu.
                 if node_kind == SchemaNodeKind::Table && self.table_supports_transfer(item_id, cx) {
                     let count = self.export_table_selection_count(item_id);
-                    let label = if count > 1 {
-                        format!("Export {count} Tables…")
-                    } else {
-                        "Export Table…".to_string()
-                    };
+                    let label = crate::labels::export_tables_label(count);
 
                     Self::append_menu_section(
                         &mut items,
@@ -332,11 +337,7 @@ impl Sidebar {
                 // targets to connected + transfer-compatible connections.
                 if node_kind == SchemaNodeKind::Table && self.table_supports_transfer(item_id, cx) {
                     let count = self.migrate_table_selection_count(item_id);
-                    let label = if count > 1 {
-                        format!("Migrate {count} Tables…")
-                    } else {
-                        "Migrate Table…".to_string()
-                    };
+                    let label = crate::labels::migrate_tables_label(count);
 
                     Self::append_menu_section(
                         &mut items,
@@ -356,8 +357,8 @@ impl Sidebar {
                     };
                     if drop_allowed {
                         let label = match node_kind {
-                            SchemaNodeKind::View => "Drop View",
-                            _ => "Drop Table",
+                            SchemaNodeKind::View => dbflux_i18n::t!("sidebar.menu.drop_view"),
+                            _ => dbflux_i18n::t!("sidebar.menu.drop_table"),
                         };
                         Self::append_menu_section(
                             &mut items,
@@ -373,14 +374,17 @@ impl Sidebar {
 
                 Self::append_menu_section(
                     &mut items,
-                    [ContextMenuItem::item("Open", ContextMenuAction::Open)],
+                    [ContextMenuItem::item(
+                        dbflux_i18n::t!("sidebar.menu.open"),
+                        ContextMenuAction::Open,
+                    )],
                 );
 
                 if self.collection_supports_child_picker(item_id, cx) {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Browse Event Streams",
+                            dbflux_i18n::t!("sidebar.menu.browse_event_streams"),
                             ContextMenuAction::OpenChildPicker,
                         )],
                     );
@@ -389,7 +393,7 @@ impl Sidebar {
                 Self::append_menu_section(
                     &mut items,
                     [ContextMenuItem::item(
-                        "Refresh",
+                        dbflux_i18n::t!("sidebar.menu.refresh"),
                         ContextMenuAction::RefreshObject,
                     )],
                 );
@@ -404,7 +408,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Query Measurement",
+                            dbflux_i18n::t!("sidebar.menu.query_measurement"),
                             ContextMenuAction::QueryCollection,
                         )],
                     );
@@ -419,7 +423,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Generate Query",
+                            dbflux_i18n::t!("sidebar.menu.generate_query"),
                             ContextMenuAction::Submenu(vec![
                                 ContextMenuItem::item(
                                     "find",
@@ -461,7 +465,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::danger(
-                            "Drop Collection",
+                            dbflux_i18n::t!("sidebar.menu.drop_collection"),
                             ContextMenuAction::DropCollection,
                         )],
                     );
@@ -1837,5 +1841,51 @@ mod parent_hover_tests {
         state.parent_stack.clear();
 
         assert!(!state.hover_parent_item(1));
+    }
+}
+
+#[cfg(test)]
+mod menu_i18n_tests {
+    const B1_KEYS: [&str; 14] = [
+        "sidebar.menu.open",
+        "sidebar.menu.browse_event_streams",
+        "sidebar.menu.view_schema",
+        "sidebar.menu.refresh",
+        "sidebar.menu.generate_sql",
+        "sidebar.menu.export_table",
+        "sidebar.menu.export_tables_many",
+        "sidebar.menu.migrate_table",
+        "sidebar.menu.migrate_tables_many",
+        "sidebar.menu.drop_view",
+        "sidebar.menu.drop_table",
+        "sidebar.menu.query_measurement",
+        "sidebar.menu.generate_query",
+        "sidebar.menu.drop_collection",
+    ];
+
+    #[test]
+    fn menu_b1_keys_resolve_in_both_locales() {
+        for key in B1_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn menu_open_differs_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.menu.open", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.menu.open", locale = "es");
+
+        assert_eq!(english, "Open");
+        assert_eq!(spanish, "Abrir");
+        assert_ne!(english, spanish);
     }
 }

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -71,6 +71,26 @@ pub(crate) fn profile_updated_label(name: &str) -> String {
     dbflux_i18n::t!("sidebar.toast.edit_reconnect_updated", name = name)
 }
 
+/// Translated label for the Export Table(s) context menu item, e.g.
+/// `"Export Table…"` for a single table or `"Export 3 Tables…"` for many.
+pub(crate) fn export_tables_label(count: usize) -> String {
+    if count > 1 {
+        dbflux_i18n::t!("sidebar.menu.export_tables_many", count = count)
+    } else {
+        dbflux_i18n::t!("sidebar.menu.export_table")
+    }
+}
+
+/// Translated label for the Migrate Table(s) context menu item, e.g.
+/// `"Migrate Table…"` for a single table or `"Migrate 3 Tables…"` for many.
+pub(crate) fn migrate_tables_label(count: usize) -> String {
+    if count > 1 {
+        dbflux_i18n::t!("sidebar.menu.migrate_tables_many", count = count)
+    } else {
+        dbflux_i18n::t!("sidebar.menu.migrate_table")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use dbflux_core::DatabaseCategory;
@@ -283,5 +303,33 @@ mod tests {
             label,
             dbflux_i18n::t!("sidebar.toast.edit_reconnect_updated", name = "prod-db")
         );
+    }
+
+    #[test]
+    fn export_tables_label_one_vs_many() {
+        let singular = super::export_tables_label(1);
+        let plural = super::export_tables_label(3);
+
+        assert_eq!(singular, dbflux_i18n::t!("sidebar.menu.export_table"));
+        assert_eq!(
+            plural,
+            dbflux_i18n::t!("sidebar.menu.export_tables_many", count = 3)
+        );
+        assert!(plural.contains('3'));
+        assert_ne!(singular, plural);
+    }
+
+    #[test]
+    fn migrate_tables_label_one_vs_many() {
+        let singular = super::migrate_tables_label(1);
+        let plural = super::migrate_tables_label(3);
+
+        assert_eq!(singular, dbflux_i18n::t!("sidebar.menu.migrate_table"));
+        assert_eq!(
+            plural,
+            dbflux_i18n::t!("sidebar.menu.migrate_tables_many", count = 3)
+        );
+        assert!(plural.contains('3'));
+        assert_ne!(singular, plural);
     }
 }


### PR DESCRIPTION
## Summary

Sidebar i18n slice B1: the table, view and collection context menu arms render through `dbflux_i18n::t!` (open, browse event streams, view schema, refresh, generate SQL, export/migrate with counts, drop, query measurement, generate query). 14 keys under `sidebar.menu.*`, English and Spanish together.

## What does this resolve?

- Refs #360 (follows #369; next: profile/database/folder/script arms, then dashboards and charts)

## How was this solved?

- Helpers `export_tables_label(count)` and `migrate_tables_label(count)` pick the plural bucket; SQL keywords and driver-supplied labels stay untouched.

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → all passed after rebase on `main`; clippy clean; fmt clean.
- Receipt-driven review (one lens): approved; remaining findings advisory. Manual smoke in Spanish: right-click a table, a view and a collection.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted below)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
