### PR TITLE
feat(i18n): translate shared control defaults and time range errors in dbflux_components

### DIFF
--- a/crates/dbflux_components/src/common/time_range/state.rs
+++ b/crates/dbflux_components/src/common/time_range/state.rs
@@ -73,7 +73,7 @@ pub fn timestamp_from_date_time(
     mode: TimestampDisplayMode,
 ) -> Result<i64, String> {
     let time = NaiveTime::from_hms_opt(hour, minute, 0)
-        .ok_or_else(|| "Time selection is invalid".to_string())?;
+        .ok_or_else(|| dbflux_i18n::t!("common.time_range.error.invalid_selection"))?;
     let naive = NaiveDateTime::new(date, time);
 
     let timestamp = match mode {
@@ -81,7 +81,7 @@ pub fn timestamp_from_date_time(
         TimestampDisplayMode::Local => Local
             .from_local_datetime(&naive)
             .single()
-            .ok_or_else(|| "Local time is ambiguous or invalid".to_string())?
+            .ok_or_else(|| dbflux_i18n::t!("common.time_range.error.ambiguous_local"))?
             .timestamp_millis(),
     };
 
@@ -102,12 +102,12 @@ pub fn validate_custom_range_parts(
     mode: TimestampDisplayMode,
 ) -> Result<(i64, i64), String> {
     let start_ms = timestamp_from_date_time(start_date, start_hour, start_minute, mode)
-        .map_err(|error| format!("Invalid start time: {error}"))?;
+        .map_err(|error| dbflux_i18n::t!("common.time_range.error.invalid_start", error = error))?;
     let end_ms = timestamp_from_date_time(end_date, end_hour, end_minute, mode)
-        .map_err(|error| format!("Invalid end time: {error}"))?;
+        .map_err(|error| dbflux_i18n::t!("common.time_range.error.invalid_end", error = error))?;
 
     if start_ms > end_ms {
-        return Err("Start time must be before end time".to_string());
+        return Err(dbflux_i18n::t!("common.time_range.error.start_after_end"));
     }
 
     Ok((start_ms, end_ms))
@@ -162,7 +162,34 @@ mod tests {
 
         assert_eq!(
             result,
-            Err("Start time must be before end time".to_string())
+            Err(dbflux_i18n::t!("common.time_range.error.start_after_end"))
         );
+    }
+
+    #[test]
+    fn time_range_error_keys_resolve_in_both_locales() {
+        let keys = [
+            "common.time_range.error.invalid_selection",
+            "common.time_range.error.ambiguous_local",
+            "common.time_range.error.invalid_start",
+            "common.time_range.error.invalid_end",
+            "common.time_range.error.start_after_end",
+            "common.time_range.error.no_date_range",
+            "common.time_range.error.incomplete_time_selection",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn time_range_start_after_end_diverges_between_locales() {
+        let en = dbflux_i18n::t!("common.time_range.error.start_after_end", locale = "en");
+        let es = dbflux_i18n::t!("common.time_range.error.start_after_end", locale = "es");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_components/src/common/time_range/view.rs
+++ b/crates/dbflux_components/src/common/time_range/view.rs
@@ -357,11 +357,11 @@ impl TimeRangePanel {
     pub fn apply_custom_range(&mut self, cx: &mut Context<Self>) -> Result<(i64, i64), String> {
         let (start_date, end_date) = self
             .custom_date_range(cx)
-            .ok_or_else(|| "No date range selected".to_string())?;
+            .ok_or_else(|| dbflux_i18n::t!("common.time_range.error.no_date_range"))?;
 
         let (start_hour, start_minute, end_hour, end_minute) = self
             .custom_time_parts(cx)
-            .ok_or_else(|| "Incomplete time selection".to_string())?;
+            .ok_or_else(|| dbflux_i18n::t!("common.time_range.error.incomplete_time_selection"))?;
 
         let (start_ms, end_ms) = validate_custom_range_parts(
             start_date,

--- a/crates/dbflux_components/src/components/multi_select.rs
+++ b/crates/dbflux_components/src/components/multi_select.rs
@@ -37,7 +37,7 @@ impl MultiSelect {
             items: Vec::new(),
             selected_indices: Vec::new(),
             open: false,
-            placeholder: "Select…".into(),
+            placeholder: dbflux_i18n::t!("controls.multi_select.placeholder").into(),
             menu_scroll_handle: ScrollHandle::new(),
             bare: false,
         }
@@ -156,7 +156,12 @@ impl MultiSelect {
         if labels.len() <= 3 {
             labels.join(", ").into()
         } else {
-            format!("{}, +{} more", labels[..2].join(", "), labels.len() - 2).into()
+            format!(
+                "{}, {}",
+                labels[..2].join(", "),
+                more_label(labels.len() - 2)
+            )
+            .into()
         }
     }
 
@@ -215,7 +220,9 @@ impl MultiSelect {
                             this.clear_selection(cx);
                         }),
                     )
-                    .child(Text::caption("Clear all")),
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "controls.multi_select.clear_all"
+                    ))),
             )
         });
 
@@ -308,3 +315,54 @@ impl Render for MultiSelect {
 }
 
 impl EventEmitter<MultiSelectChanged> for MultiSelect {}
+
+/// Label for the "+N more" trigger suffix shown when more than three items
+/// are selected.
+///
+/// Uses the singular catalog bucket only for exactly one extra item; every
+/// other count uses the plural bucket.
+fn more_label(extra: usize) -> String {
+    if extra == 1 {
+        dbflux_i18n::t!("controls.multi_select.more.one", count = extra)
+    } else {
+        dbflux_i18n::t!("controls.multi_select.more.many", count = extra)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::more_label;
+
+    #[test]
+    fn multi_select_keys_resolve_in_both_locales() {
+        let keys = [
+            "controls.multi_select.placeholder",
+            "controls.multi_select.clear_all",
+            "controls.multi_select.more.one",
+            "controls.multi_select.more.many",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(!en.is_empty() && en != key, "en missing for {key}");
+            assert!(!es.is_empty() && es != key, "es missing for {key}");
+        }
+    }
+
+    #[test]
+    fn more_label_uses_plural_buckets() {
+        let one = more_label(1);
+        assert_eq!(
+            one,
+            dbflux_i18n::t!("controls.multi_select.more.one", count = 1)
+        );
+
+        let many = more_label(3);
+        assert!(many.contains('3'));
+        assert_eq!(
+            many,
+            dbflux_i18n::t!("controls.multi_select.more.many", count = 3)
+        );
+    }
+}

--- a/crates/dbflux_components/src/composites/refresh_split_button.rs
+++ b/crates/dbflux_components/src/composites/refresh_split_button.rs
@@ -39,10 +39,10 @@ pub fn refresh_split_button(
     on_refresh: impl Fn(&mut Window, &mut App) + 'static,
     theme: &Theme,
 ) -> impl IntoElement {
-    let refresh_label = if refresh_policy.is_auto() {
-        refresh_policy.label()
+    let refresh_label: SharedString = if refresh_policy.is_auto() {
+        refresh_policy.label().into()
     } else {
-        "Refresh"
+        dbflux_i18n::t!("composites.refresh_split_button.label").into()
     };
 
     let refresh_icon = if refresh_policy.is_auto() {
@@ -96,4 +96,17 @@ pub fn refresh_split_button(
                 .when(ring_policy, |d| d.border_1().border_color(ring_color))
                 .child(refresh_dropdown),
         )
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn refresh_split_button_label_key_resolves() {
+        let en = dbflux_i18n::t!("composites.refresh_split_button.label", locale = "en");
+        let es = dbflux_i18n::t!("composites.refresh_split_button.label", locale = "es");
+
+        assert!(!en.is_empty() && en != "composites.refresh_split_button.label");
+        assert!(!es.is_empty() && es != "composites.refresh_split_button.label");
+        assert_ne!(en, es);
+    }
 }

--- a/crates/dbflux_components/src/controls/dropdown.rs
+++ b/crates/dbflux_components/src/controls/dropdown.rs
@@ -171,7 +171,7 @@ impl Dropdown {
             selected_index: None,
             highlighted_index: None,
             disabled: false,
-            placeholder: "Select".into(),
+            placeholder: dbflux_i18n::t!("controls.dropdown.placeholder").into(),
             focus_ring_color: None,
             focus_ring_visible: false,
             compact_trigger: false,
@@ -189,6 +189,11 @@ impl Dropdown {
     pub fn placeholder(mut self, placeholder: impl Into<SharedString>) -> Self {
         self.placeholder = placeholder.into();
         self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn placeholder_text(&self) -> &SharedString {
+        &self.placeholder
     }
 
     pub fn selected_index(mut self, index: Option<usize>) -> Self {
@@ -813,5 +818,15 @@ mod tests {
 
         assert_eq!(chrome.edge, ChromeEdgeRole::Popover);
         assert_eq!(chrome.radius, Radii::MD);
+    }
+
+    #[test]
+    fn dropdown_placeholder_key_resolves() {
+        let en = dbflux_i18n::t!("controls.dropdown.placeholder", locale = "en");
+        let es = dbflux_i18n::t!("controls.dropdown.placeholder", locale = "es");
+
+        assert!(!en.is_empty() && en != "controls.dropdown.placeholder");
+        assert!(!es.is_empty() && es != "controls.dropdown.placeholder");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_components/src/controls/select.rs
+++ b/crates/dbflux_components/src/controls/select.rs
@@ -14,7 +14,7 @@ pub struct Select {
 impl Select {
     pub fn new(id: impl Into<ElementId>) -> Self {
         Self {
-            dropdown: Dropdown::new(id).placeholder("Select"),
+            dropdown: Dropdown::new(id),
         }
     }
 
@@ -56,5 +56,20 @@ impl Select {
 
     pub fn selected_value(&self) -> Option<SharedString> {
         self.dropdown.selected_value()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Select;
+
+    #[test]
+    fn select_uses_shared_dropdown_placeholder() {
+        let select = Select::new("select-test");
+
+        assert_eq!(
+            select.dropdown.placeholder_text().to_string(),
+            dbflux_i18n::t!("controls.dropdown.placeholder")
+        );
     }
 }

--- a/crates/dbflux_components/src/primitives/file_picker.rs
+++ b/crates/dbflux_components/src/primitives/file_picker.rs
@@ -37,7 +37,7 @@ impl FilePicker {
         Self {
             id: id.into(),
             current_value: current_value.into(),
-            placeholder: SharedString::from("Browse\u{2026}"),
+            placeholder: dbflux_i18n::t!("components.file_picker.browse").into(),
             folder_icon: folder_icon.into(),
             clear_icon: clear_icon.into(),
             on_browse: None,
@@ -161,7 +161,7 @@ impl RenderOnce for FilePicker {
 /// basename is shown so the row stays compact.
 pub fn file_picker_label(value: &str) -> String {
     if value.trim().is_empty() {
-        return "Browse\u{2026}".to_string();
+        return dbflux_i18n::t!("components.file_picker.browse");
     }
 
     std::path::Path::new(value)
@@ -176,12 +176,18 @@ mod tests {
 
     #[test]
     fn empty_value_returns_browse_placeholder() {
-        assert_eq!(file_picker_label(""), "Browse\u{2026}");
+        assert_eq!(
+            file_picker_label(""),
+            dbflux_i18n::t!("components.file_picker.browse")
+        );
     }
 
     #[test]
     fn whitespace_only_value_returns_browse_placeholder() {
-        assert_eq!(file_picker_label("   "), "Browse\u{2026}");
+        assert_eq!(
+            file_picker_label("   "),
+            dbflux_i18n::t!("components.file_picker.browse")
+        );
     }
 
     #[test]
@@ -197,5 +203,15 @@ mod tests {
     #[test]
     fn bare_filename_returns_itself() {
         assert_eq!(file_picker_label("server.crt"), "server.crt");
+    }
+
+    #[test]
+    fn file_picker_browse_key_resolves() {
+        let en = dbflux_i18n::t!("components.file_picker.browse", locale = "en");
+        let es = dbflux_i18n::t!("components.file_picker.browse", locale = "es");
+
+        assert!(!en.is_empty() && en != "components.file_picker.browse");
+        assert!(!es.is_empty() && es != "components.file_picker.browse");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -14,6 +14,16 @@ chart:
     annotate: Annotate
     copy_as_query: Copy as query
     coming_soon: Coming soon
+common:
+  time_range:
+    error:
+      invalid_selection: Time selection is invalid
+      ambiguous_local: Local time is ambiguous or invalid
+      invalid_start: "Invalid start time: %{error}"
+      invalid_end: "Invalid end time: %{error}"
+      start_after_end: Start time must be before end time
+      no_date_range: No date range selected
+      incomplete_time_selection: Incomplete time selection
 components:
   json_editor:
     empty_error: Document cannot be empty
@@ -28,6 +38,20 @@ components:
     parameter: Parameter Store
     auth: Auth Session Field
     json_key_placeholder: JSON key (optional)
+  file_picker:
+    browse: "Browse…"
+composites:
+  refresh_split_button:
+    label: Refresh
+controls:
+  dropdown:
+    placeholder: Select
+  multi_select:
+    placeholder: "Select…"
+    clear_all: Clear all
+    more:
+      one: "+%{count} more"
+      many: "+%{count} more"
 document:
   data:
     grid:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -14,6 +14,16 @@ chart:
     annotate: Anotar
     copy_as_query: Copiar como consulta
     coming_soon: Próximamente
+common:
+  time_range:
+    error:
+      invalid_selection: La selección de hora no es válida
+      ambiguous_local: La hora local es ambigua o no válida
+      invalid_start: "Hora de inicio no válida: %{error}"
+      invalid_end: "Hora de fin no válida: %{error}"
+      start_after_end: La hora de inicio debe ser anterior a la hora de fin
+      no_date_range: No se seleccionó un rango de fechas
+      incomplete_time_selection: Selección de hora incompleta
 components:
   json_editor:
     empty_error: El documento no puede estar vacío
@@ -28,6 +38,20 @@ components:
     parameter: Parameter Store
     auth: Campo de sesión de autenticación
     json_key_placeholder: Clave JSON (opcional)
+  file_picker:
+    browse: "Explorar…"
+composites:
+  refresh_split_button:
+    label: Actualizar
+controls:
+  dropdown:
+    placeholder: Seleccionar
+  multi_select:
+    placeholder: "Seleccionar…"
+    clear_all: Borrar todo
+    more:
+      one: "+%{count} más"
+      many: "+%{count} más"
 document:
   data:
     grid:


### PR DESCRIPTION
## Summary

Fifth and last `dbflux_components` i18n slice: shared control defaults (dropdown and select placeholders, multi-select "more" counter and clear-all, refresh split button, file picker browse) and the time-range picker errors render through `dbflux_i18n::t!`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows #374; closes the `dbflux_components` series)

## How was this solved?

- Same mechanism; `more_label(count)` picks the plural bucket. Remaining literals in `time_range/view.rs` ("Select date range", HH/MM tokens) are listed as a follow-up.

## Validation

- `cargo nextest run -p dbflux_components -p dbflux_i18n` → green after rebase on `main`; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: open a dropdown, a multi-select and the time-range picker.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
