### PR TITLE
feat(i18n): translate the sidebar connection pipeline stages and task details

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -800,6 +800,18 @@ sidebar:
     post_connect_hook_cancelled: Post-connect hook cancelled
     disconnect_hook_cancelled: Disconnect hook cancelled
     post_disconnect_hook_cancelled: Post-disconnect hook cancelled
+    pipeline:
+      connecting: "Connecting to %{name} (pipeline)"
+      cancelled: Pipeline cancelled
+      failed: "Pipeline failed: %{error}"
+      completed: Pipeline completed
+      stage:
+        authenticating: "Pipeline: Authenticating (%{provider})"
+        waiting_for_login: "Pipeline: Waiting for %{provider} login"
+        resolving_values: "Pipeline: Resolving values (%{resolved}/%{total})"
+        opening_access: "Pipeline: Opening access (%{method})"
+        connecting: "Pipeline: Connecting driver (%{driver})"
+        fetching_schema: "Pipeline: Fetching schema"
   toast:
     edit_reconnect_updated: "'%{name}' updated"
     edit_reconnect_body: Reconnect to apply the changes to the live session.

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -800,6 +800,18 @@ sidebar:
     post_connect_hook_cancelled: Hook posterior a la conexión cancelado
     disconnect_hook_cancelled: Hook de desconexión cancelado
     post_disconnect_hook_cancelled: Hook posterior a la desconexión cancelado
+    pipeline:
+      connecting: "Conectando a %{name} (pipeline)"
+      cancelled: Pipeline cancelado
+      failed: "Pipeline con error: %{error}"
+      completed: Pipeline completado
+      stage:
+        authenticating: "Pipeline: autenticando (%{provider})"
+        waiting_for_login: "Pipeline: esperando el inicio de sesión de %{provider}"
+        resolving_values: "Pipeline: resolviendo valores (%{resolved}/%{total})"
+        opening_access: "Pipeline: abriendo acceso (%{method})"
+        connecting: "Pipeline: conectando el driver (%{driver})"
+        fetching_schema: "Pipeline: obteniendo el esquema"
   toast:
     edit_reconnect_updated: "'%{name}' actualizado"
     edit_reconnect_body: Reconecta para aplicar los cambios a la sesión activa.

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -1,7 +1,7 @@
 //! Translated label helpers for sidebar chrome (tabs, footer, tree folders).
 
 use dbflux_app::ExternalDriverStage;
-use dbflux_core::{DatabaseCategory, RelationKind};
+use dbflux_core::{DatabaseCategory, PipelineState, RelationKind};
 
 /// Translated label for a schema-tree container folder, e.g. `"Tables (12)"`.
 pub(crate) fn container_folder_label(category: DatabaseCategory, count: usize) -> String {
@@ -446,6 +446,64 @@ pub(crate) fn external_driver_unavailable_label(
         socket_id = socket_id,
         summary = summary
     )
+}
+
+/// Translated task-panel label for an in-flight pipeline connect attempt,
+/// e.g. `"Connecting to prod-db (pipeline)"`.
+pub(crate) fn pipeline_connecting_task_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.pipeline.connecting", name = name)
+}
+
+/// Translated task-detail line appended when a pipeline connect attempt is
+/// cancelled.
+pub(crate) fn pipeline_cancelled_detail_label() -> String {
+    dbflux_i18n::t!("sidebar.task.pipeline.cancelled")
+}
+
+/// Translated task-detail line appended when a pipeline connect attempt
+/// fails, e.g. `"Pipeline failed: connection refused"`.
+pub(crate) fn pipeline_failed_detail_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.pipeline.failed", error = error)
+}
+
+/// Translated task-detail line appended when a pipeline connect attempt
+/// completes successfully.
+pub(crate) fn pipeline_completed_detail_label() -> String {
+    dbflux_i18n::t!("sidebar.task.pipeline.completed")
+}
+
+/// Translated task-panel label for the current pipeline stage, shown as a
+/// subtask under the pipeline connect task. Returns `None` for stages with
+/// no user-facing subtask (idle and terminal states).
+pub(crate) fn pipeline_stage_label(state: &PipelineState) -> Option<String> {
+    match state {
+        PipelineState::Idle => None,
+        PipelineState::Authenticating { provider_name } => Some(dbflux_i18n::t!(
+            "sidebar.task.pipeline.stage.authenticating",
+            provider = provider_name
+        )),
+        PipelineState::WaitingForLogin { provider_name, .. } => Some(dbflux_i18n::t!(
+            "sidebar.task.pipeline.stage.waiting_for_login",
+            provider = provider_name
+        )),
+        PipelineState::ResolvingValues { total, resolved } => Some(dbflux_i18n::t!(
+            "sidebar.task.pipeline.stage.resolving_values",
+            resolved = resolved,
+            total = total
+        )),
+        PipelineState::OpeningAccess { method_label } => Some(dbflux_i18n::t!(
+            "sidebar.task.pipeline.stage.opening_access",
+            method = method_label
+        )),
+        PipelineState::Connecting { driver_name } => Some(dbflux_i18n::t!(
+            "sidebar.task.pipeline.stage.connecting",
+            driver = driver_name
+        )),
+        PipelineState::FetchingSchema => Some(dbflux_i18n::t!(
+            "sidebar.task.pipeline.stage.fetching_schema"
+        )),
+        PipelineState::Connected | PipelineState::Failed { .. } | PipelineState::Cancelled => None,
+    }
 }
 
 #[cfg(test)]
