### PR TITLE
feat(i18n): translate the connection manager auth flow, driver settings, and MCP governance

### DIFF
--- a/crates/dbflux/tests/mcp_ui_governance_acceptance_tests.rs
+++ b/crates/dbflux/tests/mcp_ui_governance_acceptance_tests.rs
@@ -42,8 +42,12 @@ fn ui_contains_trusted_client_and_connection_policy_controls() {
 
     assert!(connection_form.contains("save_mcp_connection_policy_assignment"));
     assert!(connection_form.contains("ConnectionPolicyUpdated"));
-    assert!(connection_tabs.contains("Scope/policy assignment preview"));
-    assert!(connection_tabs.contains("Enable MCP for this connection"));
+    assert!(connection_tabs.contains("connection_manager.scope_policy_preview"));
+    assert!(connection_tabs.contains("connection_manager.enable_mcp"));
+
+    let english_catalog = read_workspace_file("../dbflux_i18n/locales/en.yml");
+    assert!(english_catalog.contains("scope_policy_preview: Scope/policy assignment preview"));
+    assert!(english_catalog.contains("enable_mcp: Enable MCP for this connection"));
 }
 
 #[test]

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -144,6 +144,37 @@ connection_manager:
   filter_certificates: Certificates / keys
   filter_all_files: All files
   select_database_file: Select Database File
+  auth:
+    profile_created_sso: Selected profile created by AWS SSO wizard.
+    profile_created_wizard: Selected profile created by wizard.
+    refreshing_sessions: Refreshing auth profile sessions...
+    select_before_login: Select an auth profile before logging in.
+    provider_unavailable: "Auth provider '%{provider_id}' is not available."
+    interactive_login_unavailable: Interactive login is not available for this auth profile.
+    login_starting: "Starting auth-provider login for '%{name}'..."
+    login_completed: Auth-provider login completed.
+    login_failed: "Auth-provider login failed: %{error}"
+    session_status_valid_expires: "Session status: valid (expires at %{expires_at})"
+    session_status_valid: "Session status: valid"
+    session_status_expired: "Session status: expired"
+    session_status_login_required: "Session status: login required"
+  driver_settings_title: Driver Settings
+  driver_no_custom_settings: This driver has no custom settings.
+  mcp_disabled: MCP disabled for this connection
+  mcp_enabled_select_actor: MCP enabled — select a trusted client to bind
+  mcp_preview_summary: "Actor '%{actor}' | role: %{role} | policy: %{policy}"
+  mcp_preview_none: none
+  mcp_governance_title: MCP Governance
+  enable_mcp: Enable MCP for this connection
+  trusted_client_actor: Trusted Client (Actor)
+  mcp_actor_hint: AI agent identity — configure in Settings → MCP
+  role_label: Role
+  mcp_role_hint: Configure roles in Settings → MCP → Roles
+  additional_roles_optional: Additional roles (optional)
+  policy_label: Policy
+  mcp_policy_hint: Configure policies in Settings → MCP → Policies
+  additional_policies_optional: Additional policies (optional)
+  scope_policy_preview: Scope/policy assignment preview
 document:
   code:
     toolbar:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -144,6 +144,37 @@ connection_manager:
   filter_certificates: Certificados / claves
   filter_all_files: Todos los archivos
   select_database_file: Seleccionar archivo de base de datos
