### PR TITLE
feat(i18n): translate the new-key modal and the remaining key-value copy

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -556,6 +556,89 @@ document:
       edit_value: Edit Value
       new_key: New Key
       rename: Rename
+    mutation:
+      error:
+        connection_inactive: Connection is no longer active
+        member_target_unavailable: "Cannot delete member: connection or key unavailable"
+        key_not_deleted: Key was not deleted
+      task:
+        delete_member: "Delete member from %{key}"
+        edit_member: "Edit member in %{key}"
+        add_member: "Add member to %{key}"
+        create_key: "Create key %{key}"
+    new_key:
+      title: New Key
+      key_type:
+        label: Key Type*
+        placeholder: "Select type"
+      ttl:
+        label: TTL
+        placeholder: No limit
+      key_name:
+        label: Key Name*
+        placeholder: Enter Key Name
+      value:
+        label: Value
+        placeholder: Enter Value
+      field_placeholder: Enter Field
+      member_placeholder: Enter Member
+      score_placeholder: Enter Score
+      error:
+        key_name_required: Key name is required
+        ttl_invalid: TTL must be a positive integer
+        stream_requires_field: Stream requires at least one field/value pair
+        prefix: "Error: %{error}"
+      cancel: Cancel
+      create: Create
+      type:
+        string: String
+        hash: Hash
+        list: List
+        set: Set
+        sorted_set: Sorted Set
+        json: JSON
+        stream: Stream
+    pagination:
+      error:
+        background_task_limit: Too many background tasks running, please wait
+    parsing:
+      type:
+        string: String
+        bytes: Bytes
+        hash: Hash
+        list: List
+        set: Set
+        sorted_set: ZSet
+        json: JSON
+        stream: Stream
+        unknown: "?"
+    render:
+      delete_key:
+        title: Delete key?
+        message: 'Delete "%{key}"? This action cannot be undone.'
+      delete_member:
+        title: Delete member?
+        message: 'Delete "%{member}"? This action cannot be undone.'
+      unknown_type: Unknown
+      value_header: Value
+      id_header: ID
+      fields_header: Fields
+      field_score_header: Field/Score
+      click_to_edit: Click or press Enter to edit
+      select_key_prompt: Select a key to inspect
+      prev: Prev
+      next: Next
+      page: "Page %{page}"
+      keys_count:
+        one: "%{count} key"
+        many: "%{count} keys"
+      filter:
+        keys_placeholder: "Filter keys..."
+        members_placeholder: "Filter members..."
+      ttl:
+        no_limit: No limit
+        missing: Missing
+        expired: Expired
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -556,6 +556,89 @@ document:
       edit_value: Editar valor
       new_key: Nueva clave
       rename: Renombrar
