### PR TITLE
feat(i18n): translate the drop-table relation badges, schema-drift nullable label, and chart aggregation pill

### DIFF
--- a/crates/dbflux_components/src/chart/axis_bar.rs
+++ b/crates/dbflux_components/src/chart/axis_bar.rs
@@ -38,6 +38,17 @@ pub enum AxisPill {
     Agg,
 }
 
+/// Translated label shown on the "Agg" pill for a given aggregation kind.
+fn agg_label(kind: AggKind) -> String {
+    match kind {
+        AggKind::None => dbflux_i18n::t!("chart.axis_bar.aggregation.none"),
+        AggKind::Sum => dbflux_i18n::t!("chart.axis_bar.aggregation.sum"),
+        AggKind::Avg => dbflux_i18n::t!("chart.axis_bar.aggregation.avg"),
+        AggKind::Min => dbflux_i18n::t!("chart.axis_bar.aggregation.min"),
+        AggKind::Max => dbflux_i18n::t!("chart.axis_bar.aggregation.max"),
+    }
+}
+
 /// Render the AxisBar pill row.
 ///
 /// # Parameters
@@ -108,14 +119,7 @@ where
         .unwrap_or_else(|| "—".to_string())
         .into();
 
-    let agg_label: SharedString = match bindings.aggregation {
-        AggKind::None => "none",
-        AggKind::Sum => "sum",
-        AggKind::Avg => "avg",
-        AggKind::Min => "min",
-        AggKind::Max => "max",
-    }
-    .into();
+    let agg_label: SharedString = agg_label(bindings.aggregation).into();
 
     let x_open = open_pill == Some(AxisPill::X);
     let y_open = open_pill == Some(AxisPill::Y);
@@ -738,15 +742,48 @@ mod tests {
             (AggKind::Max, "max"),
         ];
         for (kind, expected) in pairs {
-            let label = match kind {
-                AggKind::None => "none",
-                AggKind::Sum => "sum",
-                AggKind::Avg => "avg",
-                AggKind::Min => "min",
-                AggKind::Max => "max",
-            };
-            assert_eq!(label, *expected, "mismatch for {:?}", kind);
+            assert_eq!(agg_label(*kind), *expected, "mismatch for {:?}", kind);
         }
