### PR TITLE
feat(i18n): translate the workspace empty state, status bar, tasks panel, and shutdown overlay

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1691,6 +1691,14 @@ settings:
     mcp_roles: Roles
     mcp_policies: Policies
 
+shutdown:
+  signal_sent: Shutting down...
+  cancelling_tasks: Cancelling tasks...
+  closing_connections: Closing connections...
+  flushing_logs: Flushing logs...
+  complete: Shutdown complete
+  failed: Shutdown failed
+
 sidebar:
   confirm:
     delete_hint: Press x to confirm delete, ESC to cancel
@@ -1987,8 +1995,39 @@ sso_wizard:
     roles_discovered: SSO role discovery completed
     roles_failed: "Failed to discover roles: %{error}"
     profile_created: Created AWS SSO auth profile
+status_bar:
+  disconnected: disconnected
+  tasks_label: Tasks
+  tasks_running:
+    one: "1 running"
+    many: "%{count} running"
+tasks_panel:
+  empty: No background tasks
+  output_truncated: ... output truncated in panel
 toast:
   action:
     copy: Copy
     show_details: Show details
     hide_details: Hide details
+workspace:
+  background_tasks: Background Tasks
+  empty_documents: No documents open
+  hint:
+    new_query: new query
+    command_palette: command palette
+    open: open script from disk
+    new_connection: new connection
+  mcp_approvals: MCP Approvals
+  event_streams: Event Streams
+  action:
+    delete: Delete
+    drop: Drop
+    delete_folder: Delete folder
+    delete_connection: Delete connection
+    cancel: Cancel
+  confirm:
+    delete_selected: "Delete %{count} selected items?"
+    drop_object: 'Drop %{object_type} "%{name}"?'
+    delete_folder: 'Delete folder "%{name}"?'
+    delete_connection: 'Delete connection "%{name}"?'
+  default_object_type: Object

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1691,6 +1691,14 @@ settings:
     mcp_roles: Roles
     mcp_policies: Políticas
 
+shutdown:
+  signal_sent: Cerrando la aplicación...
+  cancelling_tasks: Cancelando tareas...
+  closing_connections: Cerrando conexiones...
+  flushing_logs: Guardando registros...
+  complete: Cierre completado
+  failed: Error al cerrar
+
 sidebar:
   confirm:
     delete_hint: Presiona x para confirmar la eliminación, ESC para cancelar
@@ -1987,8 +1995,39 @@ sso_wizard:
     roles_discovered: Descubrimiento de roles de SSO completado
     roles_failed: "Error al descubrir roles: %{error}"
     profile_created: Perfil de autenticación de AWS SSO creado
+status_bar:
+  disconnected: desconectado
+  tasks_label: Tareas
+  tasks_running:
+    one: "1 en curso"
+    many: "%{count} en curso"
+tasks_panel:
+  empty: No hay tareas en segundo plano
+  output_truncated: ... salida truncada en el panel
 toast:
   action:
     copy: Copiar
     show_details: Mostrar detalles
     hide_details: Ocultar detalles
+workspace:
+  background_tasks: Tareas en segundo plano
+  empty_documents: No hay documentos abiertos
+  hint:
+    new_query: nueva consulta
+    command_palette: paleta de comandos
+    open: abrir script desde el disco
+    new_connection: nueva conexión
+  mcp_approvals: Aprobaciones de MCP
+  event_streams: Flujos de eventos
+  action:
+    delete: Eliminar
+    drop: Eliminar (DDL)
+    delete_folder: Eliminar carpeta
+    delete_connection: Eliminar conexión
+    cancel: Cancelar
+  confirm:
+    delete_selected: "¿Eliminar %{count} elementos seleccionados?"
+    drop_object: '¿Eliminar (DDL) %{object_type} "%{name}"?'
+    delete_folder: '¿Eliminar la carpeta "%{name}"?'
+    delete_connection: '¿Eliminar la conexión "%{name}"?'
+  default_object_type: Objeto

