### PR TITLE
feat(i18n): translate the SSH tunnels and proxies settings sections

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -2153,6 +2153,68 @@ settings:
       delete: Delete
       update: Update
       create: Create
+  ssh_tunnels:
+    placeholder_name: SSH tunnel
+    placeholder_password: password
+    placeholder_passphrase: passphrase
+    section_title: SSH Tunnels
+    section_description: Manage reusable SSH tunnels for bastion and jump-host access
+    empty: No saved SSH tunnels
+    new: New Tunnel
+    field:
+      name: Name
+    delete_dialog_title: Delete SSH Tunnel
+    delete_dialog:
+      body: 'Are you sure you want to delete "%{name}"?'
+    action:
+      import: "Import…"
+      export: Export
+      delete: Delete
+  proxies:
+    placeholder_name: Proxy name
+    placeholder_username: username
+    placeholder_password: password
+    section_title: Proxy Profiles
+    section_description: Manage proxy configurations for database connections
+    empty: No saved proxies
+    new: New Proxy
+    panel_title: Proxy
+    kind:
+      http: HTTP
+      https: HTTPS
+      socks5: SOCKS5
+    field:
+      name: Name
+      protocol: Protocol
+      authentication: Authentication
+      username: Username
+      password: Password
+      host: Host
+      port: Port
+      no_proxy: No Proxy
+      enabled: Enabled
+    hint:
+      no_proxy_list: Comma-separated hosts/CIDRs to bypass the proxy
+    auth:
+      none: None
+      basic: Basic
+    status:
+      disabled_caption: "off"
+    action:
+      save: Save
+      import: "Import…"
+      export: Export
+      delete: Delete
+      update: Update
+      create: Create
+    delete_dialog_title: Delete Proxy
+    delete_dialog:
+      body_none: 'Are you sure you want to delete "%{name}"?'
+      body_one: 'Are you sure you want to delete "%{name}"? 1 connection using this proxy will be updated.'
+      body_many: 'Are you sure you want to delete "%{name}"? %{count} connections using this proxy will be updated.'
+    discard_dialog_title: Discard Proxy Changes
+    discard_dialog:
+      body: You have unsaved proxy changes. Discard them?
   nav:
     general_group: General
     general: General

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -2153,6 +2153,68 @@ settings:
       delete: Eliminar
       update: Actualizar
       create: Crear
+  ssh_tunnels:
+    placeholder_name: Túnel SSH
+    placeholder_password: contraseña
+    placeholder_passphrase: frase
+    section_title: Túneles SSH
+    section_description: Gestiona túneles SSH reutilizables para acceso a bastiones y saltos
+    empty: No hay túneles SSH guardados
+    new: Nuevo túnel
+    field:
+      name: Nombre
+    delete_dialog_title: Eliminar túnel SSH
+    delete_dialog:
+      body: '¿Seguro que quieres eliminar "%{name}"?'
+    action:
+      import: "Importar…"
+      export: Exportar
+      delete: Eliminar
+  proxies:
+    placeholder_name: Nombre del proxy
+    placeholder_username: usuario
+    placeholder_password: contraseña
+    section_title: Perfiles de proxy
+    section_description: Gestiona las configuraciones de proxy para conexiones de base de datos
+    empty: No hay proxies guardados
+    new: Nuevo proxy
+    panel_title: Proxy
+    kind:
+      http: HTTP
+      https: HTTPS
+      socks5: SOCKS5
+    field:
+      name: Nombre
+      protocol: Protocolo
+      authentication: Autenticación
+      username: Usuario
+      password: Contraseña
+      host: Host
+      port: Puerto
+      no_proxy: Sin proxy
+      enabled: Habilitado
+    hint:
+      no_proxy_list: Hosts/CIDR separados por comas que omiten el proxy
+    auth:
+      none: Ninguna
+      basic: Básica
+    status:
+      disabled_caption: apagado
+    action:
+      save: Guardar
+      import: "Importar…"
+      export: Exportar
+      delete: Eliminar
+      update: Actualizar
+      create: Crear
+    delete_dialog_title: Eliminar proxy
+    delete_dialog:
+      body_none: '¿Seguro que quieres eliminar "%{name}"?'
+      body_one: '¿Seguro que quieres eliminar "%{name}"? Se actualizará 1 conexión que usa este proxy.'
+      body_many: '¿Seguro que quieres eliminar "%{name}"? Se actualizarán %{count} conexiones que usan este proxy.'
+    discard_dialog_title: Descartar cambios del proxy
+    discard_dialog:
+      body: Tienes cambios sin guardar en el proxy. ¿Deseas descartarlos?
   nav:
     general_group: General
     general: General

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -267,6 +267,25 @@ pub(crate) fn rpc_services_duplicate_socket_id(id: &str) -> String {
     dbflux_i18n::t!("settings.rpc_services.error.duplicate_socket_id", id = id)
 }
 
