### PR TITLE
feat(i18n): translate the visual query builder panel and section controls

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -475,14 +475,88 @@ document:
         references: REFERENCES
         row: ROW
   query_builder:
+    aggregate:
+      fn:
+        count_star: "COUNT(*)"
+        count: COUNT
+        count_distinct: COUNT DISTINCT
+        sum: SUM
+        avg: AVG
+        min: MIN
+        max: MAX
+    assignments:
+      add_button: "+ Add assignment"
+      column_placeholder: column
+      value_placeholder: value
+      raw_sql_warning: "Raw SQL — expression is interpolated verbatim. Verify before running."
+      kind:
+        literal: Literal
+        raw_sql: Raw SQL
+        "null": "NULL"
+        default: DEFAULT
     chrome:
       save: Save
       reset: Reset
       untitled_query: Untitled query
+    columns:
+      all_columns: "All columns (*)"
+    comparator:
+      eq: "="
+      neq: "≠"
+      gt: ">"
+      lt: "<"
+      gte: "≥"
+      lte: "≤"
+      like: LIKE
+      ilike: ILIKE
+      in: IN
+      is_null: IS NULL
+      is_not_null: IS NOT NULL
+    execution:
+      mode_label: "Mode:"
+      chunk_size_label: "Chunk size:"
+      lock_timeout_label: "Lock timeout (ms):"
+      lock_timeout_none: none
+      counting: "Counting rows…"
+      rows_estimated: "%{count} rows estimated"
+      timed_out: "Row count timed out — chunked mode recommended"
+      failed: "Row count failed: %{message}"
+      mode:
+        single_tx: Single TX
+        chunked_tx: Chunked TX
+        direct: Direct
+    filters:
+      no_filters: No filters
+      add_filter: "+ Filter"
+      add_subgroup: "+ Sub-group"
+      max_depth: "Maximum filter nesting depth reached (%{depth} levels)"
+      bool_op:
+        and: AND
+        or: OR
+    group_by:
+      heading: Group by columns
+      add_column: "+ Group-by column"
+      aggregates_heading: Aggregates
+      add_aggregate: "+ %{function}"
+      alias_placeholder: alias
+    join:
+      kind:
+        inner: INNER
+        left: LEFT
+        right: RIGHT
+        full: FULL
+    joins:
+      no_fk_metadata: "No foreign key metadata available. Enter conditions as raw expressions."
+      loading_fk: "Loading foreign keys…"
+      add_join: "+ Join"
+      add_condition: "+ Condition"
+      table_placeholder: table
     mode:
       select: SELECT
       update: UPDATE
       delete: DELETE
+    mutation:
+      preview_placeholder: "-- %{kind}: configure assignments / filter to preview SQL"
     section:
       columns: COLUMNS
       execution: EXECUTION
@@ -490,6 +564,14 @@ document:
       filters_where: FILTERS (WHERE)
       sort: SORT
       sql_preview: SQL PREVIEW
+    sort:
+      direction:
+        asc: ASC
+        desc: DESC
+      key_order: Sort key order
+      key_order_named: "Sort key order (%{name})"
+      key_limited_hint: Ordering is limited to the sort key for this driver.
+      invalid_column: "\"%{column}\" is not in the GROUP BY columns or aggregate aliases"
     status:
       limit: Limit
       offset: Offset
@@ -503,6 +585,7 @@ document:
         one: "%{count} aggregate row is incomplete and will be excluded from the query"
         many: "%{count} aggregate rows are incomplete and will be excluded from the query"
   shared:
+    add: Add
     refresh:
       off: Off
       custom: Custom

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -475,14 +475,88 @@ document:
         references: REFERENCIAS
         row: FILA
   query_builder:
+    aggregate:
+      fn:
+        count_star: "COUNT(*)"
+        count: COUNT
+        count_distinct: COUNT DISTINCT
+        sum: SUM
+        avg: AVG
+        min: MIN
+        max: MAX
+    assignments:
+      add_button: "+ Agregar asignación"
+      column_placeholder: columna
+      value_placeholder: valor
+      raw_sql_warning: "SQL sin procesar — la expresión se interpola literalmente. Verifique antes de ejecutar."
+      kind:
+        literal: Valor literal
+        raw_sql: SQL sin procesar
+        "null": "NULL"
+        default: DEFAULT
     chrome:
       save: Guardar
       reset: Restablecer
       untitled_query: Consulta sin título
+    columns:
+      all_columns: "Todas las columnas (*)"
+    comparator:
+      eq: "="
+      neq: "≠"
+      gt: ">"
+      lt: "<"
+      gte: "≥"
+      lte: "≤"
+      like: LIKE
+      ilike: ILIKE
+      in: IN
+      is_null: IS NULL
+      is_not_null: IS NOT NULL
+    execution:
+      mode_label: "Modo:"
+      chunk_size_label: "Tamaño de lote:"
+      lock_timeout_label: "Tiempo de espera del bloqueo (ms):"
+      lock_timeout_none: ninguno
+      counting: "Contando filas…"
+      rows_estimated: "%{count} filas estimadas"
+      timed_out: "El conteo de filas expiró — se recomienda el modo por lotes"
+      failed: "Error al contar filas: %{message}"
+      mode:
+        single_tx: TX única
+        chunked_tx: TX por lotes
+        direct: Directo
+    filters:
+      no_filters: Sin filtros
+      add_filter: "+ Filtro"
+      add_subgroup: "+ Subgrupo"
+      max_depth: "Se alcanzó la profundidad máxima de anidamiento de filtros (%{depth} niveles)"
+      bool_op:
+        and: AND
+        or: OR
+    group_by:
+      heading: Agrupar por columnas
+      add_column: "+ Columna de agrupación"
+      aggregates_heading: Agregaciones
+      add_aggregate: "+ %{function}"
+      alias_placeholder: alias
+    join:
+      kind:
+        inner: INNER
+        left: LEFT
+        right: RIGHT
+        full: FULL
+    joins:
+      no_fk_metadata: "No hay metadatos de clave foránea disponibles. Ingrese las condiciones como expresiones sin procesar."
+      loading_fk: "Cargando claves foráneas…"
+      add_join: "+ Unión"
+      add_condition: "+ Condición"
+      table_placeholder: tabla
     mode:
       select: SELECT
       update: UPDATE
       delete: DELETE
+    mutation:
+      preview_placeholder: "-- %{kind}: configure las asignaciones o el filtro para previsualizar el SQL"
     section:
       columns: COLUMNAS
       execution: EJECUCIÓN
@@ -490,6 +564,14 @@ document:
       filters_where: FILTROS (WHERE)
       sort: ORDEN
       sql_preview: VISTA PREVIA SQL
