### PR TITLE
feat(i18n): translate the audit detail panes and source labels

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -212,6 +212,43 @@ connection_manager:
     configure_named: "Configure %{name}"
 document:
   audit:
+    actor:
+      app: App
+      external_auth_provider: External Auth Provider
+      external_driver: External Driver
+      hook: Hook
+      mcp_client: MCP Client
+      script: Script
+      system: System
+      user: User
+    category:
+      config: Config
+      connection: Connection
+      governance: Governance
+      hook: Hook
+      mcp: MCP
+      object_storage: Object Storage
+      query: Query
+      script: Script
+      system: System
+    detail:
+      action: Action
+      actor: Actor
+      category: Category
+      connection_driver: "Connection/Driver"
+      correlation_id: Correlation ID
+      details: Details
+      duration: Duration
+      error: Error
+      event_id: Event ID
+      level: Level
+      message: Message
+      outcome: Outcome
+      partition: Partition
+      secondary_time: Secondary Time
+      source: Source
+      summary: Summary
+      time: Time
     filter:
       apply: Apply
       clear: Clear
@@ -224,6 +261,13 @@ document:
       y_scale:
         linear: "Y: Linear"
         log: "Y: Log"
+    level:
+      debug: Debug
+      error: Error
+      fatal: Fatal
+      info: Info
+      trace: Trace
+      warn: Warning
     menu:
       copy_row_as_csv: Copy Row as CSV
       copy_summary: Copy Summary
@@ -232,6 +276,25 @@ document:
         csv: CSV
         json: JSON
       filter_by_correlation: Filter by Correlation
+    outcome:
+      cancelled: Cancelled
+      failure: Failure
+      pending: Pending
+      success: Success
+    row:
+      unit:
+        events: events
+        rows: rows
+    source:
+      empty:
+        external: "No events match the current filters."
+        internal: "No audit events match the current filters."
+      error_heading:
+        external: "Failed to load events"
+        internal: "Failed to load audit events"
+      loading:
+        external: "Loading events…"
+        internal: "Loading audit events…"
   code:
     toolbar:
       refresh: Refresh

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -212,6 +212,43 @@ connection_manager:
     configure_named: "Configurar %{name}"
 document:
   audit:
+    actor:
+      app: Aplicación
+      external_auth_provider: Proveedor de autenticación externo
+      external_driver: Driver externo
+      hook: Hook
+      mcp_client: Cliente MCP
+      script: Script
+      system: Sistema
+      user: Usuario
+    category:
+      config: Configuración
+      connection: Conexión
+      governance: Gobernanza
+      hook: Hook
+      mcp: MCP
+      object_storage: Almacenamiento de objetos
+      query: Consulta
+      script: Script
+      system: Sistema
+    detail:
+      action: Acción
+      actor: Actor
+      category: Categoría
+      connection_driver: "Conexión/Driver"
+      correlation_id: ID de correlación
+      details: Detalles
+      duration: Duración
+      error: Error
+      event_id: ID de evento
+      level: Nivel
+      message: Mensaje
+      outcome: Resultado
+      partition: Partición
+      secondary_time: Hora secundaria
+      source: Origen
+      summary: Resumen
+      time: Hora
     filter:
       apply: Aplicar
       clear: Limpiar
@@ -224,6 +261,13 @@ document:
       y_scale:
         linear: "Y: Lineal"
         log: "Y: Logarítmica"
+    level:
+      debug: Depuración
+      error: Error
+      fatal: Fatal
+      info: Información
+      trace: Traza
+      warn: Advertencia
     menu:
       copy_row_as_csv: Copiar fila como CSV
       copy_summary: Copiar resumen
@@ -232,6 +276,25 @@ document:
         csv: CSV
         json: JSON
       filter_by_correlation: Filtrar por correlación
+    outcome:
+      cancelled: Cancelado
+      failure: Fallo
+      pending: Pendiente
+      success: Éxito
+    row:
+      unit:
+        events: eventos
+        rows: filas
+    source:
+      empty:
+        external: "Ningún evento coincide con los filtros actuales."
+        internal: "Ningún evento de auditoría coincide con los filtros actuales."
+      error_heading:
+        external: "Error al cargar eventos"
+        internal: "Error al cargar eventos de auditoría"
+      loading:
+        external: "Cargando eventos…"
+        internal: "Cargando eventos de auditoría…"
   code:
     toolbar:
       refresh: Actualizar

