### PR TITLE
feat(i18n): translate the migrate wizard

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1289,6 +1289,77 @@ document:
         no_limit: No limit
         missing: Missing
         expired: Expired
+  migrate_wizard:
+    title: Migrate Data
+    rail:
+      source_target: Source & Target
+      tables_mapping: Tables Mapping
+      options: Options
+      confirm: Confirm
+      run: Run
+    mapping_mode:
+      create: Create
+      existing: "Existing (insert only)"
+      recreate: "Recreate (drop + create)"
+      skip: Skip
+      truncate: "Truncate (empty + insert)"
+    options:
+      segment_size_label: Segment / commit size
+      segment_size_placeholder: Segment / commit size
+      segment_size_invalid: "Must be a whole number of 1 or more; kept the previous value."
+      disable_referential_integrity: Disable referential integrity during migration
+    confirm:
+      review_plan: Review migration plan
+      destructive_ack: "I understand this plan will drop or empty existing data in the target."
+      destructive_tag: destructive
+      start_migration: Start Migration
+      mode_label:
+        create: Create
+        existing: Existing
+        recreate: Recreate
+        skip: Skip
+        truncate: Truncate
+      reorder:
+        warning: "These tables reference each other in a cycle and cannot be ordered automatically. Choose the load order before starting:"
+        up: Up
+        down: Down
+        accept: Use this order
+    running:
+      title: "Migrating…"
+      position:
+        of_total: "Table %{index} of %{total}"
+        preparing: Preparing
+      progress:
+        of_total: "%{done} / %{total} rows"
+        only: "%{done} rows"
+    done:
+      completed_in: "Completed in %{elapsed}"
+    toast:
+      success: Migration completed
+    status:
+      cancelled: Migration cancelled
+    error:
+      no_source_connection: No active connection for the source profile
+      no_target_connection: No active connection for the target profile
+      table_schema_read_failed: "Could not read table schema: %{error}"
+      foreign_keys_read_failed: "Could not read foreign keys: %{error}"
+      table_failed: "Migration failed on table '%{table}': %{error}"
+      cyclic_order: "Migration failed: FK order became cyclic mid-run"
+      failed: "Migration failed: %{error}"
+    summary:
+      with_failures: "Migrated %{completed} table(s), %{rows} row(s) total (%{skipped} skipped, %{failed} failed)"
+      ok: "Migrated %{completed} table(s), %{rows} row(s) total (%{skipped} skipped)"
+    status_line:
+      completed: "%{table}: completed (%{rows} row(s))"
+      skipped: "%{table}: skipped"
+      failed: "%{table}: FAILED — %{error}"
+      not_attempted: "%{table}: not attempted"
+    footer:
+      back: Back
+      continue: Continue
+      loading: "Loading…"
+      cancel: Cancel
+      close: Close
   object_browser:
     columns:
       class: Class

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1354,6 +1354,34 @@ document:
       skipped: "%{table}: skipped"
       failed: "%{table}: FAILED — %{error}"
       not_attempted: "%{table}: not attempted"
+    mapping:
+      target_placeholder: Target table
+      mode_placeholder: Mode
+      unset_option: "(unset)"
+      set_all_label: "Set all:"
+      columns_button: "Columns…"
+      unmapped_count:
+        one: "%{count} unmapped"
+        many: "%{count} unmapped"
+      column_mapping_title: "Column mapping — %{table}"
+      target_column_header: Target column
+      source_column_header: Source column
+      unmapped_columns: "Unmapped source columns: %{columns}"
+      header_source: Source
+      header_target: Target
+      header_mapping_mode: Mapping mode
+      header_transform: Transform
+    source_target:
+      source_title: Source
+      target_title: Target
+      checked_count:
+        one: "%{count} checked"
+        many: "%{count} checked"
+      no_target_selected: No target selected
+      retry: "Retry — %{error}"
+      source_connection_gone: Source connection is gone
+      target_connection_gone: Target connection is gone
+      cross_database_error: "A migration has a single source database. Only tables in '%{source}' can be selected — tables in '%{other}' can't be mixed in."
     footer:
       back: Back
       continue: Continue

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1354,6 +1354,34 @@ document:
       skipped: "%{table}: omitida"
       failed: "%{table}: FALLIDA — %{error}"
       not_attempted: "%{table}: no intentada"
+    mapping:
+      target_placeholder: Tabla destino
+      mode_placeholder: Modo
+      unset_option: "(sin asignar)"
+      set_all_label: "Establecer todo:"
+      columns_button: "Columnas…"
+      unmapped_count:
+        one: "%{count} columna sin asignar"
+        many: "%{count} columnas sin asignar"
+      column_mapping_title: "Mapeo de columnas — %{table}"
+      target_column_header: Columna destino
+      source_column_header: Columna origen
+      unmapped_columns: "Columnas de origen sin asignar: %{columns}"
+      header_source: Origen
+      header_target: Destino
+      header_mapping_mode: Modo de mapeo
+      header_transform: Transformación
+    source_target:
+      source_title: Origen
+      target_title: Destino
+      checked_count:
+        one: "%{count} marcada"
+        many: "%{count} marcadas"
+      no_target_selected: Ningún destino seleccionado
+      retry: "Reintentar — %{error}"
+      source_connection_gone: La conexión de origen ya no está disponible
+      target_connection_gone: La conexión de destino ya no está disponible
+      cross_database_error: "Una migración usa una única base de datos de origen. Solo se pueden seleccionar tablas de «%{source}»; las tablas de «%{other}» no se pueden combinar."
     footer:
       back: Atrás
       continue: Continuar

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1289,6 +1289,77 @@ document:
         no_limit: Sin límite
         missing: Ausente
         expired: Expirado
+  migrate_wizard:
+    title: Migrar datos
+    rail:
+      source_target: Origen y destino
+      tables_mapping: Mapeo de tablas
+      options: Opciones
+      confirm: Confirmar
+      run: Ejecutar
+    mapping_mode:
+      create: Crear
+      existing: "Existente (solo insertar)"
+      recreate: "Recrear (eliminar + crear)"
+      skip: Omitir
+      truncate: "Truncar (vaciar + insertar)"
+    options:
+      segment_size_label: Tamaño de segmento / confirmación
+      segment_size_placeholder: Tamaño de segmento / confirmación
+      segment_size_invalid: "Debe ser un número entero de 1 o más; se mantuvo el valor anterior."
+      disable_referential_integrity: Deshabilitar la integridad referencial durante la migración
+    confirm:
+      review_plan: Revisar plan de migración
+      destructive_ack: "Entiendo que este plan eliminará o vaciará los datos existentes en el destino."
+      destructive_tag: destructiva
+      start_migration: Iniciar migración
+      mode_label:
+        create: Crear
+        existing: Existente
+        recreate: Recrear
+        skip: Omitir
+        truncate: Truncar
+      reorder:
+        warning: "Estas tablas se referencian entre sí en un ciclo y no se pueden ordenar automáticamente. Elige el orden de carga antes de comenzar:"
+        up: Subir
+        down: Bajar
+        accept: Usar este orden
+    running:
+      title: "Migrando…"
+      position:
+        of_total: "Tabla %{index} de %{total}"
+        preparing: Preparando
+      progress:
+        of_total: "%{done} / %{total} filas"
+        only: "%{done} filas"
+    done:
+      completed_in: "Completado en %{elapsed}"
+    toast:
+      success: Migración completada
+    status:
+      cancelled: Migración cancelada
+    error:
+      no_source_connection: No hay una conexión activa para el perfil de origen
+      no_target_connection: No hay una conexión activa para el perfil de destino
+      table_schema_read_failed: "No se pudo leer el esquema de la tabla: %{error}"
+      foreign_keys_read_failed: "No se pudieron leer las claves foráneas: %{error}"
+      table_failed: "La migración falló en la tabla «%{table}»: %{error}"
+      cyclic_order: "Error de migración: el orden de claves foráneas se volvió cíclico durante la ejecución"
+      failed: "Error de migración: %{error}"
+    summary:
+      with_failures: "Se migraron %{completed} tabla(s), %{rows} fila(s) en total (%{skipped} omitida(s), %{failed} fallida(s))"
+      ok: "Se migraron %{completed} tabla(s), %{rows} fila(s) en total (%{skipped} omitida(s))"
+    status_line:
+      completed: "%{table}: completada (%{rows} fila(s))"
+      skipped: "%{table}: omitida"
+      failed: "%{table}: FALLIDA — %{error}"
+      not_attempted: "%{table}: no intentada"
+    footer:
+      back: Atrás
+      continue: Continuar
+      loading: "Cargando…"
+      cancel: Cancelar
+      close: Cerrar
   object_browser:
     columns:
       class: Clase

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1591,6 +1591,95 @@ pub(crate) fn export_running_rows_label(rows_done: u64, estimated_total: Option<
     }
 }
 