+    sort:
+      direction:
+        asc: ASC
+        desc: DESC
+      key_order: Orden de la clave de ordenamiento
+      key_order_named: "Orden de la clave de ordenamiento (%{name})"
+      key_limited_hint: El ordenamiento está limitado a la clave de ordenamiento para este controlador.
+      invalid_column: "\"%{column}\" no está en las columnas de GROUP BY ni en los alias de agregación"
     status:
       limit: Límite
       offset: Desplazamiento
@@ -503,6 +585,7 @@ document:
         one: "%{count} fila agregada está incompleta y se excluirá de la consulta"
         many: "%{count} filas agregadas están incompletas y se excluirán de la consulta"
   shared:
+    add: Agregar
     refresh:
       off: Apagado
       custom: Personalizado

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -613,17 +613,179 @@ pub(crate) fn dangerous_query_body(kind: dbflux_core::DangerousQueryKind) -> Str
     }
 }
 
+/// Label for a `dbflux_core::Comparator` shown in filter/join predicate rows.
+///
+/// Every arm routes through the catalog for translation consistency, but the
+/// `en`/`es` catalog values stay byte-identical because these are SQL
+/// operators, not prose.
+pub(crate) fn comparator_label(comparator: dbflux_core::Comparator) -> String {
+    use dbflux_core::Comparator;
+
+    match comparator {
+        Comparator::Eq => dbflux_i18n::t!("document.query_builder.comparator.eq"),
+        Comparator::Neq => dbflux_i18n::t!("document.query_builder.comparator.neq"),
+        Comparator::Gt => dbflux_i18n::t!("document.query_builder.comparator.gt"),
+        Comparator::Lt => dbflux_i18n::t!("document.query_builder.comparator.lt"),
+        Comparator::Gte => dbflux_i18n::t!("document.query_builder.comparator.gte"),
+        Comparator::Lte => dbflux_i18n::t!("document.query_builder.comparator.lte"),
+        Comparator::Like => dbflux_i18n::t!("document.query_builder.comparator.like"),
+        Comparator::ILike => dbflux_i18n::t!("document.query_builder.comparator.ilike"),
+        Comparator::In => dbflux_i18n::t!("document.query_builder.comparator.in"),
+        Comparator::IsNull => dbflux_i18n::t!("document.query_builder.comparator.is_null"),
+        Comparator::IsNotNull => {
+            dbflux_i18n::t!("document.query_builder.comparator.is_not_null")
+        }
+    }
+}
+
+/// Label for a `dbflux_core::JoinKind` shown in the join-kind dropdown.
+///
+/// Every arm routes through the catalog for translation consistency, but the
+/// `en`/`es` catalog values stay byte-identical because these are SQL join
+/// keywords, not prose.
+pub(crate) fn join_kind_label(kind: dbflux_core::JoinKind) -> String {
+    use dbflux_core::JoinKind;
+
+    match kind {
+        JoinKind::Inner => dbflux_i18n::t!("document.query_builder.join.kind.inner"),
+        JoinKind::Left => dbflux_i18n::t!("document.query_builder.join.kind.left"),
+        JoinKind::Right => dbflux_i18n::t!("document.query_builder.join.kind.right"),
+        JoinKind::Full => dbflux_i18n::t!("document.query_builder.join.kind.full"),
+    }
+}
+
+/// Display text for a `dbflux_core::AggFn` shown in aggregate function
+/// dropdowns and the "+ function" quick-add buttons.
+///
+/// Every arm routes through the catalog for translation consistency, but the
+/// `en`/`es` catalog values stay byte-identical because these are SQL
+/// aggregate function names, not prose.
+pub(crate) fn agg_fn_display(function: dbflux_core::AggFn) -> String {
+    use dbflux_core::AggFn;
+
+    match function {
+        AggFn::CountStar => dbflux_i18n::t!("document.query_builder.aggregate.fn.count_star"),
+        AggFn::Count => dbflux_i18n::t!("document.query_builder.aggregate.fn.count"),
+        AggFn::CountDistinct => {
+            dbflux_i18n::t!("document.query_builder.aggregate.fn.count_distinct")
+        }
+        AggFn::Sum => dbflux_i18n::t!("document.query_builder.aggregate.fn.sum"),
+        AggFn::Avg => dbflux_i18n::t!("document.query_builder.aggregate.fn.avg"),
+        AggFn::Min => dbflux_i18n::t!("document.query_builder.aggregate.fn.min"),
+        AggFn::Max => dbflux_i18n::t!("document.query_builder.aggregate.fn.max"),
+    }
+}
+
+/// Label for a `dbflux_core::BoolOp` shown on the AND/OR group-toggle button
+/// in the Filters and Joins sections.
+///
+/// Every arm routes through the catalog for translation consistency, but the
+/// `en`/`es` catalog values stay byte-identical because these are SQL boolean
+/// keywords, not prose.
+pub(crate) fn bool_op_label(op: dbflux_core::BoolOp) -> String {
+    use dbflux_core::BoolOp;
+
+    match op {
+        BoolOp::And => dbflux_i18n::t!("document.query_builder.filters.bool_op.and"),
+        BoolOp::Or => dbflux_i18n::t!("document.query_builder.filters.bool_op.or"),
+    }
+}
+
+/// Label for a `dbflux_core::VisualSortDirection` shown on sort-direction
+/// toggle buttons.
+///
+/// Every arm routes through the catalog for translation consistency, but the
+/// `en`/`es` catalog values stay byte-identical because these are SQL sort
+/// keywords, not prose.
+pub(crate) fn sort_direction_label(direction: dbflux_core::VisualSortDirection) -> String {
+    use dbflux_core::VisualSortDirection;
+
+    match direction {
+        VisualSortDirection::Asc => dbflux_i18n::t!("document.query_builder.sort.direction.asc"),
+        VisualSortDirection::Desc => {
+            dbflux_i18n::t!("document.query_builder.sort.direction.desc")
+        }
+    }
+}
+
+/// Label for an `AssignmentValue` kind-cycle button in the mutation
+/// assignments section.
+///
+/// `Null` and `Default` render the literal SQL keywords `NULL`/`DEFAULT`
+/// (byte-identical across locales); `Literal` and `Expression` are UI
+/// concept names and translate normally.
+pub(crate) fn assignment_value_kind_label(value: &dbflux_core::AssignmentValue) -> String {
+    use dbflux_core::AssignmentValue;
+
+    match value {
+        AssignmentValue::Literal(_) => {
+            dbflux_i18n::t!("document.query_builder.assignments.kind.literal")
+        }
+        AssignmentValue::Expression(_) => {
+            dbflux_i18n::t!("document.query_builder.assignments.kind.raw_sql")
+        }
+        AssignmentValue::Null => dbflux_i18n::t!("document.query_builder.assignments.kind.null"),
+        AssignmentValue::Default => {
+            dbflux_i18n::t!("document.query_builder.assignments.kind.default")
+        }
+    }
+}
+
+/// Label for an `ExecutionMode` shown on the execution-mode segmented
+/// control.
+pub(crate) fn execution_mode_label(
+    mode: crate::data_grid_panel::mutation_executor::ExecutionMode,
+) -> String {
+    use crate::data_grid_panel::mutation_executor::ExecutionMode;
+
+    match mode {
+        ExecutionMode::SingleTransaction => {
+            dbflux_i18n::t!("document.query_builder.execution.mode.single_tx")
+        }
+        ExecutionMode::ChunkedTransaction => {
+            dbflux_i18n::t!("document.query_builder.execution.mode.chunked_tx")
+        }
+        ExecutionMode::DirectAutocommit => {
+            dbflux_i18n::t!("document.query_builder.execution.mode.direct")
+        }
+    }
+}
+
+/// Label for the mutation execution section's row-count estimate state.
+pub(crate) fn execution_count_state_label(
+    state: &crate::data_grid_panel::mutation_executor::CountState,
+) -> String {
+    use crate::data_grid_panel::mutation_executor::{CountState, CountUnknownReason};
+
+    match state {
+        CountState::Counting => dbflux_i18n::t!("document.query_builder.execution.counting"),
+        CountState::Done(n) => {
+            dbflux_i18n::t!("document.query_builder.execution.rows_estimated", count = n)
+        }
+        CountState::Unknown { reason } => match reason {
+            CountUnknownReason::TimedOut => {
+                dbflux_i18n::t!("document.query_builder.execution.timed_out")
+            }
+            CountUnknownReason::Failed(message) => {
+                dbflux_i18n::t!("document.query_builder.execution.failed", message = message)
+            }
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        MutationItemKind, builder_mode_label, bulk_delete_success_label, chart_degraded_copy,
-        chart_dock_shape_label, chart_rail_why_text, code_toolbar_shortcut_hint_label,
+        MutationItemKind, agg_fn_display, assignment_value_kind_label, bool_op_label,
+        builder_mode_label, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
+        chart_rail_why_text, code_toolbar_shortcut_hint_label, comparator_label,
         copy_query_language_label, dangerous_query_body, dangerous_query_title,
-        delete_confirm_copy, delete_rows_label, incomplete_aggregate_rows_label,
-        live_output_lines_label, live_output_truncated_label, partial_delete_label,
-        pending_change_count_label, pending_edits_summary, refresh_policy_label,
-        result_tab_count_label, row_count_label, script_confirm_message_label,
-        unsaved_changes_label, update_columns_label, valid_lines_label,
+        delete_confirm_copy, delete_rows_label, execution_count_state_label, execution_mode_label,
+        incomplete_aggregate_rows_label, join_kind_label, live_output_lines_label,
+        live_output_truncated_label, partial_delete_label, pending_change_count_label,
+        pending_edits_summary, refresh_policy_label, result_tab_count_label, row_count_label,
+        script_confirm_message_label, sort_direction_label, unsaved_changes_label,
+        update_columns_label, valid_lines_label,
     };
     use dbflux_components::chart::ChartDetection;
     use dbflux_core::{DangerousQueryKind, QueryLanguage, RefreshPolicy};
@@ -1431,5 +1593,202 @@ mod tests {
                 "document.code.dangerous_query.kind.raw_expression_in_set.body"
             }
         }
+    }
+
+    #[test]
+    fn comparator_label_covers_all_variants_and_stays_identical_across_locales() {
+        use dbflux_core::Comparator;
+
+        let cases = [
+            (Comparator::Eq, "="),
+            (Comparator::Neq, "≠"),
+            (Comparator::Gt, ">"),
+            (Comparator::Lt, "<"),
+            (Comparator::Gte, "≥"),
+            (Comparator::Lte, "≤"),
+            (Comparator::Like, "LIKE"),
+            (Comparator::ILike, "ILIKE"),
+            (Comparator::In, "IN"),
+            (Comparator::IsNull, "IS NULL"),
+            (Comparator::IsNotNull, "IS NOT NULL"),
+        ];
+
+        for (comparator, expected) in cases {
+            assert_eq!(comparator_label(comparator), expected);
+        }
+    }
+
+    #[test]
+    fn join_kind_label_covers_all_variants_and_stays_identical_across_locales() {
+        use dbflux_core::JoinKind;
+
+        let cases = [
+            (JoinKind::Inner, "INNER"),
+            (JoinKind::Left, "LEFT"),
+            (JoinKind::Right, "RIGHT"),
+            (JoinKind::Full, "FULL"),
+        ];
+
+        for (kind, expected) in cases {
+            assert_eq!(join_kind_label(kind), expected);
+        }
+    }
+
+    #[test]
+    fn agg_fn_display_covers_all_variants_and_stays_identical_across_locales() {
+        use dbflux_core::AggFn;
+
+        let cases = [
+            (AggFn::CountStar, "COUNT(*)"),
+            (AggFn::Count, "COUNT"),
+            (AggFn::CountDistinct, "COUNT DISTINCT"),
+            (AggFn::Sum, "SUM"),
+            (AggFn::Avg, "AVG"),
+            (AggFn::Min, "MIN"),
+            (AggFn::Max, "MAX"),
+        ];
+
+        for (function, expected) in cases {
+            assert_eq!(agg_fn_display(function), expected);
+        }
+    }
+
+    #[test]
+    fn bool_op_label_covers_all_variants_and_stays_identical_across_locales() {
+        use dbflux_core::BoolOp;
+
+        assert_eq!(bool_op_label(BoolOp::And), "AND");
+        assert_eq!(bool_op_label(BoolOp::Or), "OR");
+    }
+
+    #[test]
+    fn sort_direction_label_covers_all_variants_and_stays_identical_across_locales() {
+        use dbflux_core::VisualSortDirection;
+
+        assert_eq!(sort_direction_label(VisualSortDirection::Asc), "ASC");
+        assert_eq!(sort_direction_label(VisualSortDirection::Desc), "DESC");
+    }
+
+    #[test]
+    fn query_builder_sql_literal_keys_resolve_identically_in_both_locales() {
+        let keys = [
+            "document.query_builder.comparator.eq",
+            "document.query_builder.comparator.neq",
+            "document.query_builder.comparator.gt",
+            "document.query_builder.comparator.lt",
+            "document.query_builder.comparator.gte",
+            "document.query_builder.comparator.lte",
+            "document.query_builder.comparator.like",
+            "document.query_builder.comparator.ilike",
+            "document.query_builder.comparator.in",
+            "document.query_builder.comparator.is_null",
+            "document.query_builder.comparator.is_not_null",
+            "document.query_builder.join.kind.inner",
+            "document.query_builder.join.kind.left",
+            "document.query_builder.join.kind.right",
+            "document.query_builder.join.kind.full",
+            "document.query_builder.aggregate.fn.count_star",
+            "document.query_builder.aggregate.fn.count",
+            "document.query_builder.aggregate.fn.count_distinct",
+            "document.query_builder.aggregate.fn.sum",
+            "document.query_builder.aggregate.fn.avg",
+            "document.query_builder.aggregate.fn.min",
+            "document.query_builder.aggregate.fn.max",
+            "document.query_builder.filters.bool_op.and",
+            "document.query_builder.filters.bool_op.or",
+            "document.query_builder.sort.direction.asc",
+            "document.query_builder.sort.direction.desc",
+            "document.query_builder.assignments.kind.null",
+            "document.query_builder.assignments.kind.default",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert_ne!(en, key);
+            assert_ne!(en, format!("en.{key}"));
+            assert!(!en.is_empty());
+            assert_eq!(en, es, "SQL literal key {key} must match across locales");
+        }
+    }
+
+    #[test]
+    fn assignment_value_kind_label_covers_all_variants() {
+        use dbflux_core::{AssignmentValue, ScalarLiteral};
+
+        assert_eq!(
+            assignment_value_kind_label(&AssignmentValue::Literal(ScalarLiteral::Text(
+                String::new()
+            ))),
+            "Literal"
+        );
+        assert_eq!(
+            assignment_value_kind_label(&AssignmentValue::Expression(String::new())),
+            "Raw SQL"
+        );
+        assert_eq!(assignment_value_kind_label(&AssignmentValue::Null), "NULL");
+        assert_eq!(
+            assignment_value_kind_label(&AssignmentValue::Default),
+            "DEFAULT"
+        );
+
+        for key in [
+            "document.query_builder.assignments.kind.literal",
+            "document.query_builder.assignments.kind.raw_sql",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert_ne!(en, es, "prose kind label {key} did not translate");
+        }
+    }
+
+    #[test]
+    fn execution_mode_label_covers_all_variants_and_translates_per_locale() {
+        use crate::data_grid_panel::mutation_executor::ExecutionMode;
+
+        for mode in [
+            ExecutionMode::SingleTransaction,
+            ExecutionMode::ChunkedTransaction,
+            ExecutionMode::DirectAutocommit,
+        ] {
+            let en = execution_mode_label(mode);
+            let key = match mode {
+                ExecutionMode::SingleTransaction => {
+                    "document.query_builder.execution.mode.single_tx"
+                }
+                ExecutionMode::ChunkedTransaction => {
+                    "document.query_builder.execution.mode.chunked_tx"
+                }
+                ExecutionMode::DirectAutocommit => "document.query_builder.execution.mode.direct",
+            };
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!en.is_empty());
+            assert_ne!(en, es, "execution mode label {key} did not translate");
+        }
+    }
+
+    #[test]
+    fn execution_count_state_label_zero_one_many_and_reasons() {
+        use crate::data_grid_panel::mutation_executor::{CountState, CountUnknownReason};
+
+        let counting = execution_count_state_label(&CountState::Counting);
+        let done_one = execution_count_state_label(&CountState::Done(1));
+        let done_many = execution_count_state_label(&CountState::Done(42));
+        let timed_out = execution_count_state_label(&CountState::Unknown {
+            reason: CountUnknownReason::TimedOut,
+        });
+        let failed = execution_count_state_label(&CountState::Unknown {
+            reason: CountUnknownReason::Failed("boom".to_string()),
+        });
+
+        assert!(counting.contains("Counting"));
+        assert!(done_one.contains('1'));
+        assert!(done_many.contains("42"));
+        assert_ne!(done_one, done_many);
+        assert!(timed_out.contains("chunked"));
+        assert!(failed.contains("boom"));
     }
 }

