### PR TITLE
feat(i18n): translate the connection manager proxy tab

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -14,6 +14,21 @@ access:
   ssm_remote_port: Remote Port
   ssm_port_hint: DBFlux and the OS auto-assign the local tunnel port. Only Remote Port is configurable here.
   auth_profile: Auth Profile
+  proxy_no_profiles: No proxy profiles configured
+  proxy_no_profiles_hint: Add proxies in Settings > Proxies
+  proxy_disabled_label: "%{name} (disabled)"
+  select_proxy: Select Proxy
+  clear: Clear
+  proxy_details: Proxy Details
+  proxy_type: Type
+  proxy_host: Host
+  proxy_auth: Auth
+  proxy_enabled: Enabled
+  proxy_no_proxy: No Proxy
+  value_yes: "Yes"
+  value_no: "No"
+  no_proxy_placeholder: (none)
+  edit_in_settings: Edit in Settings
 chart:
   axis_bar:
     group: Group

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -14,6 +14,21 @@ access:
   ssm_remote_port: Puerto remoto
   ssm_port_hint: DBFlux y el sistema operativo asignan automáticamente el puerto del túnel local. Aquí solo se puede configurar el puerto remoto.
   auth_profile: Perfil de autenticación
+  proxy_no_profiles: No hay perfiles de proxy configurados
+  proxy_no_profiles_hint: Agregar proxies en Ajustes > Proxies
+  proxy_disabled_label: "%{name} (deshabilitado)"
+  select_proxy: Seleccionar proxy
+  clear: Quitar
+  proxy_details: Detalles del proxy
+  proxy_type: Tipo
+  proxy_host: Host
+  proxy_auth: Autenticación
+  proxy_enabled: Habilitado
+  proxy_no_proxy: Sin proxy
+  value_yes: "Sí"
+  value_no: "No"
+  no_proxy_placeholder: (ninguno)
+  edit_in_settings: Editar en Ajustes
 chart:
   axis_bar:
     group: Grupo

--- a/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
@@ -473,8 +473,10 @@ impl ConnectionManagerWindow {
                             .flex_col()
                             .items_center()
                             .gap_2()
-                            .child(Text::muted("No proxy profiles configured"))
-                            .child(Text::caption("Add proxies in Settings > Proxies")),
+                            .child(Text::muted(dbflux_i18n::t!("access.proxy_no_profiles")))
+                            .child(Text::caption(dbflux_i18n::t!(
+                                "access.proxy_no_profiles_hint"
+                            ))),
                     )
                     .into_any_element(),
             );
