### PR TITLE
feat(i18n): translate the hook form, footer actions, and interpreter labels

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -452,11 +452,52 @@ settings:
       unreadable:
         title: Unreadable hook rows
         hint: Unreadable — cannot be edited
+    form:
+      title:
+        edit: Edit Hook
+        new: New Hook
+      id: Hook ID
+      kind: Type
+      command: Command
+      args: Arguments
+      args_hint: Arguments separated by spaces
+      language: Language
+      file_path: File Path
+      file_path_hint: Scripts are edited in the app editor and stored under hooks/ by default
+      open_in_app: Open in App
+      open_in_editor: Open in Editor
+      interpreter: Interpreter
+      interpreter_hint: "Leave empty for %{default_interpreter}"
+      interpreter_auto: "auto (%{value})"
+      interpreter_unsupported: Unsupported on this platform
+      capabilities: Capabilities
+      capability:
+        logging: Logging
+        env_read: Environment read
+        connection_metadata: Connection metadata
+        process_run: Controlled process run
+        process_run_hint: "Enables `dbflux.process.run(...)` without exposing the Lua `os` library"
+      execution_mode: Execution Mode
+      execution_mode_hint: Detached runs in background and does not block connect/disconnect
+      ready_signal: Ready Signal
+      ready_signal_hint: DBFlux waits for this text in hook output before continuing. Required for detached pre-connect hooks.
+      cwd: Working Directory
+      env: Environment
+      env_hint: Comma-separated KEY=value pairs
+      env_denylist: Env Denylist
+      env_denylist_hint: Comma-separated variable names to strip from inherited env
+      timeout: Timeout (ms)
+      resolved_command: Resolved Command
+      enabled: Enabled
+      inherit_env: Inherit parent environment
+      on_failure: On Failure
+      preview_placeholder: "<enter a command>"
     status:
       unsupported_platform: Unsupported on this platform
       script_missing: Script file does not exist yet
       interpreter_missing: "Interpreter '%{interpreter}' was not found in PATH"
       language_unsupported: Selected language is unsupported on this platform
+      lua_process_run_warning: "Lua process.run is enabled: this hook can execute external programs with your user permissions. The program allowlist is a convenience filter, not a security isolation boundary — a program earlier on $PATH can be substituted under the same name."
     error:
       open_script: "Failed to open script: %{error}"
       command_not_editable: Commands do not open in the script editor

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -452,11 +452,52 @@ settings:
       unreadable:
         title: Filas de hooks ilegibles
         hint: Ilegible — no se puede editar
+    form:
+      title:
+        edit: Editar hook
+        new: Nuevo hook
+      id: ID del hook
+      kind: Tipo
+      command: Comando
+      args: Argumentos
+      args_hint: Argumentos separados por espacios
+      language: Lenguaje
+      file_path: Ruta del archivo
+      file_path_hint: Los scripts se editan en el editor de la app y se guardan en hooks/ de forma predeterminada
+      open_in_app: Abrir en la app
+      open_in_editor: Abrir en el editor
+      interpreter: Intérprete
+      interpreter_hint: "Déjalo vacío para %{default_interpreter}"
+      interpreter_auto: "automático (%{value})"
+      interpreter_unsupported: No compatible en esta plataforma
+      capabilities: Capacidades
+      capability:
+        logging: Registro
+        env_read: Lectura de entorno
+        connection_metadata: Metadatos de conexión
+        process_run: Ejecución de procesos controlada
+        process_run_hint: "Habilita `dbflux.process.run(...)` sin exponer la biblioteca `os` de Lua"
+      execution_mode: Modo de ejecución
+      execution_mode_hint: El modo desacoplado se ejecuta en segundo plano y no bloquea la conexión ni la desconexión
+      ready_signal: Señal de listo
+      ready_signal_hint: DBFlux espera este texto en la salida del hook antes de continuar. Obligatorio para hooks de preconexión desacoplados.
+      cwd: Directorio de trabajo
+      env: Entorno
+      env_hint: Pares CLAVE=valor separados por comas
+      env_denylist: Lista de exclusión de entorno
+      env_denylist_hint: Nombres de variables separados por comas a excluir del entorno heredado
+      timeout: Tiempo de espera (ms)
+      resolved_command: Comando resuelto
+      enabled: Habilitado
+      inherit_env: Heredar entorno del proceso padre
+      on_failure: Ante un error
+      preview_placeholder: "<ingresa un comando>"
     status:
       unsupported_platform: No compatible en esta plataforma
       script_missing: El archivo del script aún no existe
       interpreter_missing: "No se encontró el intérprete '%{interpreter}' en PATH"
       language_unsupported: El lenguaje seleccionado no es compatible en esta plataforma
