### PR TITLE
feat(i18n): translate the sidebar loading, drop, script, and export toasts

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -772,6 +772,12 @@ settings:
 sidebar:
   confirm:
     delete_hint: Press x to confirm delete, ESC to cancel
+    items:
+      one: 1 item
+      many: "%{count} items"
+  dialog:
+    import_script_title: Import Script
+    script_files_filter: Script files
   empty:
     connections_title: No connections yet
     connections_hint: Use + to add a new connection
@@ -841,6 +847,9 @@ sidebar:
       page_label: "Page %{current}/%{total} (%{start}-%{end})"
       page_label_empty: Page 0/0
       unsupported: Event streams are not available for this collection
+    skipped_tables:
+      one: 1 table outside the active profile/database was skipped
+      many: "%{count} tables outside the active profile/database were skipped"
   status:
     connection_summary: "%{connected} connected · %{idle} idle"
     profile_fallback_name: connection
@@ -854,6 +863,12 @@ sidebar:
     post_connect_hook_cancelled: Post-connect hook cancelled
     disconnect_hook_cancelled: Disconnect hook cancelled
     post_disconnect_hook_cancelled: Post-disconnect hook cancelled
+    loading_event_streams: "Loading event streams: %{name}"
+    dropping:
+      table: "Dropping table %{name}"
+      view: "Dropping view %{name}"
+      collection: "Dropping collection %{name}"
+      database: "Dropping database %{name}"
     pipeline:
       connecting: "Connecting to %{name} (pipeline)"
       cancelled: Pipeline cancelled
@@ -880,6 +895,13 @@ sidebar:
     disconnected_hook_cancelled: Disconnected, but post-disconnect hook was cancelled
     disconnected_hook_error: "Disconnected from %{name}, but %{error}"
     profile_not_found: Profile not found
+    schema_drop_cancelled: Schema drop cancelled
+    drop_failed: "Failed to drop: %{error}"
+    reveal_failed: "Failed to reveal in file manager: %{error}"
+    schema_snapshot_failed: "Failed to capture schema snapshot: %{error}"
+    load_failed:
+      table: "Failed to load %{name} schema: %{error}"
+      collection: "Failed to load event streams for %{name}: %{error}"
     connected:
       plain: "Connected to %{name}"
       one: "Connected to %{name} (with 1 hook warning)"

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -772,6 +772,12 @@ settings:
 sidebar:
   confirm:
     delete_hint: Presiona x para confirmar la eliminación, ESC para cancelar
+    items:
+      one: 1 elemento
+      many: "%{count} elementos"
+  dialog:
+    import_script_title: Importar script
+    script_files_filter: Archivos de script
   empty:
     connections_title: Aún no hay conexiones
     connections_hint: Usa + para agregar una nueva conexión
@@ -841,6 +847,9 @@ sidebar:
       page_label: "Página %{current}/%{total} (%{start}-%{end})"
       page_label_empty: Página 0/0
       unsupported: Los flujos de eventos no están disponibles para esta colección
+    skipped_tables:
+      one: Se omitió 1 tabla fuera del perfil/base de datos activos
+      many: "Se omitieron %{count} tablas fuera del perfil/base de datos activos"
   status:
     connection_summary: "%{connected} conectadas · %{idle} inactivas"
     profile_fallback_name: conexión
@@ -854,6 +863,12 @@ sidebar:
     post_connect_hook_cancelled: Hook posterior a la conexión cancelado
     disconnect_hook_cancelled: Hook de desconexión cancelado
     post_disconnect_hook_cancelled: Hook posterior a la desconexión cancelado
+    loading_event_streams: "Cargando flujos de eventos: %{name}"
+    dropping:
+      table: "Eliminando la tabla %{name}"
+      view: "Eliminando la vista %{name}"
+      collection: "Eliminando la colección %{name}"
+      database: "Eliminando la base de datos %{name}"
     pipeline:
       connecting: "Conectando a %{name} (pipeline)"
       cancelled: Pipeline cancelado
