### PR TITLE
feat(i18n): translate the data grid mutation confirm summary and mutation toasts

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -188,6 +188,45 @@ document:
         deleted:
           one: "%{count} delete"
           many: "%{count} deletes"
+    mutation:
+      confirm:
+        delete:
+          summary:
+            one: 'Delete %{count} row from "%{table}"'
+            many: 'Delete %{count} rows from "%{table}"'
+            unknown: 'Delete rows from "%{table}"'
+        update:
+          summary:
+            one: 'Update %{count} column in "%{table}"'
+            many: 'Update %{count} columns in "%{table}"'
+      error:
+        update_document_unsupported_id: "Cannot update document field: the document has an unsupported _id value"
+        update_document_failed: "Failed to update document: %{error}"
+        save_row_unsupported_pk: "Cannot save row: primary key uses an unsupported value type"
+        save_row_identity_failed: "Cannot save row: failed to build row identity from primary key columns"
+        save_row_unsupported_values: "Cannot save row: unsupported values are read-only"
+        save_failed: "Save failed: %{error}"
+        save_document_unsupported_id: "Cannot save document: it has an unsupported _id value"
+        insert_failed: "Insert failed: %{error}"
+        insert_no_values: "Cannot insert: no values provided"
+        delete_document_unsupported_id: "Cannot delete document: it has an unsupported _id value"
+        delete_failed: "Delete failed: %{error}"
+        delete_no_primary_key: "Cannot delete: no primary key defined for this table"
+        delete_identity_failed: "Cannot delete: failed to identify row"
+        bulk_delete_no_rows_identified: "Cannot delete: failed to identify any rows"
+        bulk_delete_no_documents_identified: "Cannot delete: failed to identify any documents"
+      toast:
+        document_updated: Document updated
+        saved: Saved
+        document_inserted: Document inserted
+        row_inserted: Row inserted
+        document_deleted: Document deleted
+        row_deleted: Row deleted
+        rows_deleted: "%{count} row(s) deleted"
+        documents_deleted: "%{count} document(s) deleted"
+        partial_delete:
+          row: "Deleted %{done} of %{total} row(s), then failed: %{error}"
+          document: "Deleted %{done} of %{total} document(s), then failed: %{error}"
     row_inspector:
       badge:
         primary_key: PK

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -188,6 +188,45 @@ document:
         deleted:
           one: "%{count} eliminación"
           many: "%{count} eliminaciones"