+  auth:
+    profile_created_sso: Perfil seleccionado creado por el asistente de AWS SSO.
+    profile_created_wizard: Perfil seleccionado creado por el asistente.
+    refreshing_sessions: Actualizando sesiones de perfiles de autenticación...
+    select_before_login: Selecciona un perfil de autenticación antes de iniciar sesión.
+    provider_unavailable: "El proveedor de autenticación '%{provider_id}' no está disponible."
+    interactive_login_unavailable: El inicio de sesión interactivo no está disponible para este perfil.
+    login_starting: "Iniciando sesión del proveedor de autenticación para '%{name}'..."
+    login_completed: Inicio de sesión del proveedor completado.
+    login_failed: "Error al iniciar sesión con el proveedor: %{error}"
+    session_status_valid_expires: "Estado de la sesión: válida (expira el %{expires_at})"
+    session_status_valid: "Estado de la sesión: válida"
+    session_status_expired: "Estado de la sesión: expirada"
+    session_status_login_required: "Estado de la sesión: requiere inicio de sesión"
+  driver_settings_title: Ajustes del driver
+  driver_no_custom_settings: Este driver no tiene ajustes personalizados.
+  mcp_disabled: MCP deshabilitado para esta conexión
+  mcp_enabled_select_actor: MCP habilitado — selecciona un cliente de confianza para vincular
+  mcp_preview_summary: "Actor '%{actor}' | rol: %{role} | política: %{policy}"
+  mcp_preview_none: ninguno
+  mcp_governance_title: Gobernanza de MCP
+  enable_mcp: Habilitar MCP para esta conexión
+  trusted_client_actor: Cliente de confianza (actor)
+  mcp_actor_hint: Identidad del agente de IA — configúrala en Ajustes → MCP
+  role_label: Rol
+  mcp_role_hint: Configura roles en Ajustes → MCP → Roles
+  additional_roles_optional: Roles adicionales (opcional)
+  policy_label: Política
+  mcp_policy_hint: Configura políticas en Ajustes → MCP → Políticas
+  additional_policies_optional: Políticas adicionales (opcional)
+  scope_policy_preview: Vista previa de alcance y políticas
 document:
   code:
     toolbar:

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -2881,8 +2881,9 @@ impl ConnectionManagerWindow {
                     self.access.selected_ssm_auth_profile_id = Some(profile_id);
                 }
 
-                self.auth_profile.auth_profile_action_message =
-                    Some("Selected profile created by AWS SSO wizard.".to_string());
+                self.auth_profile.auth_profile_action_message = Some(dbflux_i18n::t!(
+                    "connection_manager.auth.profile_created_sso"
+                ));
             }
 
             self.auth_profile.pending_wizard_auth_profile_selection = false;
@@ -2902,8 +2903,9 @@ impl ConnectionManagerWindow {
         }
 
         self.auth_profile.pending_wizard_auth_profile_selection = false;
-        self.auth_profile.auth_profile_action_message =
-            Some("Selected profile created by wizard.".to_string());
+        self.auth_profile.auth_profile_action_message = Some(dbflux_i18n::t!(
+            "connection_manager.auth.profile_created_wizard"
+        ));
 
         self.populate_auth_profile_dropdown(cx);
         self.refresh_auth_profile_sessions(cx);
