### PR TITLE
feat(i18n): translate the settings navigation, about, and keybindings sections

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -353,6 +353,50 @@ settings:
       button: Save
       error: "Failed to save general settings: %{error}"
       success: Settings saved. Some changes apply on next startup.
+  about:
+    title: About
+    subtitle: Project information
+    report_bug: Report a bug
+    or: or
+    view_source: view the source code
+    on_github: on GitHub.
+    copyright: "Copyright © 2026 %{author} and contributors."
+    license: "Licensed under the %{license} licenses."
+    third_party_licenses: Third-Party Licenses
+    lucide: UI icons from Lucide (ISC License)
+    simple_icons: Brand icons from Simple Icons (CC0 1.0)
+  keybindings:
+    title: Keyboard Shortcuts
+    subtitle: View all keyboard shortcuts by context
+    filter_placeholder: Filter keybindings...
+    binding_count:
+      one: (1 binding)
+      many: "(%{count} bindings)"
+    inherits_from: "inherits from %{parent}"
+    inherited: inherited
+    conflict:
+      title: "Conflict: %{chord} also bound to %{others}"
+      body: Two or more commands share this chord in this context.
+      unknown_other: another binding
+  nav:
+    general_group: General
+    general: General
+    keybindings: Keybindings
+    audit: Audit
+    about: About
+    network: Network
+    ssh_tunnels: SSH Tunnels
+    proxies: Proxy
+    auth_profiles: Access Providers
+    connection: Connection
+    hooks: Hooks
+    drivers: Drivers
+    services: RPC Services
+    mcp_governance: MCP Governance
+    mcp_clients: Clients
+    mcp_roles: Roles
+    mcp_policies: Policies
+
 sidebar:
   confirm:
     delete_hint: Press x to confirm delete, ESC to cancel

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -353,6 +353,50 @@ settings:
       button: Guardar
       error: "No se pudo guardar la configuración general: %{error}"
       success: Configuración guardada. Algunos cambios se aplican al reiniciar.
+  about:
+    title: Acerca de
+    subtitle: Información del proyecto
+    report_bug: Reportar un error
+    or: o
+    view_source: ver el código fuente
+    on_github: en GitHub.
+    copyright: "Copyright © 2026 %{author} y colaboradores."
+    license: "Con licencias %{license}."
+    third_party_licenses: Licencias de terceros
+    lucide: Iconos de interfaz de Lucide (Licencia ISC)
+    simple_icons: Iconos de marca de Simple Icons (CC0 1.0)
+  keybindings:
+    title: Atajos de teclado
+    subtitle: Ver todos los atajos de teclado por contexto
+    filter_placeholder: Filtrar atajos de teclado...
+    binding_count:
+      one: (1 atajo)
+      many: "(%{count} atajos)"
+    inherits_from: "hereda de %{parent}"
+    inherited: heredado
+    conflict:
+      title: "Conflicto: %{chord} también está asignado a %{others}"
+      body: Dos o más comandos comparten este atajo en este contexto.
+      unknown_other: otro atajo
+  nav:
+    general_group: General
+    general: General
+    keybindings: Atajos de teclado
+    audit: Auditoría
+    about: Acerca de
+    network: Red
+    ssh_tunnels: Túneles SSH
+    proxies: Proxy
+    auth_profiles: Proveedores de acceso
+    connection: Conexión
+    hooks: Hooks
+    drivers: Drivers
+    services: Servicios RPC
+    mcp_governance: Gobernanza MCP
+    mcp_clients: Clientes
+    mcp_roles: Roles
+    mcp_policies: Políticas
+
 sidebar:
   confirm:
     delete_hint: Presiona x para confirmar la eliminación, ESC para cancelar

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -1,0 +1,38 @@
+//! Translation helpers shared across settings-window sections.
+//!
+//! These wrap [`dbflux_i18n::t!`] calls that need named arguments so
+//! per-row rendering code can build the label once instead of repeating
+//! the placeholder substitution inline on every render pass.
+
+/// Formats the "(N bindings)" count shown next to a keybindings context header.
+pub(crate) fn keybindings_binding_count(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("settings.keybindings.binding_count.one")
+    } else {
+        dbflux_i18n::t!("settings.keybindings.binding_count.many", count = count)
+    }
+}
+
+/// Formats the "inherits from <parent context>" hint on a context header.
+pub(crate) fn keybindings_inherits_from(parent: &str) -> String {
+    dbflux_i18n::t!("settings.keybindings.inherits_from", parent = parent)
+}
+
+/// Formats the conflict banner title for a chord shared by multiple commands.
+pub(crate) fn keybindings_conflict_title(chord: &str, others: &str) -> String {
+    dbflux_i18n::t!(
+        "settings.keybindings.conflict.title",
+        chord = chord,
+        others = others
+    )
+}
+
+/// Formats the About section copyright line with the resolved author name.
+pub(crate) fn about_copyright(author: &str) -> String {
+    dbflux_i18n::t!("settings.about.copyright", author = author)
+}
+
+/// Formats the About section license line with the resolved license identifier.
+pub(crate) fn about_license(license: &str) -> String {
+    dbflux_i18n::t!("settings.about.license", license = license)
+}