+    mutation:
+      confirm:
+        delete:
+          summary:
+            one: 'Eliminar %{count} fila de "%{table}"'
+            many: 'Eliminar %{count} filas de "%{table}"'
+            unknown: 'Eliminar filas de "%{table}"'
+        update:
+          summary:
+            one: 'Actualizar %{count} columna en "%{table}"'
+            many: 'Actualizar %{count} columnas en "%{table}"'
+      error:
+        update_document_unsupported_id: "No se puede actualizar el campo del documento: el documento tiene un valor de _id no admitido"
+        update_document_failed: "No se pudo actualizar el documento: %{error}"
+        save_row_unsupported_pk: "No se puede guardar la fila: la clave primaria usa un tipo de valor no admitido"
+        save_row_identity_failed: "No se puede guardar la fila: no se pudo construir la identidad de la fila a partir de las columnas de clave primaria"
+        save_row_unsupported_values: "No se puede guardar la fila: los valores no admitidos son de solo lectura"
+        save_failed: "Error al guardar: %{error}"
+        save_document_unsupported_id: "No se puede guardar el documento: tiene un valor de _id no admitido"
+        insert_failed: "Error al insertar: %{error}"
+        insert_no_values: "No se puede insertar: no se proporcionaron valores"
+        delete_document_unsupported_id: "No se puede eliminar el documento: tiene un valor de _id no admitido"
+        delete_failed: "Error al eliminar: %{error}"
+        delete_no_primary_key: "No se puede eliminar: esta tabla no tiene clave primaria definida"
+        delete_identity_failed: "No se puede eliminar: no se pudo identificar la fila"
+        bulk_delete_no_rows_identified: "No se puede eliminar: no se pudo identificar ninguna fila"
+        bulk_delete_no_documents_identified: "No se puede eliminar: no se pudo identificar ningún documento"
+      toast:
+        document_updated: Documento actualizado
+        saved: Guardado
+        document_inserted: Documento insertado
+        row_inserted: Fila insertada
+        document_deleted: Documento eliminado
+        row_deleted: Fila eliminada
+        rows_deleted: "%{count} fila(s) eliminada(s)"
+        documents_deleted: "%{count} documento(s) eliminado(s)"
+        partial_delete:
+          row: "Se eliminaron %{done} de %{total} fila(s); luego falló: %{error}"
+          document: "Se eliminaron %{done} de %{total} documento(s); luego falló: %{error}"
     row_inspector:
       badge:
         primary_key: PK

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutation_confirm.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutation_confirm.rs
@@ -181,21 +181,9 @@ pub fn build_pending_modal(
     };
 
     let summary = match &spec.kind {
-        MutationKind::Delete => {
-            let row_desc = match est_rows {
-                Some(n) => format!("{} rows", n),
-                None => "rows".to_string(),
-            };
-            format!("Delete {} from \"{}\"", row_desc, table_name)
-        }
+        MutationKind::Delete => crate::labels::delete_rows_label(est_rows, &table_name),
         MutationKind::Update { assignments } => {
-            let col_count = assignments.len();
-            format!(
-                "Update {} column{} in \"{}\"",
-                col_count,
-                if col_count == 1 { "" } else { "s" },
-                table_name
-            )
+            crate::labels::update_columns_label(assignments.len(), &table_name)
         }
     };
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
@@ -241,7 +241,9 @@ impl DataGridPanel {
                     report_error(
                         UserFacingError::new(
                             ErrorKind::User,
-                            "Cannot update document field: the document has an unsupported _id value",
+                            dbflux_i18n::t!(
+                                "document.data.mutation.error.update_document_unsupported_id"
+                            ),
                         ),
                         cx,
                     );
@@ -330,7 +332,9 @@ impl DataGridPanel {
                             }
 
                             panel.pending.toast = Some(PendingToast {
-                                message: "Document updated".to_string(),
+                                message: dbflux_i18n::t!(
+                                    "document.data.mutation.toast.document_updated"
+                                ),
                                 is_error: false,
                             });
                         }
