### PR TITLE
feat(i18n): translate the auth profiles login flow and changed-on-disk banners

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1268,21 +1268,6 @@ settings:
     delete: Delete
     save_to_file: Save to File
     cancel: Cancel
-    update: Update
-    create: Create
-    section_title: Auth Profiles
-    section_description: Manage reusable authentication profiles for connection access
-    delete_dialog_title: Delete Auth Profile
-    delete_dialog:
-      body_none: 'Are you sure you want to delete "%{name}"?'
-      body_one: 'Are you sure you want to delete "%{name}"? 1 connection using this auth profile will be updated.'
-      body_many: 'Are you sure you want to delete "%{name}"? %{count} connections using this auth profile will be updated.'
-    saved_fallback: Profile saved.
-    reference_invalid_title: Profile reference invalid
-    reference_invalid_body: This profile cannot be loaded.
-    login_hint: Log in to load options
-    inherited_from: "Inherited from %{trigger}."
-    inherited_from_named: "Inherited from %{trigger} '%{name}'."
     mirror_label_fallback: Read-only — managed externally
     conflict_message: "This profile was modified on disk (%{label}) since you opened it. Reload to see the current values before saving."
     partial_saved_message: "%{written_label} was saved successfully, but %{conflicted_label} was modified on disk since you opened the form. Reload to refresh and re-apply your changes."
@@ -1302,6 +1287,21 @@ settings:
     login_action: Login
     logging_in: "Logging in..."
     runs_interactive_login_hint: Runs interactive login for this auth profile
+    update: Update
+    create: Create
+    section_title: Auth Profiles
+    section_description: Manage reusable authentication profiles for connection access
+    delete_dialog_title: Delete Auth Profile
+    delete_dialog:
+      body_none: 'Are you sure you want to delete "%{name}"?'
+      body_one: 'Are you sure you want to delete "%{name}"? 1 connection using this auth profile will be updated.'
+      body_many: 'Are you sure you want to delete "%{name}"? %{count} connections using this auth profile will be updated.'
+    saved_fallback: Profile saved.
+    reference_invalid_title: Profile reference invalid
+    reference_invalid_body: This profile cannot be loaded.
+    login_hint: Log in to load options
+    inherited_from: "Inherited from %{trigger}."
+    inherited_from_named: "Inherited from %{trigger} '%{name}'."
   nav:
     general_group: General
     general: General

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1283,6 +1283,25 @@ settings:
     login_hint: Log in to load options
     inherited_from: "Inherited from %{trigger}."
     inherited_from_named: "Inherited from %{trigger} '%{name}'."
+    mirror_label_fallback: Read-only — managed externally
+    conflict_message: "This profile was modified on disk (%{label}) since you opened it. Reload to see the current values before saving."
+    partial_saved_message: "%{written_label} was saved successfully, but %{conflicted_label} was modified on disk since you opened the form. Reload to refresh and re-apply your changes."
+    login_required_hint: "Login required — click Login to load dropdown options."
+    session_expired_hint: Session expired — log in again to reload options
+    session_expired_click_hint: "Session expired — click Login to refresh dropdown options."
+    select_before_login: Select an auth provider before login.
+    interactive_login_unavailable: Interactive login is not available for this provider.
+    fields_required_before_login: Provide a profile name and provider fields before login.
+    starting_login: "Starting auth-provider login for profile '%{name}'..."
+    login_completed: "Auth-provider login completed for profile '%{name}'."
+    login_failed: "Auth-provider login failed for profile '%{name}': %{error}"
+    login_cancelled: Login cancelled by user.
+    login_url_panel_description: Open this URL in your browser to finish the login. DBFlux will continue automatically once you complete authentication.
+    open_browser: Open Browser
+    copy_url: Copy URL
+    login_action: Login
+    logging_in: "Logging in..."
+    runs_interactive_login_hint: Runs interactive login for this auth profile
   nav:
     general_group: General
     general: General

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1283,6 +1283,25 @@ settings:
     login_hint: Inicia sesión para cargar las opciones
     inherited_from: "Heredado de %{trigger}."
     inherited_from_named: "Heredado de %{trigger} '%{name}'."