--- a/crates/dbflux_ui_windows/src/lib.rs
+++ b/crates/dbflux_ui_windows/src/lib.rs
@@ -10,4 +10,5 @@ pub mod connection_manager;
 pub mod settings;
 pub mod ssh_shared;
 
+mod labels;
 mod style_guardrails;

--- a/crates/dbflux_ui_windows/src/settings/about_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/about_section.rs
@@ -43,6 +43,8 @@ impl Render for AboutSection {
         let issues_url = format!("{}/issues", REPOSITORY);
         let author_name = AUTHORS.split('<').next().unwrap_or(AUTHORS).trim();
         let license_display = LICENSE.replace(" OR ", " and ");
+        let copyright_line = crate::labels::about_copyright(author_name);
+        let license_line = crate::labels::about_license(&license_display);
 
         div()
             .flex_1()
@@ -51,8 +53,8 @@ impl Render for AboutSection {
             .flex_col()
             .overflow_hidden()
             .child(dbflux_components::composites::section_header(
-                "About",
-                "Project information",
+                dbflux_i18n::t!("settings.about.title"),
+                dbflux_i18n::t!("settings.about.subtitle"),
                 cx,
             ))
             .child(
@@ -97,9 +99,14 @@ impl Render for AboutSection {
                                             .on_mouse_down(MouseButton::Left, move |_, _, cx| {
                                                 cx.open_url(&issues_url);
                                             })
-                                            .child(Body::new("Report a bug").color(theme.link)),
+                                            .child(
+                                                Body::new(dbflux_i18n::t!(
+                                                    "settings.about.report_bug"
+                                                ))
+                                                .color(theme.link),
+                                            ),
                                     )
-                                    .child(Body::new("or"))
+                                    .child(Body::new(dbflux_i18n::t!("settings.about.or")))
                                     .child(
                                         div()
                                             .id("about-link-repo")
@@ -109,20 +116,17 @@ impl Render for AboutSection {
                                                 cx.open_url(REPOSITORY);
                                             })
                                             .child(
-                                                Body::new("view the source code").color(theme.link),
+                                                Body::new(dbflux_i18n::t!(
+                                                    "settings.about.view_source"
+                                                ))
+                                                .color(theme.link),
                                             ),
                                     )
-                                    .child(Body::new("on GitHub.")),
+                                    .child(Body::new(dbflux_i18n::t!("settings.about.on_github"))),
                             ),
                         )