--- a/crates/dbflux_ui/src/ui/labels.rs
+++ b/crates/dbflux_ui/src/ui/labels.rs
@@ -1,0 +1,218 @@
+//! Translation helpers shared across `dbflux_ui` shell chrome.
+//!
+//! These wrap [`dbflux_i18n::t!`] calls that need named arguments, plural
+//! selection, or an exhaustive match so render code can build the label
+//! once instead of repeating the substitution inline on every render pass.
+
+use dbflux_core::ShutdownPhase;
+
+/// Formats the "N running" status-bar label for the current task count.
+pub(crate) fn tasks_running_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("status_bar.tasks_running.one")
+    } else {
+        dbflux_i18n::t!("status_bar.tasks_running.many", count = count)
+    }
+}
+
+/// Formats the shutdown overlay message for the given phase.
+///
+/// `NotStarted` has no visible message — the overlay only renders while
+/// `ShutdownPhase::is_active()` is true — so it resolves to an empty string
+/// like the phase it mirrors.
+pub(crate) fn shutdown_phase_label(phase: ShutdownPhase) -> String {
+    match phase {
+        ShutdownPhase::NotStarted => String::new(),
+        ShutdownPhase::SignalSent => dbflux_i18n::t!("shutdown.signal_sent"),
+        ShutdownPhase::CancellingTasks => dbflux_i18n::t!("shutdown.cancelling_tasks"),
+        ShutdownPhase::ClosingConnections => dbflux_i18n::t!("shutdown.closing_connections"),
+        ShutdownPhase::FlushingLogs => dbflux_i18n::t!("shutdown.flushing_logs"),
+        ShutdownPhase::Complete => dbflux_i18n::t!("shutdown.complete"),
+        ShutdownPhase::Failed => dbflux_i18n::t!("shutdown.failed"),
+    }
+}
+
+/// Formats the confirmation prompt for deleting several selected items.
+pub(crate) fn workspace_delete_selected_message(count: usize) -> String {
+    dbflux_i18n::t!("workspace.confirm.delete_selected", count = count)
+}
+
+/// Formats the confirmation prompt for a DDL drop, falling back to a
+/// generic object-type label when the sidebar didn't supply one.
+pub(crate) fn workspace_drop_object_message(object_type: Option<&str>, name: &str) -> String {
+    let object_type = object_type
+        .map(str::to_string)
+        .unwrap_or_else(|| dbflux_i18n::t!("workspace.default_object_type"));
+
+    dbflux_i18n::t!(
+        "workspace.confirm.drop_object",
+        object_type = object_type,
+        name = name
+    )
+}
+
+/// Formats the confirmation prompt for deleting a sidebar folder.
+pub(crate) fn workspace_delete_folder_message(name: &str) -> String {
+    dbflux_i18n::t!("workspace.confirm.delete_folder", name = name)
+}
+
+/// Formats the confirmation prompt for deleting a connection.
+pub(crate) fn workspace_delete_connection_message(name: &str) -> String {
+    dbflux_i18n::t!("workspace.confirm.delete_connection", name = name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        shutdown_phase_label, tasks_running_label, workspace_delete_connection_message,
+        workspace_delete_folder_message, workspace_delete_selected_message,
+        workspace_drop_object_message,
+    };
+    use dbflux_core::ShutdownPhase;
+
+    const WORKSPACE_CATALOG_KEYS: &[&str] = &[
+        "workspace.background_tasks",
+        "workspace.empty_documents",
+        "workspace.hint.new_query",
+        "workspace.hint.command_palette",
+        "workspace.hint.open",
+        "workspace.hint.new_connection",
+        "workspace.mcp_approvals",
+        "workspace.event_streams",
+        "workspace.action.delete",
+        "workspace.action.drop",
+        "workspace.action.delete_folder",
+        "workspace.action.delete_connection",
+        "workspace.action.cancel",
+        "workspace.confirm.delete_selected",
+        "workspace.confirm.drop_object",
+        "workspace.confirm.delete_folder",
+        "workspace.confirm.delete_connection",
+        "workspace.default_object_type",
+    ];
+
+    const STATUS_BAR_AND_SHELL_CATALOG_KEYS: &[&str] = &[
+        "status_bar.disconnected",
+        "status_bar.tasks_label",
+        "status_bar.tasks_running.one",
+        "status_bar.tasks_running.many",
+        "tasks_panel.empty",
+        "tasks_panel.output_truncated",
+        "shutdown.signal_sent",
+        "shutdown.cancelling_tasks",
+        "shutdown.closing_connections",
+        "shutdown.flushing_logs",
+        "shutdown.complete",
+        "shutdown.failed",
+    ];
+
+    #[test]
+    fn workspace_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in WORKSPACE_CATALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn status_bar_and_shell_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in STATUS_BAR_AND_SHELL_CATALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn workspace_background_tasks_differs_between_locales() {
+        let english = dbflux_i18n::t!("workspace.background_tasks", locale = "en");
+        let spanish = dbflux_i18n::t!("workspace.background_tasks", locale = "es");
+
+        assert_eq!(english, "Background Tasks");
+        assert_eq!(spanish, "Tareas en segundo plano");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn tasks_running_label_uses_singular_and_plural_forms() {
+        assert!(tasks_running_label(1).contains('1'));
+        assert!(tasks_running_label(0).contains('0'));
+        assert!(tasks_running_label(3).contains('3'));
+        assert_ne!(tasks_running_label(1), tasks_running_label(3));
+        assert_ne!(tasks_running_label(1), tasks_running_label(0));
+    }
+
+    #[test]
+    fn shutdown_phase_label_is_exhaustive_and_not_started_is_empty() {
+        assert_eq!(shutdown_phase_label(ShutdownPhase::NotStarted), "");
+
+        for phase in [
+            ShutdownPhase::SignalSent,
+            ShutdownPhase::CancellingTasks,
+            ShutdownPhase::ClosingConnections,
+            ShutdownPhase::FlushingLogs,
+            ShutdownPhase::Complete,
+            ShutdownPhase::Failed,
+        ] {
+            assert!(
+                !shutdown_phase_label(phase).is_empty(),
+                "{phase:?} resolved to an empty message"
+            );
+        }
+    }
+
+    #[test]
+    fn workspace_delete_selected_message_embeds_count() {
+        let message = workspace_delete_selected_message(3);
+
+        assert!(message.contains('3'));
+    }
+
+    #[test]
+    fn workspace_drop_object_message_falls_back_to_default_object_type() {
+        let with_type = workspace_drop_object_message(Some("Table"), "users");
+        let without_type = workspace_drop_object_message(None, "users");
+
+        assert!(with_type.contains("Table"));
+        assert!(with_type.contains("users"));
+        assert!(without_type.contains("users"));
+        assert_ne!(with_type, without_type);
+    }
+
+    #[test]
+    fn workspace_delete_folder_message_embeds_name() {
+        let message = workspace_delete_folder_message("scratch");
+
+        assert!(message.contains("scratch"));
+    }
+
+    #[test]
+    fn workspace_delete_connection_message_embeds_name() {
+        let message = workspace_delete_connection_message("prod-db");
+
+        assert!(message.contains("prod-db"));
+    }
+}

--- a/crates/dbflux_ui/src/ui/mod.rs
+++ b/crates/dbflux_ui/src/ui/mod.rs
@@ -3,6 +3,7 @@ pub mod components;
 pub mod dock;
 pub mod document;
 pub mod icons;
+pub(crate) mod labels;
 pub mod overlays;
 pub mod views;
 

--- a/crates/dbflux_ui/src/ui/overlays/shutdown_overlay.rs
+++ b/crates/dbflux_ui/src/ui/overlays/shutdown_overlay.rs
@@ -82,7 +82,7 @@ impl Render for ShutdownOverlay {
         }
 
         let theme = cx.theme();
-        let message = phase.message();
+        let message = crate::ui::labels::shutdown_phase_label(phase);
 
         div()
             .id("shutdown-overlay")

--- a/crates/dbflux_ui/src/ui/views/status_bar.rs
+++ b/crates/dbflux_ui/src/ui/views/status_bar.rs
@@ -269,7 +269,9 @@ impl Render for StatusBar {
                                 this.child(Self::metadata_text(connection_name))
                             })
                             .when(!is_connected, |this| {
-                                this.child(Self::metadata_text("disconnected"))
+                                this.child(Self::metadata_text(dbflux_i18n::t!(
+                                    "status_bar.disconnected"
+                                )))
                             }),
                     )
                     // Running task info — shown with a divider when a task is active
