### PR TITLE
feat(i18n): translate the sidebar tree folder and status labels, part two

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -592,11 +592,32 @@ sidebar:
       object_storage: Buckets (%{count})
     folder:
       databases: Databases
+      fields: "Fields (%{count})"
+      indexes: "Indexes (%{count})"
+      indexes_plain: Indexes
+      foreign_keys: "Foreign Keys (%{count})"
+      foreign_keys_plain: Foreign Keys
+      routines: "Routines (%{count})"
+      routines_plain: Routines
+      columns: "Columns (%{count})"
+      constraints: "Constraints (%{count})"
+      data_types: "Data Types (%{count})"
+      data_types_plain: Data Types
+      views: "Views (%{count})"
+      storage: "Storage (%{count})"
     status:
       loading: Loading…
       profile_connecting: "Connecting to %{name}…"
       database_loading: "%{name} (loading…)"
       error_retry: "Error: %{error} — click to retry"
+      used_by_objects:
+        one: Used by 1 object
+        many: "Used by %{count} objects"
+      dependent_kind:
+        view: View
+        materialized_view: Materialized View
+        foreign_key_child: FK Child
+        trigger: Trigger
     empty:
       buckets: No buckets
 sql_preview:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -592,11 +592,32 @@ sidebar:
       object_storage: Buckets (%{count})
     folder:
       databases: Bases de datos
+      fields: "Campos (%{count})"
+      indexes: "Índices (%{count})"
+      indexes_plain: Índices
+      foreign_keys: "Claves foráneas (%{count})"
+      foreign_keys_plain: Claves foráneas
+      routines: "Rutinas (%{count})"
+      routines_plain: Rutinas
+      columns: "Columnas (%{count})"
+      constraints: "Restricciones (%{count})"
+      data_types: "Tipos de datos (%{count})"
+      data_types_plain: Tipos de datos
+      views: "Vistas (%{count})"
+      storage: "Almacenamiento (%{count})"
     status:
       loading: Cargando…
       profile_connecting: "Conectando a %{name}…"
       database_loading: "%{name} (cargando…)"
       error_retry: "Error: %{error} — clic para reintentar"
+      used_by_objects:
+        one: Usado por 1 objeto
+        many: "Usado por %{count} objetos"
+      dependent_kind:
+        view: Vista
+        materialized_view: Vista materializada
+        foreign_key_child: FK hija
+        trigger: Trigger
     empty:
       buckets: Sin buckets
 sql_preview:

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -1,6 +1,6 @@
 //! Translated label helpers for sidebar chrome (tabs, footer, tree folders).
 
