### PR TITLE
feat(i18n): translate the chart document toolbar, shell states, and stats rail

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -432,6 +432,52 @@ document:
       toast:
         created: "Created bucket \"%{name}\""
         created_with_limitations: "Created bucket \"%{name}\" with limitations"
+  chart:
+    toolbar:
+      type_label: TYPE
+      stats: Stats
+      save_chart: Save chart
+      points:
+        one: "%{count} pt"
+        many: "%{count} pts"
+    shell:
+      run: Run
+      running: "Running…"
+      save: Save
+      cancel: Cancel
+      name_placeholder: Chart name
+      degraded:
+        loading_metric: "Loading metric data…"
+        no_data_points: "No data points for the selected window."
+        run_query: "Run the query to populate the chart."
+        no_time_column: "No time column detected in result."
+        no_numeric_series: "No numeric series detected in result."
+        build_failed: "Chart build failed."
+      custom_range:
+        apply: Apply
+      stats_rail:
+        rebuilding: "Rebuilding chart…"
+        no_stats: "No stats available for this series."
+        unavailable: unavailable
+        window_title: Window
+        window:
+          start: Start
+          end: End
+          span: Span
+          points: Points
+        source_title: Source
+    status:
+      task_label: Chart query
+    toast:
+      chart_saved: Chart saved
+      save_failed: "Failed to save chart: %{error}"
+      png_export_coming: "PNG export coming in v0.7"
+    error:
+      source: "Chart source error: %{error}"
+      no_connection_selected: No connection selected
+      connection_not_found: Connection not found
+      connection_error: "Connection error: %{error}"
+      collection_source_unsupported: "Collection source not supported in ChartDocument; open via DataDocument"
   code:
     toolbar:
       refresh: Refresh

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -432,6 +432,52 @@ document:
       toast:
         created: "Bucket \"%{name}\" creado"
         created_with_limitations: "Bucket \"%{name}\" creado con limitaciones"
+  chart:
+    toolbar:
+      type_label: TIPO
+      stats: Estadísticas
+      save_chart: Guardar gráfico
+      points:
+        one: "%{count} punto"
+        many: "%{count} puntos"
+    shell:
+      run: Ejecutar
+      running: "Ejecutando…"
+      save: Guardar
+      cancel: Cancelar
+      name_placeholder: Nombre del gráfico
+      degraded:
+        loading_metric: "Cargando datos de la métrica…"
+        no_data_points: "No hay puntos de datos para la ventana seleccionada."
+        run_query: "Ejecuta la consulta para generar el gráfico."
+        no_time_column: "No se detectó ninguna columna de tiempo en el resultado."
+        no_numeric_series: "No se detectó ninguna serie numérica en el resultado."
+        build_failed: "No se pudo generar el gráfico."
+      custom_range:
+        apply: Aplicar
+      stats_rail:
+        rebuilding: "Regenerando el gráfico…"
+        no_stats: "No hay estadísticas disponibles para esta serie."
+        unavailable: no disponible
+        window_title: Ventana
+        window:
+          start: Inicio
+          end: Fin
+          span: Duración
+          points: Puntos
+        source_title: Origen
+    status:
+      task_label: Consulta de gráfico
+    toast:
+      chart_saved: Gráfico guardado
+      save_failed: "No se pudo guardar el gráfico: %{error}"
+      png_export_coming: "La exportación a PNG llega en la v0.7"
+    error:
+      source: "Error del origen del gráfico: %{error}"
+      no_connection_selected: No hay ninguna conexión seleccionada
+      connection_not_found: Conexión no encontrada
+      connection_error: "Error de conexión: %{error}"
+      collection_source_unsupported: "El origen de colección no es compatible con ChartDocument; ábrelo desde DataDocument"
   code:
     toolbar:
       refresh: Actualizar

--- a/crates/dbflux_ui_document/src/chart/toolbar.rs
+++ b/crates/dbflux_ui_document/src/chart/toolbar.rs
@@ -15,6 +15,7 @@
 //! assembled separately in each caller.
 
 use super::shell::{ChartRailTab, ChartShell};
+use crate::labels::configure_chart_kind_label;
 use dbflux_components::chart::{ChartKind, format_resolution, format_x_value};
 use dbflux_components::composites::refresh_split_button;
 use dbflux_components::controls::Dropdown;
@@ -156,7 +157,7 @@ pub fn render_chart_toolbar(
     );
 
     // --- Toolbar action button helper ---
