### PR TITLE
feat(i18n): translate the data grid toolbar and edit toolbar

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -13,6 +13,17 @@ document:
         dirty:
           one: "%{count} unsaved change"
           many: "%{count} unsaved changes"
+        save: Save
+        revert: Revert
+      toolbar:
+        refresh: Refresh
+        builder: Builder
+        switch_to_document: Switch to Document View
+        switch_to_table: Switch to Table View
+  shared:
+    refresh:
+      off: Off
+      custom: Custom
   tabs:
     menu:
       close: Close

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -13,6 +13,17 @@ document:
         dirty:
           one: "%{count} cambio sin guardar"
           many: "%{count} cambios sin guardar"
+        save: Guardar
+        revert: Descartar
+      toolbar:
+        refresh: Actualizar
+        builder: Constructor
+        switch_to_document: Cambiar a vista de documento
+        switch_to_table: Cambiar a vista de tabla
+  shared:
+    refresh:
+      off: Apagado
+      custom: Personalizado
   tabs:
     menu:
       close: Cerrar

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -989,9 +989,9 @@ impl DataGridPanel {
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let refresh_label = if self.refresh.refresh_policy.is_auto() {
-            self.refresh.refresh_policy.label()
+            crate::labels::refresh_policy_label(self.refresh.refresh_policy)
         } else {
-            "Refresh"
+            dbflux_i18n::t!("document.data.grid.toolbar.refresh")
         };
 
         let toolbar_has_filter_error =
@@ -1147,8 +1147,12 @@ impl DataGridPanel {
                     DataViewMode::Document => AppIcon::Braces,
                 };
                 let _tooltip = match mode {
-                    DataViewMode::Table => "Switch to Document View",
-                    DataViewMode::Document => "Switch to Table View",
+                    DataViewMode::Table => {
+                        dbflux_i18n::t!("document.data.grid.toolbar.switch_to_document")
+                    }
+                    DataViewMode::Document => {
+                        dbflux_i18n::t!("document.data.grid.toolbar.switch_to_table")
+                    }
                 };
 
                 d.child(
@@ -1191,7 +1195,9 @@ impl DataGridPanel {
                                 .small()
                                 .color(theme.muted_foreground),
                         )
-                        .child(Text::muted("Builder")),
+                        .child(Text::muted(dbflux_i18n::t!(
+                            "document.data.grid.toolbar.builder"
+                        ))),
                 )
             })
             .child(
@@ -1272,20 +1278,13 @@ impl DataGridPanel {
             .border_color(theme.border)
             // Left: status text
             .child(
-                Text::caption(if has_changes {
-                    format!(
-                        "{} unsaved change{}",
-                        dirty_count,
-                        if dirty_count == 1 { "" } else { "s" }
-                    )
-                } else {
-                    "No unsaved changes".to_string()
-                })
-                .color(if has_changes {
-                    theme.warning
-                } else {
-                    theme.muted_foreground
-                }),
+                Text::caption(crate::labels::unsaved_changes_label(dirty_count)).color(
+                    if has_changes {
+                        theme.warning
+                    } else {
+                        theme.muted_foreground
+                    },
+                ),
             )
             // Right: buttons
             .child(
@@ -1408,11 +1407,14 @@ impl DataGridPanel {
                                     }))
                             })
                             .when(!has_changes, |d| d.border_color(theme.border))
-                            .child(Text::caption("Save").color(if has_changes {
-                                theme.primary_foreground
-                            } else {
-                                theme.muted_foreground
-                            }))
+                            .child(
+                                Text::caption(dbflux_i18n::t!("document.data.grid.edit_bar.save"))
+                                    .color(if has_changes {
+                                        theme.primary_foreground
+                                    } else {
+                                        theme.muted_foreground
+                                    }),
+                            )
                             .child(Text::caption(SAVE_ROW_SHORTCUT_HINT).color(if has_changes {
                                 theme.primary_foreground.opacity(0.7)
                             } else {
@@ -1443,11 +1445,16 @@ impl DataGridPanel {
                                         window.focus(&this.focus_handle);
                                     }))
                             })
-                            .child(Text::caption("Revert").color(if has_changes {
-                                theme.foreground
-                            } else {
-                                theme.muted_foreground
-                            })),
+                            .child(
+                                Text::caption(dbflux_i18n::t!(
+                                    "document.data.grid.edit_bar.revert"
+                                ))
+                                .color(if has_changes {
+                                    theme.foreground
+                                } else {
+                                    theme.muted_foreground
+                                }),
+                            ),
                     ),
             )
     }