--- a/crates/dbflux_ui_document/src/audit/mod.rs
+++ b/crates/dbflux_ui_document/src/audit/mod.rs
@@ -836,35 +836,35 @@ impl AuditDocument {
         filters
     }
 
-    fn source_loading_label(&self) -> &'static str {
+    fn source_loading_label(&self) -> String {
         if self.is_external_event_stream() {
-            "Loading events..."
+            dbflux_i18n::t!("document.audit.source.loading.external")
         } else {
-            "Loading audit events..."
+            dbflux_i18n::t!("document.audit.source.loading.internal")
         }
     }
 
-    fn source_error_heading(&self) -> &'static str {
+    fn source_error_heading(&self) -> String {
         if self.is_external_event_stream() {
-            "Failed to load events"
+            dbflux_i18n::t!("document.audit.source.error_heading.external")
         } else {
-            "Failed to load audit events"
+            dbflux_i18n::t!("document.audit.source.error_heading.internal")
         }
     }
 
-    fn source_empty_label(&self) -> &'static str {
+    fn source_empty_label(&self) -> String {
         if self.is_external_event_stream() {
-            "No events match the current filters."
+            dbflux_i18n::t!("document.audit.source.empty.external")
         } else {
-            "No audit events match the current filters."
+            dbflux_i18n::t!("document.audit.source.empty.internal")
         }
     }
 
-    fn source_row_label(&self) -> &'static str {
+    fn source_row_label(&self) -> String {
         if self.is_external_event_stream() {
-            "events"
+            dbflux_i18n::t!("document.audit.row.unit.events")
         } else {
-            "rows"
+            dbflux_i18n::t!("document.audit.row.unit.rows")
         }
     }
 
