### PR TITLE
feat(i18n): translate the sidebar tree folder and status labels, part one

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -524,8 +524,15 @@ sidebar:
       wide_column: Tables (%{count})
       log_stream: Log Groups (%{count})
       object_storage: Buckets (%{count})
+    folder:
+      databases: Databases
     status:
       loading: Loading…
+      profile_connecting: "Connecting to %{name}…"
+      database_loading: "%{name} (loading…)"
+      error_retry: "Error: %{error} — click to retry"
+    empty:
+      buckets: No buckets
 sql_preview:
   title:
     sql: SQL Preview

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -524,8 +524,15 @@ sidebar:
       wide_column: Tablas (%{count})
       log_stream: Log Groups (%{count})
       object_storage: Buckets (%{count})
+    folder:
+      databases: Bases de datos
     status:
       loading: Cargando…
+      profile_connecting: "Conectando a %{name}…"
+      database_loading: "%{name} (cargando…)"
+      error_retry: "Error: %{error} — clic para reintentar"
+    empty:
+      buckets: Sin buckets
 sql_preview:
   title:
     sql: Vista previa de SQL

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -3,9 +3,6 @@
 use dbflux_core::DatabaseCategory;
 
 /// Translated label for a schema-tree container folder, e.g. `"Tables (12)"`.
-///
-/// Not yet wired into `tree_builder.rs` — that lands in a follow-up slice.
-#[allow(dead_code)]
 pub(crate) fn container_folder_label(category: DatabaseCategory, count: usize) -> String {
     match category {
         DatabaseCategory::Relational => {
@@ -99,6 +96,24 @@ pub(crate) fn delete_items_label(count: usize) -> String {
     } else {
         dbflux_i18n::t!("sidebar.menu.delete")
     }
+}
+
+/// Translated label for a connecting profile row, e.g. `"Connecting to
+/// prod-db…"`.
+pub(crate) fn profile_connecting_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.tree.status.profile_connecting", name = name)
+}
+
+/// Translated label for a database node still loading its schema, e.g.
+/// `"orders (loading…)"`.
+pub(crate) fn node_loading_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.tree.status.database_loading", name = name)
+}
+
+/// Translated label for a retryable fetch error sentinel row, e.g.
+/// `"Error: access denied — click to retry"`.
+pub(crate) fn error_retry_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.tree.status.error_retry", error = error)
 }
 
 #[cfg(test)]
@@ -355,5 +370,38 @@ mod tests {
         );
         assert!(plural.contains('3'));
         assert_ne!(singular, plural);
