### PR TITLE
feat(i18n): translate the data grid status bar, export menu, banners, and views

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -67,6 +67,50 @@ document:
         builder: Builder
         switch_to_document: Switch to Document View
         switch_to_table: Switch to Table View
+      editing:
+        aggregated: Aggregated results cannot be edited
+        no_primary_key: This table has no primary key - editing is disabled
+        not_single_table: "Editing disabled: result is not bound to a single table."
+      loading: Loading…
+      empty: No data
+      views:
+        table: Data
+        chart: Chart
+        json: JSON
+        text: Text
+        raw: Raw
+        truncated: "(truncated at %{max_lines} lines)"
+        empty: "(empty)"
+      status:
+        rows:
+          one: "%{count} row"
+          many: "%{count} rows"
+        pending_changes:
+          one: "%{count} pending change"
+          many: "%{count} pending changes"
+      export:
+        trigger: Export
+        save_as_file: Save as file
+        copy_to_clipboard: Copy to clipboard
+        png_coming_soon: "PNG export coming in v0.7 — %{detail}"
+        format:
+          csv: CSV
+          json_pretty: "JSON (pretty)"
+          json_compact: "JSON (compact)"
+          text: Text
+          binary: Binary
+          hex: Hex
+          base64: Base64
+      pending:
+        inserted:
+          one: "%{count} insert"
+          many: "%{count} inserts"
+        updated:
+          one: "%{count} update"
+          many: "%{count} updates"
+        deleted:
+          one: "%{count} delete"
+          many: "%{count} deletes"
   shared:
     refresh:
       off: Off

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -67,6 +67,50 @@ document:
         builder: Constructor
         switch_to_document: Cambiar a vista de documento
         switch_to_table: Cambiar a vista de tabla
+      editing:
+        aggregated: Los resultados agregados no se pueden editar
+        no_primary_key: Esta tabla no tiene clave primaria; la edición está deshabilitada
+        not_single_table: "Edición deshabilitada: el resultado no está vinculado a una sola tabla."
+      loading: Cargando…
+      empty: Sin datos
+      views:
+        table: Datos
+        chart: Gráfico
+        json: JSON
+        text: Texto
+        raw: Sin procesar
+        truncated: "(truncado en %{max_lines} líneas)"
+        empty: "(vacío)"
+      status:
+        rows:
+          one: "%{count} fila"
+          many: "%{count} filas"
+        pending_changes:
+          one: "%{count} cambio pendiente"
+          many: "%{count} cambios pendientes"
+      export:
+        trigger: Exportar
+        save_as_file: Guardar como archivo
+        copy_to_clipboard: Copiar al portapapeles
+        png_coming_soon: "Exportación PNG disponible en v0.7 — %{detail}"
+        format:
+          csv: CSV
+          json_pretty: "JSON (con formato)"
+          json_compact: "JSON (compacto)"
+          text: Texto
+          binary: Binario
+          hex: Hex
+          base64: Base64
+      pending:
+        inserted:
+          one: "%{count} inserción"
+          many: "%{count} inserciones"
+        updated:
+          one: "%{count} actualización"
+          many: "%{count} actualizaciones"
+        deleted:
+          one: "%{count} eliminación"
+          many: "%{count} eliminaciones"
   shared:
     refresh:
       off: Apagado

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -2301,14 +2301,7 @@ impl DataGridPanel {
     pub fn change_summary(&self, cx: &App) -> Option<String> {
         let (inserts, updates, deletes) = self.pending_edit_counts(cx);
 
-        if inserts == 0 && updates == 0 && deletes == 0 {
-            None
-        } else {
-            Some(format!(
-                "{} inserts · {} updates · {} deletes",
-                inserts, updates, deletes
-            ))
-        }
+        crate::labels::pending_edits_summary(inserts, updates, deletes)
     }
 
     // === Filter bar presentation helpers ===

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -443,7 +443,7 @@ impl DataGridPanel {
                                 .color(st.theme.muted_foreground),
                         )
                         .child(
-                            Text::caption("Aggregated results cannot be edited")
+                            Text::caption(dbflux_i18n::t!("document.data.grid.editing.aggregated"))
                                 .color(st.theme.muted_foreground),
                         ),
                 )
