### PR TITLE
feat(i18n): translate the sidebar profile, database, folder, and script context menus

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -292,6 +292,28 @@ sidebar:
     query_measurement: Query Measurement
     generate_query: Generate Query
     drop_collection: Drop Collection
+    connect: Connect
+    disconnect: Disconnect
+    edit: Edit
+    duplicate: Duplicate
+    rename: Rename
+    export_ellipsis: Export…
+    import_ellipsis: Import…
+    compare_schema: Compare Schema…
+    move_to: Move to...
+    delete: Delete
+    delete_count: "Delete %{count} items"
+    close: Close
+    new_query: New Query
+    drop_database: Drop Database
+    new_connection: New Connection
+    new_folder: New Folder
+    root: Root
+    new_script_file: New File
+    new_script_folder: New Folder
+    reveal_file_manager: Reveal in File Manager
+    copy_path: Copy Path
+    schema_diff_unsupported: Schema diff is only available for relational connections.
   overlay:
     add_folder: New Folder
     add_connection: New Connection

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -292,6 +292,28 @@ sidebar:
     query_measurement: Consultar medición
     generate_query: Generar consulta
     drop_collection: Eliminar colección
+    connect: Conectar
+    disconnect: Desconectar
+    edit: Editar
+    duplicate: Duplicar
+    rename: Renombrar
+    export_ellipsis: Exportar…
+    import_ellipsis: Importar…
+    compare_schema: Comparar esquema…
+    move_to: Mover a...
+    delete: Eliminar
+    delete_count: "Eliminar %{count} elementos"
+    close: Cerrar
+    new_query: Nueva consulta
+    drop_database: Eliminar base de datos
+    new_connection: Nueva conexión
+    new_folder: Nueva carpeta
+    root: Raíz
+    new_script_file: Nuevo archivo
+    new_script_folder: Nueva carpeta
+    reveal_file_manager: Mostrar en el explorador de archivos
+    copy_path: Copiar ruta
+    schema_diff_unsupported: La comparación de esquemas solo está disponible para conexiones relacionales.
   overlay:
     add_folder: Nueva carpeta
     add_connection: Nueva conexión

--- a/crates/dbflux_ui_sidebar/src/context_menu.rs
+++ b/crates/dbflux_ui_sidebar/src/context_menu.rs
@@ -217,9 +217,9 @@ impl Sidebar {
         };
 
         if !self.node_supports_schema_diff(item_id, cx) {
-            dbflux_ui_base::toast::Toast::warning(
-                "Schema diff is only available for relational connections.",
-            )
+            dbflux_ui_base::toast::Toast::warning(dbflux_i18n::t!(
+                "sidebar.menu.schema_diff_unsupported"
+            ))
             .push(cx);
             return;
         }
@@ -239,7 +239,7 @@ impl Sidebar {
             return None;
         }
         let count = self.deletable_multi_selection().len();
-        (count > 1).then(|| format!("Delete {count} items"))
+        (count > 1).then(|| crate::labels::delete_items_label(count))
     }
 
     /// If the right-clicked item is part of a deletable multi-selection of >1
@@ -490,24 +490,45 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [
-                            ContextMenuItem::item("Disconnect", ContextMenuAction::Disconnect),
-                            ContextMenuItem::item("Refresh", ContextMenuAction::Refresh),
+                            ContextMenuItem::item(
+                                dbflux_i18n::t!("sidebar.menu.disconnect"),
+                                ContextMenuAction::Disconnect,
+                            ),
+                            ContextMenuItem::item(
+                                dbflux_i18n::t!("sidebar.menu.refresh"),
+                                ContextMenuAction::Refresh,
+                            ),
                         ],
                     );
                 } else {
                     Self::append_menu_section(
                         &mut items,
-                        [ContextMenuItem::item("Connect", ContextMenuAction::Connect)],
+                        [ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.connect"),
+                            ContextMenuAction::Connect,
+                        )],
                     );
                 }
 
                 Self::append_menu_section(
                     &mut items,
                     [
-                        ContextMenuItem::item("Edit", ContextMenuAction::Edit),
-                        ContextMenuItem::item("Duplicate", ContextMenuAction::Duplicate),
-                        ContextMenuItem::item("Rename", ContextMenuAction::RenameFolder),
-                        ContextMenuItem::item("Export\u{2026}", ContextMenuAction::Export),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.edit"),
+                            ContextMenuAction::Edit,
+                        ),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.duplicate"),
+                            ContextMenuAction::Duplicate,
+                        ),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.rename"),
+                            ContextMenuAction::RenameFolder,
+                        ),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.export_ellipsis"),
+                            ContextMenuAction::Export,
+                        ),
                     ],
                 );
 
