### PR TITLE
feat(i18n): translate the schema diff apply flow, summaries, and source messages

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -871,11 +871,53 @@ document:
       apply: "Apply…"
       compute_diff: Compute Diff
       preview_ddl: Preview DDL
+    apply:
+      read_only: This connection is read-only. Schema changes are not allowed.
+    change:
+      column_added: "Add column %{name} %{type_name}"
+      column_removed: "Drop column %{name}"
+      default_dropped: "Drop default on %{column}"
+      default_set: "Set default on %{column} to %{value}"
+      foreign_key_changed: Change foreign keys
+      index_added: "Add index %{name}"
+      index_removed: "Drop index %{name}"
+      not_null: "Make %{column} NOT NULL"
+      nullable: "Make %{column} nullable"
+      primary_key_changed: Change primary key
+      type_changed: "Change %{column} type %{before} → %{after}"
+    source:
+      risk:
+        destructive: Destructive
+        safe: Safe
+        warning: Warning
+      schema_not_loaded: "The schema for \"%{database}\" is not loaded yet. Expand that database in the sidebar first, then run Compute Diff again."
     status:
       computing: "Computing diff…"
       empty: No differences found between the two schemas.
       idle: Pick a source and run Compute Diff to see schema changes.
       unsupported: Unsupported
+    summary:
+      apply: "Apply %{count} schema change(s) to %{target}"
+      this_connection: this connection
+    table_action:
+      create: "Create table %{table}"
+      drop: "Drop table %{table}"
+    toast:
+      applied: "Applied %{statements} DDL statement(s) across %{tables} table(s)."
+      apply_partial_failure: "Applied %{applied} of %{total} table(s) (%{statements} DDL statement(s)) before failing on %{table}: %{error}. %{remaining} table(s) were not attempted."
+      approval_queue_failed: "Failed to queue for approval: %{error}"
+      approval_queued: Schema changes queued for approval.
+      approval_unavailable: This connection requires approval, which is unavailable in this build.
+      connection_unavailable: Target connection is no longer available.
+      ddl_build_failed: "Cannot build DDL: %{error}"
+      read_only: This connection is read-only. Schema changes are not allowed.
+      reference_connection_disconnected: The chosen reference connection is not connected.
+      reference_not_picked: Pick a reference database or connection to compare against.
+      select_at_least_one: Select at least one change first.
+      select_at_least_one_to_apply: Select at least one change to apply.
+      snapshot_load_failed: "Failed to load snapshot: %{error}"
+      snapshot_missing: Selected snapshot no longer exists.
+      snapshot_not_picked: Pick a snapshot to compare against.
     view:
       compare_against: Compare against
       mode:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -871,11 +871,53 @@ document:
       apply: "Aplicar…"
       compute_diff: Calcular diferencia
       preview_ddl: Vista previa del DDL
+    apply:
+      read_only: Esta conexión es de solo lectura. No se permiten cambios de esquema.
+    change:
+      column_added: "Agregar columna %{name} %{type_name}"
+      column_removed: "Eliminar columna %{name}"
+      default_dropped: "Eliminar el valor predeterminado de %{column}"
+      default_set: "Establecer el valor predeterminado de %{column} en %{value}"
+      foreign_key_changed: Cambiar claves foráneas
+      index_added: "Agregar índice %{name}"
+      index_removed: "Eliminar índice %{name}"
+      not_null: "Hacer que %{column} sea NOT NULL"
+      nullable: "Hacer que %{column} admita valores nulos"
+      primary_key_changed: Cambiar clave primaria
+      type_changed: "Cambiar el tipo de %{column} de %{before} a %{after}"
+    source:
+      risk:
+        destructive: Destructivo
+        safe: Seguro
+        warning: Advertencia
+      schema_not_loaded: "El esquema de \"%{database}\" aún no está cargado. Expande esa base de datos en la barra lateral primero y vuelve a ejecutar Calcular diferencia."
     status:
       computing: "Calculando diferencia…"
       empty: No se encontraron diferencias entre los dos esquemas.
       idle: Elige un origen y ejecuta Calcular diferencia para ver los cambios de esquema.
       unsupported: No compatible