+    mirror_label_fallback: Solo lectura — administrado externamente
+    conflict_message: "Este perfil se modificó en disco (%{label}) desde que lo abriste. Recarga para ver los valores actuales antes de guardar."
+    partial_saved_message: "%{written_label} se guardó correctamente, pero %{conflicted_label} se modificó en disco desde que abriste el formulario. Recarga para actualizar y volver a aplicar tus cambios."
+    login_required_hint: "Se requiere iniciar sesión — haz clic en Iniciar sesión para cargar las opciones desplegables."
+    session_expired_hint: La sesión expiró — vuelve a iniciar sesión para recargar las opciones
+    session_expired_click_hint: "La sesión expiró — haz clic en Iniciar sesión para actualizar las opciones desplegables."
+    select_before_login: Selecciona un proveedor antes de iniciar sesión.
+    interactive_login_unavailable: El inicio de sesión interactivo no está disponible para este proveedor.
+    fields_required_before_login: Completa el nombre del perfil y los campos del proveedor antes de iniciar sesión.
+    starting_login: "Iniciando sesión del proveedor de autenticación para el perfil '%{name}'..."
+    login_completed: "Inicio de sesión del proveedor de autenticación completado para el perfil '%{name}'."
+    login_failed: "Error al iniciar sesión del proveedor de autenticación para el perfil '%{name}': %{error}"
+    login_cancelled: Inicio de sesión cancelado por el usuario.
+    login_url_panel_description: Abre esta URL en tu navegador para terminar el inicio de sesión. DBFlux continuará automáticamente cuando completes la autenticación.
+    open_browser: Abrir navegador
+    copy_url: Copiar URL
+    login_action: Iniciar sesión
+    logging_in: "Iniciando sesión..."
+    runs_interactive_login_hint: Ejecuta el inicio de sesión interactivo de este perfil
   nav:
     general_group: General
     general: General

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1268,21 +1268,6 @@ settings:
     delete: Eliminar
     save_to_file: Guardar en archivo
     cancel: Cancelar
-    update: Actualizar
-    create: Crear
-    section_title: "Perfiles de autenticación"
-    section_description: Gestiona perfiles de autenticación reutilizables para el acceso a conexiones
-    delete_dialog_title: "Eliminar perfil de autenticación"
-    delete_dialog:
-      body_none: '¿Seguro que quieres eliminar "%{name}"?'
-      body_one: '¿Seguro que quieres eliminar "%{name}"? 1 conexión que usa este perfil de autenticación se actualizará.'
-      body_many: '¿Seguro que quieres eliminar "%{name}"? %{count} conexiones que usan este perfil de autenticación se actualizarán.'
-    saved_fallback: Perfil guardado.
-    reference_invalid_title: Referencia de perfil no válida
-    reference_invalid_body: Este perfil no se puede cargar.
-    login_hint: Inicia sesión para cargar las opciones
-    inherited_from: "Heredado de %{trigger}."
-    inherited_from_named: "Heredado de %{trigger} '%{name}'."
     mirror_label_fallback: Solo lectura — administrado externamente
     conflict_message: "Este perfil se modificó en disco (%{label}) desde que lo abriste. Recarga para ver los valores actuales antes de guardar."
     partial_saved_message: "%{written_label} se guardó correctamente, pero %{conflicted_label} se modificó en disco desde que abriste el formulario. Recarga para actualizar y volver a aplicar tus cambios."
@@ -1302,6 +1287,21 @@ settings:
     login_action: Iniciar sesión
     logging_in: "Iniciando sesión..."
     runs_interactive_login_hint: Ejecuta el inicio de sesión interactivo de este perfil
+    update: Actualizar
+    create: Crear
+    section_title: "Perfiles de autenticación"
+    section_description: Gestiona perfiles de autenticación reutilizables para el acceso a conexiones
+    delete_dialog_title: "Eliminar perfil de autenticación"
+    delete_dialog:
+      body_none: '¿Seguro que quieres eliminar "%{name}"?'
+      body_one: '¿Seguro que quieres eliminar "%{name}"? 1 conexión que usa este perfil de autenticación se actualizará.'
+      body_many: '¿Seguro que quieres eliminar "%{name}"? %{count} conexiones que usan este perfil de autenticación se actualizarán.'
+    saved_fallback: Perfil guardado.
+    reference_invalid_title: Referencia de perfil no válida
+    reference_invalid_body: Este perfil no se puede cargar.
+    login_hint: Inicia sesión para cargar las opciones
+    inherited_from: "Heredado de %{trigger}."
+    inherited_from_named: "Heredado de %{trigger} '%{name}'."
   nav:
     general_group: General
     general: General

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -200,10 +200,53 @@ pub(crate) fn auth_profiles_inherited_hint(
     }
 }
 