@@ -3814,5 +3821,49 @@ mod tests {
         let mode = super::content_mode_for_result(false, DataViewMode::Document, true, false);
 
         assert_eq!(mode, DataGridContentMode::EmptyFallback);
+    }
+
+    const DATA_GRID_TOOLBAR_KEYS: &[&str] = &[
+        "document.data.grid.toolbar.refresh",
+        "document.data.grid.toolbar.builder",
+        "document.data.grid.toolbar.switch_to_document",
+        "document.data.grid.toolbar.switch_to_table",
+        "document.data.grid.edit_bar.save",
+        "document.data.grid.edit_bar.revert",
+        "document.shared.refresh.off",
+        "document.shared.refresh.custom",
+    ];
+
+    #[test]
+    fn data_grid_toolbar_keys_resolve_in_both_locales() {
+        for key in DATA_GRID_TOOLBAR_KEYS {
+            let english = dbflux_i18n::t!(*key, locale = "en");
+            let spanish = dbflux_i18n::t!(*key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(english, *key, "English translation missing for {key}");
+            assert_ne!(spanish, *key, "Spanish translation missing for {key}");
+            assert_ne!(
+                english,
+                format!("en.{key}"),
+                "English translation missing for {key}"
+            );
+            assert_ne!(
+                spanish,
+                format!("es.{key}"),
+                "Spanish translation missing for {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn data_grid_toolbar_refresh_differs_between_locales() {
+        let english = dbflux_i18n::t!("document.data.grid.toolbar.refresh", locale = "en");
+        let spanish = dbflux_i18n::t!("document.data.grid.toolbar.refresh", locale = "es");
+
+        assert_eq!(english, "Refresh");
+        assert_eq!(spanish, "Actualizar");
+        assert_ne!(english, spanish);
     }
 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -10,8 +10,6 @@
 /// Uses the singular catalog bucket only for exactly one pending edit;
 /// every other count, including zero, uses the plural bucket. Zero maps to
 /// the dedicated "clean" bucket instead of the plural one.
-// Wired into the data grid edit bar in a later PR of this change.
-#[allow(dead_code)]
 pub(crate) fn unsaved_changes_label(count: usize) -> String {
     match count {
         0 => dbflux_i18n::t!("document.data.grid.edit_bar.clean"),
@@ -20,9 +18,30 @@ pub(crate) fn unsaved_changes_label(count: usize) -> String {
     }
 }
 
+/// Label for a [`dbflux_core::RefreshPolicy`], mirroring
+/// `RefreshPolicy::label()` in English while routing every arm through the
+/// translation catalog.
+///
+/// A named interval renders its seconds directly (`"{every_secs}s"`), which
+/// is a unit suffix, not translated prose, so it stays outside the catalog.
+/// Manual and any interval outside the named set fall back to their
+/// respective `document.shared.refresh.*` catalog entries.
+pub(crate) fn refresh_policy_label(policy: dbflux_core::RefreshPolicy) -> String {
+    use dbflux_core::RefreshPolicy;
+
+    match policy {
+        RefreshPolicy::Manual => dbflux_i18n::t!("document.shared.refresh.off"),
+        RefreshPolicy::Interval { every_secs } if RefreshPolicy::ALL.contains(&policy) => {
+            format!("{every_secs}s")
+        }
+        RefreshPolicy::Interval { .. } => dbflux_i18n::t!("document.shared.refresh.custom"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::unsaved_changes_label;
+    use super::{refresh_policy_label, unsaved_changes_label};
+    use dbflux_core::RefreshPolicy;
 
     #[test]
     fn unsaved_changes_label_zero_one_many() {
@@ -34,6 +53,18 @@ mod tests {
         assert!(one.contains('1'));
         assert!(many.contains('2'));
         assert_ne!(one, many);
+    }
+
+    #[test]
+    fn refresh_policy_label_covers_all_variants() {
+        for policy in RefreshPolicy::ALL {
+            assert_eq!(refresh_policy_label(*policy), policy.label());
+        }
+
+        assert_eq!(refresh_policy_label(RefreshPolicy::Manual), "Off");
+
+        let custom = RefreshPolicy::Interval { every_secs: 7 };
+        assert_eq!(refresh_policy_label(custom), "Custom");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Document i18n slice 2a: the data grid toolbar (refresh label, builder toggle, view-switch tooltips) and the edit toolbar (unsaved-changes counter, Save, Revert) render through `dbflux_i18n::t!`. 8 keys under `document.data.grid.*` and `document.shared.refresh.*`, English and Spanish together.

## What does this resolve?

- Refs #360 (follows the document foundation PR; next: status bar, export menu, banners and views)

## How was this solved?

- `refresh_policy_label(policy)` mirrors `RefreshPolicy::label()` in the UI crate so `dbflux_core` stays i18n-free; named intervals keep the unit-neutral `Ns` form. `LIMIT` stays literal.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 876 passed; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: open a table, toggle the builder, edit a row and read the edit bar.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted below)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
