### PR TITLE
feat(i18n): translate the data grid context menu items and delete confirmation

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -137,6 +137,37 @@ document:
           field: field
           host: host
           region: region
+    context_menu:
+      item:
+        copy: Copy
+        view_document: View Document
+        add_document: Add Document
+        duplicate_document: Duplicate Document
+        delete_document: Delete Document
+        paste: Paste
+        edit: Edit
+        edit_in_modal: Edit in Modal
+        set_default: Set to Default
+        set_null: Set to NULL
+        add_row: Add Row
+        inspect_row: Inspect Row
+        duplicate_row: Duplicate Row
+        delete_row: Delete Row
+        chart_this_query: Chart this query
+      submenu:
+        copy_query:
+          sql: Copy as SQL
+          query: Copy as Query
+          command: Copy as Command
+      delete_confirm:
+        title:
+          one: Delete row?
+          many: "Delete %{count} rows?"
+        description:
+          one: This action cannot be undone.
+          many: "%{count} rows will be permanently deleted. This cannot be undone."
+        cancel: Cancel
+        delete: Delete
     grid:
       edit_bar:
         clean: No unsaved changes

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -137,6 +137,37 @@ document:
           field: campo
           host: host
           region: región
+    context_menu:
+      item:
+        copy: Copiar
+        view_document: Ver documento
+        add_document: Agregar documento
+        duplicate_document: Duplicar documento
+        delete_document: Eliminar documento
+        paste: Pegar
+        edit: Editar
+        edit_in_modal: Editar en modal
+        set_default: Establecer valor predeterminado
+        set_null: Establecer NULL
+        add_row: Agregar fila
+        inspect_row: Inspeccionar fila
+        duplicate_row: Duplicar fila
+        delete_row: Eliminar fila
+        chart_this_query: Graficar esta consulta
+      submenu:
+        copy_query:
+          sql: Copiar como SQL
+          query: Copiar como consulta
+          command: Copiar como comando
+      delete_confirm:
+        title:
+          one: "¿Eliminar fila?"
+          many: "¿Eliminar %{count} filas?"
+        description:
+          one: Esta acción no se puede deshacer.
+          many: "%{count} filas se eliminarán de forma permanente. Esta acción no se puede deshacer."
+        cancel: Cancelar
+        delete: Eliminar
     grid:
       edit_bar:
         clean: Sin cambios pendientes

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/items.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/items.rs
@@ -15,14 +15,14 @@ pub(super) fn build_context_menu_items(
         if has_row_target {
             items.extend([
                 ContextMenuItem {
-                    label: "Copy",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.copy").into(),
                     action: Some(ContextMenuAction::Copy),
                     icon: Some(AppIcon::Layers),
                     is_separator: false,
                     is_danger: false,
                 },
                 ContextMenuItem {
-                    label: "View Document",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.view_document").into(),
                     action: Some(ContextMenuAction::EditInModal),
                     icon: Some(AppIcon::Maximize2),
                     is_separator: false,
@@ -34,7 +34,7 @@ pub(super) fn build_context_menu_items(
         if is_editable {
             if !items.is_empty() {
                 items.push(ContextMenuItem {
-                    label: "",
+                    label: "".into(),
                     action: None,
                     icon: None,
                     is_separator: true,
@@ -43,7 +43,7 @@ pub(super) fn build_context_menu_items(
             }
 
             items.push(ContextMenuItem {
-                label: "Add Document",
+                label: dbflux_i18n::t!("document.data.context_menu.item.add_document").into(),
                 action: Some(ContextMenuAction::AddRow),
                 icon: Some(AppIcon::Plus),
                 is_separator: false,
@@ -53,14 +53,18 @@ pub(super) fn build_context_menu_items(
             if has_row_target {
                 items.extend([
                     ContextMenuItem {
-                        label: "Duplicate Document",
+                        label: dbflux_i18n::t!(
+                            "document.data.context_menu.item.duplicate_document"
+                        )
+                        .into(),
                         action: Some(ContextMenuAction::DuplicateRow),
                         icon: Some(AppIcon::Layers),
                         is_separator: false,
                         is_danger: false,
                     },
                     ContextMenuItem {
-                        label: "Delete Document",
+                        label: dbflux_i18n::t!("document.data.context_menu.item.delete_document")
+                            .into(),
                         action: Some(ContextMenuAction::DeleteRow),
                         icon: Some(AppIcon::Delete),
                         is_separator: false,
@@ -74,7 +78,7 @@ pub(super) fn build_context_menu_items(
     }
 
     let mut items = vec![ContextMenuItem {
-        label: "Copy",
+        label: dbflux_i18n::t!("document.data.context_menu.item.copy").into(),
         action: Some(ContextMenuAction::Copy),
         icon: Some(AppIcon::Layers),
         is_separator: false,
@@ -85,49 +89,49 @@ pub(super) fn build_context_menu_items(
         if has_row_target {
             items.extend([
                 ContextMenuItem {
-                    label: "Paste",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.paste").into(),
                     action: Some(ContextMenuAction::Paste),
                     icon: Some(AppIcon::Download),
                     is_separator: false,
                     is_danger: false,
                 },
                 ContextMenuItem {
-                    label: "Edit",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.edit").into(),
                     action: Some(ContextMenuAction::Edit),
                     icon: Some(AppIcon::Pencil),
                     is_separator: false,
                     is_danger: false,
                 },
                 ContextMenuItem {
-                    label: "Edit in Modal",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.edit_in_modal").into(),
                     action: Some(ContextMenuAction::EditInModal),
                     icon: Some(AppIcon::Maximize2),
                     is_separator: false,
                     is_danger: false,
                 },
                 ContextMenuItem {
-                    label: "",
+                    label: "".into(),
                     action: None,
                     icon: None,
                     is_separator: true,
                     is_danger: false,
                 },
                 ContextMenuItem {
-                    label: "Set to Default",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.set_default").into(),
                     action: Some(ContextMenuAction::SetDefault),
                     icon: Some(AppIcon::RotateCcw),
                     is_separator: false,
                     is_danger: false,
                 },
                 ContextMenuItem {
-                    label: "Set to NULL",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.set_null").into(),
                     action: Some(ContextMenuAction::SetNull),
                     icon: Some(AppIcon::X),
                     is_separator: false,
                     is_danger: false,
                 },
                 ContextMenuItem {
-                    label: "",
+                    label: "".into(),
                     action: None,
                     icon: None,
                     is_separator: true,
@@ -137,7 +141,7 @@ pub(super) fn build_context_menu_items(
         }
 
         items.push(ContextMenuItem {
-            label: "Add Row",
+            label: dbflux_i18n::t!("document.data.context_menu.item.add_row").into(),
             action: Some(ContextMenuAction::AddRow),
             icon: Some(AppIcon::Plus),
             is_separator: false,
@@ -147,7 +151,7 @@ pub(super) fn build_context_menu_items(
         if has_row_target {
             if inspect_row_enabled {
                 items.push(ContextMenuItem {
-                    label: "Inspect Row",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.inspect_row").into(),
                     action: Some(ContextMenuAction::InspectRow),
                     icon: Some(AppIcon::Info),
                     is_separator: false,
@@ -157,14 +161,14 @@ pub(super) fn build_context_menu_items(
 
             items.extend([
                 ContextMenuItem {
-                    label: "Duplicate Row",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.duplicate_row").into(),
                     action: Some(ContextMenuAction::DuplicateRow),
                     icon: Some(AppIcon::Layers),
                     is_separator: false,
                     is_danger: false,
                 },
                 ContextMenuItem {
-                    label: "Delete Row",
+                    label: dbflux_i18n::t!("document.data.context_menu.item.delete_row").into(),
                     action: Some(ContextMenuAction::DeleteRow),
                     icon: Some(AppIcon::Delete),
                     is_separator: false,
@@ -176,14 +180,14 @@ pub(super) fn build_context_menu_items(
 
     if can_chart {
         items.push(ContextMenuItem {
-            label: "",
+            label: "".into(),
             action: None,
             icon: None,
             is_separator: true,
             is_danger: false,
         });
         items.push(ContextMenuItem {
-            label: "Chart this query",
+            label: dbflux_i18n::t!("document.data.context_menu.item.chart_this_query").into(),
             action: Some(ContextMenuAction::ChartThisQuery),
             icon: Some(AppIcon::ChartSpline),
             is_separator: false,

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
@@ -1174,20 +1174,7 @@ impl DataGridPanel {
             .map(|c| c.row_indices.len())
             .unwrap_or(1);
 
-        let (title, description) = if count == 1 {
-            (
-                "Delete row?".to_string(),
-                "This action cannot be undone.".to_string(),
-            )
-        } else {
-            (
-                format!("Delete {} rows?", count),
-                format!(
-                    "{} rows will be permanently deleted. This cannot be undone.",
-                    count
-                ),
-            )
-        };
+        let (title, description) = crate::labels::delete_confirm_copy(count);
 
         // Backdrop with centered modal
         div()
@@ -1245,7 +1232,9 @@ impl DataGridPanel {
                                     .child(
                                         Icon::new(AppIcon::X).small().color(theme.muted_foreground),
                                     )
-                                    .child(Text::caption("Cancel")),
+                                    .child(Text::caption(dbflux_i18n::t!(
+                                        "document.data.context_menu.delete_confirm.cancel"
+                                    ))),
                             )
                             .child(
                                 div()
@@ -1265,7 +1254,12 @@ impl DataGridPanel {
                                     .child(
                                         Icon::new(AppIcon::Delete).small().color(theme.background),
                                     )
-                                    .child(Text::caption("Delete").color(theme.background)),
+                                    .child(
+                                        Text::caption(dbflux_i18n::t!(
+                                            "document.data.context_menu.delete_confirm.delete"
+                                        ))
+                                        .color(theme.background),
+                                    ),
                             ),
                     ),
             )
@@ -3074,11 +3068,13 @@ impl DataGridPanel {
 
     // -- Copy as Query --
 
-    fn copy_query_submenu_label(&self, cx: &App) -> &'static str {
+    fn copy_query_submenu_label(&self, cx: &App) -> String {
         let profile_id = match &self.source {
             DataSource::Table { profile_id, .. } => profile_id,
             DataSource::Collection { profile_id, .. } => profile_id,
-            DataSource::QueryResult { .. } => return "Copy as Query",
+            DataSource::QueryResult { .. } => {
+                return crate::labels::copy_query_language_label(None);
+            }
         };
 
         let language = self
@@ -3088,12 +3084,7 @@ impl DataGridPanel {
             .get(profile_id)
             .map(|c| c.connection.metadata().query_language.clone());
 
-        match language {
-            Some(dbflux_core::QueryLanguage::Sql) => "Copy as SQL",
-            Some(dbflux_core::QueryLanguage::MongoQuery) => "Copy as Query",
-            Some(dbflux_core::QueryLanguage::RedisCommands) => "Copy as Command",
-            _ => "Copy as Query",
-        }
+        crate::labels::copy_query_language_label(language)
     }
 
     fn has_copy_query_support(&self) -> bool {
@@ -3612,12 +3603,16 @@ fn record_clipboard_audit(
 mod tests {
     use super::DataGridPanel;
 
-    fn labels(items: &[super::ContextMenuItem]) -> Vec<&'static str> {
+    fn labels(items: &[super::ContextMenuItem]) -> Vec<String> {
         items
             .iter()
             .filter(|item| !item.is_separator)
-            .map(|item| item.label)
+            .map(|item| item.label.to_string())
             .collect()
+    }
+
+    fn item_label(key: &str) -> String {
+        dbflux_i18n::t!(key)
     }
 
     #[test]
@@ -3625,18 +3620,21 @@ mod tests {
         let items = DataGridPanel::build_context_menu_items(true, false, false, false, true);
         let labels = labels(&items);
 
-        assert!(labels.contains(&"Add Row"));
-        assert!(!labels.contains(&"Edit"));
-        assert!(!labels.contains(&"Edit in Modal"));
-        assert!(!labels.contains(&"Duplicate Row"));
-        assert!(!labels.contains(&"Delete Row"));
+        assert!(labels.contains(&item_label("document.data.context_menu.item.add_row")));
+        assert!(!labels.contains(&item_label("document.data.context_menu.item.edit")));
+        assert!(!labels.contains(&item_label("document.data.context_menu.item.edit_in_modal")));
+        assert!(!labels.contains(&item_label("document.data.context_menu.item.duplicate_row")));
+        assert!(!labels.contains(&item_label("document.data.context_menu.item.delete_row")));
     }
 
     #[test]
     fn non_editable_table_menu_stays_unchanged_without_row_target() {
         let items = DataGridPanel::build_context_menu_items(false, false, false, false, true);
 
-        assert_eq!(labels(&items), vec!["Copy"]);
+        assert_eq!(
+            labels(&items),
+            vec![item_label("document.data.context_menu.item.copy")]
+        );
     }
 
     #[test]
@@ -3644,29 +3642,32 @@ mod tests {
         let items = DataGridPanel::build_context_menu_items(true, false, true, false, true);
         let labels = labels(&items);
 
-        assert!(labels.contains(&"Edit"));
-        assert!(labels.contains(&"Edit in Modal"));
-        assert!(labels.contains(&"Add Row"));
-        assert!(labels.contains(&"Duplicate Row"));
-        assert!(labels.contains(&"Delete Row"));
+        assert!(labels.contains(&item_label("document.data.context_menu.item.edit")));
+        assert!(labels.contains(&item_label("document.data.context_menu.item.edit_in_modal")));
+        assert!(labels.contains(&item_label("document.data.context_menu.item.add_row")));
+        assert!(labels.contains(&item_label("document.data.context_menu.item.duplicate_row")));
+        assert!(labels.contains(&item_label("document.data.context_menu.item.delete_row")));
     }
 
     #[test]
     fn chart_this_query_absent_when_can_chart_false() {
         // can_chart = false: item must NOT appear regardless of other flags.
         let table_items = DataGridPanel::build_context_menu_items(false, false, false, false, true);
-        assert!(!labels(&table_items).contains(&"Chart this query"));
+        let chart_label = item_label("document.data.context_menu.item.chart_this_query");
+        assert!(!labels(&table_items).contains(&chart_label));
 
         let editable_items =
             DataGridPanel::build_context_menu_items(true, false, true, false, true);
-        assert!(!labels(&editable_items).contains(&"Chart this query"));
+        assert!(!labels(&editable_items).contains(&chart_label));
     }
 
     #[test]
     fn chart_this_query_present_only_when_can_chart_true() {
         // can_chart = true: item must appear.
         let items = DataGridPanel::build_context_menu_items(false, false, false, true, true);
-        assert!(labels(&items).contains(&"Chart this query"));
+        assert!(labels(&items).contains(&item_label(
+            "document.data.context_menu.item.chart_this_query"
+        )));
     }
 
     #[test]
@@ -3674,7 +3675,9 @@ mod tests {
         // Document-view menu never shows Chart this query because the source is never
         // a QueryResult when is_document_view is true.
         let doc_items = DataGridPanel::build_context_menu_items(false, true, false, true, true);
-        assert!(!labels(&doc_items).contains(&"Chart this query"));
+        assert!(!labels(&doc_items).contains(&item_label(
+            "document.data.context_menu.item.chart_this_query"
+        )));
     }
 
     #[test]
@@ -3682,7 +3685,8 @@ mod tests {
         let items_with_target =
             DataGridPanel::build_context_menu_items(true, false, true, false, false);
         assert!(
-            !labels(&items_with_target).contains(&"Inspect Row"),
+            !labels(&items_with_target)
+                .contains(&item_label("document.data.context_menu.item.inspect_row")),
             "Inspect Row must not appear when inspect_row_enabled=false"
         );
     }
@@ -3691,7 +3695,7 @@ mod tests {
     fn inspect_row_present_when_enabled_and_has_target() {
         let items = DataGridPanel::build_context_menu_items(true, false, true, false, true);
         assert!(
-            labels(&items).contains(&"Inspect Row"),
+            labels(&items).contains(&item_label("document.data.context_menu.item.inspect_row")),
             "Inspect Row must appear when inspect_row_enabled=true and has_row_target=true"
         );
     }

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/sections.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/sections.rs
@@ -39,7 +39,7 @@ impl DataGridPanel {
 
             let is_selected = *visual_index == selected_index;
             let is_danger = item.is_danger;
-            let label = item.label;
+            let label = item.label.clone();
             let icon = item.icon;
             let current_index = *visual_index;
 
@@ -51,7 +51,7 @@ impl DataGridPanel {
 
             menu_items.push(
                 div()
-                    .id(SharedString::from(label))
+                    .id(label.clone())
                     .flex()
                     .items_center()
                     .gap(Spacing::SM)

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -364,7 +364,7 @@ struct TableContextMenu {
 
 /// A single item in the context menu.
 struct ContextMenuItem {
-    label: &'static str,
+    label: SharedString,
     action: Option<ContextMenuAction>,
     icon: Option<dbflux_components::icons::AppIcon>,
     is_separator: bool,

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -329,16 +329,62 @@ pub(crate) fn bulk_delete_success_label(kind: MutationItemKind, count: usize) ->
     dbflux_i18n::t!(key, count = count)
 }
 
+/// Label for the context menu's "Copy as ..." submenu trigger, keyed by the
+/// active connection's query language.
+///
+/// `None` covers both an unresolved connection and a `QueryResult` source
+/// (which has no connection to query), and shares the generic "Copy as
+/// Query" bucket with any query language that has no dedicated wording.
+pub(crate) fn copy_query_language_label(language: Option<dbflux_core::QueryLanguage>) -> String {
+    match language {
+        Some(dbflux_core::QueryLanguage::Sql) => {
+            dbflux_i18n::t!("document.data.context_menu.submenu.copy_query.sql")
+        }
+        Some(dbflux_core::QueryLanguage::MongoQuery) => {
+            dbflux_i18n::t!("document.data.context_menu.submenu.copy_query.query")
+        }
+        Some(dbflux_core::QueryLanguage::RedisCommands) => {
+            dbflux_i18n::t!("document.data.context_menu.submenu.copy_query.command")
+        }
+        _ => dbflux_i18n::t!("document.data.context_menu.submenu.copy_query.query"),
+    }
+}
+
+/// Title and body copy for the row-delete confirmation modal, with the
+/// affected row count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one row; every other
+/// count uses the plural bucket.
+pub(crate) fn delete_confirm_copy(count: usize) -> (String, String) {
+    if count == 1 {
+        (
+            dbflux_i18n::t!("document.data.context_menu.delete_confirm.title.one"),
+            dbflux_i18n::t!("document.data.context_menu.delete_confirm.description.one"),
+        )
+    } else {
+        (
+            dbflux_i18n::t!(
+                "document.data.context_menu.delete_confirm.title.many",
+                count = count
+            ),
+            dbflux_i18n::t!(
+                "document.data.context_menu.delete_confirm.description.many",
+                count = count
+            ),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         MutationItemKind, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
-        chart_rail_why_text, delete_rows_label, partial_delete_label, pending_change_count_label,
-        pending_edits_summary, refresh_policy_label, row_count_label, unsaved_changes_label,
-        update_columns_label,
+        chart_rail_why_text, copy_query_language_label, delete_confirm_copy, delete_rows_label,
+        partial_delete_label, pending_change_count_label, pending_edits_summary,
+        refresh_policy_label, row_count_label, unsaved_changes_label, update_columns_label,
     };
     use dbflux_components::chart::ChartDetection;
-    use dbflux_core::RefreshPolicy;
+    use dbflux_core::{QueryLanguage, RefreshPolicy};
 
     #[test]
     fn unsaved_changes_label_zero_one_many() {
@@ -682,6 +728,93 @@ mod tests {
         );
         let es = dbflux_i18n::t!(
             "document.data.mutation.confirm.delete.summary.many",
+            locale = "es"
+        );
+
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn copy_query_submenu_label_covers_all_variants() {
+        assert_eq!(
+            copy_query_language_label(Some(QueryLanguage::Sql)),
+            "Copy as SQL"
+        );
+        assert_eq!(
+            copy_query_language_label(Some(QueryLanguage::MongoQuery)),
+            "Copy as Query"
+        );
+        assert_eq!(
+            copy_query_language_label(Some(QueryLanguage::RedisCommands)),
+            "Copy as Command"
+        );
+        assert_eq!(copy_query_language_label(None), "Copy as Query");
+    }
+
+    #[test]
+    fn delete_confirm_copy_singular_and_plural() {
+        let (one_title, one_body) = delete_confirm_copy(1);
+        let (many_title, many_body) = delete_confirm_copy(3);
+
+        assert_eq!(one_title, "Delete row?");
+        assert_eq!(one_body, "This action cannot be undone.");
+        assert_eq!(many_title, "Delete 3 rows?");
+        assert!(many_body.contains('3'));
+        assert_ne!(one_title, many_title);
+    }
+
+    #[test]
+    fn context_menu_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.data.context_menu.item.copy",
+            "document.data.context_menu.item.view_document",
+            "document.data.context_menu.item.add_document",
+            "document.data.context_menu.item.duplicate_document",
+            "document.data.context_menu.item.delete_document",
+            "document.data.context_menu.item.paste",
+            "document.data.context_menu.item.edit",
+            "document.data.context_menu.item.edit_in_modal",
+            "document.data.context_menu.item.set_default",
+            "document.data.context_menu.item.set_null",
+            "document.data.context_menu.item.add_row",
+            "document.data.context_menu.item.inspect_row",
+            "document.data.context_menu.item.duplicate_row",
+            "document.data.context_menu.item.delete_row",
+            "document.data.context_menu.item.chart_this_query",
+            "document.data.context_menu.submenu.copy_query.sql",
+            "document.data.context_menu.submenu.copy_query.query",
+            "document.data.context_menu.submenu.copy_query.command",
+            "document.data.context_menu.delete_confirm.title.one",
+            "document.data.context_menu.delete_confirm.title.many",
+            "document.data.context_menu.delete_confirm.description.one",
+            "document.data.context_menu.delete_confirm.description.many",
+            "document.data.context_menu.delete_confirm.cancel",
+            "document.data.context_menu.delete_confirm.delete",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn context_menu_delete_confirm_title_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.data.context_menu.delete_confirm.title.many",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.data.context_menu.delete_confirm.title.many",
             locale = "es"
         );
 


### PR DESCRIPTION
## Summary

Document i18n slice 6a: data grid context menu item labels carry `SharedString` and resolve through `dbflux_i18n::t!`; the copy-query submenu label and the delete confirmation copy come from labels.rs helpers. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 5; next: the context menu sections)

## How was this solved?

- Export/clipboard and JSON mutation toasts inside `context_menu/mod.rs` are listed for a follow-up slice (6a-bis).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 904 passed; clippy clean; fmt clean. Manual smoke in Spanish: right-click a cell and open the copy-query submenu.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
