### PR TITLE
feat(i18n): translate the connection overrides and connection hooks section

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -115,11 +115,20 @@ connection_manager:
     select_trusted_client: Select trusted client
     no_role: No role
     no_policy: No policy
+    extra_hook_ids: extra hook IDs (comma-separated)
+    use_connection_auth_profile: Use Connection Auth Profile
   access_method:
     direct: Direct
     ssh_tunnel: SSH Tunnel
     proxy: Proxy
     ssm: SSM Port Forwarding
+  overrides:
+    default_caption: "Default: %{value}"
+    default_seconds_caption: "Default: %{value}s"
+    on: "On"
+    off: "Off"
+  connection_overrides_title: Connection Overrides
+  connection_hooks_title: Connection Hooks
   new_auth_profile: "New Auth Profile..."
   aws_sso_wizard_title: AWS SSO Wizard
   aws_sso_open_failed: Failed to open AWS SSO wizard window
@@ -797,6 +806,7 @@ settings:
       label: Use the stable database
       error: Failed to update the shared-database setting
       hint: "Applied on next launch. Shares the stable database (dbflux.db) instead of this nightly build's dbflux-nightly.db."
+    override_value_header: Override Value
     save:
       button: Save
       error: "Failed to save general settings: %{error}"

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -123,6 +123,11 @@ connection_manager:
     proxy: Proxy
     ssm: SSM Port Forwarding
   overrides:
+    refresh_policy: "Refresh policy"
+    refresh_interval: "Refresh interval (s)"
+    confirm_dangerous: "Confirm dangerous queries"
+    requires_where: "Requires WHERE clause"
+    requires_preview: "Requires preview"
     default_caption: "Default: %{value}"
     default_seconds_caption: "Default: %{value}s"
     on: "On"

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -123,6 +123,11 @@ connection_manager:
     proxy: Proxy
     ssm: Reenvío de puertos SSM
   overrides:
+    refresh_policy: "Política de actualización"
+    refresh_interval: "Intervalo de actualización (s)"
+    confirm_dangerous: "Confirmar consultas peligrosas"
+    requires_where: "Requiere cláusula WHERE"
+    requires_preview: "Requiere previsualización"
     default_caption: "Predeterminado: %{value}"
     default_seconds_caption: "Predeterminado: %{value}s"
     on: Activado

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -115,11 +115,20 @@ connection_manager:
     select_trusted_client: Seleccionar cliente de confianza
     no_role: Sin rol
     no_policy: Sin política
+    extra_hook_ids: IDs de hooks extra (separados por coma)
+    use_connection_auth_profile: Usar el perfil de autenticación de la conexión
   access_method:
     direct: Directo
     ssh_tunnel: Túnel SSH
     proxy: Proxy
     ssm: Reenvío de puertos SSM
+  overrides:
+    default_caption: "Predeterminado: %{value}"
+    default_seconds_caption: "Predeterminado: %{value}s"
+    on: Activado
+    off: Desactivado
+  connection_overrides_title: Anulaciones de conexión
+  connection_hooks_title: Hooks de conexión
   new_auth_profile: "Nuevo perfil de autenticación..."
   aws_sso_wizard_title: Asistente de AWS SSO
   aws_sso_open_failed: No se pudo abrir el asistente de AWS SSO
@@ -797,6 +806,7 @@ settings:
       label: Usar la base de datos estable
       error: No se pudo actualizar la configuración de base de datos compartida
       hint: "Se aplica en el próximo inicio. Comparte la base de datos estable (dbflux.db) en lugar de la dbflux-nightly.db de esta compilación nightly."
