### PR TITLE
feat(i18n): translate the login modal and the charts and dashboards workspace messages

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -70,6 +70,44 @@ common:
       start_after_end: Start time must be before end time
       no_date_range: No date range selected
       incomplete_time_selection: Incomplete time selection
+charts:
+  default_import_name: Imported Dashboard
+  orphaned_profile_label: (orphaned)
+  status:
+    loading_namespaces: Loading metric namespaces
+    loading_metrics: "Loading metrics for %{namespace}"
+  toast:
+    chart_not_found: Saved chart not found
+    dashboard_not_found: Dashboard not found
+    connection_not_found: Connection not found for this dashboard.
+    add_profile_first: Add a connection profile before creating a dashboard.
+    import_success: "Imported %{count} panels into a new dashboard."
+    panel_already_exists: "A panel for %{namespace}/%{metric} is already in this dashboard"
+  error:
+    cannot_open_chart: "Cannot open chart: %{error}"
+    rescale_failed: Failed to rescale panel to 12-column grid
+    no_active_connection_import: "No active connection — connect to a profile before importing."
+    import_unsupported: The active connection does not support dashboard import.
+    import_failed: "Dashboard import failed: %{error}"
+    persist_import_chart_failed: "Failed to persist imported chart '%{name}'"
+    persist_import_dashboard_failed: "Failed to persist imported dashboard '%{name}'"
+    persist_import_panels_failed: Failed to persist imported dashboard panels
+    save_dashboard_failed: "Failed to save dashboard '%{name}': %{message}"
+    browsing_unsupported: The connection does not support dashboard browsing.
+    parse_unsupported: The connection cannot parse dashboards.
+    remote_parse_failed: "Dashboard parse failed: %{error}"
+    create_dashboard_failed: "Failed to create dashboard: %{error}"
+    delete_dashboard_failed: "Failed to delete dashboard: %{error}"
+    duplicate_dashboard_failed: "Failed to duplicate dashboard: %{error}"
+    rename_failed: "Failed to rename: %{error}"
+    delete_chart_failed: "Failed to delete saved chart: %{error}"
+    duplicate_chart_failed: "Failed to duplicate saved chart: %{error}"
+    load_namespaces_failed: "Failed to load metric namespaces: %{error}"
+    load_metrics_failed: "Failed to load metrics: %{error}"
+    persist_chart_for_panel_failed: "Failed to persist chart '%{name}' for new panel"
+    add_panel_failed: "Failed to add panel: %{error}"
+    persist_metric_chart_for_panel_failed: "Failed to persist metric chart '%{name}' for new panel"
+    add_panels_failed: "Failed to add panels: %{error}"
 components:
   json_editor:
     empty_error: Document cannot be empty
@@ -1206,6 +1244,29 @@ hooks:
   tab:
     intro: Select reusable hooks configured in Settings -> Hooks
     lua_process_run_note: Selected hook enables Lua process.run and can execute external programs with your user permissions
+login:
+  window_title: Connection Flow
+  field:
+    start_url: Start URL
+  action:
+    open_browser: Open Browser
+    copy_url: Copy URL
+    cancel: Cancel
+    close: Close
+    open_auth_profiles: Open Auth Profiles
+  banner:
+    connection_failed: Connection failed
+    completed: Login completed
+    closing: Authentication succeeded. Closing this dialog...
+  body:
+    sign_in_prompt: 'Sign in with %{provider} to continue connecting "%{profile}".'
+    instructions: Open the login URL in your browser and finish authentication. DBFlux will continue automatically once the login completes.
+    elapsed: "Login can take up to 5 minutes. Elapsed: %{seconds}s"
+    browser_open_failed: "Could not open browser automatically. Open the URL manually. (%{error}; fallback failed: %{fallback_error})"
+  error:
+    timed_out: Login timed out after 5 minutes
+    no_url: No login URL is available for this provider.
+    no_url_provided: Login URL not provided by provider
 modals:
   active_query:
     title: Active query running

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -70,6 +70,44 @@ common:
       start_after_end: La hora de inicio debe ser anterior a la hora de fin
       no_date_range: No se seleccionó un rango de fechas
       incomplete_time_selection: Selección de hora incompleta