-                        .child(Body::new(format!(
-                            "Copyright © 2026 {} and contributors.",
-                            author_name
-                        )))
-                        .child(Body::new(format!(
-                            "Licensed under the {} licenses.",
-                            license_display
-                        )))
+                        .child(Body::new(copyright_line))
+                        .child(Body::new(license_line))
                         .child(
                             div()
                                 .mt_4()
@@ -132,17 +136,84 @@ impl Render for AboutSection {
                                 .flex()
                                 .flex_col()
                                 .gap_2()
-                                .child(FieldLabel::new("Third-Party Licenses"))
+                                .child(FieldLabel::new(dbflux_i18n::t!(
+                                    "settings.about.third_party_licenses"
+                                )))
                                 .child(
-                                    Body::new("UI icons from Lucide (ISC License)")
+                                    Body::new(dbflux_i18n::t!("settings.about.lucide"))
                                         .color(theme.muted_foreground),
                                 )
                                 .child(
-                                    Body::new("Brand icons from Simple Icons (CC0 1.0)")
+                                    Body::new(dbflux_i18n::t!("settings.about.simple_icons"))
                                         .color(theme.muted_foreground),
                                 ),
                         ),
                 ),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::labels::{about_copyright, about_license};
+
+    const ABOUT_CATALOG_KEYS: &[&str] = &[
+        "settings.about.title",
+        "settings.about.subtitle",
+        "settings.about.report_bug",
+        "settings.about.or",
+        "settings.about.view_source",
+        "settings.about.on_github",
+        "settings.about.copyright",
+        "settings.about.license",
+        "settings.about.third_party_licenses",
+        "settings.about.lucide",
+        "settings.about.simple_icons",
+    ];
+
+    #[test]
+    fn settings_about_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in ABOUT_CATALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn settings_about_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("settings.about.title", locale = "en");
+        let spanish = dbflux_i18n::t!("settings.about.title", locale = "es");
+
+        assert_eq!(english, "About");
+        assert_eq!(spanish, "Acerca de");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn about_copyright_embeds_author_name() {
+        let en = about_copyright("Jane Doe");
+        let es = about_copyright("Jane Doe");
+
+        assert!(en.contains("Jane Doe"));
+        assert!(es.contains("Jane Doe"));
+    }
+
+    #[test]
+    fn about_license_embeds_license_identifier() {
+        let en = about_license("MIT and Apache-2.0");
+
+        assert!(en.contains("MIT and Apache-2.0"));
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/keybindings.rs
+++ b/crates/dbflux_ui_windows/src/settings/keybindings.rs
@@ -131,6 +131,12 @@ impl KeybindingsSection {
             self.keybindings_scroll_handle.scroll_to_item(scroll_idx);
         }
 
+        // Hoisted once per render: shared across every row in the list below,
+        // rather than re-resolving the same static translation per row.
+        let inherited_label = dbflux_i18n::t!("settings.keybindings.inherited");
+        let conflict_body = dbflux_i18n::t!("settings.keybindings.conflict.body");
+        let conflict_unknown_other = dbflux_i18n::t!("settings.keybindings.conflict.unknown_other");
+
         div()
             .flex_1()
             .min_h_0()
@@ -138,8 +144,8 @@ impl KeybindingsSection {
             .flex_col()
             .overflow_hidden()
             .child(dbflux_components::composites::section_header(
-                "Keyboard Shortcuts",
-                "View all keyboard shortcuts by context",
+                dbflux_i18n::t!("settings.keybindings.title"),
+                dbflux_i18n::t!("settings.keybindings.subtitle"),
                 cx,
             ))
             .child(
@@ -240,16 +246,19 @@ impl KeybindingsSection {
                                             .gap_2()
                                             .child(FieldLabel::new(context.display_name()))
                                             .child(
-                                                Body::new(format!("({} bindings)", binding_count))
-                                                    .color(muted_foreground),
+                                                Body::new(
+                                                    crate::labels::keybindings_binding_count(
+                                                        binding_count,
+                                                    ),
+                                                )
+                                                .color(muted_foreground),
                                             ),
                                     )
                                     // Inherits info
                                     .when(has_parent, |d| {
-                                        d.child(MonoCaption::new(format!(
-                                            "inherits from {}",
-                                            parent_name
-                                        )))
+                                        d.child(MonoCaption::new(
+                                            crate::labels::keybindings_inherits_from(parent_name),
+                                        ))
                                     })
                                     .into_any_element()
                             }
@@ -272,6 +281,7 @@ impl KeybindingsSection {
                                     muted_foreground,
                                     secondary,
                                     border,
+                                    &inherited_label,
                                     cx,
                                 )
                                 .into_any_element(),
@@ -279,8 +289,13 @@ impl KeybindingsSection {
                             KeybindingsListItem::ConflictWarning {
                                 chord,
                                 other_cmd_names,
-                            } => Self::render_conflict_warning(&chord, &other_cmd_names)
-                                .into_any_element(),
+                            } => Self::render_conflict_warning(
+                                &chord,
+                                &other_cmd_names,
+                                &conflict_body,
+                                &conflict_unknown_other,
+                            )
+                            .into_any_element(),
                         }
                     })),
             )
