### PR TITLE
feat(i18n): translate the connection manager access tab direct and SSM sections

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1,3 +1,19 @@
+access:
+  tab_label: Access
+  method_label: Access Method
+  direct_hint: Direct connections use the database fields from the Main tab.
+  auth_profile_optional: Auth Profile (optional)
+  manage: Manage
+  login: Login
+  refresh: Refresh
+  auth_profile_hint: Used for resolving Secret/Parameter/Auth value sources in Direct mode.
+  session_valid: Auth profile session is valid
+  ssm_title: SSM Port Forwarding
+  ssm_instance_id: Instance ID
+  ssm_region: Region
+  ssm_remote_port: Remote Port
+  ssm_port_hint: DBFlux and the OS auto-assign the local tunnel port. Only Remote Port is configurable here.
+  auth_profile: Auth Profile
 chart:
   axis_bar:
     group: Group

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1,3 +1,19 @@
+access:
+  tab_label: Acceso
+  method_label: Método de acceso
+  direct_hint: Las conexiones directas usan los campos de la pestaña Principal.
+  auth_profile_optional: Perfil de autenticación (opcional)
+  manage: Gestionar
+  login: Iniciar sesión
+  refresh: Actualizar
+  auth_profile_hint: Se utiliza para resolver los orígenes de valor Secret/Parameter/Auth en modo Directo.
+  session_valid: La sesión del perfil de autenticación es válida
+  ssm_title: Reenvío de puertos SSM
+  ssm_instance_id: ID de instancia
+  ssm_region: Región
+  ssm_remote_port: Puerto remoto
+  ssm_port_hint: DBFlux y el sistema operativo asignan automáticamente el puerto del túnel local. Aquí solo se puede configurar el puerto remoto.
+  auth_profile: Perfil de autenticación
 chart:
   axis_bar:
     group: Grupo