@@ -1031,7 +1031,7 @@ impl AuditDocument {
         let request_id = self.load_request_id;
         self.is_loading = true;
         self.export_menu_open = false;
-        self.status_message = Some(self.source_loading_label().to_string());
+        self.status_message = Some(self.source_loading_label());
         cx.notify();
 
         let page_filter = self.active_filter(
@@ -1774,5 +1774,51 @@ mod tests {
             0o600,
             "export file must be owner read/write only"
         );
+    }
+
+    const SOURCE_AND_ROW_KEYS: &[&str] = &[
+        "document.audit.row.unit.events",
+        "document.audit.row.unit.rows",
+        "document.audit.source.empty.external",
+        "document.audit.source.empty.internal",
+        "document.audit.source.error_heading.external",
+        "document.audit.source.error_heading.internal",
+        "document.audit.source.loading.external",
+        "document.audit.source.loading.internal",
+    ];
+
+    #[test]
+    fn audit_source_and_row_keys_resolve_in_both_locales() {
+        for key in SOURCE_AND_ROW_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn audit_source_loading_internal_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.audit.source.loading.internal", locale = "en");
+        let es = dbflux_i18n::t!("document.audit.source.loading.internal", locale = "es");
+
+        assert_eq!(en, "Loading audit events…");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn audit_row_unit_rows_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.audit.row.unit.rows", locale = "en");
+        let es = dbflux_i18n::t!("document.audit.row.unit.rows", locale = "es");
+
+        assert_eq!(en, "rows");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_ui_document/src/audit/render.rs
+++ b/crates/dbflux_ui_document/src/audit/render.rs
@@ -758,7 +758,7 @@ impl AuditDocument {
 
     pub(super) fn render_detail_field(
         &self,
-        label: &'static str,
+        label: impl Into<SharedString>,
         value: Option<String>,
         theme: &gpui_component::Theme,
     ) -> Div {
@@ -786,23 +786,38 @@ impl AuditDocument {
 
         let theme = cx.theme().clone();
         let timestamp = self.format_timestamp_ms(event.created_at_epoch_ms);
-        let level = event.level.clone();
-        let category = match Self::short_category_label(event.category.as_deref()) {
-            "NULL" => None,
-            label => Some(label.to_string()),
-        };
-        let outcome = event.outcome.clone();
+        let level = event
+            .level
+            .as_deref()
+            .and_then(dbflux_core::EventSeverity::from_str_repr)
+            .map(crate::labels::audit_level_label)
+            .or_else(|| event.level.clone());
+        let category = event
+            .category
+            .as_deref()
+            .and_then(dbflux_core::EventCategory::from_str_repr)
+            .map(crate::labels::audit_category_label)
+            .or_else(|| event.category.clone());
+        let outcome = event
+            .outcome
+            .as_deref()
+            .and_then(dbflux_core::EventOutcome::from_str_repr)
+            .map(crate::labels::audit_outcome_label)
+            .or_else(|| event.outcome.clone());
         let actor = if event
             .actor_type
             .as_deref()
             .filter(|actor_type| !actor_type.is_empty() && *actor_type != "system")
             .is_some()
         {
-            format!(
-                "{} ({})",
-                event.actor_id,
-                event.actor_type.as_deref().unwrap_or("")
-            )
+            let actor_type_label = event
+                .actor_type
+                .as_deref()
+                .and_then(dbflux_core::EventActorType::from_str_repr)
+                .map(crate::labels::audit_actor_type_label)
+                .unwrap_or_else(|| event.actor_type.clone().unwrap_or_default());
+
+            format!("{} ({})", event.actor_id, actor_type_label)
         } else {
             event.actor_id.clone()
         };
@@ -839,30 +854,62 @@ impl AuditDocument {
                     .flex_wrap()
                     .gap_4()
                     .children(vec![
-                        self.render_detail_field("Time", Some(timestamp), &theme)
-                            .into_any_element(),
-                        self.render_detail_field("Level", level, &theme)
-                            .into_any_element(),
-                        self.render_detail_field("Category", category, &theme)
-                            .into_any_element(),
-                        self.render_detail_field("Outcome", outcome, &theme)
-                            .into_any_element(),
-                        self.render_detail_field("Actor", Some(actor), &theme)
-                            .into_any_element(),
-                        self.render_detail_field("Action", action, &theme)
-                            .into_any_element(),
-                        self.render_detail_field("Source", source, &theme)
-                            .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.time"),
+                            Some(timestamp),
+                            &theme,
+                        )
+                        .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.level"),
+                            level,
+                            &theme,
+                        )
+                        .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.category"),
+                            category,
+                            &theme,
+                        )
+                        .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.outcome"),
+                            outcome,
+                            &theme,
+                        )
+                        .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.actor"),
+                            Some(actor),
+                            &theme,
+                        )
+                        .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.action"),
+                            action,
+                            &theme,
+                        )
+                        .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.source"),
+                            source,
+                            &theme,
+                        )
+                        .into_any_element(),
                     ])
                     .when_some(connection_driver, |row, value| {
                         row.child(self.render_detail_field(
-                            "Connection/Driver",
+                            dbflux_i18n::t!("document.audit.detail.connection_driver"),
                             Some(value),
                             &theme,
                         ))
                     })
                     .when_some(duration, |row, value| {
-                        row.child(self.render_detail_field("Duration", Some(value), &theme))
+                        row.child(self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.duration"),
+                            Some(value),
+                            &theme,
+                        ))
                     }),
             )
             .when_some(summary, |root, value| {
@@ -870,7 +917,7 @@ impl AuditDocument {
                     div()
                         .flex_col()
                         .gap_1p5()
-                        .child(Label::new("Summary"))
+                        .child(Label::new(dbflux_i18n::t!("document.audit.detail.summary")))
                         .child(Text::body(value)),
                 )
             })
@@ -879,7 +926,10 @@ impl AuditDocument {
                     div()
                         .flex_col()
                         .gap_1p5()
-                        .child(Label::new("Error").text_color(theme.danger))
+                        .child(
+                            Label::new(dbflux_i18n::t!("document.audit.detail.error"))
+                                .text_color(theme.danger),
+                        )
                         .child(Text::body(value).danger()),
                 )
             })
