### PR TITLE
feat(i18n): translate the connection manager import panel

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -264,6 +264,112 @@ connection_manager:
     cancel: Cancel
     configure: Configure
     configure_named: "Configure %{name}"
+  import:
+    placeholder:
+      bundle_passphrase: Bundle passphrase
+      bundle_path: "Path to TOML bundle…"
+      secret_value: Enter secret value
+    dialog:
+      open_title: Open Connection Bundle
+    filter:
+      toml: TOML bundle
+      all: All files
+    error:
+      choose_file: Choose a bundle file to import.
+      cannot_read_file: "Cannot read file: %{error}"
+      parse_error: "Parse error: %{error}"
+      encrypted_needs_passphrase: This bundle is encrypted. Enter the passphrase and try again.
+      encryption_unavailable: This bundle is passphrase-encrypted but the encryption feature is not available in this build of DBFlux.
+      wrong_passphrase: Passphrase incorrect or bundle corrupted.
+      decryption_error: "Decryption error: %{error}"
+      import_failed: "Import failed: %{error}"
+      secret_failures_toast:
+        one: "%{count} secret could not be written to the keyring during import. The keyring may be locked or unavailable."
+        many: "%{count} secrets could not be written to the keyring during import. The keyring may be locked or unavailable."
+    field:
+      bundle_file: Bundle file
+      bundle_encrypted: Bundle is encrypted
+      passphrase: Passphrase
+    hint:
+      no_native_picker: No native file picker on this system — type or paste the bundle path above.
+      external_refs: External value references travel as-is
+      external_refs_body: SSM, Secrets Manager, and environment references are imported unchanged and resolved against this machine at connect time.
+      leave_empty_skip: Leave empty to skip.
+      select_profile_or_skip: "Select a profile or skip:"
+    modal_title: Import
+    preview:
+      intro: "This bundle will import the following:"
+      count:
+        connections:
+          one: "%{count} connection"
+          many: "%{count} connections"
+        auth_profiles:
+          one: "%{count} auth profile"
+          many: "%{count} auth profiles"
+        ssh_tunnels:
+          one: "%{count} SSH tunnel"
+          many: "%{count} SSH tunnels"
+        proxies:
+          one: "%{count} proxy profile"
+          many: "%{count} proxy profiles"
+      conflicts_banner:
+        one: "%{count} profile already exists at the destination — you will choose how to resolve it."
+        many: "%{count} profiles already exist at the destination — you will choose how to resolve each."
+      required_banner:
+        one: "%{count} value may be required after import — secrets omitted from the bundle can be entered or skipped."
+        many: "%{count} values may be required after import — secrets omitted from the bundle can be entered or skipped."
+      driver_not_installed_banner: One or more connections reference a driver not installed on this machine and will be skipped.
+    conflict_kind:
+      auth_profile: Auth profile
+      ssh_tunnel: SSH tunnel
+      proxy: Proxy
+      connection: Connection
+    conflicts:
+      intro: Some profiles in this bundle already exist. Choose how to handle each conflict.
+      row_label: "%{kind}: \"%{bundle_name}\" conflicts with \"%{existing_name}\""
+    required:
+      intro: The following values may be required. Leave a secret empty to skip it — the connection still imports without it.
+      secret_label: "Secret for \"%{owner}\": %{field}"
+      aws_reference_label: "AWS auth profile \"%{name}\" (%{provider_id}) for \"%{owner}\""
+      auth_profile_ref_label: "Auth profile for \"%{owner}\": %{field}"
+      no_matching_auth_profile: No matching auth profile on this machine. The connection imports without one; assign it later in Settings > Auth Profiles.
+    status:
+      complete: Import complete.
+      loading: "Loading…"
+      importing: "Importing…"
+      imported_toast:
+        one: "Imported %{count} entity."
+        many: "Imported %{count} entities."
+    banner:
+      failed: Import failed
+    outcome:
+      succeeded:
+        one: "%{count} entity imported."
+        many: "%{count} entities imported."
+      needs_driver:
+        one: "%{count} connection skipped — driver not installed."
+        many: "%{count} connections skipped — driver not installed."
+      config_failures:
+        one: "%{count} connection could not be configured."
+        many: "%{count} connections could not be configured."
+      unresolved_refs:
+        one: "%{count} connection had unresolvable references and was not imported."
+        many: "%{count} connections had unresolvable references and were not imported."
+      secret_failures:
+        one: "%{count} secret could not be written to the keyring. Enter it manually for the affected connection."
+        many: "%{count} secrets could not be written to the keyring. Enter them manually for each affected connection."
+    action:
+      reuse_existing: Reuse existing
+      create_new: Create new
+      map_to: "Map to: %{name}"
+      skip: Skip
+      use_profile: "Use: %{name}"
+      cancel: Cancel
+      back: Back
+      done: Done
+      load: Load
+      continue_: Continue
+      import: Import
 connections:
   window:
     manager_title: Connection Manager

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -264,6 +264,112 @@ connection_manager:
     cancel: Cancelar
     configure: Configurar
     configure_named: "Configurar %{name}"
