### PR TITLE
feat(web): resolve doc links within the active locale and fix the edit and cross-version links

### DIFF
--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -5,6 +5,8 @@ import sitemap from '@astrojs/sitemap';
 import { routeForRepoPath, titleForRepoPath } from './src/data/nav';
 import { DOCS_MODE, ORIGIN } from './src/data/site';
 import { hostRedirects } from './src/integrations/host-redirects';
+import { DEFAULT_LOCALE } from './src/i18n';
+import type { Locale } from './src/i18n';
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 
@@ -12,6 +14,45 @@ const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
 function textOf(node: any): string {
   if (node.type === 'text') return node.value;
   return (node.children ?? []).map(textOf).join('');
+}
+
+/**
+ * The repository root a rendered doc file was materialised from, and the
+ * locale it renders in.
+ *
+ * `content.config.ts` mirrors each version's repository tree under
+ * `.versions/<version>/` (see `scripts/fetch-docs.mjs`), so a source file's
+ * `fromDir` sits inside that per-version mirror, not inside the actual
+ * checkout `REPO_ROOT` points at. Resolving a relative link against
+ * `REPO_ROOT` therefore left `web/.versions/<version>/` in the computed repo
+ * path, which never matched `routeForRepoPath`'s patterns and silently fell
+ * back to a broken `github.com/.../blob/main/web/.versions/...` link. The
+ * per-version mirror root is the correct base for that resolution.
+ *
+ * The locale is read the same way: `docs/es/<page>.md` inside the mirror is
+ * the Spanish sibling `content.config.ts` loads under the `es/` id segment.
+ * The version is the mirror's own directory name, needed so a link written
+ * inside a version-exclusive page (e.g. a driver only shipped in `nightly`)
+ * resolves within that same version instead of silently falling back to the
+ * current release.
+ */
+function versionContext(
+  filePath: string,
+): { root: string; locale: Locale; version: string } | null {
+  const marker = '/.versions/';
+  const markerIndex = filePath.indexOf(marker);
+  if (markerIndex === -1) return null;
+
+  const afterMarker = filePath.slice(markerIndex + marker.length);
+  const versionEnd = afterMarker.indexOf('/');
+  if (versionEnd === -1) return null;
+
+  const version = afterMarker.slice(0, versionEnd);
+  const root = filePath.slice(0, markerIndex + marker.length) + version;
+  const repoPath = afterMarker.slice(versionEnd + 1);
+  const locale: Locale = repoPath.startsWith('docs/es/') ? 'es' : 'en';
+
+  return { root, locale, version };
 }
 
 /**
@@ -26,7 +67,12 @@ function textOf(node: any): string {
  */
 function rehypeRepoLinks() {
   return (tree: any, file: any) => {
-    const fromDir = dirname(file.path ?? file.history?.[0] ?? '');
+    const filePath = file.path ?? file.history?.[0] ?? '';
+    const context = versionContext(filePath);
+    const root = context?.root ?? REPO_ROOT;
+    const locale = context?.locale ?? DEFAULT_LOCALE;
+    const version = context?.version;
+    const fromDir = dirname(filePath);
 
     const visit = (node: any) => {
       if (node.type === 'element' && node.tagName === 'a') {
@@ -36,9 +82,10 @@ function rehypeRepoLinks() {
           const [target, hash] = href.split('#');
 
           if (target.endsWith('.md')) {
-            const repoPath = relative(REPO_ROOT, resolve(fromDir, target)).split('\\').join('/');
+            const repoPath = relative(root, resolve(fromDir, target)).split('\\').join('/');
 
-            node.properties.href = routeForRepoPath(repoPath) + (hash ? `#${hash}` : '');
+            node.properties.href =
+              routeForRepoPath(repoPath, locale, version) + (hash ? `#${hash}` : '');
 
             // Only relabel when the text is the path itself. A link already
             // written as a sentence is the author's wording and stays.
@@ -69,7 +116,7 @@ function rehypeRepoLinks() {
           return {
             type: 'element',
             tagName: 'a',
-            properties: { href: routeForRepoPath(repoPath) },
+            properties: { href: routeForRepoPath(repoPath, locale, version) },
             children: [{ type: 'text', value: title }],
           };
         });

--- a/web/src/data/docs.ts
+++ b/web/src/data/docs.ts
@@ -67,4 +67,20 @@ export function sectionsFor(available: readonly string[]): {
   return { sections, unfiled: available.filter((path) => !listed.has(path)).sort() };
 }
 
+/**
+ * The repository path a materialised doc file was copied from, for the
+ * "Edit this page" link.
+ *
+ * `entry.filePath` (from the `glob` loader) is relative to the site root,
+ * e.g. `.versions/v0.7/docs/es/SETTINGS.md` or
+ * `.versions/v0.7/crates/dbflux_driver_postgres/README.md` — stripping the
+ * `.versions/<versionId>/` mirror prefix recovers the real path in the
+ * repository (`docs/es/SETTINGS.md`, `crates/dbflux_driver_postgres/README.md`).
+ */
+export function repoPathFor(filePath: string, versionId: string): string {
+  const prefix = `.versions/${versionId}/`;
+
+  return filePath.startsWith(prefix) ? filePath.slice(prefix.length) : filePath;
+}
+
 export { docTitle };

--- a/web/src/data/nav.ts
+++ b/web/src/data/nav.ts
@@ -1,4 +1,7 @@
 import { docsUrl } from './site';
+import { CURRENT } from './versions';
+import { DEFAULT_LOCALE } from '../i18n';
+import type { Locale } from '../i18n';
 
 export const REPO = 'https://github.com/0xErwin1/dbflux';
 
@@ -99,17 +102,41 @@ export const REPO_URL = REPO;
  * Map a repository path to the page that renders it, or to the repository when
  * the site does not host it.
  *
+ * `locale` selects the URL prefix for a repository path that does not itself
+ * say which locale it belongs to (a driver README, `ARCHITECTURE.md`, or an
+ * English `docs/<page>.md`) — typically the locale of the page doing the
+ * linking. A `docs/es/<page>.md` path is unambiguous on its own and always
+ * resolves to its Spanish route regardless of `locale`, matching the id
+ * `content.config.ts` assigns it.
+ *
+ * `versionId` selects the URL's version prefix, matching the version of the
+ * page doing the linking (e.g. `nightly` for a link written inside nightly's
+ * own documentation). Left unset, it resolves against the current release —
+ * correct for the common case, but wrong for a version-exclusive page (a
+ * driver only shipped in `nightly`) linking to another page that only exists
+ * in that same version.
+ *
  * Kept in step with the patterns in `src/content.config.ts`.
  */
-export function routeForRepoPath(path: string): string {
+export function routeForRepoPath(
+  path: string,
+  locale: Locale = DEFAULT_LOCALE,
+  versionId?: string,
+): string {
+  const versionPrefix =
+    versionId === undefined ? undefined : versionId === CURRENT.id ? '' : versionId;
+
   const driver = path.match(/^crates\/dbflux_driver_([^/]+)\/README\.md$/);
-  if (driver) return docsUrl(`drivers/${driver[1]}`);
+  if (driver) return docsUrl(`drivers/${driver[1]}`, versionPrefix, locale);
+
+  const esDoc = path.match(/^docs\/es\/([^/]+)\.md$/);
+  if (esDoc) return docsUrl(esDoc[1].toLowerCase(), versionPrefix, 'es');
 
   const doc = path.match(/^docs\/([^/]+)\.md$/);
-  if (doc) return docsUrl(doc[1].toLowerCase());
+  if (doc) return docsUrl(doc[1].toLowerCase(), versionPrefix, locale);
 
-  if (path === 'ARCHITECTURE.md') return docsUrl('architecture');
-  if (path === 'CONTRIBUTING.md') return docsUrl('contributing');
+  if (path === 'ARCHITECTURE.md') return docsUrl('architecture', versionPrefix, locale);
+  if (path === 'CONTRIBUTING.md') return docsUrl('contributing', versionPrefix, locale);
 
   return `${REPO}/blob/main/${path}`;
 }
@@ -125,7 +152,7 @@ export function titleForRepoPath(path: string): string | null {
   const driver = path.match(/^crates\/dbflux_driver_([^/]+)\/README\.md$/);
   if (driver) return DOC_TITLES[`drivers/${driver[1]}`] ?? null;
 
-  const doc = path.match(/^docs\/([^/]+)\.md$/);
+  const doc = path.match(/^docs\/(?:es\/)?([^/]+)\.md$/);
   if (doc) return DOC_TITLES[doc[1].toLowerCase()] ?? null;
 
   if (path === 'ARCHITECTURE.md') return DOC_TITLES.architecture ?? null;

--- a/web/src/layouts/DocsLayout.astro
+++ b/web/src/layouts/DocsLayout.astro
@@ -134,10 +134,7 @@ const showsFallback = locale !== DEFAULT_LOCALE && !translated;
       {
         editPath && (
           <div class="toc__edit">
-            <a
-              href={`https://github.com/0xErwin1/dbflux/blob/main/docs/${editPath}`}
-              rel="noopener"
-            >
+            <a href={`https://github.com/0xErwin1/dbflux/blob/main/${editPath}`} rel="noopener">
               {t(locale, 'docs_tree.edit_page')}
             </a>
             <a href="https://github.com/0xErwin1/dbflux/issues/new" rel="noopener">

--- a/web/src/pages/[...path].astro
+++ b/web/src/pages/[...path].astro
@@ -2,7 +2,7 @@
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '../layouts/DocsLayout.astro';
 import DocsIndex from '../components/DocsIndex.astro';
-import { docTitle, pathsForVersion, splitId } from '../data/docs';
+import { docTitle, pathsForVersion, repoPathFor, splitId } from '../data/docs';
 import { CURRENT, VERSIONS, docsRoute, versionById, versionLabel } from '../data/versions';
 import { DOCS_MODE } from '../data/site';
 import { DEFAULT_LOCALE, LOCALES } from '../i18n';
@@ -105,7 +105,7 @@ const description = doc
   headings={rendered?.headings ?? []}
   title={title}
   description={description}
-  editPath={doc?.filePath?.split('/').pop()}
+  editPath={doc?.filePath ? repoPathFor(doc.filePath, versionId) : undefined}
   locale={locale}
   translated={translated}
 >


### PR DESCRIPTION
## Summary

Website i18n, docs links: relative markdown links now resolve within the active locale (a page under `/es/` links to `/es/` targets, including from future `docs/es/*.md` sources), and the "Edit this page" link points at the real repository path of the rendered source. Two pre-existing production bugs fixed along the way, both required by this work: (1) `rehypeRepoLinks` resolved relative targets against the checkout root instead of the per-version mirror, so every real markdown-syntax link (`[text](FILE.md)`) in the published docs pointed at a broken GitHub blob URL — undetected because `check-links.mjs` only validates same-origin hrefs; (2) `routeForRepoPath` never carried the version prefix, so links between version-exclusive pages (e.g. nightly's ClickHouse driver) resolved into the current release and 404'd.

## What does this resolve?

- Refs #360 (website phase 2b; next: the first translated docs with a per-locale title source)

## How was this solved?

- The rehype plugin derives `{root, locale, version}` from the rendered file's `.versions/<id>/…` path; `routeForRepoPath(path, locale, versionId)` stays default-compatible for every existing call site.
- Proven with a gitignored `.versions/` fixture (translated page with relative, parent-relative and bare-mention links), removed before the final build.

## Validation

- `pnpm check` → 0 errors; `pnpm build` → 188 pages and `DOCS_MODE=docs` → 186; `node scripts/check-links.mjs` → ok in both modes. Driver README and version-exclusive links inspected in `dist/`.
- Receipt-driven review: skipped for this candidate (native review store defect after a machine reboot; candidate-scoped decline).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` (consolidated entry when the web series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
