### PR TITLE
feat(i18n): translate object browser errors, preview content messages, and the presign modal

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -767,6 +767,9 @@ document:
       filtered: No keys match this filter
       loading: "Loading objects…"
       prefix: This prefix is empty
+    error:
+      api_unavailable: Object-store API unavailable
+      connection_unavailable: Connection is no longer active
     gate:
       archived: "This object is archived and cannot be previewed. Restore it in your S3 console to access its contents."
       too_large: "This object is %{size} and exceeds the %{limit} preview limit. Download it to inspect its contents."
@@ -780,6 +783,30 @@ document:
       size: Size
       storage_class: Storage class
       versions: Versions
+    presign:
+      title: Presigned URL
+      method_field_label: Method
+      expiry_field_label: Expires in
+      signing: "Signing URL…"
+      close: Close
+      copy_url: Copy URL
+      copied_toast: Copied presigned URL to clipboard
+      signing_identity_fallback: this connection
+      method:
+        get: GET download
+        put: PUT upload
+      expiry:
+        fifteen_minutes: 15 min
+        one_hour: 1 hour
+        twelve_hours: 12 hours
+        seven_days: 7 days
+      warning:
+        capability:
+          get: download this object
+          put: overwrite this object
+        until_instant: "until %{instant}"
+        until_it_expires: until it expires
+        body: 'Anyone holding this URL can %{capability} %{expiry}. It is signed with the credentials of "%{signed_by}" and carries their permissions.'
     preview:
       action:
         copy_uri: Copy URI
@@ -789,8 +816,12 @@ document:
         presign: Presign
       body:
         fit_to_width: Fit to width
+        image_decode_error: "Could not decode the image: %{error}"
+        image_header_error: "Could not read the image header: %{error}"
         loading: "Loading preview…"
         loading_metadata: "Loading metadata…"
+        svg_invalid_utf8: "This object is not valid UTF-8, so it cannot be an SVG."
+        svg_missing_root: "This object does not contain an <svg> root element."
         unpreviewable:
           generic: "This file type has no in-app preview. Download this object or open it in your system viewer."
           pdf: "PDFs are not rendered in-app. Download this object or open it in your system viewer."

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -767,6 +767,9 @@ document:
       filtered: Ninguna clave coincide con este filtro
       loading: "Cargando objetos…"
       prefix: Este prefijo está vacío
+    error:
+      api_unavailable: La API de almacenamiento de objetos no está disponible
+      connection_unavailable: La conexión ya no está activa
     gate:
       archived: "Este objeto está archivado y no se puede previsualizar. Restáuralo en tu consola de S3 para acceder a su contenido."
       too_large: "Este objeto pesa %{size} y supera el límite de %{limit} para la vista previa. Descárgalo para inspeccionar su contenido."
@@ -780,6 +783,30 @@ document:
       size: Tamaño
       storage_class: Clase de almacenamiento
       versions: Versiones
+    presign:
+      title: URL prefirmada
+      method_field_label: Método
+      expiry_field_label: Expira en
+      signing: "Firmando URL…"
+      close: Cerrar
+      copy_url: Copiar URL
+      copied_toast: URL prefirmada copiada al portapapeles
+      signing_identity_fallback: esta conexión
+      method:
+        get: Descarga GET
+        put: Carga PUT
+      expiry:
+        fifteen_minutes: 15 min
+        one_hour: 1 hora
+        twelve_hours: 12 horas
+        seven_days: 7 días
+      warning:
+        capability:
+          get: descargar este objeto
+          put: sobrescribir este objeto
+        until_instant: "hasta %{instant}"
+        until_it_expires: hasta que expire
+        body: 'Cualquiera que tenga esta URL puede %{capability} %{expiry}. Está firmada con las credenciales de "%{signed_by}" y conlleva sus permisos.'
     preview:
       action:
         copy_uri: Copiar URI
@@ -789,8 +816,12 @@ document:
         presign: Prefirmar
       body:
         fit_to_width: Ajustar al ancho
