### PR TITLE
feat(i18n): translate the history modal and the add-member modal

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -541,6 +541,22 @@ document:
         references: REFERENCES
         row: ROW
   key_value:
+    add_member_modal:
+      cancel: Cancel
+      error:
+        at_least_one_entry: At least one entry is required
+        prefix: "Error: %{error}"
+      section:
+        fields: Fields
+        members: Members
+      submit: Add
+      title:
+        default: Add Member
+        hash: Add Hash Fields
+        list: Add List Members
+        set: Add Set Members
+        sorted_set: Add Sorted Set Members
+        stream: Add Stream Entry
     context_menu:
       add_entry: Add Entry
       add_member: Add Member
@@ -556,6 +572,23 @@ document:
       edit_value: Edit Value
       new_key: New Key
       rename: Rename
+    history_modal:
+      empty:
+        recent: No history yet
+        saved: No saved queries
+      footer:
+        items:
+          one: "%{count} item"
+          many: "%{count} items"
+      save:
+        name_placeholder: Query name
+        name_required: Enter a name for the query
+        success_toast: Saved query
+        title: Save Query
+      search_placeholder: "Search..."
+      tabs:
+        recent: Recent
+        saved: Saved
     mutation:
       error:
         connection_inactive: Connection is no longer active

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -541,6 +541,22 @@ document:
         references: REFERENCIAS
         row: FILA
   key_value:
+    add_member_modal:
+      cancel: Cancelar
+      error:
+        at_least_one_entry: Se requiere al menos una entrada
+        prefix: "Error: %{error}"
+      section:
+        fields: Campos
+        members: Miembros
+      submit: Agregar
+      title:
+        default: Agregar miembro
+        hash: Agregar campos de hash
+        list: Agregar miembros de lista
+        set: Agregar miembros de conjunto
+        sorted_set: Agregar miembros de conjunto ordenado
+        stream: Agregar entrada de stream
     context_menu:
       add_entry: Agregar entrada
       add_member: Agregar miembro
@@ -556,6 +572,23 @@ document:
       edit_value: Editar valor
       new_key: Nueva clave
       rename: Renombrar
+    history_modal:
+      empty:
+        recent: Aún no hay historial
+        saved: No hay consultas guardadas
+      footer:
+        items:
+          one: "%{count} elemento"
+          many: "%{count} elementos"
+      save:
+        name_placeholder: Nombre de la consulta
+        name_required: Ingresa un nombre para la consulta
+        success_toast: Consulta guardada
+        title: Guardar consulta
+      search_placeholder: "Buscar..."
+      tabs:
+        recent: Recientes
+        saved: Guardadas
     mutation:
       error:
         connection_inactive: La conexión ya no está activa

