### PR TITLE
feat(i18n): translate the chart dock rail, configure tab, and stats tab

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -82,6 +82,55 @@ document:
         x_axis_label: X axis (time / label column)
         y_axis_label: Y axis (numeric columns)
         apply: Apply
+      rail:
+        shape:
+          rows:
+            one: "%{count} row"
+            many: "%{count} rows"
+          columns:
+            one: "%{count} column"
+            many: "%{count} columns"
+          template: "%{rows} × %{columns}"
+      configure:
+        why:
+          numeric:
+            one: "%{count} numeric column"
+            many: "%{count} numeric columns"
+          timestamp:
+            one: "%{count} timestamp-like column"
+            many: "%{count} timestamp-like columns"
+          template: "The result has %{numeric} and %{timestamp}. Pick which one is the time axis and which series to plot."
+          title: Why this panel
+        time_column:
+          title: Time column
+        series:
+          title: Series
+        axis_stacking:
+          title: Axis & Stacking
+          y_axis: y-axis
+          y_axis_value: linear · 0 → auto
+          stack: stack
+          stack_value: off (v0.6.0)
+          interpolation: interpolation
+          interpolation_value: linear
+        reset: Reset
+      stats:
+        rebuilding: "Rebuilding chart…"
+        no_stats: No stats available for this series.
+        unavailable: unavailable
+        title: Stats
+        window:
+          title: Window
+          start: start
+          end: end
+          span: span
+          points: points
+        source:
+          title: Source
+          measurement: measurement
+          field: field
+          host: host
+          region: region
     grid:
       edit_bar:
         clean: No unsaved changes

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -82,6 +82,55 @@ document:
         x_axis_label: Eje X (columna de tiempo o etiqueta)
         y_axis_label: Eje Y (columnas numéricas)
         apply: Aplicar
