### PR TITLE
feat(i18n): translate the buckets table and the new bucket modal

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -333,6 +333,79 @@ document:
       loading:
         external: "Loading events…"
         internal: "Loading audit events…"
+  buckets_table:
+    title: "Buckets — %{connection}"
+    search_placeholder: "Find buckets by name…"
+    toolbar:
+      refresh: Refresh
+      new_bucket: New bucket
+    columns:
+      name: Name
+      region: Region
+      objects: Objects
+      size: Size
+      versioning: Versioning
+      created: Created
+    versioning:
+      on: "On"
+      suspended: Suspended
+      off: "Off"
+    details:
+      calculate_size: Calculate size
+      calculating: "Calculating…"
+    footer:
+      buckets:
+        one: "%{count} bucket"
+        many: "%{count} buckets"
+      regions:
+        one: "%{count} region"
+        many: "%{count} regions"
+      hint:
+        open: Enter browse
+        properties: Space properties
+        delete: x delete (empty only)
+    empty:
+      loading: "Loading buckets…"
+      error: Failed to list buckets
+      error_detail: "Failed to list buckets: %{error}"
+      no_match: "No buckets match \"%{query}\""
+      no_buckets: This connection has no buckets
+      hint_refresh: r refresh
+    delete_confirm:
+      title: Delete bucket?
+      body: "\"%{bucket}\" is empty and will be removed. This cannot be undone."
+      cancel: Cancel
+      confirm: Delete
+    error:
+      bucket_not_empty: "Bucket \"%{bucket}\" is not empty. Delete its objects with a recursive prefix delete before removing the bucket."
+    status:
+      duration_tooltip: Client-side duration of the last object-store call
+    new_bucket:
+      title: New Bucket
+      field:
+        name: Name
+        name_hint: "3-63 characters · lowercase letters, digits, dots and hyphens"
+        region: Region
+        encryption: Default encryption
+      section:
+        options: Options
+      option:
+        versioning: Enable versioning
+        block_public_access: Block all public access
+        object_lock: Object lock
+        object_lock_warning: "Object lock cannot be disabled after the bucket is created."
+      encryption:
+        none: None
+      applied_immediately: applied immediately
+      cancel: Cancel
+      create: Create
+      creating: "Creating…"
+      error:
+        length: "Bucket names must be 3-63 characters long."
+        charset: "Bucket names may only contain lowercase letters, digits, dots and hyphens."
+      toast:
+        created: "Created bucket \"%{name}\""
+        created_with_limitations: "Created bucket \"%{name}\" with limitations"
   code:
     toolbar:
       refresh: Refresh

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -333,6 +333,79 @@ document:
       loading:
         external: "Cargando eventos…"
         internal: "Cargando eventos de auditoría…"
+  buckets_table:
+    title: "Buckets — %{connection}"
+    search_placeholder: "Buscar buckets por nombre…"
+    toolbar:
+      refresh: Actualizar
+      new_bucket: Nuevo bucket
+    columns:
+      name: Nombre
+      region: Región
+      objects: Objetos
+      size: Tamaño
+      versioning: Versionado
+      created: Creado
+    versioning:
+      on: Activado
+      suspended: Suspendido
+      off: Desactivado
+    details:
+      calculate_size: Calcular tamaño
+      calculating: "Calculando…"
+    footer:
+      buckets:
+        one: "%{count} bucket"
+        many: "%{count} buckets"
+      regions:
+        one: "%{count} región"
+        many: "%{count} regiones"
+      hint:
+        open: Enter para abrir
+        properties: Espacio para propiedades
+        delete: x eliminar (solo vacíos)
+    empty:
+      loading: "Cargando buckets…"
+      error: Error al listar buckets
+      error_detail: "Error al listar buckets: %{error}"
+      no_match: "Ningún bucket coincide con \"%{query}\""
+      no_buckets: Esta conexión no tiene buckets
+      hint_refresh: r para actualizar
+    delete_confirm:
+      title: ¿Eliminar bucket?
+      body: "\"%{bucket}\" está vacío y se eliminará. Esta acción no se puede deshacer."
+      cancel: Cancelar
+      confirm: Eliminar
+    error:
+      bucket_not_empty: "El bucket \"%{bucket}\" no está vacío. Elimina sus objetos con una eliminación recursiva de prefijo antes de eliminar el bucket."
+    status:
+      duration_tooltip: Duración local de la última llamada al almacenamiento de objetos
+    new_bucket:
+      title: Nuevo bucket
+      field:
+        name: Nombre
+        name_hint: "3-63 caracteres · letras minúsculas, dígitos, puntos y guiones"
+        region: Región
+        encryption: Cifrado predeterminado
+      section:
+        options: Opciones
+      option:
+        versioning: Habilitar versionado
+        block_public_access: Bloquear todo acceso público
+        object_lock: Bloqueo de objetos
+        object_lock_warning: "El bloqueo de objetos no se puede deshabilitar después de crear el bucket."
+      encryption:
+        none: Ninguno
+      applied_immediately: se aplica de inmediato
+      cancel: Cancelar
+      create: Crear
+      creating: "Creando…"
+      error:
+        length: "Los nombres de bucket deben tener entre 3 y 63 caracteres."
+        charset: "Los nombres de bucket solo pueden contener letras minúsculas, dígitos, puntos y guiones."
+      toast:
+        created: "Bucket \"%{name}\" creado"
+        created_with_limitations: "Bucket \"%{name}\" creado con limitaciones"
   code:
     toolbar:
       refresh: Actualizar

