### PR TITLE
feat(i18n): translate the import wizard rail, steps, mapping modes, and summaries

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -880,6 +880,63 @@ document:
         column: COLUMN
         references: REFERENCES
         row: ROW
+  import_wizard:
+    title: Import Data
+    rail:
+      pick_folder: Pick Folder
+      configure: Configure
+      confirm: Confirm
+      run: Run
+    pick_folder:
+      description: "Choose the folder that contains manifest.json and the exported table files."
+      choose_folder: "Choose Folder..."
+      reading_manifest: "Reading manifest..."
+      dialog_title: Choose Import Folder
+      error:
+        no_connection: No active connection for this profile
+        no_dialog: No folder picker available on this platform
+        invalid_bundle: "Invalid import bundle: %{error}"
+    configure:
+      mode_placeholder: Mode
+      target_placeholder: Target column
+      source_placeholder: Source column
+      source_unset: "(unset)"
+      apply_mapping: Apply Mapping
+      continue: Continue
+      unmatched_source: "Unmatched source column(s), will be skipped unless remapped: %{names}"
+    mapping_mode:
+      create: Create
+      existing: Existing (insert only)
+      recreate: Recreate (drop + create)
+      skip: Skip
+      truncate: Truncate (empty + insert)
+    confirm:
+      body: "This will drop-and-recreate or truncate the following table(s) before loading data: %{tables}"
+      warning: This cannot be undone. Confirm to proceed.
+      back: Back
+      proceed: "Yes, proceed"
+    running:
+      title: "Importing..."
+      progress:
+        of_total: "%{done} / %{total} rows"
+        only: "%{done} rows"
+    done:
+      close: Close
+    error:
+      no_connection: No active connection for this import
+    toast:
+      cancelled: Import cancelled
+      completed: Import completed
+      table_failed: "Import failed on table '%{table}': %{error}"
+      failed: "Import failed: %{error}"
+    summary:
+      with_failures: "Imported %{completed} table(s), %{rows} row(s) total (%{skipped} skipped, %{failed} failed)"
+      ok: "Imported %{completed} table(s), %{rows} row(s) total (%{skipped} skipped)"
+    status_line:
+      completed: "%{table}: completed (%{rows} row(s))"
+      skipped: "%{table}: skipped"
+      failed: "%{table}: FAILED — %{error}"
+      not_attempted: "%{table}: not attempted"
   key_value:
     add_member_modal:
       cancel: Cancel

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -880,6 +880,63 @@ document:
         column: COLUMNA
         references: REFERENCIAS
         row: FILA
+  import_wizard:
+    title: Importar datos
+    rail:
+      pick_folder: Elegir carpeta
+      configure: Configurar
+      confirm: Confirmar
+      run: Ejecutar
+    pick_folder:
+      description: "Elige la carpeta que contiene manifest.json y los archivos de tabla exportados."
+      choose_folder: "Elegir carpeta…"
+      reading_manifest: "Leyendo manifiesto…"
+      dialog_title: Elegir carpeta de importación
+      error:
+        no_connection: No hay una conexión activa para este perfil
+        no_dialog: No hay selector de carpetas disponible en esta plataforma
+        invalid_bundle: "Paquete de importación inválido: %{error}"
+    configure:
+      mode_placeholder: Modo
+      target_placeholder: Columna destino
+      source_placeholder: Columna origen
+      source_unset: "(sin asignar)"
+      apply_mapping: Aplicar mapeo
+      continue: Continuar
+      unmatched_source: "Columna(s) de origen sin coincidencia, se omitirán salvo que se remapeen: %{names}"
+    mapping_mode:
+      create: Crear
+      existing: "Existente (solo insertar)"
+      recreate: "Recrear (eliminar + crear)"
+      skip: Omitir
+      truncate: "Truncar (vaciar + insertar)"
+    confirm:
+      body: "Esto eliminará y recreará o truncará la(s) siguiente(s) tabla(s) antes de cargar los datos: %{tables}"
+      warning: Esta acción no se puede deshacer. Confirma para continuar.
+      back: Atrás
+      proceed: "Sí, continuar"
+    running:
+      title: "Importando…"
+      progress:
+        of_total: "%{done} / %{total} filas"
+        only: "%{done} filas"
+    done:
+      close: Cerrar
+    error:
+      no_connection: No hay una conexión activa para esta importación
+    toast:
+      cancelled: Importación cancelada
+      completed: Importación completada
+      table_failed: "La importación falló en la tabla «%{table}»: %{error}"
+      failed: "Error al importar: %{error}"
+    summary:
+      with_failures: "Se importaron %{completed} tabla(s), %{rows} fila(s) en total (%{skipped} omitida(s), %{failed} fallida(s))"
+      ok: "Se importaron %{completed} tabla(s), %{rows} fila(s) en total (%{skipped} omitida(s))"
+    status_line:
+      completed: "%{table}: completada (%{rows} fila(s))"
+      skipped: "%{table}: omitida"
+      failed: "%{table}: FALLIDA — %{error}"
+      not_attempted: "%{table}: no intentada"
   key_value:
     add_member_modal:
       cancel: Cancelar