-use dbflux_core::DatabaseCategory;
+use dbflux_core::{DatabaseCategory, RelationKind};
 
 /// Translated label for a schema-tree container folder, e.g. `"Tables (12)"`.
 pub(crate) fn container_folder_label(category: DatabaseCategory, count: usize) -> String {
@@ -114,6 +114,106 @@ pub(crate) fn node_loading_label(name: &str) -> String {
 /// `"Error: access denied — click to retry"`.
 pub(crate) fn error_retry_label(error: &str) -> String {
     dbflux_i18n::t!("sidebar.tree.status.error_retry", error = error)
+}
+
+/// Translated label for the table-dependents folder, e.g. `"Used by 1
+/// object"` or `"Used by 3 objects"`.
+pub(crate) fn used_by_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("sidebar.tree.status.used_by_objects.one")
+    } else {
+        dbflux_i18n::t!("sidebar.tree.status.used_by_objects.many", count = count)
+    }
+}
+
+/// Translated kind suffix for a table-dependents child row, e.g. `"orders_v
+/// (View)"`. `Trigger` intentionally stays untranslated in every locale.
+pub(crate) fn dependent_kind_label(kind: &RelationKind) -> String {
+    match kind {
+        RelationKind::View => dbflux_i18n::t!("sidebar.tree.status.dependent_kind.view"),
+        RelationKind::MaterializedView => {
+            dbflux_i18n::t!("sidebar.tree.status.dependent_kind.materialized_view")
+        }
+        RelationKind::ForeignKeyChild => {
+            dbflux_i18n::t!("sidebar.tree.status.dependent_kind.foreign_key_child")
+        }
+        RelationKind::Trigger => dbflux_i18n::t!("sidebar.tree.status.dependent_kind.trigger"),
+    }
+}
+
+/// Translated label for a collection's Fields folder, e.g. `"Fields (5)"`.
+pub(crate) fn fields_folder_label(count: usize) -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.fields", count = count)
+}
+
+/// Translated label for an Indexes folder (collection, table, or schema
+/// level), e.g. `"Indexes (2)"`.
+pub(crate) fn indexes_folder_label(count: usize) -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.indexes", count = count)
+}
+
+/// Translated label for an Indexes folder while its contents are still
+/// loading, before a count is known.
+pub(crate) fn indexes_folder_label_plain() -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.indexes_plain")
+}
+
+/// Translated label for a Foreign Keys folder (table or schema level), e.g.
+/// `"Foreign Keys (1)"`.
+pub(crate) fn foreign_keys_folder_label(count: usize) -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.foreign_keys", count = count)
+}
+
+/// Translated label for a Foreign Keys folder while its contents are still
+/// loading, before a count is known.
+pub(crate) fn foreign_keys_folder_label_plain() -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.foreign_keys_plain")
+}
+
+/// Translated label for a schema-level Routines folder, e.g. `"Routines
+/// (4)"`.
+pub(crate) fn routines_folder_label(count: usize) -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.routines", count = count)
+}
+
+/// Translated label for a Routines folder while its contents are still
+/// loading, before a count is known.
+pub(crate) fn routines_folder_label_plain() -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.routines_plain")
+}
+
+/// Translated label for a table's Columns folder, e.g. `"Columns (6)"`.
+pub(crate) fn columns_folder_label(count: usize) -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.columns", count = count)
+}
+
+/// Translated label for a table's Constraints folder, e.g. `"Constraints
+/// (2)"`.
+pub(crate) fn constraints_folder_label(count: usize) -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.constraints", count = count)
+}
+
+/// Translated label for a schema-level Data Types folder, e.g. `"Data Types
+/// (3)"`.
+pub(crate) fn data_types_folder_label(count: usize) -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.data_types", count = count)
+}
+
+/// Translated label for a Data Types folder while its contents are still
+/// loading, before a count is known.
+pub(crate) fn data_types_folder_label_plain() -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.data_types_plain")
+}
+
+/// Translated label for a schema-level Views folder, e.g. `"Views (2)"`.
+pub(crate) fn views_folder_label(count: usize) -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.views", count = count)
+}
+
+/// Translated label for a table's Storage folder (driver-supplied storage
+/// hints such as distribution and sort keys), e.g. `"Storage (3)"`.
+pub(crate) fn storage_folder_label(count: usize) -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.storage", count = count)
 }
 
 #[cfg(test)]