+charts:
+  default_import_name: Imported Dashboard
+  orphaned_profile_label: (huérfano)
+  status:
+    loading_namespaces: Cargando namespaces de métricas
+    loading_metrics: "Cargando métricas de %{namespace}"
+  toast:
+    chart_not_found: No se encontró el gráfico guardado
+    dashboard_not_found: No se encontró el dashboard
+    connection_not_found: No se encontró la conexión de este dashboard.
+    add_profile_first: Agrega un perfil de conexión antes de crear un dashboard.
+    import_success: "Se importaron %{count} paneles en un nuevo dashboard."
+    panel_already_exists: "Ya existe un panel para %{namespace}/%{metric} en este dashboard"
+  error:
+    cannot_open_chart: "No se pudo abrir el gráfico: %{error}"
+    rescale_failed: No se pudo reescalar el panel a la cuadrícula de 12 columnas
+    no_active_connection_import: "No hay conexión activa. Conéctate a un perfil antes de importar."
+    import_unsupported: La conexión activa no admite la importación de dashboards.
+    import_failed: "Fallo en la importación del dashboard: %{error}"
+    persist_import_chart_failed: "No se pudo guardar el gráfico importado '%{name}'"
+    persist_import_dashboard_failed: "No se pudo guardar el dashboard importado '%{name}'"
+    persist_import_panels_failed: No se pudieron guardar los paneles del dashboard importado
+    save_dashboard_failed: "No se pudo guardar el dashboard '%{name}': %{message}"
+    browsing_unsupported: La conexión no admite la exploración de dashboards.
+    parse_unsupported: La conexión no puede interpretar dashboards.
+    remote_parse_failed: "Fallo al interpretar el dashboard: %{error}"
+    create_dashboard_failed: "No se pudo crear el dashboard: %{error}"
+    delete_dashboard_failed: "No se pudo eliminar el dashboard: %{error}"
+    duplicate_dashboard_failed: "No se pudo duplicar el dashboard: %{error}"
+    rename_failed: "No se pudo renombrar: %{error}"
+    delete_chart_failed: "No se pudo eliminar el gráfico guardado: %{error}"
+    duplicate_chart_failed: "No se pudo duplicar el gráfico guardado: %{error}"
+    load_namespaces_failed: "No se pudieron cargar los namespaces de métricas: %{error}"
+    load_metrics_failed: "No se pudieron cargar las métricas: %{error}"
+    persist_chart_for_panel_failed: "No se pudo guardar el gráfico '%{name}' del nuevo panel"
+    add_panel_failed: "No se pudo agregar el panel: %{error}"
+    persist_metric_chart_for_panel_failed: "No se pudo guardar el gráfico de métrica '%{name}' del nuevo panel"
+    add_panels_failed: "No se pudieron agregar los paneles: %{error}"
 components:
   json_editor:
     empty_error: El documento no puede estar vacío
@@ -1206,6 +1244,29 @@ hooks:
   tab:
     intro: Selecciona hooks reutilizables configurados en Ajustes -> Hooks
     lua_process_run_note: El hook seleccionado habilita Lua process.run y puede ejecutar programas externos con tus permisos de usuario
+login:
+  window_title: Flujo de conexión
+  field:
+    start_url: URL de inicio
+  action:
+    open_browser: Abrir navegador
+    copy_url: Copiar URL
+    cancel: Cancelar
+    close: Cerrar
+    open_auth_profiles: Abrir perfiles de autenticación
+  banner:
+    connection_failed: Fallo en la conexión
+    completed: Inicio de sesión completado
+    closing: Autenticación correcta. Cerrando este diálogo...
+  body:
+    sign_in_prompt: 'Inicia sesión con %{provider} para continuar conectando "%{profile}".'
+    instructions: Abre la URL de inicio de sesión en tu navegador y completa la autenticación. DBFlux continuará automáticamente cuando el inicio de sesión finalice.
+    elapsed: "El inicio de sesión puede tardar hasta 5 minutos. Transcurrido: %{seconds}s"
+    browser_open_failed: "No se pudo abrir el navegador automáticamente. Abre la URL manualmente. (%{error}; fallo alternativo: %{fallback_error})"
+  error:
+    timed_out: El inicio de sesión superó el tiempo de espera de 5 minutos
+    no_url: No hay URL de inicio de sesión disponible para este proveedor.
+    no_url_provided: El proveedor no facilitó la URL de inicio de sesión
 modals:
   active_query:
     title: Consulta en ejecución

--- a/crates/dbflux_ui/src/ui/labels.rs
+++ b/crates/dbflux_ui/src/ui/labels.rs
@@ -61,6 +61,148 @@ pub(crate) fn workspace_delete_connection_message(name: &str) -> String {
     dbflux_i18n::t!("workspace.confirm.delete_connection", name = name)
 }
 