+  import:
+    placeholder:
+      bundle_passphrase: Frase del paquete
+      bundle_path: "Ruta al paquete TOML…"
+      secret_value: Introduce el valor secreto
+    dialog:
+      open_title: Abrir paquete de conexión
+    filter:
+      toml: Paquete TOML
+      all: Todos los archivos
+    error:
+      choose_file: Elige un archivo de paquete para importar.
+      cannot_read_file: "No se pudo leer el archivo: %{error}"
+      parse_error: "Error de análisis: %{error}"
+      encrypted_needs_passphrase: Este paquete está cifrado. Introduce la frase e inténtalo de nuevo.
+      encryption_unavailable: Este paquete está cifrado con frase, pero la función de cifrado no está disponible en esta compilación de DBFlux.
+      wrong_passphrase: Frase incorrecta o paquete dañado.
+      decryption_error: "Error de descifrado: %{error}"
+      import_failed: "Fallo en la importación: %{error}"
+      secret_failures_toast:
+        one: "%{count} secreto no se pudo escribir en el llavero durante la importación. Es posible que el llavero esté bloqueado o no disponible."
+        many: "%{count} secretos no se pudieron escribir en el llavero durante la importación. Es posible que el llavero esté bloqueado o no disponible."
+    field:
+      bundle_file: Archivo del paquete
+      bundle_encrypted: El paquete está cifrado
+      passphrase: Frase
+    hint:
+      no_native_picker: No hay selector de archivos nativo en este sistema — escribe o pega la ruta del paquete arriba.
+      external_refs: Las referencias a valores externos se mantienen igual
+      external_refs_body: Las referencias SSM, Secrets Manager y de entorno se importan sin cambios y se resuelven en esta máquina al conectar.
+      leave_empty_skip: Déjalo vacío para omitir.
+      select_profile_or_skip: "Selecciona un perfil u omítelo:"
+    modal_title: Importar
+    preview:
+      intro: "Este paquete importará lo siguiente:"
+      count:
+        connections:
+          one: "%{count} conexión"
+          many: "%{count} conexiones"
+        auth_profiles:
+          one: "%{count} perfil de autenticación"
+          many: "%{count} perfiles de autenticación"
+        ssh_tunnels:
+          one: "%{count} túnel SSH"
+          many: "%{count} túneles SSH"
+        proxies:
+          one: "%{count} perfil de proxy"
+          many: "%{count} perfiles de proxy"
+      conflicts_banner:
+        one: "%{count} perfil ya existe en el destino — elige cómo resolverlo."
+        many: "%{count} perfiles ya existen en el destino — elige cómo resolver cada uno."
+      required_banner:
+        one: "%{count} valor puede ser necesario después de importar — los secretos omitidos del paquete se pueden introducir u omitir."
+        many: "%{count} valores pueden ser necesarios después de importar — los secretos omitidos del paquete se pueden introducir u omitir."
+      driver_not_installed_banner: Una o más conexiones hacen referencia a un driver no instalado en esta máquina y se omitirán.
+    conflict_kind:
+      auth_profile: Perfil de autenticación
+      ssh_tunnel: Túnel SSH
+      proxy: Proxy
+      connection: Conexión
+    conflicts:
+      intro: Algunos perfiles de este paquete ya existen. Elige cómo gestionar cada conflicto.
+      row_label: "%{kind}: \"%{bundle_name}\" entra en conflicto con \"%{existing_name}\""
+    required:
+      intro: Los siguientes valores pueden ser necesarios. Deja un secreto vacío para omitirlo — la conexión se importa igual sin él.
+      secret_label: "Secreto para \"%{owner}\": %{field}"
+      aws_reference_label: "Perfil de autenticación de AWS \"%{name}\" (%{provider_id}) para \"%{owner}\""
+      auth_profile_ref_label: "Perfil de autenticación para \"%{owner}\": %{field}"
+      no_matching_auth_profile: No hay ningún perfil de autenticación coincidente en esta máquina. La conexión se importa sin uno; asígnalo más tarde en Ajustes > Perfiles de autenticación.
+    status:
+      complete: Importación completa.
+      loading: "Cargando…"
+      importing: "Importando…"
+      imported_toast:
+        one: "Se importó %{count} entidad."
+        many: "Se importaron %{count} entidades."
+    banner:
+      failed: Fallo en la importación
+    outcome:
+      succeeded:
+        one: "%{count} entidad importada."
+        many: "%{count} entidades importadas."
+      needs_driver:
+        one: "%{count} conexión omitida — driver no instalado."
+        many: "%{count} conexiones omitidas — driver no instalado."
+      config_failures:
+        one: "%{count} conexión no se pudo configurar."
+        many: "%{count} conexiones no se pudieron configurar."
+      unresolved_refs:
+        one: "%{count} conexión tenía referencias sin resolver y no se importó."
+        many: "%{count} conexiones tenían referencias sin resolver y no se importaron."
+      secret_failures:
+        one: "%{count} secreto no se pudo escribir en el llavero. Introdúcelo manualmente para la conexión afectada."
+        many: "%{count} secretos no se pudieron escribir en el llavero. Introdúcelos manualmente para cada conexión afectada."
+    action:
+      reuse_existing: Reutilizar existente
+      create_new: Crear nuevo
+      map_to: "Asignar a: %{name}"
+      skip: Omitir
+      use_profile: "Usar: %{name}"
+      cancel: Cancelar
+      back: Atrás
+      done: Finalizar
+      load: Cargar
+      continue_: Continuar
+      import: Importar
 connections:
   window:
     manager_title: Administrador de conexiones

--- a/crates/dbflux_ui_windows/src/connection_manager/import_panel.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/import_panel.rs
@@ -14,8 +14,7 @@ use dbflux_components::tokens::{FontSizes, Heights, Spacing};
 use dbflux_core::secrecy::SecretString;
 use dbflux_core::{AuthProfile, ConnectionProfile, ProxyProfile, SshTunnelProfile};
 use dbflux_portability::{
-    ConflictChoice, ConflictKind, ImportPlan, ParsedBundle, RequiredResolutionKind,
-    ResolutionChoices,
+    ConflictChoice, ImportPlan, ParsedBundle, RequiredResolutionKind, ResolutionChoices,
 };
 use dbflux_ui_base::AppStateEntity;
 use dbflux_ui_base::user_error::{ErrorKind, UserFacingError, report_error};
@@ -207,7 +206,9 @@ impl ImportConnectionsPanel {
     ) -> Self {
         let passphrase_input = cx.new(|cx| {
             InputState::new(window, cx)
-                .placeholder("Bundle passphrase")
+                .placeholder(dbflux_i18n::t!(
+                    "connection_manager.import.placeholder.bundle_passphrase"
+                ))
                 .masked(true)
         });
 
@@ -218,8 +219,11 @@ impl ImportConnectionsPanel {
             }
         });
 
