### PR TITLE
feat(i18n): translate the metric picker dimensions, validation, and apply controls

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -478,6 +478,31 @@ document:
       connection_not_found: Connection not found
       connection_error: "Connection error: %{error}"
       collection_source_unsupported: "Collection source not supported in ChartDocument; open via DataDocument"
+    metric_picker:
+      apply: Apply
+      dropdown:
+        custom: "Custom…"
+      period:
+        placeholder: Period (seconds)
+        error: "Period: %{message}"
+        validation:
+          not_a_number: "period must be a number, got %{value}"
+          too_low: period must be at least 1 second
+          too_high: period must not exceed 86400 seconds (24 hours)
+      statistic:
+        placeholder: "Statistic (e.g. p99)"
+        error: "Statistic: %{message}"
+        validation:
+          empty: statistic must not be empty
+      dimensions:
+        title: DIMENSIONS
+        loading: "Loading dimensions…"
+        error: "Error: %{message}"
+        retry: Retry
+        aggregate_all: Aggregate all
+        empty: No dimension combinations
+        connection_not_found: Connection not found or not active
+        catalog_unsupported: Connection does not support metric catalog
   code:
     toolbar:
       refresh: Refresh

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -478,6 +478,31 @@ document:
       connection_not_found: Conexión no encontrada
       connection_error: "Error de conexión: %{error}"
       collection_source_unsupported: "El origen de colección no es compatible con ChartDocument; ábrelo desde DataDocument"
+    metric_picker:
+      apply: Aplicar
+      dropdown:
+        custom: "Personalizado…"
+      period:
+        placeholder: Período (segundos)
+        error: "Período: %{message}"
+        validation:
+          not_a_number: "el período debe ser un número, se recibió %{value}"
+          too_low: el período debe ser de al menos 1 segundo
+          too_high: el período no debe superar los 86400 segundos (24 horas)
+      statistic:
+        placeholder: "Estadística (p. ej. p99)"
+        error: "Estadística: %{message}"
+        validation:
+          empty: la estadística no debe estar vacía
+      dimensions:
+        title: DIMENSIONES
+        loading: "Cargando dimensiones…"
+        error: "Se produjo un error: %{message}"
+        retry: Reintentar
+        aggregate_all: Agregar todo
+        empty: No hay combinaciones de dimensiones
+        connection_not_found: Conexión no encontrada o inactiva
+        catalog_unsupported: La conexión no admite el catálogo de métricas
   code:
     toolbar:
       refresh: Actualizar

--- a/crates/dbflux_ui_document/src/chart/metric_picker.rs
+++ b/crates/dbflux_ui_document/src/chart/metric_picker.rs
@@ -62,7 +62,9 @@ pub const DEFAULT_STATISTIC_IDX: usize = 0;
 /// accepted period (1..=86400 seconds) or statistic (e.g. `p99`, `p99.9`,
 /// `trimmed_mean`) that does not appear in the preset list. The free-text
 /// value is run through `validate_period` / `validate_statistic` on commit.
