### PR TITLE
feat(i18n): translate the sidebar connection tasks and toasts

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -682,11 +682,39 @@ sidebar:
   tabs:
     connections: CONNECTIONS
     scripts: SCRIPTS
+  task:
+    connecting: "Connecting to %{name}"
+    disconnecting: "Disconnecting %{name}"
+    connection_hook_cancelled: Connection hook cancelled
+    post_connect_hook_cancelled: Post-connect hook cancelled
+    disconnect_hook_cancelled: Disconnect hook cancelled
+    post_disconnect_hook_cancelled: Post-disconnect hook cancelled
   toast:
     edit_reconnect_updated: "'%{name}' updated"
     edit_reconnect_body: Reconnect to apply the changes to the live session.
     edit_reconnect_now: Reconnect now
     edit_reconnect_later: Later
+    connection_already_pending: Connection already pending
+    operation_started_elsewhere: Operation started by another thread
+    background_task_limit: Too many background tasks running, please wait
+    connection_cancelled_by_hook: Connection cancelled by hook
+    connection_cancelled_by_post_connect_hook: Connection cancelled by post-connect hook
+    disconnect_cancelled_by_hook: Disconnect cancelled by hook
+    disconnected_hook_cancelled: Disconnected, but post-disconnect hook was cancelled
+    disconnected_hook_error: "Disconnected from %{name}, but %{error}"
+    profile_not_found: Profile not found
+    connected:
+      plain: "Connected to %{name}"
+      one: "Connected to %{name} (with 1 hook warning)"
+      many: "Connected to %{name} (with %{count} hook warnings)"
+    disconnected:
+      plain: "Disconnected from %{name}"
+      one: "Disconnected from %{name} (with 1 hook warning)"
+      many: "Disconnected from %{name} (with %{count} hook warnings)"
+    external_driver_unavailable:
+      config: "External driver '%{driver_id}' is unavailable because service '%{socket_id}' has an invalid configuration: %{summary}"
+      launch: "External driver '%{driver_id}' is unavailable because service '%{socket_id}' did not start: %{summary}"
+      probe: "External driver '%{driver_id}' is unavailable because service '%{socket_id}' failed during driver probe: %{summary}"
   tree:
     container:
       relational: Tables (%{count})

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -682,11 +682,39 @@ sidebar:
   tabs:
     connections: CONEXIONES
     scripts: SCRIPTS
+  task:
+    connecting: "Conectando a %{name}"
+    disconnecting: "Desconectando %{name}"
+    connection_hook_cancelled: Hook de conexión cancelado
+    post_connect_hook_cancelled: Hook posterior a la conexión cancelado
+    disconnect_hook_cancelled: Hook de desconexión cancelado
+    post_disconnect_hook_cancelled: Hook posterior a la desconexión cancelado
   toast:
     edit_reconnect_updated: "'%{name}' actualizado"
     edit_reconnect_body: Reconecta para aplicar los cambios a la sesión activa.
     edit_reconnect_now: Reconectar ahora
     edit_reconnect_later: Más tarde
+    connection_already_pending: Ya hay una conexión pendiente
+    operation_started_elsewhere: Otro proceso ya inició la operación
+    background_task_limit: Hay demasiadas tareas en segundo plano, espera un momento
+    connection_cancelled_by_hook: Conexión cancelada por un hook
+    connection_cancelled_by_post_connect_hook: Conexión cancelada por el hook posterior a la conexión
+    disconnect_cancelled_by_hook: Desconexión cancelada por un hook
+    disconnected_hook_cancelled: Desconectado, pero se canceló el hook posterior a la desconexión
+    disconnected_hook_error: "Desconectado de %{name}, pero %{error}"
+    profile_not_found: Perfil no encontrado
+    connected:
+      plain: "Conectado a %{name}"
+      one: "Conectado a %{name} (con 1 advertencia de hook)"
+      many: "Conectado a %{name} (con %{count} advertencias de hook)"
+    disconnected:
+      plain: "Desconectado de %{name}"
+      one: "Desconectado de %{name} (con 1 advertencia de hook)"
+      many: "Desconectado de %{name} (con %{count} advertencias de hook)"
+    external_driver_unavailable:
+      config: "El driver externo '%{driver_id}' no está disponible porque el servicio '%{socket_id}' tiene una configuración inválida: %{summary}"
+      launch: "El driver externo '%{driver_id}' no está disponible porque el servicio '%{socket_id}' no inició: %{summary}"
+      probe: "El driver externo '%{driver_id}' no está disponible porque el servicio '%{socket_id}' falló durante la prueba del driver: %{summary}"
   tree:
     container:
       relational: Tablas (%{count})

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -1,5 +1,6 @@
 //! Translated label helpers for sidebar chrome (tabs, footer, tree folders).
 
