### PR TITLE
feat(i18n): translate the connection manager SSH tab and add the shared ssh vocabulary

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -29,6 +29,15 @@ access:
   value_no: "No"
   no_proxy_placeholder: (none)
   edit_in_settings: Edit in Settings
+  use_ssh_tunnel: Use SSH Tunnel
+  ssh_tunnel_label: SSH Tunnel
+  ssh_server_saved: SSH Server (saved tunnel)
+  test_ssh: Test SSH
+  testing_ssh: Testing SSH connection...
+  ssh_success: SSH connection successful
+  ssh_failed: SSH connection failed
+  save_as_tunnel: Save as tunnel
+  ssh_disabled_hint: Enable SSH tunnel to configure connection through a bastion host
 chart:
   axis_bar:
     group: Group
@@ -1044,6 +1053,29 @@ sql_preview:
     refresh: Refresh
     copy: Copy
     close: Close
+ssh:
+  agent_default: SSH Agent / default
+  authentication: Authentication
+  private_key: Private Key
+  password: Password
+  private_key_path: Private Key Path
+  browse: Browse
+  key_passphrase: Key Passphrase
+  save: Save
+  passphrase_hint: Leave empty if key has no passphrase
+  ssh_password: SSH Password
+  ssh_server: SSH Server
+  host: Host
+  port: Port
+  username: Username
+  host_user_required: Host and user are required
+  private_key_short: Private key
+  update: Update
+  create: Create
+  test: Test
+  private_key_with_path: "Private Key (%{path})"
+  private_key_hint: "Leave empty to use SSH agent or default keys (~/.ssh/id_rsa)"
+  auth_label: Auth
 sso_wizard:
   title: AWS SSO Wizard
   step:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -29,6 +29,15 @@ access:
   value_no: "No"
   no_proxy_placeholder: (ninguno)
   edit_in_settings: Editar en Ajustes
+  use_ssh_tunnel: Usar túnel SSH
+  ssh_tunnel_label: Túnel SSH
+  ssh_server_saved: Servidor SSH (túnel guardado)
+  test_ssh: Probar SSH
+  testing_ssh: Probando conexión SSH...
+  ssh_success: Conexión SSH correcta
+  ssh_failed: Fallo en la conexión SSH
+  save_as_tunnel: Guardar como túnel
+  ssh_disabled_hint: Habilita el túnel SSH para configurar la conexión a través de un host bastión
 chart:
   axis_bar:
     group: Grupo
@@ -1044,6 +1053,29 @@ sql_preview:
     refresh: Actualizar
     copy: Copiar
     close: Cerrar
+ssh:
+  agent_default: Agente SSH / predeterminado
+  authentication: Autenticación
+  private_key: Clave privada
+  password: Contraseña
+  private_key_path: Ruta de la clave privada
+  browse: Examinar
+  key_passphrase: Frase de la clave
+  save: Guardar
+  passphrase_hint: Déjala vacía si la clave no tiene frase
+  ssh_password: Contraseña SSH
+  ssh_server: Servidor SSH
+  host: Host
+  port: Puerto
+  username: Usuario
+  host_user_required: El host y el usuario son obligatorios
+  private_key_short: Clave privada
+  update: Actualizar
+  create: Crear
+  test: Probar
+  private_key_with_path: "Clave privada (%{path})"
+  private_key_hint: "Déjala vacía para usar el agente SSH o las claves predeterminadas (~/.ssh/id_rsa)"
+  auth_label: Autenticación
 sso_wizard:
   title: Asistente de AWS SSO
   step:

--- a/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
@@ -648,7 +648,7 @@ impl ConnectionManagerWindow {
                         cx.notify();
                     })),
             )
-            .child(Label::new("Use SSH Tunnel"));
+            .child(Label::new(dbflux_i18n::t!("access.use_ssh_tunnel")));
 
         let tunnel_items: Vec<DropdownItem> = ssh_tunnels
             .iter()
@@ -672,54 +672,58 @@ impl ConnectionManagerWindow {
             dropdown.set_focus_ring(focus_color, cx);
         });
 
