### PR TITLE
feat(i18n): translate the object browser context menu, editor, upload, transfer, and delete-prefix modal

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -762,6 +762,20 @@ document:
       key: Key
       last_modified: Last modified
       size: Size
+    context_menu:
+      item:
+        preview: Preview
+        open_in_editor: Open in editor
+        download: Download
+        rename: Rename
+        presign: Presign
+        copy_uri: Copy S3 URI
+        delete: Delete
+        collapse: Collapse
+        expand: Expand
+        open: Open
+        new_folder_inside: New folder inside
+        delete_folder: Delete folder
     create_folder:
       cancel: Cancel
       confirm: Create
@@ -787,6 +801,45 @@ document:
       deleted_toast:
         one: "Deleted %{count} object under %{uri}"
         many: "Deleted %{count} objects under %{uri}"
+    delete_prefix_modal:
+      title: Delete folder — recursive
+      body_intro: Everything under this path will be deleted.
+      counting: "Counting objects…"
+      counting_progress: "Counting… %{totals} so far (%{pages} pages)"
+      cancelled: "%{totals} counted before cancelling"
+      capped: "at least %{totals} (stopped at %{pages} pages)"
+      error: "Could not count objects: %{error}"
+      cancel_probe: Stop counting
+      first_keys_label: First keys affected
+      remaining_keys: "… %{count} more"
+      confirm_hint: 'Type "%{phrase}" to confirm'
+      batched_caption: "DeleteObjects · batched ×1000"
+      cancel: Cancel
+      delete_button:
+        default: Delete objects
+        one: "Delete %{count} object"
+        many: "Delete %{count} objects"
+    editor:
+      nav:
+        open: "open %{key}"
+        leave_bucket_root: leave for the bucket root
+        leave_for: "leave for %{prefix}"
+        close_preview: close this preview
+        delete: "delete %{key}"
+        rename: "rename %{key}"
+      unsaved_summary: "Unsaved edits to %{key}"
+      toast:
+        saved: "Saved %{uri}"
+      footer:
+        saving: "Saving…"
+        save: Save
+        discard: Discard
+        find: Find
+      dirty_badge: modified
+      unsaved_confirm:
+        title: Unsaved edits
+        body: '"%{key}" has unsaved edits. Save them before you %{action}?'
+        cancel: Cancel
     empty:
       bucket: This bucket is empty
       filtered: No keys match this filter
@@ -893,6 +946,26 @@ document:
       refresh: Refresh
       tree: Tree
       upload: Upload
+    transfer:
+      dialog_title: Save Object As
+      dialog_filter_all_files: All Files
+      error:
+        fallback_dir_failed: "File dialog unavailable and the fallback directory could not be created: %{error}"
+      toast:
+        saved: "Saved %{name} (%{size}) to %{path}"
+        opened: "Opened %{name} in the system viewer"
+        no_handler: "No system handler could be started for %{name}; it was saved to %{path}"
+    upload:
+      dialog_title: Upload Objects
+      error:
+        no_file_picker: No file picker is available on this platform
+      toast:
+        uploaded:
+          one: "Uploaded %{count} object to %{uri}"
+          many: "Uploaded %{count} objects to %{uri}"
+        failed_suffix:
+          one: " (%{count} failed upload)"
+          many: " (%{count} failed uploads)"
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -762,6 +762,20 @@ document:
       key: Clave
       last_modified: Última modificación
       size: Tamaño
+    context_menu:
+      item:
+        preview: Vista previa
+        open_in_editor: Abrir en el editor
+        download: Descargar
+        rename: Renombrar
+        presign: Prefirmar
+        copy_uri: Copiar URI de S3
+        delete: Eliminar
+        collapse: Colapsar
+        expand: Expandir
+        open: Abrir
+        new_folder_inside: Nueva carpeta dentro
+        delete_folder: Eliminar carpeta
     create_folder:
       cancel: Cancelar
       confirm: Crear
@@ -787,6 +801,45 @@ document:
       deleted_toast:
         one: "Se eliminó %{count} objeto bajo %{uri}"
         many: "Se eliminaron %{count} objetos bajo %{uri}"
+    delete_prefix_modal:
+      title: Eliminar carpeta — recursivo
+      body_intro: Todo lo que esté bajo esta ruta se eliminará.
+      counting: "Contando objetos…"
+      counting_progress: "Contando… %{totals} hasta ahora (%{pages} páginas)"
+      cancelled: "%{totals} contados antes de cancelar"
+      capped: "al menos %{totals} (detenido en %{pages} páginas)"
+      error: "No se pudieron contar los objetos: %{error}"
+      cancel_probe: Detener el conteo
+      first_keys_label: Primeras claves afectadas
+      remaining_keys: "… %{count} más"
+      confirm_hint: 'Escribe "%{phrase}" para confirmar'
+      batched_caption: "DeleteObjects · en lotes de ×1000"
+      cancel: Cancelar
+      delete_button:
+        default: Eliminar objetos
+        one: "Eliminar %{count} objeto"
+        many: "Eliminar %{count} objetos"
+    editor:
+      nav:
+        open: "abrir %{key}"
+        leave_bucket_root: salir hacia la raíz del bucket
+        leave_for: "salir hacia %{prefix}"
+        close_preview: cerrar esta vista previa
+        delete: "eliminar %{key}"
+        rename: "renombrar %{key}"
+      unsaved_summary: "Cambios sin guardar en %{key}"
+      toast:
+        saved: "Guardado %{uri}"
+      footer:
+        saving: "Guardando…"
+        save: Guardar
+        discard: Descartar
+        find: Buscar
+      dirty_badge: modificado
+      unsaved_confirm:
+        title: Cambios sin guardar
+        body: '"%{key}" tiene cambios sin guardar. ¿Guardarlos antes de %{action}?'
+        cancel: Cancelar
     empty:
       bucket: Este bucket está vacío
       filtered: Ninguna clave coincide con este filtro
