### PR TITLE
feat(i18n): translate the governance view, code document, and remaining document chrome

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -763,6 +763,55 @@ document:
         raw_expression_in_set:
           title: Raw SQL expression in SET
           body: SET clause contains a raw SQL expression — bypasses parameter binding
+    context_bar:
+      placeholder:
+        connection: No connection
+        database: Database
+        schema: Schema
+      label:
+        connection: "Connection:"
+        source: "Source:"
+        database: "Database:"
+        schema: "Schema:"
+      fallback:
+        syntax: Syntax
+        sources: Sources
+        time: Time
+        start: Start
+        end: End
+      apply: Apply
+      connect_error: "Cannot connect to database '%{database}'"
+      connect_failed: "Failed to connect to database '%{database}': %{error}"
+    execution:
+      toast:
+        select_query: Select query text to run
+        enter_query: Enter a query to run
+        no_active_connection: No active connection
+        connection_not_found: Connection not found
+        auto_refresh_blocked: "Auto-refresh blocked: query modifies data"
+        explain_unavailable: Explain is not available for scripts
+        enter_query_to_explain: Enter a query to explain
+        enter_script_content: Enter script content to run
+        write_query_first: Write a query first to open it in a chart
+        connecting: "Connecting to database '%{database}', please wait..."
+        redis_flush_disabled: FLUSHALL / FLUSHDB is disabled in settings
+      result_title:
+        query_failed: Query failed
+        script_failed: Script failed
+      copy_error: Copy error
+      result_tab_title: "Result %{index}"
+    file_ops:
+      save_as:
+        title: Save Script As
+        all_files: All Files
+      error:
+        save_failed: "Failed to save file: %{error}"
+        dialog_unavailable: "Save failed — file dialog unavailable and fallback directory could not be created: %{error}"
+        save_script_failed: "Failed to save script: %{error}"
+        auto_save_failed: "Auto-save failed for %{path}"
+      native_picker_fallback: "Native file picker unavailable — script saved to %{path} instead. Install xdg-desktop-portal, zenity, or kdialog for a save dialog."
+    title:
+      untitled: Untitled
   dashboard:
     builder:
       preset:

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -941,6 +941,9 @@ document:
         builder: Builder
         switch_to_document: Switch to Document View
         switch_to_table: Switch to Table View
+      mode:
+        table: Table
+        document: Document
       editing:
         aggregated: Aggregated results cannot be edited
         no_primary_key: This table has no primary key - editing is disabled
@@ -1100,6 +1103,16 @@ document:
       back: Back
       continue: Continue
       close: Close
+  governance:
+    refresh: Refresh Pending
+    no_pending: No pending executions
+    pending_title: "Pending %{id}"
+    approval_context: Approval context
+    execution_plan: Execution plan
+    approve: Approve
+    reject: Reject
+    select_prompt: Select a pending request to review details.
+    load_failed: "Failed to load pending execution %{id}: %{error}"
   import_wizard:
     title: Import Data
     rail:
@@ -1157,6 +1170,19 @@ document:
       skipped: "%{table}: skipped"
       failed: "%{table}: FAILED — %{error}"
       not_attempted: "%{table}: not attempted"
+  instance_inspector:
+    task_label: "Inspector: %{metric_id}"
+    connection_not_found: Connection not found
+    connection_error: "Connection error: %{detail}"
+    action_unavailable: "Action cancelled — connection is no longer available. Reconnect and try again."
+    kill_default_label: Kill
+    kill_confirm_body: This action will terminate the selected operation. It cannot be undone.
+    cancel: Cancel
+    confirm: Confirm
+    error_prefix: "Error: %{error}"
+    loading: "Loading…"
+    empty: No data. Connect and click Refresh.
+    kill_failed_cause: "Action '%{action_label}' on inspector '%{metric_id}' failed"
   key_value:
     add_member_modal:
       cancel: Cancel
@@ -1791,6 +1817,16 @@ document:
     refresh:
       off: Off
       custom: Custom
+    result_warnings:
+      context:
+        query: query result
+        table_browse: table browse result
+        visual_query: visual query result
+        collection_browse: collection browse result
+        crud_returning: mutation RETURNING result
+        mutation_preview: mutation preview result
+      summary: "Unsupported database type '%{type_name}' in %{context}"
+      cause: "The %{context} contains values of unsupported type '%{type_name}'."
   tabs:
     menu:
       close: Close

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -483,6 +483,8 @@ document:
       clear: Clear
       group_label: "Group:"
       loading: "Loading…"
+      placeholder:
+        local: Local
       retry: Retry
       view_mode:
         chart: Chart
@@ -800,6 +802,12 @@ document:
         script_failed: Script failed
       copy_error: Copy error
       result_tab_title: "Result %{index}"
+      error:
+        select_source: Select at least one source
+        start_time_required: Start time is required
+        end_time_required: End time is required
+        start_before_end: Start time must be earlier than end time
+      hint_prefix: "%{message}\nHint: %{hint}"
     file_ops:
       save_as:
         title: Save Script As
@@ -977,6 +985,13 @@ document:
         remove: Remove ordering
       generate_sql:
         title: Generate SQL
+      error:
+        no_results_to_export: No results to export
+        invalid_json: Invalid JSON
+        document_must_be_json_object: Document must be a JSON object
+        document_missing_id: Document must have an _id field
+        table_state_not_available: Table state not available
+        primary_key_not_determined: Could not determine document primary key
     grid:
       edit_bar:
         clean: No unsaved changes
@@ -1037,6 +1052,17 @@ document:
         deleted:
           one: "%{count} delete"
           many: "%{count} deletes"
+      error:
+        limit_must_be_positive: Limit must be greater than 0
+        invalid_limit: Invalid limit value
+        connection_not_found: Connection not found
+        connection_not_available: Connection not available
+        invalid_json_filter: Invalid JSON filter
+      placeholder:
+        chart_name: Chart name
+      toast:
+        query_imported: Query imported successfully
+        mutation_queued: Mutation queued for approval.
     mutation:
       confirm:
         delete:
@@ -1653,6 +1679,7 @@ document:
       refresh: Refresh
       tree: Tree
       upload: Upload
+      filter_prefix_placeholder: "Filter this prefix…"
     transfer:
       dialog_title: Save Object As
       dialog_filter_all_files: All Files
@@ -1863,6 +1890,7 @@ document:
         drop: Drop table
   shared:
     add: Add
+    error_with_detail_clipboard: "%{title}: %{detail}"
     refresh:
       off: Off
       custom: Custom

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -483,6 +483,8 @@ document:
       clear: Limpiar
       group_label: "Agrupar:"
       loading: "Cargando…"
+      placeholder:
+        local: Local
       retry: Reintentar
       view_mode:
         chart: Gráfico
@@ -800,6 +802,12 @@ document:
         script_failed: Script fallido
       copy_error: Copiar error
       result_tab_title: "Resultado %{index}"
+      error:
+        select_source: Selecciona al menos un origen
+        start_time_required: La hora de inicio es obligatoria
+        end_time_required: La hora de fin es obligatoria
+        start_before_end: La hora de inicio debe ser anterior a la hora de fin
+      hint_prefix: "%{message}\nSugerencia: %{hint}"
     file_ops:
       save_as:
         title: Guardar script como
@@ -977,6 +985,13 @@ document:
         remove: Quitar orden
       generate_sql:
         title: Generar SQL
+      error:
+        no_results_to_export: No hay resultados para exportar
+        invalid_json: JSON no válido
+        document_must_be_json_object: El documento debe ser un objeto JSON
+        document_missing_id: El documento debe tener un campo _id
+        table_state_not_available: Estado de la tabla no disponible
+        primary_key_not_determined: No se pudo determinar la clave primaria del documento
     grid:
       edit_bar:
         clean: Sin cambios pendientes
@@ -1037,6 +1052,17 @@ document:
         deleted:
           one: "%{count} eliminación"
           many: "%{count} eliminaciones"
+      error:
+        limit_must_be_positive: El límite debe ser mayor que 0
+        invalid_limit: Valor de límite no válido
+        connection_not_found: Conexión no encontrada
+        connection_not_available: Conexión no disponible
+        invalid_json_filter: Filtro JSON no válido
+      placeholder:
+        chart_name: Nombre del gráfico
+      toast:
+        query_imported: Consulta importada correctamente
+        mutation_queued: Mutación en cola para aprobación.
     mutation:
       confirm:
         delete:
@@ -1653,6 +1679,7 @@ document:
       refresh: Actualizar
       tree: Árbol
       upload: Subir
+      filter_prefix_placeholder: "Filtrar este prefijo…"
     transfer:
       dialog_title: Guardar objeto como
       dialog_filter_all_files: Todos los archivos
@@ -1863,6 +1890,7 @@ document:
         drop: Eliminar tabla
   shared:
     add: Agregar
+    error_with_detail_clipboard: "%{title}: %{detail}"
     refresh:
       off: Apagado
       custom: Personalizado

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -941,6 +941,9 @@ document:
         builder: Constructor
         switch_to_document: Cambiar a vista de documento
         switch_to_table: Cambiar a vista de tabla
+      mode:
+        table: Tabla
+        document: Documento
       editing:
         aggregated: Los resultados agregados no se pueden editar
         no_primary_key: Esta tabla no tiene clave primaria; la edición está deshabilitada
@@ -1100,6 +1103,16 @@ document:
       back: Atrás
       continue: Continuar
       close: Cerrar
+  governance:
+    refresh: Actualizar pendientes
+    no_pending: No hay ejecuciones pendientes
+    pending_title: "Pendiente %{id}"
+    approval_context: Contexto de aprobación
+    execution_plan: Plan de ejecución
+    approve: Aprobar
+    reject: Rechazar
+    select_prompt: Selecciona una solicitud pendiente para ver los detalles.
+    load_failed: "No se pudo cargar la ejecución pendiente %{id}: %{error}"
   import_wizard:
     title: Importar datos
     rail:
@@ -1157,6 +1170,19 @@ document:
       skipped: "%{table}: omitida"
       failed: "%{table}: FALLIDA — %{error}"
       not_attempted: "%{table}: no intentada"
+  instance_inspector:
+    task_label: "Inspector: %{metric_id}"
+    connection_not_found: Conexión no encontrada
+    connection_error: "Error de conexión: %{detail}"
+    action_unavailable: "Acción cancelada — la conexión ya no está disponible. Reconecta e inténtalo de nuevo."
+    kill_default_label: Terminar
+    kill_confirm_body: Esta acción terminará la operación seleccionada. No se puede deshacer.
+    cancel: Cancelar
+    confirm: Confirmar
+    error_prefix: "Error: %{error}"
+    loading: "Cargando…"
+    empty: Sin datos. Conecta y haz clic en Actualizar.
+    kill_failed_cause: "La acción '%{action_label}' en el inspector '%{metric_id}' falló"
   key_value:
     add_member_modal:
       cancel: Cancelar
@@ -1791,6 +1817,16 @@ document:
     refresh:
       off: Apagado
       custom: Personalizado
+    result_warnings:
+      context:
+        query: resultado de consulta
+        table_browse: resultado de exploración de tabla
+        visual_query: resultado de consulta visual
+        collection_browse: resultado de exploración de colección
+        crud_returning: resultado RETURNING de la mutación
+        mutation_preview: resultado de vista previa de mutación
+      summary: "Tipo de base de datos no compatible '%{type_name}' en %{context}"
+      cause: "El %{context} contiene valores de tipo no compatible '%{type_name}'."
   tabs:
     menu:
       close: Cerrar

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -763,6 +763,55 @@ document:
         raw_expression_in_set:
           title: Expresión SQL cruda en SET
           body: "La cláusula SET contiene una expresión SQL cruda — evita el enlace de parámetros"
+    context_bar:
+      placeholder:
+        connection: Sin conexión
+        database: Base de datos
+        schema: Esquema
+      label:
+        connection: "Conexión:"
+        source: "Origen:"
+        database: "Base de datos:"
+        schema: "Esquema:"
+      fallback:
+        syntax: Sintaxis
+        sources: Orígenes
+        time: Hora
+        start: Inicio
+        end: Fin
+      apply: Aplicar
+      connect_error: "No se puede conectar a la base de datos '%{database}'"
+      connect_failed: "No se pudo conectar a la base de datos '%{database}': %{error}"
+    execution:
+      toast:
+        select_query: Selecciona el texto de la consulta a ejecutar
+        enter_query: Escribe una consulta para ejecutar
+        no_active_connection: No hay ninguna conexión activa
+        connection_not_found: Conexión no encontrada
+        auto_refresh_blocked: "Actualización automática bloqueada: la consulta modifica datos"
+        explain_unavailable: Explain no está disponible para scripts
+        enter_query_to_explain: Escribe una consulta para analizar con Explain
+        enter_script_content: Escribe contenido del script para ejecutar
+        write_query_first: Escribe primero una consulta para abrirla en una gráfica
+        connecting: "Conectando a la base de datos '%{database}', espera..."
+        redis_flush_disabled: FLUSHALL / FLUSHDB está deshabilitado en la configuración
+      result_title:
+        query_failed: Consulta fallida
+        script_failed: Script fallido
+      copy_error: Copiar error
+      result_tab_title: "Resultado %{index}"
+    file_ops:
+      save_as:
+        title: Guardar script como
+        all_files: Todos los archivos
+      error:
+        save_failed: "No se pudo guardar el archivo: %{error}"
+        dialog_unavailable: "Error al guardar — el selector de archivos no está disponible y no se pudo crear el directorio alternativo: %{error}"
+        save_script_failed: "No se pudo guardar el script: %{error}"
+        auto_save_failed: "El guardado automático falló para %{path}"
+      native_picker_fallback: "Selector de archivos nativo no disponible — el script se guardó en %{path}. Instala xdg-desktop-portal, zenity o kdialog para tener un selector de guardado."
+    title:
+      untitled: Sin título
   dashboard:
     builder:
       preset:

--- a/crates/dbflux_ui_document/src/audit/mod.rs
+++ b/crates/dbflux_ui_document/src/audit/mod.rs
@@ -287,7 +287,7 @@ impl AuditDocument {
 
         let dropdown_timestamp_mode = cx.new(|_cx| {
             Dropdown::new("audit-timestamp-mode")
-                .placeholder("Local")
+                .placeholder(dbflux_i18n::t!("document.audit.filter.placeholder.local"))
                 .items(Self::timestamp_mode_items())
                 .selected_index(Some(0))
                 .toolbar_style(true)
@@ -295,21 +295,24 @@ impl AuditDocument {
 
         let multi_select_level = cx.new(|cx| {
             let items: Vec<DropdownItem> = Self::level_items();
-            let mut ms = MultiSelect::new("audit-level").placeholder("Level");
+            let mut ms = MultiSelect::new("audit-level")
+                .placeholder(dbflux_i18n::t!("document.audit.detail.level"));
             ms.set_items(items, cx);
             ms
         });
 
         let multi_select_category = cx.new(|cx| {
             let items: Vec<DropdownItem> = Self::category_items();
-            let mut ms = MultiSelect::new("audit-category").placeholder("Category");
+            let mut ms = MultiSelect::new("audit-category")
+                .placeholder(dbflux_i18n::t!("document.audit.detail.category"));
             ms.set_items(items, cx);
             ms
         });
 
         let multi_select_outcome = cx.new(|cx| {
             let items: Vec<DropdownItem> = Self::outcome_items();
-            let mut ms = MultiSelect::new("audit-outcome").placeholder("Outcome");
+            let mut ms = MultiSelect::new("audit-outcome")
+                .placeholder(dbflux_i18n::t!("document.audit.detail.outcome"));
             ms.set_items(items, cx);
             ms
         });

--- a/crates/dbflux_ui_document/src/code/context_bar.rs
+++ b/crates/dbflux_ui_document/src/code/context_bar.rs
@@ -76,7 +76,9 @@ impl CodeDocument {
             Dropdown::new("ctx-connection")
                 .items(items)
                 .selected_index(selected_index)
-                .placeholder("No connection")
+                .placeholder(dbflux_i18n::t!(
+                    "document.code.context_bar.placeholder.connection"
+                ))
                 .toolbar_style(true)
         });
 
@@ -426,7 +428,7 @@ impl CodeDocument {
         let targets_placeholder = source_spec
             .as_ref()
             .map(|spec| spec.targets_placeholder.clone())
-            .unwrap_or_else(|| "Sources".to_string());
+            .unwrap_or_else(|| dbflux_i18n::t!("document.code.context_bar.fallback.sources"));
 
         self.source.source_targets.update(cx, |multi_select, cx| {
             multi_select.set_placeholder(targets_placeholder, cx);
@@ -662,7 +664,9 @@ impl CodeDocument {
             Dropdown::new("ctx-database")
                 .items(items)
                 .selected_index(selected_index)
-                .placeholder("Database")
+                .placeholder(dbflux_i18n::t!(
+                    "document.code.context_bar.placeholder.database"
+                ))
                 .toolbar_style(true)
         });
 
@@ -694,7 +698,9 @@ impl CodeDocument {
             Dropdown::new("ctx-schema")
                 .items(items)
                 .selected_index(selected_index)
-                .placeholder("Schema")
+                .placeholder(dbflux_i18n::t!(
+                    "document.code.context_bar.placeholder.schema"
+                ))
                 .toolbar_style(true)
         });
 
@@ -839,7 +845,10 @@ impl CodeDocument {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Network,
-                        format!("Cannot connect to database '{database}'"),
+                        dbflux_i18n::t!(
+                            "document.code.context_bar.connect_error",
+                            database = database
+                        ),
                     )
                     .with_cause(e),
                     cx,
@@ -886,9 +895,10 @@ impl CodeDocument {
                         this.update(cx, |doc, cx| {
                             doc.revert_database_selection(prev_database, prev_schema, cx);
 
-                            doc.pending.error = Some(format!(
-                                "Failed to connect to database '{}': {}",
-                                target_db, e
+                            doc.pending.error = Some(dbflux_i18n::t!(
+                                "document.code.context_bar.connect_failed",
+                                database = target_db,
+                                error = e
                             ));
                             cx.notify();
                         })
@@ -1319,7 +1329,9 @@ impl CodeDocument {
                     .items_center()
                     .gap_1()
                     .child(Icon::new(AppIcon::Database).size(px(12.0)).muted()) // guardrail-allow: 12px icon size, no ICON_XS token
-                    .child(Text::caption("Connection:")),
+                    .child(Text::caption(dbflux_i18n::t!(
+                        "document.code.context_bar.label.connection"
+                    ))),
             )
             .child(
                 div()
@@ -1347,7 +1359,11 @@ impl CodeDocument {
                                 div().flex_none().child(Text::caption(
                                     source_spec
                                         .and_then(|spec| spec.query_mode_label.clone())
-                                        .unwrap_or_else(|| "Syntax".to_string()),
+                                        .unwrap_or_else(|| {
+                                            dbflux_i18n::t!(
+                                                "document.code.context_bar.fallback.syntax"
+                                            )
+                                        }),
                                 )),
                             )
                             .child(
@@ -1371,7 +1387,9 @@ impl CodeDocument {
                     // across all drivers.  The driver-specific label (spec.targets_label)
                     // is intentionally not used here — the placeholder already carries
                     // driver-specific phrasing (e.g. "Select bucket...").
-                    .child(div().flex_none().child(Text::caption("Source:")))
+                    .child(div().flex_none().child(Text::caption(dbflux_i18n::t!(
+                        "document.code.context_bar.label.source"
+                    ))))
                     .child(div().flex_none().min_w(px(260.0)).child(focus_frame(
                         context_slot_is_keyboard_focused(
                             self.focus_mode,
@@ -1394,9 +1412,12 @@ impl CodeDocument {
                         .map(|p| {
                             let panel = p.read(cx);
                             let dropdown = panel.dropdown_time_range.clone();
-                            let label = source_spec
-                                .map(|s| s.start_label.clone())
-                                .unwrap_or_else(|| "Time".to_string());
+                            let label =
+                                source_spec
+                                    .map(|s| s.start_label.clone())
+                                    .unwrap_or_else(|| {
+                                        dbflux_i18n::t!("document.code.context_bar.fallback.time")
+                                    });
                             (dropdown, label)
                         }),
                     |el, (dropdown, label)| {
@@ -1420,7 +1441,9 @@ impl CodeDocument {
                             div().flex_none().child(Text::caption(
                                 source_spec
                                     .map(|spec| spec.start_label.clone())
-                                    .unwrap_or_else(|| "Start".to_string()),
+                                    .unwrap_or_else(|| {
+                                        dbflux_i18n::t!("document.code.context_bar.fallback.start")
+                                    }),
                             )),
                         )
                         .child(div().flex_none().min_w(px(180.0)).child(focus_frame(
@@ -1437,7 +1460,9 @@ impl CodeDocument {
                             div().flex_none().child(Text::caption(
                                 source_spec
                                     .map(|spec| spec.end_label.clone())
-                                    .unwrap_or_else(|| "End".to_string()),
+                                    .unwrap_or_else(|| {
+                                        dbflux_i18n::t!("document.code.context_bar.fallback.end")
+                                    }),
                             )),
                         )
                         .child(div().flex_none().min_w(px(180.0)).child(focus_frame(
@@ -1454,40 +1479,44 @@ impl CodeDocument {
                 )
             })
             .when(!show_source_controls && show_db, |el| {
-                el.child(div().flex_none().child(Text::caption("Database:")))
-                    .child(
-                        div()
-                            .flex_none()
-                            .min_w(context_dropdown_min_width(1))
-                            .child(focus_frame(
-                                context_slot_is_keyboard_focused(
-                                    self.focus_mode,
-                                    self.context_bar_slot,
-                                    ContextBarSlot::Database,
-                                ),
-                                Some(theme.ring),
-                                control_shell(self.source.database_dropdown.clone(), cx),
-                                cx,
-                            )),
-                    )
+                el.child(div().flex_none().child(Text::caption(dbflux_i18n::t!(
+                    "document.code.context_bar.label.database"
+                ))))
+                .child(
+                    div()
+                        .flex_none()
+                        .min_w(context_dropdown_min_width(1))
+                        .child(focus_frame(
+                            context_slot_is_keyboard_focused(
+                                self.focus_mode,
+                                self.context_bar_slot,
+                                ContextBarSlot::Database,
+                            ),
+                            Some(theme.ring),
+                            control_shell(self.source.database_dropdown.clone(), cx),
+                            cx,
+                        )),
+                )
             })
             .when(!show_source_controls && show_schema, |el| {
-                el.child(div().flex_none().child(Text::caption("Schema:")))
-                    .child(
-                        div()
-                            .flex_none()
-                            .min_w(context_dropdown_min_width(2))
-                            .child(focus_frame(
-                                context_slot_is_keyboard_focused(
-                                    self.focus_mode,
-                                    self.context_bar_slot,
-                                    ContextBarSlot::Schema,
-                                ),
-                                Some(theme.ring),
-                                control_shell(self.source.schema_dropdown.clone(), cx),
-                                cx,
-                            )),
-                    )
+                el.child(div().flex_none().child(Text::caption(dbflux_i18n::t!(
+                    "document.code.context_bar.label.schema"
+                ))))
+                .child(
+                    div()
+                        .flex_none()
+                        .min_w(context_dropdown_min_width(2))
+                        .child(focus_frame(
+                            context_slot_is_keyboard_focused(
+                                self.focus_mode,
+                                self.context_bar_slot,
+                                ContextBarSlot::Schema,
+                            ),
+                            Some(theme.ring),
+                            control_shell(self.source.schema_dropdown.clone(), cx),
+                            cx,
+                        )),
+                )
             })
             .child(div().flex_1())
             .when_some(self.editor.path.as_ref(), |el, path| {
@@ -1522,10 +1551,14 @@ impl CodeDocument {
                         .pt(Spacing::XS)
                         .child(panel.read(cx).render_custom_picker_row(px(320.0), cx))
                         .child(
-                            Button::new("ctx-time-range-apply", "Apply")
-                                .small()
-                                .disabled(!can_apply)
-                                .on_click(cx.listener(move |this, _, _, cx| {
+                            Button::new(
+                                "ctx-time-range-apply",
+                                dbflux_i18n::t!("document.code.context_bar.apply"),
+                            )
+                            .small()
+                            .disabled(!can_apply)
+                            .on_click(cx.listener(
+                                move |this, _, _, cx| {
                                     panel.update(cx, |p, cx| {
                                         // Ignore the returned bounds — the panel emits
                                         // TimeRangeChanged which is the authoritative signal.
@@ -1534,7 +1567,8 @@ impl CodeDocument {
                                     this.sync_source_exec_context(cx);
                                     cx.emit(DocumentEvent::MetaChanged);
                                     cx.notify();
-                                })),
+                                },
+                            )),
                         ),
                 )
             })
@@ -1693,5 +1727,64 @@ mod tests {
             }
             other => panic!("expected CollectionWindow source context, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn context_bar_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.code.context_bar.placeholder.connection",
+            "document.code.context_bar.placeholder.database",
+            "document.code.context_bar.placeholder.schema",
+            "document.code.context_bar.label.connection",
+            "document.code.context_bar.label.source",
+            "document.code.context_bar.label.database",
+            "document.code.context_bar.label.schema",
+            "document.code.context_bar.fallback.syntax",
+            "document.code.context_bar.fallback.sources",
+            "document.code.context_bar.fallback.time",
+            "document.code.context_bar.fallback.start",
+            "document.code.context_bar.fallback.end",
+            "document.code.context_bar.apply",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn context_bar_connection_placeholder_exact_value_and_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.code.context_bar.placeholder.connection",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.code.context_bar.placeholder.connection",
+            locale = "es"
+        );
+
+        assert_eq!(en, "No connection");
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn context_bar_connect_error_interpolates_database_name() {
+        let en = dbflux_i18n::t!(
+            "document.code.context_bar.connect_error",
+            locale = "en",
+            database = "logs"
+        );
+
+        assert_eq!(en, "Cannot connect to database 'logs'");
     }
 }

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -321,7 +321,9 @@ impl CodeDocument {
                 ValidationResult::Valid => {}
                 ValidationResult::SyntaxError(diag) => {
                     let msg = match diag.hint {
-                        Some(ref hint) => format!("{}\nHint: {}", diag.message, hint),
+                        Some(ref hint) => {
+                            crate::labels::syntax_error_with_hint(&diag.message, hint)
+                        }
                         None => diag.message,
                     };
                     let toast_msg = msg.to_string();
@@ -357,7 +359,7 @@ impl CodeDocument {
                 }
                 Err(message) => {
                     self.source.exec_ctx.source = None;
-                    let toast_msg = message.to_string();
+                    let toast_msg = crate::labels::source_window_error_message(message);
                     Toast::error(toast_msg.clone())
                         .meta_right(now_hms())
                         .action(copy_action(toast_msg))

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -37,9 +37,9 @@ fn evaluate_dangerous_with_effective_settings(
     use dbflux_core::DangerousQueryKind::*;
 
     if !allow_redis_flush && matches!(kind, RedisFlushAll | RedisFlushDb) {
-        return dbflux_core::DangerousAction::Block(
-            "FLUSHALL / FLUSHDB is disabled in settings".to_string(),
-        );
+        return dbflux_core::DangerousAction::Block(dbflux_i18n::t!(
+            "document.code.execution.toast.redis_flush_disabled"
+        ));
     }
 
     if !effective.confirm_dangerous {
@@ -162,9 +162,11 @@ impl CodeDocument {
 
     pub fn run_selected_query(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let Some(query) = self.selected_query(window, cx) else {
-            Toast::warning("Select query text to run")
-                .meta_right(now_hms())
-                .push(cx);
+            Toast::warning(dbflux_i18n::t!(
+                "document.code.execution.toast.select_query"
+            ))
+            .meta_right(now_hms())
+            .push(cx);
             return;
         };
 
@@ -246,7 +248,7 @@ impl CodeDocument {
         cx: &mut Context<Self>,
     ) {
         if query.trim().is_empty() {
-            Toast::warning("Enter a query to run")
+            Toast::warning(dbflux_i18n::t!("document.code.execution.toast.enter_query"))
                 .meta_right(now_hms())
                 .push(cx);
             return;
@@ -533,9 +535,10 @@ impl CodeDocument {
         cx: &mut Context<Self>,
     ) {
         let Some(conn_id) = self.connection_id else {
-            Toast::error("No active connection")
+            let msg = dbflux_i18n::t!("document.code.execution.toast.no_active_connection");
+            Toast::error(msg.clone())
                 .meta_right(now_hms())
-                .action(copy_action("No active connection"))
+                .action(copy_action(msg))
                 .push(cx);
             return;
         };
@@ -543,9 +546,10 @@ impl CodeDocument {
         let (connection, active_database, task_target) = {
             let connections = self.app_state.read(cx).connections();
             let Some(connected) = connections.get(&conn_id) else {
-                Toast::error("Connection not found")
+                let msg = dbflux_i18n::t!("document.code.execution.toast.connection_not_found");
+                Toast::error(msg.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Connection not found"))
+                    .action(copy_action(msg))
                     .push(cx);
                 return;
             };
@@ -566,7 +570,10 @@ impl CodeDocument {
                 Err(dbflux_core::ConnectionResolutionError::PendingDatabaseConnection {
                     database,
                 }) => {
-                    let msg = format!("Connecting to database '{}', please wait...", database);
+                    let msg = dbflux_i18n::t!(
+                        "document.code.execution.toast.connecting",
+                        database = database
+                    );
                     Toast::error(msg.clone())
                         .meta_right(now_hms())
                         .action(copy_action(msg))
@@ -963,9 +970,11 @@ impl CodeDocument {
             self.refresh.refresh_dropdown.update(cx, |dd, cx| {
                 dd.set_selected_index(Some(dbflux_core::RefreshPolicy::Manual.index()), cx);
             });
-            Toast::warning("Auto-refresh blocked: query modifies data")
-                .meta_right(now_hms())
-                .push(cx);
+            Toast::warning(dbflux_i18n::t!(
+                "document.code.execution.toast.auto_refresh_blocked"
+            ))
+            .meta_right(now_hms())
+            .push(cx);
             return;
         }
 
@@ -1113,9 +1122,9 @@ impl CodeDocument {
                 self.state = DocumentState::Error;
 
                 let title: SharedString = if is_script {
-                    "Script failed".into()
+                    dbflux_i18n::t!("document.code.execution.result_title.script_failed").into()
                 } else {
-                    "Query failed".into()
+                    dbflux_i18n::t!("document.code.execution.result_title.query_failed").into()
                 };
                 let now = dbflux_core::chrono::Local::now()
                     .format("%H:%M:%S")
@@ -1147,13 +1156,16 @@ impl CodeDocument {
                 };
 
                 toast = toast.action(
-                    dbflux_ui_base::toast::ToastAction::new("copy-error", "Copy error")
-                        .primary()
-                        .on_click(move |cx: &mut App| {
-                            cx.write_to_clipboard(gpui::ClipboardItem::new_string(
-                                copy_payload.clone(),
-                            ));
-                        }),
+                    dbflux_ui_base::toast::ToastAction::new(
+                        "copy-error",
+                        dbflux_i18n::t!("document.code.execution.copy_error"),
+                    )
+                    .primary()
+                    .on_click(move |cx: &mut App| {
+                        cx.write_to_clipboard(gpui::ClipboardItem::new_string(
+                            copy_payload.clone(),
+                        ));
+                    }),
                 );
                 toast.push(cx);
                 let _ = window;
@@ -1275,7 +1287,10 @@ impl CodeDocument {
     ) {
         self.result_tabs.result_tab_counter += 1;
         let tab_id = Uuid::new_v4();
-        let title = format!("Result {}", self.result_tabs.result_tab_counter);
+        let title = dbflux_i18n::t!(
+            "document.code.execution.result_tab_title",
+            index = self.result_tabs.result_tab_counter
+        );
 
         let app_state = self.app_state.clone();
         let grid = cx.new(|cx| {
@@ -1440,17 +1455,21 @@ impl CodeDocument {
     /// The result appears in the same Results panel as a regular query.
     pub fn run_explain(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.supports_connection_context() {
-            Toast::warning("Explain is not available for scripts")
-                .meta_right(now_hms())
-                .push(cx);
+            Toast::warning(dbflux_i18n::t!(
+                "document.code.execution.toast.explain_unavailable"
+            ))
+            .meta_right(now_hms())
+            .push(cx);
             return;
         }
 
         let base_query = self.selected_or_full_query(window, cx);
         if base_query.trim().is_empty() {
-            Toast::warning("Enter a query to explain")
-                .meta_right(now_hms())
-                .push(cx);
+            Toast::warning(dbflux_i18n::t!(
+                "document.code.execution.toast.enter_query_to_explain"
+            ))
+            .meta_right(now_hms())
+            .push(cx);
             return;
         }
 
@@ -1519,9 +1538,11 @@ impl CodeDocument {
 
         let content = self.editor.input_state.read(cx).value().to_string();
         if content.trim().is_empty() {
-            Toast::warning("Enter script content to run")
-                .meta_right(now_hms())
-                .push(cx);
+            Toast::warning(dbflux_i18n::t!(
+                "document.code.execution.toast.enter_script_content"
+            ))
+            .meta_right(now_hms())
+            .push(cx);
             return;
         }
 
@@ -2299,5 +2320,75 @@ mod tests {
             "SELECT 2",
             "stored query must be preserved across the put-back"
         );
+    }
+
+    #[test]
+    fn execution_toast_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.code.execution.toast.select_query",
+            "document.code.execution.toast.enter_query",
+            "document.code.execution.toast.no_active_connection",
+            "document.code.execution.toast.connection_not_found",
+            "document.code.execution.toast.auto_refresh_blocked",
+            "document.code.execution.toast.explain_unavailable",
+            "document.code.execution.toast.enter_query_to_explain",
+            "document.code.execution.toast.enter_script_content",
+            "document.code.execution.toast.write_query_first",
+            "document.code.execution.toast.connecting",
+            "document.code.execution.toast.redis_flush_disabled",
+            "document.code.execution.result_title.query_failed",
+            "document.code.execution.result_title.script_failed",
+            "document.code.execution.copy_error",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn execution_connecting_toast_interpolates_database_name() {
+        let en = dbflux_i18n::t!(
+            "document.code.execution.toast.connecting",
+            locale = "en",
+            database = "logs"
+        );
+
+        assert_eq!(en, "Connecting to database 'logs', please wait...");
+    }
+
+    #[test]
+    fn execution_result_tab_title_interpolates_index() {
+        let en = dbflux_i18n::t!(
+            "document.code.execution.result_tab_title",
+            locale = "en",
+            index = 3
+        );
+
+        assert_eq!(en, "Result 3");
+    }
+
+    #[test]
+    fn execution_result_titles_differ_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.code.execution.result_title.query_failed",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.code.execution.result_title.query_failed",
+            locale = "es"
+        );
+
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_ui_document/src/code/file_ops.rs
+++ b/crates/dbflux_ui_document/src/code/file_ops.rs
@@ -58,7 +58,7 @@ impl CodeDocument {
                     report_error_async(
                         UserFacingError::new(
                             ErrorKind::Storage,
-                            format!("Failed to save file: {e}"),
+                            dbflux_i18n::t!("document.code.file_ops.error.save_failed", error = e),
                         ),
                         cx,
                     );
@@ -97,10 +97,13 @@ impl CodeDocument {
         self._pending_save = Some(cx.spawn(async move |_this, cx| {
             let target: Option<(std::path::PathBuf, bool)> = if dialog_available {
                 let file_handle = rfd::AsyncFileDialog::new()
-                    .set_title("Save Script As")
+                    .set_title(dbflux_i18n::t!("document.code.file_ops.save_as.title"))
                     .set_file_name(&suggested_name)
                     .add_filter(&language_name, &[&default_ext])
-                    .add_filter("All Files", &["*"])
+                    .add_filter(
+                        dbflux_i18n::t!("document.code.file_ops.save_as.all_files"),
+                        &["*"],
+                    )
                     .save_file()
                     .await;
 
@@ -115,8 +118,9 @@ impl CodeDocument {
                         report_error_async(
                             UserFacingError::new(
                                 ErrorKind::Storage,
-                                format!(
-                                    "Save failed — file dialog unavailable and fallback directory could not be created: {err}"
+                                dbflux_i18n::t!(
+                                    "document.code.file_ops.error.dialog_unavailable",
+                                    error = err
                                 ),
                             ),
                             cx,
@@ -152,9 +156,9 @@ impl CodeDocument {
                         });
 
                         if used_fallback {
-                            dbflux_ui_base::toast::Toast::warning(format!(
-                                "Native file picker unavailable — script saved to {} instead. Install xdg-desktop-portal, zenity, or kdialog for a save dialog.",
-                                path_for_update.display()
+                            dbflux_ui_base::toast::Toast::warning(dbflux_i18n::t!(
+                                "document.code.file_ops.native_picker_fallback",
+                                path = path_for_update.display().to_string()
                             ))
                             .meta_right(dbflux_ui_base::toast::now_hms())
                             .push(cx);
@@ -164,7 +168,13 @@ impl CodeDocument {
                 }
                 Err(e) => {
                     report_error_async(
-                        UserFacingError::new(ErrorKind::Storage, format!("Failed to save script: {e}")),
+                        UserFacingError::new(
+                            ErrorKind::Storage,
+                            dbflux_i18n::t!(
+                                "document.code.file_ops.error.save_script_failed",
+                                error = e
+                            ),
+                        ),
                         cx,
                     );
                 }
@@ -238,7 +248,10 @@ impl CodeDocument {
                     report_error_async(
                         UserFacingError::new(
                             ErrorKind::Storage,
-                            format!("Auto-save failed for {}", target.display()),
+                            dbflux_i18n::t!(
+                                "document.code.file_ops.error.auto_save_failed",
+                                path = target.display().to_string()
+                            ),
                         )
                         .with_cause(format!("{e}")),
                         cx,
@@ -385,5 +398,51 @@ mod tests {
         let content = build_file_content_for_language("print('hi')", &exec_ctx, false, "#");
 
         assert_eq!(content, "print('hi')");
+    }
+
+    #[test]
+    fn file_ops_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.code.file_ops.save_as.title",
+            "document.code.file_ops.save_as.all_files",
+            "document.code.file_ops.error.save_failed",
+            "document.code.file_ops.error.dialog_unavailable",
+            "document.code.file_ops.error.save_script_failed",
+            "document.code.file_ops.error.auto_save_failed",
+            "document.code.file_ops.native_picker_fallback",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn file_ops_save_failed_interpolates_error() {
+        let en = dbflux_i18n::t!(
+            "document.code.file_ops.error.save_failed",
+            locale = "en",
+            error = "disk full"
+        );
+
+        assert_eq!(en, "Failed to save file: disk full");
+    }
+
+    #[test]
+    fn file_ops_save_as_title_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.code.file_ops.save_as.title", locale = "en");
+        let es = dbflux_i18n::t!("document.code.file_ops.save_as.title", locale = "es");
+
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -738,9 +738,11 @@ impl CodeDocument {
                     this.refresh.refresh_dropdown.update(cx, |dd, cx| {
                         dd.set_selected_index(Some(RefreshPolicy::Manual.index()), cx);
                     });
-                    Toast::warning("Auto-refresh blocked: query modifies data")
-                        .meta_right(now_hms())
-                        .push(cx);
+                    Toast::warning(dbflux_i18n::t!(
+                        "document.code.execution.toast.auto_refresh_blocked"
+                    ))
+                    .meta_right(now_hms())
+                    .push(cx);
                     return;
                 }
 
@@ -805,7 +807,7 @@ impl CodeDocument {
             Self::create_schema_dropdown(&app_state, &exec_ctx, window, cx);
         let source_query_mode_dropdown = cx.new(|_cx| {
             Dropdown::new("ctx-source-query-mode")
-                .placeholder("Syntax")
+                .placeholder(dbflux_i18n::t!("document.code.context_bar.fallback.syntax"))
                 .toolbar_style(true)
         });
         // bare() suppresses the trigger's own border/background because the
@@ -813,7 +815,9 @@ impl CodeDocument {
         let source_targets = cx.new(|_cx| {
             MultiSelect::new("ctx-source-targets")
                 .bare()
-                .placeholder("Sources")
+                .placeholder(dbflux_i18n::t!(
+                    "document.code.context_bar.fallback.sources"
+                ))
         });
         let source_start_input =
             cx.new(|cx| InputState::new(window, cx).placeholder("2026-04-24T00:00:00Z"));
@@ -986,9 +990,11 @@ impl CodeDocument {
     /// surfaces a toast instead of emitting so the user gets feedback.
     pub fn emit_chart_this_query(&mut self, cx: &mut Context<Self>) {
         let Some(query) = self.current_query_text(cx) else {
-            Toast::warning("Write a query first to open it in a chart")
-                .meta_right(now_hms())
-                .push(cx);
+            Toast::warning(dbflux_i18n::t!(
+                "document.code.execution.toast.write_query_first"
+            ))
+            .meta_right(now_hms())
+            .push(cx);
             return;
         };
 
@@ -1252,10 +1258,11 @@ impl CodeDocument {
 
     pub fn title(&self) -> String {
         if let Some(path) = &self.editor.path {
+            let untitled = dbflux_i18n::t!("document.code.title.untitled");
             let name = path
                 .file_name()
                 .and_then(|n| n.to_str())
-                .unwrap_or("Untitled");
+                .unwrap_or(untitled.as_str());
 
             if self.editor.is_dirty {
                 format!("{}*", name)
@@ -1914,5 +1921,29 @@ mod tests {
 
         assert_eq!(values.0, "2024-01-01T00:00:00Z");
         assert_eq!(values.1, "2024-01-01T01:00:00Z");
+    }
+
+    #[test]
+    fn code_title_untitled_key_resolves_in_both_locales() {
+        for locale in ["en", "es"] {
+            let key = "document.code.title.untitled";
+            let value = dbflux_i18n::t!(key, locale = locale);
+
+            assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+            assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+            assert_ne!(
+                value,
+                format!("{locale}.{key}"),
+                "{key} missing from {locale} catalog"
+            );
+        }
+    }
+
+    #[test]
+    fn code_title_untitled_differs_between_locales() {
+        let en = dbflux_i18n::t!("document.code.title.untitled", locale = "en");
+        let es = dbflux_i18n::t!("document.code.title.untitled", locale = "es");
+
+        assert_ne!(en, es);
     }
 }

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -139,6 +139,8 @@ fn build_source_window_context(
     let requires_targets = query_mode.as_deref() != Some("sql");
 
     if requires_targets && targets.is_empty() {
+        // This is a stable token, not display text: `labels::source_window_error_message`
+        // maps it to the translated catalog entry at the toast display site.
         return Err("Select at least one source");
     }
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
@@ -935,9 +935,10 @@ impl DataGridPanel {
             && self.result.text_body.is_none()
             && self.result.raw_bytes.is_none()
         {
-            Toast::error("No results to export")
+            let message = dbflux_i18n::t!("document.data.context_menu.error.no_results_to_export");
+            Toast::error(message.clone())
                 .meta_right(now_hms())
-                .action(copy_action("No results to export"))
+                .action(copy_action(message))
                 .push(cx);
             return;
         }
@@ -2092,10 +2093,14 @@ impl DataGridPanel {
             Ok(v) => v,
             Err(e) => {
                 let toast_body = e.to_string();
-                Toast::error("Invalid JSON")
+                let title = dbflux_i18n::t!("document.data.context_menu.error.invalid_json");
+                Toast::error(title.clone())
                     .meta_right(now_hms())
                     .body(toast_body.clone())
-                    .action(copy_action(format!("Invalid JSON: {}", toast_body)))
+                    .action(copy_action(crate::labels::error_with_detail_clipboard(
+                        &title,
+                        &toast_body,
+                    )))
                     .push(cx);
                 return;
             }
@@ -2121,9 +2126,10 @@ impl DataGridPanel {
             };
 
             let Some(conn) = conn else {
-                Toast::error("Connection not available")
+                let message = dbflux_i18n::t!("document.data.grid.error.connection_not_available");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Connection not available"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             };
@@ -2131,9 +2137,12 @@ impl DataGridPanel {
             let doc_map = match new_doc {
                 serde_json::Value::Object(m) => m,
                 _ => {
-                    Toast::error("Document must be a JSON object")
+                    let message = dbflux_i18n::t!(
+                        "document.data.context_menu.error.document_must_be_json_object"
+                    );
+                    Toast::error(message.clone())
                         .meta_right(now_hms())
-                        .action(copy_action("Document must be a JSON object"))
+                        .action(copy_action(message))
                         .push(cx);
                     return;
                 }
@@ -2190,9 +2199,11 @@ impl DataGridPanel {
             match new_doc.get("_id") {
                 Some(id) => DocumentFilter::new(serde_json::json!({"_id": id})),
                 None => {
-                    Toast::error("Document must have an _id field")
+                    let message =
+                        dbflux_i18n::t!("document.data.context_menu.error.document_missing_id");
+                    Toast::error(message.clone())
                         .meta_right(now_hms())
-                        .action(copy_action("Document must have an _id field"))
+                        .action(copy_action(message))
                         .push(cx);
                     return;
                 }
@@ -2200,9 +2211,11 @@ impl DataGridPanel {
         } else {
             // Extract PK values from the current row
             let Some(table_state) = &self.grid_table.table_state else {
-                Toast::error("Table state not available")
+                let message =
+                    dbflux_i18n::t!("document.data.context_menu.error.table_state_not_available");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Table state not available"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             };
@@ -2218,9 +2231,11 @@ impl DataGridPanel {
             }
 
             if filter_obj.is_empty() {
-                Toast::error("Could not determine document primary key")
+                let message =
+                    dbflux_i18n::t!("document.data.context_menu.error.primary_key_not_determined");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Could not determine document primary key"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             }
@@ -2252,9 +2267,10 @@ impl DataGridPanel {
         };
 
         let Some(conn) = conn else {
-            Toast::error("Connection not available")
+            let message = dbflux_i18n::t!("document.data.grid.error.connection_not_available");
+            Toast::error(message.clone())
                 .meta_right(now_hms())
-                .action(copy_action("Connection not available"))
+                .action(copy_action(message))
                 .push(cx);
             return;
         };

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -1247,7 +1247,8 @@ impl DataGridPanel {
         let bindings = shell.read(cx).active_bindings();
 
         let name_input = cx.new(|cx| {
-            dbflux_components::controls::InputState::new(window, cx).placeholder("Chart name")
+            dbflux_components::controls::InputState::new(window, cx)
+                .placeholder(dbflux_i18n::t!("document.data.grid.placeholder.chart_name"))
         });
 
         let sub = cx.subscribe_in(
@@ -3611,9 +3612,11 @@ impl DataGridPanel {
 
         match result {
             Ok(_summary) => {
-                dbflux_ui_base::toast::Toast::success("Query imported successfully")
-                    .meta_right(dbflux_ui_base::toast::now_hms())
-                    .push(cx);
+                dbflux_ui_base::toast::Toast::success(dbflux_i18n::t!(
+                    "document.data.grid.toast.query_imported"
+                ))
+                .meta_right(dbflux_ui_base::toast::now_hms())
+                .push(cx);
             }
             Err(e) => {
                 dbflux_ui_base::user_error::report_error(
@@ -3706,8 +3709,10 @@ impl DataGridPanel {
                     });
                     match enqueue_result {
                         Ok(_) => {
-                            dbflux_ui_base::toast::Toast::info("Mutation queued for approval.")
-                                .push(cx);
+                            dbflux_ui_base::toast::Toast::info(dbflux_i18n::t!(
+                                "document.data.grid.toast.mutation_queued"
+                            ))
+                            .push(cx);
                         }
                         Err(e) => {
                             dbflux_ui_base::user_error::report_error(
@@ -3852,7 +3857,10 @@ impl DataGridPanel {
             });
             match enqueue_result {
                 Ok(_) => {
-                    dbflux_ui_base::toast::Toast::info("Mutation queued for approval.").push(cx);
+                    dbflux_ui_base::toast::Toast::info(dbflux_i18n::t!(
+                        "document.data.grid.toast.mutation_queued"
+                    ))
+                    .push(cx);
                 }
                 Err(e) => {
                     dbflux_ui_base::user_error::report_error(

--- a/crates/dbflux_ui_document/src/data_grid_panel/query.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/query.rs
@@ -96,15 +96,17 @@ impl DataGridPanel {
         let limit_str = limit_value.trim();
         let pagination = match limit_str.parse::<u32>() {
             Ok(0) => {
-                Toast::warning("Limit must be greater than 0")
-                    .meta_right(now_hms())
-                    .push(cx);
+                Toast::warning(dbflux_i18n::t!(
+                    "document.data.grid.error.limit_must_be_positive"
+                ))
+                .meta_right(now_hms())
+                .push(cx);
                 pagination
             }
             Ok(limit) if limit != pagination.limit() => pagination.with_limit(limit).reset_offset(),
             Ok(_) => pagination,
             Err(_) if !limit_str.is_empty() => {
-                Toast::warning("Invalid limit value")
+                Toast::warning(dbflux_i18n::t!("document.data.grid.error.invalid_limit"))
                     .meta_right(now_hms())
                     .push(cx);
                 pagination
@@ -163,9 +165,10 @@ impl DataGridPanel {
         let conn = {
             let state = self.app_state.read(cx);
             let Some(connected) = state.connections().get(&profile_id) else {
-                Toast::error("Connection not found")
+                let message = dbflux_i18n::t!("document.data.grid.error.connection_not_found");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Connection not found"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             };
@@ -322,9 +325,10 @@ impl DataGridPanel {
         let conn = {
             let state = self.app_state.read(cx);
             let Some(connected) = state.connections().get(&profile_id) else {
-                Toast::error("Connection not found")
+                let message = dbflux_i18n::t!("document.data.grid.error.connection_not_found");
+                Toast::error(message.clone())
                     .meta_right(now_hms())
-                    .action(copy_action("Connection not found"))
+                    .action(copy_action(message))
                     .push(cx);
                 return;
             };
@@ -466,15 +470,17 @@ impl DataGridPanel {
         let limit_str = limit_value.trim();
         let pagination = match limit_str.parse::<u32>() {
             Ok(0) => {
-                Toast::warning("Limit must be greater than 0")
-                    .meta_right(now_hms())
-                    .push(cx);
+                Toast::warning(dbflux_i18n::t!(
+                    "document.data.grid.error.limit_must_be_positive"
+                ))
+                .meta_right(now_hms())
+                .push(cx);
                 pagination
             }
             Ok(limit) if limit != pagination.limit() => pagination.with_limit(limit).reset_offset(),
             Ok(_) => pagination,
             Err(_) if !limit_str.is_empty() => {
-                Toast::warning("Invalid limit value")
+                Toast::warning(dbflux_i18n::t!("document.data.grid.error.invalid_limit"))
                     .meta_right(now_hms())
                     .push(cx);
                 pagination
@@ -487,9 +493,10 @@ impl DataGridPanel {
             match state.connections().get(&profile_id) {
                 Some(c) => Some(c.connection.clone()),
                 None => {
-                    Toast::error("Connection not found")
+                    let message = dbflux_i18n::t!("document.data.grid.error.connection_not_found");
+                    Toast::error(message.clone())
                         .meta_right(now_hms())
-                        .action(copy_action("Connection not found"))
+                        .action(copy_action(message))
                         .push(cx);
                     return;
                 }
@@ -497,9 +504,10 @@ impl DataGridPanel {
         };
 
         let Some(conn) = conn else {
-            Toast::error("Connection not available")
+            let message = dbflux_i18n::t!("document.data.grid.error.connection_not_available");
+            Toast::error(message.clone())
                 .meta_right(now_hms())
-                .action(copy_action("Connection not available"))
+                .action(copy_action(message))
                 .push(cx);
             return;
         };
@@ -513,10 +521,14 @@ impl DataGridPanel {
                 Ok(v) => Some(v),
                 Err(e) => {
                     let toast_body = e.to_string();
-                    Toast::error("Invalid JSON filter")
+                    let title = dbflux_i18n::t!("document.data.grid.error.invalid_json_filter");
+                    Toast::error(title.clone())
                         .meta_right(now_hms())
                         .body(toast_body.clone())
-                        .action(copy_action(format!("Invalid JSON filter: {}", toast_body)))
+                        .action(copy_action(crate::labels::error_with_detail_clipboard(
+                            &title,
+                            &toast_body,
+                        )))
                         .push(cx);
                     return;
                 }

--- a/crates/dbflux_ui_document/src/data_view.rs
+++ b/crates/dbflux_ui_document/src/data_view.rs
@@ -37,10 +37,10 @@ impl DataViewMode {
         }
     }
 
-    pub fn label(&self) -> &'static str {
+    pub fn label(&self) -> String {
         match self {
-            DataViewMode::Table => "Table",
-            DataViewMode::Document => "Document",
+            DataViewMode::Table => dbflux_i18n::t!("document.data.grid.mode.table"),
+            DataViewMode::Document => dbflux_i18n::t!("document.data.grid.mode.document"),
         }
     }
 }

--- a/crates/dbflux_ui_document/src/governance.rs
+++ b/crates/dbflux_ui_document/src/governance.rs
@@ -63,9 +63,10 @@ impl McpApprovalsView {
             }
             Err(error) => {
                 self.selected_detail = None;
-                self.status_message = Some(format!(
-                    "Failed to load pending execution {}: {}",
-                    pending_id, error
+                self.status_message = Some(dbflux_i18n::t!(
+                    "document.governance.load_failed",
+                    id = pending_id,
+                    error = error
                 ));
             }
         }
@@ -178,12 +179,15 @@ impl Render for McpApprovalsView {
                     .flex_col()
                     .gap_2()
                     .child(
-                        Button::new("mcp-approvals-refresh", "Refresh Pending")
-                            .small()
-                            .ghost()
-                            .on_click(cx.listener(|this, _, _, cx| {
-                                this.refresh(cx);
-                            })),
+                        Button::new(
+                            "mcp-approvals-refresh",
+                            dbflux_i18n::t!("document.governance.refresh"),
+                        )
+                        .small()
+                        .ghost()
+                        .on_click(cx.listener(|this, _, _, cx| {
+                            this.refresh(cx);
+                        })),
                     )
                     .child(
                         div()
@@ -193,7 +197,9 @@ impl Render for McpApprovalsView {
                             .flex_col()
                             .gap_1()
                             .when(self.pending.is_empty(), |root| {
-                                root.child(Text::muted("No pending executions"))
+                                root.child(Text::muted(dbflux_i18n::t!(
+                                    "document.governance.no_pending"
+                                )))
                             })
                             .children(self.pending.iter().map(|entry| {
                                 let entry_id = entry.id.clone();
@@ -241,41 +247,60 @@ impl Render for McpApprovalsView {
                     .flex_col()
                     .gap_3()
                     .when_some(self.selected_detail.clone(), |root, detail| {
-                        root.child(Text::heading(format!("Pending {}", detail.summary.id)))
-                            .child(
-                                div()
-                                    .child(Text::caption("Approval context"))
-                                    .child(Text::body(Self::semantics_preview(&detail))),
-                            )
-                            .child(
-                                div()
-                                    .child(Text::caption("Execution plan"))
-                                    .child(Text::body(detail.plan.to_string())),
-                            )
-                            .child(
-                                div()
-                                    .flex()
-                                    .gap_2()
-                                    .child(
-                                        Button::new("mcp-approval-approve", "Approve")
-                                            .small()
-                                            .primary()
-                                            .on_click(cx.listener(|this, _, _, cx| {
-                                                this.approve_selected(cx);
-                                            })),
+                        root.child(Text::heading(dbflux_i18n::t!(
+                            "document.governance.pending_title",
+                            id = detail.summary.id
+                        )))
+                        .child(
+                            div()
+                                .child(Text::caption(dbflux_i18n::t!(
+                                    "document.governance.approval_context"
+                                )))
+                                .child(Text::body(Self::semantics_preview(&detail))),
+                        )
+                        .child(
+                            div()
+                                .child(Text::caption(dbflux_i18n::t!(
+                                    "document.governance.execution_plan"
+                                )))
+                                .child(Text::body(detail.plan.to_string())),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .gap_2()
+                                .child(
+                                    Button::new(
+                                        "mcp-approval-approve",
+                                        dbflux_i18n::t!("document.governance.approve"),
                                     )
-                                    .child(
-                                        Button::new("mcp-approval-reject", "Reject")
-                                            .small()
-                                            .danger()
-                                            .on_click(cx.listener(|this, _, _, cx| {
-                                                this.reject_selected(cx);
-                                            })),
-                                    ),
-                            )
+                                    .small()
+                                    .primary()
+                                    .on_click(cx.listener(
+                                        |this, _, _, cx| {
+                                            this.approve_selected(cx);
+                                        },
+                                    )),
+                                )
+                                .child(
+                                    Button::new(
+                                        "mcp-approval-reject",
+                                        dbflux_i18n::t!("document.governance.reject"),
+                                    )
+                                    .small()
+                                    .danger()
+                                    .on_click(cx.listener(
+                                        |this, _, _, cx| {
+                                            this.reject_selected(cx);
+                                        },
+                                    )),
+                                ),
+                        )
                     })
                     .when(self.selected_detail.is_none(), |root| {
-                        root.child(Text::muted("Select a pending request to review details."))
+                        root.child(Text::muted(dbflux_i18n::t!(
+                            "document.governance.select_prompt"
+                        )))
                     })
                     .when_some(self.status_message.clone(), |root, message| {
                         root.child(Text::body(message).danger())

--- a/crates/dbflux_ui_document/src/instance_inspector/mod.rs
+++ b/crates/dbflux_ui_document/src/instance_inspector/mod.rs
@@ -212,7 +212,9 @@ impl InspectorPanel {
         let conn = {
             let state = self.app_state.read(cx);
             let Some(connected) = state.connections().get(&profile_id) else {
-                self.last_error = Some("Connection not found".to_string());
+                self.last_error = Some(dbflux_i18n::t!(
+                    "document.instance_inspector.connection_not_found"
+                ));
                 self.state = DocumentState::Error;
                 cx.notify();
                 return;
@@ -220,7 +222,10 @@ impl InspectorPanel {
             match connected.resolve_connection_for_execution(None) {
                 Ok(c) => c,
                 Err(e) => {
-                    self.last_error = Some(format!("Connection error: {:?}", e));
+                    self.last_error = Some(dbflux_i18n::t!(
+                        "document.instance_inspector.connection_error",
+                        detail = format!("{e:?}")
+                    ));
                     self.state = DocumentState::Error;
                     cx.notify();
                     return;
@@ -231,7 +236,10 @@ impl InspectorPanel {
         let request = build_inspector_request(&self.metric_id);
         let (task_id, cancel_token) = self.runner.start_primary(
             dbflux_core::TaskKind::Query,
-            format!("Inspector: {}", self.metric_id),
+            dbflux_i18n::t!(
+                "document.instance_inspector.task_label",
+                metric_id = self.metric_id
+            ),
             cx,
         );
 
@@ -403,7 +411,7 @@ impl InspectorPanel {
             let Some(conn) = connection else {
                 let uf = UserFacingError::new(
                     ErrorKind::Driver,
-                    "Action cancelled — connection is no longer available. Reconnect and try again.",
+                    dbflux_i18n::t!("document.instance_inspector.action_unavailable"),
                 );
                 report_error_async(uf, cx);
                 return;
@@ -456,11 +464,10 @@ impl InspectorPanel {
             .pending_kill_confirm
             .as_ref()
             .map(|c| c.action_label.clone())
-            .unwrap_or_else(|| "Kill".to_string());
+            .unwrap_or_else(|| dbflux_i18n::t!("document.instance_inspector.kill_default_label"));
 
         let title = format!("{}?", action_label);
-        let description =
-            "This action will terminate the selected operation. It cannot be undone.".to_string();
+        let description = dbflux_i18n::t!("document.instance_inspector.kill_confirm_body");
 
         div()
             .id("kill-confirm-overlay")
@@ -517,7 +524,9 @@ impl InspectorPanel {
                                     .child(
                                         Icon::new(AppIcon::X).small().color(theme.muted_foreground),
                                     )
-                                    .child(Text::caption("Cancel")),
+                                    .child(Text::caption(dbflux_i18n::t!(
+                                        "document.instance_inspector.cancel"
+                                    ))),
                             )
                             .child(
                                 div()
@@ -537,7 +546,12 @@ impl InspectorPanel {
                                     .child(
                                         Icon::new(AppIcon::Delete).small().color(theme.background),
                                     )
-                                    .child(Text::caption("Confirm").color(theme.background)),
+                                    .child(
+                                        Text::caption(dbflux_i18n::t!(
+                                            "document.instance_inspector.confirm"
+                                        ))
+                                        .color(theme.background),
+                                    ),
                             ),
                     ),
             )
@@ -629,11 +643,11 @@ impl Render for InspectorPanel {
 
         // No result yet — show a loading or error placeholder.
         let msg = if let Some(err) = &self.last_error {
-            format!("Error: {err}")
+            dbflux_i18n::t!("document.instance_inspector.error_prefix", error = err)
         } else if self.state == DocumentState::Loading {
-            "Loading…".to_string()
+            dbflux_i18n::t!("document.instance_inspector.loading")
         } else {
-            "No data. Connect and click Refresh.".to_string()
+            dbflux_i18n::t!("document.instance_inspector.empty")
         };
 
         div()
@@ -685,8 +699,10 @@ pub(crate) fn kill_error_to_user_facing(
     metric_id: &str,
     err: &dbflux_core::DbError,
 ) -> UserFacingError {
-    UserFacingError::new(ErrorKind::Driver, err.to_string()).with_cause(format!(
-        "Action '{action_label}' on inspector '{metric_id}' failed"
+    UserFacingError::new(ErrorKind::Driver, err.to_string()).with_cause(dbflux_i18n::t!(
+        "document.instance_inspector.kill_failed_cause",
+        action_label = action_label,
+        metric_id = metric_id
     ))
 }
 

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1718,6 +1718,51 @@ pub(crate) fn migrate_source_target_checked_count_label(count: usize) -> String 
     }
 }
 
+/// Translated message for a `build_source_window_context` validation
+/// failure.
+///
+/// `build_source_window_context` returns a `&'static str` token instead of a
+/// translated string so its own tests stay locale-independent; this maps
+/// each token to its catalog entry once, at the toast display site, instead
+/// of threading a `Context<Self>` through the validation helper.
+pub(crate) fn source_window_error_message(err: &'static str) -> String {
+    match err {
+        "Select at least one source" => {
+            dbflux_i18n::t!("document.code.execution.error.select_source")
+        }
+        "Start time is required" => {
+            dbflux_i18n::t!("document.code.execution.error.start_time_required")
+        }
+        "End time is required" => {
+            dbflux_i18n::t!("document.code.execution.error.end_time_required")
+        }
+        "Start time must be earlier than end time" => {
+            dbflux_i18n::t!("document.code.execution.error.start_before_end")
+        }
+        other => other.to_string(),
+    }
+}
+
+/// Label for a query-syntax error toast, appending the driver-provided hint
+/// (when present) on its own line.
+pub(crate) fn syntax_error_with_hint(message: &str, hint: &str) -> String {
+    dbflux_i18n::t!(
+        "document.code.execution.hint_prefix",
+        message = message,
+        hint = hint
+    )
+}
+
+/// Clipboard text for a toast copy action that pairs a translated error
+/// title with a dynamic detail (for example a parser error message).
+pub(crate) fn error_with_detail_clipboard(title: &str, detail: &str) -> String {
+    dbflux_i18n::t!(
+        "document.shared.error_with_detail_clipboard",
+        title = title,
+        detail = detail
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1730,12 +1775,13 @@ mod tests {
         comparator_label, configure_chart_kind_label, copy_query_language_label,
         dangerous_query_body, dangerous_query_title, delete_confirm_copy,
         delete_prefix_delete_button_label, delete_prefix_deleted_toast, delete_prefix_probe_totals,
-        delete_rows_label, execution_count_state_label, execution_mode_label,
-        export_running_position_label, export_running_rows_label, export_summary_label,
-        export_table_status_line, history_items_count_label, history_tab_label, image_decode_error,
-        image_header_error, import_mapping_mode_label, import_rail_labels, import_summary_label,
-        import_table_status_line, incomplete_aggregate_rows_label, join_kind_label,
-        live_output_lines_label, live_output_truncated_label, metric_picker_custom_dropdown_label,
+        delete_rows_label, error_with_detail_clipboard, execution_count_state_label,
+        execution_mode_label, export_running_position_label, export_running_rows_label,
+        export_summary_label, export_table_status_line, history_items_count_label,
+        history_tab_label, image_decode_error, image_header_error, import_mapping_mode_label,
+        import_rail_labels, import_summary_label, import_table_status_line,
+        incomplete_aggregate_rows_label, join_kind_label, live_output_lines_label,
+        live_output_truncated_label, metric_picker_custom_dropdown_label,
         metric_picker_dimensions_error_label, metric_picker_period_error_label,
         metric_picker_period_not_a_number_error, metric_picker_statistic_error_label,
         migrate_mapping_unmapped_count_label, migrate_running_position_label,
@@ -1744,9 +1790,9 @@ mod tests {
         object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
         pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
         refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
-        script_confirm_message_label, sort_direction_label, table_action_description,
-        unsaved_changes_label, update_columns_label, valid_lines_label, versioning_off_label,
-        versioning_status_label,
+        script_confirm_message_label, sort_direction_label, source_window_error_message,
+        syntax_error_with_hint, table_action_description, unsaved_changes_label,
+        update_columns_label, valid_lines_label, versioning_off_label, versioning_status_label,
     };
     use crate::buckets_table::BucketEncryptionChoice;
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
@@ -4990,5 +5036,152 @@ mod tests {
 
             assert_ne!(en, es, "{key} should differ between en and es");
         }
+    }
+
+    #[test]
+    fn sweep_leftover_keys_resolve_in_both_locales() {
+        // New keys introduced by this sweep.
+        let new_keys = [
+            "document.data.grid.error.limit_must_be_positive",
+            "document.data.grid.error.invalid_limit",
+            "document.data.grid.error.connection_not_found",
+            "document.data.grid.error.connection_not_available",
+            "document.data.grid.error.invalid_json_filter",
+            "document.data.grid.placeholder.chart_name",
+            "document.data.grid.toast.query_imported",
+            "document.data.grid.toast.mutation_queued",
+            "document.data.context_menu.error.no_results_to_export",
+            "document.data.context_menu.error.invalid_json",
+            "document.data.context_menu.error.document_must_be_json_object",
+            "document.data.context_menu.error.document_missing_id",
+            "document.data.context_menu.error.table_state_not_available",
+            "document.data.context_menu.error.primary_key_not_determined",
+            "document.object_browser.toolbar.filter_prefix_placeholder",
+            "document.audit.filter.placeholder.local",
+            "document.code.execution.error.select_source",
+            "document.code.execution.error.start_time_required",
+            "document.code.execution.error.end_time_required",
+            "document.code.execution.error.start_before_end",
+            "document.code.execution.hint_prefix",
+            "document.shared.error_with_detail_clipboard",
+        ];
+
+        // Existing keys reused as-is because their English value is
+        // byte-identical to a leftover literal found in this sweep.
+        let reused_keys = [
+            "document.audit.detail.level",
+            "document.audit.detail.category",
+            "document.audit.detail.outcome",
+        ];
+
+        for key in new_keys.iter().chain(reused_keys.iter()) {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(*key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, *key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sweep_leftover_keys_differ_between_locales() {
+        // "document.audit.filter.placeholder.local" is intentionally
+        // excluded: "Local" is the same word in English and Spanish.
+        let keys = [
+            "document.data.grid.error.limit_must_be_positive",
+            "document.data.context_menu.error.no_results_to_export",
+            "document.object_browser.toolbar.filter_prefix_placeholder",
+            "document.code.execution.error.select_source",
+            "document.code.execution.hint_prefix",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert_ne!(en, es, "{key} should differ between en and es");
+        }
+    }
+
+    #[test]
+    fn source_window_error_message_covers_every_build_source_window_context_variant() {
+        // Relies on the process-wide default locale ("en"); no test in this
+        // suite calls `set_locale`, so the default is stable across tests.
+        let variants = [
+            (
+                "Select at least one source",
+                "document.code.execution.error.select_source",
+            ),
+            (
+                "Start time is required",
+                "document.code.execution.error.start_time_required",
+            ),
+            (
+                "End time is required",
+                "document.code.execution.error.end_time_required",
+            ),
+            (
+                "Start time must be earlier than end time",
+                "document.code.execution.error.start_before_end",
+            ),
+        ];
+
+        for (variant, key) in variants {
+            let value = source_window_error_message(variant);
+
+            assert_eq!(
+                value,
+                dbflux_i18n::t!(key),
+                "{variant} did not route through {key}"
+            );
+        }
+    }
+
+    #[test]
+    fn source_window_error_message_falls_back_to_input_for_unmapped_tokens() {
+        let value = source_window_error_message("not a known validation token");
+
+        assert_eq!(value, "not a known validation token");
+    }
+
+    #[test]
+    fn source_window_error_message_keys_resolve_in_spanish() {
+        let keys = [
+            "document.code.execution.error.select_source",
+            "document.code.execution.error.start_time_required",
+            "document.code.execution.error.end_time_required",
+            "document.code.execution.error.start_before_end",
+        ];
+
+        for key in keys {
+            let value = dbflux_i18n::t!(key, locale = "es");
+
+            assert!(!value.is_empty(), "{key} resolved empty in es");
+            assert_ne!(value, format!("es.{key}"), "{key} missing from es catalog");
+        }
+    }
+
+    #[test]
+    fn syntax_error_with_hint_interpolates_message_and_hint() {
+        let value = syntax_error_with_hint("unexpected token", "check your syntax");
+
+        assert!(value.contains("unexpected token"));
+        assert!(value.contains("check your syntax"));
+        assert_ne!(value, "document.code.execution.hint_prefix");
+    }
+
+    #[test]
+    fn error_with_detail_clipboard_interpolates_title_and_detail() {
+        let value = error_with_detail_clipboard("Invalid JSON filter", "unexpected end of input");
+
+        assert!(value.contains("Invalid JSON filter"));
+        assert!(value.contains("unexpected end of input"));
+        assert_ne!(value, "document.shared.error_with_detail_clipboard");
     }
 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -4922,4 +4922,73 @@ mod tests {
         assert!(zero_total.contains("10"));
         assert!(!zero_total.contains('/'));
     }
+
+    /// PR 27b: the remaining-chrome sweep across `governance.rs`,
+    /// `result_warnings.rs`, `data_view.rs`, and `instance_inspector/mod.rs`.
+    #[test]
+    fn final_sweep_keys_resolve_in_both_locales() {
+        let keys = [
+            "document.governance.refresh",
+            "document.governance.no_pending",
+            "document.governance.pending_title",
+            "document.governance.approval_context",
+            "document.governance.execution_plan",
+            "document.governance.approve",
+            "document.governance.reject",
+            "document.governance.select_prompt",
+            "document.governance.load_failed",
+            "document.shared.result_warnings.context.query",
+            "document.shared.result_warnings.context.table_browse",
+            "document.shared.result_warnings.context.visual_query",
+            "document.shared.result_warnings.context.collection_browse",
+            "document.shared.result_warnings.context.crud_returning",
+            "document.shared.result_warnings.context.mutation_preview",
+            "document.shared.result_warnings.summary",
+            "document.shared.result_warnings.cause",
+            "document.data.grid.mode.table",
+            "document.data.grid.mode.document",
+            "document.instance_inspector.task_label",
+            "document.instance_inspector.connection_not_found",
+            "document.instance_inspector.connection_error",
+            "document.instance_inspector.action_unavailable",
+            "document.instance_inspector.kill_default_label",
+            "document.instance_inspector.kill_confirm_body",
+            "document.instance_inspector.cancel",
+            "document.instance_inspector.confirm",
+            "document.instance_inspector.error_prefix",
+            "document.instance_inspector.loading",
+            "document.instance_inspector.empty",
+            "document.instance_inspector.kill_failed_cause",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn final_sweep_keys_differ_between_locales() {
+        let keys = [
+            "document.governance.no_pending",
+            "document.shared.result_warnings.context.query",
+            "document.instance_inspector.kill_confirm_body",
+        ];
+
+        for key in keys {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert_ne!(en, es, "{key} should differ between en and es");
+        }
+    }
 }

--- a/crates/dbflux_ui_document/src/object_browser/mod.rs
+++ b/crates/dbflux_ui_document/src/object_browser/mod.rs
@@ -184,8 +184,11 @@ impl ObjectBrowserDocument {
     ) -> Self {
         let tree = ObjectTree::new(bucket.clone());
 
-        let filter_input =
-            cx.new(|cx| InputState::new(window, cx).placeholder("Filter this prefix…"));
+        let filter_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "document.object_browser.toolbar.filter_prefix_placeholder"
+            ))
+        });
 
         let filter_subscription = cx.subscribe_in(
             &filter_input,

--- a/crates/dbflux_ui_document/src/result_warnings.rs
+++ b/crates/dbflux_ui_document/src/result_warnings.rs
@@ -14,14 +14,24 @@ pub(crate) enum ResultWarningContext {
 }
 
 impl ResultWarningContext {
-    fn label(self) -> &'static str {
+    fn label(self) -> String {
         match self {
-            Self::Query => "query result",
-            Self::TableBrowse => "table browse result",
-            Self::VisualQuery => "visual query result",
-            Self::CollectionBrowse => "collection browse result",
-            Self::CrudReturning => "mutation RETURNING result",
-            Self::MutationPreview => "mutation preview result",
+            Self::Query => dbflux_i18n::t!("document.shared.result_warnings.context.query"),
+            Self::TableBrowse => {
+                dbflux_i18n::t!("document.shared.result_warnings.context.table_browse")
+            }
+            Self::VisualQuery => {
+                dbflux_i18n::t!("document.shared.result_warnings.context.visual_query")
+            }
+            Self::CollectionBrowse => {
+                dbflux_i18n::t!("document.shared.result_warnings.context.collection_browse")
+            }
+            Self::CrudReturning => {
+                dbflux_i18n::t!("document.shared.result_warnings.context.crud_returning")
+            }
+            Self::MutationPreview => {
+                dbflux_i18n::t!("document.shared.result_warnings.context.mutation_preview")
+            }
         }
     }
 }
@@ -139,14 +149,16 @@ fn unsupported_type_warnings(
         .map(|type_name| {
             UserFacingError::new(
                 ErrorKind::Driver,
-                format!(
-                    "Unsupported database type '{type_name}' in {}",
-                    context.label()
+                dbflux_i18n::t!(
+                    "document.shared.result_warnings.summary",
+                    type_name = type_name,
+                    context = context.label()
                 ),
             )
-            .with_cause(format!(
-                "The {} contains values of unsupported type '{type_name}'.",
-                context.label()
+            .with_cause(dbflux_i18n::t!(
+                "document.shared.result_warnings.cause",
+                type_name = type_name,
+                context = context.label()
             ))
             .with_severity(EventSeverity::Warn)
         })
@@ -325,6 +337,21 @@ mod tests {
                 .iter_mut()
                 .all(|result| take_crud_result_warning_types(result).is_empty())
         );
+    }
+
+    #[test]
+    fn context_labels_resolve_in_both_locales() {
+        for context in [
+            ResultWarningContext::Query,
+            ResultWarningContext::TableBrowse,
+            ResultWarningContext::VisualQuery,
+            ResultWarningContext::CollectionBrowse,
+            ResultWarningContext::CrudReturning,
+            ResultWarningContext::MutationPreview,
+        ] {
+            let en_label = context.label();
+            assert!(!en_label.is_empty());
+        }
     }
 
     fn assert_query_handoff_reports_once(


### PR DESCRIPTION
## Summary

Document i18n slices 27b + 27c + 27d (three commits, one PR): the MCP governance view, result warnings, data view modes and instance inspector (27b); the code document context bar, execution toasts, file operations and title fallback (27c); and the sweep leftovers — data grid and context menu errors, chart-name placeholder, object browser prefix filter, audit filter placeholders, source-window validation messages, syntax-error hint wrapper (27d) — render through `dbflux_i18n::t!`. English and Spanish together. Format-example placeholders, persisted defaults (`Query 1`, lowercase `untitled`), classification tokens and audit summaries stay data.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `DataViewMode::label()` / `ResultWarningContext::label()` widen to `String`; `source_window_error_message` maps the four `&'static str` validation tokens exhaustively; `error_with_detail_clipboard` replaces two title+detail `format!` concatenations.
- Size: 1348 lines across the three slices (`size:exception`); each slice was reviewed separately.

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1124 passed; clippy clean; fmt clean. Manual smoke in Spanish: open MCP approvals, run a query without a connection, save a script as, enter an invalid JSON filter, filter a prefix in the object browser.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