+    mutation:
+      error:
+        connection_inactive: La conexión ya no está activa
+        member_target_unavailable: "No se puede eliminar el miembro: conexión o clave no disponible"
+        key_not_deleted: La clave no fue eliminada
+      task:
+        delete_member: "Eliminar miembro de %{key}"
+        edit_member: "Editar miembro en %{key}"
+        add_member: "Agregar miembro a %{key}"
+        create_key: "Crear clave %{key}"
+    new_key:
+      title: Nueva clave
+      key_type:
+        label: Tipo de clave*
+        placeholder: "Seleccionar tipo"
+      ttl:
+        label: TTL
+        placeholder: Sin límite
+      key_name:
+        label: Nombre de clave*
+        placeholder: Ingresar nombre de clave
+      value:
+        label: Valor
+        placeholder: Ingresar valor
+      field_placeholder: Ingresar campo
+      member_placeholder: Ingresar miembro
+      score_placeholder: Ingresar puntuación
+      error:
+        key_name_required: El nombre de la clave es obligatorio
+        ttl_invalid: El TTL debe ser un entero positivo
+        stream_requires_field: El stream requiere al menos un par campo/valor
+        prefix: "Error: %{error}"
+      cancel: Cancelar
+      create: Crear
+      type:
+        string: String
+        hash: Hash
+        list: List
+        set: Set
+        sorted_set: Sorted Set
+        json: JSON
+        stream: Stream
+    pagination:
+      error:
+        background_task_limit: Demasiadas tareas en segundo plano en ejecución, espere por favor
+    parsing:
+      type:
+        string: String
+        bytes: Bytes
+        hash: Hash
+        list: List
+        set: Set
+        sorted_set: ZSet
+        json: JSON
+        stream: Stream
+        unknown: "?"
+    render:
+      delete_key:
+        title: ¿Eliminar clave?
+        message: '¿Eliminar "%{key}"? Esta acción no se puede deshacer.'
+      delete_member:
+        title: ¿Eliminar miembro?
+        message: '¿Eliminar "%{member}"? Esta acción no se puede deshacer.'
+      unknown_type: Desconocido
+      value_header: Valor
+      id_header: ID
+      fields_header: Campos
+      field_score_header: Campo/Puntuación
+      click_to_edit: Clic o presiona Enter para editar
+      select_key_prompt: Selecciona una clave para inspeccionar
+      prev: Anterior
+      next: Siguiente
+      page: "Página %{page}"
+      keys_count:
+        one: "%{count} clave"
+        many: "%{count} claves"
+      filter:
+        keys_placeholder: "Filtrar claves..."
+        members_placeholder: "Filtrar miembros..."
+      ttl:
+        no_limit: Sin límite
+        missing: Ausente
+        expired: Expirado
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_ui_document/src/key_value/mod.rs
+++ b/crates/dbflux_ui_document/src/key_value/mod.rs
@@ -167,9 +167,16 @@ impl KeyValueDocument {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let filter_input = cx.new(|cx| InputState::new(window, cx).placeholder("Filter keys..."));
-        let members_filter_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Filter members..."));
+        let filter_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.key_value.render.filter.keys_placeholder"
+            ))
+        });
+        let members_filter_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.key_value.render.filter.members_placeholder"
+            ))
+        });
         let mut subscriptions = Vec::new();
 
         subscriptions.push(cx.subscribe_in(
@@ -377,15 +384,15 @@ impl KeyValueDocument {
         match entry.ttl_seconds {
             None | Some(-1) => {
                 self.ttl_state = TtlState::NoLimit;
-                self.ttl_display = "No limit".into();
+                self.ttl_display = dbflux_i18n::t!("document.key_value.render.ttl.no_limit");
             }
             Some(-2) => {
                 self.ttl_state = TtlState::Missing;
-                self.ttl_display = "Missing".into();
+                self.ttl_display = dbflux_i18n::t!("document.key_value.render.ttl.missing");
             }
             Some(0) => {
                 self.ttl_state = TtlState::Expired;
-                self.ttl_display = "Expired".into();
+                self.ttl_display = dbflux_i18n::t!("document.key_value.render.ttl.expired");
             }
             Some(secs) if secs > 0 => {
                 let deadline = Instant::now() + Duration::from_secs(secs as u64);
@@ -395,7 +402,7 @@ impl KeyValueDocument {
             }
             _ => {
                 self.ttl_state = TtlState::NoLimit;
-                self.ttl_display = "No limit".into();
+                self.ttl_display = dbflux_i18n::t!("document.key_value.render.ttl.no_limit");
             }
         }
     }
@@ -415,7 +422,7 @@ impl KeyValueDocument {
 
         if remaining.is_zero() {
             self.ttl_state = TtlState::Expired;
-            self.ttl_display = "Expired".into();
+            self.ttl_display = dbflux_i18n::t!("document.key_value.render.ttl.expired");
             self._ttl_countdown_timer = None;
         } else {
             self.ttl_display = format!("{}s", remaining.as_secs());

--- a/crates/dbflux_ui_document/src/key_value/mutations.rs
+++ b/crates/dbflux_ui_document/src/key_value/mutations.rs
@@ -82,7 +82,9 @@ impl super::KeyValueDocument {
             || self.selected_key_type().is_none()
             || self.get_connection(cx).is_none()
         {
-            self.last_error = Some("Cannot delete member: connection or key unavailable".into());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.key_value.mutation.error.member_target_unavailable"
+            ));
             cx.notify();
             return;
         }
@@ -114,7 +116,9 @@ impl super::KeyValueDocument {
 
     fn delete_key_async(&mut self, key: String, cx: &mut Context<Self>) {
         let Some(connection) = self.get_connection(cx) else {
-            self.last_error = Some("Connection is no longer active".to_string());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.key_value.mutation.error.connection_inactive"
+            ));
             cx.notify();
             return;
         };
@@ -146,9 +150,11 @@ impl super::KeyValueDocument {
                             this.last_error = None;
                         }
                         Ok(false) => {
-                            this.runner
-                                .fail_mutation(task_id, "Key was not deleted", cx);
-                            this.last_error = Some("Key was not deleted".to_string());
+                            let message = dbflux_i18n::t!(
+                                "document.key_value.mutation.error.key_not_deleted"
+                            );
+                            this.runner.fail_mutation(task_id, message.clone(), cx);
+                            this.last_error = Some(message);
                             this.reload_keys(cx);
                             return;
                         }
@@ -180,9 +186,9 @@ impl super::KeyValueDocument {
 
         let (task_id, _cancel_token) = self.runner.start_mutation(
             TaskKind::KeyMutation,
-            format!(
-                "Delete member from {}",
-                dbflux_core::truncate_string_safe(&key, 40)
+            dbflux_i18n::t!(
+                "document.key_value.mutation.task.delete_member",
+                key = dbflux_core::truncate_string_safe(&key, 40)
             ),
             cx,
         );
@@ -329,7 +335,9 @@ impl super::KeyValueDocument {
         cx.notify();
 
         let Some(connection) = self.get_connection(cx) else {
-            self.last_error = Some("Connection is no longer active".to_string());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.key_value.mutation.error.connection_inactive"
+            ));
             cx.notify();
             return;
         };
@@ -610,9 +618,9 @@ impl super::KeyValueDocument {
 
         let (task_id, _cancel_token) = self.runner.start_mutation(
             TaskKind::KeyMutation,
-            format!(
-                "Edit member in {}",
-                dbflux_core::truncate_string_safe(&key, 40)
+            dbflux_i18n::t!(
+                "document.key_value.mutation.task.edit_member",
+                key = dbflux_core::truncate_string_safe(&key, 40)
             ),
             cx,
         );
@@ -735,16 +743,18 @@ impl super::KeyValueDocument {
             return;
         };
         let Some(connection) = self.get_connection(cx) else {
-            self.last_error = Some("Connection is no longer active".to_string());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.key_value.mutation.error.connection_inactive"
+            ));
             cx.notify();
             return;
         };
 
         let (task_id, _cancel_token) = self.runner.start_mutation(
             TaskKind::KeyMutation,
-            format!(
-                "Add member to {}",
-                dbflux_core::truncate_string_safe(&key, 40)
+            dbflux_i18n::t!(
+                "document.key_value.mutation.task.add_member",
+                key = dbflux_core::truncate_string_safe(&key, 40)
             ),
             cx,
         );
@@ -843,16 +853,18 @@ impl super::KeyValueDocument {
         cx: &mut Context<Self>,
     ) {
         let Some(connection) = self.get_connection(cx) else {
-            self.last_error = Some("Connection is no longer active".to_string());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.key_value.mutation.error.connection_inactive"
+            ));
             cx.notify();
             return;
         };
 
         let (task_id, _cancel_token) = self.runner.start_mutation(
             TaskKind::KeyMutation,
-            format!(
-                "Create key {}",
-                dbflux_core::truncate_string_safe(&event.key_name, 40)
+            dbflux_i18n::t!(
+                "document.key_value.mutation.task.create_key",
+                key = dbflux_core::truncate_string_safe(&event.key_name, 40)
             ),
             cx,
         );
@@ -981,5 +993,52 @@ impl super::KeyValueDocument {
             .log_if_dropped();
         })
         .detach();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn key_value_mutation_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.key_value.mutation.error.connection_inactive",
+            "document.key_value.mutation.error.member_target_unavailable",
+            "document.key_value.mutation.error.key_not_deleted",
+            "document.key_value.mutation.task.delete_member",
+            "document.key_value.mutation.task.edit_member",
+            "document.key_value.mutation.task.add_member",
+            "document.key_value.mutation.task.create_key",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn key_value_mutation_task_descriptions_interpolate_key_name() {
+        let delete_member = dbflux_i18n::t!(
+            "document.key_value.mutation.task.delete_member",
+            locale = "en",
+            key = "session:42"
+        );
+        let create_key = dbflux_i18n::t!(
+            "document.key_value.mutation.task.create_key",
+            locale = "en",
+            key = "session:42"
+        );
+
+        assert!(delete_member.contains("session:42"));
+        assert!(create_key.contains("session:42"));
     }
 }

--- a/crates/dbflux_ui_document/src/key_value/pagination.rs
+++ b/crates/dbflux_ui_document/src/key_value/pagination.rs
@@ -51,13 +51,17 @@ impl super::KeyValueDocument {
         self.cancel_member_edit(cx);
 
         let Some(connection) = self.get_connection(cx) else {
-            self.last_error = Some("Connection is no longer active".to_string());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.key_value.mutation.error.connection_inactive"
+            ));
             cx.notify();
             return;
         };
 
         if self.app_state.read(cx).is_background_task_limit_reached() {
-            self.last_error = Some("Too many background tasks running, please wait".to_string());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.key_value.pagination.error.background_task_limit"
+            ));
             cx.notify();
             return;
         }
@@ -166,7 +170,9 @@ impl super::KeyValueDocument {
         };
 
         let Some(connection) = self.get_connection(cx) else {
-            self.last_error = Some("Connection is no longer active".to_string());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.key_value.mutation.error.connection_inactive"
+            ));
             cx.notify();
             return;
         };