+        image_decode_error: "No se pudo decodificar la imagen: %{error}"
+        image_header_error: "No se pudo leer el encabezado de la imagen: %{error}"
         loading: "Cargando vista previa…"
         loading_metadata: "Cargando metadatos…"
+        svg_invalid_utf8: "Este objeto no es UTF-8 válido, por lo que no puede ser un SVG."
+        svg_missing_root: "Este objeto no contiene un elemento raíz <svg>."
         unpreviewable:
           generic: "Este tipo de archivo no tiene vista previa en la aplicación. Descarga este objeto o ábrelo en tu visor del sistema."
           pdf: "Los PDF no se renderizan en la aplicación. Descarga este objeto o ábrelo en tu visor del sistema."

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1132,6 +1132,60 @@ pub(crate) fn object_browser_versions_count_label(count: usize) -> String {
     }
 }
 
+/// Error shown in the preview pane when a fetched image's bytes fail the
+/// header-guess probe before any decode is attempted. `cause` is the
+/// underlying decoder error and is interpolated verbatim, never translated.
+pub(crate) fn image_header_error(cause: &str) -> String {
+    dbflux_i18n::t!(
+        "document.object_browser.preview.body.image_header_error",
+        error = cause
+    )
+}
+
+/// Error shown in the preview pane when a fetched image's bytes have a
+/// recognised header but fail to fully decode. `cause` is the underlying
+/// decoder error and is interpolated verbatim, never translated.
+pub(crate) fn image_decode_error(cause: &str) -> String {
+    dbflux_i18n::t!(
+        "document.object_browser.preview.body.image_decode_error",
+        error = cause
+    )
+}
+
+/// Segment label for a [`crate::object_browser::PresignMethodChoice`].
+/// Exhaustive by construction so a new method fails this crate's build until
+/// its catalog key is added here.
+pub(crate) fn presign_method_label(choice: crate::object_browser::PresignMethodChoice) -> String {
+    use crate::object_browser::PresignMethodChoice;
+
+    match choice {
+        PresignMethodChoice::Get => dbflux_i18n::t!("document.object_browser.presign.method.get"),
+        PresignMethodChoice::Put => dbflux_i18n::t!("document.object_browser.presign.method.put"),
+    }
+}
+
+/// Segment label for a [`crate::object_browser::PresignExpiry`].
+/// Exhaustive by construction so a new expiry choice fails this crate's
+/// build until its catalog key is added here.
+pub(crate) fn presign_expiry_label(expiry: crate::object_browser::PresignExpiry) -> String {
+    use crate::object_browser::PresignExpiry;
+
+    match expiry {
+        PresignExpiry::FifteenMinutes => {
+            dbflux_i18n::t!("document.object_browser.presign.expiry.fifteen_minutes")
+        }
+        PresignExpiry::OneHour => {
+            dbflux_i18n::t!("document.object_browser.presign.expiry.one_hour")
+        }
+        PresignExpiry::TwelveHours => {
+            dbflux_i18n::t!("document.object_browser.presign.expiry.twelve_hours")
+        }
+        PresignExpiry::SevenDays => {
+            dbflux_i18n::t!("document.object_browser.presign.expiry.seven_days")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1142,15 +1196,16 @@ mod tests {
         chart_dock_shape_label, chart_rail_why_text, code_toolbar_shortcut_hint_label,
         comparator_label, copy_query_language_label, dangerous_query_body, dangerous_query_title,
         delete_confirm_copy, delete_rows_label, execution_count_state_label, execution_mode_label,
-        history_items_count_label, history_tab_label, incomplete_aggregate_rows_label,
-        join_kind_label, live_output_lines_label, live_output_truncated_label,
-        object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
-        pending_change_count_label, pending_edits_summary, preview_gate_message,
+        history_items_count_label, history_tab_label, image_decode_error, image_header_error,
+        incomplete_aggregate_rows_label, join_kind_label, live_output_lines_label,
+        live_output_truncated_label, object_browser_status_summary,
+        object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
+        pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
         refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
         script_confirm_message_label, sort_direction_label, table_action_description,
         unsaved_changes_label, update_columns_label, valid_lines_label,
     };
-    use crate::object_browser::PreviewGate;
+    use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
     use crate::schema_diff::apply::TableLevelAction;
     use dbflux_components::chart::ChartDetection;
     use dbflux_core::{
@@ -2757,6 +2812,12 @@ mod tests {
             "document.object_browser.metadata.storage_class",
             "document.object_browser.metadata.encryption",
             "document.object_browser.metadata.versions",
+            "document.object_browser.error.connection_unavailable",
+            "document.object_browser.error.api_unavailable",
+            "document.object_browser.preview.body.svg_invalid_utf8",
+            "document.object_browser.preview.body.svg_missing_root",
+            "document.object_browser.preview.body.image_header_error",
+            "document.object_browser.preview.body.image_decode_error",
         ];
 
         for key in keys {
@@ -2821,6 +2882,154 @@ mod tests {
         let archived_es = dbflux_i18n::t!("document.object_browser.gate.archived", locale = "es");
 
         assert_ne!(archived_en, archived_es);
+    }
+
+    /// T19: the "connection dropped" and "no object-store API" fallbacks
+    /// used across the object browser's background loaders translate and
+    /// diverge between locales.
+    #[test]
+    fn object_browser_error_keys_differ_between_locales() {
+        let connection_en = dbflux_i18n::t!(
+            "document.object_browser.error.connection_unavailable",
+            locale = "en"
+        );
+        let connection_es = dbflux_i18n::t!(
+            "document.object_browser.error.connection_unavailable",
+            locale = "es"
+        );
+        assert_ne!(connection_en, connection_es);
+
+        let api_en = dbflux_i18n::t!(
+            "document.object_browser.error.api_unavailable",
+            locale = "en"
+        );
+        let api_es = dbflux_i18n::t!(
+            "document.object_browser.error.api_unavailable",
+            locale = "es"
+        );
+        assert_ne!(api_en, api_es);
+    }
+
+    /// T19: the SVG body-validation refusals translate and diverge between
+    /// locales.
+    #[test]
+    fn object_browser_svg_validation_keys_differ_between_locales() {
+        let utf8_en = dbflux_i18n::t!(
+            "document.object_browser.preview.body.svg_invalid_utf8",
+            locale = "en"
+        );
+        let utf8_es = dbflux_i18n::t!(
+            "document.object_browser.preview.body.svg_invalid_utf8",
+            locale = "es"
+        );
+        assert_ne!(utf8_en, utf8_es);
+
+        let root_en = dbflux_i18n::t!(
+            "document.object_browser.preview.body.svg_missing_root",
+            locale = "en"
+        );
+        let root_es = dbflux_i18n::t!(
+            "document.object_browser.preview.body.svg_missing_root",
+            locale = "es"
+        );
+        assert_ne!(root_en, root_es);
+    }
+
+    /// T19: the image decode-failure helpers interpolate the underlying
+    /// decoder cause verbatim into the translated prefix.
+    #[test]
+    fn image_error_helpers_interpolate_the_cause() {
+        let header = image_header_error("truncated header");
+        assert!(header.contains("truncated header"));
+        assert_ne!(header, "truncated header");
+
+        let decode = image_decode_error("unsupported color type");
+        assert!(decode.contains("unsupported color type"));
+        assert_ne!(decode, "unsupported color type");
+    }
+
+    /// T19: every `PresignMethodChoice` variant has a translated segment
+    /// label, and no variant resolves to an empty or key-fallback string.
+    #[test]
+    fn presign_method_label_covers_all_variants() {
+        for choice in PresignMethodChoice::all() {
+            let label = presign_method_label(choice);
+            assert!(!label.is_empty(), "{choice:?} resolved empty");
+        }
+
+        assert_ne!(
+            presign_method_label(PresignMethodChoice::Get),
+            presign_method_label(PresignMethodChoice::Put)
+        );
+    }
+
+    /// T19: every `PresignExpiry` variant has a translated segment label.
+    #[test]
+    fn presign_expiry_label_covers_all_variants() {
+        for expiry in PresignExpiry::all() {
+            let label = presign_expiry_label(expiry);
+            assert!(!label.is_empty(), "{expiry:?} resolved empty");
+        }
+    }
+
+    /// T19: the presign method/expiry labels translate and diverge between
+    /// locales.
+    #[test]
+    fn presign_method_and_expiry_keys_differ_between_locales() {
+        let get_en = dbflux_i18n::t!("document.object_browser.presign.method.get", locale = "en");
+        let get_es = dbflux_i18n::t!("document.object_browser.presign.method.get", locale = "es");
+        assert_ne!(get_en, get_es);
+
+        let one_hour_en = dbflux_i18n::t!(
+            "document.object_browser.presign.expiry.one_hour",
+            locale = "en"
+        );
+        let one_hour_es = dbflux_i18n::t!(
+            "document.object_browser.presign.expiry.one_hour",
+            locale = "es"
+        );
+        assert_ne!(one_hour_en, one_hour_es);
+    }
+
+    /// T19: every `document.object_browser.presign.*` key resolves in both
+    /// locales.
+    #[test]
+    fn presign_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.object_browser.presign.title",
+            "document.object_browser.presign.method_field_label",
+            "document.object_browser.presign.expiry_field_label",
+            "document.object_browser.presign.signing",
+            "document.object_browser.presign.close",
+            "document.object_browser.presign.copy_url",
+            "document.object_browser.presign.copied_toast",
+            "document.object_browser.presign.signing_identity_fallback",
+            "document.object_browser.presign.method.get",
+            "document.object_browser.presign.method.put",
+            "document.object_browser.presign.expiry.fifteen_minutes",
+            "document.object_browser.presign.expiry.one_hour",
+            "document.object_browser.presign.expiry.twelve_hours",
+            "document.object_browser.presign.expiry.seven_days",
+            "document.object_browser.presign.warning.capability.get",
+            "document.object_browser.presign.warning.capability.put",
+            "document.object_browser.presign.warning.until_instant",
+            "document.object_browser.presign.warning.until_it_expires",
+            "document.object_browser.presign.warning.body",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
     }
 
     /// T19: the footer summary covers the singular/plural boundary

--- a/crates/dbflux_ui_document/src/object_browser/data.rs
+++ b/crates/dbflux_ui_document/src/object_browser/data.rs
@@ -86,10 +86,14 @@ impl ObjectBrowserDocument {
         cx.notify();
 
         let Some(connection) = self.get_connection(cx) else {
-            self.tree
-                .apply_error(&prefix, "Connection is no longer active".to_string());
+            self.tree.apply_error(
+                &prefix,
+                dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
+            );
             self.state = DocumentState::Error;
-            self.last_error = Some("Connection is no longer active".to_string());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.object_browser.error.connection_unavailable"
+            ));
             cx.notify();
             return;
         };
@@ -105,9 +109,9 @@ impl ObjectBrowserDocument {
                 Some(api) => {
                     api.list_objects(&bucket, &prefix_for_task, continuation_token.as_deref())
                 }
-                None => Err(DbError::NotSupported(
-                    "Object-store API unavailable".to_string(),
-                )),
+                None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))),
             };
 
             (result, started.elapsed().as_millis())