+      lua_process_run_warning: "process.run de Lua está habilitado: este hook puede ejecutar programas externos con tus permisos de usuario. La lista de programas permitidos es un filtro de conveniencia, no un límite de aislamiento de seguridad — un programa anterior en $PATH puede sustituirse bajo el mismo nombre."
     error:
       open_script: "No se pudo abrir el script: %{error}"
       command_not_editable: Los comandos no se abren en el editor de scripts

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -80,12 +80,26 @@ pub(crate) fn hooks_env_pair_invalid(pair: &str) -> String {
     dbflux_i18n::t!("settings.hooks.validation.env_pair", pair = pair)
 }
 
+/// Formats the "auto (<interpreter>)" placeholder shown when the interpreter field is empty.
+pub(crate) fn hooks_interpreter_auto_label(value: &str) -> String {
+    dbflux_i18n::t!("settings.hooks.form.interpreter_auto", value = value)
+}
+
+/// Formats the "Leave empty for <default interpreter>" hint under the interpreter field.
+pub(crate) fn hooks_form_interpreter_hint(default_interpreter: &str) -> String {
+    dbflux_i18n::t!(
+        "settings.hooks.form.interpreter_hint",
+        default_interpreter = default_interpreter
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         hooks_create_dir_failed, hooks_delete_message, hooks_delete_unreadable_message,
-        hooks_duplicate_id, hooks_env_pair_invalid, hooks_interpreter_missing,
-        hooks_open_script_failed, hooks_write_script_failed,
+        hooks_duplicate_id, hooks_env_pair_invalid, hooks_form_interpreter_hint,
+        hooks_interpreter_auto_label, hooks_interpreter_missing, hooks_open_script_failed,
+        hooks_write_script_failed,
     };
 
     #[test]
@@ -148,5 +162,19 @@ mod tests {
         let message = hooks_env_pair_invalid("FOO");
 
         assert_eq!(message, "Invalid env pair 'FOO'. Expected KEY=value format");
+    }
+
+    #[test]
+    fn hooks_interpreter_auto_label_embeds_interpreter() {
+        let message = hooks_interpreter_auto_label("python3");
+
+        assert_eq!(message, "auto (python3)");
+    }
+
+    #[test]
+    fn hooks_form_interpreter_hint_embeds_default_interpreter() {
+        let message = hooks_form_interpreter_hint("auto (python3)");
+
+        assert_eq!(message, "Leave empty for auto (python3)");
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/hooks.rs
+++ b/crates/dbflux_ui_windows/src/settings/hooks.rs
@@ -26,7 +26,8 @@ use super::hooks_section::{
 };
 use super::layout;
 use crate::labels::{
-    hooks_create_dir_failed, hooks_duplicate_id, hooks_env_pair_invalid, hooks_interpreter_missing,
+    hooks_create_dir_failed, hooks_duplicate_id, hooks_env_pair_invalid,
+    hooks_form_interpreter_hint, hooks_interpreter_auto_label, hooks_interpreter_missing,
     hooks_open_script_failed, hooks_write_script_failed,
 };
 
@@ -224,8 +225,8 @@ impl HooksSection {
     fn default_script_interpreter_label(&self, cx: &App) -> String {
         self.selected_script_language(cx)
             .default_interpreter()
-            .map(|value| format!("auto ({value})"))
-            .unwrap_or_else(|| "unsupported on this platform".to_string())
+            .map(hooks_interpreter_auto_label)
+            .unwrap_or_else(|| dbflux_i18n::t!("settings.hooks.form.interpreter_unsupported"))
     }
 
     fn hook_form_preview(&self, cx: &App) -> String {
@@ -235,7 +236,7 @@ impl HooksSection {
                 let args = self.input_hook_args.read(cx).value().trim().to_string();
 
                 if command.is_empty() {
-                    "<enter a command>".to_string()
+                    dbflux_i18n::t!("settings.hooks.form.preview_placeholder")
                 } else if args.is_empty() {
                     command
                 } else {
@@ -315,13 +316,9 @@ impl HooksSection {
         }
 
         if hook_kind == HookKindSelection::Lua && self.hook_lua_process_run {
-            warnings.push(
-                "Lua process.run is enabled: this hook can execute external programs with your \
-                 user permissions. The program allowlist is a convenience filter, not a security \
-                 isolation boundary — a program earlier on $PATH can be substituted under the \
-                 same name."
-                    .to_string(),
-            );
+            warnings.push(dbflux_i18n::t!(
+                "settings.hooks.status.lua_process_run_warning"
+            ));
         }
 
         warnings
@@ -1566,7 +1563,11 @@ impl HooksSection {
         let theme = cx.theme();
 
         let editing = self.editing_hook_id.is_some();
-        let title = if editing { "Edit Hook" } else { "New Hook" };
+        let title = if editing {
+            dbflux_i18n::t!("settings.hooks.form.title.edit")
+        } else {
+            dbflux_i18n::t!("settings.hooks.form.title.new")
+        };
         let hook_kind = self.selected_hook_kind(cx);
         let is_script = hook_kind == HookKindSelection::Script;
         let is_lua = hook_kind == HookKindSelection::Lua;
@@ -1594,7 +1595,7 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("Hook ID"))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.id")))
                             .child(Input::new(&self.input_hook_id).small()),
                     )
                     .child(
@@ -1602,7 +1603,7 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("Type"))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.kind")))
                             .child(div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_kind_dropdown.clone())),
                     )
                     .when(hook_kind == HookKindSelection::Command, |container| {
@@ -1616,7 +1617,7 @@ impl HooksSection {
                                         .flex()
                                         .flex_col()
                                         .gap_1()
-                                        .child(Label::new("Command"))
+                                        .child(Label::new(dbflux_i18n::t!("settings.hooks.form.command")))
                                         .child(Input::new(&self.input_hook_command).small()),
                                 )
                                 .child(
@@ -1624,8 +1625,8 @@ impl HooksSection {
                                         .flex()
                                         .flex_col()
                                         .gap_1()
-                                        .child(Label::new("Arguments"))
-                                        .child(Body::new("Arguments separated by spaces").color(
+                                        .child(Label::new(dbflux_i18n::t!("settings.hooks.form.args")))
+                                        .child(Body::new(dbflux_i18n::t!("settings.hooks.form.args_hint")).color(
                                             theme.muted_foreground,
                                         ))
                                         .child(Input::new(&self.input_hook_args).small()),
@@ -1644,7 +1645,7 @@ impl HooksSection {
                                             .flex()
                                             .flex_col()
                                             .gap_1()
-                                            .child(Label::new("Language"))
+                                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.language")))
                                             .child(
                                                 div()
                                                     .w(Widths::SETTINGS_FORM_LABEL)
@@ -1657,14 +1658,14 @@ impl HooksSection {
                                         .flex()
                                         .flex_col()
                                         .gap_1()
-                                        .child(Label::new("File Path")),
+                                        .child(Label::new(dbflux_i18n::t!("settings.hooks.form.file_path"))),
                                 )
                                 .child(
                                     div()
                                         .flex()
                                         .flex_col()
                                         .gap_1()
-                                        .child(Body::new("Scripts are edited in the app editor and stored under hooks/ by default").color(theme.muted_foreground))
+                                        .child(Body::new(dbflux_i18n::t!("settings.hooks.form.file_path_hint")).color(theme.muted_foreground))
                                         .child(
                                             Input::new(&self.input_hook_script_file_path).small(),
                                         )
@@ -1673,14 +1674,14 @@ impl HooksSection {
                                                 .flex()
                                                 .gap_2()
                                                 .child(
-                                                    Button::new("open-script-app", "Open in App")
+                                                    Button::new("open-script-app", dbflux_i18n::t!("settings.hooks.form.open_in_app"))
                                                         .small()
                                                         .on_click(cx.listener(|this, _, window, cx| {
                                                             this.open_script_in_app(window, cx);
                                                         })),
                                                 )
                                                 .child(
-                                                    Button::new("open-script-editor", "Open in Editor")
+                                                    Button::new("open-script-editor", dbflux_i18n::t!("settings.hooks.form.open_in_editor"))
                                                         .small()
                                                         .on_click(cx.listener(|this, _, window, cx| {
                                                             this.open_script_in_default_editor(window, cx);
@@ -1694,8 +1695,8 @@ impl HooksSection {
                                             .flex()
                                             .flex_col()
                                             .gap_1()
-                                            .child(Label::new("Interpreter"))
-                                            .child(Body::new(format!("Leave empty for {default_interpreter}")).color(theme.muted_foreground))
+                                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.interpreter")))
+                                            .child(Body::new(hooks_form_interpreter_hint(&default_interpreter)).color(theme.muted_foreground))
                                             .child(Input::new(&self.input_hook_interpreter).small()),
                                     )
                                 })
@@ -1705,7 +1706,7 @@ impl HooksSection {
                                             .flex()
                                             .flex_col()
                                             .gap_2()
-                                            .child(Label::new("Capabilities"))
+                                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.capabilities")))
                                             .child(
                                                 div()
                                                     .flex()
@@ -1719,7 +1720,7 @@ impl HooksSection {
                                                                 cx.notify();
                                                             })),
                                                     )
-                                                    .child(Body::new("Logging")),
+                                                    .child(Body::new(dbflux_i18n::t!("settings.hooks.form.capability.logging"))),
                                             )
                                             .child(
                                                 div()
@@ -1734,7 +1735,7 @@ impl HooksSection {
                                                                 cx.notify();
                                                             })),
                                                     )
-                                                    .child(Body::new("Environment read")),
+                                                    .child(Body::new(dbflux_i18n::t!("settings.hooks.form.capability.env_read"))),
                                             )
                                             .child(
                                                 div()
@@ -1749,7 +1750,7 @@ impl HooksSection {
                                                                 cx.notify();
                                                             })),
                                                     )
-                                                    .child(Body::new("Connection metadata")),
+                                                    .child(Body::new(dbflux_i18n::t!("settings.hooks.form.capability.connection_metadata"))),
                                             )
                                             .child(
                                                 div()
@@ -1764,10 +1765,10 @@ impl HooksSection {
                                                                 cx.notify();
                                                             })),
                                                     )
-                                                    .child(Body::new("Controlled process run")),
+                                                    .child(Body::new(dbflux_i18n::t!("settings.hooks.form.capability.process_run"))),
                                             )
                                             .child(Body::new(
-                                                "Enables `dbflux.process.run(...)` without exposing the Lua `os` library",
+                                                dbflux_i18n::t!("settings.hooks.form.capability.process_run_hint"),
                                             )
                                             .color(theme.muted_foreground)),
                                     )
@@ -1780,8 +1781,8 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("Execution Mode"))
-                            .child(Body::new("Detached runs in background and does not block connect/disconnect").color(theme.muted_foreground))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.execution_mode")))
+                            .child(Body::new(dbflux_i18n::t!("settings.hooks.form.execution_mode_hint")).color(theme.muted_foreground))
                             .child(div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_execution_mode_dropdown.clone())),
                     )
                     })