+/// Formats the delete-confirmation body for a named SSH tunnel.
+pub(crate) fn ssh_tunnels_delete_body(name: &str) -> String {
+    dbflux_i18n::t!("settings.ssh_tunnels.delete_dialog.body", name = name)
+}
+
+/// Builds the delete-confirmation body for a proxy profile, embedding the
+/// proxy name and pluralizing the affected-connections count.
+pub(crate) fn proxies_delete_body(name: &str, affected_connections: usize) -> String {
+    match affected_connections {
+        0 => dbflux_i18n::t!("settings.proxies.delete_dialog.body_none", name = name),
+        1 => dbflux_i18n::t!("settings.proxies.delete_dialog.body_one", name = name),
+        count => dbflux_i18n::t!(
+            "settings.proxies.delete_dialog.body_many",
+            name = name,
+            count = count
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -277,7 +296,8 @@ mod tests {
         hooks_delete_message, hooks_delete_unreadable_message, hooks_duplicate_id,
         hooks_env_pair_invalid, hooks_form_interpreter_hint, hooks_interpreter_auto_label,
         hooks_interpreter_missing, hooks_open_script_failed, hooks_write_script_failed,
-        mcp_preview_summary, ssh_private_key_with_path,
+        mcp_preview_summary, proxies_delete_body, ssh_private_key_with_path,
+        ssh_tunnels_delete_body,
     };
 
     #[test]
@@ -502,5 +522,36 @@ mod tests {
 
         assert!(message.contains('4'));
         assert!(message.contains('2'));
+    }
+
+    #[test]
+    fn ssh_tunnels_delete_body_embeds_tunnel_name() {
+        let message = ssh_tunnels_delete_body("bastion-prod");
+
+        assert!(message.contains("bastion-prod"));
+    }
+
+    #[test]
+    fn proxies_delete_body_uses_singular_form_for_one_connection() {
+        let message = proxies_delete_body("corporate-proxy", 1);
+
+        assert!(message.contains("corporate-proxy"));
+        assert!(message.contains('1'));
+    }
+
+    #[test]
+    fn proxies_delete_body_embeds_name_and_count_for_many_connections() {
+        let message = proxies_delete_body("corporate-proxy", 3);
+
+        assert!(message.contains("corporate-proxy"));
+        assert!(message.contains('3'));
+    }
+
+    #[test]
+    fn proxies_delete_body_omits_count_when_no_connections_affected() {
+        let message = proxies_delete_body("corporate-proxy", 0);
+
+        assert!(message.contains("corporate-proxy"));
+        assert!(!message.contains('0'));
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/proxies_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/proxies_section.rs
@@ -5,6 +5,7 @@ use super::layout;
 use super::proxies::ProxyFormNav;
 use super::section_trait::{SectionFocusEvent, SectionPortabilityEvent};
 use crate::connection_manager::ExportTarget;
+use crate::labels::proxies_delete_body;
 use dbflux_components::controls::Button;
 use dbflux_components::controls::{GpuiInput as Input, InputEvent, InputState};
 use dbflux_components::icons::AppIcon;
@@ -106,7 +107,10 @@ impl ProxiesSection {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let input_proxy_name = cx.new(|cx| InputState::new(window, cx).placeholder("Proxy name"));
+        let input_proxy_name = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("settings.proxies.placeholder_name"))
+        });
         let input_proxy_host =
             cx.new(|cx| InputState::new(window, cx).placeholder("proxy.example.com"));
         let input_proxy_port = cx.new(|cx| {
@@ -114,10 +118,13 @@ impl ProxiesSection {
                 .placeholder("8080")
                 .default_value("8080")
         });
-        let input_proxy_username = cx.new(|cx| InputState::new(window, cx).placeholder("username"));
+        let input_proxy_username = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("settings.proxies.placeholder_username"))
+        });
         let input_proxy_password = cx.new(|cx| {
             InputState::new(window, cx)
-                .placeholder("password")
+                .placeholder(dbflux_i18n::t!("settings.proxies.placeholder_password"))
                 .masked(true)
         });
         let input_proxy_no_proxy =
@@ -299,22 +306,37 @@ impl ProxiesSection {
         let current_kind = self.proxy_kind;
 
         let kinds = [
-            (ProxyFormField::KindHttp, ProxyKind::Http, "HTTP"),
-            (ProxyFormField::KindHttps, ProxyKind::Https, "HTTPS"),
-            (ProxyFormField::KindSocks5, ProxyKind::Socks5, "SOCKS5"),
+            (
+                ProxyFormField::KindHttp,
+                ProxyKind::Http,
+                dbflux_i18n::t!("settings.proxies.kind.http"),
+            ),
+            (
+                ProxyFormField::KindHttps,
+                ProxyKind::Https,
+                dbflux_i18n::t!("settings.proxies.kind.https"),
+            ),
+            (
+                ProxyFormField::KindSocks5,
+                ProxyKind::Socks5,
+                dbflux_i18n::t!("settings.proxies.kind.socks5"),
+            ),
         ];
 
         div()
             .flex()
             .flex_col()
             .gap_2()
-            .child(Label::new("Protocol"))
+            .child(Label::new(dbflux_i18n::t!(
+                "settings.proxies.field.protocol"
+            )))
             .child(div().flex().gap_4().children(kinds.into_iter().map(
                 |(form_field, kind, label)| {
                     let is_focused = is_form_focused && current_field == form_field;
+                    let item_id = format!("proxy-kind-{}", label);
 
                     div()
-                        .id(SharedString::from(format!("proxy-kind-{}", label)))
+                        .id(SharedString::from(item_id))
                         .flex()
                         .items_center()
                         .gap_2()
@@ -364,7 +386,9 @@ impl ProxiesSection {
             .flex()
             .flex_col()
             .gap_2()
-            .child(Label::new("Authentication"))
+            .child(Label::new(dbflux_i18n::t!(
+                "settings.proxies.field.authentication"
+            )))
             .child(
                 div()
                     .flex()
@@ -395,7 +419,11 @@ impl ProxiesSection {
                                 primary,
                                 border,
                             ))
-                            .child(div().text_sm().child("None")),
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .child(dbflux_i18n::t!("settings.proxies.auth.none")),
+                            ),
                     )
                     .child(
                         div()
@@ -423,7 +451,11 @@ impl ProxiesSection {
                                 primary,
                                 border,
                             ))
-                            .child(div().text_sm().child("Basic")),
+                            .child(
+                                div()
+                                    .text_sm()
+                                    .child(dbflux_i18n::t!("settings.proxies.auth.basic")),
+                            ),
                     ),
             )
     }
@@ -465,7 +497,11 @@ impl ProxiesSection {
                                 cx.notify();
                             })),
                     )