@@ -461,8 +461,10 @@ impl DataGridPanel {
                         .border_color(st.theme.warning.opacity(0.3))
                         .child(Icon::new(AppIcon::TriangleAlert).small().warning())
                         .child(
-                            Text::caption("This table has no primary key - editing is disabled")
-                                .warning(),
+                            Text::caption(dbflux_i18n::t!(
+                                "document.data.grid.editing.no_primary_key"
+                            ))
+                            .warning(),
                         ),
                 )
             })
@@ -483,9 +485,9 @@ impl DataGridPanel {
                                 .color(st.theme.muted_foreground),
                         )
                         .child(
-                            Text::caption(
-                                "Editing disabled: result is not bound to a single table.",
-                            )
+                            Text::caption(dbflux_i18n::t!(
+                                "document.data.grid.editing.not_single_table"
+                            ))
                             .color(st.theme.muted_foreground),
                         ),
                 )
@@ -597,10 +599,13 @@ impl DataGridPanel {
                                             .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                             .color(theme.muted_foreground),
                                     )
-                                    .child(Text::muted("Loading…"))
+                                    .child(Text::muted(dbflux_i18n::t!(
+                                        "document.data.grid.loading"
+                                    )))
                                     .into_any_element()
                             } else {
-                                Text::muted("No data").into_any_element()
+                                Text::muted(dbflux_i18n::t!("document.data.grid.empty"))
+                                    .into_any_element()
                             })
                     },
                 );
@@ -679,9 +684,9 @@ pub(super) fn render_filter_bar_as_segment(
     let theme = cx.theme().clone();
 
     let refresh_label = if refresh_policy.is_auto() {
-        refresh_policy.label()
+        crate::labels::refresh_policy_label(refresh_policy)
     } else {
-        "Refresh"
+        dbflux_i18n::t!("document.data.grid.toolbar.refresh")
     };
 
     let can_open_builder = g.can_open_builder(cx);
@@ -912,7 +917,9 @@ pub(super) fn render_filter_bar_as_segment(
                             });
                         })
                         .child(Icon::new(AppIcon::ListFilter).small().color(icon_color))
-                        .child(Text::muted("Builder")),
+                        .child(Text::muted(dbflux_i18n::t!(
+                            "document.data.grid.toolbar.builder"
+                        ))),
                 )
             }
         })