@@ -380,10 +382,14 @@ impl Render for StatusBar {
                                         .size(px(12.0))
                                         .primary(),
                                 )
-                                .child(Self::status_text(format!("{} running", running_count)))
+                                .child(Self::status_text(
+                                    crate::ui::labels::tasks_running_label(running_count),
+                                ))
                             })
                             .when(running_count == 0, |this| {
-                                this.child(Self::status_text("Tasks"))
+                                this.child(Self::status_text(dbflux_i18n::t!(
+                                    "status_bar.tasks_label"
+                                )))
                             }),
                     ),
             )

--- a/crates/dbflux_ui/src/ui/views/tasks_panel.rs
+++ b/crates/dbflux_ui/src/ui/views/tasks_panel.rs
@@ -267,7 +267,7 @@ impl TasksPanel {
 
                 if lines.len() > 40 {
                     lines.truncate(40);
-                    lines.push("... output truncated in panel".to_string());
+                    lines.push(dbflux_i18n::t!("tasks_panel.output_truncated"));
                 }
 
                 el.child(
@@ -323,7 +323,7 @@ impl Render for TasksPanel {
                         .items_center()
                         .justify_center()
                         .py_4()
-                        .child(Text::muted("No background tasks")),
+                        .child(Text::muted(dbflux_i18n::t!("tasks_panel.empty"))),
                 )
             })
             .children(task_rows)