@@ -235,5 +241,27 @@ impl super::KeyValueDocument {
             .log_if_dropped();
         })
         .detach();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn key_value_pagination_keys_resolve_in_both_locales() {
+        let keys = ["document.key_value.pagination.error.background_task_limit"];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
     }
 }

--- a/crates/dbflux_ui_document/src/key_value/parsing.rs
+++ b/crates/dbflux_ui_document/src/key_value/parsing.rs
@@ -27,17 +27,17 @@ pub(super) fn key_type_icon(key_type: Option<KeyType>) -> (AppIcon, Hsla) {
     }
 }
 
-pub(super) fn key_type_label(key_type: KeyType) -> &'static str {
+pub(super) fn key_type_label(key_type: KeyType) -> String {
     match key_type {
-        KeyType::String => "String",
-        KeyType::Bytes => "Bytes",
-        KeyType::Hash => "Hash",
-        KeyType::List => "List",
-        KeyType::Set => "Set",
-        KeyType::SortedSet => "ZSet",
-        KeyType::Json => "JSON",
-        KeyType::Stream => "Stream",
-        KeyType::Unknown => "?",
+        KeyType::String => dbflux_i18n::t!("document.key_value.parsing.type.string"),
+        KeyType::Bytes => dbflux_i18n::t!("document.key_value.parsing.type.bytes"),
+        KeyType::Hash => dbflux_i18n::t!("document.key_value.parsing.type.hash"),
+        KeyType::List => dbflux_i18n::t!("document.key_value.parsing.type.list"),
+        KeyType::Set => dbflux_i18n::t!("document.key_value.parsing.type.set"),
+        KeyType::SortedSet => dbflux_i18n::t!("document.key_value.parsing.type.sorted_set"),
+        KeyType::Json => dbflux_i18n::t!("document.key_value.parsing.type.json"),
+        KeyType::Stream => dbflux_i18n::t!("document.key_value.parsing.type.stream"),
+        KeyType::Unknown => dbflux_i18n::t!("document.key_value.parsing.type.unknown"),
     }
 }
 
