### PR TITLE
feat(i18n): translate the services delete dialog, connection form validation, and SSH tunnel leftovers

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1674,6 +1674,39 @@ errors:
   correlation:
     detail: "Correlation: %{id}"
     clipboard: "%{summary}\nCorrelation: %{id}"
+form:
+  validation:
+    connection_name_required: Connection name is required
+    no_driver_selected: No driver selected
+    field_required: "%{field} is required"
+    field_invalid_number: "%{field} must be a valid number"
+    ssh_host_required: SSH Host is required when SSH is enabled
+    ssh_user_required: SSH User is required when SSH is enabled
+    ssh_port_invalid: SSH Port must be a valid number
+    ssm_instance_id_required: SSM Instance ID is required
+    ssm_instance_id_format: SSM Instance ID must start with 'i-' or 'mi-'
+    ssm_region_required: SSM Region is required
+    ssm_remote_port_positive: SSM Remote Port must be greater than 0
+    ssm_remote_port_invalid: SSM Remote Port must be a valid number
+    auth_profile_not_found: "AWS profile '%{id}' not found in ~/.aws/config — please restore or recreate the profile in ~/.aws/config before connecting."
+    auth_profile_dangling_keyring_only: "Auth profile '%{name}' is only in the DBFlux keyring and no longer has a corresponding entry in ~/.aws/config or ~/.aws/credentials. Add the credentials to ~/.aws/credentials to connect with this profile."
+    auth_profile_dangling: "Auth profile '%{name}' could not be found in ~/.aws/config. Please recreate the profile or update the connection binding."
+    dynamic_auth_profile_required: Dynamic value sources require an Auth Profile. Select one in Access tab.
+    auth_profile_no_provider: "Selected Auth Profile '%{name}' has no registered provider for dynamic value sources."
+  action:
+    updating: Updating
+    saving: Saving
+  warning:
+    refresh_interval_invalid: "Refresh interval override ignored: value must be a positive number"
+  error:
+    build_profile_failed: Failed to build profile
+    test_cancelled_pre: Test connection cancelled by pre-connect hook
+    test_cancelled_post: Test connection cancelled by post-connect hook
+    test_cleanup_failed: "Test connection cleanup failed: %{error}"
+    test_cleanup_warning: "%{primary_error} (cleanup warning: %{cleanup_error})"
+    detached_hook_cleanup_failed: "Failed to release detached test hook tasks for profile '%{profile_name}' (%{profile_id}); scoped task IDs [%{task_ids}]: %{error}"
+    aws_credentials_missing: "AWS credentials for profile '%{name}' could not be resolved. Add the credentials to ~/.aws/credentials (or use environment variables / IAM role) and retry. DBFlux does not store AWS access keys — credentials are read directly by the AWS SDK."
+    pipeline_stage_failed: "Pipeline stage '%{stage}': %{source}"
 hooks:
   kind:
     command: Command
@@ -2470,6 +2503,9 @@ settings:
     empty: No RPC services configured
     edit_title: Edit RPC Service
     new_title: New RPC Service
+    delete_dialog_title: Delete Service
+    delete_dialog:
+      body: 'Are you sure you want to delete "%{name}"?'
     error:
       socket_id_required: Socket ID is required
       timeout_invalid: Timeout must be a valid number (milliseconds)
@@ -2511,6 +2547,8 @@ settings:
       import: "Import…"
       export: Export
       delete: Delete
+    error:
+      host_and_user_required: Host and user are required
   proxies:
     placeholder_name: Proxy name
     placeholder_username: username

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1674,6 +1674,39 @@ errors:
   correlation:
     detail: "Correlación: %{id}"
     clipboard: "%{summary}\nCorrelación: %{id}"