@@ -402,6 +502,55 @@ mod tests {
         assert_eq!(
             label,
             dbflux_i18n::t!("sidebar.tree.status.error_retry", error = "access denied")
+        );
+    }
+
+    #[test]
+    fn used_by_label_one_vs_many() {
+        let singular = super::used_by_label(1);
+        let plural = super::used_by_label(3);
+
+        assert_eq!(
+            singular,
+            dbflux_i18n::t!("sidebar.tree.status.used_by_objects.one")
+        );
+        assert_eq!(
+            plural,
+            dbflux_i18n::t!("sidebar.tree.status.used_by_objects.many", count = 3)
+        );
+        assert!(plural.contains('3'));
+        assert_ne!(singular, plural);
+    }
+
+    #[test]
+    fn used_by_label_diverges_between_locales() {
+        let english_template =
+            dbflux_i18n::t!("sidebar.tree.status.used_by_objects.many", locale = "en");
+        let spanish_template =
+            dbflux_i18n::t!("sidebar.tree.status.used_by_objects.many", locale = "es");
+
+        assert_ne!(english_template, spanish_template);
+    }
+
+    #[test]
+    fn dependent_kind_label_covers_every_relation_kind() {
+        use dbflux_core::RelationKind;
+
+        assert_eq!(
+            super::dependent_kind_label(&RelationKind::View),
+            dbflux_i18n::t!("sidebar.tree.status.dependent_kind.view")
+        );
+        assert_eq!(
+            super::dependent_kind_label(&RelationKind::MaterializedView),
+            dbflux_i18n::t!("sidebar.tree.status.dependent_kind.materialized_view")
+        );
+        assert_eq!(
+            super::dependent_kind_label(&RelationKind::ForeignKeyChild),
+            dbflux_i18n::t!("sidebar.tree.status.dependent_kind.foreign_key_child")
+        );
+        assert_eq!(
+            super::dependent_kind_label(&RelationKind::Trigger),
+            dbflux_i18n::t!("sidebar.tree.status.dependent_kind.trigger")
         );
     }
 }

--- a/crates/dbflux_ui_sidebar/src/tree_builder.rs
+++ b/crates/dbflux_ui_sidebar/src/tree_builder.rs
@@ -1179,7 +1179,7 @@ impl Sidebar {
                         collection: coll_name.to_string(),
                     }
                     .to_string(),
-                    format!("Fields ({})", field_count),
+                    crate::labels::fields_folder_label(field_count),
                 )
                 .expanded(false)
                 .children(field_children),
@@ -1190,7 +1190,7 @@ impl Sidebar {
                         collection: coll_name.to_string(),
                     }
                     .to_string(),
-                    format!("Indexes ({})", index_count),
+                    crate::labels::indexes_folder_label(index_count),
                 )
                 .expanded(false)
                 .children(index_children),
@@ -2010,7 +2010,7 @@ fn build_db_collection_indexes_folder(
                 database: database_name.to_string(),
             }
             .to_string(),
-            format!("Indexes ({})", all_index_items.len()),
+            crate::labels::indexes_folder_label(all_index_items.len()),
         )
         .expanded(false)
         .children(all_index_items),
@@ -2186,7 +2186,7 @@ fn build_table_storage_children(
                 table: table_name.to_string(),
             }
             .to_string(),
-            format!("Storage ({})", hint_items.len()),
+            crate::labels::storage_folder_label(hint_items.len()),
         )
         .expanded(false)
         .children(hint_items),