-        let tunnel_selector: Option<AnyElement> = if ssh_enabled && !ssh_tunnels.is_empty() {
-            let selected_tunnel_name = selected_tunnel_id
-                .and_then(|id| ssh_tunnels.iter().find(|t| t.id == id))
-                .map(|t| t.name.clone());
+        let tunnel_selector: Option<AnyElement> =
+            if ssh_enabled && !ssh_tunnels.is_empty() {
+                let selected_tunnel_name = selected_tunnel_id
+                    .and_then(|id| ssh_tunnels.iter().find(|t| t.id == id))
+                    .map(|t| t.name.clone());
 
-            Some(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap_2()
-                    .child(Label::new("SSH Tunnel"))
-                    .child(
-                        div()
-                            .flex()
-                            .items_center()
-                            .gap_2()
-                            .child(
-                                div()
-                                    .flex_1()
-                                    .child(self.access.ssh_tunnel_dropdown.clone()),
-                            )
-                            .when(selected_tunnel_name.is_some(), |d| {
-                                d.child(
+                Some(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap_2()
+                        .child(Label::new(dbflux_i18n::t!("access.ssh_tunnel_label")))
+                        .child(
+                            div()
+                                .flex()
+                                .items_center()
+                                .gap_2()
+                                .child(
                                     div()
-                                        .rounded(Radii::SM)
-                                        .border_2()
-                                        .when(tunnel_clear_focused, |dd| {
-                                            dd.border_color(ring_color)
-                                        })
-                                        .when(!tunnel_clear_focused, |dd| {
-                                            dd.border_color(gpui::transparent_black())
-                                        })
-                                        .child(
-                                            Button::new("clear-ssh-tunnel", "Clear")
+                                        .flex_1()
+                                        .child(self.access.ssh_tunnel_dropdown.clone()),
+                                )
+                                .when(selected_tunnel_name.is_some(), |d| {
+                                    d.child(
+                                        div()
+                                            .rounded(Radii::SM)
+                                            .border_2()
+                                            .when(tunnel_clear_focused, |dd| {
+                                                dd.border_color(ring_color)
+                                            })
+                                            .when(!tunnel_clear_focused, |dd| {
+                                                dd.border_color(gpui::transparent_black())
+                                            })
+                                            .child(
+                                                Button::new(
+                                                    "clear-ssh-tunnel",
+                                                    dbflux_i18n::t!("access.clear"),
+                                                )
                                                 .small()
                                                 .ghost()
                                                 .on_click(cx.listener(|this, _, window, cx| {
                                                     this.clear_ssh_tunnel_selection(window, cx);
                                                 })),
-                                        ),
-                                )
-                            }),
-                    )
-                    .into_any_element(),
-            )
-        } else {
-            None
-        };
+                                            ),
+                                    )
+                                }),
+                        )
+                        .into_any_element(),
+                )
+            } else {
+                None
+            };
 
         let theme = cx.theme().clone();
         let _muted_fg = theme.muted_foreground;
@@ -736,28 +740,42 @@ impl ConnectionManagerWindow {
                         let path_str = key_path
                             .as_ref()
                             .map(|p| p.to_string_lossy().to_string())
-                            .unwrap_or_else(|| "SSH Agent / default".to_string());
-                        format!("Private Key ({})", path_str)
+                            .unwrap_or_else(|| dbflux_i18n::t!("ssh.agent_default"));
+                        crate::labels::ssh_private_key_with_path(&path_str)
                     }
-                    dbflux_core::SshAuthMethod::Password => "Password".to_string(),
+                    dbflux_core::SshAuthMethod::Password => dbflux_i18n::t!("ssh.password"),
                 };
 
                 let edit_focused = show_focus && focus == FormFocus::SshEditInSettings;
 