@@ -168,9 +172,9 @@ impl ObjectBrowserDocument {
         self.metadata = Some(ObjectMetadataState::Loading);
 
         let Some(connection) = self.get_connection(cx) else {
-            self.metadata = Some(ObjectMetadataState::Error(
-                "Connection is no longer active".to_string(),
-            ));
+            self.metadata = Some(ObjectMetadataState::Error(dbflux_i18n::t!(
+                "document.object_browser.error.connection_unavailable"
+            )));
             cx.notify();
             return;
         };
@@ -184,9 +188,9 @@ impl ObjectBrowserDocument {
 
             let result = match connection.object_store_api() {
                 Some(api) => api.head_object(&bucket, &key_for_task),
-                None => Err(DbError::NotSupported(
-                    "Object-store API unavailable".to_string(),
-                )),
+                None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))),
             };
 
             (result, started.elapsed().as_millis())
@@ -291,8 +295,9 @@ impl ObjectBrowserDocument {
         self.preview_content = PreviewContentState::Loading;
 
         let Some(connection) = self.get_connection(cx) else {
-            self.preview_content =
-                PreviewContentState::Failed("Connection is no longer active".to_string());
+            self.preview_content = PreviewContentState::Failed(dbflux_i18n::t!(
+                "document.object_browser.error.connection_unavailable"
+            ));
             cx.notify();
             return;
         };
@@ -306,9 +311,9 @@ impl ObjectBrowserDocument {
 
             let bytes = match connection.object_store_api() {
                 Some(api) => api.get_object(&bucket, &key_for_task),
-                None => Err(DbError::NotSupported(
-                    "Object-store API unavailable".to_string(),
-                )),
+                None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))),
             };
 
             let elapsed_millis = started.elapsed().as_millis();