+    override_value_header: Valor de anulación
     save:
       button: Guardar
       error: "No se pudo guardar la configuración general: %{error}"

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -508,7 +508,9 @@ impl ConnectionManagerWindow {
         let ssm_remote_port_value_source_selector =
             cx.new(|cx| ValueSourceSelector::new("cm-ssm-remote-port", window, cx));
         let ssm_auth_profile_dropdown = cx.new(|_cx| {
-            Dropdown::new("ssm-auth-profile-dropdown").placeholder("Use Connection Auth Profile")
+            Dropdown::new("ssm-auth-profile-dropdown").placeholder(dbflux_i18n::t!(
+                "connection_manager.placeholder.use_connection_auth_profile"
+            ))
         });
 
         let conn_refresh_policy_dropdown = cx.new(|_cx| {
@@ -552,14 +554,26 @@ impl ConnectionManagerWindow {
             Dropdown::new("conn-post-disconnect-hook")
                 .placeholder(dbflux_i18n::t!("connection_manager.placeholder.no_hook"))
         });
-        let conn_pre_hook_extra_input = cx
-            .new(|cx| InputState::new(window, cx).placeholder("extra hook IDs (comma-separated)"));
-        let conn_post_hook_extra_input = cx
-            .new(|cx| InputState::new(window, cx).placeholder("extra hook IDs (comma-separated)"));
-        let conn_pre_disconnect_hook_extra_input = cx
-            .new(|cx| InputState::new(window, cx).placeholder("extra hook IDs (comma-separated)"));
-        let conn_post_disconnect_hook_extra_input = cx
-            .new(|cx| InputState::new(window, cx).placeholder("extra hook IDs (comma-separated)"));
+        let conn_pre_hook_extra_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "connection_manager.placeholder.extra_hook_ids"
+            ))
+        });
+        let conn_post_hook_extra_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "connection_manager.placeholder.extra_hook_ids"
+            ))
+        });
+        let conn_pre_disconnect_hook_extra_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "connection_manager.placeholder.extra_hook_ids"
+            ))
+        });
+        let conn_post_disconnect_hook_extra_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "connection_manager.placeholder.extra_hook_ids"
+            ))
+        });
         let conn_mcp_actor_dropdown = cx.new(|_cx| {
             Dropdown::new("conn-mcp-actor").placeholder(dbflux_i18n::t!(
                 "connection_manager.placeholder.select_trusted_client"
@@ -1847,8 +1861,14 @@ impl ConnectionManagerWindow {
         let effective = self.resolve_driver_effective_settings(cx);
 
         let policy_items = vec![
-            dbflux_components::controls::DropdownItem::with_value("Manual", "manual"),
-            dbflux_components::controls::DropdownItem::with_value("Interval", "interval"),
+            dbflux_components::controls::DropdownItem::with_value(
+                dbflux_i18n::t!("settings.general.refresh_policy.option.manual"),
+                "manual",
+            ),
+            dbflux_components::controls::DropdownItem::with_value(
+                dbflux_i18n::t!("settings.general.refresh_policy.option.interval"),
+                "interval",
+            ),
         ];
         let policy_index = match overrides.refresh_policy.unwrap_or(effective.refresh_policy) {
             dbflux_core::RefreshPolicySetting::Manual => 0,
@@ -1871,9 +1891,18 @@ impl ConnectionManagerWindow {
             });
 
         let boolean_items = vec![
-            dbflux_components::controls::DropdownItem::with_value("Use Driver Default", "default"),
-            dbflux_components::controls::DropdownItem::with_value("On", "on"),
-            dbflux_components::controls::DropdownItem::with_value("Off", "off"),
+            dbflux_components::controls::DropdownItem::with_value(
+                dbflux_i18n::t!("connection_manager.placeholder.use_driver_default"),
+                "default",
+            ),
+            dbflux_components::controls::DropdownItem::with_value(
+                dbflux_i18n::t!("connection_manager.overrides.on"),
+                "on",
+            ),
+            dbflux_components::controls::DropdownItem::with_value(
+                dbflux_i18n::t!("connection_manager.overrides.off"),
+                "off",
+            ),
         ];
 
         let bool_index = |opt: Option<bool>| -> usize {
@@ -1904,7 +1933,8 @@ impl ConnectionManagerWindow {
             });
 
         let mut hook_items = vec![dbflux_components::controls::DropdownItem::with_value(
-            "No hook", "",
+            dbflux_i18n::t!("connection_manager.placeholder.no_hook"),
+            "",
         )];
 
         let hook_definitions = self.app_state.read(cx).hook_definitions().clone();
@@ -2609,7 +2639,7 @@ impl ConnectionManagerWindow {
             "",
         )];
         let mut ssm_items = vec![dbflux_components::controls::DropdownItem::with_value(
-            "Use Connection Auth Profile",
+            dbflux_i18n::t!("connection_manager.placeholder.use_connection_auth_profile"),
             "",
         )];
 

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -327,8 +327,12 @@ impl ConnectionManagerWindow {
 
         // --- Global Overrides Section ---
         let policy_label = match effective.refresh_policy {
-            dbflux_core::RefreshPolicySetting::Manual => "Manual",
-            dbflux_core::RefreshPolicySetting::Interval => "Interval",
+            dbflux_core::RefreshPolicySetting::Manual => {
+                dbflux_i18n::t!("settings.general.refresh_policy.option.manual")
+            }
+            dbflux_core::RefreshPolicySetting::Interval => {
+                dbflux_i18n::t!("settings.general.refresh_policy.option.interval")
+            }
         };
 
         let override_rows = div()
@@ -341,7 +345,9 @@ impl ConnectionManagerWindow {
                     .items_center()
                     .gap_3()
                     .child(div().w(px(200.0)))
-                    .child(div().w(px(160.0)).child(Text::caption("Override Value"))),
+                    .child(div().w(px(160.0)).child(Text::caption(dbflux_i18n::t!(
+                        "settings.general.override_value_header"
+                    )))),
             )
             // Refresh policy row
             .child(
@@ -368,7 +374,12 @@ impl ConnectionManagerWindow {
                                 cx.notify();
                             })),
                     )
-                    .child(div().w(px(180.0)).text_sm().child("Refresh policy"))
+                    .child(
+                        div()
+                            .w(px(180.0))
+                            .text_sm()
+                            .child(dbflux_i18n::t!("settings.general.refresh_policy.label")),
+                    )
                     .child(
                         div()
                             .min_w(px(160.0))
@@ -390,7 +401,9 @@ impl ConnectionManagerWindow {
                                 )
                             }),
                     )
-                    .child(Text::caption(format!("Default: {}", policy_label))),
+                    .child(Text::caption(crate::labels::override_default_caption(
+                        &policy_label,
+                    ))),
             )
             // Refresh interval row
             .child(
@@ -417,7 +430,12 @@ impl ConnectionManagerWindow {
                                 cx.notify();
                             })),
                     )