@@ -518,7 +539,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Import\u{2026}",
+                            dbflux_i18n::t!("sidebar.menu.import_ellipsis"),
                             ContextMenuAction::ImportTables,
                         )],
                     );
@@ -531,7 +552,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Compare Schema\u{2026}",
+                            dbflux_i18n::t!("sidebar.menu.compare_schema"),
                             ContextMenuAction::CompareSchema,
                         )],
                     );
@@ -543,7 +564,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Move to...",
+                            dbflux_i18n::t!("sidebar.menu.move_to"),
                             ContextMenuAction::Submenu(move_to_items),
                         )
                         .with_icon(AppIcon::Folder)],
@@ -552,7 +573,7 @@ impl Sidebar {
 
                 let delete_label = self
                     .batch_delete_label(item_id)
-                    .unwrap_or_else(|| "Delete".to_string());
+                    .unwrap_or_else(|| dbflux_i18n::t!("sidebar.menu.delete"));
                 Self::append_menu_section(
                     &mut items,
                     [ContextMenuItem::danger(
@@ -573,7 +594,7 @@ impl Sidebar {
                         Self::append_menu_section(
                             &mut items,
                             [ContextMenuItem::item(
-                                "Close",
+                                dbflux_i18n::t!("sidebar.menu.close"),
                                 ContextMenuAction::CloseDatabase,
                             )],
                         );
@@ -582,7 +603,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Refresh",
+                            dbflux_i18n::t!("sidebar.menu.refresh"),
                             ContextMenuAction::RefreshDatabase,
                         )],
                     );
@@ -592,7 +613,7 @@ impl Sidebar {
                         Self::append_menu_section(
                             &mut items,
                             [ContextMenuItem::item(
-                                "Compare Schema\u{2026}",
+                                dbflux_i18n::t!("sidebar.menu.compare_schema"),
                                 ContextMenuAction::CompareSchema,
                             )],
                         );
@@ -605,7 +626,7 @@ impl Sidebar {
                         Self::append_menu_section(
                             &mut items,
                             [ContextMenuItem::item(
-                                "New Query",
+                                dbflux_i18n::t!("sidebar.menu.new_query"),
                                 ContextMenuAction::NewQueryForDatabase,
                             )],
                         );
@@ -619,7 +640,7 @@ impl Sidebar {
                         Self::append_menu_section(
                             &mut items,
                             [ContextMenuItem::danger(
-                                "Drop Database",
+                                dbflux_i18n::t!("sidebar.menu.drop_database"),
                                 ContextMenuAction::DropDatabase,
                             )],
                         );
@@ -628,7 +649,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Open",
+                            dbflux_i18n::t!("sidebar.menu.open"),
                             ContextMenuAction::OpenDatabase,
                         )],
                     );
@@ -642,15 +663,21 @@ impl Sidebar {
                 Self::append_menu_section(
                     &mut items,
                     [
-                        ContextMenuItem::item("New Connection", ContextMenuAction::NewConnection),
-                        ContextMenuItem::item("New Folder", ContextMenuAction::NewFolder),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.new_connection"),
+                            ContextMenuAction::NewConnection,
+                        ),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.new_folder"),
+                            ContextMenuAction::NewFolder,
+                        ),
                     ],
                 );
 
                 Self::append_menu_section(
                     &mut items,
                     [ContextMenuItem::item(
-                        "Rename",
+                        dbflux_i18n::t!("sidebar.menu.rename"),
                         ContextMenuAction::RenameFolder,
                     )],
                 );
@@ -660,7 +687,7 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Move to...",
+                            dbflux_i18n::t!("sidebar.menu.move_to"),
                             ContextMenuAction::Submenu(move_to_items),
                         )
                         .with_icon(AppIcon::Folder)],