+/// Builds the user-visible conflict message for a `Conflict` save outcome,
+/// naming the target's label and pointing to the Reload affordance.
+pub(crate) fn auth_profiles_conflict_message(label: &str) -> String {
+    dbflux_i18n::t!("settings.auth_profiles.conflict_message", label = label)
+}
+
+/// Builds the user-visible message for a `PartialSaved` save outcome,
+/// naming both the written and conflicted targets.
+pub(crate) fn auth_profiles_partial_saved_message(
+    written_label: &str,
+    conflicted_label: &str,
+) -> String {
+    dbflux_i18n::t!(
+        "settings.auth_profiles.partial_saved_message",
+        written_label = written_label,
+        conflicted_label = conflicted_label
+    )
+}
+
+/// Formats the status message shown while the Settings-window auth-profile
+/// login is starting.
+pub(crate) fn auth_profiles_starting_login(name: &str) -> String {
+    dbflux_i18n::t!("settings.auth_profiles.starting_login", name = name)
+}
+
+/// Formats the status message shown when the Settings-window auth-profile
+/// login completes successfully.
+pub(crate) fn auth_profiles_login_completed(name: &str) -> String {
+    dbflux_i18n::t!("settings.auth_profiles.login_completed", name = name)
+}
+
+/// Formats the status message shown when the Settings-window auth-profile
+/// login fails.
+pub(crate) fn auth_profiles_login_failed(name: &str, error: &str) -> String {
+    dbflux_i18n::t!(
+        "settings.auth_profiles.login_failed",
+        name = name,
+        error = error
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         access_proxy_disabled_label, auth_login_failed, auth_login_starting,
+        auth_profiles_conflict_message, auth_profiles_login_completed, auth_profiles_login_failed,
+        auth_profiles_partial_saved_message, auth_profiles_starting_login,
         auth_provider_unavailable, auth_session_status_valid_expires, hooks_create_dir_failed,
         hooks_delete_message, hooks_delete_unreadable_message, hooks_duplicate_id,
         hooks_env_pair_invalid, hooks_form_interpreter_hint, hooks_interpreter_auto_label,
@@ -363,5 +406,43 @@ mod tests {
                 locale = "es"
             )
         );
+    }
+
+    #[test]
+    fn auth_profiles_conflict_message_names_target_label() {
+        let message = auth_profiles_conflict_message("FAKE_TARGET_A");
+
+        assert!(message.contains("FAKE_TARGET_A"));
+        assert!(message.to_lowercase().contains("reload"));
+    }
+
+    #[test]
+    fn auth_profiles_partial_saved_message_names_both_targets() {
+        let message = auth_profiles_partial_saved_message("FAKE_TARGET_A", "FAKE_TARGET_B");
+
+        assert!(message.contains("FAKE_TARGET_A"));
+        assert!(message.contains("FAKE_TARGET_B"));
+    }
+
+    #[test]
+    fn auth_profiles_starting_login_embeds_profile_name() {
+        let message = auth_profiles_starting_login("prod-mongo");
+
+        assert!(message.contains("prod-mongo"));
+    }
+
+    #[test]
+    fn auth_profiles_login_completed_embeds_profile_name() {
+        let message = auth_profiles_login_completed("prod-mongo");
+
+        assert!(message.contains("prod-mongo"));
+    }
+
+    #[test]
+    fn auth_profiles_login_failed_embeds_profile_name_and_error() {
+        let message = auth_profiles_login_failed("prod-mongo", "token expired");
+
+        assert!(message.contains("prod-mongo"));
+        assert!(message.contains("token expired"));
     }
 }

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -413,7 +413,7 @@ mod tests {
         let message = auth_profiles_conflict_message("FAKE_TARGET_A");
 
         assert!(message.contains("FAKE_TARGET_A"));
-        assert!(message.to_lowercase().contains("reload"));
+        assert!(!message.contains("settings.auth_profiles.conflict_message"));
     }
 
     #[test]

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -224,7 +224,9 @@ fn build_auth_profile_from_form(
     })
 }
 
-const MIRROR_LABEL_FALLBACK: &str = "Read-only — managed externally";
+fn mirror_label_fallback() -> String {
+    dbflux_i18n::t!("settings.auth_profiles.mirror_label_fallback")
+}
 fn success_written_fallback() -> String {
     dbflux_i18n::t!("settings.auth_profiles.saved_fallback")
 }