+/// Terminal summary line for a finished migration run, with every count
+/// interpolated. Uses the "with failures" bucket only when at least one
+/// table failed; otherwise the plain bucket.
+pub(crate) fn migrate_summary_label(
+    completed: usize,
+    rows: u64,
+    skipped: usize,
+    failed: usize,
+) -> String {
+    if failed > 0 {
+        dbflux_i18n::t!(
+            "document.migrate_wizard.summary.with_failures",
+            completed = completed,
+            rows = rows,
+            skipped = skipped,
+            failed = failed
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.migrate_wizard.summary.ok",
+            completed = completed,
+            rows = rows,
+            skipped = skipped
+        )
+    }
+}
+
+/// One itemized per-table status line shown when a migration run left any
+/// table failed or not started (see
+/// [`crate::migrate_wizard::MigrateWizard::itemized_status_lines`]).
+/// Exhaustive by construction so a new [`dbflux_transfer::TableTransferStatus`]
+/// variant fails this crate's build until its catalog key is added here.
+pub(crate) fn migrate_table_status_line(
+    table: &dbflux_transfer::migration::MigratedTable,
+) -> String {
+    use dbflux_transfer::TableTransferStatus;
+
+    match &table.status {
+        TableTransferStatus::Completed { rows } => dbflux_i18n::t!(
+            "document.migrate_wizard.status_line.completed",
+            table = table.source_table,
+            rows = rows
+        ),
+        TableTransferStatus::Skipped => dbflux_i18n::t!(
+            "document.migrate_wizard.status_line.skipped",
+            table = table.source_table
+        ),
+        TableTransferStatus::Failed { error } => dbflux_i18n::t!(
+            "document.migrate_wizard.status_line.failed",
+            table = table.source_table,
+            error = error
+        ),
+        TableTransferStatus::NotStarted => dbflux_i18n::t!(
+            "document.migrate_wizard.status_line.not_attempted",
+            table = table.source_table
+        ),
+    }
+}
+
+/// The migrate wizard's running phase "Table N of M" position line, or the
+/// "Preparing" fallback before the first table starts (`total_tables == 0`).
+pub(crate) fn migrate_running_position_label(current_index: usize, total_tables: usize) -> String {
+    if total_tables > 0 {
+        dbflux_i18n::t!(
+            "document.migrate_wizard.running.position.of_total",
+            index = current_index + 1,
+            total = total_tables
+        )
+    } else {
+        dbflux_i18n::t!("document.migrate_wizard.running.position.preparing")
+    }
+}
+
+/// The migrate wizard's running phase row-count line: `"done / total rows"`
+/// once the engine reports an estimate, otherwise just `"done rows"`.
+pub(crate) fn migrate_running_rows_label(rows_done: u64, estimated_total: Option<u64>) -> String {
+    match estimated_total {
+        Some(total) if total > 0 => dbflux_i18n::t!(
+            "document.migrate_wizard.running.progress.of_total",
+            done = rows_done,
+            total = total
+        ),
+        _ => dbflux_i18n::t!(
+            "document.migrate_wizard.running.progress.only",
+            done = rows_done
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1611,12 +1700,14 @@ mod tests {
         live_output_lines_label, live_output_truncated_label, metric_picker_custom_dropdown_label,
         metric_picker_dimensions_error_label, metric_picker_period_error_label,
         metric_picker_period_not_a_number_error, metric_picker_statistic_error_label,
-        object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
-        pending_change_count_label, pending_edits_summary, presign_expiry_label,
-        presign_method_label, preview_gate_message, refresh_policy_label, result_tab_count_label,
-        row_count_label, schema_change_description, script_confirm_message_label,
-        sort_direction_label, table_action_description, unsaved_changes_label,
-        update_columns_label, valid_lines_label, versioning_off_label, versioning_status_label,
+        migrate_running_position_label, migrate_running_rows_label, migrate_summary_label,
+        migrate_table_status_line, object_browser_status_summary,
+        object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
+        pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
+        refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
+        script_confirm_message_label, sort_direction_label, table_action_description,
+        unsaved_changes_label, update_columns_label, valid_lines_label, versioning_off_label,
+        versioning_status_label,
     };
     use crate::buckets_table::BucketEncryptionChoice;
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
@@ -4486,6 +4577,175 @@ mod tests {
         assert!(!without_total.contains("100"));
 
         let zero_total = export_running_rows_label(10, Some(0));
+        assert!(zero_total.contains("10"));
+        assert!(!zero_total.contains('/'));
+    }
+
+    // ── PR 27a: migrate_wizard/{phases,mod,options,column_mapping,confirm_run}.rs ──
+
+    const MIGRATE_WIZARD_KEYS: &[&str] = &[
+        "document.migrate_wizard.title",
+        "document.migrate_wizard.rail.source_target",
+        "document.migrate_wizard.rail.tables_mapping",
+        "document.migrate_wizard.rail.options",
+        "document.migrate_wizard.rail.confirm",
+        "document.migrate_wizard.rail.run",
+        "document.migrate_wizard.mapping_mode.create",
+        "document.migrate_wizard.mapping_mode.existing",
+        "document.migrate_wizard.mapping_mode.recreate",
+        "document.migrate_wizard.mapping_mode.skip",
+        "document.migrate_wizard.mapping_mode.truncate",
+        "document.migrate_wizard.options.segment_size_label",
+        "document.migrate_wizard.options.segment_size_placeholder",
+        "document.migrate_wizard.options.segment_size_invalid",
+        "document.migrate_wizard.options.disable_referential_integrity",
+        "document.migrate_wizard.confirm.review_plan",
+        "document.migrate_wizard.confirm.destructive_ack",
+        "document.migrate_wizard.confirm.destructive_tag",
+        "document.migrate_wizard.confirm.start_migration",
+        "document.migrate_wizard.confirm.mode_label.create",
+        "document.migrate_wizard.confirm.mode_label.existing",
+        "document.migrate_wizard.confirm.mode_label.recreate",
+        "document.migrate_wizard.confirm.mode_label.skip",
+        "document.migrate_wizard.confirm.mode_label.truncate",
+        "document.migrate_wizard.confirm.reorder.warning",
+        "document.migrate_wizard.confirm.reorder.up",
+        "document.migrate_wizard.confirm.reorder.down",
+        "document.migrate_wizard.confirm.reorder.accept",
+        "document.migrate_wizard.running.title",
+        "document.migrate_wizard.running.position.of_total",
+        "document.migrate_wizard.running.position.preparing",
+        "document.migrate_wizard.running.progress.of_total",
+        "document.migrate_wizard.running.progress.only",
+        "document.migrate_wizard.done.completed_in",
+        "document.migrate_wizard.toast.success",
+        "document.migrate_wizard.status.cancelled",
+        "document.migrate_wizard.error.no_source_connection",
+        "document.migrate_wizard.error.no_target_connection",
+        "document.migrate_wizard.error.table_schema_read_failed",
+        "document.migrate_wizard.error.foreign_keys_read_failed",
+        "document.migrate_wizard.error.table_failed",
+        "document.migrate_wizard.error.cyclic_order",
+        "document.migrate_wizard.error.failed",
+        "document.migrate_wizard.summary.with_failures",
+        "document.migrate_wizard.summary.ok",
+        "document.migrate_wizard.status_line.completed",
+        "document.migrate_wizard.status_line.skipped",
+        "document.migrate_wizard.status_line.failed",
+        "document.migrate_wizard.status_line.not_attempted",
+        "document.migrate_wizard.footer.back",
+        "document.migrate_wizard.footer.continue",
+        "document.migrate_wizard.footer.loading",
+        "document.migrate_wizard.footer.cancel",
+        "document.migrate_wizard.footer.close",
+    ];
+
+    /// PR 27a: every `document.migrate_wizard.*` key introduced by
+    /// `phases.rs`/`mod.rs`/`options.rs`/`column_mapping.rs`/`confirm_run.rs`
+    /// resolves to a non-empty, non-fallback value in both locales.
+    #[test]
+    fn migrate_wizard_keys_resolve_in_both_locales() {
+        for key in MIGRATE_WIZARD_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// PR 27a: a representative sample of `document.migrate_wizard.*` keys
+    /// diverges between locales.
+    #[test]
+    fn migrate_wizard_keys_differ_between_locales() {
+        for key in [
+            "document.migrate_wizard.title",
+            "document.migrate_wizard.rail.source_target",
+            "document.migrate_wizard.confirm.start_migration",
+            "document.migrate_wizard.running.title",
+            "document.migrate_wizard.toast.success",
+            "document.migrate_wizard.footer.continue",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
+    }
+
+    /// PR 27a: `migrate_summary_label` picks the "with failures" bucket only
+    /// when `failed > 0`, and interpolates every count.
+    #[test]
+    fn migrate_summary_label_switches_bucket_on_failed_count() {
+        let ok = migrate_summary_label(3, 120, 1, 0);
+        assert!(ok.contains('3') && ok.contains("120") && ok.contains('1'));
+        assert!(!ok.to_lowercase().contains("fail"));
+
+        let with_failures = migrate_summary_label(2, 40, 1, 1);
+        assert!(with_failures.contains('2') && with_failures.contains("40"));
+        assert!(with_failures.to_lowercase().contains("fail"));
+    }
+
+    /// PR 27a: `migrate_table_status_line` covers every `TableTransferStatus`
+    /// variant (exhaustive match, no wildcard arm).
+    #[test]
+    fn migrate_table_status_line_covers_all_variants() {
+        use dbflux_transfer::TableTransferStatus;
+        use dbflux_transfer::migration::MigratedTable;
+
+        let statuses = [
+            TableTransferStatus::Completed { rows: 5 },
+            TableTransferStatus::Skipped,
+            TableTransferStatus::Failed {
+                error: "boom".to_string(),
+            },
+            TableTransferStatus::NotStarted,
+        ];
+        for status in statuses {
+            let table = MigratedTable {
+                source_table: "users".to_string(),
+                target_table: "users".to_string(),
+                status,
+            };
+            let line = migrate_table_status_line(&table);
+            assert!(!line.is_empty());
+            assert!(line.contains("users"));
+        }
+    }
+
+    /// PR 27a: `migrate_running_position_label` reports "Table N of M" once
+    /// tables are known, and falls back to "Preparing" beforehand.
+    #[test]
+    fn migrate_running_position_label_falls_back_to_preparing_before_tables_are_known() {
+        let preparing = migrate_running_position_label(0, 0);
+        assert_eq!(
+            preparing,
+            dbflux_i18n::t!("document.migrate_wizard.running.position.preparing")
+        );
+
+        let positioned = migrate_running_position_label(1, 3);
+        assert!(positioned.contains('2'));
+        assert!(positioned.contains('3'));
+    }
+
+    /// PR 27a: `migrate_running_rows_label` switches between "done / total"
+    /// and a bare "done rows" once no estimate is available.
+    #[test]
+    fn migrate_running_rows_label_switches_on_estimated_total() {
+        let with_total = migrate_running_rows_label(10, Some(100));
+        assert!(with_total.contains("10"));
+        assert!(with_total.contains("100"));
+
+        let without_total = migrate_running_rows_label(10, None);
+        assert!(without_total.contains("10"));
+        assert!(!without_total.contains("100"));
+
+        let zero_total = migrate_running_rows_label(10, Some(0));
         assert!(zero_total.contains("10"));
         assert!(!zero_total.contains('/'));
     }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1680,6 +1680,44 @@ pub(crate) fn migrate_running_rows_label(rows_done: u64, estimated_total: Option
     }
 }
 
+/// Label for the Tables Mapping grid's per-row "N unmapped" warning, with the
+/// unmatched-source-column count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one unmapped column;
+/// every other count, including zero, uses the plural bucket.
+pub(crate) fn migrate_mapping_unmapped_count_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "document.migrate_wizard.mapping.unmapped_count.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.migrate_wizard.mapping.unmapped_count.many",
+            count = count
+        )
+    }
+}
+
+/// Label for the Source & Target phase's source-panel subtitle, with the
+/// checked-table count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one checked table;
+/// every other count, including zero, uses the plural bucket.
+pub(crate) fn migrate_source_target_checked_count_label(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "document.migrate_wizard.source_target.checked_count.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.migrate_wizard.source_target.checked_count.many",
+            count = count
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1700,8 +1738,9 @@ mod tests {
         live_output_lines_label, live_output_truncated_label, metric_picker_custom_dropdown_label,
         metric_picker_dimensions_error_label, metric_picker_period_error_label,
         metric_picker_period_not_a_number_error, metric_picker_statistic_error_label,
-        migrate_running_position_label, migrate_running_rows_label, migrate_summary_label,
-        migrate_table_status_line, object_browser_status_summary,
+        migrate_mapping_unmapped_count_label, migrate_running_position_label,
+        migrate_running_rows_label, migrate_source_target_checked_count_label,
+        migrate_summary_label, migrate_table_status_line, object_browser_status_summary,
         object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
         pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
         refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
@@ -4640,6 +4679,35 @@ mod tests {
         "document.migrate_wizard.footer.close",
     ];
 
+    // ── PR 27a-2: migrate_wizard/{mapping,source_target}.rs ──
+
+    const MIGRATE_MAPPING_SOURCE_TARGET_KEYS: &[&str] = &[
+        "document.migrate_wizard.mapping.target_placeholder",
+        "document.migrate_wizard.mapping.mode_placeholder",
+        "document.migrate_wizard.mapping.unset_option",
+        "document.migrate_wizard.mapping.set_all_label",
+        "document.migrate_wizard.mapping.columns_button",
+        "document.migrate_wizard.mapping.unmapped_count.one",
+        "document.migrate_wizard.mapping.unmapped_count.many",
+        "document.migrate_wizard.mapping.column_mapping_title",
+        "document.migrate_wizard.mapping.target_column_header",
+        "document.migrate_wizard.mapping.source_column_header",
+        "document.migrate_wizard.mapping.unmapped_columns",
+        "document.migrate_wizard.mapping.header_source",
+        "document.migrate_wizard.mapping.header_target",
+        "document.migrate_wizard.mapping.header_mapping_mode",
+        "document.migrate_wizard.mapping.header_transform",
+        "document.migrate_wizard.source_target.source_title",
+        "document.migrate_wizard.source_target.target_title",
+        "document.migrate_wizard.source_target.checked_count.one",
+        "document.migrate_wizard.source_target.checked_count.many",
+        "document.migrate_wizard.source_target.no_target_selected",
+        "document.migrate_wizard.source_target.retry",
+        "document.migrate_wizard.source_target.source_connection_gone",
+        "document.migrate_wizard.source_target.target_connection_gone",
+        "document.migrate_wizard.source_target.cross_database_error",
+    ];
+
     /// PR 27a: every `document.migrate_wizard.*` key introduced by
     /// `phases.rs`/`mod.rs`/`options.rs`/`column_mapping.rs`/`confirm_run.rs`
     /// resolves to a non-empty, non-fallback value in both locales.
@@ -4676,6 +4744,111 @@ mod tests {
             let es = dbflux_i18n::t!(key, locale = "es");
             assert_ne!(en, es, "{key} must differ between en and es");
         }
+    }
+
+    /// PR 27a-2: every `document.migrate_wizard.{mapping,source_target}.*`
+    /// key introduced by `mapping.rs`/`source_target.rs` resolves to a
+    /// non-empty, non-fallback value in both locales.
+    #[test]
+    fn migrate_mapping_source_target_keys_resolve_in_both_locales() {
+        for key in MIGRATE_MAPPING_SOURCE_TARGET_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// PR 27a-2: a representative sample of
+    /// `document.migrate_wizard.{mapping,source_target}.*` keys diverges
+    /// between locales.
+    #[test]
+    fn migrate_mapping_source_target_keys_differ_between_locales() {
+        for key in [
+            "document.migrate_wizard.mapping.set_all_label",
+            "document.migrate_wizard.mapping.column_mapping_title",
+            "document.migrate_wizard.source_target.no_target_selected",
+            "document.migrate_wizard.source_target.cross_database_error",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
+    }
+
+    /// PR 27a-2: `migrate_mapping_unmapped_count_label` uses the singular
+    /// catalog bucket only for exactly one unmapped column; every other
+    /// count, including zero, uses the plural bucket.
+    #[test]
+    fn migrate_mapping_unmapped_count_label_switches_bucket_on_count() {
+        let one = migrate_mapping_unmapped_count_label(1);
+        assert_eq!(
+            one,
+            dbflux_i18n::t!(
+                "document.migrate_wizard.mapping.unmapped_count.one",
+                count = 1
+            )
+        );
+
+        let many = migrate_mapping_unmapped_count_label(3);
+        assert_eq!(
+            many,
+            dbflux_i18n::t!(
+                "document.migrate_wizard.mapping.unmapped_count.many",
+                count = 3
+            )
+        );
+        assert_ne!(one, many);
+
+        let zero = migrate_mapping_unmapped_count_label(0);
+        assert_eq!(
+            zero,
+            dbflux_i18n::t!(
+                "document.migrate_wizard.mapping.unmapped_count.many",
+                count = 0
+            )
+        );
+    }
+
+    /// PR 27a-2: `migrate_source_target_checked_count_label` uses the
+    /// singular catalog bucket only for exactly one checked table; every
+    /// other count, including zero, uses the plural bucket.
+    #[test]
+    fn migrate_source_target_checked_count_label_switches_bucket_on_count() {
+        let one = migrate_source_target_checked_count_label(1);
+        assert_eq!(
+            one,
+            dbflux_i18n::t!(
+                "document.migrate_wizard.source_target.checked_count.one",
+                count = 1
+            )
+        );
+
+        let many = migrate_source_target_checked_count_label(3);
+        assert_eq!(
+            many,
+            dbflux_i18n::t!(
+                "document.migrate_wizard.source_target.checked_count.many",
+                count = 3
+            )
+        );
+        assert_ne!(one, many);
+
+        let zero = migrate_source_target_checked_count_label(0);
+        assert_eq!(
+            zero,
+            dbflux_i18n::t!(
+                "document.migrate_wizard.source_target.checked_count.many",
+                count = 0
+            )
+        );
     }
 
     /// PR 27a: `migrate_summary_label` picks the "with failures" bucket only

--- a/crates/dbflux_ui_document/src/migrate_wizard/column_mapping.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/column_mapping.rs
@@ -9,23 +9,44 @@
 use dbflux_core::{TableRef, TransferColumn};
 use dbflux_transfer::{ColumnMappingOverride, TableMappingMode};
 
-/// Ordered (label, mode) pairs for the mapping-mode picker. `Truncate` is
-/// filtered out by [`mapping_mode_options`] when the target lacks
+/// Ordered mapping modes for the mapping-mode picker. `Truncate` is filtered
+/// out by [`mapping_mode_options`] when the target lacks
 /// `DriverCapabilities::TRUNCATE_TABLE` — unavailable, not a runtime error
 /// (mirrors the `DISABLE_FK_CHECKS` missing-capability pattern from R7).
-const MAPPING_MODE_OPTIONS: &[(&str, TableMappingMode)] = &[
-    ("Create", TableMappingMode::Create),
-    ("Existing (insert only)", TableMappingMode::Existing),
-    ("Recreate (drop + create)", TableMappingMode::Recreate),
-    ("Skip", TableMappingMode::Skip),
-    ("Truncate (empty + insert)", TableMappingMode::Truncate),
+const MAPPING_MODE_VALUES: &[TableMappingMode] = &[
+    TableMappingMode::Create,
+    TableMappingMode::Existing,
+    TableMappingMode::Recreate,
+    TableMappingMode::Skip,
+    TableMappingMode::Truncate,
 ];
 
-pub fn mapping_mode_options(supports_truncate: bool) -> Vec<(&'static str, TableMappingMode)> {
-    MAPPING_MODE_OPTIONS
+/// The mapping-mode picker's label for `mode`, resolved through the
+/// translation catalog. Exhaustive by construction so a new
+/// [`TableMappingMode`] variant fails this crate's build until its
+/// `document.migrate_wizard.mapping_mode.*` entry is added here.
+pub fn mapping_mode_option_label(mode: TableMappingMode) -> String {
+    match mode {
+        TableMappingMode::Create => dbflux_i18n::t!("document.migrate_wizard.mapping_mode.create"),
+        TableMappingMode::Existing => {
+            dbflux_i18n::t!("document.migrate_wizard.mapping_mode.existing")
+        }
+        TableMappingMode::Recreate => {
+            dbflux_i18n::t!("document.migrate_wizard.mapping_mode.recreate")
+        }
+        TableMappingMode::Skip => dbflux_i18n::t!("document.migrate_wizard.mapping_mode.skip"),
+        TableMappingMode::Truncate => {
+            dbflux_i18n::t!("document.migrate_wizard.mapping_mode.truncate")
+        }
+    }
+}
+
+pub fn mapping_mode_options(supports_truncate: bool) -> Vec<(String, TableMappingMode)> {
+    MAPPING_MODE_VALUES
         .iter()
         .copied()
-        .filter(|(_, mode)| supports_truncate || *mode != TableMappingMode::Truncate)
+        .filter(|mode| supports_truncate || *mode != TableMappingMode::Truncate)
+        .map(|mode| (mapping_mode_option_label(mode), mode))
         .collect()
 }
 
@@ -164,6 +185,52 @@ mod tests {
                 .iter()
                 .any(|(_, mode)| *mode == TableMappingMode::Truncate)
         );
+    }
+
+    /// `mapping_mode_option_label` covers every `TableMappingMode` variant
+    /// (exhaustive match, no wildcard arm — a new variant fails the build
+    /// until its `document.migrate_wizard.mapping_mode.*` entry is added
+    /// here), resolves non-empty in both locales, and diverges between them.
+    #[test]
+    fn mapping_mode_option_label_resolves_and_differs_in_both_locales() {
+        let modes = [
+            TableMappingMode::Create,
+            TableMappingMode::Existing,
+            TableMappingMode::Recreate,
+            TableMappingMode::Skip,
+            TableMappingMode::Truncate,
+        ];
+        for mode in modes {
+            let key = match mode {
+                TableMappingMode::Create => "document.migrate_wizard.mapping_mode.create",
+                TableMappingMode::Existing => "document.migrate_wizard.mapping_mode.existing",
+                TableMappingMode::Recreate => "document.migrate_wizard.mapping_mode.recreate",
+                TableMappingMode::Skip => "document.migrate_wizard.mapping_mode.skip",
+                TableMappingMode::Truncate => "document.migrate_wizard.mapping_mode.truncate",
+            };
+
+            let label = mapping_mode_option_label(mode);
+            assert!(
+                !label.is_empty(),
+                "mapping_mode_option_label({mode:?}) resolved empty"
+            );
+            assert_eq!(label, dbflux_i18n::t!(key));
+
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
@@ -63,16 +63,29 @@ pub fn decide_order(result: OrderResult) -> OrderDecision {
     }
 }
 
-/// The human-readable mode label shown in the Confirm summary — the same
-/// wording used by the mapping grid's mode picker, kept as a small pure map so
-/// the summary never has to reach back into the dropdown's option list.
-pub fn mapping_mode_label(mode: TableMappingMode) -> &'static str {
+/// The human-readable mode label shown in the Confirm summary — a shorter
+/// wording than the mapping grid's mode picker (see
+/// [`crate::migrate_wizard::column_mapping::mapping_mode_options`]), resolved
+/// through the translation catalog. Exhaustive by construction so a new
+/// [`TableMappingMode`] variant fails this crate's build until its
+/// `document.migrate_wizard.confirm.mode_label.*` entry is added here.
+pub fn mapping_mode_label(mode: TableMappingMode) -> String {
     match mode {
-        TableMappingMode::Create => "Create",
-        TableMappingMode::Existing => "Existing",
-        TableMappingMode::Recreate => "Recreate",
-        TableMappingMode::Skip => "Skip",
-        TableMappingMode::Truncate => "Truncate",
+        TableMappingMode::Create => {
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.create")
+        }
+        TableMappingMode::Existing => {
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.existing")
+        }
+        TableMappingMode::Recreate => {
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.recreate")
+        }
+        TableMappingMode::Skip => {
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.skip")
+        }
+        TableMappingMode::Truncate => {
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.truncate")
+        }
     }
 }
 
@@ -80,7 +93,7 @@ pub fn mapping_mode_label(mode: TableMappingMode) -> &'static str {
 pub struct PlanSummaryRow {
     pub source: String,
     pub target: String,
-    pub mode_label: &'static str,
+    pub mode_label: String,
     pub destructive: bool,
 }
 
@@ -476,7 +489,8 @@ impl ConfirmRunPhase {
                     report_error(UserFacingError::new(ErrorKind::Driver, message.clone()), cx);
                 }
                 if toast_success {
-                    Toast::success("Migration completed").push(cx);
+                    Toast::success(dbflux_i18n::t!("document.migrate_wizard.toast.success"))
+                        .push(cx);
                 }
             })
             .ok();
@@ -525,7 +539,7 @@ fn resolve_run_outcome(
             task_action: RunTaskAction::Cancel,
             report: None,
             toast_success: false,
-            summary: "Migration cancelled".to_string(),
+            summary: dbflux_i18n::t!("document.migrate_wizard.status.cancelled"),
             warnings: Vec::new(),
         },
         Ok(MigrationOutcome::Completed(outcome)) => {
@@ -542,7 +556,11 @@ fn resolve_run_outcome(
             match failed_table {
                 Some((table, error)) => RunResolution {
                     task_action: RunTaskAction::Fail(format!("{table}: {error}")),
-                    report: Some(format!("Migration failed on table '{table}': {error}")),
+                    report: Some(dbflux_i18n::t!(
+                        "document.migrate_wizard.error.table_failed",
+                        table = table,
+                        error = error
+                    )),
                     toast_success: false,
                     summary,
                     warnings,
@@ -557,9 +575,9 @@ fn resolve_run_outcome(
             }
         }
         Ok(MigrationOutcome::CyclicOrderRequired { .. }) => {
-            let message = "Migration failed: FK order became cyclic mid-run".to_string();
+            let message = dbflux_i18n::t!("document.migrate_wizard.error.cyclic_order");
             RunResolution {
-                task_action: RunTaskAction::Fail("FK order became cyclic mid-run".to_string()),
+                task_action: RunTaskAction::Fail(message.clone()),
                 report: Some(message.clone()),
                 toast_success: false,
                 summary: message,
@@ -567,7 +585,7 @@ fn resolve_run_outcome(
             }
         }
         Err(e) => {
-            let message = format!("Migration failed: {e}");
+            let message = dbflux_i18n::t!("document.migrate_wizard.error.failed", error = e);
             RunResolution {
                 task_action: RunTaskAction::Fail(e.to_string()),
                 report: Some(message.clone()),
@@ -620,7 +638,9 @@ impl ConfirmRunPhase {
             .flex()
             .flex_col()
             .gap(Spacing::XS)
-            .child(Text::label("Review migration plan"))
+            .child(Text::label(dbflux_i18n::t!(
+                "document.migrate_wizard.confirm.review_plan"
+            )))
             .child(Text::caption(format!(
                 "{} → {}",
                 self.summary.source_container, self.summary.target_container
@@ -678,9 +698,14 @@ impl ConfirmRunPhase {
                         .overflow_hidden()
                         .child(Text::body(format!("{} → {}", row.source, row.target))),
                 )
-                .child(Text::caption(row.mode_label))
+                .child(Text::caption(row.mode_label.clone()))
                 .when(row.destructive, |el| {
-                    el.child(Text::caption("destructive").danger())
+                    el.child(
+                        Text::caption(dbflux_i18n::t!(
+                            "document.migrate_wizard.confirm.destructive_tag"
+                        ))
+                        .danger(),
+                    )
                 })
                 .into_any_element()
         });
@@ -700,9 +725,9 @@ impl ConfirmRunPhase {
                 parent.child(
                     Checkbox::new("migrate-confirm-destructive-ack")
                         .checked(self.destructive_ack)
-                        .label(
-                            "I understand this plan will drop or empty existing data in the target.",
-                        )
+                        .label(dbflux_i18n::t!(
+                            "document.migrate_wizard.confirm.destructive_ack"
+                        ))
                         .on_click(cx.listener(|this, checked: &bool, _, cx| {
                             this.destructive_ack = *checked;
                             cx.notify();
@@ -711,13 +736,14 @@ impl ConfirmRunPhase {
             })
             .child(
                 div().flex().justify_end().child(
-                    Button::new("migrate-confirm-start", "Start Migration")
-                        .small()
-                        .primary()
-                        .disabled(!start_enabled)
-                        .on_click(
-                            cx.listener(|this, _event, _window, cx| this.on_start_migration(cx)),
-                        ),
+                    Button::new(
+                        "migrate-confirm-start",
+                        dbflux_i18n::t!("document.migrate_wizard.confirm.start_migration"),
+                    )
+                    .small()
+                    .primary()
+                    .disabled(!start_enabled)
+                    .on_click(cx.listener(|this, _event, _window, cx| this.on_start_migration(cx))),
                 ),
             )
             .into_any_element()
@@ -744,7 +770,7 @@ impl ConfirmRunPhase {
                 .child(
                     Button::new(
                         SharedString::from(format!("migrate-reorder-up-{index}")),
-                        "Up",
+                        dbflux_i18n::t!("document.migrate_wizard.confirm.reorder.up"),
                     )
                     .small()
                     .ghost()
@@ -756,7 +782,7 @@ impl ConfirmRunPhase {
                 .child(
                     Button::new(
                         SharedString::from(format!("migrate-reorder-down-{index}")),
-                        "Down",
+                        dbflux_i18n::t!("document.migrate_wizard.confirm.reorder.down"),
                     )
                     .small()
                     .ghost()
@@ -773,19 +799,21 @@ impl ConfirmRunPhase {
             .flex_col()
             .gap(Spacing::SM)
             .child(
-                Text::caption(
-                    "These tables reference each other in a cycle and cannot be ordered \
-                     automatically. Choose the load order before starting:",
-                )
+                Text::caption(dbflux_i18n::t!(
+                    "document.migrate_wizard.confirm.reorder.warning"
+                ))
                 .warning(),
             )
             .children(rows)
             .child(
                 div().flex().justify_end().child(
-                    Button::new("migrate-reorder-accept", "Use this order")
-                        .small()
-                        .primary()
-                        .on_click(cx.listener(|this, _event, _window, cx| this.accept_reorder(cx))),
+                    Button::new(
+                        "migrate-reorder-accept",
+                        dbflux_i18n::t!("document.migrate_wizard.confirm.reorder.accept"),
+                    )
+                    .small()
+                    .primary()
+                    .on_click(cx.listener(|this, _event, _window, cx| this.accept_reorder(cx))),
                 ),
             )
             .into_any_element()
@@ -822,10 +850,8 @@ impl ConfirmRunPhase {
         let total_tables = names.len();
         let current_index = progress.table_index.min(total_tables.saturating_sub(1));
 
-        let rows_label = match progress.estimated_total {
-            Some(total) if total > 0 => format!("{} / {} rows", progress.rows_done, total),
-            _ => format!("{} rows", progress.rows_done),
-        };
+        let rows_label =
+            crate::labels::migrate_running_rows_label(progress.rows_done, progress.estimated_total);
         let determinate = matches!(progress.estimated_total, Some(total) if total > 0);
         let fraction = match progress.estimated_total {
             Some(total) if total > 0 => (progress.rows_done as f32 / total as f32).clamp(0.0, 1.0),
@@ -838,11 +864,8 @@ impl ConfirmRunPhase {
             .unwrap_or_default();
 
         let current_table = names.get(current_index).cloned().unwrap_or_default();
-        let position_label = if total_tables > 0 {
-            format!("Table {} of {}", current_index + 1, total_tables)
-        } else {
-            "Preparing".to_string()
-        };
+        let position_label =
+            crate::labels::migrate_running_position_label(current_index, total_tables);
 
         let steps_rows_label = rows_label.clone();
         let steps = names.iter().enumerate().map(move |(index, name)| {
@@ -903,7 +926,9 @@ impl ConfirmRunPhase {
                     .flex()
                     .items_center()
                     .justify_between()
-                    .child(Text::label("Migrating…"))
+                    .child(Text::label(dbflux_i18n::t!(
+                        "document.migrate_wizard.running.title"
+                    )))
                     .child(Text::caption(format_elapsed(elapsed)).muted_foreground()),
             )
             .child(
@@ -961,8 +986,11 @@ impl ConfirmRunPhase {
             })
             .when_some(self.run_elapsed, |el, elapsed| {
                 el.child(
-                    Text::caption(format!("Completed in {}", format_elapsed(elapsed)))
-                        .muted_foreground(),
+                    Text::caption(dbflux_i18n::t!(
+                        "document.migrate_wizard.done.completed_in",
+                        elapsed = format_elapsed(elapsed)
+                    ))
+                    .muted_foreground(),
                 )
             })
             .when(!self.result_warnings.is_empty(), |el| {
@@ -1054,11 +1082,63 @@ mod tests {
 
     #[test]
     fn mapping_mode_label_covers_every_mode() {
-        assert_eq!(mapping_mode_label(TableMappingMode::Create), "Create");
-        assert_eq!(mapping_mode_label(TableMappingMode::Existing), "Existing");
-        assert_eq!(mapping_mode_label(TableMappingMode::Recreate), "Recreate");
-        assert_eq!(mapping_mode_label(TableMappingMode::Skip), "Skip");
-        assert_eq!(mapping_mode_label(TableMappingMode::Truncate), "Truncate");
+        assert_eq!(
+            mapping_mode_label(TableMappingMode::Create),
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.create")
+        );
+        assert_eq!(
+            mapping_mode_label(TableMappingMode::Existing),
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.existing")
+        );
+        assert_eq!(
+            mapping_mode_label(TableMappingMode::Recreate),
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.recreate")
+        );
+        assert_eq!(
+            mapping_mode_label(TableMappingMode::Skip),
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.skip")
+        );
+        assert_eq!(
+            mapping_mode_label(TableMappingMode::Truncate),
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.truncate")
+        );
+    }
+
+    /// Every `document.migrate_wizard.confirm.mode_label.*` key resolves to a
+    /// non-empty, non-fallback value in both locales, and diverges between
+    /// locales — exhaustive over every `TableMappingMode` variant.
+    #[test]
+    fn mapping_mode_label_resolves_and_differs_in_both_locales() {
+        for mode in [
+            TableMappingMode::Create,
+            TableMappingMode::Existing,
+            TableMappingMode::Recreate,
+            TableMappingMode::Skip,
+            TableMappingMode::Truncate,
+        ] {
+            let key = match mode {
+                TableMappingMode::Create => "document.migrate_wizard.confirm.mode_label.create",
+                TableMappingMode::Existing => "document.migrate_wizard.confirm.mode_label.existing",
+                TableMappingMode::Recreate => "document.migrate_wizard.confirm.mode_label.recreate",
+                TableMappingMode::Skip => "document.migrate_wizard.confirm.mode_label.skip",
+                TableMappingMode::Truncate => "document.migrate_wizard.confirm.mode_label.truncate",
+            };
+
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
     }
 
     #[test]
@@ -1079,10 +1159,16 @@ mod tests {
         assert_eq!(summary.rows.len(), 2);
 
         assert_eq!(summary.rows[0].target, "users");
-        assert_eq!(summary.rows[0].mode_label, "Existing");
+        assert_eq!(
+            summary.rows[0].mode_label,
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.existing")
+        );
         assert!(!summary.rows[0].destructive);
 
-        assert_eq!(summary.rows[1].mode_label, "Recreate");
+        assert_eq!(
+            summary.rows[1].mode_label,
+            dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.recreate")
+        );
         assert!(summary.rows[1].destructive);
 
         assert!(summary.has_destructive());

--- a/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
@@ -270,7 +270,7 @@ impl MappingPhase {
                 .position(|(_, mode)| *mode == config.mapping_mode);
             let mode_items: Vec<DropdownItem> = mode_options
                 .iter()
-                .map(|(label, _)| DropdownItem::new(*label))
+                .map(|(label, _)| DropdownItem::new(label.clone()))
                 .collect();
             let mode_dropdown = cx.new(|_cx| {
                 Dropdown::new(SharedString::from(format!("migrate-mode-{row_index}")))
@@ -352,7 +352,7 @@ impl MappingPhase {
 
     fn on_mode_changed(&mut self, row_index: usize, index: usize, cx: &mut Context<Self>) {
         let mode_options = mapping_mode_options(self.supports_truncate);
-        let Some((_, mode)) = mode_options.get(index).copied() else {
+        let Some((_, mode)) = mode_options.get(index).cloned() else {
             return;
         };
         if let Some(row) = self.rows.get_mut(row_index) {

--- a/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
@@ -48,7 +48,6 @@ use crate::migrate_wizard::tree_model::NodeLoad;
 const TARGET_COL_W: Pixels = px(220.0);
 const MODE_COL_W: Pixels = px(200.0);
 const TRANSFORM_COL_W: Pixels = px(160.0);
-const UNSET_LABEL: &str = "(unset)";
 
 /// Whether a typed target-table name refers to a table that already exists in
 /// the chosen target container (⇒ [`TargetResolution::Existing`]) or a new one
@@ -261,7 +260,9 @@ impl MappingPhase {
             let target_input = cx.new(|cx| {
                 InputState::new(window, cx)
                     .default_value(config.target_table.clone())
-                    .placeholder("Target table")
+                    .placeholder(dbflux_i18n::t!(
+                        "document.migrate_wizard.mapping.target_placeholder"
+                    ))
             });
 
             let mode_options = mapping_mode_options(supports_truncate);
@@ -276,7 +277,9 @@ impl MappingPhase {
                 Dropdown::new(SharedString::from(format!("migrate-mode-{row_index}")))
                     .items(mode_items)
                     .selected_index(selected_mode)
-                    .placeholder("Mode")
+                    .placeholder(dbflux_i18n::t!(
+                        "document.migrate_wizard.mapping.mode_placeholder"
+                    ))
             });
 
             let input_sub = cx.subscribe_in(
@@ -457,7 +460,9 @@ impl MappingPhase {
         let mut subscriptions = Vec::new();
 
         for (target_index, binding) in row.config.bindings.iter().enumerate() {
-            let mut items = vec![DropdownItem::new(UNSET_LABEL)];
+            let mut items = vec![DropdownItem::new(dbflux_i18n::t!(
+                "document.migrate_wizard.mapping.unset_option"
+            ))];
             items.extend(source_names.iter().cloned().map(DropdownItem::new));
 
             let selected = binding.map(|source_index| source_index + 1).or(Some(0));
@@ -590,32 +595,43 @@ impl MappingPhase {
             .flex_row()
             .items_center()
             .gap(Spacing::SM)
-            .child(Text::caption("Set all:"))
+            .child(Text::caption(dbflux_i18n::t!(
+                "document.migrate_wizard.mapping.set_all_label"
+            )))
             .child(
-                Button::new("migrate-bulk-existing", "Existing")
-                    .small()
-                    .ghost()
-                    .on_click(cx.listener(|this, _event, _window, cx| {
-                        this.set_all_modes(TableMappingMode::Existing, cx);
-                    })),
+                Button::new(
+                    "migrate-bulk-existing",
+                    dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.existing"),
+                )
+                .small()
+                .ghost()
+                .on_click(cx.listener(|this, _event, _window, cx| {
+                    this.set_all_modes(TableMappingMode::Existing, cx);
+                })),
             )
             .when(supports_truncate, |parent| {
                 parent.child(
-                    Button::new("migrate-bulk-truncate", "Truncate")
-                        .small()
-                        .ghost()
-                        .on_click(cx.listener(|this, _event, _window, cx| {
-                            this.set_all_modes(TableMappingMode::Truncate, cx);
-                        })),
-                )
-            })
-            .child(
-                Button::new("migrate-bulk-skip", "Skip")
+                    Button::new(
+                        "migrate-bulk-truncate",
+                        dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.truncate"),
+                    )
                     .small()
                     .ghost()
                     .on_click(cx.listener(|this, _event, _window, cx| {
-                        this.set_all_modes(TableMappingMode::Skip, cx);
+                        this.set_all_modes(TableMappingMode::Truncate, cx);
                     })),
+                )
+            })
+            .child(
+                Button::new(
+                    "migrate-bulk-skip",
+                    dbflux_i18n::t!("document.migrate_wizard.confirm.mode_label.skip"),
+                )
+                .small()
+                .ghost()
+                .on_click(cx.listener(|this, _event, _window, cx| {
+                    this.set_all_modes(TableMappingMode::Skip, cx);
+                })),
             )
     }
 
@@ -636,7 +652,7 @@ impl MappingPhase {
             .child(
                 Button::new(
                     SharedString::from(format!("migrate-transform-{row_index}")),
-                    "Columns…",
+                    dbflux_i18n::t!("document.migrate_wizard.mapping.columns_button"),
                 )
                 .small()
                 .ghost()
@@ -647,8 +663,10 @@ impl MappingPhase {
             )
             .when(!unmatched.is_empty(), |parent| {
                 parent.child(
-                    Text::caption(SharedString::from(format!("{} unmapped", unmatched.len())))
-                        .color(theme.warning),
+                    Text::caption(crate::labels::migrate_mapping_unmapped_count_label(
+                        unmatched.len(),
+                    ))
+                    .color(theme.warning),
                 )
             });
 
@@ -709,18 +727,23 @@ impl MappingPhase {
                     .items_center()
                     .gap(Spacing::SM)
                     .child(
-                        Button::new("migrate-drilldown-back", "Back")
-                            .small()
-                            .ghost()
-                            .icon(AppIcon::ChevronLeft)
-                            .on_click(cx.listener(|this, _event, _window, cx| {
+                        Button::new(
+                            "migrate-drilldown-back",
+                            dbflux_i18n::t!("document.migrate_wizard.footer.back"),
+                        )
+                        .small()
+                        .ghost()
+                        .icon(AppIcon::ChevronLeft)
+                        .on_click(cx.listener(
+                            |this, _event, _window, cx| {
                                 this.close_drilldown(cx);
-                            })),
+                            },
+                        )),
                     )
-                    .child(Text::body(SharedString::from(format!(
-                        "Column mapping — {}",
-                        row.config.source_table.qualified_name()
-                    )))),
+                    .child(Text::body(dbflux_i18n::t!(
+                        "document.migrate_wizard.mapping.column_mapping_title",
+                        table = row.config.source_table.qualified_name()
+                    ))),
             )
             .child(
                 div()
@@ -728,8 +751,12 @@ impl MappingPhase {
                     .flex_row()
                     .items_center()
                     .gap(Spacing::SM)
-                    .child(div().w(TARGET_COL_W).child(Text::label("Target column")))
-                    .child(div().w(TARGET_COL_W).child(Text::label("Source column"))),
+                    .child(div().w(TARGET_COL_W).child(Text::label(dbflux_i18n::t!(
+                        "document.migrate_wizard.mapping.target_column_header"
+                    ))))
+                    .child(div().w(TARGET_COL_W).child(Text::label(dbflux_i18n::t!(
+                        "document.migrate_wizard.mapping.source_column_header"
+                    )))),
             )
             .child(
                 div()
@@ -744,10 +771,10 @@ impl MappingPhase {
             )
             .when(!unmatched.is_empty(), |parent| {
                 parent.child(
-                    Text::caption(SharedString::from(format!(
-                        "Unmapped source columns: {}",
-                        unmatched.join(", ")
-                    )))
+                    Text::caption(dbflux_i18n::t!(
+                        "document.migrate_wizard.mapping.unmapped_columns",
+                        columns = unmatched.join(", ")
+                    ))
                     .color(theme.warning),
                 )
             })
@@ -766,10 +793,23 @@ fn render_grid_header(cx: &mut Context<MappingPhase>) -> impl IntoElement {
         .h(Heights::ROW)
         .border_b_1()
         .border_color(theme.border)
-        .child(div().flex_1().min_w(px(0.0)).child(Text::label("Source")))
-        .child(div().w(TARGET_COL_W).child(Text::label("Target")))
-        .child(div().w(MODE_COL_W).child(Text::label("Mapping mode")))
-        .child(div().w(TRANSFORM_COL_W).child(Text::label("Transform")))
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.0))
+                .child(Text::label(dbflux_i18n::t!(
+                    "document.migrate_wizard.mapping.header_source"
+                ))),
+        )
+        .child(div().w(TARGET_COL_W).child(Text::label(dbflux_i18n::t!(
+            "document.migrate_wizard.mapping.header_target"
+        ))))
+        .child(div().w(MODE_COL_W).child(Text::label(dbflux_i18n::t!(
+            "document.migrate_wizard.mapping.header_mapping_mode"
+        ))))
+        .child(div().w(TRANSFORM_COL_W).child(Text::label(dbflux_i18n::t!(
+            "document.migrate_wizard.mapping.header_transform"
+        ))))
 }
 
 fn render_binding_row(
@@ -917,5 +957,69 @@ mod tests {
         config.set_binding(1, None);
         let overrides = config.to_overrides();
         assert_eq!(overrides[1].source_column, None);
+    }
+
+    // ── PR 27a-2: migrate_wizard/mapping.rs ──
+
+    const MIGRATE_MAPPING_KEYS: &[&str] = &[
+        "document.migrate_wizard.mapping.target_placeholder",
+        "document.migrate_wizard.mapping.mode_placeholder",
+        "document.migrate_wizard.mapping.unset_option",
+        "document.migrate_wizard.mapping.set_all_label",
+        "document.migrate_wizard.mapping.columns_button",
+        "document.migrate_wizard.mapping.unmapped_count.one",
+        "document.migrate_wizard.mapping.unmapped_count.many",
+        "document.migrate_wizard.mapping.column_mapping_title",
+        "document.migrate_wizard.mapping.target_column_header",
+        "document.migrate_wizard.mapping.source_column_header",
+        "document.migrate_wizard.mapping.unmapped_columns",
+        "document.migrate_wizard.mapping.header_source",
+        "document.migrate_wizard.mapping.header_target",
+        "document.migrate_wizard.mapping.header_mapping_mode",
+        "document.migrate_wizard.mapping.header_transform",
+        // Reused from PR 27a (`confirm.mode_label.*`, `footer.back`), listed
+        // here because the bulk "Set all" buttons and the drilldown Back
+        // button resolve them from this file too.
+        "document.migrate_wizard.confirm.mode_label.existing",
+        "document.migrate_wizard.confirm.mode_label.truncate",
+        "document.migrate_wizard.confirm.mode_label.skip",
+        "document.migrate_wizard.footer.back",
+    ];
+
+    /// Every `document.migrate_wizard.mapping.*` key introduced by this file
+    /// (plus the keys it reuses from PR 27a) resolves to a non-empty,
+    /// non-fallback value in both locales.
+    #[test]
+    fn migrate_mapping_keys_resolve_in_both_locales() {
+        for key in MIGRATE_MAPPING_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// A representative sample of `document.migrate_wizard.mapping.*` keys
+    /// diverges between locales.
+    #[test]
+    fn migrate_mapping_keys_differ_between_locales() {
+        for key in [
+            "document.migrate_wizard.mapping.target_placeholder",
+            "document.migrate_wizard.mapping.set_all_label",
+            "document.migrate_wizard.mapping.columns_button",
+            "document.migrate_wizard.mapping.column_mapping_title",
+            "document.migrate_wizard.mapping.header_mapping_mode",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
     }
 }

--- a/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mod.rs
@@ -838,7 +838,7 @@ impl MigrateWizard {
         let Some(source_connection) = self.resolve_source_connection(cx) else {
             self.report_advance_error(
                 ErrorKind::Storage,
-                "No active connection for the source profile",
+                dbflux_i18n::t!("document.migrate_wizard.error.no_source_connection"),
                 cx,
             );
             return;
@@ -848,7 +848,7 @@ impl MigrateWizard {
         else {
             self.report_advance_error(
                 ErrorKind::Storage,
-                "No active connection for the target profile",
+                dbflux_i18n::t!("document.migrate_wizard.error.no_target_connection"),
                 cx,
             );
             return;
@@ -959,7 +959,10 @@ impl MigrateWizard {
                     Err(e) => {
                         this.report_advance_error(
                             ErrorKind::Driver,
-                            format!("Could not read table schema: {e}"),
+                            dbflux_i18n::t!(
+                                "document.migrate_wizard.error.table_schema_read_failed",
+                                error = e
+                            ),
                             cx,
                         );
                     }
@@ -1064,7 +1067,7 @@ impl MigrateWizard {
         let Some(source_connection) = self.resolve_source_connection(cx) else {
             self.report_advance_error(
                 ErrorKind::Storage,
-                "No active connection for the source profile",
+                dbflux_i18n::t!("document.migrate_wizard.error.no_source_connection"),
                 cx,
             );
             return;
@@ -1074,7 +1077,7 @@ impl MigrateWizard {
         else {
             self.report_advance_error(
                 ErrorKind::Storage,
-                "No active connection for the target profile",
+                dbflux_i18n::t!("document.migrate_wizard.error.no_target_connection"),
                 cx,
             );
             return;
@@ -1183,7 +1186,10 @@ impl MigrateWizard {
                     Err(e) => {
                         this.report_advance_error(
                             ErrorKind::Driver,
-                            format!("Could not read foreign keys: {e}"),
+                            dbflux_i18n::t!(
+                                "document.migrate_wizard.error.foreign_keys_read_failed",
+                                error = e
+                            ),
                             cx,
                         );
                     }
@@ -1266,13 +1272,7 @@ impl MigrateWizard {
             })
             .sum();
 
-        if failed > 0 {
-            format!(
-                "Migrated {completed} table(s), {rows} row(s) total ({skipped} skipped, {failed} failed)"
-            )
-        } else {
-            format!("Migrated {completed} table(s), {rows} row(s) total ({skipped} skipped)")
-        }
+        crate::labels::migrate_summary_label(completed, rows, skipped, failed)
     }
 
     /// Renders one status line per planned table when the run left any table
@@ -1299,16 +1299,7 @@ impl MigrateWizard {
     }
 
     fn table_status_line(table: &MigratedTable) -> String {
-        match &table.status {
-            TableTransferStatus::Completed { rows } => {
-                format!("{}: completed ({rows} row(s))", table.source_table)
-            }
-            TableTransferStatus::Skipped => format!("{}: skipped", table.source_table),
-            TableTransferStatus::Failed { error } => {
-                format!("{}: FAILED — {error}", table.source_table)
-            }
-            TableTransferStatus::NotStarted => format!("{}: not attempted", table.source_table),
-        }
+        crate::labels::migrate_table_status_line(table)
     }
 }
 
@@ -1326,7 +1317,7 @@ impl Render for MigrateWizard {
         };
 
         let frame = ModalFrame::new("migrate-wizard", &self.focus_handle, close)
-            .title("Migrate Data")
+            .title(dbflux_i18n::t!("document.migrate_wizard.title"))
             .icon(AppIcon::ArrowUpDown)
             .width(px(1000.0))
             .height_fraction(0.8)
@@ -1419,9 +1410,9 @@ impl MigrateWizard {
         let shows_continue = next_phase(self.phase).is_some();
         let continue_enabled = !self.advancing && self.continue_enabled(cx);
         let continue_label = if self.advancing {
-            "Loading…"
+            dbflux_i18n::t!("document.migrate_wizard.footer.loading")
         } else {
-            "Continue"
+            dbflux_i18n::t!("document.migrate_wizard.footer.continue")
         };
 
         let actions = div()
@@ -1431,11 +1422,14 @@ impl MigrateWizard {
             .gap(Spacing::SM)
             .when(shows_back, |parent| {
                 parent.child(
-                    Button::new("migrate-wizard-back", "Back")
-                        .small()
-                        .ghost()
-                        .disabled(self.advancing)
-                        .on_click(cx.listener(|this, _event, _window, cx| this.go_back(cx))),
+                    Button::new(
+                        "migrate-wizard-back",
+                        dbflux_i18n::t!("document.migrate_wizard.footer.back"),
+                    )
+                    .small()
+                    .ghost()
+                    .disabled(self.advancing)
+                    .on_click(cx.listener(|this, _event, _window, cx| this.go_back(cx))),
                 )
             })
             .when(shows_continue, |parent| {
@@ -1449,18 +1443,24 @@ impl MigrateWizard {
             })
             .when(running, |parent| {
                 parent.child(
-                    Button::new("migrate-wizard-cancel", "Cancel")
-                        .small()
-                        .ghost()
-                        .on_click(cx.listener(|this, _event, _window, cx| this.cancel_run(cx))),
+                    Button::new(
+                        "migrate-wizard-cancel",
+                        dbflux_i18n::t!("document.migrate_wizard.footer.cancel"),
+                    )
+                    .small()
+                    .ghost()
+                    .on_click(cx.listener(|this, _event, _window, cx| this.cancel_run(cx))),
                 )
             })
             .when(done, |parent| {
                 parent.child(
-                    Button::new("migrate-wizard-close", "Close")
-                        .small()
-                        .primary()
-                        .on_click(cx.listener(|this, _event, _window, cx| this.request_close(cx))),
+                    Button::new(
+                        "migrate-wizard-close",
+                        dbflux_i18n::t!("document.migrate_wizard.footer.close"),
+                    )
+                    .small()
+                    .primary()
+                    .on_click(cx.listener(|this, _event, _window, cx| this.request_close(cx))),
                 )
             });
 

--- a/crates/dbflux_ui_document/src/migrate_wizard/options.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/options.rs
@@ -65,7 +65,9 @@ impl OptionsPhase {
         let segment_size_input = cx.new(|cx| {
             InputState::new(window, cx)
                 .default_value(DEFAULT_SEGMENT_SIZE.to_string())
-                .placeholder("Segment / commit size")
+                .placeholder(dbflux_i18n::t!(
+                    "document.migrate_wizard.options.segment_size_placeholder"
+                ))
         });
 
         let mut phase = Self {
@@ -159,7 +161,9 @@ impl OptionsPhase {
             .flex()
             .flex_col()
             .gap(Spacing::XS)
-            .child(Text::label("Segment / commit size"))
+            .child(Text::label(dbflux_i18n::t!(
+                "document.migrate_wizard.options.segment_size_label"
+            )))
             .child(
                 div()
                     .w(SEGMENT_SIZE_INPUT_WIDTH)
@@ -167,8 +171,10 @@ impl OptionsPhase {
             )
             .when(self.segment_size_invalid, |parent| {
                 parent.child(
-                    Text::caption("Must be a whole number of 1 or more; kept the previous value.")
-                        .danger(),
+                    Text::caption(dbflux_i18n::t!(
+                        "document.migrate_wizard.options.segment_size_invalid"
+                    ))
+                    .danger(),
                 )
             })
     }
@@ -176,7 +182,9 @@ impl OptionsPhase {
     fn render_disable_ri(&self, cx: &mut Context<Self>) -> impl IntoElement {
         Checkbox::new("migrate-options-disable-ri")
             .checked(self.disable_referential_integrity_requested)
-            .label("Disable referential integrity during migration")
+            .label(dbflux_i18n::t!(
+                "document.migrate_wizard.options.disable_referential_integrity"
+            ))
             .on_click(cx.listener(|this, checked: &bool, _, cx| {
                 this.on_disable_ri_toggled(*checked, cx);
             }))

--- a/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/phases.rs
@@ -27,14 +27,21 @@ pub enum WizardPhase {
 }
 
 impl WizardPhase {
-    /// The rail's display label for this phase.
-    pub fn label(self) -> &'static str {
+    /// The rail's display label for this phase, resolved through the
+    /// translation catalog. Exhaustive by construction so a new phase fails
+    /// this crate's build until its `document.migrate_wizard.rail.*` entry is
+    /// added here.
+    pub fn label(self) -> String {
         match self {
-            WizardPhase::SourceTarget => "Source & Target",
-            WizardPhase::TablesMapping => "Tables Mapping",
-            WizardPhase::Options => "Options",
-            WizardPhase::Confirm => "Confirm",
-            WizardPhase::Run => "Run",
+            WizardPhase::SourceTarget => {
+                dbflux_i18n::t!("document.migrate_wizard.rail.source_target")
+            }
+            WizardPhase::TablesMapping => {
+                dbflux_i18n::t!("document.migrate_wizard.rail.tables_mapping")
+            }
+            WizardPhase::Options => dbflux_i18n::t!("document.migrate_wizard.rail.options"),
+            WizardPhase::Confirm => dbflux_i18n::t!("document.migrate_wizard.rail.confirm"),
+            WizardPhase::Run => dbflux_i18n::t!("document.migrate_wizard.rail.run"),
         }
     }
 }
@@ -576,11 +583,70 @@ mod tests {
 
     #[test]
     fn phase_labels_cover_every_rail_entry() {
-        assert_eq!(WizardPhase::SourceTarget.label(), "Source & Target");
-        assert_eq!(WizardPhase::TablesMapping.label(), "Tables Mapping");
-        assert_eq!(WizardPhase::Options.label(), "Options");
-        assert_eq!(WizardPhase::Confirm.label(), "Confirm");
-        assert_eq!(WizardPhase::Run.label(), "Run");
+        assert_eq!(
+            WizardPhase::SourceTarget.label(),
+            dbflux_i18n::t!("document.migrate_wizard.rail.source_target")
+        );
+        assert_eq!(
+            WizardPhase::TablesMapping.label(),
+            dbflux_i18n::t!("document.migrate_wizard.rail.tables_mapping")
+        );
+        assert_eq!(
+            WizardPhase::Options.label(),
+            dbflux_i18n::t!("document.migrate_wizard.rail.options")
+        );
+        assert_eq!(
+            WizardPhase::Confirm.label(),
+            dbflux_i18n::t!("document.migrate_wizard.rail.confirm")
+        );
+        assert_eq!(
+            WizardPhase::Run.label(),
+            dbflux_i18n::t!("document.migrate_wizard.rail.run")
+        );
+    }
+
+    /// Every `document.migrate_wizard.rail.*` key resolves to a non-empty,
+    /// non-fallback value in both locales — exhaustive over every
+    /// `WizardPhase` variant (no wildcard arm in `label()`).
+    #[test]
+    fn phase_labels_resolve_in_both_locales() {
+        for phase in RAIL_PHASES {
+            for locale in ["en", "es"] {
+                let key = match phase {
+                    WizardPhase::SourceTarget => "document.migrate_wizard.rail.source_target",
+                    WizardPhase::TablesMapping => "document.migrate_wizard.rail.tables_mapping",
+                    WizardPhase::Options => "document.migrate_wizard.rail.options",
+                    WizardPhase::Confirm => "document.migrate_wizard.rail.confirm",
+                    WizardPhase::Run => "document.migrate_wizard.rail.run",
+                };
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// Every rail phase label diverges between locales.
+    #[test]
+    fn phase_labels_differ_between_locales() {
+        for phase in RAIL_PHASES {
+            let key = match phase {
+                WizardPhase::SourceTarget => "document.migrate_wizard.rail.source_target",
+                WizardPhase::TablesMapping => "document.migrate_wizard.rail.tables_mapping",
+                WizardPhase::Options => "document.migrate_wizard.rail.options",
+                WizardPhase::Confirm => "document.migrate_wizard.rail.confirm",
+                WizardPhase::Run => "document.migrate_wizard.rail.run",
+            };
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/migrate_wizard/source_target.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/source_target.rs
@@ -140,15 +140,18 @@ fn status_child(parent: &SharedString, load: &NodeLoad) -> Option<TreeNavNode> {
     match load {
         NodeLoad::Loaded => None,
         NodeLoad::NotLoaded | NodeLoad::Loading => {
-            let mut node =
-                TreeNavNode::leaf(status_child_id(parent), "Loading…", Some(AppIcon::Loader));
+            let mut node = TreeNavNode::leaf(
+                status_child_id(parent),
+                dbflux_i18n::t!("document.migrate_wizard.footer.loading"),
+                Some(AppIcon::Loader),
+            );
             node.selectable = false;
             Some(node)
         }
         NodeLoad::Failed(error) => {
             let mut node = TreeNavNode::leaf(
                 retry_child_id(parent),
-                SharedString::from(format!("Retry — {error}")),
+                dbflux_i18n::t!("document.migrate_wizard.source_target.retry", error = error),
                 Some(AppIcon::RotateCcw),
             );
             node.selectable = true;
@@ -653,10 +656,10 @@ impl SourceTargetPhase {
                     cx.emit(SourceTargetChanged);
                     cx.notify();
                 } else {
-                    self.error = Some(format!(
-                        "A migration has a single source database. Only tables in \
-                         '{}' can be selected — tables in '{database}' can't be mixed in.",
-                        self.source_database
+                    self.error = Some(dbflux_i18n::t!(
+                        "document.migrate_wizard.source_target.cross_database_error",
+                        source = self.source_database,
+                        other = database
                     ));
                     cx.notify();
                 }
@@ -727,7 +730,9 @@ impl SourceTargetPhase {
         let Some(connection) = self.resolve_source_connection(&database, cx) else {
             self.source.model.set_load(
                 node_id,
-                NodeLoad::Failed("Source connection is gone".to_string()),
+                NodeLoad::Failed(dbflux_i18n::t!(
+                    "document.migrate_wizard.source_target.source_connection_gone"
+                )),
             );
             self.rebuild_side(TreeSide::Source);
             cx.notify();
@@ -791,7 +796,9 @@ impl SourceTargetPhase {
         let Some(connection) = self.resolve_target_connection(profile_id, cx) else {
             self.target.model.set_load(
                 node_id,
-                NodeLoad::Failed("Target connection is gone".to_string()),
+                NodeLoad::Failed(dbflux_i18n::t!(
+                    "document.migrate_wizard.source_target.target_connection_gone"
+                )),
             );
             self.rebuild_side(TreeSide::Target);
             cx.notify();
@@ -979,8 +986,8 @@ impl Render for SourceTargetPhase {
                     .gap(Spacing::MD)
                     .flex_1()
                     .min_h(px(0.0))
-                    .child(self.render_tree_panel(TreeSide::Source, "Source", cx))
-                    .child(self.render_tree_panel(TreeSide::Target, "Target", cx)),
+                    .child(self.render_tree_panel(TreeSide::Source, cx))
+                    .child(self.render_tree_panel(TreeSide::Target, cx)),
             )
             .when_some(self.error.clone(), |parent, error| {
                 parent.child(Text::caption(error).danger())
@@ -989,20 +996,32 @@ impl Render for SourceTargetPhase {
 }
 
 impl SourceTargetPhase {
-    fn render_tree_panel(
-        &self,
-        side: TreeSide,
-        title: &str,
-        cx: &mut Context<Self>,
-    ) -> impl IntoElement {
+    fn render_tree_panel(&self, side: TreeSide, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme().clone();
+
+        // `id_segment` stays a fixed, untranslated ASCII literal — the GPUI
+        // element id must never be built from catalog-resolved text.
+        let (title, id_segment) = match side {
+            TreeSide::Source => (
+                dbflux_i18n::t!("document.migrate_wizard.source_target.source_title"),
+                "source",
+            ),
+            TreeSide::Target => (
+                dbflux_i18n::t!("document.migrate_wizard.source_target.target_title"),
+                "target",
+            ),
+        };
         let subtitle = match side {
-            TreeSide::Source => format!("{} checked", self.source.model.checked_count()),
+            TreeSide::Source => crate::labels::migrate_source_target_checked_count_label(
+                self.source.model.checked_count(),
+            ),
             TreeSide::Target => self
                 .target_selection
                 .as_ref()
                 .map(|selection| selection.database.clone())
-                .unwrap_or_else(|| "No target selected".to_string()),
+                .unwrap_or_else(|| {
+                    dbflux_i18n::t!("document.migrate_wizard.source_target.no_target_selected")
+                }),
         };
 
         div()
@@ -1021,12 +1040,12 @@ impl SourceTargetPhase {
                     .py(Spacing::XS)
                     .border_b_1()
                     .border_color(theme.border)
-                    .child(Text::body(title.to_string()))
+                    .child(Text::body(title))
                     .child(Text::caption(subtitle)),
             )
             .child(
                 div()
-                    .id(SharedString::from(format!("migrate-tree-{title}")))
+                    .id(SharedString::from(format!("migrate-tree-{id_segment}")))
                     .flex_1()
                     .min_h(px(0.0))
                     .overflow_y_scroll()
@@ -1561,5 +1580,66 @@ mod tests {
         assert_eq!(parent_of_synthetic("db:1:app::__status"), Some("db:1:app"));
         assert_eq!(parent_of_synthetic("conn:1::__retry"), Some("conn:1"));
         assert_eq!(parent_of_synthetic("db:1:app"), None);
+    }
+
+    // ── PR 27a-2: migrate_wizard/source_target.rs ──
+
+    const MIGRATE_SOURCE_TARGET_KEYS: &[&str] = &[
+        "document.migrate_wizard.source_target.source_title",
+        "document.migrate_wizard.source_target.target_title",
+        "document.migrate_wizard.source_target.checked_count.one",
+        "document.migrate_wizard.source_target.checked_count.many",
+        "document.migrate_wizard.source_target.no_target_selected",
+        "document.migrate_wizard.source_target.retry",
+        "document.migrate_wizard.source_target.source_connection_gone",
+        "document.migrate_wizard.source_target.target_connection_gone",
+        "document.migrate_wizard.source_target.cross_database_error",
+        // Reused from PR 27a (`footer.loading`), listed here because the
+        // unloaded-branch placeholder row resolves it from this file too.
+        "document.migrate_wizard.footer.loading",
+    ];
+
+    /// Every `document.migrate_wizard.source_target.*` key introduced by this
+    /// file (plus the key it reuses from PR 27a) resolves to a non-empty,
+    /// non-fallback value in both locales.
+    #[test]
+    fn migrate_source_target_keys_resolve_in_both_locales() {
+        for key in MIGRATE_SOURCE_TARGET_KEYS {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    /// A representative sample of `document.migrate_wizard.source_target.*`
+    /// keys diverges between locales.
+    #[test]
+    fn migrate_source_target_keys_differ_between_locales() {
+        for key in [
+            "document.migrate_wizard.source_target.source_title",
+            "document.migrate_wizard.source_target.no_target_selected",
+            "document.migrate_wizard.source_target.retry",
+            "document.migrate_wizard.source_target.cross_database_error",
+        ] {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+            assert_ne!(en, es, "{key} must differ between en and es");
+        }
+    }
+
+    /// `IMPLICIT_DATABASE_LABEL` names an actual SQLite database identity
+    /// ("main"), not UI chrome, so it is never routed through the
+    /// translation catalog.
+    #[test]
+    fn implicit_database_label_is_the_real_sqlite_database_name() {
+        assert_eq!(super::IMPLICIT_DATABASE_LABEL, "main");
     }
 }


### PR DESCRIPTION
## Summary

Document i18n slices 27a + 27a-2 (two commits, one PR): the whole migrate wizard — phases, footer, options, column mapping modes, the confirm-run step (review plan, destructive acknowledgement, reorder warning, running/completed states, toasts, failures), the Tables Mapping grid and the Source & Target pickers — renders through `dbflux_i18n::t!` under `document.migrate_wizard.*`. English and Spanish together. Table, schema and driver names, DDL, row counts and the implicit SQLite `main` database stay data.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `WizardPhase::label()`, `mapping_mode_label` and `mapping_mode_options` widen to `String`; the mapping-mode dropdown and the confirm summary keep separate keys because their English differs (`Existing (insert only)` vs `Existing`).
- `render_tree_panel` no longer builds its GPUI id from the translated title; bulk mode buttons reuse the confirm `mode_label.*` short forms.
- Size: 1444 lines across all eight migrate_wizard files (`size:exception`); each half was reviewed separately by the receipt-driven review.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1102 passed; clippy clean; fmt clean. Manual smoke in Spanish: run the migrate wizard end to end, map tables in bulk, acknowledge a destructive plan, start and cancel.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