@@ -669,7 +696,7 @@ impl Sidebar {
 
                 let delete_label = self
                     .batch_delete_label(item_id)
-                    .unwrap_or_else(|| "Delete".to_string());
+                    .unwrap_or_else(|| dbflux_i18n::t!("sidebar.menu.delete"));
                 Self::append_menu_section(
                     &mut items,
                     [ContextMenuItem::danger(
@@ -710,8 +737,11 @@ impl Sidebar {
                     vec![]
                 } else {
                     vec![
-                        ContextMenuItem::item("Generate SQL", ContextMenuAction::Submenu(submenu))
-                            .with_icon(AppIcon::Code),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.generate_sql"),
+                            ContextMenuAction::Submenu(submenu),
+                        )
+                        .with_icon(AppIcon::Code),
                     ]
                 }
             }
@@ -742,8 +772,11 @@ impl Sidebar {
                     vec![]
                 } else {
                     vec![
-                        ContextMenuItem::item("Generate SQL", ContextMenuAction::Submenu(submenu))
-                            .with_icon(AppIcon::Code),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.generate_sql"),
+                            ContextMenuAction::Submenu(submenu),
+                        )
+                        .with_icon(AppIcon::Code),
                     ]
                 }
             }
@@ -780,8 +813,11 @@ impl Sidebar {
                     vec![]
                 } else {
                     vec![
-                        ContextMenuItem::item("Generate SQL", ContextMenuAction::Submenu(submenu))
-                            .with_icon(AppIcon::Code),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.generate_sql"),
+                            ContextMenuAction::Submenu(submenu),
+                        )
+                        .with_icon(AppIcon::Code),
                     ]
                 }
             }
@@ -792,8 +828,14 @@ impl Sidebar {
                 Self::append_menu_section(
                     &mut items,
                     [
-                        ContextMenuItem::item("New File", ContextMenuAction::NewScriptFile),
-                        ContextMenuItem::item("New Folder", ContextMenuAction::NewScriptFolder),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.new_script_file"),
+                            ContextMenuAction::NewScriptFile,
+                        ),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.new_script_folder"),
+                            ContextMenuAction::NewScriptFolder,
+                        ),
                     ],
                 );
 
@@ -803,14 +845,14 @@ impl Sidebar {
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::item(
-                            "Rename",
+                            dbflux_i18n::t!("sidebar.menu.rename"),
                             ContextMenuAction::RenameScript,
                         )],
                     );
 
                     let delete_label = self
                         .batch_delete_label(item_id)