+    }
+
+    #[test]
+    fn chart_axis_bar_aggregation_keys_resolve_in_both_locales() {
+        let keys = [
+            "chart.axis_bar.aggregation.none",
+            "chart.axis_bar.aggregation.sum",
+            "chart.axis_bar.aggregation.avg",
+            "chart.axis_bar.aggregation.min",
+            "chart.axis_bar.aggregation.max",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert!(
+                !en.is_empty() && !en.starts_with("en."),
+                "en missing for {key}, got {en:?}"
+            );
+            assert!(
+                !es.is_empty() && !es.starts_with("es."),
+                "es missing for {key}, got {es:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn axis_role_labels_are_accepted_untranslated_single_tokens() {
+        for role in ["X", "Y", "Agg"] {
+            assert_eq!(role.split_whitespace().count(), 1);
+        }
+    }
+
+    #[test]
+    fn agg_label_sum_diverges_between_locales() {
+        let en = dbflux_i18n::t!("chart.axis_bar.aggregation.sum", locale = "en");
+        let es = dbflux_i18n::t!("chart.axis_bar.aggregation.sum", locale = "es");
+        assert_eq!(en, "sum");
+        assert_eq!(es, "suma");
+        assert_ne!(en, es);
     }
 
     #[test]

--- a/crates/dbflux_components/src/modals/drop_table.rs
+++ b/crates/dbflux_components/src/modals/drop_table.rs
@@ -52,12 +52,16 @@ impl DropTableRequest {
     }
 }
 
-fn relation_kind_label(kind: &RelationKind) -> &'static str {
+fn relation_kind_label(kind: &RelationKind) -> String {
     match kind {
-        RelationKind::View => "View",
-        RelationKind::MaterializedView => "MatView",
-        RelationKind::ForeignKeyChild => "FK",
-        RelationKind::Trigger => "Trigger",
+        RelationKind::View => dbflux_i18n::t!("modals.drop_table.relation_kind.view"),
+        RelationKind::MaterializedView => {
+            dbflux_i18n::t!("modals.drop_table.relation_kind.materialized_view")
+        }
+        RelationKind::ForeignKeyChild => {
+            dbflux_i18n::t!("modals.drop_table.relation_kind.foreign_key")
+        }
+        RelationKind::Trigger => dbflux_i18n::t!("modals.drop_table.relation_kind.trigger"),
     }
 }
 
@@ -373,6 +377,10 @@ mod tests {
             "modals.drop_table.confirm_prompt",
             "modals.drop_table.cascade_warning",
             "modals.drop_table.delete_warning",
+            "modals.drop_table.relation_kind.view",
+            "modals.drop_table.relation_kind.materialized_view",
+            "modals.drop_table.relation_kind.foreign_key",
+            "modals.drop_table.relation_kind.trigger",
         ];
 
         for key in keys {
@@ -387,6 +395,26 @@ mod tests {
     fn drop_table_title_diverges_between_locales() {
         let en = dbflux_i18n::t!("modals.drop_table.title", locale = "en");
         let es = dbflux_i18n::t!("modals.drop_table.title", locale = "es");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn relation_kind_label_covers_every_kind() {
+        assert_eq!(relation_kind_label(&RelationKind::View), "View");
+        assert_eq!(
+            relation_kind_label(&RelationKind::MaterializedView),
+            "MatView"
+        );
+        assert_eq!(relation_kind_label(&RelationKind::ForeignKeyChild), "FK");
+        assert_eq!(relation_kind_label(&RelationKind::Trigger), "Trigger");
+    }
+
+    #[test]
+    fn relation_kind_label_view_diverges_between_locales() {
+        let en = dbflux_i18n::t!("modals.drop_table.relation_kind.view", locale = "en");
+        let es = dbflux_i18n::t!("modals.drop_table.relation_kind.view", locale = "es");
+        assert_eq!(en, "View");
+        assert_eq!(es, "Vista");
         assert_ne!(en, es);
     }
 

--- a/crates/dbflux_components/src/modals/schema_drift.rs
+++ b/crates/dbflux_components/src/modals/schema_drift.rs
@@ -269,8 +269,9 @@ fn render_change_row(
             before,
             after,
         } => {
-            let before_label = if *before { "nullable" } else { "NOT NULL" };
-            let after_label = if *after { "nullable" } else { "NOT NULL" };
+            let nullable_label = dbflux_i18n::t!("modals.schema_drift.change.nullable");
+            let before_label = if *before { &nullable_label } else { "NOT NULL" };
+            let after_label = if *after { &nullable_label } else { "NOT NULL" };
             drift_row(
                 warning_bg,
                 column,
@@ -417,6 +418,7 @@ mod tests {
             "modals.schema_drift.change.changed",
             "modals.schema_drift.change.primary_key",
             "modals.schema_drift.change.foreign_keys",
+            "modals.schema_drift.change.nullable",
             "modals.schema_drift.continue_stale",
             "modals.schema_drift.cancel",
             "modals.schema_drift.refreshing",
@@ -443,6 +445,15 @@ mod tests {
         let es = dbflux_i18n::t!("modals.schema_drift.refresh", locale = "es");
         assert_eq!(en, "Refresh and re-run");
         assert_eq!(es, "Actualizar y volver a ejecutar");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn schema_drift_nullable_label_diverges_between_locales() {
+        let en = dbflux_i18n::t!("modals.schema_drift.change.nullable", locale = "en");
+        let es = dbflux_i18n::t!("modals.schema_drift.change.nullable", locale = "es");
+        assert_eq!(en, "nullable");
+        assert_eq!(es, "admite NULL");
         assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1,6 +1,12 @@
 chart:
   axis_bar:
     group: Group
+    aggregation:
+      none: none
+      sum: sum
+      avg: avg
+      min: min
+      max: max
   engine:
     no_data: No data
   point_inspector:
@@ -212,6 +218,11 @@ modals:
     confirm_prompt: 'Type "%{table}" to confirm'
     cascade_warning: "Dependent objects will also be dropped (CASCADE):"
     delete_warning: This will permanently delete the table and any dependent objects.
+    relation_kind:
+      view: View
+      materialized_view: MatView
+      foreign_key: FK
+      trigger: Trigger
   import_dashboard:
     title: Import Dashboard from JSON
     name_label: Dashboard name
@@ -259,6 +270,7 @@ modals:
       changed: changed
       primary_key: (primary key)
       foreign_keys: (foreign keys)
+      nullable: nullable
     continue_stale: Continue with stale schema
     cancel: Cancel
     refreshing: Refreshing…

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1,6 +1,12 @@
 chart:
   axis_bar:
     group: Grupo
+    aggregation:
+      none: ninguna
+      sum: suma
+      avg: promedio
+      min: mín
+      max: máx
   engine:
     no_data: Sin datos
   point_inspector:
@@ -212,6 +218,11 @@ modals:
     confirm_prompt: 'Escribe "%{table}" para confirmar'
     cascade_warning: "También se eliminarán los objetos dependientes (CASCADE):"
     delete_warning: Esto eliminará de forma permanente la tabla y cualquier objeto dependiente.
+    relation_kind:
+      view: Vista
+      materialized_view: Vista mat.
+      foreign_key: FK
+      trigger: Trigger
   import_dashboard:
     title: Importar dashboard desde JSON
     name_label: Nombre del dashboard
@@ -259,6 +270,7 @@ modals:
       changed: modificado
       primary_key: (clave primaria)
       foreign_keys: (claves foráneas)
+      nullable: admite NULL
     continue_stale: Continuar con el esquema desactualizado
     cancel: Cancelar
     refreshing: Actualizando…


### PR DESCRIPTION
## Summary

Verification follow-up for the `dbflux_components` i18n series: the drop-table dependency badges (`relation_kind_label`), the schema-drift "nullable" label and the chart aggregation pill values route through `dbflux_i18n::t!` with exhaustive matches over `RelationKind` and `AggKind`. `NOT NULL` and the X/Y/Agg role labels stay literal (recorded as accepted exceptions in tests).

## What does this resolve?

- Refs #360 (closes the three CRITICAL findings of the `dbflux_components` verification after #383)

## How was this solved?

- Same mechanism; 12 catalog lines per locale. No behavior change beyond the labels.

## Validation

- `cargo nextest run -p dbflux_components -p dbflux_i18n` → 407 passed; clippy clean; fmt clean.
- Receipt-driven review: approved; remaining findings advisory. Manual smoke in Spanish: open the drop-table confirmation on a table with dependents, trigger a schema drift with a nullability change, open the chart aggregation pill.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
