### PR TITLE
feat(i18n): translate the remaining sidebar schema, bucket, and refresh messages

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -989,6 +989,11 @@ sidebar:
     connections_hint: Use + to add a new connection
     scripts_title: No scripts yet
     scripts_hint: Use + to create a new script or import an existing file
+  error:
+    cannot_load_schema_types: Cannot load schema types
+    cannot_load_schema_indexes: Cannot load schema indexes
+    cannot_load_schema_foreign_keys: Cannot load schema foreign keys
+    cannot_load_schema_routines: Cannot load schema routines
   filter:
     connections_placeholder: Filter connections and schema...
     scripts_placeholder: Filter scripts...
@@ -1070,6 +1075,11 @@ sidebar:
     disconnect_hook_cancelled: Disconnect hook cancelled
     post_disconnect_hook_cancelled: Post-disconnect hook cancelled
     loading_event_streams: "Loading event streams: %{name}"
+    listing_buckets: "Listing buckets: %{name}"
+    loading_database_schema: "Loading schema: %{name}"
+    connecting_to_database: "Connecting to database: %{name}"
+    refreshing_database: "Refreshing database: %{name}"
+    refreshing_schema_object: "Refreshing schema object: %{name}"
     dropping:
       table: "Dropping table %{name}"
       view: "Dropping view %{name}"
@@ -1108,6 +1118,19 @@ sidebar:
     load_failed:
       table: "Failed to load %{name} schema: %{error}"
       collection: "Failed to load event streams for %{name}: %{error}"
+      data_types: "Failed to load data types: %{error}"
+      indexes: "Failed to load indexes: %{error}"
+      foreign_keys: "Failed to load foreign keys: %{error}"
+      routines: "Failed to load routines: %{error}"
+    list_buckets_failed: "Failed to list buckets: %{error}"
+    code_generation_failed: "Code generation failed: %{error}"
+    loading_event_streams: Loading event streams...
+    load_schema_failed: "Failed to load schema: %{error}"
+    connect_database_failed: "Failed to connect to database: %{error}"
+    refresh_database_failed: "Failed to refresh database: %{error}"
+    database_refresh_pending: Database refresh already pending
+    prepare_schema_object_refresh_failed: Failed to prepare schema object refresh
+    refresh_schema_object_failed: "Failed to refresh schema object: %{error}"
     connected:
       plain: "Connected to %{name}"
       one: "Connected to %{name} (with 1 hook warning)"

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -989,6 +989,11 @@ sidebar:
     connections_hint: Usa + para agregar una nueva conexión
     scripts_title: Aún no hay scripts
     scripts_hint: Usa + para crear un script nuevo o importar un archivo existente
+  error:
+    cannot_load_schema_types: No se pueden cargar los tipos de datos del esquema
+    cannot_load_schema_indexes: No se pueden cargar los índices del esquema
+    cannot_load_schema_foreign_keys: No se pueden cargar las claves foráneas del esquema
+    cannot_load_schema_routines: No se pueden cargar las rutinas del esquema
   filter:
     connections_placeholder: Filtrar conexiones y esquema...
     scripts_placeholder: Filtrar scripts...
@@ -1070,6 +1075,11 @@ sidebar:
     disconnect_hook_cancelled: Hook de desconexión cancelado
     post_disconnect_hook_cancelled: Hook posterior a la desconexión cancelado
     loading_event_streams: "Cargando flujos de eventos: %{name}"
+    listing_buckets: "Listando buckets: %{name}"
+    loading_database_schema: "Cargando esquema: %{name}"
+    connecting_to_database: "Conectando a la base de datos: %{name}"
+    refreshing_database: "Actualizando base de datos: %{name}"
+    refreshing_schema_object: "Actualizando objeto del esquema: %{name}"
     dropping:
       table: "Eliminando la tabla %{name}"
       view: "Eliminando la vista %{name}"
@@ -1108,6 +1118,19 @@ sidebar:
     load_failed:
       table: "Error al cargar el esquema de %{name}: %{error}"
       collection: "Error al cargar los flujos de eventos de %{name}: %{error}"
