### PR TITLE
fix(i18n): translate the audit event source status messages

### DIFF
--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -469,6 +469,15 @@ document:
       query: Query
       script: Script
       system: System
+    export:
+      unsupported_source: Export is only available for the built-in audit viewer
+      exported:
+        one: "Exported %{count} event to %{path}"
+        many: "Exported %{count} events to %{path}"
+      write_failed: "Export failed to write file: %{error}"
+      failed: "Export failed: %{error}"
+    task:
+      loading_event_stream: "Loading event stream: %{title}"
     detail:
       action: Action
       actor: Actor
@@ -809,6 +818,8 @@ document:
       result_title:
         query_failed: Query failed
         script_failed: Script failed
+      task:
+        run_script: "Run %{name} script"
       copy_error: Copy error
       result_tab_title: "Result %{index}"
       error:
@@ -1002,6 +1013,7 @@ document:
         table_state_not_available: Table state not available
         primary_key_not_determined: Could not determine document primary key
       export:
+        dialog_title: "Export as %{format}"
         error:
           dialog_unavailable_fallback_failed: "Export failed — file dialog unavailable and fallback directory could not be created: %{error}"
           failed: "Export failed: %{error}"
@@ -1089,6 +1101,9 @@ document:
         connection_not_available: Connection not available
         invalid_json_filter: Invalid JSON filter
         chart_save_failed: 'Failed to save chart "%{name}": %{error}'
+        pk_details_fetch_failed: "Failed to fetch table details for PK: %{error}"
+        query_failed: "Query failed: %{error}"
+        chart_save_no_profile_binding: "Cannot save chart: query has no profile binding"
       placeholder:
         chart_name: Chart name
       filter:
@@ -1097,6 +1112,7 @@ document:
         query_imported: Query imported successfully
         mutation_queued: Mutation queued for approval.
         chart_saved: 'Chart "%{name}" saved'
+        auto_refresh_unavailable: Auto-refresh not available for query results
     saved_query:
       toast:
         saved_as: 'Saved as "%{name}"'
@@ -1115,6 +1131,23 @@ document:
           summary:
             one: 'Update %{count} column in "%{table}"'
             many: 'Update %{count} columns in "%{table}"'
+      task:
+        delete_rows:
+          one: "Delete %{count} row"
+          many: "Delete %{count} rows"
+        delete_documents:
+          one: "Delete %{count} document"
+          many: "Delete %{count} documents"
+        update_document_field: Update document field
+        save_row: Save row
+        save_document: Save document
+        insert_document: Insert document
+        insert_row: Insert row
+        delete_document: Delete document
+        delete_row: Delete row
+        visual_mutation_chunked: "Visual mutation (chunked)"
+        visual_mutation_direct: "Visual mutation (direct)"
+        visual_mutation_single_transaction: "Visual mutation (single transaction)"
       error:
         update_document_unsupported_id: "Cannot update document field: the document has an unsupported _id value"
         update_document_failed: "Failed to update document: %{error}"
@@ -1179,8 +1212,12 @@ document:
         column: COLUMN
         references: REFERENCES
         row: ROW
+      title: "Row %{row}"
   export_wizard:
     title: Export Data
+    task:
+      one: "Export %{count} table from %{profile}"
+      many: "Export %{count} tables from %{profile}"
     rail:
       tables: Tables
       format_options: Format & Options
@@ -1246,6 +1283,9 @@ document:
     load_failed: "Failed to load pending execution %{id}: %{error}"
   import_wizard:
     title: Import Data
+    task:
+      one: "Import %{count} table"
+      many: "Import %{count} tables"
     rail:
       pick_folder: Pick Folder
       configure: Configure
@@ -1451,6 +1491,9 @@ document:
         expired: Expired
   migrate_wizard:
     title: Migrate Data
+    task:
+      one: "Migrate %{count} table"
+      many: "Migrate %{count} tables"
     rail:
       source_target: Source & Target
       tables_mapping: Tables Mapping

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -535,6 +535,8 @@ document:
         events: events
         rows: rows
     source:
+      connection_not_found: Connection not found for this event source
+      load_failed: "Error loading events: %{error}"
       empty:
         external: "No events match the current filters."
         internal: "No audit events match the current filters."

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -535,6 +535,8 @@ document:
         events: eventos
         rows: filas
     source:
+      connection_not_found: No se encontró la conexión de esta fuente de eventos
+      load_failed: "Error al cargar los eventos: %{error}"
       empty:
         external: "Ningún evento coincide con los filtros actuales."
         internal: "Ningún evento de auditoría coincide con los filtros actuales."

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -469,6 +469,15 @@ document:
       query: Consulta
       script: Script
       system: Sistema
+    export:
+      unsupported_source: La exportación solo está disponible para el visor de auditoría integrado
+      exported:
+        one: "Se exportó %{count} evento a %{path}"
+        many: "Se exportaron %{count} eventos a %{path}"
+      write_failed: "La exportación falló al escribir el archivo: %{error}"
+      failed: "Exportación fallida: %{error}"
+    task:
+      loading_event_stream: "Cargando flujo de eventos: %{title}"
     detail:
       action: Acción
       actor: Actor
@@ -809,6 +818,8 @@ document:
       result_title:
         query_failed: Consulta fallida
         script_failed: Script fallido
+      task:
+        run_script: "Ejecutar script %{name}"
       copy_error: Copiar error
       result_tab_title: "Resultado %{index}"
       error:
@@ -1002,6 +1013,7 @@ document:
         table_state_not_available: Estado de la tabla no disponible
         primary_key_not_determined: No se pudo determinar la clave primaria del documento
       export:
+        dialog_title: "Exportar como %{format}"
         error:
           dialog_unavailable_fallback_failed: "Error al exportar — el selector de archivos no está disponible y no se pudo crear el directorio de reserva: %{error}"
           failed: "Error al exportar: %{error}"
@@ -1089,6 +1101,9 @@ document:
         connection_not_available: Conexión no disponible
         invalid_json_filter: Filtro JSON no válido
         chart_save_failed: 'No se pudo guardar el gráfico "%{name}": %{error}'
+        pk_details_fetch_failed: "Error al obtener los detalles de la tabla para la PK: %{error}"
+        query_failed: "Consulta fallida: %{error}"
+        chart_save_no_profile_binding: "No se puede guardar el gráfico: la consulta no tiene un perfil vinculado"
       placeholder:
         chart_name: Nombre del gráfico
       filter:
@@ -1097,6 +1112,7 @@ document:
         query_imported: Consulta importada correctamente
         mutation_queued: Mutación en cola para aprobación.
         chart_saved: 'Gráfico "%{name}" guardado'
+        auto_refresh_unavailable: La actualización automática no está disponible para resultados de consultas
     saved_query:
       toast:
         saved_as: 'Guardada como "%{name}"'
