### PR TITLE
feat(i18n): translate the chart dock toolbar, save overlay, degraded state, and picker

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -54,6 +54,34 @@ controls:
       many: "+%{count} more"
 document:
   data:
+    chart_dock:
+      toolbar:
+        apply: Apply
+      save:
+        title: Save chart
+        name_placeholder: Chart name
+        cancel: Cancel
+        save: Save
+      degraded:
+        no_time_column:
+          title: No time column detected
+          body: This result has no Timestamp column. Pick a column to use as the time axis.
+        no_numeric_series:
+          title: No numeric series
+          body: This result has no Float or Integer columns to plot as series.
+        no_data:
+          title: No data yet
+          body: Run the query to populate the chart view.
+        build_failed:
+          title: Chart build failed
+          body: The query result has chartable columns but the chart could not be built.
+        open_table_tab: Open Table tab
+        pick_time_column: "Pick time column…"
+        hide_picker: Hide picker
+      picker:
+        x_axis_label: X axis (time / label column)
+        y_axis_label: Y axis (numeric columns)
+        apply: Apply
     grid:
       edit_bar:
         clean: No unsaved changes

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -54,6 +54,34 @@ controls:
       many: "+%{count} más"
 document:
   data:
+    chart_dock:
+      toolbar:
+        apply: Aplicar
+      save:
+        title: Guardar gráfico
+        name_placeholder: Nombre del gráfico
+        cancel: Cancelar
+        save: Guardar
+      degraded:
+        no_time_column:
+          title: No se detectó una columna de tiempo
+          body: Este resultado no tiene una columna Timestamp. Elige una columna para usarla como eje de tiempo.
+        no_numeric_series:
+          title: No hay series numéricas
+          body: Este resultado no tiene columnas Float ni Integer para graficar como series.
+        no_data:
+          title: Aún no hay datos
+          body: Ejecuta la consulta para poblar la vista de gráfico.
+        build_failed:
+          title: No se pudo construir el gráfico
+          body: El resultado de la consulta tiene columnas graficables, pero el gráfico no se pudo construir.
+        open_table_tab: Abrir pestaña de tabla
+        pick_time_column: "Elegir columna de tiempo…"
+        hide_picker: Ocultar selector
+      picker:
+        x_axis_label: Eje X (columna de tiempo o etiqueta)
+        y_axis_label: Eje Y (columnas numéricas)
+        apply: Aplicar
     grid:
       edit_bar:
         clean: Sin cambios pendientes

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -1784,17 +1784,20 @@ impl DataGridPanel {
                     .bg(theme.tab_bar)
                     .child(picker_row)
                     .child(
-                        Button::new("data-grid-chart-time-range-apply", "Apply")
-                            .small()
-                            .disabled(!can_apply)
-                            .on_click(move |_, _, cx| {
-                                panel_clone.update(cx, |p, cx| {
-                                    // The returned bounds are intentionally discarded:
-                                    // the parent CodeDocument's TimeRangeChanged
-                                    // subscription drives re-execution.
-                                    let _ = p.apply_custom_range(cx);
-                                });
-                            }),
+                        Button::new(
+                            "data-grid-chart-time-range-apply",
+                            dbflux_i18n::t!("document.data.chart_dock.toolbar.apply"),
+                        )
+                        .small()
+                        .disabled(!can_apply)
+                        .on_click(move |_, _, cx| {
+                            panel_clone.update(cx, |p, cx| {
+                                // The returned bounds are intentionally discarded:
+                                // the parent CodeDocument's TimeRangeChanged
+                                // subscription drives re-execution.
+                                let _ = p.apply_custom_range(cx);
+                            });
+                        }),
                     );
 
                 Some(row.into_any_element())
@@ -2234,8 +2237,12 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(Spacing::SM)
-                    .child(Text::label("Save chart"))
-                    .child(Input::new(&name_input).placeholder("Chart name"))
+                    .child(Text::label(dbflux_i18n::t!(
+                        "document.data.chart_dock.save.title"
+                    )))
+                    .child(Input::new(&name_input).placeholder(dbflux_i18n::t!(
+                        "document.data.chart_dock.save.name_placeholder"
+                    )))
                     .child(
                         div()
                             .flex()
@@ -2244,7 +2251,7 @@ impl DataGridPanel {
                             .justify_end()
                             .child(
                                 Button::new("cancel-collection-chart-save")
-                                    .label("Cancel")
+                                    .label(dbflux_i18n::t!("document.data.chart_dock.save.cancel"))
                                     .small()
                                     .on_click(cx.listener(|this, _, _window, cx| {
                                         this.cancel_collection_chart_save(cx);
@@ -2252,7 +2259,7 @@ impl DataGridPanel {
                             )
                             .child(
                                 Button::new("confirm-collection-chart-save")
-                                    .label("Save")
+                                    .label(dbflux_i18n::t!("document.data.chart_dock.save.save"))
                                     .small()
                                     .with_variant(ButtonVariant::Primary)
                                     .on_click(cx.listener(|this, _, _window, cx| {
@@ -2285,28 +2292,11 @@ impl DataGridPanel {
             })
             .unwrap_or((None, false));
 
-        let (title, body, can_pick) = match &detection {
-            Some(ChartDetection::NoTimeColumn) | None => (
-                "No time column detected",
-                "This result has no Timestamp column. Pick a column to use as the time axis.",
-                true,
-            ),
-            Some(ChartDetection::NoNumericSeries) => (
-                "No numeric series",
-                "This result has no Float or Integer columns to plot as series.",
-                true,
-            ),
-            Some(ChartDetection::EmptyResult) => (
-                "No data yet",
-                "Run the query to populate the chart view.",
-                false,
-            ),
-            Some(ChartDetection::Ok { .. }) => (
-                "Chart build failed",
-                "The query result has chartable columns but the chart could not be built.",
-                false,
-            ),
-        };
+        let (title, body) = crate::labels::chart_degraded_copy(&detection);
+        let can_pick = matches!(
+            &detection,
+            Some(ChartDetection::NoTimeColumn) | Some(ChartDetection::NoNumericSeries) | None
+        );
 
         // Column shape preview chips.
         let row_count = self.result.row_count();
@@ -2424,14 +2414,16 @@ impl DataGridPanel {
                                     this.set_result_view_mode(ResultViewMode::Table, cx);
                                 }),
                             )
-                            .child("Open Table tab"),
+                            .child(dbflux_i18n::t!(
+                                "document.data.chart_dock.degraded.open_table_tab"
+                            )),
                     )
                     // "Pick time column…" primary button (only when picker makes sense)
                     .when(can_pick, |d| {
                         let label = if picker_open {
-                            "Hide picker"
+                            dbflux_i18n::t!("document.data.chart_dock.degraded.hide_picker")
                         } else {
-                            "Pick time column…"
+                            dbflux_i18n::t!("document.data.chart_dock.degraded.pick_time_column")
                         };
                         let primary = cx.theme().primary;
                         d.child(
@@ -2552,7 +2544,9 @@ impl DataGridPanel {
                     .child(
                         div()
                             .text_size(FontSizes::SM)
-                            .child(Text::body("X axis (time / label column)")),
+                            .child(Text::body(dbflux_i18n::t!(
+                                "document.data.chart_dock.picker.x_axis_label"
+                            ))),
                     )
                     .child(div().flex().flex_wrap().gap(Spacing::XS).children(
                         x_candidates.iter().enumerate().map(
@@ -2598,7 +2592,9 @@ impl DataGridPanel {
                 .child(
                     div()
                         .text_size(FontSizes::SM)
-                        .child(Text::body("Y axis (numeric columns)")),
+                        .child(Text::body(dbflux_i18n::t!(
+                            "document.data.chart_dock.picker.y_axis_label"
+                        ))),
                 )
                 .child(
                     div().flex().flex_col().gap(Spacing::XS).children(
@@ -2689,7 +2685,7 @@ impl DataGridPanel {
                     ..chart_colors.muted_fg
                 })
             })
-            .child("Apply");
+            .child(dbflux_i18n::t!("document.data.chart_dock.picker.apply"));
 
         picker.child(apply_btn)
     }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -154,12 +154,44 @@ fn pending_deleted_label(count: usize) -> String {
     }
 }
 
+/// Title and body copy for the chart dock's degraded-state card, keyed by
+/// the chart auto-detection outcome.
+///
+/// `None` shares the `NoTimeColumn` copy because the dock renders the
+/// degraded card before detection has run at least once, and both cases
+/// point the user at the same recovery action (pick a time column).
+pub(crate) fn chart_degraded_copy(
+    detection: &Option<dbflux_components::chart::ChartDetection>,
+) -> (String, String) {
+    use dbflux_components::chart::ChartDetection;
+
+    match detection {
+        Some(ChartDetection::NoTimeColumn) | None => (
+            dbflux_i18n::t!("document.data.chart_dock.degraded.no_time_column.title"),
+            dbflux_i18n::t!("document.data.chart_dock.degraded.no_time_column.body"),
+        ),
+        Some(ChartDetection::NoNumericSeries) => (
+            dbflux_i18n::t!("document.data.chart_dock.degraded.no_numeric_series.title"),
+            dbflux_i18n::t!("document.data.chart_dock.degraded.no_numeric_series.body"),
+        ),
+        Some(ChartDetection::EmptyResult) => (
+            dbflux_i18n::t!("document.data.chart_dock.degraded.no_data.title"),
+            dbflux_i18n::t!("document.data.chart_dock.degraded.no_data.body"),
+        ),
+        Some(ChartDetection::Ok { .. }) => (
+            dbflux_i18n::t!("document.data.chart_dock.degraded.build_failed.title"),
+            dbflux_i18n::t!("document.data.chart_dock.degraded.build_failed.body"),
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        pending_change_count_label, pending_edits_summary, refresh_policy_label, row_count_label,
-        unsaved_changes_label,
+        chart_degraded_copy, pending_change_count_label, pending_edits_summary,
+        refresh_policy_label, row_count_label, unsaved_changes_label,
     };
+    use dbflux_components::chart::ChartDetection;
     use dbflux_core::RefreshPolicy;
 
     #[test]
@@ -234,5 +266,74 @@ mod tests {
     fn pending_change_count_label_one_many() {
         assert_eq!(pending_change_count_label(1), "1 pending change");
         assert_eq!(pending_change_count_label(2), "2 pending changes");
+    }
+
+    #[test]
+    fn chart_dock_part1_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.data.chart_dock.toolbar.apply",
+            "document.data.chart_dock.save.title",
+            "document.data.chart_dock.save.name_placeholder",
+            "document.data.chart_dock.save.cancel",
+            "document.data.chart_dock.save.save",
+            "document.data.chart_dock.degraded.no_time_column.title",
+            "document.data.chart_dock.degraded.no_time_column.body",
+            "document.data.chart_dock.degraded.no_numeric_series.title",
+            "document.data.chart_dock.degraded.no_numeric_series.body",
+            "document.data.chart_dock.degraded.no_data.title",
+            "document.data.chart_dock.degraded.no_data.body",
+            "document.data.chart_dock.degraded.build_failed.title",
+            "document.data.chart_dock.degraded.build_failed.body",
+            "document.data.chart_dock.degraded.open_table_tab",
+            "document.data.chart_dock.degraded.pick_time_column",
+            "document.data.chart_dock.degraded.hide_picker",
+            "document.data.chart_dock.picker.x_axis_label",
+            "document.data.chart_dock.picker.y_axis_label",
+            "document.data.chart_dock.picker.apply",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn chart_dock_degraded_title_differs_between_locales() {
+        for detection in [
+            None,
+            Some(ChartDetection::NoTimeColumn),
+            Some(ChartDetection::NoNumericSeries),
+            Some(ChartDetection::EmptyResult),
+            Some(ChartDetection::Ok {
+                time_col: 0,
+                numeric_cols: vec![1],
+            }),
+        ] {
+            let (title, body) = chart_degraded_copy(&detection);
+
+            assert!(!title.is_empty());
+            assert!(!body.is_empty());
+        }
+
+        let (en_title, _) = chart_degraded_copy(&Some(ChartDetection::NoTimeColumn));
+        assert_eq!(en_title, "No time column detected");
+    }
+
+    #[test]
+    fn chart_degraded_copy_none_matches_no_time_column() {
+        let none_copy = chart_degraded_copy(&None);
+        let no_time_copy = chart_degraded_copy(&Some(ChartDetection::NoTimeColumn));
+
+        assert_eq!(none_copy, no_time_copy);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 3a: the chart dock's custom-range apply button, the collection chart save overlay, the degraded-state copy (through a `chart_degraded_copy` helper over `ChartDetection`) and the chart picker overlay render through `dbflux_i18n::t!`. 19 keys under `document.data.chart_dock.*`, English and Spanish together.

## What does this resolve?

- Refs #360 (follows #385; next: chart dock rail/configure/stats, row inspector, mutation toasts)

## How was this solved?

- The point inspector and legend row have no literals of their own (they delegate to `dbflux_components`). Column names and values stay data.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 886 passed; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: open a chart on a result without a time column and with one, use the picker.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
