### PR TITLE
feat(i18n): translate the keybindings command, category, and context names

### DIFF
--- a/crates/dbflux_core/src/keymap_types.rs
+++ b/crates/dbflux_core/src/keymap_types.rs
@@ -258,6 +258,207 @@ impl Command {
         }
     }
 
+    /// Returns a stable, locale-independent identifier for this command.
+    ///
+    /// Where the command is also addressable from the command palette (see
+    /// [`Command::from_palette_id`]), this returns the exact same string so
+    /// the settings translation catalog and the palette translation catalog
+    /// can share one `<id>` namespace per command.
+    pub fn id(&self) -> &'static str {
+        match self {
+            Command::ToggleCommandPalette => "toggle_command_palette",
+            Command::NewQueryTab => "new_query_tab",
+            Command::CloseCurrentTab => "close_tab",
+            Command::NextTab => "next_tab",
+            Command::PrevTab => "prev_tab",
+            Command::SwitchToTab(_) => "switch_to_tab",
+            Command::OpenTabMenu => "open_tab_menu",
+
+            Command::FocusSidebar => "focus_sidebar",
+            Command::FocusEditor => "focus_editor",
+            Command::FocusResults => "focus_results",
+            Command::FocusBackgroundTasks => "focus_tasks",
+            Command::CycleFocusForward => "cycle_focus_forward",
+            Command::CycleFocusBackward => "cycle_focus_backward",
+            Command::FocusLeft => "focus_left",
+            Command::FocusRight => "focus_right",
+            Command::FocusUp => "focus_up",
+            Command::FocusDown => "focus_down",
+
+            Command::SelectNext => "select_next",
+            Command::SelectPrev => "select_prev",
+            Command::SelectFirst => "select_first",
+            Command::SelectLast => "select_last",
+            Command::PageDown => "page_down",
+            Command::PageUp => "page_up",
+
+            Command::ExtendSelectNext => "extend_select_next",
+            Command::ExtendSelectPrev => "extend_select_prev",
+            Command::ToggleSelection => "toggle_selection",
+            Command::MoveSelectedUp => "move_selected_up",
+            Command::MoveSelectedDown => "move_selected_down",
+
+            Command::ColumnLeft => "column_left",
+            Command::ColumnRight => "column_right",
+
+            Command::Execute => "execute",
+            Command::Cancel => "cancel",
+            Command::ExpandCollapse => "expand_collapse",
+            Command::Delete => "delete",
+            Command::Rename => "rename",
+            Command::FocusSearch => "focus_search",
+            Command::ToggleFavorite => "toggle_favorite",
+
+            Command::RunQuery => "run_query",
+            Command::RunQueryInNewTab => "run_query_in_new_tab",
+            Command::CancelQuery => "cancel_query",
+            Command::ToggleHistoryDropdown => "open_history",
+            Command::OpenSavedQueries => "open_saved_queries",
+            Command::SaveQuery => "save_query",
+            Command::SaveFileAs => "save_file_as",
+            Command::OpenScriptFile => "open_script_file",
+
+            Command::ExportResults => "export_results",
+            Command::ResultsNextPage => "results_next_page",
+            Command::ResultsPrevPage => "results_prev_page",
+            Command::FocusToolbar => "focus_toolbar",
+            Command::TogglePanel => "toggle_panel",
+            Command::ResultsDeleteRow => "results_delete_row",
+            Command::ResultsAddRow => "results_add_row",
+            Command::ResultsDuplicateRow => "results_duplicate_row",
+            Command::ResultsCopyRow => "results_copy_row",
+            Command::ResultsCopyCell => "results_copy_cell",
+            Command::ResultsSetNull => "results_set_null",
+            Command::OpenContextMenu => "open_context_menu",
+            Command::MenuUp => "menu_up",
+            Command::MenuDown => "menu_down",
+            Command::MenuSelect => "menu_select",
+            Command::MenuBack => "menu_back",
+
+            Command::SidebarNextTab => "sidebar_next_tab",
+            Command::RefreshSchema => "refresh_schema",
+            Command::OpenConnectionManager => "open_connection_manager",
+            Command::ExportConnections => "export_connections",
+            Command::Disconnect => "disconnect",
+            Command::OpenItemMenu => "open_item_menu",
+            Command::CreateFolder => "create_folder",
+
+            Command::ToggleEditor => "toggle_editor",
+            Command::ToggleResults => "toggle_results",
+            Command::ToggleTasks => "toggle_tasks",
+            Command::ToggleSidebar => "toggle_sidebar",
+            Command::OpenSettings => "open_settings",
+            Command::OpenLoginModal => "open_login_modal",
+            Command::OpenSsoWizard => "open_sso_wizard",
+            Command::OpenAuditViewer => "open_audit_viewer",
+            #[cfg(feature = "mcp")]
+            Command::OpenMcpApprovals => "open_mcp_approvals",
+            #[cfg(feature = "mcp")]
+            Command::RefreshMcpGovernance => "refresh_mcp_governance",
+
+            Command::OpenSavedChart => "open_saved_chart",
+            Command::ImportDashboard => "import_dashboard",
+            Command::NewDashboard => "new_dashboard",
+        }
+    }
+
+    /// Returns one instance of every [`Command`] variant, using a
+    /// representative payload for variants that carry one.
+    ///
+    /// Intended for exhaustive coverage in tests (id uniqueness, translation
+    /// coverage) across `dbflux_core` and downstream UI crates.
+    pub fn all_variants() -> Vec<Command> {
+        let mut variants = vec![
+            Command::ToggleCommandPalette,
+            Command::NewQueryTab,
+            Command::CloseCurrentTab,
+            Command::NextTab,
+            Command::PrevTab,
+            Command::SwitchToTab(0),
+            Command::OpenTabMenu,
+            Command::FocusSidebar,
+            Command::FocusEditor,
+            Command::FocusResults,
+            Command::FocusBackgroundTasks,
+            Command::CycleFocusForward,
+            Command::CycleFocusBackward,
+            Command::FocusLeft,
+            Command::FocusRight,
+            Command::FocusUp,
+            Command::FocusDown,
+            Command::SelectNext,
+            Command::SelectPrev,
+            Command::SelectFirst,
+            Command::SelectLast,
+            Command::PageDown,
+            Command::PageUp,
+            Command::ExtendSelectNext,
+            Command::ExtendSelectPrev,
+            Command::ToggleSelection,
+            Command::MoveSelectedUp,
+            Command::MoveSelectedDown,
+            Command::ColumnLeft,
+            Command::ColumnRight,
+            Command::Execute,
+            Command::Cancel,
+            Command::ExpandCollapse,
+            Command::Delete,
+            Command::Rename,
+            Command::FocusSearch,
+            Command::ToggleFavorite,
+            Command::RunQuery,
+            Command::RunQueryInNewTab,
+            Command::CancelQuery,
+            Command::ToggleHistoryDropdown,
+            Command::OpenSavedQueries,
+            Command::SaveQuery,
+            Command::SaveFileAs,
+            Command::OpenScriptFile,
+            Command::ExportResults,
+            Command::ResultsNextPage,
+            Command::ResultsPrevPage,
+            Command::FocusToolbar,
+            Command::TogglePanel,
+            Command::ResultsDeleteRow,
+            Command::ResultsAddRow,
+            Command::ResultsDuplicateRow,
+            Command::ResultsCopyRow,
+            Command::ResultsCopyCell,
+            Command::ResultsSetNull,
+            Command::OpenContextMenu,
+            Command::MenuUp,
+            Command::MenuDown,
+            Command::MenuSelect,
+            Command::MenuBack,
+            Command::SidebarNextTab,
+            Command::RefreshSchema,
+            Command::OpenConnectionManager,
+            Command::ExportConnections,
+            Command::Disconnect,
+            Command::OpenItemMenu,
+            Command::CreateFolder,
+            Command::ToggleEditor,
+            Command::ToggleResults,
+            Command::ToggleTasks,
+            Command::ToggleSidebar,
+            Command::OpenSettings,
+            Command::OpenLoginModal,
+            Command::OpenSsoWizard,
+            Command::OpenAuditViewer,
+            Command::OpenSavedChart,
+            Command::ImportDashboard,
+            Command::NewDashboard,
+        ];
+
+        #[cfg(feature = "mcp")]
+        {
+            variants.push(Command::OpenMcpApprovals);
+            variants.push(Command::RefreshMcpGovernance);
+        }
+
+        variants
+    }
+
     /// Returns the category for this command (used in command palette grouping).
     #[allow(dead_code)]
     pub fn category(&self) -> &'static str {