@@ -384,8 +389,9 @@ impl ObjectBrowserDocument {
         self.preview_content = PreviewContentState::Loading;
 
         let Some(connection) = self.get_connection(cx) else {
-            self.preview_content =
-                PreviewContentState::Failed("Connection is no longer active".to_string());
+            self.preview_content = PreviewContentState::Failed(dbflux_i18n::t!(
+                "document.object_browser.error.connection_unavailable"
+            ));
             cx.notify();
             return;
         };
@@ -399,9 +405,9 @@ impl ObjectBrowserDocument {
 
             let bytes = match connection.object_store_api() {
                 Some(api) => api.get_object(&bucket, &key_for_task),
-                None => Err(DbError::NotSupported(
-                    "Object-store API unavailable".to_string(),
-                )),
+                None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))),
             };
 
             let elapsed_millis = started.elapsed().as_millis();
@@ -507,8 +513,9 @@ impl ObjectBrowserDocument {
         self.bucket_details = BucketDetailsState::Loading;
 
         let Some(connection) = self.get_connection(cx) else {
-            self.bucket_details =
-                BucketDetailsState::Error("Connection is no longer active".to_string());
+            self.bucket_details = BucketDetailsState::Error(dbflux_i18n::t!(
+                "document.object_browser.error.connection_unavailable"
+            ));
             return;
         };
 
@@ -518,9 +525,9 @@ impl ObjectBrowserDocument {
         let task = cx.background_executor().spawn(async move {
             match connection.object_store_api() {
                 Some(api) => api.get_bucket_details(&bucket),
-                None => Err(DbError::NotSupported(
-                    "Object-store API unavailable".to_string(),
-                )),
+                None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))),
             }
         });
 
