### PR TITLE
feat(i18n): translate the connection manager tabs, main form chrome, dialogs, and driver select

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -158,6 +158,7 @@ connection_manager:
     session_status_valid: "Session status: valid"
     session_status_expired: "Session status: expired"
     session_status_login_required: "Session status: login required"
+    ssh_config_incomplete: SSH configuration incomplete
   driver_settings_title: Driver Settings
   driver_no_custom_settings: This driver has no custom settings.
   mcp_disabled: MCP disabled for this connection
@@ -175,6 +176,40 @@ connection_manager:
   mcp_policy_hint: Configure policies in Settings → MCP → Policies
   additional_policies_optional: Additional policies (optional)
   scope_policy_preview: Scope/policy assignment preview
+  tab:
+    main: Main
+    settings: Settings
+    mcp: MCP
+  field:
+    name: Name
+    ssl_mode: SSL mode
+    ca_certificate: CA certificate
+    client_cert: Client cert
+    client_key: Client key
+  section:
+    transport: TRANSPORT
+  banner:
+    correct_following: Please correct the following
+    testing_connection: "Testing connection…"
+    connection_successful: Connection successful
+    connection_successful_warnings: Connection successful with warnings
+    connection_failed: Connection failed
+  action:
+    copy: Copy
+    back: Back
+    test_connection: Test Connection
+    save: Save
+    browse: Browse
+  window_title: Connection Manager
+  driver_select:
+    search_placeholder: "Filter by name, driver, port…"
+    title: New Connection
+    subtitle: choose a database type
+    empty_state: No drivers match your filter
+    import_from_file: "Import from file…"
+    cancel: Cancel
+    configure: Configure
+    configure_named: "Configure %{name}"
 document:
   code:
     toolbar:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -158,6 +158,7 @@ connection_manager:
     session_status_valid: "Estado de la sesión: válida"
     session_status_expired: "Estado de la sesión: expirada"
     session_status_login_required: "Estado de la sesión: requiere inicio de sesión"
+    ssh_config_incomplete: Configuración SSH incompleta
   driver_settings_title: Ajustes del driver
   driver_no_custom_settings: Este driver no tiene ajustes personalizados.
   mcp_disabled: MCP deshabilitado para esta conexión
@@ -175,6 +176,40 @@ connection_manager:
   mcp_policy_hint: Configura políticas en Ajustes → MCP → Políticas
   additional_policies_optional: Políticas adicionales (opcional)
   scope_policy_preview: Vista previa de alcance y políticas
+  tab:
+    main: Principal
+    settings: Ajustes
+    mcp: MCP
+  field:
+    name: Nombre
+    ssl_mode: Modo SSL
+    ca_certificate: Certificado de CA
+    client_cert: Certificado de cliente
+    client_key: Clave de cliente
+  section:
+    transport: TRANSPORTE
+  banner:
+    correct_following: Corrige lo siguiente
+    testing_connection: "Probando la conexión…"
+    connection_successful: Conexión correcta
+    connection_successful_warnings: Conexión correcta con advertencias
+    connection_failed: Fallo en la conexión
+  action:
+    copy: Copiar
+    back: Atrás
+    test_connection: Probar conexión
+    save: Guardar
+    browse: Examinar
+  window_title: Administrador de conexiones
+  driver_select:
+    search_placeholder: "Filtrar por nombre, driver, puerto…"
+    title: Nueva conexión
+    subtitle: elige un tipo de base de datos
+    empty_state: Ningún driver coincide con tu filtro
+    import_from_file: "Importar desde archivo…"
+    cancel: Cancelar
+    configure: Configurar
+    configure_named: "Configurar %{name}"
 document:
   code:
     toolbar:

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -416,8 +416,11 @@ impl ConnectionManagerWindow {
                 "connection_manager.placeholder.connection_name"
             ))
         });