+      data_types: "Error al cargar los tipos de datos: %{error}"
+      indexes: "Error al cargar los índices: %{error}"
+      foreign_keys: "Error al cargar las claves foráneas: %{error}"
+      routines: "Error al cargar las rutinas: %{error}"
+    list_buckets_failed: "Error al listar buckets: %{error}"
+    code_generation_failed: "Error al generar el código: %{error}"
+    loading_event_streams: Cargando flujos de eventos...
+    load_schema_failed: "Error al cargar el esquema: %{error}"
+    connect_database_failed: "Error al conectar a la base de datos: %{error}"
+    refresh_database_failed: "Error al actualizar la base de datos: %{error}"
+    database_refresh_pending: La actualización de la base de datos ya está en curso
+    prepare_schema_object_refresh_failed: Error al preparar la actualización del objeto del esquema
+    refresh_schema_object_failed: "Error al actualizar el objeto del esquema: %{error}"
     connected:
       plain: "Conectado a %{name}"
       one: "Conectado a %{name} (con 1 advertencia de hook)"

--- a/crates/dbflux_ui_sidebar/src/code_generation.rs
+++ b/crates/dbflux_ui_sidebar/src/code_generation.rs
@@ -204,7 +204,7 @@ impl Sidebar {
             Err(e) => {
                 log::error!("Code generation for view failed: {}", e);
                 self.pending_toast = Some(PendingToast {
-                    message: format!("Code generation failed: {}", e),
+                    message: crate::labels::code_generation_failed_label(&e.to_string()),
                     is_error: true,
                 });
                 cx.notify();
@@ -290,7 +290,7 @@ impl Sidebar {
                 Err(e) => {
                     log::error!("Code generation failed: {}", e);
                     self.pending_toast = Some(PendingToast {
-                        message: format!("Code generation failed: {}", e),
+                        message: crate::labels::code_generation_failed_label(&e.to_string()),
                         is_error: true,
                     });
                     cx.notify();

--- a/crates/dbflux_ui_sidebar/src/context_menu.rs
+++ b/crates/dbflux_ui_sidebar/src/context_menu.rs
@@ -1401,13 +1401,13 @@ impl Sidebar {
             }
             TableDetailsStatus::Loading => {
                 self.pending_toast = Some(PendingToast {
-                    message: "Loading event streams...".to_string(),
+                    message: crate::labels::loading_event_streams_toast_label(),
                     is_error: false,
                 });
             }
             TableDetailsStatus::NotFound => {
                 self.pending_toast = Some(PendingToast {
-                    message: "Event streams are not available for this collection".to_string(),
+                    message: dbflux_i18n::t!("sidebar.overlay.child_picker.unsupported"),
                     is_error: true,
                 });
             }

--- a/crates/dbflux_ui_sidebar/src/expansion.rs
+++ b/crates/dbflux_ui_sidebar/src/expansion.rs
@@ -779,7 +779,7 @@ impl Sidebar {
         let load_task_id = app_state.update(cx, |state, _| {
             let (task_id, _) = state.start_task_for_profile(
                 TaskKind::LoadSchema,
-                format!("Listing buckets: {profile_name}"),
+                crate::labels::listing_buckets_task_label(&profile_name),
                 Some(profile_id),
             );
             task_id
@@ -805,7 +805,7 @@ impl Sidebar {
                         });
                     }
                     Err(message) => {
-                        let details = format!("Failed to list buckets: {message}");
+                        let details = crate::labels::list_buckets_failed_label(message);
                         app_state.update(cx, |state, _| {
                             state.fail_task_with_details(load_task_id, message.clone(), details);
                         });

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -567,6 +567,123 @@ pub(crate) fn schema_snapshot_failed_label(error: &str) -> String {
     dbflux_i18n::t!("sidebar.toast.schema_snapshot_failed", error = error)
 }
 
+/// Translated `UserFacingError` message for a failed schema-types fetch.
+pub(crate) fn cannot_load_schema_types_label() -> String {
+    dbflux_i18n::t!("sidebar.error.cannot_load_schema_types")
+}
+
+/// Translated `UserFacingError` message for a failed schema-indexes fetch.
+pub(crate) fn cannot_load_schema_indexes_label() -> String {
+    dbflux_i18n::t!("sidebar.error.cannot_load_schema_indexes")
+}
+
+/// Translated `UserFacingError` message for a failed foreign-keys fetch.
+pub(crate) fn cannot_load_schema_foreign_keys_label() -> String {
+    dbflux_i18n::t!("sidebar.error.cannot_load_schema_foreign_keys")
+}
+
+/// Translated `UserFacingError` message for a failed routines fetch.
+pub(crate) fn cannot_load_schema_routines_label() -> String {
+    dbflux_i18n::t!("sidebar.error.cannot_load_schema_routines")
+}
+
+/// Translated toast reported when loading a schema's data types fails.
+pub(crate) fn data_types_load_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.load_failed.data_types", error = error)
+}
+
+/// Translated toast reported when loading a schema's indexes fails.
+pub(crate) fn indexes_load_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.load_failed.indexes", error = error)
+}
+
+/// Translated toast reported when loading a schema's foreign keys fails.
+pub(crate) fn foreign_keys_load_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.load_failed.foreign_keys", error = error)
+}
+
+/// Translated toast reported when loading a schema's routines fails.
+pub(crate) fn routines_load_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.load_failed.routines", error = error)
+}
+
+/// Translated task-panel label for a background bucket listing, e.g.
+/// `"Listing buckets: prod-db"`.
+pub(crate) fn listing_buckets_task_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.listing_buckets", name = name)
+}
+
+/// Translated task-failure detail reported when listing buckets fails.
+pub(crate) fn list_buckets_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.list_buckets_failed", error = error)
+}
+
+/// Translated toast reported when SQL/query code generation fails.
+pub(crate) fn code_generation_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.code_generation_failed", error = error)
+}
+
+/// Translated toast shown while an event-stream child-picker fetch is still
+/// loading in the background.
+pub(crate) fn loading_event_streams_toast_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.loading_event_streams")
+}
+
+/// Translated task-panel label for a database schema fetch, e.g. `"Loading
+/// schema: orders"`.
+pub(crate) fn loading_database_schema_task_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.loading_database_schema", name = name)
+}
+
+/// Translated toast reported when loading a database's schema fails.
+pub(crate) fn load_schema_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.load_schema_failed", error = error)
+}
+
+/// Translated task-panel label for a per-database connection switch, e.g.
+/// `"Connecting to database: orders"`.
+pub(crate) fn connecting_to_database_task_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.connecting_to_database", name = name)
+}
+
+/// Translated toast reported when switching the active database fails.
+pub(crate) fn connect_database_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.connect_database_failed", error = error)
+}
+
+/// Translated task-panel label for a database schema refresh, e.g.
+/// `"Refreshing database: orders"`.
+pub(crate) fn refreshing_database_task_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.refreshing_database", name = name)
+}
+
+/// Translated toast reported when a database schema refresh fails.
+pub(crate) fn refresh_database_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.refresh_database_failed", error = error)
+}
+
+/// Translated toast shown when a database refresh is rejected because one is
+/// already running for that database.
+pub(crate) fn database_refresh_pending_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.database_refresh_pending")
+}
+
+/// Translated task-panel label for a schema-object refresh, e.g.
+/// `"Refreshing schema object: orders"`.
+pub(crate) fn refreshing_schema_object_task_label(name: &str) -> String {
+    dbflux_i18n::t!("sidebar.task.refreshing_schema_object", name = name)
+}
+
+/// Translated toast shown when preparing a schema-object refresh fails.
+pub(crate) fn prepare_schema_object_refresh_failed_label() -> String {
+    dbflux_i18n::t!("sidebar.toast.prepare_schema_object_refresh_failed")
+}
+
+/// Translated toast reported when a schema-object refresh fails.
+pub(crate) fn refresh_schema_object_failed_label(error: &str) -> String {
+    dbflux_i18n::t!("sidebar.toast.refresh_schema_object_failed", error = error)
+}
+
 /// Translated task-panel label for the current pipeline stage, shown as a
 /// subtask under the pipeline connect task. Returns `None` for stages with
 /// no user-facing subtask (idle and terminal states).