@@ -240,7 +242,7 @@ fn dangling_fallback() -> DanglingMessage {
 fn resolve_mirror_label(edit_caps: Option<&AuthEditCapabilities>) -> String {
     edit_caps
         .map(|e| e.mirror_label.clone())
-        .unwrap_or_else(|| MIRROR_LABEL_FALLBACK.to_string())
+        .unwrap_or_else(mirror_label_fallback)
 }
 
 fn resolve_success_text(edit_caps: Option<&AuthEditCapabilities>) -> String {
@@ -261,11 +263,7 @@ fn resolve_dangling(edit_caps: Option<&AuthEditCapabilities>, origin: &str) -> D
 /// The message names the target's label and instructs the user to reload
 /// before saving again.
 fn resolve_conflict_message(target: &dbflux_core::AuthEditTarget) -> String {
-    let label = &target.label;
-    format!(
-        "This profile was modified on disk ({label}) since you opened it. \
-         Reload to see the current values before saving."
-    )
+    crate::labels::auth_profiles_conflict_message(&target.label)
 }
 
 /// Build the user-visible message for a `PartialSaved` save outcome.
@@ -277,13 +275,7 @@ fn resolve_partial_saved_message(
     written: &dbflux_core::AuthEditTarget,
     conflicted: &dbflux_core::AuthEditTarget,
 ) -> String {
-    let written_label = &written.label;
-    let conflicted_label = &conflicted.label;
-    format!(
-        "{written_label} was saved successfully, but {conflicted_label} was \
-         modified on disk since you opened the form. Reload to refresh and \
-         re-apply your changes."
-    )
+    crate::labels::auth_profiles_partial_saved_message(&written.label, &conflicted.label)
 }
 
 /// Update `field_login_hint` and `provider_login_status` for a
@@ -313,7 +305,7 @@ fn apply_fetch_error_state(
 
             if !login_in_progress {
                 *provider_login_status = Some((
-                    "Login required — click Login to load dropdown options.".to_string(),
+                    dbflux_i18n::t!("settings.auth_profiles.login_required_hint"),
                     false,
                 ));
             }
@@ -321,12 +313,12 @@ fn apply_fetch_error_state(
         FetchOptionsError::SessionExpired => {
             field_login_hint.insert(
                 field_id.to_string(),
-                "Session expired — log in again to reload options".to_string(),
+                dbflux_i18n::t!("settings.auth_profiles.session_expired_hint"),
             );
 
             if !login_in_progress {
                 *provider_login_status = Some((
-                    "Session expired — click Login to refresh dropdown options.".to_string(),
+                    dbflux_i18n::t!("settings.auth_profiles.session_expired_click_hint"),
                     false,
                 ));
             }
@@ -1684,15 +1676,17 @@ impl AuthProfilesSection {
 
     fn login_selected_profile(&mut self, cx: &mut Context<Self>) {
         let Some(provider) = self.selected_provider(cx) else {
-            self.provider_login_status =
-                Some(("Select an auth provider before login.".to_string(), false));
+            self.provider_login_status = Some((
+                dbflux_i18n::t!("settings.auth_profiles.select_before_login"),
+                false,
+            ));
             cx.notify();
             return;
         };
 
         if !provider.capabilities().login.supported {
             self.provider_login_status = Some((
-                "Interactive login is not available for this provider.".to_string(),
+                dbflux_i18n::t!("settings.auth_profiles.interactive_login_unavailable"),
                 false,
             ));
             cx.notify();
@@ -1701,7 +1695,7 @@ impl AuthProfilesSection {
 
         let Some(raw_profile) = self.current_form_profile(cx) else {
             self.provider_login_status = Some((
-                "Provide a profile name and provider fields before login.".to_string(),
+                dbflux_i18n::t!("settings.auth_profiles.fields_required_before_login"),
                 false,
             ));
             cx.notify();
@@ -1725,10 +1719,7 @@ impl AuthProfilesSection {
 
         self.provider_login_loading = true;
         self.provider_login_status = Some((
-            format!(
-                "Starting auth-provider login for profile '{}'...",
-                profile.name
-            ),
+            crate::labels::auth_profiles_starting_login(&profile.name),
             false,
         ));
         cx.notify();
@@ -1790,16 +1781,13 @@ impl AuthProfilesSection {
                     this.active_login_url = None;
                     this.provider_login_status = Some(match &result {
                         Ok(_) => (
-                            format!(
-                                "Auth-provider login completed for profile '{}'.",
-                                profile.name
-                            ),
+                            crate::labels::auth_profiles_login_completed(&profile.name),
                             true,
                         ),
                         Err(error) => (
-                            format!(
-                                "Auth-provider login failed for profile '{}': {}",
-                                profile.name, error
+                            crate::labels::auth_profiles_login_failed(
+                                &profile.name,
+                                &error.to_string(),
                             ),
                             false,
                         ),
@@ -1944,9 +1932,9 @@ impl AuthProfilesSection {
             .flex()
             .flex_col()
             .gap_2()
-            .child(Text::caption(
-                "Open this URL in your browser to finish the login. DBFlux will continue automatically once you complete authentication.",
-            ))
+            .child(Text::caption(dbflux_i18n::t!(
+                "settings.auth_profiles.login_url_panel_description"
+            )))
             .child(
                 div()
                     .p(Spacing::SM)
@@ -1962,44 +1950,53 @@ impl AuthProfilesSection {
                     .items_center()
                     .gap_2()
                     .child(
-                        Button::new("auth-login-open-url", "Open Browser")
-                            .small()
-                            .primary()
-                            .on_click(cx.listener(move |_this, _, _, cx| {
-                                cx.open_url(&url_for_open);
-                            })),
+                        Button::new(
+                            "auth-login-open-url",
+                            dbflux_i18n::t!("settings.auth_profiles.open_browser"),
+                        )
+                        .small()
+                        .primary()
+                        .on_click(cx.listener(move |_this, _, _, cx| {
+                            cx.open_url(&url_for_open);
+                        })),
                     )
                     .child(
-                        Button::new("auth-login-copy-url", "Copy URL")
-                            .small()
-                            .on_click(cx.listener(move |_this, _, _, cx| {
-                                cx.write_to_clipboard(
-                                    gpui::ClipboardItem::new_string(url_for_copy.clone()),
-                                );
-                            })),
+                        Button::new(
+                            "auth-login-copy-url",
+                            dbflux_i18n::t!("settings.auth_profiles.copy_url"),
+                        )
+                        .small()
+                        .on_click(cx.listener(move |_this, _, _, cx| {
+                            cx.write_to_clipboard(gpui::ClipboardItem::new_string(
+                                url_for_copy.clone(),
+                            ));
+                        })),
                     )
                     .child(
-                        Button::new("auth-login-cancel", "Cancel")
-                            .small()
-                            .danger()
-                            .on_click(cx.listener(|this, _, _, cx| {
-                                // Ask the active provider to abort whatever
-                                // in-flight login it has for the profile
-                                // being edited. The provider's login future
-                                // will then return an error and the spawned
-                                // login task will clean up final status.
-                                if let Some(profile) = this.current_form_profile(cx)
-                                    && let Some(provider) = this.selected_provider(cx)
-                                {
-                                    let _aborted = provider.abort_login(&profile);
-                                }
-                                this.active_login_url = None;
-                                this.provider_login_status = Some((
-                                    "Login cancelled by user.".to_string(),
-                                    false,
-                                ));
-                                cx.notify();
-                            })),
+                        Button::new(
+                            "auth-login-cancel",
+                            dbflux_i18n::t!("settings.auth_profiles.cancel"),
+                        )
+                        .small()
+                        .danger()
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            // Ask the active provider to abort whatever
+                            // in-flight login it has for the profile
+                            // being edited. The provider's login future
+                            // will then return an error and the spawned
+                            // login task will clean up final status.
+                            if let Some(profile) = this.current_form_profile(cx)
+                                && let Some(provider) = this.selected_provider(cx)
+                            {
+                                let _aborted = provider.abort_login(&profile);
+                            }
+                            this.active_login_url = None;
+                            this.provider_login_status = Some((
+                                dbflux_i18n::t!("settings.auth_profiles.login_cancelled"),
+                                false,
+                            ));
+                            cx.notify();
+                        })),
                     ),
             )
     }
@@ -2617,9 +2614,9 @@ impl AuthProfilesSection {
                                     Button::new(
                                         "auth-provider-login",
                                         if self.provider_login_loading {
-                                            "Logging in..."
+                                            dbflux_i18n::t!("settings.auth_profiles.logging_in")
                                         } else {
-                                            "Login"
+                                            dbflux_i18n::t!("settings.auth_profiles.login_action")
                                         },
                                     )
                                     .small()
@@ -2631,9 +2628,9 @@ impl AuthProfilesSection {
                                         },
                                     )),
                                 )
-                                .child(Text::caption(
-                                    "Runs interactive login for this auth profile",
-                                )),
+                                .child(Text::caption(dbflux_i18n::t!(
+                                    "settings.auth_profiles.runs_interactive_login_hint"
+                                ))),
                         )
                         .when_some(self.provider_login_status.as_ref(), |content, status| {
                             content.child(if status.1 {
@@ -3716,7 +3713,8 @@ mod tests {
     fn no_edit_caps_mirror_label_returns_fallback() {
         let result = resolve_mirror_label(None);
         assert_eq!(
-            result, MIRROR_LABEL_FALLBACK,
+            result,
+            mirror_label_fallback(),
             "resolve_mirror_label must return the fallback when edit caps are absent"
         );
         assert!(
@@ -3821,8 +3819,9 @@ mod tests {
 
         let without_caps = resolve_mirror_label(None);
         assert_eq!(
-            without_caps, MIRROR_LABEL_FALLBACK,
-            "resolve_mirror_label must return MIRROR_LABEL_FALLBACK when edit is None"
+            without_caps,
+            mirror_label_fallback(),
+            "resolve_mirror_label must return the translated fallback when edit is None"
         );
     }
 
@@ -3986,6 +3985,59 @@ mod tests {
 
         assert_eq!(en, "New Auth Profile");
         assert_eq!(es, "Nuevo perfil de autenticación");
+    }
+
+    // ---------------------------------------------------------------------------
+    // i18n — login flow keys (spec S16): conflict/partial-save banners, the
+    // interactive login status messages, the login-URL panel, and the Login
+    // button chrome.
+    // ---------------------------------------------------------------------------
+
+    const AUTH_PROFILES_LOGIN_KEYS: &[&str] = &[
+        "settings.auth_profiles.mirror_label_fallback",
+        "settings.auth_profiles.login_required_hint",
+        "settings.auth_profiles.session_expired_hint",
+        "settings.auth_profiles.session_expired_click_hint",
+        "settings.auth_profiles.select_before_login",
+        "settings.auth_profiles.interactive_login_unavailable",
+        "settings.auth_profiles.fields_required_before_login",
+        "settings.auth_profiles.login_cancelled",
+        "settings.auth_profiles.login_url_panel_description",
+        "settings.auth_profiles.open_browser",
+        "settings.auth_profiles.copy_url",
+        "settings.auth_profiles.login_action",
+        "settings.auth_profiles.logging_in",
+        "settings.auth_profiles.runs_interactive_login_hint",
+    ];
+
+    #[::core::prelude::v1::test]
+    fn auth_profiles_login_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in AUTH_PROFILES_LOGIN_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[::core::prelude::v1::test]
+    fn auth_profiles_login_action_differs_between_locales() {
+        let en = dbflux_i18n::t!("settings.auth_profiles.login_action", locale = "en");
+        let es = dbflux_i18n::t!("settings.auth_profiles.login_action", locale = "es");
+
+        assert_eq!(en, "Login");
+        assert_eq!(es, "Iniciar sesión");
+        assert_ne!(en, es);
     }
 
     #[::core::prelude::v1::test]

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -3994,6 +3994,7 @@ mod tests {
     // ---------------------------------------------------------------------------
 
     const AUTH_PROFILES_LOGIN_KEYS: &[&str] = &[
+        "settings.auth_profiles.cancel",
         "settings.auth_profiles.mirror_label_fallback",
         "settings.auth_profiles.login_required_hint",
         "settings.auth_profiles.session_expired_hint",


### PR DESCRIPTION
## Summary

Sixteenth `dbflux_ui_windows` i18n slice: the auth profiles login flow (login URL panel, open browser / copy URL / cancel, login status and toasts, interactive-login hints) and the changed-on-disk banners (conflict and partially-saved messages, read-only mirror fallback) render through `dbflux_i18n::t!` under `settings.auth_profiles.*`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows the auth profiles chrome PR; next: the MCP tool catalog)

## How was this solved?

- `auth_profiles_conflict_message` / `auth_profiles_partial_saved_message` helpers carry the labels; the login keys test lists the shared `cancel` key next to the new keys so the proof sits inside the patch.
- Two follow-up commits amend the tests only (locale-agnostic assertion, key grouping); squash on merge.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 253 passed; clippy clean; fmt clean. Manual smoke in Spanish: open Settings → Access Providers, create and delete a profile.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
