### PR TITLE
feat(web): route every doc under /es/ with an English fallback notice and noindex

### DIFF
--- a/web/scripts/fetch-docs.mjs
+++ b/web/scripts/fetch-docs.mjs
@@ -20,7 +20,7 @@ export const VERSIONS_DIR = join(WEB, '.versions');
 
 /** Paths every version contributes, matching the collection in content.config.ts. */
 const WANTED =
-  /^(docs\/[^/]+\.md|ARCHITECTURE\.md|CONTRIBUTING\.md|crates\/dbflux_driver_[^/]+\/README\.md)$/;
+  /^(docs\/[^/]+\.md|docs\/es\/[^/]+\.md|ARCHITECTURE\.md|CONTRIBUTING\.md|crates\/dbflux_driver_[^/]+\/README\.md)$/;
 
 const git = (args) =>
   execFileSync('git', args, { cwd: REPO, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });

--- a/web/src/components/DocsIndex.astro
+++ b/web/src/components/DocsIndex.astro
@@ -24,7 +24,7 @@ const { sections, unfiled } = sectionsFor(available);
       <ul>
         {section.entries.map((path) => (
           <li>
-            <a href={docsHref(`${versionId}/${path}`)}>{docTitle(path)}</a>
+            <a href={docsHref(`${versionId}/${path}`, locale)}>{docTitle(path)}</a>
           </li>
         ))}
       </ul>
@@ -40,7 +40,7 @@ const { sections, unfiled } = sectionsFor(available);
       <ul>
         {unfiled.map((path) => (
           <li>
-            <a href={docsHref(`${versionId}/${path}`)}>{path}</a>
+            <a href={docsHref(`${versionId}/${path}`, locale)}>{path}</a>
           </li>
         ))}
       </ul>