@@ -298,6 +313,7 @@ impl KeybindingsSection {
         muted_foreground: Hsla,
         secondary: Hsla,
         border: Hsla,
+        inherited_label: &str,
         cx: &mut Context<Self>,
     ) -> Stateful<Div> {
         div()
@@ -343,7 +359,7 @@ impl KeybindingsSection {
                         .py(px(2.0))
                         .rounded(Radii::SM)
                         .bg(secondary)
-                        .child(MonoCaption::new("inherited")),
+                        .child(MonoCaption::new(inherited_label.to_string())),
                 )
             })
     }
@@ -368,9 +384,14 @@ impl KeybindingsSection {
         parts
     }
 
-    fn render_conflict_warning(chord: &KeyChord, others: &[String]) -> impl IntoElement {
+    fn render_conflict_warning(
+        chord: &KeyChord,
+        others: &[String],
+        conflict_body: &str,
+        conflict_unknown_other: &str,
+    ) -> impl IntoElement {
         let other_list = if others.is_empty() {
-            "another binding".to_string()
+            conflict_unknown_other.to_string()
         } else {
             others.join(", ")
         };
@@ -378,9 +399,9 @@ impl KeybindingsSection {
         div().ml(px(28.0)).py_1().child(
             BannerBlock::new(
                 BannerVariant::Warning,
-                format!("Conflict: {} also bound to {}", chord, other_list),
+                crate::labels::keybindings_conflict_title(&chord.to_string(), &other_list),
             )
-            .with_body("Two or more commands share this chord in this context."),
+            .with_body(conflict_body.to_string()),
         )
     }
 
@@ -592,5 +613,77 @@ impl KeybindingsSection {
             }
         }
         flat_idx
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::labels::{
+        keybindings_binding_count, keybindings_conflict_title, keybindings_inherits_from,
+    };
+
+    const KEYBINDINGS_CATALOG_KEYS: &[&str] = &[
+        "settings.keybindings.title",
+        "settings.keybindings.subtitle",
+        "settings.keybindings.filter_placeholder",
+        "settings.keybindings.binding_count.one",
+        "settings.keybindings.binding_count.many",
+        "settings.keybindings.inherits_from",
+        "settings.keybindings.inherited",
+        "settings.keybindings.conflict.title",
+        "settings.keybindings.conflict.body",
+        "settings.keybindings.conflict.unknown_other",
+    ];
+
+    #[test]
+    fn settings_keybindings_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in KEYBINDINGS_CATALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn settings_keybindings_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("settings.keybindings.title", locale = "en");
+        let spanish = dbflux_i18n::t!("settings.keybindings.title", locale = "es");
+
+        assert_eq!(english, "Keyboard Shortcuts");
+        assert_eq!(spanish, "Atajos de teclado");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn keybindings_binding_count_uses_singular_and_plural_forms() {
+        assert!(keybindings_binding_count(1).contains('1'));
+        assert!(keybindings_binding_count(3).contains('3'));
+        assert_ne!(keybindings_binding_count(1), keybindings_binding_count(3));
+    }
+
+    #[test]
+    fn keybindings_inherits_from_embeds_parent_context_name() {
+        let label = keybindings_inherits_from("Global");
+
+        assert!(label.contains("Global"));
+    }
+
+    #[test]
+    fn keybindings_conflict_title_embeds_chord_and_other_commands() {
+        let title = keybindings_conflict_title("ctrl-k", "Run Query");
+
+        assert!(title.contains("ctrl-k"));
+        assert!(title.contains("Run Query"));
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/keybindings_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/keybindings_section.rs
@@ -57,8 +57,10 @@ pub(super) struct KeybindingsSection {
 
 impl KeybindingsSection {
     pub(super) fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let keybindings_filter =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Filter keybindings..."));
+        let keybindings_filter = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("settings.keybindings.filter_placeholder"))
+        });
 
         let mut keybindings_expanded = HashSet::new();
         keybindings_expanded.insert(ContextId::Global);

--- a/crates/dbflux_ui_windows/src/settings/sidebar_nav.rs
+++ b/crates/dbflux_ui_windows/src/settings/sidebar_nav.rs
@@ -11,48 +11,96 @@ impl SettingsCoordinator {
         let nodes = vec![
             TreeNavNode::group(
                 "general-group",
-                "General",
+                dbflux_i18n::t!("settings.nav.general_group"),
                 Some(AppIcon::Settings),
                 vec![
-                    TreeNavNode::leaf("general", "General", Some(AppIcon::Settings)),
-                    TreeNavNode::leaf("keybindings", "Keybindings", Some(AppIcon::Keyboard)),
-                    TreeNavNode::leaf("audit", "Audit", Some(AppIcon::History)),
-                    TreeNavNode::leaf("about", "About", Some(AppIcon::Info)),
+                    TreeNavNode::leaf(
+                        "general",
+                        dbflux_i18n::t!("settings.nav.general"),
+                        Some(AppIcon::Settings),
+                    ),
+                    TreeNavNode::leaf(
+                        "keybindings",
+                        dbflux_i18n::t!("settings.nav.keybindings"),
+                        Some(AppIcon::Keyboard),
+                    ),
+                    TreeNavNode::leaf(
+                        "audit",
+                        dbflux_i18n::t!("settings.nav.audit"),
+                        Some(AppIcon::History),
+                    ),
+                    TreeNavNode::leaf(
+                        "about",
+                        dbflux_i18n::t!("settings.nav.about"),
+                        Some(AppIcon::Info),
+                    ),
                 ],
             ),
             TreeNavNode::group(
                 "network",
-                "Network",
+                dbflux_i18n::t!("settings.nav.network"),
                 Some(AppIcon::Server),
                 vec![
                     TreeNavNode::leaf(
                         "ssh-tunnels",
-                        "SSH Tunnels",
+                        dbflux_i18n::t!("settings.nav.ssh_tunnels"),
                         Some(AppIcon::FingerprintPattern),
                     ),
-                    TreeNavNode::leaf("proxies", "Proxy", Some(AppIcon::Server)),
-                    TreeNavNode::leaf("auth-profiles", "Access Providers", Some(AppIcon::KeyRound)),
+                    TreeNavNode::leaf(
+                        "proxies",
+                        dbflux_i18n::t!("settings.nav.proxies"),
+                        Some(AppIcon::Server),
+                    ),
+                    TreeNavNode::leaf(
+                        "auth-profiles",
+                        dbflux_i18n::t!("settings.nav.auth_profiles"),
+                        Some(AppIcon::KeyRound),
+                    ),
                 ],
             ),
             TreeNavNode::group(
                 "connection",
-                "Connection",
+                dbflux_i18n::t!("settings.nav.connection"),
                 Some(AppIcon::Link2),
                 vec![
-                    TreeNavNode::leaf("hooks", "Hooks", Some(AppIcon::SquareTerminal)),
-                    TreeNavNode::leaf("drivers", "Drivers", Some(AppIcon::Database)),
-                    TreeNavNode::leaf("services", "RPC Services", Some(AppIcon::Plug)),
+                    TreeNavNode::leaf(
+                        "hooks",
+                        dbflux_i18n::t!("settings.nav.hooks"),
+                        Some(AppIcon::SquareTerminal),
+                    ),
+                    TreeNavNode::leaf(
+                        "drivers",
+                        dbflux_i18n::t!("settings.nav.drivers"),
+                        Some(AppIcon::Database),
+                    ),
+                    TreeNavNode::leaf(
+                        "services",
+                        dbflux_i18n::t!("settings.nav.services"),
+                        Some(AppIcon::Plug),
+                    ),
                 ],
             ),
             #[cfg(feature = "mcp")]
             TreeNavNode::group(
                 "mcp-governance",
-                "MCP Governance",
+                dbflux_i18n::t!("settings.nav.mcp_governance"),
                 Some(AppIcon::Bot),
                 vec![
-                    TreeNavNode::leaf("mcp-clients", "Clients", Some(AppIcon::Plug)),
-                    TreeNavNode::leaf("mcp-roles", "Roles", Some(AppIcon::KeyRound)),
-                    TreeNavNode::leaf("mcp-policies", "Policies", Some(AppIcon::ScrollText)),
+                    TreeNavNode::leaf(
+                        "mcp-clients",
+                        dbflux_i18n::t!("settings.nav.mcp_clients"),
+                        Some(AppIcon::Plug),
+                    ),
+                    TreeNavNode::leaf(
+                        "mcp-roles",
+                        dbflux_i18n::t!("settings.nav.mcp_roles"),
+                        Some(AppIcon::KeyRound),
+                    ),
+                    TreeNavNode::leaf(
+                        "mcp-policies",
+                        dbflux_i18n::t!("settings.nav.mcp_policies"),
+                        Some(AppIcon::ScrollText),
+                    ),
                 ],
             ),
         ];
@@ -197,6 +245,59 @@ mod tests {
             .find(|row| row.id.as_ref() == "services")
             .expect("services row");
 
-        assert_eq!(services_row.label.as_ref(), "RPC Services");
+        assert_eq!(
+            services_row.label.as_ref(),
+            dbflux_i18n::t!("settings.nav.services")
+        );
+    }
+
+    const NAV_CATALOG_KEYS: &[&str] = &[
+        "settings.nav.general_group",
+        "settings.nav.general",
+        "settings.nav.keybindings",
+        "settings.nav.audit",
+        "settings.nav.about",
+        "settings.nav.network",
+        "settings.nav.ssh_tunnels",
+        "settings.nav.proxies",
+        "settings.nav.auth_profiles",
+        "settings.nav.connection",
+        "settings.nav.hooks",
+        "settings.nav.drivers",
+        "settings.nav.services",
+        "settings.nav.mcp_governance",
+        "settings.nav.mcp_clients",
+        "settings.nav.mcp_roles",
+        "settings.nav.mcp_policies",
+    ];
+
+    #[test]
+    fn settings_nav_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in NAV_CATALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn settings_nav_keybindings_differs_between_locales() {
+        let english = dbflux_i18n::t!("settings.nav.keybindings", locale = "en");
+        let spanish = dbflux_i18n::t!("settings.nav.keybindings", locale = "es");
+
+        assert_eq!(english, "Keybindings");
+        assert_eq!(spanish, "Atajos de teclado");
+        assert_ne!(english, spanish);
     }
 }


### PR DESCRIPTION
## Summary

Third `dbflux_ui`/`dbflux_ui_windows` i18n slice: the settings tree labels, the About section copy and the Keybindings section chrome (filter placeholder, binding counts, inheritance hints, conflict banner) render through `dbflux_i18n::t!`. 38 keys under `settings.{nav,about,keybindings}.*`, English and Spanish together, plus a crate-local `labels.rs` for the interpolated strings.

## What does this resolve?

- Refs #360 (follows #375; next: shared hooks vocabulary, hooks settings, hooks form)

## How was this solved?

- Tree ids, key chords, the product name, license identifiers and URLs stay data. Command and context display names in the keybindings table come from `dbflux_core::keymap_types` (~50 variants) and are left for a dedicated follow-up so `dbflux_core` stays i18n-free.
- The About links sentence is split into link/plain fragments because GPUI renders the links as separate elements; the Spanish keeps the sentence readable in that order.
- Size: 446 lines, mostly catalog YAML for 38 keys in two locales (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 188 passed; clippy clean; fmt clean. Workspace-wide gates run in CI.
- Receipt-driven review (four lenses): approved; remaining findings advisory. Manual smoke in Spanish: open Settings, walk the tree, open About and Keybindings.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