@@ -1115,6 +1131,23 @@ document:
           summary:
             one: 'Actualizar %{count} columna en "%{table}"'
             many: 'Actualizar %{count} columnas en "%{table}"'
+      task:
+        delete_rows:
+          one: "Eliminar %{count} fila"
+          many: "Eliminar %{count} filas"
+        delete_documents:
+          one: "Eliminar %{count} documento"
+          many: "Eliminar %{count} documentos"
+        update_document_field: Actualizar campo del documento
+        save_row: Guardar fila
+        save_document: Guardar documento
+        insert_document: Insertar documento
+        insert_row: Insertar fila
+        delete_document: Eliminar documento
+        delete_row: Eliminar fila
+        visual_mutation_chunked: "Mutación visual (por segmentos)"
+        visual_mutation_direct: "Mutación visual (directa)"
+        visual_mutation_single_transaction: "Mutación visual (transacción única)"
       error:
         update_document_unsupported_id: "No se puede actualizar el campo del documento: el documento tiene un valor de _id no admitido"
         update_document_failed: "No se pudo actualizar el documento: %{error}"
@@ -1179,8 +1212,12 @@ document:
         column: COLUMNA
         references: REFERENCIAS
         row: FILA
+      title: "Fila %{row}"
   export_wizard:
     title: Exportar datos
+    task:
+      one: "Exportar %{count} tabla desde %{profile}"
+      many: "Exportar %{count} tablas desde %{profile}"
     rail:
       tables: Tablas
       format_options: Formato y opciones
@@ -1246,6 +1283,9 @@ document:
     load_failed: "No se pudo cargar la ejecución pendiente %{id}: %{error}"
   import_wizard:
     title: Importar datos
+    task:
+      one: "Importar %{count} tabla"
+      many: "Importar %{count} tablas"
     rail:
       pick_folder: Elegir carpeta
       configure: Configurar
@@ -1451,6 +1491,9 @@ document:
         expired: Expirado
   migrate_wizard:
     title: Migrar datos
+    task:
+      one: "Migrar %{count} tabla"
+      many: "Migrar %{count} tablas"
     rail:
       source_target: Origen y destino
       tables_mapping: Mapeo de tablas

--- a/crates/dbflux_ui_document/src/audit/mod.rs
+++ b/crates/dbflux_ui_document/src/audit/mod.rs
@@ -1083,7 +1083,7 @@ impl AuditDocument {
                     self.expanded_event_ids.clear();
                     self.is_loading = false;
                     self.status_message =
-                        Some("Connection not found for this event source".to_string());
+                        Some(crate::labels::audit_event_source_connection_not_found());
                     cx.notify();
                     return;
                 };
