### PR TITLE
feat(i18n): translate the data grid mutation, saved query, export, clipboard, and remaining document messages

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -992,6 +992,27 @@ document:
         document_missing_id: Document must have an _id field
         table_state_not_available: Table state not available
         primary_key_not_determined: Could not determine document primary key
+      export:
+        error:
+          dialog_unavailable_fallback_failed: "Export failed — file dialog unavailable and fallback directory could not be created: %{error}"
+          failed: "Export failed: %{error}"
+        toast:
+          native_picker_fallback: "Native file picker unavailable — exported to %{path} instead. Install xdg-desktop-portal, zenity, or kdialog for a save dialog."
+          exported: "Exported to %{path}"
+      clipboard:
+        error:
+          binary_unsupported: Raw binary cannot be copied to the clipboard — choose Hex or Base64 instead.
+          non_utf8: "Cannot copy non-UTF8 output: %{error}"
+          failed: "Copy failed: %{error}"
+        toast:
+          copied: "Copied %{format} (%{bytes} bytes) to clipboard"
+      document:
+        toast:
+          inserted: Document inserted
+          updated: Document updated
+        error:
+          insert_failed: "Failed to insert document: %{error}"
+          update_failed: "Failed to update document: %{error}"
     grid:
       edit_bar:
         clean: No unsaved changes
@@ -1058,11 +1079,22 @@ document:
         connection_not_found: Connection not found
         connection_not_available: Connection not available
         invalid_json_filter: Invalid JSON filter
+        chart_save_failed: 'Failed to save chart "%{name}": %{error}'
       placeholder:
         chart_name: Chart name
+      filter:
+        open_in_builder: Open in builder
       toast:
         query_imported: Query imported successfully
         mutation_queued: Mutation queued for approval.
+        chart_saved: 'Chart "%{name}" saved'
+    saved_query:
+      toast:
+        saved_as: 'Saved as "%{name}"'
+      error:
+        already_exists: 'A saved query named "%{name}" already exists'
+        target_connection_unavailable: Target connection not available
+        import_failed: "Import failed: source table not found on target connection"
     mutation:
       confirm:
         delete:
@@ -1090,6 +1122,13 @@ document:
         delete_identity_failed: "Cannot delete: failed to identify row"
         bulk_delete_no_rows_identified: "Cannot delete: failed to identify any rows"
         bulk_delete_no_documents_identified: "Cannot delete: failed to identify any documents"
+        read_only_connection: This connection is read-only. Mutations are not allowed.
+        approval_queue_failed: "Failed to queue mutation for approval: %{error}"
+        approval_requires_mcp: Mutations require approval for this connection. Enable the MCP feature to activate the approval workflow.
+        connection_not_found: "Connection not found — cannot execute mutation."
+        chunked_requires_primary_key: "Chunked mode requires a primary key — none found for this table."
+        chunked_execution_failed: "Chunked mutation on '%{table}' failed: %{error}"
+        execution_failed: "Mutation on '%{table}' failed: %{error}"
       toast:
         document_updated: Document updated
         saved: Saved
@@ -1102,6 +1141,14 @@ document:
         partial_delete:
           row: "Deleted %{done} of %{total} row(s), then failed: %{error}"
           document: "Deleted %{done} of %{total} document(s), then failed: %{error}"
+        chunk_size_reduced: "Chunk size reduced from %{original} to %{effective} — driver parameter limit forced the chunk floor below %{floor}. Processing will be slower than expected."
+        chunk_size_adjusted: "Chunk size adjusted from %{original} to %{effective} to stay within driver parameter limits."
+        execution_completed:
+          one: "Mutation completed: %{count} row affected"
+          many: "Mutation completed: %{count} rows affected"
+        execution_cancelled:
+          one: "Mutation cancelled after %{count} row processed"
+          many: "Mutation cancelled after %{count} rows processed"
     row_inspector:
       badge:
         primary_key: PK
@@ -1370,6 +1417,9 @@ document:
       delete_member:
         title: Delete member?
         message: 'Delete "%{member}"? This action cannot be undone.'
+      delete_confirm:
+        cancel: Cancel
+        delete: Delete
       unknown_type: Unknown
       value_header: Value
       id_header: ID
@@ -1472,6 +1522,8 @@ document:
       header_target: Target
       header_mapping_mode: Mapping mode
       header_transform: Transform
+      error:
+        target_schema_read_failed: "Could not read target table schema: %{error}"
     source_target:
       source_title: Source
       target_title: Target
@@ -1495,6 +1547,8 @@ document:
       key: Key
       last_modified: Last modified
       size: Size
+    toast:
+      copied: "Copied %{uri}"
     context_menu:
       item:
         preview: Preview
@@ -1890,10 +1944,14 @@ document:
         drop: Drop table
   shared:
     add: Add
+    error_prefix: "Error: %{message}"
     error_with_detail_clipboard: "%{title}: %{detail}"
+    hint:
+      enter_save_esc_cancel: "Enter to save, Esc to cancel"
     refresh:
       off: Off
       custom: Custom
+      on_open: On open
     result_warnings:
       context:
         query: query result

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -992,6 +992,27 @@ document:
         document_missing_id: El documento debe tener un campo _id
         table_state_not_available: Estado de la tabla no disponible
         primary_key_not_determined: No se pudo determinar la clave primaria del documento
+      export:
+        error:
+          dialog_unavailable_fallback_failed: "Error al exportar — el selector de archivos no está disponible y no se pudo crear el directorio de reserva: %{error}"
+          failed: "Error al exportar: %{error}"
+        toast:
+          native_picker_fallback: "Selector de archivos nativo no disponible — se exportó a %{path} en su lugar. Instala xdg-desktop-portal, zenity o kdialog para obtener un diálogo de guardado."
+          exported: "Exportado a %{path}"
+      clipboard:
+        error:
+          binary_unsupported: El binario sin procesar no se puede copiar al portapapeles — elige Hex o Base64 en su lugar.
+          non_utf8: "No se puede copiar una salida que no es UTF-8: %{error}"
+          failed: "Error al copiar: %{error}"
+        toast:
+          copied: "Copiado %{format} (%{bytes} bytes) al portapapeles"
+      document:
+        toast:
+          inserted: Documento insertado
+          updated: Documento actualizado
+        error:
+          insert_failed: "Error al insertar el documento: %{error}"
+          update_failed: "Error al actualizar el documento: %{error}"
     grid:
       edit_bar:
         clean: Sin cambios pendientes
@@ -1058,11 +1079,22 @@ document:
         connection_not_found: Conexión no encontrada
         connection_not_available: Conexión no disponible
         invalid_json_filter: Filtro JSON no válido
+        chart_save_failed: 'No se pudo guardar el gráfico "%{name}": %{error}'
       placeholder:
         chart_name: Nombre del gráfico
+      filter:
+        open_in_builder: Abrir en el generador
       toast:
         query_imported: Consulta importada correctamente
         mutation_queued: Mutación en cola para aprobación.
+        chart_saved: 'Gráfico "%{name}" guardado'
+    saved_query:
+      toast:
+        saved_as: 'Guardada como "%{name}"'
+      error:
+        already_exists: 'Ya existe una consulta guardada con el nombre "%{name}"'
+        target_connection_unavailable: La conexión de destino no está disponible
+        import_failed: "Error al importar: no se encontró la tabla de origen en la conexión de destino"
     mutation:
       confirm:
         delete:
@@ -1090,6 +1122,13 @@ document:
         delete_identity_failed: "No se puede eliminar: no se pudo identificar la fila"
         bulk_delete_no_rows_identified: "No se puede eliminar: no se pudo identificar ninguna fila"
         bulk_delete_no_documents_identified: "No se puede eliminar: no se pudo identificar ningún documento"
+        read_only_connection: Esta conexión es de solo lectura. No se permiten mutaciones.
+        approval_queue_failed: "No se pudo encolar la mutación para aprobación: %{error}"
+        approval_requires_mcp: Las mutaciones en esta conexión requieren aprobación. Activa la función MCP para habilitar el flujo de aprobación.
+        connection_not_found: "Conexión no encontrada — no se puede ejecutar la mutación."
+        chunked_requires_primary_key: "El modo por lotes requiere una clave primaria — no se encontró ninguna para esta tabla."
+        chunked_execution_failed: "La mutación por lotes en '%{table}' falló: %{error}"
+        execution_failed: "La mutación en '%{table}' falló: %{error}"
       toast:
         document_updated: Documento actualizado
         saved: Guardado