@@ -2911,16 +2913,18 @@ impl ConnectionManagerWindow {
     }
 
     fn refresh_auth_profile_statuses(&mut self, cx: &mut Context<Self>) {
-        self.auth_profile.auth_profile_action_message =
-            Some("Refreshing auth profile sessions...".to_string());
+        self.auth_profile.auth_profile_action_message = Some(dbflux_i18n::t!(
+            "connection_manager.auth.refreshing_sessions"
+        ));
         self.refresh_auth_profile_sessions(cx);
         cx.notify();
     }
 
     fn login_selected_auth_profile(&mut self, cx: &mut Context<Self>) {
         let Some(profile) = self.selected_auth_profile(cx) else {
-            self.auth_profile.auth_profile_action_message =
-                Some("Select an auth profile before logging in.".to_string());
+            self.auth_profile.auth_profile_action_message = Some(dbflux_i18n::t!(
+                "connection_manager.auth.select_before_login"
+            ));
             cx.notify();
             return;
         };
@@ -2930,26 +2934,24 @@ impl ConnectionManagerWindow {
             .read(cx)
             .auth_provider_by_id(&profile.provider_id)
         else {
-            self.auth_profile.auth_profile_action_message = Some(format!(
-                "Auth provider '{}' is not available.",
-                profile.provider_id
-            ));
+            self.auth_profile.auth_profile_action_message = Some(
+                crate::labels::auth_provider_unavailable(&profile.provider_id),
+            );
             cx.notify();
             return;
         };
 
         if !provider.capabilities().login.supported {
-            self.auth_profile.auth_profile_action_message =
-                Some("Interactive login is not available for this auth profile.".to_string());
+            self.auth_profile.auth_profile_action_message = Some(dbflux_i18n::t!(
+                "connection_manager.auth.interactive_login_unavailable"
+            ));
             cx.notify();
             return;
         }
 
         self.auth_profile.auth_profile_login_in_progress = true;
-        self.auth_profile.auth_profile_action_message = Some(format!(
-            "Starting auth-provider login for '{}'...",
-            profile.name
-        ));
+        self.auth_profile.auth_profile_action_message =
+            Some(crate::labels::auth_login_starting(&profile.name));
         cx.notify();
 
         let this = cx.entity().clone();
@@ -2962,8 +2964,10 @@ impl ConnectionManagerWindow {
                     this.update(cx, |this, cx| {
                         this.auth_profile.auth_profile_login_in_progress = false;
                         this.auth_profile.auth_profile_action_message = Some(match result {
-                            Ok(_) => "Auth-provider login completed.".to_string(),
-                            Err(error) => format!("Auth-provider login failed: {}", error),
+                            Ok(_) => {
+                                dbflux_i18n::t!("connection_manager.auth.login_completed")
+                            }
+                            Err(error) => crate::labels::auth_login_failed(&error.to_string()),
                         });
 
                         this.refresh_auth_profile_sessions(cx);
@@ -2987,16 +2991,22 @@ impl ConnectionManagerWindow {
         let text = match status {
             AuthSessionState::Valid { expires_at } => {
                 if let Some(expires_at) = expires_at {
-                    return Some(format!("Session status: valid (expires at {})", expires_at));
+                    return Some(crate::labels::auth_session_status_valid_expires(
+                        &expires_at.to_string(),
+                    ));
                 }
 
-                "Session status: valid"
+                dbflux_i18n::t!("connection_manager.auth.session_status_valid")
             }
-            AuthSessionState::Expired => "Session status: expired",
-            AuthSessionState::LoginRequired => "Session status: login required",
+            AuthSessionState::Expired => {
+                dbflux_i18n::t!("connection_manager.auth.session_status_expired")
+            }
+            AuthSessionState::LoginRequired => {
+                dbflux_i18n::t!("connection_manager.auth.session_status_login_required")
+            }
         };
 
-        Some(text.to_string())
+        Some(text)
     }
 
     fn selected_auth_profile_is_valid(&self, cx: &App) -> bool {
@@ -4059,5 +4069,61 @@ mod tests {
                 "dropdown item id must stay untranslated for locale {locale}"
             );
         }
+    }
+
+    // --- auth flow i18n ---
+
+    const CONNECTION_MANAGER_AUTH_KEYS: &[&str] = &[
+        "connection_manager.auth.profile_created_sso",
+        "connection_manager.auth.profile_created_wizard",
+        "connection_manager.auth.refreshing_sessions",
+        "connection_manager.auth.select_before_login",
+        "connection_manager.auth.provider_unavailable",
+        "connection_manager.auth.interactive_login_unavailable",
+        "connection_manager.auth.login_starting",
+        "connection_manager.auth.login_completed",
+        "connection_manager.auth.login_failed",
+        "connection_manager.auth.session_status_valid_expires",
+        "connection_manager.auth.session_status_valid",
+        "connection_manager.auth.session_status_expired",
+        "connection_manager.auth.session_status_login_required",
+    ];
+
+    #[test]
+    fn connection_manager_auth_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in CONNECTION_MANAGER_AUTH_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn connection_manager_auth_login_completed_differs_between_locales() {
+        let en = dbflux_i18n::t!("connection_manager.auth.login_completed", locale = "en");
+        let es = dbflux_i18n::t!("connection_manager.auth.login_completed", locale = "es");
+
+        assert_ne!(
+            en, es,
+            "connection_manager.auth.login_completed should differ between en and es"
+        );
+    }
+
+    #[test]
+    fn connection_manager_auth_login_completed_exact_english_value() {
+        let en = dbflux_i18n::t!("connection_manager.auth.login_completed", locale = "en");
+
+        assert_eq!(en, "Auth-provider login completed.");
     }
 }

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -737,13 +737,22 @@ impl ConnectionManagerWindow {
             );
 
             sections.push(
-                self.render_section("Driver Settings", schema_fields, &theme)
-                    .into_any_element(),
+                self.render_section(
+                    &dbflux_i18n::t!("connection_manager.driver_settings_title"),
+                    schema_fields,
+                    &theme,
+                )
+                .into_any_element(),
             );
         }
 
         if sections.len() == 1 {
-            sections.push(Text::muted("This driver has no custom settings.").into_any_element());
+            sections.push(
+                Text::muted(dbflux_i18n::t!(
+                    "connection_manager.driver_no_custom_settings"
+                ))
+                .into_any_element(),
+            );
         }
 
         sections
@@ -768,7 +777,7 @@ impl ConnectionManagerWindow {
             .selected_value()
             .filter(|v| !v.is_empty())
             .map(|v| v.to_string())
-            .unwrap_or_else(|| "none".to_string());
+            .unwrap_or_else(|| dbflux_i18n::t!("connection_manager.mcp_preview_none"));
         let policy_label = self
             .mcp_tab
             .conn_mcp_policy_dropdown
@@ -776,17 +785,14 @@ impl ConnectionManagerWindow {
             .selected_value()
             .filter(|v| !v.is_empty())
             .map(|v| v.to_string())
-            .unwrap_or_else(|| "none".to_string());
+            .unwrap_or_else(|| dbflux_i18n::t!("connection_manager.mcp_preview_none"));
 
         let preview_text = if !enabled {
-            "MCP disabled for this connection".to_string()
+            dbflux_i18n::t!("connection_manager.mcp_disabled")
         } else if actor_label.is_empty() {
-            "MCP enabled — select a trusted client to bind".to_string()
+            dbflux_i18n::t!("connection_manager.mcp_enabled_select_actor")
         } else {
-            format!(
-                "Actor '{}' | role: {} | policy: {}",
-                actor_label, role_label, policy_label
-            )
+            crate::labels::mcp_preview_summary(&actor_label, &role_label, &policy_label)
         };
 
         let content = div()
@@ -804,7 +810,11 @@ impl ConnectionManagerWindow {
                             cx.notify();
                         }),
                     ))
-                    .child(div().text_sm().child("Enable MCP for this connection")),
+                    .child(
+                        div()
+                            .text_sm()
+                            .child(dbflux_i18n::t!("connection_manager.enable_mcp")),
+                    ),
             )
             .child(
                 div()
@@ -812,10 +822,12 @@ impl ConnectionManagerWindow {
                     .flex_col()
                     .gap_1()
                     .opacity(opacity)
-                    .child(Label::new("Trusted Client (Actor)"))
-                    .child(Text::caption(
-                        "AI agent identity — configure in Settings → MCP",
-                    ))
+                    .child(Label::new(dbflux_i18n::t!(
+                        "connection_manager.trusted_client_actor"
+                    )))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "connection_manager.mcp_actor_hint"
+                    )))
                     .child(self.mcp_tab.conn_mcp_actor_dropdown.clone()),
             )
             .child(
@@ -824,12 +836,14 @@ impl ConnectionManagerWindow {
                     .flex_col()
                     .gap_1()
                     .opacity(opacity)
-                    .child(Label::new("Role"))
-                    .child(Text::caption(
-                        "Configure roles in Settings \u{2192} MCP \u{2192} Roles",
-                    ))
+                    .child(Label::new(dbflux_i18n::t!("connection_manager.role_label")))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "connection_manager.mcp_role_hint"
+                    )))
                     .child(self.mcp_tab.conn_mcp_role_dropdown.clone())
