### PR TITLE
feat(i18n): translate the object editor document and object text messages

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -966,6 +966,17 @@ document:
         failed_suffix:
           one: " (%{count} failed upload)"
           many: " (%{count} failed uploads)"
+  object_editor:
+    error:
+      not_previewable_fallback: This object cannot be opened in-app.
+      not_text: This object is not text and cannot be edited in-app.
+      not_utf8: This object is not valid UTF-8 text and cannot be edited in-app.
+    status:
+      bucket_tooltip: Bucket
+      key_tooltip: Object key
+      loading: "Loading object…"
+      preparing: "Preparing editor…"
+      size_tooltip: Size of the object as last loaded or saved
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -966,6 +966,17 @@ document:
         failed_suffix:
           one: " (%{count} subida fallida)"
           many: " (%{count} subidas fallidas)"
+  object_editor:
+    error:
+      not_previewable_fallback: Este objeto no se puede abrir en la aplicación.
+      not_text: Este objeto no es de texto y no se puede editar en la aplicación.
+      not_utf8: Este objeto no es texto UTF-8 válido y no se puede editar en la aplicación.
+    status:
+      bucket_tooltip: Bucket
+      key_tooltip: Clave del objeto
+      loading: "Cargando objeto…"
+      preparing: "Preparando editor…"
+      size_tooltip: Tamaño del objeto tal como se cargó o guardó por última vez
   query_builder:
     aggregate:
       fn:

--- a/crates/dbflux_ui_document/src/object_editor/mod.rs
+++ b/crates/dbflux_ui_document/src/object_editor/mod.rs
@@ -174,8 +174,12 @@ impl ObjectEditorDocument {
 
     /// Summary for the tab's dirty-dot tooltip and the unsaved-changes modal.
     pub fn change_summary(&self) -> Option<String> {
-        self.is_dirty()
-            .then(|| format!("Unsaved edits to {}", self.key))
+        self.is_dirty().then(|| {
+            dbflux_i18n::t!(
+                "document.object_browser.editor.unsaved_summary",
+                key = self.key.as_str()
+            )
+        })
     }
 
     pub fn refresh_policy(&self) -> RefreshPolicy {
@@ -229,7 +233,9 @@ impl ObjectEditorDocument {
         cx.notify();
 
         let Some(connection) = self.get_connection(cx) else {
-            self.load = LoadState::Failed("Connection is no longer active".to_string());
+            self.load = LoadState::Failed(dbflux_i18n::t!(
+                "document.object_browser.error.connection_unavailable"
+            ));
             cx.notify();
             return;
         };
@@ -383,7 +389,7 @@ impl ObjectEditorDocument {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Driver,
-                    "Connection is no longer active".to_string(),
+                    dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
                 ),
                 cx,
             );
@@ -409,9 +415,9 @@ impl ObjectEditorDocument {
                     bytes,
                     content_type.as_deref(),
                 ),
-                None => Err(DbError::NotSupported(
-                    "Object-store API unavailable".to_string(),
-                )),
+                None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))),
             }
         });
 
@@ -462,9 +468,12 @@ impl ObjectEditorDocument {
             buffer.byte_len = byte_len;
         }
 
-        Toast::success(format!("Saved s3://{}/{}", self.bucket, self.key))
-            .meta_right(now_hms())
-            .push(cx);
+        Toast::success(dbflux_i18n::t!(
+            "document.object_browser.editor.toast.saved",
+            uri = format!("s3://{}/{}", self.bucket, self.key).as_str()
+        ))
+        .meta_right(now_hms())
+        .push(cx);
 
         let notify_opener = self.on_saved.clone();
         let key = self.key.clone();
