### PR TITLE
feat(i18n): translate the object browser rename, create folder, and delete modals

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -762,6 +762,31 @@ document:
       key: Key
       last_modified: Last modified
       size: Size
+    create_folder:
+      cancel: Cancel
+      confirm: Create
+      confirm_in_progress: "Creating…"
+      created_toast: "Created folder %{uri}"
+      hint: 'Created as a zero-byte key ending in "/"'
+      location: "in %{uri}"
+      name_placeholder: folder-name
+      title: New folder
+      error:
+        consecutive_slashes: Folder name cannot contain consecutive slashes.
+        empty: Folder name cannot be empty.
+        leading_trailing_slash: Folder name cannot start or end with a slash.
+    delete:
+      body: '"%{key}" (%{size}) will be removed. This cannot be undone.'
+      cancel: Cancel
+      confirm: Delete
+      deleted_toast: "Deleted %{uri}"
+      title: Delete object?
+      unknown_size: unknown size
+    delete_prefix:
+      versioning_note: "This bucket has versioning enabled — deleted objects become delete markers, not permanently removed."
+      deleted_toast:
+        one: "Deleted %{count} object under %{uri}"
+        many: "Deleted %{count} objects under %{uri}"
     empty:
       bucket: This bucket is empty
       filtered: No keys match this filter
@@ -834,6 +859,17 @@ document:
           many: "%{count} versions"
         loading: "Loading…"
         view: View versions
+    rename:
+      cancel: Cancel
+      confirm: Rename
+      confirm_in_progress: "Renaming…"
+      name_placeholder: object-name
+      renamed_toast: "Renamed to %{uri}"
+      title: Rename object
+      error:
+        contains_slash: "Name cannot contain a slash — rename stays in the same folder."
+        empty: Name cannot be empty.
+        unchanged: New name must differ from the current name.
     status:
       folders:
         one: "%{count} folder"

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -762,6 +762,31 @@ document:
       key: Clave
       last_modified: Última modificación
       size: Tamaño
+    create_folder:
+      cancel: Cancelar
+      confirm: Crear
+      confirm_in_progress: "Creando…"
+      created_toast: "Carpeta creada en %{uri}"
+      hint: 'Se crea como una clave de cero bytes terminada en "/"'
+      location: "en %{uri}"
+      name_placeholder: nombre-carpeta
+      title: Nueva carpeta
+      error:
+        consecutive_slashes: El nombre de la carpeta no puede contener barras consecutivas.
+        empty: El nombre de la carpeta no puede estar vacío.
+        leading_trailing_slash: El nombre de la carpeta no puede empezar ni terminar con una barra.
+    delete:
+      body: '"%{key}" (%{size}) se eliminará. Esta acción no se puede deshacer.'
+      cancel: Cancelar
+      confirm: Eliminar
+      deleted_toast: "Eliminado %{uri}"
+      title: "¿Eliminar objeto?"
+      unknown_size: tamaño desconocido
+    delete_prefix:
+      versioning_note: "Este bucket tiene el versionado habilitado: los objetos eliminados se convierten en marcadores de eliminación, no se eliminan de forma permanente."
+      deleted_toast:
+        one: "Se eliminó %{count} objeto bajo %{uri}"
+        many: "Se eliminaron %{count} objetos bajo %{uri}"
     empty:
       bucket: Este bucket está vacío
       filtered: Ninguna clave coincide con este filtro
@@ -834,6 +859,17 @@ document:
           many: "%{count} versiones"
         loading: "Cargando…"
         view: Ver versiones
+    rename:
+      cancel: Cancelar
+      confirm: Renombrar
+      confirm_in_progress: "Renombrando…"
+      name_placeholder: nombre-objeto
+      renamed_toast: "Renombrado a %{uri}"
+      title: Renombrar objeto
+      error:
+        contains_slash: "El nombre no puede contener una barra: el cambio de nombre permanece en la misma carpeta."
+        empty: El nombre no puede estar vacío.
+        unchanged: El nuevo nombre debe ser diferente del nombre actual.
     status:
       folders:
         one: "%{count} carpeta"

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1186,6 +1186,25 @@ pub(crate) fn presign_expiry_label(expiry: crate::object_browser::PresignExpiry)
     }
 }
 