+/// Formats the login modal's "Sign in with X to continue connecting Y" prompt.
+pub(crate) fn login_sign_in_prompt(provider_name: &str, profile_name: &str) -> String {
+    dbflux_i18n::t!(
+        "login.body.sign_in_prompt",
+        provider = provider_name,
+        profile = profile_name
+    )
+}
+
+/// Formats the "Elapsed: Ns" caption shown while waiting for login to complete.
+pub(crate) fn login_elapsed_message(elapsed_secs: u64) -> String {
+    dbflux_i18n::t!("login.body.elapsed", seconds = elapsed_secs)
+}
+
+/// Formats the fallback message shown when the login browser could not be launched.
+pub(crate) fn login_browser_open_failed_message(
+    error: impl std::fmt::Display,
+    fallback_error: impl std::fmt::Display,
+) -> String {
+    dbflux_i18n::t!(
+        "login.body.browser_open_failed",
+        error = error,
+        fallback_error = fallback_error
+    )
+}
+
+/// Formats the error shown when a saved chart fails source validation on open.
+pub(crate) fn charts_cannot_open_chart_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.cannot_open_chart", error = error)
+}
+
+/// Formats the error shown when a dashboard import parse/build step fails.
+pub(crate) fn charts_import_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.import_failed", error = error)
+}
+
+/// Formats the error shown when an imported chart fails to persist.
+pub(crate) fn charts_persist_import_chart_failed_message(name: &str) -> String {
+    dbflux_i18n::t!("charts.error.persist_import_chart_failed", name = name)
+}
+
+/// Formats the error shown when an imported dashboard fails to persist.
+pub(crate) fn charts_persist_import_dashboard_failed_message(name: &str) -> String {
+    dbflux_i18n::t!("charts.error.persist_import_dashboard_failed", name = name)
+}
+
+/// Formats the error shown when a dashboard's charts/panels fail to save.
+pub(crate) fn charts_save_dashboard_failed_message(name: &str, message: &str) -> String {
+    dbflux_i18n::t!(
+        "charts.error.save_dashboard_failed",
+        name = name,
+        message = message
+    )
+}
+
+/// Formats the toast shown after a successful dashboard import.
+pub(crate) fn charts_import_success_message(count: usize) -> String {
+    dbflux_i18n::t!("charts.toast.import_success", count = count)
+}
+
+/// Formats the error shown when a remote dashboard fails to parse.
+pub(crate) fn charts_remote_parse_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.remote_parse_failed", error = error)
+}
+
+/// Formats the error shown when creating a dashboard fails.
+pub(crate) fn charts_create_dashboard_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.create_dashboard_failed", error = error)
+}
+
+/// Formats the error shown when deleting a dashboard fails.
+pub(crate) fn charts_delete_dashboard_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.delete_dashboard_failed", error = error)
+}
+
+/// Formats the error shown when duplicating a dashboard fails.
+pub(crate) fn charts_duplicate_dashboard_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.duplicate_dashboard_failed", error = error)
+}
+
+/// Formats the error shown when renaming a dashboard or saved chart fails.
+pub(crate) fn charts_rename_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.rename_failed", error = error)
+}
+
+/// Formats the error shown when deleting a saved chart fails.
+pub(crate) fn charts_delete_chart_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.delete_chart_failed", error = error)
+}
+
+/// Formats the error shown when duplicating a saved chart fails.
+pub(crate) fn charts_duplicate_chart_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.duplicate_chart_failed", error = error)
+}
+
+/// Formats the error shown when loading metric namespaces fails.
+pub(crate) fn charts_load_namespaces_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.load_namespaces_failed", error = error)
+}
+
+/// Formats the background-task label shown while loading metrics for a namespace.
+pub(crate) fn charts_loading_metrics_label(namespace: &str) -> String {
+    dbflux_i18n::t!("charts.status.loading_metrics", namespace = namespace)
+}
+
+/// Formats the error shown when loading metrics for a namespace fails.
+pub(crate) fn charts_load_metrics_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.load_metrics_failed", error = error)
+}
+
+/// Formats the error shown when a query-backed chart fails to persist for a new panel.
+pub(crate) fn charts_persist_chart_for_panel_failed_message(name: &str) -> String {
+    dbflux_i18n::t!("charts.error.persist_chart_for_panel_failed", name = name)
+}
+
+/// Formats the error shown when adding a panel to a dashboard fails.
+pub(crate) fn charts_add_panel_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.add_panel_failed", error = error)
+}
+
+/// Formats the error shown when a metric-backed chart fails to persist for a new panel.
+pub(crate) fn charts_persist_metric_chart_for_panel_failed_message(name: &str) -> String {
+    dbflux_i18n::t!(
+        "charts.error.persist_metric_chart_for_panel_failed",
+        name = name
+    )
+}
+
+/// Formats the toast shown when a panel for the same metric already exists.
+pub(crate) fn charts_panel_already_exists_message(namespace: &str, metric: &str) -> String {
+    dbflux_i18n::t!(
+        "charts.toast.panel_already_exists",
+        namespace = namespace,
+        metric = metric
+    )
+}
+
+/// Formats the error shown when adding several panels to a dashboard fails.
+pub(crate) fn charts_add_panels_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("charts.error.add_panels_failed", error = error)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/crates/dbflux_ui/src/ui/overlays/login_modal.rs
+++ b/crates/dbflux_ui/src/ui/overlays/login_modal.rs
@@ -1,4 +1,7 @@
 use crate::ui::icons::AppIcon;
+use crate::ui::labels::{
+    login_browser_open_failed_message, login_elapsed_message, login_sign_in_prompt,
+};
 use dbflux_components::controls::Button;
 use dbflux_components::primitives::Text;
 use dbflux_components::tokens::{Radii, Spacing};