+use dbflux_app::ExternalDriverStage;
 use dbflux_core::{DatabaseCategory, RelationKind};
 
 /// Translated label for a schema-tree container folder, e.g. `"Tables (12)"`.
@@ -306,6 +307,145 @@ pub(crate) fn instance_overview_label() -> String {
 /// browsing, e.g. CloudWatch namespaces).
 pub(crate) fn metrics_folder_label() -> String {
     dbflux_i18n::t!("sidebar.tree.folder.metrics")
+}
+
+/// Translated task-panel label for an in-flight connect attempt, e.g.
+/// `"Connecting to prod-db"`.
+pub(crate) fn connecting_task_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.connecting", name = name)
+}
+
+/// Translated task-panel label for an in-flight disconnect, e.g.
+/// `"Disconnecting prod-db"`.
+pub(crate) fn disconnecting_task_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.disconnecting", name = name)
+}
+
+/// Translated task failure message when a pre-connect hook is cancelled.
+pub(crate) fn connection_hook_cancelled_task_label() -> String {
+    dbflux_i18n::t!("sidebar.task.connection_hook_cancelled")
+}
+
+/// Translated task failure message when a post-connect hook is cancelled.
+pub(crate) fn post_connect_hook_cancelled_task_label() -> String {
+    dbflux_i18n::t!("sidebar.task.post_connect_hook_cancelled")
+}
+
+/// Translated task failure message when a pre-disconnect hook is cancelled.
+pub(crate) fn disconnect_hook_cancelled_task_label() -> String {
+    dbflux_i18n::t!("sidebar.task.disconnect_hook_cancelled")
+}
+
+/// Translated task failure message when a post-disconnect hook is cancelled.
+pub(crate) fn post_disconnect_hook_cancelled_task_label() -> String {
+    dbflux_i18n::t!("sidebar.task.post_disconnect_hook_cancelled")
+}
+
+/// Translated toast shown when a connect/disconnect request is rejected
+/// because an operation is already pending for the same profile.
+pub(crate) fn connection_already_pending_toast_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.connection_already_pending")
+}
+
+/// Translated toast shown when a pending-operation slot was claimed by
+/// another thread between the check and the reservation.
+pub(crate) fn operation_started_elsewhere_toast_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.operation_started_elsewhere")
+}
+
+/// Translated toast shown when the background task limit blocks a new
+/// connect or disconnect request.
+pub(crate) fn background_task_limit_toast_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.background_task_limit")
+}
+
+/// Translated toast shown when a pre-connect hook cancels the connect flow.
+pub(crate) fn connection_cancelled_by_hook_toast_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.connection_cancelled_by_hook")
+}
+
+/// Translated toast shown when a post-connect hook cancels the connect flow.
+pub(crate) fn connection_cancelled_by_post_connect_hook_toast_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.connection_cancelled_by_post_connect_hook")
+}
+
+/// Translated toast shown when a pre-disconnect hook cancels the disconnect
+/// flow.
+pub(crate) fn disconnect_cancelled_by_hook_toast_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.disconnect_cancelled_by_hook")
+}
+
+/// Translated toast shown when the disconnect itself completed but the
+/// post-disconnect hook was cancelled.
+pub(crate) fn disconnected_hook_cancelled_toast_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.disconnected_hook_cancelled")
+}
+
+/// Translated error message for editing a connection profile that no longer
+/// exists.
+pub(crate) fn profile_not_found_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.profile_not_found")
+}
+
+/// Translated toast reporting a successful connect, e.g. `"Connected to
+/// prod-db"`, optionally noting how many hook warnings were logged.
+pub(crate) fn connected_toast_label(name: &str, warning_count: usize) -> String {
+    match warning_count {
+        0 => dbflux_i18n::t!("sidebar.toast.connected.plain", name = name),
+        1 => dbflux_i18n::t!("sidebar.toast.connected.one", name = name),
+        _ => dbflux_i18n::t!(
+            "sidebar.toast.connected.many",
+            name = name,
+            count = warning_count
+        ),
+    }
+}
+
+/// Translated toast reporting a successful disconnect, e.g. `"Disconnected
+/// from prod-db"`, optionally noting how many hook warnings were logged.
+pub(crate) fn disconnected_toast_label(name: &str, warning_count: usize) -> String {
+    match warning_count {
+        0 => dbflux_i18n::t!("sidebar.toast.disconnected.plain", name = name),
+        1 => dbflux_i18n::t!("sidebar.toast.disconnected.one", name = name),
+        _ => dbflux_i18n::t!(
+            "sidebar.toast.disconnected.many",
+            name = name,
+            count = warning_count
+        ),
+    }
+}
+
+/// Translated toast reporting a disconnect that completed despite a
+/// post-disconnect hook error, e.g. `"Disconnected from prod-db, but the
+/// hook timed out"`.
+pub(crate) fn disconnected_hook_error_toast_label(name: &str, error: &str) -> String {
+    dbflux_i18n::t!(
+        "sidebar.toast.disconnected_hook_error",
+        name = name,
+        error = error
+    )
+}
+
+/// Translated toast for an external (RPC-backed) driver that failed to
+/// become available, with wording specific to which stage failed.
+pub(crate) fn external_driver_unavailable_label(
+    stage: &ExternalDriverStage,
+    driver_id: &str,
+    socket_id: &str,
+    summary: &str,
+) -> String {
+    let key = match stage {
+        ExternalDriverStage::Config => "sidebar.toast.external_driver_unavailable.config",
+        ExternalDriverStage::Launch => "sidebar.toast.external_driver_unavailable.launch",
+        ExternalDriverStage::Probe => "sidebar.toast.external_driver_unavailable.probe",
+    };
+
+    dbflux_i18n::t!(
+        key,
+        driver_id = driver_id,
+        socket_id = socket_id,
+        summary = summary
+    )
 }
 
 #[cfg(test)]