-                    .child(div().w(px(180.0)).text_sm().child("Refresh interval (s)"))
+                    .child(
+                        div()
+                            .w(px(180.0))
+                            .text_sm()
+                            .child(dbflux_i18n::t!("settings.general.refresh_interval.label")),
+                    )
                     .child(
                         div()
                             .w(px(100.0))
@@ -432,10 +450,11 @@ impl ConnectionManagerWindow {
                                     .disabled(!self.settings_tab.conn_override_refresh_interval),
                             ),
                     )
-                    .child(Text::caption(format!(
-                        "Default: {}s",
-                        effective.refresh_interval_secs
-                    ))),
+                    .child(Text::caption(
+                        crate::labels::override_default_seconds_caption(
+                            effective.refresh_interval_secs,
+                        ),
+                    )),
             )
             // Confirm dangerous queries
             .child(
@@ -458,20 +477,19 @@ impl ConnectionManagerWindow {
                         div()
                             .w(px(200.0))
                             .text_sm()
-                            .child("Confirm dangerous queries"),
+                            .child(dbflux_i18n::t!("settings.general.confirm_dangerous.label")),
                     )
                     .child(
                         div()
                             .min_w(px(160.0))
                             .child(self.settings_tab.conn_confirm_dangerous_dropdown.clone()),
                     )
-                    .child(Text::caption(format!(
-                        "Default: {}",
-                        if effective.confirm_dangerous {
-                            "On"
+                    .child(Text::caption(crate::labels::override_default_caption(
+                        &if effective.confirm_dangerous {
+                            dbflux_i18n::t!("connection_manager.overrides.on")
                         } else {
-                            "Off"
-                        }
+                            dbflux_i18n::t!("connection_manager.overrides.off")
+                        },
                     ))),
             )
             // Requires WHERE clause
@@ -491,19 +509,23 @@ impl ConnectionManagerWindow {
                         |d| d.border_color(gpui::transparent_black()),
                     )
                     .p(px(2.0))
-                    .child(div().w(px(200.0)).text_sm().child("Requires WHERE clause"))
+                    .child(
+                        div()
+                            .w(px(200.0))
+                            .text_sm()
+                            .child(dbflux_i18n::t!("settings.general.requires_where.label")),
+                    )
                     .child(
                         div()
                             .min_w(px(160.0))
                             .child(self.settings_tab.conn_requires_where_dropdown.clone()),
                     )
-                    .child(Text::caption(format!(
-                        "Default: {}",
-                        if effective.requires_where {
-                            "On"
+                    .child(Text::caption(crate::labels::override_default_caption(
+                        &if effective.requires_where {
+                            dbflux_i18n::t!("connection_manager.overrides.on")
                         } else {
-                            "Off"
-                        }
+                            dbflux_i18n::t!("connection_manager.overrides.off")
+                        },
                     ))),
             )
             // Requires preview
@@ -523,32 +545,44 @@ impl ConnectionManagerWindow {
                         |d| d.border_color(gpui::transparent_black()),
                     )
                     .p(px(2.0))
-                    .child(div().w(px(200.0)).text_sm().child("Requires preview"))
+                    .child(
+                        div()
+                            .w(px(200.0))
+                            .text_sm()
+                            .child(dbflux_i18n::t!("settings.general.requires_preview.label")),
+                    )
                     .child(
                         div()
                             .min_w(px(160.0))
                             .child(self.settings_tab.conn_requires_preview_dropdown.clone()),
                     )
-                    .child(Text::caption(format!(
-                        "Default: {}",
-                        if effective.requires_preview {
-                            "On"
+                    .child(Text::caption(crate::labels::override_default_caption(
+                        &if effective.requires_preview {
+                            dbflux_i18n::t!("connection_manager.overrides.on")
                         } else {
-                            "Off"
-                        }
+                            dbflux_i18n::t!("connection_manager.overrides.off")
+                        },
                     ))),
             );
 
         sections.push(
-            self.render_section("Connection Overrides", override_rows, &theme)
-                .into_any_element(),
+            self.render_section(
+                dbflux_i18n::t!("connection_manager.connection_overrides_title").as_str(),
+                override_rows,
+                &theme,
+            )
+            .into_any_element(),
         );
 
         let hooks_rows = self.render_hooks_rows(muted, cx);
 
         sections.push(
-            self.render_section("Connection Hooks", hooks_rows, &theme)
-                .into_any_element(),
+            self.render_section(
+                dbflux_i18n::t!("connection_manager.connection_hooks_title").as_str(),
+                hooks_rows,
+                &theme,
+            )
+            .into_any_element(),
         );
 
         // --- Driver Schema Section ---
@@ -622,7 +656,9 @@ impl ConnectionManagerWindow {
                                                 },
                                             )),
                                         )
-                                        .child(Text::caption(format!("Default: {}", default_val)))
+                                        .child(Text::caption(
+                                            crate::labels::override_default_caption(default_val),
+                                        ))
                                         .into_any_element(),
                                 )
                             }
@@ -659,10 +695,11 @@ impl ConnectionManagerWindow {
                                                 .items_center()
                                                 .gap_2()
                                                 .child(div().text_sm().child(field.label.clone()))
-                                                .child(Text::caption(format!(
-                                                    "Default: {}",
-                                                    default_val
-                                                ))),
+                                                .child(Text::caption(
+                                                    crate::labels::override_default_caption(
+                                                        &default_val,
+                                                    ),
+                                                )),
                                         )
                                         .child(div().w(Widths::CM_FORM_DROPDOWN).child(dropdown))
                                         .into_any_element(),
@@ -700,10 +737,11 @@ impl ConnectionManagerWindow {
                                                 .items_center()
                                                 .gap_2()
                                                 .child(div().text_sm().child(field.label.clone()))
-                                                .child(Text::caption(format!(
-                                                    "Default: {}",
-                                                    default_val
-                                                ))),
+                                                .child(Text::caption(
+                                                    crate::labels::override_default_caption(
+                                                        &default_val,
+                                                    ),
+                                                )),
                                         )
                                         .child(Input::new(&input).small().disabled(!enabled))
                                         .into_any_element(),
@@ -835,4 +873,89 @@ impl ConnectionManagerWindow {
 
 // The `file_picker_label` helper and its tests moved to
 // `dbflux_components::primitives::file_picker` together with the `FilePicker`
+
+#[cfg(test)]
+mod connection_overrides_i18n_tests {
+    const CONNECTION_OVERRIDES_KEYS: &[&str] = &[
+        "connection_manager.connection_overrides_title",
+        "connection_manager.connection_hooks_title",
+        "connection_manager.overrides.on",
+        "connection_manager.overrides.off",
+        "connection_manager.placeholder.extra_hook_ids",
+        "connection_manager.placeholder.use_connection_auth_profile",
+        "settings.general.override_value_header",
+    ];
+
+    #[test]
+    fn connection_overrides_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in CONNECTION_OVERRIDES_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn connection_overrides_title_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "connection_manager.connection_overrides_title",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "connection_manager.connection_overrides_title",
+            locale = "es"
+        );
+
+        assert_ne!(
+            en, es,
+            "connection_manager.connection_overrides_title should differ between en and es"
+        );
+    }
+
+    #[test]
+    fn connection_overrides_reuses_settings_general_keys() {
+        let refresh_policy_label =
+            dbflux_i18n::t!("settings.general.refresh_policy.label", locale = "en");
+        let refresh_interval_label =
+            dbflux_i18n::t!("settings.general.refresh_interval.label", locale = "en");
+        let confirm_dangerous_label =
+            dbflux_i18n::t!("settings.general.confirm_dangerous.label", locale = "en");
+        let requires_where_label =
+            dbflux_i18n::t!("settings.general.requires_where.label", locale = "en");
+        let requires_preview_label =
+            dbflux_i18n::t!("settings.general.requires_preview.label", locale = "en");
+
+        assert_eq!(refresh_policy_label, "Default refresh policy");
+        assert_eq!(refresh_interval_label, "Default refresh interval (seconds)");
+        assert_eq!(confirm_dangerous_label, "Confirm dangerous queries");
+        assert_eq!(requires_where_label, "Require WHERE for DELETE/UPDATE");
+        assert_eq!(
+            requires_preview_label,
+            "Always require preview (ignore suppressions)"
+        );
+    }
+
+    #[test]
+    fn overrides_on_off_have_expected_english_text() {
+        assert_eq!(
+            dbflux_i18n::t!("connection_manager.overrides.on", locale = "en"),
+            "On"
+        );
+        assert_eq!(
+            dbflux_i18n::t!("connection_manager.overrides.off", locale = "en"),
+            "Off"
+        );
+    }
+}
 // primitive itself.

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -374,12 +374,9 @@ impl ConnectionManagerWindow {
                                 cx.notify();
                             })),
                     )