@@ -893,6 +946,26 @@ document:
       refresh: Actualizar
       tree: Árbol
       upload: Subir
+    transfer:
+      dialog_title: Guardar objeto como
+      dialog_filter_all_files: Todos los archivos
+      error:
+        fallback_dir_failed: "El selector de archivos no está disponible y no se pudo crear el directorio alternativo: %{error}"
+      toast:
+        saved: "Guardado %{name} (%{size}) en %{path}"
+        opened: "Se abrió %{name} en el visor del sistema"
+        no_handler: "No se pudo iniciar ningún controlador del sistema para %{name}; se guardó en %{path}"
+    upload:
+      dialog_title: Subir objetos
+      error:
+        no_file_picker: No hay un selector de archivos disponible en esta plataforma
+      toast:
+        uploaded:
+          one: "Se subió %{count} objeto a %{uri}"
+          many: "Se subieron %{count} objetos a %{uri}"
+        failed_suffix:
+          one: " (%{count} subida fallida)"
+          many: " (%{count} subidas fallidas)"
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1205,6 +1205,53 @@ pub(crate) fn delete_prefix_deleted_toast(count: u64, uri: &str) -> String {
     }
 }
 
+/// Object-count-and-size totals line for the recursive-delete modal's probe
+/// summary, shared between the running and settled states. The byte total is
+/// S3 data and stays outside the catalog.
+///
+/// Uses the singular catalog bucket only for exactly one object; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn delete_prefix_probe_totals(object_count: u64, total_bytes: u64) -> String {
+    let objects_label = if object_count == 1 {
+        dbflux_i18n::t!(
+            "document.object_browser.status.objects.one",
+            count = object_count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.object_browser.status.objects.many",
+            count = object_count
+        )
+    };
+
+    format!(
+        "{objects_label} · {}",
+        crate::buckets_table::format_bytes(total_bytes)
+    )
+}
+
+/// Danger-button label for the recursive-delete modal, with the settled
+/// object count interpolated. `None` renders the generic label used while
+/// the probe is still counting.
+///
+/// Uses the singular catalog bucket only for exactly one object; every other
+/// count uses the plural bucket.
+pub(crate) fn delete_prefix_delete_button_label(object_count: Option<u64>) -> String {
+    match object_count {
+        Some(1) => dbflux_i18n::t!(
+            "document.object_browser.delete_prefix_modal.delete_button.one",
+            count = 1u64
+        ),
+        Some(count) => dbflux_i18n::t!(
+            "document.object_browser.delete_prefix_modal.delete_button.many",
+            count = count
+        ),
+        None => {
+            dbflux_i18n::t!("document.object_browser.delete_prefix_modal.delete_button.default")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1214,16 +1261,16 @@ mod tests {
         bool_op_label, builder_mode_label, bulk_delete_success_label, chart_degraded_copy,
         chart_dock_shape_label, chart_rail_why_text, code_toolbar_shortcut_hint_label,
         comparator_label, copy_query_language_label, dangerous_query_body, dangerous_query_title,
-        delete_confirm_copy, delete_prefix_deleted_toast, delete_rows_label,
-        execution_count_state_label, execution_mode_label, history_items_count_label,
-        history_tab_label, image_decode_error, image_header_error, incomplete_aggregate_rows_label,
-        join_kind_label, live_output_lines_label, live_output_truncated_label,
-        object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
-        pending_change_count_label, pending_edits_summary, presign_expiry_label,
-        presign_method_label, preview_gate_message, refresh_policy_label, result_tab_count_label,
-        row_count_label, schema_change_description, script_confirm_message_label,
-        sort_direction_label, table_action_description, unsaved_changes_label,
-        update_columns_label, valid_lines_label,
+        delete_confirm_copy, delete_prefix_delete_button_label, delete_prefix_deleted_toast,
+        delete_prefix_probe_totals, delete_rows_label, execution_count_state_label,
+        execution_mode_label, history_items_count_label, history_tab_label, image_decode_error,
+        image_header_error, incomplete_aggregate_rows_label, join_kind_label,
+        live_output_lines_label, live_output_truncated_label, object_browser_status_summary,
+        object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
+        pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
+        refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
+        script_confirm_message_label, sort_direction_label, table_action_description,
+        unsaved_changes_label, update_columns_label, valid_lines_label,
     };
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
     use crate::schema_diff::apply::TableLevelAction;
@@ -3160,6 +3207,122 @@ mod tests {
         assert_eq!(
             delete_prefix_deleted_toast(4, "s3://my-bucket/logs/"),
             "Deleted 4 objects under s3://my-bucket/logs/"
+        );
+    }
+
+    /// T20b: the recursive-delete modal's probe totals reuse the shared
+    /// object-count buckets and stay in the singular for exactly one object.
+    #[test]
+    fn delete_prefix_probe_totals_covers_singular_and_plural() {
+        assert_eq!(delete_prefix_probe_totals(1, 1024), "1 object · 1.0 KiB");
+        assert_eq!(delete_prefix_probe_totals(2, 2048), "2 objects · 2.0 KiB");
+    }
+
+    /// T20b: the danger button label distinguishes the still-counting state
+    /// from a settled singular/plural count.
+    #[test]
+    fn delete_prefix_delete_button_label_covers_default_singular_and_plural() {
+        assert_eq!(delete_prefix_delete_button_label(None), "Delete objects");
+        assert_eq!(
+            delete_prefix_delete_button_label(Some(1)),
+            "Delete 1 object"
+        );
+        assert_eq!(
+            delete_prefix_delete_button_label(Some(2)),
+            "Delete 2 objects"
+        );
+    }
+
+    /// T20b: every `document.object_browser.{delete_prefix_modal,upload,
+    /// transfer,context_menu,editor}.*` key resolves in both locales.
+    #[test]
+    fn object_browser_ops_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.object_browser.delete_prefix_modal.title",
+            "document.object_browser.delete_prefix_modal.body_intro",
+            "document.object_browser.delete_prefix_modal.counting",
+            "document.object_browser.delete_prefix_modal.counting_progress",
+            "document.object_browser.delete_prefix_modal.cancelled",
+            "document.object_browser.delete_prefix_modal.capped",
+            "document.object_browser.delete_prefix_modal.error",
+            "document.object_browser.delete_prefix_modal.cancel_probe",
+            "document.object_browser.delete_prefix_modal.first_keys_label",
+            "document.object_browser.delete_prefix_modal.remaining_keys",
+            "document.object_browser.delete_prefix_modal.confirm_hint",
+            "document.object_browser.delete_prefix_modal.batched_caption",
+            "document.object_browser.delete_prefix_modal.cancel",
+            "document.object_browser.delete_prefix_modal.delete_button.default",
+            "document.object_browser.delete_prefix_modal.delete_button.one",
+            "document.object_browser.delete_prefix_modal.delete_button.many",
+            "document.object_browser.upload.dialog_title",
+            "document.object_browser.upload.error.no_file_picker",
+            "document.object_browser.upload.toast.uploaded.one",
+            "document.object_browser.upload.toast.uploaded.many",
+            "document.object_browser.upload.toast.failed_suffix.one",
+            "document.object_browser.upload.toast.failed_suffix.many",
+            "document.object_browser.transfer.dialog_title",
+            "document.object_browser.transfer.dialog_filter_all_files",
+            "document.object_browser.transfer.error.fallback_dir_failed",
+            "document.object_browser.transfer.toast.saved",
+            "document.object_browser.transfer.toast.opened",
+            "document.object_browser.transfer.toast.no_handler",
+            "document.object_browser.context_menu.item.preview",
+            "document.object_browser.context_menu.item.open_in_editor",
+            "document.object_browser.context_menu.item.download",
+            "document.object_browser.context_menu.item.rename",
+            "document.object_browser.context_menu.item.presign",
+            "document.object_browser.context_menu.item.copy_uri",
+            "document.object_browser.context_menu.item.delete",
+            "document.object_browser.context_menu.item.collapse",
+            "document.object_browser.context_menu.item.expand",
+            "document.object_browser.context_menu.item.open",
+            "document.object_browser.context_menu.item.new_folder_inside",
+            "document.object_browser.context_menu.item.delete_folder",
+            "document.object_browser.editor.nav.open",
+            "document.object_browser.editor.nav.leave_bucket_root",
+            "document.object_browser.editor.nav.leave_for",
+            "document.object_browser.editor.nav.close_preview",
+            "document.object_browser.editor.nav.delete",
+            "document.object_browser.editor.nav.rename",
+            "document.object_browser.editor.unsaved_summary",
+            "document.object_browser.editor.toast.saved",
+            "document.object_browser.editor.footer.saving",
+            "document.object_browser.editor.footer.save",
+            "document.object_browser.editor.footer.discard",
+            "document.object_browser.editor.footer.find",
+            "document.object_browser.editor.dirty_badge",
+            "document.object_browser.editor.unsaved_confirm.title",
+            "document.object_browser.editor.unsaved_confirm.body",
+            "document.object_browser.editor.unsaved_confirm.cancel",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// T20b: the delete-prefix modal's title diverges between locales.
+    #[test]
+    fn delete_prefix_modal_title_differs_between_locales() {
+        assert_ne!(
+            dbflux_i18n::t!(
+                "document.object_browser.delete_prefix_modal.title",
+                locale = "en"
+            ),
+            dbflux_i18n::t!(
+                "document.object_browser.delete_prefix_modal.title",
+                locale = "es"
+            )
         );
     }
 }

--- a/crates/dbflux_ui_document/src/object_browser/context_menu.rs
+++ b/crates/dbflux_ui_document/src/object_browser/context_menu.rs
@@ -62,43 +62,44 @@ impl ObjectBrowserDocument {
     fn build_object_menu_items(&self) -> Vec<ObjectMenuItem> {
         vec![
             ObjectMenuItem {
-                label: "Preview".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.preview").into(),
                 action: ObjectMenuAction::Preview,
                 icon: AppIcon::Eye,
                 is_danger: false,
             },
             ObjectMenuItem {
-                label: "Open in editor".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.open_in_editor")
+                    .into(),
                 action: ObjectMenuAction::OpenInEditor,
                 icon: AppIcon::Maximize2,
                 is_danger: false,
             },
             ObjectMenuItem {
-                label: "Download".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.download").into(),
                 action: ObjectMenuAction::Download,
                 icon: AppIcon::Download,
                 is_danger: false,
             },
             ObjectMenuItem {
-                label: "Rename".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.rename").into(),
                 action: ObjectMenuAction::Rename,
                 icon: AppIcon::Pencil,
                 is_danger: false,
             },
             ObjectMenuItem {
-                label: "Presign".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.presign").into(),
                 action: ObjectMenuAction::Presign,
                 icon: AppIcon::Link2,
                 is_danger: false,
             },
             ObjectMenuItem {
-                label: "Copy S3 URI".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.copy_uri").into(),
                 action: ObjectMenuAction::CopyUri,
                 icon: AppIcon::Copy,
                 is_danger: false,
             },
             ObjectMenuItem {
-                label: "Delete".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.delete").into(),
                 action: ObjectMenuAction::DeleteObject,
                 icon: AppIcon::Delete,
                 is_danger: true,
@@ -113,10 +114,11 @@ impl ObjectBrowserDocument {
         let disclosure = if self.tree.is_tree_mode() {
             ObjectMenuItem {
                 label: if self.tree.is_expanded(prefix) {
-                    "Collapse".into()
+                    dbflux_i18n::t!("document.object_browser.context_menu.item.collapse")
                 } else {
-                    "Expand".into()
-                },
+                    dbflux_i18n::t!("document.object_browser.context_menu.item.expand")
+                }
+                .into(),
                 action: ObjectMenuAction::ToggleNode,
                 icon: if self.tree.is_expanded(prefix) {
                     AppIcon::ChevronDown
@@ -127,7 +129,7 @@ impl ObjectBrowserDocument {
             }
         } else {
             ObjectMenuItem {
-                label: "Open".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.open").into(),
                 action: ObjectMenuAction::OpenPrefix,
                 icon: AppIcon::Folder,
                 is_danger: false,
@@ -137,19 +139,23 @@ impl ObjectBrowserDocument {
         vec![
             disclosure,
             ObjectMenuItem {
-                label: "New folder inside".into(),
+                label: dbflux_i18n::t!(
+                    "document.object_browser.context_menu.item.new_folder_inside"
+                )
+                .into(),
                 action: ObjectMenuAction::NewFolderInside,
                 icon: AppIcon::Plus,
                 is_danger: false,
             },
             ObjectMenuItem {
-                label: "Copy S3 URI".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.copy_uri").into(),
                 action: ObjectMenuAction::CopyUri,
                 icon: AppIcon::Copy,
                 is_danger: false,
             },
             ObjectMenuItem {
-                label: "Delete folder".into(),
+                label: dbflux_i18n::t!("document.object_browser.context_menu.item.delete_folder")
+                    .into(),
                 action: ObjectMenuAction::DeletePrefix,
                 icon: AppIcon::Delete,
                 is_danger: true,

--- a/crates/dbflux_ui_document/src/object_browser/delete_prefix_modal.rs
+++ b/crates/dbflux_ui_document/src/object_browser/delete_prefix_modal.rs
@@ -8,7 +8,7 @@
 use super::delete_prefix::{DeletePrefixConfirmState, DeletePrefixProbeState, PrefixDeleteProbe};
 use super::tree::ObjectTreeNodeId;
 use super::{ObjectBrowserDocument, ObjectBrowserFocusMode};
-use crate::buckets_table::{BucketDetailsState, format_bytes};
+use crate::buckets_table::BucketDetailsState;
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Text, TypeToConfirm};
 use dbflux_components::tokens::{Heights, Radii, Spacing};
@@ -19,31 +19,31 @@ use gpui_component::ActiveTheme;
 
 /// What the probe has established so far, as one line of modal copy.
 pub(super) fn probe_summary_line(probe: &PrefixDeleteProbe) -> String {
-    let totals = format!(
-        "{} {} · {}",
-        probe.object_count,
-        if probe.object_count == 1 {
-            "object"
-        } else {
-            "objects"
-        },
-        format_bytes(probe.total_bytes)
-    );
+    let totals = crate::labels::delete_prefix_probe_totals(probe.object_count, probe.total_bytes);
 
     match &probe.state {
-        DeletePrefixProbeState::Idle => "Counting objects…".to_string(),
-        DeletePrefixProbeState::Running => {
-            format!("Counting… {totals} so far ({} pages)", probe.pages_walked)
+        DeletePrefixProbeState::Idle => {
+            dbflux_i18n::t!("document.object_browser.delete_prefix_modal.counting")
         }
+        DeletePrefixProbeState::Running => dbflux_i18n::t!(
+            "document.object_browser.delete_prefix_modal.counting_progress",
+            totals = totals,
+            pages = probe.pages_walked
+        ),
         DeletePrefixProbeState::Done => totals,
-        DeletePrefixProbeState::Cancelled => format!("{totals} counted before cancelling"),
-        DeletePrefixProbeState::Capped => {
-            format!(
-                "at least {totals} (stopped at {} pages)",
-                probe.pages_walked
-            )
-        }
-        DeletePrefixProbeState::Error(message) => format!("Could not count objects: {message}"),
+        DeletePrefixProbeState::Cancelled => dbflux_i18n::t!(
+            "document.object_browser.delete_prefix_modal.cancelled",
+            totals = totals
+        ),
+        DeletePrefixProbeState::Capped => dbflux_i18n::t!(
+            "document.object_browser.delete_prefix_modal.capped",
+            totals = totals,
+            pages = probe.pages_walked
+        ),
+        DeletePrefixProbeState::Error(message) => dbflux_i18n::t!(
+            "document.object_browser.delete_prefix_modal.error",
+            error = message.as_str()
+        ),
     }
 }
 
@@ -56,7 +56,10 @@ pub(super) fn remaining_keys_line(probe: &PrefixDeleteProbe) -> Option<String> {
         return None;
     }
 
-    Some(format!("… {} more", probe.object_count - previewed))
+    Some(dbflux_i18n::t!(
+        "document.object_browser.delete_prefix_modal.remaining_keys",
+        count = probe.object_count - previewed
+    ))
 }
 
 /// Label of the danger button. The count is omitted while the probe is still
@@ -64,14 +67,9 @@ pub(super) fn remaining_keys_line(probe: &PrefixDeleteProbe) -> Option<String> {
 pub(super) fn delete_button_label(probe: &PrefixDeleteProbe) -> String {
     match probe.state {
         DeletePrefixProbeState::Done | DeletePrefixProbeState::Cancelled => {
-            let word = if probe.object_count == 1 {
-                "object"
-            } else {
-                "objects"
-            };
-            format!("Delete {} {word}", probe.object_count)
+            crate::labels::delete_prefix_delete_button_label(Some(probe.object_count))
         }
-        _ => "Delete objects".to_string(),
+        _ => crate::labels::delete_prefix_delete_button_label(None),
     }
 }
 
@@ -180,7 +178,9 @@ impl ObjectBrowserDocument {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Text::body("Everything under this path will be deleted."))
+                    .child(Text::body(dbflux_i18n::t!(
+                        "document.object_browser.delete_prefix_modal.body_intro"
+                    )))
                     .child(Text::code(scope).primary())
                     .child(
                         div()
@@ -209,7 +209,9 @@ impl ObjectBrowserDocument {
                         this.cancel_delete_prefix_probe(cx);
                     }))
                     .child(Icon::new(AppIcon::X).small().muted())
-                    .child(Text::caption("Stop counting")),
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.object_browser.delete_prefix_modal.cancel_probe"
+                    ))),
             );
         }
 
@@ -223,7 +225,12 @@ impl ObjectBrowserDocument {
                 .border_l_2()
                 .border_color(theme.border)
                 .bg(theme.secondary)
-                .child(Text::caption("First keys affected").muted_foreground())
+                .child(
+                    Text::caption(dbflux_i18n::t!(
+                        "document.object_browser.delete_prefix_modal.first_keys_label"
+                    ))
+                    .muted_foreground(),
+                )
                 .children(
                     confirm
                         .probe
@@ -254,9 +261,9 @@ impl ObjectBrowserDocument {
             .flex()
             .flex_col()
             .gap(Spacing::XS)
-            .child(Text::caption(format!(
-                "Type \"{}\" to confirm",
-                confirm.expected_phrase
+            .child(Text::caption(dbflux_i18n::t!(
+                "document.object_browser.delete_prefix_modal.confirm_hint",
+                phrase = confirm.expected_phrase.as_str()
             )));
 
         if let Some(input) = self.delete_prefix_input.as_ref() {
@@ -269,7 +276,12 @@ impl ObjectBrowserDocument {
                 .items_center()
                 .justify_between()
                 .gap(Spacing::MD)
-                .child(Text::caption("DeleteObjects · batched ×1000").muted_foreground())
+                .child(
+                    Text::caption(dbflux_i18n::t!(
+                        "document.object_browser.delete_prefix_modal.batched_caption"
+                    ))
+                    .muted_foreground(),
+                )
                 .child(
                     div()
                         .flex()
@@ -289,7 +301,9 @@ impl ObjectBrowserDocument {
                                 .on_click(cx.listener(|this, _, _, cx| {
                                     this.close_delete_prefix_confirm(cx);
                                 }))
-                                .child(Text::caption("Cancel")),
+                                .child(Text::caption(dbflux_i18n::t!(
+                                    "document.object_browser.delete_prefix_modal.cancel"
+                                ))),
                         )
                         .child(
                             div()
@@ -324,7 +338,9 @@ impl ObjectBrowserDocument {
             &self.focus_handle,
             close,
         )
-        .title("Delete folder — recursive")
+        .title(dbflux_i18n::t!(
+            "document.object_browser.delete_prefix_modal.title"
+        ))
         .icon(AppIcon::TriangleAlert)
         .width(px(560.0))
         .max_height(px(560.0))

--- a/crates/dbflux_ui_document/src/object_browser/editor.rs
+++ b/crates/dbflux_ui_document/src/object_browser/editor.rs
@@ -95,14 +95,28 @@ pub(super) enum GuardedNavigation {
 impl GuardedNavigation {
     fn description(&self) -> String {
         match self {
-            GuardedNavigation::OpenPreview(key) => format!("open {key}"),
+            GuardedNavigation::OpenPreview(key) => dbflux_i18n::t!(
+                "document.object_browser.editor.nav.open",
+                key = key.as_str()
+            ),
             GuardedNavigation::NavigateToPrefix(prefix) if prefix.is_empty() => {
-                "leave for the bucket root".to_string()
+                dbflux_i18n::t!("document.object_browser.editor.nav.leave_bucket_root")
             }
-            GuardedNavigation::NavigateToPrefix(prefix) => format!("leave for {prefix}"),
-            GuardedNavigation::ClosePreview => "close this preview".to_string(),
-            GuardedNavigation::DeleteObject(key) => format!("delete {key}"),
-            GuardedNavigation::RenameObject(key) => format!("rename {key}"),
+            GuardedNavigation::NavigateToPrefix(prefix) => dbflux_i18n::t!(
+                "document.object_browser.editor.nav.leave_for",
+                prefix = prefix.as_str()
+            ),
+            GuardedNavigation::ClosePreview => {
+                dbflux_i18n::t!("document.object_browser.editor.nav.close_preview")
+            }
+            GuardedNavigation::DeleteObject(key) => dbflux_i18n::t!(
+                "document.object_browser.editor.nav.delete",
+                key = key.as_str()
+            ),
+            GuardedNavigation::RenameObject(key) => dbflux_i18n::t!(
+                "document.object_browser.editor.nav.rename",
+                key = key.as_str()
+            ),
         }
     }
 }
@@ -124,9 +138,12 @@ impl ObjectBrowserDocument {
     pub fn change_summary(&self) -> Option<String> {
         let editor = self.editor.as_ref()?;
 
-        editor
-            .dirty
-            .then(|| format!("Unsaved edits to {}", editor.key))
+        editor.dirty.then(|| {
+            dbflux_i18n::t!(
+                "document.object_browser.editor.unsaved_summary",
+                key = editor.key.as_str()
+            )
+        })
     }
 
     /// Builds the buffer for a freshly fetched body. Called from `render`,
@@ -247,7 +264,7 @@ impl ObjectBrowserDocument {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Driver,
-                    "Connection is no longer active".to_string(),
+                    dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
                 ),
                 cx,
             );
@@ -276,9 +293,9 @@ impl ObjectBrowserDocument {
                     bytes,
                     content_type.as_deref(),
                 ),
-                None => Err(DbError::NotSupported(
-                    "Object-store API unavailable".to_string(),
-                )),
+                None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))),
             };
 
             (result, started.elapsed().as_millis())
@@ -346,9 +363,12 @@ impl ObjectBrowserDocument {
         editor.dirty = false;
         editor.byte_len = byte_len;
 
-        Toast::success(format!("Saved s3://{}/{key}", self.bucket))
-            .meta_right(now_hms())
-            .push(cx);
+        Toast::success(dbflux_i18n::t!(
+            "document.object_browser.editor.toast.saved",
+            uri = format!("s3://{}/{key}", self.bucket).as_str()
+        ))
+        .meta_right(now_hms())
+        .push(cx);
 
         // Size, last-modified, and ETag all changed server-side.
         self.load_object_metadata(key, cx);
@@ -534,8 +554,12 @@ impl ObjectBrowserDocument {
                                 .color(theme.primary_foreground),
                             )
                             .child(
-                                Text::caption(if is_saving { "Saving…" } else { "Save" })
-                                    .color(theme.primary_foreground),
+                                Text::caption(if is_saving {
+                                    dbflux_i18n::t!("document.object_browser.editor.footer.saving")
+                                } else {
+                                    dbflux_i18n::t!("document.object_browser.editor.footer.save")
+                                })
+                                .color(theme.primary_foreground),
                             )
                             .child(
                                 Text::key_hint(SAVE_SHORTCUT_HINT).color(theme.primary_foreground),
@@ -559,7 +583,9 @@ impl ObjectBrowserDocument {
                                     }))
                             })
                             .child(Icon::new(AppIcon::RotateCcw).small().muted())
-                            .child(Text::caption("Discard")),
+                            .child(Text::caption(dbflux_i18n::t!(
+                                "document.object_browser.editor.footer.discard"
+                            ))),
                     )
                     .child(
                         div()
@@ -576,7 +602,9 @@ impl ObjectBrowserDocument {
                                 this.open_editor_find(window, cx);
                             }))
                             .child(Icon::new(AppIcon::Search).small().muted())
-                            .child(Text::caption("Find"))
+                            .child(Text::caption(dbflux_i18n::t!(
+                                "document.object_browser.editor.footer.find"
+                            )))
                             .child(Text::key_hint(FIND_SHORTCUT_HINT)),
                     ),
             )
@@ -616,7 +644,12 @@ impl ObjectBrowserDocument {
             .border_1()
             .border_color(theme.warning)
             .child(div().size(DIRTY_DOT).rounded(Radii::FULL).bg(theme.warning))
-            .child(Text::caption("modified").warning())
+            .child(
+                Text::caption(dbflux_i18n::t!(
+                    "document.object_browser.editor.dirty_badge"
+                ))
+                .warning(),
+            )
             .into_any_element()
     }
 
@@ -663,11 +696,14 @@ impl ObjectBrowserDocument {
                                     .size(Heights::ICON_MD)
                                     .warning(),
                             )
-                            .child(Text::heading("Unsaved edits")),
+                            .child(Text::heading(dbflux_i18n::t!(
+                                "document.object_browser.editor.unsaved_confirm.title"
+                            ))),
                     )
-                    .child(Text::muted(format!(
-                        "\"{key}\" has unsaved edits. Save them before you {}?",
-                        navigation.description()
+                    .child(Text::muted(dbflux_i18n::t!(
+                        "document.object_browser.editor.unsaved_confirm.body",
+                        key = key.as_str(),
+                        action = navigation.description().as_str()
                     )))
                     .child(
                         div()
@@ -688,7 +724,9 @@ impl ObjectBrowserDocument {
                                     .on_click(cx.listener(|this, _, _, cx| {
                                         this.cancel_guarded_navigation(cx);
                                     }))
-                                    .child(Text::caption("Cancel")),
+                                    .child(Text::caption(dbflux_i18n::t!(
+                                        "document.object_browser.editor.unsaved_confirm.cancel"
+                                    ))),
                             )
                             .child(
                                 div()
@@ -706,7 +744,9 @@ impl ObjectBrowserDocument {
                                         this.discard_and_navigate(window, cx);
                                     }))
                                     .child(Icon::new(AppIcon::RotateCcw).small().muted())
-                                    .child(Text::caption("Discard")),
+                                    .child(Text::caption(dbflux_i18n::t!(
+                                        "document.object_browser.editor.footer.discard"
+                                    ))),
                             )
                             .child(
                                 div()
@@ -728,7 +768,12 @@ impl ObjectBrowserDocument {
                                             .small()
                                             .color(theme.primary_foreground),
                                     )
-                                    .child(Text::caption("Save").color(theme.primary_foreground)),
+                                    .child(
+                                        Text::caption(dbflux_i18n::t!(
+                                            "document.object_browser.editor.footer.save"
+                                        ))
+                                        .color(theme.primary_foreground),
+                                    ),
                             ),
                     ),
             )

--- a/crates/dbflux_ui_document/src/object_browser/transfer.rs
+++ b/crates/dbflux_ui_document/src/object_browser/transfer.rs
@@ -106,8 +106,9 @@ impl ObjectBrowserDocument {
         cx: &mut Context<Self>,
     ) {
         let Some(connection) = self.get_connection(cx) else {
-            self.preview_content =
-                PreviewContentState::Failed("Connection is no longer active".to_string());
+            self.preview_content = PreviewContentState::Failed(dbflux_i18n::t!(
+                "document.object_browser.error.connection_unavailable"
+            ));
             cx.notify();
             return;
         };
@@ -197,17 +198,20 @@ impl ObjectBrowserDocument {
                 let name = object_file_name(&key);
 
                 match (purpose, handler_started) {
-                    (TransferPurpose::Download, _) => Toast::success(format!(
-                        "Saved {name} ({}) to {}",
-                        format_bytes(byte_len),
-                        destination.display()
+                    (TransferPurpose::Download, _) => Toast::success(dbflux_i18n::t!(
+                        "document.object_browser.transfer.toast.saved",
+                        name = name.as_str(),
+                        size = format_bytes(byte_len).as_str(),
+                        path = destination.display().to_string().as_str()
                     )),
-                    (TransferPurpose::OpenExternally, true) => {
-                        Toast::success(format!("Opened {name} in the system viewer"))
-                    }
-                    (TransferPurpose::OpenExternally, false) => Toast::error(format!(
-                        "No system handler could be started for {name}; it was saved to {}",
-                        destination.display()
+                    (TransferPurpose::OpenExternally, true) => Toast::success(dbflux_i18n::t!(
+                        "document.object_browser.transfer.toast.opened",
+                        name = name.as_str()
+                    )),
+                    (TransferPurpose::OpenExternally, false) => Toast::error(dbflux_i18n::t!(
+                        "document.object_browser.transfer.toast.no_handler",
+                        name = name.as_str(),
+                        path = destination.display().to_string().as_str()
                     )),
                 }
                 .meta_right(now_hms())
@@ -228,8 +232,9 @@ async fn choose_download_path(
 ) -> Result<Option<PathBuf>, String> {
     if !dialog_available {
         let dir = file_dialog::fallback_export_dir().map_err(|err| {
-            format!(
-                "File dialog unavailable and the fallback directory could not be created: {err}"
+            dbflux_i18n::t!(
+                "document.object_browser.transfer.error.fallback_dir_failed",
+                error = err.as_str()
             )
         })?;
 
@@ -240,9 +245,14 @@ async fn choose_download_path(
     }
 
     let handle = rfd::AsyncFileDialog::new()
-        .set_title("Save Object As")
+        .set_title(dbflux_i18n::t!(
+            "document.object_browser.transfer.dialog_title"
+        ))
         .set_file_name(suggested_name)
-        .add_filter("All Files", &["*"])
+        .add_filter(
+            dbflux_i18n::t!("document.object_browser.transfer.dialog_filter_all_files"),
+            &["*"],
+        )
         .save_file()
         .await;
 
@@ -256,9 +266,9 @@ fn fetch_and_write(
     destination: &Path,
 ) -> Result<u64, TransferError> {
     let api = connection.object_store_api().ok_or_else(|| {
-        TransferError::Driver(Box::new(DbError::NotSupported(
-            "Object-store API unavailable".to_string(),
-        )))
+        TransferError::Driver(Box::new(DbError::NotSupported(dbflux_i18n::t!(
+            "document.object_browser.error.api_unavailable"
+        ))))
     })?;
 
     api.download_object(bucket, key, destination)

--- a/crates/dbflux_ui_document/src/object_browser/upload.rs
+++ b/crates/dbflux_ui_document/src/object_browser/upload.rs
@@ -30,7 +30,7 @@ impl ObjectBrowserDocument {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    "No file picker is available on this platform",
+                    dbflux_i18n::t!("document.object_browser.upload.error.no_file_picker"),
                 ),
                 cx,
             );
@@ -39,7 +39,10 @@ impl ObjectBrowserDocument {
 
         let Some(connection) = self.get_connection(cx) else {
             report_error(
-                UserFacingError::new(ErrorKind::Storage, "Connection is no longer active"),
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
+                ),
                 cx,
             );
             return;
@@ -53,7 +56,9 @@ impl ObjectBrowserDocument {
 
         cx.spawn(async move |_this, cx| {
             let handles = rfd::AsyncFileDialog::new()
-                .set_title("Upload Objects")
+                .set_title(dbflux_i18n::t!(
+                    "document.object_browser.upload.dialog_title"
+                ))
                 .pick_files()
                 .await;
 
@@ -87,7 +92,9 @@ impl ObjectBrowserDocument {
                     .background_executor()
                     .spawn(async move {
                         let api = connection.object_store_api().ok_or_else(|| {
-                            DbError::NotSupported("Object-store API unavailable".to_string())
+                            DbError::NotSupported(dbflux_i18n::t!(
+                                "document.object_browser.error.api_unavailable"
+                            ))
                         })?;
 
                         api.upload_object(&bucket_for_task, &key_for_task, &path_for_task, None)
@@ -113,13 +120,34 @@ impl ObjectBrowserDocument {
 
             cx.update(|cx| {
                 if uploaded > 0 {
-                    let word = if uploaded == 1 { "object" } else { "objects" };
-                    let mut message =
-                        format!("Uploaded {uploaded} {word} to s3://{bucket}/{prefix}");
+                    let uri = format!("s3://{bucket}/{prefix}");
+                    let mut message = if uploaded == 1 {
+                        dbflux_i18n::t!(
+                            "document.object_browser.upload.toast.uploaded.one",
+                            count = uploaded,
+                            uri = uri.as_str()
+                        )
+                    } else {
+                        dbflux_i18n::t!(
+                            "document.object_browser.upload.toast.uploaded.many",
+                            count = uploaded,
+                            uri = uri.as_str()
+                        )
+                    };
 
                     if failed > 0 {
-                        let failed_word = if failed == 1 { "upload" } else { "uploads" };
-                        message.push_str(&format!(" ({failed} failed {failed_word})"));
+                        let suffix = if failed == 1 {
+                            dbflux_i18n::t!(
+                                "document.object_browser.upload.toast.failed_suffix.one",
+                                count = failed
+                            )
+                        } else {
+                            dbflux_i18n::t!(
+                                "document.object_browser.upload.toast.failed_suffix.many",
+                                count = failed
+                            )
+                        };
+                        message.push_str(&suffix);
                     }
 
                     Toast::success(message).meta_right(now_hms()).push(cx);


### PR DESCRIPTION
## Summary

Document i18n slice 20b: the object browser context menu, the delete-prefix modal (probe totals, confirm hint, batched caption), the object editor chrome (footer, dirty badge, unsaved-edits prompt, guarded navigation), upload and transfer dialogs and toasts render through `dbflux_i18n::t!` under `document.object_browser.{context_menu,delete_prefix_modal,editor,upload,transfer}.*`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `delete_prefix_probe_totals` reuses the `status.objects.one/many` bucket; the upload toast pluralizes uploaded and failed counts independently.
- Audit summaries (`Downloaded`, `Opened externally`, `Uploaded s3://…`) and AWS operation names stay English.
- Size: 652 lines, the pre-sliced five-file boundary (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1024 passed; clippy clean; fmt clean. Manual smoke in Spanish: open the context menu, upload a file, download an object, edit and save a text object, delete a prefix.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