@@ -1102,6 +1141,14 @@ document:
         partial_delete:
           row: "Se eliminaron %{done} de %{total} fila(s); luego falló: %{error}"
           document: "Se eliminaron %{done} de %{total} documento(s); luego falló: %{error}"
+        chunk_size_reduced: "Tamaño de lote reducido de %{original} a %{effective} — el límite de parámetros del controlador forzó el piso del lote por debajo de %{floor}. El procesamiento será más lento de lo esperado."
+        chunk_size_adjusted: "Tamaño de lote ajustado de %{original} a %{effective} para mantenerse dentro de los límites de parámetros del controlador."
+        execution_completed:
+          one: "Mutación completada: %{count} fila afectada"
+          many: "Mutación completada: %{count} filas afectadas"
+        execution_cancelled:
+          one: "Mutación cancelada después de procesar %{count} fila"
+          many: "Mutación cancelada después de procesar %{count} filas"
     row_inspector:
       badge:
         primary_key: PK
@@ -1370,6 +1417,9 @@ document:
       delete_member:
         title: ¿Eliminar miembro?
         message: '¿Eliminar "%{member}"? Esta acción no se puede deshacer.'
+      delete_confirm:
+        cancel: Cancelar
+        delete: Eliminar
       unknown_type: Desconocido
       value_header: Valor
       id_header: ID
@@ -1472,6 +1522,8 @@ document:
       header_target: Destino
       header_mapping_mode: Modo de mapeo
       header_transform: Transformación
+      error:
+        target_schema_read_failed: "No se pudo leer el esquema de la tabla de destino: %{error}"
     source_target:
       source_title: Origen
       target_title: Destino
@@ -1495,6 +1547,8 @@ document:
       key: Clave
       last_modified: Última modificación
       size: Tamaño
+    toast:
+      copied: "Copiado %{uri}"
     context_menu:
       item:
         preview: Vista previa
@@ -1890,10 +1944,14 @@ document:
         drop: Eliminar tabla
   shared:
     add: Agregar
+    error_prefix: "Error: %{message}"
     error_with_detail_clipboard: "%{title}: %{detail}"
+    hint:
+      enter_save_esc_cancel: "Enter para guardar, Esc para cancelar"
     refresh:
       off: Apagado
       custom: Personalizado
+      on_open: Al abrir
     result_warnings:
       context:
         query: resultado de consulta

--- a/crates/dbflux_ui_document/src/dashboard/mod.rs
+++ b/crates/dbflux_ui_document/src/dashboard/mod.rs
@@ -41,7 +41,7 @@ pub(crate) use crate::refresh::REFRESH_POLICY_OPTIONS;
 pub(crate) fn refresh_policy_index(policy: SavedChartRefreshPolicy) -> usize {
     REFRESH_POLICY_OPTIONS
         .iter()
-        .position(|(p, _)| *p == policy)
+        .position(|p| *p == policy)
         .unwrap_or(0)
 }
 