@@ -888,7 +938,7 @@ impl AuditDocument {
                     div()
                         .flex_col()
                         .gap_1p5()
-                        .child(Label::new("Details"))
+                        .child(Label::new(dbflux_i18n::t!("document.audit.detail.details")))
                         .child(
                             div()
                                 .bg(theme.secondary)
@@ -905,7 +955,9 @@ impl AuditDocument {
                     div()
                         .flex_col()
                         .gap_1p5()
-                        .child(Label::new("Correlation ID"))
+                        .child(Label::new(dbflux_i18n::t!(
+                            "document.audit.detail.correlation_id"
+                        )))
                         .child(
                             div()
                                 .cursor_pointer()
@@ -961,17 +1013,37 @@ impl AuditDocument {
                     .flex_wrap()
                     .gap_4()
                     .children(vec![
-                        self.render_detail_field("Time", Some(timestamp), &theme)
-                            .into_any_element(),
-                        self.render_detail_field("Source", source_name, &theme)
-                            .into_any_element(),
-                        self.render_detail_field("Partition", source_partition, &theme)
-                            .into_any_element(),
-                        self.render_detail_field("Event ID", event_id, &theme)
-                            .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.time"),
+                            Some(timestamp),
+                            &theme,
+                        )
+                        .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.source"),
+                            source_name,
+                            &theme,
+                        )
+                        .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.partition"),
+                            source_partition,
+                            &theme,
+                        )
+                        .into_any_element(),
+                        self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.event_id"),
+                            event_id,
+                            &theme,
+                        )
+                        .into_any_element(),
                     ])
                     .when_some(secondary_timestamp, |row, value| {
-                        row.child(self.render_detail_field("Secondary Time", Some(value), &theme))
+                        row.child(self.render_detail_field(
+                            dbflux_i18n::t!("document.audit.detail.secondary_time"),
+                            Some(value),
+                            &theme,
+                        ))
                     }),
             )
             .when_some(message, |root, value| {
@@ -982,7 +1054,7 @@ impl AuditDocument {
                     div()
                         .flex_col()
                         .gap_1p5()
-                        .child(Label::new("Message"))
+                        .child(Label::new(dbflux_i18n::t!("document.audit.detail.message")))
                         .child(SelectableText::new(&message_input).w_full()),
                 )
             })
