### PR TITLE
feat(docs): translate the install, usage, and connections guides to Spanish

### DIFF
--- a/docs/es/CONNECTIONS.md
+++ b/docs/es/CONNECTIONS.md
@@ -1,0 +1,259 @@
+# Conectar a una base de datos — Configuración avanzada
+
+Esta guía cubre todo lo que hay en el Connection Manager más allá del formulario
+básico de "host, port, user, password": llegar a una base de datos a través de un
+túnel SSH, un proxy o AWS SSM; autenticarse con Auth Profiles gestionados por un
+provider (AWS SSO); y obtener valores de campos individuales desde un secret
+manager o parameter store en lugar de escribirlos directamente.
+
+Para el flujo del día a día (crear una conexión, explorar el schema, ejecutar
+queries) consulta la [Guía de uso](USAGE.md). Este documento continúa desde la
+pestaña **Access** del Connection Manager y los selectores de fuente de valores.
+
+---
+
+## La pestaña Access: cómo llega DBFlux a la base de datos
+
+Cada conexión usa exactamente **un** método de acceso, elegido en el desplegable
+**Access Method**. Cambiar de método borra la configuración de los demás — una
+conexión es Direct, SSH, Proxy o SSM, nunca una combinación.
+
+| Método | Qué hace |
+|--------|--------------|
+| **Direct** | Conecta directamente al host/port de la pestaña Main. Puede seguir resolviendo fuentes de valores por campo (ver [Fuentes de valores](#fuentes-de-valores-secret-manager-parameter-store-auth-session)). |
+| **SSH Tunnel** | Abre un port-forward local a través de un host SSH, y conecta a través de él. |
+| **Proxy** | Enruta la conexión a través de un proxy SOCKS5 o HTTP/HTTPS. |
+| **SSM Port Forwarding** | Usa AWS Systems Manager para hacer port-forward a una instancia y conecta a través del túnel. Requiere el build feature `aws`. |
+
+### Qué ocurre cuando pulsas Connect
+
+DBFlux ejecuta un pipeline pre-connect fijo antes de que el driver abra un
+socket:
+
+1. **Authenticating** — valida o refresca la sesión del Auth Profile
+   seleccionado (aquí puede ocurrir un login por navegador de AWS SSO).
+2. **Resolving values** — resuelve cada fuente de valores por campo (secret
+   manager, parameter store, variable de entorno, campo de auth-session) y las
+   aplica a la configuración.
+3. **Opening access** — establece el túnel SSH, el proxy o la sesión SSM (o
+   nada, en el caso de Direct).
+4. **Driver connect + schema fetch** — el driver conecta y DBFlux carga el
+   schema superficial.
+
+Los **hooks** de conexión (si tienes alguno vinculado) se ejecutan en las fases
+PreConnect, PostConnect, PreDisconnect y PostDisconnect alrededor de este
+pipeline. Ver [Settings & Hooks](SETTINGS.md#connection-hooks).
+
+---
+
+## Túneles SSH
+
+Puedes usar un túnel SSH de dos formas:
+
+- **Referenciar un túnel guardado** — elige un perfil de túnel que gestiones de
+  forma centralizada en **Settings → SSH Tunnels**. Recomendado cuando reutilizas
+  el mismo bastion en varias conexiones.
+- **Inline** — rellena los campos SSH directamente en la pestaña Access. Más
+  adelante puedes pulsar **Save as tunnel** para convertirlo en un perfil
+  reutilizable.
+
+### Campos SSH
+
+| Campo | Notas |
+|-------|-------|
+| **Host** / **Port** | El servidor SSH. El puerto suele ser `22`. |
+| **Username** | Usuario SSH. |
+| **Auth method** | **Private Key** o **Password**. |
+| **Key path** (Private Key) | Ruta a la clave privada. **Déjalo vacío para usar tu SSH agent o las claves por defecto** (`~/.ssh/id_rsa`, etc.). |
+| **Key passphrase** (Private Key) | Opcional; se guarda en el keyring del sistema operativo al marcar **Save**. |
+| **Password** (Password auth) | Se guarda en el keyring del sistema operativo al marcar **Save**. |
+
+No existe una opción separada de "SSH agent" — la autenticación basada en agente
+es lo que obtienes al elegir **Private Key** y dejar la ruta de la clave vacía.
+
+**Test SSH** verifica el túnel sin guardar la conexión.
+
+### Dónde viven los secretos SSH
+
+Las passphrases y contraseñas se guardan en el **keyring del sistema
+operativo**, nunca en la base de datos. La casilla **Save** solo aparece cuando
+hay un keyring disponible; si no lo hay, los secretos no se persisten y tendrás
+que reintroducirlos cada sesión. Ver
+[Datos y privacidad → Secretos](DATA_AND_PRIVACY.md#secrets-and-the-os-keyring).
+
+---
+
+## Proxies
+
+Los proxies se gestionan en **Settings → Proxies**; la pestaña Access solo
+*selecciona* un proxy guardado y muestra sus detalles. Si no tienes ninguno, la
+pestaña te enlaza a Settings.
+
+| Campo | Notas |
+|-------|-------|
+| **Type** | `SOCKS5`, `HTTP` o `HTTPS`. Puerto por defecto: `1080` para SOCKS5, `8080` para HTTP/HTTPS. |
+| **Host** / **Port** | El endpoint del proxy. |
+| **Auth** | `None`, o `Basic` con un usuario (la contraseña se guarda en el keyring). |
+| **No Proxy** | Hosts/patrones separados por comas para omitir el proxy. Soporta `*` (todos), hosts exactos y coincidencias de sufijo (con o sin punto inicial), sin distinguir mayúsculas/minúsculas. **No soporta rangos CIDR.** |
+| **Enabled** | Cuando un perfil de proxy está deshabilitado, la conexión recurre a una conexión **directa** (con un aviso) en lugar de fallar. |
+
+> **Aviso:** un proxy deshabilitado, o un host remoto que coincide con **No
+> Proxy**, resulta en una conexión directa silenciosa. Si esperabas que el
+> tráfico pasara por el proxy y no fue así, revisa primero estos dos casos.
+
+---
+
+## Auth Profiles (AWS SSO y credenciales compartidas)
+
+Los Auth Profiles contienen autenticación gestionada por un provider que DBFlux
+resuelve en el momento de conectar. Se crean en **Settings → Auth Profiles** y se
+seleccionan por conexión. En este build los providers integrados son
+**solo AWS**:
+
+| Provider | Para qué se usa |
+|----------|------------|
+| **AWS SSO** | Login de IAM Identity Center (SSO) que resuelve una cuenta + rol. |
+| **AWS SSO Session** | Una sesión SSO reutilizable (Start URL + región + scopes) de la que pueden heredar los perfiles AWS SSO. |
+| **AWS Shared Credentials** | Un perfil con nombre escrito en `~/.aws/credentials` (access key / secret / session token opcional). |
+
+Los providers de auth RPC registrados externamente pueden añadir más entradas
+aquí; ver [RPC Services](RPC_SERVICES_CONFIG.md).
+
+> Los perfiles AWS que DBFlux refleja en vivo desde tu `~/.aws/config` aparecen
+> como **de solo lectura** — puedes seleccionarlos pero no editarlos aquí; edita
+> los archivos de AWS directamente.
+
+### Crear un perfil AWS SSO
+
+El formulario está guiado por el provider. Para AWS SSO rellenas:
+
+| Campo | Notas |
+|-------|-------|
+| **Profile name** | p. ej. `dev`. |
+| **SSO session** | Referencia opcional a un perfil **AWS SSO Session**. Al fijarla, el Start URL y la región se heredan y sus campos inline se deshabilitan visualmente. |
+| **SSO Start URL** | La URL de tu portal de Identity Center (omítela si usas una sesión). |
+| **Region** | p. ej. `us-east-1`. |
+| **Account** | Un desplegable que se rellena **después de iniciar sesión** — lista las cuentas a las que tu sesión SSO tiene acceso. |
+| **Role** | Un desplegable que se rellena una vez elegida una cuenta. |
+
+Los desplegables **Account** y **Role** son dinámicos: requieren una sesión SSO
+activa y se refrescan cuando cambian sus dependencias. Si están vacíos, inicia
+sesión primero (ver abajo).
+
+El **SSO Wizard** ofrece el mismo flujo como un creador guiado, paso a paso:
+introduce nombre, Start URL y región; te inicia sesión y luego lista las cuentas
+y roles para que elijas.
+
+### El flujo de login SSO
+
+Cuando una conexión (o los desplegables Account/Role) necesita una sesión SSO,
+DBFlux abre un modal de login:
+
+- **Abre tu navegador automáticamente** en la URL de verificación.
+- Si el navegador no se puede abrir, el modal muestra la URL con una acción
+  **Copy URL** para que la abras manualmente.
+- DBFlux continúa automáticamente en cuanto terminas de autenticarte en el
+  navegador.
+- **El login SSO expira a los 5 minutos.**
+
+### Seleccionar un Auth Profile por conexión
+
+- **Modo Direct** — el Auth Profile es *opcional*. Se usa solo para resolver
+  fuentes de valores Secret/Parameter/Auth (siguiente sección).
+- **Modo SSM** — el Auth Profile es **obligatorio**.
+- Si algún campo usa una fuente de valores Secret/Parameter cuyo provider es un
+  auth provider, se requiere un Auth Profile correspondiente o la conexión se
+  rechaza antes de conectar.
+
+Cada fila de perfil tiene botones **Manage**, **Login** y **Refresh**.
+**Login** solo está habilitado cuando el perfil seleccionado realmente necesita
+iniciar sesión.
+
+---
+
+## SSM Port Forwarding (acceso gestionado)
+
+El acceso "gestionado" permite que un provider abra el camino hacia el host por
+ti. La implementación incluida es **AWS SSM Port Forwarding** (requiere el
+feature `aws`).
+
+| Campo | Notas |
+|-------|-------|
+| **Instance ID** | Instancia EC2 de destino. Soporta un selector de fuente de valores. |
+| **Region** | Por defecto `us-east-1` si se deja en blanco. |
+| **Remote Port** | El puerto de la instancia al que se hace el forward. |
+| **Auth Profile** | **Obligatorio** — el perfil AWS usado para iniciar la sesión SSM. |
+
+El puerto **local** del túnel lo asigna automáticamente DBFlux y el sistema
+operativo — solo el puerto remoto es configurable.
+
+---
+
+## Fuentes de valores: Secret Manager, Parameter Store, Auth Session
+
+Cualquier campo individual de una conexión (host, password, etc.) puede obtener
+su valor desde una fuente externa en lugar de un literal. Haz clic en el
+selector de fuente junto a un campo y elige:
+
+| Fuente | Qué hace |
+|--------|--------------|
+| **Literal** | El valor que escribes (por defecto). |
+| **Environment Variable** | Se lee de una variable de entorno por nombre. |
+| **Secret Manager** | Se obtiene de un secret provider (AWS Secrets Manager). |
+| **Parameter Store** | Se obtiene de un parameter provider (AWS SSM Parameter Store). |
+| **Auth Session Field** | Toma un campo de la sesión/credenciales resuelta del Auth Profile. |
+
+Notas:
+
+- Las fuentes Secret/Parameter pueden apuntar a una **clave JSON** dentro de un
+  secreto JSON, de forma que un único documento JSON almacenado puede alimentar
+  varios campos.
+- Los valores resueltos se cachean durante **5 minutos** para evitar volver a
+  obtenerlos en cada reconexión.
+- Las fuentes Secret/Parameter respaldadas por un auth provider **requieren un
+  Auth Profile** en la conexión (se valida antes de conectar).
+
+---
+
+## Modo formulario vs. URI directa
+
+La mayoría de los drivers relacionales te permiten indicar los detalles de
+conexión como campos individuales o como una única cadena de conexión. Un
+interruptor **Use URI** en la pestaña Main alterna entre ambos.
+
+- El modo URI está disponible para **PostgreSQL, MySQL/MariaDB, SQL Server,
+  MongoDB y Redis**. SQLite, DynamoDB, CloudWatch e InfluxDB usan sus propios
+  formularios basados en campos.
+- Con el modo URI **activado**, el campo único de URI es la fuente de verdad y
+  los campos individuales se ignoran; con él **desactivado**, se usan los
+  campos.
+- Una contraseña embebida en una URI se extrae y se guarda por separado (en el
+  keyring al guardarla), no se conserva en el texto de la URI.
+- Al conectar a través de un túnel SSH/proxy/SSM, DBFlux siempre usa la
+  configuración basada en campos (reescrita a `127.0.0.1:<local port>`), incluso
+  si escribiste una URI.
+
+---
+
+## Referencia rápida: problemas frecuentes
+
+- **Un método de acceso por conexión.** Cambiar de método borra los demás.
+- **Los secretos viven en el keyring del sistema operativo**, nunca en la base
+  de datos de DBFlux. Si el keyring no está disponible, las casillas "Save"
+  desaparecen y los secretos no se conservan.
+- **Un proxy deshabilitado o una coincidencia en No-Proxy conecta directamente
+  de forma silenciosa.**
+- **`No Proxy` no soporta CIDR** — lista hosts/sufijos, no rangos de IP.
+- **SSM y las fuentes de valores respaldadas por auth requieren ambas un Auth
+  Profile.**
+- **Solo los providers de auth de AWS están integrados** (SSO, SSO Session,
+  Shared Credentials). Otros providers vienen de servicios RPC externos.
+- **El login SSO abre el navegador automáticamente y expira a los 5 minutos.**
+
+## Relacionado
+
+- [Guía de uso](USAGE.md) — el flujo básico de conectar/consultar/resultados.
+- [Settings & Hooks](SETTINGS.md) — gestión de perfiles SSH/proxy/auth y hooks.
+- [Datos y privacidad](DATA_AND_PRIVACY.md) — dónde se almacenan las
+  credenciales y los datos.
+- [RPC Services](RPC_SERVICES_CONFIG.md) — drivers externos y auth providers.

--- a/docs/es/INSTALL.md
+++ b/docs/es/INSTALL.md
@@ -1,0 +1,191 @@
+# Instalar DBFlux
+
+## Linux
+
+### Tarball (recomendado)
+
+```bash
+# Instalar en /usr/local (requiere sudo)
+curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/install.sh | sudo bash
+
+# Instalar en ~/.local (sin sudo)
+curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/install.sh | bash -s -- --prefix ~/.local
+```
+
+### AppImage (portable)
+
+```bash
+# Descargar desde releases (reemplaza amd64 por arm64 para ARM)
+wget https://github.com/0xErwin1/dbflux/releases/latest/download/dbflux-linux-amd64.AppImage
+chmod +x dbflux-linux-amd64.AppImage
+./dbflux-linux-amd64.AppImage
+```
+
+### Arch Linux
+
+Disponible en el AUR:
+
+```bash
+# Usando un helper de AUR
+paru -S dbflux
+# o
+yay -S dbflux
+```
+
+### Debian / Ubuntu
+
+Descarga el paquete `.deb` desde [Releases](https://github.com/0xErwin1/dbflux/releases):
+
+```bash
+# Reemplaza amd64 por arm64 para ARM
+wget https://github.com/0xErwin1/dbflux/releases/latest/download/dbflux-linux-amd64.deb
+sudo dpkg -i dbflux-linux-amd64.deb
+```
+
+### Fedora / RHEL / CentOS
+
+Descarga el paquete `.rpm` desde [Releases](https://github.com/0xErwin1/dbflux/releases):
+
+```bash
+# Reemplaza amd64 por arm64 para ARM
+sudo dnf install https://github.com/0xErwin1/dbflux/releases/latest/download/dbflux-linux-amd64.rpm
+```
+
+### Nix
+
+Usando flakes (el paquete por defecto es un **binario prebuilt** para Linux x86_64 / aarch64, sin compilación):
+
+```bash
+# Ejecutar directamente (prebuilt)
+nix run github:0xErwin1/dbflux
+
+# Instalar en el perfil (prebuilt)
+nix profile install github:0xErwin1/dbflux
+
+# Shell de desarrollo
+nix develop github:0xErwin1/dbflux
+```
+
+Compilar desde el código fuente en lugar de usar el binario prebuilt:
+
+```bash
+nix run    github:0xErwin1/dbflux#dbflux-source
+nix build  github:0xErwin1/dbflux#dbflux-source
+```
+
+Los builds nightly siguen `main` y se instalan en paralelo con la versión estable (app id, icono y base de datos `dbflux-nightly.db` distintos). Consúmelos desde la referencia `nightly`:
+
+```bash
+nix run github:0xErwin1/dbflux/nightly#dbflux-nightly
+nix profile install github:0xErwin1/dbflux/nightly#dbflux-nightly
+```
+
+Consulta [docs/RELEASE.md](RELEASE.md) para el modelo de canales.
+
+NixOS / nix-darwin vía overlay:
+
+```nix
+{
+  inputs.dbflux.url = "github:0xErwin1/dbflux";
+
+  outputs = { nixpkgs, dbflux, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [
+        ({ pkgs, ... }: {
+          nixpkgs.overlays = [ dbflux.overlays.default ];
+          environment.systemPackages = [
+            pkgs.dbflux         # binario prebuilt, sin compilación local
+            # pkgs.dbflux-source  # alternativa: compilar desde el código fuente
+          ];
+        })
+      ];
+    };
+  };
+}
+```
+
+## macOS
+
+DBFlux para macOS no está firmado con un certificado de desarrollador de Apple. Al abrirlo por primera vez, verás una advertencia sobre un "desarrollador no identificado".
+
+### Instalación
+
+1. Descarga el DMG para tu arquitectura desde [Releases](https://github.com/0xErwin1/dbflux/releases):
+   - **Macs Intel**: `dbflux-macos-amd64.dmg`
+   - **Apple Silicon (M1/M2/M3/M4)**: `dbflux-macos-arm64.dmg`
+2. Abre el DMG y arrastra DBFlux a Applications
+3. Cuando veas la advertencia de "desarrollador no identificado":
+   - Ve a **Ajustes del Sistema → Privacidad y Seguridad**
+   - Haz clic en **Abrir de todos modos** junto a la advertencia de seguridad
+   - Confirma que quieres abrir la aplicación
+
+### Saltar Gatekeeper desde la terminal
+
+```bash
+# Eliminar el atributo de cuarentena (permite abrir sin confirmación por GUI)
+xattr -cr /Applications/DBFlux.app
+
+# Ahora puedes abrirlo normalmente
+open /Applications/DBFlux.app
+```
+
+### Requisitos
+
+- macOS 11.0 (Big Sur) o posterior
+
+## Windows
+
+### Instalador
+
+1. Descarga `dbflux-windows-amd64-setup.exe` desde [Releases](https://github.com/0xErwin1/dbflux/releases)
+2. Ejecuta el instalador y sigue el asistente
+
+### Portable
+
+1. Descarga `dbflux-windows-amd64.zip` desde [Releases](https://github.com/0xErwin1/dbflux/releases)
+2. Extrae en cualquier carpeta
+3. Ejecuta `dbflux.exe`
+
+> **Nota**: El ejecutable no está firmado con un certificado de firma de código de Windows. Windows SmartScreen puede mostrar una advertencia. Haz clic en "Más información" → "Ejecutar de todas formas" para continuar.
+
+### Requisitos
+
+- Windows 10 o posterior
+- x86_64 (ARM64 aún no soportado)
+
+## Compilar desde el código fuente
+
+```bash
+# Vía script de instalación (Linux)
+curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/install.sh | bash -s -- --build
+
+# O manualmente
+git clone https://github.com/0xErwin1/dbflux.git
+cd dbflux
+
+# Recomendado: compilar con el conjunto completo de features por defecto
+cargo build --release --features sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,clickhouse,lua,aws,mcp
+
+# Build mínimo (solo drivers relacionales, sin AI/MCP, sin Lua)
+cargo build --release --no-default-features --features sqlite,postgres,mysql
+
+./target/release/dbflux
+```
+
+## Desinstalar (Linux)
+
+```bash
+# Si se instaló con install.sh
+curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/uninstall.sh | sudo bash
+
+# Desde ~/.local
+curl -fsSL https://raw.githubusercontent.com/0xErwin1/dbflux/main/scripts/uninstall.sh | bash -s -- --prefix ~/.local
+
+# Eliminar también la configuración y los datos del usuario
+./scripts/uninstall.sh --remove-config
+```
+
+## Próximos pasos
+
+- [Guía de uso](USAGE.md) — primer inicio, creación de una conexión y tu primera consulta
+- [Conectar — Configuración avanzada](CONNECTIONS.md) — túneles SSH, proxies, AWS SSO y fuentes de valores

--- a/docs/es/USAGE.md
+++ b/docs/es/USAGE.md
@@ -1,0 +1,628 @@
+# Guía de uso de DBFlux
+
+Una introducción práctica, orientada al usuario final, para trabajar con
+DBFlux: conectar a una base de datos, explorar su schema, ejecutar queries,
+trabajar con resultados, graficar, y el modelo de teclado.
+
+DBFlux es keyboard-first. Casi todas las acciones tienen tanto un gesto de
+ratón como un atajo de teclado. Los atajos listados en esta guía son los
+valores por defecto de la aplicación; puedes revisar el keymap activo completo
+en **Settings → Keybindings** (un visor de solo lectura — ver el
+[Resumen de Settings](#8-resumen-de-settings)).
+
+---
+
+## 1. Primer inicio y creación de una conexión
+
+Al arrancar, DBFlux restaura tu sesión anterior (pestañas abiertas). En una
+instalación nueva no hay nada que restaurar, así que el foco recae por defecto
+en el sidebar.
+
+### Abrir el Connection Manager
+
+Abre el Connection Manager para crear o editar conexiones:
+
+- Desde el sidebar, pulsa `c`.
+- O usa el command palette (`Ctrl+Shift+P` / `Cmd+Shift+P` en macOS) y ejecuta
+  **Open Connection Manager**.
+
+### Elegir un driver
+
+El Connection Manager muestra un selector de drivers. Los drivers disponibles
+dependen de los features con los que se compiló el binario; el build estándar
+incluye SQLite, PostgreSQL, MySQL/MariaDB, MongoDB, Redis, DynamoDB, Microsoft
+SQL Server, e integraciones respaldadas por AWS. Los drivers RPC registrados
+externamente también aparecen aquí cuando están configurados (ver
+`docs/RPC_SERVICES_CONFIG.md`).
+
+Usa `/` para filtrar la lista de drivers, `j`/`k` (o las flechas) para
+moverte, y `Enter` para seleccionar.
+
+### Modo formulario vs. URI directa
+
+Cada driver ofrece su propio formulario de conexión. El formulario es
+dinámico: solo muestra los campos que ese driver realmente necesita. La
+mayoría de los drivers relacionales soportan dos formas de indicar los
+detalles de conexión:
+
+- **Basado en formulario**: campos individuales (host, port, database, user,
+  etc.).
+- **URI directa**: un único campo con la cadena de conexión.
+
+Los drivers respaldados por archivo, como SQLite, usan en su lugar un
+formulario de ruta de archivo.
+
+### Pestaña Access: direct, SSH, proxy, managed
+
+La pestaña **Access** controla cómo llega DBFlux a la base de datos:
+
+- **Direct** — conecta directamente al host desde los campos de la pestaña
+  Main. El modo Direct puede seguir resolviendo fuentes de valores
+  Secret/Parameter/Auth para campos individuales.
+- **SSH** — encamina la conexión a través de un host SSH. Los perfiles de
+  túnel SSH se gestionan de forma centralizada en Settings y se seleccionan
+  por conexión.
+- **Proxy** — encamina a través de un proxy SOCKS5 o HTTP CONNECT. Proxy y SSH
+  son mutuamente excluyentes para una misma conexión.
+- **Managed** — acceso gestionado por un provider (por ejemplo `aws-ssm`),
+  donde DBFlux abre el acceso a través de un provider externo antes de
+  conectar.
+
+Al conectar, DBFlux ejecuta un pipeline pre-connect: autenticación y
+validación de sesión, resolución dinámica de valores, y luego la
+configuración del acceso managed/direct, seguido del connect del driver y una
+carga inicial del schema. Los hooks de conexión (si están configurados) se
+ejecutan en las fases PreConnect, PostConnect, PreDisconnect y
+PostDisconnect. Ver el resumen de Settings para dónde se definen los hooks.
+
+---
+
+## 2. Explorar el schema
+
+El sidebar tiene dos pestañas:
+
+- **Connections** — el árbol del schema (bases de datos, schemas,
+  tablas/collections, columnas, índices y — donde el driver lo soporte — una
+  carpeta Routines).
+- **Scripts** — gestión de archivos y carpetas para archivos de query
+  guardados, script hooks y otros archivos de usuario.
+
+Cambia entre las dos pestañas con `q` o `e`.
+
+### Navegar el árbol
+
+- `j`/`k` (o `Down`/`Up`) — mueve la selección.
+- `h` colapsa, `l` expande el nodo actual. `Space` alterna expandir/colapsar.
+- `g` salta al primer elemento, `Shift+g` al último; `Home`/`End` hacen lo
+  mismo.
+- `Ctrl+d`/`Ctrl+u` (o `PageDown`/`PageUp`) — recorre listas largas por
+  páginas.
+- `/` enfoca la búsqueda/filtro del sidebar.
+- `Enter` abre el elemento seleccionado (por ejemplo, una tabla abre un data
+  grid).
+- `r` refresca el schema; `d` desconecta la conexión activa.
+- `m` abre el menú contextual del elemento seleccionado.
+
+### Carga diferida (lazy loading)
+
+El schema se carga de forma diferida. Al conectar, DBFlux obtiene metadatos
+superficiales (nombres). Los metadatos detallados — columnas, índices y
+similares — se obtienen bajo demanda al expandir un nodo. Esto mantiene rápida
+la conexión inicial en bases de datos grandes.
+
+### Rutinas / procedimientos almacenados
+
+Para los drivers que declaran soporte de rutinas (PostgreSQL es la primera
+implementación), el árbol del schema incluye una carpeta **Routines** con
+funciones, procedimientos, agregados y rutinas de ventana. Abrir una rutina
+abre un documento de código de solo lectura que muestra su definición. El
+documento no es editable, pero puedes seleccionar y copiar su texto; los
+controles de ejecución y mutación están ocultos.
+
+---
+
+## 3. Ejecutar queries
+
+Abre una nueva pestaña de query con `Ctrl+n` (`Cmd+n` en macOS), o abre un
+archivo de script con `Ctrl+o`. El lenguaje de query del editor (SQL, sintaxis
+de queries de MongoDB, comandos de Redis, etc.) lo determina el driver de la
+conexión activa, que también controla el resaltado de sintaxis y el texto de
+placeholder.
+
+### Ejecutar
+
+- `Ctrl+Enter` (`Cmd+Enter`) — **Run Query**.
+- `Ctrl+Shift+Enter` (`Cmd+Shift+Enter`) — **Run Query in New Tab**.
+
+Si existe una selección de texto no vacía, solo se ejecuta el texto
+seleccionado. Sin selección, se usa el buffer completo del editor.
+
+### Scripts multi-statement
+
+Cuando ejecutas sin selección y el buffer contiene varias sentencias
+separadas por `;`, y el driver activo declara soporte de batch, DBFlux
+muestra un diálogo de confirmación (`Run entire script (N statements)?`)
+antes de ejecutar. Al confirmar, el conjunto de resultados de cada sentencia
+se renderiza en su propia pestaña de resultado.
+
+La división en sentencias es consciente del lenguaje para los lenguajes de la
+familia SQL: los separadores dentro de strings, identificadores, comentarios
+de línea/bloque y los cuerpos dollar-quoted de PostgreSQL no se tratan como
+límites de sentencia. Los lenguajes no SQL siguen siendo de sentencia única.
+El soporte de batch es por driver — entre los drivers SQL integrados,
+PostgreSQL, MySQL/MariaDB, SQLite y Microsoft SQL Server lo soportan. Una
+selección siempre se ejecuta tal cual y nunca dispara la confirmación de
+script.
+
+### Confirmación de queries peligrosas
+
+DBFlux detecta operaciones peligrosas entre lenguajes — `DELETE`/`DROP`/
+`TRUNCATE` de SQL y `DELETE`/`UPDATE` sin `WHERE`, `deleteMany`/`drop` de
+MongoDB, `FLUSHALL`/`FLUSHDB`/`KEYS` de Redis — y pide confirmación antes de
+ejecutar. Este comportamiento se controla desde settings: la confirmación de
+queries peligrosas se puede desactivar, se puede requerir una cláusula
+`WHERE` para `DELETE`/`UPDATE`, y `FLUSHALL`/`FLUSHDB` de Redis se puede
+deshabilitar por completo (en cuyo caso esos comandos quedan bloqueados en
+lugar de confirmados).
+
+### Scripts (Lua / Python / Bash)
+
+Los documentos Lua, Python y Bash se ejecutan como scripts en lugar de
+queries de base de datos. Su salida se transmite en vivo al área de salida
+del documento mientras se ejecutan, y la salida final se conserva como un
+resultado de texto. Ver `docs/LUA.md` para el runtime de Lua embebido.
+
+### Constructor visual de queries
+
+Para conexiones SQL puedes componer queries sin escribir SQL. Desde la
+toolbar del data grid de una tabla, haz clic en **Builder** para abrir un
+panel en el rail derecho. El builder solo está disponible en drivers SQL; las
+conexiones no SQL no lo muestran.
+
+El panel tiene un selector de modo en la parte superior — **SELECT**,
+**UPDATE**, **DELETE** — y una vista previa de SQL en vivo que se regenera
+con cada cambio. La vista previa siempre es visible. Pulsa **Run** para
+ejecutar, o (en modo SELECT) **Open in Editor** para volcar el SQL generado
+en un editor de query normal. La cabecera tiene **Save** y **Reset**.
+
+| Teclas | Acción |
+|------|--------|
+| `Cmd+Enter` / `Ctrl+Enter` | Ejecutar |
+| `Cmd+E` / `Ctrl+E` | Abrir en el editor (modo SELECT) |
+| `Cmd+S` / `Ctrl+S` | Guardar |
+| `Cmd+Shift+S` / `Ctrl+Shift+S` | Guardar como |
+| `Cmd+Backspace` / `Ctrl+Backspace` | Reiniciar |
+
+#### Construir un SELECT
+
+El cuerpo del SELECT tiene secciones que rellenas de arriba a abajo:
+
+- **Columns** — la proyección (qué columnas seleccionar).
+- **Filters** — un árbol de predicados `WHERE`. Los predicados se pueden
+  anidar en grupos AND/OR, así que puedes construir condiciones complejas de
+  forma visual.
+- **Joins** — tablas adicionales con un alias y una condición `ON`.
+- **Group By / Aggregates** — ver más abajo.
+- **Sort** — entradas de `ORDER BY`.
+- **Limit & Offset** — límites de paginación.
+
+La vista previa de SQL está parametrizada: los valores literales se emiten
+como placeholders para el dialecto activo (SQLite, PostgreSQL,
+MySQL/MariaDB o SQL Server).
+
+#### GROUP BY y agregados
+
+Añade columnas de agrupación y agregados en la sección **Group By /
+Aggregates**. Las funciones de agregado soportadas son `COUNT`, `COUNT(*)`,
+`COUNT(DISTINCT)`, `SUM`, `AVG`, `MIN` y `MAX`. Cada agregado obtiene un alias
+editable que se genera automáticamente a partir de la función y la columna.
+
+Una vez agrupada la query:
+
+- La sección **Columns** se reemplaza por una vista previa de solo lectura
+  del `SELECT` efectivo (columnas de agrupación seguidas de los alias de los
+  agregados).
+- Aparece una sección **Having**, que usa el mismo editor de predicados que
+  Filters pero aplicado a `HAVING`.
+- Las entradas de **Sort** quedan restringidas a las columnas de agrupación y
+  los alias de los agregados; las entradas inválidas se rechazan con un error
+  visible.
+
+Cómo se comportan los resultados agrupados en el data grid se describe en
+[Resultados agregados](#resultados-agregados).
+
+#### Autocompletado consciente del schema
+
+Los inputs de una sola línea del builder (filtro, orden, columnas
+proyectadas, la tabla destino del join, y ambos lados de un `ON` de join)
+ofrecen sugerencias inline obtenidas del schema en vivo y de la propia
+especificación del builder: columnas de la tabla origen, alias de join
+declarados, y columnas de la tabla unida (obtenidas de forma diferida en
+segundo plano). Escribir `<alias>.` restringe las sugerencias solo a las
+columnas de ese alias. La coincidencia es solo por prefijo.
+
+| Teclas | Acción |
+|------|--------|
+| `Up` / `Down` | Moverse entre sugerencias |
+| `Tab` / `Enter` | Confirmar la sugerencia resaltada |
+| `Esc` (o pérdida de foco) | Descartar |
+
+El mismo autocompletado está disponible en el input de filtro `WHERE` del
+data grid (ver [Filtrar resultados](#filtrar-resultados)).
+
+#### Queries guardadas
+
+Los builders se pueden guardar por perfil de conexión y reabrir más tarde.
+Las queries guardadas están acotadas al perfil, con nombres únicos. Una query
+guardada también se puede importar a otra conexión; al importar, DBFlux
+verifica que las tablas referenciadas existan en la conexión destino antes de
+cargarla.
+
+#### UPDATE y DELETE visuales
+
+Cambia el selector de modo a **UPDATE** o **DELETE** para construir una
+mutación. Ambos modos reutilizan el mismo editor de filtros para la cláusula
+`WHERE`; UPDATE añade una sección de asignaciones para las columnas del `SET`
+(incluyendo asignaciones de expresión en bruto). La vista previa de SQL
+permanece visible todo el tiempo.
+
+Las mutaciones están sujetas a una política que combina el estado de solo
+lectura de la conexión y el contexto del actor:
+
+| Política | Efecto |
+|--------|--------|
+| Allowed | La mutación puede ejecutarse. |
+| Read-only | La ejecución está bloqueada (por ejemplo, un perfil de solo lectura). |
+| Approval required | La mutación debe aprobarse antes de ejecutarse. |
+
+**Modo de ejecución.** La sección **Execution** ofrece tres modos, con uno
+por defecto sugerido automáticamente a partir de la estimación de número de
+filas, el soporte de transacciones del driver, y la disponibilidad de una
+primary key. Anular la sugerencia muestra un modal de tradeoffs.
+
+| Modo | Comportamiento |
+|------|----------|
+| **Single TX** | Una única transacción para todo el cambio. |
+| **Chunked TX** | Chunks paginados por keyset sobre la primary key de la tabla (tamaño de chunk acotado entre 1000 y 10000, por defecto 5000). Cada chunk es su propia transacción, aparece como una entrada del panel Tasks, se puede cancelar entre chunks, y hace rollback si falla. |
+| **Direct** | Sin envoltorio de transacción (autocommit). Se usa cuando el driver no soporta transacciones. |
+
+**Gate de query peligrosa.** Un `UPDATE` o `DELETE` sin `WHERE` pasa por la
+confirmación de queries peligrosas (ver
+[Confirmación de queries peligrosas](#confirmación-de-queries-peligrosas))
+antes de ejecutarse.
+
+---
+
+## 4. Trabajar con resultados
+
+Los resultados se renderizan en pestañas de resultado dentro del documento.
+El modo de vista se elige automáticamente según la categoría de la base de
+datos:
+
+- **Vista de tabla** para bases de datos relacionales.
+- **Vista de árbol de documentos** para bases de datos de documentos (por
+  ejemplo MongoDB, DynamoDB).
+- **Vista clave-valor** para Redis.
+
+Los contenedores de tipo event-stream se abren como event streams cuando el
+driver declara esa presentación.
+
+### Navegar el data grid
+
+Cuando el panel de resultados tiene el foco:
+
+- `j`/`k` (o `Down`/`Up`) — moverse entre filas.
+- `h`/`l` (o `Left`/`Right`) — moverse entre columnas.
+- `g`/`Shift+g` (o `Home`/`End`) — primera / última fila.
+- `Ctrl+d`/`Ctrl+u` (o `PageDown`/`PageUp`) — recorrer filas por páginas.
+- `[` / `]` — página anterior / siguiente de resultados (paginación).
+- `f` enfoca la toolbar; `/` enfoca la búsqueda/filtro.
+- `z` alterna el colapso del panel.
+- `m` (o `Shift+F10`) abre el menú contextual de fila/celda.
+
+### Filtrar resultados
+
+La toolbar del data grid tiene un input de filtro `WHERE` que vuelve a
+ejecutar la query con la condición que escribas. Para conexiones SQL soporta
+dos estilos:
+
+- **`WHERE` en bruto** — escribe una condición plana (por ejemplo
+  `status = 'active'`). Este es el comportamiento por defecto.
+- **Rutas relacionales (estilo ORM)** — escribe una ruta con puntos que
+  recorre foreign keys, por ejemplo `created_by.email LIKE '%@acme.com'` o
+  `created_by.organization.name = 'Acme'`. DBFlux resuelve la ruta contra los
+  metadatos de foreign key de la tabla y hace los joins hasta la tabla
+  referenciada por ti; no hace falta escribir los JOINs a mano.
+
+Cuando un filtro relacional se resuelve, un chip muestra cuántos joins
+añadió. Si un segmento es ambiguo o no se puede resolver, aparece un error
+inline con un enlace **Open in builder** que abre el constructor visual de
+queries precargado con los joins resueltos hasta ese punto. La entrada sin
+puntos siempre mantiene el comportamiento de `WHERE` en bruto.
+
+El input de filtro también ofrece autocompletado consciente del schema
+(misma navegación que el builder — ver
+[Autocompletado consciente del schema](#autocompletado-consciente-del-schema)).
+
+### Editar y CRUD
+
+En el data grid:
+
+- `o` — añadir una fila.
+- `x` — eliminar la fila seleccionada.
+- `r` — renombrar / editar (según el contexto).
+- `y` — copiar la fila seleccionada.
+- `Ctrl+c` (`Cmd+c`) — copiar la(s) celda(s) seleccionada(s) al portapapeles.
+
+#### Cuándo los resultados son editables
+
+Los browses de tabla planos son editables cuando la tabla tiene una primary
+key. Los resultados producidos por el **constructor visual de queries** (modo
+SELECT) también son editables, pero solo cuando están demostrablemente
+vinculados a una única tabla: el resultado mapea 1:1 a una tabla subyacente y
+cada columna de primary key de esa tabla está proyectada con su nombre
+original. Las ediciones y eliminaciones construyen entonces su `WHERE` a
+partir de los valores de primary key proyectados.
+
+Los JOINs están permitidos: las columnas de la tabla origen son editables,
+mientras que las columnas unidas son de solo lectura.
+
+Un resultado del builder recae en **solo lectura** — con una pista en la
+toolbar explicando por qué — cuando se cumple alguna de estas condiciones:
+
+- La query agrega o usa `GROUP BY` / `HAVING`.
+- La proyección es un wildcard a través de un JOIN.
+- Falta una columna de primary key o está proyectada bajo un alias.
+- Las keys de la tabla aún no se han cargado desde la caché del schema (el
+  grid se actualiza a editable en cuanto llegan las keys).
+
+El SQL de forma libre escrito en el editor sigue siendo de solo lectura; la
+edición inline solo aplica a browses de tabla planos y a SELECTs generados
+por el builder.
+
+#### Resultados agregados
+
+Cuando un resultado proviene de una query agrupada (`GROUP BY`), las filas
+muestran la salida agregada y la edición está deshabilitada — añadir fila,
+eliminar fila, editar celda e inspeccionar fila no están disponibles, con
+tooltips explicativos. La paginación cuenta las filas agrupadas (no las filas
+subyacentes), así que el total de páginas es correcto. Las columnas de
+agregado conservan el tipo de columna correcto, así que graficar sigue
+funcionando.
+
+### Copiar como query
+
+El menú contextual de resultados incluye **Copy as Query**, que genera una
+sentencia de mutación específica del driver (o un envelope, para drivers no
+SQL) a partir de la fila seleccionada usando el generador de queries propio
+del driver.
+
+### Exportar
+
+Pulsa `Ctrl+e` (`Cmd+e`) en el panel de resultados, o ejecuta **Export
+Results** desde el command palette. Los formatos disponibles dependen de la
+forma del resultado e incluyen:
+
+- **CSV**
+- **JSON (pretty)** y **JSON (compact)**
+- **Text**
+- **Binary** (para resultados con forma binaria)
+
+---
+
+## 5. Graficar resultados
+
+Cualquier query que produzca resultados tabulares se puede graficar. En la
+toolbar del editor de queries, haz clic en el botón de gráfico (tooltip:
+"Open current query in a chart document") para abrir la query actual en un
+documento de gráfico.
+
+Los gráficos usan los metadatos de tipo de columna que aporta el driver para
+autodetectar los ejes (columnas de tiempo, columnas numéricas, etc.). Los
+tipos de gráfico soportados son:
+
+- **Line**
+- **Bar**
+- **Scatter**
+- **Area**
+- **Stacked Bar**
+- **Pie**
+
+Los gráficos se pueden guardar por perfil de conexión. Para reabrir un
+gráfico guardado, ejecuta **Open Chart...** desde el command palette
+(`OpenSavedChart`), que lista los gráficos guardados del perfil actual en un
+overlay de búsqueda difusa.
+
+---
+
+## 6. Queries guardadas e historial
+
+DBFlux mantiene un historial de las queries completadas y te permite guardar
+queries con nombre.
+
+- `Alt+h` (en el editor) alterna el desplegable de historial de queries.
+- `Ctrl+s` (`Cmd+s`) — **Save** la query actual.
+- `Ctrl+Shift+s` (`Cmd+Shift+s`) — **Save File As**.
+- `Ctrl+p` (`Cmd+p`, en el editor) — abre el explorador de queries guardadas.
+
+Dentro del modal de historial puedes navegar con `Ctrl+j`/`Ctrl+k` (o las
+flechas), abrir una entrada con `Enter`, y usar los mnemónicos locales
+`Ctrl+f` (marcar como favorito), `Ctrl+r` (renombrar) y `Ctrl+d` (eliminar).
+`/` enfoca la búsqueda del modal.
+
+---
+
+## 7. Referencia de teclado
+
+DBFlux usa un keymap por capas, sensible al contexto. La capa activa depende
+de qué panel tiene el foco. Los atajos escritos con el modificador
+**primary** usan `Cmd` en macOS y `Ctrl` en el resto de plataformas; los
+atajos escritos con `Ctrl` literal se mantienen como `Ctrl` en todas las
+plataformas (para evitar conflictos con los atajos del sistema en macOS).
+
+### Global (disponible sin importar el foco)
+
+| Teclas | Acción |
+|------|--------|
+| `Ctrl+Shift+P` / `Cmd+Shift+P` | Alternar command palette |
+| `Ctrl+n` / `Cmd+n` | Nueva pestaña de query |
+| `Ctrl+w` / `Cmd+w` | Cerrar pestaña actual |
+| `Ctrl+Tab` / `Ctrl+Shift+Tab` | Pestaña siguiente / anterior |
+| `Ctrl+1` .. `Ctrl+9` / `Cmd+1` .. `Cmd+9` | Cambiar a la pestaña N |
+| `Ctrl+o` / `Cmd+o` | Abrir archivo de script |
+| `Ctrl+Enter` / `Cmd+Enter` | Ejecutar query |
+| `Ctrl+Shift+Enter` / `Cmd+Shift+Enter` | Ejecutar query en nueva pestaña |
+| `Escape` | Cancelar / cerrar modal |
+| `Tab` / `Shift+Tab` | Ciclar el foco adelante / atrás |
+| `Ctrl+Shift+1` | Enfocar sidebar |
+| `Ctrl+Shift+2` | Enfocar editor |
+| `Ctrl+Shift+3` | Enfocar resultados |
+| `Ctrl+Shift+4` | Enfocar tareas en segundo plano |
+| `Ctrl+Shift+A` / `Cmd+Shift+A` | Abrir el visor de auditoría |
+| `Ctrl+b` / `Cmd+b` | Alternar sidebar |
+| `Ctrl+m` | Abrir el menú contextual de la pestaña |
+
+### Sidebar
+
+| Teclas | Acción |
+|------|--------|
+| `q` / `e` | Cambiar de pestaña del sidebar (Connections / Scripts) |
+| `/` | Enfocar búsqueda |
+| `j` / `k` (o `Down` / `Up`) | Seleccionar siguiente / anterior |
+| `h` / `l` | Colapsar / expandir nodo |
+| `Space` | Expandir / colapsar |
+| `g` / `Shift+g` (o `Home` / `End`) | Primer / último elemento |
+| `Ctrl+d` / `Ctrl+u` (o `PageDown` / `PageUp`) | Página abajo / arriba |
+| `Enter` | Abrir / ejecutar elemento |
+| `r` | Refrescar schema |
+| `c` | Abrir el Connection Manager |
+| `d` | Desconectar |
+| `m` | Abrir el menú del elemento |
+| `Shift+j` / `Shift+k` | Extender la selección abajo / arriba |
+| `Space` (con Shift) | Alternar selección |
+| `Ctrl+j` / `Ctrl+k` | Mover el elemento seleccionado abajo / arriba |
+| `Shift+r` | Renombrar |
+| `x` | Eliminar |
+| `Shift+n` | Crear carpeta |
+| `Ctrl+l` | Enfocar el panel de la derecha |
+
+### Editor
+
+| Teclas | Acción |
+|------|--------|
+| `Ctrl+h` / `Ctrl+j` / `Ctrl+k` | Enfocar panel izquierda / abajo / arriba |
+| `Alt+h` | Alternar desplegable de historial |
+| `Ctrl+p` / `Cmd+p` | Abrir queries guardadas |
+| `Ctrl+s` / `Cmd+s` | Guardar query |
+| `Ctrl+Shift+s` / `Cmd+Shift+s` | Guardar archivo como |
+| `Enter` | Enfocar / ejecutar |
+
+(Las letras sin modificador se dejan intencionadamente para el input de
+texto, así la escritura funciona con normalidad.)
+
+### Resultados
+
+| Teclas | Acción |
+|------|--------|
+| `Ctrl+h` / `Ctrl+k` / `Ctrl+l` | Enfocar panel izquierda / arriba / derecha |
+| `Ctrl+j` | Enfocar toolbar |
+| `j` / `k` (o `Down` / `Up`) | Fila siguiente / anterior |
+| `h` / `l` (o `Left` / `Right`) | Columna izquierda / derecha |
+| `g` / `Shift+g` (o `Home` / `End`) | Primera / última fila |
+| `Ctrl+d` / `Ctrl+u` (o `PageDown` / `PageUp`) | Página abajo / arriba |
+| `]` / `[` | Página siguiente / anterior de resultados |
+| `Ctrl+e` / `Cmd+e` | Exportar resultados |
+| `f` | Enfocar toolbar |
+| `/` | Enfocar búsqueda/filtro |
+| `x` | Eliminar fila |
+| `r` | Renombrar / editar |
+| `o` | Añadir fila |
+| `y` | Copiar fila |
+| `Ctrl+c` / `Cmd+c` | Copiar celda(s) |
+| `z` | Alternar colapso del panel |
+| `m` (o `Shift+F10`) | Abrir menú contextual |
+
+### Tareas en segundo plano
+
+| Teclas | Acción |
+|------|--------|
+| `Ctrl+h` / `Ctrl+j` / `Ctrl+k` | Enfocar panel izquierda / abajo / arriba |
+| `j` / `k` (o `Down` / `Up`) | Seleccionar siguiente / anterior |
+| `g` / `Shift+g` (o `Home` / `End`) | Primero / último |
+| `Ctrl+d` / `Ctrl+u` (o `PageDown` / `PageUp`) | Página abajo / arriba |
+| `z` | Alternar colapso del panel |
+
+### Command palette
+
+| Teclas | Acción |
+|------|--------|
+| `j` / `k` (o `Down` / `Up`) | Seleccionar siguiente / anterior |
+| `Enter` | Ejecutar |
+| `Escape` | Cancelar |
+
+### Menú contextual
+
+| Teclas | Acción |
+|------|--------|
+| `j` / `k` (o `Down` / `Up`) | Mover abajo / arriba |
+| `Enter` / `l` (o `Right`) | Seleccionar / entrar en submenú |
+| `Escape` / `h` (o `Left`) | Volver / cerrar |
+
+### Modal de historial
+
+| Teclas | Acción |
+|------|--------|
+| `Ctrl+j` / `Ctrl+k` (o `Down` / `Up`) | Seleccionar siguiente / anterior |
+| `Enter` | Abrir entrada |
+| `Ctrl+f` | Alternar favorito |
+| `Ctrl+r` | Renombrar |
+| `Ctrl+d` | Eliminar |
+| `/` | Enfocar búsqueda |
+| `Ctrl+s` / `Cmd+s` | Guardar query |
+
+---
+
+## 8. Resumen de Settings
+
+Settings tiene estas secciones (las secciones de MCP solo aparecen en builds
+con soporte de AI/MCP, que es el valor por defecto):
+
+- **General** — preferencias globales de la aplicación: tema, inicio/sesión,
+  valores por defecto de refresco, y el comportamiento de confirmación de
+  queries peligrosas.
+- **Audit** — qué captura el log de auditoría (nivel mínimo de captura de
+  log) y la retención.
+- **MCP Clients / Roles / Policies** — gobernanza de clientes de AI (clientes
+  confiables, roles, políticas). Ver `docs/MCP_AI_INTEGRATION.md`.
+- **Keybindings** — un visor de **solo lectura** del keymap activo, con un
+  filtro de texto y avisos de conflicto. Reasignar teclas desde la UI no está
+  disponible.
+- **Proxies** — perfiles de proxy SOCKS5 / HTTP CONNECT.
+- **SSH Tunnels** — perfiles de túnel SSH seleccionables por conexión.
+- **Auth Profiles** — perfiles de autenticación gestionados por un provider
+  (AWS SSO / credenciales compartidas).
+- **Services** — servicios RPC registrados externamente (drivers y auth
+  providers). Ver `docs/RPC_SERVICES_CONFIG.md`.
+- **Hooks** — definiciones globales de connection hooks (modos Command,
+  Script y Lua). Los bindings de fase por perfil viven en la pestaña Hooks
+  del Connection Manager.
+- **Drivers** — overrides y ajustes por driver.
+- **About** — información de versión y build.
+
+Para una referencia completa por ajuste y la guía de connection hooks, ver
+`docs/SETTINGS.md`.
+
+### Documentación relacionada
+
+- Configuración avanzada de conexión (SSH, proxy, AWS SSO, fuentes de
+  valores): `docs/CONNECTIONS.md`
+- Referencia completa de Settings y connection hooks: `docs/SETTINGS.md`
+- Almacenamiento de datos y privacidad (dónde viven los datos y secretos,
+  backup, reset): `docs/DATA_AND_PRIVACY.md`
+- Dashboards, gráficos guardados y el visor de auditoría (uso):
+  `docs/DASHBOARDS_AND_AUDIT.md`
+- Connection hooks y el runtime de Lua embebido: `docs/LUA.md`
+- Integración de clientes de AI (MCP): `docs/MCP_AI_INTEGRATION.md`
+- Log de auditoría y schema de eventos: `docs/AUDIT.md`
+- Drivers/servicios RPC externos: `docs/RPC_SERVICES_CONFIG.md`,
+  `docs/DRIVER_RPC_PROTOCOL.md`

--- a/web/src/components/DocsIndex.astro
+++ b/web/src/components/DocsIndex.astro
@@ -1,5 +1,5 @@
 ---
-import { docTitle, sectionsFor } from '../data/docs';
+import { localizedDocTitle, sectionsFor } from '../data/docs';
 import { docsHref } from '../data/versions';
 import { localeFromPathname, t } from '../i18n';
 import type { Locale } from '../i18n';
@@ -8,9 +8,16 @@ interface Props {
   versionId: string;
   available: readonly string[];
   locale?: Locale;
+  /** Spanish page titles sourced from each translated doc's own H1 — see `docs.ts`. */
+  esTitles?: Readonly<Record<string, string>>;
 }
 
-const { versionId, available, locale = localeFromPathname(Astro.url.pathname) } = Astro.props;
+const {
+  versionId,
+  available,
+  locale = localeFromPathname(Astro.url.pathname),
+  esTitles = {},
+} = Astro.props;
 const { sections, unfiled } = sectionsFor(available);
 ---
 
@@ -24,7 +31,9 @@ const { sections, unfiled } = sectionsFor(available);
       <ul>
         {section.entries.map((path) => (
           <li>
-            <a href={docsHref(`${versionId}/${path}`, locale)}>{docTitle(path)}</a>
+            <a href={docsHref(`${versionId}/${path}`, locale)}>
+              {localizedDocTitle(path, locale, esTitles)}
+            </a>
           </li>
         ))}
       </ul>

--- a/web/src/components/DocsTree.astro
+++ b/web/src/components/DocsTree.astro
@@ -1,6 +1,6 @@
 ---
 import Icon from '../components/Icon.astro';
-import { docTitle, sectionsFor } from '../data/docs';
+import { localizedDocTitle, sectionsFor } from '../data/docs';
 import type { DocsVersion } from '../data/versions';
 import { docsHref } from '../data/versions';
 import { localeFromPathname, t } from '../i18n';
@@ -12,6 +12,8 @@ interface Props {
   current?: string;
   available: readonly string[];
   locale?: Locale;
+  /** Spanish page titles sourced from each translated doc's own H1 — see `docs.ts`. */
+  esTitles?: Readonly<Record<string, string>>;
 }
 
 const {
@@ -19,6 +21,7 @@ const {
   current,
   available,
   locale = localeFromPathname(Astro.url.pathname),
+  esTitles = {},
 } = Astro.props;
 
 const sections = sectionsFor(available).sections.map((section) => ({
@@ -53,7 +56,7 @@ const sections = sectionsFor(available).sections.map((section) => ({
                     href={docsHref(`${version.id}/${id}`, locale)}
                     aria-current={id === current ? 'page' : undefined}
                   >
-                    {docTitle(id)}
+                    {localizedDocTitle(id, locale, esTitles)}
                   </a>
                 </li>
               ))}

--- a/web/src/data/docs.ts
+++ b/web/src/data/docs.ts
@@ -3,6 +3,22 @@ import type { Locale } from '../i18n';
 import { DOCS_SECTIONS, docTitle } from './nav';
 
 /**
+ * The nav/rail/breadcrumb label for a page in `locale`.
+ *
+ * Spanish uses the translated doc's own H1 when one exists (`esTitles`);
+ * otherwise — untranslated pages, or the English locale — it falls back to
+ * the fixed `DOC_TITLES` rail label so navigation never renders a blank spot
+ * for a page that has not been translated yet.
+ */
+export function localizedDocTitle(
+  id: string,
+  locale: Locale,
+  esTitles: Readonly<Record<string, string>>,
+): string {
+  return (locale === 'es' ? esTitles[id] : undefined) ?? docTitle(id);
+}
+
+/**
  * Split a collection id of the form `<version>/<path>`, or its Spanish
  * counterpart `<version>/es/<path>` (see `content.config.ts`). The locale
  * segment is reported separately so callers never have to special-case it out
@@ -65,6 +81,43 @@ export function sectionsFor(available: readonly string[]): {
   const listed = new Set(sections.flatMap((section) => section.entries));
 
   return { sections, unfiled: available.filter((path) => !listed.has(path)).sort() };
+}
+
+/**
+ * The first-level heading of a doc's raw markdown body, if it has one.
+ *
+ * Every page in this collection is authored with its own H1 as the first
+ * line, so this is a plain first-match rather than a full markdown parse.
+ */
+export function firstHeading(body: string | undefined): string | undefined {
+  const match = body?.match(/^#\s+(.+)$/m);
+
+  return match?.[1].trim();
+}
+
+/**
+ * Spanish page titles, sourced from each translated doc's own H1.
+ *
+ * The English `DOC_TITLES` dictionary in `nav.ts` is a fixed rail label, not
+ * the page's own heading, so it never doubles as the Spanish title — pages
+ * without an `es` sibling are simply absent from the returned map and callers
+ * fall back to `docTitle(path)`.
+ */
+export function esTitlesFor(
+  entries: readonly CollectionEntry<'docs'>[],
+  versionId: string,
+): Record<string, string> {
+  const titles: Record<string, string> = {};
+
+  for (const entry of entries) {
+    const parsed = splitId(entry.id);
+    if (parsed.version !== versionId || parsed.locale !== 'es') continue;
+
+    const heading = firstHeading(entry.body);
+    if (heading) titles[parsed.path] = heading;
+  }
+
+  return titles;
 }
 
 /**

--- a/web/src/layouts/DocsLayout.astro
+++ b/web/src/layouts/DocsLayout.astro
@@ -2,7 +2,6 @@
 import Base from '../layouts/Base.astro';
 import DocsTree from '../components/DocsTree.astro';
 import VersionPicker from '../components/VersionPicker.astro';
-import { docTitle } from '../data/nav';
 import type { DocsVersion } from '../data/versions';
 import { CURRENT, docsHref, versionHome, versionLabel } from '../data/versions';
 import { docsUrl } from '../data/site';
@@ -31,6 +30,8 @@ interface Props {
    * untranslated notice below and forces `noindex` regardless of `version`.
    */
   translated?: boolean;
+  /** Spanish page titles sourced from each translated doc's own H1 — see `docs.ts`. */
+  esTitles?: Readonly<Record<string, string>>;
 }
 
 const {
@@ -43,6 +44,7 @@ const {
   editPath,
   locale = localeFromPathname(Astro.url.pathname),
   translated = false,
+  esTitles = {},
 } = Astro.props;
 const onThisPage = headings.filter((heading) => heading.depth === 2);
 
@@ -90,7 +92,13 @@ const showsFallback = locale !== DEFAULT_LOCALE && !translated;
 
     <aside class="docs__rail" id="docs-rail">
       <VersionPicker version={version} currentPath={currentPath} locale={locale} />
-      <DocsTree version={version} current={currentPath} available={available} locale={locale} />
+      <DocsTree
+        version={version}
+        current={currentPath}
+        available={available}
+        locale={locale}
+        esTitles={esTitles}
+      />
     </aside>
 
     <article class="docs__body">
@@ -98,7 +106,7 @@ const showsFallback = locale !== DEFAULT_LOCALE && !translated;
         <a href={versionHome(version, locale)}>{t(locale, 'docs_tree.crumb_docs')}</a>
         <span>/</span>
         <span class="crumbs__here">
-          {currentPath ? docTitle(currentPath) : t(locale, 'docs_tree.crumb_overview')}
+          {currentPath ? title : t(locale, 'docs_tree.crumb_overview')}
         </span>
       </p>
       {

--- a/web/src/pages/[...path].astro
+++ b/web/src/pages/[...path].astro
@@ -2,7 +2,7 @@
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '../layouts/DocsLayout.astro';
 import DocsIndex from '../components/DocsIndex.astro';
-import { docTitle, pathsForVersion, repoPathFor, splitId } from '../data/docs';
+import { docTitle, esTitlesFor, pathsForVersion, repoPathFor, splitId } from '../data/docs';
 import { CURRENT, VERSIONS, docsRoute, versionById, versionLabel } from '../data/versions';
 import { DOCS_MODE } from '../data/site';
 import { DEFAULT_LOCALE, LOCALES } from '../i18n';
@@ -77,12 +77,18 @@ export async function getStaticPaths() {
 const { versionId, path, doc, locale, translated } = Astro.props;
 
 const version = versionById(versionId)!;
-const available = pathsForVersion(await getCollection('docs'), versionId);
+const allDocs = await getCollection('docs');
+const available = pathsForVersion(allDocs, versionId);
+const esTitles = esTitlesFor(allDocs, versionId);
 const isCurrent = versionId === CURRENT.id;
 
 const rendered = doc ? await render(doc) : undefined;
 
-const title = path ? docTitle(path) : 'Documentation';
+// A translated page's `<title>`/breadcrumb use its own Spanish H1 rather than
+// the fixed English rail label; a fallback page (English body under `/es/`)
+// keeps the English title since it is not actually showing translated text.
+const localizedTitle = locale === 'es' && translated && path ? esTitles[path] : undefined;
+const title = path ? (localizedTitle ?? docTitle(path)) : 'Documentation';
 
 const firstParagraph = doc?.body
   ?.split('\n\n')
@@ -108,12 +114,13 @@ const description = doc
   editPath={doc?.filePath ? repoPathFor(doc.filePath, versionId) : undefined}
   locale={locale}
   translated={translated}
+  esTitles={esTitles}
 >
   {
     rendered ? (
       <rendered.Content />
     ) : (
-      <DocsIndex versionId={versionId} available={available} locale={locale} />
+      <DocsIndex versionId={versionId} available={available} locale={locale} esTitles={esTitles} />
     )
   }
 </DocsLayout>


### PR DESCRIPTION
## Summary

First translated documentation: `docs/es/INSTALL.md`, `docs/es/USAGE.md` and `docs/es/CONNECTIONS.md` (neutral professional Spanish, imperative tú; commands, flags, paths, code blocks and DB vocabulary stay English; internal anchors re-derived for the translated headings). The site renders them as real translations — no fallback notice, no `noindex`, reciprocal hreflang — and gains a per-locale title mechanism: a translated page's first H1 drives its `<title>`, breadcrumb, rail label and version-index label; untranslated pages keep the English titles.

## What does this resolve?

- Refs #360 (website phase 2c; next: landing/about polish and the Weblate components for web and docs)

## How was this solved?

- `esTitlesFor()` extracts the H1 per version once and `localizedDocTitle()` centralizes the fallback, so title, tree and index cannot drift; future translations only need a `# Título` on line 1.
- The translations read correctly on GitHub (`docs/es/…` mirrors the English structure and links).

## Validation

- `pnpm check` → 0 errors; `astro build` → 188 pages (186 in docs mode); `check-links` → ok in both modes; manual assertions on the three `/es/docs/` pages (no banner, no robots meta, Spanish titles, hreflang pairs) and on an untranslated control page (mixed rail labels).
- Receipt-driven review: skipped for this candidate (native review store defect after a machine reboot; candidate-scoped decline).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` (consolidated entry when the web series completes)
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