@@ -1791,8 +1792,8 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("Ready Signal"))
-                            .child(Body::new("DBFlux waits for this text in hook output before continuing. Required for detached pre-connect hooks.").color(theme.muted_foreground))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.ready_signal")))
+                            .child(Body::new(dbflux_i18n::t!("settings.hooks.form.ready_signal_hint")).color(theme.muted_foreground))
                             .child(Input::new(&self.input_hook_ready_signal).small()),
                     )
                     })
@@ -1802,7 +1803,7 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("Working Directory"))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.cwd")))
                             .child(Input::new(&self.input_hook_cwd).small()),
                     )
                     })
@@ -1812,8 +1813,8 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("Environment"))
-                            .child(Body::new("Comma-separated KEY=value pairs").color(theme.muted_foreground))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.env")))
+                            .child(Body::new(dbflux_i18n::t!("settings.hooks.form.env_hint")).color(theme.muted_foreground))
                             .child(Input::new(&self.input_hook_env).small()),
                     )
                     })
@@ -1823,8 +1824,8 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("Env Denylist"))
-                            .child(Body::new("Comma-separated variable names to strip from inherited env").color(theme.muted_foreground))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.env_denylist")))
+                            .child(Body::new(dbflux_i18n::t!("settings.hooks.form.env_denylist_hint")).color(theme.muted_foreground))
                             .child(Input::new(&self.input_hook_env_denylist).small()),
                     )
                     })