--- a/crates/dbflux_ui/src/ui/views/workspace/render.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/render.rs
@@ -30,7 +30,7 @@ impl Workspace {
 /// muted description.
 fn empty_state_shortcut<const N: usize>(
     keys: [&'static str; N],
-    description: &'static str,
+    description: impl Into<gpui::SharedString>,
 ) -> gpui::Div {
     gpui::div()
         .flex()
@@ -165,7 +165,7 @@ impl Render for Workspace {
             let workspace = cx.entity().clone();
             let tasks_header = panel_header_collapsible_variant(
                 "panel-header-Background Tasks",
-                "Background Tasks",
+                dbflux_i18n::t!("workspace.background_tasks"),
                 PanelHeaderVariant::WorkspaceTasks,
                 !tasks_expanded,
                 tasks_focused,
@@ -273,7 +273,7 @@ impl Render for Workspace {
             let workspace = cx.entity().clone();
             let tasks_header_empty = panel_header_collapsible_variant(
                 "panel-header-Background Tasks",
-                "Background Tasks",
+                dbflux_i18n::t!("workspace.background_tasks"),
                 PanelHeaderVariant::WorkspaceTasks,
                 !tasks_expanded,
                 tasks_focused,
@@ -305,25 +305,31 @@ impl Render for Workspace {
                                         .size(px(64.0))
                                         .color(muted_fg.opacity(0.5)),
                                 )
-                                .child(Body::new("No documents open").muted(cx))
+                                .child(
+                                    Body::new(dbflux_i18n::t!("workspace.empty_documents"))
+                                        .muted(cx),
+                                )
                                 .child(
                                     div()
                                         .mt_4()
                                         .flex()
                                         .flex_col()
                                         .gap_2()
-                                        .child(empty_state_shortcut(["Ctrl", "N"], "new query"))
+                                        .child(empty_state_shortcut(
+                                            ["Ctrl", "N"],
+                                            dbflux_i18n::t!("workspace.hint.new_query"),
+                                        ))
                                         .child(empty_state_shortcut(
                                             ["Ctrl", "Shift", "P"],
-                                            "command palette",
+                                            dbflux_i18n::t!("workspace.hint.command_palette"),
                                         ))
                                         .child(empty_state_shortcut(
                                             ["Ctrl", "O"],
-                                            "open script from disk",
+                                            dbflux_i18n::t!("workspace.hint.open"),
                                         ))
                                         .child(empty_state_shortcut(
                                             ["Ctrl", "Shift", "N"],
-                                            "new connection",
+                                            dbflux_i18n::t!("workspace.hint.new_connection"),
                                         )),
                                 ),
                         ),
@@ -729,7 +735,9 @@ impl Render for Workspace {
                     root.when_some(self.active_governance_panel, |root, panel| {
                         let _close_entity = cx.entity().clone();
                         let title = match panel {
-                            super::GovernancePanel::Approvals => "MCP Approvals",
+                            super::GovernancePanel::Approvals => {
+                                dbflux_i18n::t!("workspace.mcp_approvals")
+                            }
                         };
 
                         let content = match panel {
@@ -805,7 +813,7 @@ impl Render for Workspace {
                     )
                     .context_id(ContextId::EventStreamsPicker)
                     .icon(AppIcon::ScrollText)
-                    .title("Event Streams")
+                    .title(dbflux_i18n::t!("workspace.event_streams"))
                     .width(px(1000.0))
                     .height(px(720.0))
                     .top_offset(px(60.0))
@@ -980,27 +988,35 @@ impl Render for Workspace {
                     let sidebar_close = self.sidebar.clone();
 
                     let title = if modal_state.multi_count.is_some() {
-                        "Delete"
+                        dbflux_i18n::t!("workspace.action.delete")
                     } else if modal_state.is_ddl {
-                        "Drop"
+                        dbflux_i18n::t!("workspace.action.drop")
                     } else if modal_state.is_folder {
-                        "Delete folder"
+                        dbflux_i18n::t!("workspace.action.delete_folder")
                     } else {
-                        "Delete connection"
+                        dbflux_i18n::t!("workspace.action.delete_connection")
                     };
 
                     let message = if let Some(count) = modal_state.multi_count {
-                        format!("Delete {count} selected items?")
+                        crate::ui::labels::workspace_delete_selected_message(count)
                     } else if modal_state.is_ddl {
-                        let object_type = modal_state.object_type.unwrap_or("Object");
-                        format!("Drop {} \"{}\"?", object_type, modal_state.item_name)
+                        crate::ui::labels::workspace_drop_object_message(
+                            modal_state.object_type,
+                            modal_state.item_name,
+                        )
                     } else if modal_state.is_folder {
-                        format!("Delete folder \"{}\"?", modal_state.item_name)
+                        crate::ui::labels::workspace_delete_folder_message(modal_state.item_name)
                     } else {
-                        format!("Delete connection \"{}\"?", modal_state.item_name)
+                        crate::ui::labels::workspace_delete_connection_message(
+                            modal_state.item_name,
+                        )
                     };
 
-                    let confirm_label = if modal_state.is_ddl { "Drop" } else { "Delete" };
+                    let confirm_label = if modal_state.is_ddl {
+                        dbflux_i18n::t!("workspace.action.drop")
+                    } else {
+                        dbflux_i18n::t!("workspace.action.delete")
+                    };
                     let variant = if modal_state.is_ddl {
                         ModalVariant::Danger
                     } else {
@@ -1013,7 +1029,11 @@ impl Render for Workspace {
                         .flex()
                         .gap(Spacing::SM)
                         .child(
-                            Button::new("delete-cancel", "Cancel").on_click(move |_, _, cx| {
+                            Button::new(
+                                "delete-cancel",
+                                dbflux_i18n::t!("workspace.action.cancel"),
+                            )
+                            .on_click(move |_, _, cx| {
                                 sidebar_cancel.update(cx, |this, cx| {
                                     this.cancel_modal_delete(cx);
                                 });


### PR DESCRIPTION
## Summary

Twentieth slice of the windows/shell series, this time in `dbflux_ui`: the workspace empty state and shortcut hints, panel titles, delete/drop confirmation dialogs, the status bar (`disconnected`, tasks count), the tasks panel and the shutdown overlay phases render through `dbflux_i18n::t!` under `workspace.*`, `status_bar.*`, `tasks_panel.*`, `shutdown.*`. English and Spanish together. `DBFlux` and key chords stay data.

## What does this resolve?

- Refs #360 (follows the drivers settings PR; next: login modal and chart toasts)

## How was this solved?

- New `crates/dbflux_ui/src/ui/labels.rs` with `tasks_running_label`, `shutdown_phase_label` (exhaustive over `ShutdownPhase`, kept out of `dbflux_core` so core gains no i18n dependency) and the four confirmation-message helpers.

## Validation

- `cargo nextest run -p dbflux_ui -p dbflux_i18n` → 137 passed; clippy clean; fmt clean. Manual smoke in Spanish: close all tabs, read the empty state, run a long task, quit with a task running.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
