### PR TITLE
feat(i18n): add the shared hooks vocabulary and translate the hooks section chrome

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -27,6 +27,40 @@ errors:
   correlation:
     detail: "Correlation: %{id}"
     clipboard: "%{summary}\nCorrelation: %{id}"
+hooks:
+  kind:
+    command: Command
+    script: Script
+  source:
+    file: File
+  script:
+    placeholder: "Enter script content..."
+  execution:
+    blocking: Blocking
+    detached: Detached
+  failure:
+    disconnect: Disconnect
+    warn: Warn
+    ignore: Ignore
+  delete:
+    title: Delete Hook
+    message: 'Are you sure you want to delete hook "%{name}"?'
+  delete_unreadable:
+    title: Delete Unreadable Hook Row
+    message: 'Permanently delete the unreadable hook row "%{name}"? Its stored data cannot be recovered, but its name becomes reusable afterwards.'
+  action:
+    delete: Delete
+    update: Update
+    create: Create
+  phase:
+    pre_connect_hook: Pre-connect hook
+    extra_pre_connect: Extra pre-connect
+    post_connect_hook: Post-connect hook
+    extra_post_connect: Extra post-connect
+    pre_disconnect_hook: Pre-disconnect hook
+    extra_pre_disconnect: Extra pre-disconnect
+    post_disconnect_hook: Post-disconnect hook
+    extra_post_disconnect: Extra post-disconnect
 modals:
   active_query:
     title: Active query running

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -27,6 +27,40 @@ errors:
   correlation:
     detail: "Correlación: %{id}"
     clipboard: "%{summary}\nCorrelación: %{id}"
