### PR TITLE
feat(i18n): translate the workspace action toasts, dialogs, and default names

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -38,6 +38,15 @@ access:
   ssh_failed: SSH connection failed
   save_as_tunnel: Save as tunnel
   ssh_disabled_hint: Enable SSH tunnel to configure connection through a bastion host
+audit:
+  toast:
+    focus_existing_viewer: Focusing existing audit viewer
+    opened_viewer: Opened audit viewer
+    opened_mcp_approvals: Opened MCP approvals
+    mcp_governance_persisted: MCP governance state persisted
+  error:
+    open_viewer_failed: "Cannot open audit viewer: %{error}"
+    persist_mcp_governance_failed: "Failed to persist MCP governance: %{error}"
 chart:
   axis_bar:
     group: Group
@@ -108,6 +117,13 @@ charts:
     add_panel_failed: "Failed to add panel: %{error}"
     persist_metric_chart_for_panel_failed: "Failed to persist metric chart '%{name}' for new panel"
     add_panels_failed: "Failed to add panels: %{error}"
+  instance_overview:
+    editable_name: "%{name} (editable)"
+    toast:
+      no_dashboard_defined: This driver does not define an Instance Overview dashboard.
+      created_editable: Created editable dashboard with all overview panels.
+    error:
+      create_editable_failed: "Failed to create editable dashboard: %{error}"
 components:
   json_editor:
     empty_error: Document cannot be empty
@@ -248,6 +264,16 @@ connection_manager:
     cancel: Cancel
     configure: Configure
     configure_named: "Configure %{name}"
+connections:
+  window:
+    manager_title: Connection Manager
+    edit_title: Edit Connection
+  toast:
+    disconnecting: "Disconnecting from %{name}..."
+    no_active_connection: No active connection
+    refreshing_schema: Refreshing schema...
+  error:
+    refresh_schema_failed: "Failed to refresh schema: %{error}"
 document:
   audit:
     actor:
@@ -1201,6 +1227,22 @@ document_tree:
     raw_json: Raw JSON
   no_matches: No matches
   document_label: "Document %{index}"
+documents:
+  default_title: Untitled
+  new_query_name: Query
+  toast:
+    schema_diff_opened: Opened schema diff
+    no_active_connection_for:
+      table: No active connection for this table
+      collection: No active connection for this collection
+      event_source: No active connection for this event source
+      key_value_db: No active connection for this key-value database
+      object_storage_account: No active connection for this object-storage account
+      bucket: No active connection for this bucket
+      object: No active connection for this object
+  error:
+    write_initial_script_failed: "Failed to write initial script content: %{error}"
+    save_session_failed: Failed to save session manifest
 errors:
   action:
     view_in_audit: View in Audit
@@ -1522,7 +1564,19 @@ palette:
     view: View
     charts: Charts
     dashboards: Dashboards
+scripts:
+  dialog:
+    title: Open Script
+    filter:
+      sql: SQL Files
+      javascript_mongodb: JavaScript (MongoDB)
+      redis: Redis
+      all_files: All Files
+  error:
+    read_file_failed: "Failed to read file %{path}: %{error}"
 settings:
+  action:
+    default_connection_name: connection
   general:
     header:
       title: General

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -38,6 +38,15 @@ access:
   ssh_failed: Fallo en la conexión SSH
   save_as_tunnel: Guardar como túnel
   ssh_disabled_hint: Habilita el túnel SSH para configurar la conexión a través de un host bastión
+audit:
+  toast:
+    focus_existing_viewer: Se enfocó el visor de auditoría existente
+    opened_viewer: Se abrió el visor de auditoría
+    opened_mcp_approvals: Se abrieron las aprobaciones de MCP
+    mcp_governance_persisted: Se guardó el estado de gobernanza de MCP
+  error:
+    open_viewer_failed: "No se pudo abrir el visor de auditoría: %{error}"
+    persist_mcp_governance_failed: "No se pudo guardar la gobernanza de MCP: %{error}"
 chart:
   axis_bar:
     group: Grupo
@@ -108,6 +117,13 @@ charts:
     add_panel_failed: "No se pudo agregar el panel: %{error}"
     persist_metric_chart_for_panel_failed: "No se pudo guardar el gráfico de métrica '%{name}' del nuevo panel"
     add_panels_failed: "No se pudieron agregar los paneles: %{error}"
+  instance_overview:
+    editable_name: "%{name} (editable)"
+    toast:
+      no_dashboard_defined: Este controlador no define un dashboard de Vista general de instancia.
+      created_editable: Se creó un dashboard editable con todos los paneles de la vista general.
+    error:
+      create_editable_failed: "No se pudo crear el dashboard editable: %{error}"
 components:
   json_editor:
     empty_error: El documento no puede estar vacío
@@ -248,6 +264,16 @@ connection_manager:
     cancel: Cancelar
     configure: Configurar
     configure_named: "Configurar %{name}"
+connections:
+  window:
+    manager_title: Administrador de conexiones
+    edit_title: Editar conexión
+  toast:
+    disconnecting: "Desconectando de %{name}..."
+    no_active_connection: No hay conexión activa
+    refreshing_schema: Actualizando esquema...
+  error:
+    refresh_schema_failed: "No se pudo actualizar el esquema: %{error}"
 document:
   audit:
     actor:
@@ -1201,6 +1227,22 @@ document_tree:
     raw_json: JSON sin formato
   no_matches: Sin coincidencias
   document_label: "Documento %{index}"
+documents:
+  default_title: Sin título
+  new_query_name: Consulta
+  toast:
+    schema_diff_opened: Se abrió la comparación de esquemas
+    no_active_connection_for:
+      table: No hay conexión activa para esta tabla
+      collection: No hay conexión activa para esta colección
+      event_source: No hay conexión activa para esta fuente de eventos
+      key_value_db: No hay conexión activa para esta base clave-valor
+      object_storage_account: No hay conexión activa para esta cuenta de almacenamiento de objetos
+      bucket: No hay conexión activa para este bucket
+      object: No hay conexión activa para este objeto
+  error:
+    write_initial_script_failed: "No se pudo escribir el contenido inicial del script: %{error}"
+    save_session_failed: No se pudo guardar el manifiesto de la sesión
 errors:
   action:
     view_in_audit: Ver en auditoría
@@ -1522,7 +1564,19 @@ palette:
     view: Vista
     charts: Gráficos
     dashboards: Dashboards
+scripts:
+  dialog:
+    title: Abrir script
+    filter:
+      sql: Archivos SQL
+      javascript_mongodb: JavaScript (MongoDB)
+      redis: Redis
+      all_files: Todos los archivos
+  error:
+    read_file_failed: "No se pudo leer el archivo %{path}: %{error}"
 settings:
+  action:
+    default_connection_name: conexión
   general:
     header:
       title: General

--- a/crates/dbflux_ui/src/ui/labels.rs
+++ b/crates/dbflux_ui/src/ui/labels.rs
@@ -203,12 +203,227 @@ pub(crate) fn charts_add_panels_failed_message(error: impl std::fmt::Display) ->
     dbflux_i18n::t!("charts.error.add_panels_failed", error = error)
 }
 