@@ -1833,7 +1834,7 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("Timeout (ms)"))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.timeout")))
                             .child(Input::new(&self.input_hook_timeout).small()),
                     )
                     .child(
@@ -1841,7 +1842,7 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("Resolved Command"))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.resolved_command")))
                             .child(MonoCaption::new(preview)),
                     )
                     .when(!warnings.is_empty(), |container| {
@@ -1883,7 +1884,7 @@ impl HooksSection {
                                         cx.notify();
                                     })),
                             )
-                            .child(Body::new("Enabled")),
+                            .child(Body::new(dbflux_i18n::t!("settings.hooks.form.enabled"))),
                     )
                     .when(!is_lua, |container| {
                         container.child(
@@ -1899,7 +1900,7 @@ impl HooksSection {
                                             cx.notify();
                                         })),
                                 )
-                                .child(Body::new("Inherit parent environment")),
+                                .child(Body::new(dbflux_i18n::t!("settings.hooks.form.inherit_env"))),
                         )
                     })
                     .child(
@@ -1907,7 +1908,7 @@ impl HooksSection {
                             .flex()
                             .flex_col()
                             .gap_1()
-                            .child(Label::new("On Failure"))
+                            .child(Label::new(dbflux_i18n::t!("settings.hooks.form.on_failure")))
                             .child(div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_failure_dropdown.clone())),
                     )),
             None,
