### PR TITLE
feat(i18n): translate the visual query builder chrome and mode bar

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -460,6 +460,27 @@ document:
         column: COLUMN
         references: REFERENCES
         row: ROW
+  query_builder:
+    chrome:
+      save: Save
+      reset: Reset
+      untitled_query: Untitled query
+    mode:
+      select: SELECT
+      update: UPDATE
+      delete: DELETE
+    status:
+      limit: Limit
+      offset: Offset
+      valid_lines:
+        one: "valid · %{count} line"
+        many: "valid · %{count} lines"
+      run: Run
+      apply_update: Apply Update
+      open_in_editor: Open in Editor
+      incomplete_aggregate_rows:
+        one: "%{count} aggregate row is incomplete and will be excluded from the query"
+        many: "%{count} aggregate rows are incomplete and will be excluded from the query"
   shared:
     refresh:
       off: Off

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -460,6 +460,27 @@ document:
         column: COLUMNA
         references: REFERENCIAS
         row: FILA
+  query_builder:
+    chrome:
+      save: Guardar
+      reset: Restablecer
+      untitled_query: Consulta sin título
+    mode:
+      select: SELECT
+      update: UPDATE
+      delete: DELETE
+    status:
+      limit: Límite
+      offset: Desplazamiento
+      valid_lines:
+        one: "válido · %{count} línea"
+        many: "válido · %{count} líneas"
+      run: Ejecutar
+      apply_update: Aplicar actualización
+      open_in_editor: Abrir en el editor
+      incomplete_aggregate_rows:
+        one: "%{count} fila agregada está incompleta y se excluirá de la consulta"
+        many: "%{count} filas agregadas están incompletas y se excluirán de la consulta"
   shared:
     refresh:
       off: Apagado

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -441,6 +441,62 @@ pub(crate) fn script_confirm_message_label(statement_count: usize) -> String {
     }
 }
 
+/// Label for the query builder's mode-switch bar entry (SELECT / UPDATE /
+/// DELETE).
+///
+/// Every arm routes through the catalog for translation consistency, but
+/// the `en`/`es` catalog values stay byte-identical because these are SQL
+/// statement names, not prose.
+pub(crate) fn builder_mode_label(
+    mode: crate::query_builder::mutation_state::BuilderMode,
+) -> String {
+    use crate::query_builder::mutation_state::BuilderMode;
+
+    match mode {
+        BuilderMode::Select => dbflux_i18n::t!("document.query_builder.mode.select"),
+        BuilderMode::Update => dbflux_i18n::t!("document.query_builder.mode.update"),
+        BuilderMode::Delete => dbflux_i18n::t!("document.query_builder.mode.delete"),
+    }
+}
+
+/// Label for the query builder's SQL preview line-count status line, with
+/// the line count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one line; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn valid_lines_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "document.query_builder.status.valid_lines.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.query_builder.status.valid_lines.many",
+            count = count
+        )
+    }
+}
+
+/// Label for the query builder footer's incomplete-aggregate-row warning,
+/// with the row count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one incomplete row;
+/// every other count uses the plural bucket.
+pub(crate) fn incomplete_aggregate_rows_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "document.query_builder.status.incomplete_aggregate_rows.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.query_builder.status.incomplete_aggregate_rows.many",
+            count = count
+        )
+    }
+}
+
 /// Title for the dangerous-query confirmation modal, one per
 /// `DangerousQueryKind` variant.
 ///
