### PR TITLE
feat(i18n): translate the document tree, chart inspector, and value source selector in dbflux_components

### DIFF
--- a/crates/dbflux_components/src/chart/axis_bar.rs
+++ b/crates/dbflux_components/src/chart/axis_bar.rs
@@ -194,11 +194,12 @@ where
     };
 
     // Group pill
+    let group_role = dbflux_i18n::t!("chart.axis_bar.group");
     let group_pill = {
         let handler = on_pill_click.clone();
         pill_element(
             "axis-pill-group",
-            "Group",
+            &group_role,
             group_label,
             group_open,
             colors,
@@ -299,7 +300,7 @@ where
 /// When `active`, the pill border is highlighted.
 fn pill_element(
     id: impl Into<ElementId>,
-    role: &'static str,
+    role: &str,
     value: SharedString,
     active: bool,
     colors: &ChartColors,
@@ -344,7 +345,7 @@ fn pill_element(
                 .text_size(ChartGeometry::FONT_TINY)
                 .font_weight(gpui::FontWeight::SEMIBOLD)
                 .text_color(colors.label_fg)
-                .child(SharedString::from(role)),
+                .child(SharedString::from(role.to_string())),
         )
         .child(
             div()
@@ -791,5 +792,14 @@ mod tests {
 
         // cpu (1) and count (3) qualify; ts and host do not.
         assert_eq!(candidates, vec![1, 3]);
+    }
+
+    #[test]
+    fn axis_bar_group_key_resolves() {
+        let en = dbflux_i18n::t!("chart.axis_bar.group", locale = "en");
+        let es = dbflux_i18n::t!("chart.axis_bar.group", locale = "es");
+        assert_eq!(en, "Group");
+        assert_eq!(es, "Grupo");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_components/src/chart/engine.rs
+++ b/crates/dbflux_components/src/chart/engine.rs
@@ -1975,7 +1975,7 @@ fn render_number_chart(view: &ChartView, cx: &mut Context<ChartView>) -> impl In
             .items_center()
             .justify_center()
             .text_color(chart_colors.label_fg)
-            .child("No data");
+            .child(dbflux_i18n::t!("chart.engine.no_data"));
     }
 
     div()
@@ -3643,6 +3643,15 @@ mod tests {
 
         let view = ChartView::build(&result, spec).expect("build with Pie kind must not fail");
         assert_eq!(view.kind(), crate::chart::spec::ChartKind::Pie);
+    }
+
+    #[test]
+    fn engine_no_data_key_resolves() {
+        let en = dbflux_i18n::t!("chart.engine.no_data", locale = "en");
+        let es = dbflux_i18n::t!("chart.engine.no_data", locale = "es");
+        assert_eq!(en, "No data");
+        assert_eq!(es, "Sin datos");
+        assert_ne!(en, es);
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/dbflux_components/src/chart/point_inspector.rs
+++ b/crates/dbflux_components/src/chart/point_inspector.rs
@@ -6,7 +6,7 @@
 //! only renders when `ChartHost::source_for_point` returns `Some`.
 
 use gpui::prelude::*;
-use gpui::{AnyElement, div, px};
+use gpui::{AnyElement, SharedString, div, px};
 
 use crate::semantic::ChartColors;
 use crate::tokens::{ChartGeometry, FontSizes, Spacing, Widths};
@@ -92,7 +92,7 @@ pub fn point_inspector_element(
                         .text_size(FontSizes::XS)
                         .text_color(colors.label_fg)
                         .font_weight(gpui::FontWeight::SEMIBOLD)
-                        .child("SERIES"),
+                        .child(dbflux_i18n::t!("chart.point_inspector.series")),
                 )
                 .child(
                     div()
@@ -105,20 +105,28 @@ pub fn point_inspector_element(
         )
         // Hovered point section
         .child(inspector_section(
-            "HOVERED POINT",
+            dbflux_i18n::t!("chart.point_inspector.hovered_point"),
             div()
                 .flex()
                 .flex_col()
                 .gap(Spacing::XS)
-                .child(kv_row("Time", hovered_x, colors))
-                .child(kv_row("Value", hovered_y, colors))
+                .child(kv_row(
+                    &dbflux_i18n::t!("chart.point_inspector.time"),
+                    hovered_x,
+                    colors,
+                ))
+                .child(kv_row(
+                    &dbflux_i18n::t!("chart.point_inspector.value"),
+                    hovered_y,
+                    colors,
+                ))
                 .when_some(delta_prev, |d, v| d.child(kv_row("Δ prev", v, colors)))
                 .when_some(delta_avg, |d, v| d.child(kv_row("Δ avg", v, colors))),
             colors,
         ))
         // Source doc section: pretty-print the row fields
         .child(inspector_section(
-            "SOURCE DOC",
+            dbflux_i18n::t!("chart.point_inspector.source_doc"),
             div()
                 .flex()
                 .flex_col()
@@ -164,7 +172,7 @@ pub fn point_inspector_element(
                         .text_size(FontSizes::XS)
                         .text_color(colors.muted_fg)
                         .font_weight(gpui::FontWeight::SEMIBOLD)
-                        .child("QUICK ACTIONS"),
+                        .child(dbflux_i18n::t!("chart.point_inspector.quick_actions")),
                 )
                 .child(
                     div()
@@ -178,17 +186,21 @@ pub fn point_inspector_element(
                         // as a stable display-only element; the host wraps the inspector
                         // in its own on_click listener pattern.
                         .child(action_button(
-                            "Show in tree",
-                            false,
+                            dbflux_i18n::t!("chart.point_inspector.show_in_tree"),
+                            "show-in-tree",
                             show_in_tree_source.row_idx,
                             colors,
                         ))
                         // "Annotate" — stub, coming soon.
-                        .child(action_button_disabled("Annotate", "Coming soon", colors))
+                        .child(action_button_disabled(
+                            dbflux_i18n::t!("chart.point_inspector.annotate"),
+                            &dbflux_i18n::t!("chart.point_inspector.coming_soon"),
+                            colors,
+                        ))
                         // "Copy as query" — stub.
                         .child(action_button_disabled(
-                            "Copy as query",
-                            "Coming soon",
+                            dbflux_i18n::t!("chart.point_inspector.copy_as_query"),
+                            &dbflux_i18n::t!("chart.point_inspector.coming_soon"),
                             colors,
                         )),
                 ),
@@ -201,7 +213,7 @@ pub fn point_inspector_element(
 // ---------------------------------------------------------------------------
 
 fn inspector_section(
-    label: &'static str,
+    label: impl Into<SharedString>,
     content: impl IntoElement,
     colors: &ChartColors,
 ) -> impl IntoElement {
@@ -218,12 +230,12 @@ fn inspector_section(
                 .text_size(FontSizes::XS)
                 .text_color(colors.muted_fg)
                 .font_weight(gpui::FontWeight::SEMIBOLD)
-                .child(label),
+                .child(label.into()),
         )
         .child(content)
 }
 
-fn kv_row(key: &'static str, value: &str, colors: &ChartColors) -> impl IntoElement {
+fn kv_row(key: &str, value: &str, colors: &ChartColors) -> impl IntoElement {
     div()
         .flex()
         .items_center()
@@ -234,7 +246,7 @@ fn kv_row(key: &'static str, value: &str, colors: &ChartColors) -> impl IntoElem
                 .flex_shrink_0()
                 .text_size(FontSizes::XS)
                 .text_color(colors.muted_fg)
-                .child(key),
+                .child(key.to_string()),
         )
         .child(
             div()
@@ -246,24 +258,26 @@ fn kv_row(key: &'static str, value: &str, colors: &ChartColors) -> impl IntoElem
         )
 }
 
-/// Active action button (hover-enabled). The `_row_idx` parameter is the
-/// `SourceRowRef.row_idx` encoded in the element ID so the host can read it
-/// from the DOM event. The actual scroll is wired by the host — the inspector
-/// does not own the target entity.
+/// Element ID for an active inspector action button. The slug is
+/// locale-independent so the ID does not change with the active language,
+/// and the row index stays recoverable as the trailing `-row-N` segment.
+fn action_button_element_id(id_slug: &str, row_idx: usize) -> String {
+    format!("inspector-action-{}-row-{}", id_slug, row_idx)
+}
+
+/// Active action button (hover-enabled). `id_slug` is a stable, locale-independent
+/// suffix for the element ID (previously derived from the English label) so the
+/// host can still read the `SourceRowRef.row_idx` encoded in it. The actual
+/// scroll is wired by the host — the inspector does not own the target entity.
 fn action_button(
-    label: &'static str,
-    _disabled: bool,
+    label: String,
+    id_slug: &'static str,
     row_idx: usize,
     colors: &ChartColors,
 ) -> impl IntoElement {
     div()
         .id(gpui::ElementId::Name(
-            format!(
-                "inspector-action-{}-row-{}",
-                label.replace(' ', "-"),
-                row_idx
-            )
-            .into(),
+            action_button_element_id(id_slug, row_idx).into(),
         ))
         .px(Spacing::SM)
         .py(ChartGeometry::TICK_GAP)
@@ -279,11 +293,7 @@ fn action_button(
 }
 
 /// Disabled action button with a tooltip hint.
-fn action_button_disabled(
-    label: &'static str,
-    _tooltip: &'static str,
-    colors: &ChartColors,
-) -> impl IntoElement {
+fn action_button_disabled(label: String, _tooltip: &str, colors: &ChartColors) -> impl IntoElement {
     div()
         .px(Spacing::SM)
         .py(ChartGeometry::TICK_GAP)
@@ -355,5 +365,50 @@ mod tests {
         let source = SourceRowRef { row_idx: 3 };
         assert_eq!(source.row_idx, 3);
         assert_eq!(row_values.len(), 5);
+    }
+
+    #[test]
+    fn point_inspector_keys_resolve_in_both_locales() {
+        let keys = [
+            "chart.point_inspector.series",
+            "chart.point_inspector.hovered_point",
+            "chart.point_inspector.time",
+            "chart.point_inspector.value",
+            "chart.point_inspector.source_doc",
+            "chart.point_inspector.quick_actions",
+            "chart.point_inspector.show_in_tree",
+            "chart.point_inspector.annotate",
+            "chart.point_inspector.copy_as_query",
+            "chart.point_inspector.coming_soon",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn point_inspector_show_in_tree_differs_between_locales() {
+        let en = dbflux_i18n::t!("chart.point_inspector.show_in_tree", locale = "en");
+        let es = dbflux_i18n::t!("chart.point_inspector.show_in_tree", locale = "es");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn action_button_element_id_is_locale_independent_and_keeps_row_index() {
+        let id = super::action_button_element_id("show-in-tree", 7);
+
+        assert_eq!(id, "inspector-action-show-in-tree-row-7");
+        assert!(!id.contains(' '));
+
+        let row_idx: usize = id
+            .rsplit("-row-")
+            .next()
+            .and_then(|suffix| suffix.parse().ok())
+            .expect("row index suffix");
+        assert_eq!(row_idx, 7);
     }
 }

--- a/crates/dbflux_components/src/components/document_tree/state.rs
+++ b/crates/dbflux_components/src/components/document_tree/state.rs
@@ -121,7 +121,7 @@ impl DocumentTreeState {
             let doc_value = Self::extract_document_value(row, &result.columns);
 
             let node_id = NodeId::root(row_idx);
-            let key = format!("Document {}", row_idx);
+            let key = document_label(row_idx);
             let node_value = NodeValue::from_value(&doc_value);
 
             self.raw_documents.push(doc_value);
@@ -923,6 +923,11 @@ impl Focusable for DocumentTreeState {
     }
 }
 
+/// Build the root-node label for a document at the given row index.
+fn document_label(index: usize) -> String {
+    dbflux_i18n::t!("document_tree.document_label", index = index)
+}
+
 fn should_expand_scalar_value(value: &Value) -> bool {
     match value {
         Value::Text(text) => text.contains('\n') || text.len() > 100,
@@ -1044,7 +1049,10 @@ fn value_to_json(value: &Value) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
-    use super::{DocumentTreeState, set_value_at_path, should_expand_scalar_value, value_to_json};
+    use super::{
+        DocumentTreeState, document_label, set_value_at_path, should_expand_scalar_value,
+        value_to_json,
+    };
     use dbflux_core::{ColumnKind, ColumnMeta, Value};
     use std::collections::BTreeMap;
 
@@ -1129,6 +1137,16 @@ mod tests {
             value_to_json(&Value::Unsupported("xml".to_string())),
             serde_json::json!({"$unsupported":"xml"})
         );
+    }
+
+    #[test]
+    fn document_label_interpolates_index() {
+        let label = document_label(3);
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("document_tree.document_label", index = 3)
+        );
+        assert!(label.contains('3'));
     }
 
     #[test]

--- a/crates/dbflux_components/src/components/document_tree/tree.rs
+++ b/crates/dbflux_components/src/components/document_tree/tree.rs
@@ -130,7 +130,10 @@ impl DocumentTree {
             return input.clone();
         }
 
-        let input = cx.new(|cx| InputState::new(window, cx).placeholder("Search..."));
+        let input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("document_tree.search_placeholder"))
+        });
 
         let state = self.state.clone();
         let subscription = cx.subscribe(&input, move |_this, input, event, cx| {
@@ -435,9 +438,9 @@ fn render_toolbar(
         .bg(theme.secondary.opacity(0.3))
         .child(
             Text::caption(if is_tree_mode {
-                "Tree View"
+                dbflux_i18n::t!("document_tree.view.tree")
             } else {
-                "Raw JSON"
+                dbflux_i18n::t!("document_tree.view.raw_json")
             })
             .font_size(FontSizes::XS),
         )
@@ -487,7 +490,7 @@ fn render_search_bar(
             match_count
         )
     } else {
-        "No matches".to_string()
+        dbflux_i18n::t!("document_tree.no_matches")
     };
 
     div()
@@ -788,5 +791,36 @@ fn render_value_preview_with_expand(
                     }
                 });
             })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn document_tree_keys_resolve_in_both_locales() {
+        let keys = [
+            "document_tree.search_placeholder",
+            "document_tree.view.tree",
+            "document_tree.view.raw_json",
+            "document_tree.no_matches",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn document_tree_raw_json_differs_between_locales() {
+        let en = dbflux_i18n::t!("document_tree.view.raw_json", locale = "en");
+        let es = dbflux_i18n::t!("document_tree.view.raw_json", locale = "es");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_components/src/components/value_source_selector.rs
+++ b/crates/dbflux_components/src/components/value_source_selector.rs
@@ -44,19 +44,34 @@ impl ValueSourceSelector {
     pub fn new(id_prefix: &'static str, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let source_dropdown = cx.new(|_cx| {
             Dropdown::new(id_prefix)
-                .placeholder("Literal")
+                .placeholder(dbflux_i18n::t!("components.value_source.literal"))
                 .items(vec![
-                    DropdownItem::with_value("Literal", "literal"),
-                    DropdownItem::with_value("Environment Variable", "env"),
-                    DropdownItem::with_value("Secret Manager", "secret"),
-                    DropdownItem::with_value("Parameter Store", "parameter"),
-                    DropdownItem::with_value("Auth Session Field", "auth"),
+                    DropdownItem::with_value(
+                        dbflux_i18n::t!("components.value_source.literal"),
+                        "literal",
+                    ),
+                    DropdownItem::with_value(dbflux_i18n::t!("components.value_source.env"), "env"),
+                    DropdownItem::with_value(
+                        dbflux_i18n::t!("components.value_source.secret"),
+                        "secret",
+                    ),
+                    DropdownItem::with_value(
+                        dbflux_i18n::t!("components.value_source.parameter"),
+                        "parameter",
+                    ),
+                    DropdownItem::with_value(
+                        dbflux_i18n::t!("components.value_source.auth"),
+                        "auth",
+                    ),
                 ])
                 .selected_index(Some(0))
         });
 
-        let secondary_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("JSON key (optional)"));
+        let secondary_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "components.value_source.json_key_placeholder"
+            ))
+        });
 
         let dropdown_subscription = cx.subscribe(
             &source_dropdown,
@@ -230,5 +245,38 @@ impl Render for ValueSourceSelector {
                     .child(self.source_dropdown.clone()),
             )
             .into_any_element()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn value_source_keys_resolve_in_both_locales() {
+        let keys = [
+            "components.value_source.literal",
+            "components.value_source.env",
+            "components.value_source.secret",
+            "components.value_source.parameter",
+            "components.value_source.auth",
+            "components.value_source.json_key_placeholder",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn value_source_env_differs_between_locales() {
+        let en = dbflux_i18n::t!("components.value_source.env", locale = "en");
+        let es = dbflux_i18n::t!("components.value_source.env", locale = "es");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1,3 +1,19 @@
+chart:
+  axis_bar:
+    group: Group
+  engine:
+    no_data: No data
+  point_inspector:
+    series: SERIES
+    hovered_point: HOVERED POINT
+    time: Time
+    value: Value
+    source_doc: SOURCE DOC
+    quick_actions: QUICK ACTIONS
+    show_in_tree: Show in tree
+    annotate: Annotate
+    copy_as_query: Copy as query
+    coming_soon: Coming soon
 components:
   json_editor:
     empty_error: Document cannot be empty
@@ -5,6 +21,13 @@ components:
     compact: Compact
     cancel: Cancel
     save: Save
+  value_source:
+    literal: Literal
+    env: Environment Variable
+    secret: Secret Manager
+    parameter: Parameter Store
+    auth: Auth Session Field
+    json_key_placeholder: JSON key (optional)
 document:
   data:
     grid:
@@ -21,6 +44,13 @@ document:
       close_others: Close Others
       close_right: Close to the Right
     unsaved_changes: Unsaved changes
+document_tree:
+  search_placeholder: Search...
+  view:
+    tree: Tree View
+    raw_json: Raw JSON
+  no_matches: No matches
+  document_label: "Document %{index}"
 errors:
   action:
     view_in_audit: View in Audit

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1,3 +1,19 @@
+chart:
+  axis_bar:
+    group: Grupo
+  engine:
+    no_data: Sin datos
+  point_inspector:
+    series: SERIE
+    hovered_point: PUNTO SELECCIONADO
+    time: Hora
+    value: Valor
+    source_doc: DOCUMENTO DE ORIGEN
+    quick_actions: ACCIONES RÁPIDAS
+    show_in_tree: Mostrar en árbol
+    annotate: Anotar
+    copy_as_query: Copiar como consulta
+    coming_soon: Próximamente
 components:
   json_editor:
     empty_error: El documento no puede estar vacío
@@ -5,6 +21,13 @@ components:
     compact: Compactar
     cancel: Cancelar
     save: Guardar
+  value_source:
+    literal: Literal
+    env: Variable de entorno
+    secret: Secret Manager
+    parameter: Parameter Store
+    auth: Campo de sesión de autenticación
+    json_key_placeholder: Clave JSON (opcional)
 document:
   data:
     grid:
@@ -21,6 +44,13 @@ document:
       close_others: Cerrar las demás
       close_right: Cerrar a la derecha
     unsaved_changes: Cambios sin guardar
+document_tree:
+  search_placeholder: Buscar...
+  view:
+    tree: Vista de árbol
+    raw_json: JSON sin formato
+  no_matches: Sin coincidencias
+  document_label: "Documento %{index}"
 errors:
   action:
     view_in_audit: Ver en auditoría


### PR DESCRIPTION
## Summary

Fourth `dbflux_components` i18n slice: the document tree (node actions, empty/loading states), the chart point inspector, axis bar and engine labels, and the value-source selector render through `dbflux_i18n::t!`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows #370; next: controls, multi-select, refresh split button, file picker and time range)

## How was this solved?

- Same mechanism; helpers for counted/interpolated labels; chart column names, values and units stay data.

## Validation

- `cargo nextest run -p dbflux_components -p dbflux_i18n` → all passed after rebase on `main`; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: expand a document in the tree, hover a chart point, open the value-source selector.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted below)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