@@ -581,9 +590,9 @@ fn load_editable_body(
     limit_bytes: u64,
 ) -> Result<Result<LoadedBody, LoadRefusal>, DbError> {
     let Some(api) = connection.object_store_api() else {
-        return Err(DbError::NotSupported(
-            "Object-store API unavailable".to_string(),
-        ));
+        return Err(DbError::NotSupported(dbflux_i18n::t!(
+            "document.object_browser.error.api_unavailable"
+        )));
     };
 
     let metadata: ObjectMetadata = api.head_object(bucket, key)?;
@@ -647,6 +656,34 @@ mod tests {
             .expect_err("not text");
 
         assert!(refusal.contains("text"));
+    }
+
+    /// The "not text" refusal routes through the catalog and diverges between
+    /// locales, matching the reused `PreviewGate::message()` pattern from
+    /// PR 19: both refusal paths in `detect_editable_text` are translated,
+    /// not just the gate check.
+    #[test]
+    fn non_text_refusal_message_resolves_in_both_locales() {
+        let refusal = detect_editable_text(&metadata("a.png", 10, Some("image/png")), 1024)
+            .expect_err("not text");
+
+        assert_ne!(refusal, "document.object_editor.error.not_text");
+
+        let es = dbflux_i18n::t!("document.object_editor.error.not_text", locale = "es");
+        assert_ne!(refusal, es);
+    }
+
+    /// The size-refusal path reuses `PreviewGate::message()` exactly as the
+    /// object browser preview pane does (PR 19) — the editor never carries
+    /// its own copy of the gate's explanation.
+    #[test]
+    fn oversized_refusal_message_matches_the_shared_gate_mapping() {
+        let metadata = metadata("a.txt", 4096, Some("text/plain"));
+        let gate = crate::object_browser::evaluate_preview_gate(&metadata, 1024);
+
+        let refusal = detect_editable_text(&metadata, 1024).expect_err("over the limit");
+
+        assert_eq!(Some(refusal), gate.message());
     }
 
     /// An archived object is refused even when it would fit under the limit.
@@ -838,6 +875,50 @@ mod tests {
         });
 
         assert!(saved.borrow().is_empty());
+    }
+
+    /// The dirty-tab summary reuses the object browser preview editor's
+    /// `editor.unsaved_summary` catalog entry — the two editing surfaces
+    /// describe an unsaved buffer with the same translated sentence.
+    ///
+    /// The `t!` macro has no arm combining named interpolation with an
+    /// explicit `locale =` override (only `(key)` / `(key, locale=)` /
+    /// `(key, name=value+)`), so the interpolated-value check and the
+    /// locale-divergence check stay two separate assertions, matching the
+    /// schema_diff PR 17 precedent.
+    #[test]
+    fn change_summary_reuses_the_shared_editor_catalog_entry() {
+        let en = dbflux_i18n::t!(
+            "document.object_browser.editor.unsaved_summary",
+            key = "notes.md"
+        );
+        assert_eq!(en, "Unsaved edits to notes.md");
+
+        let template_en = dbflux_i18n::t!(
+            "document.object_browser.editor.unsaved_summary",
+            locale = "en"
+        );
+        let template_es = dbflux_i18n::t!(
+            "document.object_browser.editor.unsaved_summary",
+            locale = "es"
+        );
+        assert_ne!(template_en, template_es);
+    }
+
+    /// The save toast reuses the shared `editor.toast.saved` catalog entry.
+    #[test]
+    fn save_toast_reuses_the_shared_editor_catalog_entry() {
+        let en = dbflux_i18n::t!(
+            "document.object_browser.editor.toast.saved",
+            uri = "s3://my-bucket/notes.md"
+        );
+        assert_eq!(en, "Saved s3://my-bucket/notes.md");
+
+        let template_en =
+            dbflux_i18n::t!("document.object_browser.editor.toast.saved", locale = "en");
+        let template_es =
+            dbflux_i18n::t!("document.object_browser.editor.toast.saved", locale = "es");
+        assert_ne!(template_en, template_es);
     }
 
     /// A refused object reports `Error` and keeps no buffer, so the tab shows

--- a/crates/dbflux_ui_document/src/object_editor/pane.rs
+++ b/crates/dbflux_ui_document/src/object_editor/pane.rs
@@ -14,18 +14,20 @@ impl ObjectEditorDocument {
         let mut segments = vec![
             StatusSegment {
                 text: self.bucket().to_string().into(),
-                tooltip: Some("Bucket".into()),
+                tooltip: Some(
+                    dbflux_i18n::t!("document.object_editor.status.bucket_tooltip").into(),
+                ),
             },
             StatusSegment {
                 text: self.key().to_string().into(),
-                tooltip: Some("Object key".into()),
+                tooltip: Some(dbflux_i18n::t!("document.object_editor.status.key_tooltip").into()),
             },
         ];
 
         if let Some(byte_len) = self.byte_len() {
             segments.push(StatusSegment {
                 text: crate::buckets_table::format_bytes(byte_len).into(),
-                tooltip: Some("Size of the object as last loaded or saved".into()),
+                tooltip: Some(dbflux_i18n::t!("document.object_editor.status.size_tooltip").into()),
             });
         }
 
@@ -151,5 +153,35 @@ impl ObjectEditorDocument {
         });
 
         pane
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The three status-bar tooltips resolve in both locales.
+    ///
+    /// `bucket_tooltip` is excluded from the divergence check: "bucket"
+    /// stays "bucket" in Spanish per the change's vocabulary rule (see
+    /// `document.object_browser.empty.bucket` for the same precedent), so
+    /// its `en` and `es` values are identical by design, not a translation
+    /// gap.
+    #[test]
+    fn status_tooltip_keys_resolve_in_both_locales() {
+        for key in [
+            "document.object_editor.status.bucket_tooltip",
+            "document.object_editor.status.key_tooltip",
+            "document.object_editor.status.size_tooltip",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!en.is_empty());
+            assert_ne!(en, key);
+            assert_ne!(en, format!("en.{key}"));
+
+            if key != "document.object_editor.status.bucket_tooltip" {
+                assert_ne!(en, es);
+            }
+        }
     }
 }

