### PR TITLE
feat(i18n): translate the key-value context menu and refresh label

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -505,6 +505,22 @@ document:
         column: COLUMN
         references: REFERENCES
         row: ROW
+  key_value:
+    context_menu:
+      add_entry: Add Entry
+      add_member: Add Member
+      copy_as_command: Copy as Command
+      copy_entry: Copy Entry
+      copy_key: Copy Key
+      copy_member: Copy Member
+      copy_value: Copy Value
+      delete_entry: Delete Entry
+      delete_key: Delete Key
+      delete_member: Delete Member
+      edit_member: Edit Member
+      edit_value: Edit Value
+      new_key: New Key
+      rename: Rename
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -505,6 +505,22 @@ document:
         column: COLUMNA
         references: REFERENCIAS
         row: FILA
+  key_value:
+    context_menu:
+      add_entry: Agregar entrada
+      add_member: Agregar miembro
+      copy_as_command: Copiar como comando
+      copy_entry: Copiar entrada
+      copy_key: Copiar clave
+      copy_member: Copiar miembro
+      copy_value: Copiar valor
+      delete_entry: Eliminar entrada
+      delete_key: Eliminar clave
+      delete_member: Eliminar miembro
+      edit_member: Editar miembro
+      edit_value: Editar valor
+      new_key: Nueva clave
+      rename: Renombrar
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_ui_document/src/key_value/context_menu.rs
+++ b/crates/dbflux_ui_document/src/key_value/context_menu.rs
@@ -19,7 +19,7 @@ pub(super) enum KvMenuTarget {
 }
 
 pub(super) struct KvMenuItem {
-    pub label: &'static str,
+    pub label: SharedString,
     pub action: KvMenuAction,
     pub icon: AppIcon,
     pub is_danger: bool,
@@ -44,31 +44,31 @@ impl super::KeyValueDocument {
     pub(super) fn build_key_menu_items(&self) -> Vec<KvMenuItem> {
         let mut items = vec![
             KvMenuItem {
-                label: "Copy Key",
+                label: dbflux_i18n::t!("document.key_value.context_menu.copy_key").into(),
                 action: KvMenuAction::CopyKey,
                 icon: AppIcon::Columns,
                 is_danger: false,
             },
             KvMenuItem {
-                label: "Copy as Command",
+                label: dbflux_i18n::t!("document.key_value.context_menu.copy_as_command").into(),
                 action: KvMenuAction::CopyAsCommand,
                 icon: AppIcon::Code,
                 is_danger: false,
             },
             KvMenuItem {
-                label: "Rename",
+                label: dbflux_i18n::t!("document.key_value.context_menu.rename").into(),
                 action: KvMenuAction::RenameKey,
                 icon: AppIcon::Pencil,
                 is_danger: false,
             },
             KvMenuItem {
-                label: "New Key",
+                label: dbflux_i18n::t!("document.key_value.context_menu.new_key").into(),
                 action: KvMenuAction::NewKey,
                 icon: AppIcon::Plus,
                 is_danger: false,
             },
             KvMenuItem {
-                label: "Delete Key",
+                label: dbflux_i18n::t!("document.key_value.context_menu.delete_key").into(),
                 action: KvMenuAction::DeleteKey,
                 icon: AppIcon::Delete,
                 is_danger: true,
@@ -86,25 +86,26 @@ impl super::KeyValueDocument {
         if self.is_stream_type() {
             vec![
                 KvMenuItem {
-                    label: "Copy Entry",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.copy_entry").into(),
                     action: KvMenuAction::CopyMember,
                     icon: AppIcon::Columns,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Copy as Command",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.copy_as_command")
+                        .into(),
                     action: KvMenuAction::CopyAsCommand,
                     icon: AppIcon::Code,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Add Entry",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.add_entry").into(),
                     action: KvMenuAction::AddMember,
                     icon: AppIcon::Plus,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Delete Entry",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.delete_entry").into(),
                     action: KvMenuAction::DeleteMember,
                     icon: AppIcon::Delete,
                     is_danger: true,
@@ -113,31 +114,32 @@ impl super::KeyValueDocument {
         } else if self.is_structured_type() {
             vec![
                 KvMenuItem {
-                    label: "Copy Member",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.copy_member").into(),
                     action: KvMenuAction::CopyMember,
                     icon: AppIcon::Columns,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Copy as Command",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.copy_as_command")
+                        .into(),
                     action: KvMenuAction::CopyAsCommand,
                     icon: AppIcon::Code,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Edit Member",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.edit_member").into(),
                     action: KvMenuAction::EditMember,
                     icon: AppIcon::Pencil,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Add Member",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.add_member").into(),
                     action: KvMenuAction::AddMember,
                     icon: AppIcon::Plus,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Delete Member",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.delete_member").into(),
                     action: KvMenuAction::DeleteMember,
                     icon: AppIcon::Delete,
                     is_danger: true,
@@ -146,25 +148,26 @@ impl super::KeyValueDocument {
         } else {
             vec![
                 KvMenuItem {
-                    label: "Copy Value",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.copy_value").into(),
                     action: KvMenuAction::CopyValue,
                     icon: AppIcon::Columns,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Copy as Command",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.copy_as_command")
+                        .into(),
                     action: KvMenuAction::CopyAsCommand,
                     icon: AppIcon::Code,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Edit Value",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.edit_value").into(),
                     action: KvMenuAction::EditValue,
                     icon: AppIcon::Pencil,
                     is_danger: false,
                 },
                 KvMenuItem {
-                    label: "Delete Key",
+                    label: dbflux_i18n::t!("document.key_value.context_menu.delete_key").into(),
                     action: KvMenuAction::DeleteKey,
                     icon: AppIcon::Delete,
                     is_danger: true,
@@ -344,5 +347,66 @@ impl super::KeyValueDocument {
         }
 
         cx.notify();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{KvMenuAction, KvMenuItem};
+    use dbflux_components::icons::AppIcon;
+
+    const CONTEXT_MENU_KEYS: &[&str] = &[
+        "document.key_value.context_menu.add_entry",
+        "document.key_value.context_menu.add_member",
+        "document.key_value.context_menu.copy_as_command",
+        "document.key_value.context_menu.copy_entry",
+        "document.key_value.context_menu.copy_key",
+        "document.key_value.context_menu.copy_member",
+        "document.key_value.context_menu.copy_value",
+        "document.key_value.context_menu.delete_entry",
+        "document.key_value.context_menu.delete_key",
+        "document.key_value.context_menu.delete_member",
+        "document.key_value.context_menu.edit_member",
+        "document.key_value.context_menu.edit_value",
+        "document.key_value.context_menu.new_key",
+        "document.key_value.context_menu.rename",
+    ];
+
+    #[test]
+    fn key_value_context_menu_keys_resolve_in_both_locales() {
+        for key in CONTEXT_MENU_KEYS {
+            let english = dbflux_i18n::t!(key, locale = "en");
+            let spanish = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!english.is_empty(), "empty English translation for {key}");
+            assert!(!spanish.is_empty(), "empty Spanish translation for {key}");
+            assert_ne!(english, *key, "English translation missing for {key}");
+            assert_ne!(spanish, *key, "Spanish translation missing for {key}");
+            assert_ne!(
+                english,
+                format!("en.{key}"),
+                "English translation missing for {key}"
+            );
+            assert_ne!(
+                spanish,
+                format!("es.{key}"),
+                "Spanish translation missing for {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn key_value_context_menu_label_round_trips_translated_value() {
+        let item = KvMenuItem {
+            label: dbflux_i18n::t!("document.key_value.context_menu.copy_key").into(),
+            action: KvMenuAction::CopyKey,
+            icon: AppIcon::Columns,
+            is_danger: false,
+        };
+
+        assert_eq!(
+            item.label.to_string(),
+            dbflux_i18n::t!("document.key_value.context_menu.copy_key")
+        );
     }
 }

--- a/crates/dbflux_ui_document/src/key_value/render.rs
+++ b/crates/dbflux_ui_document/src/key_value/render.rs
@@ -12,6 +12,19 @@ use gpui::*;
 use gpui_component::ActiveTheme;
 use gpui_component::scroll::ScrollableElement;
 
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn key_value_refresh_label_differs_between_locales() {
+        let english = dbflux_i18n::t!("document.data.grid.toolbar.refresh", locale = "en");
+        let spanish = dbflux_i18n::t!("document.data.grid.toolbar.refresh", locale = "es");
+
+        assert_eq!(english, "Refresh");
+        assert_eq!(spanish, "Actualizar");
+        assert_ne!(english, spanish);
+    }
+}
+
 impl Render for super::KeyValueDocument {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         // Handle deferred modal opens before borrowing theme
@@ -474,9 +487,9 @@ impl Render for super::KeyValueDocument {
         };
 
         let refresh_label = if self.refresh_policy.is_auto() {
-            self.refresh_policy.label()
+            crate::labels::refresh_policy_label(self.refresh_policy)
         } else {
-            "Refresh"
+            dbflux_i18n::t!("document.data.grid.toolbar.refresh")
         };
 
         // -- Left panel --

--- a/crates/dbflux_ui_document/src/key_value/view.rs
+++ b/crates/dbflux_ui_document/src/key_value/view.rs
@@ -160,7 +160,7 @@ pub(super) fn render_kv_context_menu(
         .map(|(idx, item)| {
             let is_selected = idx == selected_index;
             let is_danger = item.is_danger;
-            let label = item.label;
+            let label = item.label.clone();
             let icon = item.icon;
             let action = item.action;
 
@@ -173,7 +173,7 @@ pub(super) fn render_kv_context_menu(
             };
 
             div()
-                .id(SharedString::from(label))
+                .id(label.clone())
                 .flex()
                 .items_center()
                 .gap(Spacing::SM)


### PR DESCRIPTION
## Summary

Document i18n slice 12: key and value context menu items carry `SharedString` labels resolved through `dbflux_i18n::t!`; the key-value refresh label reuses the data grid refresh keys. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 11; next: the new-key modal and remaining key-value copy)

## How was this solved?

- Remaining key-value render literals are listed for the next slice.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 940 passed; clippy clean; fmt clean. Manual smoke in Spanish: right-click a Redis key and a value.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