+hooks:
+  kind:
+    command: Comando
+    script: Script
+  source:
+    file: Archivo
+  script:
+    placeholder: "Escribe el contenido del script..."
+  execution:
+    blocking: Bloqueante
+    detached: Independiente
+  failure:
+    disconnect: Desconectar
+    warn: Advertir
+    ignore: Ignorar
+  delete:
+    title: Eliminar hook
+    message: '¿Seguro que quieres eliminar el hook "%{name}"?'
+  delete_unreadable:
+    title: Eliminar fila de hook no legible
+    message: '¿Eliminar permanentemente la fila de hook no legible "%{name}"? Sus datos almacenados no se pueden recuperar, pero su nombre podrá reutilizarse después.'
+  action:
+    delete: Eliminar
+    update: Actualizar
+    create: Crear
+  phase:
+    pre_connect_hook: Hook previo a la conexión
+    extra_pre_connect: Extra previo a la conexión
+    post_connect_hook: Hook posterior a la conexión
+    extra_post_connect: Extra posterior a la conexión
+    pre_disconnect_hook: Hook previo a la desconexión
+    extra_pre_disconnect: Extra previo a la desconexión
+    post_disconnect_hook: Hook posterior a la desconexión
+    extra_post_disconnect: Extra posterior a la desconexión
 modals:
   active_query:
     title: Consulta en ejecución

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -36,3 +36,38 @@ pub(crate) fn about_copyright(author: &str) -> String {
 pub(crate) fn about_license(license: &str) -> String {
     dbflux_i18n::t!("settings.about.license", license = license)
 }
+
+/// Formats the confirmation prompt for deleting a named hook.
+pub(crate) fn hooks_delete_message(name: &str) -> String {
+    dbflux_i18n::t!("hooks.delete.message", name = name)
+}
+
+/// Formats the confirmation prompt for deleting an unreadable hook row.
+pub(crate) fn hooks_delete_unreadable_message(name: &str) -> String {
+    dbflux_i18n::t!("hooks.delete_unreadable.message", name = name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hooks_delete_message, hooks_delete_unreadable_message};
+
+    #[test]
+    fn hooks_delete_message_embeds_hook_name() {
+        let message = hooks_delete_message("nightly-backup");
+
+        assert_eq!(
+            message,
+            "Are you sure you want to delete hook \"nightly-backup\"?"
+        );
+    }
+
+    #[test]
+    fn hooks_delete_unreadable_message_embeds_row_name() {
+        let message = hooks_delete_unreadable_message("legacy-row");
+
+        assert_eq!(
+            message,
+            "Permanently delete the unreadable hook row \"legacy-row\"? Its stored data cannot be recovered, but its name becomes reusable afterwards."
+        );
+    }
+}

--- a/crates/dbflux_ui_windows/src/settings/hooks_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/hooks_section.rs
@@ -3,6 +3,7 @@ use super::SettingsSection;
 use super::SettingsSectionId;
 use super::form_section::FormSection;
 use super::section_trait::SectionFocusEvent;
+use crate::labels::{hooks_delete_message, hooks_delete_unreadable_message};
 use dbflux_app::config_loader::EditableGlobalHook;
 use dbflux_app::keymap::Modifiers;
 use dbflux_components::controls::{Dropdown, DropdownItem, DropdownSelectionChanged};
@@ -287,15 +288,15 @@ impl HooksSection {
         let hook_kind_dropdown = cx.new(|_cx| {
             #[cfg(feature = "lua")]
             let items = vec![
-                DropdownItem::with_value("Command", "command"),
-                DropdownItem::with_value("Script", "script"),
+                DropdownItem::with_value(dbflux_i18n::t!("hooks.kind.command"), "command"),
+                DropdownItem::with_value(dbflux_i18n::t!("hooks.kind.script"), "script"),
                 DropdownItem::with_value("Lua", "lua"),
             ];
 
             #[cfg(not(feature = "lua"))]
             let items = vec![
-                DropdownItem::with_value("Command", "command"),
-                DropdownItem::with_value("Script", "script"),
+                DropdownItem::with_value(dbflux_i18n::t!("hooks.kind.command"), "command"),
+                DropdownItem::with_value(dbflux_i18n::t!("hooks.kind.script"), "script"),
             ];
 
             Dropdown::new("hook-kind")
@@ -318,7 +319,10 @@ impl HooksSection {
         });
         let script_source_dropdown = cx.new(|_cx| {
             Dropdown::new("hook-script-source")
-                .items(vec![DropdownItem::with_value("File", "file")])
+                .items(vec![DropdownItem::with_value(
+                    dbflux_i18n::t!("hooks.source.file"),
+                    "file",
+                )])
                 .selected_index(Some(0))
         });
         let input_hook_script_file_path =
@@ -328,14 +332,20 @@ impl HooksSection {
                 .code_editor("python")
                 .line_number(true)
                 .soft_wrap(true)
-                .placeholder("Enter script content...")
+                .placeholder(dbflux_i18n::t!("hooks.script.placeholder"))
         });
         let input_hook_interpreter = cx.new(|cx| InputState::new(window, cx).placeholder("auto"));
         let hook_execution_mode_dropdown = cx.new(|_cx| {
             Dropdown::new("hook-execution-mode")
                 .items(vec![
-                    DropdownItem::with_value("Blocking", "blocking"),
-                    DropdownItem::with_value("Detached", "detached"),
+                    DropdownItem::with_value(
+                        dbflux_i18n::t!("hooks.execution.blocking"),
+                        "blocking",
+                    ),
+                    DropdownItem::with_value(
+                        dbflux_i18n::t!("hooks.execution.detached"),
+                        "detached",
+                    ),
                 ])
                 .selected_index(Some(0))
         });
@@ -351,9 +361,12 @@ impl HooksSection {
         let hook_failure_dropdown = cx.new(|_cx| {
             Dropdown::new("hook-failure-mode")
                 .items(vec![
-                    DropdownItem::with_value("Disconnect", "disconnect"),
-                    DropdownItem::with_value("Warn", "warn"),
-                    DropdownItem::with_value("Ignore", "ignore"),
+                    DropdownItem::with_value(
+                        dbflux_i18n::t!("hooks.failure.disconnect"),
+                        "disconnect",
+                    ),
+                    DropdownItem::with_value(dbflux_i18n::t!("hooks.failure.warn"), "warn"),
+                    DropdownItem::with_value(dbflux_i18n::t!("hooks.failure.ignore"), "ignore"),
                 ])
                 .selected_index(Some(0))
         });
@@ -795,7 +808,7 @@ impl Render for HooksSection {
 
                 element.child(
                     Dialog::new(window, cx)
-                        .title("Delete Hook")
+                        .title(dbflux_i18n::t!("hooks.delete.title"))
                         .confirm()
                         .on_ok(move |_, window, cx| {
                             entity.update(cx, |section, cx| {
@@ -809,10 +822,11 @@ impl Render for HooksSection {
                             });
                             true
                         })
-                        .child(div().text_sm().child(format!(
-                            "Are you sure you want to delete hook \"{}\"?",
-                            hook_delete_name
-                        ))),
+                        .child(
+                            div()
+                                .text_sm()
+                                .child(hooks_delete_message(&hook_delete_name)),
+                        ),
                 )
             })
             .when(show_protected_delete, |element| {
@@ -821,7 +835,7 @@ impl Render for HooksSection {
 
                 element.child(
                     Dialog::new(window, cx)
-                        .title("Delete Unreadable Hook Row")
+                        .title(dbflux_i18n::t!("hooks.delete_unreadable.title"))
                         .confirm()
                         .on_ok(move |_, _, cx| {
                             entity.update(cx, |section, cx| {
@@ -835,11 +849,11 @@ impl Render for HooksSection {
                             });
                             true
                         })
-                        .child(div().text_sm().child(format!(
-                            "Permanently delete the unreadable hook row \"{}\"? Its stored data \
-                             cannot be recovered, but its name becomes reusable afterwards.",
-                            protected_delete_label
-                        ))),
+                        .child(
+                            div()
+                                .text_sm()
+                                .child(hooks_delete_unreadable_message(&protected_delete_label)),
+                        ),
                 )
             })
     }
@@ -949,5 +963,71 @@ mod tests {
         assert!(rows.contains(&vec![HookFormField::LuaLogging]));
         assert!(!rows.contains(&vec![HookFormField::ExecutionMode]));
         assert!(!rows.contains(&vec![HookFormField::ReadySignal]));
+    }
+
+    const HOOKS_CATALOG_KEYS: &[&str] = &[
+        "hooks.kind.command",
+        "hooks.kind.script",
+        "hooks.source.file",
+        "hooks.script.placeholder",
+        "hooks.execution.blocking",
+        "hooks.execution.detached",
+        "hooks.failure.disconnect",
+        "hooks.failure.warn",
+        "hooks.failure.ignore",
+        "hooks.delete.title",
+        "hooks.delete.message",
+        "hooks.delete_unreadable.title",
+        "hooks.delete_unreadable.message",
+        "hooks.action.delete",
+        "hooks.action.update",
+        "hooks.action.create",
+        "hooks.phase.pre_connect_hook",
+        "hooks.phase.extra_pre_connect",
+        "hooks.phase.post_connect_hook",
+        "hooks.phase.extra_post_connect",
+        "hooks.phase.pre_disconnect_hook",
+        "hooks.phase.extra_pre_disconnect",
+        "hooks.phase.post_disconnect_hook",
+        "hooks.phase.extra_post_disconnect",
+    ];
+
+    #[test]
+    fn hooks_vocabulary_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in HOOKS_CATALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hooks_failure_warn_differs_between_locales() {
+        let english = dbflux_i18n::t!("hooks.failure.warn", locale = "en");
+        let spanish = dbflux_i18n::t!("hooks.failure.warn", locale = "es");
+
+        assert_eq!(english, "Warn");
+        assert_eq!(spanish, "Advertir");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn hooks_kind_script_is_script_in_both_locales() {
+        let english = dbflux_i18n::t!("hooks.kind.script", locale = "en");
+        let spanish = dbflux_i18n::t!("hooks.kind.script", locale = "es");
+
+        assert_eq!(english, "Script");
+        assert_eq!(spanish, "Script");
     }
 }


### PR DESCRIPTION
## Summary

Fourth `dbflux_ui_windows` i18n slice: a shared `hooks.*` catalog namespace (kinds, sources, execution and failure modes, delete dialogs, actions, phases) and the hooks section chrome that uses it (dropdowns, script placeholder, delete confirmations) render through `dbflux_i18n::t!`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows #377; next: hooks settings list/toasts/validation, then the hook form and the connection hooks tab, all reusing `hooks.*`)

## How was this solved?

- The `hooks.action.*` and `hooks.phase.*` keys land now so the three consumers share one key set; this PR wires only `hooks_section.rs`. Lua, env tokens, paths and example placeholders stay literal.
- `hooks_delete_message(name)` and `hooks_delete_unreadable_message(name)` helpers carry the interpolated names.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → green after rebase on `main`; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: open Settings → Hooks, open the kind/execution/failure dropdowns, delete a hook.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