+    }
+
+    #[test]
+    fn profile_connecting_label_includes_the_profile_name() {
+        let label = super::profile_connecting_label("prod-db");
+
+        assert!(label.contains("prod-db"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.tree.status.profile_connecting", name = "prod-db")
+        );
+    }
+
+    #[test]
+    fn node_loading_label_includes_the_database_name() {
+        let label = super::node_loading_label("orders");
+
+        assert!(label.contains("orders"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.tree.status.database_loading", name = "orders")
+        );
+    }
+
+    #[test]
+    fn error_retry_label_includes_the_error_message() {
+        let label = super::error_retry_label("access denied");
+
+        assert!(label.contains("access denied"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.tree.status.error_retry", error = "access denied")
+        );
     }
 }

--- a/crates/dbflux_ui_sidebar/src/tree_builder.rs
+++ b/crates/dbflux_ui_sidebar/src/tree_builder.rs
@@ -97,7 +97,7 @@ impl Sidebar {
         if self.loading_items.contains(&item_id) && children.is_empty() {
             children.push(TreeItem::new(
                 format!("{}_loading", item_id),
-                "Loading...".to_string(),
+                dbflux_i18n::t!("sidebar.tree.status.loading"),
             ));
         }
 
@@ -251,7 +251,7 @@ impl Sidebar {
         let is_connecting = state.is_operation_pending(profile_id, None);
 
         let profile_label = if is_connecting {
-            format!("{} (connecting...)", profile.name)
+            crate::labels::profile_connecting_label(&profile.name)
         } else {
             profile.name.clone()
         };
@@ -501,7 +501,7 @@ impl Sidebar {
     fn build_databases_folder_item(profile_id: Uuid, children: Vec<TreeItem>) -> TreeItem {
         TreeItem::new(
             SchemaNodeId::DatabasesFolder { profile_id }.to_string(),
-            "Databases".to_string(),
+            dbflux_i18n::t!("sidebar.tree.folder.databases"),
         )
         .expanded(true)
         .children(children)
@@ -1012,7 +1012,7 @@ impl Sidebar {
         suffix: &str,
     ) -> TreeItem {
         let id = format!("{}|{}|{}", suffix, profile_id, database_name);
-        TreeItem::new(id, "Loading...".to_string())
+        TreeItem::new(id, dbflux_i18n::t!("sidebar.tree.status.loading"))
     }
 
     /// Build an error retry placeholder child for metric sidebar nodes.
@@ -1020,7 +1020,7 @@ impl Sidebar {
     /// The sentinel ID encodes the retry key so `execute_item` can route it
     /// back to the appropriate fetch helper.
     pub(crate) fn error_retry_placeholder(retry_sentinel_id: &str, error_msg: &str) -> TreeItem {
-        let label = format!("Error: {} — click to retry", error_msg);
+        let label = crate::labels::error_retry_label(error_msg);
         TreeItem::new(retry_sentinel_id.to_string(), label)
     }
 
@@ -1062,7 +1062,10 @@ impl Sidebar {
                     database: database_name.to_string(),
                 }
                 .to_string(),
-                format!("Measurements ({})", measurements.len()),
+                crate::labels::container_folder_label(
+                    dbflux_core::DatabaseCategory::TimeSeries,
+                    measurements.len(),
+                ),
             )
             .expanded(true)
             .children(measurement_items),
@@ -1495,14 +1498,14 @@ fn build_kv_database_children(
                     database: database_name.clone(),
                 }
                 .to_string(),
-                "Loading...".to_string(),
+                dbflux_i18n::t!("sidebar.tree.status.loading"),
             )]
         } else {
             Vec::new()
         };
 
         let db_label = if is_pending {
-            format!("{} (loading...)", database_name)
+            crate::labels::node_loading_label(&database_name)
         } else {
             database_name.clone()
         };
@@ -1652,7 +1655,7 @@ fn resolve_db_children(
                     database: db_name.to_owned(),
                 }
                 .to_string(),
-                "Loading...".to_string(),
+                dbflux_i18n::t!("sidebar.tree.status.loading"),
             )]
         } else {
             Vec::new()
@@ -1742,7 +1745,7 @@ fn resolve_db_children(
                 database: db_name.to_owned(),
             }
             .to_string(),
-            "Loading...".to_string(),
+            dbflux_i18n::t!("sidebar.tree.status.loading"),
         )]
     } else {
         Vec::new()
@@ -1766,7 +1769,7 @@ fn build_named_db_item(
     db_children: Vec<TreeItem>,
 ) -> TreeItem {
     let db_label = if is_pending {
-        format!("{} (loading...)", db_name)
+        crate::labels::node_loading_label(db_name)
     } else {
         db_name.to_owned()
     };
@@ -1854,7 +1857,7 @@ fn build_bucket_children(
     if buckets.is_empty() {
         return vec![TreeItem::new(
             format!("buckets-empty|{profile_id}"),
-            "No buckets".to_string(),
+            dbflux_i18n::t!("sidebar.tree.empty.buckets"),
         )];
     }
 
@@ -1906,7 +1909,7 @@ fn build_collections_folder(
                 database: database_name.to_string(),
             }
             .to_string(),
-            format!("{} ({})", category.container_name(), db_schema.tables.len()),
+            crate::labels::container_folder_label(category, db_schema.tables.len()),
         )
         .expanded(category.default_expand_container())
         .children(collection_children),
@@ -3074,7 +3077,10 @@ mod tests {
         let children = build_bucket_children(profile_id, &cache);
 
         assert_eq!(children.len(), 1);
-        assert_eq!(children[0].label.as_ref(), "No buckets");
+        assert_eq!(
+            children[0].label.as_ref(),
+            dbflux_i18n::t!("sidebar.tree.empty.buckets")
+        );
     }
 
     #[test]
@@ -3217,7 +3223,10 @@ mod tests {
         // Should produce exactly one "Measurements (N)" folder
         assert_eq!(result.len(), 1);
         let folder = &result[0];
-        assert_eq!(folder.label.as_ref(), "Measurements (2)");
+        assert_eq!(
+            folder.label.as_ref(),
+            crate::labels::container_folder_label(dbflux_core::DatabaseCategory::TimeSeries, 2)
+        );
         assert!(folder.is_expanded());
 
         // Each measurement becomes a Collection leaf
@@ -3518,7 +3527,10 @@ mod tests {
             Sidebar::build_remote_dashboard_children(profile_id, &state, &folder_id, &errors);
 
         assert_eq!(children.len(), 1);
-        assert_eq!(children[0].label.as_ref(), "Loading...");
+        assert_eq!(
+            children[0].label.as_ref(),
+            dbflux_i18n::t!("sidebar.tree.status.loading")
+        );
     }
 
     #[test]
@@ -4337,6 +4349,52 @@ mod tests {
         assert!(
             empty_children.is_empty(),
             "empty storage_hints must produce no folder"
+        );
+    }
+
+    /// Every translation key wired into this slice's tree-builder functions
+    /// must resolve to a real value in both shipped locales, never fall back
+    /// to the raw key or the `{locale}.{key}` miss sentinel.
+    #[test]
+    fn tree_c1a_keys_resolve_in_both_locales() {
+        const KEYS: [&str; 5] = [
+            "sidebar.tree.folder.databases",
+            "sidebar.tree.status.profile_connecting",
+            "sidebar.tree.status.database_loading",
+            "sidebar.tree.status.error_retry",
+            "sidebar.tree.empty.buckets",
+        ];
+
+        for key in KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    /// `build_collections_folder`'s container title, now routed through
+    /// `container_folder_label`, must render different text per locale
+    /// instead of the English-only literal it used to hardcode.
+    #[test]
+    fn tree_folder_tables_differs_between_locales() {
+        let english_template = dbflux_i18n::t!("sidebar.tree.container.relational", locale = "en");
+        let spanish_template = dbflux_i18n::t!("sidebar.tree.container.relational", locale = "es");
+
+        assert_ne!(english_template, spanish_template);
+
+        let resolved =
+            crate::labels::container_folder_label(dbflux_core::DatabaseCategory::Relational, 5);
+
+        assert_eq!(
+            resolved,
+            dbflux_i18n::t!("sidebar.tree.container.relational", count = 5)
         );
     }
 }


### PR DESCRIPTION
## Summary

Sidebar i18n slice C1a: database folders, loading and error placeholders, time-series, key-value, named-database and bucket children, and collection folders in the tree builder render through `dbflux_i18n::t!` and the sidebar label helpers (`container_folder_label` is now wired). English and Spanish together; AWS terms stay English.

## What does this resolve?

- Refs #360 (follows #378; next: the remaining tree folders, then dashboards/charts/metrics folders, then connection and operation toasts)

## How was this solved?

- Helpers `profile_connecting_label`, `node_loading_label`, `error_retry_label` carry interpolated names/errors; tests that asserted English folder names now read the catalog.

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 156 passed; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: connect a relational and a document profile and expand the tree.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