@@ -1930,7 +1931,7 @@ impl HooksSection {
                 container.child(layout::footer_action_frame(
                     is_form_focused && self.hook_form_field == HookFormField::DeleteButton,
                     primary,
-                    Button::new("delete-hook", "Delete")
+                    Button::new("delete-hook", dbflux_i18n::t!("hooks.action.delete"))
                         .small()
                         .danger()
                         .w_full()
@@ -1942,13 +1943,20 @@ impl HooksSection {
             .child(layout::footer_action_frame(
                 is_form_focused && self.hook_form_field == HookFormField::SaveButton,
                 primary,
-                Button::new("save-hook", if editing { "Update" } else { "Create" })
-                    .small()
-                    .primary()
-                    .w_full()
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.save_hook(window, cx);
-                    })),
+                Button::new(
+                    "save-hook",
+                    if editing {
+                        dbflux_i18n::t!("hooks.action.update")
+                    } else {
+                        dbflux_i18n::t!("hooks.action.create")
+                    },
+                )
+                .small()
+                .primary()
+                .w_full()
+                .on_click(cx.listener(|this, _, window, cx| {
+                    this.save_hook(window, cx);
+                })),
             ))
             .into_any_element()
     }
@@ -2329,10 +2337,46 @@ mod tests {
         "settings.hooks.list.empty",
         "settings.hooks.list.unreadable.title",
         "settings.hooks.list.unreadable.hint",
+        "settings.hooks.form.title.edit",
+        "settings.hooks.form.title.new",
+        "settings.hooks.form.id",
+        "settings.hooks.form.kind",
+        "settings.hooks.form.command",
+        "settings.hooks.form.args",
+        "settings.hooks.form.args_hint",
+        "settings.hooks.form.language",
+        "settings.hooks.form.file_path",
+        "settings.hooks.form.file_path_hint",
+        "settings.hooks.form.open_in_app",
+        "settings.hooks.form.open_in_editor",
+        "settings.hooks.form.interpreter",
+        "settings.hooks.form.interpreter_unsupported",
+        "settings.hooks.form.capabilities",
+        "settings.hooks.form.capability.logging",
+        "settings.hooks.form.capability.env_read",
+        "settings.hooks.form.capability.connection_metadata",
+        "settings.hooks.form.capability.process_run",
+        "settings.hooks.form.capability.process_run_hint",
+        "settings.hooks.form.execution_mode",
+        "settings.hooks.form.execution_mode_hint",
+        "settings.hooks.form.ready_signal",
+        "settings.hooks.form.ready_signal_hint",
+        "settings.hooks.form.cwd",
+        "settings.hooks.form.env",
+        "settings.hooks.form.env_hint",
+        "settings.hooks.form.env_denylist",
+        "settings.hooks.form.env_denylist_hint",
+        "settings.hooks.form.timeout",
+        "settings.hooks.form.resolved_command",
+        "settings.hooks.form.enabled",
+        "settings.hooks.form.inherit_env",
+        "settings.hooks.form.on_failure",
+        "settings.hooks.form.preview_placeholder",
         "settings.hooks.status.unsupported_platform",
         "settings.hooks.status.script_missing",
         "settings.hooks.status.interpreter_missing",
         "settings.hooks.status.language_unsupported",
+        "settings.hooks.status.lua_process_run_warning",
         "settings.hooks.error.open_script",
         "settings.hooks.error.command_not_editable",
         "settings.hooks.error.write_script",
@@ -2379,6 +2423,15 @@ mod tests {
         let spanish = dbflux_i18n::t!("settings.hooks.toast.saved", locale = "es");
 
         assert_eq!(english, "Hook saved");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn settings_hooks_form_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("settings.hooks.form.title.edit", locale = "en");
+        let spanish = dbflux_i18n::t!("settings.hooks.form.title.edit", locale = "es");
+
+        assert_eq!(english, "Edit Hook");
         assert_ne!(english, spanish);
     }
 }


### PR DESCRIPTION
## Summary

Sixth `dbflux_ui_windows` i18n slice: the hook form title, field labels and hints, capability checkboxes, footer actions, interpreter auto/unsupported labels, the command preview placeholder and the Lua process.run warning render through `dbflux_i18n::t!` under `settings.hooks.form.*`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows #380; next: the connection manager hooks tab, then the access tab)

## How was this solved?

- API names and env tokens stay literal inside the Spanish text.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 204 passed; clippy clean; fmt clean. Manual smoke in Spanish: open Settings → Hooks and create a hook.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