-                        .unwrap_or_else(|| "Delete".to_string());
+                        .unwrap_or_else(|| dbflux_i18n::t!("sidebar.menu.delete"));
                     Self::append_menu_section(
                         &mut items,
                         [ContextMenuItem::danger(
@@ -824,10 +866,13 @@ impl Sidebar {
                     &mut items,
                     [
                         ContextMenuItem::item(
-                            "Reveal in File Manager",
+                            dbflux_i18n::t!("sidebar.menu.reveal_file_manager"),
                             ContextMenuAction::RevealInFileManager,
                         ),
-                        ContextMenuItem::item("Copy Path", ContextMenuAction::CopyPath),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.copy_path"),
+                            ContextMenuAction::CopyPath,
+                        ),
                     ],
                 );
 
@@ -839,13 +884,16 @@ impl Sidebar {
 
                 Self::append_menu_section(
                     &mut items,
-                    [ContextMenuItem::item("Open", ContextMenuAction::OpenScript)],
+                    [ContextMenuItem::item(
+                        dbflux_i18n::t!("sidebar.menu.open"),
+                        ContextMenuAction::OpenScript,
+                    )],
                 );
 
                 Self::append_menu_section(
                     &mut items,
                     [ContextMenuItem::item(
-                        "Rename",
+                        dbflux_i18n::t!("sidebar.menu.rename"),
                         ContextMenuAction::RenameScript,
                     )],
                 );
@@ -854,16 +902,19 @@ impl Sidebar {
                     &mut items,
                     [
                         ContextMenuItem::item(
-                            "Reveal in File Manager",
+                            dbflux_i18n::t!("sidebar.menu.reveal_file_manager"),
                             ContextMenuAction::RevealInFileManager,
                         ),
-                        ContextMenuItem::item("Copy Path", ContextMenuAction::CopyPath),
+                        ContextMenuItem::item(
+                            dbflux_i18n::t!("sidebar.menu.copy_path"),
+                            ContextMenuAction::CopyPath,
+                        ),
                     ],
                 );
 
                 let delete_label = self
                     .batch_delete_label(item_id)
-                    .unwrap_or_else(|| "Delete".to_string());
+                    .unwrap_or_else(|| dbflux_i18n::t!("sidebar.menu.delete"));
                 Self::append_menu_section(
                     &mut items,
                     [ContextMenuItem::danger(
@@ -1078,7 +1129,7 @@ impl Sidebar {
         // Add "Root" option if not already at root
         if current_parent.is_some() {
             items.push(ContextMenuItem::item(
-                "Root",
+                dbflux_i18n::t!("sidebar.menu.root"),
                 ContextMenuAction::MoveToFolder(None),
             ));
         }
@@ -1886,6 +1937,57 @@ mod menu_i18n_tests {
 
         assert_eq!(english, "Open");
         assert_eq!(spanish, "Abrir");
+        assert_ne!(english, spanish);
+    }
+
+    const B2_KEYS: [&str; 22] = [
+        "sidebar.menu.connect",
+        "sidebar.menu.disconnect",
+        "sidebar.menu.edit",
+        "sidebar.menu.duplicate",
+        "sidebar.menu.rename",
+        "sidebar.menu.export_ellipsis",
+        "sidebar.menu.import_ellipsis",
+        "sidebar.menu.compare_schema",
+        "sidebar.menu.move_to",
+        "sidebar.menu.delete",
+        "sidebar.menu.delete_count",
+        "sidebar.menu.close",
+        "sidebar.menu.new_query",
+        "sidebar.menu.drop_database",
+        "sidebar.menu.new_connection",
+        "sidebar.menu.new_folder",
+        "sidebar.menu.root",
+        "sidebar.menu.new_script_file",
+        "sidebar.menu.new_script_folder",
+        "sidebar.menu.reveal_file_manager",
+        "sidebar.menu.copy_path",
+        "sidebar.menu.schema_diff_unsupported",
+    ];
+
+    #[test]
+    fn menu_b2_keys_resolve_in_both_locales() {
+        for key in B2_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn menu_connect_differs_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.menu.connect", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.menu.connect", locale = "es");
+
+        assert_eq!(english, "Connect");
+        assert_eq!(spanish, "Conectar");
         assert_ne!(english, spanish);
     }
 }

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -91,6 +91,16 @@ pub(crate) fn migrate_tables_label(count: usize) -> String {
     }
 }
 
+/// Translated label for the batch/single Delete context menu item, e.g.
+/// `"Delete"` for a single item or `"Delete 3 items"` for a multi-selection.
+pub(crate) fn delete_items_label(count: usize) -> String {
+    if count > 1 {
+        dbflux_i18n::t!("sidebar.menu.delete_count", count = count)
+    } else {
+        dbflux_i18n::t!("sidebar.menu.delete")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use dbflux_core::DatabaseCategory;
@@ -314,6 +324,20 @@ mod tests {
         assert_eq!(
             plural,
             dbflux_i18n::t!("sidebar.menu.export_tables_many", count = 3)
+        );
+        assert!(plural.contains('3'));
+        assert_ne!(singular, plural);
+    }
+
+    #[test]
+    fn delete_items_label_one_vs_many() {
+        let singular = super::delete_items_label(1);
+        let plural = super::delete_items_label(3);
+
+        assert_eq!(singular, dbflux_i18n::t!("sidebar.menu.delete"));
+        assert_eq!(
+            plural,
+            dbflux_i18n::t!("sidebar.menu.delete_count", count = 3)
         );
         assert!(plural.contains('3'));
         assert_ne!(singular, plural);


### PR DESCRIPTION
## Summary

Sidebar i18n slice B2: the profile, database, connection-folder, index, foreign-key, custom-type, scripts-folder and script-file context menu arms, the batch-delete label and the schema-diff unsupported toast render through `dbflux_i18n::t!`. 22 keys under `sidebar.menu.*`, English and Spanish together.

## What does this resolve?

- Refs #360 (follows B1; next: dashboards, charts and instance arms)

## How was this solved?

- `delete_items_label(count)` picks between the single Delete label and the counted form; DDL submenu labels (CREATE INDEX, DROP TYPE, ...) stay as SQL.

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 151 passed; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: right-click a connection, a database, a folder and a script.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted below)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
