### PR TITLE
feat(i18n): translate the sidebar dashboards, charts, metrics, and instance tree folders

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -640,11 +640,21 @@ sidebar:
       data_types_plain: Data Types
       views: "Views (%{count})"
       storage: "Storage (%{count})"
+      dashboards: Dashboards
+      saved_charts: Saved Charts
+      instance_metrics: Instance Metrics
+      instance_inspectors: Instance Inspectors
+      metrics: Metrics
+    node:
+      instance_overview: Instance Overview
+      untitled_chart: Untitled chart
     status:
       loading: Loading…
       profile_connecting: "Connecting to %{name}…"
       database_loading: "%{name} (loading…)"
       error_retry: "Error: %{error} — click to retry"
+      remote_listing_count: "%{label} (%{count})"
+      remote_dashboards_error_retry: "Error: %{error} — collapse and expand to retry"
       used_by_objects:
         one: Used by 1 object
         many: "Used by %{count} objects"
@@ -655,6 +665,12 @@ sidebar:
         trigger: Trigger
     empty:
       buckets: No buckets
+      dashboards: No dashboards yet — right-click to create
+      dashboards_with_import: No dashboards yet — right-click to create or import
+      saved_charts: No saved charts yet — save a chart from a query result
+      metrics: No metrics available
+      inspectors: No inspectors available
+      remote_dashboards: No dashboards in this account/region
 sql_preview:
   title:
     sql: SQL Preview

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -640,11 +640,21 @@ sidebar:
       data_types_plain: Tipos de datos
       views: "Vistas (%{count})"
       storage: "Almacenamiento (%{count})"
+      dashboards: Dashboards
+      saved_charts: Gráficos guardados
+      instance_metrics: Métricas de instancia
+      instance_inspectors: Inspectores de instancia
+      metrics: Métricas
+    node:
+      instance_overview: Resumen de instancia
+      untitled_chart: Gráfico sin título
     status:
       loading: Cargando…
       profile_connecting: "Conectando a %{name}…"
       database_loading: "%{name} (cargando…)"
       error_retry: "Error: %{error} — clic para reintentar"
+      remote_listing_count: "%{label} (%{count})"
+      remote_dashboards_error_retry: "Error: %{error} — colapsa y expande para reintentar"
       used_by_objects:
         one: Usado por 1 objeto
         many: "Usado por %{count} objetos"
@@ -655,6 +665,12 @@ sidebar:
         trigger: Trigger
     empty:
       buckets: Sin buckets
+      dashboards: Aún no hay dashboards — clic derecho para crear
+      dashboards_with_import: Aún no hay dashboards — clic derecho para crear o importar
+      saved_charts: Aún no hay gráficos guardados — guarda un gráfico desde un resultado de consulta
+      metrics: No hay métricas disponibles
+      inspectors: No hay inspectores disponibles
+      remote_dashboards: No hay dashboards en esta cuenta/región
 sql_preview:
   title:
     sql: Vista previa de SQL

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -216,6 +216,98 @@ pub(crate) fn storage_folder_label(count: usize) -> String {
     dbflux_i18n::t!("sidebar.tree.folder.storage", count = count)
 }
 