@@ -551,8 +558,9 @@ impl ObjectBrowserDocument {
         cx.notify();
 
         let Some(connection) = self.get_connection(cx) else {
-            self.versions =
-                ObjectVersionsState::Error("Connection is no longer active".to_string());
+            self.versions = ObjectVersionsState::Error(dbflux_i18n::t!(
+                "document.object_browser.error.connection_unavailable"
+            ));
             cx.notify();
             return;
         };
@@ -564,9 +572,9 @@ impl ObjectBrowserDocument {
         let task = cx.background_executor().spawn(async move {
             match connection.object_store_api() {
                 Some(api) => api.list_object_versions(&bucket, &key_for_task),
-                None => Err(DbError::NotSupported(
-                    "Object-store API unavailable".to_string(),
-                )),
+                None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))),
             }
         });
 

--- a/crates/dbflux_ui_document/src/object_browser/presign.rs
+++ b/crates/dbflux_ui_document/src/object_browser/presign.rs
@@ -41,6 +41,14 @@ impl PresignMethodChoice {
         }
     }
 
+    /// Stable English token for audit summaries; never localized.
+    pub fn audit_label(self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Put => "PUT",
+        }
+    }
+
     pub fn method(self) -> PresignMethod {
         match self {
             Self::Get => PresignMethod::Get,
@@ -55,11 +63,8 @@ impl PresignMethodChoice {
         }
     }
 
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Get => "GET download",
-            Self::Put => "PUT upload",
-        }
+    pub fn label(self) -> String {
+        crate::labels::presign_method_label(self)
     }
 
     pub fn from_id(id: &str) -> Option<Self> {
@@ -95,13 +100,8 @@ impl PresignExpiry {
         }
     }
 
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::FifteenMinutes => "15 min",
-            Self::OneHour => "1 hour",
-            Self::TwelveHours => "12 hours",
-            Self::SevenDays => "7 days",
-        }
+    pub fn label(self) -> String {
+        crate::labels::presign_expiry_label(self)
     }
 
     pub fn from_id(id: &str) -> Option<Self> {
@@ -151,17 +151,27 @@ pub(super) fn presign_warning(
     signed_by: &str,
 ) -> String {
     let capability = match method {
-        PresignMethod::Get => "download this object",
-        PresignMethod::Put => "overwrite this object",
+        PresignMethod::Get => {
+            dbflux_i18n::t!("document.object_browser.presign.warning.capability.get")
+        }
+        PresignMethod::Put => {
+            dbflux_i18n::t!("document.object_browser.presign.warning.capability.put")
+        }
     };
 
     let expiry = match expires_at {
-        Some(at) => format!("until {}", at.format("%Y-%m-%d %H:%M UTC")),
-        None => "until it expires".to_string(),
+        Some(at) => dbflux_i18n::t!(
+            "document.object_browser.presign.warning.until_instant",
+            instant = at.format("%Y-%m-%d %H:%M UTC")
+        ),
+        None => dbflux_i18n::t!("document.object_browser.presign.warning.until_it_expires"),
     };
 
-    format!(
-        "Anyone holding this URL can {capability} {expiry}. It is signed with the credentials of \"{signed_by}\" and carries their permissions."
+    dbflux_i18n::t!(
+        "document.object_browser.presign.warning.body",
+        capability = capability,
+        expiry = expiry,
+        signed_by = signed_by
     )
 }
 
@@ -234,15 +244,12 @@ impl ObjectBrowserDocument {
         cx.notify();
 
         let Some(connection) = self.get_connection(cx) else {
+            let message = dbflux_i18n::t!("document.object_browser.error.connection_unavailable");
             report_error(
-                UserFacingError::new(ErrorKind::Storage, "Connection is no longer active"),
+                UserFacingError::new(ErrorKind::Storage, message.clone()),
                 cx,
             );
-            self.apply_presigned_url(
-                generation,
-                Err("Connection is no longer active".to_string()),
-                cx,
-            );
+            self.apply_presigned_url(generation, Err(message), cx);
             return;
         };
 
@@ -259,7 +266,9 @@ impl ObjectBrowserDocument {
                     let key = key.clone();
                     async move {
                         let api = connection.object_store_api().ok_or_else(|| {
-                            DbError::NotSupported("Object-store API unavailable".to_string())
+                            DbError::NotSupported(dbflux_i18n::t!(
+                                "document.object_browser.error.api_unavailable"
+                            ))
                         })?;
                         api.presign(&bucket, &key, method, expiry.duration())
                     }
@@ -331,9 +340,11 @@ impl ObjectBrowserDocument {
         };
 
         cx.write_to_clipboard(ClipboardItem::new_string(url));
-        Toast::success("Copied presigned URL to clipboard")
-            .meta_right(now_hms())
-            .push(cx);
+        Toast::success(dbflux_i18n::t!(
+            "document.object_browser.presign.copied_toast"
+        ))
+        .meta_right(now_hms())
+        .push(cx);
     }
 
     /// Name the URL is signed as, shown in the warning line.
@@ -343,7 +354,9 @@ impl ObjectBrowserDocument {
             .connections()
             .get(&self.profile_id)
             .map(|connected| connected.profile.name.clone())
-            .unwrap_or_else(|| "this connection".to_string())
+            .unwrap_or_else(|| {
+                dbflux_i18n::t!("document.object_browser.presign.signing_identity_fallback")
+            })
     }
 
     pub(super) fn render_presign_modal(
@@ -411,7 +424,9 @@ impl ObjectBrowserDocument {
                 .items_center()
                 .gap(Spacing::SM)
                 .child(Icon::new(AppIcon::Loader).small().muted())
-                .child(Text::caption("Signing URL…"))
+                .child(Text::caption(dbflux_i18n::t!(
+                    "document.object_browser.presign.signing"
+                )))
                 .into_any_element(),
             PresignUrlState::Ready(url) => Text::code(url.clone())
                 .muted_foreground()
@@ -435,7 +450,9 @@ impl ObjectBrowserDocument {
                     .items_center()
                     .justify_between()
                     .gap(Spacing::MD)
-                    .child(Text::caption("Method"))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.object_browser.presign.method_field_label"
+                    )))
                     .child(method_control),
             )
             .child(
@@ -444,7 +461,9 @@ impl ObjectBrowserDocument {
                     .items_center()
                     .justify_between()
                     .gap(Spacing::MD)
-                    .child(Text::caption("Expires in"))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.object_browser.presign.expiry_field_label"
+                    )))
                     .child(expiry_control),
             )
             .child(
@@ -493,7 +512,12 @@ impl ObjectBrowserDocument {
                             .on_click(cx.listener(|this, _, _, cx| {
                                 this.close_presign(cx);
                             }))
-                            .child(Text::caption("Close").color(theme.foreground)),
+                            .child(
+                                Text::caption(dbflux_i18n::t!(
+                                    "document.object_browser.presign.close"
+                                ))
+                                .color(theme.foreground),
+                            ),
                     )
                     .child(
                         div()
@@ -515,12 +539,17 @@ impl ObjectBrowserDocument {
                                     .size(Heights::ICON_SM)
                                     .color(theme.primary_foreground),
                             )
-                            .child(Text::caption("Copy URL").color(theme.primary_foreground)),
+                            .child(
+                                Text::caption(dbflux_i18n::t!(
+                                    "document.object_browser.presign.copy_url"
+                                ))
+                                .color(theme.primary_foreground),
+                            ),
                     ),
             );
 
         ModalFrame::new("object-browser-presign-modal", &self.focus_handle, close)
