### PR TITLE
feat(i18n): translate the MCP tool catalog names and descriptions

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1335,6 +1335,83 @@ settings:
     login_hint: Log in to load options
     inherited_from: "Inherited from %{trigger}."
     inherited_from_named: "Inherited from %{trigger} '%{name}'."
+  mcp:
+    tool:
+      list_connections:
+        name: List Connections
+        description: Enumerate all configured database connections
+      get_connection:
+        name: Get Connection
+        description: Retrieve full details of a specific connection
+      get_connection_metadata:
+        name: Connection Metadata
+        description: Fetch driver capabilities and metadata for a connection
+      list_databases:
+        name: List Databases
+        description: List all databases accessible on a connection
+      list_schemas:
+        name: List Schemas
+        description: List schemas within a database
+      list_tables:
+        name: List Tables
+        description: List tables and collections within a schema
+      list_collections:
+        name: List Collections
+        description: List MongoDB collections or similar document stores
+      describe_object:
+        name: Describe Object
+        description: Get column/field definitions and indexes for a table or collection
+      read_query:
+        name: Read Query
+        description: Execute a SELECT or equivalent read-only query
+      explain_query:
+        name: Explain Query
+        description: Show the query execution plan without running it
+      preview_mutation:
+        name: Preview Mutation
+        description: Dry-run a write/delete query and report affected rows
+      list_scripts:
+        name: List Scripts
+        description: List saved scripts in the scripts directory
+      get_script:
+        name: Get Script
+        description: Retrieve the source of a specific saved script
+      create_script:
+        name: Create Script
+        description: Save a new script to the scripts directory
+      update_script:
+        name: Update Script
+        description: Overwrite an existing saved script
+      delete_script:
+        name: Delete Script
+        description: Permanently remove a script from the scripts directory
+      run_script:
+        name: Run Script
+        description: Execute a saved Lua/SQL/shell script against a connection
+      request_execution:
+        name: Request Execution
+        description: Submit a mutation for human approval before it runs
+      list_pending_executions:
+        name: List Pending
+        description: View all executions awaiting approval
+      get_pending_execution:
+        name: Get Pending
+        description: Retrieve details of a specific pending execution
+      approve_execution:
+        name: Approve Execution
+        description: Approve and trigger a pending mutation
+      reject_execution:
+        name: Reject Execution
+        description: Reject and discard a pending mutation
+      query_audit_logs:
+        name: Query Audit Logs
+        description: Search and filter the audit trail
+      get_audit_entry:
+        name: Get Audit Entry
+        description: Retrieve a single audit log entry by ID
+      export_audit_logs:
+        name: Export Audit Logs
+        description: Download audit log entries as a file
   nav:
     general_group: General
     general: General

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1335,6 +1335,83 @@ settings:
     login_hint: Inicia sesión para cargar las opciones
     inherited_from: "Heredado de %{trigger}."
     inherited_from_named: "Heredado de %{trigger} '%{name}'."