-                    .child(Text::caption("Additional roles (optional)"))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "connection_manager.additional_roles_optional"
+                    )))
                     .child(self.mcp_tab.conn_mcp_role_multi_select.clone()),
             )
             .child(
@@ -838,20 +852,31 @@ impl ConnectionManagerWindow {
                     .flex_col()
                     .gap_1()
                     .opacity(opacity)
-                    .child(Text::label("Policy"))
-                    .child(Text::caption(
-                        "Configure policies in Settings \u{2192} MCP \u{2192} Policies",
-                    ))
+                    .child(Text::label(dbflux_i18n::t!(
+                        "connection_manager.policy_label"
+                    )))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "connection_manager.mcp_policy_hint"
+                    )))
                     .child(self.mcp_tab.conn_mcp_policy_dropdown.clone())
-                    .child(Text::caption("Additional policies (optional)"))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "connection_manager.additional_policies_optional"
+                    )))
                     .child(self.mcp_tab.conn_mcp_policy_multi_select.clone()),
             )
-            .child(Text::caption("Scope/policy assignment preview").into_any_element())
+            .child(
+                Text::caption(dbflux_i18n::t!("connection_manager.scope_policy_preview"))
+                    .into_any_element(),
+            )
             .child(Text::body(preview_text));
 
         vec![
-            self.render_section("MCP Governance", content, &theme)
-                .into_any_element(),
+            self.render_section(
+                &dbflux_i18n::t!("connection_manager.mcp_governance_title"),
+                content,
+                &theme,
+            )
+            .into_any_element(),
         ]
     }
 }
