### PR TITLE
feat(i18n): translate the audit viewer filter bar, context menu, and export menu

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -211,6 +211,27 @@ connection_manager:
     configure: Configure
     configure_named: "Configure %{name}"
 document:
+  audit:
+    filter:
+      apply: Apply
+      clear: Clear
+      group_label: "Group:"
+      loading: "Loading…"
+      retry: Retry
+      view_mode:
+        chart: Chart
+        table: Table
+      y_scale:
+        linear: "Y: Linear"
+        log: "Y: Log"
+    menu:
+      copy_row_as_csv: Copy Row as CSV
+      copy_summary: Copy Summary
+      export: Export
+      export_format:
+        csv: CSV
+        json: JSON
+      filter_by_correlation: Filter by Correlation
   code:
     toolbar:
       refresh: Refresh

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -211,6 +211,27 @@ connection_manager:
     configure: Configurar
     configure_named: "Configurar %{name}"
 document:
+  audit:
+    filter:
+      apply: Aplicar
+      clear: Limpiar
+      group_label: "Agrupar:"
+      loading: "Cargando…"
+      retry: Reintentar
+      view_mode:
+        chart: Gráfico
+        table: Tabla
+      y_scale:
+        linear: "Y: Lineal"
+        log: "Y: Logarítmica"
+    menu:
+      copy_row_as_csv: Copiar fila como CSV
+      copy_summary: Copiar resumen
+      export: Exportar
+      export_format:
+        csv: CSV
+        json: JSON
+      filter_by_correlation: Filtrar por correlación
   code:
     toolbar:
       refresh: Actualizar

