### PR TITLE
feat(i18n): translate the export wizard phases, steps, run summaries, and toasts

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -986,6 +986,61 @@ document:
         column: COLUMN
         references: REFERENCES
         row: ROW
+  export_wizard:
+    title: Export Data
+    rail:
+      tables: Tables
+      format_options: Format & Options
+      confirm: Confirm
+      run: Run
+    tables:
+      selected_count: "%{count} table(s) selected for export"
+    format_options:
+      format_label: Format
+      output_folder_label: Output folder
+      no_folder_chosen: No folder chosen
+      choose_folder: "Choose Folder..."
+      choosing: "Choosing..."
+      dialog_title: Choose Export Folder
+      segment_size_label: Segment / chunk size (advanced)
+      segment_size_placeholder: Segment / chunk size
+      segment_size_invalid: "Must be a whole number of 1 or more; kept the previous value."
+      error:
+        no_dialog_fallback_failed: "No folder picker available and the fallback export directory could not be created: %{error}"
+    confirm:
+      title: Review export plan
+      summary: "%{count} table(s) as %{format} to %{folder}"
+      segment_size: "Segment / chunk size: %{size}"
+      start_export: Start Export
+    running:
+      title: "Exporting..."
+      position:
+        of_total: "Table %{index} of %{total}"
+        preparing: Preparing
+      progress:
+        of_total: "%{done} / %{total} rows"
+        only: "%{done} rows"
+      cancel: Cancel
+    error:
+      no_connection: No active connection for this export
+    toast:
+      cancelled: Export cancelled
+      success: "%{summary}. Saved to %{folder}"
+      schema_fetch_failed: "Export failed while reading table schema: %{error}"
+      table_failed: "Export failed on table '%{table}': %{error}"
+      failed: "Export failed: %{error}"
+    summary:
+      with_failures: "Exported %{completed} table(s), %{rows} row(s) total (%{skipped} skipped, %{failed} failed)"
+      ok: "Exported %{completed} table(s), %{rows} row(s) total (%{skipped} skipped)"
+    status_line:
+      completed: "%{table}: completed (%{rows} row(s))"
+      skipped: "%{table}: skipped"
+      failed: "%{table}: FAILED — %{error}"
+      not_attempted: "%{table}: not attempted"
+    footer:
+      back: Back
+      continue: Continue
+      close: Close
   import_wizard:
     title: Import Data
     rail:

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -986,6 +986,61 @@ document:
         column: COLUMNA
         references: REFERENCIAS
         row: FILA
+  export_wizard:
+    title: Exportar datos
+    rail:
+      tables: Tablas
+      format_options: Formato y opciones
+      confirm: Confirmar
+      run: Ejecutar
+    tables:
+      selected_count: "%{count} tabla(s) seleccionada(s) para exportar"
+    format_options:
+      format_label: Formato
+      output_folder_label: Carpeta de destino
+      no_folder_chosen: Ninguna carpeta elegida
+      choose_folder: "Elegir carpeta…"
+      choosing: "Eligiendo…"
+      dialog_title: Elegir carpeta de exportación
+      segment_size_label: Tamaño de segmento / bloque (avanzado)
+      segment_size_placeholder: Tamaño de segmento / bloque
+      segment_size_invalid: "Debe ser un número entero de 1 o más; se mantuvo el valor anterior."
+      error:
+        no_dialog_fallback_failed: "No hay selector de carpetas disponible y no se pudo crear la carpeta de exportación de respaldo: %{error}"
+    confirm:
+      title: Revisar plan de exportación
+      summary: "%{count} tabla(s) como %{format} hacia %{folder}"
+      segment_size: "Tamaño de segmento / bloque: %{size}"
+      start_export: Iniciar exportación
+    running:
+      title: "Exportando…"
+      position:
+        of_total: "Tabla %{index} de %{total}"
+        preparing: Preparando
+      progress:
+        of_total: "%{done} / %{total} filas"
+        only: "%{done} filas"
+      cancel: Cancelar
+    error:
+      no_connection: No hay una conexión activa para esta exportación
+    toast:
+      cancelled: Exportación cancelada
+      success: "%{summary}. Guardado en %{folder}"
+      schema_fetch_failed: "La exportación falló al leer el esquema de la tabla: %{error}"
+      table_failed: "La exportación falló en la tabla «%{table}»: %{error}"
+      failed: "Error al exportar: %{error}"
+    summary:
+      with_failures: "Se exportaron %{completed} tabla(s), %{rows} fila(s) en total (%{skipped} omitida(s), %{failed} fallida(s))"
+      ok: "Se exportaron %{completed} tabla(s), %{rows} fila(s) en total (%{skipped} omitida(s))"
+    status_line:
+      completed: "%{table}: completada (%{rows} fila(s))"
+      skipped: "%{table}: omitida"
+      failed: "%{table}: FALLIDA — %{error}"
+      not_attempted: "%{table}: no intentada"
+    footer:
+      back: Atrás
+      continue: Continuar
+      close: Cerrar
   import_wizard:
     title: Importar datos
     rail:

--- a/crates/dbflux_ui_document/src/export_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/export_wizard/mod.rs
@@ -103,7 +103,9 @@ impl ExportWizard {
             Dropdown::new("export-wizard-format")
                 .items(format_items())
                 .selected_index(Some(0))
-                .placeholder("Format")
+                .placeholder(dbflux_i18n::t!(
+                    "document.export_wizard.format_options.format_label"
+                ))
         });
         let format_dropdown_sub = cx.subscribe(
             &format_dropdown,
@@ -116,7 +118,9 @@ impl ExportWizard {
         let segment_size_input = cx.new(|cx| {
             InputState::new(window, cx)
                 .default_value(phases::DEFAULT_SEGMENT_SIZE.to_string())
-                .placeholder("Segment / chunk size")
+                .placeholder(dbflux_i18n::t!(
+                    "document.export_wizard.format_options.segment_size_placeholder"
+                ))
         });
         let segment_size_sub = cx.subscribe_in(
             &segment_size_input,
@@ -274,7 +278,7 @@ impl ExportWizard {
         cx.spawn(async move |this, cx| {
             let picked = if dialog_available {
                 rfd::AsyncFileDialog::new()
-                    .set_title("Choose Export Folder")
+                    .set_title(dbflux_i18n::t!("document.export_wizard.format_options.dialog_title"))
                     .pick_folder()
                     .await
                     .map(|handle| handle.path().to_path_buf())
@@ -284,9 +288,9 @@ impl ExportWizard {
                     Err(err) => {
                         this.update(cx, |this, cx| {
                             this.choosing_folder = false;
-                            this.folder_error = Some(format!(
-                                "No folder picker available and the fallback export \
-                                 directory could not be created: {err}"
+                            this.folder_error = Some(dbflux_i18n::t!(
+                                "document.export_wizard.format_options.error.no_dialog_fallback_failed",
+                                error = err
                             ));
                             cx.notify();
                         })
@@ -361,7 +365,7 @@ impl Render for ExportWizard {
         };
 
         let frame = ModalFrame::new("export-wizard", &self.focus_handle, close)
-            .title("Export Data")
+            .title(dbflux_i18n::t!("document.export_wizard.title"))
             .icon(AppIcon::ArrowUp)
             .width(px(720.0))
             .height_fraction(0.7)
@@ -429,9 +433,9 @@ impl ExportWizard {
             .flex_col()
             .gap(Spacing::MD)
             .size_full()
-            .child(Text::label(format!(
-                "{} table(s) selected for export",
-                self.tables.len()
+            .child(Text::label(dbflux_i18n::t!(
+                "document.export_wizard.tables.selected_count",
+                count = self.tables.len()
             )))
             .child(
                 div()
@@ -448,11 +452,10 @@ impl ExportWizard {
     }
 
     fn render_format_options(&self, cx: &mut Context<Self>) -> AnyElement {
-        let folder_label = self
-            .output_dir
-            .as_ref()
-            .map(|dir| dir.display().to_string())
-            .unwrap_or_else(|| "No folder chosen".to_string());
+        let folder_label = self.output_dir.as_ref().map_or_else(
+            || dbflux_i18n::t!("document.export_wizard.format_options.no_folder_chosen"),
+            |dir| dir.display().to_string(),
+        );
 
         div()
             .flex()
@@ -463,7 +466,9 @@ impl ExportWizard {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Text::label("Format"))
+                    .child(Text::label(dbflux_i18n::t!(
+                        "document.export_wizard.format_options.format_label"
+                    )))
                     .child(self.format_dropdown.clone()),
             )
             .child(
@@ -471,15 +476,19 @@ impl ExportWizard {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Text::label("Output folder"))
+                    .child(Text::label(dbflux_i18n::t!(
+                        "document.export_wizard.format_options.output_folder_label"
+                    )))
                     .child(Text::caption(folder_label))
                     .child(
                         Button::new(
                             "export-wizard-choose-folder",
                             if self.choosing_folder {
-                                "Choosing…"
+                                dbflux_i18n::t!("document.export_wizard.format_options.choosing")
                             } else {
-                                "Choose Folder…"
+                                dbflux_i18n::t!(
+                                    "document.export_wizard.format_options.choose_folder"
+                                )
                             },
                         )
                         .small()
@@ -495,7 +504,9 @@ impl ExportWizard {
                     .flex()
                     .flex_col()
                     .gap(Spacing::XS)
-                    .child(Text::label("Segment / chunk size (advanced)"))
+                    .child(Text::label(dbflux_i18n::t!(
+                        "document.export_wizard.format_options.segment_size_label"
+                    )))
                     .child(
                         div()
                             .w(SEGMENT_SIZE_INPUT_WIDTH)
@@ -503,9 +514,9 @@ impl ExportWizard {
                     )
                     .when(self.segment_size_invalid, |parent| {
                         parent.child(
-                            Text::caption(
-                                "Must be a whole number of 1 or more; kept the previous value.",
-                            )
+                            Text::caption(dbflux_i18n::t!(
+                                "document.export_wizard.format_options.segment_size_invalid"
+                            ))
                             .danger(),
                         )
                     }),
@@ -524,22 +535,28 @@ impl ExportWizard {
             .flex()
             .flex_col()
             .gap(Spacing::MD)
-            .child(Text::label("Review export plan"))
-            .child(Text::caption(format!(
-                "{} table(s) as {} to {folder_label}",
-                self.tables.len(),
-                self.selected_format().label(),
+            .child(Text::label(dbflux_i18n::t!(
+                "document.export_wizard.confirm.title"
             )))
-            .child(Text::caption(format!(
-                "Segment / chunk size: {}",
-                self.segment_size
+            .child(Text::caption(dbflux_i18n::t!(
+                "document.export_wizard.confirm.summary",
+                count = self.tables.len(),
+                format = self.selected_format().label(),
+                folder = folder_label
+            )))
+            .child(Text::caption(dbflux_i18n::t!(
+                "document.export_wizard.confirm.segment_size",
+                size = self.segment_size
             )))
             .child(
                 div().flex().justify_end().child(
-                    Button::new("export-wizard-start", "Start Export")
-                        .small()
-                        .primary()
-                        .on_click(cx.listener(|this, _event, _window, cx| this.start_export(cx))),
+                    Button::new(
+                        "export-wizard-start",
+                        dbflux_i18n::t!("document.export_wizard.confirm.start_export"),
+                    )
+                    .small()
+                    .primary()
+                    .on_click(cx.listener(|this, _event, _window, cx| this.start_export(cx))),
                 ),
             )
             .into_any_element()
@@ -560,29 +577,29 @@ impl ExportWizard {
         let current_index = progress.table_index.min(total_tables.saturating_sub(1));
         let current_table = names.get(current_index).cloned().unwrap_or_default();
 
-        let rows_label = match progress.estimated_total {
-            Some(total) if total > 0 => format!("{} / {} rows", progress.rows_done, total),
-            _ => format!("{} rows", progress.rows_done),
-        };
-        let position_label = if total_tables > 0 {
-            format!("Table {} of {}", current_index + 1, total_tables)
-        } else {
-            "Preparing".to_string()
-        };
+        let rows_label =
+            crate::labels::export_running_rows_label(progress.rows_done, progress.estimated_total);
+        let position_label =
+            crate::labels::export_running_position_label(current_index, total_tables);
 
         div()
             .flex()
             .flex_col()
             .gap(Spacing::MD)
-            .child(Text::label("Exporting…"))
+            .child(Text::label(dbflux_i18n::t!(
+                "document.export_wizard.running.title"
+            )))
             .child(Text::caption(format!("{position_label}: {current_table}")))
             .child(Text::caption(rows_label).muted_foreground())
             .child(
                 div().flex().justify_end().child(
-                    Button::new("export-wizard-cancel", "Cancel")
-                        .small()
-                        .ghost()
-                        .on_click(cx.listener(|this, _event, _window, cx| this.cancel_run(cx))),
+                    Button::new(
+                        "export-wizard-cancel",
+                        dbflux_i18n::t!("document.export_wizard.running.cancel"),
+                    )
+                    .small()
+                    .ghost()
+                    .on_click(cx.listener(|this, _event, _window, cx| this.cancel_run(cx))),
                 ),
             )
             .into_any_element()
@@ -620,27 +637,36 @@ impl ExportWizard {
             .gap(Spacing::SM)
             .when(shows_back, |parent| {
                 parent.child(
-                    Button::new("export-wizard-back", "Back")
-                        .small()
-                        .ghost()
-                        .on_click(cx.listener(|this, _event, _window, cx| this.go_back(cx))),
+                    Button::new(
+                        "export-wizard-back",
+                        dbflux_i18n::t!("document.export_wizard.footer.back"),
+                    )
+                    .small()
+                    .ghost()
+                    .on_click(cx.listener(|this, _event, _window, cx| this.go_back(cx))),
                 )
             })
             .when(shows_continue, |parent| {
                 parent.child(
-                    Button::new("export-wizard-continue", "Continue")
-                        .small()
-                        .primary()
-                        .disabled(!continue_enabled)
-                        .on_click(cx.listener(|this, _event, _window, cx| this.advance(cx))),
+                    Button::new(
+                        "export-wizard-continue",
+                        dbflux_i18n::t!("document.export_wizard.footer.continue"),
+                    )
+                    .small()
+                    .primary()
+                    .disabled(!continue_enabled)
+                    .on_click(cx.listener(|this, _event, _window, cx| this.advance(cx))),
                 )
             })
             .when(done, |parent| {
                 parent.child(
-                    Button::new("export-wizard-close", "Close")
-                        .small()
-                        .primary()
-                        .on_click(cx.listener(|this, _event, _window, cx| this.close(cx))),
+                    Button::new(
+                        "export-wizard-close",
+                        dbflux_i18n::t!("document.export_wizard.footer.close"),
+                    )
+                    .small()
+                    .primary()
+                    .on_click(cx.listener(|this, _event, _window, cx| this.close(cx))),
                 )
             });
 

--- a/crates/dbflux_ui_document/src/export_wizard/phases.rs
+++ b/crates/dbflux_ui_document/src/export_wizard/phases.rs
@@ -20,13 +20,18 @@ pub enum ExportPhase {
 }
 
 impl ExportPhase {
-    /// The rail's display label for this phase.
-    pub fn label(self) -> &'static str {
+    /// The rail's display label for this phase, resolved through the
+    /// translation catalog. Exhaustive by construction so a new phase fails
+    /// this crate's build until its `document.export_wizard.rail.*` entry is
+    /// added here.
+    pub fn label(self) -> String {
         match self {
-            ExportPhase::Tables => "Tables",
-            ExportPhase::FormatOptions => "Format & Options",
-            ExportPhase::Confirm => "Confirm",
-            ExportPhase::Run => "Run",
+            ExportPhase::Tables => dbflux_i18n::t!("document.export_wizard.rail.tables"),
+            ExportPhase::FormatOptions => {
+                dbflux_i18n::t!("document.export_wizard.rail.format_options")
+            }
+            ExportPhase::Confirm => dbflux_i18n::t!("document.export_wizard.rail.confirm"),
+            ExportPhase::Run => dbflux_i18n::t!("document.export_wizard.rail.run"),
         }
     }
 }
@@ -128,10 +133,74 @@ mod tests {
 
     #[test]
     fn phase_labels_cover_every_rail_entry() {
-        assert_eq!(ExportPhase::Tables.label(), "Tables");
-        assert_eq!(ExportPhase::FormatOptions.label(), "Format & Options");
-        assert_eq!(ExportPhase::Confirm.label(), "Confirm");
-        assert_eq!(ExportPhase::Run.label(), "Run");
+        assert_eq!(
+            ExportPhase::Tables.label(),
+            dbflux_i18n::t!("document.export_wizard.rail.tables")
+        );
+        assert_eq!(
+            ExportPhase::FormatOptions.label(),
+            dbflux_i18n::t!("document.export_wizard.rail.format_options")
+        );
+        assert_eq!(
+            ExportPhase::Confirm.label(),
+            dbflux_i18n::t!("document.export_wizard.rail.confirm")
+        );
+        assert_eq!(
+            ExportPhase::Run.label(),
+            dbflux_i18n::t!("document.export_wizard.rail.run")
+        );
+    }
+
+    /// Every `document.export_wizard.rail.*` key resolves to a non-empty,
+    /// non-fallback value in both locales — exhaustive over every
+    /// `ExportPhase` variant (no wildcard arm in `label()`).
+    #[test]
+    fn phase_labels_resolve_in_both_locales() {
+        for phase in RAIL_PHASES {
+            for locale in ["en", "es"] {
+                let key = match phase {
+                    ExportPhase::Tables => "document.export_wizard.rail.tables",
+                    ExportPhase::FormatOptions => "document.export_wizard.rail.format_options",
+                    ExportPhase::Confirm => "document.export_wizard.rail.confirm",
+                    ExportPhase::Run => "document.export_wizard.rail.run",
+                };
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// Every rail phase label diverges between locales.
+    #[test]
+    fn phase_labels_differ_between_locales() {
+        for phase in RAIL_PHASES {
+            let en = dbflux_i18n::t!(
+                match phase {
+                    ExportPhase::Tables => "document.export_wizard.rail.tables",
+                    ExportPhase::FormatOptions => "document.export_wizard.rail.format_options",
+                    ExportPhase::Confirm => "document.export_wizard.rail.confirm",
+                    ExportPhase::Run => "document.export_wizard.rail.run",
+                },
+                locale = "en"
+            );
+            let es = dbflux_i18n::t!(
+                match phase {
+                    ExportPhase::Tables => "document.export_wizard.rail.tables",
+                    ExportPhase::FormatOptions => "document.export_wizard.rail.format_options",
+                    ExportPhase::Confirm => "document.export_wizard.rail.confirm",
+                    ExportPhase::Run => "document.export_wizard.rail.run",
+                },
+                locale = "es"
+            );
+            assert_ne!(en, es, "{phase:?} rail label must differ between en and es");
+        }
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/export_wizard/run.rs
+++ b/crates/dbflux_ui_document/src/export_wizard/run.rs
@@ -28,6 +28,7 @@ use gpui::*;
 
 use crate::export_wizard::ExportWizard;
 use crate::export_wizard::phases::{ExportPhase, RunState};
+use crate::labels::{export_summary_label, export_table_status_line};
 
 /// Live counters for the running export: which table (by the wizard's fixed
 /// table order) is currently streaming, and its row progress — mirrors the
@@ -140,7 +141,7 @@ fn resolve_run_outcome(result: Result<ExportOutcome, TransferError>) -> RunResol
             task_action_details: None,
             report: None,
             toast_success: false,
-            summary: "Export cancelled".to_string(),
+            summary: dbflux_i18n::t!("document.export_wizard.toast.cancelled"),
             warnings: Vec::new(),
         },
         Ok(outcome) => {
@@ -156,7 +157,11 @@ fn resolve_run_outcome(result: Result<ExportOutcome, TransferError>) -> RunResol
                 Some((table, error)) => RunResolution {
                     task_action: RunTaskAction::Fail(format!("{table}: {error}")),
                     task_action_details: Some(itemized_table_details(&outcome.tables)),
-                    report: Some(format!("Export failed on table '{table}': {error}")),
+                    report: Some(dbflux_i18n::t!(
+                        "document.export_wizard.toast.table_failed",
+                        table = table,
+                        error = error
+                    )),
                     toast_success: false,
                     summary,
                     warnings,
@@ -172,7 +177,7 @@ fn resolve_run_outcome(result: Result<ExportOutcome, TransferError>) -> RunResol
             }
         }
         Err(e) => {
-            let message = format!("Export failed: {e}");
+            let message = dbflux_i18n::t!("document.export_wizard.toast.failed", error = e);
             RunResolution {
                 task_action: RunTaskAction::Fail(e.to_string()),
                 task_action_details: None,
@@ -210,13 +215,7 @@ fn summarize(outcome: &ExportOutcome) -> String {
         })
         .sum();
 
-    if failed > 0 {
-        format!(
-            "Exported {completed} table(s), {rows} row(s) total ({skipped} skipped, {failed} failed)"
-        )
-    } else {
-        format!("Exported {completed} table(s), {rows} row(s) total ({skipped} skipped)")
-    }
+    export_summary_label(completed, rows, skipped, failed)
 }
 
 /// Renders one status line per planned table when the run left any table
@@ -243,12 +242,7 @@ fn itemized_status_lines(tables: &[ExportedTable], engine_warnings: &[String]) -
 
 fn table_status_line(table: &ExportedTable) -> String {
     let label = table_label(&table.schema, &table.name);
-    match &table.status {
-        TableTransferStatus::Completed { rows } => format!("{label}: completed ({rows} row(s))"),
-        TableTransferStatus::Skipped => format!("{label}: skipped"),
-        TableTransferStatus::Failed { error } => format!("{label}: FAILED — {error}"),
-        TableTransferStatus::NotStarted => format!("{label}: not attempted"),
-    }
+    export_table_status_line(&label, &table.status)
 }
 
 /// Renders the Tasks panel's expandable per-table details for a failed run.
@@ -272,7 +266,10 @@ impl ExportWizard {
 
         let Some(connection) = self.resolve_connection(cx) else {
             report_error(
-                UserFacingError::new(ErrorKind::Storage, "No active connection for this export"),
+                UserFacingError::new(
+                    ErrorKind::Storage,
+                    dbflux_i18n::t!("document.export_wizard.error.no_connection"),
+                ),
                 cx,
             );
             return;
@@ -334,7 +331,10 @@ impl ExportWizard {
                             report_error(
                                 UserFacingError::new(
                                     ErrorKind::Driver,
-                                    format!("Export failed while reading table schema: {err}"),
+                                    dbflux_i18n::t!(
+                                        "document.export_wizard.toast.schema_fetch_failed",
+                                        error = err
+                                    ),
                                 ),
                                 cx,
                             );
@@ -344,7 +344,10 @@ impl ExportWizard {
                         this.update(cx, |this, cx| {
                             this.run_state = RunState::Done;
                             this.cancel_token = None;
-                            this.result_summary = Some(format!("Export failed: {err}"));
+                            this.result_summary = Some(dbflux_i18n::t!(
+                                "document.export_wizard.toast.failed",
+                                error = err
+                            ));
                             cx.notify();
                         })
                         .ok();
@@ -507,9 +510,10 @@ impl ExportWizard {
                     report_error(UserFacingError::new(ErrorKind::Driver, message.clone()), cx);
                 }
                 if toast_success {
-                    Toast::success(format!(
-                        "{summary}. Saved to {}",
-                        output_dir_for_toast.display()
+                    Toast::success(dbflux_i18n::t!(
+                        "document.export_wizard.toast.success",
+                        summary = summary,
+                        folder = output_dir_for_toast.display().to_string()
                     ))
                     .push(cx);
                 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1502,6 +1502,95 @@ pub(crate) fn import_table_status_line(table: &dbflux_transfer::import::Imported
     }
 }
 
+/// Terminal summary line for a finished export run, with every count
+/// interpolated. Uses the "with failures" bucket only when at least one
+/// table failed; otherwise the plain bucket.
+pub(crate) fn export_summary_label(
+    completed: usize,
+    rows: u64,
+    skipped: usize,
+    failed: usize,
+) -> String {
+    if failed > 0 {
+        dbflux_i18n::t!(
+            "document.export_wizard.summary.with_failures",
+            completed = completed,
+            rows = rows,
+            skipped = skipped,
+            failed = failed
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.export_wizard.summary.ok",
+            completed = completed,
+            rows = rows,
+            skipped = skipped
+        )
+    }
+}
+
+/// One itemized per-table status line shown when an export run left any
+/// table failed or not started (see
+/// [`crate::export_wizard::run::itemized_status_lines`]). Exhaustive by
+/// construction so a new [`dbflux_transfer::TableTransferStatus`] variant
+/// fails this crate's build until its catalog key is added here.
+pub(crate) fn export_table_status_line(
+    label: &str,
+    status: &dbflux_transfer::TableTransferStatus,
+) -> String {
+    use dbflux_transfer::TableTransferStatus;
+
+    match status {
+        TableTransferStatus::Completed { rows } => dbflux_i18n::t!(
+            "document.export_wizard.status_line.completed",
+            table = label,
+            rows = rows
+        ),
+        TableTransferStatus::Skipped => {
+            dbflux_i18n::t!("document.export_wizard.status_line.skipped", table = label)
+        }
+        TableTransferStatus::Failed { error } => dbflux_i18n::t!(
+            "document.export_wizard.status_line.failed",
+            table = label,
+            error = error
+        ),
+        TableTransferStatus::NotStarted => dbflux_i18n::t!(
+            "document.export_wizard.status_line.not_attempted",
+            table = label
+        ),
+    }
+}
+
+/// The export wizard's running phase "Table N of M" position line, or the
+/// "Preparing" fallback before the first table starts (`total_tables == 0`).
+pub(crate) fn export_running_position_label(current_index: usize, total_tables: usize) -> String {
+    if total_tables > 0 {
+        dbflux_i18n::t!(
+            "document.export_wizard.running.position.of_total",
+            index = current_index + 1,
+            total = total_tables
+        )
+    } else {
+        dbflux_i18n::t!("document.export_wizard.running.position.preparing")
+    }
+}
+
+/// The export wizard's running phase row-count line: `"done / total rows"`
+/// once the engine reports an estimate, otherwise just `"done rows"`.
+pub(crate) fn export_running_rows_label(rows_done: u64, estimated_total: Option<u64>) -> String {
+    match estimated_total {
+        Some(total) if total > 0 => dbflux_i18n::t!(
+            "document.export_wizard.running.progress.of_total",
+            done = rows_done,
+            total = total
+        ),
+        _ => dbflux_i18n::t!(
+            "document.export_wizard.running.progress.only",
+            done = rows_done
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1515,8 +1604,9 @@ mod tests {
         dangerous_query_body, dangerous_query_title, delete_confirm_copy,
         delete_prefix_delete_button_label, delete_prefix_deleted_toast, delete_prefix_probe_totals,
         delete_rows_label, execution_count_state_label, execution_mode_label,
-        history_items_count_label, history_tab_label, image_decode_error, image_header_error,
-        import_mapping_mode_label, import_rail_labels, import_summary_label,
+        export_running_position_label, export_running_rows_label, export_summary_label,
+        export_table_status_line, history_items_count_label, history_tab_label, image_decode_error,
+        image_header_error, import_mapping_mode_label, import_rail_labels, import_summary_label,
         import_table_status_line, incomplete_aggregate_rows_label, join_kind_label,
         live_output_lines_label, live_output_truncated_label, metric_picker_custom_dropdown_label,
         metric_picker_dimensions_error_label, metric_picker_period_error_label,
@@ -4249,5 +4339,154 @@ mod tests {
             labels[0],
             dbflux_i18n::t!("document.import_wizard.rail.pick_folder")
         );
+    }
+
+    // ── PR 26b: export_wizard/*.rs ───────────────────────────────────────
+
+    const EXPORT_WIZARD_KEYS: &[&str] = &[
+        "document.export_wizard.title",
+        "document.export_wizard.rail.tables",
+        "document.export_wizard.rail.format_options",
+        "document.export_wizard.rail.confirm",
+        "document.export_wizard.rail.run",
+        "document.export_wizard.tables.selected_count",
+        "document.export_wizard.format_options.format_label",
+        "document.export_wizard.format_options.output_folder_label",
+        "document.export_wizard.format_options.no_folder_chosen",
+        "document.export_wizard.format_options.choose_folder",
+        "document.export_wizard.format_options.choosing",
+        "document.export_wizard.format_options.dialog_title",
+        "document.export_wizard.format_options.segment_size_label",
+        "document.export_wizard.format_options.segment_size_placeholder",
+        "document.export_wizard.format_options.segment_size_invalid",
+        "document.export_wizard.format_options.error.no_dialog_fallback_failed",
+        "document.export_wizard.confirm.title",
+        "document.export_wizard.confirm.summary",
+        "document.export_wizard.confirm.segment_size",
+        "document.export_wizard.confirm.start_export",
+        "document.export_wizard.running.title",
+        "document.export_wizard.running.position.of_total",
+        "document.export_wizard.running.position.preparing",
+        "document.export_wizard.running.progress.of_total",
+        "document.export_wizard.running.progress.only",
+        "document.export_wizard.running.cancel",
+        "document.export_wizard.error.no_connection",
+        "document.export_wizard.toast.cancelled",
+        "document.export_wizard.toast.success",
+        "document.export_wizard.toast.schema_fetch_failed",
+        "document.export_wizard.toast.table_failed",
+        "document.export_wizard.toast.failed",
+        "document.export_wizard.summary.with_failures",
+        "document.export_wizard.summary.ok",
+        "document.export_wizard.status_line.completed",
+        "document.export_wizard.status_line.skipped",
+        "document.export_wizard.status_line.failed",
+        "document.export_wizard.status_line.not_attempted",
+        "document.export_wizard.footer.back",
+        "document.export_wizard.footer.continue",
+        "document.export_wizard.footer.close",
+    ];
+
+    /// PR 26b: every `document.export_wizard.*` key resolves to a
+    /// non-empty, non-fallback value in both locales.
+    #[test]
+    fn export_wizard_keys_resolve_in_both_locales() {
+        for key in EXPORT_WIZARD_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// PR 26b: a representative sample of `document.export_wizard.*` keys
+    /// diverges between locales.
+    #[test]
+    fn export_wizard_keys_differ_between_locales() {
+        for key in [
+            "document.export_wizard.title",
+            "document.export_wizard.format_options.choose_folder",
+            "document.export_wizard.confirm.start_export",
+            "document.export_wizard.running.title",
+            "document.export_wizard.footer.continue",
+            "document.export_wizard.toast.cancelled",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
+    }
+
+    /// PR 26b: `export_summary_label` picks the "with failures" bucket only
+    /// when `failed > 0`, and interpolates every count.
+    #[test]
+    fn export_summary_label_switches_bucket_on_failed_count() {
+        let ok = export_summary_label(3, 120, 1, 0);
+        assert!(ok.contains('3') && ok.contains("120") && ok.contains('1'));
+        assert!(!ok.to_lowercase().contains("fail"));
+
+        let with_failures = export_summary_label(2, 40, 1, 1);
+        assert!(with_failures.contains('2') && with_failures.contains("40"));
+        assert!(with_failures.to_lowercase().contains("fail"));
+    }
+
+    /// PR 26b: `export_table_status_line` covers every `TableTransferStatus`
+    /// variant (exhaustive match, no wildcard arm).
+    #[test]
+    fn export_table_status_line_covers_all_variants() {
+        use dbflux_transfer::TableTransferStatus;
+
+        let statuses = [
+            TableTransferStatus::Completed { rows: 5 },
+            TableTransferStatus::Skipped,
+            TableTransferStatus::Failed {
+                error: "boom".to_string(),
+            },
+            TableTransferStatus::NotStarted,
+        ];
+        for status in statuses {
+            let line = export_table_status_line("public.users", &status);
+            assert!(!line.is_empty());
+            assert!(line.contains("public.users"));
+        }
+    }
+
+    /// PR 26b: `export_running_position_label` reports "Table N of M" once
+    /// tables are known, and falls back to "Preparing" beforehand.
+    #[test]
+    fn export_running_position_label_falls_back_to_preparing_before_tables_are_known() {
+        let preparing = export_running_position_label(0, 0);
+        assert_eq!(
+            preparing,
+            dbflux_i18n::t!("document.export_wizard.running.position.preparing")
+        );
+
+        let positioned = export_running_position_label(1, 3);
+        assert!(positioned.contains('2'));
+        assert!(positioned.contains('3'));
+    }
+
+    /// PR 26b: `export_running_rows_label` switches between "done / total"
+    /// and a bare "done rows" once no estimate is available.
+    #[test]
+    fn export_running_rows_label_switches_on_estimated_total() {
+        let with_total = export_running_rows_label(10, Some(100));
+        assert!(with_total.contains("10"));
+        assert!(with_total.contains("100"));
+
+        let without_total = export_running_rows_label(10, None);
+        assert!(without_total.contains("10"));
+        assert!(!without_total.contains("100"));
+
+        let zero_total = export_running_rows_label(10, Some(0));
+        assert!(zero_total.contains("10"));
+        assert!(!zero_total.contains('/'));
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slice 26b: the export wizard (phase labels, modal title, placeholders, folder dialog, the four phase bodies, footer buttons, run toasts and errors, summaries and per-table status lines) renders through `dbflux_i18n::t!` under `document.export_wizard.*`. English and Spanish together. Table names, paths, formats and row counts stay data.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `ExportPhase::label()` widens to `String` with local `t!` calls; `export_summary_label`, `export_table_status_line` (exhaustive), `export_running_position_label`, `export_running_rows_label` live in labels.rs.
- Known leftover for the final slice: the task-manager task title/failure messages in `run.rs` stay English here; 27b brings them in line with the sidebar's translated task titles.
- Size: 640 lines in one namespace boundary (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1083 passed; clippy clean; fmt clean. Manual smoke in Spanish: run the export wizard end to end and cancel one.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