--- a/web/src/components/DocsTree.astro
+++ b/web/src/components/DocsTree.astro
@@ -50,7 +50,7 @@ const sections = sectionsFor(available).sections.map((section) => ({
               {section.entries.map((id) => (
                 <li>
                   <a
-                    href={docsHref(`${version.id}/${id}`)}
+                    href={docsHref(`${version.id}/${id}`, locale)}
                     aria-current={id === current ? 'page' : undefined}
                   >
                     {docTitle(id)}

--- a/web/src/components/SiteNav.astro
+++ b/web/src/components/SiteNav.astro
@@ -3,7 +3,7 @@ import Icon from './Icon.astro';
 import BrandMark from './BrandMark.astro';
 import { REPO } from '../data/nav';
 import { docsUrl, siteUrl } from '../data/site';
-import { localeFromPathname, t } from '../i18n';
+import { localeFromPathname, t, withLocale } from '../i18n';
 import type { Locale } from '../i18n';
 
 interface Props {
@@ -21,14 +21,14 @@ const LINKS = [
 ] as const;
 
 /**
- * `/` and `/es/` are the only pages that currently exist in both locales — the
- * docs and about routes gain their `/es/` counterpart in a later slice. Until
- * then the switcher only appears on the home page, so it never links to an
- * unbuilt page.
+ * Home and every docs page now have an `/es/` counterpart — a real translation
+ * where one exists, the English body with a fallback notice otherwise (never a
+ * 404). `about` has not gained its `/es/` route yet, so the switcher stays off
+ * there until it does.
  */
 const pathname = Astro.url.pathname;
-const isHome = pathname === '/' || pathname === '/es/' || pathname === '/es';
-const switchTarget = locale === 'es' ? '/' : '/es/';
+const showSwitcher = current === 'home' || current === 'docs';
+const switchTarget = withLocale(pathname, locale === 'es' ? 'en' : 'es');
 const switchHreflang = locale === 'es' ? 'en' : 'es';
 ---
 
@@ -55,7 +55,7 @@ const switchHreflang = locale === 'es' ? 'en' : 'es';
 
     <div class="nav__actions">
       {
-        isHome && (
+        showSwitcher && (
           <a class="nav__link nav__switch" href={switchTarget} hreflang={switchHreflang}>
             {t(locale, 'nav.switch_locale')}
           </a>
@@ -84,7 +84,7 @@ const switchHreflang = locale === 'es' ? 'en' : 'es';
   <div class="nav__sheet" id="nav-sheet" hidden>
     {LINKS.map((link) => <a href={link.href}>{link.label}</a>)}
     {
-      isHome && (
+      showSwitcher && (
         <a href={switchTarget} hreflang={switchHreflang}>
           {t(locale, 'nav.switch_locale')}
         </a>

--- a/web/src/components/VersionPicker.astro
+++ b/web/src/components/VersionPicker.astro
@@ -39,7 +39,7 @@ const targets = VERSIONS.map((candidate) => {
 
   return {
     version: candidate,
-    href: has ? docsHref(`${candidate.id}/${currentPath}`) : versionHome(candidate),
+    href: has ? docsHref(`${candidate.id}/${currentPath}`, locale) : versionHome(candidate, locale),
     exact: has,
   };
 });

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -12,12 +12,18 @@ import { glob } from 'astro/loaders';
  * The site never keeps its own copy of a document: the driver READMEs and the
  * architecture and contributing guides are read from the repository too, so a
  * change in behaviour and the paragraph describing it stay in one commit.
+ *
+ * A Spanish sibling lives at `docs/es/<page>.md`. Its generated id naturally
+ * becomes `<version>/es/<page>` — the leading `docs/` strip below leaves the
+ * `es/` segment in place — so no extra id logic is needed to keep English and
+ * Spanish entries apart.
  */
 const docs = defineCollection({
   loader: glob({
     base: '.versions',
     pattern: [
       '*/docs/*.md',
+      '*/docs/es/*.md',
       '*/ARCHITECTURE.md',
       '*/CONTRIBUTING.md',
       '*/crates/dbflux_driver_*/README.md',

--- a/web/src/data/docs.ts
+++ b/web/src/data/docs.ts
@@ -1,20 +1,39 @@
 import type { CollectionEntry } from 'astro:content';
+import type { Locale } from '../i18n';
 import { DOCS_SECTIONS, docTitle } from './nav';
 
-/** Split a collection id of the form `<version>/<path>`. */
-export function splitId(id: string): { version: string; path: string } {
+/**
+ * Split a collection id of the form `<version>/<path>`, or its Spanish
+ * counterpart `<version>/es/<path>` (see `content.config.ts`). The locale
+ * segment is reported separately so callers never have to special-case it out
+ * of `path` themselves.
+ */
+export function splitId(id: string): { version: string; locale: Locale; path: string } {
   const separator = id.indexOf('/');
+  const version = id.slice(0, separator);
+  const rest = id.slice(separator + 1);
 
-  return { version: id.slice(0, separator), path: id.slice(separator + 1) };
+  if (rest.startsWith('es/')) return { version, locale: 'es', path: rest.slice(3) };
+
+  return { version, locale: 'en', path: rest };
 }
 
-/** The pages a version actually ships, as version-less paths. */
+/**
+ * The pages a version actually ships, as version-less paths.
+ *
+ * Restricted to the English entries: this drives the sidebar tree and the
+ * version-switcher's "does this page exist there" check, both of which stay
+ * on the canonical English page set until W2b translates navigation itself.
+ */
 export function pathsForVersion(
   entries: readonly CollectionEntry<'docs'>[],
   versionId: string,
 ): string[] {
   return entries
-    .filter((entry) => splitId(entry.id).version === versionId)
+    .filter((entry) => {
+      const parsed = splitId(entry.id);
+      return parsed.version === versionId && parsed.locale === 'en';
+    })
     .map((entry) => splitId(entry.id).path);
 }
 

--- a/web/src/data/versions.ts
+++ b/web/src/data/versions.ts
@@ -1,6 +1,8 @@
 // Vite inlines this at build time. Reading it with `fs` instead breaks once the
 // module is bundled, because the relative path no longer points at the file.
 import { docsPath, docsUrl } from './site';
+import { DEFAULT_LOCALE } from '../i18n';
+import type { Locale } from '../i18n';
 import registry from '../../versions.json';
 import manifest from '../../.versions/manifest.json';
 
@@ -98,16 +100,22 @@ function prefixFor(versionId: string): string {
   return versionId === CURRENT.id ? '' : versionId;
 }
 
-/** Documentation URL for an entry id of the form `<version>/<path>`. */
-export function docsHref(entryId: string): string {
+/**
+ * Documentation URL for an entry id of the form `<version>/<path>`.
+ *
+ * `entryId` is always the canonical English id, never the `<version>/es/<path>`
+ * shape a Spanish collection entry carries — `locale` is what selects the
+ * `/es/` URL prefix, independent of which entry's content is being linked to.
+ */
+export function docsHref(entryId: string, locale: Locale = DEFAULT_LOCALE): string {
   const separator = entryId.indexOf('/');
 
-  return docsUrl(entryId.slice(separator + 1), prefixFor(entryId.slice(0, separator)));
+  return docsUrl(entryId.slice(separator + 1), prefixFor(entryId.slice(0, separator)), locale);
 }
 
 /** Root of a version's documentation. */
-export function versionHome(version: DocsVersion): string {
-  return docsUrl('', prefixFor(version.id));
+export function versionHome(version: DocsVersion, locale: Locale = DEFAULT_LOCALE): string {
+  return docsUrl('', prefixFor(version.id), locale);
 }
 
 /**
@@ -115,6 +123,10 @@ export function versionHome(version: DocsVersion): string {
  *
  * Distinct from `docsHref`, which is for linking and may point at another host.
  */
-export function docsRoute(versionId: string, path: string): string {
-  return docsPath(path, prefixFor(versionId));
+export function docsRoute(
+  versionId: string,
+  path: string,
+  locale: Locale = DEFAULT_LOCALE,
+): string {
+  return docsPath(path, prefixFor(versionId), locale);
 }

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -52,6 +52,7 @@ export const en = {
     edit_page: 'Edit this page',
     report_issue: 'Report an issue',
     not_translated: 'This page has not been translated yet. Showing the English version.',
+    view_in_english: 'View in English',
   },
   docs_index: {
     title: 'Documentation',

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -52,6 +52,7 @@ export const es: Dictionary = {
     edit_page: 'Editar esta página',
     report_issue: 'Reportar un problema',
     not_translated: 'Esta página aún no está traducida. Se muestra la versión en inglés.',
+    view_in_english: 'Ver en inglés',
   },
   docs_index: {
     title: 'Documentación',

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -66,6 +66,7 @@ export interface Dictionary {
     edit_page: string;
     report_issue: string;
     not_translated: string;
+    view_in_english: string;
   };
   docs_index: {
     title: string;

--- a/web/src/layouts/DocsLayout.astro
+++ b/web/src/layouts/DocsLayout.astro
@@ -4,9 +4,9 @@ import DocsTree from '../components/DocsTree.astro';
 import VersionPicker from '../components/VersionPicker.astro';
 import { docTitle } from '../data/nav';
 import type { DocsVersion } from '../data/versions';
-import { CURRENT, versionHome, versionLabel } from '../data/versions';
+import { CURRENT, docsHref, versionHome, versionLabel } from '../data/versions';
 import { docsUrl } from '../data/site';
-import { localeFromPathname, t } from '../i18n';
+import { DEFAULT_LOCALE, localeFromPathname, t } from '../i18n';
 import type { Locale } from '../i18n';
 
 interface Heading {
@@ -25,7 +25,11 @@ interface Props {
   description: string;
   editPath?: string;
   locale?: Locale;
-  /** Forwarded to `Base` — see its `translated` prop. Only the docs index is today. */
+  /**
+   * Forwarded to `Base` — see its `translated` prop. `false` on a non-English
+   * page means it is showing the English fallback, which also drives the
+   * untranslated notice below and forces `noindex` regardless of `version`.
+   */
   translated?: boolean;
 }
 
@@ -52,6 +56,13 @@ const suffix = isCurrent ? '' : ` (${versionLabel(version)})`;
  * active locale is passed through rather than always resolving to English.
  */
 const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '', undefined, locale);
+
+/**
+ * A non-English page that fell back to the English body (no Spanish sibling
+ * yet) must stay out of search results: it would otherwise index as a
+ * near-duplicate of the canonical English page under a different URL.
+ */
+const showsFallback = locale !== DEFAULT_LOCALE && !translated;
 ---
 
 <Base
@@ -59,7 +70,7 @@ const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '', undefin
   description={description}
   current="docs"
   wide
-  noindex={version.noindex}
+  noindex={version.noindex || showsFallback}
   canonicalPath={canonicalPath}
   searchIndex={isCurrent ? '/search-index.json' : `/${version.id}/search-index.json`}
   locale={locale}
@@ -84,12 +95,22 @@ const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '', undefin
 
     <article class="docs__body">
       <p class="crumbs">
-        <a href={versionHome(version)}>{t(locale, 'docs_tree.crumb_docs')}</a>
+        <a href={versionHome(version, locale)}>{t(locale, 'docs_tree.crumb_docs')}</a>
         <span>/</span>
         <span class="crumbs__here">
           {currentPath ? docTitle(currentPath) : t(locale, 'docs_tree.crumb_overview')}
         </span>
       </p>
+      {
+        showsFallback && currentPath && (
+          <p class="docs__fallback-notice" role="status">
+            {t(locale, 'docs_tree.not_translated')}{' '}
+            <a href={docsHref(`${version.id}/${currentPath}`, DEFAULT_LOCALE)}>
+              {t(locale, 'docs_tree.view_in_english')}
+            </a>
+          </p>
+        )
+      }
       <div class="prose"><slot /></div>
     </article>
 
@@ -207,6 +228,20 @@ const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '', undefin
 
   .crumbs__here {
     color: var(--text) !important;
+  }
+
+  .docs__fallback-notice {
+    margin: 0 0 var(--s-6);
+    padding: var(--s-4) var(--s-5);
+    background: var(--panel);
+    border: var(--bw) solid var(--border);
+    border-left: var(--bw-emphasis) solid var(--accent);
+    font-size: var(--fs-small);
+    color: var(--text-muted);
+  }
+
+  .docs__fallback-notice a {
+    color: var(--text);
   }
 
   .toc__title {

--- a/web/src/lib/search-index.ts
+++ b/web/src/lib/search-index.ts
@@ -50,8 +50,11 @@ export async function buildSearchIndex(versionId: string): Promise<Section[]> {
   const sections: Section[] = [];
 
   for (const doc of docs) {
-    const { version, path } = splitId(doc.id);
-    if (version !== versionId) continue;
+    const { version, locale, path } = splitId(doc.id);
+    // The index stays English-only for now — a Spanish entry's id carries an
+    // `es/` path segment that `docsHref` does not expect, and there is no
+    // Spanish snippet UI yet to show its matches in.
+    if (version !== versionId || locale !== 'en') continue;
 
     const { headings } = await render(doc);
     const href = docsHref(doc.id);

--- a/web/src/pages/[...path].astro
+++ b/web/src/pages/[...path].astro
@@ -5,14 +5,20 @@ import DocsIndex from '../components/DocsIndex.astro';
 import { docTitle, pathsForVersion, splitId } from '../data/docs';
 import { CURRENT, VERSIONS, docsRoute, versionById, versionLabel } from '../data/versions';
 import { DOCS_MODE } from '../data/site';
+import { DEFAULT_LOCALE, LOCALES } from '../i18n';
 
 /**
- * Every documentation page, for every published version.
+ * Every documentation page, for every published version, in every locale.
  *
  * One catch-all rather than a route file per shape, because the URL prefix moves
  * with the deployment: `/docs/usage/` when the documentation shares the site's
- * origin, `/usage/` when it has its own. A file tree cannot express that; a
+ * origin, `/usage/` when it has its own — and now also with the locale:
+ * `/es/docs/usage/` alongside `/docs/usage/`. A file tree cannot express that; a
  * computed path can.
+ *
+ * A page missing its Spanish translation is never a 404: it renders the English
+ * body under the `/es/` URL, with `translated: false` telling `DocsLayout` to
+ * show the fallback notice and keep the page out of search results.
  */
 export async function getStaticPaths() {
   // This build does not carry the documentation. The URLs it used to publish
@@ -22,28 +28,53 @@ export async function getStaticPaths() {
   if (DOCS_MODE === 'site') return [];
 
   const docs = await getCollection('docs');
+  const enDocs = docs.filter((doc) => splitId(doc.id).locale === 'en');
 
-  const pages = docs.map((doc) => {
-    const { version, path } = splitId(doc.id);
+  const esByKey = new Map(
+    docs
+      .filter((doc) => splitId(doc.id).locale === 'es')
+      .map((doc) => {
+        const { version, path } = splitId(doc.id);
+        return [`${version}/${path}`, doc] as const;
+      }),
+  );
 
-    return {
-      params: { path: docsRoute(version, path) },
-      props: { versionId: version, path, doc },
-    };
-  });
+  const pages = LOCALES.flatMap((locale) =>
+    enDocs.map((doc) => {
+      const { version, path } = splitId(doc.id);
+      const esDoc = esByKey.get(`${version}/${path}`);
+      // hreflang only pairs pages that genuinely exist in both locales — an
+      // English page never alternates to a Spanish URL that is only showing
+      // its own English fallback, and vice versa.
+      const translated = esDoc !== undefined;
+      const activeDoc = locale === 'es' && esDoc ? esDoc : doc;
 
-  const indexes = VERSIONS.map((version) => ({
-    params: { path: docsRoute(version.id, '') || undefined },
-    props: { versionId: version.id, path: undefined, doc: undefined },
-  }))
-    // With the documentation at the root of its own host, the current release's
-    // index is `/`, which `index.astro` already owns.
-    .filter((entry) => entry.params.path !== undefined);
+      return {
+        params: { path: docsRoute(version, path, locale) },
+        props: { versionId: version, path, doc: activeDoc, locale, translated },
+      };
+    }),
+  );
+
+  // The version index has no translatable body of its own — `DocsIndex` is
+  // rendered entirely from the chrome dictionary, so it exists in every locale
+  // the same way `/` and `/es/` already do.
+  const indexes = LOCALES.flatMap((locale) =>
+    VERSIONS.map((version) => ({
+      params: { path: docsRoute(version.id, '', locale) },
+      props: { versionId: version.id, path: undefined, doc: undefined, locale, translated: true },
+    })).filter(
+      // With the documentation at the root of its own host, the current
+      // release's index is `/` (or `/es/`), which `index.astro` (or
+      // `es/index.astro`) already owns.
+      (entry) => entry.params.path !== (locale === DEFAULT_LOCALE ? '' : locale),
+    ),
+  );
 
   return [...pages, ...indexes];
 }
 
-const { versionId, path, doc } = Astro.props;
+const { versionId, path, doc, locale, translated } = Astro.props;
 
 const version = versionById(versionId)!;
 const available = pathsForVersion(await getCollection('docs'), versionId);
@@ -75,6 +106,14 @@ const description = doc
   title={title}
   description={description}
   editPath={doc?.filePath?.split('/').pop()}
+  locale={locale}
+  translated={translated}
 >
-  {rendered ? <rendered.Content /> : <DocsIndex versionId={versionId} available={available} />}
+  {
+    rendered ? (
+      <rendered.Content />
+    ) : (
+      <DocsIndex versionId={versionId} available={available} locale={locale} />
+    )
+  }
 </DocsLayout>


### PR DESCRIPTION
## Summary

Website i18n, docs pipeline: every documentation page now exists under `/es/docs/…` and `/es/<version>/docs/…`. When a Spanish sibling (`docs/es/<NAME>.md`, fetched per version ref) exists it renders as a real translation with reciprocal hreflang; when it does not, the page renders the English body with a visible "not yet translated" notice, a link to the English version, and `noindex`. English ids and URLs are unchanged (Spanish entries get `<version>/es/<path>`); the search index stays English-only for now; the language switcher now works on doc pages.

## What does this resolve?

- Refs #360 (website phase 2a; next: locale-aware link rewriting and nav titles, then the first translated docs)

## How was this solved?

- hreflang is reciprocal: the English page only claims a translation when a real sibling exists, so fallback pages never form a false pair.
- Known pre-existing issue flagged for the next slice: `editPath` keeps only the basename, so the "Edit this page" link is already wrong for driver READMEs and will be for `docs/es/*` — fix lands with the first real translations.

## Validation

- `pnpm check` → 0 errors; `pnpm build` → 188 pages (every `/es/` doc route); `DOCS_MODE=docs pnpm build` → 186 pages with `/es/` owned by the landing route; `node scripts/check-links.mjs` → ok. English `dist/` verified byte-identical except the switcher anchor and the one new CSS rule.
- Receipt-driven review: skipped for this candidate (native review store defect after a machine reboot; candidate-scoped decline).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` (consolidated entry when the web series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