--- a/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
@@ -41,15 +41,17 @@ impl ConnectionManagerWindow {
             && self.selected_auth_profile_needs_login(cx);
         let auth_profile_is_valid = self.selected_auth_profile_is_valid(cx);
 
+        let access_tab_label = dbflux_i18n::t!("access.tab_label");
+
         let mut sections = vec![
             self.render_section(
-                "Access",
+                &access_tab_label,
                 div().flex().flex_col().gap_2().child(
                     div()
                         .flex()
                         .flex_col()
                         .gap_1()
-                        .child(Label::new("Access Method"))
+                        .child(Label::new(dbflux_i18n::t!("access.method_label")))
                         .child(
                             div()
                                 .min_w(Widths::CM_FORM_DROPDOWN)
@@ -68,13 +70,13 @@ impl ConnectionManagerWindow {
                         .flex()
                         .flex_col()
                         .gap_3()
-                        .child(Text::muted("Direct connections use the database fields from the Main tab."))
+                        .child(Text::muted(dbflux_i18n::t!("access.direct_hint")))
                         .child(
                             div()
                                 .flex()
                                 .flex_col()
                                 .gap_1()
-                                .child(Label::new("Auth Profile (optional)"))
+                                .child(Label::new(dbflux_i18n::t!("access.auth_profile_optional")))
                                 .child(
                                     self.render_focus_shell(
                                         show_focus && self.form_focus == FormFocus::SsmAuthProfile,
@@ -82,17 +84,17 @@ impl ConnectionManagerWindow {
                                         self.auth_profile.auth_profile_dropdown.clone(),
                                         cx,
                                     )
-                                        .min_w(px(280.0))
-                                        .on_mouse_down(
-                                            MouseButton::Left,
-                                            cx.listener(|this, _, window, cx| {
-                                                this.enter_edit_mode_for_field(
-                                                    FormFocus::SsmAuthProfile,
-                                                    window,
-                                                    cx,
-                                                );
-                                            }),
-                                        ),
+                                    .min_w(px(280.0))
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        cx.listener(|this, _, window, cx| {
+                                            this.enter_edit_mode_for_field(
+                                                FormFocus::SsmAuthProfile,
+                                                window,
+                                                cx,
+                                            );
+                                        }),
+                                    ),
                                 )
                                 .child(
                                     div()
@@ -104,77 +106,85 @@ impl ConnectionManagerWindow {
                                                 show_focus
                                                     && self.form_focus == FormFocus::SsmAuthManage,
                                                 ring_color,
-                                                Button::new("auth-open-settings", "Manage")
-                                                    .ghost()
-                                                    .small()
-                                                    .on_click(cx.listener(|this, _, _, cx| {
-                                                        this.open_auth_profiles_settings(cx);
-                                                    })),
+                                                Button::new(
+                                                    "auth-open-settings",
+                                                    dbflux_i18n::t!("access.manage"),
+                                                )
+                                                .ghost()
+                                                .small()
+                                                .on_click(cx.listener(|this, _, _, cx| {
+                                                    this.open_auth_profiles_settings(cx);
+                                                })),
                                                 cx,
                                             )
-                                                .on_mouse_down(
-                                                    MouseButton::Left,
-                                                    cx.listener(|this, _, window, cx| {
-                                                        this.enter_edit_mode_for_field(
-                                                            FormFocus::SsmAuthManage,
-                                                            window,
-                                                            cx,
-                                                        );
-                                                    }),
-                                                ),
+                                            .on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(|this, _, window, cx| {
+                                                    this.enter_edit_mode_for_field(
+                                                        FormFocus::SsmAuthManage,
+                                                        window,
+                                                        cx,
+                                                    );
+                                                }),
+                                            ),
                                         )
                                         .child(
                                             self.render_focus_shell(
                                                 show_focus
                                                     && self.form_focus == FormFocus::SsmAuthLogin,
                                                 ring_color,
-                                                Button::new("auth-login-selected", "Login")
-                                                    .ghost()
-                                                    .small()
-                                                    .disabled(!login_enabled)
-                                                    .on_click(cx.listener(|this, _, _, cx| {
-                                                        this.login_selected_auth_profile(cx);
-                                                    })),
+                                                Button::new(
+                                                    "auth-login-selected",
+                                                    dbflux_i18n::t!("access.login"),
+                                                )
+                                                .ghost()
+                                                .small()
+                                                .disabled(!login_enabled)
+                                                .on_click(cx.listener(|this, _, _, cx| {
+                                                    this.login_selected_auth_profile(cx);
+                                                })),
                                                 cx,
                                             )
-                                                .on_mouse_down(
-                                                    MouseButton::Left,
-                                                    cx.listener(|this, _, window, cx| {
-                                                        this.enter_edit_mode_for_field(
-                                                            FormFocus::SsmAuthLogin,
-                                                            window,
-                                                            cx,
-                                                        );
-                                                    }),
-                                                ),
+                                            .on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(|this, _, window, cx| {
+                                                    this.enter_edit_mode_for_field(
+                                                        FormFocus::SsmAuthLogin,
+                                                        window,
+                                                        cx,
+                                                    );
+                                                }),
+                                            ),
                                         )
                                         .child(
                                             self.render_focus_shell(
                                                 show_focus
-                                                    && self.form_focus
-                                                        == FormFocus::SsmAuthRefresh,
+                                                    && self.form_focus == FormFocus::SsmAuthRefresh,
                                                 ring_color,
-                                                Button::new("auth-refresh-session", "Refresh")
-                                                    .ghost()
-                                                    .small()
-                                                    .on_click(cx.listener(|this, _, _, cx| {
-                                                        this.refresh_auth_profile_statuses(cx);
-                                                    })),
+                                                Button::new(
+                                                    "auth-refresh-session",
+                                                    dbflux_i18n::t!("access.refresh"),
+                                                )
+                                                .ghost()
+                                                .small()
+                                                .on_click(cx.listener(|this, _, _, cx| {
+                                                    this.refresh_auth_profile_statuses(cx);
+                                                })),
                                                 cx,
                                             )
-                                                .on_mouse_down(
-                                                    MouseButton::Left,
-                                                    cx.listener(|this, _, window, cx| {
-                                                        this.enter_edit_mode_for_field(
-                                                            FormFocus::SsmAuthRefresh,
-                                                            window,
-                                                            cx,
-                                                        );
-                                                    }),
-                                                ),
+                                            .on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(|this, _, window, cx| {
+                                                    this.enter_edit_mode_for_field(
+                                                        FormFocus::SsmAuthRefresh,
+                                                        window,
+                                                        cx,
+                                                    );
+                                                }),
+                                            ),
                                         ),
                                 )
-                                .child(Text::caption("Used for resolving Secret/Parameter/Auth value sources in Direct mode.")),
+                                .child(Text::caption(dbflux_i18n::t!("access.auth_profile_hint"))),
                         )
                         .when_some(self.selected_auth_profile_status_text(cx), |d, status| {
                             d.child(Text::caption(status))
@@ -182,12 +192,13 @@ impl ConnectionManagerWindow {
                         .when(auth_profile_is_valid, |d| {
                             d.child(
                                 StatusIndicator::new(Status::Connected)
-                                    .label("Auth profile session is valid"),
+                                    .label(dbflux_i18n::t!("access.session_valid")),
                             )
                         })
-                        .when_some(self.auth_profile.auth_profile_action_message.as_ref(), |d, message| {
-                            d.child(Text::caption(message.clone()))
-                        })
+                        .when_some(
+                            self.auth_profile.auth_profile_action_message.as_ref(),
+                            |d, message| d.child(Text::caption(message.clone())),
+                        )
                         .into_any_element(),
                 );
             }
@@ -208,14 +219,19 @@ impl ConnectionManagerWindow {
             && self.selected_auth_profile_needs_login(cx);
         let auth_profile_is_valid = self.selected_auth_profile_is_valid(cx);
 
+        let ssm_title = dbflux_i18n::t!("access.ssm_title");
+        let ssm_instance_id_label = dbflux_i18n::t!("access.ssm_instance_id");
+        let ssm_region_label = dbflux_i18n::t!("access.ssm_region");
+        let ssm_remote_port_label = dbflux_i18n::t!("access.ssm_remote_port");
+
         self.render_section(
-            "SSM Port Forwarding",
+            &ssm_title,
             div()
                 .flex()
                 .flex_col()
                 .gap_3()
                 .child(self.render_ssm_value_field(
-                    "Instance ID",
+                    &ssm_instance_id_label,
                     &self.access.input_ssm_instance_id,
                     self.access.ssm_instance_id_value_source_selector.clone(),
                     true,
@@ -227,7 +243,7 @@ impl ConnectionManagerWindow {
                     cx,
                 ))
                 .child(self.render_ssm_value_field(
-                    "Region",
+                    &ssm_region_label,
                     &self.access.input_ssm_region,
                     self.access.ssm_region_value_source_selector.clone(),
                     true,
@@ -239,7 +255,7 @@ impl ConnectionManagerWindow {
                     cx,
                 ))
                 .child(self.render_ssm_value_field(
-                    "Remote Port",
+                    &ssm_remote_port_label,
                     &self.access.input_ssm_remote_port,
                     self.access.ssm_remote_port_value_source_selector.clone(),
                     false,
@@ -250,13 +266,13 @@ impl ConnectionManagerWindow {
                     FormFocus::SsmRemotePort,
                     cx,
                 ))
-                .child(Text::caption("DBFlux and the OS auto-assign the local tunnel port. Only Remote Port is configurable here."))
+                .child(Text::caption(dbflux_i18n::t!("access.ssm_port_hint")))
                 .child(
                     div()
                         .flex()
                         .flex_col()
                         .gap_1()
-                        .child(Label::new("Auth Profile"))
+                        .child(Label::new(dbflux_i18n::t!("access.auth_profile")))
                         .child(
                             self.render_focus_shell(
                                 show_focus && self.form_focus == FormFocus::SsmAuthProfile,
@@ -264,17 +280,17 @@ impl ConnectionManagerWindow {
                                 self.auth_profile.auth_profile_dropdown.clone(),
                                 cx,
                             )
-                                .min_w(px(280.0))
-                                .on_mouse_down(
-                                    MouseButton::Left,
-                                    cx.listener(|this, _, window, cx| {
-                                        this.enter_edit_mode_for_field(
-                                            FormFocus::SsmAuthProfile,
-                                            window,
-                                            cx,
-                                        );
-                                    }),
-                                ),
+                            .min_w(px(280.0))
+                            .on_mouse_down(
+                                MouseButton::Left,
+                                cx.listener(|this, _, window, cx| {
+                                    this.enter_edit_mode_for_field(
+                                        FormFocus::SsmAuthProfile,
+                                        window,
+                                        cx,
+                                    );
+                                }),
+                            ),
                         )
                         .child(
                             div()
@@ -285,71 +301,86 @@ impl ConnectionManagerWindow {
                                     self.render_focus_shell(
                                         show_focus && self.form_focus == FormFocus::SsmAuthManage,
                                         ring_color,
-                                        Button::new("ssm-auth-open-settings", "Manage")
-                                            .ghost()
-                                            .small()
-                                            .on_click(cx.listener(|this, _, _, cx| {
+                                        Button::new(
+                                            "ssm-auth-open-settings",
+                                            dbflux_i18n::t!("access.manage"),
+                                        )
+                                        .ghost()
+                                        .small()
+                                        .on_click(
+                                            cx.listener(|this, _, _, cx| {
                                                 this.open_auth_profiles_settings(cx);
-                                            })),
-                                        cx,
-                                    )
-                                        .on_mouse_down(
-                                            MouseButton::Left,
-                                            cx.listener(|this, _, window, cx| {
-                                                this.enter_edit_mode_for_field(
-                                                    FormFocus::SsmAuthManage,
-                                                    window,
-                                                    cx,
-                                                );
                                             }),
                                         ),
+                                        cx,
+                                    )
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        cx.listener(|this, _, window, cx| {
+                                            this.enter_edit_mode_for_field(
+                                                FormFocus::SsmAuthManage,
+                                                window,
+                                                cx,
+                                            );
+                                        }),
+                                    ),
                                 )
                                 .child(
                                     self.render_focus_shell(
                                         show_focus && self.form_focus == FormFocus::SsmAuthLogin,
                                         ring_color,
-                                        Button::new("ssm-auth-login-selected", "Login")
-                                            .ghost()
-                                            .small()
-                                            .disabled(!login_enabled)
-                                            .on_click(cx.listener(|this, _, _, cx| {
+                                        Button::new(
+                                            "ssm-auth-login-selected",
+                                            dbflux_i18n::t!("access.login"),
+                                        )
+                                        .ghost()
+                                        .small()
+                                        .disabled(!login_enabled)
+                                        .on_click(
+                                            cx.listener(|this, _, _, cx| {
                                                 this.login_selected_auth_profile(cx);
-                                            })),
-                                        cx,
-                                    )
-                                        .on_mouse_down(
-                                            MouseButton::Left,
-                                            cx.listener(|this, _, window, cx| {
-                                                this.enter_edit_mode_for_field(
-                                                    FormFocus::SsmAuthLogin,
-                                                    window,
-                                                    cx,
-                                                );
                                             }),
                                         ),
+                                        cx,
+                                    )
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        cx.listener(|this, _, window, cx| {
+                                            this.enter_edit_mode_for_field(
+                                                FormFocus::SsmAuthLogin,
+                                                window,
+                                                cx,
+                                            );
+                                        }),
+                                    ),
                                 )
                                 .child(
                                     self.render_focus_shell(
                                         show_focus && self.form_focus == FormFocus::SsmAuthRefresh,
                                         ring_color,
-                                        Button::new("ssm-auth-refresh-session", "Refresh")
-                                            .ghost()
-                                            .small()
-                                            .on_click(cx.listener(|this, _, _, cx| {
+                                        Button::new(
+                                            "ssm-auth-refresh-session",
+                                            dbflux_i18n::t!("access.refresh"),
+                                        )
+                                        .ghost()
+                                        .small()
+                                        .on_click(
+                                            cx.listener(|this, _, _, cx| {
                                                 this.refresh_auth_profile_statuses(cx);
-                                            })),
-                                        cx,
-                                    )
-                                        .on_mouse_down(
-                                            MouseButton::Left,
-                                            cx.listener(|this, _, window, cx| {
-                                                this.enter_edit_mode_for_field(
-                                                    FormFocus::SsmAuthRefresh,
-                                                    window,
-                                                    cx,
-                                                );
                                             }),
                                         ),
+                                        cx,
+                                    )
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        cx.listener(|this, _, window, cx| {
+                                            this.enter_edit_mode_for_field(
+                                                FormFocus::SsmAuthRefresh,
+                                                window,
+                                                cx,
+                                            );
+                                        }),
+                                    ),
                                 ),
                         )
                         .when_some(self.selected_auth_profile_status_text(cx), |d, status| {
@@ -358,7 +389,7 @@ impl ConnectionManagerWindow {
                         .when(auth_profile_is_valid, |d| {
                             d.child(
                                 StatusIndicator::new(Status::Connected)
-                                    .label("Auth profile session is valid"),
+                                    .label(dbflux_i18n::t!("access.session_valid")),
                             )
                         }),
                 ),
@@ -1261,5 +1292,66 @@ impl ConnectionManagerWindow {
                 )
                 .into_any_element(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const ACCESS_DIRECT_SSM_KEYS: &[&str] = &[
+        "access.tab_label",
+        "access.method_label",
+        "access.direct_hint",
+        "access.auth_profile_optional",
+        "access.manage",
+        "access.login",
+        "access.refresh",
+        "access.auth_profile_hint",
+        "access.session_valid",
+        "access.ssm_title",
+        "access.ssm_instance_id",
+        "access.ssm_region",
+        "access.ssm_remote_port",
+        "access.ssm_port_hint",
+        "access.auth_profile",
+    ];
+
+    #[test]
+    fn access_direct_ssm_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in ACCESS_DIRECT_SSM_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn access_method_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("access.method_label", locale = "en");
+        let es = dbflux_i18n::t!("access.method_label", locale = "es");
+
+        assert_ne!(
+            en, es,
+            "access.method_label should differ between en and es"
+        );
+    }
+
+    #[test]
+    fn access_ssm_instance_id_label_exact_values() {
+        let en = dbflux_i18n::t!("access.ssm_instance_id", locale = "en");
+        let es = dbflux_i18n::t!("access.ssm_instance_id", locale = "es");
+
+        assert_eq!(en, "Instance ID");
+        assert_eq!(es, "ID de instancia");
     }
 }


### PR DESCRIPTION
## Summary

Eighth `dbflux_ui_windows` i18n slice: the connection manager access tab direct and SSM sections (method chrome, direct hint, auth profile controls, SSM port forwarding fields) render through `dbflux_i18n::t!` under a new `access.*` namespace. English and Spanish together.

## What does this resolve?

- Refs #360 (follows the hooks tab PR; next: the proxy and SSH sections)

## How was this solved?

- Product names and the Secret/Parameter/Auth value-source shorthand stay untranslated.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 210 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a connection's Access tab in Direct and SSM modes.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