-                    .child(div().text_sm().child("Save")),
+                    .child(
+                        div()
+                            .text_sm()
+                            .child(dbflux_i18n::t!("settings.proxies.action.save")),
+                    ),
             )
         } else {
             None
@@ -483,7 +519,7 @@ impl ProxiesSection {
             .flex_col()
             .gap_3()
             .child(self.render_proxy_field(
-                "Username",
+                &dbflux_i18n::t!("settings.proxies.field.username"),
                 &self.input_proxy_username,
                 is_form_focused && current_field == ProxyFormField::Username,
                 primary,
@@ -502,7 +538,7 @@ impl ProxiesSection {
                             .items_end()
                             .gap_1()
                             .child(div().flex_1().child(self.render_proxy_field(
-                                "Password",
+                                &dbflux_i18n::t!("settings.proxies.field.password"),
                                 &self.input_proxy_password,
                                 is_password_focused,
                                 primary,
@@ -550,7 +586,7 @@ impl ProxiesSection {
                                 transparent_black()
                             })
                             .child(
-                                Button::new("new-proxy", "New Proxy")
+                                Button::new("new-proxy", dbflux_i18n::t!("settings.proxies.new"))
                                     .icon(Icon::new(AppIcon::Plus))
                                     .small()
                                     .w_full()
@@ -564,14 +600,17 @@ impl ProxiesSection {
                             ),
                     )
                     .child(
-                        Button::new("import-proxy", "Import\u{2026}")
-                            .icon(Icon::new(AppIcon::Download))
-                            .small()
-                            .ghost()
-                            .w_full()
-                            .on_click(cx.listener(|this, _, _, cx| {
-                                this.request_import(cx);
-                            })),
+                        Button::new(
+                            "import-proxy",
+                            dbflux_i18n::t!("settings.proxies.action.import"),
+                        )
+                        .icon(Icon::new(AppIcon::Download))
+                        .small()
+                        .ghost()
+                        .w_full()
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.request_import(cx);
+                        })),
                     ),
             )
             .child(
@@ -584,9 +623,10 @@ impl ProxiesSection {
                     .gap_1()
                     .when(proxies.is_empty(), |root: Div| {
                         root.child(
-                            div()
-                                .p_4()
-                                .child(Body::new("No saved proxies").color(theme.muted_foreground)),
+                            div().p_4().child(
+                                Body::new(dbflux_i18n::t!("settings.proxies.empty"))
+                                    .color(theme.muted_foreground),
+                            ),
                         )
                     })
                     .children(proxies.iter().enumerate().map(|(idx, proxy)| {
@@ -641,7 +681,9 @@ impl ProxiesSection {
                                                     .color(theme.muted_foreground),
                                             )
                                             .when(!proxy.enabled, |root| {
-                                                root.child(MonoCaption::new("off"))
+                                                root.child(MonoCaption::new(dbflux_i18n::t!(
+                                                    "settings.proxies.status.disabled_caption"
+                                                )))
                                             }),
                                     )
                                     .child(
@@ -672,13 +714,16 @@ impl ProxiesSection {
         let field = self.proxy_form_field;
 
         layout::sticky_form_shell(
-            PanelTitle::new(layout::editor_panel_title("Proxy", editing_id.is_some())),
+            PanelTitle::new(layout::editor_panel_title(
+                &dbflux_i18n::t!("settings.proxies.panel_title"),
+                editing_id.is_some(),
+            )),
             div()
                 .flex()
                 .flex_col()
                 .gap_4()
                 .child(self.render_proxy_field(
-                    "Name",
+                    &dbflux_i18n::t!("settings.proxies.field.name"),
                     &self.input_proxy_name,
                     is_form_focused && field == ProxyFormField::Name,
                     primary,
@@ -691,7 +736,7 @@ impl ProxiesSection {
                         .flex()
                         .gap_3()
                         .child(div().flex_1().child(self.render_proxy_field(
-                            "Host",
+                            &dbflux_i18n::t!("settings.proxies.field.host"),
                             &self.input_proxy_host,
                             is_form_focused && field == ProxyFormField::Host,
                             primary,
@@ -699,7 +744,7 @@ impl ProxiesSection {
                             cx,
                         )))
                         .child(div().w(px(80.0)).child(self.render_proxy_field(
-                            "Port",
+                            &dbflux_i18n::t!("settings.proxies.field.port"),
                             &self.input_proxy_port,
                             is_form_focused && field == ProxyFormField::Port,
                             primary,
@@ -725,7 +770,7 @@ impl ProxiesSection {
                         .flex_col()
                         .gap_1()
                         .child(self.render_proxy_field(
-                            "No Proxy",
+                            &dbflux_i18n::t!("settings.proxies.field.no_proxy"),
                             &self.input_proxy_no_proxy,
                             is_form_focused && field == ProxyFormField::NoProxy,
                             primary,
@@ -733,7 +778,7 @@ impl ProxiesSection {
                             cx,
                         ))
                         .child(
-                            Body::new("Comma-separated hosts/CIDRs to bypass the proxy")
+                            Body::new(dbflux_i18n::t!("settings.proxies.hint.no_proxy_list"))
                                 .color(theme.muted_foreground),
                         ),
                 )
@@ -761,7 +806,7 @@ impl ProxiesSection {
                                     cx.notify();
                                 })),
                         )
-                        .child(Body::new("Enabled"))
+                        .child(Body::new(dbflux_i18n::t!("settings.proxies.field.enabled")))
                 }),
             None,
             &theme,
@@ -787,24 +832,30 @@ impl ProxiesSection {
                 root.child(layout::footer_action_frame(
                     is_form_focused && field == ProxyFormField::ExportButton,
                     primary,
-                    Button::new("export-proxy", "Export")
-                        .small()
-                        .ghost()
-                        .w_full()
-                        .on_click(cx.listener(|this, _, _, cx| {
-                            this.request_export(cx);
-                        })),
+                    Button::new(
+                        "export-proxy",
+                        dbflux_i18n::t!("settings.proxies.action.export"),
+                    )
+                    .small()
+                    .ghost()
+                    .w_full()
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.request_export(cx);
+                    })),
                 ))
                 .child(layout::footer_action_frame(
                     is_form_focused && field == ProxyFormField::DeleteButton,
                     primary,
-                    Button::new("delete-proxy", "Delete")
-                        .small()
-                        .danger()
-                        .w_full()
-                        .on_click(cx.listener(move |this, _, _, cx| {
-                            this.request_delete_proxy(proxy_id, cx);
-                        })),
+                    Button::new(
+                        "delete-proxy",
+                        dbflux_i18n::t!("settings.proxies.action.delete"),
+                    )
+                    .small()
+                    .danger()
+                    .w_full()
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.request_delete_proxy(proxy_id, cx);
+                    })),
                 ))
             })
             .child(layout::footer_action_frame(
@@ -813,9 +864,9 @@ impl ProxiesSection {
                 Button::new(
                     "save-proxy",
                     if editing_id.is_some() {
-                        "Update"
+                        dbflux_i18n::t!("settings.proxies.action.update")
                     } else {
-                        "Create"
+                        dbflux_i18n::t!("settings.proxies.action.create")
                     },
                 )
                 .small()
@@ -1026,73 +1077,168 @@ impl Render for ProxiesSection {
 
         layout::split_section_shell(
             dbflux_components::composites::section_header(
-                "Proxy Profiles",
-                "Manage proxy configurations for database connections",
+                dbflux_i18n::t!("settings.proxies.section_title"),
+                dbflux_i18n::t!("settings.proxies.section_description"),
                 cx,
             ),
             self.render_proxy_list(&proxies, editing_id, cx),
             self.render_proxy_form(editing_id, keyring_available, cx),
         )
-            .when(show_proxy_delete, |element| {
-                let entity = cx.entity().clone();
-                let entity_cancel = entity.clone();
+        .when(show_proxy_delete, |element| {
+            let entity = cx.entity().clone();
+            let entity_cancel = entity.clone();
+            let body = proxies_delete_body(&proxy_delete_name, proxy_affected_count);
 
-                let body = if proxy_affected_count > 0 {
-                    format!(
-                        "Are you sure you want to delete \"{}\"? {} connection{} using this proxy will be updated.",
-                        proxy_delete_name,
-                        proxy_affected_count,
-                        if proxy_affected_count == 1 { "" } else { "s" }
-                    )
-                } else {
-                    format!("Are you sure you want to delete \"{}\"?", proxy_delete_name)
-                };
+            element.child(
+                Dialog::new(window, cx)
+                    .title(dbflux_i18n::t!("settings.proxies.delete_dialog_title"))
+                    .confirm()
+                    .on_ok(move |_, _, cx| {
+                        entity.update(cx, |section, cx| {
+                            section.confirm_delete_proxy(cx);
+                        });
+                        true
+                    })
+                    .on_cancel(move |_, _, cx| {
+                        entity_cancel.update(cx, |section, cx| {
+                            section.cancel_delete_proxy(cx);
+                        });
+                        true
+                    })
+                    .child(div().text_sm().child(body)),
+            )
+        })
+        .when(show_discard_confirm, |element| {
+            let entity = cx.entity().clone();
+            let entity_cancel = entity.clone();
 
-                element.child(
-                    Dialog::new(window, cx)
-                        .title("Delete Proxy")
-                        .confirm()
-                        .on_ok(move |_, _, cx| {
-                            entity.update(cx, |section, cx| {
-                                section.confirm_delete_proxy(cx);
-                            });
-                            true
-                        })
-                        .on_cancel(move |_, _, cx| {
-                            entity_cancel.update(cx, |section, cx| {
-                                section.cancel_delete_proxy(cx);
-                            });
-                            true
-                        })
-                        .child(div().text_sm().child(body)),
-                )
-            })
-            .when(show_discard_confirm, |element| {
-                let entity = cx.entity().clone();
-                let entity_cancel = entity.clone();
+            element.child(
+                Dialog::new(window, cx)
+                    .title(dbflux_i18n::t!("settings.proxies.discard_dialog_title"))
+                    .confirm()
+                    .on_ok(move |_, window, cx| {
+                        entity.update(cx, |section, cx| {
+                            section.confirm_discard_changes(window, cx);
+                        });
+                        true
+                    })
+                    .on_cancel(move |_, _, cx| {
+                        entity_cancel.update(cx, |section, cx| {
+                            section.cancel_discard_changes(cx);
+                        });
+                        true
+                    })
+                    .child(
+                        div()
+                            .text_sm()
+                            .child(dbflux_i18n::t!("settings.proxies.discard_dialog.body")),
+                    ),
+            )
+        })
+    }
+}
 
-                element.child(
-                    Dialog::new(window, cx)
-                        .title("Discard Proxy Changes")
-                        .confirm()
-                        .on_ok(move |_, window, cx| {
-                            entity.update(cx, |section, cx| {
-                                section.confirm_discard_changes(window, cx);
-                            });
-                            true
-                        })
-                        .on_cancel(move |_, _, cx| {
-                            entity_cancel.update(cx, |section, cx| {
-                                section.cancel_discard_changes(cx);
-                            });
-                            true
-                        })
-                        .child(
-                            div()
-                                .text_sm()
-                                .child("You have unsaved proxy changes. Discard them?"),
-                        ),
-                )
-            })
+#[cfg(test)]
+mod tests {
+    const PROXIES_KEYS: &[&str] = &[
+        "settings.proxies.placeholder_name",
+        "settings.proxies.placeholder_username",
+        "settings.proxies.placeholder_password",
+        "settings.proxies.section_title",
+        "settings.proxies.section_description",
+        "settings.proxies.empty",
+        "settings.proxies.new",
+        "settings.proxies.panel_title",
+        "settings.proxies.kind.http",
+        "settings.proxies.kind.https",
+        "settings.proxies.kind.socks5",
+        "settings.proxies.field.name",
+        "settings.proxies.field.protocol",
+        "settings.proxies.field.authentication",
+        "settings.proxies.field.username",
+        "settings.proxies.field.password",
+        "settings.proxies.field.host",
+        "settings.proxies.field.port",
+        "settings.proxies.field.no_proxy",
+        "settings.proxies.field.enabled",
+        "settings.proxies.hint.no_proxy_list",
+        "settings.proxies.auth.none",
+        "settings.proxies.auth.basic",
+        "settings.proxies.status.disabled_caption",
+        "settings.proxies.action.save",
+        "settings.proxies.action.import",
+        "settings.proxies.action.export",
+        "settings.proxies.action.delete",
+        "settings.proxies.action.update",
+        "settings.proxies.action.create",
+        "settings.proxies.delete_dialog_title",
+        "settings.proxies.delete_dialog.body_none",
+        "settings.proxies.delete_dialog.body_one",
+        "settings.proxies.delete_dialog.body_many",
+        "settings.proxies.discard_dialog_title",
+        "settings.proxies.discard_dialog.body",
+    ];
+
+    #[test]
+    fn proxies_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in PROXIES_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn proxies_section_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("settings.proxies.section_title", locale = "en");
+        let spanish = dbflux_i18n::t!("settings.proxies.section_title", locale = "es");
+
+        assert_eq!(english, "Proxy Profiles");
+        assert_eq!(spanish, "Perfiles de proxy");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn proxies_kind_labels_stay_untranslated_protocol_names() {
+        for locale in ["en", "es"] {
+            assert_eq!(
+                dbflux_i18n::t!("settings.proxies.kind.http", locale = locale),
+                "HTTP"
+            );
+            assert_eq!(
+                dbflux_i18n::t!("settings.proxies.kind.https", locale = locale),
+                "HTTPS"
+            );
+            assert_eq!(
+                dbflux_i18n::t!("settings.proxies.kind.socks5", locale = locale),
+                "SOCKS5"
+            );
+        }
+    }
+
+    #[test]
+    fn proxies_auth_labels_differ_between_locales() {
+        let none_en = dbflux_i18n::t!("settings.proxies.auth.none", locale = "en");
+        let none_es = dbflux_i18n::t!("settings.proxies.auth.none", locale = "es");
+        let basic_en = dbflux_i18n::t!("settings.proxies.auth.basic", locale = "en");
+        let basic_es = dbflux_i18n::t!("settings.proxies.auth.basic", locale = "es");
+
+        assert_eq!(none_en, "None");
+        assert_eq!(none_es, "Ninguna");
+        assert_eq!(basic_en, "Basic");
+        assert_eq!(basic_es, "Básica");
+        assert_ne!(none_en, none_es);
+        assert_ne!(basic_en, basic_es);
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
@@ -5,6 +5,7 @@ use super::layout;
 use super::section_trait::{SectionFocusEvent, SectionPortabilityEvent};
 use super::ssh_tunnels::SshFormNav;
 use crate::connection_manager::ExportTarget;
+use crate::labels::ssh_tunnels_delete_body;
 use crate::ssh_shared::{self, SshAuthSelection};
 use dbflux_components::controls::Button;
 use dbflux_components::controls::{GpuiInput as Input, InputState};
@@ -252,7 +253,10 @@ impl SshTunnelsSection {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        let input_tunnel_name = cx.new(|cx| InputState::new(window, cx).placeholder("SSH tunnel"));
+        let input_tunnel_name = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("settings.ssh_tunnels.placeholder_name"))
+        });
         let input_ssh_host =
             cx.new(|cx| InputState::new(window, cx).placeholder("bastion.example.com"));
         let input_ssh_port = cx.new(|cx| {
@@ -265,12 +269,14 @@ impl SshTunnelsSection {
             cx.new(|cx| InputState::new(window, cx).placeholder("~/.ssh/id_rsa"));
         let input_ssh_key_passphrase = cx.new(|cx| {
             InputState::new(window, cx)
-                .placeholder("passphrase")
+                .placeholder(dbflux_i18n::t!(
+                    "settings.ssh_tunnels.placeholder_passphrase"
+                ))
                 .masked(true)
         });
         let input_ssh_password = cx.new(|cx| {
             InputState::new(window, cx)
-                .placeholder("password")
+                .placeholder(dbflux_i18n::t!("settings.ssh_tunnels.placeholder_password"))
                 .masked(true)
         });
 
@@ -405,7 +411,7 @@ impl SshTunnelsSection {
             .flex()
             .flex_col()
             .gap_2()
-            .child(Label::new("Authentication"))
+            .child(Label::new(dbflux_i18n::t!("ssh.authentication")))
             .child(
                 div()
                     .flex()
@@ -436,7 +442,7 @@ impl SshTunnelsSection {
                                 primary,
                                 border,
                             ))
-                            .child(div().text_sm().child("Private Key")),
+                            .child(div().text_sm().child(dbflux_i18n::t!("ssh.private_key"))),
                     )
                     .child(
                         div()
@@ -464,7 +470,7 @@ impl SshTunnelsSection {
                                 primary,
                                 border,
                             ))
-                            .child(div().text_sm().child("Password")),
+                            .child(div().text_sm().child(dbflux_i18n::t!("ssh.password"))),
                     ),
             )
     }
@@ -500,7 +506,7 @@ impl SshTunnelsSection {
                         cx.notify();
                     })),
             )
-            .child(div().text_sm().child("Save"))
+            .child(div().text_sm().child(dbflux_i18n::t!("ssh.save")))
     }
 
     fn render_private_key_fields(
@@ -540,7 +546,7 @@ impl SshTunnelsSection {
                     .items_end()
                     .gap_3()
                     .child(div().flex_1().child(self.render_ssh_field(
-                        "Private Key Path",
+                        &dbflux_i18n::t!("ssh.private_key_path"),
                         &self.input_ssh_key_path,
                         is_form_focused && current_field == SshFormField::KeyPath,
                         primary,
@@ -560,7 +566,7 @@ impl SshTunnelsSection {
                                 transparent_black()
                             })
                             .child(
-                                Button::new("browse-ssh-key", "Browse")
+                                Button::new("browse-ssh-key", dbflux_i18n::t!("ssh.browse"))
                                     .small()
                                     .ghost()
                                     .on_click(cx.listener(|this, _, window, cx| {
@@ -570,7 +576,7 @@ impl SshTunnelsSection {
                     }),
             )
             .child(
-                Body::new("Leave empty to use SSH agent or default keys (~/.ssh/id_rsa)")
+                Body::new(dbflux_i18n::t!("ssh.private_key_hint"))
                     .color(cx.theme().muted_foreground),
             )
             .child(
@@ -585,7 +591,7 @@ impl SshTunnelsSection {
                             .items_end()
                             .gap_1()
                             .child(div().flex_1().child(self.render_ssh_field(
-                                "Key Passphrase",
+                                &dbflux_i18n::t!("ssh.key_passphrase"),
                                 &self.input_ssh_key_passphrase,
                                 is_form_focused && current_field == SshFormField::Passphrase,
                                 primary,
@@ -597,7 +603,7 @@ impl SshTunnelsSection {
                     .when_some(save_checkbox, |div, checkbox| div.child(checkbox)),
             )
             .child(
-                Body::new("Leave empty if the key has no passphrase")
+                Body::new(dbflux_i18n::t!("ssh.passphrase_hint"))
                     .color(cx.theme().muted_foreground),
             )
     }
@@ -639,7 +645,7 @@ impl SshTunnelsSection {
                     .items_end()
                     .gap_1()
                     .child(div().flex_1().child(self.render_ssh_field(
-                        "SSH Password",
+                        &dbflux_i18n::t!("ssh.ssh_password"),
                         &self.input_ssh_password,
                         is_form_focused && current_field == SshFormField::Password,
                         primary,
@@ -686,24 +692,32 @@ impl SshTunnelsSection {
                                 transparent_black()
                             })
                             .child(
-                                Button::new("new-ssh-tunnel", "New Tunnel")
-                                    .icon(Icon::new(AppIcon::Plus))
-                                    .small()
-                                    .w_full()
-                                    .on_click(cx.listener(|this, _, window, cx| {
+                                Button::new(
+                                    "new-ssh-tunnel",
+                                    dbflux_i18n::t!("settings.ssh_tunnels.new"),
+                                )
+                                .icon(Icon::new(AppIcon::Plus))
+                                .small()
+                                .w_full()
+                                .on_click(cx.listener(
+                                    |this, _, window, cx| {
                                         this.clear_form(window, cx);
-                                    })),
+                                    },
+                                )),
                             ),
                     )
                     .child(
-                        Button::new("import-ssh-tunnel", "Import\u{2026}")
-                            .icon(Icon::new(AppIcon::Download))
-                            .small()
-                            .ghost()
-                            .w_full()
-                            .on_click(cx.listener(|this, _, _, cx| {
-                                this.request_import(cx);
-                            })),
+                        Button::new(
+                            "import-ssh-tunnel",
+                            dbflux_i18n::t!("settings.ssh_tunnels.action.import"),
+                        )
+                        .icon(Icon::new(AppIcon::Download))
+                        .small()
+                        .ghost()
+                        .w_full()
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.request_import(cx);
+                        })),
                     ),
             )
             .child(
@@ -717,7 +731,8 @@ impl SshTunnelsSection {
                     .when(tunnels.is_empty(), |root: Div| {
                         root.child(
                             div().p_4().child(
-                                Body::new("No saved SSH tunnels").color(theme.muted_foreground),
+                                Body::new(dbflux_i18n::t!("settings.ssh_tunnels.empty"))
+                                    .color(theme.muted_foreground),
                             ),
                         )
                     })
@@ -730,8 +745,10 @@ impl SshTunnelsSection {
                             tunnel.config.user, tunnel.config.host, tunnel.config.port
                         );
                         let auth_label = match tunnel.config.auth_method {
-                            dbflux_core::SshAuthMethod::PrivateKey { .. } => "Private key",
-                            dbflux_core::SshAuthMethod::Password => "Password",
+                            dbflux_core::SshAuthMethod::PrivateKey { .. } => {
+                                dbflux_i18n::t!("ssh.private_key_short")
+                            }
+                            dbflux_core::SshAuthMethod::Password => dbflux_i18n::t!("ssh.password"),
                         };
 
                         div()
@@ -789,12 +806,12 @@ impl SshTunnelsSection {
         match self.ssh_test_status {
             SshTestStatus::None => None,
             SshTestStatus::Testing => Some(
-                Body::new("Testing SSH connection...")
+                Body::new(dbflux_i18n::t!("access.testing_ssh"))
                     .color(_cx.theme().muted_foreground)
                     .into_any_element(),
             ),
             SshTestStatus::Success => Some(
-                Body::new("SSH connection successful")
+                Body::new(dbflux_i18n::t!("access.ssh_success"))
                     .color(_cx.theme().success)
                     .into_any_element(),
             ),
@@ -802,7 +819,7 @@ impl SshTunnelsSection {
                 Body::new(
                     self.ssh_test_error
                         .clone()
-                        .unwrap_or_else(|| "SSH connection failed".to_string()),
+                        .unwrap_or_else(|| dbflux_i18n::t!("access.ssh_failed")),
                 )
                 .color(_cx.theme().danger)
                 .into_any_element(),
@@ -824,7 +841,7 @@ impl SshTunnelsSection {
 
         layout::sticky_form_shell(
             PanelTitle::new(layout::editor_panel_title(
-                "SSH Tunnel",
+                &dbflux_i18n::t!("access.ssh_tunnel_label"),
                 editing_id.is_some(),
             )),
             div()
@@ -832,7 +849,7 @@ impl SshTunnelsSection {
                 .flex_col()
                 .gap_4()
                 .child(self.render_ssh_field(
-                    "Name",
+                    &dbflux_i18n::t!("settings.ssh_tunnels.field.name"),
                     &self.input_tunnel_name,
                     is_form_focused && field == SshFormField::Name,
                     primary,
@@ -844,7 +861,7 @@ impl SshTunnelsSection {
                         .flex()
                         .gap_3()
                         .child(div().flex_1().child(self.render_ssh_field(
-                            "Host",
+                            &dbflux_i18n::t!("ssh.host"),
                             &self.input_ssh_host,
                             is_form_focused && field == SshFormField::Host,
                             primary,
@@ -852,7 +869,7 @@ impl SshTunnelsSection {
                             cx,
                         )))
                         .child(div().w(px(80.0)).child(self.render_ssh_field(
-                            "Port",
+                            &dbflux_i18n::t!("ssh.port"),
                             &self.input_ssh_port,
                             is_form_focused && field == SshFormField::Port,
                             primary,
@@ -861,7 +878,7 @@ impl SshTunnelsSection {
                         ))),
                 )
                 .child(self.render_ssh_field(
-                    "Username",
+                    &dbflux_i18n::t!("ssh.username"),
                     &self.input_ssh_user,
                     is_form_focused && field == SshFormField::User,
                     primary,
@@ -902,30 +919,36 @@ impl SshTunnelsSection {
                 root.child(layout::footer_action_frame(
                     is_form_focused && field == SshFormField::ExportButton,
                     primary,
-                    Button::new("export-ssh-tunnel", "Export")
-                        .small()
-                        .ghost()
-                        .w_full()
-                        .on_click(cx.listener(|this, _, _, cx| {
-                            this.request_export(cx);
-                        })),
+                    Button::new(
+                        "export-ssh-tunnel",
+                        dbflux_i18n::t!("settings.ssh_tunnels.action.export"),
+                    )
+                    .small()
+                    .ghost()
+                    .w_full()
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.request_export(cx);
+                    })),
                 ))
                 .child(layout::footer_action_frame(
                     is_form_focused && field == SshFormField::DeleteButton,
                     primary,
-                    Button::new("delete-ssh-tunnel", "Delete")
-                        .small()
-                        .danger()
-                        .w_full()
-                        .on_click(cx.listener(move |this, _, _, cx| {
-                            this.request_delete_tunnel(tunnel_id, cx);
-                        })),
+                    Button::new(
+                        "delete-ssh-tunnel",
+                        dbflux_i18n::t!("settings.ssh_tunnels.action.delete"),
+                    )
+                    .small()
+                    .danger()
+                    .w_full()
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.request_delete_tunnel(tunnel_id, cx);
+                    })),
                 ))
             })
             .child(layout::footer_action_frame(
                 is_form_focused && field == SshFormField::TestButton,
                 primary,
-                Button::new("test-ssh-tunnel", "Test")
+                Button::new("test-ssh-tunnel", dbflux_i18n::t!("ssh.test"))
                     .small()
                     .ghost()
                     .w_full()
@@ -940,9 +963,9 @@ impl SshTunnelsSection {
                 Button::new(
                     "save-ssh-tunnel",
                     if editing_id.is_some() {
-                        "Update"
+                        dbflux_i18n::t!("ssh.update")
                     } else {
-                        "Create"
+                        dbflux_i18n::t!("ssh.create")
                     },
                 )
                 .small()
@@ -1041,8 +1064,8 @@ impl Render for SshTunnelsSection {
 
         layout::split_section_shell(
             dbflux_components::composites::section_header(
-                "SSH Tunnels",
-                "Manage reusable SSH tunnels for bastion and jump-host access",
+                dbflux_i18n::t!("settings.ssh_tunnels.section_title"),
+                dbflux_i18n::t!("settings.ssh_tunnels.section_description"),
                 cx,
             ),
             self.render_ssh_list(&tunnels, editing_id, cx),
@@ -1054,7 +1077,7 @@ impl Render for SshTunnelsSection {
 
             element.child(
                 Dialog::new(window, cx)
-                    .title("Delete SSH Tunnel")
+                    .title(dbflux_i18n::t!("settings.ssh_tunnels.delete_dialog_title"))
                     .confirm()
                     .on_ok(move |_, _, cx| {
                         entity.update(cx, |section, cx| {
@@ -1068,11 +1091,105 @@ impl Render for SshTunnelsSection {
                         });
                         true
                     })
-                    .child(div().text_sm().child(format!(
-                        "Are you sure you want to delete \"{}\"?",
-                        tunnel_delete_name
-                    ))),
+                    .child(
+                        div()
+                            .text_sm()
+                            .child(ssh_tunnels_delete_body(&tunnel_delete_name)),
+                    ),
             )
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const SSH_TUNNELS_KEYS: &[&str] = &[
+        "settings.ssh_tunnels.placeholder_name",
+        "settings.ssh_tunnels.placeholder_password",
+        "settings.ssh_tunnels.placeholder_passphrase",
+        "settings.ssh_tunnels.section_title",
+        "settings.ssh_tunnels.section_description",
+        "settings.ssh_tunnels.empty",
+        "settings.ssh_tunnels.new",
+        "settings.ssh_tunnels.field.name",
+        "settings.ssh_tunnels.delete_dialog_title",
+        "settings.ssh_tunnels.delete_dialog.body",
+        "settings.ssh_tunnels.action.import",
+        "settings.ssh_tunnels.action.export",
+        "settings.ssh_tunnels.action.delete",
+    ];
+
+    // Reused from the shared `ssh.*` vocabulary (slice S10, `access_tab.rs`).
+    const SSH_TUNNELS_REUSED_SSH_KEYS: &[&str] = &[
+        "ssh.authentication",
+        "ssh.private_key",
+        "ssh.password",
+        "ssh.private_key_path",
+        "ssh.browse",
+        "ssh.key_passphrase",
+        "ssh.save",
+        "ssh.passphrase_hint",
+        "ssh.private_key_hint",
+        "ssh.ssh_password",
+        "ssh.host",
+        "ssh.port",
+        "ssh.username",
+        "ssh.private_key_short",
+        "ssh.update",
+        "ssh.create",
+        "ssh.test",
+    ];
+
+    // Reused from the `access.*` namespace (slice S10, `access_tab.rs`) since
+    // the SSH test-status strings are identical to the Access tab's.
+    const SSH_TUNNELS_REUSED_ACCESS_KEYS: &[&str] = &[
+        "access.testing_ssh",
+        "access.ssh_success",
+        "access.ssh_failed",
+        "access.ssh_tunnel_label",
+    ];
+
+    #[test]
+    fn ssh_tunnels_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in SSH_TUNNELS_KEYS
+                .iter()
+                .chain(SSH_TUNNELS_REUSED_SSH_KEYS)
+                .chain(SSH_TUNNELS_REUSED_ACCESS_KEYS)
+            {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ssh_tunnels_section_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("settings.ssh_tunnels.section_title", locale = "en");
+        let spanish = dbflux_i18n::t!("settings.ssh_tunnels.section_title", locale = "es");
+
+        assert_eq!(english, "SSH Tunnels");
+        assert_eq!(spanish, "Túneles SSH");
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
+    fn ssh_tunnels_empty_state_differs_between_locales() {
+        let english = dbflux_i18n::t!("settings.ssh_tunnels.empty", locale = "en");
+        let spanish = dbflux_i18n::t!("settings.ssh_tunnels.empty", locale = "es");
+
+        assert_eq!(english, "No saved SSH tunnels");
+        assert_eq!(spanish, "No hay túneles SSH guardados");
+        assert_ne!(english, spanish);
     }
 }


### PR DESCRIPTION
## Summary

Twenty-fourth `dbflux_ui_windows` i18n slice: the SSH tunnels and proxies settings sections (titles and descriptions, empty states, New/Export/Delete, panel titles, field labels, placeholders, hints, auth and protocol option labels, delete and discard dialogs, toasts) render through `dbflux_i18n::t!` under `settings.ssh_tunnels.*` and `settings.proxies.*`, reusing the `ssh.*` / `access.*` vocabulary. English and Spanish together. Protocol names (HTTP/HTTPS/SOCKS5) and example hosts/paths stay data.

## What does this resolve?

- Refs #360 (follows the RPC services PR; next: audit settings)

## How was this solved?

- `ssh_tunnels_delete_body` / `proxies_delete_body` helpers carry the names and affected-connection counts.
- Size: 790 lines across the two assigned section files (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 282 passed; clippy clean; fmt clean. Manual smoke in Spanish: Settings → SSH Tunnels, create and test a tunnel; Settings → Proxies, create a SOCKS5 proxy, discard, delete.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