+form:
+  validation:
+    connection_name_required: El nombre de la conexión es obligatorio
+    no_driver_selected: No se seleccionó ningún driver
+    field_required: "%{field} es obligatorio"
+    field_invalid_number: "%{field} debe ser un número válido"
+    ssh_host_required: El host SSH es obligatorio cuando SSH está habilitado
+    ssh_user_required: El usuario SSH es obligatorio cuando SSH está habilitado
+    ssh_port_invalid: El puerto SSH debe ser un número válido
+    ssm_instance_id_required: El ID de instancia SSM es obligatorio
+    ssm_instance_id_format: 'El ID de instancia SSM debe comenzar con "i-" o "mi-"'
+    ssm_region_required: La región SSM es obligatoria
+    ssm_remote_port_positive: El puerto remoto SSM debe ser mayor que 0
+    ssm_remote_port_invalid: El puerto remoto SSM debe ser un número válido
+    auth_profile_not_found: "No se encontró el perfil de AWS '%{id}' en ~/.aws/config — restaura o recrea el perfil en ~/.aws/config antes de conectar."
+    auth_profile_dangling_keyring_only: "El perfil de autenticación '%{name}' solo existe en el llavero de DBFlux y ya no tiene una entrada correspondiente en ~/.aws/config o ~/.aws/credentials. Agrega las credenciales a ~/.aws/credentials para conectar con este perfil."
+    auth_profile_dangling: "No se pudo encontrar el perfil de autenticación '%{name}' en ~/.aws/config. Recrea el perfil o actualiza el enlace de la conexión."
+    dynamic_auth_profile_required: Las fuentes de valores dinámicos requieren un perfil de autenticación. Selecciona uno en la pestaña Acceso.
+    auth_profile_no_provider: "El perfil de autenticación seleccionado '%{name}' no tiene un proveedor registrado para fuentes de valores dinámicos."
+  action:
+    updating: Actualizando
+    saving: Guardando
+  warning:
+    refresh_interval_invalid: "Anulación del intervalo de actualización ignorada: el valor debe ser un número positivo"
+  error:
+    build_profile_failed: No se pudo construir el perfil
+    test_cancelled_pre: La prueba de conexión fue cancelada por el hook previo a la conexión
+    test_cancelled_post: La prueba de conexión fue cancelada por el hook posterior a la conexión
+    test_cleanup_failed: "Error al limpiar la conexión de prueba: %{error}"
+    test_cleanup_warning: "%{primary_error} (advertencia de limpieza: %{cleanup_error})"
+    detached_hook_cleanup_failed: "No se pudieron liberar las tareas de hook de prueba independientes para el perfil '%{profile_name}' (%{profile_id}); IDs de tarea con alcance [%{task_ids}]: %{error}"
+    aws_credentials_missing: "No se pudieron resolver las credenciales de AWS para el perfil '%{name}'. Agrega las credenciales a ~/.aws/credentials (o usa variables de entorno / rol de IAM) y vuelve a intentarlo. DBFlux no almacena claves de acceso de AWS: las credenciales se leen directamente desde el SDK de AWS."
+    pipeline_stage_failed: "Etapa de la canalización '%{stage}': %{source}"
 hooks:
   kind:
     command: Comando
@@ -2470,6 +2503,9 @@ settings:
     empty: No hay servicios RPC configurados
     edit_title: Editar servicio RPC
     new_title: Nuevo servicio RPC
+    delete_dialog_title: Eliminar servicio
+    delete_dialog:
+      body: '¿Seguro que quieres eliminar "%{name}"?'
     error:
       socket_id_required: El ID del socket es obligatorio
       timeout_invalid: El tiempo de espera debe ser un número válido (milisegundos)
@@ -2511,6 +2547,8 @@ settings:
       import: "Importar…"
       export: Exportar
       delete: Eliminar
+    error:
+      host_and_user_required: El host y el usuario son obligatorios
   proxies:
     placeholder_name: Nombre del proxy
     placeholder_username: usuario

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -95,13 +95,13 @@ impl ConnectionManagerWindow {
             let name = self.form.input_name.read(cx).value().to_string();
             if name.trim().is_empty() {
                 self.validation_errors
-                    .push("Connection name is required".to_string());
+                    .push(dbflux_i18n::t!("form.validation.connection_name_required"));
             }
         }
 
         let Some(driver) = &self.form.selected_driver else {
             self.validation_errors
-                .push("No driver selected".to_string());
+                .push(dbflux_i18n::t!("form.validation.no_driver_selected"));
             return false;
         };
 