@@ -1084,5 +1142,152 @@ mod tests {
         let spanish = dbflux_i18n::t!("sidebar.toast.connected.many", locale = "es");
 
         assert_ne!(english, spanish);
+    }
+
+    const D1B_KEYS: [&str; 10] = [
+        "sidebar.task.pipeline.connecting",
+        "sidebar.task.pipeline.cancelled",
+        "sidebar.task.pipeline.failed",
+        "sidebar.task.pipeline.completed",
+        "sidebar.task.pipeline.stage.authenticating",
+        "sidebar.task.pipeline.stage.waiting_for_login",
+        "sidebar.task.pipeline.stage.resolving_values",
+        "sidebar.task.pipeline.stage.opening_access",
+        "sidebar.task.pipeline.stage.connecting",
+        "sidebar.task.pipeline.stage.fetching_schema",
+    ];
+
+    #[test]
+    fn d1b_keys_resolve_in_both_locales() {
+        for key in D1B_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sidebar_task_pipeline_connecting_diverges_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.task.pipeline.connecting", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.task.pipeline.connecting", locale = "es");
+
+        assert_ne!(english, spanish);
+    }
+
+    use dbflux_core::PipelineState;
+
+    #[test]
+    fn pipeline_stage_label_covers_all_variants() {
+        assert_eq!(
+            super::pipeline_stage_label(&PipelineState::Idle),
+            None,
+            "idle has no subtask label"
+        );
+        assert_eq!(
+            super::pipeline_stage_label(&PipelineState::Connected),
+            None,
+            "connected has no subtask label"
+        );
+        assert_eq!(
+            super::pipeline_stage_label(&PipelineState::Cancelled),
+            None,
+            "cancelled has no subtask label"
+        );
+        assert_eq!(
+            super::pipeline_stage_label(&PipelineState::Failed {
+                stage: "driver_connect".to_string(),
+                error: "boom".to_string(),
+            }),
+            None,
+            "failed has no subtask label"
+        );
+
+        let authenticating = super::pipeline_stage_label(&PipelineState::Authenticating {
+            provider_name: "aws-sso".to_string(),
+        })
+        .expect("authenticating has a subtask label");
+        assert_eq!(
+            authenticating,
+            dbflux_i18n::t!(
+                "sidebar.task.pipeline.stage.authenticating",
+                provider = "aws-sso"
+            )
+        );
+
+        let waiting_for_login = super::pipeline_stage_label(&PipelineState::WaitingForLogin {
+            provider_name: "aws-sso".to_string(),
+            verification_url: None,
+        })
+        .expect("waiting_for_login has a subtask label");
+        assert_eq!(
+            waiting_for_login,
+            dbflux_i18n::t!(
+                "sidebar.task.pipeline.stage.waiting_for_login",
+                provider = "aws-sso"
+            )
+        );
+
+        let resolving_values = super::pipeline_stage_label(&PipelineState::ResolvingValues {
+            total: 3,
+            resolved: 1,
+        })
+        .expect("resolving_values has a subtask label");
+        assert_eq!(
+            resolving_values,
+            dbflux_i18n::t!(
+                "sidebar.task.pipeline.stage.resolving_values",
+                resolved = 1,
+                total = 3
+            )
+        );
+
+        let opening_access = super::pipeline_stage_label(&PipelineState::OpeningAccess {
+            method_label: "SSH tunnel".to_string(),
+        })
+        .expect("opening_access has a subtask label");
+        assert_eq!(
+            opening_access,
+            dbflux_i18n::t!(
+                "sidebar.task.pipeline.stage.opening_access",
+                method = "SSH tunnel"
+            )
+        );
+
+        let connecting = super::pipeline_stage_label(&PipelineState::Connecting {
+            driver_name: "PostgreSQL".to_string(),
+        })
+        .expect("connecting has a subtask label");
+        assert_eq!(
+            connecting,
+            dbflux_i18n::t!(
+                "sidebar.task.pipeline.stage.connecting",
+                driver = "PostgreSQL"
+            )
+        );
+
+        let fetching_schema = super::pipeline_stage_label(&PipelineState::FetchingSchema)
+            .expect("fetching_schema has a subtask label");
+        assert_eq!(
+            fetching_schema,
+            dbflux_i18n::t!("sidebar.task.pipeline.stage.fetching_schema")
+        );
+    }
+
+    #[test]
+    fn pipeline_failed_detail_label_includes_the_error() {
+        let label = super::pipeline_failed_detail_label("connection refused");
+
+        assert!(label.contains("connection refused"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.task.pipeline.failed", error = "connection refused")
+        );
     }
 }