-                    .child(
-                        div()
-                            .w(px(180.0))
-                            .text_sm()
-                            .child(dbflux_i18n::t!("settings.general.refresh_policy.label")),
-                    )
+                    .child(div().w(px(180.0)).text_sm().child(dbflux_i18n::t!(
+                        "connection_manager.overrides.refresh_policy"
+                    )))
                     .child(
                         div()
                             .min_w(px(160.0))
@@ -430,12 +427,9 @@ impl ConnectionManagerWindow {
                                 cx.notify();
                             })),
                     )
-                    .child(
-                        div()
-                            .w(px(180.0))
-                            .text_sm()
-                            .child(dbflux_i18n::t!("settings.general.refresh_interval.label")),
-                    )
+                    .child(div().w(px(180.0)).text_sm().child(dbflux_i18n::t!(
+                        "connection_manager.overrides.refresh_interval"
+                    )))
                     .child(
                         div()
                             .w(px(100.0))
@@ -473,12 +467,9 @@ impl ConnectionManagerWindow {
                         |d| d.border_color(gpui::transparent_black()),
                     )
                     .p(px(2.0))
-                    .child(
-                        div()
-                            .w(px(200.0))
-                            .text_sm()
-                            .child(dbflux_i18n::t!("settings.general.confirm_dangerous.label")),
-                    )
+                    .child(div().w(px(200.0)).text_sm().child(dbflux_i18n::t!(
+                        "connection_manager.overrides.confirm_dangerous"
+                    )))
                     .child(
                         div()
                             .min_w(px(160.0))
@@ -509,12 +500,9 @@ impl ConnectionManagerWindow {
                         |d| d.border_color(gpui::transparent_black()),
                     )
                     .p(px(2.0))
-                    .child(
-                        div()
-                            .w(px(200.0))
-                            .text_sm()
-                            .child(dbflux_i18n::t!("settings.general.requires_where.label")),
-                    )
+                    .child(div().w(px(200.0)).text_sm().child(dbflux_i18n::t!(
+                        "connection_manager.overrides.requires_where"
+                    )))
                     .child(
                         div()
                             .min_w(px(160.0))
@@ -545,12 +533,9 @@ impl ConnectionManagerWindow {
                         |d| d.border_color(gpui::transparent_black()),
                     )
                     .p(px(2.0))
-                    .child(
-                        div()
-                            .w(px(200.0))
-                            .text_sm()
-                            .child(dbflux_i18n::t!("settings.general.requires_preview.label")),
-                    )
+                    .child(div().w(px(200.0)).text_sm().child(dbflux_i18n::t!(
+                        "connection_manager.overrides.requires_preview"
+                    )))
                     .child(
                         div()
                             .min_w(px(160.0))
@@ -924,25 +909,39 @@ mod connection_overrides_i18n_tests {
     }
 
     #[test]
-    fn connection_overrides_reuses_settings_general_keys() {
-        let refresh_policy_label =
-            dbflux_i18n::t!("settings.general.refresh_policy.label", locale = "en");
-        let refresh_interval_label =
-            dbflux_i18n::t!("settings.general.refresh_interval.label", locale = "en");
-        let confirm_dangerous_label =
-            dbflux_i18n::t!("settings.general.confirm_dangerous.label", locale = "en");
-        let requires_where_label =
-            dbflux_i18n::t!("settings.general.requires_where.label", locale = "en");
-        let requires_preview_label =
-            dbflux_i18n::t!("settings.general.requires_preview.label", locale = "en");
-
-        assert_eq!(refresh_policy_label, "Default refresh policy");
-        assert_eq!(refresh_interval_label, "Default refresh interval (seconds)");
-        assert_eq!(confirm_dangerous_label, "Confirm dangerous queries");
-        assert_eq!(requires_where_label, "Require WHERE for DELETE/UPDATE");
+    fn connection_overrides_keep_their_own_row_labels() {
         assert_eq!(
-            requires_preview_label,
-            "Always require preview (ignore suppressions)"
+            dbflux_i18n::t!("connection_manager.overrides.refresh_policy", locale = "en"),
+            "Refresh policy"
+        );
+        assert_eq!(
+            dbflux_i18n::t!(
+                "connection_manager.overrides.refresh_interval",
+                locale = "en"
+            ),
+            "Refresh interval (s)"
+        );
+        assert_eq!(
+            dbflux_i18n::t!(
+                "connection_manager.overrides.confirm_dangerous",
+                locale = "en"
+            ),
+            "Confirm dangerous queries"
+        );
+        assert_eq!(
+            dbflux_i18n::t!("connection_manager.overrides.requires_where", locale = "en"),
+            "Requires WHERE clause"
+        );
+        assert_eq!(
+            dbflux_i18n::t!(
+                "connection_manager.overrides.requires_preview",
+                locale = "en"
+            ),
+            "Requires preview"
+        );
+        assert_ne!(
+            dbflux_i18n::t!("connection_manager.overrides.requires_where", locale = "en"),
+            dbflux_i18n::t!("connection_manager.overrides.requires_where", locale = "es")
         );
     }
 

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -93,6 +93,22 @@ pub(crate) fn hooks_form_interpreter_hint(default_interpreter: &str) -> String {
     )
 }
 
+/// Formats the "Default: <value>" caption under a connection override control.
+pub(crate) fn override_default_caption(value: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.overrides.default_caption",
+        value = value
+    )
+}
+
+/// Formats the "Default: <seconds>s" caption under the refresh interval override.
+pub(crate) fn override_default_seconds_caption(seconds: u32) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.overrides.default_seconds_caption",
+        value = seconds
+    )
+}
+
 /// Formats the "<name> (disabled)" label shown for a disabled proxy in the proxy dropdown.
 pub(crate) fn access_proxy_disabled_label(name: &str) -> String {
     dbflux_i18n::t!("access.proxy_disabled_label", name = name)
@@ -200,5 +216,21 @@ mod tests {
         let message = ssh_private_key_with_path("~/.ssh/id_ed25519");
 
         assert_eq!(message, "Private Key (~/.ssh/id_ed25519)");
+    }
+
+    #[test]
+    fn override_default_captions_embed_value() {
+        assert!(super::override_default_caption("On").contains("On"));
+        assert!(super::override_default_seconds_caption(30).contains("30"));
+        assert_ne!(
+            dbflux_i18n::t!(
+                "connection_manager.overrides.default_caption",
+                locale = "en"
+            ),
+            dbflux_i18n::t!(
+                "connection_manager.overrides.default_caption",
+                locale = "es"
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary

Twelfth `dbflux_ui_windows` i18n slice: the Connection Overrides and Connection Hooks section (titles, override row labels reusing the Settings General keys, On/Off and driver-default items, default captions, extra hook ids and connection auth profile placeholders) renders through `dbflux_i18n::t!`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows the placeholders PR; next: auth flow, then dialogs/tabs)

## How was this solved?

- `override_default_caption` / `override_default_seconds_caption` carry the interpolated defaults.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 229 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a connection's Settings tab overrides.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