@@ -880,6 +895,13 @@ sidebar:
     disconnected_hook_cancelled: Desconectado, pero se canceló el hook posterior a la desconexión
     disconnected_hook_error: "Desconectado de %{name}, pero %{error}"
     profile_not_found: Perfil no encontrado
+    schema_drop_cancelled: Eliminación de esquema cancelada
+    drop_failed: "Error al eliminar: %{error}"
+    reveal_failed: "Error al mostrar en el explorador de archivos: %{error}"
+    schema_snapshot_failed: "Error al capturar la instantánea del esquema: %{error}"
+    load_failed:
+      table: "Error al cargar el esquema de %{name}: %{error}"
+      collection: "Error al cargar los flujos de eventos de %{name}: %{error}"
     connected:
       plain: "Conectado a %{name}"
       one: "Conectado a %{name} (con 1 advertencia de hook)"

--- a/crates/dbflux_ui_sidebar/src/deletion.rs
+++ b/crates/dbflux_ui_sidebar/src/deletion.rs
@@ -190,7 +190,7 @@ impl Sidebar {
 
         self.delete_confirm_modal = Some(DeleteConfirmState {
             item_id: anchor_id,
-            item_name: format!("{count} items"),
+            item_name: crate::labels::items_label(count),
             is_folder: false,
             object_type: None,
             is_ddl: false,

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -1,7 +1,7 @@
 //! Translated label helpers for sidebar chrome (tabs, footer, tree folders).
 
 use dbflux_app::ExternalDriverStage;
-use dbflux_core::{DatabaseCategory, PipelineState, RelationKind};
+use dbflux_core::{DatabaseCategory, PipelineState, RelationKind, SchemaObjectKind};
 
 /// Translated label for a schema-tree container folder, e.g. `"Tables (12)"`.
 pub(crate) fn container_folder_label(category: DatabaseCategory, count: usize) -> String {
@@ -470,6 +470,101 @@ pub(crate) fn pipeline_failed_detail_label(error: &str) -> String {
 /// completes successfully.
 pub(crate) fn pipeline_completed_detail_label() -> String {
     dbflux_i18n::t!("sidebar.task.pipeline.completed")
+}
+
+/// Translated task-panel label for a background schema fetch that loads
+/// event streams for a collection, e.g. `"Loading event streams: orders"`.
+pub(crate) fn loading_event_streams_task_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.loading_event_streams", name = name)
+}
+
+/// Translated toast reported when loading a table's schema details fails,
+/// e.g. `"Failed to load orders schema: connection reset"`.
+pub(crate) fn table_load_failed_label(name: &str, error: &str) -> String {
+    dbflux_i18n::t!(
+        "sidebar.toast.load_failed.table",
+        name = name,
+        error = error
+    )
+}
+
+/// Translated toast reported when loading a collection's event streams
+/// fails, e.g. `"Failed to load event streams for orders: connection
+/// reset"`.
+pub(crate) fn collection_load_failed_label(name: &str, error: &str) -> String {
+    dbflux_i18n::t!(
+        "sidebar.toast.load_failed.collection",
+        name = name,
+        error = error
+    )
+}
+
+/// Translated label for the batch/single delete confirmation item count,
+/// e.g. `"1 item"` or `"3 items"`.
+pub(crate) fn items_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("sidebar.confirm.items.one")
+    } else {
+        dbflux_i18n::t!("sidebar.confirm.items.many", count = count)
+    }
+}
+
+/// Translated task-panel label for a background DDL drop, e.g. `"Dropping
+/// table orders"`.
+pub(crate) fn dropping_task_label(kind: &SchemaObjectKind, name: &str) -> String {
+    let key = match kind {
+        SchemaObjectKind::Table => "sidebar.task.dropping.table",
+        SchemaObjectKind::View => "sidebar.task.dropping.view",
+        SchemaObjectKind::Collection => "sidebar.task.dropping.collection",
+        SchemaObjectKind::Database => "sidebar.task.dropping.database",
+    };
+
+    dbflux_i18n::t!(key, name = name)
+}
+
+/// Translated toast/task-error message for a schema drop cancelled by the
+/// user or a hook.
+pub(crate) fn schema_drop_cancelled_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.schema_drop_cancelled")
+}
+
+/// Translated toast reported when a schema drop fails, e.g. `"Failed to
+/// drop: permission denied"`.
+pub(crate) fn drop_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.drop_failed", error = error)
+}
+
+/// Translated toast reported when revealing a script file/folder in the
+/// system file manager fails.
+pub(crate) fn reveal_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.reveal_failed", error = error)
+}
+
+/// Translated title for the rfd "Import Script" file picker dialog.
+pub(crate) fn import_script_dialog_title() -> String {
+    dbflux_i18n::t!("sidebar.dialog.import_script_title")
+}
+
+/// Translated filter label for the rfd "Import Script" file picker dialog.
+pub(crate) fn script_files_filter_label() -> String {
+    dbflux_i18n::t!("sidebar.dialog.script_files_filter")
+}
+
+/// Translated warning shown when an Export/Migrate Tables action skipped
+/// tables outside the active profile/database, e.g. `"3 tables outside the
+/// active profile/database were skipped"`.
+pub(crate) fn skipped_tables_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("sidebar.overlay.skipped_tables.one")
+    } else {
+        dbflux_i18n::t!("sidebar.overlay.skipped_tables.many", count = count)
+    }
+}
+
+/// Translated toast reported when capturing a schema snapshot fails during
+/// a pipeline connect.
+pub(crate) fn schema_snapshot_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.schema_snapshot_failed", error = error)
 }
 
 /// Translated task-panel label for the current pipeline stage, shown as a