--- a/crates/dbflux_ui_sidebar/src/operations/pipeline.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/pipeline.rs
@@ -6,31 +6,8 @@ use dbflux_ui_base::toast::PendingToast;
 use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error_async};
 use std::sync::Arc;
 
-fn pipeline_stage_task_description(state: &PipelineState) -> Option<String> {
-    match state {
-        PipelineState::Idle => None,
-        PipelineState::Authenticating { provider_name } => {
-            Some(format!("Pipeline: Authenticating ({provider_name})"))
-        }
-        PipelineState::WaitingForLogin { provider_name, .. } => {
-            Some(format!("Pipeline: Waiting for {provider_name} login"))
-        }
-        PipelineState::ResolvingValues { total, resolved } => {
-            Some(format!("Pipeline: Resolving values ({resolved}/{total})"))
-        }
-        PipelineState::OpeningAccess { method_label } => {
-            Some(format!("Pipeline: Opening access ({method_label})"))
-        }
-        PipelineState::Connecting { driver_name } => {
-            Some(format!("Pipeline: Connecting driver ({driver_name})"))
-        }
-        PipelineState::FetchingSchema => Some("Pipeline: Fetching schema".to_string()),
-        PipelineState::Connected | PipelineState::Failed { .. } | PipelineState::Cancelled => None,
-    }
-}
-
 fn pipeline_stage_task_detail_line(state: &PipelineState) -> Option<String> {
-    pipeline_stage_task_description(state).map(|description| format!("> {description}"))
+    crate::labels::pipeline_stage_label(state).map(|description| format!("> {description}"))
 }
 
 impl Sidebar {
@@ -46,11 +23,17 @@ impl Sidebar {
             hook_context,
         ) = match self.app_state.update(cx, |state, _cx| {
             if state.is_operation_pending(profile_id, None) {
-                return Err(("Connection already pending".to_string(), false));
+                return Err((
+                    crate::labels::connection_already_pending_toast_label(),
+                    false,
+                ));
             }
 
             if !state.start_pending_operation(profile_id, None) {
-                return Err(("Operation started by another thread".to_string(), false));
+                return Err((
+                    crate::labels::operation_started_elsewhere_toast_label(),
+                    false,
+                ));
             }
 
             let cancel = CancelToken::new();
@@ -102,7 +85,7 @@ impl Sidebar {
                 state.finish_pending_operation(profile_id, None);
             });
             self.pending_toast = Some(PendingToast {
-                message: "Too many background tasks running, please wait".to_string(),
+                message: crate::labels::background_task_limit_toast_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -113,7 +96,7 @@ impl Sidebar {
         let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
             let result = state.start_task(
                 TaskKind::Connect,
-                format!("Connecting to {} (pipeline)", profile_name),
+                crate::labels::pipeline_connecting_task_label(&profile_name),
             );
             cx.emit(dbflux_ui_base::AppStateChanged);
             result
@@ -138,7 +121,7 @@ impl Sidebar {
 
                 let state = watcher.borrow().clone();
 
-                if let Some(description) = pipeline_stage_task_description(&state)
+                if let Some(description) = crate::labels::pipeline_stage_label(&state)
                     && current_stage
                         .as_ref()
                         .is_none_or(|(active, _)| active != &description)
@@ -183,20 +166,33 @@ impl Sidebar {
                             if let Some((_, stage_task_id)) = current_stage.take() {
                                 match &terminal_state {
                                     PipelineState::Cancelled => {
-                                        app_state
-                                            .append_task_details(task_id, "Pipeline cancelled\n");
+                                        app_state.append_task_details(
+                                            task_id,
+                                            format!(
+                                                "{}\n",
+                                                crate::labels::pipeline_cancelled_detail_label()
+                                            ),
+                                        );
                                         app_state.cancel_task(stage_task_id);
                                     }
                                     PipelineState::Failed { error, .. } => {
                                         app_state.append_task_details(
                                             task_id,
-                                            format!("Pipeline failed: {error}\n"),
+                                            format!(
+                                                "{}\n",
+                                                crate::labels::pipeline_failed_detail_label(error)
+                                            ),
                                         );
                                         app_state.fail_task(stage_task_id, error.clone());
                                     }
                                     _ => {
-                                        app_state
-                                            .append_task_details(task_id, "Pipeline completed\n");
+                                        app_state.append_task_details(
+                                            task_id,
+                                            format!(
+                                                "{}\n",
+                                                crate::labels::pipeline_completed_detail_label()
+                                            ),
+                                        );
                                         app_state.complete_task(stage_task_id);
                                     }
                                 }
@@ -305,14 +301,17 @@ impl Sidebar {
                         }
 
                         app_state.update(cx, |state, cx| {
-                            state.fail_task(task_id, "Connection hook cancelled");
+                            state.fail_task(
+                                task_id,
+                                crate::labels::connection_hook_cancelled_task_label(),
+                            );
                             state.finish_pending_operation(profile_id, None);
                             cx.emit(dbflux_ui_base::AppStateChanged);
                         });
 
                         sidebar.update(cx, |sidebar, cx| {
                             sidebar.pending_toast = Some(PendingToast {
-                                message: "Connection cancelled by hook".to_string(),
+                                message: crate::labels::connection_cancelled_by_hook_toast_label(),
                                 is_error: true,
                             });
                             sidebar.refresh_tree(cx);
@@ -577,14 +576,18 @@ impl Sidebar {
                         }
 
                         app_state.update(cx, |state, cx| {
-                            state.fail_task(task_id, "Post-connect hook cancelled");
+                            state.fail_task(
+                                task_id,
+                                crate::labels::post_connect_hook_cancelled_task_label(),
+                            );
                             state.finish_pending_operation(profile_id, None);
                             cx.emit(dbflux_ui_base::AppStateChanged);
                         });
 
                         sidebar.update(cx, |sidebar, cx| {
                             sidebar.pending_toast = Some(PendingToast {
-                                message: "Connection cancelled by post-connect hook".to_string(),
+                                message:
+                                    crate::labels::connection_cancelled_by_post_connect_hook_toast_label(),
                                 is_error: true,
                             });
                             sidebar.refresh_tree(cx);
@@ -669,16 +672,8 @@ impl Sidebar {
                     cx.notify();
                 });
 
-                let message = if hook_warnings.is_empty() {
-                    format!("Connected to {}", connected_name)
-                } else {
-                    format!(
-                        "Connected to {} (with {} hook warning{})",
-                        connected_name,
-                        hook_warnings.len(),
-                        if hook_warnings.len() == 1 { "" } else { "s" }
-                    )
-                };
+                let message =
+                    crate::labels::connected_toast_label(&connected_name, hook_warnings.len());
 
                 sidebar.update(cx, |sidebar, cx| {
                     sidebar.pending_toast = Some(PendingToast {


### PR DESCRIPTION
## Summary

Sidebar i18n slice D1b: pipeline stage labels, the pipeline task line, task detail lines and pipeline toasts render through `dbflux_i18n::t!`, reusing the connection toast keys. English and Spanish together.

## What does this resolve?

- Refs #360 (follows D1a; next: loading/drop/script/export toasts (last sidebar slice))

## How was this solved?

- `pipeline_stage_label` maps `PipelineState` exhaustively in the UI crate; audit summaries and logs stay English.

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 191 passed; clippy clean; fmt clean. Manual smoke in Spanish: connect through the auth pipeline and watch the Tasks panel.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
