### PR TITLE
feat(i18n): translate the settings save-failure toasts, editor panel titles, and remaining placeholders

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -171,6 +171,8 @@ connection_manager:
     no_policy: No policy
     extra_hook_ids: extra hook IDs (comma-separated)
     use_connection_auth_profile: Use Connection Auth Profile
+    select_additional_roles: "Select additional roles…"
+    select_additional_policies: "Select additional policies…"
   access_method:
     direct: Direct
     ssh_tunnel: SSH Tunnel
@@ -233,6 +235,9 @@ connection_manager:
   mcp_policy_hint: Configure policies in Settings → MCP → Policies
   additional_policies_optional: Additional policies (optional)
   scope_policy_preview: Scope/policy assignment preview
+  mcp_governance_error:
+    save_policy: "Failed to save MCP connection policy assignment: %{error}"
+    clear_policy: "Failed to clear MCP connection policy assignment: %{error}"
   tab:
     main: Main
     settings: Settings
@@ -2098,6 +2103,12 @@ settings:
   discard:
     title: Discard Unsaved Changes
     body: "You have unsaved changes. Discard them and switch to %{section}?"
+  editor_panel:
+    title:
+      edit: "Edit %{noun}"
+      new: "New %{noun}"
+  mcp_governance:
+    persist_error: "Failed to persist MCP governance: %{error}"
   general:
     header:
       title: General
@@ -2334,6 +2345,9 @@ settings:
     login_hint: Log in to load options
     inherited_from: "Inherited from %{trigger}."
     inherited_from_named: "Inherited from %{trigger} '%{name}'."
+    error:
+      secret_store_failed: "The profile's secret could not be stored (the OS keyring may be locked or unavailable) and will not persist after restart."
+      write_config_failed: "Failed to write profile to config: %{error}"
   mcp:
     tool:
       list_connections:
@@ -2518,6 +2532,7 @@ settings:
     error:
       refresh_interval_empty: Refresh interval override must not be empty
       refresh_interval_invalid: Refresh interval override must be a number greater than 0
+      save_failed: "Failed to save driver settings: %{error}"
     toast:
       saved: Driver settings saved.
       saved_warnings: Driver settings saved with warnings
@@ -2575,6 +2590,7 @@ settings:
       socket_id_required: Socket ID is required
       timeout_invalid: Timeout must be a valid number (milliseconds)
       duplicate_socket_id: "A service with socket ID '%{id}' already exists"
+      save_failed: "Failed to save RPC service config: %{error}"
     toast:
       saved: RPC service saved. Restart required to apply changes.
       deleted: RPC service deleted. Restart required to apply changes.
@@ -2614,6 +2630,7 @@ settings:
       delete: Delete
     error:
       host_and_user_required: Host and user are required
+      save_failed: "Failed to save SSH tunnel profiles: %{error}"
   proxies:
     placeholder_name: Proxy name
     placeholder_username: username
@@ -2644,6 +2661,8 @@ settings:
       basic: Basic
     status:
       disabled_caption: "off"
+    error:
+      save_failed: "Failed to save proxy profiles: %{error}"
     action:
       save: Save
       import: "Import…"

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -186,6 +186,9 @@ connection_manager:
     default_seconds_caption: "Default: %{value}s"
     on: "On"
     off: "Off"
+  form_title:
+    edit: "Edit %{driver} Connection"
+    new: "New %{driver} Connection"
   connection_overrides_title: Connection Overrides
   connection_hooks_title: Connection Hooks
   new_auth_profile: "New Auth Profile..."
@@ -1748,6 +1751,7 @@ form:
     auth_profile_dangling: "Auth profile '%{name}' could not be found in ~/.aws/config. Please recreate the profile or update the connection binding."
     dynamic_auth_profile_required: Dynamic value sources require an Auth Profile. Select one in Access tab.
     auth_profile_no_provider: "Selected Auth Profile '%{name}' has no registered provider for dynamic value sources."
+    unknown_hook: "Unknown %{label} hook '%{token}'. Configure it in Settings > Hooks"
   action:
     updating: Updating
     saving: Saving
@@ -2090,6 +2094,10 @@ scripts:
 settings:
   action:
     default_connection_name: connection
+    close: Close
+  discard:
+    title: Discard Unsaved Changes
+    body: "You have unsaved changes. Discard them and switch to %{section}?"
   general:
     header:
       title: General
@@ -2163,6 +2171,8 @@ settings:
       error: Failed to update the shared-database setting
       hint: "Applied on next launch. Shares the stable database (dbflux.db) instead of this nightly build's dbflux-nightly.db."
     override_value_header: Override Value
+    placeholder:
+      refresh_policy: Refresh policy
     save:
       button: Save
       error: "Failed to save general settings: %{error}"

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -154,6 +154,7 @@ controls:
       many: "+%{count} more"
 connection_manager:
   placeholder:
+    seconds: seconds
     connection_name: Connection name
     password: Password
     key_passphrase_optional: Key passphrase (optional)
@@ -2998,7 +2999,6 @@ ssh:
   host: Host
   port: Port
   username: Username