@@ -2206,12 +2206,7 @@ fn build_table_dependents_folder(
     let dep_items: Vec<TreeItem> = deps
         .iter()
         .map(|dep| {
-            let kind_label = match dep.kind {
-                dbflux_core::RelationKind::View => "View",
-                dbflux_core::RelationKind::MaterializedView => "Materialized View",
-                dbflux_core::RelationKind::ForeignKeyChild => "FK Child",
-                dbflux_core::RelationKind::Trigger => "Trigger",
-            };
+            let kind_label = crate::labels::dependent_kind_label(&dep.kind);
             let label = format!("{} ({})", dep.qualified_name, kind_label);
 
             TreeItem::new(
@@ -2235,7 +2230,7 @@ fn build_table_dependents_folder(
                 table: table_name.to_string(),
             }
             .to_string(),
-            format!("Used by {} objects", deps.len()),
+            crate::labels::used_by_label(deps.len()),
         )
         .expanded(false)
         .children(dep_items),
@@ -2297,32 +2292,35 @@ fn build_table_sections(
         vec![
             TreeItem::new(
                 columns_folder_id,
-                format!("Columns ({})", children.columns.len()),
+                crate::labels::columns_folder_label(children.columns.len()),
             )
             .expanded(false)
             .children(children.columns),
             TreeItem::new(
                 indexes_folder_id,
-                format!("Indexes ({})", children.indexes.len()),
+                crate::labels::indexes_folder_label(children.indexes.len()),
             )
             .expanded(false)
             .children(children.indexes),
             TreeItem::new(
                 fks_folder_id,
-                format!("Foreign Keys ({})", children.foreign_keys.len()),
+                crate::labels::foreign_keys_folder_label(children.foreign_keys.len()),
             )
             .expanded(false)
             .children(children.foreign_keys),
             TreeItem::new(
                 constraints_folder_id,
-                format!("Constraints ({})", children.constraints.len()),
+                crate::labels::constraints_folder_label(children.constraints.len()),
             )
             .expanded(false)
             .children(children.constraints),
         ]
     } else {
         let table_loading_id = format!("T|{}|{}|{}_loading", profile_id, schema_name, table_name);
-        vec![TreeItem::new(table_loading_id, "Loading…".to_string())]
+        vec![TreeItem::new(
+            table_loading_id,
+            dbflux_i18n::t!("sidebar.tree.status.loading"),
+        )]
     };
 
     sections.extend(children.storage);
@@ -2368,7 +2366,10 @@ fn build_schema_tables_folder(
                 schema: schema_name.to_string(),
             }
             .to_string(),
-            format!("Tables ({})", tables.len()),
+            crate::labels::container_folder_label(
+                dbflux_core::DatabaseCategory::Relational,
+                tables.len(),
+            ),
         )
         .expanded(true)
         .children(table_children),
@@ -2409,7 +2410,7 @@ fn build_schema_views_folder(
                 schema: schema_name.to_string(),
             }
             .to_string(),
-            format!("Views ({})", views.len()),
+            crate::labels::views_folder_label(views.len()),
         )
         .expanded(true)
         .children(view_children),
@@ -2447,11 +2448,14 @@ fn build_schema_types_folder(
                 })
                 .collect();
 
-            TreeItem::new(types_item_id, format!("Data Types ({})", types.len()))
-                .expanded(false)
-                .children(type_children)
+            TreeItem::new(
+                types_item_id,
+                crate::labels::data_types_folder_label(types.len()),
+            )
+            .expanded(false)
+            .children(type_children)
         } else {
-            TreeItem::new(types_item_id, "Data Types (0)".to_string())
+            TreeItem::new(types_item_id, crate::labels::data_types_folder_label(0))
                 .expanded(false)
                 .children(vec![])
         }
@@ -2463,12 +2467,15 @@ fn build_schema_types_folder(
                 schema: schema_name.to_string(),
             }
             .to_string(),
-            "Loading...".to_string(),
+            dbflux_i18n::t!("sidebar.tree.status.loading"),
         );
 
-        TreeItem::new(types_item_id, "Data Types".to_string())
-            .expanded(false)
-            .children(vec![placeholder])
+        TreeItem::new(
+            types_item_id,
+            crate::labels::data_types_folder_label_plain(),
+        )
+        .expanded(false)
+        .children(vec![placeholder])
     }
 }
 
@@ -2515,11 +2522,11 @@ fn build_schema_indexes_folder(
                 })
                 .collect();
 
-            TreeItem::new(item_id, format!("Indexes ({})", indexes.len()))
+            TreeItem::new(item_id, crate::labels::indexes_folder_label(indexes.len()))
                 .expanded(false)
                 .children(index_children)
         } else {
-            TreeItem::new(item_id, "Indexes (0)".to_string())
+            TreeItem::new(item_id, crate::labels::indexes_folder_label(0))
                 .expanded(false)
                 .children(vec![])
         }
@@ -2531,10 +2538,10 @@ fn build_schema_indexes_folder(
                 schema: schema_name.to_string(),
             }
             .to_string(),
-            "Loading...".to_string(),
+            dbflux_i18n::t!("sidebar.tree.status.loading"),
         );
 