--- a/crates/dbflux_ui_document/src/query_builder/panel/grouping.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel/grouping.rs
@@ -155,7 +155,9 @@ impl QueryBuilderPanel {
 
             let alias_text = self.aggregate_rows[i].alias.clone();
             let alias_input = cx.new(|cx| {
-                let mut state = InputState::new(window, cx).placeholder("alias");
+                let mut state = InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                    "document.query_builder.group_by.alias_placeholder"
+                ));
                 state.set_value(&alias_text, window, cx);
                 state
             });
@@ -195,9 +197,9 @@ impl QueryBuilderPanel {
                 .collect();
 
             if !valid.contains(column) {
-                self.sort_validation_error = Some(format!(
-                    "\"{}\" is not in the GROUP BY columns or aggregate aliases",
-                    column
+                self.sort_validation_error = Some(dbflux_i18n::t!(
+                    "document.query_builder.sort.invalid_column",
+                    column = column
                 ));
                 cx.notify();
                 return;

--- a/crates/dbflux_ui_document/src/query_builder/panel/joins.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel/joins.rs
@@ -46,7 +46,9 @@ impl QueryBuilderPanel {
                 };
 
                 let to_table_state = cx.new(|cx| {
-                    let mut state = InputState::new(window, cx).placeholder("table");
+                    let mut state = InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                        "document.query_builder.joins.table_placeholder"
+                    ));
                     state.set_value(&to_table_val, window, cx);
                     state
                 });

--- a/crates/dbflux_ui_document/src/query_builder/panel/mod.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel/mod.rs
@@ -21,6 +21,7 @@ use uuid::Uuid;
 use dbflux_ui_base::AppStateEntity;
 
 use crate::data_grid_panel::DataGridPanel;
+use crate::labels::{agg_fn_display, comparator_label, join_kind_label};
 use crate::query_builder::completion::{
     AliasBinding, CompletionMode, SchemaCache, SchemaCompletionProvider,
 };
@@ -949,22 +950,6 @@ const JOIN_KIND_ORDER: &[JoinKind] = &[
     JoinKind::Full,
 ];
 
-fn comparator_label(c: Comparator) -> &'static str {
-    match c {
-        Comparator::Eq => "=",
-        Comparator::Neq => "≠",
-        Comparator::Gt => ">",
-        Comparator::Lt => "<",
-        Comparator::Gte => "≥",
-        Comparator::Lte => "≤",
-        Comparator::Like => "LIKE",
-        Comparator::ILike => "ILIKE",
-        Comparator::In => "IN",
-        Comparator::IsNull => "IS NULL",
-        Comparator::IsNotNull => "IS NOT NULL",
-    }
-}
-
 fn comparator_value(c: Comparator) -> &'static str {
     // Stable identifier per variant; matches the label except for spaces in
     // multi-word operators, which would otherwise be ambiguous with other UI
@@ -984,15 +969,6 @@ fn comparator_value(c: Comparator) -> &'static str {
     }
 }
 