--- a/crates/dbflux_ui_document/src/audit/commands.rs
+++ b/crates/dbflux_ui_document/src/audit/commands.rs
@@ -117,12 +117,12 @@ impl AuditDocument {
     pub(super) fn context_menu_items(has_correlation: bool) -> Vec<AuditMenuItem> {
         let mut items = vec![
             AuditMenuItem::item(
-                "Copy Row as CSV",
+                dbflux_i18n::t!("document.audit.menu.copy_row_as_csv"),
                 AuditContextMenuAction::CopyRowAsCsv,
                 AppIcon::Layers,
             ),
             AuditMenuItem::item(
-                "Copy Summary",
+                dbflux_i18n::t!("document.audit.menu.copy_summary"),
                 AuditContextMenuAction::CopySummary,
                 AppIcon::Layers,
             ),
@@ -131,7 +131,7 @@ impl AuditDocument {
         if has_correlation {
             items.push(AuditMenuItem::separator());
             items.push(AuditMenuItem::item(
-                "Filter by Correlation",
+                dbflux_i18n::t!("document.audit.menu.filter_by_correlation"),
                 AuditContextMenuAction::FilterByCorrelation,
                 AppIcon::ListFilter,
             ));
@@ -562,3 +562,77 @@ impl AuditDocument {
 // Suppress unused import warnings from items used only in commands.rs's
 // `use super::` that come from mod.rs private items.
 use super::ToolbarSlot;
+
+#[cfg(test)]
+mod tests {
+    use super::{AuditContextMenuAction, AuditDocument, AuditMenuItem};
+
+    const MENU_KEYS: &[&str] = &[
+        "document.audit.menu.copy_row_as_csv",
+        "document.audit.menu.copy_summary",
+        "document.audit.menu.export",
+        "document.audit.menu.export_format.csv",
+        "document.audit.menu.export_format.json",
+        "document.audit.menu.filter_by_correlation",
+    ];
+
+    #[test]
+    fn audit_context_menu_keys_resolve_in_both_locales() {
+        for key in MENU_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn audit_context_menu_copy_row_as_csv_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.audit.menu.copy_row_as_csv", locale = "en");
+        let es = dbflux_i18n::t!("document.audit.menu.copy_row_as_csv", locale = "es");
+
+        assert_eq!(en, "Copy Row as CSV");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn audit_context_menu_label_round_trips_translated_value() {
+        let item = AuditMenuItem::item(
+            dbflux_i18n::t!("document.audit.menu.copy_row_as_csv"),
+            AuditContextMenuAction::CopyRowAsCsv,
+            dbflux_components::icons::AppIcon::Layers,
+        );
+
+        assert_eq!(
+            item.label.to_string(),
+            dbflux_i18n::t!("document.audit.menu.copy_row_as_csv")
+        );
+    }
+
+    #[test]
+    fn context_menu_items_includes_correlation_entry_only_when_present() {
+        let without_correlation = AuditDocument::context_menu_items(false);
+        let with_correlation = AuditDocument::context_menu_items(true);
+
+        assert_eq!(without_correlation.len(), 2);
+        assert!(
+            !without_correlation
+                .iter()
+                .any(|item| item.action == Some(AuditContextMenuAction::FilterByCorrelation))
+        );
+
+        assert_eq!(with_correlation.len(), 4);
+        assert!(
+            with_correlation
+                .iter()
+                .any(|item| item.action == Some(AuditContextMenuAction::FilterByCorrelation))
+        );
+    }
+}

--- a/crates/dbflux_ui_document/src/audit/mod.rs
+++ b/crates/dbflux_ui_document/src/audit/mod.rs
@@ -62,31 +62,31 @@ struct AuditContextMenuState {
 }
 
 /// Flat list of context menu items.  Separators carry `action: None`.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct AuditMenuItem {
-    label: &'static str,
+    label: SharedString,
     action: Option<AuditContextMenuAction>,
     icon: Option<AppIcon>,
 }
 
 impl AuditMenuItem {
-    const fn item(label: &'static str, action: AuditContextMenuAction, icon: AppIcon) -> Self {
+    fn item(label: impl Into<SharedString>, action: AuditContextMenuAction, icon: AppIcon) -> Self {
         Self {
-            label,
+            label: label.into(),
             action: Some(action),
             icon: Some(icon),
         }
     }
 
-    const fn separator() -> Self {
+    fn separator() -> Self {
         Self {
-            label: "",
+            label: SharedString::default(),
             action: None,
             icon: None,
         }
     }
 
-    fn is_separator(self) -> bool {
+    fn is_separator(&self) -> bool {
         self.action.is_none()
     }
 }

--- a/crates/dbflux_ui_document/src/audit/render.rs
+++ b/crates/dbflux_ui_document/src/audit/render.rs
@@ -152,7 +152,7 @@ impl AuditDocument {
             };
 
             let is_selected = idx == selected_index;
-            let label = item.label;
+            let label = item.label.clone();
             let icon = item.icon;
 
             // Icon color follows the DataGridPanel context menu convention.
@@ -306,7 +306,7 @@ impl AuditDocument {
 
         let can_apply_custom_time_range = self.can_apply_custom_time_range(cx);
         let custom_apply_button = ToolbarButton::new("audit-custom-time-apply")
-            .label("Apply")
+            .label(dbflux_i18n::t!("document.audit.filter.apply"))
             .focused(self.slot_has_ring(ToolbarSlot::CustomApply))
             .disabled(!can_apply_custom_time_range)
             .on_click(cx.listener(|this, _, _, cx| {
@@ -407,7 +407,7 @@ impl AuditDocument {
 
         // Clear button.
         let clear_btn = ToolbarButton::new("audit-clear-btn")
-            .label("Clear")
+            .label(dbflux_i18n::t!("document.audit.filter.clear"))
             .variant(ToolbarButtonVariant::Ghost)
             .focused(self.slot_has_ring(ToolbarSlot::Clear))
             .on_click(cx.listener(|this, _, window, cx| {
@@ -439,7 +439,11 @@ impl AuditDocument {
             if !self.is_external_event_stream() {
                 let is_chart = matches!(self.view_mode, AuditViewMode::Chart);
 
-                let toggle_label = if is_chart { "Table" } else { "Chart" };
+                let toggle_label = if is_chart {
+                    dbflux_i18n::t!("document.audit.filter.view_mode.table")
+                } else {
+                    dbflux_i18n::t!("document.audit.filter.view_mode.chart")
+                };
                 let view_toggle = div()
                     .id("audit-view-toggle")
                     .h(Heights::BUTTON)
@@ -480,7 +484,9 @@ impl AuditDocument {
                         .items_center()
                         .gap_1()
                         .w(px(148.0))
-                        .child(Text::caption("Group:"))
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "document.audit.filter.group_label"
+                        )))
                         .child(div().flex_1().child(self.dropdown_chart_group_by.clone()));
                     items.push(group_by_control.into_any_element());
 
@@ -488,8 +494,8 @@ impl AuditDocument {
                     // Fixed-width so it does not stretch the toolbar row.
                     let current_y_scale = self.chart.chart_shell.read(cx).y_scale();
                     let y_scale_label = match current_y_scale {
-                        YScale::Linear => "Y: Linear",
-                        YScale::Log => "Y: Log",
+                        YScale::Linear => dbflux_i18n::t!("document.audit.filter.y_scale.linear"),
+                        YScale::Log => dbflux_i18n::t!("document.audit.filter.y_scale.log"),
                     };
                     let y_scale_toggle = div()
                         .id("audit-y-scale-toggle")
@@ -557,7 +563,7 @@ impl AuditDocument {
                 .child(Text::muted(self.status_message.clone().unwrap_or_default()))
                 .child(
                     gpui_component::button::Button::new("audit-retry")
-                        .label("Retry")
+                        .label(dbflux_i18n::t!("document.audit.filter.retry"))
                         .small()
                         .ghost()
                         .on_click(cx.listener(|this, _, _, cx| this.refresh(cx))),
@@ -1029,7 +1035,7 @@ impl AuditDocument {
                     .size(Heights::ICON_SM)
                     .muted(),
             )
-            .child(Text::caption("Export"))
+            .child(Text::caption(dbflux_i18n::t!("document.audit.menu.export")))
             .child(Icon::new(AppIcon::ChevronDown).size(px(12.0)).muted()) // guardrail-allow: 12px icon size, no ICON_XS token
             .when(menu_open, |trigger| {
                 trigger.child(self.render_export_menu(theme, cx))
@@ -1041,29 +1047,38 @@ impl AuditDocument {
         theme: &gpui_component::Theme,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let items = [("CSV", "csv"), ("JSON", "json")]
-            .into_iter()
-            .enumerate()
-            .map(|(index, (label, format))| {
-                // Identical to DataGridPanel::render_export_menu items.
-                div()
-                    .id(SharedString::from(format!("audit-export-{}", index)))
-                    .flex()
-                    .items_center()
-                    .gap(Spacing::SM)
-                    .h(Heights::ROW_COMPACT)
-                    .px(Spacing::SM)
-                    .mx(Spacing::XS)
-                    .rounded(Radii::SM)
-                    .cursor_pointer()
-                    .hover(|d| d.bg(theme.secondary))
-                    .on_click(cx.listener(move |this, _, _, cx| {
-                        this.export_with_format(format, cx);
-                    }))
-                    .child(Text::body(label))
-                    .into_any_element()
-            })
-            .collect::<Vec<_>>();
+        let items = [
+            (
+                dbflux_i18n::t!("document.audit.menu.export_format.csv"),
+                "csv",
+            ),
+            (
+                dbflux_i18n::t!("document.audit.menu.export_format.json"),
+                "json",
+            ),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, (label, format))| {
+            // Identical to DataGridPanel::render_export_menu items.
+            div()
+                .id(SharedString::from(format!("audit-export-{}", index)))
+                .flex()
+                .items_center()
+                .gap(Spacing::SM)
+                .h(Heights::ROW_COMPACT)
+                .px(Spacing::SM)
+                .mx(Spacing::XS)
+                .rounded(Radii::SM)
+                .cursor_pointer()
+                .hover(|d| d.bg(theme.secondary))
+                .on_click(cx.listener(move |this, _, _, cx| {
+                    this.export_with_format(format, cx);
+                }))
+                .child(Text::body(label))
+                .into_any_element()
+        })
+        .collect::<Vec<_>>();
 
         // Identical to DataGridPanel::render_export_menu container.
         deferred(
@@ -1204,7 +1219,7 @@ impl AuditDocument {
                                     .size(px(12.0)) // guardrail-allow: 12px icon size, no ICON_XS token
                                     .color(theme.muted_foreground),
                             )
-                            .child(Text::dim("Loading…")),
+                            .child(Text::dim(dbflux_i18n::t!("document.audit.filter.loading"))),
                     )
                 },
             );
@@ -1367,5 +1382,46 @@ impl AuditDocument {
         );
 
         format!("{}\n{}", header, row)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const FILTER_KEYS: &[&str] = &[
+        "document.audit.filter.apply",
+        "document.audit.filter.clear",
+        "document.audit.filter.group_label",
+        "document.audit.filter.loading",
+        "document.audit.filter.retry",
+        "document.audit.filter.view_mode.chart",
+        "document.audit.filter.view_mode.table",
+        "document.audit.filter.y_scale.linear",
+        "document.audit.filter.y_scale.log",
+    ];
+
+    #[test]
+    fn audit_filter_keys_resolve_in_both_locales() {
+        for key in FILTER_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn audit_filter_clear_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.audit.filter.clear", locale = "en");
+        let es = dbflux_i18n::t!("document.audit.filter.clear", locale = "es");
+
+        assert_eq!(en, "Clear");
+        assert_ne!(en, es);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 15: the audit viewer toolbar actions, view toggles, export menu and loading indicator render through `dbflux_i18n::t!`; menu items carry SharedString labels. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 14; next: audit rows and detail panes)

## How was this solved?

- `audit/filters.rs` and `saved_filter.rs` hold no user-visible text.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 965 passed; clippy clean; fmt clean. Manual smoke in Spanish: open the audit viewer, apply a filter, export CSV.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