-        let driver_filter_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Filter by name, driver, port…"));
+        let driver_filter_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "connection_manager.driver_select.search_placeholder"
+            ))
+        });
         let input_password = cx.new(|cx| {
             InputState::new(window, cx)
                 .placeholder(dbflux_i18n::t!("connection_manager.placeholder.password"))
@@ -3373,7 +3376,9 @@ impl ConnectionManagerWindow {
 
         let Some((ssh_config, ssh_secret)) = self.effective_ssh_test_target(cx) else {
             self.ssh_test_status = TestStatus::Failed;
-            self.ssh_test_error = Some("SSH configuration incomplete".to_string());
+            self.ssh_test_error = Some(dbflux_i18n::t!(
+                "connection_manager.auth.ssh_config_incomplete"
+            ));
             cx.notify();
             return;
         };
@@ -4125,5 +4130,90 @@ mod tests {
         let en = dbflux_i18n::t!("connection_manager.auth.login_completed", locale = "en");
 
         assert_eq!(en, "Auth-provider login completed.");
+    }
+
+    // --- dialog / tab / driver-select i18n (PR14) ---
+
+    const CONNECTION_MANAGER_DIALOG_KEYS: &[&str] = &[
+        "connection_manager.tab.main",
+        "connection_manager.tab.settings",
+        "connection_manager.tab.mcp",
+        "connection_manager.field.name",
+        "connection_manager.field.ssl_mode",
+        "connection_manager.field.ca_certificate",
+        "connection_manager.field.client_cert",
+        "connection_manager.field.client_key",
+        "connection_manager.section.transport",
+        "connection_manager.banner.correct_following",
+        "connection_manager.banner.testing_connection",
+        "connection_manager.banner.connection_successful",
+        "connection_manager.banner.connection_successful_warnings",
+        "connection_manager.banner.connection_failed",
+        "connection_manager.action.copy",
+        "connection_manager.action.back",
+        "connection_manager.action.test_connection",
+        "connection_manager.action.save",
+        "connection_manager.action.browse",
+        "connection_manager.window_title",
+        "connection_manager.driver_select.search_placeholder",
+        "connection_manager.driver_select.title",
+        "connection_manager.driver_select.subtitle",
+        "connection_manager.driver_select.empty_state",
+        "connection_manager.driver_select.import_from_file",
+        "connection_manager.driver_select.cancel",
+        "connection_manager.driver_select.configure",
+        "connection_manager.driver_select.configure_named",
+        "connection_manager.auth.ssh_config_incomplete",
+    ];
+
+    #[test]
+    fn connection_manager_dialog_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in CONNECTION_MANAGER_DIALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn connection_manager_window_title_differs_between_locales() {
+        let en = dbflux_i18n::t!("connection_manager.window_title", locale = "en");
+        let es = dbflux_i18n::t!("connection_manager.window_title", locale = "es");
+
+        assert_ne!(
+            en, es,
+            "connection_manager.window_title should differ between en and es"
+        );
+    }
+
+    #[test]
+    fn connection_manager_window_title_exact_values() {
+        let en = dbflux_i18n::t!("connection_manager.window_title", locale = "en");
+        let es = dbflux_i18n::t!("connection_manager.window_title", locale = "es");
+
+        assert_eq!(en, "Connection Manager");
+        assert_eq!(es, "Administrador de conexiones");
+    }
+
+    #[test]
+    fn connection_manager_banner_connection_failed_differs_between_locales() {
+        let en = dbflux_i18n::t!("connection_manager.banner.connection_failed", locale = "en");
+        let es = dbflux_i18n::t!("connection_manager.banner.connection_failed", locale = "es");
+
+        assert_ne!(
+            en, es,
+            "connection_manager.banner.connection_failed should differ between en and es"
+        );
     }
 }

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -199,7 +199,9 @@ impl ConnectionManagerWindow {
                                             cx.notify();
                                         })),
                                 )
-                                .child(Body::new("Save")),
+                                .child(Body::new(dbflux_i18n::t!(
+                                    "connection_manager.action.save"
+                                ))),
                         )
                     }),
             )