+/// Formats the toast shown when the driver has no Instance Overview dashboard.
+pub(crate) fn charts_instance_overview_no_dashboard_message() -> String {
+    dbflux_i18n::t!("charts.instance_overview.toast.no_dashboard_defined")
+}
+
+/// Formats the toast shown after cloning a read-only overview into an editable dashboard.
+pub(crate) fn charts_instance_overview_created_editable_message() -> String {
+    dbflux_i18n::t!("charts.instance_overview.toast.created_editable")
+}
+
+/// Formats the persisted display name for a dashboard cloned from a read-only
+/// Instance Overview into an editable copy.
+pub(crate) fn charts_instance_overview_editable_name(source_title: &str) -> String {
+    dbflux_i18n::t!(
+        "charts.instance_overview.editable_name",
+        name = source_title
+    )
+}
+
+/// Formats the error shown when cloning an overview into an editable dashboard fails.
+pub(crate) fn charts_instance_overview_create_editable_failed_message(
+    error: impl std::fmt::Display,
+) -> String {
+    dbflux_i18n::t!(
+        "charts.instance_overview.error.create_editable_failed",
+        error = error
+    )
+}
+
+/// Formats the "Connection Manager" window title.
+pub(crate) fn connections_manager_window_title() -> String {
+    dbflux_i18n::t!("connections.window.manager_title")
+}
+
+/// Formats the "Edit Connection" window title.
+pub(crate) fn connections_edit_window_title() -> String {
+    dbflux_i18n::t!("connections.window.edit_title")
+}
+
+/// Formats the "Disconnecting from X..." toast shown while tearing down a connection.
+pub(crate) fn connections_disconnecting_message(name: &str) -> String {
+    dbflux_i18n::t!("connections.toast.disconnecting", name = name)
+}
+
+/// Formats the "No active connection" warning toast for schema refresh.
+pub(crate) fn connections_no_active_connection_message() -> String {
+    dbflux_i18n::t!("connections.toast.no_active_connection")
+}
+
+/// Formats the "Refreshing schema..." toast shown while a schema reload is in flight.
+pub(crate) fn connections_refreshing_schema_message() -> String {
+    dbflux_i18n::t!("connections.toast.refreshing_schema")
+}
+
+/// Formats the error shown when a schema refresh fails.
+pub(crate) fn connections_refresh_schema_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("connections.error.refresh_schema_failed", error = error)
+}
+
+/// Formats the "Open Script" file dialog title.
+pub(crate) fn scripts_open_dialog_title() -> String {
+    dbflux_i18n::t!("scripts.dialog.title")
+}
+
+/// Formats the SQL file-dialog filter label.
+pub(crate) fn scripts_filter_sql_label() -> String {
+    dbflux_i18n::t!("scripts.dialog.filter.sql")
+}
+
+/// Formats the MongoDB JavaScript file-dialog filter label.
+pub(crate) fn scripts_filter_javascript_mongodb_label() -> String {
+    dbflux_i18n::t!("scripts.dialog.filter.javascript_mongodb")
+}
+
+/// Formats the Redis file-dialog filter label.
+pub(crate) fn scripts_filter_redis_label() -> String {
+    dbflux_i18n::t!("scripts.dialog.filter.redis")
+}
+
+/// Formats the "All Files" file-dialog filter label.
+pub(crate) fn scripts_filter_all_files_label() -> String {
+    dbflux_i18n::t!("scripts.dialog.filter.all_files")
+}
+
+/// Formats the error shown when reading a script file from disk fails.
+pub(crate) fn scripts_read_file_failed_message(
+    path: impl std::fmt::Display,
+    error: impl std::fmt::Display,
+) -> String {
+    dbflux_i18n::t!(
+        "scripts.error.read_file_failed",
+        path = path.to_string(),
+        error = error
+    )
+}
+
+/// Formats the "Focusing existing audit viewer" toast.
+pub(crate) fn audit_focus_existing_viewer_message() -> String {
+    dbflux_i18n::t!("audit.toast.focus_existing_viewer")
+}
+
+/// Formats the "Opened audit viewer" toast.
+pub(crate) fn audit_opened_viewer_message() -> String {
+    dbflux_i18n::t!("audit.toast.opened_viewer")
+}
+
+/// Formats the "Opened MCP approvals" toast.
+pub(crate) fn audit_opened_mcp_approvals_message() -> String {
+    dbflux_i18n::t!("audit.toast.opened_mcp_approvals")
+}
+
+/// Formats the "MCP governance state persisted" toast.
+pub(crate) fn audit_mcp_governance_persisted_message() -> String {
+    dbflux_i18n::t!("audit.toast.mcp_governance_persisted")
+}
+
+/// Formats the error shown when the audit viewer cannot open its repository.
+pub(crate) fn audit_open_viewer_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("audit.error.open_viewer_failed", error = error)
+}
+
+/// Formats the error shown when persisting MCP governance state fails.
+pub(crate) fn audit_persist_mcp_governance_failed_message(error: impl std::fmt::Display) -> String {
+    dbflux_i18n::t!("audit.error.persist_mcp_governance_failed", error = error)
+}
+
+/// The document/resource kind behind a "No active connection for this X" toast.
+///
+/// Exhaustively matched by [`documents_no_active_connection_message`] so a new
+/// variant without a matching catalog key fails to compile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NoActiveConnectionKind {
+    Table,
+    Collection,
+    EventSource,
+    KeyValueDb,
+    ObjectStorageAccount,
+    Bucket,
+    Object,
+}
+
+/// Formats the "No active connection for this X" toast for the given resource kind.
+pub(crate) fn documents_no_active_connection_message(kind: NoActiveConnectionKind) -> String {
+    match kind {
+        NoActiveConnectionKind::Table => {
+            dbflux_i18n::t!("documents.toast.no_active_connection_for.table")
+        }
+        NoActiveConnectionKind::Collection => {
+            dbflux_i18n::t!("documents.toast.no_active_connection_for.collection")
+        }
+        NoActiveConnectionKind::EventSource => {
+            dbflux_i18n::t!("documents.toast.no_active_connection_for.event_source")
+        }
+        NoActiveConnectionKind::KeyValueDb => {
+            dbflux_i18n::t!("documents.toast.no_active_connection_for.key_value_db")
+        }
+        NoActiveConnectionKind::ObjectStorageAccount => {
+            dbflux_i18n::t!("documents.toast.no_active_connection_for.object_storage_account")
+        }
+        NoActiveConnectionKind::Bucket => {
+            dbflux_i18n::t!("documents.toast.no_active_connection_for.bucket")
+        }
+        NoActiveConnectionKind::Object => {
+            dbflux_i18n::t!("documents.toast.no_active_connection_for.object")
+        }
+    }
+}
+
+/// Formats the default title used for a tab whose real name could not be resolved.
+pub(crate) fn documents_default_title() -> String {
+    dbflux_i18n::t!("documents.default_title")
+}
+
+/// Formats the default file name used for a freshly created query tab.
+pub(crate) fn documents_new_query_name() -> String {
+    dbflux_i18n::t!("documents.new_query_name")
+}
+
+/// Formats the "Opened schema diff" toast.
+pub(crate) fn documents_schema_diff_opened_message() -> String {
+    dbflux_i18n::t!("documents.toast.schema_diff_opened")
+}
+
+/// Formats the error shown when writing a new query tab's initial script content fails.
+pub(crate) fn documents_write_initial_script_failed_message(
+    error: impl std::fmt::Display,
+) -> String {
+    dbflux_i18n::t!("documents.error.write_initial_script_failed", error = error)
+}
+
+/// Formats the error shown when the workspace session manifest fails to save.
+pub(crate) fn documents_save_session_failed_message() -> String {
+    dbflux_i18n::t!("documents.error.save_session_failed")
+}
+
+/// Formats the fallback profile name used when opening the login modal manually
+/// with no active connection to name it after.
+pub(crate) fn settings_default_connection_name() -> String {
+    dbflux_i18n::t!("settings.action.default_connection_name")
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        shutdown_phase_label, tasks_running_label, workspace_delete_connection_message,
-        workspace_delete_folder_message, workspace_delete_selected_message,
-        workspace_drop_object_message,
+        NoActiveConnectionKind, audit_focus_existing_viewer_message,
+        audit_mcp_governance_persisted_message, audit_open_viewer_failed_message,
+        audit_opened_mcp_approvals_message, audit_opened_viewer_message,
+        audit_persist_mcp_governance_failed_message,
+        charts_instance_overview_create_editable_failed_message,
+        charts_instance_overview_created_editable_message, charts_instance_overview_editable_name,
+        charts_instance_overview_no_dashboard_message, connections_disconnecting_message,
+        connections_edit_window_title, connections_manager_window_title,
+        connections_no_active_connection_message, connections_refresh_schema_failed_message,
+        connections_refreshing_schema_message, documents_default_title, documents_new_query_name,
+        documents_no_active_connection_message, documents_save_session_failed_message,
+        documents_schema_diff_opened_message, documents_write_initial_script_failed_message,
+        scripts_filter_all_files_label, scripts_filter_javascript_mongodb_label,
+        scripts_filter_redis_label, scripts_filter_sql_label, scripts_open_dialog_title,
+        scripts_read_file_failed_message, settings_default_connection_name, shutdown_phase_label,
+        tasks_running_label, workspace_delete_connection_message, workspace_delete_folder_message,
+        workspace_delete_selected_message, workspace_drop_object_message,
     };
     use dbflux_core::ShutdownPhase;
 