--- a/crates/dbflux_ui_document/src/import_wizard/column_mapping.rs
+++ b/crates/dbflux_ui_document/src/import_wizard/column_mapping.rs
@@ -9,23 +9,26 @@ use dbflux_core::TransferColumn;
 use dbflux_transfer::manifest::ManifestTable;
 use dbflux_transfer::{ColumnMappingOverride, TableMappingMode};
 
-/// Ordered (label, mode) pairs for the mapping-mode picker. `Truncate` is
-/// filtered out by [`mapping_mode_options`] when the target lacks
+/// Ordered modes for the mapping-mode picker. `Truncate` is filtered out by
+/// [`mapping_mode_options`] when the target lacks
 /// `DriverCapabilities::TRUNCATE_TABLE` — unavailable, not a runtime error
 /// (mirrors the `DISABLE_FK_CHECKS` missing-capability pattern from R7).
-const MAPPING_MODE_OPTIONS: &[(&str, TableMappingMode)] = &[
-    ("Create", TableMappingMode::Create),
-    ("Existing (insert only)", TableMappingMode::Existing),
-    ("Recreate (drop + create)", TableMappingMode::Recreate),
-    ("Skip", TableMappingMode::Skip),
-    ("Truncate (empty + insert)", TableMappingMode::Truncate),
+const MAPPING_MODE_OPTIONS: &[TableMappingMode] = &[
+    TableMappingMode::Create,
+    TableMappingMode::Existing,
+    TableMappingMode::Recreate,
+    TableMappingMode::Skip,
+    TableMappingMode::Truncate,
 ];
 
-pub fn mapping_mode_options(supports_truncate: bool) -> Vec<(&'static str, TableMappingMode)> {
+/// Translated (label, mode) pairs for the mapping-mode dropdown, via
+/// `crate::labels::import_mapping_mode_label`.
+pub fn mapping_mode_options(supports_truncate: bool) -> Vec<(String, TableMappingMode)> {
     MAPPING_MODE_OPTIONS
         .iter()
         .copied()
-        .filter(|(_, mode)| supports_truncate || *mode != TableMappingMode::Truncate)
+        .filter(|mode| supports_truncate || *mode != TableMappingMode::Truncate)
+        .map(|mode| (crate::labels::import_mapping_mode_label(mode), mode))
         .collect()
 }
 
@@ -172,6 +175,19 @@ mod tests {
                 .iter()
                 .any(|(_, mode)| *mode == TableMappingMode::Truncate)
         );
+    }
+
+    /// PR 26a: `mapping_mode_options` is widened from `Vec<(&'static str,
+    /// TableMappingMode)>` to `Vec<(String, TableMappingMode)>`, with every
+    /// label routed through `crate::labels::import_mapping_mode_label` and
+    /// the translation catalog rather than a hardcoded English literal.
+    #[test]
+    fn mapping_mode_options_labels_are_owned_strings_from_the_translation_catalog() {
+        let options: Vec<(String, TableMappingMode)> = mapping_mode_options(true);
+
+        for (label, mode) in &options {
+            assert_eq!(*label, crate::labels::import_mapping_mode_label(*mode));
+        }
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/import_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/import_wizard/mod.rs
@@ -45,13 +45,6 @@ enum WizardStep {
     Done,
 }
 
-/// The rail's four fixed entries, in display order. `Confirm` stays a rail
-/// entry even on a non-destructive plan, where `continue_from_configure`
-/// skips straight from `Configure` to `Running` — it simply never becomes
-/// `current` in that flow and reads as already passed, matching a linear
-/// progress rail rather than a literal per-click history.
-const RAIL_LABELS: [&str; 4] = ["Pick Folder", "Configure", "Confirm", "Run"];
-
 /// `Running` and `Done` collapse onto the same rail index so the terminal
 /// steps of the five-variant `WizardStep` state machine share the rail's
 /// fourth "Run" entry instead of growing a fifth marker.
@@ -66,16 +59,16 @@ fn rail_index(step: WizardStep) -> usize {
 
 /// Maps the wizard's current [`WizardStep`] to the shared rail composite's
 /// domain-free [`RailItem`]s, marking every entry before the current one as
-/// completed — see [`RAIL_LABELS`] for why `Confirm` may show completed
-/// without the user ever visiting it.
+/// completed — see [`crate::labels::import_rail_labels`] for why `Confirm`
+/// may show completed without the user ever visiting it.
 fn import_rail_items(step: WizardStep) -> Vec<RailItem> {
     let current_index = rail_index(step);
 
-    RAIL_LABELS
-        .iter()
+    crate::labels::import_rail_labels()
+        .into_iter()
         .enumerate()
         .map(|(index, label)| RailItem {
-            label: SharedString::from(*label),
+            label: SharedString::from(label),
             completed: index < current_index,
             current: index == current_index,
         })
@@ -196,7 +189,9 @@ impl ImportWizard {
 
     fn choose_folder(&mut self, cx: &mut Context<Self>) {
         let Some(connection) = self.resolve_connection(cx) else {
-            self.manifest_error = Some("No active connection for this profile".to_string());
+            self.manifest_error = Some(dbflux_i18n::t!(
+                "document.import_wizard.pick_folder.error.no_connection"
+            ));
             cx.notify();
             return;
         };
@@ -210,7 +205,9 @@ impl ImportWizard {
         cx.spawn(async move |this, cx| {
             let dir = if dialog_available {
                 match rfd::AsyncFileDialog::new()
-                    .set_title("Choose Import Folder")
+                    .set_title(dbflux_i18n::t!(
+                        "document.import_wizard.pick_folder.dialog_title"
+                    ))
                     .pick_folder()
                     .await
                 {
@@ -227,8 +224,9 @@ impl ImportWizard {
             } else {
                 this.update(cx, |this, cx| {
                     this.loading = false;
-                    this.manifest_error =
-                        Some("No folder picker available on this platform".to_string());
+                    this.manifest_error = Some(dbflux_i18n::t!(
+                        "document.import_wizard.pick_folder.error.no_dialog"
+                    ));
                     cx.notify();
                 })
                 .ok();
@@ -246,7 +244,10 @@ impl ImportWizard {
                 Err(e) => {
                     this.update(cx, |this, cx| {
                         this.loading = false;
-                        this.manifest_error = Some(format!("Invalid import bundle: {e}"));
+                        this.manifest_error = Some(dbflux_i18n::t!(
+                            "document.import_wizard.pick_folder.error.invalid_bundle",
+                            error = e.to_string()
+                        ));
                         cx.notify();
                     })
                     .ok();
@@ -310,14 +311,16 @@ impl ImportWizard {
                 .position(|(_, mode)| *mode == config.mapping_mode);
             let mode_items: Vec<DropdownItem> = mode_options
                 .iter()
-                .map(|(label, _)| DropdownItem::new(*label))
+                .map(|(label, _)| DropdownItem::new(label.clone()))
                 .collect();
 
             let mapping_mode_dropdown = cx.new(|_cx| {
                 Dropdown::new(SharedString::from(format!("import-mode-{table_index}")))
                     .items(mode_items)
                     .selected_index(selected_mode_index)
-                    .placeholder("Mode")
+                    .placeholder(dbflux_i18n::t!(
+                        "document.import_wizard.configure.mode_placeholder"
+                    ))
             });
 
             let target_items: Vec<DropdownItem> = config
@@ -328,10 +331,14 @@ impl ImportWizard {
             let rebind_target_dropdown = cx.new(|_cx| {
                 Dropdown::new(SharedString::from(format!("import-target-{table_index}")))
                     .items(target_items)
-                    .placeholder("Target column")
+                    .placeholder(dbflux_i18n::t!(
+                        "document.import_wizard.configure.target_placeholder"
+                    ))
             });
 
-            let mut source_items = vec![DropdownItem::new("(unset)")];
+            let mut source_items = vec![DropdownItem::new(dbflux_i18n::t!(
+                "document.import_wizard.configure.source_unset"
+            ))];
             source_items.extend(
                 config
                     .source_columns
@@ -341,7 +348,9 @@ impl ImportWizard {
             let rebind_source_dropdown = cx.new(|_cx| {
                 Dropdown::new(SharedString::from(format!("import-source-{table_index}")))
                     .items(source_items)
-                    .placeholder("Source column")
+                    .placeholder(dbflux_i18n::t!(
+                        "document.import_wizard.configure.source_placeholder"
+                    ))
             });
 
             let mode_sub = cx.subscribe(
@@ -424,7 +433,10 @@ impl ImportWizard {
     fn start_import(&mut self, cx: &mut Context<Self>) {
         let Some(connection) = self.resolve_connection(cx) else {
             report_error(
-                UserFacingError::new(ErrorKind::Storage, "No active connection for this import"),
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    dbflux_i18n::t!("document.import_wizard.error.no_connection"),
+                ),
                 cx,
             );
             return;
@@ -548,7 +560,8 @@ impl ImportWizard {
                             state.tasks_mut().cancel(task_id);
                             cx.emit(AppStateChanged);
                         });
-                        this.result_summary = Some("Import cancelled".to_string());
+                        this.result_summary =
+                            Some(dbflux_i18n::t!("document.import_wizard.toast.cancelled"));
                     }
                     Ok(outcome) => {
                         let failed_table = outcome.tables.iter().find_map(|t| match &t.status {
@@ -566,7 +579,11 @@ impl ImportWizard {
                             report_error(
                                 UserFacingError::new(
                                     ErrorKind::Driver,
-                                    format!("Import failed on table '{table}': {error}"),
+                                    dbflux_i18n::t!(
+                                        "document.import_wizard.toast.table_failed",
+                                        table = table,
+                                        error = error
+                                    ),
                                 ),
                                 cx,
                             );
@@ -575,7 +592,10 @@ impl ImportWizard {
                                 state.complete_task(task_id);
                                 cx.emit(AppStateChanged);
                             });
-                            Toast::success("Import completed").push(cx);
+                            Toast::success(dbflux_i18n::t!(
+                                "document.import_wizard.toast.completed"
+                            ))
+                            .push(cx);
                         }
 
                         this.result_summary = Some(Self::summarize(&outcome));
@@ -587,11 +607,12 @@ impl ImportWizard {
                             state.fail_task(task_id, e.to_string());
                             cx.emit(AppStateChanged);
                         });
-                        report_error(
-                            UserFacingError::new(ErrorKind::Driver, format!("Import failed: {e}")),
-                            cx,
+                        let message = dbflux_i18n::t!(
+                            "document.import_wizard.toast.failed",
+                            error = e.to_string()
                         );
-                        this.result_summary = Some(format!("Import failed: {e}"));
+                        report_error(UserFacingError::new(ErrorKind::Driver, message.clone()), cx);
+                        this.result_summary = Some(message);
                     }
                 }
 
@@ -627,13 +648,7 @@ impl ImportWizard {
             })
             .sum();
 
-        if failed > 0 {
-            format!(
-                "Imported {completed} table(s), {rows} row(s) total ({skipped} skipped, {failed} failed)"
-            )
-        } else {
-            format!("Imported {completed} table(s), {rows} row(s) total ({skipped} skipped)")
-        }
+        crate::labels::import_summary_label(completed, rows, skipped, failed)
     }
 
     /// Renders one status line per planned table when the run left any table
@@ -654,22 +669,12 @@ impl ImportWizard {
             return engine_warnings.to_vec();
         }
 
-        let mut lines: Vec<String> = tables.iter().map(Self::table_status_line).collect();
+        let mut lines: Vec<String> = tables
+            .iter()
+            .map(crate::labels::import_table_status_line)
+            .collect();
         lines.extend(engine_warnings.iter().cloned());
         lines
-    }
-
-    fn table_status_line(table: &ImportedTable) -> String {
-        match &table.status {
-            TableTransferStatus::Completed { rows } => {
-                format!("{}: completed ({rows} row(s))", table.source_table)
-            }
-            TableTransferStatus::Skipped => format!("{}: skipped", table.source_table),
-            TableTransferStatus::Failed { error } => {
-                format!("{}: FAILED — {error}", table.source_table)
-            }
-            TableTransferStatus::NotStarted => format!("{}: not attempted", table.source_table),
-        }
     }
 }
 
@@ -685,7 +690,7 @@ impl Render for ImportWizard {
         };
 
         let mut frame = ModalFrame::new("import-wizard", &self.focus_handle, close)
-            .title("Import Data")
+            .title(dbflux_i18n::t!("document.import_wizard.title"))
             .icon(AppIcon::Download)
             .width(px(720.0))
             .max_height(px(640.0));
@@ -732,9 +737,9 @@ impl ImportWizard {
             .flex_col()
             .gap(Spacing::MD)
             .p(Spacing::MD)
-            .child(Text::body(
-                "Choose the folder that contains manifest.json and the exported table files.",
-            ))
+            .child(Text::body(dbflux_i18n::t!(
+                "document.import_wizard.pick_folder.description"
+            )))
             .when_some(self.manifest_error.clone(), |d, error| {
                 d.child(Text::caption(error))
             })
@@ -742,9 +747,9 @@ impl ImportWizard {
                 Button::new(
                     "import-wizard-choose-folder",
                     if self.loading {
-                        "Reading manifest..."
+                        dbflux_i18n::t!("document.import_wizard.pick_folder.reading_manifest")
                     } else {
-                        "Choose Folder..."
+                        dbflux_i18n::t!("document.import_wizard.pick_folder.choose_folder")
                     },
                 )
                 .disabled(self.loading)
@@ -777,7 +782,7 @@ impl ImportWizard {
                         .child(
                             Button::new(
                                 SharedString::from(format!("import-apply-mapping-{table_index}")),
-                                "Apply Mapping",
+                                dbflux_i18n::t!("document.import_wizard.configure.apply_mapping"),
                             )
                             .ghost()
                             .on_click(cx.listener(
@@ -788,9 +793,9 @@ impl ImportWizard {
                         ),
                 )
                 .when(!unmatched.is_empty(), |d| {
-                    d.child(Text::caption(format!(
-                        "Unmatched source column(s), will be skipped unless remapped: {}",
-                        unmatched.join(", ")
+                    d.child(Text::caption(dbflux_i18n::t!(
+                        "document.import_wizard.configure.unmatched_source",
+                        names = unmatched.join(", ")
                     )))
                 })
                 .into_any_element()
@@ -803,8 +808,11 @@ impl ImportWizard {
             .p(Spacing::MD)
             .children(rows)
             .child(
-                Button::new("import-wizard-continue", "Continue")
-                    .on_click(cx.listener(|this, _, _, cx| this.continue_from_configure(cx))),
+                Button::new(
+                    "import-wizard-continue",
+                    dbflux_i18n::t!("document.import_wizard.configure.continue"),
+                )
+                .on_click(cx.listener(|this, _, _, cx| this.continue_from_configure(cx))),
             )
             .into_any_element()
     }
@@ -822,27 +830,37 @@ impl ImportWizard {
             .flex_col()
             .gap(Spacing::MD)
             .p(Spacing::MD)
-            .child(Text::body(format!(
-                "This will drop-and-recreate or truncate the following table(s) before loading data: {}",
-                destructive_tables.join(", ")
+            .child(Text::body(dbflux_i18n::t!(
+                "document.import_wizard.confirm.body",
+                tables = destructive_tables.join(", ")
             )))
-            .child(Text::caption("This cannot be undone. Confirm to proceed."))
+            .child(Text::caption(dbflux_i18n::t!(
+                "document.import_wizard.confirm.warning"
+            )))
             .child(
                 div()
                     .flex()
                     .gap(Spacing::SM)
                     .child(
-                        Button::new("import-wizard-cancel-confirm", "Back")
-                            .ghost()
-                            .on_click(cx.listener(|this, _, _, cx| {
-                                this.step = WizardStep::Configure;
-                                this.confirmed_destructive = false;
-                                cx.notify();
-                            })),
+                        Button::new(
+                            "import-wizard-cancel-confirm",
+                            dbflux_i18n::t!("document.import_wizard.confirm.back"),
+                        )
+                        .ghost()
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.step = WizardStep::Configure;
+                            this.confirmed_destructive = false;
+                            cx.notify();
+                        })),
                     )
                     .child(
-                        Button::new("import-wizard-confirm-destructive", "Yes, proceed")
-                            .on_click(cx.listener(|this, _, _, cx| this.confirm_destructive_and_run(cx))),
+                        Button::new(
+                            "import-wizard-confirm-destructive",
+                            dbflux_i18n::t!("document.import_wizard.confirm.proceed"),
+                        )
+                        .on_click(
+                            cx.listener(|this, _, _, cx| this.confirm_destructive_and_run(cx)),
+                        ),
                     ),
             )
             .into_any_element()
@@ -851,8 +869,15 @@ impl ImportWizard {
     fn render_running(&self) -> AnyElement {
         let (rows_done, estimated_total) = *self.progress.lock().unwrap_or_else(|p| p.into_inner());
         let label = match estimated_total {
-            Some(total) if total > 0 => format!("{rows_done} / {total} rows"),
-            _ => format!("{rows_done} rows"),
+            Some(total) if total > 0 => dbflux_i18n::t!(
+                "document.import_wizard.running.progress.of_total",
+                done = rows_done,
+                total = total
+            ),
+            _ => dbflux_i18n::t!(
+                "document.import_wizard.running.progress.only",
+                done = rows_done
+            ),
         };
 
         div()
@@ -860,7 +885,9 @@ impl ImportWizard {
             .flex_col()
             .gap(Spacing::MD)
             .p(Spacing::MD)
-            .child(Text::body("Importing..."))
+            .child(Text::body(dbflux_i18n::t!(
+                "document.import_wizard.running.title"
+            )))
             .child(Text::caption(label))
             .into_any_element()
     }
@@ -878,8 +905,11 @@ impl ImportWizard {
                 d.child(Text::caption(self.result_warnings.join("; ")))
             })
             .child(
-                Button::new("import-wizard-close", "Close")
-                    .on_click(cx.listener(|this, _, _, cx| this.close(cx))),
+                Button::new(
+                    "import-wizard-close",
+                    dbflux_i18n::t!("document.import_wizard.done.close"),
+                )
+                .on_click(cx.listener(|this, _, _, cx| this.close(cx))),
             )
             .into_any_element()
     }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1412,6 +1412,96 @@ pub(crate) fn metric_picker_period_not_a_number_error(raw: &str) -> String {
     )
 }
 
+/// Label for a [`dbflux_transfer::TableMappingMode`] shown in the import
+/// wizard's per-table mapping-mode dropdown. Exhaustive by construction so a
+/// new mode fails this crate's build until its catalog key is added here.
+pub(crate) fn import_mapping_mode_label(mode: dbflux_transfer::TableMappingMode) -> String {
+    use dbflux_transfer::TableMappingMode;
+
+    match mode {
+        TableMappingMode::Create => dbflux_i18n::t!("document.import_wizard.mapping_mode.create"),
+        TableMappingMode::Existing => {
+            dbflux_i18n::t!("document.import_wizard.mapping_mode.existing")
+        }
+        TableMappingMode::Recreate => {
+            dbflux_i18n::t!("document.import_wizard.mapping_mode.recreate")
+        }
+        TableMappingMode::Skip => dbflux_i18n::t!("document.import_wizard.mapping_mode.skip"),
+        TableMappingMode::Truncate => {
+            dbflux_i18n::t!("document.import_wizard.mapping_mode.truncate")
+        }
+    }
+}
+
+/// The import wizard's four rail entries (Pick Folder / Configure / Confirm
+/// / Run), in `WizardStep` render order, resolved once through the
+/// translation catalog rather than a `&'static str` array.
+pub(crate) fn import_rail_labels() -> [String; 4] {
+    [
+        dbflux_i18n::t!("document.import_wizard.rail.pick_folder"),
+        dbflux_i18n::t!("document.import_wizard.rail.configure"),
+        dbflux_i18n::t!("document.import_wizard.rail.confirm"),
+        dbflux_i18n::t!("document.import_wizard.rail.run"),
+    ]
+}
+
+/// Terminal summary line for a finished import run, with every count
+/// interpolated. Uses the "with failures" bucket only when at least one
+/// table failed; otherwise the plain bucket.
+pub(crate) fn import_summary_label(
+    completed: usize,
+    rows: u64,
+    skipped: usize,
+    failed: usize,
+) -> String {
+    if failed > 0 {
+        dbflux_i18n::t!(
+            "document.import_wizard.summary.with_failures",
+            completed = completed,
+            rows = rows,
+            skipped = skipped,
+            failed = failed
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.import_wizard.summary.ok",
+            completed = completed,
+            rows = rows,
+            skipped = skipped
+        )
+    }
+}
+
+/// One itemized per-table status line shown when an import run left any
+/// table failed or not started (see
+/// [`crate::import_wizard::ImportWizard::itemized_status_lines`]).
+/// Exhaustive by construction so a new [`dbflux_transfer::TableTransferStatus`]
+/// variant fails this crate's build until its catalog key is added here.
+pub(crate) fn import_table_status_line(table: &dbflux_transfer::import::ImportedTable) -> String {
+    use dbflux_transfer::TableTransferStatus;
+
+    match &table.status {
+        TableTransferStatus::Completed { rows } => dbflux_i18n::t!(
+            "document.import_wizard.status_line.completed",
+            table = table.source_table,
+            rows = rows
+        ),
+        TableTransferStatus::Skipped => dbflux_i18n::t!(
+            "document.import_wizard.status_line.skipped",
+            table = table.source_table
+        ),
+        TableTransferStatus::Failed { error } => dbflux_i18n::t!(
+            "document.import_wizard.status_line.failed",
+            table = table.source_table,
+            error = error
+        ),
+        TableTransferStatus::NotStarted => dbflux_i18n::t!(
+            "document.import_wizard.status_line.not_attempted",
+            table = table.source_table
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1426,8 +1516,9 @@ mod tests {
         delete_prefix_delete_button_label, delete_prefix_deleted_toast, delete_prefix_probe_totals,
         delete_rows_label, execution_count_state_label, execution_mode_label,
         history_items_count_label, history_tab_label, image_decode_error, image_header_error,
-        incomplete_aggregate_rows_label, join_kind_label, live_output_lines_label,
-        live_output_truncated_label, metric_picker_custom_dropdown_label,
+        import_mapping_mode_label, import_rail_labels, import_summary_label,
+        import_table_status_line, incomplete_aggregate_rows_label, join_kind_label,
+        live_output_lines_label, live_output_truncated_label, metric_picker_custom_dropdown_label,
         metric_picker_dimensions_error_label, metric_picker_period_error_label,
         metric_picker_period_not_a_number_error, metric_picker_statistic_error_label,
         object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
@@ -3976,5 +4067,187 @@ mod tests {
             let es = dbflux_i18n::t!(key, locale = "es");
             assert_ne!(en, es, "{key} must differ between en and es");
         }
+    }
+
+    // ── PR 26a: import_wizard/*.rs ───────────────────────────────────────
+
+    const IMPORT_WIZARD_KEYS: &[&str] = &[
+        "document.import_wizard.title",
+        "document.import_wizard.rail.pick_folder",
+        "document.import_wizard.rail.configure",
+        "document.import_wizard.rail.confirm",
+        "document.import_wizard.rail.run",
+        "document.import_wizard.pick_folder.description",
+        "document.import_wizard.pick_folder.choose_folder",
+        "document.import_wizard.pick_folder.reading_manifest",
+        "document.import_wizard.pick_folder.dialog_title",
+        "document.import_wizard.pick_folder.error.no_connection",
+        "document.import_wizard.pick_folder.error.no_dialog",
+        "document.import_wizard.pick_folder.error.invalid_bundle",
+        "document.import_wizard.configure.mode_placeholder",
+        "document.import_wizard.configure.target_placeholder",
+        "document.import_wizard.configure.source_placeholder",
+        "document.import_wizard.configure.source_unset",
+        "document.import_wizard.configure.apply_mapping",
+        "document.import_wizard.configure.continue",
+        "document.import_wizard.configure.unmatched_source",
+        "document.import_wizard.mapping_mode.create",
+        "document.import_wizard.mapping_mode.existing",
+        "document.import_wizard.mapping_mode.recreate",
+        "document.import_wizard.mapping_mode.skip",
+        "document.import_wizard.mapping_mode.truncate",
+        "document.import_wizard.confirm.body",
+        "document.import_wizard.confirm.warning",
+        "document.import_wizard.confirm.back",
+        "document.import_wizard.confirm.proceed",
+        "document.import_wizard.running.title",
+        "document.import_wizard.running.progress.of_total",
+        "document.import_wizard.running.progress.only",
+        "document.import_wizard.done.close",
+        "document.import_wizard.error.no_connection",
+        "document.import_wizard.toast.cancelled",
+        "document.import_wizard.toast.completed",
+        "document.import_wizard.toast.table_failed",
+        "document.import_wizard.toast.failed",
+        "document.import_wizard.summary.with_failures",
+        "document.import_wizard.summary.ok",
+        "document.import_wizard.status_line.completed",
+        "document.import_wizard.status_line.skipped",
+        "document.import_wizard.status_line.failed",
+        "document.import_wizard.status_line.not_attempted",
+    ];
+
+    /// PR 26a: every `document.import_wizard.*` key resolves to a
+    /// non-empty, non-fallback value in both locales.
+    #[test]
+    fn import_wizard_keys_resolve_in_both_locales() {
+        for key in IMPORT_WIZARD_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// PR 26a: a representative sample of `document.import_wizard.*` keys
+    /// diverges between locales.
+    #[test]
+    fn import_wizard_keys_differ_between_locales() {
+        for key in [
+            "document.import_wizard.title",
+            "document.import_wizard.pick_folder.choose_folder",
+            "document.import_wizard.configure.continue",
+            "document.import_wizard.confirm.proceed",
+            "document.import_wizard.running.title",
+            "document.import_wizard.done.close",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
+    }
+
+    /// PR 26a: `import_mapping_mode_label` covers every
+    /// `TableMappingMode` variant (exhaustive match, no wildcard arm — a
+    /// new variant fails the build until its catalog key is added here).
+    #[test]
+    fn import_mapping_mode_label_covers_all_variants() {
+        use dbflux_transfer::TableMappingMode;
+
+        let modes = [
+            TableMappingMode::Create,
+            TableMappingMode::Existing,
+            TableMappingMode::Recreate,
+            TableMappingMode::Skip,
+            TableMappingMode::Truncate,
+        ];
+        for mode in modes {
+            let label = import_mapping_mode_label(mode);
+            assert!(
+                !label.is_empty(),
+                "import_mapping_mode_label({mode:?}) resolved empty"
+            );
+        }
+
+        assert_eq!(
+            import_mapping_mode_label(TableMappingMode::Create),
+            dbflux_i18n::t!("document.import_wizard.mapping_mode.create")
+        );
+    }
+
+    /// PR 26a: `import_mapping_mode_label` diverges between locales.
+    #[test]
+    fn import_mapping_mode_label_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.import_wizard.mapping_mode.recreate",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.import_wizard.mapping_mode.recreate",
+            locale = "es"
+        );
+        assert_ne!(en, es);
+    }
+
+    /// PR 26a: `import_summary_label` picks the "with failures" bucket only
+    /// when `failed > 0`, and interpolates every count.
+    #[test]
+    fn import_summary_label_switches_bucket_on_failed_count() {
+        let ok = import_summary_label(3, 120, 1, 0);
+        assert!(ok.contains('3') && ok.contains("120") && ok.contains('1'));
+        assert!(!ok.to_lowercase().contains("fail"));
+
+        let with_failures = import_summary_label(2, 40, 1, 1);
+        assert!(with_failures.contains('2') && with_failures.contains("40"));
+        assert!(with_failures.to_lowercase().contains("fail"));
+    }
+
+    /// PR 26a: `import_table_status_line` covers every `TableTransferStatus`
+    /// variant (exhaustive match, no wildcard arm).
+    #[test]
+    fn import_table_status_line_covers_all_variants() {
+        use dbflux_transfer::TableTransferStatus;
+        use dbflux_transfer::import::ImportedTable;
+
+        let statuses = [
+            TableTransferStatus::Completed { rows: 5 },
+            TableTransferStatus::Skipped,
+            TableTransferStatus::Failed {
+                error: "boom".to_string(),
+            },
+            TableTransferStatus::NotStarted,
+        ];
+        for status in statuses {
+            let table = ImportedTable {
+                source_table: "users".to_string(),
+                target_table: "users".to_string(),
+                status,
+            };
+            let line = import_table_status_line(&table);
+            assert!(!line.is_empty());
+            assert!(line.contains("users"));
+        }
+    }
+
+    /// PR 26a: `import_rail_labels` returns four non-empty, locale-resolved
+    /// labels matching `WizardStep`'s render order.
+    #[test]
+    fn import_rail_labels_resolves_four_non_empty_labels() {
+        let labels = import_rail_labels();
+        assert_eq!(labels.len(), 4);
+        for label in &labels {
+            assert!(!label.is_empty());
+        }
+        assert_eq!(
+            labels[0],
+            dbflux_i18n::t!("document.import_wizard.rail.pick_folder")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 26a: the import wizard (modal title, rail labels, pick-folder, configure with mapping modes, confirm, running, done, toasts, summaries and per-table status lines) renders through `dbflux_i18n::t!` under `document.import_wizard.*`. English and Spanish together. Table and column names, file paths and formats stay data.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `mapping_mode_options` widens to `Vec<(String, TableMappingMode)>` through an exhaustive `import_mapping_mode_label`; `RAIL_LABELS` becomes `import_rail_labels()`; `import_table_status_line` is exhaustive over the four statuses.
- Size: 619 lines in one namespace boundary (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1075 passed; clippy clean; fmt clean. Manual smoke in Spanish: run the import wizard end to end (pick folder, map columns, confirm).
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