@@ -1288,6 +1383,200 @@ mod tests {
         assert_eq!(
             label,
             dbflux_i18n::t!("sidebar.task.pipeline.failed", error = "connection refused")
+        );
+    }
+
+    const D2_KEYS: [&str; 15] = [
+        "sidebar.task.loading_event_streams",
+        "sidebar.toast.load_failed.table",
+        "sidebar.toast.load_failed.collection",
+        "sidebar.confirm.items.one",
+        "sidebar.confirm.items.many",
+        "sidebar.task.dropping.table",
+        "sidebar.task.dropping.view",
+        "sidebar.task.dropping.collection",
+        "sidebar.task.dropping.database",
+        "sidebar.toast.schema_drop_cancelled",
+        "sidebar.toast.drop_failed",
+        "sidebar.toast.reveal_failed",
+        "sidebar.dialog.import_script_title",
+        "sidebar.dialog.script_files_filter",
+        "sidebar.toast.schema_snapshot_failed",
+    ];
+
+    #[test]
+    fn d2_keys_resolve_in_both_locales() {
+        for key in D2_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn skipped_tables_label_keys_resolve_in_both_locales() {
+        for key in [
+            "sidebar.overlay.skipped_tables.one",
+            "sidebar.overlay.skipped_tables.many",
+        ] {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sidebar_task_dropping_table_diverges_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.task.dropping.table", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.task.dropping.table", locale = "es");
+
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn loading_event_streams_task_label_includes_the_collection_name() {
+        let label = super::loading_event_streams_task_label("orders");
+
+        assert!(label.contains("orders"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.task.loading_event_streams", name = "orders")
+        );
+    }
+
+    #[test]
+    fn table_load_failed_label_includes_name_and_error() {
+        let label = super::table_load_failed_label("orders", "connection reset");
+
+        assert!(label.contains("orders"));
+        assert!(label.contains("connection reset"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!(
+                "sidebar.toast.load_failed.table",
+                name = "orders",
+                error = "connection reset"
+            )
+        );
+    }
+
+    #[test]
+    fn collection_load_failed_label_includes_name_and_error() {
+        let label = super::collection_load_failed_label("orders", "connection reset");
+
+        assert!(label.contains("orders"));
+        assert!(label.contains("connection reset"));
+        assert_ne!(
+            label,
+            super::table_load_failed_label("orders", "connection reset")
+        );
+    }
+
+    #[test]
+    fn items_label_one_vs_many() {
+        let singular = super::items_label(1);
+        let plural = super::items_label(3);
+
+        assert_eq!(singular, dbflux_i18n::t!("sidebar.confirm.items.one"));
+        assert_eq!(
+            plural,
+            dbflux_i18n::t!("sidebar.confirm.items.many", count = 3)
+        );
+        assert!(plural.contains('3'));
+        assert_ne!(singular, plural);
+    }
+
+    #[test]
+    fn dropping_task_label_covers_every_object_kind() {
+        use dbflux_core::SchemaObjectKind;
+
+        assert_eq!(
+            super::dropping_task_label(&SchemaObjectKind::Table, "orders"),
+            dbflux_i18n::t!("sidebar.task.dropping.table", name = "orders")
+        );
+        assert_eq!(
+            super::dropping_task_label(&SchemaObjectKind::View, "orders_v"),
+            dbflux_i18n::t!("sidebar.task.dropping.view", name = "orders_v")
+        );
+        assert_eq!(
+            super::dropping_task_label(&SchemaObjectKind::Collection, "logs"),
+            dbflux_i18n::t!("sidebar.task.dropping.collection", name = "logs")
+        );
+        assert_eq!(
+            super::dropping_task_label(&SchemaObjectKind::Database, "analytics"),
+            dbflux_i18n::t!("sidebar.task.dropping.database", name = "analytics")
+        );
+    }
+
+    #[test]
+    fn schema_drop_cancelled_label_is_stable() {
+        assert_eq!(
+            super::schema_drop_cancelled_label(),
+            dbflux_i18n::t!("sidebar.toast.schema_drop_cancelled")
+        );
+    }
+
+    #[test]
+    fn drop_failed_label_includes_the_error() {
+        let label = super::drop_failed_label("permission denied");
+
+        assert!(label.contains("permission denied"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.toast.drop_failed", error = "permission denied")
+        );
+    }
+
+    #[test]
+    fn reveal_failed_label_includes_the_error() {
+        let label = super::reveal_failed_label("no such file");
+
+        assert!(label.contains("no such file"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.toast.reveal_failed", error = "no such file")
+        );
+    }
+
+    #[test]
+    fn skipped_tables_label_one_vs_many() {
+        let singular = super::skipped_tables_label(1);
+        let plural = super::skipped_tables_label(3);
+
+        assert_eq!(
+            singular,
+            dbflux_i18n::t!("sidebar.overlay.skipped_tables.one")
+        );
+        assert_eq!(
+            plural,
+            dbflux_i18n::t!("sidebar.overlay.skipped_tables.many", count = 3)
+        );
+        assert!(plural.contains('3'));
+        assert_ne!(singular, plural);
+    }
+
+    #[test]
+    fn schema_snapshot_failed_label_includes_the_error() {
+        let label = super::schema_snapshot_failed_label("disk full");
+
+        assert!(label.contains("disk full"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.toast.schema_snapshot_failed", error = "disk full")
         );
     }
 }

--- a/crates/dbflux_ui_sidebar/src/operations/dnd.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/dnd.rs
@@ -101,7 +101,10 @@ impl Sidebar {
                         profile_id,
                         database,
                     },
-                    task_description: format!("Dropping table {}", name),
+                    task_description: crate::labels::dropping_task_label(
+                        &SchemaObjectKind::Table,
+                        &name,
+                    ),
                     target,
                     is_database: false,
                 })
@@ -133,7 +136,10 @@ impl Sidebar {
                         profile_id,
                         database,
                     },
-                    task_description: format!("Dropping view {}", name),
+                    task_description: crate::labels::dropping_task_label(
+                        &SchemaObjectKind::View,
+                        &name,
+                    ),
                     target,
                     is_database: false,
                 })
@@ -152,7 +158,10 @@ impl Sidebar {
                     profile_id,
                     database: Some(database),
                 },
-                task_description: format!("Dropping collection {}", name),
+                task_description: crate::labels::dropping_task_label(
+                    &SchemaObjectKind::Collection,
+                    &name,
+                ),
                 is_database: false,
             }),
             SchemaNodeId::Database { name, .. } => Some(SidebarDropOperation {
@@ -166,7 +175,10 @@ impl Sidebar {
                     profile_id,
                     database: Some(name.clone()),
                 },
-                task_description: format!("Dropping database {}", name),
+                task_description: crate::labels::dropping_task_label(
+                    &SchemaObjectKind::Database,
+                    &name,
+                ),
                 is_database: true,
             }),
             _ => None,