@@ -339,7 +343,10 @@ impl DataGridPanel {
                             report_error(
                                 UserFacingError::new(
                                     ErrorKind::Driver,
-                                    format!("Failed to update document: {error}"),
+                                    dbflux_i18n::t!(
+                                        "document.data.mutation.error.update_document_failed",
+                                        error = error
+                                    ),
                                 ),
                                 cx,
                             );
@@ -444,12 +451,12 @@ impl DataGridPanel {
             .iter()
             .any(|value| matches!(value, Value::Unsupported(_)))
         {
-            let message = "Cannot save row: primary key uses an unsupported value type";
+            let message = dbflux_i18n::t!("document.data.mutation.error.save_row_unsupported_pk");
 
             table_state.update(cx, |state, cx| {
                 state
                     .edit_buffer_mut()
-                    .set_row_state(row_idx, RowState::Error(message.to_string()));
+                    .set_row_state(row_idx, RowState::Error(message.clone()));
                 cx.notify();
             });
 
@@ -461,7 +468,7 @@ impl DataGridPanel {
             report_error(
                 UserFacingError::new(
                     ErrorKind::User,
-                    "Cannot save row: failed to build row identity from primary key columns",
+                    dbflux_i18n::t!("document.data.mutation.error.save_row_identity_failed"),
                 ),
                 cx,
             );
@@ -485,12 +492,13 @@ impl DataGridPanel {
             .iter()
             .any(|a| matches!(a.value, Value::Unsupported(_)))
         {
-            let message = "Cannot save row: unsupported values are read-only";
+            let message =
+                dbflux_i18n::t!("document.data.mutation.error.save_row_unsupported_values");
 
             table_state.update(cx, |state, cx| {
                 state
                     .edit_buffer_mut()
-                    .set_row_state(row_idx, RowState::Error(message.to_string()));
+                    .set_row_state(row_idx, RowState::Error(message.clone()));
                 cx.notify();
             });
 
@@ -607,7 +615,9 @@ impl DataGridPanel {
                     report_error(
                         UserFacingError::new(
                             ErrorKind::User,
-                            "Cannot save document: it has an unsupported _id value",
+                            dbflux_i18n::t!(
+                                "document.data.mutation.error.save_document_unsupported_id"
+                            ),
                         ),
                         cx,
                     );
@@ -730,7 +740,7 @@ impl DataGridPanel {
                     cx.notify();
                 });
                 self.pending.toast = Some(PendingToast {
-                    message: "Saved".to_string(),
+                    message: dbflux_i18n::t!("document.data.mutation.toast.saved"),
                     is_error: false,
                 });
             }
@@ -742,7 +752,10 @@ impl DataGridPanel {
                     cx.notify();
                 });
                 report_error(
-                    UserFacingError::new(ErrorKind::Driver, format!("Save failed: {e}")),
+                    UserFacingError::new(
+                        ErrorKind::Driver,
+                        dbflux_i18n::t!("document.data.mutation.error.save_failed", error = e),
+                    ),
                     cx,
                 );
             }
@@ -871,7 +884,9 @@ impl DataGridPanel {
                                 cx.notify();
                             });
                             panel.pending.toast = Some(PendingToast {
-                                message: "Document inserted".to_string(),
+                                message: dbflux_i18n::t!(
+                                    "document.data.mutation.toast.document_inserted"
+                                ),
                                 is_error: false,
                             });
                             panel.queue_refresh_after_mutation_success(cx);
@@ -881,7 +896,10 @@ impl DataGridPanel {
                             report_error(
                                 UserFacingError::new(
                                     ErrorKind::Driver,
-                                    format!("Insert failed: {e}"),
+                                    dbflux_i18n::t!(
+                                        "document.data.mutation.error.insert_failed",
+                                        error = e
+                                    ),
                                 ),
                                 cx,
                             );
@@ -946,7 +964,10 @@ impl DataGridPanel {
 
         if assignments.is_empty() {
             report_error(
-                UserFacingError::new(ErrorKind::Driver, "Cannot insert: no values provided"),
+                UserFacingError::new(
+                    ErrorKind::Driver,
+                    dbflux_i18n::t!("document.data.mutation.error.insert_no_values"),
+                ),
                 cx,
             );
             return;
@@ -1014,7 +1035,9 @@ impl DataGridPanel {
                                 cx.notify();
                             });
                             panel.pending.toast = Some(PendingToast {
-                                message: "Row inserted".to_string(),
+                                message: dbflux_i18n::t!(
+                                    "document.data.mutation.toast.row_inserted"
+                                ),
                                 is_error: false,
                             });
                             panel.queue_refresh_after_mutation_success(cx);
@@ -1024,7 +1047,10 @@ impl DataGridPanel {
                             report_error(
                                 UserFacingError::new(
                                     ErrorKind::Driver,
-                                    format!("Insert failed: {e}"),
+                                    dbflux_i18n::t!(
+                                        "document.data.mutation.error.insert_failed",
+                                        error = e
+                                    ),
                                 ),
                                 cx,
                             );
@@ -1152,7 +1178,9 @@ impl DataGridPanel {
                     report_error(
                         UserFacingError::new(
                             ErrorKind::User,
-                            "Cannot delete document: it has an unsupported _id value",
+                            dbflux_i18n::t!(
+                                "document.data.mutation.error.delete_document_unsupported_id"
+                            ),
                         ),
                         cx,
                     );
@@ -1225,7 +1253,9 @@ impl DataGridPanel {
                                 cx.notify();
                             });
                             panel.pending.toast = Some(PendingToast {
-                                message: "Document deleted".to_string(),
+                                message: dbflux_i18n::t!(
+                                    "document.data.mutation.toast.document_deleted"
+                                ),
                                 is_error: false,
                             });
                             panel.pending.refresh = true;
@@ -1235,7 +1265,10 @@ impl DataGridPanel {
                             report_error(
                                 UserFacingError::new(
                                     ErrorKind::Driver,
-                                    format!("Delete failed: {e}"),
+                                    dbflux_i18n::t!(
+                                        "document.data.mutation.error.delete_failed",
+                                        error = e
+                                    ),
                                 ),
                                 cx,
                             );
@@ -1291,7 +1324,7 @@ impl DataGridPanel {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Driver,
-                    "Cannot delete: no primary key defined for this table",
+                    dbflux_i18n::t!("document.data.mutation.error.delete_no_primary_key"),
                 ),
                 cx,
             );
@@ -1300,7 +1333,10 @@ impl DataGridPanel {
 
         if pk_columns.len() != pk_count || pk_values.len() != pk_count {
             report_error(
-                UserFacingError::new(ErrorKind::Driver, "Cannot delete: failed to identify row"),
+                UserFacingError::new(
+                    ErrorKind::Driver,
+                    dbflux_i18n::t!("document.data.mutation.error.delete_identity_failed"),
+                ),
                 cx,
             );
             return;
@@ -1363,7 +1399,9 @@ impl DataGridPanel {
                                 cx.notify();
                             });
                             panel.pending.toast = Some(PendingToast {
-                                message: "Row deleted".to_string(),
+                                message: dbflux_i18n::t!(
+                                    "document.data.mutation.toast.row_deleted"
+                                ),
                                 is_error: false,
                             });
                             panel.pending.refresh = true;
@@ -1373,7 +1411,10 @@ impl DataGridPanel {
                             report_error(
                                 UserFacingError::new(
                                     ErrorKind::Driver,
-                                    format!("Delete failed: {e}"),
+                                    dbflux_i18n::t!(
+                                        "document.data.mutation.error.delete_failed",
+                                        error = e
+                                    ),
                                 ),
                                 cx,
                             );
@@ -1509,7 +1550,7 @@ impl DataGridPanel {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Driver,
-                    "Cannot delete: no primary key defined for this table",
+                    dbflux_i18n::t!("document.data.mutation.error.delete_no_primary_key"),
                 ),
                 cx,
             );
@@ -1551,7 +1592,7 @@ impl DataGridPanel {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Driver,
-                    "Cannot delete: failed to identify any rows",
+                    dbflux_i18n::t!("document.data.mutation.error.bulk_delete_no_rows_identified"),
                 ),
                 cx,
             );
@@ -1634,10 +1675,11 @@ impl DataGridPanel {
                         report_error(
                             UserFacingError::new(
                                 ErrorKind::Driver,
-                                format!(
-                                    "Deleted {} of {} row(s), then failed: {e}",
+                                crate::labels::partial_delete_label(
+                                    crate::labels::MutationItemKind::Row,
                                     success_count,
-                                    identities.len()
+                                    identities.len(),
+                                    &e.to_string(),
                                 ),
                             ),
                             cx,
@@ -1654,7 +1696,10 @@ impl DataGridPanel {
                         });
 
                         panel.pending.toast = Some(PendingToast {
-                            message: format!("{} row(s) deleted", success_count),
+                            message: crate::labels::bulk_delete_success_label(
+                                crate::labels::MutationItemKind::Row,
+                                success_count,
+                            ),
                             is_error: false,
                         });
 
@@ -1740,7 +1785,9 @@ impl DataGridPanel {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Driver,
-                    "Cannot delete: failed to identify any documents",
+                    dbflux_i18n::t!(
+                        "document.data.mutation.error.bulk_delete_no_documents_identified"
+                    ),
                 ),
                 cx,
             );
@@ -1819,10 +1866,11 @@ impl DataGridPanel {
                         report_error(
                             UserFacingError::new(
                                 ErrorKind::Driver,
-                                format!(
-                                    "Deleted {} of {} document(s), then failed: {e}",
+                                crate::labels::partial_delete_label(
+                                    crate::labels::MutationItemKind::Document,
                                     success_count,
-                                    filters.len()
+                                    filters.len(),
+                                    &e.to_string(),
                                 ),
                             ),
                             cx,
@@ -1838,7 +1886,10 @@ impl DataGridPanel {
                         });
 
                         panel.pending.toast = Some(PendingToast {
-                            message: format!("{} document(s) deleted", success_count),
+                            message: crate::labels::bulk_delete_success_label(
+                                crate::labels::MutationItemKind::Document,
+                                success_count,
+                            ),
                             is_error: false,
                         });
 

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -248,12 +248,94 @@ pub(crate) fn chart_rail_why_text(numeric_columns: usize, timestamp_columns: usi
     )
 }
 
+/// Item kind affected by a bulk delete, selecting the plural noun used in
+/// the completion toast and the partial-failure catalog buckets.
+pub(crate) enum MutationItemKind {
+    Row,
+    Document,
+}
+
+/// Confirmation-modal summary for a DELETE mutation, with the estimated row
+/// count interpolated when known.
+///
+/// Uses the singular catalog bucket only for exactly one row; every other
+/// known count uses the plural bucket. `None` (the row count has not been
+/// estimated yet) renders through the dedicated "unknown" bucket with no
+/// count at all.
+pub(crate) fn delete_rows_label(est_rows: Option<u64>, table: &str) -> String {
+    match est_rows {
+        Some(1) => dbflux_i18n::t!(
+            "document.data.mutation.confirm.delete.summary.one",
+            count = 1,
+            table = table
+        ),
+        Some(count) => dbflux_i18n::t!(
+            "document.data.mutation.confirm.delete.summary.many",
+            count = count,
+            table = table
+        ),
+        None => dbflux_i18n::t!(
+            "document.data.mutation.confirm.delete.summary.unknown",
+            table = table
+        ),
+    }
+}
+
+/// Confirmation-modal summary for an UPDATE mutation, with the affected
+/// column count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one column; every
+/// other count, including zero, uses the plural bucket.
+pub(crate) fn update_columns_label(column_count: usize, table: &str) -> String {
+    if column_count == 1 {
+        dbflux_i18n::t!(
+            "document.data.mutation.confirm.update.summary.one",
+            count = column_count,
+            table = table
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.data.mutation.confirm.update.summary.many",
+            count = column_count,
+            table = table
+        )
+    }
+}
+
+/// Toast/error text for a batch delete that stopped partway through after
+/// hitting an error, reporting how many items succeeded before the failure.
+pub(crate) fn partial_delete_label(
+    kind: MutationItemKind,
+    done: usize,
+    total: usize,
+    error: &str,
+) -> String {
+    let key = match kind {
+        MutationItemKind::Row => "document.data.mutation.toast.partial_delete.row",
+        MutationItemKind::Document => "document.data.mutation.toast.partial_delete.document",
+    };
+
+    dbflux_i18n::t!(key, done = done, total = total, error = error)
+}
+
+/// Toast text for a batch delete that completed in full, with the number of
+/// deleted items interpolated.
+pub(crate) fn bulk_delete_success_label(kind: MutationItemKind, count: usize) -> String {
+    let key = match kind {
+        MutationItemKind::Row => "document.data.mutation.toast.rows_deleted",
+        MutationItemKind::Document => "document.data.mutation.toast.documents_deleted",
+    };
+
+    dbflux_i18n::t!(key, count = count)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        chart_degraded_copy, chart_dock_shape_label, chart_rail_why_text,
-        pending_change_count_label, pending_edits_summary, refresh_policy_label, row_count_label,
-        unsaved_changes_label,
+        MutationItemKind, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
+        chart_rail_why_text, delete_rows_label, partial_delete_label, pending_change_count_label,
+        pending_edits_summary, refresh_policy_label, row_count_label, unsaved_changes_label,
+        update_columns_label,
     };
     use dbflux_components::chart::ChartDetection;
     use dbflux_core::RefreshPolicy;
@@ -494,5 +576,115 @@ mod tests {
         );
         assert!(many.contains("3 numeric columns"));
         assert!(many.contains("2 timestamp-like columns"));
+    }
+
+    #[test]
+    fn delete_rows_label_unknown_one_many() {
+        let unknown = delete_rows_label(None, "orders");
+        let one = delete_rows_label(Some(1), "orders");
+        let many = delete_rows_label(Some(3), "orders");
+
+        assert_eq!(unknown, "Delete rows from \"orders\"");
+        assert_eq!(one, "Delete 1 row from \"orders\"");
+        assert_eq!(many, "Delete 3 rows from \"orders\"");
+    }
+
+    #[test]
+    fn update_columns_label_zero_one_many() {
+        let zero = update_columns_label(0, "orders");
+        let one = update_columns_label(1, "orders");
+        let many = update_columns_label(2, "orders");
+
+        assert_eq!(zero, "Update 0 columns in \"orders\"");
+        assert_eq!(one, "Update 1 column in \"orders\"");
+        assert_eq!(many, "Update 2 columns in \"orders\"");
+    }
+
+    #[test]
+    fn partial_delete_label_rows_and_documents() {
+        let rows = partial_delete_label(MutationItemKind::Row, 2, 5, "connection lost");
+        let documents = partial_delete_label(MutationItemKind::Document, 1, 3, "timeout");
+
+        assert_eq!(rows, "Deleted 2 of 5 row(s), then failed: connection lost");
+        assert_eq!(
+            documents,
+            "Deleted 1 of 3 document(s), then failed: timeout"
+        );
+    }
+
+    #[test]
+    fn bulk_delete_success_label_rows_and_documents() {
+        assert_eq!(
+            bulk_delete_success_label(MutationItemKind::Row, 4),
+            "4 row(s) deleted"
+        );
+        assert_eq!(
+            bulk_delete_success_label(MutationItemKind::Document, 1),
+            "1 document(s) deleted"
+        );
+    }
+
+    #[test]
+    fn mutation_confirm_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.data.mutation.confirm.delete.summary.one",
+            "document.data.mutation.confirm.delete.summary.many",
+            "document.data.mutation.confirm.delete.summary.unknown",
+            "document.data.mutation.confirm.update.summary.one",
+            "document.data.mutation.confirm.update.summary.many",
+            "document.data.mutation.error.update_document_unsupported_id",
+            "document.data.mutation.error.update_document_failed",
+            "document.data.mutation.error.save_row_unsupported_pk",
+            "document.data.mutation.error.save_row_identity_failed",
+            "document.data.mutation.error.save_row_unsupported_values",
+            "document.data.mutation.error.save_failed",
+            "document.data.mutation.error.save_document_unsupported_id",
+            "document.data.mutation.error.insert_failed",
+            "document.data.mutation.error.insert_no_values",
+            "document.data.mutation.error.delete_document_unsupported_id",
+            "document.data.mutation.error.delete_failed",
+            "document.data.mutation.error.delete_no_primary_key",
+            "document.data.mutation.error.delete_identity_failed",
+            "document.data.mutation.error.bulk_delete_no_rows_identified",
+            "document.data.mutation.error.bulk_delete_no_documents_identified",
+            "document.data.mutation.toast.document_updated",
+            "document.data.mutation.toast.saved",
+            "document.data.mutation.toast.document_inserted",
+            "document.data.mutation.toast.row_inserted",
+            "document.data.mutation.toast.document_deleted",
+            "document.data.mutation.toast.row_deleted",
+            "document.data.mutation.toast.rows_deleted",
+            "document.data.mutation.toast.documents_deleted",
+            "document.data.mutation.toast.partial_delete.row",
+            "document.data.mutation.toast.partial_delete.document",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn mutation_confirm_title_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.data.mutation.confirm.delete.summary.many",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.data.mutation.confirm.delete.summary.many",
+            locale = "es"
+        );
+
+        assert_ne!(en, es);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 5: delete and update summaries, mutation error reports and completion toasts for rows and documents render through `dbflux_i18n::t!` and plural-aware helpers; SQL generation, task runner names and logs stay English. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 4; next: context menu items and sections)

## How was this solved?

- Counts now use singular/plural buckets (`1 row`); task runner names stay for a dedicated slice.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 900 passed; clippy clean; fmt clean. Manual smoke in Spanish: edit several columns and delete rows, confirm the modal and toasts.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