-        let file_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Path to TOML bundle\u{2026}"));
+        let file_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "connection_manager.import.placeholder.bundle_path"
+            ))
+        });
 
         let file_sub = cx.subscribe(&file_input, |this, _, event: &InputEvent, cx| {
             if matches!(event, InputEvent::Change | InputEvent::Blur) {
@@ -294,9 +298,17 @@ impl ImportConnectionsPanel {
             let this = cx.entity().clone();
             let task = cx.background_executor().spawn(async move {
                 rfd::FileDialog::new()
-                    .set_title("Open Connection Bundle")
-                    .add_filter("TOML bundle", &["toml"])
-                    .add_filter("All files", &["*"])
+                    .set_title(dbflux_i18n::t!(
+                        "connection_manager.import.dialog.open_title"
+                    ))
+                    .add_filter(
+                        dbflux_i18n::t!("connection_manager.import.filter.toml"),
+                        &["toml"],
+                    )
+                    .add_filter(
+                        dbflux_i18n::t!("connection_manager.import.filter.all"),
+                        &["*"],
+                    )
                     .pick_file()
             });
 
@@ -340,7 +352,9 @@ impl ImportConnectionsPanel {
     fn do_parse_and_plan(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let path = self.file_input.read(cx).value().trim().to_string();
         if path.is_empty() {
-            self.parse_error = Some("Choose a bundle file to import.".to_string());
+            self.parse_error = Some(dbflux_i18n::t!(
+                "connection_manager.import.error.choose_file"
+            ));
             cx.notify();
             return;
         }
@@ -361,12 +375,22 @@ impl ImportConnectionsPanel {
                 .spawn(async move {
                     let bytes = match std::fs::read(&path) {
                         Ok(b) => b,
-                        Err(e) => return (false, Err(format!("Cannot read file: {e}"))),
+                        Err(e) => {
+                            return (
+                                false,
+                                Err(crate::labels::import_error_cannot_read_file(&e.to_string())),
+                            );
+                        }
                     };
 
                     let mut parsed = match dbflux_portability::import::parse(&bytes) {
                         Ok(p) => p,
-                        Err(e) => return (false, Err(format!("Parse error: {e}"))),
+                        Err(e) => {
+                            return (
+                                false,
+                                Err(crate::labels::import_error_parse_error(&e.to_string())),
+                            );
+                        }
                     };
 
                     use dbflux_portability::bundle::EncryptionMode;
@@ -377,23 +401,22 @@ impl ImportConnectionsPanel {
                     if is_encrypted && passphrase.expose_secret().is_empty() {
                         return (
                             true,
-                            Err(
-                                "This bundle is encrypted. Enter the passphrase and try again."
-                                    .to_string(),
-                            ),
+                            Err(dbflux_i18n::t!(
+                                "connection_manager.import.error.encrypted_needs_passphrase"
+                            )),
                         );
                     }
 
                     if let Err(e) = dbflux_portability::import::decrypt(&mut parsed, &passphrase) {
                         use dbflux_portability::PortabilityError;
                         let msg = if e.is_encryption_unavailable() {
-                            "This bundle is passphrase-encrypted but the encryption \
-                             feature is not available in this build of DBFlux."
-                                .to_string()
+                            dbflux_i18n::t!(
+                                "connection_manager.import.error.encryption_unavailable"
+                            )
                         } else if matches!(&e, PortabilityError::Decryption(_)) {
-                            "Passphrase incorrect or bundle corrupted.".to_string()
+                            dbflux_i18n::t!("connection_manager.import.error.wrong_passphrase")
                         } else {
-                            format!("Decryption error: {e}")
+                            crate::labels::import_error_decryption_error(&e.to_string())
                         };
                         return (is_encrypted, Err(msg));
                     }
@@ -462,7 +485,9 @@ impl ImportConnectionsPanel {
 
             let input = cx.new(|cx| {
                 InputState::new(window, cx)
-                    .placeholder("Enter secret value")
+                    .placeholder(dbflux_i18n::t!(
+                        "connection_manager.import.placeholder.secret_value"
+                    ))
                     .masked(true)
             });
 
@@ -576,8 +601,9 @@ impl ImportConnectionsPanel {
                 Err(e) => {
                     this.update(cx, |this, cx| {
                         this.is_applying = false;
-                        this.run_result =
-                            Some(ImportRunResult::Failed(format!("Import failed: {e}")));
+                        this.run_result = Some(ImportRunResult::Failed(
+                            crate::labels::import_error_import_failed(&e.to_string()),
+                        ));
                         this.step = Step::Outcome;
                         cx.notify();
                     });
@@ -596,10 +622,7 @@ impl ImportConnectionsPanel {
                     // Only the first catch site reports through the user-error seam.
                     if !outcome.secret_failures.is_empty() {
                         let count = outcome.secret_failures.len();
-                        let msg = format!(
-                            "{count} secret(s) could not be written to the keyring \
-                             during import. The keyring may be locked or unavailable."
-                        );
+                        let msg = crate::labels::import_error_secret_failures_toast(count);
                         report_error(UserFacingError::new(ErrorKind::Storage, msg), cx);
                     }
 
@@ -612,9 +635,9 @@ impl ImportConnectionsPanel {
                             || !outcome.unresolved_refs.is_empty();
 
                         if !has_failures {
-                            dbflux_ui_base::toast::Toast::success(format!(
-                                "Imported {succeeded} entity/entities."
-                            ))
+                            dbflux_ui_base::toast::Toast::success(
+                                crate::labels::import_status_imported_toast(succeeded),
+                            )
                             .push(cx);
                         }
 
@@ -671,14 +694,18 @@ impl Render for ImportConnectionsPanel {
 
         let close_for_x = cx.entity().clone();
 
-        ModalShell::new("Import", body, self.render_footer(cx))
-            .width(px(640.0))
-            .on_close(move |_window, cx| {
-                close_for_x.update(cx, |_this, cx| {
-                    cx.emit(ImportConnectionsPanelEvent::Cancelled);
-                });
-            })
-            .into_any_element()
+        ModalShell::new(
+            dbflux_i18n::t!("connection_manager.import.modal_title"),
+            body,
+            self.render_footer(cx),
+        )
+        .width(px(640.0))
+        .on_close(move |_window, cx| {
+            close_for_x.update(cx, |_this, cx| {
+                cx.emit(ImportConnectionsPanelEvent::Cancelled);
+            });
+        })
+        .into_any_element()
     }
 }
 
@@ -704,14 +731,19 @@ impl ImportConnectionsPanel {
             .flex()
             .flex_col()
             .gap(Spacing::XS)
-            .child(Text::body("Bundle file").color(theme.muted_foreground))
+            .child(
+                Text::body(dbflux_i18n::t!(
+                    "connection_manager.import.field.bundle_file"
+                ))
+                .color(theme.muted_foreground),
+            )
             .child(file_row);
 
         if self.native_picker_unavailable {
             file_block = file_block.child(
-                Text::muted(
-                    "No native file picker on this system — type or paste the bundle path above.",
-                )
+                Text::muted(dbflux_i18n::t!(
+                    "connection_manager.import.hint.no_native_picker"
+                ))
                 .font_size(FontSizes::XS),
             );
         }
@@ -724,7 +756,9 @@ impl ImportConnectionsPanel {
             .child(
                 Checkbox::new("import-encrypted-toggle")
                     .checked(self.bundle_encrypted)
-                    .label("Bundle is encrypted")
+                    .label(dbflux_i18n::t!(
+                        "connection_manager.import.field.bundle_encrypted"
+                    ))
                     .on_click(cx.listener(|this, checked: &bool, _, cx| {
                         this.bundle_encrypted = *checked;
                         cx.notify();
@@ -753,7 +787,12 @@ impl ImportConnectionsPanel {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Text::body("Passphrase").color(theme.muted_foreground))
+                    .child(
+                        Text::body(dbflux_i18n::t!(
+                            "connection_manager.import.field.passphrase"
+                        ))
+                        .color(theme.muted_foreground),
+                    )
                     .child(
                         div()
                             .flex()
@@ -787,10 +826,10 @@ impl ImportConnectionsPanel {
             .gap(Spacing::XS);
 
         for line in [
-            format!("{} connection(s)", summary.connection_count),
-            format!("{} auth profile(s)", summary.auth_profile_count),
-            format!("{} SSH tunnel(s)", summary.ssh_tunnel_count),
-            format!("{} proxy profile(s)", summary.proxy_count),
+            crate::labels::import_preview_count_connections(summary.connection_count),
+            crate::labels::import_preview_count_auth_profiles(summary.auth_profile_count),
+            crate::labels::import_preview_count_ssh_tunnels(summary.ssh_tunnel_count),
+            crate::labels::import_preview_count_proxies(summary.proxy_count),
         ] {
             counts = counts.child(
                 div()
@@ -805,49 +844,40 @@ impl ImportConnectionsPanel {
             .flex_col()
             .gap(Spacing::SM)
             .child(
-                Text::body("This bundle will import the following:").color(theme.muted_foreground),
+                Text::body(dbflux_i18n::t!("connection_manager.import.preview.intro"))
+                    .color(theme.muted_foreground),
             )
             .child(counts);
 
         if summary.conflict_count > 0 {
             col = col.child(BannerBlock::new(
                 BannerVariant::Warning,
-                format!(
-                    "{} profile(s) already exist at the destination — you will choose how to \
-                     resolve each.",
-                    summary.conflict_count
-                ),
+                crate::labels::import_preview_conflicts_banner(summary.conflict_count),
             ));
         }
 
         if summary.required_resolution_count > 0 {
             col = col.child(BannerBlock::new(
                 BannerVariant::Info,
-                format!(
-                    "{} value(s) may be required after import — secrets omitted from the bundle \
-                     can be entered or skipped.",
-                    summary.required_resolution_count
-                ),
+                crate::labels::import_preview_required_banner(summary.required_resolution_count),
             ));
         }
 
         if summary.has_driver_not_installed {
             col = col.child(BannerBlock::new(
                 BannerVariant::Warning,
-                "One or more connections reference a driver not installed on this machine and \
-                 will be skipped.",
+                dbflux_i18n::t!("connection_manager.import.preview.driver_not_installed_banner"),
             ));
         }
 
         col = col.child(
             BannerBlock::new(
                 BannerVariant::Info,
-                "External value references travel as-is",
+                dbflux_i18n::t!("connection_manager.import.hint.external_refs"),
             )
-            .with_body(
-                "SSM, Secrets Manager, and environment references are imported unchanged and \
-                     resolved against this machine at connect time.",
-            ),
+            .with_body(dbflux_i18n::t!(
+                "connection_manager.import.hint.external_refs_body"
+            )),
         );
 
         col.into_any_element()
@@ -862,10 +892,8 @@ impl ImportConnectionsPanel {
         let dest = self.dest_snapshot(cx);
 
         let mut col = div().flex().flex_col().gap(Spacing::SM).child(
-            Text::body(
-                "Some profiles in this bundle already exist. Choose how to handle each conflict.",
-            )
-            .color(theme.muted_foreground),
+            Text::body(dbflux_i18n::t!("connection_manager.import.conflicts.intro"))
+                .color(theme.muted_foreground),
         );
 
         for conflict in &plan.conflicts {
@@ -883,12 +911,7 @@ impl ImportConnectionsPanel {
     ) -> AnyElement {
         let theme = cx.theme().clone();
 
-        let kind_label = match conflict.kind {
-            ConflictKind::AuthProfile => "Auth profile",
-            ConflictKind::SshTunnel => "SSH tunnel",
-            ConflictKind::Proxy => "Proxy",
-            ConflictKind::Connection => "Connection",
-        };
+        let kind_label = crate::labels::import_conflict_kind_label(conflict.kind);
 
         let candidates = mapto_candidates(conflict.kind, dest);
         let current = self
@@ -897,13 +920,19 @@ impl ImportConnectionsPanel {
             .cloned();
 
         let mut items = vec![
-            SegmentedItem::new(CHOICE_REUSE, "Reuse existing"),
-            SegmentedItem::new(CHOICE_CREATE, "Create new"),
+            SegmentedItem::new(
+                CHOICE_REUSE,
+                dbflux_i18n::t!("connection_manager.import.action.reuse_existing"),
+            ),
+            SegmentedItem::new(
+                CHOICE_CREATE,
+                dbflux_i18n::t!("connection_manager.import.action.create_new"),
+            ),
         ];
         for (candidate_id, candidate_name) in &candidates {
             items.push(SegmentedItem::new(
                 format!("{CHOICE_MAP_PREFIX}{candidate_id}"),
-                format!("Map to: {candidate_name}"),
+                crate::labels::import_action_map_to(candidate_name),
             ));
         }
 
@@ -942,9 +971,10 @@ impl ImportConnectionsPanel {
                 div()
                     .text_size(FontSizes::SM)
                     .text_color(theme.foreground)
-                    .child(format!(
-                        "{kind_label}: \"{}\" conflicts with \"{}\"",
-                        conflict.bundle_name, conflict.existing_name
+                    .child(crate::labels::import_conflicts_row_label(
+                        &kind_label,
+                        &conflict.bundle_name,
+                        &conflict.existing_name,
                     )),
             )
             .child(control)
@@ -958,11 +988,8 @@ impl ImportConnectionsPanel {
         };
 
         let mut col = div().flex().flex_col().gap(Spacing::SM).child(
-            Text::body(
-                "The following values may be required. Leave a secret empty to skip it — the \
-                 connection still imports without it.",
-            )
-            .color(theme.muted_foreground),
+            Text::body(dbflux_i18n::t!("connection_manager.import.required.intro"))
+                .color(theme.muted_foreground),
         );
 
         for resolution in &plan.required_resolutions {
@@ -999,12 +1026,17 @@ impl ImportConnectionsPanel {
                         div()
                             .text_size(FontSizes::SM)
                             .text_color(theme.foreground)
-                            .child(format!(
-                                "Secret for \"{}\": {}",
-                                resolution.owner_name, resolution.field
+                            .child(crate::labels::import_required_secret_label(
+                                &resolution.owner_name,
+                                &resolution.field,
                             )),
                     )
-                    .child(Text::muted("Leave empty to skip.").font_size(FontSizes::XS));
+                    .child(
+                        Text::muted(dbflux_i18n::t!(
+                            "connection_manager.import.hint.leave_empty_skip"
+                        ))
+                        .font_size(FontSizes::XS),
+                    );
 
                 if let Some(input) = self.secret_inputs.get(&key) {
                     row = row.child(Input::new(input));
@@ -1023,9 +1055,10 @@ impl ImportConnectionsPanel {
                     div()
                         .text_size(FontSizes::SM)
                         .text_color(theme.foreground)
-                        .child(format!(
-                            "AWS auth profile \"{name}\" ({provider_id}) for \"{}\"",
-                            resolution.owner_name
+                        .child(crate::labels::import_required_aws_reference_label(
+                            name,
+                            provider_id,
+                            &resolution.owner_name,
                         )),
                 );
 
@@ -1043,9 +1076,9 @@ impl ImportConnectionsPanel {
                     div()
                         .text_size(FontSizes::SM)
                         .text_color(theme.foreground)
-                        .child(format!(
-                            "Auth profile for \"{}\": {}",
-                            resolution.owner_name, resolution.field
+                        .child(crate::labels::import_required_auth_profile_ref_label(
+                            &resolution.owner_name,
+                            &resolution.field,
                         )),
                 );
 
@@ -1064,21 +1097,23 @@ impl ImportConnectionsPanel {
         cx: &Context<Self>,
     ) -> AnyElement {
         if candidates.is_empty() {
-            return Text::muted(
-                "No matching auth profile on this machine. The connection imports without one; \
-                 assign it later in Settings > Auth Profiles.",
-            )
+            return Text::muted(dbflux_i18n::t!(
+                "connection_manager.import.required.no_matching_auth_profile"
+            ))
             .font_size(FontSizes::XS)
             .into_any_element();
         }
 
         let current = self.auth_profile_choices.get(key).copied();
 
-        let mut items = vec![SegmentedItem::new(AUTH_SKIP, "Skip")];
+        let mut items = vec![SegmentedItem::new(
+            AUTH_SKIP,
+            dbflux_i18n::t!("connection_manager.import.action.skip"),
+        )];
         for (id, name) in candidates {
             items.push(SegmentedItem::new(
                 format!("{AUTH_USE_PREFIX}{id}"),
-                format!("Use: {name}"),
+                crate::labels::import_action_use_profile(name),
             ));
         }
 
@@ -1109,7 +1144,12 @@ impl ImportConnectionsPanel {
             .flex()
             .flex_col()
             .gap(Spacing::XS)
-            .child(Text::muted("Select a profile or skip:").font_size(FontSizes::XS))
+            .child(
+                Text::muted(dbflux_i18n::t!(
+                    "connection_manager.import.hint.select_profile_or_skip"
+                ))
+                .font_size(FontSizes::XS),
+            )
             .child(control)
             .into_any_element()
     }
@@ -1121,18 +1161,25 @@ impl ImportConnectionsPanel {
 
         match self.run_result.as_ref() {
             None => {
-                col = col.child(Text::body("Import complete.").color(theme.foreground));
+                col = col.child(
+                    Text::body(dbflux_i18n::t!("connection_manager.import.status.complete"))
+                        .color(theme.foreground),
+                );
             }
             Some(ImportRunResult::Failed(msg)) => {
                 col = col.child(
-                    BannerBlock::new(BannerVariant::Danger, "Import failed").with_body(msg.clone()),
+                    BannerBlock::new(
+                        BannerVariant::Danger,
+                        dbflux_i18n::t!("connection_manager.import.banner.failed"),
+                    )
+                    .with_body(msg.clone()),
                 );
             }
             Some(ImportRunResult::Outcome(outcome)) => {
                 if !outcome.succeeded.is_empty() {
                     col = col.child(BannerBlock::new(
                         BannerVariant::Success,
-                        format!("{} entity/entities imported.", outcome.succeeded.len()),
+                        crate::labels::import_outcome_succeeded(outcome.succeeded.len()),
                     ));
                 }
 
@@ -1146,10 +1193,7 @@ impl ImportConnectionsPanel {
                     col = col.child(
                         BannerBlock::new(
                             BannerVariant::Warning,
-                            format!(
-                                "{} connection(s) skipped — driver not installed.",
-                                outcome.needs_driver.len()
-                            ),
+                            crate::labels::import_outcome_needs_driver(outcome.needs_driver.len()),
                         )
                         .with_body(body),
                     );
@@ -1165,9 +1209,8 @@ impl ImportConnectionsPanel {
                     col = col.child(
                         BannerBlock::new(
                             BannerVariant::Warning,
-                            format!(
-                                "{} connection(s) could not be configured.",
-                                outcome.config_failures.len()
+                            crate::labels::import_outcome_config_failures(
+                                outcome.config_failures.len(),
                             ),
                         )
                         .with_body(body),
@@ -1184,9 +1227,8 @@ impl ImportConnectionsPanel {
                     col = col.child(
                         BannerBlock::new(
                             BannerVariant::Warning,
-                            format!(
-                                "{} connection(s) had unresolvable references and were not imported.",
-                                outcome.unresolved_refs.len()
+                            crate::labels::import_outcome_unresolved_refs(
+                                outcome.unresolved_refs.len(),
                             ),
                         )
                         .with_body(body),
@@ -1196,10 +1238,8 @@ impl ImportConnectionsPanel {
                 if !outcome.secret_failures.is_empty() {
                     col = col.child(BannerBlock::new(
                         BannerVariant::Warning,
-                        format!(
-                            "{} secret(s) could not be written to the keyring. \
-                             Enter them manually for each affected connection.",
-                            outcome.secret_failures.len()
+                        crate::labels::import_outcome_secret_failures(
+                            outcome.secret_failures.len(),
                         ),
                     ));
                 }
@@ -1211,42 +1251,53 @@ impl ImportConnectionsPanel {
 
     fn render_footer(&self, cx: &Context<Self>) -> AnyElement {
         let left = match self.step {
-            Step::SelectFile => {
-                Button::new("import-cancel", "Cancel")
-                    .ghost()
-                    .on_click(cx.listener(|_this, _: &gpui::ClickEvent, _, cx| {
-                        cx.emit(ImportConnectionsPanelEvent::Cancelled);
-                    }))
-            }
-            Step::Preview => Button::new("import-back", "Back")
-                .ghost()
-                .on_click(cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
-                    this.step = Step::SelectFile;
-                    cx.notify();
-                })),
-            Step::Conflicts => Button::new("import-back", "Back")
-                .ghost()
-                .on_click(cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
-                    this.step = Step::Preview;
-                    cx.notify();
-                })),
-            Step::RequiredReferences => {
-                Button::new("import-back", "Back")
-                    .ghost()
-                    .on_click(cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
-                        this.step = if this.has_conflicts() {
-                            Step::Conflicts
-                        } else {
-                            Step::Preview
-                        };
-                        cx.notify();
-                    }))
-            }
-            Step::Outcome => Button::new("import-done", "Done")
-                .ghost()
-                .on_click(cx.listener(|_this, _: &gpui::ClickEvent, _, cx| {
-                    cx.emit(ImportConnectionsPanelEvent::Completed);
-                })),
+            Step::SelectFile => Button::new(
+                "import-cancel",
+                dbflux_i18n::t!("connection_manager.import.action.cancel"),
+            )
+            .ghost()
+            .on_click(cx.listener(|_this, _: &gpui::ClickEvent, _, cx| {
+                cx.emit(ImportConnectionsPanelEvent::Cancelled);
+            })),
+            Step::Preview => Button::new(
+                "import-back",
+                dbflux_i18n::t!("connection_manager.import.action.back"),
+            )
+            .ghost()
+            .on_click(cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
+                this.step = Step::SelectFile;
+                cx.notify();
+            })),
+            Step::Conflicts => Button::new(
+                "import-back",
+                dbflux_i18n::t!("connection_manager.import.action.back"),
+            )
+            .ghost()
+            .on_click(cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
+                this.step = Step::Preview;
+                cx.notify();
+            })),
+            Step::RequiredReferences => Button::new(
+                "import-back",
+                dbflux_i18n::t!("connection_manager.import.action.back"),
+            )
+            .ghost()
+            .on_click(cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
+                this.step = if this.has_conflicts() {
+                    Step::Conflicts
+                } else {
+                    Step::Preview
+                };
+                cx.notify();
+            })),
+            Step::Outcome => Button::new(
+                "import-done",
+                dbflux_i18n::t!("connection_manager.import.action.done"),
+            )
+            .ghost()
+            .on_click(cx.listener(|_this, _: &gpui::ClickEvent, _, cx| {
+                cx.emit(ImportConnectionsPanelEvent::Completed);
+            })),
         };
 
         let primary = self.render_primary_button(cx);
@@ -1267,9 +1318,9 @@ impl ImportConnectionsPanel {
                 let can_load =
                     !self.file_input.read(cx).value().trim().is_empty() && !self.is_parsing;
                 let label = if self.is_parsing {
-                    "Loading\u{2026}"
+                    dbflux_i18n::t!("connection_manager.import.status.loading")
                 } else {
-                    "Load"
+                    dbflux_i18n::t!("connection_manager.import.action.load")
                 };
                 Some(
                     Button::new("import-load", label)
@@ -1282,32 +1333,38 @@ impl ImportConnectionsPanel {
                 )
             }
             Step::Preview => Some(
-                Button::new("import-preview-next", "Continue")
-                    .primary()
-                    .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
-                        this.advance_from_preview(window, cx);
-                    }))
-                    .into_any_element(),
+                Button::new(
+                    "import-preview-next",
+                    dbflux_i18n::t!("connection_manager.import.action.continue_"),
+                )
+                .primary()
+                .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
+                    this.advance_from_preview(window, cx);
+                }))
+                .into_any_element(),
             ),
             Step::Conflicts => {
                 let resolved = self.all_conflicts_resolved();
                 Some(
-                    Button::new("import-conflicts-next", "Continue")
-                        .primary()
-                        .disabled(!resolved)
-                        .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
-                            if this.all_conflicts_resolved() {
-                                this.advance_from_conflicts(window, cx);
-                            }
-                        }))
-                        .into_any_element(),
+                    Button::new(
+                        "import-conflicts-next",
+                        dbflux_i18n::t!("connection_manager.import.action.continue_"),
+                    )
+                    .primary()
+                    .disabled(!resolved)
+                    .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
+                        if this.all_conflicts_resolved() {
+                            this.advance_from_conflicts(window, cx);
+                        }
+                    }))
+                    .into_any_element(),
                 )
             }
             Step::RequiredReferences => {
                 let label = if self.is_applying {
-                    "Importing\u{2026}"
+                    dbflux_i18n::t!("connection_manager.import.status.importing")
                 } else {
-                    "Import"
+                    dbflux_i18n::t!("connection_manager.import.action.import")
                 };
                 Some(
                     Button::new("import-required-apply", label)
@@ -1344,4 +1401,148 @@ fn parse_conflict_choice(id: &str) -> Option<ConflictChoice> {
 fn parse_auth_choice(id: &str) -> Option<Uuid> {
     id.strip_prefix(AUTH_USE_PREFIX)
         .and_then(|uuid_str| Uuid::parse_str(uuid_str).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    /// Every `connection_manager.import.*` key this panel resolves directly via
+    /// `dbflux_i18n::t!`, including the plural `.one`/`.many` variants. Keys backed
+    /// by `crate::labels` helpers are exercised separately by `labels.rs`'s own
+    /// test module, but every leaf key they resolve is still listed here so this
+    /// slice's key coverage is self-contained in one place.
+    const IMPORT_PANEL_KEYS: &[&str] = &[
+        "connection_manager.import.placeholder.bundle_passphrase",
+        "connection_manager.import.placeholder.bundle_path",
+        "connection_manager.import.placeholder.secret_value",
+        "connection_manager.import.dialog.open_title",
+        "connection_manager.import.filter.toml",
+        "connection_manager.import.filter.all",
+        "connection_manager.import.error.choose_file",
+        "connection_manager.import.error.cannot_read_file",
+        "connection_manager.import.error.parse_error",
+        "connection_manager.import.error.encrypted_needs_passphrase",
+        "connection_manager.import.error.encryption_unavailable",
+        "connection_manager.import.error.wrong_passphrase",
+        "connection_manager.import.error.decryption_error",
+        "connection_manager.import.error.import_failed",
+        "connection_manager.import.error.secret_failures_toast.one",
+        "connection_manager.import.error.secret_failures_toast.many",
+        "connection_manager.import.field.bundle_file",
+        "connection_manager.import.field.bundle_encrypted",
+        "connection_manager.import.field.passphrase",
+        "connection_manager.import.hint.no_native_picker",
+        "connection_manager.import.hint.external_refs",
+        "connection_manager.import.hint.external_refs_body",
+        "connection_manager.import.hint.leave_empty_skip",
+        "connection_manager.import.hint.select_profile_or_skip",
+        "connection_manager.import.modal_title",
+        "connection_manager.import.preview.intro",
+        "connection_manager.import.preview.count.connections.one",
+        "connection_manager.import.preview.count.connections.many",
+        "connection_manager.import.preview.count.auth_profiles.one",
+        "connection_manager.import.preview.count.auth_profiles.many",
+        "connection_manager.import.preview.count.ssh_tunnels.one",
+        "connection_manager.import.preview.count.ssh_tunnels.many",
+        "connection_manager.import.preview.count.proxies.one",
+        "connection_manager.import.preview.count.proxies.many",
+        "connection_manager.import.preview.conflicts_banner.one",
+        "connection_manager.import.preview.conflicts_banner.many",
+        "connection_manager.import.preview.required_banner.one",
+        "connection_manager.import.preview.required_banner.many",
+        "connection_manager.import.preview.driver_not_installed_banner",
+        "connection_manager.import.conflict_kind.auth_profile",
+        "connection_manager.import.conflict_kind.ssh_tunnel",
+        "connection_manager.import.conflict_kind.proxy",
+        "connection_manager.import.conflict_kind.connection",
+        "connection_manager.import.conflicts.intro",
+        "connection_manager.import.conflicts.row_label",
+        "connection_manager.import.required.intro",
+        "connection_manager.import.required.secret_label",
+        "connection_manager.import.required.aws_reference_label",
+        "connection_manager.import.required.auth_profile_ref_label",
+        "connection_manager.import.required.no_matching_auth_profile",
+        "connection_manager.import.status.complete",
+        "connection_manager.import.status.loading",
+        "connection_manager.import.status.importing",
+        "connection_manager.import.status.imported_toast.one",
+        "connection_manager.import.status.imported_toast.many",
+        "connection_manager.import.banner.failed",
+        "connection_manager.import.outcome.succeeded.one",
+        "connection_manager.import.outcome.succeeded.many",
+        "connection_manager.import.outcome.needs_driver.one",
+        "connection_manager.import.outcome.needs_driver.many",
+        "connection_manager.import.outcome.config_failures.one",
+        "connection_manager.import.outcome.config_failures.many",
+        "connection_manager.import.outcome.unresolved_refs.one",
+        "connection_manager.import.outcome.unresolved_refs.many",
+        "connection_manager.import.outcome.secret_failures.one",
+        "connection_manager.import.outcome.secret_failures.many",
+        "connection_manager.import.action.reuse_existing",
+        "connection_manager.import.action.create_new",
+        "connection_manager.import.action.map_to",
+        "connection_manager.import.action.skip",
+        "connection_manager.import.action.use_profile",
+        "connection_manager.import.action.cancel",
+        "connection_manager.import.action.back",
+        "connection_manager.import.action.done",
+        "connection_manager.import.action.load",
+        "connection_manager.import.action.continue_",
+        "connection_manager.import.action.import",
+    ];
+
+    #[test]
+    fn import_panel_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in IMPORT_PANEL_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn import_panel_keys_diverge_between_locales() {
+        // "Proxy" is a proper noun kept identical in both locales, matching the
+        // convention already used for other proxy-facing keys in this catalog.
+        const UNTRANSLATED: &[&str] = &["connection_manager.import.conflict_kind.proxy"];
+
+        for key in IMPORT_PANEL_KEYS {
+            if UNTRANSLATED.contains(key) {
+                continue;
+            }
+
+            let english = dbflux_i18n::t!(key, locale = "en");
+            let spanish = dbflux_i18n::t!(key, locale = "es");
+
+            assert_ne!(
+                english, spanish,
+                "key {key} did not diverge between locales"
+            );
+        }
+    }
+
+    #[test]
+    fn conflict_kind_labels_are_exhaustive_over_the_enum() {
+        use dbflux_portability::ConflictKind;
+
+        for kind in [
+            ConflictKind::AuthProfile,
+            ConflictKind::SshTunnel,
+            ConflictKind::Proxy,
+            ConflictKind::Connection,
+        ] {
+            let label = crate::labels::import_conflict_kind_label(kind);
+            assert!(!label.is_empty(), "{kind:?} resolved an empty label");
+        }
+    }
 }

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -292,6 +292,305 @@ pub(crate) fn audit_save_failed_copy(error: &str) -> String {
     dbflux_i18n::t!("settings.audit.error.save_failed_copy", error = error)
 }
 
+/// Formats the "Cannot read file: <error>" import-panel error.
+pub(crate) fn import_error_cannot_read_file(error: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.import.error.cannot_read_file",
+        error = error
+    )
+}
+
+/// Formats the "Parse error: <error>" import-panel error.
+pub(crate) fn import_error_parse_error(error: &str) -> String {
+    dbflux_i18n::t!("connection_manager.import.error.parse_error", error = error)
+}
+
+/// Formats the "Decryption error: <error>" import-panel error.
+pub(crate) fn import_error_decryption_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.import.error.decryption_error",
+        error = error
+    )
+}
+
+/// Formats the "Import failed: <error>" import-panel error.
+pub(crate) fn import_error_import_failed(error: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.import.error.import_failed",
+        error = error
+    )
+}
+
+/// Formats the pluralized "N secret(s) could not be written to the keyring during import..."
+/// toast raised from the import apply pipeline.
+pub(crate) fn import_error_secret_failures_toast(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.error.secret_failures_toast.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.error.secret_failures_toast.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "N connection(s)" import-preview count line.
+pub(crate) fn import_preview_count_connections(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.count.connections.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.count.connections.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "N auth profile(s)" import-preview count line.
+pub(crate) fn import_preview_count_auth_profiles(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.count.auth_profiles.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.count.auth_profiles.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "N SSH tunnel(s)" import-preview count line.
+pub(crate) fn import_preview_count_ssh_tunnels(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.count.ssh_tunnels.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.count.ssh_tunnels.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "N proxy profile(s)" import-preview count line.
+pub(crate) fn import_preview_count_proxies(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.count.proxies.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.count.proxies.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized import-preview "already exist at the destination" conflicts banner.
+pub(crate) fn import_preview_conflicts_banner(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.conflicts_banner.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.conflicts_banner.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized import-preview "may be required after import" banner.
+pub(crate) fn import_preview_required_banner(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.required_banner.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.preview.required_banner.many",
+            count = count
+        )
+    }
+}
+
+/// Resolves the translated label for an import conflict's entity kind.
+pub(crate) fn import_conflict_kind_label(kind: dbflux_portability::ConflictKind) -> String {
+    use dbflux_portability::ConflictKind;
+
+    match kind {
+        ConflictKind::AuthProfile => {
+            dbflux_i18n::t!("connection_manager.import.conflict_kind.auth_profile")
+        }
+        ConflictKind::SshTunnel => {
+            dbflux_i18n::t!("connection_manager.import.conflict_kind.ssh_tunnel")
+        }
+        ConflictKind::Proxy => dbflux_i18n::t!("connection_manager.import.conflict_kind.proxy"),
+        ConflictKind::Connection => {
+            dbflux_i18n::t!("connection_manager.import.conflict_kind.connection")
+        }
+    }
+}
+
+/// Formats the "<kind>: "<bundle name>" conflicts with "<existing name>"" import conflict row label.
+pub(crate) fn import_conflicts_row_label(
+    kind_label: &str,
+    bundle_name: &str,
+    existing_name: &str,
+) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.import.conflicts.row_label",
+        kind = kind_label,
+        bundle_name = bundle_name,
+        existing_name = existing_name
+    )
+}
+
+/// Formats the "Secret for "<owner>": <field>" import required-resolution label.
+pub(crate) fn import_required_secret_label(owner: &str, field: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.import.required.secret_label",
+        owner = owner,
+        field = field
+    )
+}
+
+/// Formats the "AWS auth profile "<name>" (<provider>) for "<owner>"" import required-resolution label.
+pub(crate) fn import_required_aws_reference_label(
+    name: &str,
+    provider_id: &str,
+    owner: &str,
+) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.import.required.aws_reference_label",
+        name = name,
+        provider_id = provider_id,
+        owner = owner
+    )
+}
+
+/// Formats the "Auth profile for "<owner>": <field>" import required-resolution label.
+pub(crate) fn import_required_auth_profile_ref_label(owner: &str, field: &str) -> String {
+    dbflux_i18n::t!(
+        "connection_manager.import.required.auth_profile_ref_label",
+        owner = owner,
+        field = field
+    )
+}
+
+/// Formats the pluralized "Imported N entity/entities." import success toast.
+pub(crate) fn import_status_imported_toast(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.status.imported_toast.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.status.imported_toast.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "N entity/entities imported." import-outcome success banner.
+pub(crate) fn import_outcome_succeeded(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.succeeded.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.succeeded.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "N connection(s) skipped — driver not installed." import-outcome banner.
+pub(crate) fn import_outcome_needs_driver(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.needs_driver.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.needs_driver.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "N connection(s) could not be configured." import-outcome banner.
+pub(crate) fn import_outcome_config_failures(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.config_failures.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.config_failures.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "N connection(s) had unresolvable references..." import-outcome banner.
+pub(crate) fn import_outcome_unresolved_refs(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.unresolved_refs.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.unresolved_refs.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "N secret(s) could not be written to the keyring..." import-outcome banner.
+pub(crate) fn import_outcome_secret_failures(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.secret_failures.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.outcome.secret_failures.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the "Map to: <candidate name>" import conflict-resolution segment label.
+pub(crate) fn import_action_map_to(name: &str) -> String {
+    dbflux_i18n::t!("connection_manager.import.action.map_to", name = name)
+}
+
+/// Formats the "Use: <profile name>" import required-reference segment label.
+pub(crate) fn import_action_use_profile(name: &str) -> String {
+    dbflux_i18n::t!("connection_manager.import.action.use_profile", name = name)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -302,7 +601,17 @@ mod tests {
         hooks_create_dir_failed, hooks_delete_message, hooks_delete_unreadable_message,
         hooks_duplicate_id, hooks_env_pair_invalid, hooks_form_interpreter_hint,
         hooks_interpreter_auto_label, hooks_interpreter_missing, hooks_open_script_failed,
-        hooks_write_script_failed, mcp_preview_summary, proxies_delete_body,
+        hooks_write_script_failed, import_action_map_to, import_action_use_profile,
+        import_conflict_kind_label, import_conflicts_row_label, import_error_cannot_read_file,
+        import_error_decryption_error, import_error_import_failed, import_error_parse_error,
+        import_error_secret_failures_toast, import_outcome_config_failures,
+        import_outcome_needs_driver, import_outcome_secret_failures, import_outcome_succeeded,
+        import_outcome_unresolved_refs, import_preview_conflicts_banner,
+        import_preview_count_auth_profiles, import_preview_count_connections,
+        import_preview_count_proxies, import_preview_count_ssh_tunnels,
+        import_preview_required_banner, import_required_auth_profile_ref_label,
+        import_required_aws_reference_label, import_required_secret_label,
+        import_status_imported_toast, mcp_preview_summary, proxies_delete_body,
         ssh_private_key_with_path, ssh_tunnels_delete_body,
     };
 
@@ -566,5 +875,123 @@ mod tests {
         let message = audit_save_failed_copy("disk full");
 
         assert!(message.contains("disk full"));
+    }
+
+    #[test]
+    fn import_error_helpers_embed_error_cause() {
+        assert!(import_error_cannot_read_file("permission denied").contains("permission denied"));
+        assert!(import_error_parse_error("unexpected token").contains("unexpected token"));
+        assert!(import_error_decryption_error("bad tag").contains("bad tag"));
+        assert!(import_error_import_failed("disk full").contains("disk full"));
+    }
+
+    #[test]
+    fn import_preview_count_helpers_use_singular_for_one() {
+        assert_eq!(import_preview_count_connections(1), "1 connection");
+        assert_eq!(import_preview_count_auth_profiles(1), "1 auth profile");
+        assert_eq!(import_preview_count_ssh_tunnels(1), "1 SSH tunnel");
+        assert_eq!(import_preview_count_proxies(1), "1 proxy profile");
+    }
+
+    #[test]
+    fn import_preview_count_helpers_use_plural_for_many() {
+        assert_eq!(import_preview_count_connections(3), "3 connections");
+        assert_eq!(import_preview_count_auth_profiles(2), "2 auth profiles");
+        assert_eq!(import_preview_count_ssh_tunnels(2), "2 SSH tunnels");
+        assert_eq!(import_preview_count_proxies(2), "2 proxy profiles");
+    }
+
+    #[test]
+    fn import_preview_banners_pluralize_by_count() {
+        let one = import_preview_conflicts_banner(1);
+        let many = import_preview_conflicts_banner(3);
+        assert!(one.contains('1'));
+        assert!(many.contains('3'));
+        assert_ne!(one, many);
+
+        let required_one = import_preview_required_banner(1);
+        let required_many = import_preview_required_banner(2);
+        assert!(required_one.contains('1'));
+        assert!(required_many.contains('2'));
+        assert_ne!(required_one, required_many);
+    }
+
+    #[test]
+    fn import_conflict_kind_label_is_exhaustive_over_the_enum() {
+        use dbflux_portability::ConflictKind;
+
+        for kind in [
+            ConflictKind::AuthProfile,
+            ConflictKind::SshTunnel,
+            ConflictKind::Proxy,
+            ConflictKind::Connection,
+        ] {
+            let label = import_conflict_kind_label(kind);
+            assert!(!label.is_empty(), "{kind:?} resolved an empty label");
+        }
+    }
+
+    #[test]
+    fn import_conflicts_row_label_embeds_kind_and_names() {
+        let message = import_conflicts_row_label("SSH tunnel", "bastion-a", "bastion-b");
+
+        assert!(message.contains("SSH tunnel"));
+        assert!(message.contains("bastion-a"));
+        assert!(message.contains("bastion-b"));
+    }
+
+    #[test]
+    fn import_required_label_helpers_embed_their_arguments() {
+        assert!(import_required_secret_label("prod-mongo", "password").contains("prod-mongo"));
+        assert!(import_required_secret_label("prod-mongo", "password").contains("password"));
+
+        let aws = import_required_aws_reference_label(
+            "prod-sso",
+            "aws-iam-identity-center",
+            "prod-mongo",
+        );
+        assert!(aws.contains("prod-sso"));
+        assert!(aws.contains("aws-iam-identity-center"));
+        assert!(aws.contains("prod-mongo"));
+
+        let profile_ref = import_required_auth_profile_ref_label("prod-mongo", "auth_profile_id");
+        assert!(profile_ref.contains("prod-mongo"));
+        assert!(profile_ref.contains("auth_profile_id"));
+    }
+
+    #[test]
+    fn import_status_imported_toast_uses_singular_form_for_one() {
+        assert_eq!(import_status_imported_toast(1), "Imported 1 entity.");
+        assert_eq!(import_status_imported_toast(3), "Imported 3 entities.");
+    }
+
+    #[test]
+    fn import_outcome_banners_pluralize_by_count() {
+        assert_eq!(import_outcome_succeeded(1), "1 entity imported.");
+        assert_eq!(import_outcome_succeeded(2), "2 entities imported.");
+
+        assert!(import_outcome_needs_driver(1).contains('1'));
+        assert!(import_outcome_needs_driver(2).contains('2'));
+
+        assert!(import_outcome_config_failures(1).contains('1'));
+        assert!(import_outcome_config_failures(2).contains('2'));
+
+        assert!(import_outcome_unresolved_refs(1).contains('1'));
+        assert!(import_outcome_unresolved_refs(2).contains('2'));
+
+        assert!(import_outcome_secret_failures(1).contains('1'));
+        assert!(import_outcome_secret_failures(2).contains('2'));
+    }
+
+    #[test]
+    fn import_error_secret_failures_toast_pluralizes_by_count() {
+        assert!(import_error_secret_failures_toast(1).contains('1'));
+        assert!(import_error_secret_failures_toast(2).contains('2'));
+    }
+
+    #[test]
+    fn import_action_segment_labels_embed_their_names() {
+        assert!(import_action_map_to("staging-db").contains("staging-db"));
+        assert!(import_action_use_profile("prod-sso").contains("prod-sso"));
     }
 }


### PR DESCRIPTION
## Summary

Twenty-sixth `dbflux_ui_windows` i18n slice: the connection manager import panel (modal title, step labels and hints, bundle file and passphrase fields, dialog and filters, parse/decrypt/apply errors, conflict resolution, required secrets and references, outcome banners, footer buttons, toasts) renders through `dbflux_i18n::t!` under `connection_manager.import.*`. English and Spanish together. File names, profile names and secret values stay data.

## What does this resolve?

- Refs #360 (follows the audit settings PR; next: the connection manager export modal)

## How was this solved?

- 27 helpers in labels.rs carry the pluralized and multi-placeholder strings; the two secret-failure messages (toast vs banner) keep separate keys; the divergence test documents `Proxy` as an intentionally identical proper noun.
- Size: 1194 lines in one file boundary (`size:exception`), dominated by catalog keys and 1:1 substitutions.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 301 passed; clippy clean; fmt clean. Manual smoke in Spanish: import an encrypted bundle with a wrong passphrase, then a correct one, resolve a conflict, finish.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