@@ -955,6 +980,66 @@ mod connection_overrides_i18n_tests {
             dbflux_i18n::t!("connection_manager.overrides.off", locale = "en"),
             "Off"
         );
+    }
+}
+
+#[cfg(test)]
+mod driver_settings_and_mcp_governance_i18n_tests {
+    const DRIVER_SETTINGS_AND_MCP_KEYS: &[&str] = &[
+        "connection_manager.driver_settings_title",
+        "connection_manager.driver_no_custom_settings",
+        "connection_manager.mcp_disabled",
+        "connection_manager.enable_mcp",
+        "connection_manager.trusted_client_actor",
+        "connection_manager.role_label",
+        "connection_manager.additional_roles_optional",
+        "connection_manager.policy_label",
+        "connection_manager.additional_policies_optional",
+        "connection_manager.scope_policy_preview",
+        "connection_manager.mcp_governance_title",
+        "connection_manager.mcp_enabled_select_actor",
+        "connection_manager.mcp_actor_hint",
+        "connection_manager.mcp_role_hint",
+        "connection_manager.mcp_policy_hint",
+        "connection_manager.mcp_preview_none",
+    ];
+
+    #[test]
+    fn driver_settings_and_mcp_governance_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in DRIVER_SETTINGS_AND_MCP_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn connection_manager_mcp_governance_title_differs_between_locales() {
+        let en = dbflux_i18n::t!("connection_manager.mcp_governance_title", locale = "en");
+        let es = dbflux_i18n::t!("connection_manager.mcp_governance_title", locale = "es");
+
+        assert_ne!(
+            en, es,
+            "connection_manager.mcp_governance_title should differ between en and es"
+        );
+    }
+
+    #[test]
+    fn connection_manager_driver_settings_title_exact_english_value() {
+        let en = dbflux_i18n::t!("connection_manager.driver_settings_title", locale = "en");
+
+        assert_eq!(en, "Driver Settings");
     }
 }
 // primitive itself.

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -119,13 +119,51 @@ pub(crate) fn ssh_private_key_with_path(path: &str) -> String {
     dbflux_i18n::t!("ssh.private_key_with_path", path = path)
 }
 
