### PR TITLE
feat(i18n): translate the dangerous query modal

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -141,6 +141,59 @@ document:
         many: "No text is selected, so the entire script will run as %{count} statements in order. Continue?"
       cancel: Cancel
       run: Run Script
+    dangerous_query:
+      fallback:
+        title: Warning
+        body: This query may be dangerous.
+      dont_ask_again: "Don't ask again"
+      cancel: Cancel
+      run_anyway: Run Anyway
+      kind:
+        delete_no_where:
+          title: DELETE without WHERE
+          body: DELETE without WHERE may affect all rows
+        update_no_where:
+          title: UPDATE without WHERE
+          body: UPDATE without WHERE may affect all rows
+        truncate:
+          title: TRUNCATE
+          body: TRUNCATE will delete all rows
+        drop:
+          title: DROP
+          body: DROP will permanently remove the object
+        alter:
+          title: ALTER
+          body: ALTER will modify the structure
+        script:
+          title: Dangerous Script
+          body: This script contains potentially destructive statements
+        mongo_delete_many:
+          title: deleteMany with empty filter
+          body: deleteMany with empty filter will delete all documents
+        mongo_update_many:
+          title: updateMany with empty filter
+          body: updateMany with empty filter will update all documents
+        mongo_drop_collection:
+          title: drop() collection
+          body: drop() will permanently remove the collection
+        mongo_drop_database:
+          title: dropDatabase()
+          body: dropDatabase() will permanently remove the entire database
+        redis_flush_all:
+          title: FLUSHALL
+          body: FLUSHALL will delete all keys in all databases
+        redis_flush_db:
+          title: FLUSHDB
+          body: FLUSHDB will delete all keys in the current database
+        redis_multi_delete:
+          title: DEL (multiple keys)
+          body: DEL with multiple keys will delete them all
+        redis_keys_pattern:
+          title: KEYS pattern
+          body: KEYS with a pattern is a performance hazard on large databases
+        raw_expression_in_set:
+          title: Raw SQL expression in SET
+          body: SET clause contains a raw SQL expression — bypasses parameter binding
   data:
     chart_dock:
       toolbar:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -141,6 +141,59 @@ document:
         many: "No hay texto seleccionado, por lo que se ejecutará todo el script como %{count} sentencias en orden. ¿Continuar?"
       cancel: Cancelar
       run: Ejecutar script
+    dangerous_query:
+      fallback:
+        title: Advertencia
+        body: Esta consulta puede ser peligrosa.
+      dont_ask_again: No volver a preguntar
+      cancel: Cancelar
+      run_anyway: Ejecutar de todos modos
+      kind:
+        delete_no_where:
+          title: DELETE sin WHERE
+          body: DELETE sin WHERE puede afectar todas las filas
+        update_no_where:
+          title: UPDATE sin WHERE
+          body: UPDATE sin WHERE puede afectar todas las filas
+        truncate:
+          title: TRUNCATE
+          body: TRUNCATE eliminará todas las filas
+        drop:
+          title: DROP
+          body: DROP eliminará permanentemente el objeto
+        alter:
+          title: ALTER
+          body: ALTER modificará la estructura
+        script:
+          title: Script peligroso
+          body: Este script contiene sentencias potencialmente destructivas
+        mongo_delete_many:
+          title: deleteMany con filtro vacío
+          body: deleteMany con filtro vacío eliminará todos los documentos
+        mongo_update_many:
+          title: updateMany con filtro vacío
+          body: updateMany con filtro vacío actualizará todos los documentos
+        mongo_drop_collection:
+          title: drop() de colección
+          body: drop() eliminará permanentemente la colección
+        mongo_drop_database:
+          title: dropDatabase()
+          body: dropDatabase() eliminará permanentemente toda la base de datos
+        redis_flush_all:
+          title: FLUSHALL
+          body: FLUSHALL eliminará todas las claves en todas las bases de datos
+        redis_flush_db:
+          title: FLUSHDB
+          body: FLUSHDB eliminará todas las claves en la base de datos actual
+        redis_multi_delete:
+          title: DEL (múltiples claves)
+          body: DEL con múltiples claves las eliminará todas
+        redis_keys_pattern:
+          title: Patrón KEYS
+          body: KEYS con un patrón es un riesgo de rendimiento en bases de datos grandes
+        raw_expression_in_set:
+          title: Expresión SQL cruda en SET
+          body: "La cláusula SET contiene una expresión SQL cruda — evita el enlace de parámetros"
   data:
     chart_dock:
       toolbar:

--- a/crates/dbflux_ui_document/src/code/render.rs
+++ b/crates/dbflux_ui_document/src/code/render.rs
@@ -698,26 +698,17 @@ impl CodeDocument {
             .dangerous_query
             .as_ref()
             .map(|p| {
-                let title = match p.kind {
-                    DangerousQueryKind::DeleteNoWhere => "DELETE without WHERE",
-                    DangerousQueryKind::UpdateNoWhere => "UPDATE without WHERE",
-                    DangerousQueryKind::Truncate => "TRUNCATE",
-                    DangerousQueryKind::Drop => "DROP",
-                    DangerousQueryKind::Alter => "ALTER",
-                    DangerousQueryKind::Script => "Dangerous Script",
-                    DangerousQueryKind::MongoDeleteMany => "deleteMany with empty filter",
-                    DangerousQueryKind::MongoUpdateMany => "updateMany with empty filter",
-                    DangerousQueryKind::MongoDropCollection => "drop() collection",
-                    DangerousQueryKind::MongoDropDatabase => "dropDatabase()",
-                    DangerousQueryKind::RedisFlushAll => "FLUSHALL",
-                    DangerousQueryKind::RedisFlushDb => "FLUSHDB",
-                    DangerousQueryKind::RedisMultiDelete => "DEL (multiple keys)",
-                    DangerousQueryKind::RedisKeysPattern => "KEYS pattern",
-                    DangerousQueryKind::RawExpressionInSet => "Raw SQL expression in SET",
-                };
-                (title, p.kind.message())
+                (
+                    crate::labels::dangerous_query_title(p.kind),
+                    crate::labels::dangerous_query_body(p.kind),
+                )
             })
-            .unwrap_or(("Warning", "This query may be dangerous."));
+            .unwrap_or_else(|| {
+                (
+                    dbflux_i18n::t!("document.code.dangerous_query.fallback.title"),
+                    dbflux_i18n::t!("document.code.dangerous_query.fallback.body"),
+                )
+            });
 
         let body = Text::caption(message).into_any_element();
 
@@ -736,21 +727,30 @@ impl CodeDocument {
                     doc.confirm_dangerous_query(true, window, cx);
                 });
             })
-            .child(Text::caption("Don't ask again"));
+            .child(Text::caption(dbflux_i18n::t!(
+                "document.code.dangerous_query.dont_ask_again"
+            )));
 