+  mcp:
+    tool:
+      list_connections:
+        name: Listar conexiones
+        description: Enumerar todas las conexiones de base de datos configuradas
+      get_connection:
+        name: Obtener conexión
+        description: Obtener los detalles completos de una conexión específica
+      get_connection_metadata:
+        name: Metadatos de la conexión
+        description: Obtener las capacidades del controlador y los metadatos de una conexión
+      list_databases:
+        name: Listar bases de datos
+        description: Listar todas las bases de datos accesibles en una conexión
+      list_schemas:
+        name: Listar esquemas
+        description: Listar los esquemas de una base de datos
+      list_tables:
+        name: Listar tablas
+        description: Listar las tablas y colecciones de un esquema
+      list_collections:
+        name: Listar colecciones
+        description: Listar colecciones de MongoDB u otros almacenes de documentos similares
+      describe_object:
+        name: Describir objeto
+        description: Obtener las definiciones de columnas/campos e índices de una tabla o colección
+      read_query:
+        name: Consulta de lectura
+        description: Ejecutar una consulta SELECT o equivalente de solo lectura
+      explain_query:
+        name: Explicar consulta
+        description: Mostrar el plan de ejecución de la consulta sin ejecutarla
+      preview_mutation:
+        name: Previsualizar mutación
+        description: Previsualizar una consulta de escritura/eliminación e informar las filas afectadas
+      list_scripts:
+        name: Listar scripts
+        description: Listar los scripts guardados en el directorio de scripts
+      get_script:
+        name: Obtener script
+        description: Obtener el código fuente de un script guardado específico
+      create_script:
+        name: Crear script
+        description: Guardar un nuevo script en el directorio de scripts
+      update_script:
+        name: Actualizar script
+        description: Sobrescribir un script guardado existente
+      delete_script:
+        name: Eliminar script
+        description: Eliminar de forma permanente un script del directorio de scripts
+      run_script:
+        name: Ejecutar script
+        description: Ejecutar un script Lua/SQL/shell guardado sobre una conexión
+      request_execution:
+        name: Solicitar ejecución
+        description: Enviar una mutación para aprobación humana antes de ejecutarla
+      list_pending_executions:
+        name: Listar pendientes
+        description: Ver todas las ejecuciones pendientes de aprobación
+      get_pending_execution:
+        name: Obtener pendiente
+        description: Obtener los detalles de una ejecución pendiente específica
+      approve_execution:
+        name: Aprobar ejecución
+        description: Aprobar y disparar una mutación pendiente
+      reject_execution:
+        name: Rechazar ejecución
+        description: Rechazar y descartar una mutación pendiente
+      query_audit_logs:
+        name: Consultar registros de auditoría
+        description: Buscar y filtrar el registro de auditoría
+      get_audit_entry:
+        name: Obtener entrada de auditoría
+        description: Obtener una entrada del registro de auditoría por ID
+      export_audit_logs:
+        name: Exportar registros de auditoría
+        description: Descargar las entradas del registro de auditoría como archivo
   nav:
     general_group: General
     general: General

--- a/crates/dbflux_ui_windows/src/lib.rs
+++ b/crates/dbflux_ui_windows/src/lib.rs
@@ -4,7 +4,7 @@
 //! the Connection Manager window, the Settings window, and shared SSH
 //! authentication UI helpers.
 
-#![recursion_limit = "1024"]
+#![recursion_limit = "2048"]
 
 pub mod connection_manager;
 pub mod settings;

--- a/crates/dbflux_ui_windows/src/settings/mcp_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/mcp_section.rs
@@ -18,134 +18,50 @@ use gpui_component::ActiveTheme;
 use gpui_component::scroll::ScrollableElement;
 use std::collections::HashSet;
 