+    summary:
+      apply: "Aplicar %{count} cambio(s) de esquema a %{target}"
+      this_connection: esta conexión
+    table_action:
+      create: "Crear tabla %{table}"
+      drop: "Eliminar tabla %{table}"
+    toast:
+      applied: "Se aplicaron %{statements} sentencia(s) DDL en %{tables} tabla(s)."
+      apply_partial_failure: "Se aplicaron %{applied} de %{total} tabla(s) (%{statements} sentencia(s) DDL) antes de fallar en %{table}: %{error}. %{remaining} tabla(s) no se intentaron."
+      approval_queue_failed: "Error al encolar para aprobación: %{error}"
+      approval_queued: Cambios de esquema encolados para aprobación.
+      approval_unavailable: Esta conexión requiere aprobación, lo cual no está disponible en esta compilación.
+      connection_unavailable: La conexión de destino ya no está disponible.
+      ddl_build_failed: "No se puede generar el DDL: %{error}"
+      read_only: Esta conexión es de solo lectura. No se permiten cambios de esquema.
+      reference_connection_disconnected: La conexión de referencia elegida no está conectada.
+      reference_not_picked: Elige una base de datos o conexión de referencia para comparar.
+      select_at_least_one: Selecciona al menos un cambio primero.
+      select_at_least_one_to_apply: Selecciona al menos un cambio para aplicar.
+      snapshot_load_failed: "Error al cargar la instantánea: %{error}"
+      snapshot_missing: La instantánea seleccionada ya no existe.
+      snapshot_not_picked: Elige una instantánea para comparar.
     view:
       compare_against: Comparar con
       mode:

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -951,6 +951,109 @@ pub(crate) fn audit_actor_type_label(actor_type: dbflux_core::EventActorType) ->
     }
 }
 