+/// Toast text for a completed recursive-prefix delete, with the deleted
+/// object count interpolated. The target URI is S3 data and stays outside
+/// the catalog.
+pub(crate) fn delete_prefix_deleted_toast(count: u64, uri: &str) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "document.object_browser.delete_prefix.deleted_toast.one",
+            count = count,
+            uri = uri
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.object_browser.delete_prefix.deleted_toast.many",
+            count = count,
+            uri = uri
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1195,15 +1214,16 @@ mod tests {
         bool_op_label, builder_mode_label, bulk_delete_success_label, chart_degraded_copy,
         chart_dock_shape_label, chart_rail_why_text, code_toolbar_shortcut_hint_label,
         comparator_label, copy_query_language_label, dangerous_query_body, dangerous_query_title,
-        delete_confirm_copy, delete_rows_label, execution_count_state_label, execution_mode_label,
-        history_items_count_label, history_tab_label, image_decode_error, image_header_error,
-        incomplete_aggregate_rows_label, join_kind_label, live_output_lines_label,
-        live_output_truncated_label, object_browser_status_summary,
-        object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
-        pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
-        refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
-        script_confirm_message_label, sort_direction_label, table_action_description,
-        unsaved_changes_label, update_columns_label, valid_lines_label,
+        delete_confirm_copy, delete_prefix_deleted_toast, delete_rows_label,
+        execution_count_state_label, execution_mode_label, history_items_count_label,
+        history_tab_label, image_decode_error, image_header_error, incomplete_aggregate_rows_label,
+        join_kind_label, live_output_lines_label, live_output_truncated_label,
+        object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
+        pending_change_count_label, pending_edits_summary, presign_expiry_label,
+        presign_method_label, preview_gate_message, refresh_policy_label, result_tab_count_label,
+        row_count_label, schema_change_description, script_confirm_message_label,
+        sort_direction_label, table_action_description, unsaved_changes_label,
+        update_columns_label, valid_lines_label,
     };
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
     use crate::schema_diff::apply::TableLevelAction;
