### PR TITLE
feat(i18n): translate the object browser chrome, preview pane, and gate messages

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -756,6 +756,76 @@ document:
         no_limit: No limit
         missing: Missing
         expired: Expired
+  object_browser:
+    columns:
+      class: Class
+      key: Key
+      last_modified: Last modified
+      size: Size
+    empty:
+      bucket: This bucket is empty
+      filtered: No keys match this filter
+      loading: "Loading objects…"
+      prefix: This prefix is empty
+    gate:
+      archived: "This object is archived and cannot be previewed. Restore it in your S3 console to access its contents."
+      too_large: "This object is %{size} and exceeds the %{limit} preview limit. Download it to inspect its contents."
+    metadata:
+      content_type: Content-Type
+      encryption: Encryption
+      etag: ETag
+      key: Key
+      last_modified: Last modified
+      section: Object
+      size: Size
+      storage_class: Storage class
+      versions: Versions
+    preview:
+      action:
+        copy_uri: Copy URI
+        delete: Delete
+        download: Download
+        open: Open
+        presign: Presign
+      body:
+        fit_to_width: Fit to width
+        loading: "Loading preview…"
+        loading_metadata: "Loading metadata…"
+        unpreviewable:
+          generic: "This file type has no in-app preview. Download this object or open it in your system viewer."
+          pdf: "PDFs are not rendered in-app. Download this object or open it in your system viewer."
+      header:
+        open_in_editor: Open in editor
+        open_in_system_viewer: Open in system viewer
+      versions:
+        count:
+          one: "%{count} version"
+          many: "%{count} versions"
+        loading: "Loading…"
+        view: View versions
+    status:
+      folders:
+        one: "%{count} folder"
+        many: "%{count} folders"
+      key_hint:
+        delete: x delete
+        filter: / filter
+        open: Enter open
+        preview: Space preview
+        rename: r rename
+        up: "← up a level"
+      load_more: Load more
+      loading_more: "Loading more…"
+      objects:
+        one: "%{count} object"
+        many: "%{count} objects"
+      retry: Retry
+      tree_mode: tree mode
+    toolbar:
+      new_folder: New folder
+      refresh: Refresh
+      tree: Tree
+      upload: Upload
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -756,6 +756,76 @@ document:
         no_limit: Sin límite
         missing: Ausente
         expired: Expirado
+  object_browser:
+    columns:
+      class: Clase
+      key: Clave
+      last_modified: Última modificación
+      size: Tamaño
+    empty:
+      bucket: Este bucket está vacío
+      filtered: Ninguna clave coincide con este filtro
+      loading: "Cargando objetos…"
+      prefix: Este prefijo está vacío
+    gate:
+      archived: "Este objeto está archivado y no se puede previsualizar. Restáuralo en tu consola de S3 para acceder a su contenido."
+      too_large: "Este objeto pesa %{size} y supera el límite de %{limit} para la vista previa. Descárgalo para inspeccionar su contenido."
+    metadata:
+      content_type: Tipo de contenido
+      encryption: Cifrado
+      etag: ETag
+      key: Clave
+      last_modified: Última modificación
+      section: Objeto
+      size: Tamaño
+      storage_class: Clase de almacenamiento
+      versions: Versiones
+    preview:
+      action:
+        copy_uri: Copiar URI
+        delete: Eliminar
+        download: Descargar
+        open: Abrir
+        presign: Prefirmar
+      body:
+        fit_to_width: Ajustar al ancho
+        loading: "Cargando vista previa…"
+        loading_metadata: "Cargando metadatos…"
+        unpreviewable:
+          generic: "Este tipo de archivo no tiene vista previa en la aplicación. Descarga este objeto o ábrelo en tu visor del sistema."
+          pdf: "Los PDF no se renderizan en la aplicación. Descarga este objeto o ábrelo en tu visor del sistema."
+      header:
+        open_in_editor: Abrir en el editor
+        open_in_system_viewer: Abrir en el visor del sistema
+      versions:
+        count:
+          one: "%{count} versión"
+          many: "%{count} versiones"
+        loading: "Cargando…"
+        view: Ver versiones
+    status:
+      folders:
+        one: "%{count} carpeta"
+        many: "%{count} carpetas"
+      key_hint:
+        delete: x eliminar
+        filter: / filtrar
+        open: Enter abrir
+        preview: Espacio previsualizar
+        rename: r renombrar
+        up: "← subir un nivel"
+      load_more: Cargar más
+      loading_more: "Cargando más…"
+      objects:
+        one: "%{count} objeto"
+        many: "%{count} objetos"
+      retry: Reintentar
+      tree_mode: modo árbol
+    toolbar:
+      new_folder: Nueva carpeta
+      refresh: Actualizar
+      tree: Árbol
+      upload: Subir
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1054,6 +1054,84 @@ pub(crate) fn table_action_description(
     }
 }
 