+                let ssh_server_saved_title = dbflux_i18n::t!("access.ssh_server_saved");
+                let ssh_host_label = dbflux_i18n::t!("ssh.host");
+                let ssh_port_label = dbflux_i18n::t!("ssh.port");
+                let ssh_username_label = dbflux_i18n::t!("ssh.username");
+                let ssh_auth_label = dbflux_i18n::t!("ssh.auth_label");
+
                 self.render_section(
-                    "SSH Server (saved tunnel)",
+                    &ssh_server_saved_title,
                     div()
                         .flex()
                         .flex_col()
                         .gap_2()
-                        .child(self.render_readonly_row("Host", &tunnel.config.host, &theme))
                         .child(self.render_readonly_row(
-                            "Port",
+                            &ssh_host_label,
+                            &tunnel.config.host,
+                            &theme,
+                        ))
+                        .child(self.render_readonly_row(
+                            &ssh_port_label,
                             &tunnel.config.port.to_string(),
                             &theme,
                         ))
-                        .child(self.render_readonly_row("Username", &tunnel.config.user, &theme))
-                        .child(self.render_readonly_row("Auth", &auth_label, &theme))
+                        .child(self.render_readonly_row(
+                            &ssh_username_label,
+                            &tunnel.config.user,
+                            &theme,
+                        ))
+                        .child(self.render_readonly_row(&ssh_auth_label, &auth_label, &theme))
                         .child(
                             div()
                                 .mt_1()
@@ -766,10 +784,13 @@ impl ConnectionManagerWindow {
                                 .when(edit_focused, |d| d.border_color(ring_color))
                                 .when(!edit_focused, |d| d.border_color(gpui::transparent_black()))
                                 .child(
-                                    Button::new("ssh-edit-in-settings", "Edit in Settings")
-                                        .small()
-                                        .ghost()
-                                        .icon(Icon::new(AppIcon::ExternalLink)),
+                                    Button::new(
+                                        "ssh-edit-in-settings",
+                                        dbflux_i18n::t!("access.edit_in_settings"),
+                                    )
+                                    .small()
+                                    .ghost()
+                                    .icon(Icon::new(AppIcon::ExternalLink)),
                                 ),
                         ),
                     &theme,
@@ -804,9 +825,14 @@ impl ConnectionManagerWindow {
                 )
                 .into_any_element();
 
+            let ssh_server_title = dbflux_i18n::t!("ssh.ssh_server");
+            let ssh_host_label = dbflux_i18n::t!("ssh.host");
+            let ssh_port_label = dbflux_i18n::t!("ssh.port");
+            let ssh_username_label = dbflux_i18n::t!("ssh.username");
+
             let server_section = self
                 .render_section(
-                    "SSH Server",
+                    &ssh_server_title,
                     div()
                         .flex()
                         .flex_col()
@@ -817,7 +843,7 @@ impl ConnectionManagerWindow {
                                 .flex()
                                 .gap_3()
                                 .child(div().flex_1().child(self.form_field_input(
-                                    "Host",
+                                    &ssh_host_label,
                                     &self.access.input_ssh_host,
                                     true,
                                     show_focus && focus == FormFocus::SshHost,
@@ -826,7 +852,7 @@ impl ConnectionManagerWindow {
                                     cx,
                                 )))
                                 .child(div().w(px(80.0)).child(self.form_field_input(
-                                    "Port",
+                                    &ssh_port_label,
                                     &self.access.input_ssh_port,
                                     false,
                                     show_focus && focus == FormFocus::SshPort,
@@ -836,7 +862,7 @@ impl ConnectionManagerWindow {
                                 ))),
                         )
                         .child(div().id(3usize).child(self.form_field_input(
-                            "Username",
+                            &ssh_username_label,
                             &self.access.input_ssh_user,
                             true,
                             show_focus && focus == FormFocus::SshUser,
@@ -866,7 +892,7 @@ impl ConnectionManagerWindow {
                     d.border_color(gpui::transparent_black())
                 })
                 .child(
-                    Button::new("test-ssh", "Test SSH")
+                    Button::new("test-ssh", dbflux_i18n::t!("access.test_ssh"))
                         .icon(Icon::new(AppIcon::ExternalLink))
                         .small()
                         .ghost()
@@ -879,17 +905,17 @@ impl ConnectionManagerWindow {
             let status_el: Option<AnyElement> = match ssh_test_status {
                 TestStatus::None => None,
                 TestStatus::Testing => {
-                    Some(Text::muted("Testing SSH connection...").into_any_element())
+                    Some(Text::muted(dbflux_i18n::t!("access.testing_ssh")).into_any_element())
                 }
                 TestStatus::Success | TestStatus::SuccessWithWarning => Some(
                     StatusIndicator::new(Status::Connected)
-                        .label("SSH connection successful")
+                        .label(dbflux_i18n::t!("access.ssh_success"))
                         .into_any_element(),
                 ),
                 TestStatus::Failed => Some(
                     StatusIndicator::new(Status::Error)
                         .label(
-                            ssh_test_error.unwrap_or_else(|| "SSH connection failed".to_string()),
+                            ssh_test_error.unwrap_or_else(|| dbflux_i18n::t!("access.ssh_failed")),
                         )
                         .into_any_element(),
                 ),
@@ -907,13 +933,16 @@ impl ConnectionManagerWindow {
                             d.border_color(gpui::transparent_black())
                         })
                         .child(
-                            Button::new("save-ssh-tunnel", "Save as tunnel")
-                                .icon(Icon::new(AppIcon::Plus))
-                                .small()
-                                .ghost()
-                                .on_click(cx.listener(|this, _, _, cx| {
-                                    this.save_current_ssh_as_tunnel(cx);
-                                })),
+                            Button::new(
+                                "save-ssh-tunnel",
+                                dbflux_i18n::t!("access.save_as_tunnel"),
+                            )
+                            .icon(Icon::new(AppIcon::Plus))
+                            .small()
+                            .ghost()
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.save_current_ssh_as_tunnel(cx);
+                            })),
                         )
                         .into_any_element(),
                 )
@@ -954,8 +983,9 @@ impl ConnectionManagerWindow {
         }
 
         if let Some(selector) = auth_selector {
+            let authentication_title = dbflux_i18n::t!("ssh.authentication");
             sections.push(
-                self.render_section("Authentication", selector, &theme)
+                self.render_section(&authentication_title, selector, &theme)
                     .into_any_element(),
             );
         }
@@ -975,9 +1005,7 @@ impl ConnectionManagerWindow {
                     .flex()
                     .items_center()
                     .justify_center()
-                    .child(Text::muted(
-                        "Enable SSH tunnel to configure connection through a bastion host",
-                    ))
+                    .child(Text::muted(dbflux_i18n::t!("access.ssh_disabled_hint")))
                     .into_any_element(),
             );
         }
@@ -1029,7 +1057,7 @@ impl ConnectionManagerWindow {
                         primary,
                         border,
                     ))
-                    .child(div().text_sm().child("Private Key")),
+                    .child(div().text_sm().child(dbflux_i18n::t!("ssh.private_key"))),
             )
             .child(
                 div()
@@ -1051,7 +1079,7 @@ impl ConnectionManagerWindow {
                         primary,
                         border,
                     ))
-                    .child(div().text_sm().child("Password")),
+                    .child(div().text_sm().child(dbflux_i18n::t!("ssh.password"))),
             )
     }
 