@@ -130,16 +130,20 @@ impl ConnectionManagerWindow {
                         && value.trim().is_empty()
                         && !self.has_dynamic_value_ref_for_field(&field.id, cx)
                     {
-                        self.validation_errors
-                            .push(format!("{} is required", field.label));
+                        self.validation_errors.push(dbflux_i18n::t!(
+                            "form.validation.field_required",
+                            field = field.label.clone()
+                        ));
                     }
 
                     if !value.trim().is_empty()
                         && field.kind == FormFieldKind::Number
                         && value.parse::<u16>().is_err()
                     {
-                        self.validation_errors
-                            .push(format!("{} must be a valid number", field.label));
+                        self.validation_errors.push(dbflux_i18n::t!(
+                            "form.validation.field_invalid_number",
+                            field = field.label.clone()
+                        ));
                     }
                 }
             }
@@ -149,19 +153,19 @@ impl ConnectionManagerWindow {
             let ssh_host = self.access.input_ssh_host.read(cx).value().to_string();
             if ssh_host.trim().is_empty() {
                 self.validation_errors
-                    .push("SSH Host is required when SSH is enabled".to_string());
+                    .push(dbflux_i18n::t!("form.validation.ssh_host_required"));
             }
 
             let ssh_user = self.access.input_ssh_user.read(cx).value().to_string();
             if ssh_user.trim().is_empty() {
                 self.validation_errors
-                    .push("SSH User is required when SSH is enabled".to_string());
+                    .push(dbflux_i18n::t!("form.validation.ssh_user_required"));
             }
 
             let ssh_port_str = self.access.input_ssh_port.read(cx).value().to_string();
             if !ssh_port_str.trim().is_empty() && ssh_port_str.parse::<u16>().is_err() {
                 self.validation_errors
-                    .push("SSH Port must be a valid number".to_string());
+                    .push(dbflux_i18n::t!("form.validation.ssh_port_invalid"));
             }
         }
 