+/// Formats the toast shown when the selected auth profile's provider is not registered.
+pub(crate) fn auth_provider_unavailable(provider_id: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.auth.provider_unavailable",
+        provider_id = provider_id
+    )
+}
+
+/// Formats the status message shown while an auth-provider login is starting.
+pub(crate) fn auth_login_starting(name: &str) -> String {
+    dbflux_i18n::t!("connection_manager.auth.login_starting", name = name)
+}
+
+/// Formats the status message shown when an auth-provider login fails.
+pub(crate) fn auth_login_failed(error: &str) -> String {
+    dbflux_i18n::t!("connection_manager.auth.login_failed", error = error)
+}
+
+/// Formats the "Session status: valid (expires at <timestamp>)" caption.
+pub(crate) fn auth_session_status_valid_expires(expires_at: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.auth.session_status_valid_expires",
+        expires_at = expires_at
+    )
+}
+
+/// Formats the MCP tab's "Actor 'x' | role: y | policy: z" scope/policy preview line.
+pub(crate) fn mcp_preview_summary(actor: &str, role: &str, policy: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.mcp_preview_summary",
+        actor = actor,
+        role = role,
+        policy = policy
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        access_proxy_disabled_label, hooks_create_dir_failed, hooks_delete_message,
-        hooks_delete_unreadable_message, hooks_duplicate_id, hooks_env_pair_invalid,
-        hooks_form_interpreter_hint, hooks_interpreter_auto_label, hooks_interpreter_missing,
-        hooks_open_script_failed, hooks_write_script_failed, ssh_private_key_with_path,
+        access_proxy_disabled_label, auth_login_failed, auth_login_starting,
+        auth_provider_unavailable, auth_session_status_valid_expires, hooks_create_dir_failed,
+        hooks_delete_message, hooks_delete_unreadable_message, hooks_duplicate_id,
+        hooks_env_pair_invalid, hooks_form_interpreter_hint, hooks_interpreter_auto_label,
+        hooks_interpreter_missing, hooks_open_script_failed, hooks_write_script_failed,
+        mcp_preview_summary, ssh_private_key_with_path,
     };
 
     #[test]
@@ -216,6 +254,47 @@ mod tests {
         let message = ssh_private_key_with_path("~/.ssh/id_ed25519");
 
         assert_eq!(message, "Private Key (~/.ssh/id_ed25519)");
+    }
+
+    #[test]
+    fn auth_provider_unavailable_embeds_provider_id_untouched() {
+        let message = auth_provider_unavailable("acme-mongo");
+
+        assert!(message.contains("acme-mongo"));
+    }
+
+    #[test]
+    fn auth_login_starting_embeds_profile_name() {
+        let message = auth_login_starting("prod-mongo");
+
+        assert_eq!(message, "Starting auth-provider login for 'prod-mongo'...");
+    }
+
+    #[test]
+    fn auth_login_failed_embeds_error_cause() {
+        let message = auth_login_failed("token expired");
+
+        assert_eq!(message, "Auth-provider login failed: token expired");
+    }
+
+    #[test]
+    fn auth_session_status_valid_expires_embeds_timestamp() {
+        let message = auth_session_status_valid_expires("2026-08-22 00:00:00 UTC");
+
+        assert_eq!(
+            message,
+            "Session status: valid (expires at 2026-08-22 00:00:00 UTC)"
+        );
+    }
+
+    #[test]
+    fn mcp_preview_summary_embeds_actor_role_policy() {
+        let message = mcp_preview_summary("prod-agent", "read-only", "strict");
+
+        assert_eq!(
+            message,
+            "Actor 'prod-agent' | role: read-only | policy: strict"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Thirteenth `dbflux_ui_windows` i18n slice: the auth profile login/refresh/status messages, the SSO wizard callbacks, the driver settings section and the MCP governance tab render through `dbflux_i18n::t!` and labels.rs helpers under `connection_manager.*`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows the overrides PR; next: dialogs, tabs and driver select)

## How was this solved?

- Size: 410 lines (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 240 passed; clippy clean; fmt clean. Manual smoke in Spanish: log in with an auth profile from the connection manager, open the MCP tab.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