@@ -1112,7 +1140,7 @@ impl ConnectionManagerWindow {
                         .flex()
                         .flex_col()
                         .gap_1()
-                        .child(Label::new("Private Key Path"))
+                        .child(Label::new(dbflux_i18n::t!("ssh.private_key_path")))
                         .child(
                             div()
                                 .flex()
@@ -1148,26 +1176,29 @@ impl ConnectionManagerWindow {
                                             d.border_color(gpui::transparent_black())
                                         })
                                         .child(
-                                            Button::new("browse-ssh-key", "Browse")
-                                                .small()
-                                                .ghost()
-                                                .on_click(cx.listener(|this, _, window, cx| {
+                                            Button::new(
+                                                "browse-ssh-key",
+                                                dbflux_i18n::t!("ssh.browse"),
+                                            )
+                                            .small()
+                                            .ghost()
+                                            .on_click(
+                                                cx.listener(|this, _, window, cx| {
                                                     this.browse_ssh_key(window, cx);
-                                                })),
+                                                }),
+                                            ),
                                         ),
                                 ),
                         ),
                 )
-                .child(Text::caption(
-                    "Leave empty to use SSH agent or default keys (~/.ssh/id_rsa)",
-                ))
+                .child(Text::caption(dbflux_i18n::t!("ssh.private_key_hint")))
                 .child(
                     div()
                         .id(6usize)
                         .flex()
                         .flex_col()
                         .gap_1()
-                        .child(Label::new("Key Passphrase"))
+                        .child(Label::new(dbflux_i18n::t!("ssh.key_passphrase")))
                         .child(
                             div()
                                 .flex()
@@ -1226,12 +1257,16 @@ impl ConnectionManagerWindow {
                                                     .items_center()
                                                     .gap_2()
                                                     .child(checkbox)
-                                                    .child(div().text_sm().child("Save")),
+                                                    .child(
+                                                        div()
+                                                            .text_sm()
+                                                            .child(dbflux_i18n::t!("ssh.save")),
+                                                    ),
                                             ),
                                     )
                                 }),
                         )
-                        .child(Text::caption("Leave empty if key has no passphrase")),
+                        .child(Text::caption(dbflux_i18n::t!("ssh.passphrase_hint"))),
                 )
                 .into_any_element(),
             SshAuthSelection::Password => div()
@@ -1244,7 +1279,7 @@ impl ConnectionManagerWindow {
                         .flex()
                         .flex_col()
                         .gap_1()
-                        .child(Label::new("SSH Password").required(true))
+                        .child(Label::new(dbflux_i18n::t!("ssh.ssh_password")).required(true))
                         .child(
                             div()
                                 .flex()
@@ -1303,7 +1338,11 @@ impl ConnectionManagerWindow {
                                                     .items_center()
                                                     .gap_2()
                                                     .child(checkbox)
-                                                    .child(div().text_sm().child("Save")),
+                                                    .child(
+                                                        div()
+                                                            .text_sm()
+                                                            .child(dbflux_i18n::t!("ssh.save")),
+                                                    ),
                                             ),
                                     )
                                 }),