--- a/crates/dbflux_ui_document/src/object_editor/render.rs
+++ b/crates/dbflux_ui_document/src/object_editor/render.rs
@@ -292,6 +292,8 @@ mod tests {
         for key in [
             "document.object_editor.status.loading",
             "document.object_editor.status.preparing",
+            "document.object_browser.error.connection_unavailable",
+            "document.object_browser.error.api_unavailable",
         ] {
             let en = dbflux_i18n::t!(key, locale = "en");
             let es = dbflux_i18n::t!(key, locale = "es");

--- a/crates/dbflux_ui_document/src/object_editor/render.rs
+++ b/crates/dbflux_ui_document/src/object_editor/render.rs
@@ -79,7 +79,12 @@ impl ObjectEditorDocument {
                         .border_1()
                         .border_color(theme.warning)
                         .child(div().size(DIRTY_DOT).rounded(Radii::FULL).bg(theme.warning))
-                        .child(Text::caption("modified").warning()),
+                        .child(
+                            Text::caption(dbflux_i18n::t!(
+                                "document.object_browser.editor.dirty_badge"
+                            ))
+                            .warning(),
+                        ),
                 )
             })
     }
@@ -101,12 +106,16 @@ impl ObjectEditorDocument {
                         .h_full(),
                 )
                 .into_any_element(),
-            (LoadState::Loading, None) => {
-                self.render_notice("Loading object…".to_string(), false, cx)
-            }
-            (LoadState::Ready, None) => {
-                self.render_notice("Preparing editor…".to_string(), false, cx)
-            }
+            (LoadState::Loading, None) => self.render_notice(
+                dbflux_i18n::t!("document.object_editor.status.loading"),
+                false,
+                cx,
+            ),
+            (LoadState::Ready, None) => self.render_notice(
+                dbflux_i18n::t!("document.object_editor.status.preparing"),
+                false,
+                cx,
+            ),
         }
     }
 
@@ -203,8 +212,12 @@ impl ObjectEditorDocument {
                                 .color(theme.primary_foreground),
                             )
                             .child(
-                                Text::caption(if is_saving { "Saving…" } else { "Save" })
-                                    .color(theme.primary_foreground),
+                                Text::caption(if is_saving {
+                                    dbflux_i18n::t!("document.object_browser.editor.footer.saving")
+                                } else {
+                                    dbflux_i18n::t!("document.object_browser.editor.footer.save")
+                                })
+                                .color(theme.primary_foreground),
                             )
                             .child(
                                 Text::key_hint(SAVE_SHORTCUT_HINT).color(theme.primary_foreground),
@@ -228,7 +241,9 @@ impl ObjectEditorDocument {
                                     }))
                             })
                             .child(Icon::new(AppIcon::RotateCcw).small().muted())
-                            .child(Text::caption("Discard")),
+                            .child(Text::caption(dbflux_i18n::t!(
+                                "document.object_browser.editor.footer.discard"
+                            ))),
                     )
                     .when(has_buffer, |this| {
                         this.child(
@@ -246,7 +261,9 @@ impl ObjectEditorDocument {
                                     this.open_find(window, cx);
                                 }))
                                 .child(Icon::new(AppIcon::Search).small().muted())
-                                .child(Text::caption("Find"))
+                                .child(Text::caption(dbflux_i18n::t!(
+                                    "document.object_browser.editor.footer.find"
+                                )))
                                 .child(Text::key_hint(FIND_SHORTCUT_HINT)),
                         )
                     }),