@@ -1149,10 +1149,10 @@ impl AuditDocument {
                         doc.expanded_event_ids.clear();
                         doc.clear_external_inline_inputs();
                         doc.is_loading = false;
-                        doc.status_message = Some(format!("Error loading events: {}", error));
+                        doc.status_message = Some(crate::labels::audit_events_load_failed(&error));
 
                         if let Some(task_id) = task_id {
-                            let details = format!("Error loading events: {}", error);
+                            let details = crate::labels::audit_events_load_failed(&error);
                             doc.app_state.update(cx, |state, _| {
                                 state.fail_task_with_details(task_id, error.clone(), details);
                             });

--- a/crates/dbflux_ui_document/src/audit/mod.rs
+++ b/crates/dbflux_ui_document/src/audit/mod.rs
@@ -1047,7 +1047,7 @@ impl AuditDocument {
                 Some(self.app_state.update(cx, |state, _| {
                     let (task_id, _) = state.start_task_for_profile(
                         dbflux_core::TaskKind::Query,
-                        format!("Loading event stream: {}", self.title),
+                        crate::labels::audit_loading_event_stream_task_label(&self.title),
                         Some(*profile_id),
                     );
                     task_id
@@ -1520,7 +1520,7 @@ impl AuditDocument {
     fn do_export(&mut self, format: String, cx: &mut Context<Self>) {
         let AuditDocumentSource::Internal { adapter } = &self.source else {
             self.pending_toast = Some(PendingToast {
-                message: "Export is only available for the built-in audit viewer".to_string(),
+                message: crate::labels::audit_export_unsupported_source_toast(),
                 is_error: true,
             });
             cx.notify();
@@ -1551,11 +1551,11 @@ impl AuditDocument {
 
                 let message = match write_export_file(std::path::Path::new(&path), &bytes) {
                     Ok(()) => PendingToast {
-                        message: format!("Exported {} events to {}", event_count, path),
+                        message: crate::labels::audit_export_exported_toast(event_count, &path),
                         is_error: false,
                     },
                     Err(error) => PendingToast {
-                        message: format!("Export failed to write file: {}", error),
+                        message: crate::labels::audit_export_write_failed_error(&error.to_string()),
                         is_error: true,
                     },
                 };
@@ -1571,7 +1571,7 @@ impl AuditDocument {
                 let _ = cx.update(|cx| {
                     this.update(cx, |doc, cx| {
                         doc.pending_toast = Some(PendingToast {
-                            message: format!("Export failed: {}", error),
+                            message: crate::labels::audit_export_failed_error(&error),
                             is_error: true,
                         });
                         cx.notify();

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -1595,7 +1595,8 @@ impl CodeDocument {
             phase: None,
         };
 
-        let description = format!("Run {} script", self.editor.query_language.display_name());
+        let description =
+            crate::labels::run_script_task_label(self.editor.query_language.display_name());
         let (output_sender, output_receiver) = dbflux_core::output_channel();
         let (task_id, cancel_token) =
             self.runner

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
@@ -971,7 +971,7 @@ impl DataGridPanel {
         cx.spawn(async move |_this, cx| {
             let target: Option<(std::path::PathBuf, bool)> = if dialog_available {
                 let file_handle = rfd::AsyncFileDialog::new()
-                    .set_title(format!("Export as {}", format_name))
+                    .set_title(crate::labels::context_menu_export_dialog_title(format_name))
                     .set_file_name(&suggested_name)
                     .add_filter(format_name, &[extension])
                     .save_file()
@@ -1566,7 +1566,7 @@ impl DataGridPanel {
             })
             .collect();
 
-        let row_label = format!("Row {}", row + 1);
+        let row_label = crate::labels::row_inspector_title(row + 1);
         let snapshot = InspectorSnapshot {
             cells: cells.clone(),
             focused_col: col,

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -731,7 +731,7 @@ impl DataGridPanel {
                         dbflux_ui_base::user_error::report_error(
                             dbflux_ui_base::user_error::UserFacingError::new(
                                 dbflux_ui_base::user_error::ErrorKind::Driver,
-                                format!("Failed to fetch table details for PK: {}", e),
+                                crate::labels::pk_details_fetch_failed_error(&e.to_string()),
                             ),
                             cx,
                         );
@@ -1057,7 +1057,7 @@ impl DataGridPanel {
                         dd.set_selected_index(Some(RefreshPolicy::Manual.index()), cx);
                     });
                     dbflux_ui_base::toast::Toast::warning(
-                        "Auto-refresh not available for query results",
+                        crate::labels::auto_refresh_unavailable_toast(),
                     )
                     .meta_right(dbflux_ui_base::toast::now_hms())
                     .push(cx);
@@ -1307,7 +1307,7 @@ impl DataGridPanel {
             } => {
                 let Some(profile_id) = profile_id else {
                     self.pending.toast = Some(dbflux_ui_base::toast::PendingToast {
-                        message: "Cannot save chart: query has no profile binding".into(),
+                        message: crate::labels::chart_save_no_profile_binding_error(),
                         is_error: true,
                     });
                     cx.notify();
@@ -3983,7 +3983,9 @@ impl DataGridPanel {
 
             let (task_id, cancel_handle) = self.runner.start_mutation(
                 dbflux_core::TaskKind::Query,
-                "Visual mutation (chunked)",
+                crate::labels::visual_mutation_task_label(
+                    crate::labels::VisualMutationTaskMode::Chunked,
+                ),
                 cx,
             );
 
@@ -4076,7 +4078,9 @@ impl DataGridPanel {
         ) {
             let (task_id, cancel_handle) = self.runner.start_mutation(
                 dbflux_core::TaskKind::Query,
-                "Visual mutation (direct)",
+                crate::labels::visual_mutation_task_label(
+                    crate::labels::VisualMutationTaskMode::Direct,
+                ),
                 cx,
             );
 
@@ -4162,7 +4166,9 @@ impl DataGridPanel {
         } else {
             let (task_id, cancel_handle) = self.runner.start_mutation(
                 dbflux_core::TaskKind::Query,
-                "Visual mutation (single transaction)",
+                crate::labels::visual_mutation_task_label(
+                    crate::labels::VisualMutationTaskMode::SingleTransaction,
+                ),
                 cx,
             );
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mutations.rs
@@ -273,9 +273,11 @@ impl DataGridPanel {
         let update = DocumentUpdate::new(collection.name.clone(), filter, update_doc)
             .with_database(collection.database.clone());
 
-        let (task_id, _cancel_token) =
-            self.runner
-                .start_mutation(TaskKind::Query, "Update document field", cx);
+        let (task_id, _cancel_token) = self.runner.start_mutation(
+            TaskKind::Query,
+            crate::labels::mutation_update_document_field_task_label(),
+            cx,
+        );
 
         let app_state = self.app_state.clone();
         let entity = cx.entity().clone();
@@ -521,7 +523,11 @@ impl DataGridPanel {
             cx.notify();
         });
 
-        let (task_id, _cancel_token) = self.runner.start_mutation(TaskKind::Query, "Save row", cx);
+        let (task_id, _cancel_token) = self.runner.start_mutation(
+            TaskKind::Query,
+            crate::labels::mutation_save_row_task_label(),
+            cx,
+        );
 
         let app_state = self.app_state.clone();
         let entity = cx.entity().clone();
@@ -657,9 +663,11 @@ impl DataGridPanel {
             cx.notify();
         });
 
-        let (task_id, _cancel_token) =
-            self.runner
-                .start_mutation(TaskKind::Query, "Save document", cx);
+        let (task_id, _cancel_token) = self.runner.start_mutation(
+            TaskKind::Query,
+            crate::labels::mutation_save_document_task_label(),
+            cx,
+        );
 
         let app_state = self.app_state.clone();
         let entity = cx.entity().clone();
@@ -832,9 +840,11 @@ impl DataGridPanel {
         let insert = dbflux_core::DocumentInsert::one(collection.name.clone(), doc.into())
             .with_database(collection.database.clone());
 
-        let (task_id, _cancel_token) =
-            self.runner
-                .start_mutation(TaskKind::Query, "Insert document", cx);
+        let (task_id, _cancel_token) = self.runner.start_mutation(
+            TaskKind::Query,
+            crate::labels::mutation_insert_document_task_label(),
+            cx,
+        );
 
         let app_state = self.app_state.clone();
         let entity = cx.entity().clone();
@@ -979,9 +989,11 @@ impl DataGridPanel {
             assignments,
         );
 
-        let (task_id, _cancel_token) =
-            self.runner
-                .start_mutation(TaskKind::Query, "Insert row", cx);
+        let (task_id, _cancel_token) = self.runner.start_mutation(
+            TaskKind::Query,
+            crate::labels::mutation_insert_row_task_label(),
+            cx,
+        );
 
         let app_state = self.app_state.clone();
         let entity = cx.entity().clone();
@@ -1203,9 +1215,11 @@ impl DataGridPanel {
         let delete = dbflux_core::DocumentDelete::new(collection.name.clone(), filter)
             .with_database(collection.database.clone());
 
-        let (task_id, _cancel_token) =
-            self.runner
-                .start_mutation(TaskKind::Query, "Delete document", cx);
+        let (task_id, _cancel_token) = self.runner.start_mutation(
+            TaskKind::Query,
+            crate::labels::mutation_delete_document_task_label(),
+            cx,
+        );
 
         let app_state = self.app_state.clone();
         let entity = cx.entity().clone();
@@ -1345,9 +1359,11 @@ impl DataGridPanel {
         let identity = RowIdentity::new(pk_columns, pk_values);
         let delete = RowDelete::new(identity, table_ref.name.clone(), table_ref.schema.clone());
 
-        let (task_id, _cancel_token) =
-            self.runner
-                .start_mutation(TaskKind::Query, "Delete row", cx);
+        let (task_id, _cancel_token) = self.runner.start_mutation(
+            TaskKind::Query,
+            crate::labels::mutation_delete_row_task_label(),
+            cx,
+        );
 
         let app_state = self.app_state.clone();
         let entity = cx.entity().clone();
@@ -1601,7 +1617,10 @@ impl DataGridPanel {
 
         let (task_id, _cancel_token) = self.runner.start_mutation(
             TaskKind::Query,
-            format!("Delete {} row(s)", identities.len()),
+            crate::labels::mutation_delete_task_label(
+                crate::labels::MutationItemKind::Row,
+                identities.len(),
+            ),
             cx,
         );
 
@@ -1796,7 +1815,10 @@ impl DataGridPanel {
 
         let (task_id, _cancel_token) = self.runner.start_mutation(
             TaskKind::Query,
-            format!("Delete {} document(s)", filters.len()),
+            crate::labels::mutation_delete_task_label(
+                crate::labels::MutationItemKind::Document,
+                filters.len(),
+            ),
             cx,
         );
 

--- a/crates/dbflux_ui_document/src/data_grid_panel/query.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/query.rs
@@ -283,7 +283,7 @@ impl DataGridPanel {
                             panel.runner.fail_primary(task_id, e.to_string(), cx);
                             panel.refresh.state = GridState::Error;
                             panel.pending.toast = Some(PendingToast {
-                                message: format!("Query failed: {}", e),
+                                message: crate::labels::query_failed_error(&e.to_string()),
                                 is_error: true,
                             });
                             cx.notify();
@@ -440,7 +440,7 @@ impl DataGridPanel {
                             panel.runner.fail_primary(task_id, e.to_string(), cx);
                             panel.refresh.state = GridState::Error;
                             panel.pending.toast = Some(PendingToast {
-                                message: format!("Query failed: {}", e),
+                                message: crate::labels::query_failed_error(&e.to_string()),
                                 is_error: true,
                             });
                             cx.notify();
@@ -617,7 +617,7 @@ impl DataGridPanel {
                             panel.runner.fail_primary(task_id, e.to_string(), cx);
                             panel.refresh.state = GridState::Error;
                             panel.pending.toast = Some(PendingToast {
-                                message: format!("Query failed: {}", e),
+                                message: crate::labels::query_failed_error(&e.to_string()),
                                 is_error: true,
                             });
                             cx.notify();

--- a/crates/dbflux_ui_document/src/export_wizard/run.rs
+++ b/crates/dbflux_ui_document/src/export_wizard/run.rs
@@ -28,7 +28,7 @@ use gpui::*;
 
 use crate::export_wizard::ExportWizard;
 use crate::export_wizard::phases::{ExportPhase, RunState};
-use crate::labels::{export_summary_label, export_table_status_line};
+use crate::labels::{export_summary_label, export_table_status_line, export_wizard_task_label};
 
 /// Live counters for the running export: which table (by the wizard's fixed
 /// table order) is currently streaming, and its row progress — mirrors the
@@ -300,7 +300,7 @@ impl ExportWizard {
             "dbflux-export-{}",
             dbflux_core::chrono::Utc::now().format("%Y%m%d-%H%M%S%.3f")
         ));
-        let description = format!("Export {} table(s) from {profile_label}", table_specs.len());
+        let description = export_wizard_task_label(table_specs.len(), &profile_label);
 
         let app_state = self.app_state.clone();
         let (task_id, cancel_token) = app_state.update(cx, |state, cx| {

--- a/crates/dbflux_ui_document/src/import_wizard/mod.rs
+++ b/crates/dbflux_ui_document/src/import_wizard/mod.rs
@@ -466,7 +466,7 @@ impl ImportWizard {
         self.result_warnings.clear();
         *self.progress.lock().unwrap_or_else(|p| p.into_inner()) = (0, None);
 
-        let description = format!("Import {} table(s)", plans.len());
+        let description = crate::labels::import_wizard_task_label(plans.len());
         let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
             let pair = state.start_task_for_target(
                 TaskKind::Import,

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -52,6 +52,26 @@ pub(crate) fn result_view_mode_label(mode: crate::result_view::ResultViewMode) -
     }
 }
 
+/// Toast text shown when the user tries to enable auto-refresh on a result
+/// that has no backing table (a raw query result or a builder query).
+pub(crate) fn auto_refresh_unavailable_toast() -> String {
+    dbflux_i18n::t!("document.data.grid.toast.auto_refresh_unavailable")
+}
+
+/// Error text when the data grid fails to fetch a table's primary-key
+/// details in the background.
+pub(crate) fn pk_details_fetch_failed_error(error: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.grid.error.pk_details_fetch_failed",
+        error = error
+    )
+}
+
+/// Error/toast text for a failed query run against the data grid.
+pub(crate) fn query_failed_error(error: &str) -> String {
+    dbflux_i18n::t!("document.data.grid.error.query_failed", error = error)
+}
+
 /// Label for a [`dbflux_export::ExportFormat`] shown in the export menu and
 /// the export trigger button.
 pub(crate) fn export_format_label(format: dbflux_export::ExportFormat) -> String {
@@ -329,6 +349,82 @@ pub(crate) fn bulk_delete_success_label(kind: MutationItemKind, count: usize) ->
     dbflux_i18n::t!(key, count = count)
 }
 
+/// Task-panel description for a bulk row/document delete mutation, with the
+/// affected item count interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one item; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn mutation_delete_task_label(kind: MutationItemKind, count: usize) -> String {
+    let bucket = if count == 1 { "one" } else { "many" };
+    let key = match kind {
+        MutationItemKind::Row => format!("document.data.mutation.task.delete_rows.{bucket}"),
+        MutationItemKind::Document => {
+            format!("document.data.mutation.task.delete_documents.{bucket}")
+        }
+    };
+
+    dbflux_i18n::t!(&key, count = count)
+}
+
+/// Kind of single-item visual mutation run through the query builder, used to
+/// select the task-panel description.
+pub(crate) enum VisualMutationTaskMode {
+    Chunked,
+    Direct,
+    SingleTransaction,
+}
+
+/// Task-panel description for a visual-mutation run, keyed by its execution
+/// mode.
+pub(crate) fn visual_mutation_task_label(mode: VisualMutationTaskMode) -> String {
+    match mode {
+        VisualMutationTaskMode::Chunked => {
+            dbflux_i18n::t!("document.data.mutation.task.visual_mutation_chunked")
+        }
+        VisualMutationTaskMode::Direct => {
+            dbflux_i18n::t!("document.data.mutation.task.visual_mutation_direct")
+        }
+        VisualMutationTaskMode::SingleTransaction => {
+            dbflux_i18n::t!("document.data.mutation.task.visual_mutation_single_transaction")
+        }
+    }
+}
+
+/// Task-panel description for updating a single document field in place.
+pub(crate) fn mutation_update_document_field_task_label() -> String {
+    dbflux_i18n::t!("document.data.mutation.task.update_document_field")
+}
+
+/// Task-panel description for saving a single edited row.
+pub(crate) fn mutation_save_row_task_label() -> String {
+    dbflux_i18n::t!("document.data.mutation.task.save_row")
+}
+
+/// Task-panel description for saving a single edited document.
+pub(crate) fn mutation_save_document_task_label() -> String {
+    dbflux_i18n::t!("document.data.mutation.task.save_document")
+}
+
+/// Task-panel description for inserting a single new document.
+pub(crate) fn mutation_insert_document_task_label() -> String {
+    dbflux_i18n::t!("document.data.mutation.task.insert_document")
+}
+
+/// Task-panel description for inserting a single new row.
+pub(crate) fn mutation_insert_row_task_label() -> String {
+    dbflux_i18n::t!("document.data.mutation.task.insert_row")
+}
+
+/// Task-panel description for deleting a single document.
+pub(crate) fn mutation_delete_document_task_label() -> String {
+    dbflux_i18n::t!("document.data.mutation.task.delete_document")
+}
+
+/// Task-panel description for deleting a single row.
+pub(crate) fn mutation_delete_row_task_label() -> String {
+    dbflux_i18n::t!("document.data.mutation.task.delete_row")
+}
+
 /// Label for the context menu's "Copy as ..." submenu trigger, keyed by the
 /// active connection's query language.
 ///
@@ -390,6 +486,15 @@ pub(crate) fn code_toolbar_shortcut_hint_label(shortcut: &str, with_selection: b
     } else {
         shortcut.to_string()
     }
+}
+
+/// Task-panel description for a running script, with the query language's
+/// display name interpolated.
+pub(crate) fn run_script_task_label(language_name: &str) -> String {
+    dbflux_i18n::t!(
+        "document.code.execution.task.run_script",
+        name = language_name
+    )
 }
 
 /// Label for the live script output header's line count.
@@ -951,6 +1056,51 @@ pub(crate) fn audit_actor_type_label(actor_type: dbflux_core::EventActorType) ->
     }
 }
 
+/// Task-panel description for loading an external audit event stream, with
+/// the document's tab title interpolated.
+pub(crate) fn audit_loading_event_stream_task_label(title: &str) -> String {
+    dbflux_i18n::t!("document.audit.task.loading_event_stream", title = title)
+}
+
+/// Toast text when export is attempted on an audit document source that does
+/// not support it (an external event stream, not the built-in viewer).
+pub(crate) fn audit_export_unsupported_source_toast() -> String {
+    dbflux_i18n::t!("document.audit.export.unsupported_source")
+}
+
+/// Toast text after a successful audit export, with the exported event count
+/// and destination path interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one exported event;
+/// every other count, including zero, uses the plural bucket.
+pub(crate) fn audit_export_exported_toast(count: u64, path: &str) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "document.audit.export.exported.one",
+            count = count,
+            path = path
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.audit.export.exported.many",
+            count = count,
+            path = path
+        )
+    }
+}
+
+/// Toast text when an audit export fails while writing the destination
+/// file.
+pub(crate) fn audit_export_write_failed_error(error: &str) -> String {
+    dbflux_i18n::t!("document.audit.export.write_failed", error = error)
+}
+
+/// Toast text when an audit export fails before reaching the write step
+/// (for example, fetching events from the source failed).
+pub(crate) fn audit_export_failed_error(error: &str) -> String {
+    dbflux_i18n::t!("document.audit.export.failed", error = error)
+}
+
 /// Qualifies a table name with its schema for the schema-diff description
 /// helpers, mirroring `schema_diff::view::qualified` (kept as a small local
 /// copy since that helper is private to its own module). Object names are
@@ -1445,6 +1595,19 @@ pub(crate) fn import_rail_labels() -> [String; 4] {
     ]
 }
 
+/// Task-panel description for a running import, with the table count
+/// interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one table; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn import_wizard_task_label(table_count: usize) -> String {
+    if table_count == 1 {
+        dbflux_i18n::t!("document.import_wizard.task.one", count = table_count)
+    } else {
+        dbflux_i18n::t!("document.import_wizard.task.many", count = table_count)
+    }
+}
+
 /// Terminal summary line for a finished import run, with every count
 /// interpolated. Uses the "with failures" bucket only when at least one
 /// table failed; otherwise the plain bucket.
@@ -1499,6 +1662,27 @@ pub(crate) fn import_table_status_line(table: &dbflux_transfer::import::Imported
             "document.import_wizard.status_line.not_attempted",
             table = table.source_table
         ),
+    }
+}
+
+/// Task-panel description for a running export, with the table count and
+/// source profile name interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one table; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn export_wizard_task_label(table_count: usize, profile: &str) -> String {
+    if table_count == 1 {
+        dbflux_i18n::t!(
+            "document.export_wizard.task.one",
+            count = table_count,
+            profile = profile
+        )
+    } else {
+        dbflux_i18n::t!(
+            "document.export_wizard.task.many",
+            count = table_count,
+            profile = profile
+        )
     }
 }
 
@@ -1588,6 +1772,19 @@ pub(crate) fn export_running_rows_label(rows_done: u64, estimated_total: Option<
             "document.export_wizard.running.progress.only",
             done = rows_done
         ),
+    }
+}
+
+/// Task-panel description for a running migration, with the table count
+/// interpolated.
+///
+/// Uses the singular catalog bucket only for exactly one table; every other
+/// count, including zero, uses the plural bucket.
+pub(crate) fn migrate_wizard_task_label(table_count: usize) -> String {
+    if table_count == 1 {
+        dbflux_i18n::t!("document.migrate_wizard.task.one", count = table_count)
+    } else {
+        dbflux_i18n::t!("document.migrate_wizard.task.many", count = table_count)
     }
 }
 
@@ -1892,6 +2089,27 @@ pub(crate) fn chart_save_failed_error(name: &str, error: &str) -> String {
     )
 }
 
+/// Toast text when the user tries to save a chart from a raw query result
+/// that has no connection profile bound to it.
+pub(crate) fn chart_save_no_profile_binding_error() -> String {
+    dbflux_i18n::t!("document.data.grid.error.chart_save_no_profile_binding")
+}
+
+/// Title for the native "Export as ..." save-file dialog, with the format
+/// name interpolated.
+pub(crate) fn context_menu_export_dialog_title(format_name: &str) -> String {
+    dbflux_i18n::t!(
+        "document.data.context_menu.export.dialog_title",
+        format = format_name
+    )
+}
+
+/// Title for the row-inspector rail, with the 1-based row number
+/// interpolated.
+pub(crate) fn row_inspector_title(row_number: usize) -> String {
+    dbflux_i18n::t!("document.data.row_inspector.title", row = row_number)
+}
+
 /// Error text when the native export file dialog is unavailable and the
 /// fallback export directory could not be created either.
 pub(crate) fn context_menu_export_dialog_fallback_failed_error(error: &str) -> String {
@@ -1988,44 +2206,54 @@ mod tests {
     #[cfg(feature = "mcp")]
     use super::mutation_approval_queue_failed_error;
     use super::{
-        MutationItemKind, add_member_modal_placeholders, add_member_modal_section_label,
-        add_member_modal_title, agg_fn_display, assignment_value_kind_label,
-        audit_actor_type_label, audit_category_label, audit_level_label, audit_outcome_label,
+        MutationItemKind, VisualMutationTaskMode, add_member_modal_placeholders,
+        add_member_modal_section_label, add_member_modal_title, agg_fn_display,
+        assignment_value_kind_label, audit_actor_type_label, audit_category_label,
+        audit_export_exported_toast, audit_export_failed_error,
+        audit_export_unsupported_source_toast, audit_export_write_failed_error, audit_level_label,
+        audit_loading_event_stream_task_label, audit_outcome_label, auto_refresh_unavailable_toast,
         bool_op_label, bucket_encryption_choice_label, buckets_table_summary_line,
         builder_mode_label, bulk_delete_success_label, chart_degraded_copy, chart_dock_shape_label,
-        chart_rail_why_text, chart_save_failed_error, chart_saved_toast,
-        chart_toolbar_points_label, code_toolbar_shortcut_hint_label, comparator_label,
-        configure_chart_kind_label, context_menu_clipboard_copied_toast,
+        chart_rail_why_text, chart_save_failed_error, chart_save_no_profile_binding_error,
+        chart_saved_toast, chart_toolbar_points_label, code_toolbar_shortcut_hint_label,
+        comparator_label, configure_chart_kind_label, context_menu_clipboard_copied_toast,
         context_menu_clipboard_copy_failed_error, context_menu_clipboard_non_utf8_error,
         context_menu_document_insert_failed_error, context_menu_document_update_failed_error,
-        context_menu_export_dialog_fallback_failed_error, context_menu_export_exported_toast,
-        context_menu_export_failed_error, context_menu_export_native_picker_fallback_toast,
-        copy_query_language_label, dangerous_query_body, dangerous_query_title,
-        delete_confirm_copy, delete_prefix_delete_button_label, delete_prefix_deleted_toast,
-        delete_prefix_probe_totals, delete_rows_label, error_with_detail_clipboard,
-        execution_count_state_label, execution_mode_label, export_running_position_label,
-        export_running_rows_label, export_summary_label, export_table_status_line,
+        context_menu_export_dialog_fallback_failed_error, context_menu_export_dialog_title,
+        context_menu_export_exported_toast, context_menu_export_failed_error,
+        context_menu_export_native_picker_fallback_toast, copy_query_language_label,
+        dangerous_query_body, dangerous_query_title, delete_confirm_copy,
+        delete_prefix_delete_button_label, delete_prefix_deleted_toast, delete_prefix_probe_totals,
+        delete_rows_label, error_with_detail_clipboard, execution_count_state_label,
+        execution_mode_label, export_running_position_label, export_running_rows_label,
+        export_summary_label, export_table_status_line, export_wizard_task_label,
         history_items_count_label, history_tab_label, image_decode_error, image_header_error,
         import_mapping_mode_label, import_rail_labels, import_summary_label,
-        import_table_status_line, incomplete_aggregate_rows_label, join_kind_label,
-        live_output_lines_label, live_output_truncated_label, metric_picker_custom_dropdown_label,
-        metric_picker_dimensions_error_label, metric_picker_period_error_label,
-        metric_picker_period_not_a_number_error, metric_picker_statistic_error_label,
-        migrate_mapping_unmapped_count_label, migrate_running_position_label,
-        migrate_running_rows_label, migrate_source_target_checked_count_label,
-        migrate_summary_label, migrate_table_status_line,
-        migrate_wizard_target_schema_read_failed_error, mutation_chunk_size_adjusted_toast,
+        import_table_status_line, import_wizard_task_label, incomplete_aggregate_rows_label,
+        join_kind_label, live_output_lines_label, live_output_truncated_label,
+        metric_picker_custom_dropdown_label, metric_picker_dimensions_error_label,
+        metric_picker_period_error_label, metric_picker_period_not_a_number_error,
+        metric_picker_statistic_error_label, migrate_mapping_unmapped_count_label,
+        migrate_running_position_label, migrate_running_rows_label,
+        migrate_source_target_checked_count_label, migrate_summary_label,
+        migrate_table_status_line, migrate_wizard_target_schema_read_failed_error,
+        migrate_wizard_task_label, mutation_chunk_size_adjusted_toast,
         mutation_chunk_size_reduced_toast, mutation_chunked_execution_failed_error,
-        mutation_execution_cancelled_toast, mutation_execution_completed_toast,
-        mutation_execution_failed_error, object_browser_copied_uri_toast,
+        mutation_delete_document_task_label, mutation_delete_row_task_label,
+        mutation_delete_task_label, mutation_execution_cancelled_toast,
+        mutation_execution_completed_toast, mutation_execution_failed_error,
+        mutation_insert_document_task_label, mutation_insert_row_task_label,
+        mutation_save_document_task_label, mutation_save_row_task_label,
+        mutation_update_document_field_task_label, object_browser_copied_uri_toast,
         object_browser_status_summary, object_browser_versions_count_label, partial_delete_label,
-        pending_change_count_label, pending_edits_summary, presign_expiry_label,
-        presign_method_label, preview_gate_message, refresh_policy_label, result_tab_count_label,
-        row_count_label, saved_query_already_exists_error, saved_query_saved_as_toast,
+        pending_change_count_label, pending_edits_summary, pk_details_fetch_failed_error,
+        presign_expiry_label, presign_method_label, preview_gate_message, query_failed_error,
+        refresh_policy_label, result_tab_count_label, row_count_label, row_inspector_title,
+        run_script_task_label, saved_query_already_exists_error, saved_query_saved_as_toast,
         schema_change_description, script_confirm_message_label, shared_error_prefix,
         sort_direction_label, source_window_error_message, syntax_error_with_hint,
         table_action_description, unsaved_changes_label, update_columns_label, valid_lines_label,
-        versioning_off_label, versioning_status_label,
+        versioning_off_label, versioning_status_label, visual_mutation_task_label,
     };
     use crate::buckets_table::BucketEncryptionChoice;
     use crate::object_browser::{PresignExpiry, PresignMethodChoice, PreviewGate};
@@ -5729,5 +5957,262 @@ mod tests {
         assert!(value.contains("connection lost"));
         assert!(value.starts_with("Error"));
         assert_ne!(value, "document.shared.error_prefix");
+    }
+
+    #[test]
+    fn import_wizard_task_label_one_and_many() {
+        let one = import_wizard_task_label(1);
+        let many = import_wizard_task_label(3);
+
+        assert!(one.contains('1'));
+        assert!(many.contains('3'));
+        assert_ne!(one, many);
+        assert_ne!(one, "document.import_wizard.task.one");
+        assert_ne!(many, "document.import_wizard.task.many");
+    }
+
+    #[test]
+    fn export_wizard_task_label_interpolates_count_and_profile() {
+        let one = export_wizard_task_label(1, "prod-db");
+        let many = export_wizard_task_label(4, "prod-db");
+
+        assert!(one.contains('1'));
+        assert!(one.contains("prod-db"));
+        assert!(many.contains('4'));
+        assert_ne!(one, many);
+        assert_ne!(one, "document.export_wizard.task.one");
+        assert_ne!(many, "document.export_wizard.task.many");
+    }
+
+    #[test]
+    fn migrate_wizard_task_label_one_and_many() {
+        let one = migrate_wizard_task_label(1);
+        let many = migrate_wizard_task_label(2);
+
+        assert!(one.contains('1'));
+        assert!(many.contains('2'));
+        assert_ne!(one, many);
+        assert_ne!(one, "document.migrate_wizard.task.one");
+        assert_ne!(many, "document.migrate_wizard.task.many");
+    }
+
+    #[test]
+    fn mutation_delete_task_label_covers_rows_and_documents() {
+        let one_row = mutation_delete_task_label(MutationItemKind::Row, 1);
+        let many_rows = mutation_delete_task_label(MutationItemKind::Row, 5);
+        let one_document = mutation_delete_task_label(MutationItemKind::Document, 1);
+        let many_documents = mutation_delete_task_label(MutationItemKind::Document, 5);
+
+        assert!(one_row.contains('1'));
+        assert!(many_rows.contains('5'));
+        assert!(one_document.contains('1'));
+        assert!(many_documents.contains('5'));
+        assert_ne!(one_row, one_document);
+        assert_ne!(many_rows, many_documents);
+        assert_ne!(one_row, "document.data.mutation.task.delete_rows.one");
+        assert_ne!(
+            one_document,
+            "document.data.mutation.task.delete_documents.one"
+        );
+    }
+
+    #[test]
+    fn run_script_task_label_interpolates_language_name() {
+        let value = run_script_task_label("SQL");
+
+        assert!(value.contains("SQL"));
+        assert_ne!(value, "document.code.execution.task.run_script");
+    }
+
+    #[test]
+    fn auto_refresh_unavailable_toast_resolves() {
+        let value = auto_refresh_unavailable_toast();
+
+        assert_ne!(value, "document.data.grid.toast.auto_refresh_unavailable");
+    }
+
+    #[test]
+    fn pk_details_fetch_failed_error_interpolates_cause() {
+        let value = pk_details_fetch_failed_error("timeout");
+
+        assert!(value.contains("timeout"));
+        assert_ne!(value, "document.data.grid.error.pk_details_fetch_failed");
+    }
+
+    #[test]
+    fn query_failed_error_interpolates_cause() {
+        let value = query_failed_error("syntax error");
+
+        assert!(value.contains("syntax error"));
+        assert_ne!(value, "document.data.grid.error.query_failed");
+    }
+
+    #[test]
+    fn audit_export_exported_toast_one_and_many() {
+        let one = audit_export_exported_toast(1, "/tmp/audit.csv");
+        let many = audit_export_exported_toast(20, "/tmp/audit.csv");
+
+        assert!(one.contains('1'));
+        assert!(one.contains("/tmp/audit.csv"));
+        assert!(many.contains("20"));
+        assert_ne!(one, many);
+        assert_ne!(one, "document.audit.export.exported.one");
+        assert_ne!(many, "document.audit.export.exported.many");
+    }
+
+    #[test]
+    fn audit_export_write_failed_error_interpolates_cause() {
+        let value = audit_export_write_failed_error("disk full");
+
+        assert!(value.contains("disk full"));
+        assert_ne!(value, "document.audit.export.write_failed");
+    }
+
+    #[test]
+    fn audit_export_failed_error_interpolates_cause() {
+        let value = audit_export_failed_error("query timeout");
+
+        assert!(value.contains("query timeout"));
+        assert_ne!(value, "document.audit.export.failed");
+    }
+
+    #[test]
+    fn context_menu_export_dialog_title_interpolates_format() {
+        let value = context_menu_export_dialog_title("CSV");
+
+        assert!(value.contains("CSV"));
+        assert_ne!(value, "document.data.context_menu.export.dialog_title");
+    }
+
+    #[test]
+    fn row_inspector_title_interpolates_row_number() {
+        let value = row_inspector_title(1);
+
+        assert!(value.contains('1'));
+        assert_ne!(value, "document.data.row_inspector.title");
+    }
+
+    /// Divergence check across the new reverify-findings keys: proves the
+    /// English and Spanish catalog bytes actually differ, not just that the
+    /// key resolves. Runs through `translate_in` directly since `t!` cannot
+    /// combine `locale = ` with named-argument interpolation.
+    #[test]
+    fn reverify_findings_keys_resolve_in_both_locales() {
+        let plain_keys = [
+            "document.data.grid.toast.auto_refresh_unavailable",
+            "document.data.context_menu.export.dialog_title",
+            "document.data.row_inspector.title",
+            "document.data.grid.error.pk_details_fetch_failed",
+            "document.data.grid.error.query_failed",
+            "document.audit.export.write_failed",
+            "document.audit.export.failed",
+            "document.import_wizard.task.one",
+            "document.import_wizard.task.many",
+            "document.export_wizard.task.one",
+            "document.export_wizard.task.many",
+            "document.migrate_wizard.task.one",
+            "document.migrate_wizard.task.many",
+            "document.data.mutation.task.delete_rows.one",
+            "document.data.mutation.task.delete_rows.many",
+            "document.data.mutation.task.delete_documents.one",
+            "document.data.mutation.task.delete_documents.many",
+            "document.code.execution.task.run_script",
+            "document.audit.export.exported.one",
+            "document.audit.export.exported.many",
+        ];
+
+        for key in plain_keys {
+            let english = dbflux_i18n::translate_in("en", key);
+            let spanish = dbflux_i18n::translate_in("es", key);
+
+            assert_ne!(english, key, "key {key} did not resolve in en");
+            assert_ne!(spanish, key, "key {key} did not resolve in es");
+            assert_ne!(spanish, english, "key {key} has identical en/es text");
+        }
+    }
+
+    /// Additional task-panel descriptions found while sweeping every
+    /// `start_task*`/`start_mutation`/`start_primary` call site in this
+    /// crate for hardcoded English prose, beyond the findings' explicit
+    /// list.
+    #[test]
+    fn mutation_single_item_task_labels_resolve_and_differ() {
+        let cases: &[(fn() -> String, &str)] = &[
+            (
+                mutation_update_document_field_task_label,
+                "document.data.mutation.task.update_document_field",
+            ),
+            (
+                mutation_save_row_task_label,
+                "document.data.mutation.task.save_row",
+            ),
+            (
+                mutation_save_document_task_label,
+                "document.data.mutation.task.save_document",
+            ),
+            (
+                mutation_insert_document_task_label,
+                "document.data.mutation.task.insert_document",
+            ),
+            (
+                mutation_insert_row_task_label,
+                "document.data.mutation.task.insert_row",
+            ),
+            (
+                mutation_delete_document_task_label,
+                "document.data.mutation.task.delete_document",
+            ),
+            (
+                mutation_delete_row_task_label,
+                "document.data.mutation.task.delete_row",
+            ),
+            (
+                audit_export_unsupported_source_toast,
+                "document.audit.export.unsupported_source",
+            ),
+        ];
+
+        for (label_fn, key) in cases {
+            let value = label_fn();
+            assert_ne!(value, *key, "key {key} did not resolve");
+        }
+    }
+
+    #[test]
+    fn visual_mutation_task_label_covers_every_mode_and_differs() {
+        let chunked = visual_mutation_task_label(VisualMutationTaskMode::Chunked);
+        let direct = visual_mutation_task_label(VisualMutationTaskMode::Direct);
+        let single = visual_mutation_task_label(VisualMutationTaskMode::SingleTransaction);
+
+        assert_ne!(
+            chunked,
+            "document.data.mutation.task.visual_mutation_chunked"
+        );
+        assert_ne!(direct, "document.data.mutation.task.visual_mutation_direct");
+        assert_ne!(
+            single,
+            "document.data.mutation.task.visual_mutation_single_transaction"
+        );
+        assert_ne!(chunked, direct);
+        assert_ne!(direct, single);
+        assert_ne!(chunked, single);
+    }
+
+    #[test]
+    fn audit_loading_event_stream_task_label_interpolates_title() {
+        let value = audit_loading_event_stream_task_label("Application Logs");
+
+        assert!(value.contains("Application Logs"));
+        assert_ne!(value, "document.audit.task.loading_event_stream");
+    }
+
+    #[test]
+    fn chart_save_no_profile_binding_error_resolves() {
+        let value = chart_save_no_profile_binding_error();
+
+        assert_ne!(
+            value,
+            "document.data.grid.error.chart_save_no_profile_binding"
+        );
     }
 }

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -1101,6 +1101,18 @@ pub(crate) fn audit_export_failed_error(error: &str) -> String {
     dbflux_i18n::t!("document.audit.export.failed", error = error)
 }
 
+/// Status line for the audit viewer when an external event source points at
+/// a connection that no longer exists.
+pub(crate) fn audit_event_source_connection_not_found() -> String {
+    dbflux_i18n::t!("document.audit.source.connection_not_found")
+}
+
+/// Status line and task detail when loading events from an external source
+/// fails; `error` is the cause as reported and stays untranslated.
+pub(crate) fn audit_events_load_failed(error: &str) -> String {
+    dbflux_i18n::t!("document.audit.source.load_failed", error = error)
+}
+
 /// Qualifies a table name with its schema for the schema-diff description
 /// helpers, mirroring `schema_diff::view::qualified` (kept as a small local
 /// copy since that helper is private to its own module). Object names are
@@ -2209,6 +2221,7 @@ mod tests {
         MutationItemKind, VisualMutationTaskMode, add_member_modal_placeholders,
         add_member_modal_section_label, add_member_modal_title, agg_fn_display,
         assignment_value_kind_label, audit_actor_type_label, audit_category_label,
+        audit_event_source_connection_not_found, audit_events_load_failed,
         audit_export_exported_toast, audit_export_failed_error,
         audit_export_unsupported_source_toast, audit_export_write_failed_error, audit_level_label,
         audit_loading_event_stream_task_label, audit_outcome_label, auto_refresh_unavailable_toast,
@@ -6074,6 +6087,36 @@ mod tests {
 
         assert!(value.contains("query timeout"));
         assert_ne!(value, "document.audit.export.failed");
+    }
+
+    #[test]
+    fn audit_event_source_status_messages_resolve_in_both_locales() {
+        for key in [
+            "document.audit.source.connection_not_found",
+            "document.audit.source.load_failed",
+        ] {
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(key, locale = locale);
+
+                assert!(!value.is_empty());
+                assert_ne!(value, key);
+                assert_ne!(value, format!("{locale}.{key}"));
+            }
+        }
+
+        assert_ne!(
+            dbflux_i18n::t!("document.audit.source.load_failed", locale = "en"),
+            dbflux_i18n::t!("document.audit.source.load_failed", locale = "es")
+        );
+    }
+
+    #[test]
+    fn audit_events_load_failed_interpolates_cause() {
+        let value = audit_events_load_failed("socket closed");
+
+        assert!(value.contains("socket closed"));
+        assert_ne!(value, "document.audit.source.load_failed");
+        assert!(!audit_event_source_connection_not_found().is_empty());
     }
 
     #[test]

--- a/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
+++ b/crates/dbflux_ui_document/src/migrate_wizard/confirm_run.rs
@@ -36,6 +36,7 @@ use gpui::*;
 use gpui_component::ActiveTheme;
 use uuid::Uuid;
 
+use crate::labels::migrate_wizard_task_label;
 use crate::migrate_wizard::MigrateWizard;
 use crate::migrate_wizard::column_mapping::TableMigrationConfig;
 use crate::migrate_wizard::phases::{ReorderState, RunState};
@@ -320,7 +321,7 @@ impl ConfirmRunPhase {
         self.run_elapsed = None;
         *self.progress.lock().unwrap_or_else(|p| p.into_inner()) = RunProgress::default();
 
-        let description = format!("Migrate {} table(s)", plans.len());
+        let description = migrate_wizard_task_label(plans.len());
         let (task_id, cancel_token) = self.app_state.update(cx, |state, cx| {
             let pair = state.start_task_for_target(
                 TaskKind::Migrate,


### PR DESCRIPTION
## Summary

Document i18n slice 29 (closes the series): the re-verify findings — Tasks panel descriptions for import/export/migrate runs, bulk and single-item mutations, script runs and the audit event-stream loader, the auto-refresh toast, the PK details error, the three `Query failed` toasts, the audit export toasts, the export dialog title and the row inspector title — render through `dbflux_i18n::t!` with `.one/.many` helpers. English and Spanish together. Protocol-syntax task descriptions (Redis `DEL`, `SELECT …`, `find db.collection`) stay data.

## What does this resolve?

- Refs #360 (follows 19b; next: delete-prefix modal, upload, transfer, context menu, editor)

## How was this solved?

- The call-site sweep of `start_task`/`start_mutation`/`start_primary` surfaced ten more English task descriptions beyond the named findings; all translated.
- Known leftover for a separate fix: two pre-existing `let _ = cx.update(...)` in `audit/mod.rs` near the export toasts (banned pattern, predates this series).
- Size: 739 lines, half of it tests (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_ui_document -p dbflux_i18n` → 1171 passed (1175 with `mcp`); clippy clean both ways; fmt clean. Manual smoke in Spanish: open the Tasks panel during an import, run a failing query, export audit events, open the row inspector.
- Receipt-driven review: approved; remaining findings advisory.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s) (automated; manual smoke in Spanish noted above)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (consolidated entry when the crate series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