@@ -276,6 +276,35 @@ mod tests {
         assert_eq!(key_type_label(KeyType::Stream), "Stream");
         assert_eq!(key_type_label(KeyType::Bytes), "Bytes");
         assert_eq!(key_type_label(KeyType::Unknown), "?");
+    }
+
+    #[test]
+    fn key_type_label_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.key_value.parsing.type.string",
+            "document.key_value.parsing.type.bytes",
+            "document.key_value.parsing.type.hash",
+            "document.key_value.parsing.type.list",
+            "document.key_value.parsing.type.set",
+            "document.key_value.parsing.type.sorted_set",
+            "document.key_value.parsing.type.json",
+            "document.key_value.parsing.type.stream",
+            "document.key_value.parsing.type.unknown",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
     }
 
     // --- key_type_icon ---

--- a/crates/dbflux_ui_document/src/key_value/render.rs
+++ b/crates/dbflux_ui_document/src/key_value/render.rs
@@ -23,6 +23,65 @@ mod tests {
         assert_eq!(spanish, "Actualizar");
         assert_ne!(english, spanish);
     }
+
+    #[test]
+    fn key_value_render_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.key_value.render.delete_key.title",
+            "document.key_value.render.delete_key.message",
+            "document.key_value.render.delete_member.title",
+            "document.key_value.render.delete_member.message",
+            "document.key_value.render.unknown_type",
+            "document.key_value.render.value_header",
+            "document.key_value.render.id_header",
+            "document.key_value.render.fields_header",
+            "document.key_value.render.field_score_header",
+            "document.key_value.render.click_to_edit",
+            "document.key_value.render.select_key_prompt",
+            "document.key_value.render.prev",
+            "document.key_value.render.next",
+            "document.key_value.render.page",
+            "document.key_value.render.keys_count.one",
+            "document.key_value.render.keys_count.many",
+            "document.key_value.render.filter.keys_placeholder",
+            "document.key_value.render.filter.members_placeholder",
+            "document.key_value.render.ttl.no_limit",
+            "document.key_value.render.ttl.missing",
+            "document.key_value.render.ttl.expired",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn key_value_delete_key_message_interpolates_key_name() {
+        let message = dbflux_i18n::t!(
+            "document.key_value.render.delete_key.message",
+            locale = "en",
+            key = "session:42"
+        );
+
+        assert!(message.contains("session:42"));
+    }
+
+    #[test]
+    fn key_value_page_label_interpolates_page_number() {
+        let page = dbflux_i18n::t!("document.key_value.render.page", locale = "en", page = 3);
+
+        assert!(page.contains('3'));
+    }
 }
 
 impl Render for super::KeyValueDocument {
@@ -50,15 +109,18 @@ impl Render for super::KeyValueDocument {
             self.pending_key_delete.is_some() || self.pending_member_delete.is_some();
         let (delete_title, delete_message) = if let Some(pending) = &self.pending_key_delete {
             (
-                "Delete key?".to_string(),
-                format!("Delete \"{}\"? This action cannot be undone.", pending.key),
+                dbflux_i18n::t!("document.key_value.render.delete_key.title"),
+                dbflux_i18n::t!(
+                    "document.key_value.render.delete_key.message",
+                    key = pending.key
+                ),
             )
         } else if let Some(pending) = &self.pending_member_delete {
             (
-                "Delete member?".to_string(),
-                format!(
-                    "Delete \"{}\"? This action cannot be undone.",
-                    pending.member_display
+                dbflux_i18n::t!("document.key_value.render.delete_member.title"),
+                dbflux_i18n::t!(
+                    "document.key_value.render.delete_member.message",
+                    member = pending.member_display
                 ),
             )
         } else {
@@ -86,8 +148,8 @@ impl Render for super::KeyValueDocument {
             let type_label = value
                 .entry
                 .key_type
-                .map(|t| key_type_label(t).to_string())
-                .unwrap_or_else(|| "Unknown".to_string());
+                .map(key_type_label)
+                .unwrap_or_else(|| dbflux_i18n::t!("document.key_value.render.unknown_type"));
             let ttl_color = match self.ttl_state {
                 TtlState::Expired => theme.danger,
                 TtlState::Missing => theme.warning,
@@ -230,7 +292,7 @@ impl Render for super::KeyValueDocument {
                             .justify_center()
                             .border_l_1()
                             .border_color(theme.border)
-                            .child(Text::muted("No data")),
+                            .child(Text::muted(dbflux_i18n::t!("document.data.grid.empty"))),
                     );
                 }
             } else if is_structured {
@@ -283,15 +345,15 @@ impl Render for super::KeyValueDocument {
                 let is_stream = self.is_stream_type();
                 header = header.child(div().w(px(30.0)).child(Text::caption("#")));
                 header = header.child(div().flex_1().child(Text::caption(if is_stream {
-                    "ID"
+                    dbflux_i18n::t!("document.key_value.render.id_header")
                 } else {
-                    "Value"
+                    dbflux_i18n::t!("document.key_value.render.value_header")
                 })));
                 if needs_value_col {
                     header = header.child(div().w(px(200.0)).child(Text::caption(if is_stream {
-                        "Fields"
+                        dbflux_i18n::t!("document.key_value.render.fields_header")
                     } else {
-                        "Field/Score"
+                        dbflux_i18n::t!("document.key_value.render.field_score_header")
                     })));
                 }
                 header = header.child(div().w(Heights::ICON_MD));
@@ -450,11 +512,9 @@ impl Render for super::KeyValueDocument {
                         )
                         .child(value_preview)
                         .when(is_editable, |d| {
-                            d.child(
-                                div()
-                                    .pt(Spacing::SM)
-                                    .child(Text::caption("Click or press Enter to edit")),
-                            )
+                            d.child(div().pt(Spacing::SM).child(Text::caption(dbflux_i18n::t!(
+                                "document.key_value.render.click_to_edit"
+                            ))))
                         }),
                 );
             }
@@ -478,10 +538,13 @@ impl Render for super::KeyValueDocument {
                                 .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                 .color(theme.muted_foreground),
                         )
-                        .child(Text::muted("Loading…"))
+                        .child(Text::muted(dbflux_i18n::t!("document.data.grid.loading")))
                         .into_any_element()
                 } else {
-                    Text::muted("Select a key to inspect").into_any_element()
+                    Text::muted(dbflux_i18n::t!(
+                        "document.key_value.render.select_key_prompt"
+                    ))
+                    .into_any_element()
                 })
                 .into_any_element()
         };
@@ -626,9 +689,17 @@ impl Render for super::KeyValueDocument {
                                     .into_any_element()
                             })
                             .child(Text::caption(if self.runner.is_primary_active() {
-                                "Loading…".to_string()
+                                dbflux_i18n::t!("document.data.grid.loading")
+                            } else if key_count == 1 {
+                                dbflux_i18n::t!(
+                                    "document.key_value.render.keys_count.one",
+                                    count = key_count
+                                )
                             } else {
-                                format!("{} keys", key_count)
+                                dbflux_i18n::t!(
+                                    "document.key_value.render.keys_count.many",
+                                    count = key_count
+                                )
                             })),
                     )
                     .child(
@@ -663,13 +734,23 @@ impl Render for super::KeyValueDocument {
                                             .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                             .color(icon_color)
                                     })