@@ -263,5 +280,46 @@ impl ObjectEditorDocument {
                         this.child(Text::caption(cursor_label(position)).muted_foreground())
                     }),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The tab's own loading/preparing notices resolve in both locales and
+    /// diverge from English to Spanish.
+    #[test]
+    fn status_keys_resolve_in_both_locales() {
+        for key in [
+            "document.object_editor.status.loading",
+            "document.object_editor.status.preparing",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!en.is_empty());
+            assert_ne!(en, key);
+            assert_ne!(en, format!("en.{key}"));
+            assert_ne!(en, es);
+        }
+    }
+
+    /// The footer, dirty-badge, and toolbar controls reuse the same
+    /// `document.object_browser.editor.*` catalog entries the pinned
+    /// preview-pane editor uses, so the two surfaces read identically.
+    #[test]
+    fn footer_and_dirty_badge_reuse_the_shared_editor_catalog_entries() {
+        for key in [
+            "document.object_browser.editor.dirty_badge",
+            "document.object_browser.editor.footer.saving",
+            "document.object_browser.editor.footer.save",
+            "document.object_browser.editor.footer.discard",
+            "document.object_browser.editor.footer.find",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!en.is_empty());
+            assert_ne!(en, es);
+        }
     }
 }

--- a/crates/dbflux_ui_document/src/object_text.rs
+++ b/crates/dbflux_ui_document/src/object_text.rs
@@ -80,7 +80,7 @@ pub fn decode_text_body(bytes: Vec<u8>) -> Result<TextBody, String> {
     let byte_len = bytes.len() as u64;
 
     let text = String::from_utf8(bytes)
-        .map_err(|_| "This object is not valid UTF-8 text and cannot be edited in-app.")?;
+        .map_err(|_| dbflux_i18n::t!("document.object_editor.error.not_utf8"))?;
 
     let line_ending = LineEnding::detect(&text);
     let normalised = text.replace("\r\n", "\n");
@@ -193,13 +193,13 @@ pub fn detect_editable_text(
     let gate = crate::object_browser::evaluate_preview_gate(metadata, limit_bytes);
 
     if gate != PreviewGate::Allowed {
-        return Err(gate
-            .message()
-            .unwrap_or_else(|| "This object cannot be opened in-app.".to_string()));
+        return Err(gate.message().unwrap_or_else(|| {
+            dbflux_i18n::t!("document.object_editor.error.not_previewable_fallback")
+        }));
     }
 
     if detect_preview_kind(metadata.content_type.as_deref(), &metadata.key) != PreviewKind::Text {
-        return Err("This object is not text and cannot be edited in-app.".to_string());
+        return Err(dbflux_i18n::t!("document.object_editor.error.not_text"));
     }
 
     Ok(())
@@ -316,6 +316,23 @@ mod tests {
     #[test]
     fn decoding_refuses_non_utf8_bodies() {
         assert!(decode_text_body(vec![0xff, 0xfe, 0x00]).is_err());
+    }
+
+    /// The UTF-8 refusal message routes through the catalog rather than
+    /// staying a literal, so it renders in the active locale.
+    #[test]
+    fn decoding_refusal_message_resolves_in_both_locales() {
+        let message = decode_text_body(vec![0xff, 0xfe, 0x00]).expect_err("not UTF-8");
+
+        assert!(!message.is_empty());
+        assert_ne!(message, "document.object_editor.error.not_utf8");
+        assert_ne!(
+            message,
+            format!("en.{}", "document.object_editor.error.not_utf8")
+        );
+
+        let es = dbflux_i18n::t!("document.object_editor.error.not_utf8", locale = "es");
+        assert_ne!(message, es);
     }
 
     /// T30: the highlighter language comes from the extension, with a plain


### PR DESCRIPTION
## Summary

Document i18n slice 21: the standalone object editor document (change summary, save toast, status-bar tooltips, dirty badge, footer controls, loading notices) and the `object_text` refusal messages (not UTF-8, not text, fallback) render through `dbflux_i18n::t!` under `document.object_editor.{error,status}.*`, reusing the `document.object_browser.editor.*` namespace shared with the preview-pane editor. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `LineEnding::label()` (LF/CRLF) and cursor readouts are format identifiers and stay untranslated, matching the PNG/JPEG format labels from slice 19.
- The object browser's pinned preview editor (20b) and this tab share `document.object_browser.editor.*` because both call into `object_text.rs`.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1032 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a text object in the editor tab, edit, save, reload, try a binary object.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
