### PR TITLE
feat(i18n): translate the default name of a new script folder

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -3140,6 +3140,7 @@ sidebar:
       object_storage: Buckets (%{count})
     folder:
       databases: Databases
+      new_default: New Folder
       fields: "Fields (%{count})"
       indexes: "Indexes (%{count})"
       indexes_plain: Indexes

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -3140,6 +3140,7 @@ sidebar:
       object_storage: Buckets (%{count})
     folder:
       databases: Bases de datos
+      new_default: Nueva carpeta
       fields: "Campos (%{count})"
       indexes: "Índices (%{count})"
       indexes_plain: Índices

--- a/crates/dbflux_ui_sidebar/src/labels.rs
+++ b/crates/dbflux_ui_sidebar/src/labels.rs
@@ -1723,6 +1723,17 @@ mod tests {
     ];
 
     #[test]
+    fn new_folder_default_name_resolves_in_both_locales() {
+        let key = "sidebar.tree.folder.new_default";
+        let english = dbflux_i18n::t!(key, locale = "en");
+        let spanish = dbflux_i18n::t!(key, locale = "es");
+
+        assert_eq!(english, "New Folder");
+        assert_ne!(spanish, format!("es.{key}"));
+        assert_ne!(english, spanish);
+    }
+
+    #[test]
     fn sidebar_e1_keys_resolve_in_both_locales() {
         for key in E1_KEYS {
             for locale in ["en", "es"] {

--- a/crates/dbflux_ui_sidebar/src/operations/tree_edit.rs
+++ b/crates/dbflux_ui_sidebar/src/operations/tree_edit.rs
@@ -30,7 +30,7 @@ impl Sidebar {
     /// Creates a new folder at the root level.
     pub fn create_root_folder(&mut self, cx: &mut Context<Self>) {
         let folder_id = self.app_state.update(cx, |state, cx| {
-            let id = state.create_folder("New Folder", None);
+            let id = state.create_folder(dbflux_i18n::t!("sidebar.tree.folder.new_default"), None);
             cx.emit(AppStateChanged);
             id
         });
@@ -53,7 +53,10 @@ impl Sidebar {
         }
 
         let folder_id = self.app_state.update(cx, |state, cx| {
-            let id = state.create_folder("New Folder", parent_id);
+            let id = state.create_folder(
+                dbflux_i18n::t!("sidebar.tree.folder.new_default"),
+                parent_id,
+            );
             cx.emit(AppStateChanged);
             id
         });


### PR DESCRIPTION
## Summary

Sidebar i18n slice E2 (verify follow-up): the default name of a newly created script folder (`New Folder` / `Nueva carpeta`) routes through `dbflux_i18n::t!` (`sidebar.tree.folder.new_default`). Closes the last finding of the sidebar verify.

## What does this resolve?

- Refs #360 (follows E1; archive next)

## How was this solved?

- Two call sites in `operations/tree_edit.rs`; RED observed on the key resolution test before the catalog entry.

## Validation

- `cargo nextest run -p dbflux_ui_sidebar -p dbflux_i18n` → 212 passed; clippy clean; fmt clean. Manual smoke in Spanish: create a folder from the scripts sidebar.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
