### PR TITLE
feat(i18n): translate the command palette command names and categories

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -188,6 +188,78 @@ palette:
     browse_suffix: "[browse]"
   import_dashboard:
     name: Import Dashboard from JSON...
+  command:
+    new_query_tab:
+      name: New Query Tab
+    run_query:
+      name: Run Query
+    run_query_in_new_tab:
+      name: Run Query in New Tab
+    save_query:
+      name: Save Query
+    save_file_as:
+      name: Save File As
+    open_script_file:
+      name: Open Script File
+    open_history:
+      name: Open Query History
+    cancel_query:
+      name: Cancel Running Query
+    close_tab:
+      name: Close Current Tab
+    next_tab:
+      name: Next Tab
+    prev_tab:
+      name: Previous Tab
+    export_results:
+      name: Export Results
+    open_connection_manager:
+      name: Open Connection Manager
+    disconnect:
+      name: Disconnect Current
+    refresh_schema:
+      name: Refresh Schema
+    focus_sidebar:
+      name: Focus Sidebar
+    focus_editor:
+      name: Focus Editor
+    focus_results:
+      name: Focus Results
+    focus_tasks:
+      name: Focus Tasks Panel
+    toggle_sidebar:
+      name: Toggle Sidebar
+    toggle_editor:
+      name: Toggle Editor Panel
+    toggle_results:
+      name: Toggle Results Panel
+    toggle_tasks:
+      name: Toggle Tasks Panel
+    open_settings:
+      name: Open Settings
+    open_login_modal:
+      name: Open Auth Profile Login
+    open_sso_wizard:
+      name: Open AWS SSO Wizard
+    open_mcp_approvals:
+      name: Open MCP Approvals
+    refresh_mcp_governance:
+      name: Refresh MCP Governance
+    open_audit_viewer:
+      name: Open Audit Viewer
+    open_saved_chart:
+      name: "Open Chart..."
+    new_dashboard:
+      name: "New Dashboard..."
+  category:
+    editor: Editor
+    tabs: Tabs
+    results: Results
+    connections: Connections
+    focus: Focus
+    view: View
+    charts: Charts
+    dashboards: Dashboards
 settings:
   general:
     header:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -188,6 +188,78 @@ palette:
     browse_suffix: "[explorar]"
   import_dashboard:
     name: Importar dashboard desde JSON…
+  command:
+    new_query_tab:
+      name: Nueva pestaña de consulta
+    run_query:
+      name: Ejecutar consulta
+    run_query_in_new_tab:
+      name: Ejecutar consulta en nueva pestaña
+    save_query:
+      name: Guardar consulta
+    save_file_as:
+      name: Guardar archivo como
+    open_script_file:
+      name: Abrir archivo de script
+    open_history:
+      name: Abrir historial de consultas
+    cancel_query:
+      name: Cancelar consulta en ejecución
+    close_tab:
+      name: Cerrar pestaña actual
+    next_tab:
+      name: Pestaña siguiente
+    prev_tab:
+      name: Pestaña anterior
+    export_results:
+      name: Exportar resultados
+    open_connection_manager:
+      name: Abrir gestor de conexiones
+    disconnect:
+      name: Desconectar actual
+    refresh_schema:
+      name: Actualizar schema
+    focus_sidebar:
+      name: Enfocar barra lateral
+    focus_editor:
+      name: Enfocar editor
+    focus_results:
+      name: Enfocar resultados
+    focus_tasks:
+      name: Enfocar panel de tareas
+    toggle_sidebar:
+      name: Mostrar u ocultar barra lateral
+    toggle_editor:
+      name: Mostrar u ocultar panel del editor
+    toggle_results:
+      name: Mostrar u ocultar panel de resultados
+    toggle_tasks:
+      name: Mostrar u ocultar panel de tareas
+    open_settings:
+      name: Abrir configuración
+    open_login_modal:
+      name: Abrir inicio de sesión de Auth Profile
+    open_sso_wizard:
+      name: Abrir asistente de AWS SSO
+    open_mcp_approvals:
+      name: Abrir aprobaciones de MCP
+    refresh_mcp_governance:
+      name: Actualizar gobernanza de MCP
+    open_audit_viewer:
+      name: Abrir visor de auditoría
+    open_saved_chart:
+      name: "Abrir gráfico..."
+    new_dashboard:
+      name: "Nuevo dashboard..."
+  category:
+    editor: Editor
+    tabs: Pestañas
+    results: Resultados
+    connections: Conexiones
+    focus: Foco
+    view: Vista
+    charts: Gráficos
+    dashboards: Dashboards
 settings:
   general:
     header:

--- a/crates/dbflux_ui/src/ui/overlays/command_palette.rs
+++ b/crates/dbflux_ui/src/ui/overlays/command_palette.rs
@@ -1333,9 +1333,11 @@ mod tests {
         use super::super::super::views::workspace::Workspace;
 
         let commands = Workspace::palette_commands_for_test();
+        let expected_name = dbflux_i18n::t!("palette.command.new_dashboard.name");
+        let expected_category = dbflux_i18n::t!("palette.category.dashboards");
         let found = commands
             .iter()
-            .any(|c| c.name == "New Dashboard..." && c.category == "Dashboards");
+            .any(|c| c.name == expected_name && c.category == expected_category);
         assert!(
             found,
             "Palette must include 'Dashboards: New Dashboard...' entry"
@@ -1439,5 +1441,69 @@ mod tests {
             2,
             "expected the English proxy word and the translated kind word both present, got: {search_text:?}"
         );
+    }
+
+    // i18n — command palette command copy
+
+    const PALETTE_COMMAND_CATEGORIES: &[&str] = &[
+        "editor",
+        "tabs",
+        "results",
+        "connections",
+        "focus",
+        "view",
+        "charts",
+        "dashboards",
+    ];
+
+    #[test]
+    fn palette_command_keys_resolve_in_both_locales() {
+        use super::super::super::views::workspace::Workspace;
+
+        let commands = Workspace::palette_commands_for_test();
+
+        for locale in ["en", "es"] {
+            for command in &commands {
+                let key = format!("palette.command.{}.name", command.id);
+                let value = dbflux_i18n::t!(&key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+
+            for category in PALETTE_COMMAND_CATEGORIES {
+                let key = format!("palette.category.{category}");
+                let value = dbflux_i18n::t!(&key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn palette_command_name_differs_between_locales() {
+        let english = dbflux_i18n::t!("palette.command.run_query.name", locale = "en");
+        let spanish = dbflux_i18n::t!("palette.command.run_query.name", locale = "es");
+
+        assert_eq!(english, "Run Query");
+        assert_eq!(spanish, "Ejecutar consulta");
+        assert_ne!(english, spanish);
     }
 }

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -1552,65 +1552,189 @@ impl Workspace {
 
         vec![
             // Editor
-            PaletteCommand::new("new_query_tab", "New Query Tab", "Editor")
-                .with_shortcut(SC.new_query_tab),
-            PaletteCommand::new("run_query", "Run Query", "Editor").with_shortcut(SC.run_query),
-            PaletteCommand::new("run_query_in_new_tab", "Run Query in New Tab", "Editor")
-                .with_shortcut(SC.run_query_in_new_tab),
-            PaletteCommand::new("save_query", "Save Query", "Editor").with_shortcut(SC.save_query),
-            PaletteCommand::new("save_file_as", "Save File As", "Editor")
-                .with_shortcut(SC.save_file_as),
-            PaletteCommand::new("open_script_file", "Open Script File", "Editor")
-                .with_shortcut(SC.open_script_file),
-            PaletteCommand::new("open_history", "Open Query History", "Editor")
-                .with_shortcut(SC.open_history),
-            PaletteCommand::new("cancel_query", "Cancel Running Query", "Editor")
-                .with_shortcut("esc"),
+            PaletteCommand::new(
+                "new_query_tab",
+                dbflux_i18n::t!("palette.command.new_query_tab.name"),
+                dbflux_i18n::t!("palette.category.editor"),
+            )
+            .with_shortcut(SC.new_query_tab),
+            PaletteCommand::new(
+                "run_query",
+                dbflux_i18n::t!("palette.command.run_query.name"),
+                dbflux_i18n::t!("palette.category.editor"),
+            )
+            .with_shortcut(SC.run_query),
+            PaletteCommand::new(
+                "run_query_in_new_tab",
+                dbflux_i18n::t!("palette.command.run_query_in_new_tab.name"),
+                dbflux_i18n::t!("palette.category.editor"),
+            )
+            .with_shortcut(SC.run_query_in_new_tab),
+            PaletteCommand::new(
+                "save_query",
+                dbflux_i18n::t!("palette.command.save_query.name"),
+                dbflux_i18n::t!("palette.category.editor"),
+            )
+            .with_shortcut(SC.save_query),
+            PaletteCommand::new(
+                "save_file_as",
+                dbflux_i18n::t!("palette.command.save_file_as.name"),
+                dbflux_i18n::t!("palette.category.editor"),
+            )
+            .with_shortcut(SC.save_file_as),
+            PaletteCommand::new(
+                "open_script_file",
+                dbflux_i18n::t!("palette.command.open_script_file.name"),
+                dbflux_i18n::t!("palette.category.editor"),
+            )
+            .with_shortcut(SC.open_script_file),
+            PaletteCommand::new(
+                "open_history",
+                dbflux_i18n::t!("palette.command.open_history.name"),
+                dbflux_i18n::t!("palette.category.editor"),
+            )
+            .with_shortcut(SC.open_history),
+            PaletteCommand::new(
+                "cancel_query",
+                dbflux_i18n::t!("palette.command.cancel_query.name"),
+                dbflux_i18n::t!("palette.category.editor"),
+            )
+            .with_shortcut("esc"),
             // Tabs — Ctrl+Tab / Ctrl+Shift+Tab stay literal Ctrl on every
             // platform (Cmd+Tab is the macOS app switcher).
-            PaletteCommand::new("close_tab", "Close Current Tab", "Tabs")
-                .with_shortcut(SC.close_tab),
-            PaletteCommand::new("next_tab", "Next Tab", "Tabs").with_shortcut("ctrl-tab"),
-            PaletteCommand::new("prev_tab", "Previous Tab", "Tabs").with_shortcut("ctrl-shift-tab"),
+            PaletteCommand::new(
+                "close_tab",
+                dbflux_i18n::t!("palette.command.close_tab.name"),
+                dbflux_i18n::t!("palette.category.tabs"),
+            )
+            .with_shortcut(SC.close_tab),
+            PaletteCommand::new(
+                "next_tab",
+                dbflux_i18n::t!("palette.command.next_tab.name"),
+                dbflux_i18n::t!("palette.category.tabs"),
+            )
+            .with_shortcut("ctrl-tab"),
+            PaletteCommand::new(
+                "prev_tab",
+                dbflux_i18n::t!("palette.command.prev_tab.name"),
+                dbflux_i18n::t!("palette.category.tabs"),
+            )
+            .with_shortcut("ctrl-shift-tab"),
             // Results
-            PaletteCommand::new("export_results", "Export Results", "Results")
-                .with_shortcut(SC.export_results),
+            PaletteCommand::new(
+                "export_results",
+                dbflux_i18n::t!("palette.command.export_results.name"),
+                dbflux_i18n::t!("palette.category.results"),
+            )
+            .with_shortcut(SC.export_results),
             // Connections
             PaletteCommand::new(
                 "open_connection_manager",
-                "Open Connection Manager",
-                "Connections",
+                dbflux_i18n::t!("palette.command.open_connection_manager.name"),
+                dbflux_i18n::t!("palette.category.connections"),
             ),
-            PaletteCommand::new("disconnect", "Disconnect Current", "Connections"),
-            PaletteCommand::new("refresh_schema", "Refresh Schema", "Connections"),
+            PaletteCommand::new(
+                "disconnect",
+                dbflux_i18n::t!("palette.command.disconnect.name"),
+                dbflux_i18n::t!("palette.category.connections"),
+            ),
+            PaletteCommand::new(
+                "refresh_schema",
+                dbflux_i18n::t!("palette.command.refresh_schema.name"),
+                dbflux_i18n::t!("palette.category.connections"),
+            ),
             // Focus — Ctrl+Shift+1..4 stay literal Ctrl on every platform
             // (Cmd+Shift+3/4 are macOS screenshot shortcuts).
-            PaletteCommand::new("focus_sidebar", "Focus Sidebar", "Focus")
-                .with_shortcut("ctrl-shift-1"),
-            PaletteCommand::new("focus_editor", "Focus Editor", "Focus")
-                .with_shortcut("ctrl-shift-2"),
-            PaletteCommand::new("focus_results", "Focus Results", "Focus")
-                .with_shortcut("ctrl-shift-3"),
-            PaletteCommand::new("focus_tasks", "Focus Tasks Panel", "Focus")
-                .with_shortcut("ctrl-shift-4"),
+            PaletteCommand::new(
+                "focus_sidebar",
+                dbflux_i18n::t!("palette.command.focus_sidebar.name"),
+                dbflux_i18n::t!("palette.category.focus"),
+            )
+            .with_shortcut("ctrl-shift-1"),
+            PaletteCommand::new(
+                "focus_editor",
+                dbflux_i18n::t!("palette.command.focus_editor.name"),
+                dbflux_i18n::t!("palette.category.focus"),
+            )
+            .with_shortcut("ctrl-shift-2"),
+            PaletteCommand::new(
+                "focus_results",
+                dbflux_i18n::t!("palette.command.focus_results.name"),
+                dbflux_i18n::t!("palette.category.focus"),
+            )
+            .with_shortcut("ctrl-shift-3"),
+            PaletteCommand::new(
+                "focus_tasks",
+                dbflux_i18n::t!("palette.command.focus_tasks.name"),
+                dbflux_i18n::t!("palette.category.focus"),
+            )
+            .with_shortcut("ctrl-shift-4"),
             // View
-            PaletteCommand::new("toggle_sidebar", "Toggle Sidebar", "View")
-                .with_shortcut(SC.toggle_sidebar),
-            PaletteCommand::new("toggle_editor", "Toggle Editor Panel", "View"),
-            PaletteCommand::new("toggle_results", "Toggle Results Panel", "View"),
-            PaletteCommand::new("toggle_tasks", "Toggle Tasks Panel", "View"),
-            PaletteCommand::new("open_settings", "Open Settings", "View"),
-            PaletteCommand::new("open_login_modal", "Open Auth Profile Login", "View"),
-            PaletteCommand::new("open_sso_wizard", "Open AWS SSO Wizard", "View"),
+            PaletteCommand::new(
+                "toggle_sidebar",
+                dbflux_i18n::t!("palette.command.toggle_sidebar.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            )
+            .with_shortcut(SC.toggle_sidebar),
+            PaletteCommand::new(
+                "toggle_editor",
+                dbflux_i18n::t!("palette.command.toggle_editor.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            ),
+            PaletteCommand::new(
+                "toggle_results",
+                dbflux_i18n::t!("palette.command.toggle_results.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            ),
+            PaletteCommand::new(
+                "toggle_tasks",
+                dbflux_i18n::t!("palette.command.toggle_tasks.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            ),
+            PaletteCommand::new(
+                "open_settings",
+                dbflux_i18n::t!("palette.command.open_settings.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            ),
+            PaletteCommand::new(
+                "open_login_modal",
+                dbflux_i18n::t!("palette.command.open_login_modal.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            ),
+            PaletteCommand::new(
+                "open_sso_wizard",
+                dbflux_i18n::t!("palette.command.open_sso_wizard.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            ),
             #[cfg(feature = "mcp")]
-            PaletteCommand::new("open_mcp_approvals", "Open MCP Approvals", "View"),
+            PaletteCommand::new(
+                "open_mcp_approvals",
+                dbflux_i18n::t!("palette.command.open_mcp_approvals.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            ),
             #[cfg(feature = "mcp")]
-            PaletteCommand::new("refresh_mcp_governance", "Refresh MCP Governance", "View"),
-            PaletteCommand::new("open_audit_viewer", "Open Audit Viewer", "View")
-                .with_shortcut(SC.open_audit_viewer),
+            PaletteCommand::new(
+                "refresh_mcp_governance",
+                dbflux_i18n::t!("palette.command.refresh_mcp_governance.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            ),
+            PaletteCommand::new(
+                "open_audit_viewer",
+                dbflux_i18n::t!("palette.command.open_audit_viewer.name"),
+                dbflux_i18n::t!("palette.category.view"),
+            )
+            .with_shortcut(SC.open_audit_viewer),
             // Charts / Dashboards
-            PaletteCommand::new("open_saved_chart", "Open Chart...", "Charts"),
-            PaletteCommand::new("new_dashboard", "New Dashboard...", "Dashboards"),
+            PaletteCommand::new(
+                "open_saved_chart",
+                dbflux_i18n::t!("palette.command.open_saved_chart.name"),
+                dbflux_i18n::t!("palette.category.charts"),
+            ),
+            PaletteCommand::new(
+                "new_dashboard",
+                dbflux_i18n::t!("palette.command.new_dashboard.name"),
+                dbflux_i18n::t!("palette.category.dashboards"),
+            ),
         ]
     }
 


### PR DESCRIPTION
## Summary

Second `dbflux_ui` i18n slice: every default command palette command resolves its name and category through `palette.command.<id>.name` and `palette.category.*`. 31 command keys and 8 category keys, English and Spanish together.

## What does this resolve?

- Refs #360 (follows the palette foundation PR; next: settings navigation, about and keybindings sections)

## How was this solved?

- `default_commands()` calls `dbflux_i18n::t!` per command; ids and shortcut chords stay untouched, so keymap lookups and palette ids do not change.
- The existing English-literal palette test reads the catalog; two new tests cover both locales and locale divergence.

## Validation

- `cargo nextest run -p dbflux_ui -p dbflux_i18n` → 128 passed; clippy clean; fmt clean. Workspace-wide gates run in CI.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: open the palette and read the command list.
- Size: 428 lines, mostly catalog YAML and repetitive constructor calls (`size:exception`).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted below)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