--- a/crates/dbflux_ui_document/src/add_member_modal.rs
+++ b/crates/dbflux_ui_document/src/add_member_modal.rs
@@ -133,12 +133,8 @@ impl AddMemberModal {
     // -- Row management -----------------------------------------------------
 
     fn add_value_row(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let (field_placeholder, value_placeholder) = match self.key_type {
-            KeyType::Hash | KeyType::Stream => ("Enter Field", "Enter Value"),
-            KeyType::SortedSet => ("Enter Member", "Enter Score"),
-            KeyType::List | KeyType::Set => ("Enter Member", ""),
-            _ => ("Enter Field", "Enter Value"),
-        };
+        let (field_placeholder, value_placeholder) =
+            crate::labels::add_member_modal_placeholders(self.key_type);
 
         let field_input = cx.new(|cx| InputState::new(window, cx).placeholder(field_placeholder));
         let value_input = cx.new(|cx| InputState::new(window, cx).placeholder(value_placeholder));
@@ -212,7 +208,9 @@ impl AddMemberModal {
             .collect();
 
         if fields.is_empty() {
-            self.error_message = Some("At least one entry is required".to_string());
+            self.error_message = Some(dbflux_i18n::t!(
+                "document.key_value.add_member_modal.error.at_least_one_entry"
+            ));
             cx.notify();
             return;
         }
@@ -238,24 +236,12 @@ impl AddMemberModal {
         )
     }
 
-    fn title(&self) -> &'static str {
-        match self.key_type {
-            KeyType::Hash => "Add Hash Fields",
-            KeyType::Stream => "Add Stream Entry",
-            KeyType::List => "Add List Members",
-            KeyType::Set => "Add Set Members",
-            KeyType::SortedSet => "Add Sorted Set Members",
-            _ => "Add Member",
-        }
+    fn title(&self) -> String {
+        crate::labels::add_member_modal_title(self.key_type)
     }
 
-    fn section_label(&self) -> &'static str {
-        match self.key_type {
-            KeyType::Hash | KeyType::Stream => "Fields",
-            KeyType::SortedSet => "Members",
-            KeyType::List | KeyType::Set => "Members",
-            _ => "Fields",
-        }
+    fn section_label(&self) -> String {
+        crate::labels::add_member_modal_section_label(self.key_type)
     }
 }
 
@@ -565,7 +551,10 @@ impl Render for AddMemberModal {
         // -- Error message --------------------------------------------------
 
         if let Some(error) = &self.error_message {
-            body = body.child(Text::caption(format!("Error: {}", error)));
+            body = body.child(Text::caption(dbflux_i18n::t!(
+                "document.key_value.add_member_modal.error.prefix",
+                error = error
+            )));
         }
 
         // -- Footer buttons -------------------------------------------------
@@ -582,7 +571,9 @@ impl Render for AddMemberModal {
                     focus_ring(cancel_focused, ring_color).child(
                         Button::new("add-member-cancel")
                             .small()
-                            .label("Cancel")
+                            .label(dbflux_i18n::t!(
+                                "document.key_value.add_member_modal.cancel"
+                            ))
                             .with_variant(ButtonVariant::Ghost)
                             .on_click(cx.listener(|this, _, _, cx| {
                                 this.close(cx);
@@ -593,7 +584,9 @@ impl Render for AddMemberModal {
                     focus_ring(submit_focused, ring_color).child(
                         Button::new("add-member-submit")
                             .small()
-                            .label("Add")
+                            .label(dbflux_i18n::t!(
+                                "document.key_value.add_member_modal.submit"
+                            ))
                             .with_variant(ButtonVariant::Primary)
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.submit(window, cx);

--- a/crates/dbflux_ui_document/src/history_modal.rs
+++ b/crates/dbflux_ui_document/src/history_modal.rs
@@ -95,9 +95,17 @@ impl HistoryModal {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let search_input = cx.new(|cx| InputState::new(window, cx).placeholder("Search..."));
+        let search_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.key_value.history_modal.search_placeholder"
+            ))
+        });
         let rename_input = cx.new(|cx| InputState::new(window, cx));
-        let save_name_input = cx.new(|cx| InputState::new(window, cx).placeholder("Query name"));
+        let save_name_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.key_value.history_modal.save.name_placeholder"
+            ))
+        });
 
         cx.subscribe_in(
             &search_input,
@@ -402,9 +410,11 @@ impl HistoryModal {
 
         let name = self.save_name_input.read(cx).value();
         if name.trim().is_empty() {
-            Toast::warning("Enter a name for the query")
-                .meta_right(now_hms())
-                .push(cx);
+            Toast::warning(dbflux_i18n::t!(
+                "document.key_value.history_modal.save.name_required"
+            ))
+            .meta_right(now_hms())
+            .push(cx);
             return;
         }
 
@@ -413,7 +423,11 @@ impl HistoryModal {
         let id = query.id;
         (self.callbacks.on_save)(query, cx);
         cx.emit(QuerySaved { id, name });
-        Toast::success("Saved query").meta_right(now_hms()).push(cx);
+        Toast::success(dbflux_i18n::t!(
+            "document.key_value.history_modal.save.success_toast"
+        ))
+        .meta_right(now_hms())
+        .push(cx);
         self.close(cx);
     }
 
@@ -540,9 +554,14 @@ impl HistoryModal {
                                 theme,
                             )),
                     )
-                    .child(Text::body("Recent").font_size(FontSizes::SM).color(
-                        text_color_for_active(self.active_tab == HistoryTab::Recent, theme),
-                    ))
+                    .child(
+                        Text::body(crate::labels::history_tab_label(HistoryTab::Recent))
+                            .font_size(FontSizes::SM)
+                            .color(text_color_for_active(
+                                self.active_tab == HistoryTab::Recent,
+                                theme,
+                            )),
+                    )
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(|this, _, _, cx| {
@@ -576,9 +595,14 @@ impl HistoryModal {
                                 theme,
                             )),
                     )
-                    .child(Text::body("Saved").font_size(FontSizes::SM).color(
-                        text_color_for_active(self.active_tab == HistoryTab::Saved, theme),
-                    ))
+                    .child(
+                        Text::body(crate::labels::history_tab_label(HistoryTab::Saved))
+                            .font_size(FontSizes::SM)
+                            .color(text_color_for_active(
+                                self.active_tab == HistoryTab::Saved,
+                                theme,
+                            )),
+                    )
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(|this, _, _, cx| {
@@ -601,67 +625,69 @@ impl HistoryModal {
         match self.active_tab {
             HistoryTab::Recent => {
                 let entries = self.filtered_history_entries(cx);
+                let row_count_labels: Vec<Option<String>> = entries
+                    .iter()
+                    .map(|entry| entry.row_count.map(crate::labels::row_count_label))
+                    .collect();
+
                 div()
                     .flex_1()
                     .overflow_y_hidden()
-                    .children(entries.iter().enumerate().map(|(idx, entry)| {
-                        let is_selected = idx == selected;
-                        let sql = entry.sql.clone();
+                    .children(entries.iter().zip(row_count_labels).enumerate().map(
+                        |(idx, (entry, row_count_label))| {
+                            let is_selected = idx == selected;
+                            let sql = entry.sql.clone();
 
-                        div()
-                            .id(("history-entry", idx))
-                            .flex()
-                            .flex_col()
-                            .px(Spacing::SM)
-                            .py(Spacing::XS)
-                            .border_b_1()
-                            .border_color(theme.border)
-                            .cursor_pointer()
-                            .when(is_selected, |d| d.bg(theme.secondary))
-                            .hover(|d| d.bg(theme.secondary))
-                            .on_click(cx.listener(move |this, _, _, cx| {
-                                cx.emit(HistoryQuerySelected {
-                                    sql: sql.clone(),
-                                    name: None,
-                                    saved_query_id: None,
-                                });
-                                this.close(cx);
-                            }))
-                            .child(
-                                div()
-                                    .overflow_hidden()
-                                    .text_ellipsis()
-                                    .child(Text::body(entry.sql_preview(60))),
-                            )
-                            .child(
-                                div()
-                                    .flex()
-                                    .items_center()
-                                    .gap(Spacing::SM)
-                                    .child(
-                                        Text::caption(entry.formatted_timestamp())
-                                            .font_size(FontSizes::XS),
-                                    )
-                                    .when_some(entry.row_count, |d, count| {
-                                        d.child(
-                                            Text::caption(format!("{} rows", count))
+                            div()
+                                .id(("history-entry", idx))
+                                .flex()
+                                .flex_col()
+                                .px(Spacing::SM)
+                                .py(Spacing::XS)
+                                .border_b_1()
+                                .border_color(theme.border)
+                                .cursor_pointer()
+                                .when(is_selected, |d| d.bg(theme.secondary))
+                                .hover(|d| d.bg(theme.secondary))
+                                .on_click(cx.listener(move |this, _, _, cx| {
+                                    cx.emit(HistoryQuerySelected {
+                                        sql: sql.clone(),
+                                        name: None,
+                                        saved_query_id: None,
+                                    });
+                                    this.close(cx);
+                                }))
+                                .child(
+                                    div()
+                                        .overflow_hidden()
+                                        .text_ellipsis()
+                                        .child(Text::body(entry.sql_preview(60))),
+                                )
+                                .child(
+                                    div()
+                                        .flex()
+                                        .items_center()
+                                        .gap(Spacing::SM)
+                                        .child(
+                                            Text::caption(entry.formatted_timestamp())
                                                 .font_size(FontSizes::XS),
                                         )
-                                    })
-                                    .child(
-                                        Text::caption(format!("{}ms", entry.execution_time_ms))
-                                            .font_size(FontSizes::XS),
-                                    ),
-                            )
-                    }))
+                                        .when_some(row_count_label, |d, label| {
+                                            d.child(Text::caption(label).font_size(FontSizes::XS))
+                                        })
+                                        .child(
+                                            Text::caption(format!("{}ms", entry.execution_time_ms))
+                                                .font_size(FontSizes::XS),
+                                        ),
+                                )
+                        },
+                    ))
                     .when(entries.is_empty(), |d| {
-                        d.child(
-                            div()
-                                .px(Spacing::SM)
-                                .py(Spacing::LG)
-                                .text_center()
-                                .child(Text::muted("No history yet")),
-                        )
+                        d.child(div().px(Spacing::SM).py(Spacing::LG).text_center().child(
+                            Text::muted(dbflux_i18n::t!(
+                                "document.key_value.history_modal.empty.recent"
+                            )),
+                        ))
                     })
                     .into_any_element()
             }
@@ -760,13 +786,11 @@ impl HistoryModal {
                             )
                     }))
                     .when(entries.is_empty(), |d| {
-                        d.child(
-                            div()
-                                .px(Spacing::SM)
-                                .py(Spacing::LG)
-                                .text_center()
-                                .child(Text::muted("No saved queries")),
-                        )
+                        d.child(div().px(Spacing::SM).py(Spacing::LG).text_center().child(
+                            Text::muted(dbflux_i18n::t!(
+                                "document.key_value.history_modal.empty.saved"
+                            )),
+                        ))
                     })
                     .into_any_element()
             }
@@ -793,7 +817,9 @@ impl HistoryModal {
             .items_center()
             .justify_between()
             .child(Text::caption(shortcuts))
-            .child(Text::caption(format!("{} items", count)))
+            .child(Text::caption(crate::labels::history_items_count_label(
+                count,
+            )))
     }
 
     fn render_save(&self, _window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
@@ -837,7 +863,9 @@ impl HistoryModal {
                             .py(Spacing::SM)
                             .border_b_1()
                             .border_color(theme.border)
-                            .child(Text::body("Save Query")),
+                            .child(Text::body(dbflux_i18n::t!(
+                                "document.key_value.history_modal.save.title"
+                            ))),
                     )
                     .child(div().p(Spacing::MD).child(Input::new(&input).w_full()))
                     .child(

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -773,17 +773,112 @@ pub(crate) fn execution_count_state_label(
     }
 }
 
+/// Label for a [`crate::history_modal::HistoryTab`] shown on the history
+/// modal's tab bar.
+pub(crate) fn history_tab_label(tab: crate::history_modal::HistoryTab) -> String {
+    use crate::history_modal::HistoryTab;
+
+    match tab {
+        HistoryTab::Recent => dbflux_i18n::t!("document.key_value.history_modal.tabs.recent"),
+        HistoryTab::Saved => dbflux_i18n::t!("document.key_value.history_modal.tabs.saved"),
+    }
+}
+
+/// Label for the history modal footer's visible-item count.
+///
+/// Uses the singular catalog bucket only for exactly one item; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn history_items_count_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "document.key_value.history_modal.footer.items.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.key_value.history_modal.footer.items.many",
+            count = count
+        )
+    }
+}
+
+/// Title for the add-member modal, keyed by the target key's [`dbflux_core::KeyType`].
+///
+/// Every non-collection key type (`String`, `Bytes`, `Json`, `Unknown`)
+/// shares the generic fallback bucket, mirroring the pre-i18n wildcard arm.
+pub(crate) fn add_member_modal_title(key_type: dbflux_core::KeyType) -> String {
+    use dbflux_core::KeyType;
+
+    match key_type {
+        KeyType::Hash => dbflux_i18n::t!("document.key_value.add_member_modal.title.hash"),
+        KeyType::Stream => dbflux_i18n::t!("document.key_value.add_member_modal.title.stream"),
+        KeyType::List => dbflux_i18n::t!("document.key_value.add_member_modal.title.list"),
+        KeyType::Set => dbflux_i18n::t!("document.key_value.add_member_modal.title.set"),
+        KeyType::SortedSet => {
+            dbflux_i18n::t!("document.key_value.add_member_modal.title.sorted_set")
+        }
+        _ => dbflux_i18n::t!("document.key_value.add_member_modal.title.default"),
+    }
+}
+
+/// Label for the add-member modal's row-list section header, keyed by the
+/// target key's [`dbflux_core::KeyType`].
+pub(crate) fn add_member_modal_section_label(key_type: dbflux_core::KeyType) -> String {
+    use dbflux_core::KeyType;
+
+    match key_type {
+        KeyType::Hash | KeyType::Stream => {
+            dbflux_i18n::t!("document.key_value.add_member_modal.section.fields")
+        }
+        KeyType::SortedSet | KeyType::List | KeyType::Set => {
+            dbflux_i18n::t!("document.key_value.add_member_modal.section.members")
+        }
+        _ => dbflux_i18n::t!("document.key_value.add_member_modal.section.fields"),
+    }
+}
+
+/// Field/value input placeholders for a new add-member row, keyed by the
+/// target key's [`dbflux_core::KeyType`].
+///
+/// Reuses the same catalog entries as the new-key modal's field/member/score
+/// placeholders since both surfaces describe the same input concepts.
+/// `List`/`Set` rows have no second input, so the value placeholder is empty.
+pub(crate) fn add_member_modal_placeholders(key_type: dbflux_core::KeyType) -> (String, String) {
+    use dbflux_core::KeyType;
+
+    match key_type {
+        KeyType::Hash | KeyType::Stream => (
+            dbflux_i18n::t!("document.key_value.new_key.field_placeholder"),
+            dbflux_i18n::t!("document.key_value.new_key.value.placeholder"),
+        ),
+        KeyType::SortedSet => (
+            dbflux_i18n::t!("document.key_value.new_key.member_placeholder"),
+            dbflux_i18n::t!("document.key_value.new_key.score_placeholder"),
+        ),
+        KeyType::List | KeyType::Set => (
+            dbflux_i18n::t!("document.key_value.new_key.member_placeholder"),
+            String::new(),
+        ),
+        _ => (
+            dbflux_i18n::t!("document.key_value.new_key.field_placeholder"),
+            dbflux_i18n::t!("document.key_value.new_key.value.placeholder"),
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        MutationItemKind, agg_fn_display, assignment_value_kind_label, bool_op_label,
+        MutationItemKind, add_member_modal_placeholders, add_member_modal_section_label,
+        add_member_modal_title, agg_fn_display, assignment_value_kind_label, bool_op_label,
         builder_mode_label, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
         chart_rail_why_text, code_toolbar_shortcut_hint_label, comparator_label,
         copy_query_language_label, dangerous_query_body, dangerous_query_title,
         delete_confirm_copy, delete_rows_label, execution_count_state_label, execution_mode_label,
-        incomplete_aggregate_rows_label, join_kind_label, live_output_lines_label,
-        live_output_truncated_label, partial_delete_label, pending_change_count_label,
-        pending_edits_summary, refresh_policy_label, result_tab_count_label, row_count_label,
+        history_items_count_label, history_tab_label, incomplete_aggregate_rows_label,
+        join_kind_label, live_output_lines_label, live_output_truncated_label,
+        partial_delete_label, pending_change_count_label, pending_edits_summary,
+        refresh_policy_label, result_tab_count_label, row_count_label,
         script_confirm_message_label, sort_direction_label, unsaved_changes_label,
         update_columns_label, valid_lines_label,
     };
@@ -1790,5 +1885,159 @@ mod tests {
         assert_ne!(done_one, done_many);
         assert!(timed_out.contains("chunked"));
         assert!(failed.contains("boom"));
+    }
+
+    #[test]
+    fn history_tab_label_covers_both_variants() {
+        use crate::history_modal::HistoryTab;
+
+        assert_eq!(history_tab_label(HistoryTab::Recent), "Recent");
+        assert_eq!(history_tab_label(HistoryTab::Saved), "Saved");
+        assert_ne!(
+            history_tab_label(HistoryTab::Recent),
+            history_tab_label(HistoryTab::Saved)
+        );
+    }
+
+    #[test]
+    fn history_items_count_label_one_many() {
+        assert_eq!(history_items_count_label(1), "1 item");
+        assert_eq!(history_items_count_label(2), "2 items");
+        assert_eq!(history_items_count_label(0), "0 items");
+    }
+
+    #[test]
+    fn history_modal_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.key_value.history_modal.search_placeholder",
+            "document.key_value.history_modal.tabs.recent",
+            "document.key_value.history_modal.tabs.saved",
+            "document.key_value.history_modal.empty.recent",
+            "document.key_value.history_modal.empty.saved",
+            "document.key_value.history_modal.footer.items.one",
+            "document.key_value.history_modal.footer.items.many",
+            "document.key_value.history_modal.save.title",
+            "document.key_value.history_modal.save.name_placeholder",
+            "document.key_value.history_modal.save.name_required",
+            "document.key_value.history_modal.save.success_toast",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn history_modal_save_title_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.key_value.history_modal.save.title", locale = "en");
+        let es = dbflux_i18n::t!("document.key_value.history_modal.save.title", locale = "es");
+
+        assert_eq!(en, "Save Query");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn add_member_modal_title_covers_every_key_type() {
+        use dbflux_core::KeyType;
+
+        assert_eq!(add_member_modal_title(KeyType::Hash), "Add Hash Fields");
+        assert_eq!(add_member_modal_title(KeyType::Stream), "Add Stream Entry");
+        assert_eq!(add_member_modal_title(KeyType::List), "Add List Members");
+        assert_eq!(add_member_modal_title(KeyType::Set), "Add Set Members");
+        assert_eq!(
+            add_member_modal_title(KeyType::SortedSet),
+            "Add Sorted Set Members"
+        );
+        assert_eq!(add_member_modal_title(KeyType::String), "Add Member");
+    }
+
+    #[test]
+    fn add_member_modal_section_label_covers_every_key_type() {
+        use dbflux_core::KeyType;
+
+        assert_eq!(add_member_modal_section_label(KeyType::Hash), "Fields");
+        assert_eq!(add_member_modal_section_label(KeyType::Stream), "Fields");
+        assert_eq!(
+            add_member_modal_section_label(KeyType::SortedSet),
+            "Members"
+        );
+        assert_eq!(add_member_modal_section_label(KeyType::List), "Members");
+        assert_eq!(add_member_modal_section_label(KeyType::Set), "Members");
+        assert_eq!(add_member_modal_section_label(KeyType::String), "Fields");
+    }
+
+    #[test]
+    fn add_member_modal_placeholders_cover_every_key_type() {
+        use dbflux_core::KeyType;
+
+        assert_eq!(
+            add_member_modal_placeholders(KeyType::Hash),
+            ("Enter Field".to_string(), "Enter Value".to_string())
+        );
+        assert_eq!(
+            add_member_modal_placeholders(KeyType::SortedSet),
+            ("Enter Member".to_string(), "Enter Score".to_string())
+        );
+        assert_eq!(
+            add_member_modal_placeholders(KeyType::List),
+            ("Enter Member".to_string(), String::new())
+        );
+    }
+
+    #[test]
+    fn add_member_modal_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.key_value.add_member_modal.title.hash",
+            "document.key_value.add_member_modal.title.stream",
+            "document.key_value.add_member_modal.title.list",
+            "document.key_value.add_member_modal.title.set",
+            "document.key_value.add_member_modal.title.sorted_set",
+            "document.key_value.add_member_modal.title.default",
+            "document.key_value.add_member_modal.section.fields",
+            "document.key_value.add_member_modal.section.members",
+            "document.key_value.add_member_modal.error.at_least_one_entry",
+            "document.key_value.add_member_modal.error.prefix",
+            "document.key_value.add_member_modal.cancel",
+            "document.key_value.add_member_modal.submit",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn add_member_modal_title_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.key_value.add_member_modal.title.hash",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.key_value.add_member_modal.title.hash",
+            locale = "es"
+        );
+
+        assert_eq!(en, "Add Hash Fields");
+        assert_ne!(en, es);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 14: history tabs, search and save placeholders, empty states, save toasts, footer counts and the add-member modal titles, sections, placeholders, errors and actions render through `dbflux_i18n::t!`; key chords stay literal. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 13; next: the audit viewer)

## How was this solved?

- Size: 546 lines (`size:exception`, two coherent modal files).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 959 passed; clippy clean; fmt clean. Manual smoke in Spanish: open the history modal, add a member to a set.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