-            .title("Presigned URL")
+            .title(dbflux_i18n::t!("document.object_browser.presign.title"))
             .icon(AppIcon::Link2)
             .width(px(560.0))
             .max_height(px(460.0))
@@ -555,11 +584,11 @@ fn build_presign_audit_event(
         None => (EventSeverity::Info, EventOutcome::Success, "object_presign"),
     };
 
-    let method_label = PresignMethodChoice::from_method(method).label();
+    let method_label = PresignMethodChoice::from_method(method).audit_label();
 
     let mut summary = format!(
         "Presigned {method_label} URL for s3://{bucket}/{key} ({})",
-        expiry.label()
+        expiry.id()
     );
     if let Some(error) = error {
         summary.push_str(&format!(": {error}"));

--- a/crates/dbflux_ui_document/src/object_browser/preview_content.rs
+++ b/crates/dbflux_ui_document/src/object_browser/preview_content.rs
@@ -171,11 +171,11 @@ pub fn format_label(format: ImageFormat) -> &'static str {
 pub fn decode_image_dimensions(bytes: &[u8]) -> Result<(u32, u32), String> {
     let reader = image::ImageReader::new(std::io::Cursor::new(bytes))
         .with_guessed_format()
-        .map_err(|e| format!("Could not read the image header: {e}"))?;
+        .map_err(|e| crate::labels::image_header_error(&e.to_string()))?;
 
     let decoded = reader
         .decode()
-        .map_err(|e| format!("Could not decode the image: {e}"))?;
+        .map_err(|e| crate::labels::image_decode_error(&e.to_string()))?;
 
     Ok((decoded.width(), decoded.height()))
 }
@@ -185,12 +185,14 @@ pub fn decode_image_dimensions(bytes: &[u8]) -> Result<(u32, u32), String> {
 /// broken body has to be caught here to reach the decode-failure fallback.
 pub fn validate_svg_body(bytes: &[u8]) -> Result<(), String> {
     let text = std::str::from_utf8(bytes)
-        .map_err(|_| "This object is not valid UTF-8, so it cannot be an SVG.".to_string())?;
+        .map_err(|_| dbflux_i18n::t!("document.object_browser.preview.body.svg_invalid_utf8"))?;
 
     if text.to_ascii_lowercase().contains("<svg") {
         Ok(())
     } else {
-        Err("This object does not contain an <svg> root element.".to_string())
+        Err(dbflux_i18n::t!(
+            "document.object_browser.preview.body.svg_missing_root"
+        ))
     }
 }
 
@@ -272,11 +274,44 @@ mod tests {
         assert!(super::validate_svg_body(&[0xFF, 0xFE, 0x00]).is_err());
     }
 
+    /// T19: the SVG body-validation refusals route through the catalog
+    /// instead of hardcoding the English prose.
+    #[test]
+    fn svg_body_validation_errors_are_translated() {
+        assert_eq!(
+            super::validate_svg_body(&[0xFF, 0xFE, 0x00]).unwrap_err(),
+            dbflux_i18n::t!("document.object_browser.preview.body.svg_invalid_utf8")
+        );
+        assert_eq!(
+            super::validate_svg_body(b"<html></html>").unwrap_err(),
+            dbflux_i18n::t!("document.object_browser.preview.body.svg_missing_root")
+        );
+    }
+
     /// T29: garbage bytes are rejected by the decode probe instead of reaching
     /// the renderer as an empty image.
     #[test]
     fn decode_rejects_bytes_that_are_not_an_image() {
         assert!(decode_image_dimensions(b"not an image at all").is_err());
+    }
+
+    /// T19: garbage bytes with a guessable-but-wrong header fail the decode
+    /// step, and the resulting error routes through the translated
+    /// `image_decode_error` helper rather than a hardcoded English prefix,
+    /// with the underlying decoder cause interpolated verbatim.
+    #[test]
+    fn decode_failure_is_translated() {
+        let bytes: &[u8] = b"not an image at all";
+        let underlying = image::ImageReader::new(std::io::Cursor::new(bytes))
+            .with_guessed_format()
+            .expect("heuristic format guess still succeeds on this input")
+            .decode()
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+            .unwrap_err();
+
+        let message = decode_image_dimensions(bytes).unwrap_err();
+        assert_eq!(message, crate::labels::image_decode_error(&underlying));
     }
 
     /// T29: a real image reports its pixel size, which the meta strip shows


### PR DESCRIPTION
## Summary

Document i18n slice 19b: object browser errors, preview content messages (binary, image, too large) and the presign URL modal (method, expiry, copy, toasts) render through `dbflux_i18n::t!`. English and Spanish together. The audit summary keeps English tokens through `PresignMethodChoice::audit_label()`.

## What does this resolve?

- Refs #360 (follows 19; next: rename, create folder and delete modals)

## How was this solved?

- `presign_method_label` / `presign_expiry_label` and the `image_*` helpers live in labels.rs; audit payloads never receive translated labels.
- Size: 499 lines (`size:exception`), one file boundary.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1014 passed; clippy clean; fmt clean. Manual smoke in Spanish: generate a presigned URL, open an image and a binary object.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