+/// Explanation shown in place of the object browser's preview pane when
+/// [`crate::object_browser::PreviewGate`] refuses to fetch the object's
+/// bytes, or `None` when the object is previewable.
+///
+/// Exhaustive by construction (no wildcard arm) so a new `PreviewGate`
+/// variant fails this crate's build until its catalog key is added here.
+/// Sizes are S3 data and are interpolated verbatim, never translated.
+pub(crate) fn preview_gate_message(gate: &crate::object_browser::PreviewGate) -> Option<String> {
+    use crate::buckets_table::format_bytes;
+    use crate::object_browser::PreviewGate;
+
+    match gate {
+        PreviewGate::Allowed => None,
+        PreviewGate::TooLarge {
+            size_bytes,
+            limit_bytes,
+        } => Some(dbflux_i18n::t!(
+            "document.object_browser.gate.too_large",
+            size = format_bytes(*size_bytes),
+            limit = format_bytes(*limit_bytes)
+        )),
+        PreviewGate::Archived => Some(dbflux_i18n::t!("document.object_browser.gate.archived")),
+    }
+}
+
+/// Footer summary for the object browser listing: how many folders and
+/// objects are shown, and their total size. The size is S3 data and stays
+/// outside the catalog.
+pub(crate) fn object_browser_status_summary(
+    folders: usize,
+    objects: usize,
+    total_bytes: u64,
+) -> String {
+    let folders_label = if folders == 1 {
+        dbflux_i18n::t!(
+            "document.object_browser.status.folders.one",
+            count = folders
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.object_browser.status.folders.many",
+            count = folders
+        )
+    };
+    let objects_label = if objects == 1 {
+        dbflux_i18n::t!(
+            "document.object_browser.status.objects.one",
+            count = objects
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.object_browser.status.objects.many",
+            count = objects
+        )
+    };
+
+    format!(
+        "{folders_label} · {objects_label} · {}",
+        crate::buckets_table::format_bytes(total_bytes)
+    )
+}
+
+/// Version count shown in the object preview pane's metadata row when the
+/// version list has been fetched on demand.
+pub(crate) fn object_browser_versions_count_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "document.object_browser.preview.versions.count.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.object_browser.preview.versions.count.many",
+            count = count
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1066,11 +1144,13 @@ mod tests {
         delete_confirm_copy, delete_rows_label, execution_count_state_label, execution_mode_label,
         history_items_count_label, history_tab_label, incomplete_aggregate_rows_label,
         join_kind_label, live_output_lines_label, live_output_truncated_label,
-        partial_delete_label, pending_change_count_label, pending_edits_summary,
+        object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
+        pending_change_count_label, pending_edits_summary, preview_gate_message,
         refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
         script_confirm_message_label, sort_direction_label, table_action_description,
         unsaved_changes_label, update_columns_label, valid_lines_label,
     };