@@ -141,7 +144,7 @@ impl LoginModal {
                         let provider_name = provider_name.clone();
                         this.state = LoginModalState::Failed {
                             provider_name: Some(provider_name),
-                            error: "Login timed out after 5 minutes".to_string(),
+                            error: dbflux_i18n::t!("login.error.timed_out"),
                         };
                         this.visible = true;
                         cx.notify();
@@ -208,7 +211,7 @@ impl LoginModal {
         } = &mut self.state
         {
             let Some(url) = verification_url.clone() else {
-                *launch_error = Some("No login URL is available for this provider.".to_string());
+                *launch_error = Some(dbflux_i18n::t!("login.error.no_url"));
                 cx.notify();
                 return;
             };
@@ -222,10 +225,8 @@ impl LoginModal {
                         *launch_error = None;
                     }
                     Err(detached_error) => {
-                        *launch_error = Some(format!(
-                            "Could not open browser automatically. Open the URL manually. ({}; fallback failed: {})",
-                            error, detached_error
-                        ));
+                        *launch_error =
+                            Some(login_browser_open_failed_message(error, detached_error));
                     }
                 },
             }
@@ -265,7 +266,7 @@ impl Render for LoginModal {
         };
 
         let mut frame = ModalFrame::new("sso-login-modal", &self.focus_handle, close)
-            .title("Connection Flow")
+            .title(dbflux_i18n::t!("login.window_title"))
             .icon(AppIcon::Lock)
             .width(px(640.0))
             .max_height(px(500.0));
@@ -282,7 +283,7 @@ impl Render for LoginModal {
                 let elapsed = started_at.elapsed().as_secs();
                 let url_display = verification_url
                     .clone()
-                    .unwrap_or_else(|| "Login URL not provided by provider".to_string());
+                    .unwrap_or_else(|| dbflux_i18n::t!("login.error.no_url_provided"));
 
                 frame.child(
                     div()
@@ -290,13 +291,11 @@ impl Render for LoginModal {
                         .flex_col()
                         .gap(Spacing::MD)
                         .p(Spacing::MD)
-                        .child(Text::body(format!(
-                            "Sign in with {} to continue connecting \"{}\".",
-                            provider_name, profile_name
+                        .child(Text::body(login_sign_in_prompt(
+                            provider_name,
+                            profile_name,
                         )))
-                        .child(Text::caption(
-                            "Open the login URL in your browser and finish authentication. DBFlux will continue automatically once the login completes.",
-                        ))
+                        .child(Text::caption(dbflux_i18n::t!("login.body.instructions")))
                         .child(
                             div()
                                 .p(Spacing::SM)
@@ -304,16 +303,13 @@ impl Render for LoginModal {
                                 .border_1()
                                 .border_color(theme.border)
                                 .bg(theme.secondary)
-                                .child(Text::caption("Start URL"))
+                                .child(Text::caption(dbflux_i18n::t!("login.field.start_url")))
                                 .child(div().mt_1().child(Text::body(url_display))),
                         )
                         .when_some(launch_error.clone(), |el, error| {
                             el.child(Text::caption(error).warning())
                         })
-                        .child(Text::caption(format!(
-                            "Login can take up to 5 minutes. Elapsed: {}s",
-                            elapsed
-                        )))
+                        .child(Text::caption(login_elapsed_message(elapsed)))
                         .child(
                             div()
                                 .flex()
@@ -321,23 +317,38 @@ impl Render for LoginModal {
                                 .justify_end()
                                 .gap(Spacing::SM)
                                 .child(
-                                    Button::new("sso-open-browser", "Open Browser")
-                                        .when(has_url, |b| b.primary())
-                                        .on_click(cx.listener(|this, _, _, cx| {
+                                    Button::new(
+                                        "sso-open-browser",
+                                        dbflux_i18n::t!("login.action.open_browser"),
+                                    )
+                                    .when(has_url, |b| b.primary())
+                                    .on_click(cx.listener(
+                                        |this, _, _, cx| {
                                             this.open_browser(cx);
-                                        })),
+                                        },
+                                    )),
                                 )
                                 .child(
-                                    Button::new("sso-copy-url", "Copy URL")
-                                        .on_click(cx.listener(|this, _, _, cx| {
+                                    Button::new(
+                                        "sso-copy-url",
+                                        dbflux_i18n::t!("login.action.copy_url"),
+                                    )
+                                    .on_click(cx.listener(
+                                        |this, _, _, cx| {
                                             this.copy_url(cx);
-                                        })),
+                                        },
+                                    )),
                                 )
                                 .child(
-                                    Button::new("sso-cancel", "Cancel")
-                                        .on_click(cx.listener(|this, _, _, cx| {
+                                    Button::new(
+                                        "sso-cancel",
+                                        dbflux_i18n::t!("login.action.cancel"),
+                                    )
+                                    .on_click(cx.listener(
+                                        |this, _, _, cx| {
                                             this.close(cx);
-                                        })),
+                                        },
+                                    )),
                                 ),
                         ),
                 )
@@ -354,26 +365,29 @@ impl Render for LoginModal {
                     .flex()
                     .flex_col()
                     .gap(Spacing::MD)
-                    .child(Text::body("Connection failed").warning())
+                    .child(Text::body(dbflux_i18n::t!("login.banner.connection_failed")).warning())
                     .child(Text::body(error.clone()))
-                    .child(div().flex().justify_end().child(
-                        Button::new("sso-failed-close", "Close").on_click(cx.listener(
-                            |this, _, _, cx| {
-                                this.close(cx);
-                            },
-                        )),
-                    ));
+                    .child(
+                        div().flex().justify_end().child(
+                            Button::new("sso-failed-close", dbflux_i18n::t!("login.action.close"))
+                                .on_click(cx.listener(|this, _, _, cx| {
+                                    this.close(cx);
+                                })),
+                        ),
+                    );
 
                 if show_auth_profiles_button {
-                    frame
-                        .child(error_content)
-                        .child(div().flex().justify_end().child(
-                            Button::new("login-open-auth-profiles", "Open Auth Profiles").on_click(
-                                cx.listener(|this, _, _, cx| {
-                                    this.open_auth_profiles_settings(cx);
-                                }),
-                            ),
-                        ))
+                    frame.child(error_content).child(
+                        div().flex().justify_end().child(
+                            Button::new(
+                                "login-open-auth-profiles",
+                                dbflux_i18n::t!("login.action.open_auth_profiles"),
+                            )
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.open_auth_profiles_settings(cx);
+                            })),
+                        ),
+                    )
                 } else {
                     frame.child(error_content)
                 }
@@ -384,10 +398,8 @@ impl Render for LoginModal {
                     .flex()
                     .flex_col()
                     .gap(Spacing::MD)
-                    .child(Text::body("Login completed").success())
-                    .child(Text::body(
-                        "Authentication succeeded. Closing this dialog...",
-                    )),
+                    .child(Text::body(dbflux_i18n::t!("login.banner.completed")).success())
+                    .child(Text::body(dbflux_i18n::t!("login.banner.closing"))),
             ),
             _ => frame,
         };
@@ -406,5 +418,55 @@ mod tests {
             "Custom OIDC"
         )));
         assert!(!failed_state_shows_open_auth_profiles_button(None));
+    }
+
+    const LOGIN_CATALOG_KEYS: &[&str] = &[
+        "login.window_title",
+        "login.field.start_url",
+        "login.action.open_browser",
+        "login.action.copy_url",
+        "login.action.cancel",
+        "login.action.close",
+        "login.action.open_auth_profiles",
+        "login.banner.connection_failed",
+        "login.banner.completed",
+        "login.banner.closing",
+        "login.body.sign_in_prompt",
+        "login.body.instructions",
+        "login.body.elapsed",
+        "login.body.browser_open_failed",
+        "login.error.timed_out",
+        "login.error.no_url",
+        "login.error.no_url_provided",
+    ];
+
+    #[::core::prelude::v1::test]
+    fn login_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in LOGIN_CATALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[::core::prelude::v1::test]
+    fn login_window_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("login.window_title", locale = "en");
+        let spanish = dbflux_i18n::t!("login.window_title", locale = "es");
+
+        assert_eq!(english, "Connection Flow");
+        assert_eq!(spanish, "Flujo de conexión");
+        assert_ne!(english, spanish);
     }
 }

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/charts_dashboards.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/charts_dashboards.rs
@@ -1,4 +1,17 @@
 use super::*;