-fn join_kind_label(k: JoinKind) -> &'static str {
-    match k {
-        JoinKind::Inner => "INNER",
-        JoinKind::Left => "LEFT",
-        JoinKind::Right => "RIGHT",
-        JoinKind::Full => "FULL",
-    }
-}
-
 pub(crate) const AGG_FN_ORDER: &[AggFn] = &[
     AggFn::CountStar,
     AggFn::Count,
@@ -1002,18 +978,6 @@ pub(crate) const AGG_FN_ORDER: &[AggFn] = &[
     AggFn::Min,
     AggFn::Max,
 ];
-
-pub(crate) fn agg_fn_display(f: AggFn) -> &'static str {
-    match f {
-        AggFn::CountStar => "COUNT(*)",
-        AggFn::Count => "COUNT",
-        AggFn::CountDistinct => "COUNT DISTINCT",
-        AggFn::Sum => "SUM",
-        AggFn::Avg => "AVG",
-        AggFn::Min => "MIN",
-        AggFn::Max => "MAX",
-    }
-}
 
 // ---------------------------------------------------------------------------
 // GPUI integration

--- a/crates/dbflux_ui_document/src/query_builder/panel/mutation.rs
+++ b/crates/dbflux_ui_document/src/query_builder/panel/mutation.rs
@@ -69,8 +69,10 @@ impl QueryBuilderPanel {
                         BuilderMode::Select => "SELECT",
                     })
                     .unwrap_or("UPDATE");