+    use crate::object_browser::PreviewGate;
     use crate::schema_diff::apply::TableLevelAction;
     use dbflux_components::chart::ChartDetection;
     use dbflux_core::{
@@ -2618,5 +2698,154 @@ mod tests {
         let es = dbflux_i18n::t!("document.schema_diff.table_action.create", locale = "es");
 
         assert_ne!(en, es);
+    }
+
+    /// T19: every `document.object_browser.*` key resolves in both locales.
+    #[test]
+    fn object_browser_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.object_browser.toolbar.tree",
+            "document.object_browser.toolbar.upload",
+            "document.object_browser.toolbar.new_folder",
+            "document.object_browser.toolbar.refresh",
+            "document.object_browser.columns.key",
+            "document.object_browser.columns.size",
+            "document.object_browser.columns.class",
+            "document.object_browser.columns.last_modified",
+            "document.object_browser.status.folders.one",
+            "document.object_browser.status.folders.many",
+            "document.object_browser.status.objects.one",
+            "document.object_browser.status.objects.many",
+            "document.object_browser.status.retry",
+            "document.object_browser.status.tree_mode",
+            "document.object_browser.status.load_more",
+            "document.object_browser.status.loading_more",
+            "document.object_browser.status.key_hint.open",
+            "document.object_browser.status.key_hint.preview",
+            "document.object_browser.status.key_hint.up",
+            "document.object_browser.status.key_hint.filter",
+            "document.object_browser.status.key_hint.delete",
+            "document.object_browser.status.key_hint.rename",
+            "document.object_browser.empty.loading",
+            "document.object_browser.empty.filtered",
+            "document.object_browser.empty.bucket",
+            "document.object_browser.empty.prefix",
+            "document.object_browser.gate.too_large",
+            "document.object_browser.gate.archived",
+            "document.object_browser.preview.header.open_in_editor",
+            "document.object_browser.preview.header.open_in_system_viewer",
+            "document.object_browser.preview.body.fit_to_width",
+            "document.object_browser.preview.body.loading",
+            "document.object_browser.preview.body.loading_metadata",
+            "document.object_browser.preview.body.unpreviewable.pdf",
+            "document.object_browser.preview.body.unpreviewable.generic",
+            "document.object_browser.preview.versions.loading",
+            "document.object_browser.preview.versions.view",
+            "document.object_browser.preview.versions.count.one",
+            "document.object_browser.preview.versions.count.many",
+            "document.object_browser.preview.action.download",
+            "document.object_browser.preview.action.open",
+            "document.object_browser.preview.action.copy_uri",
+            "document.object_browser.preview.action.presign",
+            "document.object_browser.preview.action.delete",
+            "document.object_browser.metadata.section",
+            "document.object_browser.metadata.key",
+            "document.object_browser.metadata.size",
+            "document.object_browser.metadata.content_type",
+            "document.object_browser.metadata.last_modified",
+            "document.object_browser.metadata.etag",
+            "document.object_browser.metadata.storage_class",
+            "document.object_browser.metadata.encryption",
+            "document.object_browser.metadata.versions",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// T19: at least one object browser key must actually diverge between
+    /// locales, so the parity loop above cannot pass on English fallbacks
+    /// copied verbatim into `es.yml`.
+    #[test]
+    fn object_browser_toolbar_upload_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.object_browser.toolbar.upload", locale = "en");
+        let es = dbflux_i18n::t!("document.object_browser.toolbar.upload", locale = "es");
+
+        assert_ne!(en, es);
+    }
+
+    /// T19: the gate is exhaustive over every `PreviewGate` variant, and the
+    /// size-bound explanation interpolates the exact refused/limit sizes.
+    #[test]
+    fn preview_gate_message_covers_all_variants() {
+        assert_eq!(preview_gate_message(&PreviewGate::Allowed), None);
+
+        let too_large = preview_gate_message(&PreviewGate::TooLarge {
+            size_bytes: 20 * 1024 * 1024,
+            limit_bytes: 10 * 1024 * 1024,
+        })
+        .expect("TooLarge always explains itself");
+        assert!(too_large.contains("10.0 MiB"));
+        assert!(too_large.contains("20.0 MiB"));
+
+        let archived =
+            preview_gate_message(&PreviewGate::Archived).expect("Archived explains itself");
+        assert!(!archived.is_empty());
+    }
+
+    /// T19: both refusal explanations translate. The `t!` macro has no arm
+    /// combining named interpolation with an explicit `locale =` override
+    /// (only `(key)` / `(key, locale=)` / `(key, name=value+)`), so the
+    /// interpolated-value coverage above and this locale-divergence check
+    /// stay two separate assertions, matching the schema_diff PR 17
+    /// precedent.
+    #[test]
+    fn preview_gate_message_differs_between_locales() {
+        let too_large_en = dbflux_i18n::t!("document.object_browser.gate.too_large", locale = "en");
+        let too_large_es = dbflux_i18n::t!("document.object_browser.gate.too_large", locale = "es");
+
+        assert_ne!(too_large_en, too_large_es);
+
+        let archived_en = preview_gate_message(&PreviewGate::Archived).unwrap();
+        let archived_es = dbflux_i18n::t!("document.object_browser.gate.archived", locale = "es");
+
+        assert_ne!(archived_en, archived_es);
+    }
+
+    /// T19: the footer summary covers the singular/plural boundary
+    /// independently for folders and objects.
+    #[test]
+    fn object_browser_status_summary_covers_singular_and_plural() {
+        assert_eq!(
+            object_browser_status_summary(1, 2, 2048),
+            "1 folder · 2 objects · 2.0 KiB"
+        );
+        assert_eq!(
+            object_browser_status_summary(0, 0, 0),
+            "0 folders · 0 objects · 0 B"
+        );
+        assert_eq!(
+            object_browser_status_summary(2, 1, 512),
+            "2 folders · 1 object · 512 B"
+        );
+    }
+
+    /// T19: the on-demand version count uses the singular bucket only for
+    /// exactly one version.
+    #[test]
+    fn object_browser_versions_count_label_covers_singular_and_plural() {
+        assert_eq!(object_browser_versions_count_label(1), "1 version");
+        assert_eq!(object_browser_versions_count_label(3), "3 versions");
     }
 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1060,7 +1060,7 @@ pub(crate) fn table_action_description(
 ///
 /// Exhaustive by construction (no wildcard arm) so a new `PreviewGate`
 /// variant fails this crate's build until its catalog key is added here.
-/// Sizes are S3 data and are interpolated verbatim, never translated.
+/// Sizes are object-store data and are interpolated verbatim, never translated.
 pub(crate) fn preview_gate_message(gate: &crate::object_browser::PreviewGate) -> Option<String> {
     use crate::buckets_table::format_bytes;
     use crate::object_browser::PreviewGate;

--- a/crates/dbflux_ui_document/src/object_browser/metadata.rs
+++ b/crates/dbflux_ui_document/src/object_browser/metadata.rs
@@ -29,24 +29,11 @@ pub enum PreviewGate {
 
 impl PreviewGate {
     /// Explanation shown in place of the preview, or `None` when the object
-    /// is previewable.
+    /// is previewable. Delegates to the translated, exhaustive
+    /// `crate::labels::preview_gate_message` so every variant routes through
+    /// the catalog.
     pub fn message(&self) -> Option<String> {
-        match self {
-            PreviewGate::Allowed => None,
-            PreviewGate::TooLarge {
-                size_bytes,
-                limit_bytes,
-            } => Some(format!(
-                "This object is {} and exceeds the {} preview limit. Download it to inspect its contents.",
-                format_bytes(*size_bytes),
-                format_bytes(*limit_bytes)
-            )),
-            PreviewGate::Archived => Some(
-                "This object is archived and cannot be previewed. Restore it in your S3 console \
-                 to access its contents."
-                    .to_string(),
-            ),
-        }
+        crate::labels::preview_gate_message(self)
     }
 }
 

--- a/crates/dbflux_ui_document/src/object_browser/preview.rs
+++ b/crates/dbflux_ui_document/src/object_browser/preview.rs
@@ -13,6 +13,7 @@ use super::metadata::{
 use super::preview_content::{ImagePreview, PreviewContentState, PreviewKind};
 use super::render::{format_modified, object_icon};
 use super::{ObjectAction, ObjectBrowserDocument};
+use crate::labels::object_browser_versions_count_label;
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Text};
 use dbflux_components::tokens::{Heights, Radii, Spacing};
@@ -283,8 +284,10 @@ impl ObjectBrowserDocument {
                                 .cursor_pointer()
                                 .hover(|d| d.bg(theme.secondary))
                                 .tooltip(|window, cx| {
-                                    gpui_component::tooltip::Tooltip::new("Open in editor")
-                                        .build(window, cx)
+                                    gpui_component::tooltip::Tooltip::new(dbflux_i18n::t!(
+                                        "document.object_browser.preview.header.open_in_editor"
+                                    ))
+                                    .build(window, cx)
                                 })
                                 .on_click(cx.listener(move |this, _, _, cx| {
                                     this.request_open_object_editor(key.clone(), cx);
@@ -306,8 +309,10 @@ impl ObjectBrowserDocument {
                                 .cursor_pointer()
                                 .hover(|d| d.bg(theme.secondary))
                                 .tooltip(|window, cx| {
-                                    gpui_component::tooltip::Tooltip::new("Open in system viewer")
-                                        .build(window, cx)
+                                    gpui_component::tooltip::Tooltip::new(dbflux_i18n::t!(
+                                        "document.object_browser.preview.header.open_in_system_viewer"
+                                    ))
+                                    .build(window, cx)
                                 })
                                 .on_click(cx.listener(move |this, _, _, cx| {
                                     this.open_object_externally(key.clone(), cx);
@@ -399,7 +404,12 @@ impl ObjectBrowserDocument {
                             .items_center()
                             .gap(Spacing::XS)
                             .child(Icon::new(AppIcon::Maximize2).small().muted())
-                            .child(Text::caption("Fit to width").muted_foreground()),
+                            .child(
+                                Text::caption(dbflux_i18n::t!(
+                                    "document.object_browser.preview.body.fit_to_width"
+                                ))
+                                .muted_foreground(),
+                            ),
                     )
                     .when_some(timing, |this, timing| {
                         this.child(Text::caption(timing).muted_foreground())
@@ -414,7 +424,7 @@ impl ObjectBrowserDocument {
         if let PreviewContentState::Loading = self.preview_content() {
             return self.render_notice(
                 AppIcon::Loader,
-                "Loading preview…",
+                &dbflux_i18n::t!("document.object_browser.preview.body.loading"),
                 NoticeTone::Neutral,
                 cx,
             );
@@ -427,7 +437,7 @@ impl ObjectBrowserDocument {
         let (icon, message, tone) = match &self.metadata {
             None | Some(ObjectMetadataState::Loading) => (
                 AppIcon::Loader,
-                "Loading metadata…".to_string(),
+                dbflux_i18n::t!("document.object_browser.preview.body.loading_metadata"),
                 NoticeTone::Neutral,
             ),
             Some(ObjectMetadataState::Error(message)) => {
@@ -459,13 +469,9 @@ impl ObjectBrowserDocument {
     fn unpreviewable_message(&self) -> String {
         match self.preview_kind() {
             Some(PreviewKind::Pdf) => {
-                "PDFs are not rendered in-app. Download this object or open it in your system \
-                 viewer."
-                    .to_string()
+                dbflux_i18n::t!("document.object_browser.preview.body.unpreviewable.pdf")
             }
-            _ => "This file type has no in-app preview. Download this object or open it in your \
-                  system viewer."
-                .to_string(),
+            _ => dbflux_i18n::t!("document.object_browser.preview.body.unpreviewable.generic"),
         }
     }
 
@@ -518,46 +524,51 @@ impl ObjectBrowserDocument {
             .child(
                 div()
                     .pb(Spacing::XS)
-                    .child(Text::subsection_label("Object")),
+                    .child(Text::subsection_label(dbflux_i18n::t!(
+                        "document.object_browser.metadata.section"
+                    ))),
             )
-            .child(self.metadata_row("Key", Text::code(metadata.key.clone()).into_any_element()))
             .child(self.metadata_row(
-                "Size",
+                dbflux_i18n::t!("document.object_browser.metadata.key"),
+                Text::code(metadata.key.clone()).into_any_element(),
+            ))
+            .child(self.metadata_row(
+                dbflux_i18n::t!("document.object_browser.metadata.size"),
                 Text::code(format_size_detail(metadata.size_bytes)).into_any_element(),
             ))
             .child(self.metadata_row(
-                "Content-Type",
+                dbflux_i18n::t!("document.object_browser.metadata.content_type"),
                 Text::code(optional_value(metadata.content_type.as_deref())).into_any_element(),
             ))
             .child(self.metadata_row(
-                "Last modified",
+                dbflux_i18n::t!("document.object_browser.metadata.last_modified"),
                 Text::code(format_modified(metadata.last_modified)).into_any_element(),
             ))
             .child(
                 self.metadata_row(
-                    "ETag",
+                    dbflux_i18n::t!("document.object_browser.metadata.etag"),
                     Text::code(optional_value(metadata.etag.as_deref()))
                         .muted_foreground()
                         .into_any_element(),
                 ),
             )
             .child(self.metadata_row(
-                "Storage class",
+                dbflux_i18n::t!("document.object_browser.metadata.storage_class"),
                 self.render_storage_class(metadata.storage_class.as_deref(), cx),
             ))
             .child(self.metadata_row(
-                "Encryption",
+                dbflux_i18n::t!("document.object_browser.metadata.encryption"),
                 Text::code(optional_value(metadata.encryption.as_deref())).into_any_element(),
             ))
             .child(self.metadata_row(
-                "Versions",
+                dbflux_i18n::t!("document.object_browser.metadata.versions"),
                 self.render_versions_value(key, metadata.version_count, cx),
             ))
             .child(self.render_versions_list(cx))
             .into_any_element()
     }
 
-    fn metadata_row(&self, label: &'static str, value: AnyElement) -> impl IntoElement {
+    fn metadata_row(&self, label: impl Into<SharedString>, value: AnyElement) -> impl IntoElement {
         div()
             .flex()
             .items_start()
@@ -591,16 +602,13 @@ impl ObjectBrowserDocument {
         }
 
         match &self.versions {
-            ObjectVersionsState::Loading => Text::caption("Loading…")
-                .muted_foreground()
-                .into_any_element(),
+            ObjectVersionsState::Loading => Text::caption(dbflux_i18n::t!(
+                "document.object_browser.preview.versions.loading"
+            ))
+            .muted_foreground()
+            .into_any_element(),
             ObjectVersionsState::Loaded(versions) => {
-                let word = if versions.len() == 1 {
-                    "version"
-                } else {
-                    "versions"
-                };
-                Text::code(format!("{} {word}", versions.len())).into_any_element()
+                Text::code(object_browser_versions_count_label(versions.len())).into_any_element()
             }
             ObjectVersionsState::Error(message) => {
                 Text::caption(message.clone()).danger().into_any_element()
@@ -620,7 +628,12 @@ impl ObjectBrowserDocument {
                     .on_click(cx.listener(move |this, _, _, cx| {
                         this.load_object_versions(key.clone(), cx);
                     }))
-                    .child(Text::caption("View versions").primary())
+                    .child(
+                        Text::caption(dbflux_i18n::t!(
+                            "document.object_browser.preview.versions.view"
+                        ))
+                        .primary(),
+                    )
                     .into_any_element()
             }
         }
@@ -698,7 +711,7 @@ impl ObjectBrowserDocument {
             .child(self.preview_action_button(
                 "object-browser-download",
                 AppIcon::Download,
-                "Download",
+                dbflux_i18n::t!("document.object_browser.preview.action.download"),
                 false,
                 {
                     let key = key.to_string();
@@ -709,7 +722,7 @@ impl ObjectBrowserDocument {
             .child(self.preview_action_button(
                 "object-browser-open-externally",
                 AppIcon::ExternalLink,
-                "Open",
+                dbflux_i18n::t!("document.object_browser.preview.action.open"),
                 false,
                 {
                     let key = key.to_string();
@@ -720,7 +733,7 @@ impl ObjectBrowserDocument {
             .child(self.preview_action_button(
                 "object-browser-copy-uri",
                 AppIcon::Copy,
-                "Copy URI",
+                dbflux_i18n::t!("document.object_browser.preview.action.copy_uri"),
                 false,
                 {
                     let key = key.to_string();
@@ -731,7 +744,7 @@ impl ObjectBrowserDocument {
             .child(self.preview_action_button(
                 "object-browser-presign",
                 AppIcon::Link2,
-                "Presign",
+                dbflux_i18n::t!("document.object_browser.preview.action.presign"),
                 false,
                 {
                     let key = key.to_string();
@@ -744,7 +757,7 @@ impl ObjectBrowserDocument {
             .child(self.preview_action_button(
                 "object-browser-delete",
                 AppIcon::Delete,
-                "Delete",
+                dbflux_i18n::t!("document.object_browser.preview.action.delete"),
                 true,
                 {
                     let key = key.to_string();
@@ -760,7 +773,7 @@ impl ObjectBrowserDocument {
         &self,
         id: &'static str,
         icon: AppIcon,
-        label: &'static str,
+        label: impl Into<SharedString>,
         destructive: bool,
         on_activate: impl Fn(&mut Self, &mut Context<Self>) + 'static,
         cx: &mut Context<Self>,

--- a/crates/dbflux_ui_document/src/object_browser/render.rs
+++ b/crates/dbflux_ui_document/src/object_browser/render.rs
@@ -11,6 +11,7 @@ use super::tree::{ObjectTreeEntry, ObjectTreeNodeId, PrefixLoadState};
 use super::{ListingRow, ObjectBrowserDocument, ObjectBrowserFocusMode, VisibleRow};
 use crate::buckets_table::format_bytes;
 use crate::handle::DocumentEvent;
+use crate::labels::object_browser_status_summary;
 use crate::types::DocumentState;
 use dbflux_components::controls::Input;
 use dbflux_components::icons::AppIcon;
@@ -107,13 +108,7 @@ pub(super) fn summary_line(rows: &[VisibleRow]) -> String {
         })
         .sum();
 
-    let folder_word = if folders == 1 { "folder" } else { "folders" };
-    let object_word = if objects == 1 { "object" } else { "objects" };
-
-    format!(
-        "{folders} {folder_word} · {objects} {object_word} · {}",
-        format_bytes(total_bytes)
-    )
+    object_browser_status_summary(folders, objects, total_bytes)
 }
 
 impl ObjectBrowserDocument {
@@ -209,35 +204,32 @@ impl ObjectBrowserDocument {
         // Ghost buttons: no border, background only on hover — and, for the
         // toggles among them, a tinted background while active, the same way
         // the result-view switcher marks its current mode.
-        let action_button = |id: &'static str,
-                             icon: AppIcon,
-                             label: &'static str,
-                             active: bool,
-                             cx: &Context<Self>| {
-            let theme = cx.theme();
+        let action_button =
+            |id: &'static str, icon: AppIcon, label: String, active: bool, cx: &Context<Self>| {
+                let theme = cx.theme();
 
-            div()
-                .id(id)
-                .flex()
-                .items_center()
-                .gap(Spacing::XS)
-                .h(Heights::CONTROL)
-                .px(Spacing::SM)
-                .rounded(Radii::SM)
-                .cursor_pointer()
-                .when(active, |d| d.bg(theme.primary))
-                .when(!active, |d| d.hover(|d| d.bg(theme.secondary)))
-                .child(if active {
-                    Icon::new(icon).small().color(theme.primary_foreground)
-                } else {
-                    Icon::new(icon).small().muted()
-                })
-                .child(if active {
-                    Text::caption(label).color(theme.primary_foreground)
-                } else {
-                    Text::caption(label)
-                })
-        };
+                div()
+                    .id(id)
+                    .flex()
+                    .items_center()
+                    .gap(Spacing::XS)
+                    .h(Heights::CONTROL)
+                    .px(Spacing::SM)
+                    .rounded(Radii::SM)
+                    .cursor_pointer()
+                    .when(active, |d| d.bg(theme.primary))
+                    .when(!active, |d| d.hover(|d| d.bg(theme.secondary)))
+                    .child(if active {
+                        Icon::new(icon).small().color(theme.primary_foreground)
+                    } else {
+                        Icon::new(icon).small().muted()
+                    })
+                    .child(if active {
+                        Text::caption(label).color(theme.primary_foreground)
+                    } else {
+                        Text::caption(label)
+                    })
+            };
 
         div()
             .flex()
@@ -285,7 +277,7 @@ impl ObjectBrowserDocument {
                         action_button(
                             "object-browser-tree-mode",
                             AppIcon::Layers,
-                            "Tree",
+                            dbflux_i18n::t!("document.object_browser.toolbar.tree"),
                             tree_mode_on,
                             cx,
                         )
@@ -297,7 +289,7 @@ impl ObjectBrowserDocument {
                         action_button(
                             "object-browser-upload",
                             AppIcon::ArrowUp,
-                            "Upload",
+                            dbflux_i18n::t!("document.object_browser.toolbar.upload"),
                             false,
                             cx,
                         )
@@ -309,7 +301,7 @@ impl ObjectBrowserDocument {
                         action_button(
                             "object-browser-new-folder",
                             AppIcon::Folder,
-                            "New folder",
+                            dbflux_i18n::t!("document.object_browser.toolbar.new_folder"),
                             false,
                             cx,
                         )
@@ -325,7 +317,7 @@ impl ObjectBrowserDocument {
                             } else {
                                 AppIcon::RefreshCcw
                             },
-                            "Refresh",
+                            dbflux_i18n::t!("document.object_browser.toolbar.refresh"),
                             false,
                             cx,
                         )
@@ -348,20 +340,24 @@ impl ObjectBrowserDocument {
             .border_b_1()
             .border_color(theme.border)
             .bg(theme.secondary)
-            .child(div().flex_1().child(Text::caption("Key")))
+            .child(div().flex_1().child(Text::caption(dbflux_i18n::t!(
+                "document.object_browser.columns.key"
+            ))))
             .child(
                 div()
                     .w(SIZE_WIDTH)
                     .flex()
                     .justify_end()
-                    .child(Text::caption("Size")),
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.object_browser.columns.size"
+                    ))),
             )
-            .child(div().w(CLASS_WIDTH).child(Text::caption("Class")))
-            .child(
-                div()
-                    .w(MODIFIED_WIDTH)
-                    .child(Text::caption("Last modified")),
-            )
+            .child(div().w(CLASS_WIDTH).child(Text::caption(dbflux_i18n::t!(
+                "document.object_browser.columns.class"
+            ))))
+            .child(div().w(MODIFIED_WIDTH).child(Text::caption(dbflux_i18n::t!(
+                "document.object_browser.columns.last_modified"
+            ))))
     }
 
     pub(super) fn render_storage_class(
@@ -622,9 +618,9 @@ impl ObjectBrowserDocument {
                 .muted(),
             )
             .child(Text::caption(if loading {
-                "Loading more…"
+                dbflux_i18n::t!("document.object_browser.status.loading_more")
             } else {
-                "Load more"
+                dbflux_i18n::t!("document.object_browser.status.load_more")
             }))
     }
 
@@ -667,23 +663,25 @@ impl ObjectBrowserDocument {
                         this.reload_current_prefix(cx);
                     }))
                     .child(Icon::new(AppIcon::RefreshCcw).small().muted())
-                    .child(Text::caption("Retry")),
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.object_browser.status.retry"
+                    ))),
             )
     }
 
     fn render_empty_state(&self, loading: bool) -> AnyElement {
         let message = if loading {
-            "Loading objects…".to_string()
+            dbflux_i18n::t!("document.object_browser.empty.loading")
         } else if self
             .tree
             .level(&self.tree.current_prefix)
             .is_some_and(|level| !level.filter.trim().is_empty())
         {
-            "No keys match this filter".to_string()
+            dbflux_i18n::t!("document.object_browser.empty.filtered")
         } else if self.tree.current_prefix.is_empty() {
-            "This bucket is empty".to_string()
+            dbflux_i18n::t!("document.object_browser.empty.bucket")
         } else {
-            "This prefix is empty".to_string()
+            dbflux_i18n::t!("document.object_browser.empty.prefix")
         };
 
         div()
@@ -726,7 +724,12 @@ impl ObjectBrowserDocument {
                             .child(Text::caption(summary_line(rows))),
                     )
                     .when(tree_mode_on, |this| {
-                        this.child(Text::caption("tree mode").muted_foreground())
+                        this.child(
+                            Text::caption(dbflux_i18n::t!(
+                                "document.object_browser.status.tree_mode"
+                            ))
+                            .muted_foreground(),
+                        )
                     }),
             )
             .child(
@@ -734,12 +737,24 @@ impl ObjectBrowserDocument {
                     .flex()
                     .items_center()
                     .gap(Spacing::MD)
-                    .child(Text::key_hint("Enter open"))
-                    .child(Text::key_hint("Space preview"))
-                    .child(Text::key_hint("← up a level"))
-                    .child(Text::key_hint("/ filter"))
-                    .child(Text::key_hint("x delete"))
-                    .child(Text::key_hint("r rename")),
+                    .child(Text::key_hint(dbflux_i18n::t!(
+                        "document.object_browser.status.key_hint.open"
+                    )))
+                    .child(Text::key_hint(dbflux_i18n::t!(
+                        "document.object_browser.status.key_hint.preview"
+                    )))
+                    .child(Text::key_hint(dbflux_i18n::t!(
+                        "document.object_browser.status.key_hint.up"
+                    )))
+                    .child(Text::key_hint(dbflux_i18n::t!(
+                        "document.object_browser.status.key_hint.filter"
+                    )))
+                    .child(Text::key_hint(dbflux_i18n::t!(
+                        "document.object_browser.status.key_hint.delete"
+                    )))
+                    .child(Text::key_hint(dbflux_i18n::t!(
+                        "document.object_browser.status.key_hint.rename"
+                    ))),
             )
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 19: the object browser chrome (toolbar, columns, empty states, status line), the preview pane and the preview gate messages render through `dbflux_i18n::t!` under `document.object_browser.*`. English and Spanish together. Bucket, object keys, prefixes and sizes stay data.

## What does this resolve?

- Refs #360 (follows 18; next: object browser errors and the presign modal)

## How was this solved?

- `preview_gate_message` in labels.rs maps `PreviewGate` exhaustively so the size note carries `%{size}` instead of a formatted string.
- Size: 620 lines (`size:exception`), single object-browser boundary.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1010 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a bucket, preview a text object and one over the preview size gate.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