-                                    .child(Text::caption("Prev").color(if can_prev {
-                                        theme.foreground
-                                    } else {
-                                        theme.muted_foreground
-                                    })),
+                                    .child(
+                                        Text::caption(dbflux_i18n::t!(
+                                            "document.key_value.render.prev"
+                                        ))
+                                        .color(
+                                            if can_prev {
+                                                theme.foreground
+                                            } else {
+                                                theme.muted_foreground
+                                            },
+                                        ),
+                                    ),
                             )
-                            .child(Text::caption(format!("Page {}", current_page)))
+                            .child(Text::caption(dbflux_i18n::t!(
+                                "document.key_value.render.page",
+                                page = current_page
+                            )))
                             .child(
                                 div()
                                     .id("kv-next-page")
@@ -687,11 +768,18 @@ impl Render for super::KeyValueDocument {
                                             }))
                                     })
                                     .when(!can_next, |d| d.opacity(0.5))
-                                    .child(Text::caption("Next").color(if can_next {
-                                        theme.foreground
-                                    } else {
-                                        theme.muted_foreground
-                                    }))
+                                    .child(
+                                        Text::caption(dbflux_i18n::t!(
+                                            "document.key_value.render.next"
+                                        ))
+                                        .color(
+                                            if can_next {
+                                                theme.foreground
+                                            } else {
+                                                theme.muted_foreground
+                                            },
+                                        ),
+                                    )
                                     .child({
                                         let icon_color = if can_next {
                                             theme.foreground
@@ -773,9 +861,9 @@ impl Render for super::KeyValueDocument {
                         );
 
                         row = row.child(Text::caption(
-                            key.key_type
-                                .map(|t| key_type_label(t).to_string())
-                                .unwrap_or_else(|| "?".to_string()),
+                            key.key_type.map(key_type_label).unwrap_or_else(|| {
+                                dbflux_i18n::t!("document.key_value.parsing.type.unknown")
+                            }),
                         ));
                     }
 

--- a/crates/dbflux_ui_document/src/new_key_modal.rs
+++ b/crates/dbflux_ui_document/src/new_key_modal.rs
@@ -49,15 +49,15 @@ impl NewKeyType {
         ]
     }
 
-    pub fn label(self) -> &'static str {
+    pub fn label(self) -> String {
         match self {
-            Self::String => "String",
-            Self::Hash => "Hash",
-            Self::List => "List",
-            Self::Set => "Set",
-            Self::SortedSet => "Sorted Set",
-            Self::Json => "JSON",
-            Self::Stream => "Stream",
+            Self::String => dbflux_i18n::t!("document.key_value.new_key.type.string"),
+            Self::Hash => dbflux_i18n::t!("document.key_value.new_key.type.hash"),
+            Self::List => dbflux_i18n::t!("document.key_value.new_key.type.list"),
+            Self::Set => dbflux_i18n::t!("document.key_value.new_key.type.set"),
+            Self::SortedSet => dbflux_i18n::t!("document.key_value.new_key.type.sorted_set"),
+            Self::Json => dbflux_i18n::t!("document.key_value.new_key.type.json"),
+            Self::Stream => dbflux_i18n::t!("document.key_value.new_key.type.stream"),
         }
     }
 }