+/// Qualifies a table name with its schema for the schema-diff description
+/// helpers, mirroring `schema_diff::view::qualified` (kept as a small local
+/// copy since that helper is private to its own module). Object names are
+/// data, never translated.
+fn qualified_table_name(schema: Option<&str>, name: &str) -> String {
+    match schema {
+        Some(schema) => format!("{schema}.{name}"),
+        None => name.to_string(),
+    }
+}
+
+/// Human-readable description of a single [`dbflux_core::SchemaChange`] for
+/// the schema-diff row list, mirroring the pre-i18n `describe_change`
+/// output for `en` while routing every arm through the translation catalog.
+///
+/// Exhaustive by construction (no wildcard arm) so a new `SchemaChange`
+/// variant fails this crate's build until its catalog key is added here.
+/// Column/index names, type names, and default values are data and are
+/// interpolated verbatim, never translated.
+pub(crate) fn schema_change_description(change: &dbflux_core::SchemaChange) -> String {
+    use dbflux_core::SchemaChange;
+
+    match change {
+        SchemaChange::ColumnAdded(column) => dbflux_i18n::t!(
+            "document.schema_diff.change.column_added",
+            name = column.name.as_str(),
+            type_name = column.type_name.as_str()
+        ),
+        SchemaChange::ColumnRemoved(column) => dbflux_i18n::t!(
+            "document.schema_diff.change.column_removed",
+            name = column.name.as_str()
+        ),
+        SchemaChange::ColumnTypeChanged { before, after } => dbflux_i18n::t!(
+            "document.schema_diff.change.type_changed",
+            column = before.name.as_str(),
+            before = before.type_name.as_str(),
+            after = after.type_name.as_str()
+        ),
+        SchemaChange::NullabilityChanged { column, after, .. } => {
+            if *after {
+                dbflux_i18n::t!(
+                    "document.schema_diff.change.nullable",
+                    column = column.as_str()
+                )
+            } else {
+                dbflux_i18n::t!(
+                    "document.schema_diff.change.not_null",
+                    column = column.as_str()
+                )
+            }
+        }
+        SchemaChange::DefaultChanged { column, after, .. } => match after {
+            Some(value) => dbflux_i18n::t!(
+                "document.schema_diff.change.default_set",
+                column = column.as_str(),
+                value = value.as_str()
+            ),
+            None => dbflux_i18n::t!(
+                "document.schema_diff.change.default_dropped",
+                column = column.as_str()
+            ),
+        },
+        SchemaChange::PrimaryKeyChanged { .. } => {
+            dbflux_i18n::t!("document.schema_diff.change.primary_key_changed")
+        }
+        SchemaChange::ForeignKeyChanged => {
+            dbflux_i18n::t!("document.schema_diff.change.foreign_key_changed")
+        }
+        SchemaChange::IndexAdded(index) => dbflux_i18n::t!(
+            "document.schema_diff.change.index_added",
+            name = index.name.as_str()
+        ),
+        SchemaChange::IndexRemoved(index) => dbflux_i18n::t!(
+            "document.schema_diff.change.index_removed",
+            name = index.name.as_str()
+        ),
+    }
+}
+
+/// Human-readable description of a single
+/// [`crate::schema_diff::apply::TableLevelAction`] for the schema-diff row
+/// list, mirroring the pre-i18n `describe_table_action` output for `en`
+/// while routing every arm through the translation catalog.
+///
+/// Exhaustive by construction (no wildcard arm) so a new `TableLevelAction`
+/// variant fails this crate's build until its catalog key is added here.
+pub(crate) fn table_action_description(
+    action: &crate::schema_diff::apply::TableLevelAction,
+) -> String {
+    use crate::schema_diff::apply::TableLevelAction;
+
+    match action {
+        TableLevelAction::Create(info) => dbflux_i18n::t!(
+            "document.schema_diff.table_action.create",
+            table = qualified_table_name(info.schema.as_deref(), &info.name)
+        ),
+        TableLevelAction::Drop(table) => dbflux_i18n::t!(
+            "document.schema_diff.table_action.drop",
+            table = qualified_table_name(table.schema.as_deref(), &table.name)
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -964,14 +1067,16 @@ mod tests {
         history_items_count_label, history_tab_label, incomplete_aggregate_rows_label,
         join_kind_label, live_output_lines_label, live_output_truncated_label,
         partial_delete_label, pending_change_count_label, pending_edits_summary,
-        refresh_policy_label, result_tab_count_label, row_count_label,
-        script_confirm_message_label, sort_direction_label, unsaved_changes_label,
-        update_columns_label, valid_lines_label,
+        refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
+        script_confirm_message_label, sort_direction_label, table_action_description,
+        unsaved_changes_label, update_columns_label, valid_lines_label,
     };
+    use crate::schema_diff::apply::TableLevelAction;
     use dbflux_components::chart::ChartDetection;
     use dbflux_core::{
-        DangerousQueryKind, EventActorType, EventCategory, EventOutcome, EventSeverity,
-        QueryLanguage, RefreshPolicy,
+        ColumnSnapshot, DangerousQueryKind, EventActorType, EventCategory, EventOutcome,
+        EventSeverity, IndexSnapshot, QueryLanguage, RefreshPolicy, SchemaChange, TableInfo,
+        TableRef,
     };
 
     const ALL_DANGEROUS_QUERY_KINDS: &[DangerousQueryKind] = &[
@@ -2333,6 +2438,185 @@ mod tests {
         let es = dbflux_i18n::t!("document.audit.actor.mcp_client", locale = "es");
 
         assert_eq!(en, "MCP Client");
+        assert_ne!(en, es);
+    }
+
+    // ── i18n: schema_change_description / table_action_description ────────
+
+    fn column(name: &str, type_name: &str) -> ColumnSnapshot {
+        ColumnSnapshot {
+            name: name.to_string(),
+            type_name: type_name.to_string(),
+            nullable: true,
+            is_primary_key: false,
+            default_value: None,
+        }
+    }
+
+    fn index(name: &str) -> IndexSnapshot {
+        IndexSnapshot {
+            name: name.to_string(),
+            columns: vec!["id".to_string()],
+            is_unique: false,
+        }
+    }
+
+    /// Every `SchemaChange` construction the exhaustive match must cover,
+    /// including both branches of `NullabilityChanged` and `DefaultChanged`.
+    fn all_schema_changes() -> Vec<SchemaChange> {
+        vec![
+            SchemaChange::ColumnAdded(column("email", "text")),
+            SchemaChange::ColumnRemoved(column("legacy", "text")),
+            SchemaChange::ColumnTypeChanged {
+                before: column("id", "integer"),
+                after: column("id", "bigint"),
+            },
+            SchemaChange::NullabilityChanged {
+                column: "email".to_string(),
+                before: false,
+                after: true,
+            },
+            SchemaChange::NullabilityChanged {
+                column: "email".to_string(),
+                before: true,
+                after: false,
+            },
+            SchemaChange::DefaultChanged {
+                column: "status".to_string(),
+                before: None,
+                after: Some("'active'".to_string()),
+            },
+            SchemaChange::DefaultChanged {
+                column: "status".to_string(),
+                before: Some("'active'".to_string()),
+                after: None,
+            },
+            SchemaChange::PrimaryKeyChanged {
+                before: vec!["id".to_string()],
+                after: vec!["uuid".to_string()],
+            },
+            SchemaChange::ForeignKeyChanged,
+            SchemaChange::IndexAdded(index("idx_email")),
+            SchemaChange::IndexRemoved(index("idx_email")),
+        ]
+    }
+
+    #[test]
+    fn schema_change_description_matches_pre_i18n_english_output() {
+        let expected = [
+            "Add column email text",
+            "Drop column legacy",
+            "Change id type integer → bigint",
+            "Make email nullable",
+            "Make email NOT NULL",
+            "Set default on status to 'active'",
+            "Drop default on status",
+            "Change primary key",
+            "Change foreign keys",
+            "Add index idx_email",
+            "Drop index idx_email",
+        ];
+
+        for (change, expected) in all_schema_changes().iter().zip(expected) {
+            assert_eq!(
+                schema_change_description(change),
+                expected,
+                "unexpected description for {change:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn schema_change_description_keys_resolve_in_both_locales() {
+        const SCHEMA_CHANGE_KEYS: &[&str] = &[
+            "document.schema_diff.change.column_added",
+            "document.schema_diff.change.column_removed",
+            "document.schema_diff.change.default_dropped",
+            "document.schema_diff.change.default_set",
+            "document.schema_diff.change.foreign_key_changed",
+            "document.schema_diff.change.index_added",
+            "document.schema_diff.change.index_removed",
+            "document.schema_diff.change.not_null",
+            "document.schema_diff.change.nullable",
+            "document.schema_diff.change.primary_key_changed",
+            "document.schema_diff.change.type_changed",
+        ];
+
+        for key in SCHEMA_CHANGE_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(*key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn schema_change_description_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.schema_diff.change.column_removed", locale = "en");
+        let es = dbflux_i18n::t!("document.schema_diff.change.column_removed", locale = "es");
+
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn table_action_description_matches_pre_i18n_english_output() {
+        let table_info = TableInfo {
+            name: "orders".to_string(),
+            schema: Some("public".to_string()),
+            columns: None,
+            indexes: None,
+            foreign_keys: None,
+            constraints: None,
+            sample_fields: None,
+            presentation: Default::default(),
+            child_items: None,
+            storage_hints: None,
+        };
+        let create = TableLevelAction::Create(table_info);
+        let drop = TableLevelAction::Drop(TableRef {
+            schema: Some("public".to_string()),
+            name: "orders".to_string(),
+        });
+
+        assert_eq!(
+            table_action_description(&create),
+            "Create table public.orders"
+        );
+        assert_eq!(table_action_description(&drop), "Drop table public.orders");
+    }
+
+    #[test]
+    fn table_action_description_keys_resolve_in_both_locales() {
+        for key in [
+            "document.schema_diff.table_action.create",
+            "document.schema_diff.table_action.drop",
+        ] {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn table_action_description_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.schema_diff.table_action.create", locale = "en");
+        let es = dbflux_i18n::t!("document.schema_diff.table_action.create", locale = "es");
+
         assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_ui_document/src/schema_diff/apply.rs
+++ b/crates/dbflux_ui_document/src/schema_diff/apply.rs
@@ -322,8 +322,7 @@ impl DdlApplyExecutor {
             MutationPolicy::ApprovalRequired => return Ok(DdlApplyOutcome::Deferred),
             MutationPolicy::ReadOnly => {
                 return Ok(DdlApplyOutcome::Blocked {
-                    reason: "This connection is read-only. Schema changes are not allowed."
-                        .to_string(),
+                    reason: dbflux_i18n::t!("document.schema_diff.apply.read_only"),
                 });
             }
             MutationPolicy::Allowed => {}

--- a/crates/dbflux_ui_document/src/schema_diff/diff_source.rs
+++ b/crates/dbflux_ui_document/src/schema_diff/diff_source.rs
@@ -86,9 +86,9 @@ pub fn resolve_same_connection_shallow(
 ) -> Result<Vec<TableInfo>, String> {
     match database_schemas.get(database) {
         Some(schema) => Ok(schema.tables.clone()),
-        None => Err(format!(
-            "The schema for \"{database}\" is not loaded yet. Expand that database \
-             in the sidebar first, then run Compute Diff again."
+        None => Err(dbflux_i18n::t!(
+            "document.schema_diff.source.schema_not_loaded",
+            database = database
         )),
     }
 }
@@ -118,11 +118,15 @@ impl RiskBadge {
         }
     }
 
-    pub fn label(self) -> &'static str {
+    /// Exhaustive by construction (no wildcard arm) so a new `RiskBadge`
+    /// variant fails this crate's build until its catalog key is added here.
+    pub fn label(self) -> String {
         match self {
-            RiskBadge::Safe => "Safe",
-            RiskBadge::Warning => "Warning",
-            RiskBadge::Destructive => "Destructive",
+            RiskBadge::Safe => dbflux_i18n::t!("document.schema_diff.source.risk.safe"),
+            RiskBadge::Warning => dbflux_i18n::t!("document.schema_diff.source.risk.warning"),
+            RiskBadge::Destructive => {
+                dbflux_i18n::t!("document.schema_diff.source.risk.destructive")
+            }
         }
     }
 }
@@ -589,5 +593,92 @@ mod tests {
             }
             other => panic!("expected Unsupported, got {other:?}"),
         }
+    }
+
+    // ── i18n: RiskBadge::label / schema_not_loaded message ──────────────
+
+    const RISK_BADGE_KEYS: &[&str] = &[
+        "document.schema_diff.source.risk.destructive",
+        "document.schema_diff.source.risk.safe",
+        "document.schema_diff.source.risk.warning",
+    ];
+
+    #[test]
+    fn risk_badge_label_covers_every_variant_and_keys_resolve_in_both_locales() {
+        for badge in [RiskBadge::Safe, RiskBadge::Warning, RiskBadge::Destructive] {
+            assert!(!badge.label().is_empty());
+        }
+
+        for key in RISK_BADGE_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(*key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn risk_badge_label_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.schema_diff.source.risk.destructive",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.schema_diff.source.risk.destructive",
+            locale = "es"
+        );
+
+        assert_eq!(RiskBadge::Destructive.label(), en);
+        assert_eq!(en, "Destructive");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn schema_not_loaded_message_keys_resolve_in_both_locales_and_interpolates() {
+        for locale in ["en", "es"] {
+            let value = dbflux_i18n::t!(
+                "document.schema_diff.source.schema_not_loaded",
+                locale = locale
+            );
+
+            assert!(!value.is_empty(), "resolved empty in {locale}");
+            assert_ne!(
+                value, "document.schema_diff.source.schema_not_loaded",
+                "resolved to its own key in {locale}"
+            );
+        }
+
+        let mut schemas: HashMap<String, dbflux_core::DbSchemaInfo> = HashMap::new();
+        let err = resolve_same_connection_shallow(&schemas, "atlas_test")
+            .expect_err("an unloaded database must error");
+
+        assert!(err.contains("atlas_test"));
+
+        schemas.insert(
+            "atlas_test".to_string(),
+            db_schema_with_tables("atlas_test", &["users"]),
+        );
+        assert!(resolve_same_connection_shallow(&schemas, "atlas_test").is_ok());
+    }
+
+    #[test]
+    fn schema_not_loaded_message_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.schema_diff.source.schema_not_loaded",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.schema_diff.source.schema_not_loaded",
+            locale = "es"
+        );
+
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_ui_document/src/schema_diff/view.rs
+++ b/crates/dbflux_ui_document/src/schema_diff/view.rs
@@ -395,8 +395,9 @@ impl SchemaDiffDocument {
         let state = self.app_state.read(cx);
 
         let Some(target) = state.connections().get(&self.profile_id) else {
-            self.compute_state =
-                ComputeState::Error("Target connection is no longer available.".to_string());
+            self.compute_state = ComputeState::Error(dbflux_i18n::t!(
+                "document.schema_diff.toast.connection_unavailable"
+            ));
             cx.notify();
             return;
         };
@@ -413,9 +414,9 @@ impl SchemaDiffDocument {
         let reference_plan = match self.picker.mode {
             DiffMode::LiveVsLive => match &reference {
                 None => {
-                    self.compute_state = ComputeState::Error(
-                        "Pick a reference database or connection to compare against.".to_string(),
-                    );
+                    self.compute_state = ComputeState::Error(dbflux_i18n::t!(
+                        "document.schema_diff.toast.reference_not_picked"
+                    ));
                     cx.notify();
                     return;
                 }
@@ -443,9 +444,9 @@ impl SchemaDiffDocument {
                     database,
                 }) => {
                     let Some(other) = state.connections().get(profile_id) else {
-                        self.compute_state = ComputeState::Error(
-                            "The chosen reference connection is not connected.".to_string(),
-                        );
+                        self.compute_state = ComputeState::Error(dbflux_i18n::t!(
+                            "document.schema_diff.toast.reference_connection_disconnected"
+                        ));
                         cx.notify();
                         return;
                     };
@@ -464,22 +465,26 @@ impl SchemaDiffDocument {
             },
             DiffMode::SnapshotVsLive => {
                 let Some(snapshot_id) = self.picker.selected_snapshot else {
-                    self.compute_state =
-                        ComputeState::Error("Pick a snapshot to compare against.".to_string());
+                    self.compute_state = ComputeState::Error(dbflux_i18n::t!(
+                        "document.schema_diff.toast.snapshot_not_picked"
+                    ));
                     cx.notify();
                     return;
                 };
                 match state.schema_snapshots.get(&snapshot_id.to_string()) {
                     Ok(Some(record)) => SidePlan::Resolved(record.tables),
                     Ok(None) => {
-                        self.compute_state =
-                            ComputeState::Error("Selected snapshot no longer exists.".to_string());
+                        self.compute_state = ComputeState::Error(dbflux_i18n::t!(
+                            "document.schema_diff.toast.snapshot_missing"
+                        ));
                         cx.notify();
                         return;
                     }
                     Err(e) => {
-                        self.compute_state =
-                            ComputeState::Error(format!("Failed to load snapshot: {e}"));
+                        self.compute_state = ComputeState::Error(dbflux_i18n::t!(
+                            "document.schema_diff.toast.snapshot_load_failed",
+                            error = e.to_string()
+                        ));
                         cx.notify();
                         return;
                     }
@@ -657,11 +662,15 @@ impl SchemaDiffDocument {
     fn build_selected_sql(&self, cx: &Context<Self>) -> Result<String, String> {
         let selected = self.selected_changes_by_table();
         if selected.is_empty() {
-            return Err("Select at least one change first.".to_string());
+            return Err(dbflux_i18n::t!(
+                "document.schema_diff.toast.select_at_least_one"
+            ));
         }
 
         let Some(connection) = self.app_state.read(cx).get_connection(self.profile_id) else {
-            return Err("Target connection is no longer available.".to_string());
+            return Err(dbflux_i18n::t!(
+                "document.schema_diff.toast.connection_unavailable"
+            ));
         };
 
         let mut statements: Vec<String> = Vec::new();
@@ -674,9 +683,12 @@ impl SchemaDiffDocument {
                     policy: MutationPolicy::Allowed,
                 },
             );
-            let stmts = executor
-                .preview_statements()
-                .map_err(|e| format!("Cannot build DDL: {e}"))?;
+            let stmts = executor.preview_statements().map_err(|e| {
+                dbflux_i18n::t!(
+                    "document.schema_diff.toast.ddl_build_failed",
+                    error = e.to_string()
+                )
+            })?;
             statements.extend(stmts);
         }
 
@@ -702,7 +714,7 @@ impl SchemaDiffDocument {
         let selected = self.selected_changes_by_table();
         if selected.is_empty() {
             self.pending_toast = Some(PendingToast {
-                message: "Select at least one change to apply.".to_string(),
+                message: dbflux_i18n::t!("document.schema_diff.toast.select_at_least_one_to_apply"),
                 is_error: true,
             });
             cx.notify();
@@ -713,9 +725,14 @@ impl SchemaDiffDocument {
             .iter()
             .map(|w| w.changes.len() + w.table_action.is_some() as usize)
             .sum();
-        let summary = format!(
-            "Apply {total} schema change(s) to {}",
-            self.database.as_deref().unwrap_or("this connection")
+        let target = self
+            .database
+            .clone()
+            .unwrap_or_else(|| dbflux_i18n::t!("document.schema_diff.summary.this_connection"));
+        let summary = dbflux_i18n::t!(
+            "document.schema_diff.summary.apply",
+            count = total,
+            target = target
         );
 
         // Build a read-only DDL preview string for the confirm body through the
@@ -762,7 +779,7 @@ impl SchemaDiffDocument {
             let state = self.app_state.read(cx);
             let Some(connected) = state.connections().get(&self.profile_id) else {
                 self.pending_toast = Some(PendingToast {
-                    message: "Target connection is no longer available.".to_string(),
+                    message: dbflux_i18n::t!("document.schema_diff.toast.connection_unavailable"),
                     is_error: true,
                 });
                 cx.notify();
@@ -781,8 +798,7 @@ impl SchemaDiffDocument {
 
         if matches!(policy, MutationPolicy::ReadOnly) {
             self.pending_toast = Some(PendingToast {
-                message: "This connection is read-only. Schema changes are not allowed."
-                    .to_string(),
+                message: dbflux_i18n::t!("document.schema_diff.toast.read_only"),
                 is_error: true,
             });
             cx.notify();
@@ -848,9 +864,10 @@ impl SchemaDiffDocument {
                     match result {
                         Ok(outcome) => {
                             doc.pending_toast = Some(PendingToast {
-                                message: format!(
-                                    "Applied {} DDL statement(s) across {} table(s).",
-                                    outcome.statements_applied, outcome.tables_applied
+                                message: dbflux_i18n::t!(
+                                    "document.schema_diff.toast.applied",
+                                    statements = outcome.statements_applied,
+                                    tables = outcome.tables_applied
                                 ),
                                 is_error: false,
                             });
@@ -861,17 +878,16 @@ impl SchemaDiffDocument {
                             doc.selected_table_actions.clear();
                         }
                         Err(failure) => {
-                            let not_attempted = total_tables
-                                .saturating_sub(failure.tables_applied + 1);
-                            let message = format!(
-                                "Applied {} of {} table(s) ({} DDL statement(s)) before failing on {}: {}. \
-                                 {} table(s) were not attempted.",
-                                failure.tables_applied,
-                                total_tables,
-                                failure.statements_applied,
-                                failure.failed_table,
-                                failure.message,
-                                not_attempted
+                            let not_attempted =
+                                total_tables.saturating_sub(failure.tables_applied + 1);
+                            let message = dbflux_i18n::t!(
+                                "document.schema_diff.toast.apply_partial_failure",
+                                applied = failure.tables_applied,
+                                total = total_tables,
+                                statements = failure.statements_applied,
+                                table = failure.failed_table.as_str(),
+                                error = failure.message.as_str(),
+                                remaining = not_attempted
                             );
                             // Keep the current diff visible so the user can retry
                             // the tables that did not apply.
@@ -928,13 +944,16 @@ impl SchemaDiffDocument {
         match enqueue {
             Ok(_) => {
                 self.pending_toast = Some(PendingToast {
-                    message: "Schema changes queued for approval.".to_string(),
+                    message: dbflux_i18n::t!("document.schema_diff.toast.approval_queued"),
                     is_error: false,
                 });
             }
             Err(e) => {
                 self.pending_toast = Some(PendingToast {
-                    message: format!("Failed to queue for approval: {e}"),
+                    message: dbflux_i18n::t!(
+                        "document.schema_diff.toast.approval_queue_failed",
+                        error = e.to_string()
+                    ),
                     is_error: true,
                 });
             }
@@ -945,8 +964,7 @@ impl SchemaDiffDocument {
     #[cfg(not(feature = "mcp"))]
     fn route_to_approval(&mut self, _selected: &[SelectedTableWork], cx: &mut Context<Self>) {
         self.pending_toast = Some(PendingToast {
-            message: "This connection requires approval, which is unavailable in this build."
-                .to_string(),
+            message: dbflux_i18n::t!("document.schema_diff.toast.approval_unavailable"),
             is_error: true,
         });
         cx.notify();
@@ -1071,48 +1089,6 @@ fn qualified(table: &TableRef) -> String {
     match &table.schema {
         Some(schema) => format!("{schema}.{}", table.name),
         None => table.name.clone(),
-    }
-}
-
-fn describe_table_action(action: &TableLevelAction) -> String {
-    match action {
-        TableLevelAction::Create(info) => format!(
-            "Create table {}",
-            qualified(&TableRef {
-                schema: info.schema.clone(),
-                name: info.name.clone(),
-            })
-        ),
-        TableLevelAction::Drop(table) => format!("Drop table {}", qualified(table)),
-    }
-}
-
-/// Short human description of a single change for the diff row.
-fn describe_change(change: &SchemaChange) -> String {
-    match change {
-        SchemaChange::ColumnAdded(c) => format!("Add column {} {}", c.name, c.type_name),
-        SchemaChange::ColumnRemoved(c) => format!("Drop column {}", c.name),
-        SchemaChange::ColumnTypeChanged { before, after } => {
-            format!(
-                "Change {} type {} → {}",
-                before.name, before.type_name, after.type_name
-            )
-        }
-        SchemaChange::NullabilityChanged { column, after, .. } => {
-            if *after {
-                format!("Make {column} nullable")
-            } else {
-                format!("Make {column} NOT NULL")
-            }
-        }
-        SchemaChange::DefaultChanged { column, after, .. } => match after {
-            Some(value) => format!("Set default on {column} to {value}"),
-            None => format!("Drop default on {column}"),
-        },
-        SchemaChange::PrimaryKeyChanged { .. } => "Change primary key".to_string(),
-        SchemaChange::ForeignKeyChanged => "Change foreign keys".to_string(),
-        SchemaChange::IndexAdded(index) => format!("Add index {}", index.name),
-        SchemaChange::IndexRemoved(index) => format!("Drop index {}", index.name),
     }
 }
 
@@ -1568,7 +1544,7 @@ impl SchemaDiffDocument {
         };
         let checked = self.selected.contains(&(group_index, change_index));
         let badge = RiskBadge::from_classification(change.risk);
-        let description = describe_change(&change.change);
+        let description = crate::labels::schema_change_description(&change.change);
 
         let checkbox = div()
             .id(SharedString::from(format!(
@@ -1616,7 +1592,7 @@ impl SchemaDiffDocument {
                 };
                 let checked = self.selected_table_actions.contains(&group_index);
                 let badge = RiskBadge::from_classification(*risk);
-                let description = describe_table_action(action);
+                let description = crate::labels::table_action_description(action);
 
                 let checkbox = div()
                     .id(SharedString::from(format!("chk-table-{group_index}")))
@@ -1734,7 +1710,9 @@ fn render_unsupported_row(unsupported: &UnsupportedChange) -> AnyElement {
             dbflux_i18n::t!("document.schema_diff.status.unsupported"),
             BadgeVariant::Neutral,
         ))
-        .child(Text::body(describe_change(&unsupported.change)))
+        .child(Text::body(crate::labels::schema_change_description(
+            &unsupported.change,
+        )))
         .child(Text::caption(reason).muted_foreground())
         .into_any_element()
 }
@@ -2038,6 +2016,124 @@ mod tests {
         let es = dbflux_i18n::t!("document.schema_diff.action.compute_diff", locale = "es");
 
         assert_eq!(en, "Compute Diff");
+        assert_ne!(en, es);
+    }
+
+    // ── i18n: apply.rs / diff_source.rs / pane.rs toasts and errors ────────
+
+    const SCHEMA_DIFF_TOAST_AND_SUMMARY_KEYS: &[&str] = &[
+        "document.schema_diff.apply.read_only",
+        "document.schema_diff.summary.apply",
+        "document.schema_diff.summary.this_connection",
+        "document.schema_diff.toast.applied",
+        "document.schema_diff.toast.apply_partial_failure",
+        "document.schema_diff.toast.approval_queue_failed",
+        "document.schema_diff.toast.approval_queued",
+        "document.schema_diff.toast.approval_unavailable",
+        "document.schema_diff.toast.connection_unavailable",
+        "document.schema_diff.toast.ddl_build_failed",
+        "document.schema_diff.toast.read_only",
+        "document.schema_diff.toast.reference_connection_disconnected",
+        "document.schema_diff.toast.reference_not_picked",
+        "document.schema_diff.toast.select_at_least_one",
+        "document.schema_diff.toast.select_at_least_one_to_apply",
+        "document.schema_diff.toast.snapshot_load_failed",
+        "document.schema_diff.toast.snapshot_missing",
+        "document.schema_diff.toast.snapshot_not_picked",
+    ];
+
+    #[test]
+    fn schema_diff_toast_keys_resolve_in_both_locales() {
+        for key in SCHEMA_DIFF_TOAST_AND_SUMMARY_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(*key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn schema_diff_toast_read_only_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.schema_diff.toast.read_only", locale = "en");
+        let es = dbflux_i18n::t!("document.schema_diff.toast.read_only", locale = "es");
+
+        assert_eq!(
+            en,
+            "This connection is read-only. Schema changes are not allowed."
+        );
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn schema_diff_apply_read_only_matches_toast_read_only_in_english() {
+        // apply.rs and view.rs surface the same read-only refusal
+        // independently; both must resolve to the same English text.
+        let apply = dbflux_i18n::t!("document.schema_diff.apply.read_only", locale = "en");
+        let toast = dbflux_i18n::t!("document.schema_diff.toast.read_only", locale = "en");
+
+        assert_eq!(apply, toast);
+    }
+
+    #[test]
+    fn schema_diff_toast_applied_interpolates_counts() {
+        let message = dbflux_i18n::t!(
+            "document.schema_diff.toast.applied",
+            statements = 3,
+            tables = 2
+        );
+
+        assert!(message.contains('3'));
+        assert!(message.contains('2'));
+    }
+
+    #[test]
+    fn schema_diff_toast_applied_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.schema_diff.toast.applied", locale = "en");
+        let es = dbflux_i18n::t!("document.schema_diff.toast.applied", locale = "es");
+
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn schema_diff_toast_apply_partial_failure_interpolates_every_placeholder() {
+        let message = dbflux_i18n::t!(
+            "document.schema_diff.toast.apply_partial_failure",
+            applied = 1,
+            total = 3,
+            statements = 4,
+            table = "public.orders",
+            error = "connection reset",
+            remaining = 2
+        );
+
+        assert!(message.contains("public.orders"));
+        assert!(message.contains("connection reset"));
+    }
+
+    #[test]
+    fn schema_diff_summary_apply_interpolates_count_and_target() {
+        let message = dbflux_i18n::t!(
+            "document.schema_diff.summary.apply",
+            count = 5,
+            target = "app_db"
+        );
+
+        assert!(message.contains('5'));
+        assert!(message.contains("app_db"));
+    }
+
+    #[test]
+    fn schema_diff_summary_apply_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.schema_diff.summary.apply", locale = "en");
+        let es = dbflux_i18n::t!("document.schema_diff.summary.apply", locale = "es");
+
         assert_ne!(en, es);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 18: schema change and table-action descriptions move to exhaustive labels.rs helpers; apply toasts, selection errors, approval routing messages, risk badge labels, the unloaded-database error and the read-only blocked reason render through `dbflux_i18n::t!`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 17; next: the object browser)

## How was this solved?

- Size: 760 lines (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1002 passed; clippy clean; fmt clean. Manual smoke in Spanish: compute a diff and apply one change.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