@@ -560,13 +616,14 @@ pub(crate) fn dangerous_query_body(kind: dbflux_core::DangerousQueryKind) -> Str
 #[cfg(test)]
 mod tests {
     use super::{
-        MutationItemKind, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
-        chart_rail_why_text, code_toolbar_shortcut_hint_label, copy_query_language_label,
-        dangerous_query_body, dangerous_query_title, delete_confirm_copy, delete_rows_label,
+        MutationItemKind, builder_mode_label, bulk_delete_success_label, chart_degraded_copy,
+        chart_dock_shape_label, chart_rail_why_text, code_toolbar_shortcut_hint_label,
+        copy_query_language_label, dangerous_query_body, dangerous_query_title,
+        delete_confirm_copy, delete_rows_label, incomplete_aggregate_rows_label,
         live_output_lines_label, live_output_truncated_label, partial_delete_label,
         pending_change_count_label, pending_edits_summary, refresh_policy_label,
         result_tab_count_label, row_count_label, script_confirm_message_label,
-        unsaved_changes_label, update_columns_label,
+        unsaved_changes_label, update_columns_label, valid_lines_label,
     };
     use dbflux_components::chart::ChartDetection;
     use dbflux_core::{DangerousQueryKind, QueryLanguage, RefreshPolicy};
@@ -1152,6 +1209,68 @@ mod tests {
         assert!(many.contains('3'));
         assert!(many.contains("statements in order"));
         assert_ne!(one, many);
+    }
+
+    #[test]
+    fn valid_lines_label_zero_one_many() {
+        assert_eq!(valid_lines_label(1), "valid · 1 line");
+        assert_eq!(valid_lines_label(2), "valid · 2 lines");
+        assert_eq!(valid_lines_label(0), "valid · 0 lines");
+    }
+
+    #[test]
+    fn incomplete_aggregate_rows_label_one_many() {
+        let one = incomplete_aggregate_rows_label(1);
+        let many = incomplete_aggregate_rows_label(3);
+
+        assert!(one.contains('1'));
+        assert!(one.contains("aggregate row is incomplete"));
+        assert!(many.contains('3'));
+        assert!(many.contains("aggregate rows are incomplete"));
+        assert_ne!(one, many);
+    }
+
+    #[test]
+    fn builder_mode_label_keeps_sql_keywords_literal_and_identical_across_locales() {
+        use crate::query_builder::mutation_state::BuilderMode;
+
+        assert_eq!(builder_mode_label(BuilderMode::Select), "SELECT");
+        assert_eq!(builder_mode_label(BuilderMode::Update), "UPDATE");
+        assert_eq!(builder_mode_label(BuilderMode::Delete), "DELETE");
+
+        for key in [
+            "document.query_builder.mode.select",
+            "document.query_builder.mode.update",
+            "document.query_builder.mode.delete",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_eq!(en, es);
+        }
+    }
+
+    #[test]
+    fn query_builder_chrome_and_status_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.query_builder.chrome.save",
+            "document.query_builder.chrome.reset",
+            "document.query_builder.chrome.untitled_query",
+            "document.query_builder.status.limit",
+            "document.query_builder.status.offset",
+            "document.query_builder.status.run",
+            "document.query_builder.status.apply_update",
+            "document.query_builder.status.open_in_editor",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key);
+                assert_ne!(value, format!("{locale}.{key}"));
+                assert!(!value.is_empty());
+            }
+        }
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/query_builder/view.rs
+++ b/crates/dbflux_ui_document/src/query_builder/view.rs
@@ -128,29 +128,33 @@ fn render_header(
         })
         .child(div().flex_1())
         .child(
-            Button::new("qb-hdr-save", "Save")
-                .icon(AppIcon::Save)
-                .ghost()
-                .small()
-                .on_click(cx.listener(|this, _event, _window, cx| {
-                    use crate::query_builder::events::BuilderEvent;
-                    let name = this
-                        .loaded_id
-                        .as_deref()
-                        .unwrap_or("Untitled query")
-                        .to_string();
-                    cx.emit(BuilderEvent::SaveRequested { name });
-                })),
+            Button::new(
+                "qb-hdr-save",
+                dbflux_i18n::t!("document.query_builder.chrome.save"),
+            )
+            .icon(AppIcon::Save)
+            .ghost()
+            .small()
+            .on_click(cx.listener(|this, _event, _window, cx| {
+                use crate::query_builder::events::BuilderEvent;
+                let name = this.loaded_id.clone().unwrap_or_else(|| {
+                    dbflux_i18n::t!("document.query_builder.chrome.untitled_query")
+                });
+                cx.emit(BuilderEvent::SaveRequested { name });
+            })),
         )
         .child(
-            Button::new("qb-hdr-reset", "Reset")
-                .icon(AppIcon::RotateCcw)
-                .ghost()
-                .small()
-                .on_click(cx.listener(|_this, _event, _window, cx| {
-                    use crate::query_builder::events::BuilderEvent;
-                    cx.emit(BuilderEvent::ResetRequested);
-                })),
+            Button::new(
+                "qb-hdr-reset",
+                dbflux_i18n::t!("document.query_builder.chrome.reset"),
+            )
+            .icon(AppIcon::RotateCcw)
+            .ghost()
+            .small()
+            .on_click(cx.listener(|_this, _event, _window, cx| {
+                use crate::query_builder::events::BuilderEvent;
+                cx.emit(BuilderEvent::ResetRequested);
+            })),
         )
 }
 