@@ -356,5 +571,191 @@ mod tests {
         let message = workspace_delete_connection_message("prod-db");
 
         assert!(message.contains("prod-db"));
+    }
+
+    const WORKSPACE_ACTIONS_CATALOG_KEYS: &[&str] = &[
+        "connections.window.manager_title",
+        "connections.window.edit_title",
+        "connections.toast.disconnecting",
+        "connections.toast.no_active_connection",
+        "connections.toast.refreshing_schema",
+        "connections.error.refresh_schema_failed",
+        "scripts.dialog.title",
+        "scripts.dialog.filter.sql",
+        "scripts.dialog.filter.javascript_mongodb",
+        "scripts.dialog.filter.redis",
+        "scripts.dialog.filter.all_files",
+        "scripts.error.read_file_failed",
+        "audit.toast.focus_existing_viewer",
+        "audit.toast.opened_viewer",
+        "audit.toast.opened_mcp_approvals",
+        "audit.toast.mcp_governance_persisted",
+        "audit.error.open_viewer_failed",
+        "audit.error.persist_mcp_governance_failed",
+        "documents.toast.no_active_connection_for.table",
+        "documents.toast.no_active_connection_for.collection",
+        "documents.toast.no_active_connection_for.event_source",
+        "documents.toast.no_active_connection_for.key_value_db",
+        "documents.toast.no_active_connection_for.object_storage_account",
+        "documents.toast.no_active_connection_for.bucket",
+        "documents.toast.no_active_connection_for.object",
+        "documents.default_title",
+        "documents.new_query_name",
+        "documents.toast.schema_diff_opened",
+        "documents.error.write_initial_script_failed",
+        "documents.error.save_session_failed",
+        "settings.action.default_connection_name",
+        "charts.instance_overview.toast.no_dashboard_defined",
+        "charts.instance_overview.toast.created_editable",
+        "charts.instance_overview.editable_name",
+        "charts.instance_overview.error.create_editable_failed",
+    ];
+
+    #[test]
+    fn workspace_actions_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in WORKSPACE_ACTIONS_CATALOG_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn connections_manager_and_edit_window_titles_differ_between_locales() {
+        let manager_en = dbflux_i18n::t!("connections.window.manager_title", locale = "en");
+        let manager_es = dbflux_i18n::t!("connections.window.manager_title", locale = "es");
+        assert_ne!(manager_en, manager_es);
+        assert_eq!(manager_en, connections_manager_window_title());
+
+        let edit_en = dbflux_i18n::t!("connections.window.edit_title", locale = "en");
+        let edit_es = dbflux_i18n::t!("connections.window.edit_title", locale = "es");
+        assert_ne!(edit_en, edit_es);
+        assert_eq!(edit_en, connections_edit_window_title());
+    }
+
+    #[test]
+    fn connections_disconnecting_message_embeds_name() {
+        let message = connections_disconnecting_message("prod-db");
+        assert!(message.contains("prod-db"));
+    }
+
+    #[test]
+    fn connections_no_active_connection_and_refreshing_schema_messages_resolve() {
+        assert!(!connections_no_active_connection_message().is_empty());
+        assert!(!connections_refreshing_schema_message().is_empty());
+    }
+
+    #[test]
+    fn connections_refresh_schema_failed_message_embeds_error() {
+        let message = connections_refresh_schema_failed_message("driver timeout");
+        assert!(message.contains("driver timeout"));
+    }
+
+    #[test]
+    fn scripts_open_dialog_title_and_filters_resolve() {
+        assert!(!scripts_open_dialog_title().is_empty());
+        assert!(!scripts_filter_sql_label().is_empty());
+        assert!(!scripts_filter_javascript_mongodb_label().is_empty());
+        assert!(!scripts_filter_redis_label().is_empty());
+        assert!(!scripts_filter_all_files_label().is_empty());
+    }
+
+    #[test]
+    fn scripts_read_file_failed_message_embeds_path_and_error() {
+        let message = scripts_read_file_failed_message("/tmp/query.sql", "permission denied");
+        assert!(message.contains("/tmp/query.sql"));
+        assert!(message.contains("permission denied"));
+    }
+
+    #[test]
+    fn audit_toast_messages_resolve() {
+        assert!(!audit_focus_existing_viewer_message().is_empty());
+        assert!(!audit_opened_viewer_message().is_empty());
+        assert!(!audit_opened_mcp_approvals_message().is_empty());
+        assert!(!audit_mcp_governance_persisted_message().is_empty());
+    }
+
+    #[test]
+    fn audit_error_messages_embed_error() {
+        assert!(audit_open_viewer_failed_message("disk full").contains("disk full"));
+        assert!(
+            audit_persist_mcp_governance_failed_message("write failed").contains("write failed")
+        );
+    }
+
+    #[test]
+    fn documents_no_active_connection_message_is_exhaustive_and_distinct_per_kind() {
+        let kinds = [
+            NoActiveConnectionKind::Table,
+            NoActiveConnectionKind::Collection,
+            NoActiveConnectionKind::EventSource,
+            NoActiveConnectionKind::KeyValueDb,
+            NoActiveConnectionKind::ObjectStorageAccount,
+            NoActiveConnectionKind::Bucket,
+            NoActiveConnectionKind::Object,
+        ];
+
+        let mut messages = Vec::with_capacity(kinds.len());
+        for kind in kinds {
+            let message = documents_no_active_connection_message(kind);
+            assert!(!message.is_empty(), "{kind:?} resolved to an empty message");
+            messages.push(message);
+        }
+
+        let unique: std::collections::HashSet<_> = messages.iter().collect();
+        assert_eq!(
+            unique.len(),
+            messages.len(),
+            "every NoActiveConnectionKind must resolve to a distinct message"
+        );
+    }
+
+    #[test]
+    fn documents_default_title_and_new_query_name_resolve() {
+        assert!(!documents_default_title().is_empty());
+        assert!(!documents_new_query_name().is_empty());
+    }
+
+    #[test]
+    fn documents_schema_diff_opened_message_resolves() {
+        assert!(!documents_schema_diff_opened_message().is_empty());
+    }
+
+    #[test]
+    fn documents_error_messages_resolve() {
+        assert!(documents_write_initial_script_failed_message("disk full").contains("disk full"));
+        assert!(!documents_save_session_failed_message().is_empty());
+    }
+
+    #[test]
+    fn settings_default_connection_name_resolves() {
+        assert!(!settings_default_connection_name().is_empty());
+    }
+
+    #[test]
+    fn charts_instance_overview_messages_resolve() {
+        assert!(!charts_instance_overview_no_dashboard_message().is_empty());
+        assert!(!charts_instance_overview_created_editable_message().is_empty());
+        assert!(
+            charts_instance_overview_create_editable_failed_message("disk full")
+                .contains("disk full")
+        );
+    }
+
+    #[test]
+    fn charts_instance_overview_editable_name_embeds_source_title() {
+        let name = charts_instance_overview_editable_name("Instance Overview");
+        assert!(name.contains("Instance Overview"));
     }
 }

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/audit.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/audit.rs
@@ -1,4 +1,9 @@
 use super::*;