-        let cancel_btn = Button::new("dangerous-cancel-btn", "Cancel").on_click(move |_, _, cx| {
+        let cancel_btn = Button::new(
+            "dangerous-cancel-btn",
+            dbflux_i18n::t!("document.code.dangerous_query.cancel"),
+        )
+        .on_click(move |_, _, cx| {
             entity_cancel.update(cx, |doc, cx| {
                 doc.cancel_dangerous_query(cx);
             });
         });
 
-        let run_anyway_btn = Button::new("dangerous-confirm-btn", "Run Anyway")
-            .danger()
-            .on_click(move |_, window, cx| {
-                entity_run.update(cx, |doc, cx| {
-                    doc.confirm_dangerous_query(false, window, cx);
-                });
+        let run_anyway_btn = Button::new(
+            "dangerous-confirm-btn",
+            dbflux_i18n::t!("document.code.dangerous_query.run_anyway"),
+        )
+        .danger()
+        .on_click(move |_, window, cx| {
+            entity_run.update(cx, |doc, cx| {
+                doc.confirm_dangerous_query(false, window, cx);
             });
+        });
 
         // Footer: "Don't ask again" left-aligned, Cancel + Run Anyway right-aligned.
         // The flex_1 spacer pushes the buttons to the right within the single footer AnyElement.

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -441,18 +441,153 @@ pub(crate) fn script_confirm_message_label(statement_count: usize) -> String {
     }
 }
 
+/// Title for the dangerous-query confirmation modal, one per
+/// `DangerousQueryKind` variant.
+///
+/// Exhaustive by construction (no wildcard arm) so a new variant added to
+/// `dbflux_core::DangerousQueryKind` fails this crate's build until its
+/// catalog key is added here.
+pub(crate) fn dangerous_query_title(kind: dbflux_core::DangerousQueryKind) -> String {
+    use dbflux_core::DangerousQueryKind;
+
+    match kind {
+        DangerousQueryKind::DeleteNoWhere => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.delete_no_where.title")
+        }
+        DangerousQueryKind::UpdateNoWhere => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.update_no_where.title")
+        }
+        DangerousQueryKind::Truncate => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.truncate.title")
+        }
+        DangerousQueryKind::Drop => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.drop.title")
+        }
+        DangerousQueryKind::Alter => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.alter.title")
+        }
+        DangerousQueryKind::Script => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.script.title")
+        }
+        DangerousQueryKind::MongoDeleteMany => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.mongo_delete_many.title")
+        }
+        DangerousQueryKind::MongoUpdateMany => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.mongo_update_many.title")
+        }
+        DangerousQueryKind::MongoDropCollection => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.mongo_drop_collection.title")
+        }
+        DangerousQueryKind::MongoDropDatabase => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.mongo_drop_database.title")
+        }
+        DangerousQueryKind::RedisFlushAll => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.redis_flush_all.title")
+        }
+        DangerousQueryKind::RedisFlushDb => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.redis_flush_db.title")
+        }
+        DangerousQueryKind::RedisMultiDelete => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.redis_multi_delete.title")
+        }
+        DangerousQueryKind::RedisKeysPattern => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.redis_keys_pattern.title")
+        }
+        DangerousQueryKind::RawExpressionInSet => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.raw_expression_in_set.title")
+        }
+    }
+}
+
+/// Body for the dangerous-query confirmation modal, one per
+/// `DangerousQueryKind` variant.
+///
+/// The English catalog value must stay identical to
+/// `DangerousQueryKind::message()` (see the parity test below); the Spanish
+/// value is an independent translation of the same warning.
+pub(crate) fn dangerous_query_body(kind: dbflux_core::DangerousQueryKind) -> String {
+    use dbflux_core::DangerousQueryKind;
+
+    match kind {
+        DangerousQueryKind::DeleteNoWhere => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.delete_no_where.body")
+        }
+        DangerousQueryKind::UpdateNoWhere => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.update_no_where.body")
+        }
+        DangerousQueryKind::Truncate => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.truncate.body")
+        }
+        DangerousQueryKind::Drop => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.drop.body")
+        }
+        DangerousQueryKind::Alter => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.alter.body")
+        }
+        DangerousQueryKind::Script => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.script.body")
+        }
+        DangerousQueryKind::MongoDeleteMany => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.mongo_delete_many.body")
+        }
+        DangerousQueryKind::MongoUpdateMany => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.mongo_update_many.body")
+        }
+        DangerousQueryKind::MongoDropCollection => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.mongo_drop_collection.body")
+        }
+        DangerousQueryKind::MongoDropDatabase => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.mongo_drop_database.body")
+        }
+        DangerousQueryKind::RedisFlushAll => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.redis_flush_all.body")
+        }
+        DangerousQueryKind::RedisFlushDb => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.redis_flush_db.body")
+        }
+        DangerousQueryKind::RedisMultiDelete => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.redis_multi_delete.body")
+        }
+        DangerousQueryKind::RedisKeysPattern => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.redis_keys_pattern.body")
+        }
+        DangerousQueryKind::RawExpressionInSet => {
+            dbflux_i18n::t!("document.code.dangerous_query.kind.raw_expression_in_set.body")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         MutationItemKind, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
         chart_rail_why_text, code_toolbar_shortcut_hint_label, copy_query_language_label,
-        delete_confirm_copy, delete_rows_label, live_output_lines_label,
-        live_output_truncated_label, partial_delete_label, pending_change_count_label,
-        pending_edits_summary, refresh_policy_label, result_tab_count_label, row_count_label,
-        script_confirm_message_label, unsaved_changes_label, update_columns_label,
+        dangerous_query_body, dangerous_query_title, delete_confirm_copy, delete_rows_label,
+        live_output_lines_label, live_output_truncated_label, partial_delete_label,
+        pending_change_count_label, pending_edits_summary, refresh_policy_label,
+        result_tab_count_label, row_count_label, script_confirm_message_label,
+        unsaved_changes_label, update_columns_label,
     };
     use dbflux_components::chart::ChartDetection;