-        TreeItem::new(item_id, "Indexes".to_string())
+        TreeItem::new(item_id, crate::labels::indexes_folder_label_plain())
             .expanded(false)
             .children(vec![placeholder])
     }
@@ -2584,11 +2591,11 @@ fn build_schema_fks_folder(
                 })
                 .collect();
 
-            TreeItem::new(item_id, format!("Foreign Keys ({})", fks.len()))
+            TreeItem::new(item_id, crate::labels::foreign_keys_folder_label(fks.len()))
                 .expanded(false)
                 .children(fk_children)
         } else {
-            TreeItem::new(item_id, "Foreign Keys (0)".to_string())
+            TreeItem::new(item_id, crate::labels::foreign_keys_folder_label(0))
                 .expanded(false)
                 .children(vec![])
         }
@@ -2600,10 +2607,10 @@ fn build_schema_fks_folder(
                 schema: schema_name.to_string(),
             }
             .to_string(),
-            "Loading...".to_string(),
+            dbflux_i18n::t!("sidebar.tree.status.loading"),
         );
 
-        TreeItem::new(item_id, "Foreign Keys".to_string())
+        TreeItem::new(item_id, crate::labels::foreign_keys_folder_label_plain())
             .expanded(false)
             .children(vec![placeholder])
     }
@@ -2652,13 +2659,16 @@ fn build_schema_routines_folder(
                 .collect();
 
             Some(
-                TreeItem::new(item_id, format!("Routines ({})", routines.len()))
-                    .expanded(false)
-                    .children(routine_children),
+                TreeItem::new(
+                    item_id,
+                    crate::labels::routines_folder_label(routines.len()),
+                )
+                .expanded(false)
+                .children(routine_children),
             )
         } else {
             Some(
-                TreeItem::new(item_id, "Routines (0)".to_string())
+                TreeItem::new(item_id, crate::labels::routines_folder_label(0))
                     .expanded(false)
                     .children(vec![]),
             )
@@ -2671,11 +2681,11 @@ fn build_schema_routines_folder(
                 schema: schema_name.to_string(),
             }
             .to_string(),
-            "Loading...".to_string(),
+            dbflux_i18n::t!("sidebar.tree.status.loading"),
         );
 
         Some(
-            TreeItem::new(item_id, "Routines".to_string())
+            TreeItem::new(item_id, crate::labels::routines_folder_label_plain())
                 .expanded(false)
                 .children(vec![placeholder]),
         )
@@ -3106,8 +3116,14 @@ mod tests {
 
         assert_eq!(item.label.as_ref(), "/aws/lambda/app");
         assert_eq!(item.children.len(), 2);
-        assert!(item.children[0].label.as_ref().starts_with("Fields"));
-        assert!(item.children[1].label.as_ref().starts_with("Indexes"));
+        assert_eq!(
+            item.children[0].label.as_ref(),
+            crate::labels::fields_folder_label(0)
+        );
+        assert_eq!(
+            item.children[1].label.as_ref(),
+            crate::labels::indexes_folder_label(0)
+        );
     }
 
     #[test]