-                self.sql_preview =
-                    format!("-- {kind_label}: configure assignments / filter to preview SQL");
+                self.sql_preview = dbflux_i18n::t!(
+                    "document.query_builder.mutation.preview_placeholder",
+                    kind = kind_label
+                );
             }
         } else {
             let spec = self.current_spec.clone();
@@ -137,8 +139,10 @@ impl QueryBuilderPanel {
             .unwrap_or(0);
 
         for i in 0..count {
-            let col_placeholder = "column";
-            let val_placeholder = "value";
+            let col_placeholder =
+                dbflux_i18n::t!("document.query_builder.assignments.column_placeholder");
+            let val_placeholder =
+                dbflux_i18n::t!("document.query_builder.assignments.value_placeholder");
 
             let col_name = self
                 .mutation_state

--- a/crates/dbflux_ui_document/src/query_builder/sections/assignments.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/assignments.rs
@@ -5,18 +5,9 @@ use dbflux_components::controls::{Button, ButtonVariant, Input};
 use dbflux_components::tokens::{FontSizes, Spacing};
 use dbflux_core::{Assignment, AssignmentValue, ScalarLiteral};
 
+use crate::labels::assignment_value_kind_label;
 use crate::query_builder::mutation_state::AssignmentRow;
 use crate::query_builder::panel::QueryBuilderPanel;
-
-/// Returns the display label for an `AssignmentValue` kind selector button.
-fn value_kind_label(value: &AssignmentValue) -> &'static str {
-    match value {
-        AssignmentValue::Literal(_) => "Literal",
-        AssignmentValue::Expression(_) => "Raw SQL",
-        AssignmentValue::Null => "NULL",
-        AssignmentValue::Default => "DEFAULT",
-    }
-}
 
 /// Returns `true` when `value` is the `Expression` variant.
 fn is_expression(value: &AssignmentValue) -> bool {
@@ -73,7 +64,7 @@ pub fn render_assignments(
             .map(|r| r.assignment.value.clone())
             .unwrap_or(AssignmentValue::Null);
 
-        let kind_label = value_kind_label(&value);
+        let kind_label = assignment_value_kind_label(&value);
         let expr_mode = is_expression(&value);
         let kind_variant = if expr_mode {
             ButtonVariant::Danger
@@ -90,21 +81,19 @@ pub fn render_assignments(
 
         // Column name input
         if let Some(col_state) = panel.assign_col_inputs.get(&row_ix).cloned() {
-            row_div = row_div.child(
-                div()
-                    .w(gpui::px(140.0))
-                    .child(Input::new(&col_state).placeholder("column")),
-            );
+            row_div = row_div.child(div().w(gpui::px(140.0)).child(
+                Input::new(&col_state).placeholder(dbflux_i18n::t!(
+                    "document.query_builder.assignments.column_placeholder"
+                )),
+            ));
         }
 
         // Value input (Literal / Expression only)
         if show_value_input {
             if let Some(val_state) = panel.assign_val_inputs.get(&row_ix).cloned() {
-                row_div = row_div.child(
-                    div()
-                        .flex_1()
-                        .child(Input::new(&val_state).placeholder("value")),
-                );
+                row_div = row_div.child(div().flex_1().child(Input::new(&val_state).placeholder(
+                    dbflux_i18n::t!("document.query_builder.assignments.value_placeholder"),
+                )));
             }
         } else {
             row_div = row_div.child(
@@ -112,7 +101,7 @@ pub fn render_assignments(
                     .flex_1()
                     .text_size(FontSizes::SM)
                     .text_color(theme.muted_foreground)
-                    .child(SharedString::from(kind_label)),
+                    .child(SharedString::from(kind_label.clone())),
             );
         }
 
@@ -163,9 +152,9 @@ pub fn render_assignments(
                         .border_color(theme.border)
                         .text_size(FontSizes::XS)
                         .text_color(theme.danger)
-                        .child(
-                            "Raw SQL — expression is interpolated verbatim. Verify before running.",
-                        ),
+                        .child(SharedString::from(dbflux_i18n::t!(
+                            "document.query_builder.assignments.raw_sql_warning"
+                        ))),
                 ),
             );
         }
@@ -173,22 +162,25 @@ pub fn render_assignments(
 
     // "Add assignment" button
     container = container.child(
-        Button::new("qb-assign-add", "+ Add assignment")
-            .variant(ButtonVariant::Ghost)
-            .on_click(cx.listener(|this, _event, _window, cx| {
-                if let Some(state) = this.mutation_state.as_mut() {
-                    state.assignments.push(AssignmentRow {
-                        assignment: Assignment {
-                            column: String::new(),
-                            value: AssignmentValue::Literal(ScalarLiteral::Text(String::new())),
-                        },
-                        raw_text: String::new(),
-                    });
-                    this.pending_assign_rebuild = true;
-                }
-                this.refresh_mutation_preview_pure();
-                cx.notify();
-            })),
+        Button::new(
+            "qb-assign-add",
+            dbflux_i18n::t!("document.query_builder.assignments.add_button"),
+        )
+        .variant(ButtonVariant::Ghost)
+        .on_click(cx.listener(|this, _event, _window, cx| {
+            if let Some(state) = this.mutation_state.as_mut() {
+                state.assignments.push(AssignmentRow {
+                    assignment: Assignment {
+                        column: String::new(),
+                        value: AssignmentValue::Literal(ScalarLiteral::Text(String::new())),
+                    },
+                    raw_text: String::new(),
+                });
+                this.pending_assign_rebuild = true;
+            }
+            this.refresh_mutation_preview_pure();
+            cx.notify();
+        })),
     );
 
     container.into_any_element()

--- a/crates/dbflux_ui_document/src/query_builder/sections/columns.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/columns.rs
@@ -29,7 +29,9 @@ pub fn render_columns(
     let mut container = div().flex().flex_col().gap_1().child(
         Checkbox::new("qb-all-columns")
             .checked(all_active)
-            .label("All columns (*)")
+            .label(dbflux_i18n::t!(
+                "document.query_builder.columns.all_columns"
+            ))
             .on_click(cx.listener(|this, checked, _window, cx| {
                 this.set_all_columns(*checked, cx);
             })),
@@ -107,7 +109,7 @@ pub fn render_columns(
                     ),
                 )
                 .child(
-                    Button::new("qb-add-col", "Add")
+                    Button::new("qb-add-col", dbflux_i18n::t!("document.shared.add"))
                         .small()
                         .on_click(cx.listener(|this, _event, _window, cx| {
                             if let Some(state) = this.add_column_input_state.clone() {

--- a/crates/dbflux_ui_document/src/query_builder/sections/execution.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/execution.rs
@@ -4,31 +4,9 @@ use gpui_component::ActiveTheme;
 use dbflux_components::controls::{Button, ButtonVariant, Input};
 use dbflux_components::tokens::{FontSizes, Spacing};
 
-use crate::data_grid_panel::mutation_executor::{CountState, CountUnknownReason, ExecutionMode};
+use crate::data_grid_panel::mutation_executor::ExecutionMode;
+use crate::labels::{execution_count_state_label, execution_mode_label};
 use crate::query_builder::panel::QueryBuilderPanel;
-
-/// Returns a human-readable label for a `CountState`.
-fn count_label(state: &CountState) -> String {
-    match state {
-        CountState::Counting => "Counting rows\u{2026}".to_string(),
-        CountState::Done(n) => format!("{} rows estimated", n),
-        CountState::Unknown { reason } => match reason {
-            CountUnknownReason::TimedOut => {
-                "Row count timed out — chunked mode recommended".to_string()
-            }
-            CountUnknownReason::Failed(msg) => format!("Row count failed: {}", msg),
-        },
-    }
-}
-
-/// Returns the display label for an `ExecutionMode`.
-fn mode_label(mode: ExecutionMode) -> &'static str {
-    match mode {
-        ExecutionMode::SingleTransaction => "Single TX",
-        ExecutionMode::ChunkedTransaction => "Chunked TX",
-        ExecutionMode::DirectAutocommit => "Direct",
-    }
-}
 
 /// Renders the execution mode section.
 ///
@@ -50,7 +28,7 @@ pub fn render_execution(
         None => return div().into_any_element(),
     };
 
-    let count_text = count_label(&count_state);
+    let count_text = execution_count_state_label(&count_state);
 
     let modes = [
         ExecutionMode::SingleTransaction,
@@ -62,7 +40,9 @@ pub fn render_execution(
         div()
             .text_size(FontSizes::SM)
             .text_color(theme.muted_foreground)
-            .child("Mode:"),
+            .child(dbflux_i18n::t!(
+                "document.query_builder.execution.mode_label"
+            )),
     );
 
     for mode in modes {
@@ -73,7 +53,7 @@ pub fn render_execution(
             ButtonVariant::Default
         };
         mode_row = mode_row.child(
-            Button::new(("qb-exec-mode", mode as usize), mode_label(mode))
+            Button::new(("qb-exec-mode", mode as usize), execution_mode_label(mode))
                 .variant(variant)
                 .on_click(cx.listener(move |this, _event, _window, cx| {
                     if let Some(state) = this.mutation_state.as_mut() {
@@ -101,7 +81,9 @@ pub fn render_execution(
             div()
                 .text_size(FontSizes::SM)
                 .text_color(chunk_label_color)
-                .child("Chunk size:"),
+                .child(dbflux_i18n::t!(
+                    "document.query_builder.execution.chunk_size_label"
+                )),
         )
         .child(div().w(gpui::px(100.0)).child(
             // guardrail-allow: explicit pixel width for input field
@@ -138,14 +120,18 @@ pub fn render_execution(
             div()
                 .text_size(FontSizes::SM)
                 .text_color(lock_label_color)
-                .child("Lock timeout (ms):"),
+                .child(dbflux_i18n::t!(
+                    "document.query_builder.execution.lock_timeout_label"
+                )),
         )
         .child(div().w(gpui::px(100.0)).child(
             // guardrail-allow: explicit pixel width for input field
             if let Some(lt_state) = panel.exec_lock_timeout_input.as_ref().cloned() {
                 div().child(
                     Input::new(&lt_state)
-                        .placeholder("none")
+                        .placeholder(dbflux_i18n::t!(
+                            "document.query_builder.execution.lock_timeout_none"
+                        ))
                         .disabled(!lock_enabled),
                 )
             } else {
@@ -153,7 +139,9 @@ pub fn render_execution(
                     div()
                         .text_size(FontSizes::SM)
                         .text_color(theme.muted_foreground)
-                        .child("none"),
+                        .child(dbflux_i18n::t!(
+                            "document.query_builder.execution.lock_timeout_none"
+                        )),
                 )
             },
         ));

--- a/crates/dbflux_ui_document/src/query_builder/sections/filters.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/filters.rs
@@ -1,5 +1,6 @@
 use gpui::{AnyElement, Context, ElementId, Entity, IntoElement, SharedString, div};
 
+use crate::labels::{bool_op_label, comparator_label};
 use crate::query_builder::panel::{FILTER_DEPTH_CAP, FilterTarget, QueryBuilderPanel};
 use dbflux_components::controls::{Dropdown, InputState};
 
@@ -77,9 +78,10 @@ pub fn render_filters_for_target(
             .flex_col()
             .gap_1()
             .when(filter_depth >= FILTER_DEPTH_CAP, |this| {
-                this.child(div().text_sm().child(SharedString::from(
-                    "Maximum filter nesting depth reached (6 levels)",
-                )))
+                this.child(div().text_sm().child(SharedString::from(dbflux_i18n::t!(
+                    "document.query_builder.filters.max_depth",
+                    depth = FILTER_DEPTH_CAP
+                ))))
             });
 
     match tree {
@@ -94,13 +96,19 @@ pub fn render_filters_for_target(
                         div()
                             .flex_1()
                             .text_sm()
-                            .child(SharedString::from("No filters")),
+                            .child(SharedString::from(dbflux_i18n::t!(
+                                "document.query_builder.filters.no_filters"
+                            ))),
                     )
                     .child(
-                        Button::new(add_pred_id, "+ Filter")
-                            .ghost()
-                            .small()
-                            .on_click(cx.listener(move |this, _event, _window, cx| {
+                        Button::new(
+                            add_pred_id,
+                            dbflux_i18n::t!("document.query_builder.filters.add_filter"),
+                        )
+                        .ghost()
+                        .small()
+                        .on_click(cx.listener(
+                            move |this, _event, _window, cx| {
                                 this.add_predicate_for(
                                     target,
                                     vec![],
@@ -108,15 +116,21 @@ pub fn render_filters_for_target(
                                     "",
                                     cx,
                                 );
-                            })),
+                            },
+                        )),
                     )
                     .child(
-                        Button::new(add_group_id, "+ Sub-group")
-                            .ghost()
-                            .small()
-                            .on_click(cx.listener(move |this, _event, _window, cx| {
+                        Button::new(
+                            add_group_id,
+                            dbflux_i18n::t!("document.query_builder.filters.add_subgroup"),
+                        )
+                        .ghost()
+                        .small()
+                        .on_click(cx.listener(
+                            move |this, _event, _window, cx| {
                                 this.add_group_for(target, vec![], cx);
-                            })),
+                            },
+                        )),
                     ),
             );
         }
@@ -201,10 +215,7 @@ fn render_filter_group(
     use gpui::SharedString;
     use gpui::prelude::*;
 
-    let op_label = match op {
-        dbflux_core::BoolOp::And => "AND",
-        dbflux_core::BoolOp::Or => "OR",
-    };
+    let op_label = bool_op_label(op);
 
     let prefix = match target {
         FilterTarget::Where => "qb-grp",
@@ -238,7 +249,7 @@ fn render_filter_group(
             .child(
                 Button::new(
                     path_id(&format!("{}-add-pred", prefix), &path_for_add_pred),
-                    "+ Filter",
+                    dbflux_i18n::t!("document.query_builder.filters.add_filter"),
                 )
                 .ghost()
                 .small()
@@ -256,7 +267,7 @@ fn render_filter_group(
             .child(
                 Button::new(
                     path_id(&format!("{}-add-grp", prefix), &path_for_add_group),
-                    "+ Sub-group",
+                    dbflux_i18n::t!("document.query_builder.filters.add_subgroup"),
                 )
                 .ghost()
                 .small()
@@ -395,21 +406,4 @@ fn path_id(prefix: &str, path: &[usize]) -> ElementId {
         .collect::<Vec<_>>()
         .join("-");
     ElementId::Name(SharedString::from(key))
-}
-
-fn comparator_label(cmp: dbflux_core::Comparator) -> &'static str {
-    use dbflux_core::Comparator;
-    match cmp {
-        Comparator::Eq => "=",
-        Comparator::Neq => "≠",
-        Comparator::Gt => ">",
-        Comparator::Lt => "<",
-        Comparator::Gte => "≥",
-        Comparator::Lte => "≤",
-        Comparator::Like => "LIKE",
-        Comparator::ILike => "ILIKE",
-        Comparator::In => "IN",
-        Comparator::IsNull => "IS NULL",
-        Comparator::IsNotNull => "IS NOT NULL",
-    }
 }

--- a/crates/dbflux_ui_document/src/query_builder/sections/group_by.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/group_by.rs
@@ -12,7 +12,8 @@ pub fn render_group_by(
     panel: &mut QueryBuilderPanel,
     cx: &mut Context<QueryBuilderPanel>,
 ) -> impl IntoElement {
-    use crate::query_builder::panel::{AGG_FN_ORDER, agg_fn_display};
+    use crate::labels::agg_fn_display;
+    use crate::query_builder::panel::AGG_FN_ORDER;
     use dbflux_components::controls::{Button, Input, completion_input_keys_wrapper};
     use dbflux_components::tokens::{Heights, Radii};
     use dbflux_core::AggFn;
@@ -32,7 +33,9 @@ pub fn render_group_by(
         div()
             .text_sm()
             .text_color(cx.theme().muted_foreground)
-            .child(SharedString::from("Group by columns")),
+            .child(SharedString::from(dbflux_i18n::t!(
+                "document.query_builder.group_by.heading"
+            ))),
     );
 
     for (i, _row) in group_by_rows.iter().enumerate() {
@@ -66,19 +69,24 @@ pub fn render_group_by(
 
     let source_alias = panel.current_spec.source.alias.clone();
     container = container.child(
-        Button::new("qb-gb-add", "+ Group-by column")
-            .ghost()
-            .small()
-            .on_click(cx.listener(move |this, _event, _window, cx| {
-                this.add_group_by_column(source_alias.clone(), String::new(), cx);
-            })),
+        Button::new(
+            "qb-gb-add",
+            dbflux_i18n::t!("document.query_builder.group_by.add_column"),
+        )
+        .ghost()
+        .small()
+        .on_click(cx.listener(move |this, _event, _window, cx| {
+            this.add_group_by_column(source_alias.clone(), String::new(), cx);
+        })),
     );
 
     container = container.child(
         div()
             .text_sm()
             .text_color(cx.theme().muted_foreground)
-            .child(SharedString::from("Aggregates")),
+            .child(SharedString::from(dbflux_i18n::t!(
+                "document.query_builder.group_by.aggregates_heading"
+            ))),
     );
 
     for (i, row) in aggregate_rows.iter().enumerate() {
@@ -133,7 +141,9 @@ pub fn render_group_by(
                     Input::new(&alias_input)
                         .small()
                         .w_full()
-                        .placeholder("alias"),
+                        .placeholder(dbflux_i18n::t!(
+                            "document.query_builder.group_by.alias_placeholder"
+                        )),
                 ),
             );
         }
@@ -150,17 +160,21 @@ pub fn render_group_by(
         container = container.child(row_div);
     }
 
-    let agg_add_items: Vec<(&'static str, AggFn)> = AGG_FN_ORDER
+    let agg_add_items: Vec<(String, AggFn)> = AGG_FN_ORDER
         .iter()
         .map(|f| (agg_fn_display(*f), *f))
         .collect();
 
     let mut add_row = div().flex().flex_row().gap_1().flex_wrap();
     for (label, function) in agg_add_items {
+        let button_label = dbflux_i18n::t!(
+            "document.query_builder.group_by.add_aggregate",
+            function = label.clone()
+        );
         add_row = add_row.child(
             Button::new(
                 ElementId::Name(SharedString::from(format!("qb-agg-add-{}", label))),
-                format!("+ {label}"),
+                button_label,
             )
             .ghost()
             .small()

--- a/crates/dbflux_ui_document/src/query_builder/sections/joins.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/joins.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use gpui::{AnyElement, Context, Entity, IntoElement, SharedString, div};
 
+use crate::labels::bool_op_label;
 use crate::query_builder::panel::{FkLoadState, QueryBuilderPanel};
 use dbflux_components::controls::{Dropdown, InputState};
 
@@ -49,9 +50,9 @@ pub fn render_joins(
                         .flex_1()
                         .min_w(gpui::px(0.0))
                         .text_sm()
-                        .child(SharedString::from(
-                            "No foreign key metadata available. Enter conditions as raw expressions.",
-                        )),
+                        .child(SharedString::from(dbflux_i18n::t!(
+                            "document.query_builder.joins.no_fk_metadata"
+                        ))),
                 )
                 .child(
                     Button::new("qb-dismiss-fk-banner", "✕")
@@ -65,11 +66,9 @@ pub fn render_joins(
     }
 
     if fk_loading && !join_rows.is_empty() {
-        container = container.child(
-            div()
-                .text_sm()
-                .child(SharedString::from("Loading foreign keys…")),
-        );
+        container = container.child(div().text_sm().child(SharedString::from(dbflux_i18n::t!(
+            "document.query_builder.joins.loading_fk"
+        ))));
     }
 
     for (i, row) in join_rows.iter().enumerate() {
@@ -100,12 +99,9 @@ pub fn render_joins(
                 completion_input_keys_wrapper(to_table_state)
                     .flex_1()
                     .min_w(gpui::px(0.0))
-                    .child(
-                        Input::new(to_table_state)
-                            .small()
-                            .w_full()
-                            .placeholder("table"),
-                    ),
+                    .child(Input::new(to_table_state).small().w_full().placeholder(
+                        dbflux_i18n::t!("document.query_builder.joins.table_placeholder"),
+                    )),
             );
         } else {
             header = header.child(
@@ -186,12 +182,15 @@ pub fn render_joins(
     }
 
     container = container.child(
-        Button::new("qb-add-join", "+ Join")
-            .ghost()
-            .small()
-            .on_click(cx.listener(move |this, _event, _window, cx| {
-                this.add_join(&source_alias.clone(), cx);
-            })),
+        Button::new(
+            "qb-add-join",
+            dbflux_i18n::t!("document.query_builder.joins.add_join"),
+        )
+        .ghost()
+        .small()
+        .on_click(cx.listener(move |this, _event, _window, cx| {
+            this.add_join(&source_alias.clone(), cx);
+        })),
     );
 
     container
@@ -210,7 +209,7 @@ fn render_join_tree(
 ) -> AnyElement {
     use dbflux_components::controls::{Button, Input, completion_input_keys_wrapper};
     use dbflux_components::tokens::{Heights, Radii};
-    use dbflux_core::{BoolOp, JoinFilterNode};
+    use dbflux_core::JoinFilterNode;
     use gpui::prelude::*;
     use gpui_component::ActiveTheme;
 
@@ -279,10 +278,7 @@ fn render_join_tree(
         }
 
         JoinFilterNode::Group { op, children, .. } => {
-            let op_label = match op {
-                BoolOp::And => "AND",
-                BoolOp::Or => "OR",
-            };
+            let op_label = bool_op_label(*op);
 
             let path_for_toggle = path.clone();
             let path_for_add_pred = path.clone();
@@ -313,7 +309,7 @@ fn render_join_tree(
                 .child(
                     Button::new(
                         node_id_seed("qb-join-grp-add-cond", join_idx, &path_for_add_pred),
-                        "+ Condition",
+                        dbflux_i18n::t!("document.query_builder.joins.add_condition"),
                     )
                     .ghost()
                     .small()
@@ -324,7 +320,7 @@ fn render_join_tree(
                 .child(
                     Button::new(
                         node_id_seed("qb-join-grp-add-grp", join_idx, &path_for_add_grp),
-                        "+ Sub-group",
+                        dbflux_i18n::t!("document.query_builder.filters.add_subgroup"),
                     )
                     .ghost()
                     .small()

--- a/crates/dbflux_ui_document/src/query_builder/sections/sort.rs
+++ b/crates/dbflux_ui_document/src/query_builder/sections/sort.rs
@@ -1,5 +1,6 @@
 use gpui::{Context, IntoElement, div};
 
+use crate::labels::sort_direction_label;
 use crate::query_builder::panel::QueryBuilderPanel;
 
 /// Renders the Sort section of the Query Builder.
@@ -26,10 +27,7 @@ pub fn render_sort(
     let mut container = div().flex().flex_col().gap_1();
 
     for (i, row) in sort_rows.iter().enumerate() {
-        let dir_label = match row.direction {
-            VisualSortDirection::Asc => "ASC",
-            VisualSortDirection::Desc => "DESC",
-        };
+        let dir_label = sort_direction_label(row.direction);
 
         let label = format!("{}.{}", row.source_alias, row.column);
         let can_move_up = i > 0;
@@ -97,7 +95,7 @@ pub fn render_sort(
                     ),
                 )
                 .child(
-                    Button::new("qb-add-sort", "Add")
+                    Button::new("qb-add-sort", dbflux_i18n::t!("document.shared.add"))
                         .small()
                         .on_click(cx.listener(|this, _event, _window, cx| {
                             if let Some(state) = this.add_sort_input_state.clone() {
@@ -136,16 +134,13 @@ fn render_sort_key_only(
     use gpui_component::ActiveTheme;
 
     let direction = panel.sort_key_direction();
-    let dir_label = match direction {
-        VisualSortDirection::Asc => "ASC",
-        VisualSortDirection::Desc => "DESC",
-    };
+    let dir_label = sort_direction_label(direction);
 
     let sort_key_label = panel
         .sort_key_column()
         .filter(|name| !name.is_empty())
-        .map(|name| format!("Sort key order ({name})"))
-        .unwrap_or_else(|| "Sort key order".to_string());
+        .map(|name| dbflux_i18n::t!("document.query_builder.sort.key_order_named", name = name))
+        .unwrap_or_else(|| dbflux_i18n::t!("document.query_builder.sort.key_order"));
 
     div()
         .flex()
@@ -180,6 +175,8 @@ fn render_sort_key_only(
             div()
                 .text_xs()
                 .text_color(cx.theme().muted_foreground)
-                .child("Ordering is limited to the sort key for this driver."),
+                .child(dbflux_i18n::t!(
+                    "document.query_builder.sort.key_limited_hint"
+                )),
         )
 }


### PR DESCRIPTION
## Summary

Document i18n slice 11: comparator, join kind, aggregate, boolean operator, sort direction, assignment kind and execution labels move to exhaustive labels.rs helpers; every button, heading, hint and prose placeholder in the builder panel and sections renders through `dbflux_i18n::t!`; SQL syntax templates stay literal. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 10; next: key-value views)

## How was this solved?

- Size: 910 lines (`size:exception`): the shared helpers and catalog cannot be split between panel and sections without a half-translated intermediate state.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 937 passed; clippy clean; fmt clean. Manual smoke in Spanish: build a WHERE with comparators, a JOIN and a GROUP BY.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
