### PR TITLE
feat(i18n): wire dbflux_ui_document to dbflux_i18n and translate the tab menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3275,6 +3275,7 @@ dependencies = [
  "dbflux_core",
  "dbflux_driver_mssql",
  "dbflux_export",
+ "dbflux_i18n",
  "dbflux_mcp",
  "dbflux_policy",
  "dbflux_storage",

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -5,6 +5,22 @@ components:
     compact: Compact
     cancel: Cancel
     save: Save
+document:
+  data:
+    grid:
+      edit_bar:
+        clean: No unsaved changes
+        dirty:
+          one: "%{count} unsaved change"
+          many: "%{count} unsaved changes"
+  tabs:
+    menu:
+      close: Close
+      close_all: Close All
+      close_left: Close to the Left
+      close_others: Close Others
+      close_right: Close to the Right
+    unsaved_changes: Unsaved changes
 errors:
   action:
     view_in_audit: View in Audit

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -5,6 +5,22 @@ components:
     compact: Compactar
     cancel: Cancelar
     save: Guardar
+document:
+  data:
+    grid:
+      edit_bar:
+        clean: Sin cambios pendientes
+        dirty:
+          one: "%{count} cambio sin guardar"
+          many: "%{count} cambios sin guardar"
+  tabs:
+    menu:
+      close: Cerrar
+      close_all: Cerrar todas
+      close_left: Cerrar a la izquierda
+      close_others: Cerrar las demás
+      close_right: Cerrar a la derecha
+    unsaved_changes: Cambios sin guardar
 errors:
   action:
     view_in_audit: Ver en auditoría

--- a/crates/dbflux_ui_document/Cargo.toml
+++ b/crates/dbflux_ui_document/Cargo.toml
@@ -20,6 +20,7 @@ dbflux_app.workspace = true
 dbflux_audit.workspace = true
 dbflux_storage.workspace = true
 dbflux_export.workspace = true
+dbflux_i18n.workspace = true
 dbflux_transfer.workspace = true
 uuid.workspace = true
 log.workspace = true

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1,0 +1,48 @@
+//! Shared translated label helpers for the document subsystem.
+//!
+//! Grouped in one module so every document type resolves its user-facing
+//! strings through `dbflux_i18n::t!` with the same count-based pluralization
+//! convention instead of duplicating locale bucket selection per call site.
+
+/// Label for the data grid's edit bar, with the pending-edit count
+/// interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one pending edit;
+/// every other count, including zero, uses the plural bucket. Zero maps to
+/// the dedicated "clean" bucket instead of the plural one.
+// Wired into the data grid edit bar in a later PR of this change.
+#[allow(dead_code)]
+pub(crate) fn unsaved_changes_label(count: usize) -> String {
+    match count {
+        0 => dbflux_i18n::t!("document.data.grid.edit_bar.clean"),
+        1 => dbflux_i18n::t!("document.data.grid.edit_bar.dirty.one", count = count),
+        _ => dbflux_i18n::t!("document.data.grid.edit_bar.dirty.many", count = count),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::unsaved_changes_label;
+
+    #[test]
+    fn unsaved_changes_label_zero_one_many() {
+        let zero = unsaved_changes_label(0);
+        let one = unsaved_changes_label(1);
+        let many = unsaved_changes_label(2);
+
+        assert_eq!(zero, dbflux_i18n::t!("document.data.grid.edit_bar.clean"));
+        assert!(one.contains('1'));
+        assert!(many.contains('2'));
+        assert_ne!(one, many);
+    }
+
+    #[test]
+    fn document_namespace_present_in_both_catalogs() {
+        let english = dbflux_i18n::t!("document.tabs.menu.close", locale = "en");
+        let spanish = dbflux_i18n::t!("document.tabs.menu.close", locale = "es");
+
+        assert_ne!(english, spanish);
+        assert_ne!(english, "en.document.tabs.menu.close");
+        assert_ne!(spanish, "es.document.tabs.menu.close");
+    }
+}

--- a/crates/dbflux_ui_document/src/lib.rs
+++ b/crates/dbflux_ui_document/src/lib.rs
@@ -28,6 +28,7 @@ pub mod history_modal;
 pub mod import_wizard;
 pub mod instance_inspector;
 mod key_value;
+mod labels;
 pub mod migrate_wizard;
 mod new_key_modal;
 pub mod object_browser;

--- a/crates/dbflux_ui_document/src/tab_bar.rs
+++ b/crates/dbflux_ui_document/src/tab_bar.rs
@@ -100,12 +100,14 @@ impl TabBar {
 
     pub fn build_tab_menu_items() -> Vec<MenuItem> {
         vec![
-            MenuItem::new("Close").icon(AppIcon::X),
-            MenuItem::new("Close Others").icon(AppIcon::X),
-            MenuItem::new("Close All").icon(AppIcon::X),
+            MenuItem::new(dbflux_i18n::t!("document.tabs.menu.close")).icon(AppIcon::X),
+            MenuItem::new(dbflux_i18n::t!("document.tabs.menu.close_others")).icon(AppIcon::X),
+            MenuItem::new(dbflux_i18n::t!("document.tabs.menu.close_all")).icon(AppIcon::X),
             MenuItem::separator(),
-            MenuItem::new("Close to the Left").icon(AppIcon::ChevronLeft),
-            MenuItem::new("Close to the Right").icon(AppIcon::ChevronRight),
+            MenuItem::new(dbflux_i18n::t!("document.tabs.menu.close_left"))
+                .icon(AppIcon::ChevronLeft),
+            MenuItem::new(dbflux_i18n::t!("document.tabs.menu.close_right"))
+                .icon(AppIcon::ChevronRight),
         ]
     }
 
@@ -376,9 +378,7 @@ impl TabBar {
             .when(is_dirty, |el| {
                 let dot_color = SemBannerColors::for_current(cx).warning_bg;
                 let tooltip_text: SharedString = change_summary
-                    .as_deref()
-                    .unwrap_or("Unsaved changes")
-                    .to_string()
+                    .unwrap_or_else(|| dbflux_i18n::t!("document.tabs.unsaved_changes"))
                     .into();
 
                 el.child(
@@ -491,18 +491,60 @@ mod tests {
         let items = TabBar::build_tab_menu_items();
 
         assert_eq!(items.len(), 6);
-        assert_eq!(items[TAB_MENU_CLOSE].label.as_ref(), "Close");
-        assert_eq!(items[TAB_MENU_CLOSE_OTHERS].label.as_ref(), "Close Others");
-        assert_eq!(items[TAB_MENU_CLOSE_ALL].label.as_ref(), "Close All");
+        assert_eq!(
+            items[TAB_MENU_CLOSE].label.as_ref(),
+            dbflux_i18n::t!("document.tabs.menu.close", locale = "en")
+        );
+        assert_eq!(
+            items[TAB_MENU_CLOSE_OTHERS].label.as_ref(),
+            dbflux_i18n::t!("document.tabs.menu.close_others", locale = "en")
+        );
+        assert_eq!(
+            items[TAB_MENU_CLOSE_ALL].label.as_ref(),
+            dbflux_i18n::t!("document.tabs.menu.close_all", locale = "en")
+        );
         assert!(items[TAB_MENU_SEPARATOR].is_separator);
         assert_eq!(
             items[TAB_MENU_CLOSE_LEFT].label.as_ref(),
-            "Close to the Left"
+            dbflux_i18n::t!("document.tabs.menu.close_left", locale = "en")
         );
         assert_eq!(
             items[TAB_MENU_CLOSE_RIGHT].label.as_ref(),
-            "Close to the Right"
+            dbflux_i18n::t!("document.tabs.menu.close_right", locale = "en")
         );
+    }
+
+    #[test]
+    fn tab_menu_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.tabs.menu.close",
+            "document.tabs.menu.close_others",
+            "document.tabs.menu.close_all",
+            "document.tabs.menu.close_left",
+            "document.tabs.menu.close_right",
+            "document.tabs.unsaved_changes",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+                assert!(!value.is_empty(), "{locale}.{key} resolved empty");
+                assert_ne!(value, key, "{locale}.{key} resolved to the raw key");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{locale}.{key} resolved to the missing-translation sentinel"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tab_menu_close_differs_between_locales() {
+        let english = dbflux_i18n::t!("document.tabs.menu.close", locale = "en");
+        let spanish = dbflux_i18n::t!("document.tabs.menu.close", locale = "es");
+
+        assert_ne!(english, spanish);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First `dbflux_ui_document` i18n slice: the crate depends on `dbflux_i18n`, a `document:` catalog namespace exists, and the tab bar context menu renders through `dbflux_i18n::t!`. It also ships the crate-local `labels.rs` with `unsaved_changes_label(count)`, wired by the next slice.

## What does this resolve?

- Refs #360 (document slice 1 of ~33; next: the data grid toolbars)

## How was this solved?

- Same mechanism as the other crates; no public signature changes. Tab titles stay user data.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 873 passed after rebase on `main`; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: right-click a tab.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted below)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
