### PR TITLE
feat(i18n): translate the code editor toolbar, results, live output, and script confirm

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -90,6 +90,48 @@ controls:
       one: "+%{count} more"
       many: "+%{count} more"
 document:
+  code:
+    toolbar:
+      refresh: Refresh
+      cancel: Cancel
+      checking: "Checking…"
+      run: Run
+      shortcut_hint_with_selection: "%{shortcut} (selection/full)"
+      new_tab: New tab
+      selection: Selection
+      read_only: Read-only
+      saved: Saved
+      save: Save
+      formatter_unavailable: Formatter unavailable
+      query_history: Query history
+      explain_query: Explain query
+      open_in_chart: Open current query in a chart document
+    output:
+      running: "Running..."
+      stopped: Stopped
+      output: Output
+      lines:
+        one: "%{count} line"
+        many: "%{count} lines"
+      truncated: "(truncated at %{limit} lines)"
+    result:
+      count:
+        one: "%{count} result"
+        many: "%{count} results"
+      loading:
+        title: "Running…"
+        body: Query in progress
+      error:
+        title: Query Error
+      empty: Run a query to see results
+      awaiting_connection: Connect to this database to view the routine definition.
+    script_confirm:
+      title: Run entire script
+      message:
+        one: "No text is selected, so the entire script will run as %{count} statement in order. Continue?"
+        many: "No text is selected, so the entire script will run as %{count} statements in order. Continue?"
+      cancel: Cancel
+      run: Run Script
   data:
     chart_dock:
       toolbar:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -90,6 +90,48 @@ controls:
       one: "+%{count} más"
       many: "+%{count} más"
 document:
+  code:
+    toolbar:
+      refresh: Actualizar
+      cancel: Cancelar
+      checking: "Verificando…"
+      run: Ejecutar
+      shortcut_hint_with_selection: "%{shortcut} (selección/completo)"
+      new_tab: Nueva pestaña
+      selection: Selección
+      read_only: Solo lectura
+      saved: Guardado
+      save: Guardar
+      formatter_unavailable: Formateador no disponible
+      query_history: Historial de consultas
+      explain_query: Explicar consulta
+      open_in_chart: Abrir la consulta actual en un documento de gráfico
+    output:
+      running: "Ejecutando..."
+      stopped: Detenido
+      output: Salida
+      lines:
+        one: "%{count} línea"
+        many: "%{count} líneas"
+      truncated: "(truncado a %{limit} líneas)"
+    result:
+      count:
+        one: "%{count} resultado"
+        many: "%{count} resultados"
+      loading:
+        title: "Ejecutando…"
+        body: Consulta en progreso
+      error:
+        title: Error de consulta
+      empty: Ejecute una consulta para ver los resultados
+      awaiting_connection: Conéctese a esta base de datos para ver la definición de la rutina.
+    script_confirm:
+      title: Ejecutar todo el script
+      message:
+        one: "No hay texto seleccionado, por lo que se ejecutará todo el script como %{count} sentencia en orden. ¿Continuar?"
+        many: "No hay texto seleccionado, por lo que se ejecutará todo el script como %{count} sentencias en orden. ¿Continuar?"
+      cancel: Cancelar
+      run: Ejecutar script
   data:
     chart_dock:
       toolbar:

--- a/crates/dbflux_ui_document/src/code/render.rs
+++ b/crates/dbflux_ui_document/src/code/render.rs
@@ -24,9 +24,9 @@ impl CodeDocument {
 
         let auto_refresh_enabled = self.refresh.refresh_policy.is_auto();
         let refresh_label = if auto_refresh_enabled {
-            self.refresh.refresh_policy.label()
+            crate::labels::refresh_policy_label(self.refresh.refresh_policy)
         } else {
-            "Refresh"
+            dbflux_i18n::t!("document.code.toolbar.refresh")
         };
         let refresh_icon = if is_executing {
             AppIcon::Loader
@@ -37,11 +37,23 @@ impl CodeDocument {
         };
 
         let (run_icon, run_label, run_enabled) = if is_executing {
-            (AppIcon::X, "Cancel", true)
+            (
+                AppIcon::X,
+                dbflux_i18n::t!("document.code.toolbar.cancel"),
+                true,
+            )
         } else if is_preflight {
-            (AppIcon::Loader, "Checking…", false)
+            (
+                AppIcon::Loader,
+                dbflux_i18n::t!("document.code.toolbar.checking"),
+                false,
+            )
         } else {
-            (AppIcon::Play, "Run", true)
+            (
+                AppIcon::Play,
+                dbflux_i18n::t!("document.code.toolbar.run"),
+                true,
+            )
         };
 
         let accent = theme.accent;
@@ -56,20 +68,15 @@ impl CodeDocument {
                     .map(|finished| finished.duration_since(r.started_at))
             });
 
-        // Keep this label in sync with the RunQuery binding (Cmd+Enter on
-        // macOS, Ctrl+Enter elsewhere) registered in `keymap::defaults`.
+        // Keep this base shortcut in sync with the RunQuery binding (Cmd+Enter
+        // on macOS, Ctrl+Enter elsewhere) registered in `keymap::defaults`.
         #[cfg(target_os = "macos")]
-        let shortcut_hint = if is_db_language {
-            "Cmd+Enter (selection/full)"
-        } else {
-            "Cmd+Enter"
-        };
+        let shortcut_hint_base = "Cmd+Enter";
         #[cfg(not(target_os = "macos"))]
-        let shortcut_hint = if is_db_language {
-            "Ctrl+Enter (selection/full)"
-        } else {
-            "Ctrl+Enter"
-        };
+        let shortcut_hint_base = "Ctrl+Enter";
+
+        let shortcut_hint =
+            crate::labels::code_toolbar_shortcut_hint_label(shortcut_hint_base, is_db_language);
 
         compact_top_bar(&theme, std::iter::empty::<AnyElement>())
             .id("sql-toolbar")
@@ -97,7 +104,7 @@ impl CodeDocument {
                 el.child(
                     ToolbarButton::new("run-in-new-tab-btn")
                         .icon(AppIcon::SquarePlay)
-                        .label("New tab")
+                        .label(dbflux_i18n::t!("document.code.toolbar.new_tab"))
                         .on_click(cx.listener(|this, _, window, cx| {
                             this.run_query_in_new_tab(window, cx);
                         })),
@@ -105,7 +112,7 @@ impl CodeDocument {
                 .child(
                     ToolbarButton::new("run-selection-btn")
                         .icon(AppIcon::ScrollText)
-                        .label("Selection")
+                        .label(dbflux_i18n::t!("document.code.toolbar.selection"))
                         .on_click(cx.listener(|this, _, window, cx| {
                             this.run_selected_query(window, cx);
                         })),
@@ -113,7 +120,10 @@ impl CodeDocument {
             })
             .when(!is_read_only, |el| el.child(Text::caption(shortcut_hint)))
             .when(is_read_only, |el| {
-                el.child(Text::caption("Read-only").muted_foreground())
+                el.child(
+                    Text::caption(dbflux_i18n::t!("document.code.toolbar.read_only"))
+                        .muted_foreground(),
+                )
             })
             .child(self.render_secondary_actions(is_read_only, cx))
             .when(!is_read_only && is_db_language, |el| {
@@ -149,7 +159,9 @@ impl CodeDocument {
                 el.child(Text::caption(format!("{:.2}s", duration.as_secs_f64())))
             })
             .when(self.session.show_saved_label, |el| {
-                el.child(Text::caption("Saved"))
+                el.child(Text::caption(dbflux_i18n::t!(
+                    "document.code.toolbar.saved"
+                )))
             })
     }
 
@@ -172,7 +184,7 @@ impl CodeDocument {
                 el.child(
                     ToolbarButton::new("toolbar-save-btn")
                         .icon(AppIcon::Save)
-                        .tooltip("Save")
+                        .tooltip(dbflux_i18n::t!("document.code.toolbar.save"))
                         .on_click(cx.listener(|this, _, window, cx| {
                             if this.is_file_backed() {
                                 this.save_file(window, cx);
@@ -187,7 +199,9 @@ impl CodeDocument {
                 el.child(
                     ToolbarButton::new("toolbar-format-btn")
                         .icon(AppIcon::Zap)
-                        .tooltip("Formatter unavailable")
+                        .tooltip(dbflux_i18n::t!(
+                            "document.code.toolbar.formatter_unavailable"
+                        ))
                         .disabled(true),
                 )
             })
@@ -196,7 +210,7 @@ impl CodeDocument {
                 el.child(
                     ToolbarButton::new("toolbar-history-btn")
                         .icon(AppIcon::History)
-                        .tooltip("Query history")
+                        .tooltip(dbflux_i18n::t!("document.code.toolbar.query_history"))
                         .on_click(cx.listener(|this, _, window, cx| {
                             let is_open = this.history.history_modal.read(cx).is_visible();
                             if is_open {
@@ -216,7 +230,7 @@ impl CodeDocument {
                 el.child(
                     ToolbarButton::new("toolbar-explain-btn")
                         .icon(AppIcon::Info)
-                        .tooltip("Explain query")
+                        .tooltip(dbflux_i18n::t!("document.code.toolbar.explain_query"))
                         .on_click(cx.listener(|this, _, window, cx| {
                             this.run_explain(window, cx);
                         })),
@@ -227,7 +241,7 @@ impl CodeDocument {
                 el.child(
                     ToolbarButton::new("toolbar-chart-btn")
                         .icon(AppIcon::ChartSpline)
-                        .tooltip("Open current query in a chart document")
+                        .tooltip(dbflux_i18n::t!("document.code.toolbar.open_in_chart"))
                         .on_click(cx.listener(|this, _, _window, cx| {
                             this.emit_chart_this_query(cx);
                         })),
@@ -367,15 +381,15 @@ impl CodeDocument {
             .expect("live output state should exist when rendering");
 
         let status = if self.state == DocumentState::Executing {
-            "Running..."
+            dbflux_i18n::t!("document.code.output.running")
         } else if live_output.is_finished() {
-            "Stopped"
+            dbflux_i18n::t!("document.code.output.stopped")
         } else {
-            "Output"
+            dbflux_i18n::t!("document.code.output.output")
         };
 
         let text = SharedString::from(live_output.render_text());
-        let line_count = live_output.line_count();
+        let line_count_label = crate::labels::live_output_lines_label(live_output.line_count());
 
         div()
             .id("script-live-output")
@@ -393,7 +407,7 @@ impl CodeDocument {
                     .border_b_1()
                     .border_color(theme.border)
                     .child(Text::label(status))
-                    .child(Text::caption(format!("{} lines", line_count)))
+                    .child(Text::caption(line_count_label))
                     .when(live_output.has_stderr(), |el| {
                         el.child(Badge::new("stderr", BadgeVariant::Warning))
                     }),
@@ -406,12 +420,9 @@ impl CodeDocument {
                     .child(div().whitespace_nowrap().child(Text::code(text))),
             )
             .when(live_output.is_truncated(), |el| {
-                el.child(
-                    div()
-                        .px(Spacing::MD)
-                        .pb(Spacing::SM)
-                        .child(Text::caption("(truncated at 5000 lines)")),
-                )
+                el.child(div().px(Spacing::MD).pb(Spacing::SM).child(Text::caption(
+                    crate::labels::live_output_truncated_label(LiveOutputState::MAX_LINES),
+                )))
             })
     }
 
@@ -549,17 +560,9 @@ impl CodeDocument {
             .border_t_1()
             .border_color(theme.border)
             .bg(theme.tab_bar)
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .gap_1()
-                    .child(Text::caption(format!(
-                        "{} result{}",
-                        tab_count,
-                        if tab_count == 1 { "" } else { "s" }
-                    ))),
-            )
+            .child(div().flex().items_center().gap_1().child(Text::caption(
+                crate::labels::result_tab_count_label(tab_count),
+            )))
             .child(div().flex_1())
             .child(
                 div()
@@ -582,18 +585,24 @@ impl CodeDocument {
     fn render_loading_results(&self, _cx: &mut Context<Self>) -> impl IntoElement {
         let icon = Icon::new(AppIcon::Loader).size(px(12.0)); // guardrail-allow: 12px icon size, no ICON_XS token
         div().p(Spacing::MD).size_full().child(
-            BannerBlock::new(BannerVariant::Info, "Running…")
-                .with_icon(icon)
-                .with_body("Query in progress"),
+            BannerBlock::new(
+                BannerVariant::Info,
+                dbflux_i18n::t!("document.code.result.loading.title"),
+            )
+            .with_icon(icon)
+            .with_body(dbflux_i18n::t!("document.code.result.loading.body")),
         )
     }
 
     fn render_error_state(&self, error: &str, _cx: &mut Context<Self>) -> impl IntoElement {
         let icon = Icon::new(AppIcon::CircleX).size(Heights::ICON_SM);
         div().p(Spacing::MD).size_full().overflow_y_hidden().child(
-            BannerBlock::new(BannerVariant::Danger, "Query Error")
-                .with_icon(icon)
-                .with_pre(error.to_string()),
+            BannerBlock::new(
+                BannerVariant::Danger,
+                dbflux_i18n::t!("document.code.result.error.title"),
+            )
+            .with_icon(icon)
+            .with_pre(error.to_string()),
         )
     }
 
@@ -603,7 +612,7 @@ impl CodeDocument {
             .flex()
             .items_center()
             .justify_center()
-            .child(Text::muted("Run a query to see results"))
+            .child(Text::muted(dbflux_i18n::t!("document.code.result.empty")))
     }
 
     /// Placeholder shown for a routine document when no connection is active for
@@ -614,9 +623,9 @@ impl CodeDocument {
             .flex()
             .items_center()
             .justify_center()
-            .child(Text::muted(
-                "Connect to this database to view the routine definition.",
-            ))
+            .child(Text::muted(dbflux_i18n::t!(
+                "document.code.result.awaiting_connection"
+            )))
     }
 
     fn render_script_confirm_modal(&self, cx: &mut Context<Self>) -> impl IntoElement {
@@ -631,10 +640,7 @@ impl CodeDocument {
             .as_ref()
             .map(|p| p.statement_count)
             .unwrap_or(0);
-        let message = format!(
-            "No text is selected, so the entire script will run as {} statements in order. Continue?",
-            statement_count
-        );
+        let message = crate::labels::script_confirm_message_label(statement_count);
 
         let body = Text::caption(message).into_any_element();
 
@@ -642,30 +648,40 @@ impl CodeDocument {
             .flex()
             .gap(Spacing::SM)
             .child(
-                Button::new("script-confirm-cancel-btn", "Cancel").on_click(move |_, _, cx| {
+                Button::new(
+                    "script-confirm-cancel-btn",
+                    dbflux_i18n::t!("document.code.script_confirm.cancel"),
+                )
+                .on_click(move |_, _, cx| {
                     entity_cancel.update(cx, |doc, cx| {
                         doc.cancel_script_query(cx);
                     });
                 }),
             )
             .child(
-                Button::new("script-confirm-run-btn", "Run Script").on_click(
-                    move |_, window, cx| {
-                        entity_run.update(cx, |doc, cx| {
-                            doc.confirm_script_query(window, cx);
-                        });
-                    },
-                ),
+                Button::new(
+                    "script-confirm-run-btn",
+                    dbflux_i18n::t!("document.code.script_confirm.run"),
+                )
+                .on_click(move |_, window, cx| {
+                    entity_run.update(cx, |doc, cx| {
+                        doc.confirm_script_query(window, cx);
+                    });
+                }),
             )
             .into_any_element();
 
-        ModalShell::new("Run entire script", body, footer)
-            .width(px(460.0))
-            .on_close(move |_, cx| {
-                entity_close.update(cx, |doc, cx| {
-                    doc.cancel_script_query(cx);
-                });
-            })
+        ModalShell::new(
+            dbflux_i18n::t!("document.code.script_confirm.title"),
+            body,
+            footer,
+        )
+        .width(px(460.0))
+        .on_close(move |_, cx| {
+            entity_close.update(cx, |doc, cx| {
+                doc.cancel_script_query(cx);
+            });
+        })
     }
 
     fn render_dangerous_query_modal(&self, cx: &mut Context<Self>) -> impl IntoElement {

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -375,13 +375,81 @@ pub(crate) fn delete_confirm_copy(count: usize) -> (String, String) {
     }
 }
 
+/// Label for the code editor toolbar's run-shortcut caption.
+///
+/// `shortcut` is the platform-specific key chord (e.g. `"Cmd+Enter"`), which
+/// stays a literal outside the catalog. Only the surrounding "(selection/full)"
+/// qualifier, shown for query languages that support connection context, is
+/// translated.
+pub(crate) fn code_toolbar_shortcut_hint_label(shortcut: &str, with_selection: bool) -> String {
+    if with_selection {
+        dbflux_i18n::t!(
+            "document.code.toolbar.shortcut_hint_with_selection",
+            shortcut = shortcut
+        )
+    } else {
+        shortcut.to_string()
+    }
+}
+
+/// Label for the live script output header's line count.
+///
+/// Uses the singular catalog bucket only for exactly one line; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn live_output_lines_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("document.code.output.lines.one", count = count)
+    } else {
+        dbflux_i18n::t!("document.code.output.lines.many", count = count)
+    }
+}
+
+/// Label for the live script output truncation notice, with the line limit
+/// interpolated.
+pub(crate) fn live_output_truncated_label(limit: usize) -> String {
+    dbflux_i18n::t!("document.code.output.truncated", limit = limit)
+}
+
+/// Label for the collapsed results bar's tab count.
+///
+/// Uses the singular catalog bucket only for exactly one result tab; every
+/// other count, including zero, uses the plural bucket.
+pub(crate) fn result_tab_count_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("document.code.result.count.one", count = count)
+    } else {
+        dbflux_i18n::t!("document.code.result.count.many", count = count)
+    }
+}
+
+/// Label for the "run entire script" confirmation modal body, with the
+/// statement count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one statement; every
+/// other count, including zero, uses the plural bucket.
+pub(crate) fn script_confirm_message_label(statement_count: usize) -> String {
+    if statement_count == 1 {
+        dbflux_i18n::t!(
+            "document.code.script_confirm.message.one",
+            count = statement_count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.code.script_confirm.message.many",
+            count = statement_count
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         MutationItemKind, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
-        chart_rail_why_text, copy_query_language_label, delete_confirm_copy, delete_rows_label,
-        partial_delete_label, pending_change_count_label, pending_edits_summary,
-        refresh_policy_label, row_count_label, unsaved_changes_label, update_columns_label,
+        chart_rail_why_text, code_toolbar_shortcut_hint_label, copy_query_language_label,
+        delete_confirm_copy, delete_rows_label, live_output_lines_label,
+        live_output_truncated_label, partial_delete_label, pending_change_count_label,
+        pending_edits_summary, refresh_policy_label, result_tab_count_label, row_count_label,
+        script_confirm_message_label, unsaved_changes_label, update_columns_label,
     };
     use dbflux_components::chart::ChartDetection;
     use dbflux_core::{QueryLanguage, RefreshPolicy};
@@ -819,5 +887,135 @@ mod tests {
         );
 
         assert_ne!(en, es);
+    }
+
+    #[test]
+    fn code_render_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.code.toolbar.refresh",
+            "document.code.toolbar.cancel",
+            "document.code.toolbar.checking",
+            "document.code.toolbar.run",
+            "document.code.toolbar.shortcut_hint_with_selection",
+            "document.code.toolbar.new_tab",
+            "document.code.toolbar.selection",
+            "document.code.toolbar.read_only",
+            "document.code.toolbar.saved",
+            "document.code.toolbar.save",
+            "document.code.toolbar.formatter_unavailable",
+            "document.code.toolbar.query_history",
+            "document.code.toolbar.explain_query",
+            "document.code.toolbar.open_in_chart",
+            "document.code.output.running",
+            "document.code.output.stopped",
+            "document.code.output.output",
+            "document.code.output.lines.one",
+            "document.code.output.lines.many",
+            "document.code.output.truncated",
+            "document.code.result.count.one",
+            "document.code.result.count.many",
+            "document.code.result.loading.title",
+            "document.code.result.loading.body",
+            "document.code.result.error.title",
+            "document.code.result.empty",
+            "document.code.result.awaiting_connection",
+            "document.code.script_confirm.title",
+            "document.code.script_confirm.message.one",
+            "document.code.script_confirm.message.many",
+            "document.code.script_confirm.cancel",
+            "document.code.script_confirm.run",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn code_toolbar_run_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.code.toolbar.run", locale = "en");
+        let es = dbflux_i18n::t!("document.code.toolbar.run", locale = "es");
+
+        assert_eq!(en, "Run");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn code_output_running_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.code.output.running", locale = "en");
+        let es = dbflux_i18n::t!("document.code.output.running", locale = "es");
+
+        assert_eq!(en, "Running...");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn code_result_empty_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.code.result.empty", locale = "en");
+        let es = dbflux_i18n::t!("document.code.result.empty", locale = "es");
+
+        assert_eq!(en, "Run a query to see results");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn code_script_confirm_title_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.code.script_confirm.title", locale = "en");
+        let es = dbflux_i18n::t!("document.code.script_confirm.title", locale = "es");
+
+        assert_eq!(en, "Run entire script");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn code_toolbar_shortcut_hint_label_with_and_without_selection() {
+        let plain = code_toolbar_shortcut_hint_label("Ctrl+Enter", false);
+        let with_selection = code_toolbar_shortcut_hint_label("Ctrl+Enter", true);
+
+        assert_eq!(plain, "Ctrl+Enter");
+        assert!(with_selection.contains("Ctrl+Enter"));
+        assert_ne!(with_selection, plain);
+    }
+
+    #[test]
+    fn live_output_lines_label_one_many() {
+        assert_eq!(live_output_lines_label(1), "1 line");
+        assert_eq!(live_output_lines_label(2), "2 lines");
+        assert_eq!(live_output_lines_label(0), "0 lines");
+    }
+
+    #[test]
+    fn live_output_truncated_label_interpolates_limit() {
+        let label = live_output_truncated_label(5000);
+
+        assert_eq!(label, "(truncated at 5000 lines)");
+    }
+
+    #[test]
+    fn result_tab_count_label_one_many() {
+        assert_eq!(result_tab_count_label(1), "1 result");
+        assert_eq!(result_tab_count_label(2), "2 results");
+    }
+
+    #[test]
+    fn script_confirm_message_label_one_many() {
+        let one = script_confirm_message_label(1);
+        let many = script_confirm_message_label(3);
+
+        assert!(one.contains('1'));
+        assert!(one.contains("statement in order"));
+        assert!(many.contains('3'));
+        assert!(many.contains("statements in order"));
+        assert_ne!(one, many);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 7: the code editor toolbar and shortcut hints, live output counts and truncation, results header and empty/loading/error states, and the script confirm modal render through `dbflux_i18n::t!` and labels.rs helpers. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 6b; next: the dangerous query modal)

## How was this solved?

- Size: 458 lines (`size:exception`, one coherent render tree).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 917 passed; clippy clean; fmt clean. Manual smoke in Spanish: run a SQL script and a Lua script, read the output panel.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