-    let toolbar_btn = |id: &'static str, icon: AppIcon, label: &'static str, is_active: bool| {
+    let toolbar_btn = |id: &'static str, icon: AppIcon, label: SharedString, is_active: bool| {
         let primary = theme.primary;
         let primary_fg = theme.primary_foreground;
 
@@ -184,13 +185,19 @@ pub fn render_chart_toolbar(
 
     // --- Chart kind chips (Line | Bar) ---
     let on_select_kind = handlers.on_select_chart_kind.clone();
-    let kind_options: [(ChartKind, &'static str); 6] = [
-        (ChartKind::Line, "Line"),
-        (ChartKind::Bar, "Bar"),
-        (ChartKind::Scatter, "Scatter"),
-        (ChartKind::Area, "Area"),
-        (ChartKind::StackedBar, "Stacked"),
-        (ChartKind::Pie, "Pie"),
+    let kind_options: [(ChartKind, String); 6] = [
+        (ChartKind::Line, configure_chart_kind_label(ChartKind::Line)),
+        (ChartKind::Bar, configure_chart_kind_label(ChartKind::Bar)),
+        (
+            ChartKind::Scatter,
+            configure_chart_kind_label(ChartKind::Scatter),
+        ),
+        (ChartKind::Area, configure_chart_kind_label(ChartKind::Area)),
+        (
+            ChartKind::StackedBar,
+            configure_chart_kind_label(ChartKind::StackedBar),
+        ),
+        (ChartKind::Pie, configure_chart_kind_label(ChartKind::Pie)),
     ];
     let num_kinds = kind_options.len();
 
@@ -210,8 +217,10 @@ pub fn render_chart_toolbar(
                     let is_last = i == num_kinds - 1;
                     let handler = on_select_kind.clone();
 
+                    // The element ID is keyed by position, not by the (translated)
+                    // label text, so it stays stable regardless of active locale.
                     let mut chip = div()
-                        .id(ElementId::Name(format!("chart-kind-{label}").into()))
+                        .id(ElementId::Name(format!("chart-kind-{i}").into()))
                         .px(px(8.0))
                         .py(px(3.0))
                         .text_size(px(11.0))
@@ -249,24 +258,28 @@ pub fn render_chart_toolbar(
     let stats_btn = toolbar_btn(
         "chart-toolbar-stats",
         AppIcon::ChartBar,
-        "Stats",
+        dbflux_i18n::t!("document.chart.toolbar.stats").into(),
         is_stats_active,
     )
     .on_mouse_down(MouseButton::Left, move |_, window, cx| {
         on_stats(window, cx);
     });
 
-    let png_btn = toolbar_btn("chart-toolbar-png", AppIcon::Download, "PNG", false).on_mouse_down(
-        MouseButton::Left,
-        move |_, window, cx| {
-            on_png(window, cx);
-        },
-    );
-
-    let save_btn = toolbar_btn("chart-toolbar-save", AppIcon::Save, "Save chart", false)
+    // "PNG" is a file-format acronym, not translated prose.
+    let png_btn = toolbar_btn("chart-toolbar-png", AppIcon::Download, "PNG".into(), false)
         .on_mouse_down(MouseButton::Left, move |_, window, cx| {
-            on_save(window, cx);
+            on_png(window, cx);
         });
+
+    let save_btn = toolbar_btn(
+        "chart-toolbar-save",
+        AppIcon::Save,
+        dbflux_i18n::t!("document.chart.toolbar.save_chart").into(),
+        false,
+    )
+    .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+        on_save(window, cx);
+    });
 
     // Responsive layout: a single `flex_wrap` row that wraps onto multiple
     // lines when the viewport gets narrower. Per the project pattern
@@ -315,7 +328,9 @@ pub fn render_chart_toolbar(
                 .text_size(px(11.0))
                 .text_color(muted)
                 .font(font("JetBrains Mono"))
-                .child(SharedString::from(format!("{row_count} pts")))
+                .child(SharedString::from(
+                    crate::labels::chart_toolbar_points_label(row_count),
+                ))
                 .child("\u{00b7}")
                 .child(resolution_label),
         )
@@ -331,7 +346,7 @@ pub fn render_chart_toolbar(
                         .text_size(px(10.0))
                         .text_color(muted)
                         .font_weight(FontWeight::BOLD)
-                        .child("TYPE"),
+                        .child(dbflux_i18n::t!("document.chart.toolbar.type_label")),
                 )
                 .child(kind_chips),
         )
@@ -383,5 +398,30 @@ mod tests {
             !source_supports_save,
             "save button must be gated by source_supports_save"
         );
+    }
+
+    /// PR 24: the toolbar's chart-kind chip labels route through the same
+    /// translated `configure_chart_kind_label` helper the dashboard's
+    /// Configure popover uses (PR 23), instead of a duplicate literal set.
+    #[test]
+    fn kind_chip_labels_route_through_configure_chart_kind_label() {
+        use dbflux_components::chart::ChartKind;
+
+        let kinds = [
+            ChartKind::Line,
+            ChartKind::Bar,
+            ChartKind::Scatter,
+            ChartKind::Area,
+            ChartKind::StackedBar,
+            ChartKind::Pie,
+        ];
+
+        for kind in kinds {
+            let label = crate::labels::configure_chart_kind_label(kind);
+            assert!(
+                !label.is_empty(),
+                "configure_chart_kind_label({kind:?}) resolved empty"
+            );
+        }
     }
 }

--- a/crates/dbflux_ui_document/src/chart_document/mod.rs
+++ b/crates/dbflux_ui_document/src/chart_document/mod.rs
@@ -305,10 +305,9 @@ impl ChartDocument {
             // Collection sources are not routed through ChartDocument in W0.
             // They still open via DataDocument.
             SavedChartSource::Collection { .. } => {
-                return Err(
-                    "Collection source not supported in ChartDocument; open via DataDocument"
-                        .to_string(),
-                );
+                return Err(dbflux_i18n::t!(
+                    "document.chart.error.collection_source_unsupported"
+                ));
             }
 
             // Metric sources bypass the query path and construct a MetricSource
@@ -548,10 +547,9 @@ impl ChartDocument {
             SavedChartSource::Query { .. }
             | SavedChartSource::Metric { .. }
             | SavedChartSource::InstanceMetric { .. } => Ok(()),
-            SavedChartSource::Collection { .. } => Err(
-                "Collection source not supported in ChartDocument; open via DataDocument"
-                    .to_string(),
-            ),
+            SavedChartSource::Collection { .. } => Err(dbflux_i18n::t!(
+                "document.chart.error.collection_source_unsupported"
+            )),
         }
     }
 
@@ -816,7 +814,7 @@ impl ChartDocument {
             Err(ChartSourceError::EmptyQuery) => return,
             Err(e) => {
                 self.pending_toast = Some(PendingToast {
-                    message: format!("Chart source error: {e}"),
+                    message: dbflux_i18n::t!("document.chart.error.source", error = e),
                     is_error: true,
                 });
                 cx.notify();
@@ -826,7 +824,7 @@ impl ChartDocument {
 
         let Some(profile_id) = self.profile_id else {
             self.pending_toast = Some(PendingToast {
-                message: "No connection selected".to_string(),
+                message: dbflux_i18n::t!("document.chart.error.no_connection_selected"),
                 is_error: true,
             });
             cx.notify();
@@ -838,7 +836,7 @@ impl ChartDocument {
             let state = self.app_state.read(cx);
             let Some(connected) = state.connections().get(&profile_id) else {
                 self.pending_toast = Some(PendingToast {
-                    message: "Connection not found".to_string(),
+                    message: dbflux_i18n::t!("document.chart.error.connection_not_found"),
                     is_error: true,
                 });
                 cx.notify();
@@ -848,7 +846,10 @@ impl ChartDocument {
                 Ok(c) => c,
                 Err(e) => {
                     self.pending_toast = Some(PendingToast {
-                        message: format!("Connection error: {:?}", e),
+                        message: dbflux_i18n::t!(
+                            "document.chart.error.connection_error",
+                            error = format!("{:?}", e)
+                        ),
                         is_error: true,
                     });
                     cx.notify();
@@ -870,9 +871,11 @@ impl ChartDocument {
         request.sql =
             dbflux_core::substitute_time_macros(&request.sql, macro_window, query_language);
 
-        let (task_id, cancel_token) =
-            self.runner
-                .start_primary(dbflux_core::TaskKind::Query, "Chart query", cx);
+        let (task_id, cancel_token) = self.runner.start_primary(
+            dbflux_core::TaskKind::Query,
+            dbflux_i18n::t!("document.chart.status.task_label"),
+            cx,
+        );
 
         self.exec_state = ExecState::Running;
         self.state = DocumentState::Executing;
@@ -1044,7 +1047,10 @@ impl ChartDocument {
             String::new()
         };
 
-        let input = cx.new(|cx| InputState::new(window, cx).placeholder("Chart name"));
+        let input = cx.new(|cx| {
+            InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("document.chart.shell.name_placeholder"))
+        });
 
         if !initial.is_empty() {
             input.update(cx, |state, cx| {
@@ -1142,13 +1148,13 @@ impl ChartDocument {
                 self.saved_chart_id = Some(id);
                 self.title = name;
                 self.pending_toast = Some(PendingToast {
-                    message: "Chart saved".to_string(),
+                    message: dbflux_i18n::t!("document.chart.toast.chart_saved"),
                     is_error: false,
                 });
             }
             Err(e) => {
                 self.pending_toast = Some(PendingToast {
-                    message: format!("Failed to save chart: {e}"),
+                    message: dbflux_i18n::t!("document.chart.toast.save_failed", error = e),
                     is_error: true,
                 });
             }
@@ -1273,7 +1279,7 @@ impl ChartDocument {
     /// loop drains `pending_toast` and surfaces it through the global toast host.
     pub fn schedule_png_export_toast(&mut self, cx: &mut Context<Self>) {
         self.pending_toast = Some(PendingToast {
-            message: "PNG export coming in v0.7".to_string(),
+            message: dbflux_i18n::t!("document.chart.toast.png_export_coming"),
             is_error: false,
         });
         cx.notify();
@@ -1333,7 +1339,7 @@ impl ChartDocument {
             }
             Err(e) => {
                 self.pending_toast = Some(PendingToast {
-                    message: format!("Failed to save chart: {e}"),
+                    message: dbflux_i18n::t!("document.chart.toast.save_failed", error = e),
                     is_error: true,
                 });
                 cx.notify();
@@ -1411,7 +1417,11 @@ impl ChartDocument {
                     let is_executing = e_run.read(cx).exec_state == ExecState::Running;
                     let e = e_run.clone();
                     Button::new("run-query")
-                        .label(if is_executing { "Running…" } else { "Run" })
+                        .label(if is_executing {
+                            dbflux_i18n::t!("document.chart.shell.running")
+                        } else {
+                            dbflux_i18n::t!("document.chart.shell.run")
+                        })
                         .small()
                         .with_variant(ButtonVariant::Primary)
                         .disabled(is_executing)
@@ -1429,7 +1439,7 @@ impl ChartDocument {
                 builder: Box::new(move |_window, _cx| {
                     let e = e_save.clone();
                     Button::new("save-chart")
-                        .label("Save")
+                        .label(dbflux_i18n::t!("document.chart.shell.save"))
                         .small()
                         .on_click(move |_, window, cx| {
                             e.update(cx, |this, cx| {
@@ -2682,5 +2692,55 @@ mod tests {
                 "Query-source chart must keep Manual refresh policy"
             );
         });
+    }
+
+    /// `validate_saved_source` routes its Collection-source rejection through
+    /// the translation catalog instead of a hardcoded English literal.
+    #[test]
+    fn validate_saved_source_collection_error_is_translated() {
+        let collection_saved = SavedChart::new_collection(
+            "unused".to_string(),
+            Uuid::nil(),
+            dbflux_core::CollectionRef::new("db", "table"),
+            None,
+            dbflux_components::chart::ChartSpec {
+                kind: dbflux_components::chart::ChartKind::Line,
+                x_axis: dbflux_components::chart::AxisSpec {
+                    column_index: 0,
+                    label: String::new(),
+                    kind: dbflux_components::chart::AxisKind::Time,
+                    unit: None,
+                },
+                series: Vec::new(),
+                legend_visible: false,
+                decimation_threshold: 10_000,
+                binding: dbflux_components::chart::BindingSpec::default(),
+                track_source_indices: false,
+                y_scale: dbflux_components::chart::YScale::Linear,
+            },
+            dbflux_components::chart::BindingSpec::default(),
+        );
+
+        let err = ChartDocument::validate_saved_source(&collection_saved)
+            .expect_err("Collection source must be rejected");
+
+        assert_eq!(
+            err,
+            dbflux_i18n::t!("document.chart.error.collection_source_unsupported")
+        );
+    }
+
+    /// `schedule_png_export_toast` routes its message through the translation
+    /// catalog instead of a hardcoded English literal.
+    #[test]
+    fn png_export_toast_message_is_translated() {
+        assert_eq!(
+            dbflux_i18n::t!("document.chart.toast.png_export_coming"),
+            dbflux_i18n::t!("document.chart.toast.png_export_coming", locale = "en")
+        );
+        assert_ne!(
+            dbflux_i18n::t!("document.chart.toast.png_export_coming", locale = "en"),
+            dbflux_i18n::t!("document.chart.toast.png_export_coming", locale = "es")
+        );
     }
 }

--- a/crates/dbflux_ui_document/src/chart_document/render.rs
+++ b/crates/dbflux_ui_document/src/chart_document/render.rs
@@ -180,52 +180,60 @@ impl Render for ChartDocument {
 
         // -- Name prompt modal overlay --
         let show_name_prompt = self.name_prompt.is_some();
-        let name_prompt_element = show_name_prompt.then(|| {
-            let theme = cx.theme().clone();
-            let input = self.name_prompt.as_ref().unwrap().input.clone();
+        let name_prompt_element =
+            show_name_prompt.then(|| {
+                let theme = cx.theme().clone();
+                let input = self.name_prompt.as_ref().unwrap().input.clone();
 
-            div()
-                .absolute()
-                .inset_0()
-                .flex()
-                .items_center()
-                .justify_center()
-                .bg(theme.background.opacity(0.6))
-                .child(
-                    div()
-                        .bg(theme.secondary)
-                        .border_1()
-                        .border_color(theme.border)
-                        .p(Spacing::LG)
-                        .w(px(360.0))
-                        .flex()
-                        .flex_col()
-                        .gap(Spacing::MD)
-                        .child(Text::label("Save chart"))
-                        .child(Input::new(&input).placeholder("Chart name"))
-                        .child(
-                            div()
-                                .flex()
-                                .flex_row()
-                                .gap(Spacing::SM)
-                                .justify_end()
-                                .child(Button::new("cancel-save").label("Cancel").small().on_click(
-                                    cx.listener(|this, _, _window, cx| {
-                                        this.cancel_save(cx);
-                                    }),
-                                ))
-                                .child(
-                                    Button::new("confirm-save")
-                                        .label("Save")
-                                        .small()
-                                        .with_variant(ButtonVariant::Primary)
-                                        .on_click(cx.listener(|this, _, _window, cx| {
-                                            this.confirm_save(cx);
-                                        })),
-                                ),
-                        ),
-                )
-        });
+                div()
+                    .absolute()
+                    .inset_0()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .bg(theme.background.opacity(0.6))
+                    .child(
+                        div()
+                            .bg(theme.secondary)
+                            .border_1()
+                            .border_color(theme.border)
+                            .p(Spacing::LG)
+                            .w(px(360.0))
+                            .flex()
+                            .flex_col()
+                            .gap(Spacing::MD)
+                            .child(Text::label(dbflux_i18n::t!(
+                                "document.chart.toolbar.save_chart"
+                            )))
+                            .child(Input::new(&input).placeholder(dbflux_i18n::t!(
+                                "document.chart.shell.name_placeholder"
+                            )))
+                            .child(
+                                div()
+                                    .flex()
+                                    .flex_row()
+                                    .gap(Spacing::SM)
+                                    .justify_end()
+                                    .child(
+                                        Button::new("cancel-save")
+                                            .label(dbflux_i18n::t!("document.chart.shell.cancel"))
+                                            .small()
+                                            .on_click(cx.listener(|this, _, _window, cx| {
+                                                this.cancel_save(cx);
+                                            })),
+                                    )
+                                    .child(
+                                        Button::new("confirm-save")
+                                            .label(dbflux_i18n::t!("document.chart.shell.save"))
+                                            .small()
+                                            .with_variant(ButtonVariant::Primary)
+                                            .on_click(cx.listener(|this, _, _window, cx| {
+                                                this.confirm_save(cx);
+                                            })),
+                                    ),
+                            ),
+                    )
+            });
 
         // Outer container: tracks focus, hosts ResultPanel and the name-prompt
         // overlay as a sibling (not inside the chrome row).
@@ -267,21 +275,27 @@ impl ChartDocument {
             // For self-executing sources (MetricSource) the copy is tailored to
             // metric charts; for query/empty sources the generic copy is shown.
             let is_metric = self.data_source.is_self_executing();
-            let msg = match &chart_detection {
+            let msg: String = match &chart_detection {
                 Some(ChartDetection::EmptyResult) | None => {
                     if is_metric {
                         if self.exec_state == ExecState::Running {
-                            "Loading metric data…"
+                            dbflux_i18n::t!("document.chart.shell.degraded.loading_metric")
                         } else {
-                            "No data points for the selected window."
+                            dbflux_i18n::t!("document.chart.shell.degraded.no_data_points")
                         }
                     } else {
-                        "Run the query to populate the chart."
+                        dbflux_i18n::t!("document.chart.shell.degraded.run_query")
                     }
                 }
-                Some(ChartDetection::NoTimeColumn) => "No time column detected in result.",
-                Some(ChartDetection::NoNumericSeries) => "No numeric series detected in result.",
-                Some(ChartDetection::Ok { .. }) => "Chart build failed.",
+                Some(ChartDetection::NoTimeColumn) => {
+                    dbflux_i18n::t!("document.chart.shell.degraded.no_time_column")
+                }
+                Some(ChartDetection::NoNumericSeries) => {
+                    dbflux_i18n::t!("document.chart.shell.degraded.no_numeric_series")
+                }
+                Some(ChartDetection::Ok { .. }) => {
+                    dbflux_i18n::t!("document.chart.shell.degraded.build_failed")
+                }
             };
             div()
                 .size_full()
@@ -349,7 +363,11 @@ impl ChartDocument {
                     if let Some(doc) = weak_self_for_png.upgrade() {
                         doc.update(cx, |this, _cx| {
                             this.pending_toast = Some(PendingToast {
-                                message: format!("PNG export coming in v0.7 — {}", now_hms()),
+                                message: format!(
+                                    "{} — {}",
+                                    dbflux_i18n::t!("document.chart.toast.png_export_coming"),
+                                    now_hms()
+                                ),
                                 is_error: false,
                             });
                         });
@@ -493,7 +511,9 @@ impl ChartDocument {
                                 })
                         })
                         .when(!can_apply, |d| d.opacity(0.45))
-                        .child(Text::caption("Apply"));
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "document.chart.shell.custom_range.apply"
+                        )));
 
                     // Outer band: full-width chrome (border, bg, padding) plus
                     // flex_wrap so the picker row + Apply can wrap on narrow
@@ -692,7 +712,7 @@ impl ChartDocument {
             (cv, fi)
         };
 
-        let placeholder = |msg: &'static str| -> AnyElement {
+        let placeholder = |msg: String| -> AnyElement {
             div()
                 .p_2()
                 .text_size(FontSizes::XS)
@@ -703,7 +723,9 @@ impl ChartDocument {
 
         let Some(chart_view) = chart_view_opt else {
             return Some(self.wrap_stats_rail_chrome(
-                placeholder("Rebuilding chart…"),
+                placeholder(dbflux_i18n::t!(
+                    "document.chart.shell.stats_rail.rebuilding"
+                )),
                 theme,
                 &chart_colors,
             ));
@@ -724,7 +746,7 @@ impl ChartDocument {
 
         let Some(stats) = stats_opt else {
             return Some(self.wrap_stats_rail_chrome(
-                placeholder("No stats available for this series."),
+                placeholder(dbflux_i18n::t!("document.chart.shell.stats_rail.no_stats")),
                 theme,
                 &chart_colors,
             ));
@@ -775,7 +797,9 @@ impl ChartDocument {
                 .text_size(px(11.0))
                 .text_color(theme.muted_foreground)
                 .italic()
-                .child("unavailable")
+                .child(dbflux_i18n::t!(
+                    "document.chart.shell.stats_rail.unavailable"
+                ))
                 .into_any_element()
         };
 
@@ -808,7 +832,10 @@ impl ChartDocument {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(dock_header("Stats", &chart_colors))
+                    .child(dock_header(
+                        &dbflux_i18n::t!("document.chart.toolbar.stats"),
+                        &chart_colors,
+                    ))
                     .child(dock_kv_row("min", cyan_val(stats.min), &chart_colors))
                     .child(dock_kv_row("max", cyan_val(stats.max), &chart_colors))
                     .child(dock_kv_row("avg", cyan_val(stats.avg), &chart_colors))
@@ -824,12 +851,27 @@ impl ChartDocument {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(dock_header("Window", &chart_colors))
-                    .child(dock_kv_row("start", str_val(start_label), &chart_colors))
-                    .child(dock_kv_row("end", str_val(end_label), &chart_colors))
-                    .child(dock_kv_row("span", str_val(span_label), &chart_colors))
+                    .child(dock_header(
+                        &dbflux_i18n::t!("document.chart.shell.stats_rail.window_title"),
+                        &chart_colors,
+                    ))
                     .child(dock_kv_row(
-                        "points",
+                        &dbflux_i18n::t!("document.chart.shell.stats_rail.window.start"),
+                        str_val(start_label),
+                        &chart_colors,
+                    ))
+                    .child(dock_kv_row(
+                        &dbflux_i18n::t!("document.chart.shell.stats_rail.window.end"),
+                        str_val(end_label),
+                        &chart_colors,
+                    ))
+                    .child(dock_kv_row(
+                        &dbflux_i18n::t!("document.chart.shell.stats_rail.window.span"),
+                        str_val(span_label),
+                        &chart_colors,
+                    ))
+                    .child(dock_kv_row(
+                        &dbflux_i18n::t!("document.chart.shell.stats_rail.window.points"),
                         str_val(format!("{}", points_count)),
                         &chart_colors,
                     )),
@@ -841,7 +883,10 @@ impl ChartDocument {
                     .flex()
                     .flex_col()
                     .gap(px(2.0))
-                    .child(dock_header("Source", &chart_colors))
+                    .child(dock_header(
+                        &dbflux_i18n::t!("document.chart.shell.stats_rail.source_title"),
+                        &chart_colors,
+                    ))
                     .child(dock_kv_row("measurement", unavail_val(), &chart_colors))
                     .child(dock_kv_row("field", unavail_val(), &chart_colors))
                     .child(dock_kv_row("host", unavail_val(), &chart_colors))
@@ -879,7 +924,7 @@ impl ChartDocument {
                     .text_size(px(10.0))
                     .text_color(muted_fg)
                     .font_weight(FontWeight::BOLD)
-                    .child("STATS"),
+                    .child(dbflux_i18n::t!("document.chart.toolbar.stats").to_uppercase()),
             )
             .child(
                 div()

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1361,6 +1361,16 @@ pub(crate) fn configure_chart_kind_label(kind: dbflux_components::chart::ChartKi
     }
 }
 
+/// Point-count label for the standalone `ChartDocument` toolbar's
+/// clock/resolution segment (e.g. "1 pt" / "240 pts").
+pub(crate) fn chart_toolbar_points_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("document.chart.toolbar.points.one", count = count)
+    } else {
+        dbflux_i18n::t!("document.chart.toolbar.points.many", count = count)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1369,19 +1379,20 @@ mod tests {
         audit_actor_type_label, audit_category_label, audit_level_label, audit_outcome_label,
         bool_op_label, bucket_encryption_choice_label, buckets_table_summary_line,
         builder_mode_label, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
-        chart_rail_why_text, code_toolbar_shortcut_hint_label, comparator_label,
-        configure_chart_kind_label, copy_query_language_label, dangerous_query_body,
-        dangerous_query_title, delete_confirm_copy, delete_prefix_delete_button_label,
-        delete_prefix_deleted_toast, delete_prefix_probe_totals, delete_rows_label,
-        execution_count_state_label, execution_mode_label, history_items_count_label,
-        history_tab_label, image_decode_error, image_header_error, incomplete_aggregate_rows_label,
-        join_kind_label, live_output_lines_label, live_output_truncated_label,
-        object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
-        pending_change_count_label, pending_edits_summary, presign_expiry_label,
-        presign_method_label, preview_gate_message, refresh_policy_label, result_tab_count_label,
-        row_count_label, schema_change_description, script_confirm_message_label,
-        sort_direction_label, table_action_description, unsaved_changes_label,
-        update_columns_label, valid_lines_label, versioning_off_label, versioning_status_label,
+        chart_rail_why_text, chart_toolbar_points_label, code_toolbar_shortcut_hint_label,
+        comparator_label, configure_chart_kind_label, copy_query_language_label,
+        dangerous_query_body, dangerous_query_title, delete_confirm_copy,
+        delete_prefix_delete_button_label, delete_prefix_deleted_toast, delete_prefix_probe_totals,
+        delete_rows_label, execution_count_state_label, execution_mode_label,
+        history_items_count_label, history_tab_label, image_decode_error, image_header_error,
+        incomplete_aggregate_rows_label, join_kind_label, live_output_lines_label,
+        live_output_truncated_label, object_browser_status_summary,
+        object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
+        pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
+        refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
+        script_confirm_message_label, sort_direction_label, table_action_description,
+        unsaved_changes_label, update_columns_label, valid_lines_label, versioning_off_label,
+        versioning_status_label,
     };
     use crate::buckets_table::BucketEncryptionChoice;
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
@@ -3637,6 +3648,107 @@ mod tests {
         );
         let es = dbflux_i18n::t!(
             "document.dashboard.configure.chart_kind.line",
+            locale = "es"
+        );
+        assert_ne!(en, es);
+    }
+
+    /// PR 24: every `document.chart.*` key introduced by the standalone
+    /// `ChartDocument` toolbar/shell/host translation resolves in both
+    /// locales. Includes keys reused from PR 23 (`document.dashboard.configure.
+    /// chart_kind.*`) so a reviewer sees the full reuse list in this diff.
+    #[test]
+    fn chart_document_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.chart.toolbar.type_label",
+            "document.chart.toolbar.stats",
+            "document.chart.toolbar.save_chart",
+            "document.chart.toolbar.points.one",
+            "document.chart.toolbar.points.many",
+            "document.chart.shell.run",
+            "document.chart.shell.running",
+            "document.chart.shell.save",
+            "document.chart.shell.cancel",
+            "document.chart.shell.name_placeholder",
+            "document.chart.shell.degraded.loading_metric",
+            "document.chart.shell.degraded.no_data_points",
+            "document.chart.shell.degraded.run_query",
+            "document.chart.shell.degraded.no_time_column",
+            "document.chart.shell.degraded.no_numeric_series",
+            "document.chart.shell.degraded.build_failed",
+            "document.chart.shell.custom_range.apply",
+            "document.chart.shell.stats_rail.rebuilding",
+            "document.chart.shell.stats_rail.no_stats",
+            "document.chart.shell.stats_rail.unavailable",
+            "document.chart.shell.stats_rail.window_title",
+            "document.chart.shell.stats_rail.window.start",
+            "document.chart.shell.stats_rail.window.end",
+            "document.chart.shell.stats_rail.window.span",
+            "document.chart.shell.stats_rail.window.points",
+            "document.chart.shell.stats_rail.source_title",
+            "document.chart.status.task_label",
+            "document.chart.toast.chart_saved",
+            "document.chart.toast.save_failed",
+            "document.chart.toast.png_export_coming",
+            "document.chart.error.source",
+            "document.chart.error.no_connection_selected",
+            "document.chart.error.connection_not_found",
+            "document.chart.error.connection_error",
+            "document.chart.error.collection_source_unsupported",
+            // Reused from PR 23 — the toolbar's kind chips route through
+            // `configure_chart_kind_label` instead of a duplicate key set.
+            "document.dashboard.configure.chart_kind.line",
+            "document.dashboard.configure.chart_kind.bar",
+            "document.dashboard.configure.chart_kind.scatter",
+            "document.dashboard.configure.chart_kind.area",
+            "document.dashboard.configure.chart_kind.stacked",
+            "document.dashboard.configure.chart_kind.pie",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// PR 24: `document.chart.toolbar.type_label` exact-value check against
+    /// the English catalog.
+    #[test]
+    fn chart_toolbar_type_label_matches_english_catalog() {
+        assert_eq!(
+            dbflux_i18n::t!("document.chart.toolbar.type_label", locale = "en"),
+            "TYPE"
+        );
+    }
+
+    /// PR 24: `chart_toolbar_points_label` pluralizes independently of the
+    /// generic `pending_change_count_label` bucket (own catalog entries).
+    #[test]
+    fn chart_toolbar_points_label_one_many() {
+        assert_eq!(chart_toolbar_points_label(1), "1 pt");
+        assert_eq!(chart_toolbar_points_label(0), "0 pts");
+        assert_eq!(chart_toolbar_points_label(240), "240 pts");
+    }
+
+    /// PR 24: the standalone chart's degraded-state copy diverges between
+    /// locales (spot-checks one of the six branches).
+    #[test]
+    fn chart_shell_degraded_no_data_points_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.chart.shell.degraded.no_data_points",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.chart.shell.degraded.no_data_points",
             locale = "es"
         );
         assert_ne!(en, es);


### PR DESCRIPTION
## Summary

Document i18n slice 24: the chart document toolbar (type, stats, save, points count), the degraded-state copy, the save modal, the stats rail and window/source sections, toasts and errors render through `dbflux_i18n::t!` under `document.chart.*`. English and Spanish together. Statistic tokens (min/max/avg/p99…), dimension names, PNG and the persisted `Untitled chart` default stay data.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- Kind chips reuse `configure_chart_kind_label` from slice 23; their element ids now come from the position index instead of the label so they stay stable across locales; `chart_toolbar_points_label` carries the `.one/.many` split.
- `chart/host.rs` and `chart/shell.rs` carry no user-visible copy; the visible shell lives in `chart_document/render.rs`.
- Size: 593 lines in one namespace boundary (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1058 passed; clippy clean; fmt clean. Manual smoke in Spanish: open a saved chart as a document, change the kind, save, read the stats rail.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