@@ -3056,5 +3076,88 @@ mod tests {
     fn object_browser_versions_count_label_covers_singular_and_plural() {
         assert_eq!(object_browser_versions_count_label(1), "1 version");
         assert_eq!(object_browser_versions_count_label(3), "3 versions");
+    }
+
+    /// T20a: every `document.object_browser.{rename,create_folder,delete,
+    /// delete_prefix}.*` key resolves in both locales.
+    #[test]
+    fn object_browser_modal_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.object_browser.create_folder.title",
+            "document.object_browser.create_folder.name_placeholder",
+            "document.object_browser.create_folder.location",
+            "document.object_browser.create_folder.hint",
+            "document.object_browser.create_folder.cancel",
+            "document.object_browser.create_folder.confirm",
+            "document.object_browser.create_folder.confirm_in_progress",
+            "document.object_browser.create_folder.created_toast",
+            "document.object_browser.create_folder.error.empty",
+            "document.object_browser.create_folder.error.leading_trailing_slash",
+            "document.object_browser.create_folder.error.consecutive_slashes",
+            "document.object_browser.delete.title",
+            "document.object_browser.delete.body",
+            "document.object_browser.delete.unknown_size",
+            "document.object_browser.delete.cancel",
+            "document.object_browser.delete.confirm",
+            "document.object_browser.delete.deleted_toast",
+            "document.object_browser.delete_prefix.versioning_note",
+            "document.object_browser.delete_prefix.deleted_toast.one",
+            "document.object_browser.delete_prefix.deleted_toast.many",
+            "document.object_browser.rename.title",
+            "document.object_browser.rename.name_placeholder",
+            "document.object_browser.rename.cancel",
+            "document.object_browser.rename.confirm",
+            "document.object_browser.rename.confirm_in_progress",
+            "document.object_browser.rename.renamed_toast",
+            "document.object_browser.rename.error.empty",
+            "document.object_browser.rename.error.contains_slash",
+            "document.object_browser.rename.error.unchanged",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// T20a: the single-object delete title and the rename title translate
+    /// to their exact wording and diverge between locales.
+    #[test]
+    fn object_browser_modal_titles_have_exact_translated_text() {
+        assert_eq!(
+            dbflux_i18n::t!("document.object_browser.delete.title", locale = "en"),
+            "Delete object?"
+        );
+        assert_eq!(
+            dbflux_i18n::t!("document.object_browser.delete.title", locale = "es"),
+            "¿Eliminar objeto?"
+        );
+        assert_ne!(
+            dbflux_i18n::t!("document.object_browser.rename.title", locale = "en"),
+            dbflux_i18n::t!("document.object_browser.rename.title", locale = "es")
+        );
+    }
+
+    /// T20a: the recursive-delete toast uses the singular catalog bucket
+    /// only for exactly one deleted object.
+    #[test]
+    fn delete_prefix_deleted_toast_covers_singular_and_plural() {
+        assert_eq!(
+            delete_prefix_deleted_toast(1, "s3://my-bucket/logs/"),
+            "Deleted 1 object under s3://my-bucket/logs/"
+        );
+        assert_eq!(
+            delete_prefix_deleted_toast(4, "s3://my-bucket/logs/"),
+            "Deleted 4 objects under s3://my-bucket/logs/"
+        );
     }
 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -3083,6 +3083,8 @@ mod tests {
     #[test]
     fn object_browser_modal_keys_resolve_in_both_locales() {
         let keys = [
+            "document.object_browser.error.connection_unavailable",
+            "document.object_browser.error.api_unavailable",
             "document.object_browser.create_folder.title",
             "document.object_browser.create_folder.name_placeholder",
             "document.object_browser.create_folder.location",

--- a/crates/dbflux_ui_document/src/object_browser/create_folder.rs
+++ b/crates/dbflux_ui_document/src/object_browser/create_folder.rs
@@ -28,15 +28,21 @@ use uuid::Uuid;
 /// prefix, so any nesting must be typed as separate creates.
 pub fn folder_name_error(name: &str) -> Option<String> {
     if name.is_empty() {
-        return Some("Folder name cannot be empty.".to_string());
+        return Some(dbflux_i18n::t!(
+            "document.object_browser.create_folder.error.empty"
+        ));
     }
 
     if name.starts_with('/') || name.ends_with('/') {
-        return Some("Folder name cannot start or end with a slash.".to_string());
+        return Some(dbflux_i18n::t!(
+            "document.object_browser.create_folder.error.leading_trailing_slash"
+        ));
     }
 
     if name.contains("//") {
-        return Some("Folder name cannot contain consecutive slashes.".to_string());
+        return Some(dbflux_i18n::t!(
+            "document.object_browser.create_folder.error.consecutive_slashes"
+        ));
     }
 
     None
@@ -67,7 +73,11 @@ impl ObjectBrowserDocument {
             return;
         }
 
-        let name_input = cx.new(|cx| InputState::new(window, cx).placeholder("folder-name"));
+        let name_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.object_browser.create_folder.name_placeholder"
+            ))
+        });
 
         let subscription =
             cx.subscribe(
@@ -132,11 +142,12 @@ impl ObjectBrowserDocument {
         cx.notify();
 
         let Some(connection) = self.get_connection(cx) else {
+            let message = dbflux_i18n::t!("document.object_browser.error.connection_unavailable");
             report_error(
-                UserFacingError::new(ErrorKind::Storage, "Connection is no longer active"),
+                UserFacingError::new(ErrorKind::Storage, message.clone()),
                 cx,
             );
-            self.apply_folder_created(key, Err("Connection is no longer active".to_string()), cx);
+            self.apply_folder_created(key, Err(message), cx);
             return;
         };
 
@@ -154,7 +165,9 @@ impl ObjectBrowserDocument {
                     let key = key_for_task.clone();
                     async move {
                         let api = connection.object_store_api().ok_or_else(|| {
-                            DbError::NotSupported("Object-store API unavailable".to_string())
+                            DbError::NotSupported(dbflux_i18n::t!(
+                                "document.object_browser.error.api_unavailable"
+                            ))
                         })?;
                         api.put_object(&bucket, &key, Vec::new(), None)
                     }
@@ -204,9 +217,12 @@ impl ObjectBrowserDocument {
                     .unwrap_or_else(|| self.tree.current_prefix.clone());
 
                 self.new_folder = None;
-                Toast::success(format!("Created folder s3://{}/{key}", self.bucket))
-                    .meta_right(now_hms())
-                    .push(cx);
+                Toast::success(dbflux_i18n::t!(
+                    "document.object_browser.create_folder.created_toast",
+                    uri = format!("s3://{}/{key}", self.bucket)
+                ))
+                .meta_right(now_hms())
+                .push(cx);
                 self.reload_prefix(parent, cx);
             }
             Err(message) => {
@@ -244,11 +260,16 @@ impl ObjectBrowserDocument {
                     .items_center()
                     .gap(Spacing::SM)
                     .child(Icon::new(AppIcon::Folder).size(Heights::ICON_MD).muted())
-                    .child(Text::heading("New folder")),
+                    .child(Text::heading(dbflux_i18n::t!(
+                        "document.object_browser.create_folder.title"
+                    ))),
             )
             .child(
-                Text::caption(format!("in s3://{}/{}", self.bucket, state.parent))
-                    .muted_foreground(),
+                Text::caption(dbflux_i18n::t!(
+                    "document.object_browser.create_folder.location",
+                    uri = format!("s3://{}/{}", self.bucket, state.parent)
+                ))
+                .muted_foreground(),
             )
             .child(
                 div()
@@ -258,8 +279,10 @@ impl ObjectBrowserDocument {
                     .child(Input::new(&state.name_input).small().w_full())
                     .child(match &name_error {
                         Some(error) => Text::caption(error.clone()).danger(),
-                        None => Text::caption("Created as a zero-byte key ending in \"/\"")
-                            .muted_foreground(),
+                        None => Text::caption(dbflux_i18n::t!(
+                            "document.object_browser.create_folder.hint"
+                        ))
+                        .muted_foreground(),
                     }),
             );
 
@@ -286,7 +309,9 @@ impl ObjectBrowserDocument {
                         .on_click(cx.listener(|this, _, _, cx| {
                             this.close_new_folder(cx);
                         }))
-                        .child(Text::caption("Cancel")),
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "document.object_browser.create_folder.cancel"
+                        ))),
                 )
                 .child(
                     div()
@@ -312,14 +337,14 @@ impl ObjectBrowserDocument {
                             .size(Heights::ICON_SM)
                             .color(theme.primary_foreground),
                         )
-                        .child(
-                            Text::caption(if state.submitting {
-                                "Creating…"
+                        .child({
+                            let key = if state.submitting {
+                                "document.object_browser.create_folder.confirm_in_progress"
                             } else {
-                                "Create"
-                            })
-                            .color(theme.primary_foreground),
-                        ),
+                                "document.object_browser.create_folder.confirm"
+                            };
+                            Text::caption(dbflux_i18n::t!(key)).color(theme.primary_foreground)
+                        }),
                 ),
         );
 

--- a/crates/dbflux_ui_document/src/object_browser/delete.rs
+++ b/crates/dbflux_ui_document/src/object_browser/delete.rs
@@ -109,7 +109,10 @@ impl ObjectBrowserDocument {
 
         let Some(connection) = self.get_connection(cx) else {
             report_error(
-                UserFacingError::new(ErrorKind::Storage, "Connection is no longer active"),
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
+                ),
                 cx,
             );
             return;
@@ -129,7 +132,9 @@ impl ObjectBrowserDocument {
                     let key = key.clone();
                     async move {
                         let api = connection.object_store_api().ok_or_else(|| {
-                            DbError::NotSupported("Object-store API unavailable".to_string())
+                            DbError::NotSupported(dbflux_i18n::t!(
+                                "document.object_browser.error.api_unavailable"
+                            ))
                         })?;
                         api.delete_object(&bucket, &key)
                     }
@@ -147,9 +152,12 @@ impl ObjectBrowserDocument {
             match &result {
                 Ok(()) => {
                     cx.update(|cx| {
-                        Toast::success(format!("Deleted s3://{bucket}/{key}"))
-                            .meta_right(now_hms())
-                            .push(cx);
+                        Toast::success(dbflux_i18n::t!(
+                            "document.object_browser.delete.deleted_toast",
+                            uri = format!("s3://{bucket}/{key}")
+                        ))
+                        .meta_right(now_hms())
+                        .push(cx);
                     })
                     .ok();
                 }
@@ -183,7 +191,7 @@ impl ObjectBrowserDocument {
         let size_label = pending
             .size_bytes
             .map(crate::buckets_table::format_bytes)
-            .unwrap_or_else(|| "unknown size".to_string());
+            .unwrap_or_else(|| dbflux_i18n::t!("document.object_browser.delete.unknown_size"));
 
         div()
             .id("object-browser-delete-overlay")
@@ -214,11 +222,14 @@ impl ObjectBrowserDocument {
                                     .size(Heights::ICON_MD)
                                     .warning(),
                             )
-                            .child(Text::heading("Delete object?")),
+                            .child(Text::heading(dbflux_i18n::t!(
+                                "document.object_browser.delete.title"
+                            ))),
                     )
-                    .child(Text::muted(format!(
-                        "\"{}\" ({size_label}) will be removed. This cannot be undone.",
-                        pending.key
+                    .child(Text::muted(dbflux_i18n::t!(
+                        "document.object_browser.delete.body",
+                        key = pending.key.as_str(),
+                        size = size_label.as_str()
                     )))
                     .child(
                         div()
@@ -239,7 +250,9 @@ impl ObjectBrowserDocument {
                                     .on_click(cx.listener(|this, _, _, cx| {
                                         this.cancel_delete_object(cx);
                                     }))
-                                    .child(Text::caption("Cancel")),
+                                    .child(Text::caption(dbflux_i18n::t!(
+                                        "document.object_browser.delete.cancel"
+                                    ))),
                             )
                             .child(
                                 div()
@@ -261,7 +274,12 @@ impl ObjectBrowserDocument {
                                             .size(Heights::ICON_SM)
                                             .color(theme.background),
                                     )
-                                    .child(Text::caption("Delete").color(theme.background)),
+                                    .child(
+                                        Text::caption(dbflux_i18n::t!(
+                                            "document.object_browser.delete.confirm"
+                                        ))
+                                        .color(theme.background),
+                                    ),
                             ),
                     ),
             )

--- a/crates/dbflux_ui_document/src/object_browser/delete_prefix.rs
+++ b/crates/dbflux_ui_document/src/object_browser/delete_prefix.rs
@@ -193,9 +193,7 @@ impl DeletePrefixConfirmState {
 fn versioning_note(versioning: Option<VersioningStatus>) -> Option<String> {
     match versioning {
         Some(VersioningStatus::Enabled) | Some(VersioningStatus::Suspended) => Some(
-            "This bucket has versioning enabled — deleted objects become delete markers, \
-             not permanently removed."
-                .to_string(),
+            dbflux_i18n::t!("document.object_browser.delete_prefix.versioning_note"),
         ),
         _ => None,
     }
@@ -222,7 +220,10 @@ impl ObjectBrowserDocument {
         cx.notify();
 
         let Some(connection) = self.get_connection(cx) else {
-            self.mark_probe_error(generation, "Connection is no longer active".to_string());
+            self.mark_probe_error(
+                generation,
+                dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
+            );
             cx.notify();
             return;
         };
@@ -262,9 +263,9 @@ impl ObjectBrowserDocument {
                                 &prefix_for_call,
                                 token.as_deref(),
                             ),
-                            None => Err(DbError::NotSupported(
-                                "Object-store API unavailable".to_string(),
-                            )),
+                            None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                                "document.object_browser.error.api_unavailable"
+                            ))),
                         }
                     })
                     .await;
@@ -358,7 +359,10 @@ impl ObjectBrowserDocument {
 
         let Some(connection) = self.get_connection(cx) else {
             report_error(
-                UserFacingError::new(ErrorKind::Storage, "Connection is no longer active"),
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
+                ),
                 cx,
             );
             return;
@@ -377,7 +381,9 @@ impl ObjectBrowserDocument {
                     let target = target.clone();
                     async move {
                         let api = connection.object_store_api().ok_or_else(|| {
-                            DbError::NotSupported("Object-store API unavailable".to_string())
+                            DbError::NotSupported(dbflux_i18n::t!(
+                                "document.object_browser.error.api_unavailable"
+                            ))
                         })?;
                         api.delete_prefix(&bucket, &target)
                     }
@@ -396,14 +402,9 @@ impl ObjectBrowserDocument {
             match &result {
                 Ok(outcome) => {
                     cx.update(|cx| {
-                        let word = if outcome.deleted_count == 1 {
-                            "object"
-                        } else {
-                            "objects"
-                        };
-                        Toast::success(format!(
-                            "Deleted {} {word} under s3://{bucket}/{target}",
-                            outcome.deleted_count
+                        Toast::success(crate::labels::delete_prefix_deleted_toast(
+                            outcome.deleted_count,
+                            &format!("s3://{bucket}/{target}"),
                         ))
                         .meta_right(now_hms())
                         .push(cx);

--- a/crates/dbflux_ui_document/src/object_browser/rename.rs
+++ b/crates/dbflux_ui_document/src/object_browser/rename.rs
@@ -44,15 +44,21 @@ pub(super) fn key_leaf(key: &str) -> String {
 /// the current leaf name.
 pub fn rename_name_error(current_leaf: &str, new_name: &str) -> Option<String> {
     if new_name.is_empty() {
-        return Some("Name cannot be empty.".to_string());
+        return Some(dbflux_i18n::t!(
+            "document.object_browser.rename.error.empty"
+        ));
     }
 
     if new_name.contains('/') {
-        return Some("Name cannot contain a slash — rename stays in the same folder.".to_string());
+        return Some(dbflux_i18n::t!(
+            "document.object_browser.rename.error.contains_slash"
+        ));
     }
 
     if new_name == current_leaf {
-        return Some("New name must differ from the current name.".to_string());
+        return Some(dbflux_i18n::t!(
+            "document.object_browser.rename.error.unchanged"
+        ));
     }
 
     None
@@ -97,7 +103,9 @@ impl ObjectBrowserDocument {
         let leaf = key_leaf(&key);
 
         let name_input = cx.new(|cx| {
-            let mut state = InputState::new(window, cx).placeholder("object-name");
+            let mut state = InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.object_browser.rename.name_placeholder"
+            ));
             state.set_value(&leaf, window, cx);
             state
         });
@@ -166,16 +174,12 @@ impl ObjectBrowserDocument {
         cx.notify();
 
         let Some(connection) = self.get_connection(cx) else {
+            let message = dbflux_i18n::t!("document.object_browser.error.connection_unavailable");
             report_error(
-                UserFacingError::new(ErrorKind::Storage, "Connection is no longer active"),
+                UserFacingError::new(ErrorKind::Storage, message.clone()),
                 cx,
             );
-            self.apply_rename_outcome(
-                source_key,
-                new_key,
-                Err("Connection is no longer active".to_string()),
-                cx,
-            );
+            self.apply_rename_outcome(source_key, new_key, Err(message), cx);
             return;
         };
 
@@ -194,7 +198,9 @@ impl ObjectBrowserDocument {
                     let new_key = new_key.clone();
                     async move {
                         let api = connection.object_store_api().ok_or_else(|| {
-                            DbError::NotSupported("Object-store API unavailable".to_string())
+                            DbError::NotSupported(dbflux_i18n::t!(
+                                "document.object_browser.error.api_unavailable"
+                            ))
                         })?;
                         api.copy_object(&bucket, &source_key, &new_key)
                     }
@@ -231,7 +237,9 @@ impl ObjectBrowserDocument {
                     let source_key = source_key.clone();
                     async move {
                         let api = connection.object_store_api().ok_or_else(|| {
-                            DbError::NotSupported("Object-store API unavailable".to_string())
+                            DbError::NotSupported(dbflux_i18n::t!(
+                                "document.object_browser.error.api_unavailable"
+                            ))
                         })?;
                         api.delete_object(&bucket, &source_key)
                     }
@@ -279,9 +287,12 @@ impl ObjectBrowserDocument {
         match result {
             Ok(()) => {
                 self.rename_object = None;
-                Toast::success(format!("Renamed to s3://{}/{new_key}", self.bucket))
-                    .meta_right(now_hms())
-                    .push(cx);
+                Toast::success(dbflux_i18n::t!(
+                    "document.object_browser.rename.renamed_toast",
+                    uri = format!("s3://{}/{new_key}", self.bucket)
+                ))
+                .meta_right(now_hms())
+                .push(cx);
 
                 if self.preview_key.as_deref() == Some(source_key.as_str()) {
                     self.open_preview_now(new_key.clone(), cx);
@@ -326,7 +337,9 @@ impl ObjectBrowserDocument {
                     .items_center()
                     .gap(Spacing::SM)
                     .child(Icon::new(AppIcon::Pencil).size(Heights::ICON_MD).muted())
-                    .child(Text::heading("Rename object")),
+                    .child(Text::heading(dbflux_i18n::t!(
+                        "document.object_browser.rename.title"
+                    ))),
             )
             .child(Text::muted(format!("\"{}\"", state.key)))
             .child(
@@ -363,7 +376,9 @@ impl ObjectBrowserDocument {
                         .on_click(cx.listener(|this, _, _, cx| {
                             this.close_rename_object(cx);
                         }))
-                        .child(Text::caption("Cancel")),
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "document.object_browser.rename.cancel"
+                        ))),
                 )
                 .child(
                     div()
@@ -389,14 +404,14 @@ impl ObjectBrowserDocument {
                             .size(Heights::ICON_SM)
                             .color(theme.primary_foreground),
                         )
-                        .child(
-                            Text::caption(if state.submitting {
-                                "Renaming…"
+                        .child({
+                            let key = if state.submitting {
+                                "document.object_browser.rename.confirm_in_progress"
                             } else {
-                                "Rename"
-                            })
-                            .color(theme.primary_foreground),
-                        ),
+                                "document.object_browser.rename.confirm"
+                            };
+                            Text::caption(dbflux_i18n::t!(key)).color(theme.primary_foreground)
+                        }),
                 ),
         );
 


### PR DESCRIPTION
## Summary

Document i18n slice 20a: the object browser rename, create folder, delete and delete-prefix toasts (titles, fields, validation messages, buttons, toasts) render through `dbflux_i18n::t!` under `document.object_browser.{rename,create_folder,delete,delete_prefix}.*`. English and Spanish together. Ten stray `Connection is no longer active` / `Object-store API unavailable` literals now reuse the existing error keys.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `delete_prefix_deleted_toast(count, uri)` carries the `.one/.many` split.
- Size: 406 lines, marginally over the guard (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1020 passed; clippy clean; fmt clean. Manual smoke in Spanish: rename an object, create a folder, delete an object and a prefix.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