@@ -538,6 +739,29 @@ impl ContextId {
         }
     }
 
+    /// Returns a stable, locale-independent identifier for this context.
+    pub fn id(&self) -> &'static str {
+        match self {
+            ContextId::Global => "global",
+            ContextId::Sidebar => "sidebar",
+            ContextId::Editor => "editor",
+            ContextId::Results => "results",
+            ContextId::BackgroundTasks => "background_tasks",
+            ContextId::CommandPalette => "command_palette",
+            ContextId::ConnectionManager => "connection_manager",
+            ContextId::HistoryModal => "history_modal",
+            ContextId::TextInput => "text_input",
+            ContextId::Dropdown => "dropdown",
+            ContextId::SqlPreviewModal => "sql_preview_modal",
+            ContextId::ContextMenu => "context_menu",
+            ContextId::ConfirmModal => "confirm_modal",
+            ContextId::FormNavigation => "form_navigation",
+            ContextId::ContextBar => "context_bar",
+            ContextId::Audit => "audit",
+            ContextId::EventStreamsPicker => "event_streams_picker",
+        }
+    }
+
     /// Returns all context variants in display order.
     pub fn all_variants() -> &'static [ContextId] {
         &[
@@ -606,5 +830,67 @@ mod tests {
     fn history_modal_is_modal() {
         assert!(ContextId::HistoryModal.is_modal());
         assert_eq!(ContextId::HistoryModal.parent(), None);
+    }
+
+    #[test]
+    fn command_ids_are_unique() {
+        let ids: Vec<&str> = Command::all_variants().iter().map(Command::id).collect();
+        let unique: std::collections::HashSet<&str> = ids.iter().copied().collect();
+        assert_eq!(ids.len(), unique.len(), "duplicate command ids: {ids:?}");
+    }
+
+    #[test]
+    fn command_ids_round_trip_through_from_palette_id() {
+        const PALETTE_IDS: &[&str] = &[
+            "new_query_tab",
+            "run_query",
+            "run_query_in_new_tab",
+            "save_query",
+            "open_history",
+            "cancel_query",
+            "close_tab",
+            "next_tab",
+            "prev_tab",
+            "export_results",
+            "open_connection_manager",
+            "export_connections",
+            "disconnect",
+            "refresh_schema",
+            "focus_sidebar",
+            "focus_editor",
+            "focus_results",
+            "focus_tasks",
+            "toggle_sidebar",
+            "toggle_editor",
+            "toggle_results",
+            "toggle_tasks",
+            "open_settings",
+            "open_login_modal",
+            "open_sso_wizard",
+            "open_audit_viewer",
+            "open_saved_chart",
+            "import_dashboard",
+            "new_dashboard",
+        ];
+
+        for palette_id in PALETTE_IDS {
+            let command = Command::from_palette_id(palette_id)
+                .unwrap_or_else(|| panic!("from_palette_id lost mapping for {palette_id}"));
+            assert_eq!(
+                command.id(),
+                *palette_id,
+                "Command::id() must reuse the palette id for {palette_id}"
+            );
+        }
+    }
+
+    #[test]
+    fn context_ids_are_unique() {
+        let ids: Vec<&str> = ContextId::all_variants()
+            .iter()
+            .map(ContextId::id)
+            .collect();
+        let unique: std::collections::HashSet<&str> = ids.iter().copied().collect();
+        assert_eq!(ids.len(), unique.len(), "duplicate context ids: {ids:?}");
     }
 }

--- a/crates/dbflux_core/src/keymap_types.rs
+++ b/crates/dbflux_core/src/keymap_types.rs
@@ -368,6 +368,7 @@ impl Command {
     /// Intended for exhaustive coverage in tests (id uniqueness, translation
     /// coverage) across `dbflux_core` and downstream UI crates.
     pub fn all_variants() -> Vec<Command> {
+        #[cfg_attr(not(feature = "mcp"), allow(unused_mut))]
         let mut variants = vec![
             Command::ToggleCommandPalette,
             Command::NewQueryTab,

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -2484,6 +2484,116 @@ settings:
       title: "Conflict: %{chord} also bound to %{others}"
       body: Two or more commands share this chord in this context.
       unknown_other: another binding
+    command:
+      toggle_command_palette: Toggle Command Palette
+      new_query_tab: New Query Tab
+      close_tab: Close Current Tab
+      next_tab: Next Tab
+      prev_tab: Previous Tab
+      switch_to_tab: Switch to Tab
+      open_tab_menu: Open Tab Menu
+      focus_sidebar: Focus Sidebar
+      focus_editor: Focus Editor
+      focus_results: Focus Results
+      focus_tasks: Focus Background Tasks
+      cycle_focus_forward: Cycle Focus Forward
+      cycle_focus_backward: Cycle Focus Backward
+      focus_left: Focus Left
+      focus_right: Focus Right
+      focus_up: Focus Up
+      focus_down: Focus Down
+      select_next: Select Next
+      select_prev: Select Previous
+      select_first: Select First
+      select_last: Select Last
+      page_down: Page Down
+      page_up: Page Up
+      extend_select_next: Extend Selection Down
+      extend_select_prev: Extend Selection Up
+      toggle_selection: Toggle Selection
+      move_selected_up: Move Selected Up
+      move_selected_down: Move Selected Down
+      column_left: Column Left
+      column_right: Column Right
+      execute: Execute
+      cancel: Cancel
+      expand_collapse: Expand/Collapse
+      delete: Delete
+      rename: Rename
+      focus_search: Focus Search
+      toggle_favorite: Toggle Favorite
+      run_query: Run Query
+      run_query_in_new_tab: Run Query in New Tab
+      cancel_query: Cancel Query
+      open_history: Toggle History Dropdown
+      open_saved_queries: Open Saved Queries
+      save_query: Save
+      save_file_as: Save File As
+      open_script_file: Open Script File
+      export_results: Export Results
+      results_next_page: Results Next Page
+      results_prev_page: Results Previous Page
+      focus_toolbar: Focus Toolbar
+      toggle_panel: Toggle Panel
+      results_delete_row: Delete Row
+      results_add_row: Add Row
+      results_duplicate_row: Duplicate Row
+      results_copy_row: Copy Row
+      results_copy_cell: Copy Cell
+      results_set_null: Set Cell to NULL
+      open_context_menu: Open Context Menu
+      menu_up: Menu Up
+      menu_down: Menu Down
+      menu_select: Menu Select
+      menu_back: Menu Back
+      sidebar_next_tab: Sidebar Next Tab
+      refresh_schema: Refresh Schema
+      open_connection_manager: Open Connection Manager
+      export_connections: "Export Connections…"
+      disconnect: Disconnect
+      open_item_menu: Open Item Menu
+      create_folder: Create Folder
+      toggle_editor: Toggle Editor Panel
+      toggle_results: Toggle Results Panel
+      toggle_tasks: Toggle Tasks Panel
+      toggle_sidebar: Toggle Sidebar
+      open_settings: Open Settings
+      open_login_modal: Open Auth Profile Login
+      open_sso_wizard: Open AWS SSO Wizard
+      open_audit_viewer: Open Audit Viewer
+      open_mcp_approvals: Open MCP Approvals
+      refresh_mcp_governance: Refresh MCP Governance
+      open_saved_chart: "Open Chart..."
+      import_dashboard: "Import Dashboard from JSON..."
+      new_dashboard: "New Dashboard..."
+    context:
+      global: Global
+      sidebar: Sidebar
+      editor: Editor
+      results: Results
+      background_tasks: Background Tasks
+      command_palette: Command Palette
+      connection_manager: Connection Manager
+      history_modal: History
+      text_input: Text Input
+      dropdown: Dropdown
+      sql_preview_modal: SQL Preview
+      context_menu: Context Menu
+      confirm_modal: Confirm
+      form_navigation: Form Navigation
+      context_bar: Context Bar
+      audit: Audit Viewer
+      event_streams_picker: Event Streams Picker
+    category:
+      global: Global
+      focus: Focus
+      navigation: Navigation
+      results: Results
+      actions: Actions
+      editor: Editor
+      sidebar: Sidebar
+      view: View
+      dashboards: Dashboards
   hooks:
     header:
       title: Hooks

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -2484,6 +2484,116 @@ settings:
       title: "Conflicto: %{chord} también está asignado a %{others}"
       body: Dos o más comandos comparten este atajo en este contexto.
       unknown_other: otro atajo
+    command:
+      toggle_command_palette: Mostrar u ocultar la paleta de comandos
+      new_query_tab: Nueva pestaña de consulta
+      close_tab: Cerrar pestaña actual
+      next_tab: Pestaña siguiente
+      prev_tab: Pestaña anterior
+      switch_to_tab: Cambiar a pestaña
+      open_tab_menu: Abrir menú de pestaña
+      focus_sidebar: Enfocar barra lateral
+      focus_editor: Enfocar editor
+      focus_results: Enfocar resultados
+      focus_tasks: Enfocar tareas en segundo plano
+      cycle_focus_forward: Ciclar foco hacia adelante
+      cycle_focus_backward: Ciclar foco hacia atrás
+      focus_left: Enfocar a la izquierda
+      focus_right: Enfocar a la derecha
+      focus_up: Enfocar hacia arriba
+      focus_down: Enfocar hacia abajo
+      select_next: Seleccionar siguiente
+      select_prev: Seleccionar anterior
+      select_first: Seleccionar primero
+      select_last: Seleccionar último
+      page_down: Página siguiente
+      page_up: Página anterior
+      extend_select_next: Extender selección hacia abajo
+      extend_select_prev: Extender selección hacia arriba
+      toggle_selection: Alternar selección
+      move_selected_up: Mover selección hacia arriba
+      move_selected_down: Mover selección hacia abajo
+      column_left: Columna izquierda
+      column_right: Columna derecha
+      execute: Ejecutar
+      cancel: Cancelar
+      expand_collapse: Expandir o contraer
+      delete: Eliminar
+      rename: Renombrar
+      focus_search: Enfocar búsqueda
+      toggle_favorite: Alternar favorito
+      run_query: Ejecutar consulta
+      run_query_in_new_tab: Ejecutar consulta en nueva pestaña
+      cancel_query: Cancelar consulta
+      open_history: Mostrar u ocultar historial
+      open_saved_queries: Abrir consultas guardadas
+      save_query: Guardar
+      save_file_as: Guardar archivo como
+      open_script_file: Abrir archivo de script
+      export_results: Exportar resultados
+      results_next_page: "Resultados: página siguiente"
+      results_prev_page: "Resultados: página anterior"
+      focus_toolbar: Enfocar barra de herramientas
+      toggle_panel: Alternar panel
+      results_delete_row: Eliminar fila
+      results_add_row: Agregar fila
+      results_duplicate_row: Duplicar fila
+      results_copy_row: Copiar fila
+      results_copy_cell: Copiar celda
+      results_set_null: Establecer celda en NULL
+      open_context_menu: Abrir menú contextual
+      menu_up: "Menú: arriba"
+      menu_down: "Menú: abajo"
+      menu_select: "Menú: seleccionar"
+      menu_back: "Menú: atrás"
+      sidebar_next_tab: "Barra lateral: siguiente pestaña"
+      refresh_schema: Actualizar schema
+      open_connection_manager: Abrir gestor de conexiones
+      export_connections: "Exportar conexiones…"
+      disconnect: Desconectar
+      open_item_menu: Abrir menú del elemento
+      create_folder: Crear carpeta
+      toggle_editor: Mostrar u ocultar panel del editor
+      toggle_results: Mostrar u ocultar panel de resultados
+      toggle_tasks: Mostrar u ocultar panel de tareas
+      toggle_sidebar: Mostrar u ocultar barra lateral
+      open_settings: Abrir configuración
+      open_login_modal: Abrir inicio de sesión de Auth Profile
+      open_sso_wizard: Abrir asistente de AWS SSO
+      open_audit_viewer: Abrir visor de auditoría
+      open_mcp_approvals: Abrir aprobaciones de MCP
+      refresh_mcp_governance: Actualizar gobernanza de MCP
+      open_saved_chart: "Abrir gráfico..."
+      import_dashboard: "Importar dashboard desde JSON..."
+      new_dashboard: "Nuevo dashboard..."
+    context:
+      global: Global
+      sidebar: Barra lateral
+      editor: Editor
+      results: Resultados
+      background_tasks: Tareas en segundo plano
+      command_palette: Paleta de comandos
+      connection_manager: Gestor de conexiones
+      history_modal: Historial
+      text_input: Campo de texto
+      dropdown: Menú desplegable
+      sql_preview_modal: Vista previa de SQL
+      context_menu: Menú contextual
+      confirm_modal: Confirmar
+      form_navigation: Navegación de formulario
+      context_bar: Barra de contexto
+      audit: Visor de auditoría
+      event_streams_picker: Selector de flujos de eventos
+    category:
+      global: Global
+      focus: Foco
+      navigation: Navegación
+      results: Resultados
+      actions: Acciones
+      editor: Editor
+      sidebar: Barra lateral
+      view: Vista
+      dashboards: Dashboards
   hooks:
     header:
       title: Hooks

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -711,6 +711,54 @@ pub(crate) fn export_toast_success(kind: &str, path: &str) -> String {
     )
 }
 
+/// Translates a command's display name for the Settings → Keybindings
+/// section, keyed by [`dbflux_app::keymap::Command::id`].
+pub(crate) fn keybinding_command_name(cmd: &dbflux_app::keymap::Command) -> String {
+    dbflux_i18n::t!(&format!("settings.keybindings.command.{}", cmd.id()))
+}
+
+/// Translates a context's display name for the Settings → Keybindings
+/// section, keyed by [`dbflux_app::keymap::ContextId::id`].
+pub(crate) fn keybinding_context_name(ctx: &dbflux_app::keymap::ContextId) -> String {
+    dbflux_i18n::t!(&format!("settings.keybindings.context.{}", ctx.id()))
+}
+
+/// Translates a command category label for the Settings → Keybindings
+/// section.
+///
+/// `category` is the English string returned by
+/// [`dbflux_app::keymap::Command::category`]; it is mapped to a stable slug
+/// through an explicit match rather than derived by string munging.
+///
+/// No `settings/keybindings.rs` view currently groups bindings by category
+/// (only by [`dbflux_app::keymap::ContextId`]), so this has no production
+/// call site yet; it exists so the catalog stays complete alongside
+/// [`keybinding_command_name`] and [`keybinding_context_name`], and is
+/// exercised by the exhaustive translation-coverage tests below.
+#[allow(dead_code)]
+pub(crate) fn keybinding_category_name(category: &str) -> String {
+    dbflux_i18n::t!(&format!(
+        "settings.keybindings.category.{}",
+        keybinding_category_slug(category)
+    ))
+}
+
+#[allow(dead_code)]
+fn keybinding_category_slug(category: &str) -> &'static str {
+    match category {
+        "Global" => "global",
+        "Focus" => "focus",
+        "Navigation" => "navigation",
+        "Results" => "results",
+        "Actions" => "actions",
+        "Editor" => "editor",
+        "Sidebar" => "sidebar",
+        "View" => "view",
+        "Dashboards" => "dashboards",
+        other => panic!("keybinding_category_slug: unknown command category {other:?}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -1320,5 +1368,142 @@ mod tests {
 
         assert!(message.contains("connection"));
         assert!(message.contains("/tmp/bundle.toml"));
+    }
+}
+
+#[cfg(test)]
+mod keybinding_translation_tests {
+    use super::{keybinding_category_name, keybinding_command_name, keybinding_context_name};
+    use dbflux_app::keymap::{Command, ContextId};
+
+    const COMMAND_CATEGORIES: &[&str] = &[
+        "Global",
+        "Focus",
+        "Navigation",
+        "Results",
+        "Actions",
+        "Editor",
+        "Sidebar",
+        "View",
+        "Dashboards",
+    ];
+
+    #[test]
+    fn keybinding_command_names_resolve_in_both_locales_and_match_display_name_in_english() {
+        for command in Command::all_variants() {
+            let key = format!("settings.keybindings.command.{}", command.id());
+
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(&key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+
+            assert_eq!(
+                dbflux_i18n::t!(&key, locale = "en"),
+                command.display_name(),
+                "English catalog value for {key} must match Command::display_name()"
+            );
+        }
+    }
+
+    #[test]
+    fn keybinding_command_name_helper_matches_catalog_lookup() {
+        let command = Command::RunQuery;
+
+        assert_eq!(
+            keybinding_command_name(&command),
+            dbflux_i18n::t!("settings.keybindings.command.run_query", locale = "en")
+        );
+    }
+
+    #[test]
+    fn keybinding_context_names_resolve_in_both_locales_and_match_display_name_in_english() {
+        for context in ContextId::all_variants() {
+            let key = format!("settings.keybindings.context.{}", context.id());
+
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(&key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+
+            assert_eq!(
+                dbflux_i18n::t!(&key, locale = "en"),
+                context.display_name(),
+                "English catalog value for {key} must match ContextId::display_name()"
+            );
+        }
+    }
+
+    #[test]
+    fn keybinding_context_name_helper_matches_catalog_lookup() {
+        let context = ContextId::Sidebar;
+
+        assert_eq!(
+            keybinding_context_name(&context),
+            dbflux_i18n::t!("settings.keybindings.context.sidebar", locale = "en")
+        );
+    }
+
+    #[test]
+    fn keybinding_category_names_resolve_in_both_locales_and_match_category_in_english() {
+        for category in COMMAND_CATEGORIES {
+            let slug = category.to_ascii_lowercase();
+            let key = format!("settings.keybindings.category.{slug}");
+
+            for locale in ["en", "es"] {
+                let value = dbflux_i18n::t!(&key, locale = locale);
+
+                assert!(
+                    !value.is_empty(),
+                    "key {key} resolved empty for locale {locale}"
+                );
+                assert_ne!(value, key, "key {key} did not resolve for locale {locale}");
+                assert_ne!(
+                    value,
+                    format!("{locale}.{key}"),
+                    "key {key} fell back to the raw locale-qualified form for locale {locale}"
+                );
+            }
+
+            assert_eq!(
+                dbflux_i18n::t!(&key, locale = "en"),
+                *category,
+                "English catalog value for {key} must match the Command::category() string"
+            );
+        }
+    }
+
+    #[test]
+    fn keybinding_category_name_helper_matches_catalog_lookup() {
+        assert_eq!(
+            keybinding_category_name("Editor"),
+            dbflux_i18n::t!("settings.keybindings.category.editor", locale = "en")
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown command category")]
+    fn keybinding_category_name_panics_on_unmapped_category() {
+        keybinding_category_name("NotACategory");
     }
 }

--- a/crates/dbflux_ui_windows/src/settings/keybindings.rs
+++ b/crates/dbflux_ui_windows/src/settings/keybindings.rs
@@ -46,7 +46,7 @@ impl KeybindingsSection {
                     .iter()
                     .filter(|(chord, cmd, _)| {
                         let chord_str = chord.to_string().to_lowercase();
-                        let cmd_name = cmd.display_name().to_lowercase();
+                        let cmd_name = crate::labels::keybinding_command_name(cmd).to_lowercase();
                         chord_str.contains(&filter_text) || cmd_name.contains(&filter_text)
                     })
                     .cloned()
@@ -83,7 +83,7 @@ impl KeybindingsSection {
                     chord_groups
                         .entry(chord.clone())
                         .or_default()
-                        .push(cmd.display_name().to_string());
+                        .push(crate::labels::keybinding_command_name(cmd));
                 }
 
                 let mut emitted_conflict_for: std::collections::HashSet<KeyChord> =
@@ -102,7 +102,7 @@ impl KeybindingsSection {
                         && group.len() > 1
                         && !emitted_conflict_for.contains(chord)
                     {
-                        let current_name = cmd.display_name().to_string();
+                        let current_name = crate::labels::keybinding_command_name(cmd);
                         let others: Vec<String> = group
                             .iter()
                             .filter(|name| **name != current_name)
@@ -117,7 +117,7 @@ impl KeybindingsSection {
 
                     flat_items.push(KeybindingsListItem::Binding {
                         chord: chord.clone(),
-                        cmd_name: cmd.display_name().to_string(),
+                        cmd_name: crate::labels::keybinding_command_name(cmd),
                         is_inherited,
                         is_selected: is_binding_selected,
                         ctx_idx: idx,
@@ -187,8 +187,10 @@ impl KeybindingsSection {
                                 binding_count,
                             } => {
                                 let has_parent = context.parent().is_some();
-                                let parent_name =
-                                    context.parent().map(|p| p.display_name()).unwrap_or("");
+                                let parent_name = context
+                                    .parent()
+                                    .map(|p| crate::labels::keybinding_context_name(&p))
+                                    .unwrap_or_default();
 
                                 div()
                                     .id(SharedString::from(format!(
@@ -244,7 +246,9 @@ impl KeybindingsSection {
                                             .flex()
                                             .items_center()
                                             .gap_2()
-                                            .child(FieldLabel::new(context.display_name()))
+                                            .child(FieldLabel::new(
+                                                crate::labels::keybinding_context_name(&context),
+                                            ))
                                             .child(
                                                 Body::new(
                                                     crate::labels::keybindings_binding_count(
@@ -257,7 +261,7 @@ impl KeybindingsSection {
                                     // Inherits info
                                     .when(has_parent, |d| {
                                         d.child(MonoCaption::new(
-                                            crate::labels::keybindings_inherits_from(parent_name),
+                                            crate::labels::keybindings_inherits_from(&parent_name),
                                         ))
                                     })
                                     .into_any_element()
@@ -452,7 +456,8 @@ impl KeybindingsSection {
             bindings
                 .into_iter()
                 .filter(|(chord, cmd, _)| {
-                    Self::binding_matches_filter(chord, cmd.display_name(), filter)
+                    let cmd_name = crate::labels::keybinding_command_name(cmd);
+                    Self::binding_matches_filter(chord, &cmd_name, filter)
                 })
                 .collect()
         }


### PR DESCRIPTION
## Summary

Keybindings i18n: the Settings → Keybindings section shows translated command, category, and context names. `dbflux_core` gains `Command::id()` / `Command::all_variants()` / `ContextId::id()` (stable snake_case identifiers, palette-addressable variants reuse the exact `from_palette_id` string) while staying free of any i18n dependency; `dbflux_ui_windows` maps ids to `settings.keybindings.{command,context,category}.*` through exhaustive helpers whose tests assert every variant resolves in both locales and that English equals `display_name()` byte for byte.

## What does this resolve?

- Refs #360 (last app slice; the web series follows)

## How was this solved?

- Element ids keep deriving from `as_gpui_context()`/indexes, never translated text; `keybinding_category_name` has no render call site today (`Command::category()` was already dead code) and ships tested behind `#[allow(dead_code)]`.
- Size: 705 lines, ~214 of them catalog data and most of the rest exhaustive tests (`size:exception`).

## Validation

- `cargo nextest run -p dbflux_core -p dbflux_ui_windows -p dbflux_ui -p dbflux_i18n` → 1641 passed; clippy clean (default and `mcp`); fmt clean; decoupling guard and MCP governance acceptance tests green. Manual smoke in Spanish: Settings → Keybindings, filter by a Spanish command name, trigger a chord conflict.
- Receipt-driven review: skipped for this candidate (native review store lost the lineage after a machine reboot; candidate-scoped decline, defect not reported per user decision).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` (covered by the consolidated i18n entry, #449)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