+use crate::ui::labels::{
+    charts_add_panel_failed_message, charts_add_panels_failed_message,
+    charts_cannot_open_chart_message, charts_create_dashboard_failed_message,
+    charts_delete_chart_failed_message, charts_delete_dashboard_failed_message,
+    charts_duplicate_chart_failed_message, charts_duplicate_dashboard_failed_message,
+    charts_import_failed_message, charts_import_success_message,
+    charts_load_metrics_failed_message, charts_load_namespaces_failed_message,
+    charts_loading_metrics_label, charts_panel_already_exists_message,
+    charts_persist_chart_for_panel_failed_message, charts_persist_import_chart_failed_message,
+    charts_persist_import_dashboard_failed_message,
+    charts_persist_metric_chart_for_panel_failed_message, charts_remote_parse_failed_message,
+    charts_rename_failed_message, charts_save_dashboard_failed_message,
+};
 
 impl Workspace {
     /// Opens a new `ChartDocument` seeded with the given query.
@@ -61,7 +74,7 @@ impl Workspace {
                     .iter()
                     .find(|p| p.id == chart.profile_id)
                     .map(|p| p.name.clone())
-                    .unwrap_or_else(|| "(orphaned)".to_string());
+                    .unwrap_or_else(|| dbflux_i18n::t!("charts.orphaned_profile_label"));
 
                 PaletteItem::SavedChart {
                     id: chart.id,
@@ -109,7 +122,7 @@ impl Workspace {
             .cloned();
 
         let Some(chart) = saved_chart else {
-            Toast::error("Saved chart not found")
+            Toast::error(dbflux_i18n::t!("charts.toast.chart_not_found"))
                 .meta_right(now_hms())
                 .push(cx);
             return;
@@ -133,7 +146,10 @@ impl Workspace {
                 let validation = crate::ui::document::ChartDocument::validate_saved_source(&chart);
                 if let Err(e) = validation {
                     report_error(
-                        UserFacingError::new(ErrorKind::Storage, format!("Cannot open chart: {e}")),
+                        UserFacingError::new(
+                            ErrorKind::Storage,
+                            charts_cannot_open_chart_message(e),
+                        ),
                         cx,
                     );
                     return;
@@ -195,7 +211,7 @@ impl Workspace {
             .cloned();
 
         let Some(dashboard) = dashboard_meta else {
-            Toast::error("Dashboard not found")
+            Toast::error(dbflux_i18n::t!("charts.toast.dashboard_not_found"))
                 .meta_right(now_hms())
                 .push(cx);
             return;
@@ -260,7 +276,7 @@ impl Workspace {
                                 dbflux_core::observability::actions::CONFIG_UPDATE,
                                 "dashboard_panel",
                                 format!("{dashboard_id_local}#{panel_index}"),
-                                "Failed to rescale panel to 12-column grid".to_string(),
+                                dbflux_i18n::t!("charts.error.rescale_failed"),
                                 message,
                             );
                         });
@@ -436,11 +452,9 @@ impl Workspace {
             let app_state = self.app_state.read(cx);
 
             let Some(active) = app_state.active_connection() else {
-                return Toast::error(
-                    "No active connection — connect to a profile before importing.",
-                )
-                .meta_right(now_hms())
-                .push(cx);
+                return Toast::error(dbflux_i18n::t!("charts.error.no_active_connection_import"))
+                    .meta_right(now_hms())
+                    .push(cx);
             };
 
             let profile_id = active.profile.id;
@@ -448,17 +462,15 @@ impl Workspace {
             let importer = match active.connection.dashboard_importer() {
                 Some(i) => i,
                 None => {
-                    return Toast::error(
-                        "The active connection does not support dashboard import.",
-                    )
-                    .meta_right(now_hms())
-                    .push(cx);
+                    return Toast::error(dbflux_i18n::t!("charts.error.import_unsupported"))
+                        .meta_right(now_hms())
+                        .push(cx);
                 }
             };
 
             match importer.import(&json) {
                 Ok(specs) => Ok((profile_id, specs)),
-                Err(e) => Err(format!("Dashboard import failed: {e}")),
+                Err(e) => Err(charts_import_failed_message(e)),
             }
         };
 
@@ -476,7 +488,7 @@ impl Workspace {
         let dashboard = Dashboard {
             id: dashboard_id,
             name: if name.trim().is_empty() {
-                "Imported Dashboard".to_string()
+                dbflux_i18n::t!("charts.default_import_name")
             } else {
                 name
             },
@@ -612,7 +624,7 @@ impl Workspace {
                             dbflux_core::observability::actions::CONFIG_CREATE,
                             "saved_chart",
                             chart.id.to_string(),
-                            format!("Failed to persist imported chart '{}'", chart.name),
+                            charts_persist_import_chart_failed_message(&chart.name),
                             e.to_string(),
                         );
                         return Err((chart.name.clone(), e.to_string()));
@@ -624,7 +636,7 @@ impl Workspace {
                         dbflux_core::observability::actions::CONFIG_CREATE,
                         "dashboard",
                         dashboard.id.to_string(),
-                        format!("Failed to persist imported dashboard '{}'", dashboard.name),
+                        charts_persist_import_dashboard_failed_message(&dashboard.name),
                         e.to_string(),
                     );
                     return Err((dashboard.name.clone(), e.to_string()));
@@ -635,7 +647,7 @@ impl Workspace {
                         dbflux_core::observability::actions::CONFIG_UPDATE,
                         "dashboard_panels",
                         dashboard_id.to_string(),
-                        "Failed to persist imported dashboard panels".to_string(),
+                        dbflux_i18n::t!("charts.error.persist_import_panels_failed"),
                         e.to_string(),
                     );
                     return Err((dashboard.name.clone(), e.to_string()));
@@ -648,19 +660,16 @@ impl Workspace {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    format!("Failed to save dashboard '{name}': {message}"),
+                    charts_save_dashboard_failed_message(&name, &message),
                 ),
                 cx,
             );
             return;
         }
 
-        Toast::info(format!(
-            "Imported {} panels into a new dashboard.",
-            charts.len()
-        ))
-        .meta_right(now_hms())
-        .push(cx);
+        Toast::info(charts_import_success_message(charts.len()))
+            .meta_right(now_hms())
+            .push(cx);
 
         self.open_dashboard(dashboard_id, window, cx);
     }
@@ -705,7 +714,7 @@ impl Workspace {
         {
             Some(c) => c,
             None => {
-                return Toast::error("Connection not found for this dashboard.")
+                return Toast::error(dbflux_i18n::t!("charts.toast.connection_not_found"))
                     .meta_right(now_hms())
                     .push(cx);
             }
@@ -719,18 +728,18 @@ impl Workspace {
         let background = cx.background_executor().spawn(async move {
             let source = connection
                 .dashboard_source()
-                .ok_or_else(|| "The connection does not support dashboard browsing.".to_string())?;
+                .ok_or_else(|| dbflux_i18n::t!("charts.error.browsing_unsupported"))?;
             let remote = source
                 .fetch_dashboard(&name_for_fetch)
                 .map_err(|e| e.to_string())?;
 
             let importer = connection
                 .dashboard_importer()
-                .ok_or_else(|| "The connection cannot parse dashboards.".to_string())?;
+                .ok_or_else(|| dbflux_i18n::t!("charts.error.parse_unsupported"))?;
             importer
                 .import(&remote.body_json)
                 .map(|specs| (remote.body_json, specs))
-                .map_err(|e| format!("Dashboard parse failed: {e}"))
+                .map_err(charts_remote_parse_failed_message)
         });
 
         cx.spawn_in(window, async move |this, cx| {
@@ -980,7 +989,7 @@ impl Workspace {
                 });
             }
             None => {
-                Toast::warning("Add a connection profile before creating a dashboard.")
+                Toast::warning(dbflux_i18n::t!("charts.toast.add_profile_first"))
                     .meta_right(now_hms())
                     .push(cx);
             }
@@ -1019,7 +1028,7 @@ impl Workspace {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Storage,
-                        format!("Failed to create dashboard: {e}"),
+                        charts_create_dashboard_failed_message(e),
                     ),
                     cx,
                 );
@@ -1132,7 +1141,7 @@ impl Workspace {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Storage,
-                        format!("Failed to delete dashboard: {e}"),
+                        charts_delete_dashboard_failed_message(e),
                     ),
                     cx,
                 );
@@ -1160,7 +1169,7 @@ impl Workspace {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Storage,
-                        format!("Failed to duplicate dashboard: {e}"),
+                        charts_duplicate_dashboard_failed_message(e),
                     ),
                     cx,
                 );
@@ -1230,7 +1239,7 @@ impl Workspace {
             }
             Err(e) => {
                 report_error(
-                    UserFacingError::new(ErrorKind::Storage, format!("Failed to rename: {e}")),
+                    UserFacingError::new(ErrorKind::Storage, charts_rename_failed_message(e)),
                     cx,
                 );
             }
@@ -1323,10 +1332,7 @@ impl Workspace {
             }
             Err(e) => {
                 report_error(
-                    UserFacingError::new(
-                        ErrorKind::Storage,
-                        format!("Failed to delete saved chart: {e}"),
-                    ),
+                    UserFacingError::new(ErrorKind::Storage, charts_delete_chart_failed_message(e)),
                     cx,
                 );
             }
@@ -1353,7 +1359,7 @@ impl Workspace {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Storage,
-                        format!("Failed to duplicate saved chart: {e}"),
+                        charts_duplicate_chart_failed_message(e),
                     ),
                     cx,
                 );
@@ -1436,7 +1442,7 @@ impl Workspace {
             let (task_id, _cancel) = self.app_state.update(cx, |state, _| {
                 state.start_task_for_profile(
                     dbflux_core::TaskKind::LoadSchema,
-                    "Loading metric namespaces",
+                    dbflux_i18n::t!("charts.status.loading_namespaces"),
                     Some(profile_id),
                 )
             });
@@ -1465,7 +1471,7 @@ impl Workspace {
                         report_error(
                             UserFacingError::new(
                                 ErrorKind::Network,
-                                format!("Failed to load metric namespaces: {msg}"),
+                                charts_load_namespaces_failed_message(&msg),
                             ),
                             cx,
                         );
@@ -1505,7 +1511,7 @@ impl Workspace {
         let (task_id, _cancel) = self.app_state.update(cx, |state, _| {
             state.start_task_for_profile(
                 dbflux_core::TaskKind::LoadSchema,
-                format!("Loading metrics for {}", ev.namespace),
+                charts_loading_metrics_label(&ev.namespace),
                 Some(ev.profile_id),
             )
         });
@@ -1539,7 +1545,7 @@ impl Workspace {
                     report_error(
                         UserFacingError::new(
                             ErrorKind::Network,
-                            format!("Failed to load metrics: {msg}"),
+                            charts_load_metrics_failed_message(&msg),
                         ),
                         cx,
                     );
@@ -1600,7 +1606,7 @@ impl Workspace {
                     dbflux_core::observability::actions::CONFIG_CREATE,
                     "saved_chart",
                     chart_id.to_string(),
-                    format!("Failed to persist chart '{name}' for new panel"),
+                    charts_persist_chart_for_panel_failed_message(&name),
                     e.to_string(),
                 );
                 return Err(e);
@@ -1622,7 +1628,7 @@ impl Workspace {
             }
             Err(e) => {
                 report_error(
-                    UserFacingError::new(ErrorKind::Storage, format!("Failed to add panel: {e}")),
+                    UserFacingError::new(ErrorKind::Storage, charts_add_panel_failed_message(e)),
                     cx,
                 );
             }
@@ -1689,8 +1695,9 @@ impl Workspace {
         };
 
         if already_present {
-            Toast::error(format!(
-                "A panel for {namespace}/{metric_name} is already in this dashboard"
+            Toast::error(charts_panel_already_exists_message(
+                &namespace,
+                &metric_name,
             ))
             .meta_right(now_hms())
             .push(cx);
@@ -1736,7 +1743,7 @@ impl Workspace {
                     dbflux_core::observability::actions::CONFIG_CREATE,
                     "saved_chart",
                     chart_id.to_string(),
-                    format!("Failed to persist metric chart '{name}' for new panel"),
+                    charts_persist_metric_chart_for_panel_failed_message(&name),
                     e.to_string(),
                 );
                 return Err(e);
@@ -1758,7 +1765,7 @@ impl Workspace {
             }
             Err(e) => {
                 report_error(
-                    UserFacingError::new(ErrorKind::Storage, format!("Failed to add panel: {e}")),
+                    UserFacingError::new(ErrorKind::Storage, charts_add_panel_failed_message(e)),
                     cx,
                 );
             }
@@ -1795,10 +1802,80 @@ impl Workspace {
             }
             Err(e) => {
                 report_error(
-                    UserFacingError::new(ErrorKind::Storage, format!("Failed to add panels: {e}")),
+                    UserFacingError::new(ErrorKind::Storage, charts_add_panels_failed_message(e)),
                     cx,
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const CHARTS_CATALOG_KEYS: &[&str] = &[
+        "charts.default_import_name",
+        "charts.orphaned_profile_label",
+        "charts.status.loading_namespaces",
+        "charts.status.loading_metrics",
+        "charts.toast.chart_not_found",
+        "charts.toast.dashboard_not_found",
+        "charts.toast.connection_not_found",
+        "charts.toast.add_profile_first",
+        "charts.toast.import_success",
+        "charts.toast.panel_already_exists",
+        "charts.error.cannot_open_chart",
+        "charts.error.rescale_failed",
+        "charts.error.no_active_connection_import",
+        "charts.error.import_unsupported",
+        "charts.error.import_failed",
+        "charts.error.persist_import_chart_failed",
+        "charts.error.persist_import_dashboard_failed",
+        "charts.error.persist_import_panels_failed",
+        "charts.error.save_dashboard_failed",
+        "charts.error.browsing_unsupported",
+        "charts.error.parse_unsupported",
+        "charts.error.remote_parse_failed",
+        "charts.error.create_dashboard_failed",
+        "charts.error.delete_dashboard_failed",
+        "charts.error.duplicate_dashboard_failed",
+        "charts.error.rename_failed",
+        "charts.error.delete_chart_failed",
+        "charts.error.duplicate_chart_failed",
+        "charts.error.load_namespaces_failed",
+        "charts.error.load_metrics_failed",
+        "charts.error.persist_chart_for_panel_failed",
+        "charts.error.add_panel_failed",
+        "charts.error.persist_metric_chart_for_panel_failed",
+        "charts.error.add_panels_failed",
+    ];
+
+    #[::core::prelude::v1::test]
+    fn charts_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in CHARTS_CATALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[::core::prelude::v1::test]
+    fn charts_dashboard_not_found_differs_between_locales() {
+        let english = dbflux_i18n::t!("charts.toast.dashboard_not_found", locale = "en");
+        let spanish = dbflux_i18n::t!("charts.toast.dashboard_not_found", locale = "es");
+
+        assert_eq!(english, "Dashboard not found");
+        assert_eq!(spanish, "No se encontró el dashboard");
+        assert_ne!(english, spanish);
     }
 }


### PR DESCRIPTION
## Summary

Twenty-first slice of the windows/shell series (`dbflux_ui`): the login modal (window title, start URL, open browser / copy URL / cancel, banners, elapsed timer, timeout and no-URL errors) and every user-visible toast, error and task label in `actions/charts_dashboards.rs` render through `dbflux_i18n::t!` under `login.*` and `charts.*`. English and Spanish together. `dashboard` stays `dashboard`; the persisted `Imported Dashboard` default name stays English data.

## What does this resolve?

- Refs #360 (follows the workspace shell PR; next: the remaining workspace action toasts)

## How was this solved?

- 23 helpers in `crates/dbflux_ui/src/ui/labels.rs` carry the interpolated messages; new tests use `#[::core::prelude::v1::test]` because plain `#[test]` overflows rustc through the GPUI prelude globs in these files.
- Size: 607 lines across the two complete file boundaries (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui -p dbflux_i18n` → 141 passed; clippy clean; fmt clean. Manual smoke in Spanish: start an interactive auth login, copy the URL, cancel; import a dashboard and delete a chart.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
