### PR TITLE
feat(web): Spanish site chrome, language switcher, and localized SEO signals

### DIFF
--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -116,6 +116,11 @@ function rehypeMermaid() {
 
 export default defineConfig({
   site: ORIGIN,
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'es'],
+    routing: 'manual',
+  },
   integrations: [
     sitemap({
       // `/about/` belongs to the site host and says so in its canonical tag.

--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -127,6 +127,13 @@ export default defineConfig({
       // The documentation build emits it only because one source tree builds
       // both hosts, so keep it out of this host's sitemap.
       filter: (page) => !(DOCS_MODE === 'docs' && new URL(page).pathname.startsWith('/about')),
+      // Mirrors `i18n.locales` above so the generator can pair each page with
+      // its counterpart in the other locale and emit hreflang alternates,
+      // matching `routing: 'manual'`'s unprefixed default locale.
+      i18n: {
+        defaultLocale: 'en',
+        locales: { en: 'en', es: 'es' },
+      },
     }),
     hostRedirects(),
   ],

--- a/web/src/components/DocsIndex.astro
+++ b/web/src/components/DocsIndex.astro
@@ -1,21 +1,21 @@
 ---
 import { docTitle, sectionsFor } from '../data/docs';
 import { docsHref } from '../data/versions';
+import { localeFromPathname, t } from '../i18n';
+import type { Locale } from '../i18n';
 
 interface Props {
   versionId: string;
   available: readonly string[];
+  locale?: Locale;
 }
 
-const { versionId, available } = Astro.props;
+const { versionId, available, locale = localeFromPathname(Astro.url.pathname) } = Astro.props;
 const { sections, unfiled } = sectionsFor(available);
 ---
 
-<h1>Documentation</h1>
-<p>
-  Every page here is rendered from the markdown in the repository&rsquo;s <code>docs/</code>{' '}
-  directory, so a change in behaviour and the paragraph describing it ship in the same commit.
-</p>
+<h1>{t(locale, 'docs_index.title')}</h1>
+<p set:html={t(locale, 'docs_index.intro')} />
 
 {
   sections.map((section) => (
@@ -35,11 +35,8 @@ const { sections, unfiled } = sectionsFor(available);
 {
   unfiled.length > 0 && (
     <section>
-      <h2 id="unfiled">Not yet filed</h2>
-      <p>
-        These pages exist in this version but have no place in the reading order declared in
-        <code>src/data/nav.ts</code>.
-      </p>
+      <h2 id="unfiled">{t(locale, 'docs_index.unfiled_title')}</h2>
+      <p set:html={t(locale, 'docs_index.unfiled_body')} />
       <ul>
         {unfiled.map((path) => (
           <li>

--- a/web/src/components/DocsTree.astro
+++ b/web/src/components/DocsTree.astro
@@ -3,15 +3,23 @@ import Icon from '../components/Icon.astro';
 import { docTitle, sectionsFor } from '../data/docs';
 import type { DocsVersion } from '../data/versions';
 import { docsHref } from '../data/versions';
+import { localeFromPathname, t } from '../i18n';
+import type { Locale } from '../i18n';
 
 interface Props {
   version: DocsVersion;
   /** Version-less path of the page being read, absent on the index. */
   current?: string;
   available: readonly string[];
+  locale?: Locale;
 }
 
-const { version, current, available } = Astro.props;
+const {
+  version,
+  current,
+  available,
+  locale = localeFromPathname(Astro.url.pathname),
+} = Astro.props;
 
 const sections = sectionsFor(available).sections.map((section) => ({
   ...section,
@@ -21,7 +29,7 @@ const sections = sectionsFor(available).sections.map((section) => ({
 
 <nav class="tree" aria-label="Documentation">
   <button class="tree__search" type="button" data-search-open>
-    <span><Icon name="search" size={13} /> Search the docs</span>
+    <span><Icon name="search" size={13} /> {t(locale, 'docs_tree.search_cta')}</span>
     <kbd>Ctrl K</kbd>
   </button>
 

--- a/web/src/components/SearchDialog.astro
+++ b/web/src/components/SearchDialog.astro
@@ -6,11 +6,24 @@
  * never searches never downloads it, and a reader on an older version is never
  * shown a page that only exists in a newer one.
  */
+import { localeFromPathname, t } from '../i18n';
+import type { Locale } from '../i18n';
+
 interface Props {
   indexUrl: string;
+  locale?: Locale;
 }
 
-const { indexUrl } = Astro.props;
+const { indexUrl, locale = localeFromPathname(Astro.url.pathname) } = Astro.props;
+
+const placeholder = t(locale, 'search.placeholder');
+
+const messages = {
+  noResults: t(locale, 'search.no_results'),
+  unavailable: t(locale, 'search.unavailable'),
+  resultCountOne: t(locale, 'search.result_count_one'),
+  resultCountOther: t(locale, 'search.result_count_other'),
+};
 ---
 
 <dialog class="search" data-search data-search-index={indexUrl}>
@@ -30,8 +43,8 @@ const { indexUrl } = Astro.props;
       </svg>
       <input
         type="search"
-        placeholder="Search the documentation"
-        aria-label="Search the documentation"
+        placeholder={placeholder}
+        aria-label={placeholder}
         autocomplete="off"
         spellcheck="false"
         data-search-input
@@ -42,13 +55,20 @@ const { indexUrl } = Astro.props;
     <div class="search__results" role="listbox" aria-label="Results" data-search-results></div>
 
     <div class="search__foot">
-      <span><kbd>&uarr;</kbd><kbd>&darr;</kbd> move</span>
-      <span><kbd>&crarr;</kbd> open</span>
-      <span><kbd>Esc</kbd> close</span>
+      <span><kbd>&uarr;</kbd><kbd>&darr;</kbd> {t(locale, 'search.move')}</span>
+      <span><kbd>&crarr;</kbd> {t(locale, 'search.open')}</span>
+      <span><kbd>Esc</kbd> {t(locale, 'search.close')}</span>
       <span class="search__count" data-search-count></span>
     </div>
   </form>
 </dialog>
+
+<script
+  type="application/json"
+  data-search-messages
+  is:inline
+  set:html={JSON.stringify(messages)}
+/>
 
 <style is:global>
   /*
@@ -217,6 +237,16 @@ const { indexUrl } = Astro.props;
     s: string;
   }
 
+  interface SearchMessages {
+    noResults: string;
+    unavailable: string;
+    resultCountOne: string;
+    resultCountOther: string;
+  }
+
+  const messagesEl = document.querySelector<HTMLScriptElement>('[data-search-messages]');
+  const messages: SearchMessages = JSON.parse(messagesEl?.textContent ?? '{}');
+
   const dialog = document.querySelector<HTMLDialogElement>('[data-search]');
   const input = document.querySelector<HTMLInputElement>('[data-search-input]');
   const results = document.querySelector<HTMLElement>('[data-search-results]');
@@ -288,8 +318,10 @@ const { indexUrl } = Astro.props;
         .slice(0, 24);
 
       if (matches.length === 0) {
-        results.innerHTML = `<p class="search__empty">No page matches &ldquo;${escapeHtml(input.value.trim())}&rdquo;.</p>`;
-        count.textContent = '0 results';
+        const emptyMessage = messages.noResults.replace('{query}', escapeHtml(input.value.trim()));
+
+        results.innerHTML = `<p class="search__empty">${emptyMessage}</p>`;
+        count.textContent = messages.resultCountOther.replace('{n}', '0');
         hits = [];
         return;
       }
@@ -308,7 +340,10 @@ const { indexUrl } = Astro.props;
         })
         .join('');
 
-      count.textContent = `${matches.length} result${matches.length === 1 ? '' : 's'}`;
+      const countMessage =
+        matches.length === 1 ? messages.resultCountOne : messages.resultCountOther;
+
+      count.textContent = countMessage.replace('{n}', String(matches.length));
       hits = Array.from(results.querySelectorAll<HTMLAnchorElement>('.search__hit'));
       setCursor(0);
     };
@@ -321,7 +356,7 @@ const { indexUrl } = Astro.props;
         index = (await fetch(url).then((r) => r.json())) as Section[];
       } catch {
         index = [];
-        results.innerHTML = '<p class="search__empty">Search is unavailable right now.</p>';
+        results.innerHTML = `<p class="search__empty">${messages.unavailable}</p>`;
       }
     };
 

--- a/web/src/components/SiteFooter.astro
+++ b/web/src/components/SiteFooter.astro
@@ -2,30 +2,38 @@
 import BrandMark from './BrandMark.astro';
 import { REPO } from '../data/nav';
 import { docsUrl } from '../data/site';
+import { localeFromPathname, t } from '../i18n';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale?: Locale;
+}
+
+const { locale = localeFromPathname(Astro.url.pathname) } = Astro.props;
 
 const COLUMNS = [
   {
-    title: 'Product',
+    title: t(locale, 'footer.product'),
     links: [
-      { href: '/#features', label: 'Features' },
-      { href: '/#drivers', label: 'Drivers' },
-      { href: `${REPO}/releases`, label: 'Releases' },
+      { href: '/#features', label: t(locale, 'footer.features') },
+      { href: '/#drivers', label: t(locale, 'footer.drivers') },
+      { href: `${REPO}/releases`, label: t(locale, 'footer.releases') },
     ],
   },
   {
-    title: 'Docs',
+    title: t(locale, 'footer.docs'),
     links: [
-      { href: docsUrl('usage'), label: 'Usage guide' },
-      { href: docsUrl('connections'), label: 'Connecting' },
-      { href: docsUrl('mcp_ai_integration'), label: 'AI + MCP' },
+      { href: docsUrl('usage'), label: t(locale, 'footer.usage') },
+      { href: docsUrl('connections'), label: t(locale, 'footer.connecting') },
+      { href: docsUrl('mcp_ai_integration'), label: t(locale, 'footer.mcp') },
     ],
   },
   {
-    title: 'Project',
+    title: t(locale, 'footer.project'),
     links: [
-      { href: '/about/', label: 'About' },
-      { href: docsUrl('contributing'), label: 'Contributing' },
-      { href: REPO, label: 'Source' },
+      { href: '/about/', label: t(locale, 'footer.about') },
+      { href: docsUrl('contributing'), label: t(locale, 'footer.contributing') },
+      { href: REPO, label: t(locale, 'footer.source') },
     ],
   },
 ] as const;
@@ -38,8 +46,8 @@ const COLUMNS = [
         <BrandMark size={26} />
         <span>DBFlux</span>
       </span>
-      <p>A fully open-source alternative to DBeaver, built in the open.</p>
-      <p class="foot__license">MIT or Apache-2.0, at your option.</p>
+      <p>{t(locale, 'footer.tagline')}</p>
+      <p class="foot__license">{t(locale, 'footer.license')}</p>
     </div>
 
     <div class="foot__cols">

--- a/web/src/components/SiteNav.astro
+++ b/web/src/components/SiteNav.astro
@@ -3,19 +3,33 @@ import Icon from './Icon.astro';
 import BrandMark from './BrandMark.astro';
 import { REPO } from '../data/nav';
 import { docsUrl, siteUrl } from '../data/site';
+import { localeFromPathname, t } from '../i18n';
+import type { Locale } from '../i18n';
 
 interface Props {
   current?: 'home' | 'docs' | 'about';
+  locale?: Locale;
 }
 
-const { current } = Astro.props;
+const { current, locale = localeFromPathname(Astro.url.pathname) } = Astro.props;
 
 const LINKS = [
-  { href: `${siteUrl()}#features`, label: 'Features', key: 'features' },
-  { href: `${siteUrl()}#drivers`, label: 'Drivers', key: 'drivers' },
-  { href: docsUrl(''), label: 'Docs', key: 'docs' },
-  { href: siteUrl('about/'), label: 'About', key: 'about' },
+  { href: `${siteUrl()}#features`, label: t(locale, 'nav.features'), key: 'features' },
+  { href: `${siteUrl()}#drivers`, label: t(locale, 'nav.drivers'), key: 'drivers' },
+  { href: docsUrl(''), label: t(locale, 'nav.docs'), key: 'docs' },
+  { href: siteUrl('about/'), label: t(locale, 'nav.about'), key: 'about' },
 ] as const;
+
+/**
+ * `/` and `/es/` are the only pages that currently exist in both locales — the
+ * docs and about routes gain their `/es/` counterpart in a later slice. Until
+ * then the switcher only appears on the home page, so it never links to an
+ * unbuilt page.
+ */
+const pathname = Astro.url.pathname;
+const isHome = pathname === '/' || pathname === '/es/' || pathname === '/es';
+const switchTarget = locale === 'es' ? '/' : '/es/';
+const switchHreflang = locale === 'es' ? 'en' : 'es';
 ---
 
 <header class="nav" data-nav>
@@ -40,11 +54,20 @@ const LINKS = [
     </nav>
 
     <div class="nav__actions">
+      {
+        isHome && (
+          <a class="nav__link nav__switch" href={switchTarget} hreflang={switchHreflang}>
+            {t(locale, 'nav.switch_locale')}
+          </a>
+        )
+      }
       <a class="nav__link nav__link--icon" href={REPO} rel="noopener">
         <Icon name="github" size={16} />
-        <span>GitHub</span>
+        <span>{t(locale, 'nav.github')}</span>
       </a>
-      <a class="btn btn--primary nav__cta" href={`${siteUrl()}#install`}>Download</a>
+      <a class="btn btn--primary nav__cta" href={`${siteUrl()}#install`}>
+        {t(locale, 'nav.download')}
+      </a>
       <button
         class="nav__toggle"
         type="button"
@@ -52,7 +75,7 @@ const LINKS = [
         aria-expanded="false"
         aria-controls="nav-sheet"
       >
-        <span class="visually-hidden">Menu</span>
+        <span class="visually-hidden">{t(locale, 'nav.menu')}</span>
         <Icon name="menu" size={20} />
       </button>
     </div>
@@ -60,9 +83,20 @@ const LINKS = [
 
   <div class="nav__sheet" id="nav-sheet" hidden>
     {LINKS.map((link) => <a href={link.href}>{link.label}</a>)}
-    <a href={REPO} rel="noopener">GitHub</a>
+    {
+      isHome && (
+        <a href={switchTarget} hreflang={switchHreflang}>
+          {t(locale, 'nav.switch_locale')}
+        </a>
+      )
+    }
+    <a href={REPO} rel="noopener">
+      {t(locale, 'nav.github')}
+    </a>
     <div class="nav__sheet-cta">
-      <a class="btn btn--primary" href={`${siteUrl()}#install`}>Download</a>
+      <a class="btn btn--primary" href={`${siteUrl()}#install`}>
+        {t(locale, 'nav.download')}
+      </a>
     </div>
   </div>
 </header>

--- a/web/src/components/VersionPicker.astro
+++ b/web/src/components/VersionPicker.astro
@@ -10,14 +10,17 @@ import {
   versionHome,
   versionLabel,
 } from '../data/versions';
+import { localeFromPathname, t } from '../i18n';
+import type { Locale } from '../i18n';
 
 interface Props {
   version: DocsVersion;
   /** Version-less path of the page being read, absent on the index. */
   currentPath?: string;
+  locale?: Locale;
 }
 
-const { version, currentPath } = Astro.props;
+const { version, currentPath, locale = localeFromPathname(Astro.url.pathname) } = Astro.props;
 
 const entries = await getCollection('docs');
 const build = buildInfo(version.id);
@@ -50,7 +53,7 @@ const targets = VERSIONS.map((candidate) => {
     aria-controls="version-menu"
     data-version-toggle
   >
-    <span class="picker__label">Version</span>
+    <span class="picker__label">{t(locale, 'versions.label')}</span>
     <span class="picker__value">{versionLabel(version)}</span>
     <svg
       width="11"
@@ -85,12 +88,12 @@ const targets = VERSIONS.map((candidate) => {
           >
             <span>{versionLabel(target.version)}</span>
             {!target.exact && target.version.id !== version.id && (
-              <span class="picker__tag" title="This page does not exist in that version">
-                index
+              <span class="picker__tag" title={t(locale, 'versions.index_tag_title')}>
+                {t(locale, 'versions.index_tag')}
               </span>
             )}
             {target.exact && target.version.id === CURRENT.id && (
-              <span class="picker__tag">default</span>
+              <span class="picker__tag">{t(locale, 'versions.default_tag')}</span>
             )}
           </a>
         </li>

--- a/web/src/data/site.ts
+++ b/web/src/data/site.ts
@@ -1,3 +1,6 @@
+import { DEFAULT_LOCALE } from '../i18n';
+import type { Locale } from '../i18n';
+
 /**
  * Where the documentation lives.
  *
@@ -35,15 +38,28 @@ export const ORIGIN = DOCS_MODE === 'docs' ? DOCS_ORIGIN : SITE_ORIGIN;
 /** True when the documentation is served from the root of its own origin. */
 export const DOCS_AT_ROOT = DOCS_MODE === 'docs';
 
+/** The `/es` segment a non-default locale prefixes onto a path, empty for `en`. */
+function localeSegment(locale: Locale): string {
+  return locale === DEFAULT_LOCALE ? '' : locale;
+}
+
 /**
  * The path a documentation page is built at, without an origin.
  *
  * `path` is everything after the version, empty for a version's index. The
  * `/docs` segment exists only while the documentation shares the site's origin;
- * on its own host it is the root, which is the point of moving it there.
+ * on its own host it is the root, which is the point of moving it there. The
+ * locale segment sits ahead of the version, matching `i18n.routing: 'manual'`
+ * and the unprefixed default locale (`prefixDefaultLocale: false`).
  */
-export function docsPath(path: string, versionPrefix = ''): string {
-  const parts = [versionPrefix, DOCS_AT_ROOT ? '' : 'docs', path].filter(Boolean);
+export function docsPath(
+  path: string,
+  versionPrefix = '',
+  locale: Locale = DEFAULT_LOCALE,
+): string {
+  const parts = [localeSegment(locale), versionPrefix, DOCS_AT_ROOT ? '' : 'docs', path].filter(
+    Boolean,
+  );
 
   return parts.join('/');
 }
@@ -56,19 +72,22 @@ export function docsPath(path: string, versionPrefix = ''): string {
  * documentation sits at the root — so the link must not carry the `/docs`
  * segment this build still uses for its own redirect stubs.
  */
-export function docsUrl(path: string, versionPrefix = ''): string {
+export function docsUrl(path: string, versionPrefix = '', locale: Locale = DEFAULT_LOCALE): string {
   if (DOCS_MODE === 'site') {
-    const remote = [versionPrefix, path].filter(Boolean).join('/');
+    const remote = [localeSegment(locale), versionPrefix, path].filter(Boolean).join('/');
 
     return `${DOCS_ORIGIN}/${remote}${remote ? '/' : ''}`;
   }
 
-  return `/${docsPath(path, versionPrefix)}/`.replace(/\/+/g, '/');
+  return `/${docsPath(path, versionPrefix, locale)}/`.replace(/\/+/g, '/');
 }
 
 /** A landing-page URL, absolute when this build does not contain it. */
-export function siteUrl(path = ''): string {
-  const absolute = `/${path}`.replace(/\/+/g, '/');
+export function siteUrl(path = '', locale: Locale = DEFAULT_LOCALE): string {
+  const absolute = `/${[localeSegment(locale), path].filter(Boolean).join('/')}`.replace(
+    /\/+/g,
+    '/',
+  );
 
   return DOCS_AT_ROOT ? `${SITE_ORIGIN}${absolute}` : absolute;
 }

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -1,0 +1,238 @@
+import type { Dictionary } from './index';
+
+export const en = {
+  nav: {
+    features: 'Features',
+    drivers: 'Drivers',
+    docs: 'Docs',
+    about: 'About',
+    github: 'GitHub',
+    download: 'Download',
+    menu: 'Menu',
+    switch_locale: 'Español',
+  },
+  footer: {
+    product: 'Product',
+    features: 'Features',
+    drivers: 'Drivers',
+    releases: 'Releases',
+    docs: 'Docs',
+    usage: 'Usage guide',
+    connecting: 'Connecting',
+    mcp: 'AI + MCP',
+    project: 'Project',
+    about: 'About',
+    contributing: 'Contributing',
+    source: 'Source',
+    tagline: 'A fully open-source alternative to DBeaver, built in the open.',
+    license: 'MIT or Apache-2.0, at your option.',
+  },
+  search: {
+    placeholder: 'Search the documentation',
+    move: 'move',
+    open: 'open',
+    close: 'close',
+    no_results: 'No page matches "{query}".',
+    unavailable: 'Search is unavailable right now.',
+    result_count: '{n} result(s)',
+  },
+  versions: {
+    label: 'Version',
+    index_tag_title: 'This page does not exist in that version',
+    index_tag: 'index',
+    default_tag: 'default',
+  },
+  docs_tree: {
+    search_cta: 'Search the docs',
+    rail_toggle: 'Documentation menu',
+    on_this_page: 'On this page',
+    crumb_docs: 'Docs',
+    crumb_overview: 'Overview',
+    edit_page: 'Edit this page',
+    report_issue: 'Report an issue',
+    not_translated: 'This page has not been translated yet. Showing the English version.',
+  },
+  docs_index: {
+    title: 'Documentation',
+    intro:
+      "Every page here is rendered from the markdown in the repository's docs/ directory, so a change in behaviour and the paragraph describing it ship in the same commit.",
+    unfiled_title: 'Not yet filed',
+    unfiled_body:
+      'These pages exist in this version but have no place in the reading order declared in src/data/nav.ts.',
+  },
+  landing: {
+    title: 'Every database you run, in one keyboard-driven window.',
+    lede: 'An extensible, keyboard-first data platform. Twelve built-in drivers, a driver-neutral core, and anything else you need over the RPC driver protocol.',
+    download_linux: 'Download for Linux',
+    download_macos: 'Download for macOS',
+    download_windows: 'Download for Windows',
+    view_source: 'View source',
+    platforms_meta: 'Linux · macOS · Windows — MIT or Apache-2.0',
+    hero_caption: 'Main server — SELECT * FROM public.transactions (1.5s)',
+    hero_alt:
+      'DBFlux with a connection tree open, showing databases, schemas, routines and instance metrics for a PostgreSQL server.',
+    drivers_eyebrow: 'Built-in drivers',
+    drivers_link: 'Capability matrix →',
+    drivers_note:
+      'Relational, document, key-value, time-series and object stores share one result grid, one chart engine and one audit log. External drivers register over the RPC protocol without a fork.',
+    features_eyebrow: 'What you get',
+    feature: {
+      editor: {
+        title: 'Dialect-aware editor',
+        body: 'Completion, validation and dangerous-statement detection come from the driver, not a shared guess. A DELETE without a WHERE is caught before it runs.',
+      },
+      grid: {
+        title: 'Editable result grid',
+        body: 'Edit cells in place when the result maps cleanly back to one table, page through millions of rows by keyset, and copy any selection as a native query.',
+      },
+      charts: {
+        title: 'Charts and dashboards',
+        body: 'Turn any result into a chart, save it, and pin it to a dashboard alongside instance metrics from the same connection.',
+      },
+      hooks: {
+        title: 'Connection hooks',
+        body: 'Run a command, a script or in-process Lua around connect and disconnect, with live output in the tasks panel and a failure policy you choose.',
+      },
+      reach: {
+        title: 'Reach anything',
+        body: 'SSH tunnels, HTTP proxies and AWS SSO are first-class. Secrets live in the OS keyring, never in the profile file.',
+      },
+      audit: {
+        title: 'Auditable by default',
+        body: 'Queries, hooks, scripts and MCP calls all write to the same event log, with redaction and retention you control.',
+      },
+    },
+    keyboard_eyebrow: 'Keyboard-first',
+    keyboard_title: 'The mouse is optional, not assumed.',
+    keyboard_body:
+      'Every surface has a binding and a command-palette entry: open a connection, run a statement, jump to a table, pivot a result into a chart. The empty state tells you the four you need on day one.',
+    keyboard_link: 'Full keyboard reference →',
+    shortcut: {
+      new_query: 'new query',
+      command_palette: 'command palette',
+      open_script: 'open script from disk',
+      new_connection: 'new connection',
+    },
+    governance_eyebrow: 'Governance',
+    governance_title: 'Give an AI client a connection, not your database.',
+    governance_body:
+      'The MCP server classifies every operation — metadata, read, write, destructive, admin — and a policy engine decides per role and per connection. Write and destructive calls can sit behind human approval.',
+    audit_eyebrow: 'Audit',
+    audit_title: 'Every query, hook and tool call, on the record.',
+    audit_body:
+      'Events land in a local SQLite log with category, severity, actor and outcome. Query text is fingerprinted rather than stored, sensitive values are redacted, and the whole log exports to JSON or CSV.',
+    docs_eyebrow: 'Documentation',
+    docs_link: 'All guides →',
+    doc_card: {
+      usage: {
+        title: 'Usage guide',
+        body: 'First launch, creating a connection, running queries, browsing results, charting and exporting.',
+      },
+      connecting: {
+        title: 'Connecting',
+        body: 'SSH tunnels, proxies, AWS SSO and value sources for everything that is not a plain host and port.',
+      },
+      mcp: {
+        title: 'AI + MCP',
+        body: 'Wire an AI client to DBFlux, then set the roles, policies and approvals that keep it inside the lines.',
+      },
+    },
+  },
+  install: {
+    all_downloads: 'All downloads →',
+    copy: 'copy',
+    copied: 'copied',
+    copy_fallback: 'press ctrl+c',
+    hint: {
+      tarball:
+        'Prefer no sudo? Append -s -- --prefix ~/.local to install under your home directory.',
+      aur: 'Any AUR helper works. yay -S dbflux is equivalent.',
+      deb: 'Swap amd64 for arm64 on ARM machines. The .rpm installs the same way with dnf.',
+      appimage: 'Fully portable. Nothing is written outside your home directory.',
+      nix: 'The default package is a prebuilt binary. Use #dbflux-source to build from source instead.',
+      dmg: 'The build is not signed with an Apple developer certificate. To skip the dialog: xattr -cr /Applications/DBFlux.app. Requires macOS 11 Big Sur or later.',
+      installer:
+        'The executable is not signed with a Windows code signing certificate. Requires Windows 10 or later on x86_64; ARM64 is not supported yet.',
+      portable: 'Nothing is installed and nothing is written outside the folder you extract into.',
+    },
+    steps: {
+      dmg: [
+        'Download dbflux-macos-arm64.dmg for Apple Silicon, or dbflux-macos-amd64.dmg for Intel.',
+        'Open the DMG and drag DBFlux to Applications.',
+        'On the "unidentified developer" warning, go to System Settings → Privacy & Security and click Open Anyway.',
+      ],
+      installer: [
+        'Download dbflux-windows-amd64-setup.exe.',
+        'Run it and follow the wizard.',
+        'If SmartScreen warns, choose More info → Run anyway.',
+      ],
+      portable: ['Download dbflux-windows-amd64.zip.', 'Extract it anywhere.', 'Run dbflux.exe.'],
+    },
+  },
+  about: {
+    page_title: 'About DBFlux',
+    page_description:
+      'Why DBFlux exists, the principles behind it, and how the codebase is put together.',
+    h1: 'Why DBFlux exists',
+    intro_p1:
+      'Every database client eventually asks you to pick a side: the fast native one that speaks a single engine, or the universal one that speaks all of them and makes you wait. DBFlux takes the third option — one driver-neutral core, drivers that plug into it, and a UI that never learns the name of any of them.',
+    intro_p2:
+      'That constraint is enforced in the code, not in a style guide. The interface adapts through capability flags and metadata, so a document store gets a document view and a time-series store gets a range picker without a single branch on a driver name. Adding a database is writing a driver, not patching the app.',
+    intro_p3:
+      'The long-term goal is stated plainly on the README: a fully open-source alternative to DBeaver. Rust and GPUI are how it stays fast enough to be worth switching to.',
+    principles_eyebrow: 'Principles',
+    principle: {
+      p01: {
+        title: 'Keyboard before pointer',
+        body: 'If an action exists, it has a binding and a command-palette entry. The mouse is a fallback, and no workflow depends on it.',
+      },
+      p02: {
+        title: "The UI never knows a driver's name",
+        body: 'Category, query language and capability flags decide what renders. A driver that needs new behaviour adds a seam to the core rather than a special case to the interface.',
+      },
+      p03: {
+        title: 'Dense over decorative',
+        body: 'Square corners, hairline borders, one accent colour, monospace throughout. Screen space belongs to your data.',
+      },
+      p04: {
+        title: 'Nothing runs unrecorded',
+        body: 'Queries, hooks, scripts and AI tool calls all write to the same audit log, redacted by default and yours alone — it never leaves the machine.',
+      },
+    },
+    layers_eyebrow: 'How it is put together',
+    layer: {
+      ui: {
+        detail: 'Six crates, zero driver dependencies and zero per-driver feature flags.',
+      },
+      app: {
+        detail: 'Registers drivers, resolves RPC services, owns connection state.',
+      },
+      core: {
+        detail:
+          'DbDriver, Connection, capabilities, metadata, language services, query generators.',
+      },
+      drivers: {
+        detail: 'Twelve built in as Rust crates; anything else over the RPC driver protocol.',
+      },
+    },
+    muted_links:
+      'The full crate map and the cross-crate flows live in the architecture guide. If you want to write a driver, start with driver authoring.',
+    maintainer_title: 'Maintainer',
+    maintainer_body:
+      'Ignacio Perez, a backend and systems developer working in Rust and C. DBFlux is his, and the great majority of its commits are too.',
+    contribute_title: 'Contribute',
+    contribute_body:
+      'Issues, drivers and docs are all welcome. The contributing guide covers the checks a pull request has to pass before review.',
+    contribute_link: 'Read the contributing guide →',
+  },
+  notfound: {
+    title: 'That page does not exist.',
+    lede: 'It may have been renamed, or it may belong to a version of DBFlux other than the one you were reading.',
+    docs_button: 'Documentation',
+    home_button: 'Home',
+    versions_label: 'Documentation by version:',
+  },
+  banner: {
+    skip_link: 'Skip to content',
+  },
+} satisfies Dictionary;

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -32,9 +32,10 @@ export const en = {
     move: 'move',
     open: 'open',
     close: 'close',
-    no_results: 'No page matches "{query}".',
+    no_results: 'No page matches “{query}”.',
     unavailable: 'Search is unavailable right now.',
-    result_count: '{n} result(s)',
+    result_count_one: '{n} result',
+    result_count_other: '{n} results',
   },
   versions: {
     label: 'Version',
@@ -55,10 +56,10 @@ export const en = {
   docs_index: {
     title: 'Documentation',
     intro:
-      "Every page here is rendered from the markdown in the repository's docs/ directory, so a change in behaviour and the paragraph describing it ship in the same commit.",
+      'Every page here is rendered from the markdown in the repository’s <code>docs/</code> directory, so a change in behaviour and the paragraph describing it ship in the same commit.',
     unfiled_title: 'Not yet filed',
     unfiled_body:
-      'These pages exist in this version but have no place in the reading order declared in src/data/nav.ts.',
+      'These pages exist in this version but have no place in the reading order declared in <code>src/data/nav.ts</code>.',
   },
   landing: {
     title: 'Every database you run, in one keyboard-driven window.',

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -32,9 +32,10 @@ export const es: Dictionary = {
     move: 'mover',
     open: 'abrir',
     close: 'cerrar',
-    no_results: 'Ninguna página coincide con "{query}".',
+    no_results: 'Ninguna página coincide con “{query}”.',
     unavailable: 'La búsqueda no está disponible en este momento.',
-    result_count: '{n} resultado(s)',
+    result_count_one: '{n} resultado',
+    result_count_other: '{n} resultados',
   },
   versions: {
     label: 'Versión',
@@ -55,10 +56,10 @@ export const es: Dictionary = {
   docs_index: {
     title: 'Documentación',
     intro:
-      'Cada página aquí se genera a partir del markdown del directorio docs/ del repositorio, así que un cambio de comportamiento y el párrafo que lo describe se publican en el mismo commit.',
+      'Cada página aquí se genera a partir del markdown del directorio <code>docs/</code> del repositorio, así que un cambio de comportamiento y el párrafo que lo describe se publican en el mismo commit.',
     unfiled_title: 'Sin clasificar',
     unfiled_body:
-      'Estas páginas existen en esta versión pero no tienen un lugar en el orden de lectura declarado en src/data/nav.ts.',
+      'Estas páginas existen en esta versión pero no tienen un lugar en el orden de lectura declarado en <code>src/data/nav.ts</code>.',
   },
   landing: {
     title: 'Todas las bases de datos que usas, en una sola ventana controlada por teclado.',

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -1,0 +1,243 @@
+import type { Dictionary } from './index';
+
+export const es: Dictionary = {
+  nav: {
+    features: 'Funciones',
+    drivers: 'Drivers',
+    docs: 'Documentación',
+    about: 'Acerca de',
+    github: 'GitHub',
+    download: 'Descargar',
+    menu: 'Menú',
+    switch_locale: 'English',
+  },
+  footer: {
+    product: 'Producto',
+    features: 'Funciones',
+    drivers: 'Drivers',
+    releases: 'Versiones',
+    docs: 'Documentación',
+    usage: 'Guía de uso',
+    connecting: 'Conexión',
+    mcp: 'IA + MCP',
+    project: 'Proyecto',
+    about: 'Acerca de',
+    contributing: 'Cómo contribuir',
+    source: 'Código fuente',
+    tagline: 'Una alternativa totalmente de código abierto a DBeaver, desarrollada en abierto.',
+    license: 'MIT o Apache-2.0, a tu elección.',
+  },
+  search: {
+    placeholder: 'Busca en la documentación',
+    move: 'mover',
+    open: 'abrir',
+    close: 'cerrar',
+    no_results: 'Ninguna página coincide con "{query}".',
+    unavailable: 'La búsqueda no está disponible en este momento.',
+    result_count: '{n} resultado(s)',
+  },
+  versions: {
+    label: 'Versión',
+    index_tag_title: 'Esta página no existe en esa versión',
+    index_tag: 'índice',
+    default_tag: 'predeterminada',
+  },
+  docs_tree: {
+    search_cta: 'Busca en la documentación',
+    rail_toggle: 'Menú de documentación',
+    on_this_page: 'En esta página',
+    crumb_docs: 'Documentación',
+    crumb_overview: 'Resumen',
+    edit_page: 'Editar esta página',
+    report_issue: 'Reportar un problema',
+    not_translated: 'Esta página aún no está traducida. Se muestra la versión en inglés.',
+  },
+  docs_index: {
+    title: 'Documentación',
+    intro:
+      'Cada página aquí se genera a partir del markdown del directorio docs/ del repositorio, así que un cambio de comportamiento y el párrafo que lo describe se publican en el mismo commit.',
+    unfiled_title: 'Sin clasificar',
+    unfiled_body:
+      'Estas páginas existen en esta versión pero no tienen un lugar en el orden de lectura declarado en src/data/nav.ts.',
+  },
+  landing: {
+    title: 'Todas las bases de datos que usas, en una sola ventana controlada por teclado.',
+    lede: 'Una plataforma de datos extensible y centrada en el teclado. Doce drivers integrados, un núcleo neutral respecto al driver, y lo que necesites además a través del protocolo RPC de drivers.',
+    download_linux: 'Descargar para Linux',
+    download_macos: 'Descargar para macOS',
+    download_windows: 'Descargar para Windows',
+    view_source: 'Ver código fuente',
+    platforms_meta: 'Linux · macOS · Windows — MIT o Apache-2.0',
+    hero_caption: 'Servidor principal — SELECT * FROM public.transactions (1.5s)',
+    hero_alt:
+      'DBFlux con un árbol de conexión abierto, mostrando bases de datos, esquemas, rutinas y métricas de instancia de un servidor PostgreSQL.',
+    drivers_eyebrow: 'Drivers integrados',
+    drivers_link: 'Matriz de capacidades →',
+    drivers_note:
+      'Los almacenes relacionales, de documentos, clave-valor, de series temporales y de objetos comparten una misma cuadrícula de resultados, un motor de gráficos y un registro de auditoría. Los drivers externos se registran mediante el protocolo RPC sin necesidad de un fork.',
+    features_eyebrow: 'Qué obtienes',
+    feature: {
+      editor: {
+        title: 'Editor consciente del dialecto',
+        body: 'El autocompletado, la validación y la detección de sentencias peligrosas provienen del driver, no de una suposición compartida. Un DELETE sin WHERE se detecta antes de ejecutarse.',
+      },
+      grid: {
+        title: 'Cuadrícula de resultados editable',
+        body: 'Edita celdas directamente cuando el resultado se corresponde con una sola tabla, navega por millones de filas mediante keyset, y copia cualquier selección como una query nativa.',
+      },
+      charts: {
+        title: 'Gráficos y dashboards',
+        body: 'Convierte cualquier resultado en un gráfico, guárdalo y fíjalo en un dashboard junto a las métricas de instancia de la misma conexión.',
+      },
+      hooks: {
+        title: 'Hooks de conexión',
+        body: 'Ejecuta un comando, un script o Lua en proceso alrededor de la conexión y desconexión, con salida en vivo en el panel de tareas y una política de fallo que eliges.',
+      },
+      reach: {
+        title: 'Llega a todo',
+        body: 'Los túneles SSH, los proxies HTTP y AWS SSO son de primera clase. Los secretos viven en el keyring del sistema operativo, nunca en el archivo de perfil.',
+      },
+      audit: {
+        title: 'Auditable por defecto',
+        body: 'Las queries, hooks, scripts y llamadas MCP escriben en el mismo registro de eventos, con redacción y retención que tú controlas.',
+      },
+    },
+    keyboard_eyebrow: 'Basado en teclado',
+    keyboard_title: 'El ratón es opcional, no obligatorio.',
+    keyboard_body:
+      'Cada superficie tiene un atajo y una entrada en la paleta de comandos: abrir una conexión, ejecutar una sentencia, saltar a una tabla, convertir un resultado en gráfico. El estado vacío te muestra los cuatro que necesitas el primer día.',
+    keyboard_link: 'Referencia completa de teclado →',
+    shortcut: {
+      new_query: 'nueva query',
+      command_palette: 'paleta de comandos',
+      open_script: 'abrir script desde disco',
+      new_connection: 'nueva conexión',
+    },
+    governance_eyebrow: 'Gobernanza',
+    governance_title: 'Dale a un cliente de IA una conexión, no tu base de datos.',
+    governance_body:
+      'El servidor MCP clasifica cada operación — metadata, lectura, escritura, destructiva, administrativa — y un motor de políticas decide por rol y por conexión. Las llamadas de escritura y destructivas pueden requerir aprobación humana.',
+    audit_eyebrow: 'Auditoría',
+    audit_title: 'Cada query, hook y llamada de herramienta, registrada.',
+    audit_body:
+      'Los eventos se registran en un log local de SQLite con categoría, severidad, actor y resultado. El texto de la query se guarda como huella, no en claro; los valores sensibles se redactan, y el log completo se exporta a JSON o CSV.',
+    docs_eyebrow: 'Documentación',
+    docs_link: 'Todas las guías →',
+    doc_card: {
+      usage: {
+        title: 'Guía de uso',
+        body: 'Primer arranque, creación de una conexión, ejecución de queries, exploración de resultados, gráficos y exportación.',
+      },
+      connecting: {
+        title: 'Conexión',
+        body: 'Túneles SSH, proxies, AWS SSO y fuentes de valores para todo lo que no sea un host y puerto simples.',
+      },
+      mcp: {
+        title: 'IA + MCP',
+        body: 'Conecta un cliente de IA a DBFlux y define los roles, políticas y aprobaciones que lo mantienen dentro de los límites.',
+      },
+    },
+  },
+  install: {
+    all_downloads: 'Todas las descargas →',
+    copy: 'copiar',
+    copied: 'copiado',
+    copy_fallback: 'usa ctrl+c',
+    hint: {
+      tarball:
+        '¿Prefieres no usar sudo? Añade -s -- --prefix ~/.local para instalar en tu directorio home.',
+      aur: 'Funciona cualquier ayudante de AUR. yay -S dbflux es equivalente.',
+      deb: 'Cambia amd64 por arm64 en máquinas ARM. El .rpm se instala igual con dnf.',
+      appimage: 'Totalmente portable. No se escribe nada fuera de tu directorio home.',
+      nix: 'El paquete por defecto es un binario precompilado. Usa #dbflux-source para compilar desde el código fuente.',
+      dmg: 'El build no está firmado con un certificado de desarrollador de Apple. Para omitir el diálogo: xattr -cr /Applications/DBFlux.app. Requiere macOS 11 Big Sur o posterior.',
+      installer:
+        'El ejecutable no está firmado con un certificado de firma de código de Windows. Requiere Windows 10 o posterior en x86_64; ARM64 aún no es compatible.',
+      portable: 'No se instala nada y no se escribe nada fuera de la carpeta donde extraes.',
+    },
+    steps: {
+      dmg: [
+        'Descarga dbflux-macos-arm64.dmg para Apple Silicon, o dbflux-macos-amd64.dmg para Intel.',
+        'Abre el DMG y arrastra DBFlux a Aplicaciones.',
+        'En el aviso de "desarrollador no identificado", ve a Ajustes del Sistema → Privacidad y Seguridad y pulsa Abrir de todos modos.',
+      ],
+      installer: [
+        'Descarga dbflux-windows-amd64-setup.exe.',
+        'Ejecútalo y sigue el asistente.',
+        'Si SmartScreen avisa, elige Más información → Ejecutar de todos modos.',
+      ],
+      portable: [
+        'Descarga dbflux-windows-amd64.zip.',
+        'Extráelo donde quieras.',
+        'Ejecuta dbflux.exe.',
+      ],
+    },
+  },
+  about: {
+    page_title: 'Acerca de DBFlux',
+    page_description:
+      'Por qué existe DBFlux, los principios detrás de él, y cómo está construido el código.',
+    h1: 'Por qué existe DBFlux',
+    intro_p1:
+      'Todo cliente de bases de datos termina por pedirte que elijas un bando: el nativo rápido que habla un único motor, o el universal que habla todos ellos y te hace esperar. DBFlux toma la tercera opción — un núcleo neutral respecto al driver, drivers que se conectan a él, y una interfaz que nunca aprende el nombre de ninguno de ellos.',
+    intro_p2:
+      'Esa restricción se aplica en el código, no en una guía de estilo. La interfaz se adapta mediante flags de capacidades y metadatos, de modo que un almacén de documentos obtiene una vista de documentos y una fuente de series temporales obtiene un selector de rango sin una sola condición sobre el nombre del driver. Añadir una base de datos es escribir un driver, no parchear la aplicación.',
+    intro_p3:
+      'El objetivo a largo plazo se declara sin rodeos en el README: una alternativa totalmente de código abierto a DBeaver. Rust y GPUI son lo que lo mantienen lo bastante rápido como para valer la pena cambiarse.',
+    principles_eyebrow: 'Principios',
+    principle: {
+      p01: {
+        title: 'El teclado antes que el puntero',
+        body: 'Si una acción existe, tiene un atajo y una entrada en la paleta de comandos. El ratón es un respaldo, y ningún flujo de trabajo depende de él.',
+      },
+      p02: {
+        title: 'La interfaz nunca conoce el nombre de un driver',
+        body: 'La categoría, el lenguaje de consulta y los flags de capacidades deciden qué se renderiza. Un driver que necesita un comportamiento nuevo añade un punto de extensión al núcleo en lugar de un caso especial a la interfaz.',
+      },
+      p03: {
+        title: 'Denso antes que decorativo',
+        body: 'Esquinas cuadradas, bordes finos, un solo color de acento, monoespaciado en todas partes. El espacio en pantalla pertenece a tus datos.',
+      },
+      p04: {
+        title: 'Nada se ejecuta sin quedar registrado',
+        body: 'Las queries, hooks, scripts y llamadas de herramientas de IA escriben todas en el mismo registro de auditoría, redactado por defecto y solo tuyo — nunca sale de la máquina.',
+      },
+    },
+    layers_eyebrow: 'Cómo está construido',
+    layer: {
+      ui: {
+        detail: 'Seis crates, cero dependencias de driver y cero feature flags por driver.',
+      },
+      app: {
+        detail: 'Registra drivers, resuelve servicios RPC, gestiona el estado de conexión.',
+      },
+      core: {
+        detail:
+          'DbDriver, Connection, capabilities, metadata, language services, query generators.',
+      },
+      drivers: {
+        detail:
+          'Doce integrados como crates de Rust; cualquier otro a través del protocolo RPC de drivers.',
+      },
+    },
+    muted_links:
+      'El mapa completo de crates y los flujos entre crates viven en la guía de arquitectura. Si quieres escribir un driver, empieza por la guía de autoría de drivers.',
+    maintainer_title: 'Mantenedor',
+    maintainer_body:
+      'Ignacio Perez, desarrollador backend y de sistemas que trabaja en Rust y C. DBFlux es suyo, y la gran mayoría de sus commits también.',
+    contribute_title: 'Contribuir',
+    contribute_body:
+      'Se aceptan issues, drivers y documentación. La guía de contribución cubre las verificaciones que debe pasar un pull request antes de la revisión.',
+    contribute_link: 'Lee la guía de contribución →',
+  },
+  notfound: {
+    title: 'Esa página no existe.',
+    lede: 'Puede que haya sido renombrada, o que pertenezca a una versión de DBFlux distinta a la que estabas leyendo.',
+    docs_button: 'Documentación',
+    home_button: 'Inicio',
+    versions_label: 'Documentación por versión:',
+  },
+  banner: {
+    skip_link: 'Saltar al contenido',
+  },
+};

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -48,7 +48,8 @@ export interface Dictionary {
     close: string;
     no_results: string;
     unavailable: string;
-    result_count: string;
+    result_count_one: string;
+    result_count_other: string;
   };
   versions: {
     label: string;

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -1,0 +1,222 @@
+import { en } from './en';
+import { es } from './es';
+
+export type Locale = 'en' | 'es';
+
+export const LOCALES: readonly Locale[] = ['en', 'es'];
+
+export const DEFAULT_LOCALE: Locale = 'en';
+
+/**
+ * The complete shape of every chrome string the site renders.
+ *
+ * `en.ts` is the canonical `satisfies Dictionary` object. `es.ts` is typed
+ * `Dictionary` directly (not `satisfies`), so a key missing from the Spanish
+ * dictionary is a compile error rather than a silently widened type.
+ */
+export interface Dictionary {
+  nav: {
+    features: string;
+    drivers: string;
+    docs: string;
+    about: string;
+    github: string;
+    download: string;
+    menu: string;
+    switch_locale: string;
+  };
+  footer: {
+    product: string;
+    features: string;
+    drivers: string;
+    releases: string;
+    docs: string;
+    usage: string;
+    connecting: string;
+    mcp: string;
+    project: string;
+    about: string;
+    contributing: string;
+    source: string;
+    tagline: string;
+    license: string;
+  };
+  search: {
+    placeholder: string;
+    move: string;
+    open: string;
+    close: string;
+    no_results: string;
+    unavailable: string;
+    result_count: string;
+  };
+  versions: {
+    label: string;
+    index_tag_title: string;
+    index_tag: string;
+    default_tag: string;
+  };
+  docs_tree: {
+    search_cta: string;
+    rail_toggle: string;
+    on_this_page: string;
+    crumb_docs: string;
+    crumb_overview: string;
+    edit_page: string;
+    report_issue: string;
+    not_translated: string;
+  };
+  docs_index: {
+    title: string;
+    intro: string;
+    unfiled_title: string;
+    unfiled_body: string;
+  };
+  landing: {
+    title: string;
+    lede: string;
+    download_linux: string;
+    download_macos: string;
+    download_windows: string;
+    view_source: string;
+    platforms_meta: string;
+    hero_caption: string;
+    hero_alt: string;
+    drivers_eyebrow: string;
+    drivers_link: string;
+    drivers_note: string;
+    features_eyebrow: string;
+    feature: {
+      editor: { title: string; body: string };
+      grid: { title: string; body: string };
+      charts: { title: string; body: string };
+      hooks: { title: string; body: string };
+      reach: { title: string; body: string };
+      audit: { title: string; body: string };
+    };
+    keyboard_eyebrow: string;
+    keyboard_title: string;
+    keyboard_body: string;
+    keyboard_link: string;
+    shortcut: {
+      new_query: string;
+      command_palette: string;
+      open_script: string;
+      new_connection: string;
+    };
+    governance_eyebrow: string;
+    governance_title: string;
+    governance_body: string;
+    audit_eyebrow: string;
+    audit_title: string;
+    audit_body: string;
+    docs_eyebrow: string;
+    docs_link: string;
+    doc_card: {
+      usage: { title: string; body: string };
+      connecting: { title: string; body: string };
+      mcp: { title: string; body: string };
+    };
+  };
+  install: {
+    all_downloads: string;
+    copy: string;
+    copied: string;
+    copy_fallback: string;
+    hint: {
+      tarball: string;
+      aur: string;
+      deb: string;
+      appimage: string;
+      nix: string;
+      dmg: string;
+      installer: string;
+      portable: string;
+    };
+    steps: {
+      dmg: [string, string, string];
+      installer: [string, string, string];
+      portable: [string, string, string];
+    };
+  };
+  about: {
+    page_title: string;
+    page_description: string;
+    h1: string;
+    intro_p1: string;
+    intro_p2: string;
+    intro_p3: string;
+    principles_eyebrow: string;
+    principle: {
+      p01: { title: string; body: string };
+      p02: { title: string; body: string };
+      p03: { title: string; body: string };
+      p04: { title: string; body: string };
+    };
+    layers_eyebrow: string;
+    layer: {
+      ui: { detail: string };
+      app: { detail: string };
+      core: { detail: string };
+      drivers: { detail: string };
+    };
+    muted_links: string;
+    maintainer_title: string;
+    maintainer_body: string;
+    contribute_title: string;
+    contribute_body: string;
+    contribute_link: string;
+  };
+  notfound: {
+    title: string;
+    lede: string;
+    docs_button: string;
+    home_button: string;
+    versions_label: string;
+  };
+  banner: {
+    skip_link: string;
+  };
+}
+
+type DotPaths<T, Prefix extends string = ''> = {
+  [K in keyof T & string]: T[K] extends string ? `${Prefix}${K}` : DotPaths<T[K], `${Prefix}${K}.`>;
+}[keyof T & string];
+
+/** Every dot-delimited key path a `Dictionary` exposes, e.g. `"nav.features"`. */
+export type DictionaryKey = DotPaths<Dictionary>;
+
+const DICTIONARIES: Record<Locale, Dictionary> = { en, es };
+
+/** Resolve a dot-delimited key path against the dictionary for `locale`. */
+export function t(locale: Locale, key: DictionaryKey): string {
+  const segments = key.split('.');
+  let value: unknown = DICTIONARIES[locale];
+
+  for (const segment of segments) {
+    if (typeof value !== 'object' || value === null || !(segment in value)) {
+      throw new Error(`Missing i18n key "${key}" for locale "${locale}"`);
+    }
+
+    value = (value as Record<string, unknown>)[segment];
+  }
+
+  if (typeof value !== 'string') {
+    throw new Error(`i18n key "${key}" does not resolve to a string for locale "${locale}"`);
+  }
+
+  return value;
+}
+
+/**
+ * Derive the active locale from a request path.
+ *
+ * Routing is manual (`i18n.routing: 'manual'`), so the locale is never in
+ * `Astro.currentLocale` — it is read back from the leading `/es/` segment the
+ * same way `[...path].astro` will compute it when emitting that segment.
+ */
+export function localeFromPathname(pathname: string): Locale {
+  const [, first] = pathname.split('/');
+
+  return (LOCALES as readonly string[]).includes(first) ? (first as Locale) : DEFAULT_LOCALE;
+}

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -221,3 +221,20 @@ export function localeFromPathname(pathname: string): Locale {
 
   return (LOCALES as readonly string[]).includes(first) ? (first as Locale) : DEFAULT_LOCALE;
 }
+
+/**
+ * The same pathname with its locale segment swapped, e.g. `/about/` becomes
+ * `/es/about/` for `'es'`, and `/es/about/` becomes `/about/` for `'en'`.
+ *
+ * Used to compute hreflang alternates and the locale switcher target — both
+ * need the equivalent path in another locale without knowing anything about
+ * what kind of page it is.
+ */
+export function withLocale(pathname: string, locale: Locale): string {
+  const current = localeFromPathname(pathname);
+  const rest = current === DEFAULT_LOCALE ? pathname : pathname.slice(current.length + 1) || '/';
+
+  if (locale === DEFAULT_LOCALE) return rest;
+
+  return `/${locale}${rest}`.replace(/\/+/g, '/');
+}

--- a/web/src/integrations/host-redirects.ts
+++ b/web/src/integrations/host-redirects.ts
@@ -2,8 +2,9 @@ import { mkdir, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname } from 'node:path';
 import type { AstroIntegration } from 'astro';
-import { DOCS_MODE, SITE_ORIGIN, docsPath, docsUrl } from '../data/site';
+import { DOCS_MODE, docsPath, docsUrl, siteUrl } from '../data/site';
 import { CURRENT, VERSIONS } from '../data/versions';
+import { DEFAULT_LOCALE, LOCALES } from '../i18n';
 
 /**
  * Tell the two hosts about each other with a status code.
@@ -19,10 +20,15 @@ import { CURRENT, VERSIONS } from '../data/versions';
  */
 function rules(): string[] {
   if (DOCS_MODE === 'site') {
-    const moved = VERSIONS.map((version) => {
+    // Each version gets an English rule and a Spanish rule, one locale-prefixed
+    // pair of paths per version rather than a parallel set of version loops.
+    const moved = VERSIONS.flatMap((version) => {
       const prefix = version.id === CURRENT.id ? '' : version.id;
 
-      return { from: `/${docsPath('', prefix)}`, to: docsUrl('', prefix) };
+      return LOCALES.map((locale) => ({
+        from: `/${docsPath('', prefix, locale)}`,
+        to: docsUrl('', prefix, locale),
+      }));
     });
 
     // Cloudflare matches in file order and asks that the static rules come
@@ -36,7 +42,12 @@ function rules(): string[] {
   // The landing pages belong to the site host. This build emits `/about/` only
   // because one source tree builds both; it already canonicalises off-host.
   if (DOCS_MODE === 'docs') {
-    return [`/about ${SITE_ORIGIN}/about/ 301`, `/about/ ${SITE_ORIGIN}/about/ 301`];
+    return LOCALES.flatMap((locale) => {
+      const prefix = locale === DEFAULT_LOCALE ? '' : `/${locale}`;
+      const target = siteUrl('about/', locale);
+
+      return [`${prefix}/about ${target} 301`, `${prefix}/about/ ${target} 301`];
+    });
   }
 
   return [];

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -5,7 +5,7 @@ import BackToTop from '../components/BackToTop.astro';
 import Mermaid from '../components/Mermaid.astro';
 import SearchDialog from '../components/SearchDialog.astro';
 import { ORIGIN } from '../data/site';
-import { localeFromPathname, t } from '../i18n';
+import { DEFAULT_LOCALE, LOCALES, localeFromPathname, t, withLocale } from '../i18n';
 import type { Locale } from '../i18n';
 import '../styles/global.css';
 
@@ -22,6 +22,13 @@ interface Props {
   searchIndex?: string;
   /** Active locale. Derived from the URL when the caller does not know it yet. */
   locale?: Locale;
+  /**
+   * Whether this exact page exists in every locale, not just as an English
+   * fallback. Only `true` for `/` and `/es/` today — doc pages get this once
+   * the locale-aware docs pipeline (W2a) can say per page whether a Spanish
+   * translation exists.
+   */
+  translated?: boolean;
 }
 
 const {
@@ -33,6 +40,7 @@ const {
   canonicalPath,
   searchIndex = '/search-index.json',
   locale = localeFromPathname(Astro.url.pathname),
+  translated = false,
 } = Astro.props;
 // Astro.site is unset when the config fails to load, and a crashed canonical tag
 // should not take the whole page down with it.
@@ -45,6 +53,20 @@ const canonical = canonicalPath?.startsWith('http')
 // Open Graph rejects a relative image: the crawler resolves it against nothing
 // and the preview falls back to a blank card.
 const socialImage = new URL('/brand/og-card.jpg', ORIGIN).href;
+
+/**
+ * hreflang pairs, only for a page the caller has confirmed exists in every
+ * locale (`translated`). hreflang requires absolute URLs, so this stays empty
+ * without `Astro.site` — same guard as `canonical` above.
+ */
+const alternateHref = (target: Locale) =>
+  Astro.site ? new URL(withLocale(Astro.url.pathname, target), Astro.site).href : undefined;
+
+const alternates =
+  translated && Astro.site
+    ? LOCALES.map((target) => ({ hreflang: target, href: alternateHref(target)! }))
+    : [];
+const xDefaultHref = translated ? alternateHref(DEFAULT_LOCALE) : undefined;
 ---
 
 <!doctype html>
@@ -55,6 +77,8 @@ const socialImage = new URL('/brand/og-card.jpg', ORIGIN).href;
     <title>{title}</title>
     <meta name="description" content={description} />
     {canonical && <link rel="canonical" href={canonical} />}
+    {alternates.map((alt) => <link rel="alternate" hreflang={alt.hreflang} href={alt.href} />)}
+    {xDefaultHref && <link rel="alternate" hreflang="x-default" href={xDefaultHref} />}
     {noindex && <meta name="robots" content="noindex, follow" />}
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -90,11 +90,11 @@ const socialImage = new URL('/brand/og-card.jpg', ORIGIN).href;
   </head>
   <body data-wide={wide ? '' : undefined}>
     <a class="skip-link" href="#main">{t(locale, 'banner.skip_link')}</a>
-    <SiteNav current={current} />
+    <SiteNav current={current} locale={locale} />
     <main id="main"><slot /></main>
-    <SiteFooter />
+    <SiteFooter locale={locale} />
     <BackToTop />
     <Mermaid />
-    <SearchDialog indexUrl={searchIndex} />
+    <SearchDialog indexUrl={searchIndex} locale={locale} />
   </body>
 </html>

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -5,6 +5,8 @@ import BackToTop from '../components/BackToTop.astro';
 import Mermaid from '../components/Mermaid.astro';
 import SearchDialog from '../components/SearchDialog.astro';
 import { ORIGIN } from '../data/site';
+import { localeFromPathname, t } from '../i18n';
+import type { Locale } from '../i18n';
 import '../styles/global.css';
 
 interface Props {
@@ -18,6 +20,8 @@ interface Props {
   canonicalPath?: string;
   /** Which search index this page's dialog should load. */
   searchIndex?: string;
+  /** Active locale. Derived from the URL when the caller does not know it yet. */
+  locale?: Locale;
 }
 
 const {
@@ -28,6 +32,7 @@ const {
   noindex = false,
   canonicalPath,
   searchIndex = '/search-index.json',
+  locale = localeFromPathname(Astro.url.pathname),
 } = Astro.props;
 // Astro.site is unset when the config fails to load, and a crashed canonical tag
 // should not take the whole page down with it.
@@ -43,7 +48,7 @@ const socialImage = new URL('/brand/og-card.jpg', ORIGIN).href;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={locale}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -84,7 +89,7 @@ const socialImage = new URL('/brand/og-card.jpg', ORIGIN).href;
     />
   </head>
   <body data-wide={wide ? '' : undefined}>
-    <a class="skip-link" href="#main">Skip to content</a>
+    <a class="skip-link" href="#main">{t(locale, 'banner.skip_link')}</a>
     <SiteNav current={current} />
     <main id="main"><slot /></main>
     <SiteFooter />

--- a/web/src/layouts/DocsLayout.astro
+++ b/web/src/layouts/DocsLayout.astro
@@ -6,6 +6,8 @@ import { docTitle } from '../data/nav';
 import type { DocsVersion } from '../data/versions';
 import { CURRENT, versionHome, versionLabel } from '../data/versions';
 import { docsUrl } from '../data/site';
+import { localeFromPathname, t } from '../i18n';
+import type { Locale } from '../i18n';
 
 interface Heading {
   depth: number;
@@ -22,6 +24,7 @@ interface Props {
   title: string;
   description: string;
   editPath?: string;
+  locale?: Locale;
 }
 
 const {
@@ -32,6 +35,7 @@ const {
   title,
   description,
   editPath,
+  locale = localeFromPathname(Astro.url.pathname),
 } = Astro.props;
 const onThisPage = headings.filter((heading) => heading.depth === 2);
 
@@ -53,6 +57,7 @@ const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '');
   noindex={version.noindex}
   canonicalPath={canonicalPath}
   searchIndex={isCurrent ? '/search-index.json' : `/${version.id}/search-index.json`}
+  locale={locale}
 >
   <div class="docs">
     <button
@@ -62,20 +67,22 @@ const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '');
       aria-expanded="false"
       aria-controls="docs-rail"
     >
-      <span>Documentation menu</span>
+      <span>{t(locale, 'docs_tree.rail_toggle')}</span>
       <span class="docs__railtoggle-mark" aria-hidden="true"></span>
     </button>
 
     <aside class="docs__rail" id="docs-rail">
-      <VersionPicker version={version} currentPath={currentPath} />
-      <DocsTree version={version} current={currentPath} available={available} />
+      <VersionPicker version={version} currentPath={currentPath} locale={locale} />
+      <DocsTree version={version} current={currentPath} available={available} locale={locale} />
     </aside>
 
     <article class="docs__body">
       <p class="crumbs">
-        <a href={versionHome(version)}>Docs</a>
+        <a href={versionHome(version)}>{t(locale, 'docs_tree.crumb_docs')}</a>
         <span>/</span>
-        <span class="crumbs__here">{currentPath ? docTitle(currentPath) : 'Overview'}</span>
+        <span class="crumbs__here">
+          {currentPath ? docTitle(currentPath) : t(locale, 'docs_tree.crumb_overview')}
+        </span>
       </p>
       <div class="prose"><slot /></div>
     </article>
@@ -83,8 +90,8 @@ const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '');
     <aside class="docs__toc">
       {
         onThisPage.length > 0 && (
-          <nav aria-label="On this page" data-toc>
-            <p class="toc__title">On this page</p>
+          <nav aria-label={t(locale, 'docs_tree.on_this_page')} data-toc>
+            <p class="toc__title">{t(locale, 'docs_tree.on_this_page')}</p>
             <ul>
               {onThisPage.map((heading) => (
                 <li>
@@ -104,10 +111,10 @@ const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '');
               href={`https://github.com/0xErwin1/dbflux/blob/main/docs/${editPath}`}
               rel="noopener"
             >
-              Edit this page
+              {t(locale, 'docs_tree.edit_page')}
             </a>
             <a href="https://github.com/0xErwin1/dbflux/issues/new" rel="noopener">
-              Report an issue
+              {t(locale, 'docs_tree.report_issue')}
             </a>
           </div>
         )

--- a/web/src/layouts/DocsLayout.astro
+++ b/web/src/layouts/DocsLayout.astro
@@ -25,6 +25,8 @@ interface Props {
   description: string;
   editPath?: string;
   locale?: Locale;
+  /** Forwarded to `Base` — see its `translated` prop. Only the docs index is today. */
+  translated?: boolean;
 }
 
 const {
@@ -36,6 +38,7 @@ const {
   description,
   editPath,
   locale = localeFromPathname(Astro.url.pathname),
+  translated = false,
 } = Astro.props;
 const onThisPage = headings.filter((heading) => heading.depth === 2);
 
@@ -45,8 +48,10 @@ const suffix = isCurrent ? '' : ` (${versionLabel(version)})`;
 /**
  * Older and unreleased versions point at the current release, so a search engine
  * ranks the version most readers are running rather than whichever it crawled.
+ * The version canonical and the locale prefix are independent axes, so the
+ * active locale is passed through rather than always resolving to English.
  */
-const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '');
+const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '', undefined, locale);
 ---
 
 <Base
@@ -58,6 +63,7 @@ const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '');
   canonicalPath={canonicalPath}
   searchIndex={isCurrent ? '/search-index.json' : `/${version.id}/search-index.json`}
   locale={locale}
+  translated={translated}
 >
   <div class="docs">
     <button

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,10 @@
+import { defineMiddleware } from 'astro/middleware';
+
+/**
+ * `i18n.routing: 'manual'` disables Astro's built-in i18n middleware and
+ * requires the project to provide its own — even for a fully static build,
+ * where locale is already baked into each generated path and there is no
+ * per-request detection to do. This middleware exists to satisfy that
+ * requirement; it does no locale work itself.
+ */
+export const onRequest = defineMiddleware((_context, next) => next());

--- a/web/src/pages/es/index.astro
+++ b/web/src/pages/es/index.astro
@@ -24,6 +24,7 @@ const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CU
       title="Documentation"
       description="Guides for installing, connecting, querying, charting and governing DBFlux."
       locale="es"
+      translated
     >
       <DocsIndex versionId={CURRENT.id} available={available} locale="es" />
     </DocsLayout>
@@ -33,6 +34,7 @@ const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CU
       description="An extensible, keyboard-first data platform for Postgres, MySQL, SQL Server, MongoDB, Redis, DynamoDB and more. Open source, built in Rust on GPUI."
       current="home"
       locale="es"
+      translated
     >
       <Landing />
     </Base>

--- a/web/src/pages/es/index.astro
+++ b/web/src/pages/es/index.astro
@@ -9,9 +9,9 @@ import { CURRENT } from '../../data/versions';
 import { DOCS_AT_ROOT } from '../../data/site';
 
 /**
- * The Spanish counterpart of `index.astro`. Chrome components still render in
- * English until they are wired to the dictionary; this route only proves that
- * `/es/` resolves and carries `<html lang="es">`.
+ * The Spanish counterpart of `index.astro`. Documentation pages only exist in
+ * English so far — this route covers the `/es/` landing/index only, ahead of
+ * the locale-aware docs pipeline.
  */
 const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CURRENT.id) : [];
 ---
@@ -23,8 +23,9 @@ const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CU
       available={available}
       title="Documentation"
       description="Guides for installing, connecting, querying, charting and governing DBFlux."
+      locale="es"
     >
-      <DocsIndex versionId={CURRENT.id} available={available} />
+      <DocsIndex versionId={CURRENT.id} available={available} locale="es" />
     </DocsLayout>
   ) : (
     <Base

--- a/web/src/pages/es/index.astro
+++ b/web/src/pages/es/index.astro
@@ -1,0 +1,39 @@
+---
+import { getCollection } from 'astro:content';
+import Base from '../../layouts/Base.astro';
+import DocsLayout from '../../layouts/DocsLayout.astro';
+import DocsIndex from '../../components/DocsIndex.astro';
+import Landing from '../../components/Landing.astro';
+import { pathsForVersion } from '../../data/docs';
+import { CURRENT } from '../../data/versions';
+import { DOCS_AT_ROOT } from '../../data/site';
+
+/**
+ * The Spanish counterpart of `index.astro`. Chrome components still render in
+ * English until they are wired to the dictionary; this route only proves that
+ * `/es/` resolves and carries `<html lang="es">`.
+ */
+const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CURRENT.id) : [];
+---
+
+{
+  DOCS_AT_ROOT ? (
+    <DocsLayout
+      version={CURRENT}
+      available={available}
+      title="Documentation"
+      description="Guides for installing, connecting, querying, charting and governing DBFlux."
+    >
+      <DocsIndex versionId={CURRENT.id} available={available} />
+    </DocsLayout>
+  ) : (
+    <Base
+      title="DBFlux — a keyboard-first database client"
+      description="An extensible, keyboard-first data platform for Postgres, MySQL, SQL Server, MongoDB, Redis, DynamoDB and more. Open source, built in Rust on GPUI."
+      current="home"
+      locale="es"
+    >
+      <Landing />
+    </Base>
+  )
+}

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -22,6 +22,7 @@ const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CU
       available={available}
       title="Documentation"
       description="Guides for installing, connecting, querying, charting and governing DBFlux."
+      translated
     >
       <DocsIndex versionId={CURRENT.id} available={available} />
     </DocsLayout>
@@ -30,6 +31,7 @@ const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CU
       title="DBFlux — a keyboard-first database client"
       description="An extensible, keyboard-first data platform for Postgres, MySQL, SQL Server, MongoDB, Redis, DynamoDB and more. Open source, built in Rust on GPUI."
       current="home"
+      translated
     >
       <Landing />
     </Base>


### PR DESCRIPTION
## Summary

Website i18n, phase 1 in three commits: (1) Astro `i18n` foundation — `routing: 'manual'`, default `en`, locales `en`/`es`, typed dictionaries `web/src/i18n/{en,es}.ts` sharing one `Dictionary` shape so `pnpm check` fails on any missing key, `t(locale, key)`, `Base.astro` derives the locale from the URL and sets `<html lang>`, `/es/` landing route, required no-op middleware; (2) every chrome component (SiteNav, SiteFooter, SearchDialog, VersionPicker, DocsTree, DocsIndex, DocsLayout) reads the dictionary and the nav gains a language switcher (home page only until the `/es/` doc routes exist); (3) SEO — hreflang pairs gated by a `translated` prop, `@astrojs/sitemap` i18n alternates, locale-aware canonical orthogonal to the version canonical, `docsUrl()/siteUrl()/docsPath()` gain a `locale` parameter, and split-mode `_redirects` cover `/es/…`.

English output stays byte-identical (checked against `dist/`); `/es/` renders Spanish chrome with `<html lang="es">`.

## What does this resolve?

- Refs #360 (website phase 1 of 4; next: the docs pipeline with English fallback + "not yet translated" notice)

## How was this solved?

- `routing: 'manual'` because the site's catch-all `getStaticPaths` route generator does not fit Astro's file-based locale routing; Astro then requires a `src/middleware.ts` even for a static build.
- Dynamic client strings in SearchDialog travel via a JSON island (`define:vars` forces `is:inline` and breaks `astro check`).
- Size: ~1130 lines across the three commits, ~700 of them the dictionaries (`size:exception`).

## Validation

- `pnpm check` → 0 errors (deleting any `es` key fails with ts(2741)); `pnpm build` → 96 pages; `pnpm build:site` / `pnpm build:docs` green with `/es/` redirect pairs in `_redirects`; `node scripts/check-links.mjs` → ok. Sitemap carries `hreflang` pairs only for `/` and `/es/`.
- Receipt-driven review: skipped for these candidates (native review store lost lineages after a machine reboot; candidate-scoped declines, defect not reported per user decision).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` (consolidated entry when the web series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