@@ -1718,9 +1725,9 @@ impl DataGridPanel {
                 if let Some(panel) = weak_panel.upgrade() {
                     panel.update(cx, |this, _cx| {
                         this.pending.toast = Some(dbflux_ui_base::toast::PendingToast {
-                            message: format!(
-                                "PNG export coming in v0.7 — {}",
-                                dbflux_ui_base::toast::now_hms()
+                            message: dbflux_i18n::t!(
+                                "document.data.grid.export.png_coming_soon",
+                                detail = dbflux_ui_base::toast::now_hms()
                             ),
                             is_error: false,
                         });
@@ -3318,7 +3325,10 @@ impl DataGridPanel {
             .bg(theme.background)
             .child(div().whitespace_nowrap().child(Text::code(display_text)))
             .when(truncated, |d| {
-                d.child(Text::caption(format!("(truncated at {} lines)", MAX_LINES)))
+                d.child(Text::caption(dbflux_i18n::t!(
+                    "document.data.grid.views.truncated",
+                    max_lines = MAX_LINES
+                )))
             })
     }
 
@@ -3334,7 +3344,7 @@ impl DataGridPanel {
         } else if let Some(text) = text_body {
             text.to_string()
         } else {
-            "(empty)".to_string()
+            dbflux_i18n::t!("document.data.grid.views.empty")
         };
 
         div()
@@ -3405,10 +3415,8 @@ impl DataGridPanel {
                     // Pending-change count — visible only when there are unsaved edits
                     .when(pending_change_count > 0, |d| {
                         d.child(
-                            Text::caption(format!(
-                                "{} pending change{}",
+                            Text::caption(crate::labels::pending_change_count_label(
                                 pending_change_count,
-                                if pending_change_count == 1 { "" } else { "s" }
                             ))
                             .color(theme.warning),
                         )
@@ -3444,7 +3452,10 @@ impl DataGridPanel {
                                                 .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                                 .color(icon_color),
                                         )
-                                        .child(Self::result_mode_label(mode.label(), is_active))
+                                        .child(Self::result_mode_label(
+                                            crate::labels::result_view_mode_label(mode),
+                                            is_active,
+                                        ))
                                 }),
                             ))
                         },
@@ -3469,7 +3480,7 @@ impl DataGridPanel {
                                     .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                     .color(theme.muted_foreground),
                             )
-                            .child(Text::caption(format!("{} rows", row_count))),
+                            .child(Text::caption(crate::labels::row_count_label(row_count))),
                     )
                     .when_some(sort_info, |d, (col_name, direction, is_server)| {
                         let arrow_icon = match direction {
@@ -3583,7 +3594,7 @@ impl DataGridPanel {
         }
     }
 
-    fn result_mode_label(label: &'static str, is_active: bool) -> Text {
+    fn result_mode_label(label: impl Into<SharedString>, is_active: bool) -> Text {
         if is_active {
             Text::label_sm(label).font_size(FontSizes::XS)
         } else {
@@ -3618,7 +3629,10 @@ impl DataGridPanel {
                     .small()
                     .color(theme.muted_foreground),
             )
-            .child(Text::caption("Export").muted_foreground())
+            .child(
+                Text::caption(dbflux_i18n::t!("document.data.grid.export.trigger"))
+                    .muted_foreground(),
+            )
             .child(
                 Icon::new(AppIcon::ChevronDown)
                     .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
@@ -3635,7 +3649,7 @@ impl DataGridPanel {
         theme: &gpui_component::theme::Theme,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let section_header = |label: &'static str| -> AnyElement {
+        let section_header = |label: SharedString| -> AnyElement {
             div()
                 .px(Spacing::SM)
                 .mx(Spacing::XS)
@@ -3651,7 +3665,9 @@ impl DataGridPanel {
 
         let mut items: Vec<AnyElement> = Vec::with_capacity(formats.len() * 2 + 3);
 
-        items.push(section_header("Save as file"));
+        items.push(section_header(
+            dbflux_i18n::t!("document.data.grid.export.save_as_file").into(),
+        ));
 
         for (idx, &format) in formats.iter().enumerate() {
             items.push(
@@ -3675,7 +3691,7 @@ impl DataGridPanel {
                             .small()
                             .color(theme.muted_foreground),
                     )
-                    .child(Text::body(format.name()))
+                    .child(Text::body(crate::labels::export_format_label(format)))
                     .into_any_element(),
             );
         }
@@ -3689,7 +3705,9 @@ impl DataGridPanel {
                 .into_any_element(),
         );
 
-        items.push(section_header("Copy to clipboard"));
+        items.push(section_header(
+            dbflux_i18n::t!("document.data.grid.export.copy_to_clipboard").into(),
+        ));
 
         for (idx, &format) in formats.iter().enumerate() {
             let copyable = !matches!(format, dbflux_export::ExportFormat::Binary);
@@ -3716,7 +3734,7 @@ impl DataGridPanel {
                         .small()
                         .color(theme.muted_foreground),
                 )
-                .child(Text::body(format.name()))
+                .child(Text::body(crate::labels::export_format_label(format)))
                 .into_any_element();
             items.push(row);
         }
@@ -3791,7 +3809,7 @@ fn format_hex_dump(data: &[u8]) -> String {
     }
 
     if lines.is_empty() {
-        "(empty)".to_string()
+        dbflux_i18n::t!("document.data.grid.views.empty")
     } else {
         lines.join("\n")
     }
@@ -3865,5 +3883,77 @@ mod tests {
         assert_eq!(english, "Refresh");
         assert_eq!(spanish, "Actualizar");
         assert_ne!(english, spanish);
+    }
+
+    const DATA_GRID_STATUS_EXPORT_KEYS: &[&str] = &[
+        "document.data.grid.editing.aggregated",
+        "document.data.grid.editing.no_primary_key",
+        "document.data.grid.editing.not_single_table",
+        "document.data.grid.loading",
+        "document.data.grid.empty",
+        "document.data.grid.views.table",
+        "document.data.grid.views.chart",
+        "document.data.grid.views.json",
+        "document.data.grid.views.text",
+        "document.data.grid.views.raw",
+        "document.data.grid.views.truncated",
+        "document.data.grid.views.empty",
+        "document.data.grid.status.rows.one",
+        "document.data.grid.status.rows.many",
+        "document.data.grid.status.pending_changes.one",
+        "document.data.grid.status.pending_changes.many",
+        "document.data.grid.export.trigger",
+        "document.data.grid.export.save_as_file",
+        "document.data.grid.export.copy_to_clipboard",
+        "document.data.grid.export.png_coming_soon",
+        "document.data.grid.export.format.csv",
+        "document.data.grid.export.format.json_pretty",
+        "document.data.grid.export.format.json_compact",
+        "document.data.grid.export.format.text",
+        "document.data.grid.export.format.binary",
+        "document.data.grid.export.format.hex",
+        "document.data.grid.export.format.base64",
+        "document.data.grid.pending.inserted.one",
+        "document.data.grid.pending.inserted.many",
+        "document.data.grid.pending.updated.one",
+        "document.data.grid.pending.updated.many",
+        "document.data.grid.pending.deleted.one",
+        "document.data.grid.pending.deleted.many",
+    ];
+
+    #[test]
+    fn data_grid_status_export_keys_resolve_in_both_locales() {
+        for key in DATA_GRID_STATUS_EXPORT_KEYS {
+            let english = dbflux_i18n::t!(*key, locale = "en");
+            let spanish = dbflux_i18n::t!(*key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(english, *key, "English translation missing for {key}");
+            assert_ne!(spanish, *key, "Spanish translation missing for {key}");
+            assert_ne!(
+                english,
+                format!("en.{key}"),
+                "English translation missing for {key}"
+            );
+            assert_ne!(
+                spanish,
+                format!("es.{key}"),
+                "Spanish translation missing for {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn data_grid_export_menu_differs_between_locales() {
+        let save_en = dbflux_i18n::t!("document.data.grid.export.save_as_file", locale = "en");
+        let save_es = dbflux_i18n::t!("document.data.grid.export.save_as_file", locale = "es");
+        let copy_en = dbflux_i18n::t!("document.data.grid.export.copy_to_clipboard", locale = "en");
+        let copy_es = dbflux_i18n::t!("document.data.grid.export.copy_to_clipboard", locale = "es");
+
+        assert_eq!(save_en, "Save as file");
+        assert_ne!(save_en, save_es);
+        assert_eq!(copy_en, "Copy to clipboard");
+        assert_ne!(copy_en, copy_es);
     }
 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -38,9 +38,128 @@ pub(crate) fn refresh_policy_label(policy: dbflux_core::RefreshPolicy) -> String
     }
 }
 
+/// Label for a [`crate::result_view::ResultViewMode`] shown in the
+/// status-bar result-view mode chips.
+pub(crate) fn result_view_mode_label(mode: crate::result_view::ResultViewMode) -> String {
+    use crate::result_view::ResultViewMode;
+
+    match mode {
+        ResultViewMode::Table => dbflux_i18n::t!("document.data.grid.views.table"),
+        ResultViewMode::Chart => dbflux_i18n::t!("document.data.grid.views.chart"),
+        ResultViewMode::Json => dbflux_i18n::t!("document.data.grid.views.json"),
+        ResultViewMode::Text => dbflux_i18n::t!("document.data.grid.views.text"),
+        ResultViewMode::Raw => dbflux_i18n::t!("document.data.grid.views.raw"),
+    }
+}
+
+/// Label for a [`dbflux_export::ExportFormat`] shown in the export menu and
+/// the export trigger button.
+pub(crate) fn export_format_label(format: dbflux_export::ExportFormat) -> String {
+    use dbflux_export::ExportFormat;
+
+    match format {
+        ExportFormat::Csv => dbflux_i18n::t!("document.data.grid.export.format.csv"),
+        ExportFormat::JsonPretty => {
+            dbflux_i18n::t!("document.data.grid.export.format.json_pretty")
+        }
+        ExportFormat::JsonCompact => {
+            dbflux_i18n::t!("document.data.grid.export.format.json_compact")
+        }
+        ExportFormat::Text => dbflux_i18n::t!("document.data.grid.export.format.text"),
+        ExportFormat::Binary => dbflux_i18n::t!("document.data.grid.export.format.binary"),
+        ExportFormat::Hex => dbflux_i18n::t!("document.data.grid.export.format.hex"),
+        ExportFormat::Base64 => dbflux_i18n::t!("document.data.grid.export.format.base64"),
+    }
+}
+
+/// Label for the status bar's row count, with the count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one row; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn row_count_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("document.data.grid.status.rows.one", count = count)
+    } else {
+        dbflux_i18n::t!("document.data.grid.status.rows.many", count = count)
+    }
+}
+
+/// Label for the status bar's pending-change pill, with the count
+/// interpolated. Distinct from [`pending_edits_summary`], which breaks the
+/// count down by insert/update/delete for the tab tooltip.
+///
+/// Uses the singular catalog bucket only for exactly one pending change;
+/// every other count uses the plural bucket.
+pub(crate) fn pending_change_count_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "document.data.grid.status.pending_changes.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.data.grid.status.pending_changes.many",
+            count = count
+        )
+    }
+}
+
+/// Short summary of pending inserts, updates, and deletes for the tab
+/// tooltip, one chip per kind joined the same way the pre-i18n literal
+/// format string did.
+///
+/// Returns `None` when every count is zero. Each chip uses the singular
+/// catalog bucket only for exactly one edit of that kind; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn pending_edits_summary(
+    inserted: usize,
+    updated: usize,
+    deleted: usize,
+) -> Option<String> {
+    if inserted == 0 && updated == 0 && deleted == 0 {
+        return None;
+    }
+
+    Some(
+        [
+            pending_inserted_label(inserted),
+            pending_updated_label(updated),
+            pending_deleted_label(deleted),
+        ]
+        .join(" · "),
+    )
+}
+
+fn pending_inserted_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("document.data.grid.pending.inserted.one", count = count)
+    } else {
+        dbflux_i18n::t!("document.data.grid.pending.inserted.many", count = count)
+    }
+}
+
+fn pending_updated_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("document.data.grid.pending.updated.one", count = count)
+    } else {
+        dbflux_i18n::t!("document.data.grid.pending.updated.many", count = count)
+    }
+}
+
+fn pending_deleted_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("document.data.grid.pending.deleted.one", count = count)
+    } else {
+        dbflux_i18n::t!("document.data.grid.pending.deleted.many", count = count)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{refresh_policy_label, unsaved_changes_label};
+    use super::{
+        pending_change_count_label, pending_edits_summary, refresh_policy_label, row_count_label,
+        unsaved_changes_label,
+    };
     use dbflux_core::RefreshPolicy;
 
     #[test]
@@ -75,5 +194,45 @@ mod tests {
         assert_ne!(english, spanish);
         assert_ne!(english, "en.document.tabs.menu.close");
         assert_ne!(spanish, "es.document.tabs.menu.close");
+    }
+
+    #[test]
+    fn pending_edits_summary_zero_is_none() {
+        assert_eq!(pending_edits_summary(0, 0, 0), None);
+    }
+
+    #[test]
+    fn pending_edits_summary_matches_pre_i18n_output_for_plural_combos() {
+        // Combos chosen away from count == 1 so the plural bucket alone
+        // reproduces the pre-i18n literal `"{inserts} inserts · {updates}
+        // updates · {deletes} deletes"` format string exactly.
+        assert_eq!(
+            pending_edits_summary(2, 3, 4).as_deref(),
+            Some("2 inserts · 3 updates · 4 deletes")
+        );
+        assert_eq!(
+            pending_edits_summary(0, 5, 0).as_deref(),
+            Some("0 inserts · 5 updates · 0 deletes")
+        );
+    }
+
+    #[test]
+    fn pending_edits_summary_uses_singular_bucket_for_exactly_one() {
+        let summary = pending_edits_summary(1, 1, 1).expect("non-zero counts");
+
+        assert_eq!(summary, "1 insert · 1 update · 1 delete");
+    }
+
+    #[test]
+    fn row_count_label_one_many() {
+        assert_eq!(row_count_label(1), "1 row");
+        assert_eq!(row_count_label(2), "2 rows");
+        assert_eq!(row_count_label(0), "0 rows");
+    }
+
+    #[test]
+    fn pending_change_count_label_one_many() {
+        assert_eq!(pending_change_count_label(1), "1 pending change");
+        assert_eq!(pending_change_count_label(2), "2 pending changes");
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 2b: the data grid editing banners, loading and empty states, the filter-bar refresh and builder chips, result view mode labels, the status bar counts, the export menu and format names, the PNG export toast and the pending-edits summary render through `dbflux_i18n::t!`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows #382; next: chart dock part 1 and 2, row inspector, mutation toasts)

## How was this solved?

- Counts now use singular and plural buckets (`1 row`, `1 insert`) instead of a fixed plural noun; `pending_edits_summary` and `row_count_label` helpers carry them. `ExportFormat` and `ResultViewMode` are mapped locally so the other crates stay untouched. `LIMIT` and the shape/sort badges stay literal.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 883 passed; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: open a table, edit/insert/delete a row without saving, export to CSV, read the status bar.
- Size: 406 lines (`size:exception`).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
