### PR TITLE
feat(i18n): translate the dashboard builder, configure popover, and panel chrome

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -527,6 +527,54 @@ document:
         raw_expression_in_set:
           title: Raw SQL expression in SET
           body: SET clause contains a raw SQL expression — bypasses parameter binding
+  dashboard:
+    builder:
+      preset:
+        last_15_min: Last 15 min
+        last_24_hours: Last 24 hours
+        last_6_hours: Last 6 hours
+        last_7_days: Last 7 days
+        last_hour: Last 1 hour
+    configure:
+      action:
+        export_png: Export PNG
+        stats: Stats
+      apply: Apply
+      bindings_hint: Run the chart at least once to configure bindings.
+      cancel: Cancel
+      chart_kind:
+        area: Area
+        bar: Bar
+        line: Line
+        number: Number
+        pie: Pie
+        scatter: Scatter
+        stacked: Stacked
+      section:
+        actions: Actions
+        axis_bindings: Axis bindings
+        chart_type: Chart type
+      title: "Configure panel: %{name}"
+    panel:
+      chart_not_found:
+        body: Chart not found — saved chart was deleted
+        title: Chart not found
+      menu:
+        configure: Configure…
+        edit_title: Edit title…
+        remove: Remove panel
+    status:
+      empty_hint: Add a saved chart to get started
+    toast:
+      position_overlap: Position overlaps another panel
+      save_position_failed: "Failed to save panel position: %{message}"
+    toolbar:
+      add_panel: + Add Panel
+      apply: Apply
+      edit_mode_tooltip: Edit dashboard
+      exit_edit_mode_tooltip: Exit edit mode
+      save_as_editable: Save as editable
+      save_as_editable_tooltip: Clone this overview into a new editable dashboard
   data:
     chart_dock:
       toolbar:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -527,6 +527,54 @@ document:
         raw_expression_in_set:
           title: Expresión SQL cruda en SET
           body: "La cláusula SET contiene una expresión SQL cruda — evita el enlace de parámetros"
+  dashboard:
+    builder:
+      preset:
+        last_15_min: Últimos 15 min
+        last_24_hours: Últimas 24 horas
+        last_6_hours: Últimas 6 horas
+        last_7_days: Últimos 7 días
+        last_hour: Última hora
+    configure:
+      action:
+        export_png: Exportar PNG
+        stats: Estadísticas
+      apply: Aplicar
+      bindings_hint: Ejecuta el gráfico al menos una vez para configurar los enlaces.
+      cancel: Cancelar
+      chart_kind:
+        area: Área
+        bar: Barras
+        line: Línea
+        number: Número
+        pie: Circular
+        scatter: Dispersión
+        stacked: Apiladas
+      section:
+        actions: Acciones
+        axis_bindings: Enlaces de ejes
+        chart_type: Tipo de gráfico
+      title: "Configurar panel: %{name}"
+    panel:
+      chart_not_found:
+        body: Gráfico no encontrado — el gráfico guardado fue eliminado
+        title: Gráfico no encontrado
+      menu:
+        configure: Configurar…
+        edit_title: Editar título…
+        remove: Quitar panel
+    status:
+      empty_hint: Agrega un gráfico guardado para comenzar
+    toast:
+      position_overlap: La posición se superpone con otro panel
+      save_position_failed: "No se pudo guardar la posición del panel: %{message}"
+    toolbar:
+      add_panel: + Agregar panel
+      apply: Aplicar
+      edit_mode_tooltip: Editar dashboard
+      exit_edit_mode_tooltip: Salir del modo de edición
+      save_as_editable: Guardar como editable
+      save_as_editable_tooltip: Clonar esta vista general en un nuevo dashboard editable
   data:
     chart_dock:
       toolbar:

--- a/crates/dbflux_ui_document/src/dashboard/builder.rs
+++ b/crates/dbflux_ui_document/src/dashboard/builder.rs
@@ -154,7 +154,11 @@ impl PanelContextMenu {
 // Time-range preset helpers
 // ---------------------------------------------------------------------------
 
-/// All five time-range preset variants in display order.
+/// All five time-range preset variants in display order. The English label
+/// column is retained for structural coverage only — `preset_label` matches
+/// on the enum variant directly and resolves the translated string through
+/// the catalog instead of reading this table.
+#[allow(dead_code)]
 pub(super) const TIME_RANGE_PRESETS: &[(TimeRangePreset, &str)] = &[
     (TimeRangePreset::Last15min, "Last 15 min"),
     (TimeRangePreset::LastHour, "Last 1 hour"),
@@ -163,14 +167,24 @@ pub(super) const TIME_RANGE_PRESETS: &[(TimeRangePreset, &str)] = &[
     (TimeRangePreset::Last7Days, "Last 7 days"),
 ];
 
-/// Returns the display label for a `TimeRangePreset`.
+/// Returns the translated display label for a `TimeRangePreset`.
 #[allow(dead_code)]
-pub(super) fn preset_label(preset: TimeRangePreset) -> &'static str {
-    TIME_RANGE_PRESETS
-        .iter()
-        .find(|(p, _)| *p == preset)
-        .map(|(_, l)| *l)
-        .unwrap_or("Last 24 hours")
+pub(super) fn preset_label(preset: TimeRangePreset) -> String {
+    match preset {
+        TimeRangePreset::Last15min => {
+            dbflux_i18n::t!("document.dashboard.builder.preset.last_15_min")
+        }
+        TimeRangePreset::LastHour => dbflux_i18n::t!("document.dashboard.builder.preset.last_hour"),
+        TimeRangePreset::Last6Hours => {
+            dbflux_i18n::t!("document.dashboard.builder.preset.last_6_hours")
+        }
+        TimeRangePreset::Last24Hours => {
+            dbflux_i18n::t!("document.dashboard.builder.preset.last_24_hours")
+        }
+        TimeRangePreset::Last7Days => {
+            dbflux_i18n::t!("document.dashboard.builder.preset.last_7_days")
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -243,7 +257,7 @@ pub(super) fn dashboard_toolbar(
     });
 
     let add_btn = ToolbarButton::new("dash-add-panel-toolbar")
-        .label("+ Add Panel")
+        .label(dbflux_i18n::t!("document.dashboard.toolbar.add_panel"))
         .variant(ToolbarButtonVariant::Primary)
         .on_click(move |event, window, app| on_add_panel(event, window, app));
 
@@ -254,9 +268,15 @@ pub(super) fn dashboard_toolbar(
         this.toggle_mode(cx);
     });
     let (mode_icon, mode_tooltip) = if in_edit_mode {
-        (AppIcon::Eye, "Exit edit mode")
+        (
+            AppIcon::Eye,
+            dbflux_i18n::t!("document.dashboard.toolbar.exit_edit_mode_tooltip"),
+        )
     } else {
-        (AppIcon::Pencil, "Edit dashboard")
+        (
+            AppIcon::Pencil,
+            dbflux_i18n::t!("document.dashboard.toolbar.edit_mode_tooltip"),
+        )
     };
     let mode_btn = ToolbarButton::new("dash-mode-toggle")
         .icon(mode_icon)
@@ -275,9 +295,13 @@ pub(super) fn dashboard_toolbar(
             this.request_save_as_editable(cx);
         });
         let save_as_btn = ToolbarButton::new("dash-save-as-editable")
-            .label("Save as editable")
+            .label(dbflux_i18n::t!(
+                "document.dashboard.toolbar.save_as_editable"
+            ))
             .variant(ToolbarButtonVariant::Default)
-            .tooltip("Clone this overview into a new editable dashboard")
+            .tooltip(dbflux_i18n::t!(
+                "document.dashboard.toolbar.save_as_editable_tooltip"
+            ))
             .on_click(move |event, window, app| on_save_as(event, window, app));
         div()
             .flex_shrink_0()
@@ -351,7 +375,7 @@ fn build_custom_time_controls(
         .child(slots.end_minute)
         .child(
             ToolbarButton::new("dashboard-custom-time-apply")
-                .label("Apply")
+                .label(dbflux_i18n::t!("document.dashboard.toolbar.apply"))
                 .variant(ToolbarButtonVariant::Default)
                 .disabled(!can_apply)
                 .on_click(on_apply),
@@ -553,12 +577,22 @@ fn panel_kebab_menu(
 
     // Build the action list. "Edit title…" is omitted for slot types that
     // carry no user-editable title (Inspector, Divider).
-    let mut menu_items: Vec<MenuItem> = vec![MenuItem::new("Configure…").icon(AppIcon::Settings)];
+    let mut menu_items: Vec<MenuItem> = vec![
+        MenuItem::new(dbflux_i18n::t!("document.dashboard.panel.menu.configure"))
+            .icon(AppIcon::Settings),
+    ];
     if has_editable_title {
-        menu_items.push(MenuItem::new("Edit title…").icon(AppIcon::Pencil));
+        menu_items.push(
+            MenuItem::new(dbflux_i18n::t!("document.dashboard.panel.menu.edit_title"))
+                .icon(AppIcon::Pencil),
+        );
     }
     menu_items.push(MenuItem::separator());
-    menu_items.push(MenuItem::new("Remove panel").icon(AppIcon::Delete).danger());
+    menu_items.push(
+        MenuItem::new(dbflux_i18n::t!("document.dashboard.panel.menu.remove"))
+            .icon(AppIcon::Delete)
+            .danger(),
+    );
 
     // Map visual index → domain PanelMenuAction index, skipping the separator
     // and the conditionally absent "Edit title…" item.
@@ -760,14 +794,61 @@ mod tests {
         assert_eq!(TIME_RANGE_PRESETS.len(), 5);
     }
 
-    /// `preset_label` returns the correct human-readable string for each variant.
+    /// `preset_label` routes every `TimeRangePreset` variant through the
+    /// `document.dashboard.builder.preset.*` catalog instead of returning a
+    /// hardcoded English string.
     #[test]
     fn preset_label_returns_correct_string() {
-        assert_eq!(preset_label(TimeRangePreset::Last15min), "Last 15 min");
-        assert_eq!(preset_label(TimeRangePreset::LastHour), "Last 1 hour");
-        assert_eq!(preset_label(TimeRangePreset::Last6Hours), "Last 6 hours");
-        assert_eq!(preset_label(TimeRangePreset::Last24Hours), "Last 24 hours");
-        assert_eq!(preset_label(TimeRangePreset::Last7Days), "Last 7 days");
+        assert_eq!(
+            preset_label(TimeRangePreset::Last15min),
+            dbflux_i18n::t!("document.dashboard.builder.preset.last_15_min")
+        );
+        assert_eq!(
+            preset_label(TimeRangePreset::LastHour),
+            dbflux_i18n::t!("document.dashboard.builder.preset.last_hour")
+        );
+        assert_eq!(
+            preset_label(TimeRangePreset::Last6Hours),
+            dbflux_i18n::t!("document.dashboard.builder.preset.last_6_hours")
+        );
+        assert_eq!(
+            preset_label(TimeRangePreset::Last24Hours),
+            dbflux_i18n::t!("document.dashboard.builder.preset.last_24_hours")
+        );
+        assert_eq!(
+            preset_label(TimeRangePreset::Last7Days),
+            dbflux_i18n::t!("document.dashboard.builder.preset.last_7_days")
+        );
+    }
+
+    /// `preset_label` keys resolve in both locales and diverge between them,
+    /// so the parity loop cannot pass on English fallbacks copied verbatim
+    /// into `es.yml`.
+    #[test]
+    fn preset_label_keys_resolve_and_differ_between_locales() {
+        let keys = [
+            "document.dashboard.builder.preset.last_15_min",
+            "document.dashboard.builder.preset.last_hour",
+            "document.dashboard.builder.preset.last_6_hours",
+            "document.dashboard.builder.preset.last_24_hours",
+            "document.dashboard.builder.preset.last_7_days",
+        ];
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+
+        let en = dbflux_i18n::t!("document.dashboard.builder.preset.last_hour", locale = "en");
+        let es = dbflux_i18n::t!("document.dashboard.builder.preset.last_hour", locale = "es");
+        assert_ne!(en, es);
     }
 
     /// `snap_columns` rounds half-cell deltas to the nearest grid unit.
@@ -861,6 +942,43 @@ mod tests {
         assert_eq!(state.original_column, 4);
         assert_eq!(state.working_column, 4);
         assert!(state.active);
+    }
+
+    /// The dashboard toolbar and per-panel kebab-menu keys resolve in both
+    /// locales and are not accidentally left off the catalog.
+    #[test]
+    fn dashboard_toolbar_and_panel_menu_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.dashboard.toolbar.add_panel",
+            "document.dashboard.toolbar.apply",
+            "document.dashboard.toolbar.edit_mode_tooltip",
+            "document.dashboard.toolbar.exit_edit_mode_tooltip",
+            "document.dashboard.toolbar.save_as_editable",
+            "document.dashboard.toolbar.save_as_editable_tooltip",
+            "document.dashboard.panel.menu.configure",
+            "document.dashboard.panel.menu.edit_title",
+            "document.dashboard.panel.menu.remove",
+        ];
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// At least one toolbar key must actually diverge between locales.
+    #[test]
+    fn dashboard_toolbar_add_panel_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.dashboard.toolbar.add_panel", locale = "en");
+        let es = dbflux_i18n::t!("document.dashboard.toolbar.add_panel", locale = "es");
+        assert_ne!(en, es);
     }
 
     /// `DragResizeState` carries the resize axis along with dimensions.

--- a/crates/dbflux_ui_document/src/dashboard/configure_popover.rs
+++ b/crates/dbflux_ui_document/src/dashboard/configure_popover.rs
@@ -18,14 +18,16 @@ use dbflux_core::ColumnMeta;
 use gpui::prelude::*;
 use gpui::{AnyElement, Context, Entity, IntoElement, div, px};
 
-/// All chart kinds offered by the Configure popover, in display order.
-const CHART_KIND_OPTIONS: &[(ChartKind, &str, &str)] = &[
-    (ChartKind::Line, "Line", "configure-kind-line"),
-    (ChartKind::Bar, "Bar", "configure-kind-bar"),
-    (ChartKind::Scatter, "Scatter", "configure-kind-scatter"),
-    (ChartKind::Area, "Area", "configure-kind-area"),
-    (ChartKind::StackedBar, "Stacked", "configure-kind-stacked"),
-    (ChartKind::Pie, "Pie", "configure-kind-pie"),
+/// All chart kinds offered by the Configure popover, in display order. The
+/// translated label for each kind comes from
+/// `crate::labels::configure_chart_kind_label`, not this table.
+const CHART_KIND_OPTIONS: &[(ChartKind, &str)] = &[
+    (ChartKind::Line, "configure-kind-line"),
+    (ChartKind::Bar, "configure-kind-bar"),
+    (ChartKind::Scatter, "configure-kind-scatter"),
+    (ChartKind::Area, "configure-kind-area"),
+    (ChartKind::StackedBar, "configure-kind-stacked"),
+    (ChartKind::Pie, "configure-kind-pie"),
 ];
 
 /// Build the Configure popover overlay element for the panel at `panel_index`.
@@ -70,9 +72,18 @@ pub(super) fn render_configure_popover(
         .flex()
         .flex_col()
         .gap(Spacing::LG)
-        .child(section("Chart type", chart_kind_row))
-        .child(section("Axis bindings", bindings_row))
-        .child(section("Actions", actions_row))
+        .child(section(
+            dbflux_i18n::t!("document.dashboard.configure.section.chart_type"),
+            chart_kind_row,
+        ))
+        .child(section(
+            dbflux_i18n::t!("document.dashboard.configure.section.axis_bindings"),
+            bindings_row,
+        ))
+        .child(section(
+            dbflux_i18n::t!("document.dashboard.configure.section.actions"),
+            actions_row,
+        ))
         .into_any_element();
 
     // Footer: Cancel + Apply
@@ -88,21 +99,28 @@ pub(super) fn render_configure_popover(
         .flex_row()
         .gap(Spacing::SM)
         .child(
-            Button::new("configure-cancel", "Cancel")
-                .ghost()
-                .on_click(on_cancel),
+            Button::new(
+                "configure-cancel",
+                dbflux_i18n::t!("document.dashboard.configure.cancel"),
+            )
+            .ghost()
+            .on_click(on_cancel),
         )
         .child(
-            Button::new("configure-apply", "Apply")
-                .primary()
-                .on_click(on_apply),
+            Button::new(
+                "configure-apply",
+                dbflux_i18n::t!("document.dashboard.configure.apply"),
+            )
+            .primary()
+            .on_click(on_apply),
         )
         .into_any_element();
 
     // Bridge ModalShell's App-scoped on_close into the DashboardDocument
     // entity via a weak handle so the X button closes the popover.
     let weak_self = cx.weak_entity();
-    let modal = ModalShell::new(format!("Configure panel: {panel_title}"), body, footer)
+    let modal_title = dbflux_i18n::t!("document.dashboard.configure.title", name = panel_title);
+    let modal = ModalShell::new(modal_title, body, footer)
         .width(px(720.0))
         .on_close(move |_window, cx| {
             if let Some(this) = weak_self.upgrade() {
@@ -113,7 +131,7 @@ pub(super) fn render_configure_popover(
     Some(modal.into_any_element())
 }
 
-fn section(label: &'static str, body: AnyElement) -> AnyElement {
+fn section(label: impl Into<gpui::SharedString>, body: AnyElement) -> AnyElement {
     div()
         .flex()
         .flex_col()
@@ -130,8 +148,9 @@ fn render_chart_kind_row(
 ) -> AnyElement {
     let buttons: Vec<AnyElement> = CHART_KIND_OPTIONS
         .iter()
-        .map(|(kind, label, id)| {
+        .map(|(kind, id)| {
             let kind = *kind;
+            let label = crate::labels::configure_chart_kind_label(kind);
             let is_active = kind == current_kind;
             let on_click = cx.listener(move |this, _: &gpui::ClickEvent, _, cx| {
                 this.configure_apply_chart_kind(panel_index, kind, cx);
@@ -141,9 +160,9 @@ fn render_chart_kind_row(
             // `.ghost()` produced borderless transparent boxes which blended
             // into the modal and looked like static text.
             let btn = if is_active {
-                Button::new(*id, *label).primary().on_click(on_click)
+                Button::new(*id, label).primary().on_click(on_click)
             } else {
-                Button::new(*id, *label).on_click(on_click)
+                Button::new(*id, label).on_click(on_click)
             };
             btn.into_any_element()
         })
@@ -169,9 +188,9 @@ fn render_bindings_row(
     // surface a hint and skip the AxisBar.
     if columns.is_empty() {
         return div()
-            .child(Text::caption(
-                "Run the chart at least once to configure bindings.",
-            ))
+            .child(Text::caption(dbflux_i18n::t!(
+                "document.dashboard.configure.bindings_hint"
+            )))
             .into_any_element();
     }
 
@@ -249,8 +268,20 @@ fn render_actions_row(panel_index: usize, cx: &mut Context<DashboardDocument>) -
         .flex()
         .flex_row()
         .gap(Spacing::SM)
-        .child(Button::new("configure-stats", "Stats").on_click(on_stats))
-        .child(Button::new("configure-png", "Export PNG").on_click(on_png))
+        .child(
+            Button::new(
+                "configure-stats",
+                dbflux_i18n::t!("document.dashboard.configure.action.stats"),
+            )
+            .on_click(on_stats),
+        )
+        .child(
+            Button::new(
+                "configure-png",
+                dbflux_i18n::t!("document.dashboard.configure.action.export_png"),
+            )
+            .on_click(on_png),
+        )
         .into_any_element()
 }
 
@@ -279,7 +310,7 @@ mod tests {
         ];
         for kind in kinds {
             assert!(
-                CHART_KIND_OPTIONS.iter().any(|(k, _, _)| *k == kind),
+                CHART_KIND_OPTIONS.iter().any(|(k, _)| *k == kind),
                 "Configure popover must surface {kind:?}"
             );
         }
@@ -290,9 +321,69 @@ mod tests {
     #[test]
     fn chart_kind_option_ids_are_unique() {
         let mut seen: Vec<&str> = Vec::new();
-        for (_, _, id) in CHART_KIND_OPTIONS {
+        for (_, id) in CHART_KIND_OPTIONS {
             assert!(!seen.contains(id), "duplicate Configure popover id: {id}");
             seen.push(id);
         }
+    }
+
+    /// `crate::labels::configure_chart_kind_label` covers every chart kind
+    /// surfaced by `CHART_KIND_OPTIONS` and its labels resolve through the
+    /// catalog (widened from a hardcoded `&str` table column).
+    #[test]
+    fn chart_kind_options_labels_resolve_via_configure_chart_kind_label() {
+        for (kind, _) in CHART_KIND_OPTIONS {
+            let label = crate::labels::configure_chart_kind_label(*kind);
+            assert!(
+                !label.is_empty(),
+                "configure_chart_kind_label({kind:?}) resolved empty"
+            );
+        }
+    }
+
+    /// The Configure popover's section/action/footer keys resolve in both
+    /// locales and the popover title interpolates the panel name.
+    #[test]
+    fn configure_popover_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.dashboard.configure.section.chart_type",
+            "document.dashboard.configure.section.axis_bindings",
+            "document.dashboard.configure.section.actions",
+            "document.dashboard.configure.cancel",
+            "document.dashboard.configure.apply",
+            "document.dashboard.configure.bindings_hint",
+            "document.dashboard.configure.action.stats",
+            "document.dashboard.configure.action.export_png",
+        ];
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// The popover title interpolates the panel name via `%{name}`.
+    #[test]
+    fn configure_popover_title_interpolates_panel_name() {
+        let title = dbflux_i18n::t!("document.dashboard.configure.title", name = "My Chart");
+        assert!(
+            title.contains("My Chart"),
+            "expected the panel name to be interpolated into the title, got {title:?}"
+        );
+    }
+
+    /// At least one Configure popover key must diverge between locales.
+    #[test]
+    fn configure_popover_cancel_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.dashboard.configure.cancel", locale = "en");
+        let es = dbflux_i18n::t!("document.dashboard.configure.cancel", locale = "es");
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_ui_document/src/dashboard/mod.rs
+++ b/crates/dbflux_ui_document/src/dashboard/mod.rs
@@ -1698,7 +1698,7 @@ impl DashboardDocument {
         };
 
         if self.collides_with_other_panels(from, &proposed) {
-            Toast::info("Position overlaps another panel").push(cx);
+            Toast::info(dbflux_i18n::t!("document.dashboard.toast.position_overlap")).push(cx);
             cx.notify();
             return;
         }
@@ -1817,7 +1817,7 @@ impl DashboardDocument {
         };
 
         if self.collides_with_other_panels(idx, &proposed) {
-            Toast::info("Position overlaps another panel").push(cx);
+            Toast::info(dbflux_i18n::t!("document.dashboard.toast.position_overlap")).push(cx);
             cx.notify();
             return;
         }
@@ -1892,7 +1892,11 @@ impl DashboardDocument {
                         message.clone(),
                     );
                 });
-                Toast::error(format!("Failed to save panel position: {message}")).push(cx);
+                Toast::error(dbflux_i18n::t!(
+                    "document.dashboard.toast.save_position_failed",
+                    message = message
+                ))
+                .push(cx);
                 cx.notify();
             }
         }
@@ -2173,6 +2177,51 @@ mod tests {
             PANEL_REEXEC_CAP, 4,
             "PANEL_REEXEC_CAP must be 4 per design spec"
         );
+    }
+
+    /// PR 23: the drag/resize collision toast and the position-persist-failure
+    /// toast keys resolve in both locales, and the failure toast interpolates
+    /// the underlying storage error message.
+    #[test]
+    fn dashboard_toast_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.dashboard.toast.position_overlap",
+            "document.dashboard.toast.save_position_failed",
+        ];
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// PR 23: `document.dashboard.toast.save_position_failed` interpolates
+    /// `%{message}` with the underlying storage error.
+    #[test]
+    fn dashboard_toast_save_position_failed_interpolates_message() {
+        let toast = dbflux_i18n::t!(
+            "document.dashboard.toast.save_position_failed",
+            message = "disk full"
+        );
+        assert!(
+            toast.contains("disk full"),
+            "expected the storage error to be interpolated, got {toast:?}"
+        );
+    }
+
+    /// PR 23: at least one dashboard toast key diverges between locales.
+    #[test]
+    fn dashboard_toast_position_overlap_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.dashboard.toast.position_overlap", locale = "en");
+        let es = dbflux_i18n::t!("document.dashboard.toast.position_overlap", locale = "es");
+        assert_ne!(en, es);
     }
 
     // ---- Semaphore state-machine tests (no GPUI runtime required) ----

--- a/crates/dbflux_ui_document/src/dashboard/render.rs
+++ b/crates/dbflux_ui_document/src/dashboard/render.rs
@@ -105,12 +105,15 @@ impl Render for DashboardDocument {
                         div()
                             .id("dashboard-empty-hint")
                             .text_sm()
-                            .child("Add a saved chart to get started"),
+                            .child(dbflux_i18n::t!("document.dashboard.status.empty_hint")),
                     )
                     .child(
-                        Button::new("dashboard-add-panel-cta", "+ Add Panel")
-                            .primary()
-                            .on_click(on_add),
+                        Button::new(
+                            "dashboard-add-panel-cta",
+                            dbflux_i18n::t!("document.dashboard.toolbar.add_panel"),
+                        )
+                        .primary()
+                        .on_click(on_add),
                     )
                     .into_any_element(),
             );
@@ -175,7 +178,9 @@ impl Render for DashboardDocument {
                         .filter(|s| !s.trim().is_empty())
                         .cloned()
                         .unwrap_or_else(|| entity.read(cx).metric_id().to_string()),
-                    DashboardPanelSlot::Orphan { .. } => "Chart not found".to_string(),
+                    DashboardPanelSlot::Orphan { .. } => {
+                        dbflux_i18n::t!("document.dashboard.panel.chart_not_found.title")
+                    }
                     DashboardPanelSlot::Divider { .. } => String::new(),
                 };
 
@@ -275,7 +280,9 @@ impl Render for DashboardDocument {
                                     .id(("dashboard-orphan-panel", panel_index))
                                     .flex_1()
                                     .text_sm()
-                                    .child("Chart not found — saved chart was deleted"),
+                                    .child(dbflux_i18n::t!(
+                                        "document.dashboard.panel.chart_not_found.body"
+                                    )),
                             )
                             .when_some(resize_right, |el, r| el.child(r))
                             .when_some(resize_bottom, |el, r| el.child(r))
@@ -841,6 +848,37 @@ mod tests {
         const TOOLBAR_BTN_ID: &str = "dash-add-panel-toolbar";
         assert_eq!(CTA_ID, "dashboard-add-panel-cta");
         assert_eq!(TOOLBAR_BTN_ID, "dash-add-panel-toolbar");
+    }
+
+    /// The empty-state hint and Orphan panel's "chart not found" keys
+    /// resolve in both locales.
+    #[test]
+    fn dashboard_status_and_chart_not_found_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.dashboard.status.empty_hint",
+            "document.dashboard.panel.chart_not_found.title",
+            "document.dashboard.panel.chart_not_found.body",
+        ];
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// The empty-state hint diverges between locales.
+    #[test]
+    fn dashboard_status_empty_hint_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.dashboard.status.empty_hint", locale = "en");
+        let es = dbflux_i18n::t!("document.dashboard.status.empty_hint", locale = "es");
+        assert_ne!(en, es);
     }
 
     /// Toolbar refresh `Dropdown` ID is stable.

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1338,6 +1338,29 @@ pub(crate) fn bucket_encryption_choice_label(
     }
 }
 
+/// Label for a [`dbflux_components::chart::ChartKind`] shown as a segmented
+/// button in the dashboard panel's Configure popover. Exhaustive by
+/// construction so a new chart kind fails this crate's build until its
+/// catalog key is added here.
+pub(crate) fn configure_chart_kind_label(kind: dbflux_components::chart::ChartKind) -> String {
+    use dbflux_components::chart::ChartKind;
+
+    match kind {
+        ChartKind::Line => dbflux_i18n::t!("document.dashboard.configure.chart_kind.line"),
+        ChartKind::Bar => dbflux_i18n::t!("document.dashboard.configure.chart_kind.bar"),
+        ChartKind::Scatter => dbflux_i18n::t!("document.dashboard.configure.chart_kind.scatter"),
+        ChartKind::Area => dbflux_i18n::t!("document.dashboard.configure.chart_kind.area"),
+        ChartKind::StackedBar => {
+            dbflux_i18n::t!("document.dashboard.configure.chart_kind.stacked")
+        }
+        ChartKind::Pie => dbflux_i18n::t!("document.dashboard.configure.chart_kind.pie"),
+        // Not currently offered by `CHART_KIND_OPTIONS` (the Configure
+        // popover's chart-kind picker), but the match stays exhaustive so a
+        // future picker addition cannot forget the catalog key.
+        ChartKind::Number => dbflux_i18n::t!("document.dashboard.configure.chart_kind.number"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1347,18 +1370,18 @@ mod tests {
         bool_op_label, bucket_encryption_choice_label, buckets_table_summary_line,
         builder_mode_label, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
         chart_rail_why_text, code_toolbar_shortcut_hint_label, comparator_label,
-        copy_query_language_label, dangerous_query_body, dangerous_query_title,
-        delete_confirm_copy, delete_prefix_delete_button_label, delete_prefix_deleted_toast,
-        delete_prefix_probe_totals, delete_rows_label, execution_count_state_label,
-        execution_mode_label, history_items_count_label, history_tab_label, image_decode_error,
-        image_header_error, incomplete_aggregate_rows_label, join_kind_label,
-        live_output_lines_label, live_output_truncated_label, object_browser_status_summary,
-        object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
-        pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
-        refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
-        script_confirm_message_label, sort_direction_label, table_action_description,
-        unsaved_changes_label, update_columns_label, valid_lines_label, versioning_off_label,
-        versioning_status_label,
+        configure_chart_kind_label, copy_query_language_label, dangerous_query_body,
+        dangerous_query_title, delete_confirm_copy, delete_prefix_delete_button_label,
+        delete_prefix_deleted_toast, delete_prefix_probe_totals, delete_rows_label,
+        execution_count_state_label, execution_mode_label, history_items_count_label,
+        history_tab_label, image_decode_error, image_header_error, incomplete_aggregate_rows_label,
+        join_kind_label, live_output_lines_label, live_output_truncated_label,
+        object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
+        pending_change_count_label, pending_edits_summary, presign_expiry_label,
+        presign_method_label, preview_gate_message, refresh_policy_label, result_tab_count_label,
+        row_count_label, schema_change_description, script_confirm_message_label,
+        sort_direction_label, table_action_description, unsaved_changes_label,
+        update_columns_label, valid_lines_label, versioning_off_label, versioning_status_label,
     };
     use crate::buckets_table::BucketEncryptionChoice;
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
@@ -3572,6 +3595,50 @@ mod tests {
         let en = dbflux_i18n::t!("document.buckets_table.versioning.on", locale = "en");
         let es = dbflux_i18n::t!("document.buckets_table.versioning.on", locale = "es");
 
+        assert_ne!(en, es);
+    }
+
+    /// PR 23: `configure_chart_kind_label` covers every `ChartKind` variant
+    /// (exhaustive match, no wildcard arm — a new variant fails the build
+    /// until its catalog key is added here).
+    #[test]
+    fn configure_chart_kind_label_covers_all_variants() {
+        use dbflux_components::chart::ChartKind;
+
+        let kinds = [
+            ChartKind::Line,
+            ChartKind::Bar,
+            ChartKind::Scatter,
+            ChartKind::Area,
+            ChartKind::StackedBar,
+            ChartKind::Pie,
+            ChartKind::Number,
+        ];
+        for kind in kinds {
+            let label = configure_chart_kind_label(kind);
+            assert!(
+                !label.is_empty(),
+                "configure_chart_kind_label({kind:?}) resolved empty"
+            );
+        }
+
+        assert_eq!(
+            configure_chart_kind_label(ChartKind::Line),
+            dbflux_i18n::t!("document.dashboard.configure.chart_kind.line")
+        );
+    }
+
+    /// PR 23: `configure_chart_kind_label` diverges between locales.
+    #[test]
+    fn configure_chart_kind_label_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.dashboard.configure.chart_kind.line",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.dashboard.configure.chart_kind.line",
+            locale = "es"
+        );
         assert_ne!(en, es);
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 23: the dashboard builder toolbar and panel menu, the configure popover (sections, chart kinds, bindings hint, actions), the empty state and orphan panel, and the dashboard toasts render through `dbflux_i18n::t!` under `document.dashboard.*`. English and Spanish together. `dashboard` stays `dashboard` in Spanish; preset, metric and chart ids stay data.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `preset_label` widened to `String`; `configure_chart_kind_label` is exhaustive over `ChartKind` (including `Number`, which the picker deliberately does not offer).
- Size: 605 lines in one namespace boundary (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1051 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a dashboard, change the time-range preset, configure a panel.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