+use crate::ui::labels::{
+    audit_focus_existing_viewer_message, audit_mcp_governance_persisted_message,
+    audit_open_viewer_failed_message, audit_opened_mcp_approvals_message,
+    audit_opened_viewer_message, audit_persist_mcp_governance_failed_message,
+};
 
 impl Workspace {
     /// Opens the global audit viewer as a document tab.
@@ -32,7 +37,7 @@ impl Workspace {
             });
 
             self.set_focus(crate::keymap::FocusTarget::Document, window, cx);
-            Toast::info("Focusing existing audit viewer")
+            Toast::info(audit_focus_existing_viewer_message())
                 .meta_right(now_hms())
                 .push(cx);
             return;
@@ -44,10 +49,7 @@ impl Workspace {
             Ok(repo) => repo,
             Err(e) => {
                 report_error(
-                    UserFacingError::new(
-                        ErrorKind::Storage,
-                        format!("Cannot open audit viewer: {e}"),
-                    ),
+                    UserFacingError::new(ErrorKind::Storage, audit_open_viewer_failed_message(e)),
                     cx,
                 );
                 return;
@@ -61,7 +63,7 @@ impl Workspace {
         });
 
         self.set_focus(crate::keymap::FocusTarget::Document, window, cx);
-        Toast::info("Opened audit viewer")
+        Toast::info(audit_opened_viewer_message())
             .meta_right(now_hms())
             .push(cx);
     }
@@ -110,7 +112,7 @@ impl Workspace {
                         report_error(
                             UserFacingError::new(
                                 ErrorKind::Storage,
-                                format!("Cannot open audit viewer: {e}"),
+                                audit_open_viewer_failed_message(e),
                             ),
                             cx,
                         );
@@ -151,7 +153,7 @@ impl Workspace {
         });
 
         self.active_governance_panel = Some(super::GovernancePanel::Approvals);
-        Toast::info("Opened MCP approvals")
+        Toast::info(audit_opened_mcp_approvals_message())
             .meta_right(now_hms())
             .push(cx);
     }
@@ -167,7 +169,7 @@ impl Workspace {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Config,
-                        format!("Failed to persist MCP governance: {e}"),
+                        audit_persist_mcp_governance_failed_message(e),
                     ),
                     cx,
                 );
@@ -179,7 +181,7 @@ impl Workspace {
             }
         });
 
-        Toast::info("MCP governance state persisted")
+        Toast::info(audit_mcp_governance_persisted_message())
             .meta_right(now_hms())
             .push(cx);
     }

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/connections.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/connections.rs
@@ -1,4 +1,9 @@
 use super::*;