@@ -996,7 +1068,7 @@ impl AuditDocument {
                     div()
                         .flex_col()
                         .gap_1p5()
-                        .child(Label::new("Details"))
+                        .child(Label::new(dbflux_i18n::t!("document.audit.detail.details")))
                         .child(
                             div().bg(theme.secondary).p_2().rounded(Radii::SM).child(
                                 ReadonlyTextView::new(&details_input)
@@ -1423,5 +1495,63 @@ mod tests {
 
         assert_eq!(en, "Clear");
         assert_ne!(en, es);
+    }
+
+    const DETAIL_KEYS: &[&str] = &[
+        "document.audit.detail.action",
+        "document.audit.detail.actor",
+        "document.audit.detail.category",
+        "document.audit.detail.connection_driver",
+        "document.audit.detail.correlation_id",
+        "document.audit.detail.details",
+        "document.audit.detail.duration",
+        "document.audit.detail.error",
+        "document.audit.detail.event_id",
+        "document.audit.detail.level",
+        "document.audit.detail.message",
+        "document.audit.detail.outcome",
+        "document.audit.detail.partition",
+        "document.audit.detail.secondary_time",
+        "document.audit.detail.source",
+        "document.audit.detail.summary",
+        "document.audit.detail.time",
+    ];
+
+    #[test]
+    fn audit_detail_keys_resolve_in_both_locales() {
+        for key in DETAIL_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn audit_detail_correlation_id_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.audit.detail.correlation_id", locale = "en");
+        let es = dbflux_i18n::t!("document.audit.detail.correlation_id", locale = "es");
+
+        assert_eq!(en, "Correlation ID");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn render_detail_field_accepts_a_translated_string_label() {
+        // `render_detail_field` widened from `&'static str` to
+        // `impl Into<SharedString>` so translated `String` values from
+        // `dbflux_i18n::t!` can be passed directly without an intermediate
+        // leak or a `&'static str` catalog. This compiles only if the
+        // widened signature is in place.
+        let label: String = dbflux_i18n::t!("document.audit.detail.time");
+
+        assert!(!label.is_empty());
     }
 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -866,14 +866,100 @@ pub(crate) fn add_member_modal_placeholders(key_type: dbflux_core::KeyType) -> (
     }
 }
 
+/// Label for a [`dbflux_core::EventCategory`] shown in the audit viewer's
+/// detail pane.
+///
+/// Exhaustive by construction (no wildcard arm) so a new variant added to
+/// `dbflux_core::EventCategory` fails this crate's build until its catalog
+/// key is added here.
+pub(crate) fn audit_category_label(category: dbflux_core::EventCategory) -> String {
+    use dbflux_core::EventCategory;
+
+    match category {
+        EventCategory::Config => dbflux_i18n::t!("document.audit.category.config"),
+        EventCategory::Connection => dbflux_i18n::t!("document.audit.category.connection"),
+        EventCategory::Query => dbflux_i18n::t!("document.audit.category.query"),
+        EventCategory::Hook => dbflux_i18n::t!("document.audit.category.hook"),
+        EventCategory::Script => dbflux_i18n::t!("document.audit.category.script"),
+        EventCategory::System => dbflux_i18n::t!("document.audit.category.system"),
+        EventCategory::Mcp => dbflux_i18n::t!("document.audit.category.mcp"),
+        EventCategory::Governance => dbflux_i18n::t!("document.audit.category.governance"),
+        EventCategory::ObjectStorage => {
+            dbflux_i18n::t!("document.audit.category.object_storage")
+        }
+    }
+}
+
+/// Label for a [`dbflux_core::EventOutcome`] shown in the audit viewer's
+/// detail pane.
+///
+/// Exhaustive by construction (no wildcard arm) so a new variant added to
+/// `dbflux_core::EventOutcome` fails this crate's build until its catalog
+/// key is added here.
+pub(crate) fn audit_outcome_label(outcome: dbflux_core::EventOutcome) -> String {
+    use dbflux_core::EventOutcome;
+
+    match outcome {
+        EventOutcome::Success => dbflux_i18n::t!("document.audit.outcome.success"),
+        EventOutcome::Failure => dbflux_i18n::t!("document.audit.outcome.failure"),
+        EventOutcome::Cancelled => dbflux_i18n::t!("document.audit.outcome.cancelled"),
+        EventOutcome::Pending => dbflux_i18n::t!("document.audit.outcome.pending"),
+    }
+}
+
+/// Label for a [`dbflux_core::EventSeverity`] shown in the audit viewer's
+/// detail pane.
+///
+/// Exhaustive by construction (no wildcard arm) so a new variant added to
+/// `dbflux_core::EventSeverity` fails this crate's build until its catalog
+/// key is added here.
+pub(crate) fn audit_level_label(level: dbflux_core::EventSeverity) -> String {
+    use dbflux_core::EventSeverity;
+
+    match level {
+        EventSeverity::Trace => dbflux_i18n::t!("document.audit.level.trace"),
+        EventSeverity::Debug => dbflux_i18n::t!("document.audit.level.debug"),
+        EventSeverity::Info => dbflux_i18n::t!("document.audit.level.info"),
+        EventSeverity::Warn => dbflux_i18n::t!("document.audit.level.warn"),
+        EventSeverity::Error => dbflux_i18n::t!("document.audit.level.error"),
+        EventSeverity::Fatal => dbflux_i18n::t!("document.audit.level.fatal"),
+    }
+}
+
+/// Label for a [`dbflux_core::EventActorType`] shown in the audit viewer's
+/// detail pane.
+///
+/// Exhaustive by construction (no wildcard arm) so a new variant added to
+/// `dbflux_core::EventActorType` fails this crate's build until its catalog
+/// key is added here.
+pub(crate) fn audit_actor_type_label(actor_type: dbflux_core::EventActorType) -> String {
+    use dbflux_core::EventActorType;
+
+    match actor_type {
+        EventActorType::User => dbflux_i18n::t!("document.audit.actor.user"),
+        EventActorType::System => dbflux_i18n::t!("document.audit.actor.system"),
+        EventActorType::App => dbflux_i18n::t!("document.audit.actor.app"),
+        EventActorType::McpClient => dbflux_i18n::t!("document.audit.actor.mcp_client"),
+        EventActorType::Hook => dbflux_i18n::t!("document.audit.actor.hook"),
+        EventActorType::Script => dbflux_i18n::t!("document.audit.actor.script"),
+        EventActorType::ExternalDriver => {
+            dbflux_i18n::t!("document.audit.actor.external_driver")
+        }
+        EventActorType::ExternalAuthProvider => {
+            dbflux_i18n::t!("document.audit.actor.external_auth_provider")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         MutationItemKind, add_member_modal_placeholders, add_member_modal_section_label,
-        add_member_modal_title, agg_fn_display, assignment_value_kind_label, bool_op_label,
-        builder_mode_label, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
-        chart_rail_why_text, code_toolbar_shortcut_hint_label, comparator_label,
-        copy_query_language_label, dangerous_query_body, dangerous_query_title,
+        add_member_modal_title, agg_fn_display, assignment_value_kind_label,
+        audit_actor_type_label, audit_category_label, audit_level_label, audit_outcome_label,
+        bool_op_label, builder_mode_label, bulk_delete_success_label, chart_degraded_copy,
+        chart_dock_shape_label, chart_rail_why_text, code_toolbar_shortcut_hint_label,
+        comparator_label, copy_query_language_label, dangerous_query_body, dangerous_query_title,
         delete_confirm_copy, delete_rows_label, execution_count_state_label, execution_mode_label,
         history_items_count_label, history_tab_label, incomplete_aggregate_rows_label,
         join_kind_label, live_output_lines_label, live_output_truncated_label,
@@ -883,7 +969,10 @@ mod tests {
         update_columns_label, valid_lines_label,
     };
     use dbflux_components::chart::ChartDetection;
-    use dbflux_core::{DangerousQueryKind, QueryLanguage, RefreshPolicy};
+    use dbflux_core::{
+        DangerousQueryKind, EventActorType, EventCategory, EventOutcome, EventSeverity,
+        QueryLanguage, RefreshPolicy,
+    };
 
     const ALL_DANGEROUS_QUERY_KINDS: &[DangerousQueryKind] = &[
         DangerousQueryKind::DeleteNoWhere,
@@ -2038,6 +2127,212 @@ mod tests {
         );
 
         assert_eq!(en, "Add Hash Fields");
+        assert_ne!(en, es);
+    }
+
+    const ALL_EVENT_CATEGORIES: &[EventCategory] = &[
+        EventCategory::Config,
+        EventCategory::Connection,
+        EventCategory::Query,
+        EventCategory::Hook,
+        EventCategory::Script,
+        EventCategory::System,
+        EventCategory::Mcp,
+        EventCategory::Governance,
+        EventCategory::ObjectStorage,
+    ];
+
+    const ALL_EVENT_OUTCOMES: &[EventOutcome] = &[
+        EventOutcome::Success,
+        EventOutcome::Failure,
+        EventOutcome::Cancelled,
+        EventOutcome::Pending,
+    ];
+
+    const ALL_EVENT_SEVERITIES: &[EventSeverity] = &[
+        EventSeverity::Trace,
+        EventSeverity::Debug,
+        EventSeverity::Info,
+        EventSeverity::Warn,
+        EventSeverity::Error,
+        EventSeverity::Fatal,
+    ];
+
+    const ALL_EVENT_ACTOR_TYPES: &[EventActorType] = &[
+        EventActorType::User,
+        EventActorType::System,
+        EventActorType::App,
+        EventActorType::McpClient,
+        EventActorType::Hook,
+        EventActorType::Script,
+        EventActorType::ExternalDriver,
+        EventActorType::ExternalAuthProvider,
+    ];
+
+    fn audit_category_key(category: EventCategory) -> &'static str {
+        match category {
+            EventCategory::Config => "document.audit.category.config",
+            EventCategory::Connection => "document.audit.category.connection",
+            EventCategory::Query => "document.audit.category.query",
+            EventCategory::Hook => "document.audit.category.hook",
+            EventCategory::Script => "document.audit.category.script",
+            EventCategory::System => "document.audit.category.system",
+            EventCategory::Mcp => "document.audit.category.mcp",
+            EventCategory::Governance => "document.audit.category.governance",
+            EventCategory::ObjectStorage => "document.audit.category.object_storage",
+        }
+    }
+
+    fn audit_outcome_key(outcome: EventOutcome) -> &'static str {
+        match outcome {
+            EventOutcome::Success => "document.audit.outcome.success",
+            EventOutcome::Failure => "document.audit.outcome.failure",
+            EventOutcome::Cancelled => "document.audit.outcome.cancelled",
+            EventOutcome::Pending => "document.audit.outcome.pending",
+        }
+    }
+
+    fn audit_level_key(level: EventSeverity) -> &'static str {
+        match level {
+            EventSeverity::Trace => "document.audit.level.trace",
+            EventSeverity::Debug => "document.audit.level.debug",
+            EventSeverity::Info => "document.audit.level.info",
+            EventSeverity::Warn => "document.audit.level.warn",
+            EventSeverity::Error => "document.audit.level.error",
+            EventSeverity::Fatal => "document.audit.level.fatal",
+        }
+    }
+
+    fn audit_actor_type_key(actor_type: EventActorType) -> &'static str {
+        match actor_type {
+            EventActorType::User => "document.audit.actor.user",
+            EventActorType::System => "document.audit.actor.system",
+            EventActorType::App => "document.audit.actor.app",
+            EventActorType::McpClient => "document.audit.actor.mcp_client",
+            EventActorType::Hook => "document.audit.actor.hook",
+            EventActorType::Script => "document.audit.actor.script",
+            EventActorType::ExternalDriver => "document.audit.actor.external_driver",
+            EventActorType::ExternalAuthProvider => "document.audit.actor.external_auth_provider",
+        }
+    }
+
+    #[test]
+    fn audit_category_label_covers_all_variants_and_keys_resolve_in_both_locales() {
+        for category in ALL_EVENT_CATEGORIES {
+            let key = audit_category_key(*category);
+
+            assert_eq!(audit_category_label(*category), dbflux_i18n::t!(key));
+
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn audit_outcome_label_covers_all_variants_and_keys_resolve_in_both_locales() {
+        for outcome in ALL_EVENT_OUTCOMES {
+            let key = audit_outcome_key(*outcome);
+
+            assert_eq!(audit_outcome_label(*outcome), dbflux_i18n::t!(key));
+
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn audit_level_label_covers_all_variants_and_keys_resolve_in_both_locales() {
+        for level in ALL_EVENT_SEVERITIES {
+            let key = audit_level_key(*level);
+
+            assert_eq!(audit_level_label(*level), dbflux_i18n::t!(key));
+
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn audit_actor_type_label_covers_all_variants_and_keys_resolve_in_both_locales() {
+        for actor_type in ALL_EVENT_ACTOR_TYPES {
+            let key = audit_actor_type_key(*actor_type);
+
+            assert_eq!(audit_actor_type_label(*actor_type), dbflux_i18n::t!(key));
+
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn audit_category_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.audit.category.query", locale = "en");
+        let es = dbflux_i18n::t!("document.audit.category.query", locale = "es");
+
+        assert_eq!(en, "Query");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn audit_outcome_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.audit.outcome.success", locale = "en");
+        let es = dbflux_i18n::t!("document.audit.outcome.success", locale = "es");
+
+        assert_eq!(en, "Success");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn audit_level_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.audit.level.warn", locale = "en");
+        let es = dbflux_i18n::t!("document.audit.level.warn", locale = "es");
+
+        assert_eq!(en, "Warning");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn audit_actor_type_label_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.audit.actor.mcp_client", locale = "en");
+        let es = dbflux_i18n::t!("document.audit.actor.mcp_client", locale = "es");
+
+        assert_eq!(en, "MCP Client");
         assert_ne!(en, es);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 16: audit detail field labels and the category, outcome, level and actor type values resolve through exhaustive labels.rs helpers over the core observability enums; audit source labels render through `dbflux_i18n::t!`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 15; next: the schema diff view)

## How was this solved?

- Size: 719 lines (`size:exception`, four exhaustive enum helpers with tests).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → green; clippy clean; fmt clean. Manual smoke in Spanish: open an audit event's detail pane.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