-  host_user_required: Host and user are required
   private_key_short: Private key
   update: Update
   create: Create

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -171,6 +171,8 @@ connection_manager:
     no_policy: Sin política
     extra_hook_ids: IDs de hooks extra (separados por coma)
     use_connection_auth_profile: Usar el perfil de autenticación de la conexión
+    select_additional_roles: "Seleccionar roles adicionales…"
+    select_additional_policies: "Seleccionar políticas adicionales…"
   access_method:
     direct: Directo
     ssh_tunnel: Túnel SSH
@@ -233,6 +235,9 @@ connection_manager:
   mcp_policy_hint: Configura políticas en Ajustes → MCP → Políticas
   additional_policies_optional: Políticas adicionales (opcional)
   scope_policy_preview: Vista previa de alcance y políticas
+  mcp_governance_error:
+    save_policy: "No se pudo guardar la asignación de política MCP de la conexión: %{error}"
+    clear_policy: "No se pudo borrar la asignación de política MCP de la conexión: %{error}"
   tab:
     main: Principal
     settings: Ajustes
@@ -2098,6 +2103,12 @@ settings:
   discard:
     title: Descartar cambios sin guardar
     body: "Tienes cambios sin guardar. ¿Descartarlos y cambiar a %{section}?"
+  editor_panel:
+    title:
+      edit: "Editar %{noun}"
+      new: "Nuevo %{noun}"
+  mcp_governance:
+    persist_error: "No se pudo persistir la gobernanza de MCP: %{error}"
   general:
     header:
       title: General
@@ -2334,6 +2345,9 @@ settings:
     login_hint: Inicia sesión para cargar las opciones
     inherited_from: "Heredado de %{trigger}."
     inherited_from_named: "Heredado de %{trigger} '%{name}'."
+    error:
+      secret_store_failed: "No se pudo almacenar el secreto del perfil (el llavero del sistema operativo puede estar bloqueado o no disponible) y no persistirá tras reiniciar."
+      write_config_failed: "No se pudo escribir el perfil en la configuración: %{error}"
   mcp:
     tool:
       list_connections:
@@ -2518,6 +2532,7 @@ settings:
     error:
       refresh_interval_empty: El intervalo de actualización no puede estar vacío
       refresh_interval_invalid: El intervalo de actualización debe ser un número mayor que 0
+      save_failed: "No se pudieron guardar los ajustes del driver: %{error}"
     toast:
       saved: Ajustes del driver guardados.
       saved_warnings: Ajustes del driver guardados con advertencias
@@ -2575,6 +2590,7 @@ settings:
       socket_id_required: El ID del socket es obligatorio
       timeout_invalid: El tiempo de espera debe ser un número válido (milisegundos)
       duplicate_socket_id: "Ya existe un servicio con el ID de socket '%{id}'"
+      save_failed: "No se pudo guardar la configuración del servicio RPC: %{error}"
     toast:
       saved: Servicio RPC guardado. Es necesario reiniciar para aplicar los cambios.
       deleted: Servicio RPC eliminado. Es necesario reiniciar para aplicar los cambios.
@@ -2614,6 +2630,7 @@ settings:
       delete: Eliminar
     error:
       host_and_user_required: El host y el usuario son obligatorios
+      save_failed: "No se pudieron guardar los perfiles de túnel SSH: %{error}"
   proxies:
     placeholder_name: Nombre del proxy
     placeholder_username: usuario
@@ -2644,6 +2661,8 @@ settings:
       basic: Básica
     status:
       disabled_caption: apagado
+    error:
+      save_failed: "No se pudieron guardar los perfiles de proxy: %{error}"
     action:
       save: Guardar
       import: "Importar…"

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -186,6 +186,9 @@ connection_manager:
     default_seconds_caption: "Predeterminado: %{value}s"
     on: Activado
     off: Desactivado
+  form_title:
+    edit: "Editar conexión %{driver}"
+    new: "Nueva conexión %{driver}"
   connection_overrides_title: Anulaciones de conexión
   connection_hooks_title: Hooks de conexión
   new_auth_profile: "Nuevo perfil de autenticación..."
@@ -1748,6 +1751,7 @@ form:
     auth_profile_dangling: "No se pudo encontrar el perfil de autenticación '%{name}' en ~/.aws/config. Recrea el perfil o actualiza el enlace de la conexión."
     dynamic_auth_profile_required: Las fuentes de valores dinámicos requieren un perfil de autenticación. Selecciona uno en la pestaña Acceso.
     auth_profile_no_provider: "El perfil de autenticación seleccionado '%{name}' no tiene un proveedor registrado para fuentes de valores dinámicos."
+    unknown_hook: "Hook de %{label} desconocido '%{token}'. Configúralo en Configuración > Hooks"
   action:
     updating: Actualizando
     saving: Guardando
@@ -2090,6 +2094,10 @@ scripts:
 settings:
   action:
     default_connection_name: conexión
+    close: Cerrar
+  discard:
+    title: Descartar cambios sin guardar
+    body: "Tienes cambios sin guardar. ¿Descartarlos y cambiar a %{section}?"
   general:
     header:
       title: General