@@ -730,5 +870,219 @@ mod tests {
             super::dependent_kind_label(&RelationKind::Trigger),
             dbflux_i18n::t!("sidebar.tree.status.dependent_kind.trigger")
         );
+    }
+
+    const D1A_KEYS: [&str; 18] = [
+        "sidebar.task.connecting",
+        "sidebar.task.disconnecting",
+        "sidebar.task.connection_hook_cancelled",
+        "sidebar.task.post_connect_hook_cancelled",
+        "sidebar.task.disconnect_hook_cancelled",
+        "sidebar.task.post_disconnect_hook_cancelled",
+        "sidebar.toast.connection_already_pending",
+        "sidebar.toast.operation_started_elsewhere",
+        "sidebar.toast.background_task_limit",
+        "sidebar.toast.connection_cancelled_by_hook",
+        "sidebar.toast.connection_cancelled_by_post_connect_hook",
+        "sidebar.toast.disconnect_cancelled_by_hook",
+        "sidebar.toast.disconnected_hook_cancelled",
+        "sidebar.toast.profile_not_found",
+        "sidebar.toast.connected.plain",
+        "sidebar.toast.connected.one",
+        "sidebar.toast.connected.many",
+        "sidebar.toast.disconnected_hook_error",
+    ];
+
+    #[test]
+    fn d1a_keys_resolve_in_both_locales() {
+        for key in D1A_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn disconnected_toast_keys_resolve_in_both_locales() {
+        for key in [
+            "sidebar.toast.disconnected.plain",
+            "sidebar.toast.disconnected.one",
+            "sidebar.toast.disconnected.many",
+        ] {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn external_driver_unavailable_keys_resolve_in_both_locales() {
+        for key in [
+            "sidebar.toast.external_driver_unavailable.config",
+            "sidebar.toast.external_driver_unavailable.launch",
+            "sidebar.toast.external_driver_unavailable.probe",
+        ] {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn connecting_task_label_includes_the_profile_name() {
+        let label = super::connecting_task_label("prod-db");
+
+        assert!(label.contains("prod-db"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.task.connecting", name = "prod-db")
+        );
+    }
+
+    #[test]
+    fn disconnecting_task_label_includes_the_profile_name() {
+        let label = super::disconnecting_task_label("prod-db");
+
+        assert!(label.contains("prod-db"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.task.disconnecting", name = "prod-db")
+        );
+        assert_ne!(label, super::connecting_task_label("prod-db"));
+    }
+
+    #[test]
+    fn connected_toast_label_plain_one_and_many_diverge() {
+        let plain = super::connected_toast_label("prod-db", 0);
+        let one = super::connected_toast_label("prod-db", 1);
+        let many = super::connected_toast_label("prod-db", 3);
+
+        assert_eq!(
+            plain,
+            dbflux_i18n::t!("sidebar.toast.connected.plain", name = "prod-db")
+        );
+        assert_eq!(
+            one,
+            dbflux_i18n::t!("sidebar.toast.connected.one", name = "prod-db")
+        );
+        assert_eq!(
+            many,
+            dbflux_i18n::t!("sidebar.toast.connected.many", name = "prod-db", count = 3)
+        );
+        assert!(many.contains('3'));
+        assert_ne!(plain, one);
+        assert_ne!(one, many);
+        assert_ne!(plain, many);
+    }
+
+    #[test]
+    fn disconnected_toast_label_plain_one_and_many_diverge() {
+        let plain = super::disconnected_toast_label("prod-db", 0);
+        let one = super::disconnected_toast_label("prod-db", 1);
+        let many = super::disconnected_toast_label("prod-db", 2);
+
+        assert_eq!(
+            plain,
+            dbflux_i18n::t!("sidebar.toast.disconnected.plain", name = "prod-db")
+        );
+        assert_eq!(
+            one,
+            dbflux_i18n::t!("sidebar.toast.disconnected.one", name = "prod-db")
+        );
+        assert_eq!(
+            many,
+            dbflux_i18n::t!(
+                "sidebar.toast.disconnected.many",
+                name = "prod-db",
+                count = 2
+            )
+        );
+        assert!(many.contains('2'));
+        assert_ne!(plain, one);
+        assert_ne!(one, many);
+    }
+
+    #[test]
+    fn disconnected_hook_error_toast_label_includes_name_and_error() {
+        let label = super::disconnected_hook_error_toast_label("prod-db", "hook timed out");
+
+        assert!(label.contains("prod-db"));
+        assert!(label.contains("hook timed out"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!(
+                "sidebar.toast.disconnected_hook_error",
+                name = "prod-db",
+                error = "hook timed out"
+            )
+        );
+    }
+
+    #[test]
+    fn external_driver_unavailable_label_uses_the_stage_specific_key() {
+        use dbflux_app::ExternalDriverStage;
+
+        let config = super::external_driver_unavailable_label(
+            &ExternalDriverStage::Config,
+            "rpc:missing.sock",
+            "missing.sock",
+            "bad config",
+        );
+        let launch = super::external_driver_unavailable_label(
+            &ExternalDriverStage::Launch,
+            "rpc:missing.sock",
+            "missing.sock",
+            "did not start",
+        );
+        let probe = super::external_driver_unavailable_label(
+            &ExternalDriverStage::Probe,
+            "rpc:missing.sock",
+            "missing.sock",
+            "probe failed",
+        );
+
+        assert!(config.contains("rpc:missing.sock"));
+        assert!(config.contains("bad config"));
+        assert!(launch.contains("did not start"));
+        assert!(probe.contains("probe failed"));
+        assert_ne!(config, launch);
+        assert_ne!(launch, probe);
+    }
+
+    #[test]
+    fn sidebar_task_connecting_diverges_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.task.connecting", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.task.connecting", locale = "es");
+
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn sidebar_toast_connected_many_diverges_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.toast.connected.many", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.toast.connected.many", locale = "es");
+
+        assert_ne!(english, spanish);
     }
 }

--- a/crates/dbflux_ui_sidebar/src/lib.rs
+++ b/crates/dbflux_ui_sidebar/src/lib.rs
@@ -2026,9 +2026,14 @@ mod tests {
         };
 
         let message = format_connect_prepare_error(&error, Some(&diagnostic));
+        let expected_prefix = crate::labels::external_driver_unavailable_label(
+            &ExternalDriverStage::Probe,
+            "rpc:missing.sock",
+            "missing.sock",
+            "Probe failed",
+        );
 
-        assert!(message.contains("rpc:missing.sock"));
-        assert!(message.contains("Probe failed"));
+        assert!(message.starts_with(&expected_prefix));
         assert!(message.contains("host exited before ready"));
     }
 
@@ -2057,15 +2062,19 @@ mod tests {
         };
 
         let toast = connect_prepare_error_toast(&error, Some(&diagnostic));
+        let expected_prefix = crate::labels::external_driver_unavailable_label(
+            &ExternalDriverStage::Launch,
+            "rpc:missing.sock",
+            "missing.sock",
+            "Driver host exited before socket was ready",
+        );
 
         assert!(toast.is_error);
-        assert!(toast.message.contains("rpc:missing.sock"));
-        assert!(toast.message.contains("missing.sock"));
-        assert!(toast.message.contains("did not start"));
+        assert!(toast.message.starts_with(&expected_prefix));
         assert!(
             toast
                 .message
-                .contains("Driver host exited before socket was ready")
+                .contains("stdout:\nbooting\n\nstderr:\nmissing binary")
         );
     }
 

--- a/crates/dbflux_ui_sidebar/src/operations/connection.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/connection.rs
@@ -23,20 +23,7 @@ fn format_external_driver_stage_message(
     socket_id: &str,
     summary: &str,
 ) -> String {
-    match stage {
-        ExternalDriverStage::Config => format!(
-            "External driver '{}' is unavailable because service '{}' has an invalid configuration: {}",
-            driver_id, socket_id, summary
-        ),
-        ExternalDriverStage::Launch => format!(
-            "External driver '{}' is unavailable because service '{}' did not start: {}",
-            driver_id, socket_id, summary
-        ),
-        ExternalDriverStage::Probe => format!(
-            "External driver '{}' is unavailable because service '{}' failed during driver probe: {}",
-            driver_id, socket_id, summary
-        ),
-    }
+    crate::labels::external_driver_unavailable_label(stage, driver_id, socket_id, summary)
 }
 
 pub(crate) fn format_connect_prepare_error(
@@ -274,7 +261,7 @@ impl Sidebar {
             match self.app_state.update(cx, |state, _cx| {
                 if state.is_operation_pending(profile_id, None) {
                     return Err(PendingToast {
-                        message: "Connection already pending".to_string(),
+                        message: crate::labels::connection_already_pending_toast_label(),
                         is_error: true,
                     });
                 }
@@ -284,7 +271,7 @@ impl Sidebar {
 
                 if result.is_ok() && !state.start_pending_operation(profile_id, None) {
                     return Err(PendingToast {
-                        message: "Operation started by another thread".to_string(),
+                        message: crate::labels::operation_started_elsewhere_toast_label(),
                         is_error: true,
                     });
                 }
@@ -326,7 +313,7 @@ impl Sidebar {
                 state.finish_pending_operation(profile_id, None);
             });
             self.pending_toast = Some(PendingToast {
-                message: "Too many background tasks running, please wait".to_string(),
+                message: crate::labels::background_task_limit_toast_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -335,8 +322,10 @@ impl Sidebar {
         }
 
         let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
-            let result =
-                state.start_task(TaskKind::Connect, format!("Connecting to {}", profile_name));
+            let result = state.start_task(
+                TaskKind::Connect,
+                crate::labels::connecting_task_label(&profile_name),
+            );
             cx.emit(AppStateChanged);
             result
         });
@@ -412,14 +401,17 @@ impl Sidebar {
                         }
 
                         app_state.update(cx, |state, cx| {
-                            state.fail_task(task_id, "Connection hook cancelled");
+                            state.fail_task(
+                                task_id,
+                                crate::labels::connection_hook_cancelled_task_label(),
+                            );
                             state.finish_pending_operation(profile_id, None);
                             cx.emit(AppStateChanged);
                         });
 
                         sidebar.update(cx, |sidebar, cx| {
                             sidebar.pending_toast = Some(PendingToast {
-                                message: "Connection cancelled by hook".to_string(),
+                                message: crate::labels::connection_cancelled_by_hook_toast_label(),
                                 is_error: true,
                             });
                             sidebar.refresh_tree(cx);
@@ -677,14 +669,19 @@ impl Sidebar {
                         }
 
                         app_state.update(cx, |state, cx| {
-                            state.fail_task(task_id, "Post-connect hook cancelled");
+                            state.fail_task(
+                                task_id,
+                                crate::labels::post_connect_hook_cancelled_task_label(),
+                            );
                             state.finish_pending_operation(profile_id, None);
                             cx.emit(AppStateChanged);
                         });
 
                         sidebar.update(cx, |sidebar, cx| {
                             sidebar.pending_toast = Some(PendingToast {
-                                message: "Connection cancelled by post-connect hook".to_string(),
+                                message:
+                                    crate::labels::connection_cancelled_by_post_connect_hook_toast_label(
+                                    ),
                                 is_error: true,
                             });
                             sidebar.refresh_tree(cx);
@@ -741,16 +738,10 @@ impl Sidebar {
                     cx.notify();
                 });
 
-                let message = if hook_warnings.is_empty() {
-                    format!("Connected to {}", connected_profile_name)
-                } else {
-                    format!(
-                        "Connected to {} (with {} hook warning{})",
-                        connected_profile_name,
-                        hook_warnings.len(),
-                        if hook_warnings.len() == 1 { "" } else { "s" }
-                    )
-                };
+                let message = crate::labels::connected_toast_label(
+                    &connected_profile_name,
+                    hook_warnings.len(),
+                );
 
                 sidebar.update(cx, |sidebar, cx| {
                     sidebar.pending_toast = Some(PendingToast {
@@ -782,7 +773,7 @@ impl Sidebar {
 
         if self.app_state.read(cx).is_background_task_limit_reached() {
             self.pending_toast = Some(PendingToast {
-                message: "Too many background tasks running, please wait".to_string(),
+                message: crate::labels::background_task_limit_toast_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -797,7 +788,7 @@ impl Sidebar {
         let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
             let task = state.start_task_for_profile(
                 TaskKind::Disconnect,
-                format!("Disconnecting {}", profile_name),
+                crate::labels::disconnecting_task_label(&profile_name),
                 Some(profile_id),
             );
             cx.emit(AppStateChanged);
@@ -854,13 +845,17 @@ impl Sidebar {
                     if let Err(update_error) = cx.update(|cx| {
                         if !cancel_token.is_cancelled() {
                             app_state.update(cx, |state, cx| {
-                                state.fail_task(task_id, "Disconnect hook cancelled");
+                                state.fail_task(
+                                    task_id,
+                                    crate::labels::disconnect_hook_cancelled_task_label(),
+                                );
                                 cx.emit(AppStateChanged);
                             });
 
                             sidebar.update(cx, |sidebar, cx| {
                                 sidebar.pending_toast = Some(PendingToast {
-                                    message: "Disconnect cancelled by hook".to_string(),
+                                    message:
+                                        crate::labels::disconnect_cancelled_by_hook_toast_label(),
                                     is_error: true,
                                 });
                                 sidebar.refresh_tree(cx);
@@ -984,10 +979,9 @@ impl Sidebar {
 
                         sidebar.update(cx, |sidebar, cx| {
                             sidebar.pending_toast = Some(PendingToast {
-                                message: format!(
-                                    "Disconnected from {}, but {}",
-                                    profile_name,
-                                    error.to_lowercase()
+                                message: crate::labels::disconnected_hook_error_toast_label(
+                                    &profile_name,
+                                    &error.to_lowercase(),
                                 ),
                                 is_error: true,
                             });
@@ -1005,14 +999,17 @@ impl Sidebar {
                     if let Err(update_error) = cx.update(|cx| {
                         if !cancel_token.is_cancelled() {
                             app_state.update(cx, |state, cx| {
-                                state.fail_task(task_id, "Post-disconnect hook cancelled");
+                                state.fail_task(
+                                    task_id,
+                                    crate::labels::post_disconnect_hook_cancelled_task_label(),
+                                );
                                 cx.emit(AppStateChanged);
                             });
 
                             sidebar.update(cx, |sidebar, cx| {
                                 sidebar.pending_toast = Some(PendingToast {
-                                    message: "Disconnected, but post-disconnect hook was cancelled"
-                                        .to_string(),
+                                    message: crate::labels::disconnected_hook_cancelled_toast_label(
+                                    ),
                                     is_error: true,
                                 });
                                 sidebar.refresh_tree(cx);
@@ -1044,16 +1041,8 @@ impl Sidebar {
                     cx.emit(AppStateChanged);
                 });
 
-                let message = if hook_warnings.is_empty() {
-                    format!("Disconnected from {}", profile_name)
-                } else {
-                    format!(
-                        "Disconnected from {} (with {} hook warning{})",
-                        profile_name,
-                        hook_warnings.len(),
-                        if hook_warnings.len() == 1 { "" } else { "s" }
-                    )
-                };
+                let message =
+                    crate::labels::disconnected_toast_label(&profile_name, hook_warnings.len());
 
                 sidebar.update(cx, |sidebar, cx| {
                     sidebar.pending_toast = Some(PendingToast {
@@ -1135,7 +1124,7 @@ impl Sidebar {
 
         if !profile_exists {
             report_error(
-                UserFacingError::new(ErrorKind::User, "Profile not found")
+                UserFacingError::new(ErrorKind::User, crate::labels::profile_not_found_label())
                     .with_cause(format!("profile id {profile_id}")),
                 cx,
             );
@@ -1177,6 +1166,48 @@ mod tests {
         let (lock, condvar) = &**gate;
         *lock.lock().expect("gate lock") = true;
         condvar.notify_all();
+    }
+
+    const CONNECTION_TOAST_KEYS: [&str; 14] = [
+        "sidebar.task.connecting",
+        "sidebar.task.disconnecting",
+        "sidebar.task.connection_hook_cancelled",
+        "sidebar.task.post_connect_hook_cancelled",
+        "sidebar.task.disconnect_hook_cancelled",
+        "sidebar.task.post_disconnect_hook_cancelled",
+        "sidebar.toast.connection_already_pending",
+        "sidebar.toast.operation_started_elsewhere",
+        "sidebar.toast.background_task_limit",
+        "sidebar.toast.connection_cancelled_by_hook",
+        "sidebar.toast.connection_cancelled_by_post_connect_hook",
+        "sidebar.toast.disconnect_cancelled_by_hook",
+        "sidebar.toast.disconnected_hook_cancelled",
+        "sidebar.toast.profile_not_found",
+    ];
+
+    #[test]
+    fn connection_toast_keys_resolve_in_both_locales() {
+        for key in CONNECTION_TOAST_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn connected_toast_differs_between_locales() {
+        let english = crate::labels::connected_toast_label("prod-db", 0);
+        let spanish_key = dbflux_i18n::t!("sidebar.toast.connected.plain", locale = "es");
+
+        assert_ne!(english, spanish_key);
+        assert!(english.contains("prod-db"));
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Summary

Sidebar i18n slice D1a: connect and disconnect task lines, hook cancellation messages, connected and disconnected toasts with hook warning counts, pending and started-elsewhere notices and external driver stage messages render through `dbflux_i18n::t!` and the sidebar label helpers. English and Spanish together; audit summaries and logs stay English.

## What does this resolve?

- Refs #360 (follows C2; next: pipeline stages, then operation toasts)

## How was this solved?

- Helpers pick plain/one/many buckets for the hook warning counts; two lib.rs tests that asserted English diagnostics now read the helpers. Size: 572 lines (`size:exception`, mostly helper tests and catalog).

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 187 passed; clippy clean; fmt clean. Manual smoke in Spanish: connect and disconnect a profile with a hook that warns.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