@@ -282,7 +294,7 @@ impl Sidebar {
 
         if self.app_state.read(cx).is_background_task_limit_reached() {
             self.pending_toast = Some(PendingToast {
-                message: "Too many background tasks running, please wait".to_string(),
+                message: crate::labels::background_task_limit_toast_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -513,7 +525,7 @@ impl Sidebar {
 
                     sidebar.update(cx, |sidebar, cx| {
                         sidebar.pending_toast = Some(PendingToast {
-                            message: format!("Failed to drop: {}", error),
+                            message: crate::labels::drop_failed_label(&error),
                             is_error: true,
                         });
                         sidebar.refresh_tree(cx);
@@ -543,14 +555,16 @@ impl Sidebar {
 
                     let details = build_drop_task_details(&operation.target, None);
 
+                    let cancelled_label = crate::labels::schema_drop_cancelled_label();
+
                     app_state.update(cx, |state, cx| {
-                        state.fail_task_with_details(task_id, "Schema drop cancelled", details);
+                        state.fail_task_with_details(task_id, cancelled_label.clone(), details);
                         cx.emit(AppStateChanged);
                     });
 
                     sidebar.update(cx, |sidebar, cx| {
                         sidebar.pending_toast = Some(PendingToast {
-                            message: "Schema drop cancelled".to_string(),
+                            message: cancelled_label,
                             is_error: true,
                         });
                         sidebar.refresh_tree(cx);

--- a/crates/dbflux_ui_sidebar/src/operations/export_tables.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/export_tables.rs
@@ -104,10 +104,8 @@ impl Sidebar {
         let tables = resolution.tables;
 
         if resolution.skipped_other_profile_or_database > 0 {
-            let count = resolution.skipped_other_profile_or_database;
-            let noun = if count == 1 { "table" } else { "tables" };
-            dbflux_ui_base::toast::Toast::warning(format!(
-                "{count} {noun} outside the active profile/database were skipped"
+            dbflux_ui_base::toast::Toast::warning(crate::labels::skipped_tables_label(
+                resolution.skipped_other_profile_or_database,
             ))
             .push(cx);
         }

--- a/crates/dbflux_ui_sidebar/src/operations/migrate_tables.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/migrate_tables.rs
@@ -94,10 +94,8 @@ impl Sidebar {
         let tables = resolution.tables;
 
         if resolution.skipped_other_profile_or_database > 0 {
-            let count = resolution.skipped_other_profile_or_database;
-            let noun = if count == 1 { "table" } else { "tables" };
-            dbflux_ui_base::toast::Toast::warning(format!(
-                "{count} {noun} outside the active profile/database were skipped"
+            dbflux_ui_base::toast::Toast::warning(crate::labels::skipped_tables_label(
+                resolution.skipped_other_profile_or_database,
             ))
             .push(cx);
         }

--- a/crates/dbflux_ui_sidebar/src/operations/pipeline.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/pipeline.rs
@@ -726,7 +726,7 @@ impl Sidebar {
                     report_error_async(
                         UserFacingError::new(
                             ErrorKind::Storage,
-                            format!("Failed to capture schema snapshot: {e}"),
+                            crate::labels::schema_snapshot_failed_label(&e.to_string()),
                         ),
                         cx,
                     );

--- a/crates/dbflux_ui_sidebar/src/operations/script_ops.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/script_ops.rs
@@ -3,8 +3,10 @@ use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
 
 fn report_reveal_failure(error: std::io::Error, cx: &mut App) {
     report_error(
-        UserFacingError::new(ErrorKind::User, "Failed to reveal in file manager")
-            .with_cause(error.to_string()),
+        UserFacingError::new(
+            ErrorKind::User,
+            crate::labels::reveal_failed_label(&error.to_string()),
+        ),
         cx,
     );
 }
@@ -113,10 +115,13 @@ impl Sidebar {
         let app_state = self.app_state.clone();
         let sidebar = cx.entity().clone();
 
+        let title = crate::labels::import_script_dialog_title();
+        let filter_name = crate::labels::script_files_filter_label();
+
         let task = cx.background_executor().spawn(async move {
-            let mut dialog = rfd::FileDialog::new().set_title("Import Script");
+            let mut dialog = rfd::FileDialog::new().set_title(title.as_str());
             for ext in &extensions {
-                dialog = dialog.add_filter("Script files", &[ext]);
+                dialog = dialog.add_filter(filter_name.as_str(), &[ext]);
             }
             dialog.pick_file()
         });

--- a/crates/dbflux_ui_sidebar/src/table_loading.rs
+++ b/crates/dbflux_ui_sidebar/src/table_loading.rs
@@ -181,7 +181,7 @@ impl Sidebar {
                 if error != "Collection children already fully cached" {
                     log::warn!("Cannot fetch collection children: {}", error);
                     self.pending_toast = Some(PendingToast {
-                        message: format!("Cannot load collection children: {}", error),
+                        message: crate::labels::collection_load_failed_label(collection, &error),
                         is_error: true,
                     });
                     cx.notify();
@@ -192,7 +192,7 @@ impl Sidebar {
         };
 
         let database_name = database.to_string();
-        let task_description = format!("Loading event streams: {}", collection);
+        let task_description = crate::labels::loading_event_streams_task_label(collection);
         let load_task_id = self.app_state.update(cx, |state, _| {
             let (task_id, _) = state.start_task_for_profile(
                 TaskKind::LoadSchema,
@@ -206,12 +206,14 @@ impl Sidebar {
             .background_executor()
             .spawn(async move { params.execute() });
 
+        let collection_name = collection.to_string();
+
         self.spawn_fetch_with_result(
             pending_action,
             Some(load_task_id),
             task,
             "Failed to fetch collection children",
-            "Failed to load collection children",
+            move |error| crate::labels::collection_load_failed_label(&collection_name, error),
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_collection_children_page(
@@ -234,13 +236,13 @@ impl Sidebar {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn spawn_fetch_with_result<R, F, G>(
+    fn spawn_fetch_with_result<R, F, G, M>(
         &mut self,
         pending_action: PendingAction,
         task_id: Option<TaskId>,
         task: Task<Result<R, String>>,
         error_log_prefix: &'static str,
-        error_toast_prefix: &'static str,
+        toast_message: M,
         on_success: F,
         on_finalize: G,
         cx: &mut Context<Self>,
@@ -251,6 +253,7 @@ impl Sidebar {
             + Send
             + 'static,
         G: Fn(&Entity<dbflux_ui_base::app_state_entity::AppStateEntity>, &mut App) + Send + 'static,
+        M: Fn(&str) -> String + Send + 'static,
     {
         let item_id = pending_action.item_id().to_string();
         self.pending_actions.insert(item_id.clone(), pending_action);
@@ -281,10 +284,11 @@ impl Sidebar {
                     Err(e) => {
                         log::error!("{}: {}", error_log_prefix, e);
 
+                        let message = toast_message(&e);
+
                         if let Some(task_id) = task_id {
-                            let details = format!("{}: {}", error_toast_prefix, e);
                             app_state.update(cx, |state, _| {
-                                state.fail_task_with_details(task_id, e.clone(), details);
+                                state.fail_task_with_details(task_id, e.clone(), message.clone());
                             });
                         }
 
@@ -293,7 +297,7 @@ impl Sidebar {
                             sidebar.pending_actions.remove(&item_id);
                             sidebar.expansion_overrides.remove(&item_id);
                             sidebar.pending_toast = Some(PendingToast {
-                                message: format!("{}: {}", error_toast_prefix, e),
+                                message,
                                 is_error: true,
                             });
                             sidebar.rebuild_tree_with_overrides(cx);
@@ -330,7 +334,7 @@ impl Sidebar {
                 if e != "Table details already cached" {
                     log::warn!("Cannot fetch table details: {}", e);
                     self.pending_toast = Some(PendingToast {
-                        message: format!("Cannot load table schema: {}", e),
+                        message: crate::labels::table_load_failed_label(&parts.object_name, &e),
                         is_error: true,
                     });
                     cx.notify();
@@ -344,7 +348,7 @@ impl Sidebar {
         let load_task_id = self.app_state.update(cx, |state, _| {
             let (task_id, _) = state.start_task_for_profile(
                 TaskKind::LoadSchema,
-                format!("Loading event streams: {}", parts.object_name),
+                crate::labels::loading_event_streams_task_label(&parts.object_name),
                 Some(parts.profile_id),
             );
             task_id
@@ -354,12 +358,14 @@ impl Sidebar {
             .background_executor()
             .spawn(async move { params.execute().map_err(|e| e.to_string()) });
 
+        let table_name = parts.object_name.clone();
+
         self.spawn_fetch_with_result(
             pending_action,
             Some(load_task_id),
             task,
             "Failed to fetch table details",
-            "Failed to load table schema",
+            move |error| crate::labels::table_load_failed_label(&table_name, error),
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_table_details(
@@ -425,7 +431,7 @@ impl Sidebar {
             None,
             task,
             "Failed to fetch schema types",
-            "Failed to load data types",
+            |error| format!("Failed to load data types: {}", error),
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_schema_types(res.profile_id, res.database, res.schema, res.types);
@@ -473,7 +479,7 @@ impl Sidebar {
             None,
             task,
             "Failed to fetch schema indexes",
-            "Failed to load indexes",
+            |error| format!("Failed to load indexes: {}", error),
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_schema_indexes(res.profile_id, res.database, res.schema, res.indexes);
@@ -521,7 +527,7 @@ impl Sidebar {
             None,
             task,
             "Failed to fetch schema foreign keys",
-            "Failed to load foreign keys",
+            |error| format!("Failed to load foreign keys: {}", error),
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_schema_foreign_keys(
@@ -573,7 +579,7 @@ impl Sidebar {
             None,
             task,
             "Failed to fetch schema routines",
-            "Failed to load routines",
+            |error| format!("Failed to load routines: {}", error),
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_schema_routines(


### PR DESCRIPTION
## Summary

Sidebar i18n slice D2 (last): table and collection load failures, the event-stream loading task, drop task lines and drop/schema toasts, the reveal and import-script dialog strings, skipped-table overlays and the schema snapshot failure render through `dbflux_i18n::t!` and the sidebar label helpers. English and Spanish together.

## What does this resolve?

- Refs #360 (follows D1b; closes the sidebar series)

## How was this solved?

- `spawn_fetch_with_result` takes a message closure so each call site builds its own text; leftovers (schema-section load errors, database-drop preparation messages) are listed for a verify follow-up.

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 204 passed; `cargo test -p dbflux_ui --test decoupling_guard` green; clippy clean; fmt clean. Manual smoke in Spanish: drop a table, import a script, export tables across profiles.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