@@ -50,7 +50,7 @@ pub(crate) fn refresh_policy_index(policy: SavedChartRefreshPolicy) -> usize {
 pub(crate) fn refresh_policy_from_index(index: usize) -> SavedChartRefreshPolicy {
     REFRESH_POLICY_OPTIONS
         .get(index)
-        .map(|(p, _)| *p)
+        .copied()
         .unwrap_or(SavedChartRefreshPolicy::Off)
 }
 
@@ -494,7 +494,9 @@ impl DashboardDocument {
         let refresh_dropdown = cx.new(|_cx| {
             let items: Vec<DropdownItem> = REFRESH_POLICY_OPTIONS
                 .iter()
-                .map(|(_, label)| DropdownItem::new(*label))
+                .map(|policy| {
+                    DropdownItem::new(crate::refresh::refresh_policy_option_label(*policy))
+                })
                 .collect();
             Dropdown::new("dashboard-refresh")
                 .items(items)
@@ -3079,7 +3081,7 @@ mod tests {
     /// in `REFRESH_POLICY_OPTIONS`.
     #[test]
     fn refresh_policy_index_round_trip() {
-        for (i, (policy, _)) in REFRESH_POLICY_OPTIONS.iter().enumerate() {
+        for (i, policy) in REFRESH_POLICY_OPTIONS.iter().enumerate() {
             assert_eq!(refresh_policy_index(*policy), i);
             assert_eq!(refresh_policy_from_index(i), *policy);
         }

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
@@ -993,14 +993,16 @@ impl DataGridPanel {
                             false,
                             Some(&err),
                         );
-                        let message = format!(
-                            "Export failed — file dialog unavailable and fallback directory could not be created: {}",
-                            err
-                        );
+                        let message =
+                            crate::labels::context_menu_export_dialog_fallback_failed_error(
+                                &err.to_string(),
+                            );
                         cx.update(|cx| {
                             entity.update(cx, |panel, cx| {
-                                panel.pending.toast =
-                                    Some(PendingToast { message, is_error: true });
+                                panel.pending.toast = Some(PendingToast {
+                                    message,
+                                    is_error: true,
+                                });
                                 cx.notify();
                             });
                         })
@@ -1025,14 +1027,21 @@ impl DataGridPanel {
 
             let (message, is_error) = match &export_result {
                 Ok(()) if used_fallback => (
-                    format!(
-                        "Native file picker unavailable — exported to {} instead. Install xdg-desktop-portal, zenity, or kdialog for a save dialog.",
-                        target_path.display()
+                    crate::labels::context_menu_export_native_picker_fallback_toast(
+                        &target_path.display().to_string(),
                     ),
                     false,
                 ),
-                Ok(()) => (format!("Exported to {}", target_path.display()), false),
-                Err(e) => (format!("Export failed: {}", e), true),
+                Ok(()) => (
+                    crate::labels::context_menu_export_exported_toast(
+                        &target_path.display().to_string(),
+                    ),
+                    false,
+                ),
+                Err(e) => (
+                    crate::labels::context_menu_export_failed_error(&e.to_string()),
+                    true,
+                ),
             };
 
             record_export_audit(
@@ -1041,7 +1050,11 @@ impl DataGridPanel {
                 Some(&target_path),
                 is_error,
                 used_fallback,
-                export_result.as_ref().err().map(|e| e.to_string()).as_deref(),
+                export_result
+                    .as_ref()
+                    .err()
+                    .map(|e| e.to_string())
+                    .as_deref(),
             );
 
             cx.update(|cx| {
@@ -1065,9 +1078,9 @@ impl DataGridPanel {
 
         if matches!(format, ExportFormat::Binary) {
             self.pending.toast = Some(PendingToast {
-                message:
-                    "Raw binary cannot be copied to the clipboard — choose Hex or Base64 instead."
-                        .to_string(),
+                message: dbflux_i18n::t!(
+                    "document.data.context_menu.clipboard.error.binary_unsupported"
+                ),
                 is_error: true,
             });
             cx.notify();
@@ -1087,19 +1100,19 @@ impl DataGridPanel {
                     cx.write_to_clipboard(ClipboardItem::new_string(text));
                     record_clipboard_audit(&audit_service, format_name, Some(byte_len), None);
                     self.pending.toast = Some(PendingToast {
-                        message: format!(
-                            "Copied {} ({} bytes) to clipboard",
-                            format_name, byte_len
+                        message: crate::labels::context_menu_clipboard_copied_toast(
+                            format_name,
+                            byte_len,
                         ),
                         is_error: false,
                     });
                     cx.notify();
                 }
                 Err(e) => {
-                    let err_text = format!("Cannot copy non-UTF8 output: {}", e);
+                    let err_text = e.to_string();
                     record_clipboard_audit(&audit_service, format_name, None, Some(&err_text));
                     self.pending.toast = Some(PendingToast {
-                        message: err_text,
+                        message: crate::labels::context_menu_clipboard_non_utf8_error(&err_text),
                         is_error: true,
                     });
                     cx.notify();
@@ -1109,7 +1122,7 @@ impl DataGridPanel {
                 let err_text = e.to_string();
                 record_clipboard_audit(&audit_service, format_name, None, Some(&err_text));
                 self.pending.toast = Some(PendingToast {
-                    message: format!("Copy failed: {}", err_text),
+                    message: crate::labels::context_menu_clipboard_copy_failed_error(&err_text),
                     is_error: true,
                 });
                 cx.notify();
@@ -2169,14 +2182,19 @@ impl DataGridPanel {
                                     |warning| dbflux_ui_base::user_error::report_error(warning, cx),
                                 );
                                 panel.pending.toast = Some(PendingToast {
-                                    message: "Document inserted".to_string(),
+                                    message: dbflux_i18n::t!(
+                                        "document.data.context_menu.document.toast.inserted"
+                                    ),
                                     is_error: false,
                                 });
                                 panel.pending.refresh = true;
                             }
                             Err(e) => {
                                 panel.pending.toast = Some(PendingToast {
-                                    message: format!("Failed to insert document: {}", e),
+                                    message:
+                                        crate::labels::context_menu_document_insert_failed_error(
+                                            &e.to_string(),
+                                        ),
                                     is_error: true,
                                 });
                             }
@@ -2295,14 +2313,18 @@ impl DataGridPanel {
                                 |warning| dbflux_ui_base::user_error::report_error(warning, cx),
                             );
                             panel.pending.toast = Some(PendingToast {
-                                message: "Document updated".to_string(),
+                                message: dbflux_i18n::t!(
+                                    "document.data.context_menu.document.toast.updated"
+                                ),
                                 is_error: false,
                             });
                             panel.pending.refresh = true;
                         }
                         Err(e) => {
                             panel.pending.toast = Some(PendingToast {
-                                message: format!("Failed to update document: {}", e),
+                                message: crate::labels::context_menu_document_update_failed_error(
+                                    &e.to_string(),
+                                ),
                                 is_error: true,
                             });
                         }

--- a/crates/dbflux_ui_document/src/data_grid_panel/filter_bar.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/filter_bar.rs
@@ -213,7 +213,10 @@ pub(crate) fn render_relational_error(
                 .px(Spacing::XS)
                 .hover(move |d| d.bg(theme_hover.secondary))
                 .on_mouse_down(MouseButton::Left, on_open_builder)
-                .child(Text::caption("Open in builder").color(theme_ring))
+                .child(
+                    Text::caption(dbflux_i18n::t!("document.data.grid.filter.open_in_builder"))
+                        .color(theme_ring),
+                )
                 .child(Icon::new(AppIcon::ExternalLink).small().color(theme_ring)),
         );
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -1339,11 +1339,11 @@ impl DataGridPanel {
 
         self.pending.toast = Some(match persist_result {
             Ok(_) => dbflux_ui_base::toast::PendingToast {
-                message: format!("Chart \"{}\" saved", name),
+                message: crate::labels::chart_saved_toast(&name),
                 is_error: false,
             },
             Err(e) => dbflux_ui_base::toast::PendingToast {
-                message: format!("Failed to save chart \"{name}\": {e}"),
+                message: crate::labels::chart_save_failed_error(&name, &e.to_string()),
                 is_error: true,
             },
         });
@@ -3552,15 +3552,17 @@ impl DataGridPanel {
                         p.loaded_id = Some(summary.id);
                     });
                 }
-                dbflux_ui_base::toast::Toast::success(format!("Saved as \"{}\"", name))
-                    .meta_right(dbflux_ui_base::toast::now_hms())
-                    .push(cx);
+                dbflux_ui_base::toast::Toast::success(crate::labels::saved_query_saved_as_toast(
+                    &name,
+                ))
+                .meta_right(dbflux_ui_base::toast::now_hms())
+                .push(cx);
             }
             Err(e) => {
                 dbflux_ui_base::user_error::report_error(
                     dbflux_ui_base::user_error::UserFacingError::new(
                         dbflux_ui_base::user_error::ErrorKind::Storage,
-                        format!("A saved query named \"{}\" already exists", name),
+                        crate::labels::saved_query_already_exists_error(&name),
                     )
                     .with_cause(e.to_string()),
                     cx,
@@ -3586,7 +3588,9 @@ impl DataGridPanel {
                 dbflux_ui_base::user_error::report_error(
                     dbflux_ui_base::user_error::UserFacingError::new(
                         dbflux_ui_base::user_error::ErrorKind::User,
-                        "Target connection not available",
+                        dbflux_i18n::t!(
+                            "document.data.saved_query.error.target_connection_unavailable"
+                        ),
                     ),
                     cx,
                 );
@@ -3622,7 +3626,7 @@ impl DataGridPanel {
                 dbflux_ui_base::user_error::report_error(
                     dbflux_ui_base::user_error::UserFacingError::new(
                         dbflux_ui_base::user_error::ErrorKind::User,
-                        "Import failed: source table not found on target connection",
+                        dbflux_i18n::t!("document.data.saved_query.error.import_failed"),
                     )
                     .with_cause(e.to_string()),
                     cx,
@@ -3681,7 +3685,7 @@ impl DataGridPanel {
                 dbflux_ui_base::user_error::report_error(
                     dbflux_ui_base::user_error::UserFacingError::new(
                         dbflux_ui_base::user_error::ErrorKind::User,
-                        "This connection is read-only. Mutations are not allowed.",
+                        dbflux_i18n::t!("document.data.mutation.error.read_only_connection"),
                     ),
                     cx,
                 );
@@ -3718,7 +3722,9 @@ impl DataGridPanel {
                             dbflux_ui_base::user_error::report_error(
                                 dbflux_ui_base::user_error::UserFacingError::new(
                                     dbflux_ui_base::user_error::ErrorKind::Driver,
-                                    format!("Failed to queue mutation for approval: {e}"),
+                                    crate::labels::mutation_approval_queue_failed_error(
+                                        &e.to_string(),
+                                    ),
                                 ),
                                 cx,
                             );
@@ -3732,7 +3738,7 @@ impl DataGridPanel {
                     dbflux_ui_base::user_error::report_error(
                         dbflux_ui_base::user_error::UserFacingError::new(
                             dbflux_ui_base::user_error::ErrorKind::User,
-                            "Mutations require approval for this connection. Enable the MCP feature to activate the approval workflow.",
+                            dbflux_i18n::t!("document.data.mutation.error.approval_requires_mcp"),
                         ),
                         cx,
                     );
@@ -3820,7 +3826,7 @@ impl DataGridPanel {
                     dbflux_ui_base::user_error::report_error(
                         dbflux_ui_base::user_error::UserFacingError::new(
                             dbflux_ui_base::user_error::ErrorKind::Driver,
-                            "Connection not found — cannot execute mutation.",
+                            dbflux_i18n::t!("document.data.mutation.error.connection_not_found"),
                         ),
                         cx,
                     );
@@ -3866,7 +3872,7 @@ impl DataGridPanel {
                     dbflux_ui_base::user_error::report_error(
                         dbflux_ui_base::user_error::UserFacingError::new(
                             dbflux_ui_base::user_error::ErrorKind::Driver,
-                            format!("Failed to queue mutation for approval: {e}"),
+                            crate::labels::mutation_approval_queue_failed_error(&e.to_string()),
                         ),
                         cx,
                     );
@@ -3901,7 +3907,9 @@ impl DataGridPanel {
                 dbflux_ui_base::user_error::report_error(
                     dbflux_ui_base::user_error::UserFacingError::new(
                         dbflux_ui_base::user_error::ErrorKind::User,
-                        "Chunked mode requires a primary key — none found for this table.",
+                        dbflux_i18n::t!(
+                            "document.data.mutation.error.chunked_requires_primary_key"
+                        ),
                     ),
                     cx,
                 );
@@ -3954,19 +3962,18 @@ impl DataGridPanel {
                     if let Some(original) = reduced_from {
                         const FLOOR: u32 = 1_000;
                         if effective < FLOOR {
-                            dbflux_ui_base::toast::Toast::warning(format!(
-                                "Chunk size reduced from {} to {} — driver parameter limit \
-                                 forced the chunk floor below {FLOOR}. Processing will be \
-                                 slower than expected.",
-                                original, effective
-                            ))
+                            dbflux_ui_base::toast::Toast::warning(
+                                crate::labels::mutation_chunk_size_reduced_toast(
+                                    original, effective, FLOOR,
+                                ),
+                            )
                             .push(cx);
                         } else {
-                            dbflux_ui_base::toast::Toast::info(format!(
-                                "Chunk size adjusted from {} to {} to stay within driver \
-                                 parameter limits.",
-                                original, effective
-                            ))
+                            dbflux_ui_base::toast::Toast::info(
+                                crate::labels::mutation_chunk_size_adjusted_toast(
+                                    original, effective,
+                                ),
+                            )
                             .push(cx);
                         }
                         opts.chunk_size = effective;
@@ -4007,7 +4014,10 @@ impl DataGridPanel {
                         report_error_async(
                             UserFacingError::new(
                                 ErrorKind::Driver,
-                                format!("Chunked mutation on '{}' failed: {}", table_name, e),
+                                crate::labels::mutation_chunked_execution_failed_error(
+                                    &table_name,
+                                    &e.to_string(),
+                                ),
                             ),
                             cx,
                         );
@@ -4018,11 +4028,9 @@ impl DataGridPanel {
                                 grid.runner.complete_mutation(task_id, cx);
                             })
                             .ok();
-                            dbflux_ui_base::toast::Toast::success(format!(
-                                "Mutation completed: {} row{} affected",
-                                rows_affected,
-                                if rows_affected == 1 { "" } else { "s" }
-                            ))
+                            dbflux_ui_base::toast::Toast::success(
+                                crate::labels::mutation_execution_completed_toast(rows_affected),
+                            )
                             .push(cx);
                         })
                         .ok();
@@ -4033,11 +4041,9 @@ impl DataGridPanel {
                                 grid.runner.cancel_mutation(task_id, cx);
                             })
                             .ok();
-                            dbflux_ui_base::toast::Toast::info(format!(
-                                "Mutation cancelled after {} row{} processed",
-                                rows_affected,
-                                if rows_affected == 1 { "" } else { "s" }
-                            ))
+                            dbflux_ui_base::toast::Toast::info(
+                                crate::labels::mutation_execution_cancelled_toast(rows_affected),
+                            )
                             .push(cx);
                         })
                         .ok();
@@ -4053,7 +4059,10 @@ impl DataGridPanel {
                         report_error_async(
                             UserFacingError::new(
                                 ErrorKind::Driver,
-                                format!("Chunked mutation on '{}' failed: {}", table_name, error),
+                                crate::labels::mutation_chunked_execution_failed_error(
+                                    &table_name,
+                                    &error,
+                                ),
                             ),
                             cx,
                         );
@@ -4097,7 +4106,10 @@ impl DataGridPanel {
                         report_error_async(
                             UserFacingError::new(
                                 ErrorKind::Driver,
-                                format!("Mutation on '{}' failed: {}", table_name, e),
+                                crate::labels::mutation_execution_failed_error(
+                                    &table_name,
+                                    &e.to_string(),
+                                ),
                             ),
                             cx,
                         );
@@ -4108,11 +4120,9 @@ impl DataGridPanel {
                                 grid.runner.complete_mutation(task_id, cx);
                             })
                             .ok();
-                            dbflux_ui_base::toast::Toast::success(format!(
-                                "Mutation completed: {} row{} affected",
-                                rows_affected,
-                                if rows_affected == 1 { "" } else { "s" }
-                            ))
+                            dbflux_ui_base::toast::Toast::success(
+                                crate::labels::mutation_execution_completed_toast(rows_affected),
+                            )
                             .push(cx);
                         })
                         .ok();
@@ -4123,11 +4133,9 @@ impl DataGridPanel {
                                 grid.runner.cancel_mutation(task_id, cx);
                             })
                             .ok();
-                            dbflux_ui_base::toast::Toast::info(format!(
-                                "Mutation cancelled after {} row{} processed",
-                                rows_affected,
-                                if rows_affected == 1 { "" } else { "s" }
-                            ))
+                            dbflux_ui_base::toast::Toast::info(
+                                crate::labels::mutation_execution_cancelled_toast(rows_affected),
+                            )
                             .push(cx);
                         })
                         .ok();
@@ -4143,7 +4151,7 @@ impl DataGridPanel {
                         report_error_async(
                             UserFacingError::new(
                                 ErrorKind::Driver,
-                                format!("Mutation on '{}' failed: {}", table_name, error),
+                                crate::labels::mutation_execution_failed_error(&table_name, &error),
                             ),
                             cx,
                         );
@@ -4184,7 +4192,10 @@ impl DataGridPanel {
                         report_error_async(
                             UserFacingError::new(
                                 ErrorKind::Driver,
-                                format!("Mutation on '{}' failed: {}", table_name, e),
+                                crate::labels::mutation_execution_failed_error(
+                                    &table_name,
+                                    &e.to_string(),
+                                ),
                             ),
                             cx,
                         );
@@ -4195,11 +4206,9 @@ impl DataGridPanel {
                                 grid.runner.complete_mutation(task_id, cx);
                             })
                             .ok();
-                            dbflux_ui_base::toast::Toast::success(format!(
-                                "Mutation completed: {} row{} affected",
-                                rows_affected,
-                                if rows_affected == 1 { "" } else { "s" }
-                            ))
+                            dbflux_ui_base::toast::Toast::success(
+                                crate::labels::mutation_execution_completed_toast(rows_affected),
+                            )
                             .push(cx);
                         })
                         .ok();
@@ -4210,11 +4219,9 @@ impl DataGridPanel {
                                 grid.runner.cancel_mutation(task_id, cx);
                             })
                             .ok();
-                            dbflux_ui_base::toast::Toast::info(format!(
-                                "Mutation cancelled after {} row{} processed",
-                                rows_affected,
-                                if rows_affected == 1 { "" } else { "s" }
-                            ))
+                            dbflux_ui_base::toast::Toast::info(
+                                crate::labels::mutation_execution_cancelled_toast(rows_affected),
+                            )
                             .push(cx);
                         })
                         .ok();
@@ -4230,7 +4237,7 @@ impl DataGridPanel {
                         report_error_async(
                             UserFacingError::new(
                                 ErrorKind::Driver,
-                                format!("Mutation on '{}' failed: {}", table_name, error),
+                                crate::labels::mutation_execution_failed_error(&table_name, &error),
                             ),
                             cx,
                         );

--- a/crates/dbflux_ui_document/src/history_modal.rs
+++ b/crates/dbflux_ui_document/src/history_modal.rs
@@ -874,7 +874,9 @@ impl HistoryModal {
                             .py(Spacing::SM)
                             .border_t_1()
                             .border_color(theme.border)
-                            .child(Text::caption("Enter to save, Esc to cancel")),
+                            .child(Text::caption(dbflux_i18n::t!(
+                                "document.shared.hint.enter_save_esc_cancel"
+                            ))),
                     ),
             )
             .into_any_element()

--- a/crates/dbflux_ui_document/src/key_value/render.rs
+++ b/crates/dbflux_ui_document/src/key_value/render.rs
@@ -794,7 +794,7 @@ impl Render for super::KeyValueDocument {
                     )
             })
             .when_some(error_message, |this, message| {
-                this.child(Text::caption(format!("Error: {}", message)))
+                this.child(Text::caption(crate::labels::shared_error_prefix(&message)))
             })
             // Keys list
             .child(div().flex_1().overflow_y_scrollbar().children(

--- a/crates/dbflux_ui_document/src/key_value/view.rs
+++ b/crates/dbflux_ui_document/src/key_value/view.rs
@@ -104,7 +104,9 @@ pub(super) fn render_delete_confirm_modal(
                                     cx.notify();
                                 }))
                                 .child(Icon::new(AppIcon::X).size(Heights::ICON_SM).muted())
-                                .child(Text::caption("Cancel")),
+                                .child(Text::caption(dbflux_i18n::t!(
+                                    "document.key_value.render.delete_confirm.cancel"
+                                ))),
                         )
                         .child(
                             div()
@@ -130,7 +132,12 @@ pub(super) fn render_delete_confirm_modal(
                                         .size(Heights::ICON_SM)
                                         .color(theme.background),
                                 )
-                                .child(Text::caption("Delete").color(theme.background)),
+                                .child(
+                                    Text::caption(dbflux_i18n::t!(
+                                        "document.key_value.render.delete_confirm.delete"
+                                    ))
+                                    .color(theme.background),
+                                ),
                         ),
                 ),
         )

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1763,36 +1763,269 @@ pub(crate) fn error_with_detail_clipboard(title: &str, detail: &str) -> String {
     )
 }
 
+/// Generic `"Error: {message}"` prefix used by inline error captions that
+/// have no more specific catalog bucket of their own.
+pub(crate) fn shared_error_prefix(message: &str) -> String {
+    dbflux_i18n::t!("document.shared.error_prefix", message = message)
+}
+
+/// Toast text after a saved query is stored under a new name.
+pub(crate) fn saved_query_saved_as_toast(name: &str) -> String {
+    dbflux_i18n::t!("document.data.saved_query.toast.saved_as", name = name)
+}
+
+/// Error text when a saved query name collides with an existing one.
+pub(crate) fn saved_query_already_exists_error(name: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.saved_query.error.already_exists",
+        name = name
+    )
+}
+
+/// Error text when queueing a builder-driven mutation for MCP approval fails.
+///
+/// Only reachable from the `mcp`-gated approval flow in
+/// `DataGridPanel::on_mutation_run_requested` / `handle_mutation_confirm_outcome`.
+#[cfg(feature = "mcp")]
+pub(crate) fn mutation_approval_queue_failed_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.mutation.error.approval_queue_failed",
+        error = error
+    )
+}
+
+/// Toast shown when the effective chunk size for a chunked mutation had to
+/// be recomputed to stay within the driver's parameter limit.
+///
+/// Below `floor` this renders as a warning (processing will be slower);
+/// at or above it, as an informational adjustment notice. The caller
+/// chooses which toast severity to push based on the same floor check.
+pub(crate) fn mutation_chunk_size_reduced_toast(
+    original: u32,
+    effective: u32,
+    floor: u32,
+) -> String {
+    dbflux_i18n::t!(
+        "document.data.mutation.toast.chunk_size_reduced",
+        original = original,
+        effective = effective,
+        floor = floor
+    )
+}
+
+pub(crate) fn mutation_chunk_size_adjusted_toast(original: u32, effective: u32) -> String {
+    dbflux_i18n::t!(
+        "document.data.mutation.toast.chunk_size_adjusted",
+        original = original,
+        effective = effective
+    )
+}
+
+/// Error text for a chunked builder-mutation execution failure on `table`.
+pub(crate) fn mutation_chunked_execution_failed_error(table: &str, error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.mutation.error.chunked_execution_failed",
+        table = table,
+        error = error
+    )
+}
+
+/// Error text for a direct or single-transaction builder-mutation execution
+/// failure on `table`.
+pub(crate) fn mutation_execution_failed_error(table: &str, error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.mutation.error.execution_failed",
+        table = table,
+        error = error
+    )
+}
+
+/// Toast text for a builder mutation that completed, with the affected row
+/// count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one row; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn mutation_execution_completed_toast(rows_affected: u64) -> String {
+    if rows_affected == 1 {
+        dbflux_i18n::t!(
+            "document.data.mutation.toast.execution_completed.one",
+            count = rows_affected
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.data.mutation.toast.execution_completed.many",
+            count = rows_affected
+        )
+    }
+}
+
+/// Toast text for a builder mutation cancelled partway through, with the
+/// number of rows already processed interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one row; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn mutation_execution_cancelled_toast(rows_affected: u64) -> String {
+    if rows_affected == 1 {
+        dbflux_i18n::t!(
+            "document.data.mutation.toast.execution_cancelled.one",
+            count = rows_affected
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.data.mutation.toast.execution_cancelled.many",
+            count = rows_affected
+        )
+    }
+}
+
+/// Toast text after a collection chart is saved under `name`.
+pub(crate) fn chart_saved_toast(name: &str) -> String {
+    dbflux_i18n::t!("document.data.grid.toast.chart_saved", name = name)
+}
+
+/// Error text when saving a collection chart under `name` fails.
+pub(crate) fn chart_save_failed_error(name: &str, error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.grid.error.chart_save_failed",
+        name = name,
+        error = error
+    )
+}
+
+/// Error text when the native export file dialog is unavailable and the
+/// fallback export directory could not be created either.
+pub(crate) fn context_menu_export_dialog_fallback_failed_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.export.error.dialog_unavailable_fallback_failed",
+        error = error
+    )
+}
+
+/// Toast text when the export succeeded through the fallback path because
+/// no native file picker was available.
+pub(crate) fn context_menu_export_native_picker_fallback_toast(path: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.export.toast.native_picker_fallback",
+        path = path
+    )
+}
+
+/// Toast text after a successful export through the native file picker.
+pub(crate) fn context_menu_export_exported_toast(path: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.export.toast.exported",
+        path = path
+    )
+}
+
+/// Error text when writing the export file fails.
+pub(crate) fn context_menu_export_failed_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.export.error.failed",
+        error = error
+    )
+}
+
+/// Toast text after a result set is copied to the clipboard in `format`.
+pub(crate) fn context_menu_clipboard_copied_toast(format: &str, bytes: usize) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.clipboard.toast.copied",
+        format = format,
+        bytes = bytes
+    )
+}
+
+/// Error text when the exported buffer is not valid UTF-8 and therefore
+/// cannot be copied to the clipboard as text.
+pub(crate) fn context_menu_clipboard_non_utf8_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.clipboard.error.non_utf8",
+        error = error
+    )
+}
+
+/// Error text when the export step that feeds the clipboard copy fails.
+pub(crate) fn context_menu_clipboard_copy_failed_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.clipboard.error.failed",
+        error = error
+    )
+}
+
+/// Error text when inserting a document from the context-menu editor fails.
+pub(crate) fn context_menu_document_insert_failed_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.document.error.insert_failed",
+        error = error
+    )
+}
+
+/// Error text when updating a document from the context-menu editor fails.
+pub(crate) fn context_menu_document_update_failed_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.document.error.update_failed",
+        error = error
+    )
+}
+
+/// Toast text after an object's canonical `s3://bucket/key` URI is copied
+/// to the clipboard.
+pub(crate) fn object_browser_copied_uri_toast(uri: &str) -> String {
+    dbflux_i18n::t!("document.object_browser.toast.copied", uri = uri)
+}
+
+/// Error text when the migrate wizard's column-mapping grid cannot read the
+/// target table's schema.
+pub(crate) fn migrate_wizard_target_schema_read_failed_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.migrate_wizard.mapping.error.target_schema_read_failed",
+        error = error
+    )
+}
+
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "mcp")]
+    use super::mutation_approval_queue_failed_error;
     use super::{
         MutationItemKind, add_member_modal_placeholders, add_member_modal_section_label,
         add_member_modal_title, agg_fn_display, assignment_value_kind_label,
         audit_actor_type_label, audit_category_label, audit_level_label, audit_outcome_label,
         bool_op_label, bucket_encryption_choice_label, buckets_table_summary_line,
         builder_mode_label, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
-        chart_rail_why_text, chart_toolbar_points_label, code_toolbar_shortcut_hint_label,
-        comparator_label, configure_chart_kind_label, copy_query_language_label,
-        dangerous_query_body, dangerous_query_title, delete_confirm_copy,
-        delete_prefix_delete_button_label, delete_prefix_deleted_toast, delete_prefix_probe_totals,
-        delete_rows_label, error_with_detail_clipboard, execution_count_state_label,
-        execution_mode_label, export_running_position_label, export_running_rows_label,
-        export_summary_label, export_table_status_line, history_items_count_label,
-        history_tab_label, image_decode_error, image_header_error, import_mapping_mode_label,
-        import_rail_labels, import_summary_label, import_table_status_line,
-        incomplete_aggregate_rows_label, join_kind_label, live_output_lines_label,
-        live_output_truncated_label, metric_picker_custom_dropdown_label,
+        chart_rail_why_text, chart_save_failed_error, chart_saved_toast,
+        chart_toolbar_points_label, code_toolbar_shortcut_hint_label, comparator_label,
+        configure_chart_kind_label, context_menu_clipboard_copied_toast,
+        context_menu_clipboard_copy_failed_error, context_menu_clipboard_non_utf8_error,
+        context_menu_document_insert_failed_error, context_menu_document_update_failed_error,
+        context_menu_export_dialog_fallback_failed_error, context_menu_export_exported_toast,
+        context_menu_export_failed_error, context_menu_export_native_picker_fallback_toast,
+        copy_query_language_label, dangerous_query_body, dangerous_query_title,
+        delete_confirm_copy, delete_prefix_delete_button_label, delete_prefix_deleted_toast,
+        delete_prefix_probe_totals, delete_rows_label, error_with_detail_clipboard,
+        execution_count_state_label, execution_mode_label, export_running_position_label,
+        export_running_rows_label, export_summary_label, export_table_status_line,
+        history_items_count_label, history_tab_label, image_decode_error, image_header_error,
+        import_mapping_mode_label, import_rail_labels, import_summary_label,
+        import_table_status_line, incomplete_aggregate_rows_label, join_kind_label,
+        live_output_lines_label, live_output_truncated_label, metric_picker_custom_dropdown_label,
         metric_picker_dimensions_error_label, metric_picker_period_error_label,
         metric_picker_period_not_a_number_error, metric_picker_statistic_error_label,
         migrate_mapping_unmapped_count_label, migrate_running_position_label,
         migrate_running_rows_label, migrate_source_target_checked_count_label,
-        migrate_summary_label, migrate_table_status_line, object_browser_status_summary,
-        object_browser_versions_count_label, partial_delete_label, pending_change_count_label,
-        pending_edits_summary, presign_expiry_label, presign_method_label, preview_gate_message,
-        refresh_policy_label, result_tab_count_label, row_count_label, schema_change_description,
-        script_confirm_message_label, sort_direction_label, source_window_error_message,
-        syntax_error_with_hint, table_action_description, unsaved_changes_label,
-        update_columns_label, valid_lines_label, versioning_off_label, versioning_status_label,
+        migrate_summary_label, migrate_table_status_line,
+        migrate_wizard_target_schema_read_failed_error, mutation_chunk_size_adjusted_toast,
+        mutation_chunk_size_reduced_toast, mutation_chunked_execution_failed_error,
+        mutation_execution_cancelled_toast, mutation_execution_completed_toast,
+        mutation_execution_failed_error, object_browser_copied_uri_toast,
+        object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
+        pending_change_count_label, pending_edits_summary, presign_expiry_label,
+        presign_method_label, preview_gate_message, refresh_policy_label, result_tab_count_label,
+        row_count_label, saved_query_already_exists_error, saved_query_saved_as_toast,
+        schema_change_description, script_confirm_message_label, shared_error_prefix,
+        sort_direction_label, source_window_error_message, syntax_error_with_hint,
+        table_action_description, unsaved_changes_label, update_columns_label, valid_lines_label,
+        versioning_off_label, versioning_status_label,
     };
     use crate::buckets_table::BucketEncryptionChoice;
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
@@ -5183,5 +5416,318 @@ mod tests {
         assert!(value.contains("Invalid JSON filter"));
         assert!(value.contains("unexpected end of input"));
         assert_ne!(value, "document.shared.error_with_detail_clipboard");
+    }
+
+    /// Every catalog key introduced to fix the sdd-verify F1–F10 findings
+    /// resolves to real copy — not an empty string, not the raw key, and not
+    /// the `{locale}.{key}` fallback rust-i18n emits for a missing entry.
+    #[test]
+    fn verify_findings_keys_resolve_in_both_locales() {
+        let keys = [
+            // F1: saved query + builder mutation flow.
+            "document.data.saved_query.toast.saved_as",
+            "document.data.saved_query.error.already_exists",
+            "document.data.saved_query.error.target_connection_unavailable",
+            "document.data.saved_query.error.import_failed",
+            "document.data.mutation.error.read_only_connection",
+            "document.data.mutation.error.approval_queue_failed",
+            "document.data.mutation.error.approval_requires_mcp",
+            "document.data.mutation.error.connection_not_found",
+            "document.data.mutation.error.chunked_requires_primary_key",
+            "document.data.mutation.error.chunked_execution_failed",
+            "document.data.mutation.error.execution_failed",
+            "document.data.mutation.toast.chunk_size_reduced",
+            "document.data.mutation.toast.chunk_size_adjusted",
+            "document.data.mutation.toast.execution_completed.one",
+            "document.data.mutation.toast.execution_completed.many",
+            "document.data.mutation.toast.execution_cancelled.one",
+            "document.data.mutation.toast.execution_cancelled.many",
+            // F2: collection-chart save toast.
+            "document.data.grid.toast.chart_saved",
+            "document.data.grid.error.chart_save_failed",
+            // F3: export / clipboard / document context-menu flows.
+            "document.data.context_menu.export.error.dialog_unavailable_fallback_failed",
+            "document.data.context_menu.export.toast.native_picker_fallback",
+            "document.data.context_menu.export.toast.exported",
+            "document.data.context_menu.export.error.failed",
+            "document.data.context_menu.clipboard.error.binary_unsupported",
+            "document.data.context_menu.clipboard.toast.copied",
+            "document.data.context_menu.clipboard.error.non_utf8",
+            "document.data.context_menu.clipboard.error.failed",
+            "document.data.context_menu.document.toast.inserted",
+            "document.data.context_menu.document.toast.updated",
+            "document.data.context_menu.document.error.insert_failed",
+            "document.data.context_menu.document.error.update_failed",
+            // F4: object browser URI copy toast.
+            "document.object_browser.toast.copied",
+            // F5: key/member delete confirmation buttons.
+            "document.key_value.render.delete_confirm.cancel",
+            "document.key_value.render.delete_confirm.delete",
+            // F6: history modal save hint.
+            "document.shared.hint.enter_save_esc_cancel",
+            // F7: filter bar resolve-error action.
+            "document.data.grid.filter.open_in_builder",
+            // F8: migrate wizard column-mapping schema fetch error.
+            "document.migrate_wizard.mapping.error.target_schema_read_failed",
+            // F9: key-value render error prefix.
+            "document.shared.error_prefix",
+            // F10: dashboard refresh policy option resolver.
+            "document.shared.refresh.on_open",
+        ];
+
+        for key in keys {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty(), "{key} resolved empty in {locale}");
+                assert_ne!(value, key, "{key} resolved to its own key in {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "{key} missing from {locale} catalog"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn verify_findings_mutation_error_differs_between_locales() {
+        let en = dbflux_i18n::t!(
+            "document.data.mutation.error.read_only_connection",
+            locale = "en"
+        );
+        let es = dbflux_i18n::t!(
+            "document.data.mutation.error.read_only_connection",
+            locale = "es"
+        );
+
+        assert_ne!(en, es);
+    }
+
+    #[test]
+    fn saved_query_saved_as_toast_interpolates_name() {
+        let value = saved_query_saved_as_toast("nightly orders");
+
+        assert!(value.contains("nightly orders"));
+        assert_ne!(value, "document.data.saved_query.toast.saved_as");
+    }
+
+    #[test]
+    fn saved_query_already_exists_error_interpolates_name() {
+        let value = saved_query_already_exists_error("nightly orders");
+
+        assert!(value.contains("nightly orders"));
+        assert_ne!(value, "document.data.saved_query.error.already_exists");
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn mutation_approval_queue_failed_error_interpolates_cause() {
+        let value = mutation_approval_queue_failed_error("policy engine unavailable");
+
+        assert!(value.contains("policy engine unavailable"));
+        assert_ne!(value, "document.data.mutation.error.approval_queue_failed");
+    }
+
+    #[test]
+    fn mutation_chunk_size_reduced_toast_interpolates_all_counts() {
+        let value = mutation_chunk_size_reduced_toast(5_000, 800, 1_000);
+
+        assert!(value.contains("5000"));
+        assert!(value.contains("800"));
+        assert!(value.contains("1000"));
+        assert_ne!(value, "document.data.mutation.toast.chunk_size_reduced");
+    }
+
+    #[test]
+    fn mutation_chunk_size_adjusted_toast_interpolates_both_sizes() {
+        let value = mutation_chunk_size_adjusted_toast(5_000, 1_200);
+
+        assert!(value.contains("5000"));
+        assert!(value.contains("1200"));
+        assert_ne!(value, "document.data.mutation.toast.chunk_size_adjusted");
+    }
+
+    #[test]
+    fn mutation_chunked_execution_failed_error_interpolates_table_and_error() {
+        let value = mutation_chunked_execution_failed_error("orders", "deadlock detected");
+
+        assert!(value.contains("orders"));
+        assert!(value.contains("deadlock detected"));
+        assert_ne!(
+            value,
+            "document.data.mutation.error.chunked_execution_failed"
+        );
+    }
+
+    #[test]
+    fn mutation_execution_failed_error_interpolates_table_and_error() {
+        let value = mutation_execution_failed_error("orders", "connection reset");
+
+        assert!(value.contains("orders"));
+        assert!(value.contains("connection reset"));
+        assert_ne!(value, "document.data.mutation.error.execution_failed");
+    }
+
+    #[test]
+    fn mutation_execution_completed_toast_uses_singular_bucket_for_one_row() {
+        let one = mutation_execution_completed_toast(1);
+        let many = mutation_execution_completed_toast(2);
+
+        assert_ne!(one, many);
+        assert!(one.contains('1'));
+        assert!(many.contains('2'));
+    }
+
+    #[test]
+    fn mutation_execution_completed_toast_uses_plural_bucket_for_zero_rows() {
+        let zero = mutation_execution_completed_toast(0);
+        let many = mutation_execution_completed_toast(2);
+
+        assert_eq!(
+            zero.replace('0', "2"),
+            many,
+            "zero rows should render through the plural bucket, like other counts above one"
+        );
+    }
+
+    #[test]
+    fn mutation_execution_cancelled_toast_uses_singular_bucket_for_one_row() {
+        let one = mutation_execution_cancelled_toast(1);
+        let many = mutation_execution_cancelled_toast(3);
+
+        assert_ne!(one, many);
+        assert!(one.contains('1'));
+        assert!(many.contains('3'));
+    }
+
+    #[test]
+    fn chart_saved_toast_interpolates_name() {
+        let value = chart_saved_toast("Latency p99");
+
+        assert!(value.contains("Latency p99"));
+        assert_ne!(value, "document.data.grid.toast.chart_saved");
+    }
+
+    #[test]
+    fn chart_save_failed_error_interpolates_name_and_cause() {
+        let value = chart_save_failed_error("Latency p99", "storage unavailable");
+
+        assert!(value.contains("Latency p99"));
+        assert!(value.contains("storage unavailable"));
+        assert_ne!(value, "document.data.grid.error.chart_save_failed");
+    }
+
+    #[test]
+    fn context_menu_export_dialog_fallback_failed_error_interpolates_cause() {
+        let value = context_menu_export_dialog_fallback_failed_error("permission denied");
+
+        assert!(value.contains("permission denied"));
+        assert_ne!(
+            value,
+            "document.data.context_menu.export.error.dialog_unavailable_fallback_failed"
+        );
+    }
+
+    #[test]
+    fn context_menu_export_native_picker_fallback_toast_interpolates_path() {
+        let value = context_menu_export_native_picker_fallback_toast("/tmp/export.csv");
+
+        assert!(value.contains("/tmp/export.csv"));
+        assert_ne!(
+            value,
+            "document.data.context_menu.export.toast.native_picker_fallback"
+        );
+    }
+
+    #[test]
+    fn context_menu_export_exported_toast_interpolates_path() {
+        let value = context_menu_export_exported_toast("/tmp/export.csv");
+
+        assert!(value.contains("/tmp/export.csv"));
+        assert_ne!(value, "document.data.context_menu.export.toast.exported");
+    }
+
+    #[test]
+    fn context_menu_export_failed_error_interpolates_cause() {
+        let value = context_menu_export_failed_error("disk full");
+
+        assert!(value.contains("disk full"));
+        assert_ne!(value, "document.data.context_menu.export.error.failed");
+    }
+
+    #[test]
+    fn context_menu_clipboard_copied_toast_interpolates_format_and_bytes() {
+        let value = context_menu_clipboard_copied_toast("CSV", 4096);
+
+        assert!(value.contains("CSV"));
+        assert!(value.contains("4096"));
+        assert_ne!(value, "document.data.context_menu.clipboard.toast.copied");
+    }
+
+    #[test]
+    fn context_menu_clipboard_non_utf8_error_interpolates_cause() {
+        let value = context_menu_clipboard_non_utf8_error("invalid byte sequence");
+
+        assert!(value.contains("invalid byte sequence"));
+        assert_ne!(value, "document.data.context_menu.clipboard.error.non_utf8");
+    }
+
+    #[test]
+    fn context_menu_clipboard_copy_failed_error_interpolates_cause() {
+        let value = context_menu_clipboard_copy_failed_error("encoder failure");
+
+        assert!(value.contains("encoder failure"));
+        assert_ne!(value, "document.data.context_menu.clipboard.error.failed");
+    }
+
+    #[test]
+    fn context_menu_document_insert_failed_error_interpolates_cause() {
+        let value = context_menu_document_insert_failed_error("duplicate key");
+
+        assert!(value.contains("duplicate key"));
+        assert_ne!(
+            value,
+            "document.data.context_menu.document.error.insert_failed"
+        );
+    }
+
+    #[test]
+    fn context_menu_document_update_failed_error_interpolates_cause() {
+        let value = context_menu_document_update_failed_error("version conflict");
+
+        assert!(value.contains("version conflict"));
+        assert_ne!(
+            value,
+            "document.data.context_menu.document.error.update_failed"
+        );
+    }
+
+    #[test]
+    fn object_browser_copied_uri_toast_interpolates_uri() {
+        let value = object_browser_copied_uri_toast("s3://bucket/key.json");
+
+        assert!(value.contains("s3://bucket/key.json"));
+        assert_ne!(value, "document.object_browser.toast.copied");
+    }
+
+    #[test]
+    fn migrate_wizard_target_schema_read_failed_error_interpolates_cause() {
+        let value = migrate_wizard_target_schema_read_failed_error("timeout");
+
+        assert!(value.contains("timeout"));
+        assert_ne!(
+            value,
+            "document.migrate_wizard.mapping.error.target_schema_read_failed"
+        );
+    }
+
+    #[test]
+    fn shared_error_prefix_interpolates_message() {
+        let value = shared_error_prefix("connection lost");
+
+        assert!(value.contains("connection lost"));
+        assert!(value.starts_with("Error"));
+        assert_ne!(value, "document.shared.error_prefix");
     }
 }

--- a/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/mapping.rs
@@ -412,7 +412,9 @@ impl MappingPhase {
                             report_error(
                                 UserFacingError::new(
                                     ErrorKind::Driver,
-                                    format!("Could not read target table schema: {error}"),
+                                    crate::labels::migrate_wizard_target_schema_read_failed_error(
+                                        &error,
+                                    ),
                                 ),
                                 cx,
                             );

--- a/crates/dbflux_ui_document/src/object_browser/mod.rs
+++ b/crates/dbflux_ui_document/src/object_browser/mod.rs
@@ -736,7 +736,7 @@ impl ObjectBrowserDocument {
         let uri = format!("s3://{}/{key}", self.bucket);
 
         cx.write_to_clipboard(ClipboardItem::new_string(uri.clone()));
-        dbflux_ui_base::toast::Toast::success(format!("Copied {uri}"))
+        dbflux_ui_base::toast::Toast::success(crate::labels::object_browser_copied_uri_toast(&uri))
             .meta_right(dbflux_ui_base::toast::now_hms())
             .push(cx);
     }

--- a/crates/dbflux_ui_document/src/refresh.rs
+++ b/crates/dbflux_ui_document/src/refresh.rs
@@ -11,18 +11,34 @@ use dbflux_components::SavedChartRefreshPolicy;
 /// entities. UI dropdown options must not offer values below this floor.
 pub const MIN_REFRESH_FLOOR_SECS: u64 = 10;
 
-/// Canonical ordered list of `(policy, label)` pairs shown in refresh dropdowns.
+/// Canonical ordered list of refresh policies shown in refresh dropdowns.
 ///
 /// Order is significant — `index` lookups rely on stable position. Both
 /// `DashboardDocument` and `ChartDocument` should import this slice rather
-/// than defining their own.
-pub const REFRESH_POLICY_OPTIONS: &[(SavedChartRefreshPolicy, &str)] = &[
-    (SavedChartRefreshPolicy::Off, "Off"),
-    (SavedChartRefreshPolicy::Interval { every_secs: 10 }, "10s"),
-    (SavedChartRefreshPolicy::Interval { every_secs: 30 }, "30s"),
-    (SavedChartRefreshPolicy::Interval { every_secs: 60 }, "1m"),
-    (SavedChartRefreshPolicy::Interval { every_secs: 300 }, "5m"),
+/// than defining their own. Labels are resolved separately through
+/// [`refresh_policy_option_label`] so they route through the translation
+/// catalog instead of living as a literal alongside the policy.
+pub const REFRESH_POLICY_OPTIONS: &[SavedChartRefreshPolicy] = &[
+    SavedChartRefreshPolicy::Off,
+    SavedChartRefreshPolicy::Interval { every_secs: 10 },
+    SavedChartRefreshPolicy::Interval { every_secs: 30 },
+    SavedChartRefreshPolicy::Interval { every_secs: 60 },
+    SavedChartRefreshPolicy::Interval { every_secs: 300 },
 ];
+
+/// Translated label for a refresh policy dropdown option.
+///
+/// `Off` and `OnOpen` route through the catalog; a named interval renders
+/// its seconds directly (`"{every_secs}s"`), which is a unit suffix, not
+/// translated prose, so it stays outside the catalog — identical in every
+/// locale DBFlux ships.
+pub(crate) fn refresh_policy_option_label(policy: SavedChartRefreshPolicy) -> String {
+    match policy {
+        SavedChartRefreshPolicy::Off => dbflux_i18n::t!("document.shared.refresh.off"),
+        SavedChartRefreshPolicy::Interval { every_secs } => format!("{every_secs}s"),
+        SavedChartRefreshPolicy::OnOpen => dbflux_i18n::t!("document.shared.refresh.on_open"),
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -30,13 +46,11 @@ mod tests {
 
     #[test]
     fn refresh_policy_options_minimum_interval_is_at_least_10s() {
-        for (policy, label) in REFRESH_POLICY_OPTIONS {
+        for policy in REFRESH_POLICY_OPTIONS {
             if let SavedChartRefreshPolicy::Interval { every_secs } = policy {
                 assert!(
                     u64::from(*every_secs) >= MIN_REFRESH_FLOOR_SECS,
-                    "Refresh option {:?} ({}s) is below the 10s floor",
-                    label,
-                    every_secs
+                    "Refresh option {policy:?} is below the 10s floor",
                 );
             }
         }
@@ -46,7 +60,7 @@ mod tests {
     fn refresh_policy_options_has_no_sub_10s_interval() {
         let sub_10_count = REFRESH_POLICY_OPTIONS
             .iter()
-            .filter(|(policy, _)| {
+            .filter(|policy| {
                 matches!(policy, SavedChartRefreshPolicy::Interval { every_secs } if *every_secs < 10)
             })
             .count();
@@ -55,5 +69,29 @@ mod tests {
             sub_10_count, 0,
             "No sub-10s refresh interval option should be offered to users"
         );
+    }
+
+    #[test]
+    fn refresh_policy_option_label_off_routes_through_catalog() {
+        let value = refresh_policy_option_label(SavedChartRefreshPolicy::Off);
+
+        assert_eq!(value, dbflux_i18n::t!("document.shared.refresh.off"));
+        assert_ne!(value, "document.shared.refresh.off");
+    }
+
+    #[test]
+    fn refresh_policy_option_label_interval_renders_seconds_as_unit_suffix() {
+        let value =
+            refresh_policy_option_label(SavedChartRefreshPolicy::Interval { every_secs: 30 });
+
+        assert_eq!(value, "30s");
+    }
+
+    #[test]
+    fn refresh_policy_option_label_on_open_routes_through_catalog() {
+        let value = refresh_policy_option_label(SavedChartRefreshPolicy::OnOpen);
+
+        assert_eq!(value, dbflux_i18n::t!("document.shared.refresh.on_open"));
+        assert_ne!(value, "document.shared.refresh.on_open");
     }
 }

--- a/crates/dbflux_ui_document/src/refresh.rs
+++ b/crates/dbflux_ui_document/src/refresh.rs
@@ -29,14 +29,23 @@ pub const REFRESH_POLICY_OPTIONS: &[SavedChartRefreshPolicy] = &[
 /// Translated label for a refresh policy dropdown option.
 ///
 /// `Off` and `OnOpen` route through the catalog; a named interval renders
-/// its seconds directly (`"{every_secs}s"`), which is a unit suffix, not
+/// as a unit suffix (`"10s"`, `"30s"`, `"1m"`, `"5m"`), which is not
 /// translated prose, so it stays outside the catalog — identical in every
-/// locale DBFlux ships.
+/// locale DBFlux ships. Whole minutes render in minutes so the labels match
+/// the ones the dropdown showed before the catalog refactor.
 pub(crate) fn refresh_policy_option_label(policy: SavedChartRefreshPolicy) -> String {
     match policy {
         SavedChartRefreshPolicy::Off => dbflux_i18n::t!("document.shared.refresh.off"),
-        SavedChartRefreshPolicy::Interval { every_secs } => format!("{every_secs}s"),
+        SavedChartRefreshPolicy::Interval { every_secs } => interval_unit_label(every_secs),
         SavedChartRefreshPolicy::OnOpen => dbflux_i18n::t!("document.shared.refresh.on_open"),
+    }
+}
+
+fn interval_unit_label(every_secs: u32) -> String {
+    if every_secs >= 60 && every_secs.is_multiple_of(60) {
+        format!("{}m", every_secs / 60)
+    } else {
+        format!("{every_secs}s")
     }
 }
 
@@ -85,6 +94,20 @@ mod tests {
             refresh_policy_option_label(SavedChartRefreshPolicy::Interval { every_secs: 30 });
 
         assert_eq!(value, "30s");
+    }
+
+    #[test]
+    fn refresh_policy_option_label_whole_minutes_render_in_minutes() {
+        let one_minute =
+            refresh_policy_option_label(SavedChartRefreshPolicy::Interval { every_secs: 60 });
+        let five_minutes =
+            refresh_policy_option_label(SavedChartRefreshPolicy::Interval { every_secs: 300 });
+        let ninety_seconds =
+            refresh_policy_option_label(SavedChartRefreshPolicy::Interval { every_secs: 90 });
+
+        assert_eq!(one_minute, "1m");
+        assert_eq!(five_minutes, "5m");
+        assert_eq!(ninety_seconds, "90s");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Document i18n slice 28 (closes the series): the findings of the crate verify — the data grid saved-query / mutation-approval / chunked-mutation flow, chart-save toasts, the context menu export / clipboard / document insert-update toasts, the object browser copied toast, key-value delete buttons and error prefix, the history modal hint, the filter bar builder link, the migrate mapping schema error and the refresh-policy dropdown labels (`Off` through the catalog, `10s/30s/1m/5m` as unit tokens) — render through `dbflux_i18n::t!`. English and Spanish together.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- `REFRESH_POLICY_OPTIONS` becomes a policy list plus `refresh_policy_option_label`; the review caught that 60/300 s rendered as seconds, so whole minutes render as `1m`/`5m` again (test added).
- `mutation_approval_queue_failed_error` is `#[cfg(feature = "mcp")]` because its only caller is.
- Size: 1024 lines across thirteen files (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1153 passed (1147 with `mcp`); clippy clean both ways; fmt clean. Manual smoke in Spanish: save a query under an existing name, run a chunked mutation and cancel it, export results to a file, copy a cell, insert a document from the context menu.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