@@ -2163,6 +2171,8 @@ settings:
       error: No se pudo actualizar la configuración de base de datos compartida
       hint: "Se aplica en el próximo inicio. Comparte la base de datos estable (dbflux.db) en lugar de la dbflux-nightly.db de esta compilación nightly."
     override_value_header: Valor de anulación
+    placeholder:
+      refresh_policy: Política de actualización
     save:
       button: Guardar
       error: "No se pudo guardar la configuración general: %{error}"

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -154,6 +154,7 @@ controls:
       many: "+%{count} más"
 connection_manager:
   placeholder:
+    seconds: segundos
     connection_name: Nombre de la conexión
     password: Contraseña
     key_passphrase_optional: Frase de la clave (opcional)
@@ -2998,7 +2999,6 @@ ssh:
   host: Host
   port: Puerto
   username: Usuario
-  host_user_required: El host y el usuario son obligatorios
   private_key_short: Clave privada
   update: Actualizar
   create: Crear

--- a/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/access_tab.rs
@@ -1527,7 +1527,6 @@ mod tests {
         "ssh.host",
         "ssh.port",
         "ssh.username",
-        "ssh.host_user_required",
         "ssh.private_key_short",
         "ssh.update",
         "ssh.create",

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -655,7 +655,10 @@ impl ConnectionManagerWindow {
                         report_error(
                             UserFacingError::new(
                                 ErrorKind::Config,
-                                format!("Failed to save MCP connection policy assignment: {e}"),
+                                dbflux_i18n::t!(
+                                    "connection_manager.mcp_governance_error.save_policy",
+                                    error = e
+                                ),
                             ),
                             cx,
                         );
@@ -669,7 +672,10 @@ impl ConnectionManagerWindow {
                     report_error(
                         UserFacingError::new(
                             ErrorKind::Config,
-                            format!("Failed to clear MCP connection policy assignment: {e}"),
+                            dbflux_i18n::t!(
+                                "connection_manager.mcp_governance_error.clear_policy",
+                                error = e
+                            ),
                         ),
                         cx,
                     );

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -1736,7 +1736,8 @@ impl ConnectionManagerWindow {
             .collect();
 
         let mut role_items = vec![dbflux_components::controls::DropdownItem::with_value(
-            "No role", "",
+            dbflux_i18n::t!("connection_manager.placeholder.no_role"),
+            "",
         )];
         role_items.extend(roles.iter().map(|r| {
             let label = dbflux_mcp::builtin_display_name(&r.id)
@@ -1746,7 +1747,7 @@ impl ConnectionManagerWindow {
         }));
 
         let mut policy_items = vec![dbflux_components::controls::DropdownItem::with_value(
-            "No policy",
+            dbflux_i18n::t!("connection_manager.placeholder.no_policy"),
             "",
         )];
         policy_items.extend(policies.iter().map(|p| {
@@ -2345,9 +2346,8 @@ impl ConnectionManagerWindow {
 
         for (label, primary, extra) in phases {
             for token in Self::unresolved_hook_tokens(primary, &extra, &name_to_id, &known_ids) {
-                self.validation_errors.push(format!(
-                    "Unknown {label} hook '{token}'. Configure it in Settings > Hooks"
-                ));
+                self.validation_errors
+                    .push(crate::labels::form_unknown_hook(label, &token));
             }
         }
     }

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -587,14 +587,18 @@ impl ConnectionManagerWindow {
                 .placeholder(dbflux_i18n::t!("connection_manager.placeholder.no_role"))
         });
         let conn_mcp_role_multi_select = cx.new(|_cx| {
-            MultiSelect::new("conn-mcp-extra-roles").placeholder("Select additional roles…")
+            MultiSelect::new("conn-mcp-extra-roles").placeholder(dbflux_i18n::t!(
+                "connection_manager.placeholder.select_additional_roles"
+            ))
         });
         let conn_mcp_policy_dropdown = cx.new(|_cx| {
             Dropdown::new("conn-mcp-policy")
                 .placeholder(dbflux_i18n::t!("connection_manager.placeholder.no_policy"))
         });
         let conn_mcp_policy_multi_select = cx.new(|_cx| {
-            MultiSelect::new("conn-mcp-extra-policies").placeholder("Select additional policies…")
+            MultiSelect::new("conn-mcp-extra-policies").placeholder(dbflux_i18n::t!(
+                "connection_manager.placeholder.select_additional_policies"
+            ))
         });
 
         let dropdown_subscription = cx.subscribe(

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -523,7 +523,7 @@ impl ConnectionManagerWindow {
         });
         let conn_refresh_interval_input = cx.new(|cx| {
             InputState::new(window, cx)
-                .placeholder("seconds")
+                .placeholder(dbflux_i18n::t!("connection_manager.placeholder.seconds"))
                 .default_value("5")
         });
         let conn_confirm_dangerous_dropdown = cx.new(|_cx| {

--- a/crates/dbflux_ui_windows/src/connection_manager/render.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render.rs
@@ -265,9 +265,9 @@ impl ConnectionManagerWindow {
             .filter(|s| !s.is_empty());
         let is_editing = self.editing_profile_id.is_some();
         let title = if is_editing {
-            format!("Edit {} Connection", driver_name)
+            crate::labels::connection_manager_window_title_edit(&driver_name)
         } else {
-            format!("New {} Connection", driver_name)
+            crate::labels::connection_manager_window_title_new(&driver_name)
         };
 
         let show_focus = self.edit_state == EditState::Navigating;

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -146,7 +146,7 @@ impl ConnectionManagerWindow {
             let form_values = self.collect_form_values(driver.form_definition(), cx);
             let secret_label = driver
                 .secret_field_label(&form_values)
-                .unwrap_or_else(|| "Password".to_string());
+                .unwrap_or_else(|| dbflux_i18n::t!("connection_manager.placeholder.password"));
 
             let password_field = self.render_password_field(
                 show_focus,

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -613,8 +613,16 @@ impl ConnectionManagerWindow {
                                 let default_val = effective
                                     .driver_values
                                     .get(&field.id)
-                                    .map(|v| if v == "true" { "On" } else { "Off" })
-                                    .unwrap_or("Off");
+                                    .map(|v| {
+                                        if v == "true" {
+                                            dbflux_i18n::t!("connection_manager.overrides.on")
+                                        } else {
+                                            dbflux_i18n::t!("connection_manager.overrides.off")
+                                        }
+                                    })
+                                    .unwrap_or_else(|| {
+                                        dbflux_i18n::t!("connection_manager.overrides.off")
+                                    });
 
                                 Some(
                                     div()
@@ -650,7 +658,7 @@ impl ConnectionManagerWindow {
                                             )),
                                         )
                                         .child(Text::caption(
-                                            crate::labels::override_default_caption(default_val),
+                                            crate::labels::override_default_caption(&default_val),
                                         ))
                                         .into_any_element(),
                                 )

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -664,6 +664,28 @@ pub(crate) fn export_result_omitted_fields(count: usize) -> String {
     }
 }
 
+/// Formats the "Unknown <label> hook '<token>'. Configure it in Settings >
+/// Hooks" validation error for an unresolved hook binding.
+pub(crate) fn form_unknown_hook(label: &str, token: &str) -> String {
+    dbflux_i18n::t!("form.validation.unknown_hook", label = label, token = token)
+}
+
+/// Formats the "Edit <driver> Connection" connection-form window title.
+pub(crate) fn connection_manager_window_title_edit(driver: &str) -> String {
+    dbflux_i18n::t!("connection_manager.form_title.edit", driver = driver)
+}
+
+/// Formats the "New <driver> Connection" connection-form window title.
+pub(crate) fn connection_manager_window_title_new(driver: &str) -> String {
+    dbflux_i18n::t!("connection_manager.form_title.new", driver = driver)
+}
+
+/// Formats the "Discard them and switch to <section>?" body of the settings
+/// unsaved-changes confirmation dialog.
+pub(crate) fn settings_discard_body(section: &str) -> String {
+    dbflux_i18n::t!("settings.discard.body", section = section)
+}
+
 /// Formats the "Warning: <message>" export-result line.
 pub(crate) fn export_result_warning_line(message: &str) -> String {
     dbflux_i18n::t!(
@@ -713,11 +735,83 @@ mod tests {
         rpc_services_delete_body, ssh_private_key_with_path, ssh_tunnels_delete_body,
     };
     use super::{
+        connection_manager_window_title_edit, connection_manager_window_title_new,
+        form_unknown_hook, settings_discard_body,
+    };
+    use super::{
         export_error_cannot_determine_output_path, export_error_failed, export_error_write_failed,
         export_result_omitted_fields, export_result_success_title, export_result_warning_line,
         export_summary_auth_profile_line, export_summary_proxy_line, export_summary_ssh_line,
         export_title_with_kind, export_toast_success,
     };
+
+    /// Locale keys added or newly reused by the final windows-ui sweep (PR29):
+    /// hook-binding validation, connection-form window titles, the settings
+    /// discard-changes dialog, and the settings-window "Close" action.
+    const SWEEP_LEFTOVER_KEYS: &[&str] = &[
+        "form.validation.unknown_hook",
+        "connection_manager.form_title.edit",
+        "connection_manager.form_title.new",
+        "settings.discard.title",
+        "settings.discard.body",
+        "settings.action.close",
+        "settings.general.placeholder.refresh_policy",
+    ];
+
+    #[test]
+    fn sweep_leftover_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in SWEEP_LEFTOVER_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn sweep_leftover_keys_differ_between_locales() {
+        for key in SWEEP_LEFTOVER_KEYS {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert_ne!(en, es, "key {key} should differ between en and es");
+        }
+    }
+
+    #[test]
+    fn form_unknown_hook_embeds_label_and_token() {
+        let message = form_unknown_hook("pre-connect", "missing-hook");
+
+        assert!(message.contains("pre-connect"));
+        assert!(message.contains("missing-hook"));
+    }
+
+    #[test]
+    fn connection_manager_window_title_edit_and_new_embed_driver_name() {
+        assert!(connection_manager_window_title_edit("PostgreSQL").contains("PostgreSQL"));
+        assert!(connection_manager_window_title_new("PostgreSQL").contains("PostgreSQL"));
+        assert_ne!(
+            connection_manager_window_title_edit("PostgreSQL"),
+            connection_manager_window_title_new("PostgreSQL")
+        );
+    }
+
+    #[test]
+    fn settings_discard_body_embeds_section_name() {
+        let message = settings_discard_body("Audit");
+
+        assert!(message.contains("Audit"));
+    }
 
     #[test]
     fn hooks_delete_message_embeds_hook_name() {

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -794,6 +794,7 @@ mod tests {
     /// connection policy assignment, SSH tunnels, RPC services, proxies,
     /// driver settings, MCP governance persistence, and auth profiles.
     const FINAL_LEFTOVER_KEYS: &[&str] = &[
+        "connection_manager.placeholder.seconds",
         "connection_manager.placeholder.password",
         "connection_manager.placeholder.select_additional_roles",
         "connection_manager.placeholder.select_additional_policies",

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -788,6 +788,66 @@ mod tests {
         }
     }
 
+    /// Locale keys added or reused by the PR30 final leftover sweep: the
+    /// connection-form secret-field default label, the settings editor-panel
+    /// title template, and the `report_error`/status-banner messages across
+    /// connection policy assignment, SSH tunnels, RPC services, proxies,
+    /// driver settings, MCP governance persistence, and auth profiles.
+    const FINAL_LEFTOVER_KEYS: &[&str] = &[
+        "connection_manager.placeholder.password",
+        "connection_manager.placeholder.select_additional_roles",
+        "connection_manager.placeholder.select_additional_policies",
+        "settings.editor_panel.title.edit",
+        "settings.editor_panel.title.new",
+        "settings.auth_profiles.auth_profile_label",
+        "access.ssh_tunnel_label",
+        "settings.proxies.panel_title",
+        "connection_manager.mcp_governance_error.save_policy",
+        "connection_manager.mcp_governance_error.clear_policy",
+        "settings.ssh_tunnels.error.save_failed",
+        "settings.rpc_services.error.save_failed",
+        "settings.proxies.error.save_failed",
+        "settings.mcp_governance.persist_error",
+        "settings.drivers.error.save_failed",
+        "settings.auth_profiles.error.secret_store_failed",
+        "settings.auth_profiles.error.write_config_failed",
+    ];
+
+    #[test]
+    fn final_leftover_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in FINAL_LEFTOVER_KEYS {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, *key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn final_leftover_keys_differ_between_locales() {
+        // "Proxy" is a technical term kept identical in Spanish; every other
+        // key in this sweep carries a distinct Spanish translation.
+        for key in FINAL_LEFTOVER_KEYS
+            .iter()
+            .filter(|key| **key != "settings.proxies.panel_title")
+        {
+            let en = dbflux_i18n::t!(key, locale = "en");
+            let es = dbflux_i18n::t!(key, locale = "es");
+
+            assert_ne!(en, es, "key {key} should differ between en and es");
+        }
+    }
+
     #[test]
     fn form_unknown_hook_embeds_label_and_token() {
         let message = form_unknown_hook("pre-connect", "missing-hook");

--- a/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/auth_profiles_section.rs
@@ -1495,8 +1495,13 @@ impl AuthProfilesSection {
                 }
 
                 Some(Err(msg)) => {
-                    self.provider_login_status =
-                        Some((format!("Failed to write profile to config: {}", msg), false));
+                    self.provider_login_status = Some((
+                        dbflux_i18n::t!(
+                            "settings.auth_profiles.error.write_config_failed",
+                            error = msg
+                        ),
+                        false,
+                    ));
                     cx.notify();
                     return;
                 }
@@ -1528,8 +1533,7 @@ impl AuthProfilesSection {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    "The profile's secret could not be stored (the OS keyring may \
-                     be locked or unavailable) and will not persist after restart.",
+                    dbflux_i18n::t!("settings.auth_profiles.error.secret_store_failed"),
                 ),
                 cx,
             );

--- a/crates/dbflux_ui_windows/src/settings/drivers.rs
+++ b/crates/dbflux_ui_windows/src/settings/drivers.rs
@@ -644,7 +644,7 @@ impl DriversSection {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    format!("Failed to save driver settings: {e}"),
+                    dbflux_i18n::t!("settings.drivers.error.save_failed", error = e),
                 ),
                 cx,
             );

--- a/crates/dbflux_ui_windows/src/settings/general_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/general_section.rs
@@ -76,31 +76,33 @@ impl GeneralSection {
 
         let dropdown_theme = cx.new(move |_cx| {
             Dropdown::new("general-theme")
-                .placeholder("Theme")
+                .placeholder(dbflux_i18n::t!("settings.general.theme.label"))
                 .items(Self::theme_items())
                 .selected_index(Some(theme_index))
         });
         let dropdown_style = cx.new(move |_cx| {
             Dropdown::new("general-style")
-                .placeholder("Style")
+                .placeholder(dbflux_i18n::t!("settings.general.style.label"))
                 .items(Self::style_items())
                 .selected_index(Some(style_index))
         });
         let dropdown_language = cx.new(move |_cx| {
             Dropdown::new("general-language")
-                .placeholder("Language")
+                .placeholder(dbflux_i18n::t!("settings.general.language.label"))
                 .items(Self::language_items())
                 .selected_index(Some(language_index))
         });
         let dropdown_default_focus = cx.new(move |_cx| {
             Dropdown::new("general-default-focus")
-                .placeholder("Default focus")
+                .placeholder(dbflux_i18n::t!("settings.general.default_focus.label"))
                 .items(Self::startup_focus_items())
                 .selected_index(Some(startup_focus_index))
         });
         let dropdown_refresh_policy = cx.new(move |_cx| {
             Dropdown::new("general-refresh-policy")
-                .placeholder("Refresh policy")
+                .placeholder(dbflux_i18n::t!(
+                    "settings.general.placeholder.refresh_policy"
+                ))
                 .items(Self::refresh_policy_items())
                 .selected_index(Some(refresh_policy_index))
         });
@@ -509,5 +511,40 @@ mod tests {
         assert_eq!(GeneralSection::language_for_index(2), "es");
         // Out-of-range falls back to System.
         assert_eq!(GeneralSection::language_for_index(99), "");
+    }
+
+    #[test]
+    fn dropdown_placeholders_reuse_or_extend_settings_general_catalog_keys() {
+        assert_eq!(dbflux_i18n::t!("settings.general.theme.label"), "Theme");
+        assert_eq!(dbflux_i18n::t!("settings.general.style.label"), "Style");
+        assert_eq!(
+            dbflux_i18n::t!("settings.general.language.label"),
+            "Language"
+        );
+        assert_eq!(
+            dbflux_i18n::t!("settings.general.default_focus.label"),
+            "Default focus"
+        );
+        assert_eq!(
+            dbflux_i18n::t!("settings.general.placeholder.refresh_policy"),
+            "Refresh policy"
+        );
+
+        for locale in ["en", "es"] {
+            let value = dbflux_i18n::t!(
+                "settings.general.placeholder.refresh_policy",
+                locale = locale
+            );
+
+            assert!(
+                !value.is_empty(),
+                "settings.general.placeholder.refresh_policy resolved empty for locale {locale}"
+            );
+            assert_ne!(
+                value,
+                format!("{locale}.settings.general.placeholder.refresh_policy"),
+                "settings.general.placeholder.refresh_policy fell back to the raw key for locale {locale}"
+            );
+        }
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/layout.rs
+++ b/crates/dbflux_ui_windows/src/settings/layout.rs
@@ -7,9 +7,11 @@ pub(super) fn compact_input_shell(child: impl IntoElement) -> Div {
 }
 
 pub(super) fn editor_panel_title(noun: &str, is_editing: bool) -> String {
-    let prefix = if is_editing { "Edit" } else { "New" };
-
-    format!("{} {}", prefix, noun)
+    if is_editing {
+        dbflux_i18n::t!("settings.editor_panel.title.edit", noun = noun)
+    } else {
+        dbflux_i18n::t!("settings.editor_panel.title.new", noun = noun)
+    }
 }
 
 pub(super) fn section_container(content: impl IntoElement) -> Div {
@@ -160,6 +162,18 @@ mod tests {
     fn editor_panel_title_uses_edit_prefix_when_updating() {
         assert_eq!(editor_panel_title("Proxy", true), "Edit Proxy");
         assert_eq!(editor_panel_title("SSH Tunnel", true), "Edit SSH Tunnel");
+    }
+
+    #[test]
+    fn editor_panel_title_uses_the_translated_catalog_templates() {
+        assert_eq!(
+            editor_panel_title("Proxy", false),
+            dbflux_i18n::t!("settings.editor_panel.title.new", noun = "Proxy")
+        );
+        assert_eq!(
+            editor_panel_title("Proxy", true),
+            dbflux_i18n::t!("settings.editor_panel.title.edit", noun = "Proxy")
+        );
     }
 
     #[test]

--- a/crates/dbflux_ui_windows/src/settings/lifecycle.rs
+++ b/crates/dbflux_ui_windows/src/settings/lifecycle.rs
@@ -294,7 +294,7 @@ impl SettingsCoordinator {
                 report_error(
                     UserFacingError::new(
                         ErrorKind::Config,
-                        format!("Failed to persist MCP governance: {e}"),
+                        dbflux_i18n::t!("settings.mcp_governance.persist_error", error = e),
                     ),
                     cx,
                 );

--- a/crates/dbflux_ui_windows/src/settings/open_window.rs
+++ b/crates/dbflux_ui_windows/src/settings/open_window.rs
@@ -47,7 +47,7 @@ pub fn open_or_focus_settings<S>(
     let mut options = WindowOptions {
         app_id: Some(dbflux_core::ReleaseChannel::current().app_id().into()),
         titlebar: Some(TitlebarOptions {
-            title: Some("Settings".into()),
+            title: Some(dbflux_i18n::t!("connection_manager.tab.settings").into()),
             ..Default::default()
         }),
         window_bounds: Some(WindowBounds::Windowed(bounds)),
@@ -84,5 +84,20 @@ pub fn open_or_focus_settings<S>(
         cx.notify();
     }) {
         log::warn!("Failed to activate settings window: {:?}", e);
+    }
+}
+
+#[cfg(test)]
+mod window_title_i18n_tests {
+    #[test]
+    fn settings_window_title_key_resolves_in_both_locales() {
+        for locale in ["en", "es"] {
+            let value = dbflux_i18n::t!("connection_manager.tab.settings", locale = locale);
+
+            assert!(
+                !value.is_empty(),
+                "connection_manager.tab.settings resolved empty for locale {locale}"
+            );
+        }
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/proxies.rs
+++ b/crates/dbflux_ui_windows/src/settings/proxies.rs
@@ -279,7 +279,7 @@ impl ProxiesSection {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    format!("Failed to save proxy profiles: {e}"),
+                    dbflux_i18n::t!("settings.proxies.error.save_failed", error = e),
                 ),
                 cx,
             );

--- a/crates/dbflux_ui_windows/src/settings/render.rs
+++ b/crates/dbflux_ui_windows/src/settings/render.rs
@@ -31,24 +31,26 @@ impl SettingsCoordinator {
         }
     }
 
-    fn section_display_name(section: super::SettingsSectionId) -> &'static str {
+    fn section_display_name(section: super::SettingsSectionId) -> String {
         match section {
-            super::SettingsSectionId::General => "General",
-            super::SettingsSectionId::Audit => "Audit",
+            super::SettingsSectionId::General => dbflux_i18n::t!("settings.nav.general"),
+            super::SettingsSectionId::Audit => dbflux_i18n::t!("settings.nav.audit"),
             #[cfg(feature = "mcp")]
-            super::SettingsSectionId::McpClients => "Clients",
+            super::SettingsSectionId::McpClients => dbflux_i18n::t!("settings.nav.mcp_clients"),
             #[cfg(feature = "mcp")]
-            super::SettingsSectionId::McpRoles => "Roles",
+            super::SettingsSectionId::McpRoles => dbflux_i18n::t!("settings.nav.mcp_roles"),
             #[cfg(feature = "mcp")]
-            super::SettingsSectionId::McpPolicies => "Policies",
-            super::SettingsSectionId::Keybindings => "Keybindings",
-            super::SettingsSectionId::Proxies => "Proxy",
-            super::SettingsSectionId::SshTunnels => "SSH Tunnels",
-            super::SettingsSectionId::AuthProfiles => "Auth Profiles",
-            super::SettingsSectionId::Services => "RPC Services",
-            super::SettingsSectionId::Hooks => "Hooks",
-            super::SettingsSectionId::Drivers => "Drivers",
-            super::SettingsSectionId::About => "About",
+            super::SettingsSectionId::McpPolicies => dbflux_i18n::t!("settings.nav.mcp_policies"),
+            super::SettingsSectionId::Keybindings => dbflux_i18n::t!("settings.nav.keybindings"),
+            super::SettingsSectionId::Proxies => dbflux_i18n::t!("settings.nav.proxies"),
+            super::SettingsSectionId::SshTunnels => dbflux_i18n::t!("settings.nav.ssh_tunnels"),
+            super::SettingsSectionId::AuthProfiles => {
+                dbflux_i18n::t!("settings.auth_profiles.section_title")
+            }
+            super::SettingsSectionId::Services => dbflux_i18n::t!("settings.nav.services"),
+            super::SettingsSectionId::Hooks => dbflux_i18n::t!("settings.nav.hooks"),
+            super::SettingsSectionId::Drivers => dbflux_i18n::t!("settings.nav.drivers"),
+            super::SettingsSectionId::About => dbflux_i18n::t!("settings.nav.about"),
         }
     }
 
@@ -240,7 +242,11 @@ impl Render for SettingsCoordinator {
 
         let _ = self.app_state.read(cx);
 
-        let csd_title_bar = platform::render_csd_title_bar(_window, cx, "Settings");
+        let csd_title_bar = platform::render_csd_title_bar(
+            _window,
+            cx,
+            &dbflux_i18n::t!("connection_manager.tab.settings"),
+        );
 
         div()
             .size_full()
@@ -278,11 +284,11 @@ impl Render for SettingsCoordinator {
             .when_some(self.pending_section_confirm, |element, target_section| {
                 let confirm_entity = cx.entity().clone();
                 let cancel_entity = confirm_entity.clone();
-                let section_name = Self::section_display_name(target_section).to_string();
+                let section_name = Self::section_display_name(target_section);
 
                 element.child(
                     Dialog::new(_window, cx)
-                        .title("Discard Unsaved Changes")
+                        .title(dbflux_i18n::t!("settings.discard.title"))
                         .confirm()
                         .on_ok(move |_, window, cx| {
                             confirm_entity.update(cx, |this, cx| {
@@ -296,9 +302,8 @@ impl Render for SettingsCoordinator {
                             });
                             true
                         })
-                        .child(Body::new(format!(
-                            "You have unsaved changes. Discard them and switch to {}?",
-                            section_name
+                        .child(Body::new(crate::labels::settings_discard_body(
+                            &section_name,
                         ))),
                 )
             })
@@ -384,7 +389,7 @@ impl SettingsCoordinator {
                     .child(layout::footer_action_frame(
                         false,
                         cx.theme().primary,
-                        Button::new("settings-close", "Close")
+                        Button::new("settings-close", dbflux_i18n::t!("settings.action.close"))
                             .small()
                             .ghost()
                             .w_full()
@@ -402,5 +407,70 @@ impl SettingsCoordinator {
                     .min_w(px(120.0))
                     .when_some(section_actions, |div, actions| div.child(actions)),
             )
+    }
+}
+
+#[cfg(test)]
+mod section_title_i18n_tests {
+    use super::SettingsCoordinator;
+    use crate::settings::SettingsSectionId;
+
+    #[test]
+    fn section_display_name_covers_every_section_with_non_empty_titles() {
+        let sections: &[SettingsSectionId] = &[
+            SettingsSectionId::General,
+            SettingsSectionId::Audit,
+            #[cfg(feature = "mcp")]
+            SettingsSectionId::McpClients,
+            #[cfg(feature = "mcp")]
+            SettingsSectionId::McpRoles,
+            #[cfg(feature = "mcp")]
+            SettingsSectionId::McpPolicies,
+            SettingsSectionId::Keybindings,
+            SettingsSectionId::Proxies,
+            SettingsSectionId::SshTunnels,
+            SettingsSectionId::AuthProfiles,
+            SettingsSectionId::Services,
+            SettingsSectionId::Hooks,
+            SettingsSectionId::Drivers,
+            SettingsSectionId::About,
+        ];
+
+        for section in sections {
+            let title = SettingsCoordinator::section_display_name(*section);
+
+            assert!(!title.is_empty(), "{section:?} produced an empty title");
+        }
+    }
+
+    #[test]
+    fn section_display_name_matches_the_translated_nav_and_section_title_keys() {
+        assert_eq!(
+            SettingsCoordinator::section_display_name(SettingsSectionId::General),
+            dbflux_i18n::t!("settings.nav.general")
+        );
+        assert_eq!(
+            SettingsCoordinator::section_display_name(SettingsSectionId::Services),
+            dbflux_i18n::t!("settings.nav.services")
+        );
+        assert_eq!(
+            SettingsCoordinator::section_display_name(SettingsSectionId::AuthProfiles),
+            dbflux_i18n::t!("settings.auth_profiles.section_title")
+        );
+    }
+
+    #[test]
+    fn discard_dialog_and_close_action_keys_resolve_in_both_locales() {
+        for locale in ["en", "es"] {
+            for key in ["settings.discard.title", "settings.action.close"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, key, "key {key} did not resolve for locale {locale}");
+            }
+        }
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/rpc_services.rs
+++ b/crates/dbflux_ui_windows/src/settings/rpc_services.rs
@@ -382,7 +382,7 @@ impl ServicesSection {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    format!("Failed to save RPC service config: {e}"),
+                    dbflux_i18n::t!("settings.rpc_services.error.save_failed", error = e),
                 ),
                 cx,
             );
@@ -438,7 +438,7 @@ impl ServicesSection {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    format!("Failed to save RPC service config: {e}"),
+                    dbflux_i18n::t!("settings.rpc_services.error.save_failed", error = e),
                 ),
                 cx,
             );

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
@@ -273,7 +273,7 @@ impl SshTunnelsSection {
             report_error(
                 UserFacingError::new(
                     ErrorKind::Storage,
-                    format!("Failed to save SSH tunnel profiles: {e}"),
+                    dbflux_i18n::t!("settings.ssh_tunnels.error.save_failed", error = e),
                 ),
                 cx,
             );


### PR DESCRIPTION
## Summary

Last two `dbflux_ui_windows` i18n slices (two commits, one PR): the crate-wide sweep leftovers — connection manager window titles, unknown-hook validation, MCP role/policy defaults and multi-select placeholders, On/Off override fallback, settings section titles (exhaustive resolver), discard-changes dialog and Close, general-section placeholders, Settings window title, every settings save-failure toast, the `Edit/New %{noun}` editor panel titles and the password fallback label — render through `dbflux_i18n::t!`. English and Spanish together. The closing sweep is clean: only example/format placeholders and backend-provided messages remain.

## What does this resolve?

- Refs #360 (follows the services/form validation PR; closes the windows-ui series, verify + archive next)

## How was this solved?

- `connection_manager.form_title.{edit,new}` instead of `window_title.*` because `connection_manager.window_title` already exists as a scalar; the discard dialog lives in `settings/render.rs`, so its keys sit under `settings.discard.*`.

## Validation

- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n` → 331 passed; clippy clean (with and without `mcp`); fmt clean. Manual smoke in Spanish: open Settings, switch sections with unsaved changes, open New Proxy / Edit SSH Tunnel, force a save failure.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