@@ -487,7 +489,7 @@ impl ConnectionManagerWindow {
                 let label = if p.enabled {
                     p.name.clone()
                 } else {
-                    format!("{} (disabled)", p.name)
+                    crate::labels::access_proxy_disabled_label(&p.name)
                 };
 
                 DropdownItem::with_value(&label, p.id.to_string())
@@ -518,7 +520,7 @@ impl ConnectionManagerWindow {
             .flex()
             .flex_col()
             .gap_2()
-            .child(Label::new("Select Proxy"))
+            .child(Label::new(dbflux_i18n::t!("access.select_proxy")))
             .child(
                 div()
                     .flex()
@@ -535,7 +537,7 @@ impl ConnectionManagerWindow {
                                     dd.border_color(gpui::transparent_black())
                                 })
                                 .child(
-                                    Button::new("clear-proxy", "Clear")
+                                    Button::new("clear-proxy", dbflux_i18n::t!("access.clear"))
                                         .small()
                                         .ghost()
                                         .on_click(cx.listener(|this, _, _, cx| {
@@ -555,22 +557,36 @@ impl ConnectionManagerWindow {
             let kind_label = format!("{:?}", proxy.kind);
             let host_port = format!("{}:{}", proxy.host, proxy.port);
             let auth_label = format!("{:?}", proxy.auth);
-            let enabled_label = if proxy.enabled { "Yes" } else { "No" };
-            let no_proxy_label = proxy.no_proxy.as_deref().unwrap_or("(none)").to_string();
+            let enabled_label = if proxy.enabled {
+                dbflux_i18n::t!("access.value_yes")
+            } else {
+                dbflux_i18n::t!("access.value_no")
+            };
+            let no_proxy_label = proxy
+                .no_proxy
+                .clone()
+                .unwrap_or_else(|| dbflux_i18n::t!("access.no_proxy_placeholder"));
 
             let edit_focused = show_focus && focus == FormFocus::ProxyEditInSettings;
 
+            let proxy_details_title = dbflux_i18n::t!("access.proxy_details");
+            let proxy_type_label = dbflux_i18n::t!("access.proxy_type");
+            let proxy_host_label = dbflux_i18n::t!("access.proxy_host");
+            let proxy_auth_label = dbflux_i18n::t!("access.proxy_auth");
+            let proxy_enabled_label = dbflux_i18n::t!("access.proxy_enabled");
+            let proxy_no_proxy_label = dbflux_i18n::t!("access.proxy_no_proxy");
+
             let details = self.render_section(
-                "Proxy Details",
+                &proxy_details_title,
                 div()
                     .flex()
                     .flex_col()
                     .gap_2()
-                    .child(self.render_readonly_row("Type", &kind_label, &theme))
-                    .child(self.render_readonly_row("Host", &host_port, &theme))
-                    .child(self.render_readonly_row("Auth", &auth_label, &theme))
-                    .child(self.render_readonly_row("Enabled", enabled_label, &theme))
-                    .child(self.render_readonly_row("No Proxy", &no_proxy_label, &theme))
+                    .child(self.render_readonly_row(&proxy_type_label, &kind_label, &theme))
+                    .child(self.render_readonly_row(&proxy_host_label, &host_port, &theme))
+                    .child(self.render_readonly_row(&proxy_auth_label, &auth_label, &theme))
+                    .child(self.render_readonly_row(&proxy_enabled_label, &enabled_label, &theme))
+                    .child(self.render_readonly_row(&proxy_no_proxy_label, &no_proxy_label, &theme))
                     .child(
                         div()
                             .mt_1()
@@ -579,10 +595,13 @@ impl ConnectionManagerWindow {
                             .when(edit_focused, |d| d.border_color(ring_color))
                             .when(!edit_focused, |d| d.border_color(gpui::transparent_black()))
                             .child(
-                                Button::new("proxy-edit-in-settings", "Edit in Settings")
-                                    .small()
-                                    .ghost()
-                                    .icon(Icon::new(AppIcon::ExternalLink)),
+                                Button::new(
+                                    "proxy-edit-in-settings",
+                                    dbflux_i18n::t!("access.edit_in_settings"),
+                                )
+                                .small()
+                                .ghost()
+                                .icon(Icon::new(AppIcon::ExternalLink)),
                             ),
                     ),
                 &theme,
@@ -1353,5 +1372,63 @@ mod tests {
 
         assert_eq!(en, "Instance ID");
         assert_eq!(es, "ID de instancia");
+    }
+
+    const ACCESS_PROXY_KEYS: &[&str] = &[
+        "access.proxy_no_profiles",
+        "access.proxy_no_profiles_hint",
+        "access.proxy_disabled_label",
+        "access.select_proxy",
+        "access.clear",
+        "access.proxy_details",
+        "access.proxy_type",
+        "access.proxy_host",
+        "access.proxy_auth",
+        "access.proxy_enabled",
+        "access.proxy_no_proxy",
+        "access.value_yes",
+        "access.value_no",
+        "access.no_proxy_placeholder",
+        "access.edit_in_settings",
+    ];
+
+    #[test]
+    fn access_proxy_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in ACCESS_PROXY_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn access_proxy_details_differs_between_locales() {
+        let en = dbflux_i18n::t!("access.proxy_details", locale = "en");
+        let es = dbflux_i18n::t!("access.proxy_details", locale = "es");
+
+        assert_ne!(
+            en, es,
+            "access.proxy_details should differ between en and es"
+        );
+    }
+
+    #[test]
+    fn access_select_proxy_label_exact_values() {
+        let en = dbflux_i18n::t!("access.select_proxy", locale = "en");
+        let es = dbflux_i18n::t!("access.select_proxy", locale = "es");
+
+        assert_eq!(en, "Select Proxy");
+        assert_eq!(es, "Seleccionar proxy");
     }
 }

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -93,13 +93,18 @@ pub(crate) fn hooks_form_interpreter_hint(default_interpreter: &str) -> String {
     )
 }
 
+/// Formats the "<name> (disabled)" label shown for a disabled proxy in the proxy dropdown.
+pub(crate) fn access_proxy_disabled_label(name: &str) -> String {
+    dbflux_i18n::t!("access.proxy_disabled_label", name = name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        hooks_create_dir_failed, hooks_delete_message, hooks_delete_unreadable_message,
-        hooks_duplicate_id, hooks_env_pair_invalid, hooks_form_interpreter_hint,
-        hooks_interpreter_auto_label, hooks_interpreter_missing, hooks_open_script_failed,
-        hooks_write_script_failed,
+        access_proxy_disabled_label, hooks_create_dir_failed, hooks_delete_message,
+        hooks_delete_unreadable_message, hooks_duplicate_id, hooks_env_pair_invalid,
+        hooks_form_interpreter_hint, hooks_interpreter_auto_label, hooks_interpreter_missing,
+        hooks_open_script_failed, hooks_write_script_failed,
     };
 
     #[test]
@@ -176,5 +181,12 @@ mod tests {
         let message = hooks_form_interpreter_hint("auto (python3)");
 
         assert_eq!(message, "Leave empty for auto (python3)");
+    }
+
+    #[test]
+    fn access_proxy_disabled_label_embeds_proxy_name() {
+        let message = access_proxy_disabled_label("corporate-proxy");
+
+        assert_eq!(message, "corporate-proxy (disabled)");
     }
 }


### PR DESCRIPTION
## Summary

Ninth `dbflux_ui_windows` i18n slice: the connection manager proxy tab (selection, details, status, settings link) renders through `dbflux_i18n::t!` under `access.*`. English and Spanish together; proxy kinds and auth methods stay data.

## What does this resolve?

- Refs #360 (follows the access direct/SSM PR; next: the SSH tab)

## How was this solved?

- `access_proxy_disabled_label(name)` carries the disabled suffix.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 214 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a connection's Access tab in Proxy mode.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