@@ -175,19 +179,19 @@ impl ConnectionManagerWindow {
                 .to_string();
             if instance_id.trim().is_empty() {
                 self.validation_errors
-                    .push("SSM Instance ID is required".to_string());
+                    .push(dbflux_i18n::t!("form.validation.ssm_instance_id_required"));
             } else if !self.has_dynamic_value_ref_for_field("ssm_instance_id", cx)
                 && !instance_id.starts_with("i-")
                 && !instance_id.starts_with("mi-")
             {
                 self.validation_errors
-                    .push("SSM Instance ID must start with 'i-' or 'mi-'".to_string());
+                    .push(dbflux_i18n::t!("form.validation.ssm_instance_id_format"));
             }
 
             let region = self.access.input_ssm_region.read(cx).value().to_string();
             if region.trim().is_empty() {
                 self.validation_errors
-                    .push("SSM Region is required".to_string());
+                    .push(dbflux_i18n::t!("form.validation.ssm_region_required"));
             }
 
             let port_str = self
@@ -200,11 +204,11 @@ impl ConnectionManagerWindow {
                 match port_str.parse::<u16>() {
                     Ok(0) => {
                         self.validation_errors
-                            .push("SSM Remote Port must be greater than 0".to_string());
+                            .push(dbflux_i18n::t!("form.validation.ssm_remote_port_positive"));
                     }
                     Err(_) => {
                         self.validation_errors
-                            .push("SSM Remote Port must be a valid number".to_string());
+                            .push(dbflux_i18n::t!("form.validation.ssm_remote_port_invalid"));
                     }
                     _ => {}
                 }
@@ -225,27 +229,23 @@ impl ConnectionManagerWindow {
 
             match bound_profile {
                 None => {
-                    self.validation_errors.push(format!(
-                        "AWS profile '{}' not found in ~/.aws/config — please restore or \
-                         recreate the profile in ~/.aws/config before connecting.",
-                        auth_profile_id
+                    self.validation_errors.push(dbflux_i18n::t!(
+                        "form.validation.auth_profile_not_found",
+                        id = auth_profile_id.to_string()
                     ));
                 }
 
                 Some(profile) if profile.dangling_origin.as_deref() == Some("keyring-only") => {
-                    self.validation_errors.push(format!(
-                        "Auth profile '{}' is only in the DBFlux keyring and no longer has a \
-                         corresponding entry in ~/.aws/config or ~/.aws/credentials. \
-                         Add the credentials to ~/.aws/credentials to connect with this profile.",
-                        profile.name
+                    self.validation_errors.push(dbflux_i18n::t!(
+                        "form.validation.auth_profile_dangling_keyring_only",
+                        name = profile.name
                     ));
                 }
 
                 Some(profile) if profile.dangling_origin.is_some() => {
-                    self.validation_errors.push(format!(
-                        "Auth profile '{}' could not be found in ~/.aws/config. \
-                         Please recreate the profile or update the connection binding.",
-                        profile.name
+                    self.validation_errors.push(dbflux_i18n::t!(
+                        "form.validation.auth_profile_dangling",
+                        name = profile.name
                     ));
                 }
 
@@ -262,10 +262,9 @@ impl ConnectionManagerWindow {
 
         if uses_dynamic_auth_sources {
             let Some(auth_profile_id) = self.auth_profile.selected_auth_profile_id else {
-                self.validation_errors.push(
-                    "Dynamic value sources require an Auth Profile. Select one in Access tab."
-                        .to_string(),
-                );
+                self.validation_errors.push(dbflux_i18n::t!(
+                    "form.validation.dynamic_auth_profile_required"
+                ));
                 return self.validation_errors.is_empty();
             };
 
@@ -283,9 +282,9 @@ impl ConnectionManagerWindow {
                     .auth_provider_by_id(&profile.provider_id)
                     .is_none()
                 {
-                    self.validation_errors.push(format!(
-                        "Selected Auth Profile '{}' has no registered provider for dynamic value sources.",
-                        profile.name
+                    self.validation_errors.push(dbflux_i18n::t!(
+                        "form.validation.auth_profile_no_provider",
+                        name = profile.name
                     ));
                 }
             } else {
@@ -554,9 +553,14 @@ impl ConnectionManagerWindow {
             .read(cx)
             .is_literal(cx);
 
+        let save_action = if is_edit {
+            dbflux_i18n::t!("form.action.updating")
+        } else {
+            dbflux_i18n::t!("form.action.saving")
+        };
         info!(
             "{} profile: {}, save_password={}, password_len={}, ssh_enabled={}, ssh_auth={:?}",
-            if is_edit { "Updating" } else { "Saving" },
+            save_action,
             profile.name,
             profile.save_password,
             password.len(),
@@ -570,7 +574,7 @@ impl ConnectionManagerWindow {
                 .as_ref()
                 .is_none_or(|ov| ov.refresh_interval_secs.is_none())
         {
-            Toast::warning("Refresh interval override ignored: value must be a positive number")
+            Toast::warning(dbflux_i18n::t!("form.warning.refresh_interval_invalid"))
                 .meta_right(now_hms())
                 .push(cx);
         }
@@ -701,14 +705,14 @@ impl ConnectionManagerWindow {
 
         let Some(profile) = self.build_profile(cx) else {
             self.test_status = TestStatus::Failed;
-            self.test_error = Some("Failed to build profile".to_string());
+            self.test_error = Some(dbflux_i18n::t!("form.error.build_profile_failed"));
             cx.notify();
             return;
         };
 
         let Some(driver) = self.form.selected_driver.clone() else {
             self.test_status = TestStatus::Failed;
-            self.test_error = Some("No driver selected".to_string());
+            self.test_error = Some(dbflux_i18n::t!("form.validation.no_driver_selected"));
             cx.notify();
             return;
         };
@@ -795,9 +799,10 @@ impl ConnectionManagerWindow {
                                         dbflux_core::run_pipeline(pipeline_input, &state_tx)
                                             .await
                                             .map_err(|error| {
-                                                format!(
-                                                    "Pipeline stage '{}': {}",
-                                                    error.stage, error.source
+                                                dbflux_i18n::t!(
+                                                    "form.error.pipeline_stage_failed",
+                                                    stage = error.stage,
+                                                    source = error.source.to_string()
                                                 )
                                             })?;
 
@@ -1007,12 +1012,15 @@ where
 
     match (outcome, cleanup) {
         (Ok(result), Ok(())) => Ok(result),
-        (Ok(_), Err(cleanup_error)) => {
-            Err(format!("Test connection cleanup failed: {cleanup_error}"))
-        }
+        (Ok(_), Err(cleanup_error)) => Err(dbflux_i18n::t!(
+            "form.error.test_cleanup_failed",
+            error = cleanup_error
+        )),
         (Err(primary_error), Ok(())) => Err(primary_error),
-        (Err(primary_error), Err(cleanup_error)) => Err(format!(
-            "{primary_error} (cleanup warning: {cleanup_error})"
+        (Err(primary_error), Err(cleanup_error)) => Err(dbflux_i18n::t!(
+            "form.error.test_cleanup_warning",
+            primary_error = primary_error,
+            cleanup_error = cleanup_error
         )),
     }
 }
@@ -1045,7 +1053,7 @@ where
         HookPhaseState::Continue { warnings } => warnings,
         HookPhaseState::Aborted { error } => return Err(error),
         HookPhaseState::Cancelled => {
-            return Err("Test connection cancelled by pre-connect hook".to_string());
+            return Err(dbflux_i18n::t!("form.error.test_cancelled_pre"));
         }
     };
 
@@ -1063,9 +1071,7 @@ where
             })
         }
         HookPhaseState::Aborted { error } => Err(error),
-        HookPhaseState::Cancelled => {
-            Err("Test connection cancelled by post-connect hook".to_string())
-        }
+        HookPhaseState::Cancelled => Err(dbflux_i18n::t!("form.error.test_cancelled_post")),
     }
 }
 
@@ -1081,9 +1087,12 @@ fn format_detached_hook_cleanup_failure(
         .collect::<Vec<_>>()
         .join(", ");
 
-    format!(
-        "Failed to release detached test hook tasks for profile '{profile_name}' ({profile_id}); scoped task IDs [{task_ids}]: {}",
-        error.source()
+    dbflux_i18n::t!(
+        "form.error.detached_hook_cleanup_failed",
+        profile_name = profile_name,
+        profile_id = profile_id.to_string(),
+        task_ids = task_ids,
+        error = error.source().to_string()
     )
 }
 
@@ -1104,14 +1113,7 @@ fn normalize_aws_credentials_error(profile_name: &str, error: &str) -> String {
         || lower.contains("no credentials in chain");
 
     if is_missing_credentials {
-        return format!(
-            "AWS credentials for profile '{}' could not be resolved. \
-             Add the credentials to ~/.aws/credentials (or use environment \
-             variables / IAM role) and retry. \
-             DBFlux does not store AWS access keys — credentials are read \
-             directly by the AWS SDK.",
-            profile_name
-        );
+        return dbflux_i18n::t!("form.error.aws_credentials_missing", name = profile_name);
     }
 
     error.to_string()
@@ -1125,6 +1127,65 @@ mod tests {
     };
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
+
+    const FORM_KEYS: &[&str] = &[
+        "form.validation.connection_name_required",
+        "form.validation.no_driver_selected",
+        "form.validation.field_required",
+        "form.validation.field_invalid_number",
+        "form.validation.ssh_host_required",
+        "form.validation.ssh_user_required",
+        "form.validation.ssh_port_invalid",
+        "form.validation.ssm_instance_id_required",
+        "form.validation.ssm_instance_id_format",
+        "form.validation.ssm_region_required",
+        "form.validation.ssm_remote_port_positive",
+        "form.validation.ssm_remote_port_invalid",
+        "form.validation.auth_profile_not_found",
+        "form.validation.auth_profile_dangling_keyring_only",
+        "form.validation.auth_profile_dangling",
+        "form.validation.dynamic_auth_profile_required",
+        "form.validation.auth_profile_no_provider",
+        "form.action.updating",
+        "form.action.saving",
+        "form.warning.refresh_interval_invalid",
+        "form.error.build_profile_failed",
+        "form.error.test_cancelled_pre",
+        "form.error.test_cancelled_post",
+        "form.error.test_cleanup_failed",
+        "form.error.test_cleanup_warning",
+        "form.error.detached_hook_cleanup_failed",
+        "form.error.aws_credentials_missing",
+        "form.error.pipeline_stage_failed",
+    ];
+
+    #[::core::prelude::v1::test]
+    fn form_validation_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in FORM_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[::core::prelude::v1::test]
+    fn form_validation_connection_name_required_differs_between_locales() {
+        let english = dbflux_i18n::t!("form.validation.connection_name_required", locale = "en");
+        let spanish = dbflux_i18n::t!("form.validation.connection_name_required", locale = "es");
+
+        assert_ne!(english, spanish);
+    }
 
     fn hook(command: &str) -> ConnectionHook {
         ConnectionHook {
@@ -1497,9 +1558,12 @@ mod tests {
             current_unsaved_hook_context(),
         ));
 
-        assert!(
-            matches!(result, Err(error) if error == "driver probe failed (cleanup warning: detached hook cleanup failed)")
+        let expected = dbflux_i18n::t!(
+            "form.error.test_cleanup_warning",
+            primary_error = "driver probe failed",
+            cleanup_error = "detached hook cleanup failed"
         );
+        assert!(matches!(result, Err(error) if error == expected));
         assert_eq!(*cleanup_calls.lock().expect("cleanup log poisoned"), 1);
     }
 
@@ -1619,9 +1683,8 @@ mod tests {
             current_unsaved_hook_context(),
         ));
 
-        assert!(
-            matches!(result, Err(error) if error == "Test connection cancelled by pre-connect hook")
-        );
+        let expected = dbflux_i18n::t!("form.error.test_cancelled_pre");
+        assert!(matches!(result, Err(error) if error == expected));
         assert_eq!(*cleanup_calls.lock().expect("cleanup log poisoned"), 1);
     }
 
@@ -1641,9 +1704,11 @@ mod tests {
             current_unsaved_hook_context(),
         ));
 
-        assert!(
-            matches!(result, Err(error) if error == "Test connection cleanup failed: access handle did not close")
+        let expected = dbflux_i18n::t!(
+            "form.error.test_cleanup_failed",
+            error = "access handle did not close"
         );
+        assert!(matches!(result, Err(error) if error == expected));
     }
 
     #[::core::prelude::v1::test]

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -272,6 +272,11 @@ pub(crate) fn ssh_tunnels_delete_body(name: &str) -> String {
     dbflux_i18n::t!("settings.ssh_tunnels.delete_dialog.body", name = name)
 }
 
+/// Formats the delete-confirmation body for a named RPC service.
+pub(crate) fn rpc_services_delete_body(name: &str) -> String {
+    dbflux_i18n::t!("settings.rpc_services.delete_dialog.body", name = name)
+}
+
 /// Builds the delete-confirmation body for a proxy profile, embedding the
 /// proxy name and pluralizing the affected-connections count.
 pub(crate) fn proxies_delete_body(name: &str, affected_connections: usize) -> String {
@@ -705,7 +710,7 @@ mod tests {
         import_preview_required_banner, import_required_auth_profile_ref_label,
         import_required_aws_reference_label, import_required_secret_label,
         import_status_imported_toast, mcp_preview_summary, proxies_delete_body,
-        ssh_private_key_with_path, ssh_tunnels_delete_body,
+        rpc_services_delete_body, ssh_private_key_with_path, ssh_tunnels_delete_body,
     };
     use super::{
         export_error_cannot_determine_output_path, export_error_failed, export_error_write_failed,
@@ -943,6 +948,13 @@ mod tests {
         let message = ssh_tunnels_delete_body("bastion-prod");
 
         assert!(message.contains("bastion-prod"));
+    }
+
+    #[test]
+    fn rpc_services_delete_body_embeds_service_name() {
+        let message = rpc_services_delete_body("my-driver.sock");
+
+        assert!(message.contains("my-driver.sock"));
     }
 
     #[test]

--- a/crates/dbflux_ui_windows/src/settings/services_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/services_section.rs
@@ -376,7 +376,7 @@ impl Render for ServicesSection {
 
                 element.child(
                     Dialog::new(window, cx)
-                        .title("Delete Service")
+                        .title(dbflux_i18n::t!("settings.rpc_services.delete_dialog_title"))
                         .confirm()
                         .on_ok(move |_, window, cx| {
                             entity.update(cx, |section, cx| {
@@ -390,11 +390,48 @@ impl Render for ServicesSection {
                             });
                             true
                         })
-                        .child(div().text_sm().child(format!(
-                            "Are you sure you want to delete \"{}\"?",
-                            svc_delete_name
-                        ))),
+                        .child(
+                            div()
+                                .text_sm()
+                                .child(crate::labels::rpc_services_delete_body(&svc_delete_name)),
+                        ),
                 )
             })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const SERVICES_KEYS: &[&str] = &[
+        "settings.rpc_services.delete_dialog_title",
+        "settings.rpc_services.delete_dialog.body",
+    ];
+
+    #[test]
+    fn services_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in SERVICES_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn services_delete_dialog_title_differs_between_locales() {
+        let english = dbflux_i18n::t!("settings.rpc_services.delete_dialog_title", locale = "en");
+        let spanish = dbflux_i18n::t!("settings.rpc_services.delete_dialog_title", locale = "es");
+
+        assert_ne!(english, spanish);
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
@@ -296,7 +296,9 @@ impl SshTunnelsSection {
 
         if host.is_empty() || user.is_empty() {
             self.ssh_test_status = SshTestStatus::Failed;
-            self.ssh_test_error = Some("Host and user are required".to_string());
+            self.ssh_test_error = Some(dbflux_i18n::t!(
+                "settings.ssh_tunnels.error.host_and_user_required"
+            ));
             cx.notify();
             return;
         }
@@ -408,7 +410,7 @@ impl SshTunnelsSection {
 
         let task = cx.background_executor().spawn(async move {
             let dialog = rfd::FileDialog::new()
-                .set_title("Select SSH Private Key")
+                .set_title(dbflux_i18n::t!("connection_manager.select_ssh_key_title"))
                 .set_directory(&start_dir);
 
             dialog.pick_file()

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels_section.rs
@@ -1117,6 +1117,7 @@ mod tests {
         "settings.ssh_tunnels.action.import",
         "settings.ssh_tunnels.action.export",
         "settings.ssh_tunnels.action.delete",
+        "settings.ssh_tunnels.error.host_and_user_required",
     ];
 
     // Reused from the shared `ssh.*` vocabulary (slice S10, `access_tab.rs`).


### PR DESCRIPTION
## Summary

Twenty-eighth `dbflux_ui_windows` i18n slice: the RPC services delete dialog, every connection form validation message, build-profile and test-connection errors (hook cancellations), and two SSH tunnel leftovers (private key dialog title, host-and-user validation) render through `dbflux_i18n::t!` under `settings.rpc_services.delete_dialog_*`, `form.{validation,action,warning,error}.*` and `settings.ssh_tunnels.error.*`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows the export modal PR; next: the crate-wide sweep leftovers, then verify)

## How was this solved?

- Catalog orphan check over 799 `settings.*` / `connection_manager.*` / `access.*` / `ssh.*` / `hooks.*` keys: 0 orphans.
- `form.action.updating/saving` only surface in a log line today; translated because the spec lists them, easy to revert if verify disagrees.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 318 passed; clippy clean; fmt clean. Manual smoke in Spanish: save a connection without a name, enable SSH without a host, enter a bad SSM instance id.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