@@ -171,12 +175,6 @@ fn render_mode_selector(
         .map(|s| s.mode)
         .unwrap_or(BuilderMode::Select);
 
-    let modes: [(BuilderMode, &'static str); 3] = [
-        (BuilderMode::Select, "SELECT"),
-        (BuilderMode::Update, "UPDATE"),
-        (BuilderMode::Delete, "DELETE"),
-    ];
-
     let mut row = div()
         .flex()
         .flex_row()
@@ -188,7 +186,7 @@ fn render_mode_selector(
         .border_color(theme.border)
         .bg(theme.background);
 
-    for (mode, label) in modes {
+    for (mode, label) in mode_selector_options() {
         let is_active = mode == current_mode;
         let variant = if is_active {
             ButtonVariant::Primary
@@ -206,6 +204,30 @@ fn render_mode_selector(
     }
 
     row
+}
+
+/// The mode-switch bar's (mode, label) options, translated through the
+/// catalog.
+///
+/// A function rather than a `const` array because `dbflux_i18n::t!` is not
+/// evaluable in a const context; every arm's translated value happens to
+/// stay byte-identical between locales since these are SQL statement
+/// names, not prose.
+fn mode_selector_options() -> [(BuilderMode, String); 3] {
+    [
+        (
+            BuilderMode::Select,
+            crate::labels::builder_mode_label(BuilderMode::Select),
+        ),
+        (
+            BuilderMode::Update,
+            crate::labels::builder_mode_label(BuilderMode::Update),
+        ),
+        (
+            BuilderMode::Delete,
+            crate::labels::builder_mode_label(BuilderMode::Delete),
+        ),
+    ]
 }
 
 // ---------------------------------------------------------------------------
@@ -407,6 +429,9 @@ fn section_card(
 fn render_limit_offset_body(panel: &mut QueryBuilderPanel) -> impl IntoElement {
     let row = div().flex().flex_row().gap(Spacing::MD).items_center();
 
+    let limit_label = dbflux_i18n::t!("document.query_builder.status.limit");
+    let offset_label = dbflux_i18n::t!("document.query_builder.status.offset");
+
     let row = if let Some(limit_state) = panel.limit_input_state.as_ref() {
         row.child(
             div()
@@ -414,14 +439,14 @@ fn render_limit_offset_body(panel: &mut QueryBuilderPanel) -> impl IntoElement {
                 .flex()
                 .flex_col()
                 .gap(Spacing::XXS)
-                .child(Text::caption(SharedString::from("Limit")))
+                .child(Text::caption(SharedString::from(limit_label)))
                 .child(Input::new(limit_state).small().w_full()),
         )
     } else {
         row.child(
             div()
                 .flex_1()
-                .child(Text::caption(SharedString::from("Limit"))),
+                .child(Text::caption(SharedString::from(limit_label))),
         )
     };
 
@@ -432,14 +457,14 @@ fn render_limit_offset_body(panel: &mut QueryBuilderPanel) -> impl IntoElement {
                 .flex()
                 .flex_col()
                 .gap(Spacing::XXS)
-                .child(Text::caption(SharedString::from("Offset")))
+                .child(Text::caption(SharedString::from(offset_label)))
                 .child(Input::new(offset_state).small().w_full()),
         )
     } else {
         row.child(
             div()
                 .flex_1()
-                .child(Text::caption(SharedString::from("Offset"))),
+                .child(Text::caption(SharedString::from(offset_label))),
         )
     }
 }
@@ -498,8 +523,7 @@ fn render_effective_select_preview(
 
 fn render_preview_body(panel: &mut QueryBuilderPanel, theme: &Theme) -> impl IntoElement {
     let line_count = panel.sql_preview.lines().count().max(1);
-    let line_label = if line_count == 1 { "line" } else { "lines" };
-    let status_text = format!("valid · {line_count} {line_label}");
+    let status_text = crate::labels::valid_lines_label(line_count);
 
     div()
         .flex()
@@ -564,12 +588,12 @@ fn render_footer(
     let run_label = if is_mutation_mode {
         let has_filter = panel.current_spec.filter.is_some();
         if current_mode == BuilderMode::Update && has_filter {
-            "Apply Update"
+            dbflux_i18n::t!("document.query_builder.status.apply_update")
         } else {
-            "Run"
+            dbflux_i18n::t!("document.query_builder.status.run")
         }
     } else {
-        "Run"
+        dbflux_i18n::t!("document.query_builder.status.run")
     };
 
     let sort_error = panel.sort_validation_error.clone();
@@ -602,16 +626,9 @@ fn render_footer(
             )
         })
         .when(is_grouped && incomplete_count > 0, |d| {
-            let label = if incomplete_count == 1 {
-                SharedString::from(
-                    "1 aggregate row is incomplete and will be excluded from the query",
-                )
-            } else {
-                SharedString::from(format!(
-                    "{} aggregate rows are incomplete and will be excluded from the query",
-                    incomplete_count
-                ))
-            };
+            let label = SharedString::from(crate::labels::incomplete_aggregate_rows_label(
+                incomplete_count,
+            ));
             d.child(
                 div()
                     .flex()
@@ -668,14 +685,19 @@ fn render_footer(
                 )
                 .when(!is_mutation_mode, |row| {
                     row.child(
-                        Button::new("qb-open-editor", "Open in Editor")
-                            .icon(AppIcon::ExternalLink)
-                            .variant(ButtonVariant::Ghost)
-                            .small()
-                            .on_click(cx.listener(|_this, _event, _window, cx| {
+                        Button::new(
+                            "qb-open-editor",
+                            dbflux_i18n::t!("document.query_builder.status.open_in_editor"),
+                        )
+                        .icon(AppIcon::ExternalLink)
+                        .variant(ButtonVariant::Ghost)
+                        .small()
+                        .on_click(cx.listener(
+                            |_this, _event, _window, cx| {
                                 use crate::query_builder::events::BuilderEvent;
                                 cx.emit(BuilderEvent::OpenInEditorRequested);
-                            })),
+                            },
+                        )),
                     )
                 })
                 .child(div().flex_1()),
@@ -864,5 +886,24 @@ fn literal_to_display_string(v: &dbflux_core::LiteralValue) -> String {
         LiteralValue::Bool(b) => b.to_string(),
         LiteralValue::Timestamp(t) => t.clone(),
         LiteralValue::Null => "NULL".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mode_selector_options;
+    use crate::query_builder::mutation_state::BuilderMode;
+
+    #[test]
+    fn mode_selector_options_returns_translated_labels_for_every_mode() {
+        let options = mode_selector_options();
+
+        assert_eq!(options.len(), 3);
+        assert_eq!(options[0].0, BuilderMode::Select);
+        assert_eq!(options[0].1, "SELECT");
+        assert_eq!(options[1].0, BuilderMode::Update);
+        assert_eq!(options[1].1, "UPDATE");
+        assert_eq!(options[2].0, BuilderMode::Delete);
+        assert_eq!(options[2].1, "DELETE");
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 9: the visual query builder header actions, mode selector (SQL statement names stay literal), limit/offset captions, SQL preview status, footer actions and the incomplete-aggregate warning render through `dbflux_i18n::t!` and labels.rs helpers. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 8; next: builder section headers, then panel/sections)

## How was this solved?

- The mode table became a function since `t!` is not const.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 925 passed; clippy clean; fmt clean. Manual smoke in Spanish: open the builder and switch modes.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