-    use dbflux_core::{QueryLanguage, RefreshPolicy};
+    use dbflux_core::{DangerousQueryKind, QueryLanguage, RefreshPolicy};
+
+    const ALL_DANGEROUS_QUERY_KINDS: &[DangerousQueryKind] = &[
+        DangerousQueryKind::DeleteNoWhere,
+        DangerousQueryKind::UpdateNoWhere,
+        DangerousQueryKind::Truncate,
+        DangerousQueryKind::Drop,
+        DangerousQueryKind::Alter,
+        DangerousQueryKind::Script,
+        DangerousQueryKind::MongoDeleteMany,
+        DangerousQueryKind::MongoUpdateMany,
+        DangerousQueryKind::MongoDropCollection,
+        DangerousQueryKind::MongoDropDatabase,
+        DangerousQueryKind::RedisFlushAll,
+        DangerousQueryKind::RedisFlushDb,
+        DangerousQueryKind::RedisMultiDelete,
+        DangerousQueryKind::RedisKeysPattern,
+        DangerousQueryKind::RawExpressionInSet,
+    ];
 
     #[test]
     fn unsaved_changes_label_zero_one_many() {
@@ -1017,5 +1152,165 @@ mod tests {
         assert!(many.contains('3'));
         assert!(many.contains("statements in order"));
         assert_ne!(one, many);
+    }
+
+    #[test]
+    fn dangerous_query_body_matches_core_message_in_en() {
+        for kind in ALL_DANGEROUS_QUERY_KINDS {
+            let body = dbflux_i18n::t!(dangerous_query_body_key(*kind), locale = "en");
+
+            assert_eq!(
+                body,
+                kind.message(),
+                "en body for {kind:?} must match DangerousQueryKind::message()"
+            );
+        }
+    }
+
+    #[test]
+    fn dangerous_query_copy_differs_between_locales() {
+        // Titles for pure SQL/Redis command names (TRUNCATE, DROP, ALTER,
+        // FLUSHALL, FLUSHDB) are legitimately identical across locales —
+        // only the body sentence carries the translation for those kinds.
+        let title_may_stay_literal = |kind: DangerousQueryKind| {
+            matches!(
+                kind,
+                DangerousQueryKind::Truncate
+                    | DangerousQueryKind::Drop
+                    | DangerousQueryKind::Alter
+                    | DangerousQueryKind::RedisFlushAll
+                    | DangerousQueryKind::RedisFlushDb
+                    | DangerousQueryKind::MongoDropDatabase
+            )
+        };
+
+        for kind in ALL_DANGEROUS_QUERY_KINDS {
+            let title_en = dbflux_i18n::t!(dangerous_query_title_key(*kind), locale = "en");
+            let title_es = dbflux_i18n::t!(dangerous_query_title_key(*kind), locale = "es");
+            let body_en = dbflux_i18n::t!(dangerous_query_body_key(*kind), locale = "en");
+            let body_es = dbflux_i18n::t!(dangerous_query_body_key(*kind), locale = "es");
+
+            if !title_may_stay_literal(*kind) {
+                assert_ne!(title_en, title_es, "title for {kind:?} did not translate");
+            }
+            assert_ne!(body_en, body_es, "body for {kind:?} did not translate");
+
+            assert_eq!(dangerous_query_title(*kind), title_en);
+            assert_eq!(dangerous_query_body(*kind), body_en);
+        }
+    }
+
+    #[test]
+    fn dangerous_query_keys_resolve_in_both_locales() {
+        let mut keys = vec![
+            "document.code.dangerous_query.fallback.title".to_string(),
+            "document.code.dangerous_query.fallback.body".to_string(),
+            "document.code.dangerous_query.dont_ask_again".to_string(),
+            "document.code.dangerous_query.cancel".to_string(),
+            "document.code.dangerous_query.run_anyway".to_string(),
+        ];
+
+        for kind in ALL_DANGEROUS_QUERY_KINDS {
+            keys.push(dangerous_query_title_key(*kind).to_string());
+            keys.push(dangerous_query_body_key(*kind).to_string());
+        }
+
+        for key in &keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    fn dangerous_query_title_key(kind: DangerousQueryKind) -> &'static str {
+        match kind {
+            DangerousQueryKind::DeleteNoWhere => {
+                "document.code.dangerous_query.kind.delete_no_where.title"
+            }
+            DangerousQueryKind::UpdateNoWhere => {
+                "document.code.dangerous_query.kind.update_no_where.title"
+            }
+            DangerousQueryKind::Truncate => "document.code.dangerous_query.kind.truncate.title",
+            DangerousQueryKind::Drop => "document.code.dangerous_query.kind.drop.title",
+            DangerousQueryKind::Alter => "document.code.dangerous_query.kind.alter.title",
+            DangerousQueryKind::Script => "document.code.dangerous_query.kind.script.title",
+            DangerousQueryKind::MongoDeleteMany => {
+                "document.code.dangerous_query.kind.mongo_delete_many.title"
+            }
+            DangerousQueryKind::MongoUpdateMany => {
+                "document.code.dangerous_query.kind.mongo_update_many.title"
+            }
+            DangerousQueryKind::MongoDropCollection => {
+                "document.code.dangerous_query.kind.mongo_drop_collection.title"
+            }
+            DangerousQueryKind::MongoDropDatabase => {
+                "document.code.dangerous_query.kind.mongo_drop_database.title"
+            }
+            DangerousQueryKind::RedisFlushAll => {
+                "document.code.dangerous_query.kind.redis_flush_all.title"
+            }
+            DangerousQueryKind::RedisFlushDb => {
+                "document.code.dangerous_query.kind.redis_flush_db.title"
+            }
+            DangerousQueryKind::RedisMultiDelete => {
+                "document.code.dangerous_query.kind.redis_multi_delete.title"
+            }
+            DangerousQueryKind::RedisKeysPattern => {
+                "document.code.dangerous_query.kind.redis_keys_pattern.title"
+            }
+            DangerousQueryKind::RawExpressionInSet => {
+                "document.code.dangerous_query.kind.raw_expression_in_set.title"
+            }
+        }
+    }
+
+    fn dangerous_query_body_key(kind: DangerousQueryKind) -> &'static str {
+        match kind {
+            DangerousQueryKind::DeleteNoWhere => {
+                "document.code.dangerous_query.kind.delete_no_where.body"
+            }
+            DangerousQueryKind::UpdateNoWhere => {
+                "document.code.dangerous_query.kind.update_no_where.body"
+            }
+            DangerousQueryKind::Truncate => "document.code.dangerous_query.kind.truncate.body",
+            DangerousQueryKind::Drop => "document.code.dangerous_query.kind.drop.body",
+            DangerousQueryKind::Alter => "document.code.dangerous_query.kind.alter.body",
+            DangerousQueryKind::Script => "document.code.dangerous_query.kind.script.body",
+            DangerousQueryKind::MongoDeleteMany => {
+                "document.code.dangerous_query.kind.mongo_delete_many.body"
+            }
+            DangerousQueryKind::MongoUpdateMany => {
+                "document.code.dangerous_query.kind.mongo_update_many.body"
+            }
+            DangerousQueryKind::MongoDropCollection => {
+                "document.code.dangerous_query.kind.mongo_drop_collection.body"
+            }
+            DangerousQueryKind::MongoDropDatabase => {
+                "document.code.dangerous_query.kind.mongo_drop_database.body"
+            }
+            DangerousQueryKind::RedisFlushAll => {
+                "document.code.dangerous_query.kind.redis_flush_all.body"
+            }
+            DangerousQueryKind::RedisFlushDb => {
+                "document.code.dangerous_query.kind.redis_flush_db.body"
+            }
+            DangerousQueryKind::RedisMultiDelete => {
+                "document.code.dangerous_query.kind.redis_multi_delete.body"
+            }
+            DangerousQueryKind::RedisKeysPattern => {
+                "document.code.dangerous_query.kind.redis_keys_pattern.body"
+            }
+            DangerousQueryKind::RawExpressionInSet => {
+                "document.code.dangerous_query.kind.raw_expression_in_set.body"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 8: the dangerous query modal title and body per `DangerousQueryKind` resolve through exhaustive helpers whose English bodies mirror the core messages; checkbox and buttons render through `dbflux_i18n::t!`; command names stay literal. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 7; next: the visual query builder)

## How was this solved?

- Size: 465 lines (`size:exception`, 15 variants × title/body × 2 locales).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 920 passed; clippy clean; fmt clean. Manual smoke in Spanish: run a DELETE without WHERE and a DROP.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