--- a/crates/dbflux_ui_document/src/buckets_table/data.rs
+++ b/crates/dbflux_ui_document/src/buckets_table/data.rs
@@ -66,8 +66,9 @@ pub fn bucket_delete_allowed(page: &dbflux_core::ObjectListingPage) -> bool {
 /// Message shown when the user tries to delete a bucket that still holds
 /// objects. Points at the recursive prefix delete instead of silently failing.
 pub(super) fn bucket_not_empty_message(bucket: &str) -> String {
-    format!(
-        "Bucket \"{bucket}\" is not empty. Delete its objects with a recursive prefix delete before removing the bucket."
+    dbflux_i18n::t!(
+        "document.buckets_table.error.bucket_not_empty",
+        bucket = bucket
     )
 }
 
@@ -107,7 +108,9 @@ impl BucketsTableDocument {
 
         let Some(connection) = self.get_connection(cx) else {
             self.state = DocumentState::Error;
-            self.last_error = Some("Connection is no longer active".to_string());
+            self.last_error = Some(dbflux_i18n::t!(
+                "document.object_browser.error.connection_unavailable"
+            ));
             cx.notify();
             return;
         };
@@ -119,9 +122,9 @@ impl BucketsTableDocument {
 
             let result = match connection.object_store_api() {
                 Some(api) => api.list_buckets(),
-                None => Err(DbError::NotSupported(
-                    "Object-store API unavailable".to_string(),
-                )),
+                None => Err(DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))),
             };
 
             (result, started.elapsed().as_millis())
@@ -209,7 +212,7 @@ impl BucketsTableDocument {
         let Some(connection) = self.get_connection(cx) else {
             self.set_bucket_details_error(
                 &bucket_name,
-                "Connection is no longer active".to_string(),
+                dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
             );
             cx.notify();
             return;
@@ -219,9 +222,11 @@ impl BucketsTableDocument {
         let bucket_for_task = bucket_name.clone();
 
         let task = cx.background_executor().spawn(async move {
-            let api = connection
-                .object_store_api()
-                .ok_or_else(|| DbError::NotSupported("Object-store API unavailable".to_string()))?;
+            let api = connection.object_store_api().ok_or_else(|| {
+                DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))
+            })?;
             api.get_bucket_details(&bucket_for_task)
         });
 
@@ -294,7 +299,7 @@ impl BucketsTableDocument {
         let Some(connection) = self.get_connection(cx) else {
             self.set_bucket_size_estimate_error(
                 &bucket_name,
-                "Connection is no longer active".to_string(),
+                dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
             );
             cx.notify();
             return;
@@ -304,9 +309,11 @@ impl BucketsTableDocument {
         let bucket_for_task = bucket_name.clone();
 
         let task = cx.background_executor().spawn(async move {
-            let api = connection
-                .object_store_api()
-                .ok_or_else(|| DbError::NotSupported("Object-store API unavailable".to_string()))?;
+            let api = connection.object_store_api().ok_or_else(|| {
+                DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))
+            })?;
             api.estimate_bucket_size(&bucket_for_task, BUCKET_SIZE_ESTIMATE_CAP)
         });
 
@@ -383,7 +390,10 @@ impl BucketsTableDocument {
         let Some(connection) = self.get_connection(cx) else {
             self.delete_probe = None;
             report_error(
-                UserFacingError::new(ErrorKind::User, "Connection is no longer active"),
+                UserFacingError::new(
+                    ErrorKind::User,
+                    dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
+                ),
                 cx,
             );
             cx.notify();
@@ -394,9 +404,11 @@ impl BucketsTableDocument {
         let bucket_for_task = bucket_name.clone();
 
         let task = cx.background_executor().spawn(async move {
-            let api = connection
-                .object_store_api()
-                .ok_or_else(|| DbError::NotSupported("Object-store API unavailable".to_string()))?;
+            let api = connection.object_store_api().ok_or_else(|| {
+                DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))
+            })?;
             api.list_objects(&bucket_for_task, "", None)
         });
 
@@ -452,7 +464,10 @@ impl BucketsTableDocument {
 
         let Some(connection) = self.get_connection(cx) else {
             report_error(
-                UserFacingError::new(ErrorKind::User, "Connection is no longer active"),
+                UserFacingError::new(
+                    ErrorKind::User,
+                    dbflux_i18n::t!("document.object_browser.error.connection_unavailable"),
+                ),
                 cx,
             );
             return;
@@ -464,9 +479,11 @@ impl BucketsTableDocument {
         let bucket_for_task = bucket_name.clone();
 
         let task = cx.background_executor().spawn(async move {
-            let api = connection
-                .object_store_api()
-                .ok_or_else(|| DbError::NotSupported("Object-store API unavailable".to_string()))?;
+            let api = connection.object_store_api().ok_or_else(|| {
+                DbError::NotSupported(dbflux_i18n::t!(
+                    "document.object_browser.error.api_unavailable"
+                ))
+            })?;
             api.delete_bucket(&bucket_for_task)
         });
 

--- a/crates/dbflux_ui_document/src/buckets_table/mod.rs
+++ b/crates/dbflux_ui_document/src/buckets_table/mod.rs
@@ -76,8 +76,10 @@ impl BucketsTableDocument {
             .map(|connected| connected.profile.name.clone())
             .unwrap_or_default();
 
-        let search_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Find buckets by name…"));
+        let search_input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("document.buckets_table.search_placeholder"))
+        });
 
         let search_subscription = cx.subscribe_in(
             &search_input,
@@ -93,7 +95,10 @@ impl BucketsTableDocument {
 
         let mut doc = Self {
             id: DocumentId::new(),
-            title: format!("Buckets — {connection_name}"),
+            title: dbflux_i18n::t!(
+                "document.buckets_table.title",
+                connection = connection_name.as_str()
+            ),
             profile_id,
             app_state,
             focus_handle: cx.focus_handle(),

--- a/crates/dbflux_ui_document/src/buckets_table/new_bucket.rs
+++ b/crates/dbflux_ui_document/src/buckets_table/new_bucket.rs
@@ -24,17 +24,18 @@ use uuid::Uuid;
 /// hyphens (the subset of the S3 rules the spec pins down).
 pub fn bucket_name_error(name: &str) -> Option<String> {
     if name.len() < 3 || name.len() > 63 {
-        return Some("Bucket names must be 3-63 characters long.".to_string());
+        return Some(dbflux_i18n::t!(
+            "document.buckets_table.new_bucket.error.length"
+        ));
     }
 
     if !name
         .chars()
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-')
     {
-        return Some(
-            "Bucket names may only contain lowercase letters, digits, dots and hyphens."
-                .to_string(),
-        );
+        return Some(dbflux_i18n::t!(
+            "document.buckets_table.new_bucket.error.charset"
+        ));
     }
 
     None
@@ -62,12 +63,8 @@ impl BucketEncryptionChoice {
         }
     }
 
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::SseS3 => "SSE-S3",
-            Self::SseKms => "SSE-KMS",
-            Self::None => "None",
-        }
+    pub fn label(self) -> String {
+        crate::labels::bucket_encryption_choice_label(self)
     }
 
     pub fn from_id(id: &str) -> Option<Self> {
@@ -217,11 +214,9 @@ impl BucketsTableDocument {
         cx.notify();
 
         let Some(connection) = self.get_connection(cx) else {
-            report_error(
-                UserFacingError::new(ErrorKind::User, "Connection is no longer active"),
-                cx,
-            );
-            self.apply_bucket_created(name, Err("Connection is no longer active".to_string()), cx);
+            let message = dbflux_i18n::t!("document.object_browser.error.connection_unavailable");
+            report_error(UserFacingError::new(ErrorKind::User, message.clone()), cx);
+            self.apply_bucket_created(name, Err(message), cx);
             return;
         };
 
@@ -236,7 +231,9 @@ impl BucketsTableDocument {
                     let name = name.clone();
                     async move {
                         let api = connection.object_store_api().ok_or_else(|| {
-                            DbError::NotSupported("Object-store API unavailable".to_string())
+                            DbError::NotSupported(dbflux_i18n::t!(
+                                "document.object_browser.error.api_unavailable"
+                            ))
                         })?;
                         api.create_bucket(&name, options)
                     }
@@ -277,14 +274,20 @@ impl BucketsTableDocument {
                 self.new_bucket = None;
 
                 if outcome.warnings.is_empty() {
-                    Toast::success(format!("Created bucket \"{name}\""))
-                        .meta_right(now_hms())
-                        .push(cx);
+                    Toast::success(dbflux_i18n::t!(
+                        "document.buckets_table.new_bucket.toast.created",
+                        name = name.as_str()
+                    ))
+                    .meta_right(now_hms())
+                    .push(cx);
                 } else {
-                    Toast::warning(format!("Created bucket \"{name}\" with limitations"))
-                        .body(outcome.warnings.join("\n"))
-                        .meta_right(now_hms())
-                        .push(cx);
+                    Toast::warning(dbflux_i18n::t!(
+                        "document.buckets_table.new_bucket.toast.created_with_limitations",
+                        name = name.as_str()
+                    ))
+                    .body(outcome.warnings.join("\n"))
+                    .meta_right(now_hms())
+                    .push(cx);
                 }
 
                 self.load_buckets(cx);
@@ -357,13 +360,15 @@ impl BucketsTableDocument {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Text::caption("Name"))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.buckets_table.new_bucket.field.name"
+                    )))
                     .child(Input::new(&state.name_input).small().w_full())
                     .child(match &name_error {
                         Some(error) => Text::caption(error.clone()).danger(),
-                        None => Text::caption(
-                            "3-63 characters · lowercase letters, digits, dots and hyphens",
-                        )
+                        None => Text::caption(dbflux_i18n::t!(
+                            "document.buckets_table.new_bucket.field.name_hint"
+                        ))
                         .muted_foreground(),
                     }),
             )
@@ -372,7 +377,9 @@ impl BucketsTableDocument {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Text::caption("Region"))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.buckets_table.new_bucket.field.region"
+                    )))
                     .child(Input::new(&state.region_input).small().w_full()),
             )
             .child(
@@ -380,10 +387,12 @@ impl BucketsTableDocument {
                     .flex()
                     .flex_col()
                     .gap(Spacing::SM)
-                    .child(Text::caption("Options"))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.buckets_table.new_bucket.section.options"
+                    )))
                     .child(
                         Checkbox::new("new-bucket-versioning")
-                            .label("Enable versioning")
+                            .label(dbflux_i18n::t!("document.buckets_table.new_bucket.option.versioning"))
                             .checked(state.versioning)
                             .on_click(cx.listener(|this, checked: &bool, _window, cx| {
                                 if let Some(state) = this.new_bucket.as_mut() {
@@ -394,7 +403,9 @@ impl BucketsTableDocument {
                     )
                     .child(
                         Checkbox::new("new-bucket-block-public")
-                            .label("Block all public access")
+                            .label(dbflux_i18n::t!(
+                                "document.buckets_table.new_bucket.option.block_public_access"
+                            ))
                             .checked(state.block_public_access)
                             .on_click(cx.listener(|this, checked: &bool, _window, cx| {
                                 if let Some(state) = this.new_bucket.as_mut() {
@@ -405,7 +416,7 @@ impl BucketsTableDocument {
                     )
                     .child(
                         Checkbox::new("new-bucket-object-lock")
-                            .label("Object lock")
+                            .label(dbflux_i18n::t!("document.buckets_table.new_bucket.option.object_lock"))
                             .checked(state.object_lock)
                             .on_click(cx.listener(|this, checked: &bool, _window, cx| {
                                 if let Some(state) = this.new_bucket.as_mut() {
@@ -422,9 +433,9 @@ impl BucketsTableDocument {
                                 .gap(Spacing::SM)
                                 .child(Icon::new(AppIcon::TriangleAlert).small().warning())
                                 .child(
-                                    Text::caption(
-                                        "Object lock cannot be disabled after the bucket is created.",
-                                    )
+                                    Text::caption(dbflux_i18n::t!(
+                                        "document.buckets_table.new_bucket.option.object_lock_warning"
+                                    ))
                                     .warning(),
                                 ),
                         )
@@ -436,7 +447,9 @@ impl BucketsTableDocument {
                     .items_center()
                     .justify_between()
                     .gap(Spacing::MD)
-                    .child(Text::caption("Default encryption"))
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.buckets_table.new_bucket.field.encryption"
+                    )))
                     .child(encryption_control),
             );
 
@@ -450,7 +463,13 @@ impl BucketsTableDocument {
                 .items_center()
                 .justify_between()
                 .gap(Spacing::MD)
-                .child(Text::caption("CreateBucket · applied immediately").muted_foreground())
+                .child(
+                    Text::caption(format!(
+                        "CreateBucket · {}",
+                        dbflux_i18n::t!("document.buckets_table.new_bucket.applied_immediately")
+                    ))
+                    .muted_foreground(),
+                )
                 .child(
                     div()
                         .flex()
@@ -470,7 +489,9 @@ impl BucketsTableDocument {
                                 .on_click(cx.listener(|this, _, _, cx| {
                                     this.close_new_bucket(cx);
                                 }))
-                                .child(Text::caption("Cancel")),
+                                .child(Text::caption(dbflux_i18n::t!(
+                                    "document.buckets_table.new_bucket.cancel"
+                                ))),
                         )
                         .child(
                             div()
@@ -498,9 +519,11 @@ impl BucketsTableDocument {
                                 )
                                 .child(
                                     Text::caption(if state.submitting {
-                                        "Creating…"
+                                        dbflux_i18n::t!(
+                                            "document.buckets_table.new_bucket.creating"
+                                        )
                                     } else {
-                                        "Create"
+                                        dbflux_i18n::t!("document.buckets_table.new_bucket.create")
                                     })
                                     .color(theme.primary_foreground),
                                 ),
@@ -509,7 +532,7 @@ impl BucketsTableDocument {
         );
 
         ModalFrame::new("buckets-new-bucket-modal", &self.focus_handle, close)
-            .title("New Bucket")
+            .title(dbflux_i18n::t!("document.buckets_table.new_bucket.title"))
             .icon(AppIcon::Plus)
             .width(px(560.0))
             .max_height(px(620.0))

--- a/crates/dbflux_ui_document/src/buckets_table/pane.rs
+++ b/crates/dbflux_ui_document/src/buckets_table/pane.rs
@@ -22,14 +22,16 @@ impl BucketsTableDocument {
         }
 
         segments.push(StatusSegment {
-            text: format!("{} buckets", self.buckets().len()).into(),
+            text: crate::labels::buckets_table_bucket_count_label(self.buckets().len()).into(),
             tooltip: None,
         });
 
         if let Some(timing) = self.last_operation {
             segments.push(StatusSegment {
                 text: timing.display().into(),
-                tooltip: Some("Client-side duration of the last object-store call".into()),
+                tooltip: Some(
+                    dbflux_i18n::t!("document.buckets_table.status.duration_tooltip").into(),
+                ),
             });
         }
 

--- a/crates/dbflux_ui_document/src/buckets_table/render.rs
+++ b/crates/dbflux_ui_document/src/buckets_table/render.rs
@@ -13,7 +13,6 @@ use dbflux_components::controls::Input;
 use dbflux_components::icons::AppIcon;
 use dbflux_components::primitives::{Icon, Text, overlay_bg, surface_panel};
 use dbflux_components::tokens::{Heights, Radii, Spacing};
-use dbflux_core::VersioningStatus;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::ActiveTheme;
@@ -64,18 +63,7 @@ pub(super) fn summary_line(rows: &[&BucketRow]) -> String {
     regions.sort_unstable();
     regions.dedup();
 
-    let bucket_word = if rows.len() == 1 { "bucket" } else { "buckets" };
-    let region_word = if regions.len() == 1 {
-        "region"
-    } else {
-        "regions"
-    };
-
-    format!(
-        "{} {bucket_word} · {} {region_word}",
-        rows.len(),
-        regions.len()
-    )
+    crate::labels::buckets_table_summary_line(rows.len(), regions.len())
 }
 
 fn region_label(row: &BucketRow) -> String {
@@ -86,13 +74,11 @@ fn region_label(row: &BucketRow) -> String {
     }
 }
 
-fn versioning_label(row: &BucketRow) -> Option<&'static str> {
+fn versioning_label(row: &BucketRow) -> Option<String> {
     match &row.details {
-        BucketDetailsState::Loaded(details) => match details.versioning {
-            VersioningStatus::Enabled => Some("on"),
-            VersioningStatus::Suspended => Some("suspended"),
-            VersioningStatus::Disabled => None,
-        },
+        BucketDetailsState::Loaded(details) => {
+            crate::labels::versioning_status_label(details.versioning)
+        }
         _ => None,
     }
 }
@@ -196,7 +182,9 @@ impl BucketsTableDocument {
                                 .small()
                                 .muted(),
                             )
-                            .child(Text::caption("Refresh")),
+                            .child(Text::caption(dbflux_i18n::t!(
+                                "document.buckets_table.toolbar.refresh"
+                            ))),
                     )
                     .child(
                         div()
@@ -218,7 +206,12 @@ impl BucketsTableDocument {
                                     .size(Heights::ICON_SM)
                                     .color(theme.primary_foreground),
                             )
-                            .child(Text::caption("New bucket").color(theme.primary_foreground)),
+                            .child(
+                                Text::caption(dbflux_i18n::t!(
+                                    "document.buckets_table.toolbar.new_bucket"
+                                ))
+                                .color(theme.primary_foreground),
+                            ),
                     ),
             )
     }
@@ -235,24 +228,40 @@ impl BucketsTableDocument {
             .border_b_1()
             .border_color(theme.border)
             .bg(theme.secondary)
-            .child(div().flex_1().child(Text::caption("Name")))
-            .child(div().w(REGION_WIDTH).child(Text::caption("Region")))
+            .child(div().flex_1().child(Text::caption(dbflux_i18n::t!(
+                "document.buckets_table.columns.name"
+            ))))
+            .child(div().w(REGION_WIDTH).child(Text::caption(dbflux_i18n::t!(
+                "document.buckets_table.columns.region"
+            ))))
             .child(
                 div()
                     .w(OBJECTS_WIDTH)
                     .flex()
                     .justify_end()
-                    .child(Text::caption("Objects")),
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.buckets_table.columns.objects"
+                    ))),
             )
             .child(
                 div()
                     .w(SIZE_WIDTH)
                     .flex()
                     .justify_end()
-                    .child(Text::caption("Size")),
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.buckets_table.columns.size"
+                    ))),
             )
-            .child(div().w(VERSIONING_WIDTH).child(Text::caption("Versioning")))
-            .child(div().w(CREATED_WIDTH).child(Text::caption("Created")))
+            .child(
+                div()
+                    .w(VERSIONING_WIDTH)
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.buckets_table.columns.versioning"
+                    ))),
+            )
+            .child(div().w(CREATED_WIDTH).child(Text::caption(dbflux_i18n::t!(
+                "document.buckets_table.columns.created"
+            ))))
     }
 
     fn render_row(&self, row: &BucketRow, selected: bool, cx: &mut Context<Self>) -> AnyElement {
@@ -338,9 +347,9 @@ impl BucketsTableDocument {
         let theme = cx.theme();
         let estimate_pending = matches!(row.size_estimate, BucketSizeEstimateState::Loading);
 
-        let versioning = versioning_label(row).unwrap_or("off");
+        let versioning = versioning_label(row).unwrap_or_else(crate::labels::versioning_off_label);
 
-        let detail_pair = |label: &'static str, value: String| {
+        let detail_pair = |label: String, value: String| {
             div()
                 .flex()
                 .flex_col()
@@ -364,11 +373,26 @@ impl BucketsTableDocument {
                     .flex()
                     .items_center()
                     .gap(Spacing::XL)
-                    .child(detail_pair("Region", region_label(row)))
-                    .child(detail_pair("Versioning", versioning.to_string()))
-                    .child(detail_pair("Created", created_label(row)))
-                    .child(detail_pair("Objects", object_count_label(row)))
-                    .child(detail_pair("Size", size_label(row))),
+                    .child(detail_pair(
+                        dbflux_i18n::t!("document.buckets_table.columns.region"),
+                        region_label(row),
+                    ))
+                    .child(detail_pair(
+                        dbflux_i18n::t!("document.buckets_table.columns.versioning"),
+                        versioning,
+                    ))
+                    .child(detail_pair(
+                        dbflux_i18n::t!("document.buckets_table.columns.created"),
+                        created_label(row),
+                    ))
+                    .child(detail_pair(
+                        dbflux_i18n::t!("document.buckets_table.columns.objects"),
+                        object_count_label(row),
+                    ))
+                    .child(detail_pair(
+                        dbflux_i18n::t!("document.buckets_table.columns.size"),
+                        size_label(row),
+                    )),
             )
             .child(
                 div()
@@ -391,9 +415,9 @@ impl BucketsTableDocument {
                     .when(estimate_pending, |d| d.opacity(0.6))
                     .child(Icon::new(AppIcon::Sigma).small().muted())
                     .child(Text::caption(if estimate_pending {
-                        "Calculating…"
+                        dbflux_i18n::t!("document.buckets_table.details.calculating")
                     } else {
-                        "Calculate size"
+                        dbflux_i18n::t!("document.buckets_table.details.calculate_size")
                     })),
             )
     }
@@ -424,21 +448,33 @@ impl BucketsTableDocument {
                     .flex()
                     .items_center()
                     .gap(Spacing::MD)
-                    .child(Text::key_hint("Enter browse"))
-                    .child(Text::key_hint("Space properties"))
-                    .child(Text::key_hint("x delete (empty only)")),
+                    .child(Text::key_hint(dbflux_i18n::t!(
+                        "document.buckets_table.footer.hint.open"
+                    )))
+                    .child(Text::key_hint(dbflux_i18n::t!(
+                        "document.buckets_table.footer.hint.properties"
+                    )))
+                    .child(Text::key_hint(dbflux_i18n::t!(
+                        "document.buckets_table.footer.hint.delete"
+                    ))),
             )
     }
 
     fn render_empty_state(&self) -> AnyElement {
         let message = match (self.state, &self.last_error) {
-            (DocumentState::Loading, _) => "Loading buckets…".to_string(),
-            (DocumentState::Error, Some(err)) => format!("Failed to list buckets: {err}"),
-            (DocumentState::Error, None) => "Failed to list buckets".to_string(),
-            _ if !self.search_query.trim().is_empty() => {
-                format!("No buckets match \"{}\"", self.search_query.trim())
+            (DocumentState::Loading, _) => dbflux_i18n::t!("document.buckets_table.empty.loading"),
+            (DocumentState::Error, Some(err)) => {
+                dbflux_i18n::t!(
+                    "document.buckets_table.empty.error_detail",
+                    error = err.as_str()
+                )
             }
-            _ => "This connection has no buckets".to_string(),
+            (DocumentState::Error, None) => dbflux_i18n::t!("document.buckets_table.empty.error"),
+            _ if !self.search_query.trim().is_empty() => dbflux_i18n::t!(
+                "document.buckets_table.empty.no_match",
+                query = self.search_query.trim()
+            ),
+            _ => dbflux_i18n::t!("document.buckets_table.empty.no_buckets"),
         };
 
         let is_error = self.state == DocumentState::Error;
@@ -464,7 +500,9 @@ impl BucketsTableDocument {
             } else {
                 Text::muted(message)
             })
-            .child(Text::key_hint("r refresh"))
+            .child(Text::key_hint(dbflux_i18n::t!(
+                "document.buckets_table.empty.hint_refresh"
+            )))
             .into_any_element()
     }
 
@@ -500,10 +538,13 @@ impl BucketsTableDocument {
                                     .size(Heights::ICON_MD)
                                     .warning(),
                             )
-                            .child(Text::heading("Delete bucket?")),
+                            .child(Text::heading(dbflux_i18n::t!(
+                                "document.buckets_table.delete_confirm.title"
+                            ))),
                     )
-                    .child(Text::muted(format!(
-                        "\"{bucket}\" is empty and will be removed. This cannot be undone."
+                    .child(Text::muted(dbflux_i18n::t!(
+                        "document.buckets_table.delete_confirm.body",
+                        bucket = bucket
                     )))
                     .child(
                         div()
@@ -525,7 +566,9 @@ impl BucketsTableDocument {
                                     .on_click(cx.listener(|this, _, _, cx| {
                                         this.cancel_delete_bucket(cx);
                                     }))
-                                    .child(Text::caption("Cancel")),
+                                    .child(Text::caption(dbflux_i18n::t!(
+                                        "document.buckets_table.delete_confirm.cancel"
+                                    ))),
                             )
                             .child(
                                 div()
@@ -547,7 +590,12 @@ impl BucketsTableDocument {
                                             .size(Heights::ICON_SM)
                                             .color(theme.background),
                                     )
-                                    .child(Text::caption("Delete").color(theme.background)),
+                                    .child(
+                                        Text::caption(dbflux_i18n::t!(
+                                            "document.buckets_table.delete_confirm.confirm"
+                                        ))
+                                        .color(theme.background),
+                                    ),
                             ),
                     ),
             )
@@ -716,7 +764,10 @@ mod tests {
     /// `Disabled` collapses to the muted placeholder rather than a label.
     #[test]
     fn versioning_label_reflects_details_state() {
-        assert_eq!(versioning_label(&row("a", Some("us-east-1"))), Some("on"));
+        assert_eq!(
+            versioning_label(&row("a", Some("us-east-1"))),
+            Some(dbflux_i18n::t!("document.buckets_table.versioning.on"))
+        );
         assert_eq!(versioning_label(&row("b", None)), None);
     }
 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1252,15 +1252,102 @@ pub(crate) fn delete_prefix_delete_button_label(object_count: Option<u64>) -> St
     }
 }
 
+/// Label for a bucket's active versioning status
+/// ([`dbflux_core::VersioningStatus`]), as shown on a bucket row and in the
+/// details strip. `Disabled` has no label of its own — callers fall back to
+/// the placeholder dash or [`versioning_off_label`] instead — so this only
+/// covers the two active statuses.
+pub(crate) fn versioning_status_label(status: dbflux_core::VersioningStatus) -> Option<String> {
+    use dbflux_core::VersioningStatus;
+
+    match status {
+        VersioningStatus::Enabled => Some(dbflux_i18n::t!("document.buckets_table.versioning.on")),
+        VersioningStatus::Suspended => Some(dbflux_i18n::t!(
+            "document.buckets_table.versioning.suspended"
+        )),
+        VersioningStatus::Disabled => None,
+    }
+}
+
+/// Label for the "no versioning configured" state shown in the bucket
+/// details strip, used when [`versioning_status_label`] returns `None`.
+pub(crate) fn versioning_off_label() -> String {
+    dbflux_i18n::t!("document.buckets_table.versioning.off")
+}
+
+/// Label for how many buckets are listed, shared by the table footer and the
+/// status-bar segment.
+///
+/// Uses the singular catalog bucket only for exactly one bucket; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn buckets_table_bucket_count_label(bucket_count: usize) -> String {
+    if bucket_count == 1 {
+        dbflux_i18n::t!(
+            "document.buckets_table.footer.buckets.one",
+            count = bucket_count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.buckets_table.footer.buckets.many",
+            count = bucket_count
+        )
+    }
+}
+
+/// Footer summary line for the buckets table: how many buckets are listed
+/// and how many distinct regions they span.
+///
+/// Uses the singular catalog bucket only for exactly one bucket/region;
+/// every other count, including zero, uses the plural bucket.
+pub(crate) fn buckets_table_summary_line(bucket_count: usize, region_count: usize) -> String {
+    let buckets = buckets_table_bucket_count_label(bucket_count);
+
+    let regions = if region_count == 1 {
+        dbflux_i18n::t!(
+            "document.buckets_table.footer.regions.one",
+            count = region_count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.buckets_table.footer.regions.many",
+            count = region_count
+        )
+    };
+
+    format!("{buckets} · {regions}")
+}
+
+/// Label for a [`crate::buckets_table::BucketEncryptionChoice`] shown as a
+/// segmented-control option and echoed in the New Bucket modal. Exhaustive by
+/// construction so a new choice fails this crate's build until its catalog
+/// key is added here.
+///
+/// `SseS3`/`SseKms` are the AWS encryption algorithm names, not prose, and
+/// stay in English.
+pub(crate) fn bucket_encryption_choice_label(
+    choice: crate::buckets_table::BucketEncryptionChoice,
+) -> String {
+    use crate::buckets_table::BucketEncryptionChoice;
+
+    match choice {
+        BucketEncryptionChoice::SseS3 => "SSE-S3".to_string(),
+        BucketEncryptionChoice::SseKms => "SSE-KMS".to_string(),
+        BucketEncryptionChoice::None => {
+            dbflux_i18n::t!("document.buckets_table.new_bucket.encryption.none")
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         MutationItemKind, add_member_modal_placeholders, add_member_modal_section_label,
         add_member_modal_title, agg_fn_display, assignment_value_kind_label,
         audit_actor_type_label, audit_category_label, audit_level_label, audit_outcome_label,
-        bool_op_label, builder_mode_label, bulk_delete_success_label, chart_degraded_copy,
-        chart_dock_shape_label, chart_rail_why_text, code_toolbar_shortcut_hint_label,
-        comparator_label, copy_query_language_label, dangerous_query_body, dangerous_query_title,
+        bool_op_label, bucket_encryption_choice_label, buckets_table_summary_line,
+        builder_mode_label, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
+        chart_rail_why_text, code_toolbar_shortcut_hint_label, comparator_label,
+        copy_query_language_label, dangerous_query_body, dangerous_query_title,
         delete_confirm_copy, delete_prefix_delete_button_label, delete_prefix_deleted_toast,
         delete_prefix_probe_totals, delete_rows_label, execution_count_state_label,
         execution_mode_label, history_items_count_label, history_tab_label, image_decode_error,
@@ -1270,15 +1357,17 @@ mod tests {
         pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
         refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
         script_confirm_message_label, sort_direction_label, table_action_description,
-        unsaved_changes_label, update_columns_label, valid_lines_label,
+        unsaved_changes_label, update_columns_label, valid_lines_label, versioning_off_label,
+        versioning_status_label,
     };
+    use crate::buckets_table::BucketEncryptionChoice;
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
     use crate::schema_diff::apply::TableLevelAction;
     use dbflux_components::chart::ChartDetection;
     use dbflux_core::{
         ColumnSnapshot, DangerousQueryKind, EventActorType, EventCategory, EventOutcome,
         EventSeverity, IndexSnapshot, QueryLanguage, RefreshPolicy, SchemaChange, TableInfo,
-        TableRef,
+        TableRef, VersioningStatus,
     };
 
     const ALL_DANGEROUS_QUERY_KINDS: &[DangerousQueryKind] = &[
@@ -3324,5 +3413,165 @@ mod tests {
                 locale = "es"
             )
         );
+    }
+
+    /// T22: `versioning_status_label` (widened from `Option<&'static str>`)
+    /// covers every `VersioningStatus` variant, with `Disabled` staying
+    /// `None` for the caller's own placeholder.
+    #[test]
+    fn versioning_status_label_covers_all_variants() {
+        assert_eq!(
+            versioning_status_label(VersioningStatus::Enabled),
+            Some(dbflux_i18n::t!("document.buckets_table.versioning.on"))
+        );
+        assert_eq!(
+            versioning_status_label(VersioningStatus::Suspended),
+            Some(dbflux_i18n::t!(
+                "document.buckets_table.versioning.suspended"
+            ))
+        );
+        assert_eq!(versioning_status_label(VersioningStatus::Disabled), None);
+        assert_eq!(
+            versioning_off_label(),
+            dbflux_i18n::t!("document.buckets_table.versioning.off")
+        );
+    }
+
+    /// T22: the footer summary line routes both counts through the plural
+    /// catalog helper instead of a hand-rolled English-only word.
+    #[test]
+    fn buckets_table_summary_line_uses_zero_one_many() {
+        assert_eq!(
+            buckets_table_summary_line(0, 0),
+            format!(
+                "{} · {}",
+                dbflux_i18n::t!("document.buckets_table.footer.buckets.many", count = 0),
+                dbflux_i18n::t!("document.buckets_table.footer.regions.many", count = 0)
+            )
+        );
+        assert_eq!(
+            buckets_table_summary_line(1, 1),
+            format!(
+                "{} · {}",
+                dbflux_i18n::t!("document.buckets_table.footer.buckets.one", count = 1),
+                dbflux_i18n::t!("document.buckets_table.footer.regions.one", count = 1)
+            )
+        );
+        assert_eq!(
+            buckets_table_summary_line(4, 2),
+            format!(
+                "{} · {}",
+                dbflux_i18n::t!("document.buckets_table.footer.buckets.many", count = 4),
+                dbflux_i18n::t!("document.buckets_table.footer.regions.many", count = 2)
+            )
+        );
+    }
+
+    /// T22 (new_bucket.rs:65): `BucketEncryptionChoice::label` is widened
+    /// from `&'static str` to `String`. `SseS3`/`SseKms` stay the literal AWS
+    /// algorithm names in both locales; `None` routes through the catalog.
+    #[test]
+    fn bucket_encryption_choice_label_covers_all_variants() {
+        assert_eq!(
+            bucket_encryption_choice_label(BucketEncryptionChoice::SseS3),
+            "SSE-S3"
+        );
+        assert_eq!(
+            bucket_encryption_choice_label(BucketEncryptionChoice::SseKms),
+            "SSE-KMS"
+        );
+        assert_eq!(
+            bucket_encryption_choice_label(BucketEncryptionChoice::None),
+            dbflux_i18n::t!("document.buckets_table.new_bucket.encryption.none")
+        );
+    }
+
+    /// T22: the buckets-table keys resolve in both locales, including the
+    /// `document.object_browser.error.*` keys reused from PR 19/21 for the
+    /// "connection unavailable" / "API unavailable" driver messages.
+    #[test]
+    fn buckets_table_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.buckets_table.title",
+            "document.buckets_table.search_placeholder",
+            "document.buckets_table.toolbar.refresh",
+            "document.buckets_table.toolbar.new_bucket",
+            "document.buckets_table.columns.name",
+            "document.buckets_table.columns.region",
+            "document.buckets_table.columns.objects",
+            "document.buckets_table.columns.size",
+            "document.buckets_table.columns.versioning",
+            "document.buckets_table.columns.created",
+            "document.buckets_table.versioning.on",
+            "document.buckets_table.versioning.suspended",
+            "document.buckets_table.versioning.off",
+            "document.buckets_table.details.calculate_size",
+            "document.buckets_table.details.calculating",
+            "document.buckets_table.footer.buckets.one",
+            "document.buckets_table.footer.buckets.many",
+            "document.buckets_table.footer.regions.one",
+            "document.buckets_table.footer.regions.many",
+            "document.buckets_table.footer.hint.open",
+            "document.buckets_table.footer.hint.properties",
+            "document.buckets_table.footer.hint.delete",
+            "document.buckets_table.empty.loading",
+            "document.buckets_table.empty.error",
+            "document.buckets_table.empty.error_detail",
+            "document.buckets_table.empty.no_match",
+            "document.buckets_table.empty.no_buckets",
+            "document.buckets_table.empty.hint_refresh",
+            "document.buckets_table.delete_confirm.title",
+            "document.buckets_table.delete_confirm.body",
+            "document.buckets_table.delete_confirm.cancel",
+            "document.buckets_table.delete_confirm.confirm",
+            "document.buckets_table.error.bucket_not_empty",
+            "document.buckets_table.status.duration_tooltip",
+            "document.buckets_table.new_bucket.title",
+            "document.buckets_table.new_bucket.field.name",
+            "document.buckets_table.new_bucket.field.name_hint",
+            "document.buckets_table.new_bucket.field.region",
+            "document.buckets_table.new_bucket.field.encryption",
+            "document.buckets_table.new_bucket.section.options",
+            "document.buckets_table.new_bucket.option.versioning",
+            "document.buckets_table.new_bucket.option.block_public_access",
+            "document.buckets_table.new_bucket.option.object_lock",
+            "document.buckets_table.new_bucket.option.object_lock_warning",
+            "document.buckets_table.new_bucket.encryption.none",
+            "document.buckets_table.new_bucket.applied_immediately",
+            "document.buckets_table.new_bucket.cancel",
+            "document.buckets_table.new_bucket.create",
+            "document.buckets_table.new_bucket.creating",
+            "document.buckets_table.new_bucket.error.length",
+            "document.buckets_table.new_bucket.error.charset",
+            "document.buckets_table.new_bucket.toast.created",
+            "document.buckets_table.new_bucket.toast.created_with_limitations",
+            "document.object_browser.error.connection_unavailable",
+            "document.object_browser.error.api_unavailable",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// T22: at least one buckets-table key must actually diverge between
+    /// locales, so the parity loop above cannot pass on English fallbacks
+    /// copied verbatim into `es.yml`.
+    #[test]
+    fn buckets_table_versioning_on_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.buckets_table.versioning.on", locale = "en");
+        let es = dbflux_i18n::t!("document.buckets_table.versioning.on", locale = "es");
+
+        assert_ne!(en, es);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 22: the buckets table (toolbar, column headers, versioning status, details strip, footer and status-bar counts, empty states, delete confirmation) and the New Bucket modal (fields, encryption options, validation, buttons, toasts) render through `dbflux_i18n::t!` under `document.buckets_table.*`. English and Spanish together. Bucket names, regions, SSE-S3/SSE-KMS and AWS operation names stay data.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `versioning_label` widened to `Option<String>` and `BucketEncryptionChoice::label` to `String`; `buckets_table_bucket_count_label` is shared by the footer and the status-bar segment, which also fixes the status bar always using the plural word.
- Size: 745 lines, the pre-sliced `buckets_table/*` boundary (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1037 passed; clippy clean; fmt clean. Manual smoke in Spanish: list buckets, read the versioning column and footer, create a bucket from the modal.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