+use crate::ui::labels::{
+    connections_disconnecting_message, connections_edit_window_title,
+    connections_manager_window_title, connections_no_active_connection_message,
+    connections_refresh_schema_failed_message, connections_refreshing_schema_message,
+};
 
 impl Workspace {
     pub(in crate::ui::views::workspace) fn open_connection_manager(&self, cx: &mut Context<Self>) {
@@ -8,7 +13,7 @@ impl Workspace {
         let mut options = WindowOptions {
             app_id: Some(dbflux_core::ReleaseChannel::current().app_id().into()),
             titlebar: Some(TitlebarOptions {
-                title: Some("Connection Manager".into()),
+                title: Some(connections_manager_window_title().into()),
                 ..Default::default()
             }),
             window_bounds: Some(WindowBounds::Windowed(bounds)),
@@ -62,7 +67,7 @@ impl Workspace {
         let mut options = WindowOptions {
             app_id: Some(dbflux_core::ReleaseChannel::current().app_id().into()),
             titlebar: Some(TitlebarOptions {
-                title: Some("Edit Connection".into()),
+                title: Some(connections_edit_window_title().into()),
                 ..Default::default()
             }),
             window_bounds: Some(WindowBounds::Windowed(bounds)),
@@ -91,7 +96,7 @@ impl Workspace {
         let mut options = WindowOptions {
             app_id: Some(dbflux_core::ReleaseChannel::current().app_id().into()),
             titlebar: Some(TitlebarOptions {
-                title: Some("Connection Manager".into()),
+                title: Some(connections_manager_window_title().into()),
                 ..Default::default()
             }),
             window_bounds: Some(WindowBounds::Windowed(bounds)),
@@ -144,7 +149,7 @@ impl Workspace {
             });
 
             if let Some(name) = name {
-                Toast::info(format!("Disconnecting from {}...", name))
+                Toast::info(connections_disconnecting_message(&name))
                     .meta_right(now_hms())
                     .push(cx);
             }
@@ -159,7 +164,7 @@ impl Workspace {
         let active = self.app_state.read(cx).active_connection();
 
         let Some(active) = active else {
-            Toast::warning("No active connection")
+            Toast::warning(connections_no_active_connection_message())
                 .meta_right(now_hms())
                 .push(cx);
             return;
@@ -187,7 +192,7 @@ impl Workspace {
                     report_error(
                         UserFacingError::new(
                             ErrorKind::Driver,
-                            format!("Failed to refresh schema: {e}"),
+                            connections_refresh_schema_failed_message(e),
                         ),
                         cx,
                     );
@@ -201,7 +206,7 @@ impl Workspace {
         })
         .detach();
 
-        Toast::info("Refreshing schema...")
+        Toast::info(connections_refreshing_schema_message())
             .meta_right(now_hms())
             .push(cx);
     }

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/documents.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/documents.rs
@@ -1,4 +1,7 @@
 use super::*;
+use crate::ui::labels::{
+    NoActiveConnectionKind, documents_default_title, documents_no_active_connection_message,
+};
 
 impl Workspace {
     /// Opens a table in a new DataDocument tab, or focuses the existing one.
@@ -31,9 +34,10 @@ impl Workspace {
 
         match decide_open_document(has_connection, existing_id) {
             OpenDocumentDecision::ErrorNoConnection => {
-                Toast::error("No active connection for this table")
+                let message = documents_no_active_connection_message(NoActiveConnectionKind::Table);
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("No active connection for this table"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -120,9 +124,11 @@ impl Workspace {
 
         match decide_open_document(has_connection, existing_id) {
             OpenDocumentDecision::ErrorNoConnection => {
-                Toast::error("No active connection for this collection")
+                let message =
+                    documents_no_active_connection_message(NoActiveConnectionKind::Collection);
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("No active connection for this collection"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -213,9 +219,11 @@ impl Workspace {
 
         match decide_open_document(has_connection, existing_id) {
             OpenDocumentDecision::ErrorNoConnection => {
-                Toast::error("No active connection for this event source")
+                let message =
+                    documents_no_active_connection_message(NoActiveConnectionKind::EventSource);
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("No active connection for this event source"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -272,11 +280,11 @@ impl Workspace {
 
         match decide_open_document(has_connection, existing_id) {
             OpenDocumentDecision::ErrorNoConnection => {
-                Toast::error("No active connection for this key-value database")
+                let message =
+                    documents_no_active_connection_message(NoActiveConnectionKind::KeyValueDb);
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action(
-                        "No active connection for this key-value database",
-                    ))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -332,11 +340,12 @@ impl Workspace {
 
         match decide_open_document(has_connection, existing_id) {
             OpenDocumentDecision::ErrorNoConnection => {
-                Toast::error("No active connection for this object-storage account")
+                let message = documents_no_active_connection_message(
+                    NoActiveConnectionKind::ObjectStorageAccount,
+                );
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action(
-                        "No active connection for this object-storage account",
-                    ))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -397,9 +406,11 @@ impl Workspace {
 
         match decide_open_document(has_connection, existing_id) {
             OpenDocumentDecision::ErrorNoConnection => {
-                Toast::error("No active connection for this bucket")
+                let message =
+                    documents_no_active_connection_message(NoActiveConnectionKind::Bucket);
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("No active connection for this bucket"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -462,9 +473,11 @@ impl Workspace {
 
         match decide_open_document(has_connection, existing_id) {
             OpenDocumentDecision::ErrorNoConnection => {
-                Toast::error("No active connection for this object")
+                let message =
+                    documents_no_active_connection_message(NoActiveConnectionKind::Object);
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("No active connection for this object"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -552,7 +565,7 @@ impl Workspace {
                 .read(cx)
                 .document(doc_id)
                 .map(|d| d.tab_title(cx))
-                .unwrap_or_else(|| "Untitled".to_string());
+                .unwrap_or_else(documents_default_title);
 
             use crate::ui::overlays::modals::{DirtySummaryEntry, UnsavedChangesRequest};
             let req = UnsavedChangesRequest {

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/metrics.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/metrics.rs
@@ -1,4 +1,9 @@
 use super::*;
+use crate::ui::labels::{
+    charts_instance_overview_create_editable_failed_message,
+    charts_instance_overview_created_editable_message, charts_instance_overview_editable_name,
+    charts_instance_overview_no_dashboard_message,
+};
 
 impl Workspace {
     /// Opens a `ChartDocument` pre-populated with the metric selected in the
@@ -218,11 +223,9 @@ impl Workspace {
         };
 
         let Some(descriptor) = catalog_result else {
-            dbflux_ui_base::toast::Toast::info(
-                "This driver does not define an Instance Overview dashboard.",
-            )
-            .meta_right(now_hms())
-            .push(cx);
+            dbflux_ui_base::toast::Toast::info(charts_instance_overview_no_dashboard_message())
+                .meta_right(now_hms())
+                .push(cx);
             return;
         };
 
@@ -337,7 +340,7 @@ impl Workspace {
         use dbflux_core::chrono::Utc;
         use dbflux_ui_base::DashboardPanelDraft;
 
-        let new_name = format!("{} (editable)", source_title);
+        let new_name = charts_instance_overview_editable_name(&source_title);
 
         // Fetch the driver's default dashboard descriptor to enumerate panels.
         let descriptor: Option<dbflux_core::DefaultInstanceDashboard> = {
@@ -423,7 +426,7 @@ impl Workspace {
 
         match result {
             Ok(new_id) => {
-                Toast::info("Created editable dashboard with all overview panels.")
+                Toast::info(charts_instance_overview_created_editable_message())
                     .meta_right(now_hms())
                     .push(cx);
                 self.open_dashboard(new_id, window, cx);
@@ -432,7 +435,7 @@ impl Workspace {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Config,
-                        format!("Failed to create editable dashboard: {e}"),
+                        charts_instance_overview_create_editable_failed_message(e),
                     ),
                     cx,
                 );

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/query.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/query.rs
@@ -1,4 +1,8 @@
 use super::*;
+use crate::ui::labels::{
+    documents_default_title, documents_new_query_name, documents_save_session_failed_message,
+    documents_write_initial_script_failed_message,
+};
 
 impl Workspace {
     /// Creates a new SQL query tab backed by a script file.
@@ -19,7 +23,7 @@ impl Workspace {
 
         let script_path = self.app_state.update(cx, |state, cx| {
             let dir = state.scripts_directory_mut()?;
-            let name = dir.next_available_name("Query", extension);
+            let name = dir.next_available_name(&documents_new_query_name(), extension);
             let path = dir.create_file(None, &name, extension).ok();
             if path.is_some() {
                 cx.emit(AppStateChanged);
@@ -33,8 +37,8 @@ impl Workspace {
                 let title = path
                     .file_name()
                     .and_then(|n| n.to_str())
-                    .unwrap_or("Query")
-                    .to_string();
+                    .map(str::to_string)
+                    .unwrap_or_else(documents_new_query_name);
                 doc = doc.with_title(title).with_path(path);
             }
             doc
@@ -71,7 +75,7 @@ impl Workspace {
 
         let script_path = self.app_state.update(cx, |state, cx| {
             let dir = state.scripts_directory_mut()?;
-            let name = dir.next_available_name("Query", extension);
+            let name = dir.next_available_name(&documents_new_query_name(), extension);
             let path = dir.create_file(None, &name, extension).ok();
             if path.is_some() {
                 cx.emit(AppStateChanged);
@@ -85,8 +89,8 @@ impl Workspace {
                 let title = path
                     .file_name()
                     .and_then(|n| n.to_str())
-                    .unwrap_or("Query")
-                    .to_string();
+                    .map(str::to_string)
+                    .unwrap_or_else(documents_new_query_name);
                 doc = doc.with_title(title).with_path(path.clone());
             }
             doc.set_content(&sql, window, cx);
@@ -104,7 +108,7 @@ impl Workspace {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Storage,
-                        format!("Failed to write initial script content: {e}"),
+                        documents_write_initial_script_failed_message(e),
                     ),
                     cx,
                 );
@@ -164,7 +168,7 @@ impl Workspace {
 
         if let Err(e) = repo.save_workspace_session(&manifest) {
             report_error(
-                UserFacingError::new(ErrorKind::Storage, "Failed to save session manifest")
+                UserFacingError::new(ErrorKind::Storage, documents_save_session_failed_message())
                     .with_cause(format!("{e}")),
                 cx,
             );
@@ -363,8 +367,8 @@ impl Workspace {
                     .as_ref()
                     .and_then(|p| p.file_name())
                     .and_then(|n| n.to_str())
-                    .unwrap_or("Untitled")
-                    .to_string()
+                    .map(str::to_string)
+                    .unwrap_or_else(documents_default_title)
             };
 
             let doc = cx.new(|cx| {

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/schema_diff.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/schema_diff.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ui::labels::documents_schema_diff_opened_message;
 
 impl Workspace {
     /// Opens (or focuses) the schema-diff & apply document for a connection or
@@ -39,7 +40,7 @@ impl Workspace {
         });
 
         self.set_focus(crate::keymap::FocusTarget::Document, window, cx);
-        Toast::info("Opened schema diff")
+        Toast::info(documents_schema_diff_opened_message())
             .meta_right(now_hms())
             .push(cx);
     }

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/scripts.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/scripts.rs
@@ -1,4 +1,9 @@
 use super::*;
+use crate::ui::labels::{
+    documents_default_title, scripts_filter_all_files_label,
+    scripts_filter_javascript_mongodb_label, scripts_filter_redis_label, scripts_filter_sql_label,
+    scripts_open_dialog_title, scripts_read_file_failed_message,
+};
 
 impl Workspace {
     /// Opens a file dialog to pick a script file and opens it in a new tab.
@@ -10,12 +15,18 @@ impl Workspace {
         let tab_manager = self.tab_manager.clone();
 
         cx.spawn(async move |this, cx| {
+            let dialog_title = scripts_open_dialog_title();
+            let sql_filter_label = scripts_filter_sql_label();
+            let javascript_mongodb_filter_label = scripts_filter_javascript_mongodb_label();
+            let redis_filter_label = scripts_filter_redis_label();
+            let all_files_filter_label = scripts_filter_all_files_label();
+
             let file_handle = rfd::AsyncFileDialog::new()
-                .set_title("Open Script")
-                .add_filter("SQL Files", &["sql"])
-                .add_filter("JavaScript (MongoDB)", &["js", "mongodb"])
-                .add_filter("Redis", &["redis", "red"])
-                .add_filter("All Files", &["*"])
+                .set_title(&dialog_title)
+                .add_filter(&sql_filter_label, &["sql"])
+                .add_filter(&javascript_mongodb_filter_label, &["js", "mongodb"])
+                .add_filter(&redis_filter_label, &["redis", "red"])
+                .add_filter(&all_files_filter_label, &["*"])
                 .pick_file()
                 .await;
 
@@ -66,7 +77,7 @@ impl Workspace {
                     report_error_async(
                         UserFacingError::new(
                             ErrorKind::Storage,
-                            format!("Failed to read file {}: {e}", path.display()),
+                            scripts_read_file_failed_message(path.display(), e),
                         ),
                         cx,
                     );
@@ -124,7 +135,7 @@ impl Workspace {
                     report_error_async(
                         UserFacingError::new(
                             ErrorKind::Storage,
-                            format!("Failed to read file {}: {e}", path.display()),
+                            scripts_read_file_failed_message(path.display(), e),
                         ),
                         cx,
                     );
@@ -313,8 +324,8 @@ impl Workspace {
             title: path
                 .file_name()
                 .and_then(|name| name.to_str())
-                .unwrap_or("Untitled")
-                .to_string(),
+                .map(str::to_string)
+                .unwrap_or_else(documents_default_title),
             path: Some(path),
             body: body.to_string(),
             language,

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/settings.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/settings.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ui::labels::settings_default_connection_name;
 
 impl Workspace {
     pub(in crate::ui::views::workspace) fn open_settings(&self, cx: &mut Context<Self>) {
@@ -45,8 +46,11 @@ impl Workspace {
             .read(cx)
             .active_connection()
             .map(|connected| connected.profile.name.clone())
-            .unwrap_or_else(|| "connection".to_string());
+            .unwrap_or_else(settings_default_connection_name);
 
+        // "Auth Provider" is the persisted default display name for a manually
+        // opened login (no specific provider is known yet); it is stored, not
+        // just displayed, so it stays in English like other persisted identities.
         self.login_modal.update(cx, |modal, cx| {
             modal.open_manual("Auth Provider", profile_name, None, window, cx);
         });


### PR DESCRIPTION
## Summary

Twenty-second slice of the windows/shell series (`dbflux_ui`): every user-visible toast, error, dialog title/filter and default name in `workspace/actions/{connections,query,scripts,audit,documents,settings,metrics,schema_diff}.rs` renders through `dbflux_i18n::t!` under `connections.*`, `documents.*`, `scripts.*`, `audit.*`, `settings.action.*` and `charts.instance_overview.*`. English and Spanish together. The persisted `Auth Provider` profile name, the `Average` statistic parameter and session-manifest discriminants stay data.

## What does this resolve?

- Refs #360 (follows the login modal PR; next: RPC services settings)

## How was this solved?

- `NoActiveConnectionKind` drives an exhaustive `documents_no_active_connection_message` so a new kind without a key fails a test; the Instance Overview editable-clone name uses a `%{name}` template instead of `format!` around translated text.
- Size: 688 lines, ~400 of them helpers and tests in `labels.rs` (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui -p dbflux_i18n` → 157 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a table without an active connection, open a script from disk, open the audit viewer twice.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