@@ -3347,7 +3363,13 @@ mod tests {
 
         let tables_folder = content
             .iter()
-            .find(|item| item.label.as_ref().starts_with("Tables"))
+            .find(|item| {
+                item.label.as_ref()
+                    == crate::labels::container_folder_label(
+                        dbflux_core::DatabaseCategory::Relational,
+                        3,
+                    )
+            })
             .expect("Tables folder present");
         assert_eq!(tables_folder.children.len(), 3);
 
@@ -3363,7 +3385,7 @@ mod tests {
 
         let views_folder = content
             .iter()
-            .find(|item| item.label.as_ref().starts_with("Views"))
+            .find(|item| item.label.as_ref() == crate::labels::views_folder_label(1))
             .expect("Views folder present");
         assert_eq!(views_folder.children.len(), 1);
         let view_id: SchemaNodeId = views_folder.children[0]
@@ -3381,7 +3403,7 @@ mod tests {
 
         let types_folder = content
             .iter()
-            .find(|item| item.label.as_ref().starts_with("Data Types"))
+            .find(|item| item.label.as_ref() == crate::labels::data_types_folder_label(2))
             .expect("Data Types folder present");
         assert_eq!(types_folder.children.len(), 2);
 
@@ -4294,7 +4316,10 @@ mod tests {
             ),
             "folder must carry StorageHintsFolder node ID: {folder_id:?}"
         );
-        assert_eq!(folder.label.as_ref(), "Storage (3)");
+        assert_eq!(
+            folder.label.as_ref(),
+            crate::labels::storage_folder_label(3)
+        );
 
         assert_eq!(folder.children.len(), 3, "one child per hint");
 
@@ -4395,6 +4420,79 @@ mod tests {
         assert_eq!(
             resolved,
             dbflux_i18n::t!("sidebar.tree.container.relational", count = 5)
+        );
+    }
+
+    /// Every translation key wired into this slice's remaining tree-builder
+    /// folder and status functions must resolve to a real value in both
+    /// shipped locales, never fall back to the raw key or the
+    /// `{locale}.{key}` miss sentinel.
+    #[test]
+    fn tree_c1b_keys_resolve_in_both_locales() {
+        const KEYS: [&str; 13] = [
+            "sidebar.tree.folder.fields",
+            "sidebar.tree.folder.indexes",
+            "sidebar.tree.folder.indexes_plain",
+            "sidebar.tree.folder.foreign_keys",
+            "sidebar.tree.folder.foreign_keys_plain",
+            "sidebar.tree.folder.routines",
+            "sidebar.tree.folder.routines_plain",
+            "sidebar.tree.folder.columns",
+            "sidebar.tree.folder.constraints",
+            "sidebar.tree.folder.data_types",
+            "sidebar.tree.folder.data_types_plain",
+            "sidebar.tree.folder.views",
+            "sidebar.tree.folder.storage",
+        ];
+
+        for key in KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+
+        const STATUS_KEYS: [&str; 4] = [
+            "sidebar.tree.status.used_by_objects.one",
+            "sidebar.tree.status.dependent_kind.view",
+            "sidebar.tree.status.dependent_kind.materialized_view",
+            "sidebar.tree.status.dependent_kind.foreign_key_child",
+        ];
+
+        for key in STATUS_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    /// `build_schema_indexes_folder`'s populated-count label, now routed
+    /// through `indexes_folder_label`, must render different text per locale.
+    #[test]
+    fn tree_folder_indexes_differs_between_locales() {
+        let english_template = dbflux_i18n::t!("sidebar.tree.folder.indexes", locale = "en");
+        let spanish_template = dbflux_i18n::t!("sidebar.tree.folder.indexes", locale = "es");
+
+        assert_ne!(english_template, spanish_template);
+
+        let resolved = crate::labels::indexes_folder_label(4);
+
+        assert_eq!(
+            resolved,
+            dbflux_i18n::t!("sidebar.tree.folder.indexes", count = 4)
         );
     }
 }


### PR DESCRIPTION
## Summary

Sidebar i18n slice C1b: collection, table and schema folders (fields, columns, indexes, foreign keys, constraints, routines, data types, views, storage, dependents) and the used-by and dependent-kind labels in the tree builder render through `dbflux_i18n::t!` and the sidebar label helpers. English and Spanish together; driver-supplied hint text stays data.

## What does this resolve?

- Refs #360 (follows #381; next: dashboards/charts/metrics folders, then connection and operation toasts)

## How was this solved?

- One helper per folder shape in `labels.rs` (plain and counted variants); tests that asserted English folder names now read the catalog. `lib.rs` needed no production change (its English matches are test fixtures).

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 161 passed; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: expand a table and a schema in the tree.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