@@ -330,7 +332,7 @@ impl ConnectionManagerWindow {
                     })
                     .child(div().flex_1())
                     .child(self.form_field_input_inline(
-                        "Name",
+                        &dbflux_i18n::t!("connection_manager.field.name"),
                         &self.form.input_name,
                         show_focus && focus == FormFocus::Name,
                         ring_color,
@@ -354,8 +356,11 @@ impl ConnectionManagerWindow {
                     .when(!validation_errors.is_empty(), |d| {
                         let combined = validation_errors.join("\n");
                         d.child(
-                            BannerBlock::new(BannerVariant::Danger, "Please correct the following")
-                                .with_body(combined),
+                            BannerBlock::new(
+                                BannerVariant::Danger,
+                                dbflux_i18n::t!("connection_manager.banner.correct_following"),
+                            )
+                            .with_body(combined),
                         )
                     })
                     .children(tab_content),
@@ -371,18 +376,21 @@ impl ConnectionManagerWindow {
                     .when(test_status != TestStatus::None, |d| {
                         let banners = SemBannerColors::for_current(cx);
                         let banner = match test_status {
-                            TestStatus::Testing => {
-                                BannerBlock::new(BannerVariant::Info, "Testing connection\u{2026}")
-                                    .with_icon(
-                                        AppIconElement::new(AppIcon::Loader)
-                                            .size(Heights::ICON_SM)
-                                            .color(banners.info_fg),
-                                    )
-                            }
+                            TestStatus::Testing => BannerBlock::new(
+                                BannerVariant::Info,
+                                dbflux_i18n::t!("connection_manager.banner.testing_connection"),
+                            )
+                            .with_icon(
+                                AppIconElement::new(AppIcon::Loader)
+                                    .size(Heights::ICON_SM)
+                                    .color(banners.info_fg),
+                            ),
                             TestStatus::Success => {
                                 let mut banner = BannerBlock::new(
                                     BannerVariant::Success,
-                                    "Connection successful",
+                                    dbflux_i18n::t!(
+                                        "connection_manager.banner.connection_successful"
+                                    ),
                                 )
                                 .with_icon(
                                     AppIconElement::new(AppIcon::CircleCheck)
@@ -397,7 +405,9 @@ impl ConnectionManagerWindow {
                             TestStatus::SuccessWithWarning => {
                                 let mut banner = BannerBlock::new(
                                     BannerVariant::Warning,
-                                    "Connection successful with warnings",
+                                    dbflux_i18n::t!(
+                                        "connection_manager.banner.connection_successful_warnings"
+                                    ),
                                 )
                                 .with_icon(
                                     AppIconElement::new(AppIcon::Info)
@@ -410,28 +420,37 @@ impl ConnectionManagerWindow {
                                 banner
                             }
                             TestStatus::Failed => {
-                                let message =
-                                    test_error.unwrap_or_else(|| "Connection failed".to_string());
+                                let message = test_error.unwrap_or_else(|| {
+                                    dbflux_i18n::t!("connection_manager.banner.connection_failed")
+                                });
                                 let message_to_copy = message.clone();
-                                BannerBlock::new(BannerVariant::Danger, "Connection failed")
-                                    .with_body(message)
-                                    .with_icon(
-                                        AppIconElement::new(AppIcon::Info)
-                                            .size(Heights::ICON_SM)
-                                            .color(banners.error_fg),
+                                BannerBlock::new(
+                                    BannerVariant::Danger,
+                                    dbflux_i18n::t!("connection_manager.banner.connection_failed"),
+                                )
+                                .with_body(message)
+                                .with_icon(
+                                    AppIconElement::new(AppIcon::Info)
+                                        .size(Heights::ICON_SM)
+                                        .color(banners.error_fg),
+                                )
+                                .with_actions(
+                                    Button::new(
+                                        "copy-test-connection-error",
+                                        dbflux_i18n::t!("connection_manager.action.copy"),
                                     )
-                                    .with_actions(
-                                        Button::new("copy-test-connection-error", "Copy")
-                                            .ghost()
-                                            .small()
-                                            .text_color(gpui::white())
-                                            .icon(Icon::new(AppIcon::Copy))
-                                            .on_click(move |_, _, cx| {
-                                                cx.write_to_clipboard(ClipboardItem::new_string(
-                                                    message_to_copy.clone(),
-                                                ));
-                                            }),
-                                    )
+                                    .ghost()
+                                    .small()
+                                    .text_color(gpui::white())
+                                    .icon(Icon::new(AppIcon::Copy))
+                                    .on_click(
+                                        move |_, _, cx| {
+                                            cx.write_to_clipboard(ClipboardItem::new_string(
+                                                message_to_copy.clone(),
+                                            ));
+                                        },
+                                    ),
+                                )
                             }
                             TestStatus::None => unreachable!("guarded by when condition"),
                         };
@@ -445,13 +464,18 @@ impl ConnectionManagerWindow {
                             .gap_2()
                             .when(!is_editing, |d| {
                                 d.child(
-                                    Button::new("footer-back", "Back")
-                                        .ghost()
-                                        .icon(Icon::new(AppIcon::ChevronLeft))
-                                        .small()
-                                        .on_click(cx.listener(|this, _, window, cx| {
+                                    Button::new(
+                                        "footer-back",
+                                        dbflux_i18n::t!("connection_manager.action.back"),
+                                    )
+                                    .ghost()
+                                    .icon(Icon::new(AppIcon::ChevronLeft))
+                                    .small()
+                                    .on_click(cx.listener(
+                                        |this, _, window, cx| {
                                             this.back_to_driver_select(window, cx);
-                                        })),
+                                        },
+                                    )),
                                 )
                             })
                             .child(div().flex_1())
@@ -464,14 +488,21 @@ impl ConnectionManagerWindow {
                                         d.border_color(gpui::transparent_black())
                                     })
                                     .child(
-                                        Button::new("test-connection", "Test Connection")
-                                            .ghost()
-                                            .icon(Icon::new(AppIcon::ExternalLink))
-                                            .small()
-                                            .disabled(test_status == TestStatus::Testing)
-                                            .on_click(cx.listener(|this, _, window, cx| {
+                                        Button::new(
+                                            "test-connection",
+                                            dbflux_i18n::t!(
+                                                "connection_manager.action.test_connection"
+                                            ),
+                                        )
+                                        .ghost()
+                                        .icon(Icon::new(AppIcon::ExternalLink))
+                                        .small()
+                                        .disabled(test_status == TestStatus::Testing)
+                                        .on_click(
+                                            cx.listener(|this, _, window, cx| {
                                                 this.test_connection(window, cx);
-                                            })),
+                                            }),
+                                        ),
                                     ),
                             )
                             .child(
@@ -483,13 +514,18 @@ impl ConnectionManagerWindow {
                                         d.border_color(gpui::transparent_black())
                                     })
                                     .child(
-                                        Button::new("save-connection", "Save")
-                                            .primary()
-                                            .icon(Icon::new(AppIcon::Check))
-                                            .small()
-                                            .on_click(cx.listener(|this, _, window, cx| {
+                                        Button::new(
+                                            "save-connection",
+                                            dbflux_i18n::t!("connection_manager.action.save"),
+                                        )
+                                        .primary()
+                                        .icon(Icon::new(AppIcon::Check))
+                                        .small()
+                                        .on_click(
+                                            cx.listener(|this, _, window, cx| {
                                                 this.save_profile(window, cx);
-                                            })),
+                                            }),
+                                        ),
                                     ),
                             ),
                     ),
@@ -682,12 +718,17 @@ impl ConnectionManagerWindow {
                                 d.border_color(gpui::transparent_black())
                             })
                             .child(
-                                Button::new("browse-file-path", "Browse")
-                                    .small()
-                                    .ghost()
-                                    .on_click(cx.listener(|this, _, window, cx| {
+                                Button::new(
+                                    "browse-file-path",
+                                    dbflux_i18n::t!("connection_manager.action.browse"),
+                                )
+                                .small()
+                                .ghost()
+                                .on_click(cx.listener(
+                                    |this, _, window, cx| {
                                         this.browse_file_path(window, cx);
-                                    })),
+                                    },
+                                )),
                             ),
                     );
 
@@ -1229,7 +1270,11 @@ impl Render for ConnectionManagerWindow {
             state.set_masked(!show_ssh_password, window, cx);
         });
 
-        let csd_title_bar = platform::render_csd_title_bar(window, cx, "Connection Manager");
+        let csd_title_bar = platform::render_csd_title_bar(
+            window,
+            cx,
+            &dbflux_i18n::t!("connection_manager.window_title"),
+        );
 
         let theme = cx.theme();
 

--- a/crates/dbflux_ui_windows/src/connection_manager/render_driver_select.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_driver_select.rs
@@ -95,9 +95,15 @@ impl ConnectionManagerWindow {
                             .size(Heights::ICON_MD)
                             .color(muted),
                     )
-                    .child(Text::heading("New Connection").font_size(FontSizes::LG))
+                    .child(
+                        Text::heading(dbflux_i18n::t!("connection_manager.driver_select.title"))
+                            .font_size(FontSizes::LG),
+                    )
                     .child(div().text_size(FontSizes::SM).text_color(muted).child("·"))
-                    .child(Text::muted("choose a database type").font_size(FontSizes::SM)),
+                    .child(
+                        Text::muted(dbflux_i18n::t!("connection_manager.driver_select.subtitle"))
+                            .font_size(FontSizes::SM),
+                    ),
             )
             .child(
                 div()
@@ -157,14 +163,11 @@ impl ConnectionManagerWindow {
         }
 
         if !rendered_any {
-            body = body.child(
-                div()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .py_8()
-                    .child(Text::muted("No drivers match your filter")),
-            );
+            body = body.child(div().flex().items_center().justify_center().py_8().child(
+                Text::muted(dbflux_i18n::t!(
+                    "connection_manager.driver_select.empty_state"
+                )),
+            ));
         }
 
         body
@@ -234,8 +237,8 @@ impl ConnectionManagerWindow {
         let theme = cx.theme();
         let cta_label = focused_driver
             .as_ref()
-            .map(|d| format!("Configure {}", d.name))
-            .unwrap_or_else(|| "Configure".to_string());
+            .map(|d| crate::labels::driver_select_configure(&d.name))
+            .unwrap_or_else(|| dbflux_i18n::t!("connection_manager.driver_select.configure"));
         let cta_id = focused_driver
             .as_ref()
             .map(|d| d.id.clone())
@@ -259,19 +262,25 @@ impl ConnectionManagerWindow {
                     .items_center()
                     .gap_2()
                     .child(
-                        Button::new("cm-driver-import", "Import from file\u{2026}")
-                            .small()
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                this.open_import(window, cx);
-                            })),
+                        Button::new(
+                            "cm-driver-import",
+                            dbflux_i18n::t!("connection_manager.driver_select.import_from_file"),
+                        )
+                        .small()
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.open_import(window, cx);
+                        })),
                     )
                     .child(
-                        Button::new("cm-driver-cancel", "Cancel")
-                            .small()
-                            .on_click(cx.listener(|_, _, window, cx| {
-                                cx.emit(DismissEvent);
-                                window.remove_window();
-                            })),
+                        Button::new(
+                            "cm-driver-cancel",
+                            dbflux_i18n::t!("connection_manager.driver_select.cancel"),
+                        )
+                        .small()
+                        .on_click(cx.listener(|_, _, window, cx| {
+                            cx.emit(DismissEvent);
+                            window.remove_window();
+                        })),
                     )
                     .child({
                         let mut cta = Button::new("cm-driver-configure", cta_label)

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -28,7 +28,7 @@ impl ConnectionManagerWindow {
             .border_color(border_color)
             .child(self.render_tab_trigger(
                 "tab-main",
-                "Main",
+                dbflux_i18n::t!("connection_manager.tab.main"),
                 AppIcon::Plug,
                 ActiveTab::Main,
                 active_tab == ActiveTab::Main,
@@ -37,7 +37,7 @@ impl ConnectionManagerWindow {
             .when(show_access_tab, |d| {
                 d.child(self.render_tab_trigger(
                     "tab-access",
-                    "Access",
+                    dbflux_i18n::t!("access.tab_label"),
                     AppIcon::FingerprintPattern,
                     ActiveTab::Access,
                     active_tab == ActiveTab::Access,
@@ -46,7 +46,7 @@ impl ConnectionManagerWindow {
             })
             .child(self.render_tab_trigger(
                 "tab-settings",
-                "Settings",
+                dbflux_i18n::t!("connection_manager.tab.settings"),
                 AppIcon::Settings,
                 ActiveTab::Settings,
                 active_tab == ActiveTab::Settings,
@@ -54,7 +54,7 @@ impl ConnectionManagerWindow {
             ))
             .child(self.render_tab_trigger(
                 "tab-mcp",
-                "MCP",
+                dbflux_i18n::t!("connection_manager.tab.mcp"),
                 AppIcon::Lock,
                 ActiveTab::Mcp,
                 active_tab == ActiveTab::Mcp,
@@ -65,7 +65,7 @@ impl ConnectionManagerWindow {
     fn render_tab_trigger(
         &self,
         id: &'static str,
-        label: &'static str,
+        label: impl Into<SharedString>,
         icon: AppIcon,
         tab: ActiveTab,
         is_active: bool,
@@ -204,13 +204,21 @@ impl ConnectionManagerWindow {
             .child(ssl_control)
             .child(div().flex_1());
 
-        let ssl_row = Self::field_row_cm("SSL mode", false, ssl_control_row, None::<&str>, cx);
+        let ssl_row = Self::field_row_cm(
+            dbflux_i18n::t!("connection_manager.field.ssl_mode"),
+            false,
+            ssl_control_row,
+            None::<&str>,
+            cx,
+        );
 
         let mut section = div()
             .flex()
             .flex_col()
             .gap_2()
-            .child(SubSectionLabel::new("TRANSPORT"))
+            .child(SubSectionLabel::new(dbflux_i18n::t!(
+                "connection_manager.section.transport"
+            )))
             .child(ssl_row);
 
         // Cert path inputs — shown only when the driver declares ssl_cert_fields and the
@@ -223,7 +231,7 @@ impl ConnectionManagerWindow {
 
                 if mode_requires_root {
                     let ca_row = self.render_ssl_cert_picker_row(
-                        "CA certificate",
+                        dbflux_i18n::t!("connection_manager.field.ca_certificate"),
                         super::SslCertSlot::CaCert,
                         cx,
                     );
@@ -236,12 +244,12 @@ impl ConnectionManagerWindow {
 
                     if mode_is_cert_active {
                         let cert_row = self.render_ssl_cert_picker_row(
-                            "Client cert",
+                            dbflux_i18n::t!("connection_manager.field.client_cert"),
                             super::SslCertSlot::ClientCert,
                             cx,
                         );
                         let key_row = self.render_ssl_cert_picker_row(
-                            "Client key",
+                            dbflux_i18n::t!("connection_manager.field.client_key"),
                             super::SslCertSlot::ClientKey,
                             cx,
                         );
@@ -260,7 +268,7 @@ impl ConnectionManagerWindow {
     /// Backspace clears the selection.
     fn render_ssl_cert_picker_row(
         &self,
-        label: &'static str,
+        label: impl Into<SharedString>,
         slot: super::SslCertSlot,
         cx: &mut Context<Self>,
     ) -> AnyElement {

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -155,6 +155,15 @@ pub(crate) fn mcp_preview_summary(actor: &str, role: &str, policy: &str) -> Stri
     )
 }
 
+/// Formats the "Configure <driver name>" call-to-action label shown in the driver picker
+/// footer once a driver card is focused.
+pub(crate) fn driver_select_configure(name: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.driver_select.configure_named",
+        name = name
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -295,6 +304,13 @@ mod tests {
             message,
             "Actor 'prod-agent' | role: read-only | policy: strict"
         );
+    }
+
+    #[test]
+    fn driver_select_configure_embeds_driver_name_untouched() {
+        let message = super::driver_select_configure("MongoDB");
+
+        assert!(message.contains("MongoDB"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fourteenth `dbflux_ui_windows` i18n slice: connection manager tab labels, transport section and field labels, validation and test banners, action buttons, the window title and the driver select overlay render through `dbflux_i18n::t!`. English and Spanish together; driver-supplied form labels and category names stay data.

## What does this resolve?

- Refs #360 (follows the auth flow PR; next: the auth profiles settings section)

## How was this solved?

- Size: 430 lines (`size:exception`); the `Password` fallback label in the main tab is a recorded follow-up.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 245 passed; clippy clean; fmt clean. Manual smoke in Spanish: open the connection manager, pick a driver, test a connection.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
