### PR TITLE
feat(i18n): translate the schema diff view chrome

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -866,6 +866,31 @@ document:
       incomplete_aggregate_rows:
         one: "%{count} aggregate row is incomplete and will be excluded from the query"
         many: "%{count} aggregate rows are incomplete and will be excluded from the query"
+  schema_diff:
+    action:
+      apply: "Apply…"
+      compute_diff: Compute Diff
+      preview_ddl: Preview DDL
+    status:
+      computing: "Computing diff…"
+      empty: No differences found between the two schemas.
+      idle: Pick a source and run Compute Diff to see schema changes.
+      unsupported: Unsupported
+    view:
+      compare_against: Compare against
+      mode:
+        live: "Live ↔ Live"
+        snapshot: "Snapshot ↔ Live"
+      source:
+        connection_section: Other connections
+        database_section: Other databases on this connection
+        empty: Connect a second database or connection to compare against.
+        no_snapshots: No snapshots captured for this connection yet.
+      title: "Schema Diff — %{database}"
+      title_default: Schema Diff
+      unsupported_action:
+        create: Create table
+        drop: Drop table
   shared:
     add: Add
     refresh:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -866,6 +866,31 @@ document:
       incomplete_aggregate_rows:
         one: "%{count} fila agregada está incompleta y se excluirá de la consulta"
         many: "%{count} filas agregadas están incompletas y se excluirán de la consulta"
+  schema_diff:
+    action:
+      apply: "Aplicar…"
+      compute_diff: Calcular diferencia
+      preview_ddl: Vista previa del DDL
+    status:
+      computing: "Calculando diferencia…"
+      empty: No se encontraron diferencias entre los dos esquemas.
+      idle: Elige un origen y ejecuta Calcular diferencia para ver los cambios de esquema.
+      unsupported: No compatible
+    view:
+      compare_against: Comparar con
+      mode:
+        live: "En vivo ↔ En vivo"
+        snapshot: "Instantánea ↔ En vivo"
+      source:
+        connection_section: Otras conexiones
+        database_section: Otras bases de datos en esta conexión
+        empty: Conecta una segunda base de datos o conexión para comparar.
+        no_snapshots: Aún no hay instantáneas capturadas para esta conexión.
+      title: "Diferencia de esquema — %{database}"
+      title_default: Diferencia de esquema
+      unsupported_action:
+        create: Crear tabla
+        drop: Eliminar tabla
   shared:
     add: Agregar
     refresh:

--- a/crates/dbflux_ui_document/src/schema_diff/view.rs
+++ b/crates/dbflux_ui_document/src/schema_diff/view.rs
@@ -177,8 +177,8 @@ impl SchemaDiffDocument {
         );
 
         let title = match &database {
-            Some(db) => format!("Schema Diff — {db}"),
-            None => "Schema Diff".to_string(),
+            Some(db) => dbflux_i18n::t!("document.schema_diff.view.title", database = db),
+            None => dbflux_i18n::t!("document.schema_diff.view.title_default"),
         };
 
         let mut document = Self {
@@ -1143,7 +1143,7 @@ impl SchemaDiffDocument {
     fn primary_button(
         &self,
         id: &'static str,
-        label: &'static str,
+        label: String,
         enabled: bool,
         cx: &mut Context<Self>,
         on_click: impl Fn(&mut Self, &mut Window, &mut Context<Self>) + 'static,
@@ -1170,7 +1170,7 @@ impl SchemaDiffDocument {
     fn secondary_button(
         &self,
         id: &'static str,
-        label: &'static str,
+        label: String,
         enabled: bool,
         cx: &mut Context<Self>,
         on_click: impl Fn(&mut Self, &mut Window, &mut Context<Self>) + 'static,
@@ -1203,14 +1203,14 @@ impl SchemaDiffDocument {
             .gap(Spacing::SM)
             .child(self.mode_chip(
                 "mode-live",
-                "Live ↔ Live",
+                dbflux_i18n::t!("document.schema_diff.view.mode.live"),
                 mode == DiffMode::LiveVsLive,
                 DiffMode::LiveVsLive,
                 cx,
             ))
             .child(self.mode_chip(
                 "mode-snapshot",
-                "Snapshot ↔ Live",
+                dbflux_i18n::t!("document.schema_diff.view.mode.snapshot"),
                 mode == DiffMode::SnapshotVsLive,
                 DiffMode::SnapshotVsLive,
                 cx,
@@ -1228,7 +1228,10 @@ impl SchemaDiffDocument {
             .p(Spacing::MD)
             .border_b_1()
             .border_color(border)
-            .child(Text::label_sm("Compare against").muted_foreground())
+            .child(
+                Text::label_sm(dbflux_i18n::t!("document.schema_diff.view.compare_against"))
+                    .muted_foreground(),
+            )
             .child(mode_toggle)
             .child(reference)
             .child(
@@ -1238,7 +1241,7 @@ impl SchemaDiffDocument {
                     .gap(Spacing::SM)
                     .child(self.primary_button(
                         "compute-diff",
-                        "Compute Diff",
+                        dbflux_i18n::t!("document.schema_diff.action.compute_diff"),
                         self.can_compute() && !self.is_busy(),
                         cx,
                         |this, _w, cx| this.compute_diff(cx),
@@ -1249,7 +1252,7 @@ impl SchemaDiffDocument {
     fn mode_chip(
         &self,
         id: &'static str,
-        label: &'static str,
+        label: String,
         active: bool,
         mode: DiffMode,
         cx: &mut Context<Self>,
@@ -1325,7 +1328,7 @@ impl SchemaDiffDocument {
         if database_candidates.is_empty() && connection_candidates.is_empty() {
             return div()
                 .child(
-                    Text::caption("Connect a second database or connection to compare against.")
+                    Text::caption(dbflux_i18n::t!("document.schema_diff.view.source.empty"))
                         .muted_foreground(),
                 )
                 .into_any_element();
@@ -1335,9 +1338,11 @@ impl SchemaDiffDocument {
 
         if !database_candidates.is_empty() {
             let mut rows: Vec<AnyElement> = vec![
-                Text::label_sm("Other databases on this connection")
-                    .muted_foreground()
-                    .into_any_element(),
+                Text::label_sm(dbflux_i18n::t!(
+                    "document.schema_diff.view.source.database_section"
+                ))
+                .muted_foreground()
+                .into_any_element(),
             ];
             for database in database_candidates {
                 let selected = matches!(
@@ -1367,9 +1372,11 @@ impl SchemaDiffDocument {
 
         if !connection_candidates.is_empty() {
             let mut rows: Vec<AnyElement> = vec![
-                Text::label_sm("Other connections")
-                    .muted_foreground()
-                    .into_any_element(),
+                Text::label_sm(dbflux_i18n::t!(
+                    "document.schema_diff.view.source.connection_section"
+                ))
+                .muted_foreground()
+                .into_any_element(),
             ];
             for (id, name) in connection_candidates {
                 let selected = matches!(
@@ -1411,8 +1418,10 @@ impl SchemaDiffDocument {
         if self.snapshots.is_empty() {
             return div()
                 .child(
-                    Text::caption("No snapshots captured for this connection yet.")
-                        .muted_foreground(),
+                    Text::caption(dbflux_i18n::t!(
+                        "document.schema_diff.view.source.no_snapshots"
+                    ))
+                    .muted_foreground(),
                 )
                 .into_any_element();
         }
@@ -1459,13 +1468,16 @@ impl SchemaDiffDocument {
         match &self.compute_state {
             ComputeState::Loading => {
                 return diff_message_container()
-                    .child(Text::body("Computing diff…").muted_foreground())
+                    .child(
+                        Text::body(dbflux_i18n::t!("document.schema_diff.status.computing"))
+                            .muted_foreground(),
+                    )
                     .into_any_element();
             }
             ComputeState::Idle => {
                 return diff_message_container()
                     .child(
-                        Text::body("Pick a source and run Compute Diff to see schema changes.")
+                        Text::body(dbflux_i18n::t!("document.schema_diff.status.idle"))
                             .muted_foreground(),
                     )
                     .into_any_element();
@@ -1478,7 +1490,7 @@ impl SchemaDiffDocument {
             ComputeState::Empty => {
                 return diff_message_container()
                     .child(
-                        Text::body("No differences found between the two schemas.")
+                        Text::body(dbflux_i18n::t!("document.schema_diff.status.empty"))
                             .muted_foreground(),
                     )
                     .into_any_element();
@@ -1642,9 +1654,9 @@ impl SchemaDiffDocument {
                 ..
             } => {
                 let description = if *is_create {
-                    "Create table"
+                    dbflux_i18n::t!("document.schema_diff.view.unsupported_action.create")
                 } else {
-                    "Drop table"
+                    dbflux_i18n::t!("document.schema_diff.view.unsupported_action.drop")
                 };
                 let mut reason_text = reason.clone();
                 if let Some(followup) = followup {
@@ -1656,7 +1668,10 @@ impl SchemaDiffDocument {
                     .items_center()
                     .gap(Spacing::SM)
                     .py(Spacing::XS)
-                    .child(Badge::new("Unsupported", BadgeVariant::Neutral))
+                    .child(Badge::new(
+                        dbflux_i18n::t!("document.schema_diff.status.unsupported"),
+                        BadgeVariant::Neutral,
+                    ))
                     .child(Text::body(description))
                     .child(Text::caption(reason_text).muted_foreground())
                     .into_any_element()
@@ -1679,14 +1694,14 @@ impl SchemaDiffDocument {
             .border_color(border)
             .child(self.secondary_button(
                 "preview-ddl",
-                "Preview DDL",
+                dbflux_i18n::t!("document.schema_diff.action.preview_ddl"),
                 has_selection && !self.is_busy(),
                 cx,
                 |this, _w, cx| this.open_preview(cx),
             ))
             .child(self.primary_button(
                 "apply-ddl",
-                "Apply…",
+                dbflux_i18n::t!("document.schema_diff.action.apply"),
                 has_selection && !self.is_busy(),
                 cx,
                 |this, _w, cx| this.request_apply(cx),
@@ -1715,7 +1730,10 @@ fn render_unsupported_row(unsupported: &UnsupportedChange) -> AnyElement {
         .items_center()
         .gap(Spacing::SM)
         .py(Spacing::XS)
-        .child(Badge::new("Unsupported", BadgeVariant::Neutral))
+        .child(Badge::new(
+            dbflux_i18n::t!("document.schema_diff.status.unsupported"),
+            BadgeVariant::Neutral,
+        ))
         .child(Text::body(describe_change(&unsupported.change)))
         .child(Text::caption(reason).muted_foreground())
         .into_any_element()
@@ -1945,5 +1963,81 @@ mod tests {
             resolved[0].columns.is_some(),
             "the resolved table must carry the fetched columns, not the column-less shallow entry"
         );
+    }
+
+    // ── i18n: schema-diff view chrome keys ──────────────────────────────────
+
+    const SCHEMA_DIFF_VIEW_KEYS: &[&str] = &[
+        "document.schema_diff.action.apply",
+        "document.schema_diff.action.compute_diff",
+        "document.schema_diff.action.preview_ddl",
+        "document.schema_diff.status.computing",
+        "document.schema_diff.status.empty",
+        "document.schema_diff.status.idle",
+        "document.schema_diff.status.unsupported",
+        "document.schema_diff.view.compare_against",
+        "document.schema_diff.view.mode.live",
+        "document.schema_diff.view.mode.snapshot",
+        "document.schema_diff.view.source.connection_section",
+        "document.schema_diff.view.source.database_section",
+        "document.schema_diff.view.source.empty",
+        "document.schema_diff.view.source.no_snapshots",
+        "document.schema_diff.view.title",
+        "document.schema_diff.view.title_default",
+        "document.schema_diff.view.unsupported_action.create",
+        "document.schema_diff.view.unsupported_action.drop",
+    ];
+
+    #[test]
+    fn schema_diff_view_keys_resolve_in_both_locales() {
+        for key in SCHEMA_DIFF_VIEW_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(*key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn schema_diff_title_interpolates_database_name() {
+        let title = dbflux_i18n::t!("document.schema_diff.view.title", database = "app_db");
+
+        assert!(
+            title.contains("app_db"),
+            "title must interpolate the database name: {title}"
+        );
+    }
+
+    #[test]
+    fn schema_diff_title_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.schema_diff.view.title", locale = "en");
+        let es = dbflux_i18n::t!("document.schema_diff.view.title", locale = "es");
+
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn schema_diff_status_unsupported_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.schema_diff.status.unsupported", locale = "en");
+        let es = dbflux_i18n::t!("document.schema_diff.status.unsupported", locale = "es");
+
+        assert_eq!(en, "Unsupported");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn schema_diff_action_compute_diff_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.schema_diff.action.compute_diff", locale = "en");
+        let es = dbflux_i18n::t!("document.schema_diff.action.compute_diff", locale = "es");
+
+        assert_eq!(en, "Compute Diff");
+        assert_ne!(en, es);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 17: the schema diff view title, mode chips, source picker, section headers and empty states, compute states, unsupported badge and footer actions render through `dbflux_i18n::t!`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 16; next: the schema diff apply flow)

## How was this solved?

- Button and chip helpers take String labels.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 984 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a schema diff and switch modes.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