+      rail:
+        shape:
+          rows:
+            one: "%{count} fila"
+            many: "%{count} filas"
+          columns:
+            one: "%{count} columna"
+            many: "%{count} columnas"
+          template: "%{rows} × %{columns}"
+      configure:
+        why:
+          numeric:
+            one: "%{count} columna numérica"
+            many: "%{count} columnas numéricas"
+          timestamp:
+            one: "%{count} columna con marca de tiempo"
+            many: "%{count} columnas con marca de tiempo"
+          template: "El resultado tiene %{numeric} y %{timestamp}. Elige cuál es el eje de tiempo y qué series graficar."
+          title: Por qué este panel
+        time_column:
+          title: Columna de tiempo
+        series:
+          title: Series
+        axis_stacking:
+          title: Eje y apilamiento
+          y_axis: eje y
+          y_axis_value: lineal · 0 → auto
+          stack: apilamiento
+          stack_value: desactivado (v0.6.0)
+          interpolation: interpolación
+          interpolation_value: lineal
+        reset: Restablecer
+      stats:
+        rebuilding: "Reconstruyendo el gráfico…"
+        no_stats: No hay estadísticas disponibles para esta serie.
+        unavailable: no disponible
+        title: Estadísticas
+        window:
+          title: Ventana
+          start: inicio
+          end: fin
+          span: duración
+          points: puntos
+        source:
+          title: Origen
+          measurement: medición
+          field: campo
+          host: host
+          region: región
     grid:
       edit_bar:
         clean: Sin cambios pendientes

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -2302,7 +2302,7 @@ impl DataGridPanel {
         let row_count = self.result.row_count();
         let col_count = self.result.columns.len();
         let shape_label: SharedString =
-            format!("{} rows × {} columns", row_count, col_count).into();
+            crate::labels::chart_dock_shape_label(row_count, col_count).into();
 
         let col_chips: Vec<AnyElement> = self
             .result
@@ -2839,14 +2839,7 @@ impl DataGridPanel {
         let any_y_checked = y_checked.iter().any(|&c| c);
         let reset_enabled = detection_ok || has_manual;
 
-        let why_text = format!(
-            "The result has {} numeric column{} and {} timestamp-like column{}. \
-             Pick which one is the time axis and which series to plot.",
-            num_numeric,
-            if num_numeric == 1 { "" } else { "s" },
-            num_ts,
-            if num_ts == 1 { "" } else { "s" },
-        );
+        let why_text = crate::labels::chart_rail_why_text(num_numeric, num_ts);
 
         div()
             .id("rail-configure-scroll")
@@ -2860,7 +2853,10 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Self::dock_header("Why this panel", &chart_colors))
+                    .child(Self::dock_header(
+                        &dbflux_i18n::t!("document.data.chart_dock.configure.why.title"),
+                        &chart_colors,
+                    ))
                     .child(
                         div()
                             .text_size(px(11.0))
@@ -2875,7 +2871,10 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Self::dock_header("Time column", &chart_colors))
+                    .child(Self::dock_header(
+                        &dbflux_i18n::t!("document.data.chart_dock.configure.time_column.title"),
+                        &chart_colors,
+                    ))
                     .children(x_candidates.iter().enumerate().map(
                         |(cand_idx, (col_idx, col_name))| {
                             let col_idx = *col_idx;
@@ -2921,7 +2920,10 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XXS)
-                    .child(Self::dock_header("Series", &chart_colors))
+                    .child(Self::dock_header(
+                        &dbflux_i18n::t!("document.data.chart_dock.configure.series.title"),
+                        &chart_colors,
+                    ))
                     .children(y_candidates.iter().enumerate().map(
                         |(cand_idx, (col_idx, col_name))| {
                             let col_idx = *col_idx;
@@ -2984,29 +2986,38 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(Self::dock_header("Axis & Stacking", &chart_colors))
-                    .child(Self::dock_kv_row(
-                        "y-axis",
-                        div()
-                            .text_size(px(11.0))
-                            .text_color(theme.foreground)
-                            .child("linear · 0 → auto"),
+                    .child(Self::dock_header(
+                        &dbflux_i18n::t!("document.data.chart_dock.configure.axis_stacking.title"),
                         &chart_colors,
                     ))
                     .child(Self::dock_kv_row(
-                        "stack",
+                        &dbflux_i18n::t!("document.data.chart_dock.configure.axis_stacking.y_axis"),
+                        div().text_size(px(11.0)).text_color(theme.foreground).child(
+                            dbflux_i18n::t!(
+                                "document.data.chart_dock.configure.axis_stacking.y_axis_value"
+                            ),
+                        ),
+                        &chart_colors,
+                    ))
+                    .child(Self::dock_kv_row(
+                        &dbflux_i18n::t!("document.data.chart_dock.configure.axis_stacking.stack"),
                         div()
                             .text_size(px(11.0))
                             .text_color(theme.muted_foreground)
-                            .child("off (v0.6.0)"),
+                            .child(dbflux_i18n::t!(
+                                "document.data.chart_dock.configure.axis_stacking.stack_value"
+                            )),
                         &chart_colors,
                     ))
                     .child(Self::dock_kv_row(
-                        "interpolation",
-                        div()
-                            .text_size(px(11.0))
-                            .text_color(theme.foreground)
-                            .child("linear"),
+                        &dbflux_i18n::t!(
+                            "document.data.chart_dock.configure.axis_stacking.interpolation"
+                        ),
+                        div().text_size(px(11.0)).text_color(theme.foreground).child(
+                            dbflux_i18n::t!(
+                                "document.data.chart_dock.configure.axis_stacking.interpolation_value"
+                            ),
+                        ),
                         &chart_colors,
                     )),
                 theme,
@@ -3041,7 +3052,7 @@ impl DataGridPanel {
                             .when(!reset_enabled, |d| {
                                 d.text_color(theme.muted_foreground).opacity(0.4)
                             })
-                            .child("Reset"),
+                            .child(dbflux_i18n::t!("document.data.chart_dock.configure.reset")),
                     )
                     // Apply button
                     .child(
@@ -3074,7 +3085,7 @@ impl DataGridPanel {
                                     ..chart_colors.muted_fg
                                 })
                             })
-                            .child("Apply"),
+                            .child(dbflux_i18n::t!("document.data.chart_dock.toolbar.apply")),
                     ),
             )
     }
@@ -3123,7 +3134,7 @@ impl DataGridPanel {
                 .p_2()
                 .text_size(FontSizes::XS)
                 .text_color(theme.muted_foreground)
-                .child("Rebuilding chart…")
+                .child(dbflux_i18n::t!("document.data.chart_dock.stats.rebuilding"))
                 .into_any_element();
         };
 
@@ -3132,7 +3143,7 @@ impl DataGridPanel {
                 .p_2()
                 .text_size(FontSizes::XS)
                 .text_color(theme.muted_foreground)
-                .child("No stats available for this series.")
+                .child(dbflux_i18n::t!("document.data.chart_dock.stats.no_stats"))
                 .into_any_element();
         };
 
@@ -3181,7 +3192,9 @@ impl DataGridPanel {
                 .text_size(px(11.0))
                 .text_color(theme.muted_foreground)
                 .italic()
-                .child("unavailable")
+                .child(dbflux_i18n::t!(
+                    "document.data.chart_dock.stats.unavailable"
+                ))
                 .into_any_element()
         };
 
@@ -3214,7 +3227,10 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(Self::dock_header("Stats", &chart_colors))
+                    .child(Self::dock_header(
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.title"),
+                        &chart_colors,
+                    ))
                     .child(Self::dock_kv_row("min", cyan_val(stats.min), &chart_colors))
                     .child(Self::dock_kv_row("max", cyan_val(stats.max), &chart_colors))
                     .child(Self::dock_kv_row("avg", cyan_val(stats.avg), &chart_colors))
@@ -3234,20 +3250,27 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(Self::dock_header("Window", &chart_colors))
+                    .child(Self::dock_header(
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.window.title"),
+                        &chart_colors,
+                    ))
                     .child(Self::dock_kv_row(
-                        "start",
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.window.start"),
                         str_val(start_label),
                         &chart_colors,
                     ))
-                    .child(Self::dock_kv_row("end", str_val(end_label), &chart_colors))
                     .child(Self::dock_kv_row(
-                        "span",
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.window.end"),
+                        str_val(end_label),
+                        &chart_colors,
+                    ))
+                    .child(Self::dock_kv_row(
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.window.span"),
                         str_val(span_label),
                         &chart_colors,
                     ))
                     .child(Self::dock_kv_row(
-                        "points",
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.window.points"),
                         str_val(format!("{}", points_count)),
                         &chart_colors,
                     )),
@@ -3260,15 +3283,30 @@ impl DataGridPanel {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(Self::dock_header("Source", &chart_colors))
+                    .child(Self::dock_header(
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.source.title"),
+                        &chart_colors,
+                    ))
                     .child(Self::dock_kv_row(
-                        "measurement",
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.source.measurement"),
                         unavail_val(),
                         &chart_colors,
                     ))
-                    .child(Self::dock_kv_row("field", unavail_val(), &chart_colors))
-                    .child(Self::dock_kv_row("host", unavail_val(), &chart_colors))
-                    .child(Self::dock_kv_row("region", unavail_val(), &chart_colors)),
+                    .child(Self::dock_kv_row(
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.source.field"),
+                        unavail_val(),
+                        &chart_colors,
+                    ))
+                    .child(Self::dock_kv_row(
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.source.host"),
+                        unavail_val(),
+                        &chart_colors,
+                    ))
+                    .child(Self::dock_kv_row(
+                        &dbflux_i18n::t!("document.data.chart_dock.stats.source.region"),
+                        unavail_val(),
+                        &chart_colors,
+                    )),
                 theme,
             ))
             .into_any_element()

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -185,11 +185,75 @@ pub(crate) fn chart_degraded_copy(
     }
 }
 
+/// Row/column shape summary shown above the chart dock's degraded-state
+/// column chips, with the row and column counts pluralized independently.
+pub(crate) fn chart_dock_shape_label(rows: usize, columns: usize) -> String {
+    let rows_label = if rows == 1 {
+        dbflux_i18n::t!("document.data.chart_dock.rail.shape.rows.one", count = rows)
+    } else {
+        dbflux_i18n::t!(
+            "document.data.chart_dock.rail.shape.rows.many",
+            count = rows
+        )
+    };
+    let columns_label = if columns == 1 {
+        dbflux_i18n::t!(
+            "document.data.chart_dock.rail.shape.columns.one",
+            count = columns
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.data.chart_dock.rail.shape.columns.many",
+            count = columns
+        )
+    };
+
+    dbflux_i18n::t!(
+        "document.data.chart_dock.rail.shape.template",
+        rows = rows_label,
+        columns = columns_label
+    )
+}
+
+/// WHY-panel explanation text for the chart rail's configure tab, with the
+/// numeric- and timestamp-like column counts pluralized independently.
+pub(crate) fn chart_rail_why_text(numeric_columns: usize, timestamp_columns: usize) -> String {
+    let numeric = if numeric_columns == 1 {
+        dbflux_i18n::t!(
+            "document.data.chart_dock.configure.why.numeric.one",
+            count = numeric_columns
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.data.chart_dock.configure.why.numeric.many",
+            count = numeric_columns
+        )
+    };
+    let timestamp = if timestamp_columns == 1 {
+        dbflux_i18n::t!(
+            "document.data.chart_dock.configure.why.timestamp.one",
+            count = timestamp_columns
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.data.chart_dock.configure.why.timestamp.many",
+            count = timestamp_columns
+        )
+    };
+
+    dbflux_i18n::t!(
+        "document.data.chart_dock.configure.why.template",
+        numeric = numeric,
+        timestamp = timestamp
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        chart_degraded_copy, pending_change_count_label, pending_edits_summary,
-        refresh_policy_label, row_count_label, unsaved_changes_label,
+        chart_degraded_copy, chart_dock_shape_label, chart_rail_why_text,
+        pending_change_count_label, pending_edits_summary, refresh_policy_label, row_count_label,
+        unsaved_changes_label,
     };
     use dbflux_components::chart::ChartDetection;
     use dbflux_core::RefreshPolicy;
@@ -335,5 +399,100 @@ mod tests {
         let no_time_copy = chart_degraded_copy(&Some(ChartDetection::NoTimeColumn));
 
         assert_eq!(none_copy, no_time_copy);
+    }
+
+    #[test]
+    fn chart_dock_part2_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.data.chart_dock.rail.shape.rows.one",
+            "document.data.chart_dock.rail.shape.rows.many",
+            "document.data.chart_dock.rail.shape.columns.one",
+            "document.data.chart_dock.rail.shape.columns.many",
+            "document.data.chart_dock.configure.why.numeric.one",
+            "document.data.chart_dock.configure.why.numeric.many",
+            "document.data.chart_dock.configure.why.timestamp.one",
+            "document.data.chart_dock.configure.why.timestamp.many",
+            "document.data.chart_dock.configure.why.title",
+            "document.data.chart_dock.configure.time_column.title",
+            "document.data.chart_dock.configure.series.title",
+            "document.data.chart_dock.configure.axis_stacking.title",
+            "document.data.chart_dock.configure.axis_stacking.y_axis",
+            "document.data.chart_dock.configure.axis_stacking.y_axis_value",
+            "document.data.chart_dock.configure.axis_stacking.stack",
+            "document.data.chart_dock.configure.axis_stacking.stack_value",
+            "document.data.chart_dock.configure.axis_stacking.interpolation",
+            "document.data.chart_dock.configure.axis_stacking.interpolation_value",
+            "document.data.chart_dock.configure.reset",
+            "document.data.chart_dock.stats.rebuilding",
+            "document.data.chart_dock.stats.no_stats",
+            "document.data.chart_dock.stats.unavailable",
+            "document.data.chart_dock.stats.title",
+            "document.data.chart_dock.stats.window.title",
+            "document.data.chart_dock.stats.window.start",
+            "document.data.chart_dock.stats.window.end",
+            "document.data.chart_dock.stats.window.span",
+            "document.data.chart_dock.stats.window.points",
+            "document.data.chart_dock.stats.source.title",
+            "document.data.chart_dock.stats.source.measurement",
+            "document.data.chart_dock.stats.source.field",
+            "document.data.chart_dock.stats.source.host",
+            "document.data.chart_dock.stats.source.region",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn chart_dock_configure_title_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.data.chart_dock.configure.why.title",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.data.chart_dock.configure.why.title",
+            locale = "es"
+        );
+
+        assert_eq!(en, "Why this panel");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn chart_dock_shape_label_zero_one_many() {
+        assert_eq!(chart_dock_shape_label(0, 0), "0 rows × 0 columns");
+        assert_eq!(chart_dock_shape_label(1, 1), "1 row × 1 column");
+        assert_eq!(chart_dock_shape_label(2, 5), "2 rows × 5 columns");
+    }
+
+    #[test]
+    fn chart_rail_why_text_zero_one_many() {
+        let zero = chart_rail_why_text(0, 0);
+        let one = chart_rail_why_text(1, 1);
+        let many = chart_rail_why_text(3, 2);
+
+        assert_eq!(
+            zero,
+            "The result has 0 numeric columns and 0 timestamp-like columns. \
+             Pick which one is the time axis and which series to plot."
+        );
+        assert_eq!(
+            one,
+            "The result has 1 numeric column and 1 timestamp-like column. \
+             Pick which one is the time axis and which series to plot."
+        );
+        assert!(many.contains("3 numeric columns"));
+        assert!(many.contains("2 timestamp-like columns"));
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 3b: the chart dock rail shape summary, the configure tab copy and the stats tab headers and rows render through `dbflux_i18n::t!`, with plural-aware helpers for rows/columns and numeric/timestamp counts; stat abbreviations stay as is. English and Spanish together.

## What does this resolve?

- Refs #360 (follows #387; next: row inspector, mutation toasts, context menu)

## How was this solved?

- `render_rail_configure_tab` is currently unreachable (superseded by `AxisBar`) but was translated for completeness.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 890 passed; clippy clean; fmt clean. Manual smoke in Spanish: open the chart rail stats tab.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