-pub const CUSTOM_DROPDOWN_LABEL: &str = "Custom…";
+pub fn custom_dropdown_label() -> String {
+    crate::labels::metric_picker_custom_dropdown_label()
+}
 
 /// Dropdown index of the "Custom…" entry (last position).
 pub fn period_custom_index() -> usize {
@@ -169,13 +171,13 @@ impl MetricPickerState {
         let period_items = PERIOD_PRESETS
             .iter()
             .map(|(_, label)| DropdownItem::new(*label))
-            .chain(std::iter::once(DropdownItem::new(CUSTOM_DROPDOWN_LABEL)))
+            .chain(std::iter::once(DropdownItem::new(custom_dropdown_label())))
             .collect::<Vec<_>>();
 
         let statistic_items = STATISTIC_PRESETS
             .iter()
             .map(|s| DropdownItem::new(*s))
-            .chain(std::iter::once(DropdownItem::new(CUSTOM_DROPDOWN_LABEL)))
+            .chain(std::iter::once(DropdownItem::new(custom_dropdown_label())))
             .collect::<Vec<_>>();
 
         let period_dropdown = cx.new(|_cx| {
@@ -336,8 +338,9 @@ impl MetricPickerState {
 
         let task = match conn_result {
             None => {
-                self.dimensions_state =
-                    DimensionsState::Error("Connection not found or not active".to_string());
+                self.dimensions_state = DimensionsState::Error(dbflux_i18n::t!(
+                    "document.chart.metric_picker.dimensions.connection_not_found"
+                ));
                 return;
             }
             Some(conn) => {
@@ -376,9 +379,10 @@ impl MetricPickerState {
                                     picker.dimensions_state = DimensionsState::Error(e.to_string());
                                 }
                                 None => {
-                                    picker.dimensions_state = DimensionsState::Error(
-                                        "Connection does not support metric catalog".to_string(),
-                                    );
+                                    picker.dimensions_state =
+                                        DimensionsState::Error(dbflux_i18n::t!(
+                                            "document.chart.metric_picker.dimensions.catalog_unsupported"
+                                        ));
                                 }
                             }
                             picker.dimensions_task = None;
@@ -507,7 +511,9 @@ pub enum DimensionsState {
 /// Rejects only empty strings. The caller is responsible for trimming whitespace.
 pub fn validate_statistic(s: &str) -> Result<String, String> {
     if s.is_empty() {
-        return Err("statistic must not be empty".to_string());
+        return Err(dbflux_i18n::t!(
+            "document.chart.metric_picker.statistic.validation.empty"
+        ));
     }
     Ok(s.to_string())
 }
@@ -524,13 +530,17 @@ pub fn validate_statistic(s: &str) -> Result<String, String> {
 pub fn validate_period(s: &str) -> Result<u32, String> {
     let n: u32 = s
         .parse()
-        .map_err(|_| format!("period must be a number, got {:?}", s))?;
+        .map_err(|_| crate::labels::metric_picker_period_not_a_number_error(s))?;
 
     if n == 0 {
-        return Err("period must be at least 1 second".to_string());
+        return Err(dbflux_i18n::t!(
+            "document.chart.metric_picker.period.validation.too_low"
+        ));
     }
     if n > 86400 {
-        return Err("period must not exceed 86400 seconds (24 hours)".to_string());
+        return Err(dbflux_i18n::t!(
+            "document.chart.metric_picker.period.validation.too_high"
+        ));
     }
     Ok(n)
 }
@@ -600,15 +610,16 @@ mod tests {
     /// reveals the inline custom text input.
     #[test]
     fn custom_entry_is_last_for_period_dropdown() {
-        let labels: Vec<&str> = PERIOD_PRESETS
+        let custom_label = custom_dropdown_label();
+        let labels: Vec<String> = PERIOD_PRESETS
             .iter()
-            .map(|(_, l)| *l)
-            .chain(std::iter::once(CUSTOM_DROPDOWN_LABEL))
+            .map(|(_, l)| l.to_string())
+            .chain(std::iter::once(custom_label.clone()))
             .collect();
 
         assert_eq!(
-            labels.last().copied(),
-            Some(CUSTOM_DROPDOWN_LABEL),
+            labels.last().cloned(),
+            Some(custom_label),
             "Custom… must be the last entry in the period dropdown"
         );
         assert_eq!(
@@ -622,15 +633,16 @@ mod tests {
     /// dropdown items.
     #[test]
     fn custom_entry_is_last_for_statistic_dropdown() {
-        let labels: Vec<&str> = STATISTIC_PRESETS
+        let custom_label = custom_dropdown_label();
+        let labels: Vec<String> = STATISTIC_PRESETS
             .iter()
-            .copied()
-            .chain(std::iter::once(CUSTOM_DROPDOWN_LABEL))
+            .map(|s| s.to_string())
+            .chain(std::iter::once(custom_label.clone()))
             .collect();
 
         assert_eq!(
-            labels.last().copied(),
-            Some(CUSTOM_DROPDOWN_LABEL),
+            labels.last().cloned(),
+            Some(custom_label),
             "Custom… must be the last entry in the statistic dropdown"
         );
         assert_eq!(

--- a/crates/dbflux_ui_document/src/chart/metric_picker_render.rs
+++ b/crates/dbflux_ui_document/src/chart/metric_picker_render.rs
@@ -140,8 +140,11 @@ fn ensure_custom_inputs(
     cx: &mut Context<ChartShell>,
 ) {
     if state.period_custom_input.is_none() {
-        let input: Entity<InputState> =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Period (seconds)"));
+        let input: Entity<InputState> = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.chart.metric_picker.period.placeholder"
+            ))
+        });
         let sub = cx.subscribe(
             &input,
             |shell: &mut ChartShell, input_entity: Entity<InputState>, event: &InputEvent, cx| {
@@ -159,8 +162,11 @@ fn ensure_custom_inputs(
     }
 
     if state.statistic_custom_input.is_none() {
-        let input: Entity<InputState> =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Statistic (e.g. p99)"));
+        let input: Entity<InputState> = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.chart.metric_picker.statistic.placeholder"
+            ))
+        });
         let sub = cx.subscribe(
             &input,
             |shell: &mut ChartShell, input_entity: Entity<InputState>, event: &InputEvent, cx| {
@@ -204,18 +210,26 @@ fn render_custom_inputs_row(
     if state.period_custom_active
         && let Some(input) = state.period_custom_input.as_ref()
     {
-        row = row.child(Input::new(input).placeholder("Period (seconds)"));
+        row = row.child(Input::new(input).placeholder(dbflux_i18n::t!(
+            "document.chart.metric_picker.period.placeholder"
+        )));
         if let Some(err) = state.period_custom_error.as_ref() {
-            row = row.child(Text::muted(format!("Period: {err}")));
+            row = row.child(Text::muted(
+                crate::labels::metric_picker_period_error_label(err),
+            ));
         }
     }
 
     if state.statistic_custom_active
         && let Some(input) = state.statistic_custom_input.as_ref()
     {
-        row = row.child(Input::new(input).placeholder("Statistic (e.g. p99)"));
+        row = row.child(Input::new(input).placeholder(dbflux_i18n::t!(
+            "document.chart.metric_picker.statistic.placeholder"
+        )));
         if let Some(err) = state.statistic_custom_error.as_ref() {
-            row = row.child(Text::muted(format!("Statistic: {err}")));
+            row = row.child(Text::muted(
+                crate::labels::metric_picker_statistic_error_label(err),
+            ));
         }
     }
 
@@ -278,29 +292,39 @@ fn render_dimensions_section(
                 .text_size(px(10.0))
                 .text_color(theme.muted_foreground)
                 .font_weight(gpui::FontWeight::BOLD)
-                .child(SharedString::from("DIMENSIONS")),
+                .child(dbflux_i18n::t!(
+                    "document.chart.metric_picker.dimensions.title"
+                )),
         );
 
-    let body: AnyElement = match &state.dimensions_state {
-        DimensionsState::NotFetched | DimensionsState::Loading => div()
-            .flex_1()
-            .flex()
-            .items_center()
-            .justify_center()
-            .py(Spacing::SM)
-            .child(Text::muted("Loading dimensions…"))
-            .into_any_element(),
-
-        DimensionsState::Error(msg) => {
-            let msg = msg.clone();
-            div()
+    let body: AnyElement =
+        match &state.dimensions_state {
+            DimensionsState::NotFetched | DimensionsState::Loading => div()
+                .flex_1()
                 .flex()
-                .flex_col()
-                .p(Spacing::SM)
-                .gap(Spacing::XS)
-                .child(Text::muted(format!("Error: {msg}")))
-                .child(
-                    Button::new("metric-picker-dim-retry", "Retry")
+                .items_center()
+                .justify_center()
+                .py(Spacing::SM)
+                .child(Text::muted(dbflux_i18n::t!(
+                    "document.chart.metric_picker.dimensions.loading"
+                )))
+                .into_any_element(),
+
+            DimensionsState::Error(msg) => {
+                let msg = msg.clone();
+                div()
+                    .flex()
+                    .flex_col()
+                    .p(Spacing::SM)
+                    .gap(Spacing::XS)
+                    .child(Text::muted(
+                        crate::labels::metric_picker_dimensions_error_label(&msg),
+                    ))
+                    .child(
+                        Button::new(
+                            "metric-picker-dim-retry",
+                            dbflux_i18n::t!("document.chart.metric_picker.dimensions.retry"),
+                        )
                         .small()
                         .on_click(cx.listener(|shell, _, _, cx| {
                             if let Some(picker) = &mut shell.metric_picker {
@@ -312,86 +336,85 @@ fn render_dimensions_section(
                             }
                             cx.notify();
                         })),
-                )
-                .into_any_element()
-        }
-
-        DimensionsState::Loaded(combos) => {
-            let current_filter = &state.dimension_filter;
-
-            // AggregateAll row — always shown at the top.
-            let is_agg_selected = matches!(current_filter, DimensionFilter::AggregateAll);
-            let agg_row: AnyElement = dim_radio_row(
-                0,
-                SharedString::from("Aggregate all"),
-                is_agg_selected,
-                &theme,
-                cx,
-                |shell, _, _, cx| {
-                    if let Some(picker) = &mut shell.metric_picker {
-                        picker.dimension_filter = DimensionFilter::AggregateAll;
-                    }
-                    cx.notify();
-                },
-            )
-            .into_any_element();
-
-            let dim_rows: Vec<AnyElement> = combos
-                .iter()
-                .enumerate()
-                .map(|(i, combo)| {
-                    let label = SharedString::from(
-                        combo
-                            .iter()
-                            .map(|(k, v)| format!("{k}={v}"))
-                            .collect::<Vec<_>>()
-                            .join(", "),
-                    );
-                    let is_filter_selected = match current_filter {
-                        DimensionFilter::FilterTo(d) => d == combo,
-                        _ => false,
-                    };
-                    let combo_for_click = combo.clone();
-                    dim_radio_row(
-                        i + 1,
-                        label,
-                        is_filter_selected,
-                        &theme,
-                        cx,
-                        move |shell, _, _, cx| {
-                            if let Some(picker) = &mut shell.metric_picker {
-                                picker.dimension_filter =
-                                    DimensionFilter::FilterTo(combo_for_click.clone());
-                            }
-                            cx.notify();
-                        },
                     )
-                    .into_any_element()
-                })
-                .collect();
-
-            if combos.is_empty() {
-                div()
-                    .flex()
-                    .flex_col()
-                    .child(agg_row)
-                    .child(
-                        div()
-                            .px(Spacing::SM)
-                            .py(Spacing::XS)
-                            .child(Text::dim("No dimension combinations")),
-                    )
-                    .into_any_element()
-            } else {
-                div()
-                    .flex()
-                    .flex_col()
-                    .child(agg_row)
-                    .children(dim_rows)
                     .into_any_element()
             }
-        }
-    };
+
+            DimensionsState::Loaded(combos) => {
+                let current_filter = &state.dimension_filter;
+
+                // AggregateAll row — always shown at the top.
+                let is_agg_selected = matches!(current_filter, DimensionFilter::AggregateAll);
+                let agg_row: AnyElement = dim_radio_row(
+                    0,
+                    SharedString::from(dbflux_i18n::t!(
+                        "document.chart.metric_picker.dimensions.aggregate_all"
+                    )),
+                    is_agg_selected,
+                    &theme,
+                    cx,
+                    |shell, _, _, cx| {
+                        if let Some(picker) = &mut shell.metric_picker {
+                            picker.dimension_filter = DimensionFilter::AggregateAll;
+                        }
+                        cx.notify();
+                    },
+                )
+                .into_any_element();
+
+                let dim_rows: Vec<AnyElement> = combos
+                    .iter()
+                    .enumerate()
+                    .map(|(i, combo)| {
+                        let label = SharedString::from(
+                            combo
+                                .iter()
+                                .map(|(k, v)| format!("{k}={v}"))
+                                .collect::<Vec<_>>()
+                                .join(", "),
+                        );
+                        let is_filter_selected = match current_filter {
+                            DimensionFilter::FilterTo(d) => d == combo,
+                            _ => false,
+                        };
+                        let combo_for_click = combo.clone();
+                        dim_radio_row(
+                            i + 1,
+                            label,
+                            is_filter_selected,
+                            &theme,
+                            cx,
+                            move |shell, _, _, cx| {
+                                if let Some(picker) = &mut shell.metric_picker {
+                                    picker.dimension_filter =
+                                        DimensionFilter::FilterTo(combo_for_click.clone());
+                                }
+                                cx.notify();
+                            },
+                        )
+                        .into_any_element()
+                    })
+                    .collect();
+
+                if combos.is_empty() {
+                    div()
+                        .flex()
+                        .flex_col()
+                        .child(agg_row)
+                        .child(div().px(Spacing::SM).py(Spacing::XS).child(Text::dim(
+                            dbflux_i18n::t!("document.chart.metric_picker.dimensions.empty"),
+                        )))
+                        .into_any_element()
+                } else {
+                    div()
+                        .flex()
+                        .flex_col()
+                        .child(agg_row)
+                        .children(dim_rows)
+                        .into_any_element()
+                }
+            }
+        };
 
     div()
         .flex()
@@ -423,21 +446,24 @@ fn render_config_footer(state: &MetricPickerState, cx: &mut Context<ChartShell>)
         .child(statistic_dropdown)
         .child(div().flex_1()) // pushes Apply to the right
         .child(
-            Button::new("metric-picker-apply", "Apply")
-                .primary()
-                .small()
-                .on_click(cx.listener(|shell, _, _, cx| {
-                    if let Some(picker) = &mut shell.metric_picker {
-                        // Flush any pending Custom… inputs so the click path
-                        // commits typed values without requiring Enter.
-                        if !picker.flush_pending_custom_inputs(cx) {
-                            cx.notify();
-                            return;
-                        }
-                        let source = picker.build_metric_source();
-                        cx.emit(ChartShellEvent::MetricPickerApplied(Box::new(source)));
+            Button::new(
+                "metric-picker-apply",
+                dbflux_i18n::t!("document.chart.metric_picker.apply"),
+            )
+            .primary()
+            .small()
+            .on_click(cx.listener(|shell, _, _, cx| {
+                if let Some(picker) = &mut shell.metric_picker {
+                    // Flush any pending Custom… inputs so the click path
+                    // commits typed values without requiring Enter.
+                    if !picker.flush_pending_custom_inputs(cx) {
+                        cx.notify();
+                        return;
                     }
-                })),
+                    let source = picker.build_metric_source();
+                    cx.emit(ChartShellEvent::MetricPickerApplied(Box::new(source)));
+                }
+            })),
         )
         .into_any_element()
 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1371,6 +1371,47 @@ pub(crate) fn chart_toolbar_points_label(count: usize) -> String {
     }
 }
 
+/// Label for the trailing "Custom…" entry appended to the metric picker's
+/// period and statistic dropdowns.
+pub(crate) fn metric_picker_custom_dropdown_label() -> String {
+    dbflux_i18n::t!("document.chart.metric_picker.dropdown.custom")
+}
+
+/// Inline error shown beneath the metric picker's dimensions section when
+/// the background fetch fails or the connection cannot serve one.
+pub(crate) fn metric_picker_dimensions_error_label(message: &str) -> String {
+    dbflux_i18n::t!(
+        "document.chart.metric_picker.dimensions.error",
+        message = message
+    )
+}
+
+/// Inline error shown beneath the metric picker's period "Custom…" input.
+pub(crate) fn metric_picker_period_error_label(message: &str) -> String {
+    dbflux_i18n::t!(
+        "document.chart.metric_picker.period.error",
+        message = message
+    )
+}
+
+/// Inline error shown beneath the metric picker's statistic "Custom…"
+/// input.
+pub(crate) fn metric_picker_statistic_error_label(message: &str) -> String {
+    dbflux_i18n::t!(
+        "document.chart.metric_picker.statistic.error",
+        message = message
+    )
+}
+
+/// Validation error for a non-numeric custom period entry, with the raw
+/// user input interpolated as it was debug-formatted before this change.
+pub(crate) fn metric_picker_period_not_a_number_error(raw: &str) -> String {
+    dbflux_i18n::t!(
+        "document.chart.metric_picker.period.validation.not_a_number",
+        value = format!("{raw:?}")
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1386,13 +1427,15 @@ mod tests {
         delete_rows_label, execution_count_state_label, execution_mode_label,
         history_items_count_label, history_tab_label, image_decode_error, image_header_error,
         incomplete_aggregate_rows_label, join_kind_label, live_output_lines_label,
-        live_output_truncated_label, object_browser_status_summary,
-        object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
-        pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
-        refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
-        script_confirm_message_label, sort_direction_label, table_action_description,
-        unsaved_changes_label, update_columns_label, valid_lines_label, versioning_off_label,
-        versioning_status_label,
+        live_output_truncated_label, metric_picker_custom_dropdown_label,
+        metric_picker_dimensions_error_label, metric_picker_period_error_label,
+        metric_picker_period_not_a_number_error, metric_picker_statistic_error_label,
+        object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
+        pending_change_count_label, pending_edits_summary, presign_expiry_label,
+        presign_method_label, preview_gate_message, refresh_policy_label, result_tab_count_label,
+        row_count_label, schema_change_description, script_confirm_message_label,
+        sort_direction_label, table_action_description, unsaved_changes_label,
+        update_columns_label, valid_lines_label, versioning_off_label, versioning_status_label,
     };
     use crate::buckets_table::BucketEncryptionChoice;
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
@@ -3752,5 +3795,186 @@ mod tests {
             locale = "es"
         );
         assert_ne!(en, es);
+    }
+
+    // ── PR 25: chart/{metric_picker,metric_picker_render}.rs ────────────────
+
+    const METRIC_PICKER_KEYS: &[&str] = &[
+        "document.chart.metric_picker.apply",
+        "document.chart.metric_picker.dropdown.custom",
+        "document.chart.metric_picker.period.placeholder",
+        "document.chart.metric_picker.period.error",
+        "document.chart.metric_picker.period.validation.not_a_number",
+        "document.chart.metric_picker.period.validation.too_low",
+        "document.chart.metric_picker.period.validation.too_high",
+        "document.chart.metric_picker.statistic.placeholder",
+        "document.chart.metric_picker.statistic.error",
+        "document.chart.metric_picker.statistic.validation.empty",
+        "document.chart.metric_picker.dimensions.title",
+        "document.chart.metric_picker.dimensions.loading",
+        "document.chart.metric_picker.dimensions.error",
+        "document.chart.metric_picker.dimensions.retry",
+        "document.chart.metric_picker.dimensions.aggregate_all",
+        "document.chart.metric_picker.dimensions.empty",
+        "document.chart.metric_picker.dimensions.connection_not_found",
+        "document.chart.metric_picker.dimensions.catalog_unsupported",
+    ];
+
+    /// PR 25: every `document.chart.metric_picker.*` key resolves to a
+    /// non-empty, non-fallback value in both locales.
+    #[test]
+    fn metric_picker_keys_resolve_in_both_locales() {
+        for key in METRIC_PICKER_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(*key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// PR 25: the trailing "Custom…" dropdown entry diverges between
+    /// locales and matches the pre-i18n English literal.
+    #[test]
+    fn metric_picker_custom_dropdown_label_matches_english_and_differs_between_locales() {
+        let value = metric_picker_custom_dropdown_label();
+        assert!(
+            !value.is_empty(),
+            "metric_picker_custom_dropdown_label must not resolve empty"
+        );
+
+        let en = dbflux_i18n::t!(
+            "document.chart.metric_picker.dropdown.custom",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.chart.metric_picker.dropdown.custom",
+            locale = "es"
+        );
+
+        assert_eq!(en, "Custom…");
+        assert_ne!(en, es);
+    }
+
+    /// PR 25: `PERIOD_PRESETS` labels ("1 min", "5 min", …) stay English
+    /// data, same as `STATISTIC_PRESETS` — the vocabulary rule for this
+    /// change explicitly excludes period values from translation.
+    #[test]
+    fn period_presets_stay_untranslated_data() {
+        use crate::chart::metric_picker::PERIOD_PRESETS;
+
+        let labels: Vec<&str> = PERIOD_PRESETS.iter().map(|(_, label)| *label).collect();
+        assert_eq!(labels, vec!["1 min", "5 min", "15 min", "1 hr"]);
+    }
+
+    /// PR 25: the dimensions-section error interpolates the underlying
+    /// message and diverges between locales.
+    #[test]
+    fn metric_picker_dimensions_error_label_interpolates_message() {
+        let value = metric_picker_dimensions_error_label("boom");
+        assert!(
+            value.contains("boom"),
+            "dimensions error must interpolate the message: {value}"
+        );
+
+        let en = dbflux_i18n::t!(
+            "document.chart.metric_picker.dimensions.error",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.chart.metric_picker.dimensions.error",
+            locale = "es"
+        );
+        assert_ne!(en, es);
+    }
+
+    /// PR 25: the period "Custom…" inline error interpolates the underlying
+    /// message and diverges between locales.
+    #[test]
+    fn metric_picker_period_error_label_interpolates_message() {
+        let value = metric_picker_period_error_label("must be a number");
+        assert!(
+            value.contains("must be a number"),
+            "period error must interpolate the message: {value}"
+        );
+
+        let en = dbflux_i18n::t!("document.chart.metric_picker.period.error", locale = "en");
+        let es = dbflux_i18n::t!("document.chart.metric_picker.period.error", locale = "es");
+        assert_ne!(en, es);
+    }
+
+    /// PR 25: the statistic "Custom…" inline error interpolates the
+    /// underlying message and diverges between locales.
+    #[test]
+    fn metric_picker_statistic_error_label_interpolates_message() {
+        let value = metric_picker_statistic_error_label("must not be empty");
+        assert!(
+            value.contains("must not be empty"),
+            "statistic error must interpolate the message: {value}"
+        );
+
+        let en = dbflux_i18n::t!(
+            "document.chart.metric_picker.statistic.error",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.chart.metric_picker.statistic.error",
+            locale = "es"
+        );
+        assert_ne!(en, es);
+    }
+
+    /// PR 25: `validate_period`'s non-numeric error interpolates the raw
+    /// input, debug-formatted as it was in the pre-i18n literal.
+    #[test]
+    fn metric_picker_period_not_a_number_error_interpolates_raw_input() {
+        let value = metric_picker_period_not_a_number_error("abc");
+        assert!(
+            value.contains("\"abc\""),
+            "non-numeric error must interpolate the debug-formatted input: {value}"
+        );
+    }
+
+    /// PR 25: `document.chart.metric_picker.dimensions.title` matches the
+    /// pre-i18n "DIMENSIONS" literal in English (an uppercase section
+    /// label, same convention as `document.chart.toolbar.type_label`).
+    #[test]
+    fn metric_picker_dimensions_title_matches_english_catalog() {
+        assert_eq!(
+            dbflux_i18n::t!(
+                "document.chart.metric_picker.dimensions.title",
+                locale = "en"
+            ),
+            "DIMENSIONS"
+        );
+    }
+
+    /// PR 25: the period/statistic validation errors and the apply button
+    /// label diverge between locales.
+    #[test]
+    fn metric_picker_validation_and_apply_labels_differ_between_locales() {
+        for key in [
+            "document.chart.metric_picker.apply",
+            "document.chart.metric_picker.period.validation.too_low",
+            "document.chart.metric_picker.period.validation.too_high",
+            "document.chart.metric_picker.statistic.validation.empty",
+            "document.chart.metric_picker.dimensions.retry",
+            "document.chart.metric_picker.dimensions.aggregate_all",
+            "document.chart.metric_picker.dimensions.empty",
+            "document.chart.metric_picker.dimensions.connection_not_found",
+            "document.chart.metric_picker.dimensions.catalog_unsupported",
+            "document.chart.metric_picker.period.placeholder",
+            "document.chart.metric_picker.statistic.placeholder",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 25: the metric picker (input placeholders, dimensions section with loading/retry/aggregate-all/empty states, period and statistic validation, custom dropdown entry, Apply) renders through `dbflux_i18n::t!` under `document.chart.metric_picker.*`. English and Spanish together. Statistic tokens, period presets (`1 min`, `5 min`, `1 hr`), namespace/metric/dimension names stay data.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `CUSTOM_DROPDOWN_LABEL` becomes `custom_dropdown_label()`; five helpers in labels.rs carry the error rows; a guard test pins the period presets as untranslated data.
- Size: 606 lines, mostly rustfmt reflow of `render_dimensions_section` (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1067 passed; clippy clean; fmt clean. Manual smoke in Spanish: open the metric picker from a metrics connection, pick dimensions, enter a bad period.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