-/// Tool display metadata: (id, label, description)
-const TOOL_META: &[(&str, &str, &str)] = &[
-    (
-        "list_connections",
-        "List Connections",
-        "Enumerate all configured database connections",
-    ),
-    (
-        "get_connection",
-        "Get Connection",
-        "Retrieve full details of a specific connection",
-    ),
-    (
-        "get_connection_metadata",
-        "Connection Metadata",
-        "Fetch driver capabilities and metadata for a connection",
-    ),
-    (
-        "list_databases",
-        "List Databases",
-        "List all databases accessible on a connection",
-    ),
-    (
-        "list_schemas",
-        "List Schemas",
-        "List schemas within a database",
-    ),
-    (
-        "list_tables",
-        "List Tables",
-        "List tables and collections within a schema",
-    ),
-    (
-        "list_collections",
-        "List Collections",
-        "List MongoDB collections or similar document stores",
-    ),
-    (
-        "describe_object",
-        "Describe Object",
-        "Get column/field definitions and indexes for a table or collection",
-    ),
-    (
-        "read_query",
-        "Read Query",
-        "Execute a SELECT or equivalent read-only query",
-    ),
-    (
-        "explain_query",
-        "Explain Query",
-        "Show the query execution plan without running it",
-    ),
-    (
-        "preview_mutation",
-        "Preview Mutation",
-        "Dry-run a write/delete query and report affected rows",
-    ),
-    (
-        "list_scripts",
-        "List Scripts",
-        "List saved scripts in the scripts directory",
-    ),
-    (
-        "get_script",
-        "Get Script",
-        "Retrieve the source of a specific saved script",
-    ),
-    (
-        "create_script",
-        "Create Script",
-        "Save a new script to the scripts directory",
-    ),
-    (
-        "update_script",
-        "Update Script",
-        "Overwrite an existing saved script",
-    ),
-    (
-        "delete_script",
-        "Delete Script",
-        "Permanently remove a script from the scripts directory",
-    ),
-    (
-        "run_script",
-        "Run Script",
-        "Execute a saved Lua/SQL/shell script against a connection",
-    ),
-    (
-        "request_execution",
-        "Request Execution",
-        "Submit a mutation for human approval before it runs",
-    ),
-    (
-        "list_pending_executions",
-        "List Pending",
-        "View all executions awaiting approval",
-    ),
-    (
-        "get_pending_execution",
-        "Get Pending",
-        "Retrieve details of a specific pending execution",
-    ),
-    (
-        "approve_execution",
-        "Approve Execution",
-        "Approve and trigger a pending mutation",
-    ),
-    (
-        "reject_execution",
-        "Reject Execution",
-        "Reject and discard a pending mutation",
-    ),
-    (
-        "query_audit_logs",
-        "Query Audit Logs",
-        "Search and filter the audit trail",
-    ),
-    (
-        "get_audit_entry",
-        "Get Audit Entry",
-        "Retrieve a single audit log entry by ID",
-    ),
-    (
-        "export_audit_logs",
-        "Export Audit Logs",
-        "Download audit log entries as a file",
-    ),
+/// Tool ids in their stable display order. Each id doubles as the catalog key
+/// segment for its translated name and description: `settings.mcp.tool.<id>.name`
+/// and `settings.mcp.tool.<id>.description`.
+const TOOL_IDS: &[&str] = &[
+    "list_connections",
+    "get_connection",
+    "get_connection_metadata",
+    "list_databases",
+    "list_schemas",
+    "list_tables",
+    "list_collections",
+    "describe_object",
+    "read_query",
+    "explain_query",
+    "preview_mutation",
+    "list_scripts",
+    "get_script",
+    "create_script",
+    "update_script",
+    "delete_script",
+    "run_script",
+    "request_execution",
+    "list_pending_executions",
+    "get_pending_execution",
+    "approve_execution",
+    "reject_execution",
+    "query_audit_logs",
+    "get_audit_entry",
+    "export_audit_logs",
 ];
+
+/// Resolves the tool display metadata for the active locale: (id, translated
+/// name, translated description). Call once per render and reuse the result
+/// across the tool checkbox rows instead of re-resolving per row.
+fn tool_meta() -> Vec<(&'static str, String, String)> {
+    TOOL_IDS
+        .iter()
+        .map(|&id| {
+            let name = dbflux_i18n::t!(&format!("settings.mcp.tool.{id}.name"));
+            let description = dbflux_i18n::t!(&format!("settings.mcp.tool.{id}.description"));
+            (id, name, description)
+        })
+        .collect()
+}
 
 /// Execution class display metadata: (id, label, description)
 const CLASS_META: &[(&str, &str, &str)] = &[
@@ -227,20 +143,18 @@ const TOOL_GROUPS: &[(&str, &[&str])] = &[
     ),
 ];
 
-fn tool_label(id: &str) -> &str {
-    TOOL_META
-        .iter()
+fn tool_label(meta: &[(&'static str, String, String)], id: &str) -> String {
+    meta.iter()
         .find(|(t, _, _)| *t == id)
-        .map(|(_, l, _)| *l)
-        .unwrap_or(id)
+        .map(|(_, name, _)| name.clone())
+        .unwrap_or_else(|| id.to_string())
 }
 
-fn tool_description(id: &str) -> &'static str {
-    TOOL_META
-        .iter()
+fn tool_description(meta: &[(&'static str, String, String)], id: &str) -> String {
+    meta.iter()
         .find(|(t, _, _)| *t == id)
-        .map(|(_, _, d)| *d)
-        .unwrap_or("")
+        .map(|(_, _, description)| description.clone())
+        .unwrap_or_default()
 }
 
 use dbflux_mcp::builtin_display_name;
@@ -1007,6 +921,7 @@ impl McpSection {
 
     fn render_policies_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme().clone();
+        let tool_meta = tool_meta();
         let policies: Vec<ToolPolicyDto> = self
             .app_state
             .read(cx)
@@ -1179,8 +1094,8 @@ impl McpSection {
                             .child(div().flex().flex_col().gap_2().pl_2().children(
                                 tools.iter().map(|&tool| {
                                     let checked = self.draft_policy_tools.contains(tool);
-                                    let label = tool_label(tool);
-                                    let description = tool_description(tool);
+                                    let label = tool_label(&tool_meta, tool);
+                                    let description = tool_description(&tool_meta, tool);
                                     div()
                                         .flex()
                                         .items_start()
@@ -1680,5 +1595,79 @@ impl Render for McpSection {
                 cx,
             ))
             .child(div().flex_1().min_h_0().overflow_hidden().child(content))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tool_meta;
+
+    const EXPECTED_TOOL_IDS: &[&str] = &[
+        "list_connections",
+        "get_connection",
+        "get_connection_metadata",
+        "list_databases",
+        "list_schemas",
+        "list_tables",
+        "list_collections",
+        "describe_object",
+        "read_query",
+        "explain_query",
+        "preview_mutation",
+        "list_scripts",
+        "get_script",
+        "create_script",
+        "update_script",
+        "delete_script",
+        "run_script",
+        "request_execution",
+        "list_pending_executions",
+        "get_pending_execution",
+        "approve_execution",
+        "reject_execution",
+        "query_audit_logs",
+        "get_audit_entry",
+        "export_audit_logs",
+    ];
+
+    #[test]
+    fn mcp_tool_meta_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for id in EXPECTED_TOOL_IDS {
+                for field in ["name", "description"] {
+                    let key = format!("settings.mcp.tool.{id}.{field}");
+                    let value = dbflux_i18n::t!(&key, locale = locale);
+
+                    assert!(
+                        !value.is_empty(),
+                        "key {key} resolved empty for locale {locale}"
+                    );
+                    assert_ne!(value, key, "key {key} did not resolve for locale {locale}");
+                    assert_ne!(
+                        value,
+                        format!("{locale}.{key}"),
+                        "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn mcp_tool_meta_ids_unchanged() {
+        let meta = tool_meta();
+        let actual_ids: Vec<&str> = meta.iter().map(|(id, _, _)| *id).collect();
+
+        assert_eq!(actual_ids, EXPECTED_TOOL_IDS);
+    }
+
+    #[test]
+    fn mcp_tool_list_connections_name_differs_between_locales() {
+        let english = dbflux_i18n::t!("settings.mcp.tool.list_connections.name", locale = "en");
+        let spanish = dbflux_i18n::t!("settings.mcp.tool.list_connections.name", locale = "es");
+
+        assert_eq!(english, "List Connections");
+        assert_eq!(spanish, "Listar conexiones");
+        assert_ne!(english, spanish);
     }
 }


### PR DESCRIPTION
## Summary

Seventeenth `dbflux_ui_windows` i18n slice: the MCP settings tool catalog (25 tool names and descriptions) renders through `dbflux_i18n::t!` under `settings.mcp.tool.<id>.{name,description}`. `TOOL_META` becomes `TOOL_IDS` plus a `tool_meta()` function resolved once per render; tool ids stay data. English and Spanish together.

## What does this resolve?

- Refs #360 (follows the auth profiles login flow PR; next: the MCP settings chrome)

## How was this solved?

- `tool_meta()` replaces the const so labels resolve at render time; `tool_label`/`tool_description` take the resolved list.
- `recursion_limit` raised to 2048 in `lib.rs`: the crate test harness under `--features mcp` hit the 1024 ceiling. Tests import `super::tool_meta` narrowly instead of `super::*` (the wildcard overflows rustc under `--test --features mcp`).

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 260 passed, `--features mcp` → 263 passed; clippy clean (with and without `mcp`); fmt clean. Manual smoke in Spanish: Settings → MCP → Policies tool list.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