@@ -1577,6 +1694,107 @@ mod tests {
         assert_eq!(
             label,
             dbflux_i18n::t!("sidebar.toast.schema_snapshot_failed", error = "disk full")
+        );
+    }
+
+    const E1_KEYS: [&str; 22] = [
+        "sidebar.error.cannot_load_schema_types",
+        "sidebar.error.cannot_load_schema_indexes",
+        "sidebar.error.cannot_load_schema_foreign_keys",
+        "sidebar.error.cannot_load_schema_routines",
+        "sidebar.toast.load_failed.data_types",
+        "sidebar.toast.load_failed.indexes",
+        "sidebar.toast.load_failed.foreign_keys",
+        "sidebar.toast.load_failed.routines",
+        "sidebar.task.listing_buckets",
+        "sidebar.toast.list_buckets_failed",
+        "sidebar.toast.code_generation_failed",
+        "sidebar.toast.loading_event_streams",
+        "sidebar.task.loading_database_schema",
+        "sidebar.toast.load_schema_failed",
+        "sidebar.task.connecting_to_database",
+        "sidebar.toast.connect_database_failed",
+        "sidebar.task.refreshing_database",
+        "sidebar.toast.refresh_database_failed",
+        "sidebar.toast.database_refresh_pending",
+        "sidebar.task.refreshing_schema_object",
+        "sidebar.toast.prepare_schema_object_refresh_failed",
+        "sidebar.toast.refresh_schema_object_failed",
+    ];
+
+    #[test]
+    fn sidebar_e1_keys_resolve_in_both_locales() {
+        for key in E1_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert_ne!(value, key, "missing translation for {locale}.{key}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "translation fell back to the miss sentinel for {locale}.{key}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sidebar_task_refreshing_database_diverges_between_locales() {
+        let english = dbflux_i18n::t!("sidebar.task.refreshing_database", locale = "en");
+        let spanish = dbflux_i18n::t!("sidebar.task.refreshing_database", locale = "es");
+
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn cannot_load_schema_types_label_is_stable() {
+        assert_eq!(
+            super::cannot_load_schema_types_label(),
+            dbflux_i18n::t!("sidebar.error.cannot_load_schema_types")
+        );
+    }
+
+    #[test]
+    fn data_types_load_failed_label_includes_the_error() {
+        let label = super::data_types_load_failed_label("connection reset");
+
+        assert!(label.contains("connection reset"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!(
+                "sidebar.toast.load_failed.data_types",
+                error = "connection reset"
+            )
+        );
+    }
+
+    #[test]
+    fn listing_buckets_task_label_includes_the_profile_name() {
+        let label = super::listing_buckets_task_label("prod-db");
+
+        assert!(label.contains("prod-db"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.task.listing_buckets", name = "prod-db")
+        );
+    }
+
+    #[test]
+    fn refreshing_database_task_label_includes_the_database_name() {
+        let label = super::refreshing_database_task_label("orders");
+
+        assert!(label.contains("orders"));
+        assert_eq!(
+            label,
+            dbflux_i18n::t!("sidebar.task.refreshing_database", name = "orders")
+        );
+    }
+
+    #[test]
+    fn database_refresh_pending_label_is_stable() {
+        assert_eq!(
+            super::database_refresh_pending_label(),
+            dbflux_i18n::t!("sidebar.toast.database_refresh_pending")
         );
     }
 }

--- a/crates/dbflux_ui_sidebar/src/operations/tree_ops.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/tree_ops.rs
@@ -351,7 +351,7 @@ impl Sidebar {
         Some(self.app_state.update(cx, |state, cx| {
             let task = state.start_task_for_target(
                 TaskKind::SchemaRefresh,
-                format!("Refreshing database: {}", database),
+                crate::labels::refreshing_database_task_label(database),
                 Some(task_target),
             );
             cx.emit(AppStateChanged);
@@ -428,7 +428,7 @@ impl Sidebar {
                     .insert(item_id.to_string(), root_expanded);
                 sidebar.expansion_overrides.extend(subtree_overrides);
                 sidebar.pending_toast = Some(PendingToast {
-                    message: format!("Failed to refresh database: {}", error),
+                    message: crate::labels::refresh_database_failed_label(&error),
                     is_error: true,
                 });
             }
@@ -474,7 +474,7 @@ impl Sidebar {
                     .insert(item_id.to_string(), root_expanded);
                 self.expansion_overrides.extend(subtree_overrides);
                 self.pending_toast = Some(PendingToast {
-                    message: format!("Failed to refresh database: {}", error),
+                    message: crate::labels::refresh_database_failed_label(&error),
                     is_error: true,
                 });
                 self.refresh_tree(cx);
@@ -493,7 +493,7 @@ impl Sidebar {
                 .insert(item_id.to_string(), root_expanded);
             self.expansion_overrides.extend(subtree_overrides);
             self.pending_toast = Some(PendingToast {
-                message: "Database refresh already pending".to_string(),
+                message: crate::labels::database_refresh_pending_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -570,7 +570,7 @@ impl Sidebar {
                     .insert(item_id.to_string(), root_expanded);
                 self.expansion_overrides.extend(subtree_overrides);
                 self.pending_toast = Some(PendingToast {
-                    message: format!("Failed to refresh database: {}", error),
+                    message: crate::labels::refresh_database_failed_label(&error),
                     is_error: true,
                 });
                 self.refresh_tree(cx);
@@ -589,7 +589,7 @@ impl Sidebar {
                 .insert(item_id.to_string(), root_expanded);
             self.expansion_overrides.extend(subtree_overrides);
             self.pending_toast = Some(PendingToast {
-                message: "Database refresh already pending".to_string(),
+                message: crate::labels::database_refresh_pending_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -682,7 +682,7 @@ impl Sidebar {
                 .insert(item_id.to_string(), root_expanded);
             self.expansion_overrides.extend(subtree_overrides);
             self.pending_toast = Some(PendingToast {
-                message: "Database refresh already pending".to_string(),
+                message: crate::labels::database_refresh_pending_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -834,7 +834,7 @@ impl Sidebar {
                 } else {
                     log::error!("Failed to load database schema: {}", e);
                     self.pending_toast = Some(PendingToast {
-                        message: format!("Failed to load schema: {}", e),
+                        message: crate::labels::load_schema_failed_label(&e),
                         is_error: true,
                     });
                 }
@@ -849,7 +849,7 @@ impl Sidebar {
                 state.finish_pending_operation(profile_id, Some(db_name));
             });
             self.pending_toast = Some(PendingToast {
-                message: "Too many background tasks running, please wait".to_string(),
+                message: crate::labels::background_task_limit_toast_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -858,8 +858,10 @@ impl Sidebar {
         }
 
         let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
-            let result =
-                state.start_task(TaskKind::LoadSchema, format!("Loading schema: {}", db_name));
+            let result = state.start_task(
+                TaskKind::LoadSchema,
+                crate::labels::loading_database_schema_task_label(db_name),
+            );
             cx.emit(AppStateChanged);
             result
         });
@@ -902,7 +904,7 @@ impl Sidebar {
                         });
                         (
                             Some(PendingToast {
-                                message: format!("Failed to load schema: {}", e),
+                                message: crate::labels::load_schema_failed_label(e),
                                 is_error: true,
                             }),
                             true,
@@ -1004,7 +1006,7 @@ impl Sidebar {
                 state.finish_pending_operation(profile_id, Some(db_name));
             });
             self.pending_toast = Some(PendingToast {
-                message: "Too many background tasks running, please wait".to_string(),
+                message: crate::labels::background_task_limit_toast_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -1015,7 +1017,7 @@ impl Sidebar {
         let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
             let result = state.start_task(
                 TaskKind::SwitchDatabase,
-                format!("Connecting to database: {}", db_name),
+                crate::labels::connecting_to_database_task_label(db_name),
             );
             cx.emit(AppStateChanged);
             result
@@ -1058,7 +1060,7 @@ impl Sidebar {
                             state.fail_task(task_id, e.clone());
                         });
                         Some(PendingToast {
-                            message: format!("Failed to connect to database: {}", e),
+                            message: crate::labels::connect_database_failed_label(e),
                             is_error: true,
                         })
                     }
@@ -1110,7 +1112,7 @@ impl Sidebar {
 
         if self.app_state.read(cx).is_background_task_limit_reached() {
             self.pending_toast = Some(PendingToast {
-                message: "Too many background tasks running, please wait".to_string(),
+                message: crate::labels::background_task_limit_toast_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -1123,7 +1125,7 @@ impl Sidebar {
             Ok(held_state) => held_state,
             Err(error) => {
                 self.pending_toast = Some(PendingToast {
-                    message: format!("Failed to refresh database: {}", error),
+                    message: crate::labels::refresh_database_failed_label(&error),
                     is_error: true,
                 });
                 self.refresh_tree(cx);
@@ -1176,7 +1178,7 @@ impl Sidebar {
 
         if self.app_state.read(cx).is_background_task_limit_reached() {
             self.pending_toast = Some(PendingToast {
-                message: "Too many background tasks running, please wait".to_string(),
+                message: crate::labels::background_task_limit_toast_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -1255,7 +1257,7 @@ impl Sidebar {
             }
 
             self.pending_toast = Some(PendingToast {
-                message: "Failed to prepare schema object refresh".to_string(),
+                message: crate::labels::prepare_schema_object_refresh_failed_label(),
                 is_error: true,
             });
             self.refresh_tree(cx);
@@ -1265,7 +1267,7 @@ impl Sidebar {
         let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
             let task = state.start_task_for_target(
                 TaskKind::SchemaRefresh,
-                format!("Refreshing schema object: {}", parts.object_name),
+                crate::labels::refreshing_schema_object_task_label(&parts.object_name),
                 Some(refresh_target),
             );
             cx.emit(AppStateChanged);
@@ -1435,7 +1437,7 @@ impl Sidebar {
                             });
 
                             sidebar.pending_toast = Some(PendingToast {
-                                message: format!("Failed to refresh schema object: {}", error),
+                                message: crate::labels::refresh_schema_object_failed_label(&error),
                                 is_error: true,
                             });
                         }

--- a/crates/dbflux_ui_sidebar/src/table_loading.rs
+++ b/crates/dbflux_ui_sidebar/src/table_loading.rs
@@ -413,8 +413,11 @@ impl Sidebar {
             Err(e) => {
                 if e != "Schema types already cached" {
                     report_error(
-                        UserFacingError::new(ErrorKind::Network, "Cannot load schema types")
-                            .with_cause(e),
+                        UserFacingError::new(
+                            ErrorKind::Network,
+                            crate::labels::cannot_load_schema_types_label(),
+                        )
+                        .with_cause(e),
                         cx,
                     );
                 }
@@ -431,7 +434,7 @@ impl Sidebar {
             None,
             task,
             "Failed to fetch schema types",
-            |error| format!("Failed to load data types: {}", error),
+            crate::labels::data_types_load_failed_label,
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_schema_types(res.profile_id, res.database, res.schema, res.types);
@@ -461,8 +464,11 @@ impl Sidebar {
             Err(e) => {
                 if e != "Schema indexes already cached" {
                     report_error(
-                        UserFacingError::new(ErrorKind::Network, "Cannot load schema indexes")
-                            .with_cause(e),
+                        UserFacingError::new(
+                            ErrorKind::Network,
+                            crate::labels::cannot_load_schema_indexes_label(),
+                        )
+                        .with_cause(e),
                         cx,
                     );
                 }
@@ -479,7 +485,7 @@ impl Sidebar {
             None,
             task,
             "Failed to fetch schema indexes",
-            |error| format!("Failed to load indexes: {}", error),
+            crate::labels::indexes_load_failed_label,
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_schema_indexes(res.profile_id, res.database, res.schema, res.indexes);
@@ -509,8 +515,11 @@ impl Sidebar {
             Err(e) => {
                 if e != "Schema foreign keys already cached" {
                     report_error(
-                        UserFacingError::new(ErrorKind::Network, "Cannot load schema foreign keys")
-                            .with_cause(e),
+                        UserFacingError::new(
+                            ErrorKind::Network,
+                            crate::labels::cannot_load_schema_foreign_keys_label(),
+                        )
+                        .with_cause(e),
                         cx,
                     );
                 }
@@ -527,7 +536,7 @@ impl Sidebar {
             None,
             task,
             "Failed to fetch schema foreign keys",
-            |error| format!("Failed to load foreign keys: {}", error),
+            crate::labels::foreign_keys_load_failed_label,
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_schema_foreign_keys(
@@ -561,8 +570,11 @@ impl Sidebar {
             Err(e) => {
                 if e != "Schema routines already cached" {
                     report_error(
-                        UserFacingError::new(ErrorKind::Network, "Cannot load schema routines")
-                            .with_cause(e),
+                        UserFacingError::new(
+                            ErrorKind::Network,
+                            crate::labels::cannot_load_schema_routines_label(),
+                        )
+                        .with_cause(e),
                         cx,
                     );
                 }
@@ -579,7 +591,7 @@ impl Sidebar {
             None,
             task,
             "Failed to fetch schema routines",
-            |error| format!("Failed to load routines: {}", error),
+            crate::labels::routines_load_failed_label,
             |app_state, res, cx| {
                 app_state.update(cx, |state, cx| {
                     state.set_schema_routines(


### PR DESCRIPTION
## Summary

Sidebar i18n slice E1 (final sweep): the schema types/indexes/foreign keys/routines load errors, the bucket listing task, code generation failures, the event-stream loading toast, and the database refresh/connect task titles and toasts in `operations/tree_ops.rs` render through `dbflux_i18n::t!` and the sidebar label helpers. English and Spanish together.

## What does this resolve?

- Refs #360 (follows D2; closes the sidebar series, verify + archive next)

## How was this solved?

- 22 keys under `sidebar.{error,task,toast}.*` with one helper each in `labels.rs`; cause strings embedded as `%{error}` stay as the driver reported them.
- Left English on purpose: `log::*` lines, cache sentinels compared with `!=`, and the key:value task detail lines in `operations/dnd.rs` (`Kind:`/`Target:`/`Database:`), which are technical detail text.

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 211 passed; clippy clean; fmt clean. Manual smoke in Spanish: expand a schema section while disconnected, list buckets, refresh a database.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