@@ -153,12 +153,26 @@ impl NewKeyModal {
             Dropdown::new("new-key-type")
                 .items(items)
                 .selected_index(Some(0))
-                .placeholder("Select type")
+                .placeholder(dbflux_i18n::t!(
+                    "document.key_value.new_key.key_type.placeholder"
+                ))
         });
 
-        let key_name_input = cx.new(|cx| InputState::new(window, cx).placeholder("Enter Key Name"));
-        let ttl_input = cx.new(|cx| InputState::new(window, cx).placeholder("No limit"));
-        let value_input = cx.new(|cx| InputState::new(window, cx).placeholder("Enter Value"));
+        let key_name_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.key_value.new_key.key_name.placeholder"
+            ))
+        });
+        let ttl_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.key_value.new_key.ttl.placeholder"
+            ))
+        });
+        let value_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.key_value.new_key.value.placeholder"
+            ))
+        });
 
         let mut subscriptions = Vec::new();
 
@@ -291,14 +305,22 @@ impl NewKeyModal {
 
     fn add_value_row(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let field_placeholder = match self.selected_type {
-            NewKeyType::Hash | NewKeyType::Stream => "Enter Field",
-            NewKeyType::SortedSet => "Enter Member",
-            _ => "Enter Member",
+            NewKeyType::Hash | NewKeyType::Stream => {
+                dbflux_i18n::t!("document.key_value.new_key.field_placeholder")
+            }
+            NewKeyType::SortedSet => {
+                dbflux_i18n::t!("document.key_value.new_key.member_placeholder")
+            }
+            _ => dbflux_i18n::t!("document.key_value.new_key.member_placeholder"),
         };
         let value_placeholder = match self.selected_type {
-            NewKeyType::Hash | NewKeyType::Stream => "Enter Value",
-            NewKeyType::SortedSet => "Enter Score",
-            _ => "Enter Value",
+            NewKeyType::Hash | NewKeyType::Stream => {
+                dbflux_i18n::t!("document.key_value.new_key.value.placeholder")
+            }
+            NewKeyType::SortedSet => {
+                dbflux_i18n::t!("document.key_value.new_key.score_placeholder")
+            }
+            _ => dbflux_i18n::t!("document.key_value.new_key.value.placeholder"),
         };
 
         let field_input = cx.new(|cx| InputState::new(window, cx).placeholder(field_placeholder));
@@ -352,7 +374,9 @@ impl NewKeyModal {
     fn submit(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         let key_name = self.key_name_input.read(cx).value().trim().to_string();
         if key_name.is_empty() {
-            self.error_message = Some("Key name is required".to_string());
+            self.error_message = Some(dbflux_i18n::t!(
+                "document.key_value.new_key.error.key_name_required"
+            ));
             cx.notify();
             return;
         }
@@ -364,7 +388,9 @@ impl NewKeyModal {
             match ttl_text.parse::<u64>() {
                 Ok(v) => Some(v),
                 Err(_) => {
-                    self.error_message = Some("TTL must be a positive integer".to_string());
+                    self.error_message = Some(dbflux_i18n::t!(
+                        "document.key_value.new_key.error.ttl_invalid"
+                    ));
                     cx.notify();
                     return;
                 }
@@ -431,8 +457,9 @@ impl NewKeyModal {
                     .collect();
 
                 if fields.is_empty() {
-                    self.error_message =
-                        Some("Stream requires at least one field/value pair".to_string());
+                    self.error_message = Some(dbflux_i18n::t!(
+                        "document.key_value.new_key.error.stream_requires_field"
+                    ));
                     cx.notify();
                     return;
                 }
@@ -742,7 +769,9 @@ impl Render for NewKeyModal {
                         .flex()
                         .flex_col()
                         .gap(Spacing::XS)
-                        .child(Text::caption("Key Type*"))
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "document.key_value.new_key.key_type.label"
+                        )))
                         .child(self.key_type_dropdown.clone()),
                 )
                 .child(
@@ -752,7 +781,9 @@ impl Render for NewKeyModal {
                         .flex()
                         .flex_col()
                         .gap(Spacing::XS)
-                        .child(Text::caption("TTL"))
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "document.key_value.new_key.ttl.label"
+                        )))
                         .child(
                             focus_ring(show_ring && focus == ModalFocus::TTL, ring_color)
                                 .on_mouse_down(
@@ -773,7 +804,9 @@ impl Render for NewKeyModal {
                 .flex()
                 .flex_col()
                 .gap(Spacing::XS)
-                .child(Text::caption("Key Name*"))
+                .child(Text::caption(dbflux_i18n::t!(
+                    "document.key_value.new_key.key_name.label"
+                )))
                 .child(
                     focus_ring(show_ring && focus == ModalFocus::KeyName, ring_color)
                         .on_mouse_down(
@@ -898,7 +931,9 @@ impl Render for NewKeyModal {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Text::caption("Value"))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.key_value.new_key.value.label"
+                    )))
                     .child(
                         focus_ring(show_ring && focus == ModalFocus::Value, ring_color)
                             .on_mouse_down(
@@ -915,7 +950,10 @@ impl Render for NewKeyModal {
         // -- Error message --------------------------------------------------
 
         if let Some(error) = &self.error_message {
-            body = body.child(Text::caption(format!("Error: {}", error)));
+            body = body.child(Text::caption(dbflux_i18n::t!(
+                "document.key_value.new_key.error.prefix",
+                error = error
+            )));
         }
 
         // -- Footer buttons -------------------------------------------------
@@ -932,7 +970,7 @@ impl Render for NewKeyModal {
                     focus_ring(cancel_focused, ring_color).child(
                         Button::new("new-key-cancel")
                             .small()
-                            .label("Cancel")
+                            .label(dbflux_i18n::t!("document.key_value.new_key.cancel"))
                             .with_variant(ButtonVariant::Ghost)
                             .on_click(cx.listener(|this, _, _, cx| {
                                 this.close(cx);
@@ -943,7 +981,7 @@ impl Render for NewKeyModal {
                     focus_ring(create_focused, ring_color).child(
                         Button::new("new-key-create")
                             .small()
-                            .label("Create")
+                            .label(dbflux_i18n::t!("document.key_value.new_key.create"))
                             .with_variant(ButtonVariant::Primary)
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.submit(window, cx);
@@ -953,11 +991,80 @@ impl Render for NewKeyModal {
         );
 
         ModalFrame::new("new-key-modal", &self.focus_handle, close)
-            .title("New Key")
+            .title(dbflux_i18n::t!("document.key_value.new_key.title"))
             .icon(AppIcon::Plus)
             .width(px(600.0))
             .max_height(px(500.0))
             .child(body.into_any_element())
             .render(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NewKeyType;
+
+    #[test]
+    fn new_key_type_label_covers_all_variants() {
+        for key_type in NewKeyType::all() {
+            let label = key_type.label();
+            assert!(!label.is_empty());
+        }
+    }
+
+    #[test]
+    fn new_key_modal_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.key_value.new_key.title",
+            "document.key_value.new_key.key_type.label",
+            "document.key_value.new_key.key_type.placeholder",
+            "document.key_value.new_key.ttl.label",
+            "document.key_value.new_key.ttl.placeholder",
+            "document.key_value.new_key.key_name.label",
+            "document.key_value.new_key.key_name.placeholder",
+            "document.key_value.new_key.value.label",
+            "document.key_value.new_key.value.placeholder",
+            "document.key_value.new_key.field_placeholder",
+            "document.key_value.new_key.member_placeholder",
+            "document.key_value.new_key.score_placeholder",
+            "document.key_value.new_key.error.key_name_required",
+            "document.key_value.new_key.error.ttl_invalid",
+            "document.key_value.new_key.error.stream_requires_field",
+            "document.key_value.new_key.error.prefix",
+            "document.key_value.new_key.cancel",
+            "document.key_value.new_key.create",
+            "document.key_value.new_key.type.string",
+            "document.key_value.new_key.type.hash",
+            "document.key_value.new_key.type.list",
+            "document.key_value.new_key.type.set",
+            "document.key_value.new_key.type.sorted_set",
+            "document.key_value.new_key.type.json",
+            "document.key_value.new_key.type.stream",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn new_key_error_prefix_interpolates_error() {
+        let message = dbflux_i18n::t!(
+            "document.key_value.new_key.error.prefix",
+            locale = "en",
+            error = "Key name is required"
+        );
+
+        assert!(message.contains("Key name is required"));
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 13: the new-key modal, key-value headers, delete confirmations, edit hints, pagination, TTL and filter strings, mutation and pagination errors and task descriptions render through `dbflux_i18n::t!`; Redis command names and type tokens stay literal. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 12; next: history and add-member modals)

## How was this solved?

- Size: 698 lines (`size:exception`): the key-type label widening spans render and parsing.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 950 passed; clippy clean; fmt clean. Manual smoke in Spanish: create a key, browse a hash, page through keys.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