@@ -1430,5 +1469,108 @@ mod tests {
 
         assert_eq!(en, "Select Proxy");
         assert_eq!(es, "Seleccionar proxy");
+    }
+
+    const ACCESS_SSH_KEYS: &[&str] = &[
+        "access.use_ssh_tunnel",
+        "access.ssh_tunnel_label",
+        "access.ssh_server_saved",
+        "access.test_ssh",
+        "access.testing_ssh",
+        "access.ssh_success",
+        "access.ssh_failed",
+        "access.save_as_tunnel",
+        "access.ssh_disabled_hint",
+    ];
+
+    #[test]
+    fn access_ssh_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in ACCESS_SSH_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn access_use_ssh_tunnel_label_exact_values() {
+        let en = dbflux_i18n::t!("access.use_ssh_tunnel", locale = "en");
+        let es = dbflux_i18n::t!("access.use_ssh_tunnel", locale = "es");
+
+        assert_eq!(en, "Use SSH Tunnel");
+        assert_eq!(es, "Usar túnel SSH");
+    }
+
+    const SSH_VOCABULARY_KEYS: &[&str] = &[
+        "ssh.agent_default",
+        "ssh.authentication",
+        "ssh.private_key",
+        "ssh.password",
+        "ssh.private_key_path",
+        "ssh.browse",
+        "ssh.key_passphrase",
+        "ssh.save",
+        "ssh.passphrase_hint",
+        "ssh.ssh_password",
+        "ssh.ssh_server",
+        "ssh.host",
+        "ssh.port",
+        "ssh.username",
+        "ssh.host_user_required",
+        "ssh.private_key_short",
+        "ssh.update",
+        "ssh.create",
+        "ssh.test",
+        "ssh.private_key_with_path",
+        "ssh.private_key_hint",
+        "ssh.auth_label",
+    ];
+
+    #[test]
+    fn ssh_vocabulary_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in SSH_VOCABULARY_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ssh_authentication_differs_between_locales() {
+        let en = dbflux_i18n::t!("ssh.authentication", locale = "en");
+        let es = dbflux_i18n::t!("ssh.authentication", locale = "es");
+
+        assert_ne!(en, es, "ssh.authentication should differ between en and es");
+    }
+
+    #[test]
+    fn ssh_passphrase_hint_exact_values() {
+        let en = dbflux_i18n::t!("ssh.passphrase_hint", locale = "en");
+        let es = dbflux_i18n::t!("ssh.passphrase_hint", locale = "es");
+
+        assert_eq!(en, "Leave empty if key has no passphrase");
+        assert_eq!(es, "Déjala vacía si la clave no tiene frase");
     }
 }

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -98,13 +98,18 @@ pub(crate) fn access_proxy_disabled_label(name: &str) -> String {
     dbflux_i18n::t!("access.proxy_disabled_label", name = name)
 }
 
+/// Formats the "Private Key (<path>)" label shown for a saved SSH tunnel's private key auth.
+pub(crate) fn ssh_private_key_with_path(path: &str) -> String {
+    dbflux_i18n::t!("ssh.private_key_with_path", path = path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         access_proxy_disabled_label, hooks_create_dir_failed, hooks_delete_message,
         hooks_delete_unreadable_message, hooks_duplicate_id, hooks_env_pair_invalid,
         hooks_form_interpreter_hint, hooks_interpreter_auto_label, hooks_interpreter_missing,
-        hooks_open_script_failed, hooks_write_script_failed,
+        hooks_open_script_failed, hooks_write_script_failed, ssh_private_key_with_path,
     };
 
     #[test]
@@ -188,5 +193,12 @@ mod tests {
         let message = access_proxy_disabled_label("corporate-proxy");
 
         assert_eq!(message, "corporate-proxy (disabled)");
+    }
+
+    #[test]
+    fn ssh_private_key_with_path_embeds_key_path() {
+        let message = ssh_private_key_with_path("~/.ssh/id_ed25519");
+
+        assert_eq!(message, "Private Key (~/.ssh/id_ed25519)");
     }
 }


### PR DESCRIPTION
## Summary

Tenth `dbflux_ui_windows` i18n slice: the connection manager SSH tab (tunnel selection, server fields, auth selector and inputs, test/save actions) renders through `dbflux_i18n::t!`, and a shared `ssh.*` namespace is seeded for the SSH tunnel settings. English and Spanish together.

## What does this resolve?

- Refs #360 (follows the proxy tab PR; next: connection manager placeholders and overrides)

## How was this solved?

- Keys in `ssh.*` that only the SSH tunnel settings use are seeded now and wired when that slice lands; `ssh_private_key_with_path(path)` carries the key path.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 220 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a connection's Access tab in SSH mode and test the connection.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