+/// Translated label for the Dashboards sidebar folder. Also used as the
+/// fallback label for the remote-dashboards folder when the driver does not
+/// supply its own `DashboardSource::container_label`.
+pub(crate) fn dashboards_folder_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.dashboards")
+}
+
+/// Translated label for a remote-dashboards folder base label, suffixed with
+/// the cached listing count once it resolves (the driver-supplied base
+/// followed by `(N)`). `base` stays untranslated.
+pub(crate) fn remote_dashboards_count_label(base: &str, count: usize) -> String {
+    dbflux_i18n::t!(
+        "sidebar.tree.status.remote_listing_count",
+        label = base,
+        count = count
+    )
+}
+
+/// Translated label for a retryable remote-dashboards fetch error, e.g.
+/// `"Error: access denied — collapse and expand to retry"`.
+pub(crate) fn remote_dashboards_error_label(error: &str) -> String {
+    dbflux_i18n::t!(
+        "sidebar.tree.status.remote_dashboards_error_retry",
+        error = error
+    )
+}
+
+/// Translated placeholder for a remote-dashboards folder whose listing
+/// resolved empty.
+pub(crate) fn remote_dashboards_empty_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.empty.remote_dashboards")
+}
+
+/// Translated label for the Saved Charts sidebar folder.
+pub(crate) fn saved_charts_folder_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.saved_charts")
+}
+
+/// Translated placeholder for an empty Saved Charts folder.
+pub(crate) fn no_saved_charts_yet_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.empty.saved_charts")
+}
+
+/// Translated fallback title for a saved chart persisted with a blank name.
+pub(crate) fn untitled_chart_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.node.untitled_chart")
+}
+
+/// Translated placeholder for an empty Dashboards folder, e.g. `"No
+/// dashboards yet — right-click to create"`. `can_import` selects the
+/// variant that also mentions importing, gated on `DASHBOARD_IMPORT`.
+pub(crate) fn no_dashboards_yet_label(can_import: bool) -> String {
+    if can_import {
+        dbflux_i18n::t!("sidebar.tree.empty.dashboards_with_import")
+    } else {
+        dbflux_i18n::t!("sidebar.tree.empty.dashboards")
+    }
+}
+
+/// Translated label for the Instance Metrics sidebar folder.
+pub(crate) fn instance_metrics_folder_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.instance_metrics")
+}
+
+/// Translated label for the Instance Inspectors sidebar folder.
+pub(crate) fn instance_inspectors_folder_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.instance_inspectors")
+}
+
+/// Translated placeholder for an Instance Metrics folder whose probe
+/// resolved with no metrics.
+pub(crate) fn no_metrics_available_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.empty.metrics")
+}
+
+/// Translated placeholder for an Instance Inspectors folder whose probe
+/// resolved with no inspectors.
+pub(crate) fn no_inspectors_available_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.empty.inspectors")
+}
+
+/// Translated label for the Instance Overview sidebar leaf.
+pub(crate) fn instance_overview_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.node.instance_overview")
+}
+
+/// Translated label for a database-level Metrics folder (metric catalog
+/// browsing, e.g. CloudWatch namespaces).
+pub(crate) fn metrics_folder_label() -> String {
+    dbflux_i18n::t!("sidebar.tree.folder.metrics")
+}
+
 #[cfg(test)]
 mod tests {
     use dbflux_core::DatabaseCategory;
@@ -530,6 +622,92 @@ mod tests {
             dbflux_i18n::t!("sidebar.tree.status.used_by_objects.many", locale = "es");
 
         assert_ne!(english_template, spanish_template);
+    }
+
+    const C2_KEYS: [&str; 13] = [
+        "sidebar.tree.folder.dashboards",
+        "sidebar.tree.folder.saved_charts",
+        "sidebar.tree.folder.instance_metrics",
+        "sidebar.tree.folder.instance_inspectors",
+        "sidebar.tree.folder.metrics",
+        "sidebar.tree.node.instance_overview",
+        "sidebar.tree.node.untitled_chart",
+        "sidebar.tree.empty.dashboards",
+        "sidebar.tree.empty.dashboards_with_import",
+        "sidebar.tree.empty.saved_charts",
+        "sidebar.tree.empty.metrics",
+        "sidebar.tree.empty.inspectors",
+        "sidebar.tree.empty.remote_dashboards",
+    ];
+
+    #[test]
+    fn c2_keys_resolve_in_both_locales() {
+        for key in C2_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn saved_charts_folder_label_diverges_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.tree.folder.saved_charts", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.tree.folder.saved_charts", locale = "es");
+
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn remote_dashboards_count_label_includes_base_and_count() {
+        let label = super::remote_dashboards_count_label("CloudWatch Dashboards", 3);
+
+        assert!(label.contains("CloudWatch Dashboards"));
+        assert!(label.contains('3'));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!(
+                "sidebar.tree.status.remote_listing_count",
+                label = "CloudWatch Dashboards",
+                count = 3
+            )
+        );
+    }
+
+    #[test]
+    fn remote_dashboards_error_label_includes_the_error_message() {
+        let label = super::remote_dashboards_error_label("access denied");
+
+        assert!(label.contains("access denied"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!(
+                "sidebar.tree.status.remote_dashboards_error_retry",
+                error = "access denied"
+            )
+        );
+    }
+
+    #[test]
+    fn no_dashboards_yet_label_differs_with_and_without_import() {
+        let with_import = super::no_dashboards_yet_label(true);
+        let without_import = super::no_dashboards_yet_label(false);
+
+        assert_eq!(
+            with_import,
+            dbflux_i18n::t!("sidebar.tree.empty.dashboards_with_import")
+        );
+        assert_eq!(
+            without_import,
+            dbflux_i18n::t!("sidebar.tree.empty.dashboards")
+        );
+        assert_ne!(with_import, without_import);
     }
 
     #[test]

--- a/crates/dbflux_ui_sidebar/src/tree_builder.rs
+++ b/crates/dbflux_ui_sidebar/src/tree_builder.rs
@@ -389,7 +389,7 @@ impl Sidebar {
         let children = Self::build_dashboard_children(profile_id, state);
         TreeItem::new(
             SchemaNodeId::DashboardsFolder { profile_id }.to_string(),
-            "Dashboards".to_string(),
+            crate::labels::dashboards_folder_label(),
         )
         .expanded(false)
         .children(children)
@@ -414,14 +414,14 @@ impl Sidebar {
                     .dashboard_source()
                     .map(|s| s.container_label().to_string())
             })
-            .unwrap_or_else(|| "Dashboards".to_string());
+            .unwrap_or_else(crate::labels::dashboards_folder_label);
 
         let folder_id = SchemaNodeId::RemoteDashboardsFolder { profile_id }.to_string();
         let children =
             Self::build_remote_dashboard_children(profile_id, state, &folder_id, fetch_errors);
 
         let label = match state.remote_dashboard_cache().peek(profile_id) {
-            Some(list) => format!("{} ({})", label, list.len()),
+            Some(list) => crate::labels::remote_dashboards_count_label(&label, list.len()),
             None => label,
         };
 
@@ -446,7 +446,7 @@ impl Sidebar {
             if let Some(error) = fetch_errors.get(folder_id) {
                 return vec![TreeItem::new(
                     format!("remote_dashboards_error:{profile_id}"),
-                    format!("Error: {error} — collapse and expand to retry"),
+                    crate::labels::remote_dashboards_error_label(error),
                 )];
             }
             return vec![Self::loading_placeholder(
@@ -459,7 +459,7 @@ impl Sidebar {
         if dashboards.is_empty() {
             return vec![TreeItem::new(
                 format!("remote_dashboards_empty:{profile_id}"),
-                "No dashboards in this account/region".to_string(),
+                crate::labels::remote_dashboards_empty_label(),
             )];
         }
 
@@ -487,7 +487,7 @@ impl Sidebar {
         let children = Self::build_saved_chart_children(profile_id, state);
         TreeItem::new(
             SchemaNodeId::SavedChartsFolder { profile_id }.to_string(),
-            "Saved Charts".to_string(),
+            crate::labels::saved_charts_folder_label(),
         )
         .expanded(false)
         .children(children)
@@ -527,7 +527,7 @@ impl Sidebar {
     ) -> TreeItem {
         TreeItem::new(
             SchemaNodeId::InstanceMetricsFolder { profile_id }.to_string(),
-            "Instance Metrics".to_string(),
+            crate::labels::instance_metrics_folder_label(),
         )
         .expanded(false)
         .children(children)
@@ -545,7 +545,7 @@ impl Sidebar {
     ) -> TreeItem {
         TreeItem::new(
             SchemaNodeId::InstanceInspectorsFolder { profile_id }.to_string(),
-            "Instance Inspectors".to_string(),
+            crate::labels::instance_inspectors_folder_label(),
         )
         .expanded(false)
         .children(children)
@@ -564,14 +564,14 @@ impl Sidebar {
         let Some(metrics) = cache.get(&profile_id) else {
             return vec![TreeItem::new(
                 format!("instance-metrics-loading:{profile_id}"),
-                "Loading\u{2026}".to_string(),
+                dbflux_i18n::t!("sidebar.tree.status.loading"),
             )];
         };
 
         if metrics.is_empty() {
             return vec![TreeItem::new(
                 format!("instance-metrics-empty:{profile_id}"),
-                "No metrics available".to_string(),
+                crate::labels::no_metrics_available_label(),
             )];
         }
 
@@ -603,14 +603,14 @@ impl Sidebar {
         let Some(inspectors) = cache.get(&profile_id) else {
             return vec![TreeItem::new(
                 format!("instance-inspectors-loading:{profile_id}"),
-                "Loading\u{2026}".to_string(),
+                dbflux_i18n::t!("sidebar.tree.status.loading"),
             )];
         };
 
         if inspectors.is_empty() {
             return vec![TreeItem::new(
                 format!("instance-inspectors-empty:{profile_id}"),
-                "No inspectors available".to_string(),
+                crate::labels::no_inspectors_available_label(),
             )];
         }
 
@@ -637,7 +637,7 @@ impl Sidebar {
     pub(crate) fn build_instance_overview_leaf(profile_id: Uuid) -> TreeItem {
         TreeItem::new(
             SchemaNodeId::InstanceOverviewLeaf { profile_id }.to_string(),
-            "Instance Overview".to_string(),
+            crate::labels::instance_overview_label(),
         )
     }
 
@@ -660,15 +660,9 @@ impl Sidebar {
                     caps.contains(dbflux_core::DriverCapabilities::DASHBOARD_IMPORT)
                 });
 
-            let hint = if can_import {
-                "No dashboards yet — right-click to create or import"
-            } else {
-                "No dashboards yet — right-click to create"
-            };
-
             return vec![TreeItem::new(
                 format!("dashboards_empty:{profile_id}"),
-                hint.to_string(),
+                crate::labels::no_dashboards_yet_label(can_import),
             )];
         }
 
@@ -699,7 +693,7 @@ impl Sidebar {
         if charts.is_empty() {
             return vec![TreeItem::new(
                 format!("saved_charts_empty:{profile_id}"),
-                "No saved charts yet — save a chart from a query result".to_string(),
+                crate::labels::no_saved_charts_yet_label(),
             )];
         }
 
@@ -742,7 +736,7 @@ impl Sidebar {
             }
         }
 
-        "Untitled chart".to_string()
+        crate::labels::untitled_chart_label()
     }
 
     pub(super) fn count_visible_entries(items: &[TreeItem]) -> usize {
@@ -1936,7 +1930,7 @@ fn build_metrics_folder(
     };
 
     Some(
-        TreeItem::new(parent_id, "Metrics".to_string())
+        TreeItem::new(parent_id, crate::labels::metrics_folder_label())
             .expanded(false)
             .children(children),
     )
@@ -2958,7 +2952,7 @@ mod tests {
             "Metrics folder must appear when METRIC_CATALOG capability is set"
         );
         let folder = metrics_folder.unwrap();
-        assert_eq!(folder.label.as_ref(), "Metrics");
+        assert_eq!(folder.label.as_ref(), crate::labels::metrics_folder_label());
         assert!(!folder.is_expanded());
     }
 
@@ -3539,6 +3533,96 @@ mod tests {
     }
 
     #[test]
+    fn test_build_dashboards_folder_item_uses_translated_label() {
+        let (state, profile_id) = make_state_with_profile();
+        let item = Sidebar::build_dashboards_folder_item(profile_id, &state);
+        assert_eq!(
+            item.label.as_ref(),
+            crate::labels::dashboards_folder_label()
+        );
+    }
+
+    #[test]
+    fn test_build_saved_charts_folder_item_uses_translated_label() {
+        let (state, profile_id) = make_state_with_profile();
+        let item = Sidebar::build_saved_charts_folder_item(profile_id, &state);
+        assert_eq!(
+            item.label.as_ref(),
+            crate::labels::saved_charts_folder_label()
+        );
+    }
+
+    #[test]
+    fn tree_folder_saved_charts_differs_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.tree.folder.saved_charts", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.tree.folder.saved_charts", locale = "es");
+
+        assert_ne!(english, spanish);
+    }
+
+    const C2_TREE_KEYS: [&str; 4] = [
+        "sidebar.tree.folder.instance_metrics",
+        "sidebar.tree.folder.instance_inspectors",
+        "sidebar.tree.folder.metrics",
+        "sidebar.tree.node.instance_overview",
+    ];
+
+    #[test]
+    fn tree_c2_keys_resolve_in_both_locales() {
+        for key in C2_TREE_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_remote_dashboards_folder_item_falls_back_to_translated_label() {
+        let (state, profile_id) = make_state_with_profile();
+        let item =
+            Sidebar::build_remote_dashboards_folder_item(profile_id, &state, &HashMap::new());
+        assert_eq!(
+            item.label.as_ref(),
+            crate::labels::dashboards_folder_label()
+        );
+    }
+
+    #[test]
+    fn test_build_remote_dashboards_folder_item_appends_cached_count() {
+        let (state, profile_id) = make_state_with_profile();
+        state.remote_dashboard_cache().store(
+            profile_id,
+            vec![
+                dbflux_core::DashboardRef {
+                    name: "prod".to_string(),
+                    last_modified: None,
+                },
+                dbflux_core::DashboardRef {
+                    name: "staging".to_string(),
+                    last_modified: None,
+                },
+            ],
+        );
+
+        let item =
+            Sidebar::build_remote_dashboards_folder_item(profile_id, &state, &HashMap::new());
+        assert_eq!(
+            item.label.as_ref(),
+            crate::labels::remote_dashboards_count_label(
+                &crate::labels::dashboards_folder_label(),
+                2
+            )
+        );
+    }
+
+    #[test]
     fn test_remote_dashboard_children_show_loading_on_cache_miss() {
         let (state, profile_id) = make_state_with_profile();
         let folder_id =
@@ -3567,7 +3651,28 @@ mod tests {
             Sidebar::build_remote_dashboard_children(profile_id, &state, &folder_id, &errors);
 
         assert_eq!(children.len(), 1);
-        assert!(children[0].label.as_ref().contains("access denied"));
+        assert_eq!(
+            children[0].label.as_ref(),
+            crate::labels::remote_dashboards_error_label("access denied")
+        );
+    }
+
+    #[test]
+    fn test_remote_dashboard_children_show_placeholder_when_listing_is_empty() {
+        let (state, profile_id) = make_state_with_profile();
+        state.remote_dashboard_cache().store(profile_id, Vec::new());
+
+        let folder_id =
+            dbflux_core::SchemaNodeId::RemoteDashboardsFolder { profile_id }.to_string();
+        let errors = HashMap::new();
+        let children =
+            Sidebar::build_remote_dashboard_children(profile_id, &state, &folder_id, &errors);
+
+        assert_eq!(children.len(), 1);
+        assert_eq!(
+            children[0].label.as_ref(),
+            crate::labels::remote_dashboards_empty_label()
+        );
     }
 
     #[test]
@@ -3607,7 +3712,10 @@ mod tests {
             children[0].id.as_ref(),
             format!("dashboards_empty:{profile_id}")
         );
-        assert!(children[0].label.to_string().contains("No dashboards yet"));
+        assert_eq!(
+            children[0].label.as_ref(),
+            crate::labels::no_dashboards_yet_label(false)
+        );
     }
 
     #[test]
@@ -3619,12 +3727,45 @@ mod tests {
             children[0].id.as_ref(),
             format!("saved_charts_empty:{profile_id}")
         );
-        assert!(
-            children[0]
-                .label
-                .to_string()
-                .contains("No saved charts yet")
+        assert_eq!(
+            children[0].label.as_ref(),
+            crate::labels::no_saved_charts_yet_label()
         );
+    }
+
+    #[test]
+    fn saved_chart_display_label_falls_back_to_untitled_chart_for_a_blank_name() {
+        use dbflux_components::chart::{
+            AxisKind, AxisSpec, BindingSpec, ChartKind, ChartSpec, YScale,
+        };
+
+        let placeholder_spec = ChartSpec {
+            kind: ChartKind::Line,
+            x_axis: AxisSpec {
+                column_index: 0,
+                label: String::new(),
+                kind: AxisKind::Time,
+                unit: None,
+            },
+            series: Vec::new(),
+            legend_visible: false,
+            decimation_threshold: 10_000,
+            binding: BindingSpec::default(),
+            track_source_indices: false,
+            y_scale: YScale::Linear,
+        };
+
+        let chart = dbflux_components::SavedChart::new_query(
+            "   ".to_string(),
+            Uuid::new_v4(),
+            "SELECT 1".to_string(),
+            placeholder_spec,
+            BindingSpec::default(),
+        );
+
+        let label = Sidebar::saved_chart_display_label(&chart);
+
+        assert_eq!(label, crate::labels::untitled_chart_label());
     }
 
     #[test]
@@ -3836,10 +3977,10 @@ mod tests {
             1,
             "empty state must produce one placeholder"
         );
-        let label = children[0].label.to_string().to_ascii_lowercase();
-        assert!(
-            label.contains("import"),
-            "hint must mention 'import' when driver has DASHBOARD_IMPORT: {label:?}"
+        assert_eq!(
+            children[0].label.as_ref(),
+            crate::labels::no_dashboards_yet_label(true),
+            "hint must use the import-capable variant when driver has DASHBOARD_IMPORT"
         );
     }
 
@@ -3854,10 +3995,10 @@ mod tests {
             1,
             "empty state must produce one placeholder"
         );
-        let label = children[0].label.to_string().to_ascii_lowercase();
-        assert!(
-            !label.contains("import"),
-            "hint must not mention 'import' without DASHBOARD_IMPORT: {label:?}"
+        assert_eq!(
+            children[0].label.as_ref(),
+            crate::labels::no_dashboards_yet_label(false),
+            "hint must use the non-import variant without DASHBOARD_IMPORT"
         );
     }
 
@@ -3893,6 +4034,10 @@ mod tests {
             ),
             "folder item must carry InstanceMetricsFolder node ID: {node_id:?}"
         );
+        assert_eq!(
+            item.label.as_ref(),
+            crate::labels::instance_metrics_folder_label()
+        );
     }
 
     /// REQ-UI-1, REQ-UI-5: A driver with `INSTANCE_INSPECTOR` must produce an
@@ -3920,6 +4065,10 @@ mod tests {
                 } if pid == profile_id
             ),
             "folder item must carry InstanceInspectorsFolder node ID: {node_id:?}"
+        );
+        assert_eq!(
+            item.label.as_ref(),
+            crate::labels::instance_inspectors_folder_label()
         );
     }
 
@@ -4169,10 +4318,10 @@ mod tests {
             1,
             "must return one placeholder for empty entry"
         );
-        assert!(
-            leaves[0].label.to_string().contains("No metrics"),
-            "empty-cache placeholder must say 'No metrics available'; got {:?}",
-            leaves[0].label
+        assert_eq!(
+            leaves[0].label.as_ref(),
+            crate::labels::no_metrics_available_label(),
+            "empty-cache placeholder must use the translated 'no metrics available' label"
         );
     }
 
@@ -4191,10 +4340,10 @@ mod tests {
             1,
             "must return one placeholder for empty entry"
         );
-        assert!(
-            leaves[0].label.to_string().contains("No inspectors"),
-            "empty-cache placeholder must say 'No inspectors available'; got {:?}",
-            leaves[0].label
+        assert_eq!(
+            leaves[0].label.as_ref(),
+            crate::labels::no_inspectors_available_label(),
+            "empty-cache placeholder must use the translated 'no inspectors available' label"
         );
     }
 
@@ -4268,6 +4417,10 @@ mod tests {
                 SchemaNodeId::InstanceOverviewLeaf { profile_id: pid } if *pid == profile_id
             ),
             "leaf must carry InstanceOverviewLeaf node ID: {node_id:?}"
+        );
+        assert_eq!(
+            item.label.as_ref(),
+            crate::labels::instance_overview_label()
         );
     }
 


### PR DESCRIPTION
## Summary

Sidebar i18n slice C2: dashboards, remote dashboards, saved charts, metrics, instance metrics, inspectors and overview folders and their empty and error states in the tree builder render through `dbflux_i18n::t!` and the sidebar label helpers. English and Spanish together; "dashboard" and driver-supplied metric names stay as is.

## What does this resolve?

- Refs #360 (follows #384; next: connection tasks and toasts, pipeline stages, operation toasts)

## How was this solved?

- One helper per folder/empty-state shape; ten existing tests that asserted English now read the catalog. Size: 457 lines (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 174 passed; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: expand Dashboards, Saved Charts and Instance Metrics on a connected profile.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
