### PR TITLE
feat(i18n): add the language dropdown and translate the remaining documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to DBFlux will be documented in this file.
 
 ### Added
 
+* **Complete Spanish documentation and a language menu (#360)** — the
+  website's language switcher is now a dropdown listing every supported
+  language, ready to grow beyond two; the docs links in the navigation and
+  footer keep the reader's language across hosts. Every document the site
+  serves now ships in Spanish: the remaining fourteen guides, the
+  architecture and contributing pages, and all thirteen driver READMEs
+  (served from `docs/es/drivers/`).
+
 * **Spanish website and documentation (#360)** — dbflux.dev gains a Spanish
   edition under `/es/`: the landing page, about page, navigation, search
   dialog, install tabs and footer read from typed dictionaries with a

--- a/docs/es/ARCHITECTURE.md
+++ b/docs/es/ARCHITECTURE.md
@@ -1,0 +1,990 @@
+# Arquitectura
+
+Para el modelo conceptual y los límites de contratos, empieza por [Key Concepts](docs/CONCEPTS.md). Este documento sigue siendo canónico para los límites de crates y los archivos clave.
+
+## Descripción general
+
+- DBFlux es un cliente de bases de datos centrado en el teclado, construido con Rust y GPUI, enfocado en workflows rápidos y una UI de escritorio limpia (README.md).
+- El repositorio es un workspace de Rust con un crate de aplicación UI más tipos core compartidos, implementaciones de drivers y bibliotecas de soporte (Cargo.toml, crates/).
+- Soporta múltiples paradigmas de bases de datos: relacional (SQL), documentos (MongoDB, DynamoDB), key-value (Redis), series temporales (InfluxDB), log-stream (CloudWatch Logs), grafos y wide-column stores.
+- Este es el documento canónico de nivel superior para la estructura del proyecto, la descripción general de la arquitectura, los límites de los crates, los archivos clave y el mapa entre crates. El resto de documentos de nivel superior deben enlazar aquí en lugar de duplicar ese material.
+
+## Arquitectura de un vistazo
+
+El texto que sigue es exhaustivo pero denso; estos tres diagramas dan primero el modelo mental. Son conceptuales — los nombres exactos de los símbolos viven en las secciones siguientes.
+
+### Mapa de crates en capas
+
+Las dependencias apuntan hacia abajo. `dbflux_core` es la capa de contratos sin dependencias sobre la que se construye el resto de crates; la UI nunca depende de un crate de driver concreto (ver [Desacoplamiento Driver/UI](#sistema-de-drivers)).
+
+```mermaid
+flowchart TB
+    subgraph Shell["Shell del binario"]
+        bin["dbflux<br/>(main, CLI, IPC de instancia única,<br/>subcomando mcp)"]
+    end
+
+    subgraph UI["Presentación — 6 crates de UI"]
+        uicomp["dbflux_components<br/>(theme, tokens, icons, primitives,<br/>composites, controls, data_table,<br/>document_tree, result_panel, charts,<br/>modals, saved_chart — sin dependencia de dbflux_app)"]
+        uibase["dbflux_ui_base<br/>(AppStateEntity, events, keymap helpers,<br/>toast + throttle, user_error,<br/>modal_frame, platform,<br/>sql_preview_modal, sso_wizard)"]
+        uidoc["dbflux_ui_document<br/>(sistema tab/pane, documents,<br/>data_grid_panel, governance)"]
+        uisidebar["dbflux_ui_sidebar<br/>(árbol de sidebar de connections + scripts)"]
+        uiwindows["dbflux_ui_windows<br/>(ventanas connection_manager + settings)"]
+        uithin["dbflux_ui<br/>(integrador delgado: workspace, status_bar,<br/>tasks_panel, dock, overlays restantes,<br/>keymap glue, assets, ipc_server)"]
+        uicomp --> uibase --> uidoc & uiwindows & uisidebar --> uithin
+    end
+
+    subgraph Runtime["Runtime / dominio — dbflux_app"]
+        app["AppState, managers, hooks,<br/>registro de auth, access manager,<br/>rpc_services, config loader"]
+    end
+
+    subgraph Core["Contratos — dbflux_core"]
+        core["traits DbDriver / Connection,<br/>DriverMetadata, Value, schema,<br/>query, pipeline, modelos de storage"]
+    end
+
+    subgraph Drivers["Implementaciones de drivers"]
+        drv["postgres · mysql · sqlite · mssql · clickhouse<br/>mongodb · redis · dynamodb<br/>influxdb · cloudwatch · ipc (RPC)"]
+    end
+
+    subgraph Support["Bibliotecas de soporte"]
+        sup["storage · audit · policy · approval<br/>mcp · export · lua · aws · ssm<br/>ssh · proxy · tunnel_core · ipc"]
+    end
+
+    bin --> uithin --> app --> core
+    drv --> core
+    sup --> core
+    app --> drv
+    app --> sup
+    uithin -. "solo seams genéricos" .-> core
+```
+
+### Flujo de queries
+
+Una query viaja desde el editor document hasta una `Connection` del driver y de vuelta a una vista de resultado elegida por `DatabaseCategory` — la UI nunca bifurca según un driver id.
+
+```mermaid
+sequenceDiagram
+    participant U as Usuario
+    participant CD as CodeDocument<br/>(code/execution.rs)
+    participant LS as language_service<br/>(dangerous-query check)
+    participant Conn as Connection<br/>(driver impl)
+    participant RP as ResultPanel + DataGridPanel
+    participant V as View (según DatabaseCategory)
+
+    U->>CD: Ejecutar query (Cmd/Ctrl+Enter)
+    CD->>LS: clasificar statement(s)
+    alt dangerous (DELETE/DROP/TRUNCATE/FLUSH…)
+        LS-->>CD: necesita confirmación
+        CD->>U: diálogo de confirmación
+    end
+    CD->>Conn: ejecutar (en background executor)
+    Note over Conn: división multi-statement cuando<br/>se activa la capability MULTI_STATEMENT
+    Conn-->>CD: QueryResult(s)
+    CD->>RP: montar result(s)
+    RP->>V: Table / Document tree / Key-value<br/>(según metadata.category)
+    V-->>U: resultado renderizado
+```
+
+### Flujo de conexión
+
+Conectar ejecuta un pipeline pre-connect agnóstico del provider antes de que el driver abra, con tunneling/managed access opcional y hooks de lifecycle en cada fase.
+
+```mermaid
+flowchart TB
+    start["Conectar desde<br/>Connection Manager / sidebar"] --> prep["AppState::prepare_pipeline_input<br/>(input agnóstico del provider)"]
+    prep --> pre{{"PreConnect hooks"}}
+    pre --> auth["Pipeline: Authenticating<br/>(DynAuthProvider, p. ej. AWS SSO)"]
+    auth --> values["Pipeline: ResolvingValues<br/>(ValueRef → env/secret/param/auth)"]
+    values --> access["Pipeline: OpeningAccess"]
+    access --> tunnel{"¿Tipo de access?"}
+    tunnel -->|Direct| connect
+    tunnel -->|SSH / Proxy| t1["dbflux_tunnel_core::Tunnel<br/>(port forward local)"] --> connect
+    tunnel -->|Managed aws-ssm| t2["AccessManager<br/>(túnel SSM)"] --> connect
+    connect["DbDriver::connect → Connection"] --> schema["Fetch de schema perezoso<br/>(nombres primero, detalles al expandir)"]
+    schema --> post{{"PostConnect hooks"}}
+    post --> ready["Sidebar poblado · listo para query"]
+```
+
+## Stack Tecnológico
+
+- Lenguaje: Rust 2024 edition (crates/dbflux/Cargo.toml).
+- UI: `gpui`, `gpui-component` (Cargo.toml).
+- Bases de datos: `tokio-postgres` (PostgreSQL), `rusqlite` (SQLite), `mysql` (MySQL/MariaDB), `mongodb` (MongoDB), `redis` (Redis), `aws-sdk-dynamodb` (DynamoDB), y HTTP vía `reqwest` (ClickHouse) (Cargo.toml).
+- Auth/integración AWS: `aws-config`, `aws-sdk-sso`, `aws-sdk-ssooidc`, `aws-sdk-sts`, `aws-sdk-secretsmanager`, `aws-sdk-ssm` (`dbflux_aws`).
+- IPC/RPC: sockets locales `interprocess` + framing de mensajes `bincode` (`dbflux_ipc`, `dbflux_driver_ipc`, `dbflux_driver_host`).
+- SSH: `ssh2` vía `dbflux_ssh` (crates/dbflux_ssh/src/lib.rs).
+- Export: `csv` + `hex` + `base64` + `serde_json` vía `dbflux_export` (crates/dbflux_export/src/lib.rs).
+- Serialización/config: `serde`, `serde_json`, `dirs` (Cargo.toml).
+- Logging: `log`, `env_logger` (crates/dbflux/src/main.rs).
+
+## Estructura de Directorios
+
+```
+crates/
+  dbflux/                   # Binary shell: main entry point, CLI, single-instance IPC
+    src/
+      main.rs               # Application entry point, logging, window bootstrap, IPC socket
+      cli.rs                # CLI arg parsing, single-instance IPC client
+  dbflux_components/        # Domain-free leaf: theme, tokens, icons, primitives, composites,
+    src/                    # controls, typography, data_table, document_tree, tree_nav,
+      theme.rs              # Theme definitions
+      tokens.rs             # Design tokens (spacing, sizing constants)
+      icons/                # SVG icon system (AppIcon enum)
+        mod.rs
+      icon.rs               # Icon rendering helpers
+      primitives/           # Low-level building blocks (badge, banner, label, button, etc.)
+      controls/             # Input controls (button, checkbox, dropdown, input, select, etc.)
+      composites/           # Composed patterns (modal_frame, tab_strip, section_header, etc.)
+      components/           # Domain components
+        data_table/         # Custom virtualized data table
+          mod.rs
+          table.rs          # Main table component with phantom scroller
+          state.rs          # Table state management
+          model.rs          # CellValue and data model
+          selection.rs      # Selection handling
+          events.rs         # Event handling
+          clipboard.rs      # Copy/paste support
+          theme.rs          # Table styling
+        document_tree/      # Hierarchical document/JSON viewer
+          mod.rs
+          state.rs          # Tree state with cursor, expansion, search
+          tree.rs           # Tree rendering with keyboard navigation
+          node.rs           # Node types (document, field, array item)
+          events.rs         # Document tree events (selection, context menu)
+        tree_nav/           # Reusable tree navigation component
+          mod.rs
+          gutter.rs
+        filter_bar.rs       # Generic filter bar component
+        form_navigation.rs  # FormNavigation / FormEditState traits
+        form_renderer.rs    # Generic form field rendering
+        json_editor_view.rs # Inline JSON editor component
+        multi_select.rs     # Multi-select dropdown component
+        value_source_selector.rs # Value source dropdown (Env/Secret/Parameter/Auth)
+      modals/               # Reusable modal components (cell_editor, document_preview, etc.)
+      result_panel/         # ResultPanel + ViewHandle universal chrome host
+      chart/                # Chart engine (detect, spec, decimate, axis, legend, engine)
+      saved_chart.rs        # SavedChart + SavedChartStore type alias
+      common/               # Shared helpers (time_range picker, etc.)
+      actions.rs            # Shared action definitions
+      typography.rs
+  dbflux_ui_base/           # AppStateEntity + events, keymap helpers, platform utilities
+    src/
+      app_state_entity.rs   # AppStateEntity wrapper (Deref + EventEmitter), AppStateGlobal,
+                            # UserErrorReported + OpenAuditRequested events, unread_error_count
+      keymap.rs             # default_keymap, key_chord_from_gpui
+      async_ext.rs          # AsyncUpdateResultExt
+      toast.rs              # Toast + ToastHost with severity-aware token-bucket throttle
+      user_error/           # Centralized user-facing error reporting (UserFacingError,
+                            # ErrorKind, report_error, report_error_async) + throttle
+      modal_frame.rs        # Reusable modal chrome/frame
+      platform.rs           # X11/Wayland detection, window options
+      sql_preview_modal.rs  # SQL/query preview modal (dual-mode: SQL and generic)
+      sso_wizard.rs         # SSO account/role discovery wizard [cfg aws]
+  dbflux_ui_document/       # Tab/pane system, all document types, data_grid_panel, governance
+    src/
+      pane.rs               # PaneHandle: closure-erasing shell for typed Entity<T> documents
+      tab_manager.rs        # Tab enum, TabManager (Vec<Tab> + MRU order), TabManagerEvent
+      tab_bar.rs            # Visual tab bar rendering
+      handle.rs             # DocumentEvent enum (unified — replaces per-document event enums)
+      dedup.rs              # DocumentKey enum: identity key for tab deduplication
+      types.rs              # DocumentId, DocumentKind, DocumentMetaSnapshot, DocumentState
+      result_view.rs        # ResultViewMode enum (Table, LiveOutput, etc.)
+      task_runner.rs        # Background task tracking for documents
+      data_view.rs          # DataViewMode abstraction (Table vs Document)
+      data_view_trait.rs    # DataView trait (available_view_modes, focus_handle, active_context)
+      chrome.rs             # Shared chrome utilities
+      governance.rs         # MCP approvals view for pending executions
+      history_modal.rs      # Recent/saved queries modal
+      add_member_modal.rs   # Modal for adding Redis set/list/sorted-set members
+      new_key_modal.rs      # Modal for creating new Redis keys
+      chart_document/       # ChartDocument: saved/interactive chart tab
+        mod.rs              # ChartDocument entity
+        pane.rs             # ChartDocument::into_pane constructor
+        render.rs           # impl Render for ChartDocument
+      data_document/        # DataDocument: standalone data browsing tab
+        mod.rs              # DataDocument entity (thin shell around DataGridPanel + ResultPanel)
+        pane.rs             # DataDocument::into_pane constructor
+      data_grid_panel/      # Data grid with table/document view modes
+        mod.rs
+        context_menu.rs
+        filter_bar.rs
+        mutation_confirm.rs
+        mutation_executor.rs
+        mutations.rs
+        navigation.rs
+        query.rs
+        render.rs
+        row_inspector.rs
+        utils.rs
+      code/                 # CodeDocument: query/script editor
+        mod.rs
+        pane.rs             # CodeDocument::into_pane constructor
+        completion.rs       # Language-aware autocompletion
+        context_bar.rs      # Execution context dropdowns (connection/database/schema)
+        diagnostics.rs      # Live query diagnostics
+        execution.rs        # Query and script execution flow (incl. dangerous-query confirmation)
+        file_ops.rs         # Auto-save, scratch/shadow file management
+        focus.rs            # Internal focus management
+        live_output.rs      # Document-owned streamed script output buffer
+        render.rs           # Toolbar, editor, and live output rendering
+      key_value/            # Redis/key-value-specific document tab
+        mod.rs              # KeyValueDocument entity
+        pane.rs             # KeyValueDocument::into_pane constructor
+        view.rs             # KeyValueView boundary struct (file-level render helpers)
+        commands.rs
+        context_menu.rs
+        copy_command.rs
+        document_view.rs
+        mutations.rs
+        pagination.rs
+        parsing.rs
+        render.rs           # impl Render for KeyValueDocument
+      audit/                # AuditDocument: unified event/audit viewer tab
+        mod.rs              # AuditDocument entity
+        pane.rs             # AuditDocument::into_pane constructor
+        view.rs             # LogStreamView boundary struct
+        render.rs           # Extracted render code (~1300 LOC)
+        commands.rs         # Extracted command dispatch (~560 LOC)
+        filters.rs
+        saved_filter.rs
+        source_adapter.rs
+      chart/                # ChartShell host for metric/instance charts (distinct from chart_document/)
+        mod.rs
+        shell.rs            # ChartShell host entity
+        host.rs
+        metric_picker.rs
+        metric_picker_render.rs
+        toolbar.rs
+      instance_inspector/   # InstanceInspectorDocument (backs DocumentKey::InstanceInspector)
+        mod.rs
+        pane.rs             # into_pane constructor
+  dbflux_ui_sidebar/        # Connections + scripts sidebar tree with folders, drag-drop
+    src/
+      lib.rs                # SidebarView entity (re-exported by dbflux_ui)
+      code_generation.rs
+      context_menu.rs
+      deletion.rs
+      drag_drop.rs
+      expansion.rs
+      operations.rs
+      render.rs
+      render_footer.rs
+      render_overlays.rs
+      render_tree.rs
+      selection.rs
+      table_loading.rs
+      tree_builder.rs
+  dbflux_ui_windows/        # Settings window + connection manager window
+    src/
+      ssh_shared.rs         # Shared SSH auth UI components
+      settings/             # Settings window sections
+        mod.rs
+        render.rs           # Top-level settings window rendering
+        lifecycle.rs        # Settings window open/close/save logic
+        sidebar_nav.rs      # Settings sidebar navigation (TreeNav)
+        dirty_state.rs      # Unsaved-changes tracking for settings forms
+        form_nav.rs         # FormGridNav<F> generic 2D grid navigation
+        form_section.rs     # FormSection trait for keyboard navigation
+        section_trait.rs    # SettingsSection trait
+        general.rs          # General settings (theme, safety toggles)
+        keybindings.rs      # Keybindings settings section
+        auth_profiles_section.rs # Dynamic auth profile CRUD by provider form definition
+        proxies.rs          # Proxy CRUD form with FormGridNav
+        ssh_tunnels.rs      # SSH tunnel CRUD form with FormGridNav
+        hooks.rs            # Hook definitions CRUD
+        drivers.rs          # Per-driver settings overrides
+        rpc_services.rs     # RPC services settings UI (Driver/Auth Provider descriptors)
+        audit_section.rs    # Audit settings section
+        about_section.rs    # About section
+        mcp_section.rs      # MCP settings (trusted clients, roles, policies, audit; feature-gated)
+      connection_manager/   # Connection manager window
+        mod.rs
+        access_tab.rs       # Unified access mode editor (Direct/SSH/Proxy/SSM)
+        form.rs             # Connection form state and field management
+        navigation.rs       # Keyboard navigation within connection manager
+        render.rs           # Top-level connection manager rendering
+        render_driver_select.rs
+        render_tabs.rs
+        hooks_tab.rs        # Per-profile hook bindings
+  dbflux_ui/                # Thin integrator (~13.5k LOC): wires the six UI crates together
+    src/                    # Re-exports moved subsystems via pub use shims at old module paths
+      lib.rs                # Crate root; re-exports via shim modules
+      app.rs                # GPUI app bootstrap
+      ipc_server.rs         # App-control IPC server (Focus, OpenScript)
+      assets.rs             # GPUI AssetSource impl for embedded SVG icons
+      platform.rs           # Shim: pub use dbflux_ui_base::platform::*
+      keymap/               # Keyboard glue (actions, dispatcher)
+        mod.rs
+        actions.rs
+        dispatcher.rs
+      ui/
+        views/
+          workspace/        # Main layout, command dispatch, focus routing
+            mod.rs
+            actions.rs      # Workspace-level action handlers
+            dispatch.rs     # Command dispatch logic
+            render.rs       # Workspace rendering
+          status_bar.rs     # Status bar rendering
+          tasks_panel.rs    # Background tasks panel
+        dock/
+          sidebar_dock.rs   # Collapsible, resizable sidebar
+        overlays/           # Remaining overlays that stay in dbflux_ui
+          command_palette.rs       # Fuzzy command palette
+          login_modal.rs           # SSO login waiting modal with timeout
+          shutdown_overlay.rs      # Graceful shutdown overlay
+          # Shims at old overlay paths re-export from dbflux_ui_base / dbflux_components:
+          sql_preview_modal.rs     # → dbflux_ui_base::sql_preview_modal
+          sso_wizard.rs            # → dbflux_ui_base::sso_wizard
+          cell_editor_modal.rs     # → dbflux_components::modals::cell_editor
+          document_preview_modal.rs # → dbflux_components::modals::document_preview
+        document.rs         # Shim: pub use dbflux_ui_document::*
+        icons/mod.rs        # Shim: re-exports AppIcon + embedded_bytes (SVG resources live here)
+        theme.rs            # Shim: pub use dbflux_components::theme::*
+        tokens.rs           # Shim: pub use dbflux_components::tokens::*
+        components/
+          modal_frame.rs    # Shim: → dbflux_ui_base::modal_frame
+          toast.rs          # Shim: → dbflux_ui_base::toast
+        windows/mod.rs      # Shim: pub use dbflux_ui_windows::*
+        views/sidebar/mod.rs # Shim: pub use dbflux_ui_sidebar::*
+  dbflux_app/               # Runtime/domain: AppState (plain struct), managers, hooks, auth
+    src/
+      app_state.rs          # AppState (plain struct, no GPUI dependency)
+      access_manager.rs      # AppAccessManager for direct/managed access
+      auth_provider_registry.rs # Runtime auth provider registry
+      hook_executor.rs       # Composite hook executor routing
+      proxy.rs               # create_proxy_tunnel callback for CreateTunnelFn
+      config_loader.rs       # SQLite-backed configuration persistence
+      rpc_services/          # RPC service discovery/adaptation seam for runtime bootstrap (external_audit, ...)
+      history_manager_sqlite.rs # SQLite-backed query history
+      mcp_command.rs         # MCP subcommand integration and arg parsing
+      keymap/                # Keyboard system (pure domain types)
+        mod.rs               # Re-exports Command/ContextId from dbflux_core::keymap_types
+        focus.rs             # FocusTarget enum (pure domain)
+  dbflux_core/              # Traits, core types, storage, errors
+    src/access/             # AccessKind, AccessManager, and managed-access serialization
+      mod.rs
+    src/auth/               # AuthProfile + DynAuthProvider contracts
+      mod.rs
+      types.rs
+    src/core/               # Fundamental types and traits
+      traits.rs             # DbDriver + Connection traits
+      error.rs              # DbError type
+      error_formatter.rs    # ErrorFormatter trait for driver-specific error messages
+      value.rs              # Generic Value type for cross-database data
+      shutdown.rs           # ShutdownCoordinator
+      task.rs               # Background task tracking
+    src/driver/             # Driver metadata and form definitions
+      capabilities.rs       # DatabaseCategory, QueryLanguage, DriverCapabilities, DriverMetadata
+      form.rs               # Dynamic form definitions per driver
+    src/schema/             # Database schema types
+      types.rs              # Schema types (tables, collections, indexes, FKs)
+      builder.rs            # Builder helpers for schema construction
+      node_id.rs            # SchemaNodeId for tree identification
+    src/sql/                # SQL generation and dialects
+      dialect.rs            # SqlDialect trait for SQL flavor differences
+      generation.rs         # SQL INSERT/UPDATE/DELETE generation
+      query_builder.rs      # SqlQueryBuilder for safe query construction
+      code_generation.rs    # DDL code generation (indexes, types, FKs)
+    src/query/              # Query types and language services
+      types.rs              # QueryRequest, QueryResult, Row, ColumnMeta
+      generator.rs          # QueryGenerator trait, mutation/read templates, semantic preview helpers
+      language_service.rs   # Dangerous query detection (SQL, MongoDB, Redis)
+      safety.rs             # Safe read query detection
+      table_browser.rs      # Table browsing state and pagination
+    src/connection/         # Connection management and profiles
+      profile.rs            # Connection/SSH profiles
+      profile_manager.rs    # ProfileManager
+      manager.rs            # ConnectionManager, schema caching, connect flow
+      hook.rs               # Hook definitions, HookRunner, phase orchestration
+      tree.rs               # Folder/connection tree model
+      tree_manager.rs       # ConnectionTreeManager
+      context.rs            # Per-tab execution context (connection/database/schema)
+      proxy.rs              # ProxyProfile, ProxyKind, ProxyAuth, no_proxy matching
+      proxy_manager.rs      # ProxyManager (type alias for ItemManager<ProxyProfile>)
+      ssh_tunnel_manager.rs # SshTunnelManager
+      item_manager.rs       # Generic ItemManager<T>, Identifiable, DefaultFilename traits
+    src/storage/            # Persistence and state
+      session.rs            # Session persistence (scratch/shadow files, manifest)
+      history.rs            # History persistence
+      saved_query.rs        # Saved queries persistence
+      recent_files.rs       # Recent files tracking
+      secrets.rs            # Keyring secret storage
+      secret_manager.rs     # SecretManager with HasSecretRef trait
+      ui_state.rs           # UiStateStore for persisted UI state (sidebar collapse)
+    src/data/               # Data types and operations
+      crud.rs               # CRUD mutation types for all database paradigms
+      key_value.rs          # Key-value operation types (Hash, Set, List, ZSet, Stream)
+      view.rs               # DataViewMode (Table/Document) abstraction
+    src/config/             # Application configuration
+      app.rs                # Legacy config.json import (deprecated)
+      refresh_policy.rs     # Schema refresh policy
+      scripts_directory.rs  # Scripts folder tree (file/folder CRUD)
+    src/pipeline/           # Pre-connect pipeline (auth/value/access stages)
+      mod.rs
+      resolve.rs
+    src/values/             # ValueRef resolution + provider registry + cache
+      resolver.rs
+    src/facade/             # Session facade
+      session.rs            # Session facade for connection management
+  dbflux_ipc/               # Versioned IPC contracts and framing
+    src/auth.rs             # IPC auth token generation and file storage
+    src/envelope.rs         # ProtocolVersion + app/driver protocol constants
+    src/protocol.rs         # Single-instance app-control messages
+    src/driver_protocol.rs  # Driver RPC request/response schema (DTOs + errors)
+    src/framing.rs          # Length-prefixed bincode transport framing
+    src/socket.rs           # Cross-platform socket naming helpers
+  dbflux_driver_ipc/        # DbDriver adapter for external RPC services
+    src/driver.rs           # IpcDriver + managed host lifecycle
+    src/transport.rs        # RPC client transport and handshake
+    src/connection.rs       # Connection proxy over driver RPC
+  dbflux_driver_host/       # Host process that serves drivers over RPC
+    src/main.rs             # Driver RPC server entry point
+    src/session.rs          # Session manager and method dispatch
+  dbflux_driver_postgres/   # PostgreSQL driver implementation
+  dbflux_driver_sqlite/     # SQLite driver implementation
+  dbflux_driver_mysql/      # MySQL/MariaDB driver implementation
+  dbflux_driver_mssql/      # Microsoft SQL Server driver implementation
+  dbflux_driver_mongodb/    # MongoDB driver implementation
+    src/driver.rs           # Connection, schema discovery, CRUD operations
+    src/query_parser.rs     # MongoDB query syntax parser (db.collection.method())
+    src/query_generator.rs  # MongoDB shell query generator (insertOne, updateOne, etc.)
+  dbflux_driver_redis/      # Redis driver implementation
+    src/driver.rs           # Connection, key-value API, schema discovery
+    src/command_generator.rs # Redis command generator (SET, HSET, SADD, etc.)
+  dbflux_driver_dynamodb/   # DynamoDB driver implementation
+    src/driver.rs           # Connection, schema discovery, scan/query/put/update/delete
+    src/query_parser.rs     # JSON command envelope parser for DynamoDB operations
+    src/query_generator.rs  # Mutation -> DynamoDB command envelope generator
+    tests/live_integration.rs # Docker-backed integration tests (DynamoDB Local)
+  dbflux_driver_influxdb/   # InfluxDB driver (v1 + v2)
+    src/driver.rs           # Connection, bucket/measurement discovery, query execution
+    src/query_generator.rs  # InfluxQL (v1) and Flux (v2) query/template generation
+  dbflux_driver_clickhouse/ # ClickHouse HTTP(S) relational driver
+    src/driver.rs           # Metadata, connection form, and connection construction
+    src/connection.rs       # Query execution and system-catalog discovery
+    src/types.rs            # ClickHouse type parsing and value decoding
+    src/dialect.rs          # SQL generation dialect
+  dbflux_driver_cloudwatch/ # AWS CloudWatch Logs driver (DatabaseCategory::LogStream)
+    src/driver.rs           # Log group/stream discovery, EventStreamTarget, CollectionPresentation::EventStream
+  dbflux_driver_s3/         # AWS S3 object-storage driver (DatabaseCategory::ObjectStorage)
+    src/driver.rs           # Bucket/object discovery, ObjectStoreConnection impl, presign/copy/versions
+  dbflux_aws/               # AWS auth providers + Secrets Manager/SSM value providers
+    src/auth.rs             # AWS SSO/shared/static providers and SSO login flow
+    src/config.rs           # ~/.aws/config parser/cache and profile write-back helpers
+    src/accounts.rs         # AWS SSO account and role discovery
+  dbflux_ssm/               # AWS SSM tunnel factory for managed access
+  dbflux_lua/               # Embedded Lua runtime for in-process hooks
+    src/executor.rs         # Lua HookExecutor implementation
+    src/engine.rs           # Lua VM creation and shared runtime state
+    src/api/dbflux.rs       # dbflux.log/env/process Lua APIs
+    src/api/connection.rs   # Lua connection.* API (exposes HookContext)
+    src/api/hook.rs         # Lua hook.* API (phase, failure policy)
+  dbflux_tunnel_core/       # Shared RAII tunnel infrastructure
+    src/lib.rs              # Tunnel, TunnelConnector, ForwardingConnection<R>
+  dbflux_proxy/             # SOCKS5/HTTP CONNECT proxy tunnel
+    src/lib.rs              # ProxyTunnelConfig, SOCKS5/HTTP handshake, tunnel loop
+  dbflux_ssh/               # SSH tunnel support
+  dbflux_export/            # Export (CSV, JSON, Text, Binary)
+    src/lib.rs              # Shape-based export API and format dispatch
+    src/binary.rs           # Binary/hex/base64 exporter
+    src/csv.rs              # CSV exporter
+    src/json.rs             # JSON pretty/compact exporter
+    src/text.rs             # Text table exporter
+  dbflux_mcp/               # MCP runtime and governance
+    src/lib.rs              # Exports for runtime, governance service, tool catalog
+    src/runtime.rs          # McpRuntime implementing McpGovernanceService
+    src/governance_service.rs # McpGovernanceService trait and DTOs
+    src/tool_catalog.rs     # Canonical MCP tools and deferred tool definitions
+    src/built_ins.rs        # Built-in roles and policies
+     src/handlers/           # MCP tool handlers (query, approval, discovery, scripts)
+    src/server/             # MCP server infrastructure (router, authorization, bootstrap)
+  dbflux_mcp_server/        # Standalone MCP server binary
+    src/main.rs             # CLI entrypoint with --client-id and --config-dir
+    src/server.rs           # JSON-RPC request loop over stdin/stdout
+    src/bootstrap.rs        # Runtime initialization and state
+    src/transport.rs        # Line-based stdin/stdout transport
+    src/connection_cache.rs # Connection pool for the standalone server
+    src/handlers/           # Tool handlers adapted for standalone operation
+  dbflux_policy/            # Policy engine and classification
+    src/lib.rs              # Exports for engine, classification, trusted clients
+    src/classification.rs   # ExecutionClassification enum (Metadata/Read/Write/Destructive/AdminSafe/Admin/AdminDestructive)
+    src/engine.rs           # PolicyEngine with PolicyRole and ToolPolicy
+    src/trusted_clients.rs  # TrustedClientRegistry for known AI clients
+    src/assignments.rs      # ConnectionPolicyAssignment and PolicyBindingScope
+  dbflux_approval/           # Approval service for deferred executions
+    src/lib.rs              # Exports for ApprovalService and pending store
+    src/service.rs          # ApprovalService (approve/reject lifecycle)
+    src/store.rs            # InMemoryPendingExecutionStore and ExecutionPlan
+  dbflux_audit/             # Audit logging
+    src/lib.rs              # AuditService: validate, fingerprint, redact, record
+    src/query.rs            # AuditQueryFilter (actor, category, action, outcome, date range)
+    src/export.rs           # Audit export to JSON/CSV (basic and extended schemas)
+    src/redaction.rs        # Sensitive value redaction for details_json and error_message
+    src/purge.rs            # Retention-based event purge (batched deletes)
+    src/store/sqlite.rs     # SqliteAuditStore delegating to AuditRepository
+  dbflux_storage/            # Unified SQLite storage
+    src/bootstrap.rs        # StorageRuntime with single dbflux.db connection
+    src/paths.rs            # dbflux_db_path() returns ~/.local/share/dbflux/dbflux.db
+    src/migrations/         # Trait-based migration system
+      mod.rs                # MigrationRegistry, Migration trait
+      *.rs                  # Individual migration files (001_initial.rs, etc.)
+    src/repositories/       # All domain repositories
+      traits.rs             # Repository trait (all(), find_by_id(), upsert(), delete())
+      audit.rs              # AuditRepository with AuditEventDto
+      *.rs                  # Other domain repositories
+    src/legacy.rs           # JSON-to-SQLite import
+  dbflux_test_support/       # Docker containers and fixtures for integration tests
+    src/containers.rs       # Docker container lifecycle (Postgres, MySQL, MongoDB, Redis, DynamoDB Local)
+    src/fixtures.rs         # Test fixture helpers
+    src/fake_driver.rs      # FakeDriver for unit tests
+```
+
+## Componentes Principales
+
+### Capa de Aplicación
+
+- Punto de entrada de la app: `crates/dbflux/src/main.rs` inicializa logging, theme y la ventana principal de GPUI.
+- Estado global de la app: `crates/dbflux_app/src/app_state.rs` (struct plano, sin dependencia de GPUI) contiene drivers, profiles, conexiones activas, history, task manager y acceso al secret store.
+- CLI e instancia única: `crates/dbflux/src/cli.rs` parsea argumentos; `crates/dbflux_ui/src/ipc_server.rs` ejecuta el servidor IPC de control de la app para los comandos `Focus` y `OpenScript`.
+- Assets: `crates/dbflux_ui/src/assets.rs` implementa `AssetSource` de GPUI para servir íconos SVG embebidos.
+- Shell de UI del workspace: `crates/dbflux_ui/src/ui/views/workspace/` conecta panes (sidebar/dock, área de documents, dock inferior), command palette y el enrutado de foco. Dividido entre `mod.rs`, `actions.rs`, `dispatch.rs` y `render.rs`. Este módulo permanece en `dbflux_ui`.
+
+### Reporte de errores orientado al usuario
+
+Los fallos disparados por el usuario se enrutan a través de un único seam en `crates/dbflux_ui_base/src/user_error/mod.rs`, de modo que cada error accionable produce un toast, una fila de audit y un incremento del badge de la status bar — todos indexados por el mismo correlation id UUID v7.
+
+- **Puntos de entrada**: `report_error(UserFacingError, &mut App)` (foreground) y `report_error_async(UserFacingError, &AsyncApp)` (background / `cx.spawn` / `background_executor`). La variante sync NO debe llamarse desde un contexto background — requiere `&mut App`.
+- **Taxonomía**: `ErrorKind { Storage, Network, Auth, Hook, Driver, User, Config }` determina el estilo del badge/toast y el discriminador `action` del audit. La severidad reutiliza `dbflux_core::observability::EventSeverity`; `report_error` no agrega un enum paralelo.
+- **Alimentación desde el driver**: `UserFacingError::from_formatted(kind, FormattedError)` consume la salida existente del `ErrorFormatter` del driver. El código de la UI nunca bifurca según el driver id.
+- **Puente con audit**: el seam emite `tracing::error!(target = "dbflux_ui::user_error", correlation_id = %id, kind, action = "user_error", outcome = "failure", ...)`. `AuditFieldVisitor` (`crates/dbflux_core/src/observability/tracing_bridge/layer.rs`) enruta tanto `record_str` como `record_debug` a través de `record_string_by_name` para que el slot tipado `EventRecord.correlation_id` se rellene sin importar si el campo se registra con el sigilo `%` (Display) o `?` (Debug).
+- **Throttle de toasts**: `ToastHost` mantiene un token bucket por severidad (capacidad 5, refill de 1 token / 2 s) para Info y Warn, de forma que las tormentas de pérdida de conexión no saturen la pantalla. Error y Fatal evitan el throttle. El reloj del bucket es inyectable para tests deterministas.
+- **Badge + navegación**: `AppStateEntity::note_user_error` incrementa `unread_error_count` y emite `UserErrorReported`. El badge de la status bar se suscribe y, al hacer click, llama a `AppStateEntity::request_open_audit(None, cx)`, que emite `OpenAuditRequested`. La acción "View in Audit" del toast emite el mismo evento con `Some(correlation_id)`. El workspace se suscribe una vez a `OpenAuditRequested` y dirige `AuditDocument` mediante `set_correlation_filter` o `new_with_correlation_id`.
+- **Convención**: solo el primer catch site reporta. Los propagadores por encima NO deben volver a reportar — no hay deduplicación en runtime, los double-toasts son una cuestión de code review (ver AGENTS.md § Error Handling).
+
+### Sistema de Documents
+
+`crates/dbflux_ui_document/src/` implementa una arquitectura de documents basada en tabs con cinco capas:
+
+**Capas (de la más externa a la más interna)**
+
+1. **`Tab`** (`tab_manager.rs`) — enum `#[non_exhaustive]` con una única variante `Pane(Box<PaneHandle>)`. Se mantiene como enum por compatibilidad futura (por ejemplo, futuras variantes de pane desacoplable). `TabManager` mantiene un `Vec<Tab>` más el orden MRU.
+
+2. **`PaneHandle`** (`pane.rs`) — shell que borra closures y reemplaza al antiguo enum cerrado `DocumentHandle`. Cada una de las 22 operaciones (render, focus, dispatch_command, meta_snapshot, tab_title, can_close, connection_id, active_context, change_summary, refresh_policy, set_active_tab, set_refresh_policy, flush_auto_save, matches_dedup_key, subscribe, más helpers opcionales) es un closure `Box<dyn Fn>` que captura el `Entity<T>` tipado. `PaneHandle` es `!Clone`. Cada tipo de document provee `XxxDocument::into_pane(entity, cx) -> PaneHandle` en su propio archivo `pane.rs` (todos bajo `crates/dbflux_ui_document/src/`). Agregar un nuevo tipo de document no requiere cambios en `workspace/mod.rs`, `tab_manager.rs`, `tab_bar.rs` ni `handle.rs`.
+
+3. **`DocumentKey`** (`dedup.rs`) — enum de identidad usado para la deduplicación de tabs. Variantes: `Table`, `Collection`, `File`, `KeyValueDb`, `Chart`, `Audit`, `EventStream`, `Routine`, `MetricChart`, `Dashboard`, `InstanceMetric`, `InstanceInspector`, `InstanceOverview`, `ObjectStoreBucketsRoot`, `ObjectBrowser`, `ObjectEditor`. Reemplaza los métodos `is_*` del antiguo `DocumentHandle`. Los call sites usan `tab_manager.find_by_key(&DocumentKey::Table { ... }, cx)`.
+
+4. **`DocumentEvent`** (`handle.rs`, ~30 LOC) — enum de eventos unificado que reemplaza cuatro enums de eventos por-document que fueron eliminados. Variantes: `MetaChanged`, `ExecutionStarted`, `ExecutionFinished`, `RequestClose`, `RequestFocus`, `RequestSqlPreview`, `OpenInspector`, `ChartThisQuery`.
+
+5. **`ResultPanel` + `ViewHandle`** (`crates/dbflux_components/src/result_panel/mod.rs`) — host de chrome universal. `ResultPanel` posee una fila de chrome y delega el renderizado del cuerpo a un `ViewHandle` (7 closures: render, focus, focus_handle, toolbar_segments, available_modes, current_mode, set_mode). El sistema de slots (`ToolbarSegment { position: SegmentPosition::{Left,Center,Right}, index: u16, builder }`) permite que las views aporten chrome arbitrario: `ResultPanel` combina los segmentos integrados (barra de modos en Left/0 cuando `available_modes.len() >= 2`) con los segmentos provistos por la view, los ordena por `(position, index)` y los renderiza en una fila `flex_wrap`.
+
+**Los tipos de document**
+
+- `DataDocument` (`crates/dbflux_ui_document/src/data_document/`) — shell delgado alrededor de `DataGridPanel` + `ResultPanel`. DataGridPanel se monta como un `ViewHandle`; una filter bar se inyecta como segmento Center/0.
+- `ChartDocument` (`crates/dbflux_ui_document/src/chart_document/`) — entity `ChartShell` + `Option<Entity<ResultPanel>>` perezoso. El área del chart, la axis bar y los botones de acción se montan como segmentos Left/Center/Right. Se renderiza de forma independiente o embebido dentro de un panel de `DashboardDocument`.
+- `DashboardDocument` (`crates/dbflux_ui_document/src/dashboard/`) — grid nombrado de paneles de chart con un `TimeRangePanel` compartido y una refresh policy. Cada panel es una entity `ChartDocument` `Loaded` o un placeholder `Orphan` para un chart eliminado. La re-ejecución de paneles está acotada por `PANEL_REEXEC_CAP`. Ver `docs/DASHBOARDS.md`.
+- `CodeDocument` (`crates/dbflux_ui_document/src/code/`) — editor multi-tab. Cada tab de resultado envuelve su `DataGridPanel` en su propio `ResultPanel`. El chrome externo (editor, context bar, tab strip) se renderiza a sí mismo.
+- `KeyValueDocument` (`crates/dbflux_ui_document/src/key_value/`) — se renderiza a sí mismo. `KeyValueView` es un boundary struct a nivel de archivo (no una entity GPUI separada) que agrupa helpers de render extraídos de `key_value/render.rs`.
+- `AuditDocument` (`crates/dbflux_ui_document/src/audit/`) — se renderiza a sí mismo. `LogStreamView` es un boundary struct a nivel de archivo. El cuerpo se extrajo a `audit/render.rs` y `audit/commands.rs` como archivos `impl AuditDocument` hermanos.
+- `InstanceInspectorDocument` (`crates/dbflux_ui_document/src/instance_inspector/`) — tab tabular de snapshot de instance-inspector, indexado por `DocumentKey::InstanceInspector`.
+- `chart/` (`crates/dbflux_ui_document/src/chart/`) — el host `ChartShell` (`shell.rs`, `host.rs`) más el metric picker (`metric_picker*.rs`) y `toolbar.rs`, distinto de `chart_document/`; respalda los charts de métricas/instancia.
+- `BucketsTableDocument` (`crates/dbflux_ui_document/src/buckets_table/`) — vista de object-storage en la raíz de la conexión (nombre, región, cantidad de objetos, tamaño, versioning, fecha de creación), que reutiliza `dbflux_components::data_table` en lugar de `DataGridPanel`; indexado por `DocumentKey::ObjectStoreBucketsRoot`.
+- `ObjectBrowserDocument` (`crates/dbflux_ui_document/src/object_browser/`) — browser de object-storage con vista dividida tree/preview, navegación paginada y de tree perezoso, preview, metadata, upload, delete, rename y presign; indexado por `DocumentKey::ObjectBrowser`.
+- `ObjectEditorDocument` (`crates/dbflux_ui_document/src/object_editor/`) — tab independiente de "abrir en editor" para objetos de texto en S3, que comparte el módulo `object_text` (detección de line-ending, resaltado de lenguaje, audit de guardado) con el editor inline de `ObjectBrowserDocument`; indexado por `DocumentKey::ObjectEditor`.
+
+**Agregar un nuevo tipo de document** (sin cambios requeridos fuera del nuevo módulo):
+1. Crea `crates/dbflux_ui_document/src/<name>/mod.rs` con la entity.
+2. Crea `crates/dbflux_ui_document/src/<name>/pane.rs` con `into_pane(entity, cx) -> PaneHandle`.
+3. Agrega una variante de `DocumentKey` en `crates/dbflux_ui_document/src/dedup.rs` si se necesita dedup.
+4. Agrega una función `open_<name>` en `crates/dbflux_ui/src/ui/views/workspace/actions.rs`.
+
+**Notas de arquitectura**
+
+- `KeyValueView` y `LogStreamView` son boundary structs a nivel de archivo, no entities GPUI separadas. El modelo de borrow de `Context<T>` único de GPUI hace inviables las divisiones de `impl Render` entre entities cuando 40+ closures `cx.listener()` en un document capturan `Self`; dividir requeriría reubicar todo el estado de dominio en la view entity. El boundary logrado es a nivel de archivo.
+- El trait `DataView` (`data_view_trait.rs`) no incluye un método `render`. La spec pedía `render` en el trait, pero `impl IntoElement` no es trait-object-safe y hacer boxing a `AnyElement` entra en conflicto con los idioms de GPUI. El renderizado pasa por `ViewHandle.render` en su lugar.
+- Auto-save: los tabs se auto-guardan en scratch files (sin título) o shadow files (con archivo respaldo) con un debounce de 2 segundos. Ctrl+S escribe al archivo original. Los tabs se cierran sin avisos.
+- Restauración de sesión: `SessionStore` persiste un manifest de los tabs abiertos en `~/.local/share/dbflux/sessions/`. Al iniciar, todos los tabs se restauran con detección de conflictos para archivos modificados externamente. Solo los code documents producen `CodeSessionTabSnapshot`; el resto de tipos de document no se persisten en la sesión.
+- Prevención de duplicados: `tab_manager.find_by_key` verifica `PaneHandle::matches_dedup_key` antes de abrir un nuevo tab, enfocando el existente si lo encuentra.
+
+### Visual Query Builder
+
+Un rail lateral compone sentencias SELECT/UPDATE/DELETE sin escribir SQL y las alimenta al DataView. Es agnóstico del driver por construcción: gated en `QueryLanguage::Sql`, sin bifurcación por driver en ningún punto del camino.
+
+**Tipos de spec principales** (`crates/dbflux_core/src/query/visual_query.rs`, re-exportados desde `dbflux_core::query`):
+- `VisualQuerySpec` — el modelo del SELECT: proyección, FROM con alias, JOINs, un árbol de predicados `WHERE` recursivo (`FilterNode` / `Predicate`), GROUP BY / aggregates / HAVING, `ORDER BY` (`SortEntry`), y `LIMIT`/`OFFSET`.
+- `VisualMutationSpec` (con `MutationKind`, `ColumnAssignment` / `Assignment`, `AssignmentValue`) — el modelo de UPDATE/DELETE. Una asignación de expresión raw se rastrea mediante un flag `used_raw_expression` en lugar de un marcador textual.
+- `EditableBinding` — la prueba de que un resultado SELECT es *editable-safe* (ver Edición inline más abajo).
+
+**Generación de SQL** (`crates/dbflux_core/src/query/generator.rs`): el trait `QueryGenerator` gana tres métodos con implementación por defecto — `generate_select`, `generate_update_from_spec`, `generate_delete_from_spec`. Estos delegan al `SqlSelectBuilder` interno del crate (funciones libres `build_select_query` / `build_grouped_count_query`), que renderiza SQL específico del dialecto para SQLite, PostgreSQL, MySQL/MariaDB y SQL Server. Las queries agrupadas reutilizan `build_group_by` / `build_having` / `build_count_of_grouped`, de modo que la paginación ejecuta una subquery `COUNT(*)` sobre el SELECT agrupado. UPDATE/DELETE emiten DML fragmentado con keyset sobre la PK de la tabla.
+
+**Política de mutación** (`crates/dbflux_core/src/connection/manager.rs`): `MutationPolicy { Allowed | ReadOnly | ApprovalRequired }` compone la gobernanza del actor MCP, el read-only por perfil y una resolución por defecto `Allowed`. UPDATE/DELETE sin `WHERE` está adicionalmente gated por una verificación doble de `DangerousQueryKind` a nivel de spec y a nivel de texto.
+
+**UI** (`crates/dbflux_ui_document/src/query_builder/`): `QueryBuilderPanel` (`panel.rs`, `view.rs`) renderiza el rail con un selector de modo y secciones por cláusula bajo `sections/` (`columns`, `joins`, `filters`, `group_by`, `sort`, `assignments`, `execution`); `mutation_state.rs`, `completion.rs` (autocompletado consciente del schema), `events.rs` y `tree_ops.rs` lo respaldan. El preview de SQL siempre está visible y se regenera de forma síncrona en cada cambio.
+
+**Ejecución** (`crates/dbflux_ui_document/src/data_grid_panel/`): el builder se integra en el DataView; `MutationExecutor` (`mutation_executor.rs`) impulsa una máquina de estados `ExecutionMode` — `SingleTransaction`, `ChunkedTransaction`, `DirectAutocommit` — auto-sugerida a partir de la estimación de conteo, la capability `TRANSACTIONS` y la disponibilidad de primary key (con un modal de tradeoff ante un override del usuario). Las ejecuciones fragmentadas usan paginación con keyset (tamaño de chunk acotado a `[1000, 10000]`, por defecto 5000), muestran entries por chunk en el Tasks panel con cancelación entre chunks, y hacen `ROLLBACK` ante un fallo de chunk.
+
+**Edición inline sobre resultados del builder**: cuando un resultado SELECT es demostrablemente editable-safe — mapea 1:1 a una única tabla subyacente y proyecta cada columna de PK bajo su nombre original — el builder calcula un `EditableBinding` a partir del `VisualQuerySpec` confirmado y lo enhebra en el DataView, reutilizando el camino de mutación de tabla única con un `WHERE` construido a partir de los valores de PK proyectados (sin parsear SQL). Los JOINs están permitidos: las columnas de la tabla origen siguen siendo editables, las columnas unidas quedan de solo lectura. Aggregates / `GROUP BY` / `HAVING`, PKs proyectadas con alias o faltantes, y claves de schema aún no cargadas caen a solo lectura. La prueba vive en `dbflux_core` sobre tipos genéricos de spec/metadata, así que cada driver relacional la adopta.
+
+**Persistencia**: la migración `017_qry_saved_queries` agrega la familia de tablas `qry_*` (raíz + tablas hijas de columns/sorts/joins, FKs en cascada, `UNIQUE (profile_id, name)`), frontada por `SavedQueryRepo` (`crates/dbflux_storage/src/repositories/qry_saved_queries.rs`) y el `SavedQueryManager` en memoria (`crates/dbflux_ui_base/src/saved_query_manager.rs`). Un seam `TableProbe` verifica la existencia de la tabla al importar una saved query hacia otra conexión sin acceder al código del driver.
+
+### Visualización de Datos
+
+- **Data table**: `crates/dbflux_components/src/components/data_table/` tabla virtualizada personalizada con ordenamiento, selección, scroll horizontal vía el patrón de phantom scroller, navegación por teclado, redimensionado de columnas y menú contextual con operaciones CRUD.
+- **Document tree**: `crates/dbflux_components/src/components/document_tree/` visor jerárquico de JSON/BSON para bases de datos de documentos con navegación por teclado (j/k/h/l), búsqueda (Ctrl+F o /), nodos colapsables y modos de vista (Keys Only, Keys+Preview, Full Values).
+- **Key-value view**: `crates/dbflux_ui_document/src/key_value/` tab de document específico de Redis con renderizado por tipo (String, Hash, List, Set, SortedSet, Stream), paginación, mutations y menú contextual. Se integra con el workspace vía un `PaneHandle` construido en `key_value/pane.rs`.
+- Cell editor modal: `crates/dbflux_components/src/modals/cell_editor.rs` provee un editor modal para columnas JSON y texto largo/multilínea, con validación y formateo de JSON. (Shim en la ruta antigua de overlay en `dbflux_ui`.)
+- Document preview modal: `crates/dbflux_components/src/modals/document_preview.rs` preview de document JSON a pantalla completa con un editor JSON inline. (Shim en la ruta antigua de overlay en `dbflux_ui`.)
+- Command palette: `crates/dbflux_ui/src/ui/overlays/command_palette.rs` command palette con fuzzy-search para todas las acciones de la app.
+
+### Dashboards y Saved Charts
+
+DBFlux persiste configuraciones de chart como **Saved Charts** y las agrupa en **Dashboards** (un grid de paneles de chart y dividers markdown opcionales, con un rango de tiempo y refresh policy compartidos). Los drivers se suman al import/browse de dashboards vía seams genéricos del core — la UI nunca bifurca según driver IDs.
+
+- **Storage**: tablas `viz_*` en `~/.local/share/dbflux/dbflux.db`. Los repositorios viven en `crates/dbflux_storage/src/repositories/viz_dashboards.rs`, `viz_dashboard_panels.rs` y `viz_saved_charts.rs`. `SavedChartDto` es un aggregate root que escribe atómicamente en tres tablas.
+- **Managers** (cachés en memoria sobre repositorios): `DashboardManager` (`crates/dbflux_ui_base/src/dashboard_manager.rs`) con `Dashboard`, `DashboardPanel`, `DashboardPanelKind { Chart { saved_chart_id } | Divider { markdown } | Inspector { metric_id } }`, `DashboardPanelDraft`; `SavedChartManager` (`crates/dbflux_ui_base/src/saved_chart_manager.rs`) posee el lifecycle de `SavedChart` y `SavedChartRefreshPolicy` (`Off` | `Interval { every_secs }`).
+- **Caché de sesión para listados remotos**: `RemoteDashboardCache` (`crates/dbflux_app/src/remote_dashboard_cache.rs`) — no se persiste entre reinicios.
+- **Documents**: `ChartDocument` (`crates/dbflux_ui_document/src/chart_document/`) indexado por `DocumentKey::Chart`; `DashboardDocument` (`crates/dbflux_ui_document/src/dashboard/`) indexado por `DocumentKey::Dashboard`. Los paneles de dashboard embeben entities `ChartDocument` (`Loaded` / `Orphan`); el `TimeRangePanel` compartido propaga los cambios de ventana a cada panel cargado vía subscriptions.
+- **Seams de driver**:
+  - `DashboardImporter` (`crates/dbflux_core/src/connection/dashboard_import.rs`) — los drivers parsean el JSON del dashboard upstream a `WidgetImportSpec`s. Carga `MetricView { TimeSeries | StackedArea | SingleValue }`, `ImportedMetricSeries` y coordenadas `WidgetLayout` nativas. Gated por `DriverCapabilities::DASHBOARD_IMPORT`.
+  - `DashboardSource` (`crates/dbflux_core/src/connection/dashboard_source.rs`) — los drivers listan dashboards upstream con `RemoteDashboard` / `DashboardRef` (`last_modified` ISO8601 opcional). Gated por `DriverCapabilities::DASHBOARD_SYNC`.
+  - `CloudWatchDashboardSource` + `CloudWatchDashboardImporter` en `crates/dbflux_driver_cloudwatch/` implementan ambos para browse + import de solo lectura. DBFlux nunca escribe de vuelta a los dashboards de CloudWatch.
+  - `InstanceCatalog` (`crates/dbflux_core/src/connection/instance_catalog.rs`) — los drivers publican métricas de servidor en vivo (series temporales), inspectores tabulares (sessions, processlist, currentOp, CLIENT LIST), un descriptor de **Instance Overview** por defecto, y acciones de fila de inspector opcionales gated por probes de privilegios por driver. Gated por `DriverCapabilities::INSTANCE_METRICS` (series temporales) e `INSTANCE_INSPECTOR` (tabular). PostgreSQL, MySQL/MariaDB, MongoDB, Redis y SQL Server lo implementan.
+- **Instance Overview**: un dashboard de solo lectura auto-generado, indexado por `DocumentKey::InstanceOverview { profile_id }`, compuesto a partir del descriptor `InstanceCatalog` del driver. "Save as editable" lo clona en un `Dashboard` persistido y propiedad del usuario. El `DashboardPanelKind` `Inspector` aloja los inspectores tabulares y se persiste vía `viz_dashboard_panels.panel_kind`.
+
+Ver `docs/DASHBOARDS.md` para la referencia completa (incluyendo instance metrics e inspectors) y `docs/CHARTS.md` para el chart engine.
+
+### Schema y Navegación
+
+- Sidebar: `crates/dbflux_ui_sidebar/src/` muestra dos tabs — Connections (tree de schema con organización por carpetas, drag-drop, multi-selección) y Scripts (gestión de archivos/carpetas para saved query files, script hooks y otros archivos del usuario). Cambia de tab con las teclas `q` o `e`. Muestra tables/collections, columns, indexes por database category con carga perezosa. Re-exportado vía un shim en `crates/dbflux_ui/src/ui/views/sidebar/mod.rs`.
+- Los recursos hijos propiedad de un driver bajo collections/containers se publican a través de la metadata genérica `CollectionChildInfo`. El sidebar no debe inferir hijos específicos de un driver a partir de nombres, tipos de campo o driver IDs.
+- Las routines (functions, procedures, aggregates, window functions) aparecen como una carpeta "Routines" por schema cuando el driver activa la capability `ROUTINES` y puebla el seam `schema_routines`. La UI renderiza la carpeta de forma genérica; no hace casos especiales para ningún driver.
+- Sidebar dock: `crates/dbflux_ui/src/ui/dock/sidebar_dock.rs` provee un sidebar colapsable y redimensionable con el comando ToggleSidebar (Ctrl+B).
+- Connection tree: `crates/dbflux_core/src/connection/tree.rs` modela carpetas y conexiones como una estructura de árbol; `tree_manager.rs` maneja la gestión en memoria.
+
+### Sistema de Drivers
+
+- **Driver capabilities**: `crates/dbflux_core/src/driver/capabilities.rs` define:
+  - `DatabaseCategory`: Relational, Document, KeyValue, Graph, TimeSeries, WideColumn, LogStream, ObjectStorage
+  - `QueryLanguage`: Sql, CloudWatchLogsInsightsQl, OpenSearchPpl, OpenSearchSql, MongoQuery, RedisCommands, Cypher, InfluxQuery, Flux, Cql, Lua, Python, Bash (cada uno lleva su modo de editor, placeholder y prefijo de comentario)
+  - `DriverCapabilities`: bitflags `u64` para features como PAGINATION, TRANSACTIONS, NESTED_DOCUMENTS, MULTI_STATEMENT, ROUTINES, STORED_PROCEDURES, DASHBOARD_IMPORT, DASHBOARD_SYNC, etc.
+  - `DriverMetadata`: información estática del driver (id, name, category, query_language, capabilities, icon)
+- **Formularios de conexión propiedad del driver**: cada `DbDriver` devuelve su `&DriverFormDef` desde `form_definition()`. Las definiciones de formulario viven en el crate del driver (por ejemplo `dbflux_driver_cloudwatch::driver::CLOUDWATCH_FORM`), no en core. `DriverFormDef` lleva tabs → sections → fields, donde `FormFieldKind` cubre `Text`, `Password`, `WriteOnly` (secrets), `FilePath`, `Select`, `DynamicSelect` (opciones obtenidas en runtime, `depends_on` + `RefreshTrigger`), y `AuthProfileRef { provider_id }`.
+- **Formateo de errores**: `crates/dbflux_core/src/core/error_formatter.rs` provee el trait `ErrorFormatter` para mensajes de error específicos del driver con contexto (detail, hint, column, table, constraint).
+- API de dominio core: `crates/dbflux_core/src/core/traits.rs` define `DbDriver`, `Connection`, generación SQL, contratos de cancelación y seams genéricos de driver a UI como `EventStreamTarget` y `SourceContextSpec`.
+- **Generación de queries**: `crates/dbflux_core/src/query/generator.rs` define `QueryGenerator` como la fuente de verdad, propiedad del driver, para el texto de mutación más templates de read/query. Los drivers SQL usan `SqlMutationGenerator`; MongoDB, Redis y DynamoDB exponen sus propios generadores nativos. La UI y MCP acceden a los generadores vía `Connection::query_generator()` para que los previews y las queries copiadas provengan del driver en lugar de un formatter local a la UI.
+- Driver forms: `crates/dbflux_core/src/driver/form.rs` define schemas de formulario dinámicos que los drivers proveen para la configuración de conexión. Soporta modos de conexión tanto basados en formulario como en URI.
+- **Desacoplamiento Driver/UI**: la UI y las capas de orquestación de la app nunca deben bifurcar según driver IDs concretos ni embeber routing específico de driver. El core expone los seams, y los drivers los completan.
+  - `DriverMetadata` cubre la adaptación amplia (`DatabaseCategory`, `QueryLanguage`, `DriverCapabilities`).
+  - `CollectionPresentation` le indica a la UI cómo se abre una collection/container (por ejemplo data grid vs event stream).
+  - `CollectionChildInfo` permite a los drivers publicar fuentes hijas bajo una collection/container sin heurísticas de UI.
+  - `EventStreamTarget` le da al workspace/audit un identificador genérico para event streams propiedad del driver.
+  - `SourceContextSpec` permite a los drivers declarar controles adicionales de contexto de query sin hardcodear nombres de driver en `dbflux_ui`.
+  - `ObjectStoreConnection` (`crates/dbflux_core/src/core/traits.rs`), alcanzado vía `Connection::object_store_api()`, es el seam de object-storage (listado de bucket/object, CRUD, presign, copy, versions); `CollectionPresentation::ObjectBrowser` y `PaneHandle::status_segments()` permiten que la UI abra y decore documents de object-storage sin bifurcar según driver ID.
+  - Si la UI necesita comportamiento nuevo, agrega primero una abstracción genérica del core; no agregues `if driver_id == ...` en `dbflux_ui` ni en código de workflow orientado a la app.
+
+### Pipeline de Auth y Access
+
+- `crates/dbflux_app/src/auth_provider_registry.rs` mantiene el registro en runtime de `DynAuthProvider` en el crate de app y evita hardcodear lógica de provider de AWS en los flujos de UI de conexión.
+- `crates/dbflux_core/src/auth/` define los contratos de provider (`AuthFormDef`, `DynAuthProvider`, `ImportableProfile`, `after_profile_saved`) y los tipos serializables de auth profile/session.
+- `AuthProfile` usa un `fields: HashMap<String, String>` plano y agnóstico del provider (migrado desde payloads `config` anidados, con deserialización de compatibilidad para entradas legacy). Dos flags adicionales modelan la capa de reflejo en vivo:
+  - `read_only: bool` — se activa cuando el profile se refleja desde una fuente de verdad externa (por ejemplo `~/.aws/config`); DBFlux no edita los profiles reflejados.
+  - `dangling_origin: Option<String>` — marca profiles almacenados que perdieron su fuente respaldo. Valores: `"keyring-only"` (solo queda el secret del keyring), `"file-gone"` (la entrada del archivo desapareció).
+- **Reflejo en vivo de profiles de AWS**: `dbflux_aws/src/config.rs` lee `~/.aws/config` y `~/.aws/credentials` como fuente de verdad vía `CachedAwsConfig` (caché dual indexado por mtime, uno por archivo). `AwsProfileInfo` lleva `is_sso`, `is_sso_session`, `sso_session` (referencia con nombre), `sso_start_url`, `sso_region`, `sso_account_id`, `sso_role_name`. Las sesiones AWS SSO aparecen como entradas de auth profile de primera clase (`[sso-session <name>]`); los profiles que las referencian se expanden antes del login/validación.
+- `crates/dbflux_core/src/access/mod.rs` introduce `AccessKind::Managed { provider, params }` agnóstico del provider, con migración transparente desde el JSON legacy de profile `method = "ssm"`.
+- `crates/dbflux_core/src/pipeline/mod.rs` ejecuta los stages pre-connect (`Authenticating` -> `ResolvingValues` -> `OpeningAccess`) y publica actualizaciones de `PipelineState` para los watchers de la UI.
+- `crates/dbflux_app/src/access_manager.rs` provee la implementación de `AccessManager` del lado de la app para access directo y managed (actualmente `aws-ssm`).
+- **Desacoplamiento del dropdown de auth-profile (DEC-1)**: el connection manager renderiza su selector de auth-profile a partir del seam genérico de form-field `FormFieldKind::AuthProfileRef { provider_id: Option<String> }`, nunca haciendo match sobre driver ids. Los drivers que quieren el picker (por ejemplo DynamoDB, CloudWatch) declaran un campo `profile` como `AuthProfileRef { provider_id: None }`; un filtro `None` enumera profiles de forma agnóstica del provider, así que tanto los providers integrados como los respaldados por RPC externo aparecen. El form-field kind no se persiste, así que agregarlo o quitarlo no necesita migración de storage.
+
+### Infraestructura de Tunnels
+
+- `crates/dbflux_tunnel_core/` provee un struct `Tunnel` RAII compartido que enlaza un puerto local, verifica conectividad y lanza un thread de forwarding en background que se apaga al hacer drop.
+- Trait `TunnelConnector`: las implementaciones proveen `test_connection()` y `run_tunnel_loop()` para forwarding específico de protocolo (SOCKS5, HTTP CONNECT, SSH).
+- `ForwardingConnection<R>`: forwarding bidireccional entre un `TcpStream` local y un `R` remoto genérico (`TcpStream` para proxy, `ssh2::Channel` para SSH). Las estrategias de escritura se inyectan vía punteros a función.
+- `adaptive_sleep()`: 50ms cuando está idle, 1ms cuando hay conexiones, se salta cuando se transfirieron datos.
+- `crates/dbflux_proxy/`: tunnel de proxy SOCKS5 y HTTP CONNECT vía implementación de `TunnelConnector`.
+- `crates/dbflux_ssh/`: tunnel SSH vía implementación de `TunnelConnector`. Todas las operaciones SSH se serializan a un único thread por seguridad de libssh2.
+- Proxy+SSH son mutuamente excluyentes por conexión (impuesto en `ConnectProfileParams::execute()`).
+- El callback `CreateTunnelFn` en `dbflux_core` evita una dependencia circular: el crate de app provee la implementación real de proxy.
+
+### Connection Hooks
+
+- `crates/dbflux_core/src/connection/hook.rs` define definiciones de hook reutilizables con tres modos de ejecución: `Command`, `Script` y `Lua`.
+- Los hooks respaldados por proceso pueden ser inline o respaldados por archivo, y cubren Bash/Python más comandos arbitrarios.
+- Los hooks de Lua corren in-process a través de `dbflux_lua`, con acceso gated por capability a `hook.*`, `connection.*`, `dbflux.log.*`, `dbflux.env.*` y `dbflux.process.run()`.
+- Bindings de fase por profile: `PreConnect`, `PostConnect`, `PreDisconnect`, `PostDisconnect`.
+- `HookRunner` orquesta la ejecución con `HookPhaseOutcome` (success/warning/abort).
+- Los hooks respaldados por proceso y los subprocesos disparados por Lua comparten un executor de streaming común. La salida es visible en el Tasks panel para los hooks de lifecycle y en el results panel del document para los scripts ejecutados desde el editor.
+- Failure policies: `Disconnect` (aborta el flujo), `Warn` (continúa con advertencia), `Ignore` (solo registra).
+- Settings UI: `crates/dbflux_ui_windows/src/settings/hooks.rs` para las definiciones globales; `crates/dbflux_ui_windows/src/connection_manager/hooks_tab.rs` para los bindings de fase por profile.
+
+### Ventana de Settings
+
+- Settings se organiza en las siguientes secciones: General, Keybindings, Auth Profiles, Proxies, SSH Tunnels, Services, Hooks, Drivers, Audit y About. Las secciones de MCP (trusted clients, roles, policies) están gated bajo la feature `mcp`.
+- El sidebar usa el componente `TreeNav` con categorías Network/Connection colapsables.
+- `UiStateStore` persiste el estado de colapso del sidebar en la tabla `st_ui_state` en `~/.local/share/dbflux/dbflux.db`.
+- La sección Auth Profiles está impulsada por el provider (`DynAuthProvider::form_def`) y soporta importar profiles descubiertos por el provider (para AWS, desde `~/.aws/config`).
+- Los formularios de Proxy y SSH tunnel usan `FormGridNav<F>` para navegación 2D en grid guiada por teclado.
+- La sección Drivers muestra overrides de settings por driver filtrados por `DatabaseCategory`.
+
+### Integración IPC/RPC
+
+- `crates/dbflux_ipc/` define contratos versionados de app-control y driver RPC, framing de transporte, naming de sockets multiplataforma, y auth tokens de IPC (`auth.rs`).
+- `crates/dbflux_ui/src/ipc_server.rs` (permanece en `dbflux_ui`) ejecuta el servidor IPC de app-control para el comportamiento de instancia única (`Focus`, `OpenScript`). `crates/dbflux/src/cli.rs` actúa como cliente IPC cuando se lanza una segunda instancia.
+- `crates/dbflux_core/src/config/app.rs` maneja solo el import legacy de config.json (deprecated).
+- `crates/dbflux_app/src/app_state.rs` sondea cada servicio RPC configurado al iniciar (`Hello`) y lo registra como una driver key en memoria `rpc:<socket_id>`.
+- `crates/dbflux_driver_ipc/src/driver.rs` implementa `DbDriver` como un proxy RPC y solo apaga los hosts managed que DBFlux mismo lanzó.
+- Los profiles de conexión externos usan `DbConfig::External { kind, values }`, donde los valores del formulario provienen del `form_definition` remoto devuelto durante `Hello`.
+
+### Generación de SQL
+
+- **SQL dialect**: `crates/dbflux_core/src/sql/dialect.rs` define el trait `SqlDialect` para la sintaxis SQL específica de la base de datos (quoting, LIMIT/OFFSET, mapeo de tipos).
+- **Generación de SQL**: `crates/dbflux_core/src/sql/generation.rs` provee generación de sentencias INSERT/UPDATE/DELETE.
+- **Query builder**: `crates/dbflux_core/src/sql/query_builder.rs` ofrece `SqlQueryBuilder` para la construcción segura y parametrizada de queries.
+
+### Operaciones CRUD
+
+- **Tipos de mutación**: `crates/dbflux_core/src/data/crud.rs` define el enum `MutationRequest` que cubre todos los paradigmas de base de datos:
+  - SQL: INSERT/UPDATE/DELETE con cláusulas WHERE
+  - Document: insertOne/updateOne/deleteOne/deleteMany
+  - Key-Value: SET/DELETE/HASH_SET/SET_ADD/LIST_PUSH/ZSET_ADD y sus contrapartes de remove, más STREAM_ADD
+- **Tipos key-value**: `crates/dbflux_core/src/data/key_value.rs` define structs de request basados en Vec para comandos variádicos de Redis (por ejemplo, `HashSetRequest.fields: Vec<(String, String)>`, `SetAddRequest.members: Vec<String>`).
+- **Query safety / `LanguageService`**: `crates/dbflux_core/src/query/language_service.rs` define el trait `LanguageService` (`validate`, `detect_dangerous`, `editor_diagnostics`) y una implementación por defecto `SqlLanguageService` reutilizada por los drivers relacionales. Los dialectos no-SQL (MongoDB, Redis, T-SQL) proveen sus propias implementaciones desde el crate de driver correspondiente (por ejemplo `TSqlLanguageService` vive en `dbflux_driver_mssql`). `DangerousQueryKind` cubre SQL `DeleteNoWhere` / `UpdateNoWhere` / `Truncate` / `Drop` / `Alter` / `Script`, MongoDB `deleteMany` / `updateMany` / `dropCollection` / `dropDatabase`, y Redis `FlushAll` / `FlushDb` / `MultiDelete` / `KeysPattern`. El dispatcher `classify_query_for_language(&QueryLanguage, &str)` enruta al clasificador correcto para que la UI nunca bifurque según driver id.
+
+### Storage y Configuración
+
+**Storage SQLite unificado**: Todos los datos de runtime se almacenan en una única base de datos SQLite en `~/.local/share/dbflux/dbflux.db`. Esto reemplazó tres stores separados (config.db, state.db, audit.sqlite).
+
+**Prefijos de tabla por dominio**:
+- `cfg_*` — dominio de config (profiles, auth, proxy, SSH, hooks, services, governance, drivers, folders)
+- `st_*` — dominio de state (sessions, tabs, query history, saved queries, recent items, UI state, schema cache)
+- `aud_*` — dominio de audit (audit events, entities, attributes)
+- `viz_*` — dominio de visualización (dashboards, dashboard panels, saved charts y sus bindings/series)
+- `qry_*` — specs guardadas del visual-query-builder (raíz + projected columns, sorts, joins)
+- `sys_*` — dominio de sistema (migrations, metadata, legacy imports)
+
+**Crate de storage** (`dbflux_storage/`):
+- `bootstrap.rs`: `StorageRuntime` gestiona la única conexión `dbflux.db` con inicialización perezosa
+- `paths.rs`: `dbflux_db_path()` devuelve la ruta de base de datos consciente del channel (`dbflux.db`, o `dbflux-nightly.db` en el channel nightly a menos que `nightly_shares_stable_db()` opte de vuelta por el archivo stable vía `set_nightly_shares_stable_db`). Ver § Release Channels y Branding
+- `migrations/`: sistema de migraciones basado en traits (trait `Migration` con `name()` y `run(&Transaction)`). `MigrationRegistry` mantiene todas las migraciones y las ejecuta en orden, rastreando su finalización en `sys_migrations`. Idempotente — verifica `sys_migrations` antes de ejecutar.
+- `repositories/`: todos los repositorios de dominio implementan el trait `Repository` (`all()`, `find_by_id()`, `upsert()`, `delete()`). `AuditRepository` maneja los audit events con `AuditEventDto`.
+- `legacy.rs`: importa archivos JSON legacy a SQLite en el primer inicio (idempotente, rastreado en `sys_legacy_imports`)
+
+**Orden de import de JSON legacy**: Auth/proxy/SSH primero, luego connection profiles (orden de dependencia de FK). Fuentes de import:
+- `profiles.json` → `cfg_connection_profiles` + tablas hijas
+- `auth_profiles.json` → `cfg_auth_profiles`
+- `ssh_tunnels.json` → `cfg_ssh_tunnel_profiles`
+- `config.json` → `cfg_services` (solo servicios RPC)
+
+**Secrets**: `SecretManager` usa el trait `HasSecretRef` para las operaciones de keyring. Los secrets se almacenan en el keyring del sistema operativo, las referencias se almacenan en SQLite.
+
+**Persistencia de sesión**: archivos scratch/shadow y el manifest de sesión en `~/.local/share/dbflux/sessions/` para la restauración de tabs al iniciar.
+
+**Contexto de ejecución**: `crates/dbflux_core/src/connection/context.rs` rastrea, por tab, la connection, database, schema y el contexto de fuente genérico declarado por el driver. La forma actual del generic source-window es `ExecutionSourceContext::CollectionWindow { targets, start_ms, end_ms }`. Solo las anotaciones de connection/database/schema se serializan en los headers de archivo guardados.
+
+**History modal**: `crates/dbflux_ui_document/src/history_modal.rs` provee un modal unificado para explorar recent queries y saved queries con búsqueda, favoritos y soporte de rename.
+
+### Release Channels y Branding
+
+**Seam de channel** (`crates/dbflux_core/src/release_channel.rs`): `ReleaseChannel` (`Stable`, `Rc`, `Nightly`) se deriva una única vez a partir de la `CARGO_PKG_VERSION` compilada vía `ReleaseChannel::current()`. El pipeline de release de CI estampa la versión del workspace antes de compilar, así que el channel queda codificado en el propio binario: `-nightly` → `Nightly`, `-rc.N` → `Rc`, `MAJOR.MINOR.PATCH` plano → `Stable` (nightly gana si aparecen ambos marcadores). Esta única señal alimenta la identidad específica de channel que el runtime necesita:
+
+- `app_id()` — `app_id` de GPUI (Wayland app id / `WM_CLASS` de X11). Nightly devuelve `dbflux-nightly` para que coexista con stable en lugar de compartir su entrada de taskbar e icono; `Stable`/`Rc` devuelven `dbflux`. Se consume en `crates/dbflux/src/main.rs`.
+- `display_name()` — título de ventana y nombre de bundle (`DBFlux Nightly` vs `DBFlux`).
+- `db_file_name()` — `dbflux-nightly.db` vs `dbflux.db`, para que una migración que se rompa en un build pre-release no pueda corromper una base de datos stable cuando ambos channels corren en paralelo. Un build nightly puede optar por la base de datos stable mediante el marcador `set_nightly_shares_stable_db` (ver § Storage y Configuración).
+
+**Assets de branding**: las marcas de marca a color completo viven bajo `resources/branding/{stable,nightly}/` (`mark.svg`, `mark-256.png`, `mark-small.svg`, `wordmark.svg`) más el `resources/branding/glyph.svg` compartido. `crates/dbflux_ui/src/assets.rs` sirve la marca PNG pre-renderizada por channel para `img(...)`. La metadata de packaging (`packaging/*.yaml`, `resources/desktop/dbflux.desktop`, `resources/macos/Info.plist`, `resources/windows/installer.iss`) y el build de Nix (`nix/binary.nix`, `nix/nightly-info.nix`, `nix/release-info.nix`) sustituyen placeholders de channel para que la entrada de escritorio, la asociación MIME y el ícono del launcher coincidan con el channel en ejecución.
+
+El modelo de channel/branding es un seam de runtime: el código de UI y de app leen los accessors de `ReleaseChannel`; nunca bifurcan según el string de versión crudo ni hardcodean los identificadores `dbflux`/`dbflux-nightly`. El flujo de release/nightly en sí está documentado en `docs/RELEASE.md`.
+
+### Implementaciones de Drivers
+
+- **PostgreSQL**: `crates/dbflux_driver_postgres/` — `tokio-postgres` con TLS, cancelación, extracción detallada de errores.
+- **MySQL/MariaDB**: `crates/dbflux_driver_mysql/` — arquitectura de conexión dual (sync para schema, async para queries).
+- **SQLite**: `crates/dbflux_driver_sqlite/` — conexiones basadas en archivo con `rusqlite`.
+- **Microsoft SQL Server**: `crates/dbflux_driver_mssql/` — cliente TDS `tiberius` con TLS, SSH tunnel, routing de named-instance vía SQL Browser, introspección multi-schema, CRUD vía `OUTPUT INSERTED.*` / `OUTPUT DELETED.*`, y cancelación por side-channel basada en `KILL` con restauración automática de sesión.
+- **MongoDB**: `crates/dbflux_driver_mongodb/` — driver async `mongodb` con:
+  - Manejo y conversión de valores BSON
+  - Query parser para la sintaxis `db.collection.method()`
+  - Browsing de collections con paginación
+  - Descubrimiento de índices
+  - Operaciones CRUD sobre documents
+  - Shell query generator (`MongoShellGenerator`) para insertOne/updateOne/deleteOne
+- **Redis**: `crates/dbflux_driver_redis/` — driver `redis` con:
+  - API key-value para tipos String, Hash, List, Set, SortedSet y Stream
+  - Comandos variádicos (HSET con múltiples fields, SADD con múltiples members, etc.)
+  - Soporte de keyspace (índice de base de datos)
+  - Key scanning, gestión de TTL, rename, descubrimiento de tipo
+  - Command generator (`RedisCommandGenerator`) para todos los tipos de mutación key-value
+- **DynamoDB**: `crates/dbflux_driver_dynamodb/` — driver `aws-sdk-dynamodb` con:
+  - Descubrimiento nativo de tablas (`ListTables`, `DescribeTable`) con metadata de claves PK/SK + GSI/LSI mapeada a las abstracciones de document de DBFlux
+  - Planificación del read path (`Scan` vs `Query`) con opciones de lectura (`index`, `consistent_read`) y traducción/fallback de server-filter
+  - Soporte de mutación para paths de un solo item y multi-item (`put`, `update`, `delete`), con upsert de un solo item y manejo de reintentos acotado para batch writes sin procesar
+  - Parser de JSON command-envelope para el modo execute (`scan`, `query`, `put`, `update`, `delete`) y generación de query de mutación (`DynamoQueryGenerator`)
+  - Límites actuales: sin cancelación de query, sin superficie de API PartiQL/transaction, y sin combinación `update many + upsert`
+- **InfluxDB**: `crates/dbflux_driver_influxdb/` — driver `DatabaseCategory::TimeSeries` que cubre tanto InfluxDB v1 como v2:
+  - v1 habla InfluxQL; v2 expone Flux además de InfluxQL (`QueryGenerator` emite Flux solo cuando `version == V2`)
+  - Descubrimiento de bucket/database y measurement mapeado al modelo de schema, con paginación y export CSV/JSON
+  - Orientado a lectura: sin transactions; la generación de mutación es limitada en comparación con los drivers relacionales
+- **ClickHouse**: `crates/dbflux_driver_clickhouse/` — driver `DatabaseCategory::Relational` y `QueryLanguage::Sql` para ClickHouse self-hosted y ClickHouse Cloud:
+  - Usa la interfaz HTTP(S) de ClickHouse y decodificación dinámica de resultados JSON para schemas arbitrarios
+  - Descubre databases, tables, views, columns y metadata de engine sin representar las databases como schemas
+  - Soporta SQL orientado a lectura y generación visual de SELECT; mutations estructuradas, DDL, transactions, SSH tunneling y parámetros de query genéricos no están expuestos
+- **CloudWatch Logs**: `crates/dbflux_driver_cloudwatch/` — driver `DatabaseCategory::LogStream` para AWS CloudWatch Logs:
+  - Descubrimiento de log group/stream expuesto como collections; los log groups se abren como event streams vía `CollectionPresentation::EventStream` y un `EventStreamTarget` genérico, consumidos por el `AuditDocument`/log-stream viewer sin ninguna bifurcación de UI específica de driver
+  - Los modos de query (Logs Insights QL, OpenSearch PPL/SQL) se exponen a través de `SourceContextSpec`; `DriverMetadata.query_language` usa `Sql` por defecto para el comportamiento del editor
+  - Autenticación a través del stack de auth de AWS; sin cancelación de query todavía
+- **Amazon S3**: `crates/dbflux_driver_s3/` — driver `aws-sdk-s3` (`DatabaseCategory::ObjectStorage`):
+  - Autenticación vía AWS profile/SSO (`AuthProfileRef`) o credenciales estáticas de access-key, con override de endpoint y direccionamiento path-style para endpoints compatibles con S3 (Cloudflare R2, MinIO)
+  - Descubrimiento de buckets (`BucketsTableDocument` en la raíz de la conexión) y navegación paginada de objetos por nivel (`ObjectBrowserDocument`), con un modo de tree opcional no paginado
+  - La implementación de `ObjectStoreConnection` cubre upload, delete, delete recursivo de prefix/bucket (`DeleteObjects` en batch), copy, presign, detalles/versioning de bucket, y versions de object
+  - CRUD completo desde la UI: upload, delete recursivo con confirmación por escritura, creación de folder/bucket con degradación graceful por endpoint, rename (copy-then-delete), URLs presignadas
+  - Cada mutation se audita bajo `EventCategory::ObjectStorage`; las credenciales y URLs presignadas nunca se registran ni persisten
+
+### Política de README de drivers
+
+- Cada crate de driver (`crates/dbflux_driver_*/`) tiene un `README.md` que documenta las features y limitaciones actuales.
+- Mantén esos archivos README alineados con las capabilities de `DriverMetadata` y el comportamiento real en runtime tras cualquier cambio de driver.
+
+### Componentes de Soporte
+
+- Sistema de toasts: `crates/dbflux_ui_base/src/toast.rs` implementación personalizada con auto-dismiss (4s) para toasts de success/info/warning. (Shim en `crates/dbflux_ui/src/ui/components/toast.rs`.)
+- Infraestructura de tunnels: `crates/dbflux_tunnel_core/` provee `Tunnel` RAII con el trait `TunnelConnector` y el forwarder bidireccional `ForwardingConnection<R>`.
+- Proxy tunneling: `crates/dbflux_proxy/` implementa tunnels de proxy SOCKS5 y HTTP CONNECT vía `TunnelConnector`.
+- SSH tunneling: `crates/dbflux_ssh/src/lib.rs` implementa tunnel SSH vía `TunnelConnector`, todas las operaciones serializadas a un thread por seguridad de libssh2.
+- Export: `crates/dbflux_export/` provee export basado en shape (CSV, JSON pretty/compact, Text, Binary/Hex/Base64). La disponibilidad de formato la determina `QueryResultShape`, no el driver. Cada formato tiene su propio módulo (`binary.rs`, `csv.rs`, `json.rs`, `text.rs`). La disponibilidad del file-dialog se sondea en runtime vía `dbflux_ui_base/src/file_dialog.rs::is_native_file_dialog_available()` (en Linux: verifica `PATH` en busca de `xdg-desktop-portal`, `zenity`, `kdialog`); cuando no hay backend disponible, los exports caen a `fallback_export_dir()` (`~/.local/share/dbflux/exports/`) con deconfliction vía `unique_path_in()`. También hay disponible un path de export por clipboard como target alternativo.
+- Test support: `crates/dbflux_test_support/` provee gestión de contenedores Docker y fixtures para live integration tests en todos los drivers. DynamoDB Local se usa solo para integration tests y validación local; el uso en producción apunta a endpoints remotos de AWS DynamoDB.
+- Sistema de íconos: enum `AppIcon` definido en `crates/dbflux_components/src/icons/mod.rs`; los bytes SVG embebidos y la lista `ALL_ICONS` permanecen en `crates/dbflux_ui/src/ui/icons/mod.rs` (los recursos viven bajo `crates/dbflux_ui/resources/`), cargados vía `assets.rs`.
+- Detección de plataforma: `crates/dbflux_ui_base/src/platform.rs` maneja las diferencias entre X11/Wayland con `is_x11()`, `floating_window_kind()`, y `apply_window_options()` para los hints correctos de tamaño mínimo de ventana. (Shim en `crates/dbflux_ui/src/platform.rs`.)
+
+### Sistema de Gobernanza MCP
+
+DBFlux soporta el Model Context Protocol (MCP) para integración con clientes de IA con una capa completa de gobernanza:
+
+**Classification** (`dbflux_policy/classification.rs`):
+- Enum `ExecutionClassification`: Metadata, Read, Write, Destructive, AdminSafe, Admin, AdminDestructive
+- Se usa para categorizar operaciones por nivel de impacto para las decisiones de policy y los flujos de approval
+
+**Policy Engine** (`dbflux_policy/engine.rs`):
+- `PolicyEngine::evaluate()` toma actor, connection, tool y classification
+- Devuelve `PolicyDecision::Allow` o `PolicyDecision::Deny(reason)`
+- `PolicyRole` compone múltiples tool policies
+- `ToolPolicy` define los tools permitidos y los niveles de classification
+- `ConnectionPolicyAssignment` vincula actors/connections a roles y policies
+
+**Trusted Clients** (`dbflux_policy/trusted_clients.rs`):
+- `TrustedClientRegistry` identifica clientes de IA conocidos por id, name, issuer
+- Se usa para diferenciar entre actors trusted y untrusted en los audit logs
+
+**Approval Flow** (`dbflux_approval`):
+- `ApprovalService` gestiona el lifecycle de approve/reject para ejecuciones diferidas
+- `InMemoryPendingExecutionStore` mantiene las ejecuciones pendientes a la espera de approval humano
+- `ExecutionPlan` captura el contexto original del request para la ejecución diferida
+
+**Audit** (`dbflux_audit`):
+- `AuditService` delega en `AuditRepository` en `dbflux_storage` (`~/.local/share/dbflux/dbflux.db`, tabla `aud_audit_events`)
+- Los events usan `EventRecord` de `dbflux_core::observability` — campos estructurados para category, severity, outcome, actor type, connection, object, details y contexto de error
+- Los events se emiten a través del trait `EventSink`; las capas de servicio inyectan `Arc<dyn EventSink>` en lugar de llamar directamente a `AuditService`
+- Categories: `Query`, `Connection`, `Hook`, `Script`, `Mcp`, `Governance`, `Config`, `System`
+- Antes de almacenar: valida los campos requeridos específicos de category, hace fingerprint del texto de query como SHA256 (el texto de query nunca se almacena por defecto), redacta valores sensibles, impone un límite de payload de detail de 64 KiB
+- `AuditQueryFilter` para consultar por actor, tool, category, action, outcome, rango de fechas, texto libre y correlation ID
+- Export a JSON/CSV vía `AuditExportFormat`; `export_extended()` incluye todos los campos del DTO incluyendo `details_json`
+- Retention purge: `AuditService::purge_old_events(days, batch_size)` — en batches para evitar transacciones de escritura largas
+- Ver `docs/AUDIT.md` para el schema completo de eventos, campos requeridos y patrones de uso
+
+**MCP Runtime** (`dbflux_mcp/runtime.rs`):
+- `McpRuntime` implementa el trait `McpGovernanceService`
+- Integra el policy engine, el approval service y el audit service
+- Emite `McpRuntimeEvent` para actualizaciones de la UI (clients/roles/policies cambiados, ejecuciones pendientes)
+- El tool catalog (`tool_catalog.rs`) define los tools canónicos de MCP y los tools diferidos
+
+**Standalone Server** (`dbflux_mcp_server`):
+- Expuesto como `dbflux mcp --client-id <id>` para clientes de IA
+- Transporte JSON-RPC sobre stdin/stdout
+- `ConnectionCache` más un setup de conexión serializado evitan el teardown de PostgreSQL con scope de request y las carreras de duplicate-connect
+- Mismo stack de gobernanza que el MCP integrado en la app
+- `preview_mutation` es estrictamente de solo lectura; el inseguro `preview_ddl` intencionalmente no se expone hasta que DBFlux tenga un path de preview de DDL seguro y no mutante
+
+**Integración con la UI**:
+- `McpApprovalsView` (`crates/dbflux_ui_document/src/governance.rs`) para revisar ejecuciones pendientes
+- `mcp_section.rs` (`crates/dbflux_ui_windows/src/settings/mcp_section.rs`) en Settings para trusted clients, roles y policies
+- `AuditDocument` (`crates/dbflux_ui_document/src/audit/`) como el visor de eventos unificado tanto para los registros de audit internos como para los event streams externos respaldados por driver expuestos a través de `EventStreamTarget`s genéricos (sin path de audit document específico de driver en la UI)
+- `LoginModal` (`crates/dbflux_ui/src/ui/overlays/login_modal.rs`) y `SsoWizard` (`crates/dbflux_ui_base/src/sso_wizard.rs`, shim en la ruta antigua de overlay) para el flujo de autenticación de AWS SSO
+
+## Flujo de Datos
+
+- Startup: `main` crea `AppState` y `Workspace`, restaura la sesión previa (tabs desde `session.json`), y abre la ventana principal. Si no se restaura ningún tab, el foco por defecto va al sidebar (`crates/dbflux/src/main.rs`, `crates/dbflux_ui/src/ui/views/workspace/`).
+- Bootstrap de drivers externos: al iniciar, DBFlux lee `cfg_services` desde `~/.local/share/dbflux/dbflux.db`, sondea cada servicio, y solo registra los servicios que completan el handshake RPC (`Hello`) exitosamente.
+- Flujo de conexión: `AppState::prepare_pipeline_input` construye un input de pipeline pre-connect agnóstico del provider. El pipeline ejecuta validación de auth/session, resolución dinámica de values, y setup de access managed/direct antes del connect del driver + fetch de schema. Soporta configuración basada en formulario, input de URI directo, proxy/SSH opcional y access managed (`aws-ssm`). Los connection hooks siguen ejecutándose en cada fase (PreConnect, PostConnect, PreDisconnect, PostDisconnect).
+- Flujo de query: `CodeDocument` envía database queries a una implementación de `Connection` cuando el `QueryLanguage` activo soporta el contexto de conexión. El query language (SQL/MongoDB/etc) lo determina la metadata del driver. Los resultados se renderizan en tabs de resultado dentro del document. Las queries peligrosas (DELETE sin WHERE, DROP, TRUNCATE) disparan diálogos de confirmación (manejados en `code/execution.rs`). Cuando el driver anuncia la capability `MULTI_STATEMENT`, un script con varias sentencias separadas por `;` se ejecuta como un batch, produciendo un result set por sentencia.
+- Flujo de script: `CodeDocument` ejecuta documents de Lua, Python y Bash como script hooks en lugar de database queries. Las ejecuciones de script crean un canal de salida local, transmiten texto en vivo a un buffer propiedad del document, y mantienen la salida final como un resultado de texto cuando la ejecución termina.
+- Selección de view mode: `DataGridPanel` (en `crates/dbflux_ui_document/src/data_grid_panel/`) selecciona automáticamente el view mode apropiado según la database category — vista Table para bases de datos relacionales, vista Document tree para bases de datos de documentos como MongoDB y DynamoDB, vista key-value para Redis. Los contenedores de document tipo event-stream se abren a través de `CollectionPresentation::EventStream` en lugar de checks de driver del lado de la UI. Los menús contextuales incluyen "Copy as Query" para generar sentencias/envelopes de mutación específicos del driver vía `QueryGenerator`.
+- Query preview: `SqlPreviewModal` (en `crates/dbflux_ui_base/src/sql_preview_modal.rs`, shim en la ruta antigua de overlay) enruta los previews de lectura/DML relacionales a través de `QueryGenerator` para previews de row, table y view, mientras que el DDL sigue en `CodeGenerator`. Los lenguajes no-SQL (MongoDB, Redis) siguen usando el modo de preview genérico con texto estático y resaltado de sintaxis específico del lenguaje.
+- Schema refresh: `Workspace::refresh_schema` ejecuta `Connection::schema` en un background executor y actualiza `AppState` (`crates/dbflux_ui/src/ui/views/workspace/`).
+- Carga perezosa: los drivers obtienen la metadata de table/collection (columns, indexes) bajo demanda cuando los items se expanden en el sidebar, no durante la conexión inicial (optimización de rendimiento para bases de datos grandes).
+- Flujo de history: las queries completadas se almacenan en `HistoryStore`, se persisten a JSON, y son accesibles a través del history modal (`crates/dbflux_core/src/storage/history.rs`). La UI del history modal está en `crates/dbflux_ui_document/src/history_modal.rs`.
+- Flujo de saved queries: los usuarios pueden guardar queries con nombres vía `SavedQueryStore`; el history modal (Ctrl+P) permite explorar, buscar y cargar saved queries (`crates/dbflux_core/src/storage/saved_query.rs`).
+
+## Arquitectura de Teclado y Foco
+
+- Sistema de keymap: `crates/dbflux_ui/src/keymap/` (permanece en `dbflux_ui`) define el keymap glue (`actions.rs`, `dispatcher.rs`). Los keymap helpers (`default_keymap`, `key_chord_from_gpui`) viven en `crates/dbflux_ui_base/src/keymap.rs`. Los tipos de comando de dominio (`Command`, `ContextId`) se definen en `dbflux_core::keymap_types` y se re-exportan a través de `crates/dbflux_app/src/keymap/`.
+- Dispatch de comandos: `Workspace` implementa el trait `CommandDispatcher`; `dispatch()` en `views/workspace/dispatch.rs` enruta comandos según `focus_target` (Document, Sidebar, BackgroundTasks).
+- Diseño centrado en el document: FocusTarget se simplificó de Editor/Results/Sidebar/BackgroundTasks a Document/Sidebar/BackgroundTasks, dejando que los documents gestionen su propio estado de foco interno.
+- Capas de foco: cada contexto tiene su propia capa de keymap con bindings de estilo vim (navegación j/k/h/l).
+- Modos de foco de panel: paneles complejos como las data tables tienen máquinas de estado de foco interno (`FocusMode::Table`/`Toolbar`, `EditState::Navigating`/`Editing`) para manejar navegación por teclado anidada.
+- Sincronización mouse/teclado: los handlers de mouse actualizan el estado de foco para mantener consistente la navegación por teclado y mouse; un flag `switching_input` evita condiciones de carrera durante los eventos de blur de input.
+
+## Integraciones Externas
+
+- PostgreSQL: cliente `tokio-postgres` con TLS opcional, soporte de cancelación, carga perezosa de schema, y modo de conexión por URI (crates/dbflux_driver_postgres/src/driver.rs).
+- MySQL/MariaDB: crate `mysql` con arquitectura de conexión dual (sync para schema, async para queries), carga perezosa de schema, y modo de conexión por URI (crates/dbflux_driver_mysql/src/driver.rs).
+- SQLite: conexiones basadas en archivo con `rusqlite` y carga perezosa de schema (crates/dbflux_driver_sqlite/src/driver.rs).
+- Microsoft SQL Server: cliente TDS `tiberius` con modos TLS (`off`/`on`/`required`), SSH tunneling, lookup de named-instance vía SQL Browser, introspección multi-database/multi-schema vía queries calificadas al catálogo `sys.*`, CRUD con `OUTPUT INSERTED.*` / `OUTPUT DELETED.*`, y cancelación cooperativa vía side-channel `KILL <spid>` con restauración automática de sesión (crates/dbflux_driver_mssql/src/driver.rs).
+- MongoDB: driver async `mongodb` con manejo de BSON, query parser para la sintaxis `db.collection.method()`, descubrimiento de collection/index, CRUD de documents, generación de shell query, y soporte de descripción de collection para workflows de metadata de MCP/UI (crates/dbflux_driver_mongodb/src/driver.rs).
+- Redis: driver `redis` con API key-value para todos los tipos de Redis, comandos variádicos, soporte de keyspace, key scanning, y generación de comandos (crates/dbflux_driver_redis/src/driver.rs).
+- DynamoDB: driver `aws-sdk-dynamodb` con soporte de AWS profile/region para DynamoDB remoto, más override de endpoint opcional para emuladores locales y tests (crates/dbflux_driver_dynamodb/src/driver.rs).
+- ClickHouse: driver HTTP(S) usando `reqwest` con decodificación dinámica de JSON, descubrimiento de database/table, y soporte de SQL orientado a lectura para ClickHouse self-hosted y ClickHouse Cloud (crates/dbflux_driver_clickhouse/src/driver.rs).
+- Amazon S3: driver `aws-sdk-s3` con AWS profile/SSO o credenciales estáticas, override de endpoint y direccionamiento path-style para endpoints compatibles con S3 (Cloudflare R2, MinIO), CRUD de bucket/object, URLs presignadas, y soporte de copy/versions (crates/dbflux_driver_s3/src/driver.rs).
+- Stack de auth de AWS: `dbflux_aws` provee providers de auth AWS SSO/shared/static, orquestación de login SSO, descubrimiento de account/role, y write-back del profile `~/.aws/config` para los auth profiles recién guardados.
+- IPC/RPC local: sockets `interprocess` + envelopes versionados para app control y comunicación de servicio RPC (`crates/dbflux_ipc/`, `crates/dbflux_driver_ipc/`, `crates/dbflux_driver_host/`). `dbflux_app::rpc_services` descubre los service descriptors persistidos, adapta `RpcServiceKind::Driver` en `DbDriver`s de runtime, y conecta `RpcServiceKind::AuthProvider` a `RpcAuthProvider` (que implementa `DynAuthProvider`). Preserva la compatibilidad con `rpc:<socket_id>`. El protocolo IPC de auth-provider está en v1.2: agrega las variantes `FetchDynamicOptions` / `DynamicOptions` y el manifest flag `secret_dependency_opt_in`. Los auth tokens los gestiona `dbflux_ipc/src/auth.rs`.
+- Proxy: tunnels SOCKS5/HTTP CONNECT vía `dbflux_tunnel_core::Tunnel` (crates/dbflux_proxy/src/lib.rs).
+- SSH: sesiones `ssh2` con forwarding TCP local vía `dbflux_tunnel_core::Tunnel` (crates/dbflux_ssh/src/lib.rs).
+- OS keyring: almacenamiento opcional de secrets para passwords, SSH passphrases, y credenciales de proxy (crates/dbflux_core/src/storage/secrets.rs).
+- Export: export multi-formato basado en shape — CSV, JSON (pretty/compact), Text, Binary (raw/hex/base64) vía `dbflux_export` (`lib.rs`, `binary.rs`, `csv.rs`, `json.rs`, `text.rs`).
+
+## Configuración
+
+- Settings de workspace: `Cargo.toml` define los miembros del workspace y las dependencias compartidas.
+- Features de la app: `crates/dbflux/Cargo.toml` activa `sqlite`, `postgres`, `mysql`, `mongodb`, `redis`, `dynamodb`, `cloudwatch`, `influxdb`, `mssql`, `redshift`, `clickhouse`, `s3`, `lua`, `aws`, y `mcp` (habilitadas por defecto en esta branch).
+- Datos de runtime: toda la configuración de runtime se almacena en `~/.local/share/dbflux/dbflux.db` (un único archivo SQLite).
+  - `cfg_connection_profiles` + tablas hijas (bindings de auth, proxy, SSH)
+  - `cfg_auth_profiles` (storage de auth profile agnóstico del provider)
+  - `cfg_ssh_tunnel_profiles`, `cfg_proxy_profiles`
+  - `cfg_hooks`, `cfg_hook_bindings`
+  - `cfg_services`, `cfg_service_args`, `cfg_service_env` (descriptores de servicio RPC; `cfg_services.service_kind` registra `driver` vs `auth_provider`)
+  - tablas `cfg_governance_*` (roles, policies, trusted clients)
+  - `cfg_drivers` (overrides de settings por driver)
+  - `cfg_folders` (organización del connection tree)
+  - `st_sessions`, `st_tabs`, `st_query_history`, `st_saved_queries`, `st_recent_items`, `st_ui_state`
+  - `aud_audit_events`, `aud_audit_entities`, `aud_audit_attributes`
+  - `viz_dashboards`, `viz_dashboard_panels`, `viz_saved_charts`, `viz_saved_chart_series`, `viz_saved_chart_binding_y`, `viz_saved_chart_source_metric_dimensions`, `viz_saved_chart_source_metric_series`
+  - `qry_saved_queries`, `qry_saved_query_columns`, `qry_saved_query_sorts`, `qry_saved_query_joins`
+  - `sys_migrations`, `sys_legacy_imports`
+- Import de JSON legacy: en el primer inicio, `dbflux_storage/src/legacy.rs` importa los archivos JSON existentes a SQLite si existen:
+  - `~/.config/dbflux/profiles.json` → `cfg_connection_profiles`
+  - `~/.config/dbflux/auth_profiles.json` → `cfg_auth_profiles`
+  - `~/.config/dbflux/ssh_tunnels.json` → `cfg_ssh_tunnel_profiles`
+  - `~/.config/dbflux/config.json` (legacy, solo rpc_services) → `cfg_services` con filas legacy por defecto en `service_kind='driver'`
+  - El import es idempotente (rastreado en `sys_legacy_imports`)
+- Datos de sesión (directorio de datos):
+  - `sessions/` archivos scratch y shadow para auto-save (crates/dbflux_core/src/storage/session.rs).
+  - `scripts/` carpeta de scripts del usuario (crates/dbflux_core/src/config/scripts_directory.rs).
+- Secrets: los passwords se almacenan en el keyring del sistema operativo; las referencias se derivan de los profile IDs. El trait `HasSecretRef` unifica las operaciones de secret de SSH tunnel y proxy (crates/dbflux_core/src/storage/secrets.rs, crates/dbflux_core/src/storage/secret_manager.rs).
+
+## Build y Deploy
+
+- Build: `cargo build -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,clickhouse,aws` o `--release` (AGENTS.md).
+- Run: `cargo run -p dbflux --features sqlite,postgres,mysql,mongodb,redis,dynamodb,clickhouse,aws` (AGENTS.md).
+- Test: `cargo test --workspace` (AGENTS.md).
+- Lint/format: `cargo clippy --workspace -- -D warnings`, `cargo fmt --all` (AGENTS.md).
+- Nix: `nix build` o `nix run` usando flake.nix; `nix develop` para el dev shell.
+- Arch Linux: publicado en el AUR como `dbflux`; el PKGBUILD se mantiene en el repositorio externo del AUR, no en este repo.
+- Instalador de Linux: `curl -fsSL .../install.sh | bash` descarga e instala el release.
+- Releases: el workflow de GitHub Actions compila Linux amd64/arm64, macOS amd64/arm64, y Windows amd64, con firma GPG opcional, y publica en GitHub Releases.
+- Modelo de despliegue: app de escritorio con GUI; sin runtime de servidor en este repo.

--- a/docs/es/AUDIT.md
+++ b/docs/es/AUDIT.md
@@ -1,0 +1,499 @@
+# Sistema de Audit de DBFlux
+
+DBFlux registra todas las operaciones significativas en un audit trail unificado almacenado en SQLite. Esto cubre la ejecución de queries, el ciclo de vida de las conexiones, la ejecución de hooks, las ejecuciones de scripts, las decisiones de governance de MCP y los cambios de configuración.
+
+## Ubicación de almacenamiento
+
+Todos los audit events se almacenan en la base de datos unificada:
+
+```
+~/.local/share/dbflux/dbflux.db
+```
+
+Tabla: `aud_audit_events`
+
+La misma base de datos almacena todo el resto del estado en tiempo de ejecución (profiles, history, sessions). El schema lo gestiona el sistema de migraciones en `dbflux_storage/src/migrations/`.
+
+## Estructura de un evento
+
+Cada audit event es un `EventRecord` (`dbflux_core/src/observability/types.rs`) con estos campos:
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `id` | `i64` | Asignado automáticamente al insertar |
+| `ts_ms` | `i64` | Timestamp Unix en milisegundos |
+| `level` | `EventSeverity` | `trace`, `debug`, `info`, `warn`, `error`, `fatal` |
+| `category` | `EventCategory` | Dominio del evento (ver abajo) |
+| `action` | `String` | Identificador específico de la acción (p. ej., `query_execute`) |
+| `outcome` | `EventOutcome` | `success`, `failure`, `cancelled`, `pending` |
+| `actor_type` | `EventActorType` | Quién disparó el evento |
+| `actor_id` | `Option<String>` | Identidad del actor (client ID de MCP, nombre del hook, etc.) |
+| `source_id` | `EventSourceId` | Dónde se originó el evento |
+| `connection_id` | `Option<String>` | ID del connection profile |
+| `database_name` | `Option<String>` | Nombre de la base de datos destino |
+| `driver_id` | `Option<String>` | ID del driver (p. ej., `postgres`, `mongodb`) |
+| `object_type` | `Option<String>` | Tipo de objeto afectado (p. ej., `table`, `collection`) |
+| `object_id` | `Option<String>` | ID/nombre del objeto específico |
+| `summary` | `String` | Descripción legible por humanos |
+| `details_json` | `Option<String>` | Contexto estructurado adicional como objeto JSON |
+| `error_code` | `Option<String>` | Código de error en caso de fallo |
+| `error_message` | `Option<String>` | Mensaje de error en caso de fallo |
+| `duration_ms` | `Option<i64>` | Tiempo de ejecución en milisegundos |
+| `session_id` | `Option<String>` | ID de correlación de sesión |
+| `correlation_id` | `Option<String>` | ID de correlación entre componentes |
+
+### Categorías de eventos
+
+| Categoría | String | Qué captura |
+|-----------|--------|-----------------|
+| `Query` | `query` | Ejecución de SQL, queries de MongoDB, operaciones de scan |
+| `Connection` | `connection` | Ciclo de vida de connect, disconnect, reconnect |
+| `Hook` | `hook` | PreConnect, PostConnect, PreDisconnect, PostDisconnect |
+| `Script` | `script` | Ejecución de scripts Lua, Python, Bash |
+| `Mcp` | `mcp` | Llamadas a tools de un AI client y decisiones de policy |
+| `Governance` | `governance` | Resultados de evaluación de policy |
+| `Config` | `config` | Cambios de profile, modificaciones de settings |
+| `System` | `system` | Arranque de la aplicación, panics, migraciones |
+| `ObjectStorage` | `object_storage` | Eventos de CRUD/mutación de object storage (upload, delete, presign, rename, create bucket/folder, save-back edit) |
+
+### Tipos de actor
+
+| Tipo | String | Significado |
+|------|--------|-------------|
+| `User` | `user` | Humano operando la GUI de DBFlux |
+| `System` | `system` | Operación de sistema en segundo plano |
+| `App` | `app` | Aplicación actuando de forma autónoma |
+| `McpClient` | `mcp_client` | AI agent vía el protocolo MCP |
+| `Hook` | `hook` | Script de un lifecycle hook |
+| `Script` | `script` | Script escrito por el usuario |
+
+### Campos obligatorios por categoría
+
+La validación la aplica `AuditService::validate_event()` antes de almacenar:
+
+| Categoría | Obligatorio además de `action` + `summary` |
+|-----------|--------------------------------------|
+| `Query` | `connection_id`, `driver_id`, `duration_ms` (para eventos de ejecución) |
+| `Connection` | `connection_id` |
+| `Hook` | `object_type`, `object_id`, `connection_id` |
+| `Script` | `object_type`, `object_id` |
+| `Mcp` | `actor_id`, `object_id` (nombre de la tool) |
+| `Config` | `object_type`, `object_id` |
+| `ObjectStorage` | `connection_id`, `object_type`, `object_id` |
+| `Governance`, `System` | Sin campos adicionales |
+
+## Privacidad y redacción
+
+Por defecto, `AuditService` se ejecuta con estos ajustes:
+
+- **`redact_sensitive = true`**: los valores sensibles (contraseñas, tokens, connection strings) en `details_json` y `error_message` se reemplazan por `[REDACTED]` antes de almacenarse.
+- **`capture_query_text = false`**: el texto completo de la query nunca se almacena. En su lugar, se guardan un fingerprint SHA256 más la longitud original como `[FINGERPRINT:<16-char-hex>]` con `query_length`. Esto evita que datos sensibles en las queries se filtren al audit log.
+- **`max_detail_bytes = 65536`**: los payloads mayores de 64 KiB se rechazan para prevenir el crecimiento descontrolado del almacenamiento.
+
+Estos ajustes se pueden cambiar en tiempo de ejecución vía los métodos `AuditService::set_*()`. El servidor MCP expone algunos de ellos a través de la configuración de governance.
+
+## Ver los audit events
+
+### En la UI de DBFlux
+
+Navega a **Workspace → Audit**. La vista unificada de audit soporta:
+
+- Filtrado por actor, tool/action, rango de fechas, decision, category
+- Exportar los resultados filtrados a CSV o JSON
+
+El mismo shell de UI `AuditDocument` se reutiliza también para los event streams externos respaldados por un driver, cuando un driver los declara a través de abstracciones genéricas del core (`CollectionPresentation`, `CollectionChildInfo`, `EventStreamTarget`). La UI no debe hacer casos especiales para drivers concretos al abrir o renderizar esos streams.
+
+### Directamente vía SQLite
+
+La base de datos es un archivo SQLite estándar. Consúltala directamente:
+
+```bash
+sqlite3 ~/.local/share/dbflux/dbflux.db
+```
+
+Queries útiles:
+
+```sql
+-- All events in the last 24 hours
+SELECT id, datetime(ts_ms/1000, 'unixepoch') as ts, level, category, action, outcome, actor_id, summary
+FROM aud_audit_events
+WHERE ts_ms > (unixepoch('now') - 86400) * 1000
+ORDER BY ts_ms DESC;
+
+-- MCP tool calls only
+SELECT id, datetime(ts_ms/1000, 'unixepoch') as ts, actor_id, object_id as tool, outcome, summary
+FROM aud_audit_events
+WHERE category = 'mcp'
+ORDER BY ts_ms DESC;
+
+-- All failed operations
+SELECT id, datetime(ts_ms/1000, 'unixepoch') as ts, category, action, actor_id, error_message
+FROM aud_audit_events
+WHERE outcome = 'failure'
+ORDER BY ts_ms DESC
+LIMIT 50;
+
+-- Query events by connection
+SELECT id, datetime(ts_ms/1000, 'unixepoch') as ts, action, driver_id, duration_ms, summary
+FROM aud_audit_events
+WHERE category = 'query' AND connection_id = 'your-connection-id'
+ORDER BY ts_ms DESC;
+
+-- Events grouped by category and outcome
+SELECT category, outcome, count(*) as count
+FROM aud_audit_events
+GROUP BY category, outcome
+ORDER BY category, outcome;
+```
+
+### Vía MCP Tools (AI clients)
+
+La superficie de tools de MCP expone tres audit tools (clasificadas dentro de la execution class `read`):
+
+```
+query_audit_logs    — Filter events by actor, tool, date range, decision
+get_audit_entry     — Retrieve a single event by ID
+export_audit_logs   — Export filtered results as CSV or JSON
+```
+
+### Vía la API de Rust
+
+```rust
+use dbflux_audit::{AuditService, AuditQueryFilter, AuditExportFormat};
+
+let service = AuditService::new_sqlite_default()?;
+
+// Query recent events
+let filter = AuditQueryFilter {
+    category: Some("mcp".to_string()),
+    start_epoch_ms: Some(start_ms),
+    limit: Some(100),
+    ..Default::default()
+};
+let events = service.query(&filter)?;
+
+// Export to CSV
+let csv = service.export(&filter, AuditExportFormat::Csv)?;
+
+// Export extended (all fields including details_json)
+let json = service.export_extended(&filter, AuditExportFormat::Json)?;
+```
+
+## Generar audit events
+
+### Desde las capas de servicio
+
+Usa el trait `EventSink`. Todos los componentes que emiten audit events aceptan un `Arc<dyn EventSink>`:
+
+```rust
+use dbflux_core::observability::{
+    EventOrigin, EventRecord, EventSink,
+    types::{EventCategory, EventSeverity, EventOutcome},
+    actions,
+};
+
+// Build the event
+let event = EventRecord::new(
+    now_epoch_ms(),
+    EventSeverity::Info,
+    EventCategory::Query,
+    EventOutcome::Success,
+)
+.with_typed_action(actions::QUERY_EXECUTE)
+.with_summary("SELECT executed on users table")
+.with_actor_id("my-actor-id")
+.with_origin(EventOrigin::local())
+.with_connection_context("my-profile-id", "mydb", "postgres")
+.with_object_ref("table", "users")
+.with_duration_ms(42);
+
+// Emit through the sink (injected via constructor or DI)
+event_sink.record(event)?;
+```
+
+### Constantes canónicas de acción
+
+Las cadenas de action se definen en `dbflux_core/src/observability/actions.rs`. Usa las constantes en lugar de strings sueltos:
+
+| Constante | String | Categoría |
+|-----------|--------|-----------|
+| `QUERY_EXECUTE` | `query_execute` | Query |
+| `QUERY_EXECUTE_FAILED` | `query_execute_failed` | Query |
+| `CONNECTION_CONNECT` | `connection_connect` | Connection |
+| `CONNECTION_DISCONNECT` | `connection_disconnect` | Connection |
+| `HOOK_EXECUTE` | `hook_execute` | Hook |
+| `HOOK_EXECUTE_FAILED` | `hook_execute_failed` | Hook |
+| `SCRIPT_EXECUTE` | `script_execute` | Script |
+| `SCRIPT_EXECUTE_FAILED` | `script_execute_failed` | Script |
+| `MCP_AUTHORIZE` | `mcp_authorize` | Mcp |
+| `MCP_APPROVE_EXECUTION` | `mcp_approve_execution` | Mcp |
+| `MCP_REJECT_EXECUTION` | `mcp_reject_execution` | Mcp |
+| `MCP_TOOL_EXECUTE` | `mcp_tool_execute` | Mcp |
+| `MCP_TOOL_EXECUTE_FAILED` | `mcp_tool_execute_failed` | Mcp |
+| `SYSTEM_PANIC` | `system_panic` | System |
+
+### Checklist de campos obligatorios
+
+Antes de llamar a `record()`, asegúrate de que:
+
+1. `action` está definido y no está vacío (usa una constante de `actions`)
+2. `summary` está definido y no está vacío (legible por humanos, una frase)
+3. Los campos específicos de la categoría están presentes (ver la tabla de arriba)
+4. `details_json` es un objeto JSON válido si se proporciona — no un array ni un primitivo
+5. `details_json` ocupa menos de 64 KiB
+
+### Eventos de fallo
+
+Para los fallos, establece outcome a `EventOutcome::Failure` y rellena `error_code` y `error_message`:
+
+```rust
+let event = EventRecord::new(ts_ms, EventSeverity::Error, EventCategory::Query, EventOutcome::Failure)
+    .with_typed_action(actions::QUERY_EXECUTE_FAILED)
+    .with_summary("Query failed: syntax error")
+    .with_connection("profile-id", Some("mydb"), Some("postgres"))
+    .with_error("42601", "syntax error at or near \"SELEC\"");
+```
+
+`error_message` se redacta si contiene patrones sensibles. Usa `error_code` para identificadores de error estables y legibles por máquina.
+
+## Retención y purga
+
+Los eventos se pueden purgar según una política de retención:
+
+```rust
+// Delete events older than 90 days, in batches of 500
+let stats = service.purge_old_events(90, 500)?;
+println!("Deleted {} events in {} batches", stats.deleted_count, stats.batches);
+```
+
+La purga se ejecuta en lotes para evitar transacciones de escritura largas. No se ejecuta automáticamente — añádela a una tarea programada en segundo plano o a un runbook de operaciones.
+
+## Puente de Tracing a Audit
+
+El puente de tracing captura los eventos estructurados emitidos por las macros `log::*!` y `tracing::*!` en todos los crates de DBFlux y los escribe en la misma tabla `aud_audit_events` sin requerir migración de los call sites.
+
+### Flujo del evento
+
+```mermaid
+flowchart TD
+    LOG["log::warn!(...)"] --> BRIDGE["LogTracer (tracing-log)"]
+    BRIDGE --> EVENT["tracing event"]
+    TRACING["tracing::info!(...)"] --> EVENT
+    EVENT --> LAYER["AuditLayer::on_event"]
+    LAYER -->|level gate + recursion guard| CHANNEL["bounded mpsc::sync_channel (512)"]
+    CHANNEL --> DRAIN["drain thread"]
+    DRAIN -->|AuditService::record| TABLE[("aud_audit_events (SQLite)")]
+```
+
+### Categoría permitida por el puente
+
+Todos los eventos capturados a través del puente se asignan a la categoría `System`. Esta es la resolución de la V1: los eventos de log de formato libre no llevan los campos estructurados (`connection_id`, `object_type`, `object_id`) que otras categorías requieren, así que enrutarlos a `Connection` o `Config` haría que `validate_event` los rechazara. El `PREFIX_CATEGORY_MAP` en `dbflux_core/src/observability/tracing_bridge/category.rs` mapea prefijos de módulo a categorías previstas con fines documentales, pero todas las categorías resueltas se coaccionan a `System` en tiempo de ejecución.
+
+### Umbral de captura
+
+Solo se escriben en el audit store los eventos con nivel igual o superior al `log_capture_min_level` configurado. `TRACE` y `DEBUG` se filtran de forma estricta — nunca se escriben, sin importar el umbral configurado.
+
+El umbral se almacena como un ordinal `u8` en un `Arc<AtomicU8>` y se actualiza sin reinicializar el subscriber. El mapeo es:
+
+| Severidad | Ordinal |
+|-----------|---------|
+| Trace    | 0       |
+| Debug    | 1       |
+| Info     | 2       |
+| Warn     | 3       |
+| Error    | 4       |
+
+El umbral por defecto es `Info` (ordinal 2).
+
+### Configurar el umbral
+
+En la UI de DBFlux: desplegable **Settings → Audit → Log Capture → Minimum Level**. Al seleccionar un nivel y pulsar Save se persiste en `cfg_audit_settings.log_capture_min_level` (columna añadida por la migración 014) y se aplica al puente de forma atómica — no requiere reiniciar.
+
+Directamente en SQLite:
+
+```sql
+UPDATE cfg_audit_settings SET log_capture_min_level = 'warn';
+```
+
+Valores válidos: `trace`, `debug`, `info`, `warn`, `error`.
+
+### Contador de descartes
+
+Cuando el canal acotado está lleno (512 eventos por defecto, configurable vía `BridgeConfig::queue_capacity`), el puente descarta el evento entrante en lugar de bloquear, e incrementa un contador de descartes `Arc<AtomicU64>`. Esto evita que la ruta de audit introduzca contrapresión en el código de la aplicación. El contador de descartes actual es accesible vía `BridgeHandle::drop_count()` y se expone a través de `AuditService::dropped_log_event_count()` para observabilidad, pero no se persiste ni se muestra en la UI en la V1.
+
+### Ventana de arranque
+
+Existe un breve intervalo entre el inicio del proceso y la instalación del sink durante el cual los eventos se capturan en el canal de drenaje pero aún no se vuelcan a SQLite — el sink se instala después de que se construye `AppState` y se completa la primera lectura de audit settings. Los eventos en tránsito durante esta ventana se retienen en el canal acotado y se entregan una vez instalado el sink. Si el canal se llena durante la ventana de arranque, los eventos se descartan y se contabilizan.
+
+### Guardia de recursión
+
+Los eventos emitidos desde `dbflux_core::observability::tracing_bridge` quedan excluidos del puente para evitar bucles de realimentación en los que los diagnósticos del propio puente se retroalimenten a sí mismos. Esto se aplica mediante la constante `BRIDGE_INTERNAL_TARGET`, comprobada en `AuditLayer::on_event`.
+
+### Lista de permitidos por target
+
+Solo los eventos cuyo `target` empiece por `dbflux` se reflejan en el audit store. Dependencias upstream como `gpui`, `blade_graphics`, `naga`, `wgpu`, `hyper` y `tokio` emiten trazas verbosas de nivel `INFO` (ciclo de vida de texturas y buffers del render-loop, modo de presentación de superficie, ciclo de vida de peticiones HTTP, etc.) que de otro modo inundarían el audit log de ruido operacional sin ningún valor para el diagnóstico posterior.
+
+Estos eventos siguen fluyendo a través de la capa fmt y permanecen visibles en stderr (o en el archivo de log) según `RUST_LOG`. El gate vive en `passes_target_gate`, en `layer.rs`, y se ejecuta antes de construir el record.
+
+Para auditar un evento de una fuente que no sea `dbflux`, envuelve la emisión en un módulo de dbflux y reemítela con un target de dbflux — el puente intencionalmente no deja pasar targets upstream.
+
+### Campos de tracing con nombre
+
+El puente reconoce estos campos con nombre en los eventos de tracing y los mapea a campos de `EventRecord`:
+
+| Campo de tracing | Campo de `EventRecord` |
+|-------------------|-------------------------|
+| `message` | `summary` |
+| `category` | `category` (coaccionado a `System`) |
+| `actor_type` | `actor_type` |
+| `actor_id` | `actor_id` |
+| `connection_id` | `connection_id` |
+| `database_name` | `database_name` |
+| `driver_id` | `driver_id` |
+| `action` | `action` |
+| `outcome` | `outcome` |
+| `details_json` | `details_json` |
+
+Los campos desconocidos se acumulan en `details_json` como un objeto JSON. Si el mensaje excede los 512 caracteres, se trunca con `…` y el mensaje completo se guarda en `details_json["message"]`.
+
+El puente también mapea `correlation_id` directamente a `EventRecord.correlation_id` (no dentro de `details_json`), lo que permite la correlación entre componentes entre los toasts de error orientados al usuario y sus audit records correspondientes.
+
+### Eventos de error orientados al usuario
+
+Los errores orientados al usuario (fallos de storage, errores de driver, problemas de red, fallos al persistir la configuración) se reportan a través de `report_error` / `report_error_async` desde `dbflux_ui_base::user_error`. Cada llamada emite un evento de tracing que fluye a través del puente y además dispara una notificación toast.
+
+La forma del evento de tracing:
+
+| Campo de tracing | Valor |
+|-------------------|-------|
+| `target` | `dbflux_ui::user_error` |
+| `action` | `user_error` |
+| `outcome` | `failure` |
+| `kind` | `ErrorKind` como string (`storage`, `network`, `auth`, `hook`, `driver`, `user`, `config`) |
+| `correlation_id` | UUID v7 que vincula el toast con el audit record |
+| `message` | El resumen legible por humanos mostrado en el toast |
+
+El campo `correlation_id` lo extrae `AuditFieldVisitor` hacia `EventRecord.correlation_id`. Nótese que el visitor enruta tanto `record_str` (sigilo Display `%val`) como `record_debug` (sigilo Debug `?val`) a través del mismo dispatcher `record_string_by_name`, de forma que los nuevos slots tipados que se añadan en el futuro se recogen sin importar qué sigilo use quien llama.
+
+Hay dos caminos desde la UI de vuelta al audit document:
+
+- **Acción "View in Audit" por toast** — emite `OpenAuditRequested(Some(correlation_id))`. El workspace abre (o enfoca) el Audit document y aplica el filtro de correlation coincidente para que el usuario vea exactamente el único evento vinculado al toast.
+- **Clic en el badge de error de la status bar** — emite `OpenAuditRequested(None)`. El workspace abre el Audit document con el filtro de user-error por defecto (`target = dbflux_ui::user_error` sobre una ventana de tiempo reciente) para que el usuario pueda explorar todos los fallos orientados al usuario recientes.
+
+Ambos eventos fluyen a través de `AppStateEntity::request_open_audit` para que el workspace se suscriba una sola vez.
+
+Mapeo de severidad desde `EventSeverity`:
+- `EventSeverity::Info` y `EventSeverity::Warn` — emitidos a nivel `WARN`; regulados (throttled) (token bucket de 5, 1 recarga cada 2 segundos, por severidad)
+- `EventSeverity::Error` y `EventSeverity::Fatal` — emitidos a nivel `ERROR`; evitan el throttle
+
+### Activar el puente
+
+El puente se activa compilando `dbflux_core` con el feature `tracing-bridge` (activado por defecto para `dbflux`, `dbflux_mcp_server`). Llama a `init_tracing(BridgeConfig { .. })` una vez al arrancar el proceso:
+
+```rust
+use dbflux_core::observability::tracing_bridge::{init_tracing, BridgeConfig, FmtWriter};
+
+let handle = init_tracing(BridgeConfig {
+    include_audit_layer: true,
+    fmt_writer: FmtWriter::Stderr,
+    env_filter_default: "info",
+    ..BridgeConfig::default()
+})?;
+
+// Later, after AuditService is ready:
+handle.install_sink(Arc::new(audit_service));
+```
+
+`dbflux_driver_host` usa `include_audit_layer: false` porque los procesos de driver host son efímeros y no tienen acceso a la base de datos SQLite de audit.
+
+### Archivos clave
+
+| Archivo | Rol |
+|---------|-----|
+| `crates/dbflux_core/src/observability/tracing_bridge/mod.rs` | `init_tracing`, `BridgeHandle`, `BridgeConfig`, `LevelCode` |
+| `crates/dbflux_core/src/observability/tracing_bridge/layer.rs` | `AuditLayer`, `AuditFieldVisitor`, level gate |
+| `crates/dbflux_core/src/observability/tracing_bridge/category.rs` | `PREFIX_CATEGORY_MAP`, `resolve_category`, `BRIDGE_INTERNAL_TARGET` |
+| `crates/dbflux_storage/src/migrations/mod_014_audit_settings_log_capture_min_level.rs` | Añade la columna `log_capture_min_level` a `cfg_audit_settings` |
+
+## Emisión externa de audit (drivers RPC y auth providers)
+
+Los drivers RPC externos (protocolo v1.2+) y los auth providers (protocolo v1.3+) pueden emitir audit events de vuelta al host como frames de respuesta intermedios. El host aplica una sanitización estricta antes de escribir en `aud_audit_events`.
+
+### Política controlada por el host
+
+El host posee todos los campos de identidad, correlation y rate-limiting. Un servicio externo nunca puede falsificar su propia identidad ni reclamar una audit category para la que no tiene permiso.
+
+| Campo | Origen |
+|-------|--------|
+| `actor_type` | Siempre `ExternalDriver` o `ExternalAuthProvider` |
+| `source_id` | Siempre `ExternalDriver` / `ExternalAuthProvider` con el `socket_id` registrado |
+| `actor_id` | Siempre `rpc:<socket_id>` |
+| `connection_id` | Suministrado por el host desde el contexto de sesión (puede ser `None`) |
+| `database_name` | Suministrado por el host desde el contexto de sesión (puede ser `None`) |
+| `driver_id` | Siempre `rpc:<socket_id>` |
+| `correlation_id` | Generado por el host; uno por sesión para drivers, uno por request para auth providers |
+| `ts_ms` | Suministrado por el servicio, pero limitado si la desviación respecto al reloj de pared del host supera los cinco minutos |
+
+`correlation_id` está garantizado estructuralmente a ser generado por el host porque `AuditEventEmitDto` (el tipo de payload IPC) no tiene ningún campo `correlation_id`. Los servicios externos no pueden suministrar uno — el campo se omitió intencionalmente del DTO en el momento del diseño (ADR-3) en lugar de aceptarse y validarse después. Como resultado, el escenario "el DTO del driver lleva un correlation_id falsificado y el host lo sobrescribe en tiempo de ejecución" es imposible a nivel de tipos; el valor almacenado siempre lo produce la lógica de asignación de correlation-id del host.
+
+### Lista blanca de categorías
+
+Los drivers pueden emitir eventos `Connection`, `Query` y `System`. Los auth providers solo pueden emitir eventos `Connection`. Cualquier frame con una categoría no permitida se descarta silenciosamente.
+
+### Rate limiting
+
+Cada servicio externo (por `socket_id`) está limitado a 100 eventos cada 60 segundos mediante un token-bucket. Los frames que superan el presupuesto se descartan y se contabilizan en `AuditService::external_audit_dropped_count()`.
+
+### Flags de opt-in
+
+- **Drivers**: el driver debe incluir `DriverCapability::AuditEmit` en su respuesta hello (protocolo v1.2+). Los frames enviados por drivers que no anunciaron esta capacidad se descartan silenciosamente.
+- **Auth providers**: el provider debe establecer `audit_emit_opt_in: true` en su respuesta hello (protocolo v1.3+). Los frames de providers que no optaron por esto se descartan silenciosamente.
+
+### Campos obligatorios en cada frame emitido
+
+Un `AuditEventEmitDto` emitido debe tener `action` y `summary` no vacíos. Los frames que no cumplan esta comprobación se descartan silenciosamente.
+
+### Mecanismo de transporte
+
+Los frames emitidos llegan como frames intermedios `done=false` dentro de una secuencia de respuesta normal. La capa de transporte (`RpcClient` en `dbflux_driver_ipc`, `RpcAuthProvider::dispatch_request_loop` en `dbflux_ipc`) los intercepta antes de que lleguen a quien hizo la llamada. Quien llama solo llega a ver el frame terminal.
+
+### Archivos clave
+
+| Archivo | Rol |
+|---------|-----|
+| `crates/dbflux_ipc/src/audit.rs` | `AuditEventEmitDto`, trait `ExternalAuditEmitter`, `ExternalAuditSource` |
+| `crates/dbflux_app/src/rpc_services/external_audit.rs` | `ExternalAuditSink`, rate limiter de token-bucket, pipeline de sanitización |
+| `crates/dbflux_driver_ipc/src/transport.rs` | `RpcClient::send_raw` intercepta los frames de emisión del driver |
+| `crates/dbflux_ipc/src/auth_provider_client.rs` | `dispatch_request_loop` intercepta los frames de emisión del auth provider |
+
+## Arquitectura
+
+```
+[Service layers]
+  |  emit EventRecord via EventSink trait
+  v
+AuditService              (dbflux_audit/src/lib.rs)
+  |  validate → fingerprint query text → redact sensitive values → enforce size limit
+  v
+SqliteAuditStore          (dbflux_audit/src/store/sqlite.rs)
+  |  delegates to AuditRepository
+  v
+AuditRepository           (dbflux_storage/src/repositories/audit.rs)
+  |  inserts into aud_audit_events
+  v
+~/.local/share/dbflux/dbflux.db
+```
+
+Archivos clave:
+
+| Archivo | Rol |
+|---------|-----|
+| `crates/dbflux_core/src/observability/types.rs` | `EventRecord`, todos los tipos enum |
+| `crates/dbflux_core/src/observability/actions.rs` | Constantes canónicas de cadenas de action |
+| `crates/dbflux_audit/src/lib.rs` | `AuditService` — validate, preprocess, record |
+| `crates/dbflux_audit/src/query.rs` | `AuditQueryFilter` |
+| `crates/dbflux_audit/src/export.rs` | Export a CSV/JSON (básico y extendido) |
+| `crates/dbflux_audit/src/redaction.rs` | Lógica de redacción de valores sensibles |
+| `crates/dbflux_audit/src/purge.rs` | Purga de eventos basada en retención |
+| `crates/dbflux_audit/src/store/sqlite.rs` | Adaptador del store de SQLite |
+| `crates/dbflux_storage/src/repositories/audit.rs` | `AuditRepository` + `AuditEventDto` |

--- a/docs/es/CHARTS.md
+++ b/docs/es/CHARTS.md
@@ -1,0 +1,256 @@
+# Gráficos en DBFlux
+
+DBFlux puede convertir el resultado de una query en un chart. El motor de
+charting es completamente agnóstico al driver: solo inspecciona los metadatos
+de columna estructurados que cada driver rellena, nunca un identificador de
+driver ni una cadena de tipo específica de la base de datos. Este documento
+describe los tipos de chart soportados, cómo el motor auto-detecta los ejes,
+cómo se persisten los charts y cómo se crea un chart desde la UI.
+
+Para dashboards (grids de saved charts con un rango de tiempo compartido), las
+tablas de almacenamiento de visualización (`viz_*`) y los seams de driver para
+importar/explorar dashboards remotos, ver [`DASHBOARDS.md`](./DASHBOARDS.md).
+
+## Visión general
+
+El motor de charts vive en el crate `dbflux_components`, bajo
+`crates/dbflux_components/src/chart/`. Su `mod.rs` describe el pipeline
+completo:
+
+1. `detect` — auto-detecta columnas adecuadas a partir de un `QueryResult`
+   usando únicamente la semántica de `ColumnKind`.
+2. `spec` — tipos de especificación de chart y series, más constructores para
+   selección de columnas guiada por detección y manual.
+3. `decimate` — downsampling LTTB (Largest-Triangle-Three-Buckets) para
+   mantener el pintado rápido en datasets grandes.
+4. `axis` — generación de ticks y formateo de etiquetas para ejes numéricos y
+   de tiempo.
+5. `legend` — factory de elementos para la fila de leyenda.
+6. `engine` — `ChartView`, la entidad GPUI que posee el estado del chart y
+   renderiza el canvas.
+
+La UI del documento de chart independiente vive en
+`crates/dbflux_ui_document/src/chart_document/` (`mod.rs`, `render.rs`,
+`pane.rs`). Un `ChartDocument` posee una query, una conexión, un chart spec y
+un `ChartShell`, y aloja su renderizado a través del chrome compartido
+`ResultPanel` en `crates/dbflux_components/src/result_panel/`.
+
+## Tipos de chart
+
+Los tipos de chart se definen en el enum `ChartKind` en
+`crates/dbflux_components/src/chart/spec.rs`:
+
+| Variante | Descripción |
+|---------|-------------|
+| `Line` | Chart de línea. El tipo por defecto (`#[default]`); también el tipo elegido por todos los constructores de `ChartSpec`. |
+| `Bar` | Chart de barras. |
+| `Scatter` | Chart de dispersión. |
+| `Area` | Chart de línea con relleno; el área entre la línea de la serie y la base se sombrea. Comparte la geometría y el comportamiento de hover de Line. |
+| `StackedBar` | Barras verticales apiladas. Cada posición X muestra una barra por serie, apiladas de forma acumulativa en lugar de agrupadas lado a lado. El eje Y se reescala en tiempo de renderizado a la suma máxima del stack. |
+| `Pie` | Chart de tarta. Sin ejes X/Y; cada serie visible se convierte en una porción cuyo tamaño es la suma de los valores Y de esa serie. |
+
+`ChartKind` lleva la semántica `#[serde(default)]` en el campo contenedor
+`ChartSpec.kind`, así que los chart specs serializados que son anteriores al
+campo `kind` se deserializan como `Line`.
+
+## ColumnKind y auto-detección de ejes
+
+### ColumnKind
+
+La auto-detección se rige enteramente por el enum `ColumnKind` definido en
+`crates/dbflux_core/src/query/types.rs`:
+
+| Variante | Significado |
+|---------|---------|
+| `Timestamp` | Una columna de fecha/hora o timestamp. |
+| `Float` | Una columna numérica de punto flotante. |
+| `Integer` | Una columna numérica entera. |
+| `Text` | Una columna de texto/string. |
+| `Unknown` | El driver no pudo clasificar esta columna. |
+
+Cada driver es responsable de fijar `ColumnMeta::kind` en cada columna que
+devuelve (ver las reglas de "Adding a New Driver" en `CLAUDE.md`). Las
+columnas que quedan como `Unknown` nunca se usan como ejes ni series de
+chart.
+
+### Reglas de auto-detección
+
+`detect_chart_columns` en `crates/dbflux_components/src/chart/detect.rs`
+aplica estas reglas, en orden, a un `QueryResult`:
+
+1. Si el resultado tiene cero filas, devuelve `EmptyResult`.
+2. Elige la columna más a la izquierda con `kind == Timestamp` como eje X. Si
+   no existe ninguna, devuelve `NoTimeColumn`.
+3. Recolecta cada otra columna con `kind == Float` o `kind == Integer`, en
+   orden de columna, como las series Y numéricas. Si no queda ninguna,
+   devuelve `NoNumericSeries`.
+4. En caso contrario, devuelve `Ok { time_col, numeric_cols }`.
+
+El resultado es el enum `ChartDetection`, cuyas variantes son `Ok`,
+`NoTimeColumn`, `NoNumericSeries` y `EmptyResult`.
+
+### Por qué nunca se inspeccionan `type_name` ni los IDs de driver
+
+La documentación a nivel de módulo en `detect.rs` indica que el módulo de
+detección es el límite entre el modelo de resultado de query y el motor de
+charts, y que inspecciona valores de `ColumnKind` — nunca strings de
+`type_name` ni identificadores de driver. La función `detect_chart_columns`
+solo lee `column.kind`; nunca lee `column.type_name`, `column.name`, ni
+ningún ID de driver. Esto mantiene el motor completamente desacoplado de
+drivers específicos, en línea con la regla de desacoplamiento driver/UI de
+`CLAUDE.md`: un driver hace que sus columnas sean graficables simplemente
+clasificándolas con el `ColumnKind` correcto.
+
+Como `Unknown` no es ni `Timestamp` ni `Float`/`Integer`, una columna sin
+clasificar no puede ser ni un eje X ni una serie auto-detectados. Esto es
+intencional: obliga a los drivers a clasificar las columnas en lugar de dejar
+que el motor adivine a partir de strings de tipo.
+
+### Inferencia del tipo de eje
+
+Cuando se construye un `ChartSpec`, el tipo del eje X se infiere del
+`ColumnKind` de la columna X: `Timestamp` se mapea a `AxisKind::Time` (ticks
+formateados como fechas/horas), todo lo demás se mapea a `AxisKind::Numeric`
+(ticks decimales). El campo `AxisSpec.unit` es actualmente siempre `None`; es
+un seam de compatibilidad futura para metadatos de unidad que algún driver
+podría suministrar más adelante.
+
+### Extracción de valores numéricos
+
+Cuando el motor extrae un valor numérico de una celda (`extract_f64` en
+`engine.rs`), maneja varias formas de `Value`:
+
+- `Value::Int` → se convierte a `f64`.
+- `Value::Float` → se usa directamente cuando es finito; los valores no
+  finitos se descartan.
+- `Value::Decimal` (almacenado como string para preservar precisión) → se
+  parsea de forma tolerante a `f64`, descartando valores no finitos o no
+  parseables. Los drivers que clasifican columnas `NUMERIC`/`DECIMAL` como
+  `ColumnKind::Float` (por ejemplo `NUMERIC` de PostgreSQL, `DECIMAL` de
+  MSSQL) pasan por este camino.
+- `Value::Bool` → `true` se mapea a `1.0`, `false` a `0.0`, así que las
+  columnas `BIT`/`BOOLEAN` que algunos drivers clasifican como `Integer`
+  (por ejemplo `BIT` de MSSQL) siguen siendo graficables.
+- `Value::Text` solo se parsea para el eje de tiempo, como un timestamp RFC
+  3339.
+- `Value::Null` y el resto de formas no producen ningún valor.
+
+## Saved charts
+
+Un chart persistido es un registro `SavedChart`, definido en
+`crates/dbflux_components/src/saved_chart.rs`. Los saved charts se almacenan
+en la base de datos SQLite unificada — la tabla `viz_saved_charts` y sus
+tablas relacionadas `viz_saved_chart_*` — a través de `SavedChartsRepository`,
+con una caché en memoria gestionada por `SavedChartManager`
+(`crates/dbflux_ui_base/src/saved_chart_manager.rs`). Las escrituras van
+primero al repositorio; la caché se actualiza solo si tienen éxito.
+
+Un `SavedChart` persiste:
+
+- `id`, `name`, `profile_id` — identidad, nombre visible y el perfil de
+  conexión propietario.
+- `source` — un `SavedChartSource`, ya sea `Query { query }` (un string de
+  query ejecutado dentro de un `ChartDocument`) o `Collection { collection_ref,
+  time_window }` (una fuente de exploración de colección).
+- `chart_spec` y `bindings` — la configuración de renderizado completa
+  (`ChartSpec` y `BindingSpec`).
+- `time_range_preset`, `refresh_policy`, `created_at`, `updated_at`.
+
+Solo se persiste el string de la query (o la referencia a la colección); los
+datos de resultado en crudo nunca se almacenan.
+
+### Abrir un saved chart
+
+`Workspace::open_saved_chart` (en
+`crates/dbflux_ui/src/ui/views/workspace/actions.rs`) enruta según el tipo de
+fuente:
+
+- Las fuentes `Query` abren un `ChartDocument` independiente vía
+  `ChartDocument::from_saved`. `from_saved` y `validate_saved_source`
+  rechazan las fuentes `Collection`; el workspace valida la fuente antes de
+  asignar la entidad.
+- Las fuentes `Collection` no abren un `ChartDocument`; en su lugar reabren
+  el `DataDocument` subyacente en modo chart a través de
+  `open_collection_document`.
+
+### Deduplicación
+
+Los documentos de chart abiertos se deduplican a través de la variante
+`DocumentKey::Chart { saved_chart_id: Uuid }` en
+`crates/dbflux_ui_document/src/dedup.rs`. Antes de abrir un saved chart,
+`open_saved_chart` llama a
+`tab_manager.find_by_key(&DocumentKey::Chart { ... })` y activa la pestaña
+existente en lugar de abrir un duplicado. Un documento de chart creado desde
+una acción ad-hoc "Chart this query" aún no está vinculado a un ID guardado y,
+por tanto, no se deduplica hasta que se guarda.
+
+## Crear un chart en la UI
+
+Hay dos puntos de entrada.
+
+### Chart this query
+
+El menú contextual de un data grid ofrece un elemento "Chart this query". El
+elemento está condicionado por `can_chart_from_context_menu` en
+`crates/dbflux_ui_document/src/data_grid_panel/context_menu.rs`, que requiere
+ambas condiciones:
+
+1. La fuente del panel es un `QueryResult` con una query original no vacía, y
+2. `detect_chart_columns` sobre el resultado actual devuelve `Ok`.
+
+Seleccionar el elemento llama a `Workspace::open_chart_from_query`, que
+construye un `ChartDocument::new` sembrado con la query y la conexión, lo
+envuelve en un `PaneHandle` a través de `ChartDocument::into_pane`, y lo abre
+como una nueva pestaña. Una query no vacía hace que el documento se
+auto-ejecute en su primer render.
+
+### Open chart...
+
+El comando "Open chart..." lista los saved charts (construidos por
+`build_saved_chart_palette_items`) para el perfil activo, y abre el chart
+seleccionado a través de `open_saved_chart` como se describió arriba.
+
+### Guardar
+
+Dentro de un `ChartDocument`, el botón Save de la toolbar abre un prompt de
+nombre y luego llama a `confirm_save`, que construye un `ChartSpec` a partir
+del último resultado (usando `detect_chart_columns` / `ChartSpec::from_detection`
+cuando la detección tiene éxito) y hace upsert de un `SavedChart` en el
+gestor `saved_charts` del estado de la app. Guardar reutiliza el
+`saved_chart_id` existente cuando está presente, así que el registro se
+sobrescribe en lugar de duplicarse.
+
+```mermaid
+flowchart TD
+    QR[QueryResult with ColumnMeta.kind] --> DET[detect_chart_columns]
+    DET -->|Ok time_col, numeric_cols| SPEC[ChartSpec::from_detection]
+    DET -->|NoTimeColumn / NoNumericSeries / EmptyResult| NA[Chart this query unavailable]
+    SPEC --> CD[ChartDocument + ChartShell]
+    CD --> CV[ChartView render]
+    CD -->|Save| SC[SavedChart in saved_charts.json]
+    SC -->|Open chart...| CD
+```
+
+## Limitaciones
+
+Estas limitaciones están fundamentadas en el código actual, no son
+suposiciones:
+
+- La auto-detección requiere al menos una columna `Timestamp` para elegir un
+  eje X; sin ella, `detect_chart_columns` devuelve `NoTimeColumn` y "Chart
+  this query" no está disponible. (La selección manual a través de
+  `BindingSpec` / `ChartSpec::from_bindings` puede usar una columna X que no
+  sea de timestamp, que entonces se clasifica como un eje `AxisKind::Numeric`.)
+- Las columnas con `ColumnKind::Unknown` quedan excluidas por completo de la
+  auto-detección.
+- Los saved charts de fuente `Collection` no se pueden abrir como un
+  `ChartDocument`; en su lugar reabren el `DataDocument` subyacente en modo
+  chart. Pasar una fuente `Collection` a `ChartDocument::from_saved` devuelve
+  un error.
+- `AxisSpec.unit` siempre es `None` en esta versión; los drivers todavía no
+  suministran metadatos de unidad.
+- Todos los constructores de `ChartSpec` (`from_detection`, `from_bindings`,
+  `from_manual_selection`) producen un spec con `kind = ChartKind::Line`; los
+  demás tipos de chart se seleccionan después de la construcción.
+- La decimación de series usa un umbral LTTB cuyo valor por defecto es 10.000
+  puntos (`default_decimation_threshold`).

--- a/docs/es/CONCEPTS.md
+++ b/docs/es/CONCEPTS.md
@@ -1,0 +1,168 @@
+# Conceptos clave
+
+Esta guía es el modelo mental resumido para contributors y usuarios avanzados.
+Describe los contratos entre subsistemas; [Architecture](../ARCHITECTURE.md) sigue siendo el
+mapa canónico y exhaustivo de los límites de crates y los archivos clave.
+
+## Modelo mental
+
+```text
+UI document
+  -> app orchestration (profiles, connections, policy, lifecycle)
+    -> dbflux_core contracts (metadata, capabilities, requests, values)
+      -> built-in driver or RPC-adapted driver
+        -> QueryResult -> generic result views
+        -> EventRecord -> audit sink
+```
+
+La dirección importante es hacia adentro: la presentación y los workflows dependen de contratos,
+mientras que el comportamiento específico de cada driver se queda detrás de esos contratos. El
+audit observa el trabajo a lo largo del flujo en lugar de formar un camino de ejecución separado.
+
+## Mapa de conceptos
+
+| Concepto | Qué es | Por qué importa | Profundizar |
+|---|---|---|---|
+| Drivers | Implementaciones de los contratos `DbDriver` y `Connection`. | Las bases de datos integradas y externas entran a la app por el mismo límite. | [Core traits](../crates/dbflux_core/src/core/traits.rs), [Driver Authoring](DRIVER_AUTHORING.md) |
+| `DriverMetadata` | La identidad declarativa de un driver: categoría, lenguaje, forms y descriptores de features detallados. | Los workflows genéricos pueden elegir presentación y comportamiento sin identificar un driver concreto. | [Metadata definition](../crates/dbflux_core/src/driver/capabilities.rs) |
+| `DriverCapabilities` | Flags de feature declarados por un driver y expuestos por una conexión. | La UI habilita solo las operaciones soportadas en lugar de adivinar a partir de nombres de bases de datos. | [Capability flags](../crates/dbflux_core/src/driver/capabilities.rs) |
+| Documents | Panes con type erasure gestionados como tabs, con identidad y contratos de evento. | Los tipos de document nuevos pueden participar sin extender un enum de document cerrado. | [`PaneHandle`](../crates/dbflux_ui_document/src/pane.rs), [`TabManager`](../crates/dbflux_ui_document/src/tab_manager.rs) |
+| Query results | Shapes estructurados, columnas, filas y valores retornados por las conexiones. | Las tablas, árboles, vistas de texto, exports y charts genéricos consumen un único modelo de resultado. | [Result types](../crates/dbflux_core/src/query/types.rs), [`Value`](../crates/dbflux_core/src/core/value.rs) |
+| MCP governance | Enforcement de trusted-client, connection, classification, policy, approval y audit alrededor de las herramientas de AI. | El acceso de agentes es explícito, acotado, revisable y observable. | [AI + MCP Integration](MCP_AI_INTEGRATION.md) |
+| Audit | El seam de observability transversal `EventRecord`/`EventSink`. | Las queries, el trabajo de lifecycle, los hooks, el governance y los servicios externos comparten un trail correlacionado. | [Audit reference](AUDIT.md), [`EventSink`](../crates/dbflux_core/src/observability/source.rs) |
+| Hooks | Commands, scripts o Lua adjuntos a fases del lifecycle de conexión. | La configuración y limpieza del entorno se mantienen fuera de las implementaciones de driver, con comportamiento de fallo explícito. | [Hook contracts](../crates/dbflux_core/src/connection/hook.rs), [Settings & Hooks](SETTINGS.md#connection-hooks) |
+| RPC services | Descriptores persistidos adaptados en el startup a drivers o auth providers. | Las integraciones fuera de proceso se suman al runtime sin convertirse en casos especiales de la UI. | [RPC config](RPC_SERVICES_CONFIG.md), [protocol](DRIVER_RPC_PROTOCOL.md) |
+
+## Los drivers son contratos, no casos de UI
+
+`DbDriver` crea y describe una integración de base de datos; `Connection` expone operaciones sobre
+una conexión activa. Sus contratos actuales viven en
+[`core/traits.rs`](../crates/dbflux_core/src/core/traits.rs). Los crates integrados los implementan
+directamente, mientras que los drivers externos se adaptan vía RPC.
+
+La regla de desacoplamiento es estricta: el código de UI y de app workflow se adapta a través de
+metadata, capabilities y contratos genéricos, nunca de IDs de driver concretos. Si una feature
+requiere `if driver == "postgres"` en código de presentación o workflow, la abstracción que falta
+pertenece a la metadata, a una capability, o a un contrato del core.
+
+### Metadata y capabilities
+
+[`DriverMetadata`](../crates/dbflux_core/src/driver/capabilities.rs) describe qué es un driver:
+identidad de display, `DatabaseCategory`, lenguaje de query, descriptores de sintaxis y operación,
+límites, y otros inputs genéricos de presentación. `DriverCapabilities` declara qué features
+amplios soporta. Una conexión expone la misma metadata y capabilities para que los callers no
+necesiten su objeto driver de origen.
+
+Usa la metadata para elegir un modo genérico y las capabilities para hacer gate de una operación.
+No infieras soporte a partir de una clave de driver, un ícono, una cadena de type-name nativo, o
+una lista mantenida en la UI.
+
+## Los documents son polimorfismo abierto
+
+[`PaneHandle`](../crates/dbflux_ui_document/src/pane.rs) es el seam de polimorfismo de document.
+Hace type erasure de cada entity concreta de GPUI detrás de closures para renderizado, focus,
+commands, metadata, comportamiento de lifecycle, deduplicación y subscription. El workspace por
+lo tanto no modela los documents como un enum cerrado de tipos de document concretos.
+
+[`DocumentKey`](../crates/dbflux_ui_document/src/dedup.rs) expresa identidad de open-document. Cada
+pane decide si coincide con una key, y
+[`TabManager`](../crates/dbflux_ui_document/src/tab_manager.rs) usa ese contrato para enfocar un
+tab existente en lugar de abrir uno duplicado.
+
+Los documents emiten [`DocumentEvent`](../crates/dbflux_ui_document/src/handle.rs). El tab manager
+y el workspace traducen esos eventos en acciones cross-document sin alcanzar una implementación de
+document concreta. Agrega un comportamiento de pane en este seam en lugar de agregar matching de
+tipo concreto al código del workspace.
+
+## Los query results son datos estructurados
+
+El límite de resultado actual es [`QueryResult`](../crates/dbflux_core/src/query/types.rs): un
+`QueryResultShape` declarado, entradas de `ColumnMeta`, filas de `Value` del core, texto o bytes
+opcionales, timing de ejecución, y posibles result sets adicionales.
+[`Value`](../crates/dbflux_core/src/core/value.rs) preserva valores relacionales y de document sin
+reducir todo a JSON o cadenas de display.
+
+Los valores de resultado estructurados y la metadata de columna alimentan vistas genéricas. En
+particular, `ColumnMeta.kind` lleva información de tipo semántica como timestamp, float, integer,
+text, o unknown. Los charts y otros consumidores usan ese kind semántico; no deben inspeccionar
+`ColumnMeta.type_name` ni ramificarse por identidad de driver.
+
+## El governance de MCP envuelve la ejecución
+
+El proceso de MCP autoriza requests a través de identidad de trusted-client, el gate de MCP por
+conexión, la clasificación de ejecución, los roles y policies asignados, y approval cuando se
+requiere. Las decisiones y ejecuciones quedan auditadas. Ver el [modelo de governance](MCP_AI_INTEGRATION.md#3-governance-model-core-concepts),
+la [autorización de `dbflux_mcp`](../crates/dbflux_mcp/src/server/authorization.rs), el
+[policy engine](../crates/dbflux_policy/src/engine.rs), y el
+[approval service](../crates/dbflux_approval/src/service.rs).
+
+Las propiedades de seguridad son parte del límite:
+
+- `preview_mutation` es read-governed y produce un plan de solo lectura; no ejecuta la mutación. La
+  implementación rechaza cualquier query de preview generada por el driver que no esté clasificada
+  como metadata/read ([query tool](../crates/dbflux_mcp_server/src/tools/query.rs)).
+- `select_data` actualmente rechaza los joins solicitados en lugar de ignorarlos en silencio
+  ([read tool](../crates/dbflux_mcp_server/src/tools/read.rs)).
+- El preview de mutation no es un surface de DDL preview. Las operaciones DDL son herramientas
+  gobernadas separadas; no se expone ninguna herramienta de DDL preview en el
+  [tool catalog](../crates/dbflux_mcp/src/tool_catalog.rs) actual.
+
+Mantén las decisiones de classification, policy, approval y audit en el límite de governance. Un
+handler no debe debilitarlas porque un driver subyacente pueda realizar la operación.
+
+## El audit es el seam de observability
+
+Los servicios emiten valores canónicos de [`EventRecord`](../crates/dbflux_core/src/observability/types.rs)
+a través de [`EventSink`](../crates/dbflux_core/src/observability/source.rs). El record lleva
+actor, source, category, outcome, target context, details, y campos de correlación; el sink es
+dueño del comportamiento de validación y almacenamiento.
+
+Esto hace que el audit sea transversal: la ejecución de queries, el lifecycle de conexión, los
+hooks, las decisiones de MCP, la configuración, y los servicios RPC externos se pueden observar sin
+acoplar su lógica de dominio a la implementación de SQLite. Usa la
+[referencia de audit](AUDIT.md) para el schema, la validación, la redacción, la retención, y los
+detalles del tracing bridge.
+
+## Los hooks rodean el lifecycle de conexión
+
+[`ConnectionHook`](../crates/dbflux_core/src/connection/hook.rs) define trabajo de command, script,
+o Lua en `PreConnect`, `PostConnect`, `PreDisconnect`, y `PostDisconnect`. Los hooks pertenecen a
+la orquestación alrededor de una conexión, no al contrato de query del driver de base de datos.
+
+La failure policy es explícita: `Disconnect` aborta la fase, `Warn` continúa con una advertencia
+visible, e `Ignore` continúa mientras loguea el fallo. La ejecución puede ser bloqueante o
+detached, con controles de timeout, entorno y señal de ready. Ver
+[Settings & Connection Hooks](SETTINGS.md#connection-hooks) para configuración y detalles de
+seguridad.
+
+## Los RPC services son descriptores de runtime
+
+Los RPC services son descriptores persistidos de lanzamiento y compatibilidad clasificados como
+`Driver` o `AuthProvider`. En el startup,
+[`dbflux_app::rpc_services`](../crates/dbflux_app/src/rpc_services/) descubre descriptores, valida
+y hace probe del protocolo apropiado, y luego adapta los servicios exitosos al registro de drivers
+o de auth providers. Que una familia de servicio falle no redefine a la otra.
+
+Las keys del registro de driver externo se mantienen como `rpc:<socket_id>`. Los auth providers
+usan su identidad de provider y nunca aparecen como drivers de base de datos. La metadata de
+runtime para un driver externo viene de su handshake, no de condicionales de UI. Ver
+[RPC Services Config](RPC_SERVICES_CONFIG.md) para persistencia y
+[Driver RPC Protocol](DRIVER_RPC_PROTOCOL.md) para transport, negotiation, lifecycle, y emisión de
+audit.
+
+## Dónde hacer un cambio
+
+| Necesitas cambiar… | Empieza en… | Regla de reconocimiento |
+|---|---|---|
+| Una operación de base de datos disponible para toda integración | [`DbDriver`/`Connection`](../crates/dbflux_core/src/core/traits.rs) | Define un contrato genérico antes de implementar drivers. |
+| Si una feature genérica se muestra o se permite | [Metadata y capabilities](../crates/dbflux_core/src/driver/capabilities.rs) | Declara soporte; nunca identifiques el driver en código de UI/workflow. |
+| Renderizado de resultado o comportamiento de tipo semántico | [Query result types](../crates/dbflux_core/src/query/types.rs) | Consume shape, values, y `ColumnMeta.kind`. |
+| Un document nuevo del workspace | [`PaneHandle`](../crates/dbflux_ui_document/src/pane.rs) y [`DocumentEvent`](../crates/dbflux_ui_document/src/handle.rs) | Implementa el seam de open pane y una dedup key; no extiendas una union de document concreta. |
+| Una herramienta de AI o regla de ejecución | [MCP integration](MCP_AI_INTEGRATION.md) y [authorization](../crates/dbflux_mcp/src/server/authorization.rs) | Preserva el orden de classification, policy, approval, y audit. |
+| Una acción observable de dominio | [`EventRecord` y `EventSink`](../crates/dbflux_core/src/observability/types.rs) | Emite a través del seam; mantén los detalles de almacenamiento fuera del código de dominio. |
+| Automatización de setup o limpieza de conexión | [Hook contract](../crates/dbflux_core/src/connection/hook.rs) | Elige una fase de lifecycle y un modo de fallo explícito. |
+| Un driver o auth provider fuera de proceso | [RPC services](RPC_SERVICES_CONFIG.md) | Persiste un descriptor y adapta a través de `dbflux_app::rpc_services`. |
+
+Continúa con [Architecture](../ARCHITECTURE.md) para los límites canónicos de crates y los archivos
+clave, o con [Driver Authoring](DRIVER_AUTHORING.md) para implementar un driver integrado o
+externo.

--- a/docs/es/CONTRIBUTING.md
+++ b/docs/es/CONTRIBUTING.md
@@ -1,0 +1,234 @@
+# Contribuir a DBFlux
+
+Gracias por considerar contribuir. Esta guía explica cómo reportar issues,
+abrir pull requests y seguir las convenciones que DBFlux usa para releases y
+labels.
+
+## Enlaces rápidos
+
+- [Visión general de la arquitectura](ARCHITECTURE.md)
+- [Guía de autoría de drivers](docs/DRIVER_AUTHORING.md)
+- [Proceso de release y modelo de branching](docs/RELEASE.md)
+- [Esquema de eventos de auditoría](docs/AUDIT.md)
+- [Protocolo RPC de drivers](docs/DRIVER_RPC_PROTOCOL.md)
+- [Scripting con Lua](docs/LUA.md)
+- [Integración MCP / IA](docs/MCP_AI_INTEGRATION.md)
+
+## Configuración del proyecto
+
+DBFlux es un workspace de Rust que usa [GPUI](https://github.com/zed-industries/zed)
+para la UI. El conjunto completo de features requiere los feature flags de
+driver de base de datos:
+
+```bash
+cargo check --workspace
+cargo build
+cargo run
+```
+
+En Linux, el linker [`mold`](https://github.com/rui314/mold) es
+**obligatorio** para builds locales: `.cargo/config.toml` enlaza el target
+`x86_64-unknown-linux-gnu` con `-fuse-ld=mold` para reducir el tiempo de
+linkeo y la memoria en todo el workspace. Instálalo con tu gestor de paquetes
+(p. ej. `apt install mold`); el dev shell de Nix lo provee automáticamente.
+Windows y macOS no se ven afectados.
+
+Antes de abrir un PR ejecuta:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+```
+
+Los tests también pueden ejecutarse con [`cargo-nextest`](https://nexte.st)
+(más rápido en este workspace, provisto por el dev shell de Nix). Ten en
+cuenta que nextest no ejecuta doctests:
+
+```bash
+cargo nextest run --workspace
+cargo test --doc --workspace
+```
+
+Hay un dev shell de Nix disponible: `nix develop`.
+
+## Modelo de branching
+
+DBFlux usa **trunk-based development con release branches de vida corta**:
+
+- `main` es la única rama de vida larga. Todo el trabajo apunta a `main`.
+- Las ramas `release/vX.Y` se cortan desde `main` solo cuando un minor
+  necesita estabilizarse para una release estable. Aceptan únicamente fixes
+  cherry-picked desde `main` — sin features nuevas.
+
+Los contribuidores deben **siempre** apuntar sus PRs a `main`. Hacer
+backport a una release branch es responsabilidad de los maintainers.
+
+Las reglas completas (tags, bumps de versión, procedimiento de corte,
+disciplina del CHANGELOG) viven en [`docs/RELEASE.md`](docs/RELEASE.md).
+
+## Convención de commits
+
+Usa [Conventional Commits](https://www.conventionalcommits.org/) donde
+encaje naturalmente:
+
+- `feat(scope): …` — nueva capacidad orientada al usuario
+- `fix(scope): …` — corrección de bug
+- `refactor(scope): …` — cambio interno sin cambio de comportamiento
+- `perf(scope): …` — mejora de rendimiento
+- `docs(scope): …` — solo documentación
+- `test(scope): …` — solo tests
+- `ci(scope): …` — cambios de CI / release workflow
+- `chore(scope): …` — plomería del repositorio (deps, tooling, bumps de
+  versión)
+
+El scope es el área afectada: el nombre de un driver (`postgres`,
+`mongodb`), `ui`, `mcp`, `audit`, `rpc`, `release`, etc. Mantén el subject
+bajo 70 caracteres; explica el *por qué* en el body cuando no sea obvio.
+
+## Pull Requests
+
+1. Crea la rama desde `main`. Mantén los PRs enfocados en una sola
+   preocupación.
+2. Completa el [template de PR](.github/pull_request_template.md): resumen,
+   qué resuelve, cómo se resolvió, evidencia de validación y dónde se probó.
+3. Enlaza el issue que cierra con `Resolves #N` en la descripción.
+4. Aplica los labels que describen el cambio. Ver [Guía de etiquetas](#guia-de-etiquetas)
+   más abajo.
+5. Mantén los diffs revisables. Los PRs de más de ~400 líneas cambiadas
+   deben dividirse en PRs apilados/encadenados salvo que el maintainer
+   apruebe un `size:exception`.
+6. CI debe pasar (`tests.yml`, `style.yml`). Vuelve a ejecutar localmente
+   antes de hacer push si algo falla.
+
+### Los mensajes de commit importan
+
+DBFlux usa [git-cliff](https://git-cliff.org) para generar el changelog y
+las release notes directamente desde el historial de git. **No edites a
+mano `CHANGELOG.md` ni `[Unreleased]`.** Tu mensaje de commit es lo que se
+muestra a los usuarios.
+
+Reglas sobre qué aparece en el changelog:
+
+| Type | ¿Aparece en el changelog? |
+|------|------------------------|
+| `feat` | Sí — bajo **Added** |
+| `fix` | Sí — bajo **Fixed** |
+| `perf` | Sí — bajo **Changed** |
+| `refactor`, `test`, `ci`, `chore`, `docs`, `style`, `build` | No — solo interno |
+| Cualquier type con scope `(security)` o footer `Security:` | Sí — bajo **Security** |
+
+Los breaking changes (`feat!:`, `fix!:`, o un footer `BREAKING CHANGE:`)
+siempre se muestran sin importar el type.
+
+**Qué significa esto en la práctica:**
+
+- Los cambios visibles para el usuario **deben** usar `feat`, `fix` o
+  `perf` como type. Un commit `chore` o `refactor` es invisible para los
+  usuarios en el changelog.
+- Escribe un subject claro e imperativo — se convierte en el bullet del
+  changelog tal cual.
+- Si un solo PR contiene cambios internos y visibles al usuario a la vez,
+  sepáralos en commits distintos con los types apropiados.
+- Fixes de seguridad: usa `fix(security): ...` o añade un trailer
+  `Security: ...` para que el cambio caiga bajo la sección Security.
+
+## Issues
+
+Antes de abrir un issue:
+
+- Busca en los issues existentes para evitar duplicados.
+- Reproduce contra un build reciente si puedes.
+
+Incluye:
+
+- Versión de DBFlux (`dbflux --version`), OS / display server (X11 vs
+  Wayland en Linux), y motor de base de datos + versión.
+- Pasos para reproducir.
+- Comportamiento esperado vs. actual.
+- Logs si son relevantes. Redacta los secretos.
+
+Aplica los labels que describen el issue. Ver [Guía de etiquetas](#guia-de-etiquetas).
+
+## Guía de etiquetas
+
+El repositorio usa una taxonomía de labels estructurada. Aplica **un label
+de cada eje aplicable** al abrir un issue o PR. Los maintainers pueden
+ajustarlos durante el triage.
+
+### Kind (uno de `*:bug` o `*:feature` por área afectada)
+
+Áreas que tienen división bug/feature:
+
+| Área      | Bug                | Feature              |
+|-----------|--------------------|----------------------|
+| AWS       | `aws:bug`          | `aws:feature`        |
+| Audit     | `audit:bug`        | `audit:feature`      |
+| Driver    | `driver:bug`       | `driver:feature`     |
+| MCP       | `mcp:bug`          | `mcp:feature`        |
+| Pipeline  | `pipeline:bug`     | `pipeline:feature`   |
+| Proxy     | `proxy:bug`        | `proxy:feature`      |
+| Query     | `query:bug`        | `query:feature`      |
+| RPC       | `rpc:bug`          | `rpc:feature`        |
+| SSH       | `ssh:bug`          | `ssh:feature`        |
+| Storage   | `storage:bug`      | `storage:feature`    |
+| UI        | `ui:bug`           | `ui:feature`         |
+
+Además los genéricos por defecto de GitHub: `bug`, `documentation`,
+`question`, `help wanted`, `good first issue`, `invalid`.
+
+### Flags de subsistema (aplicar cuando sea relevante)
+
+- `aws`, `proxy`, `ssh`, `query`, `driver`, `mcp`
+
+### Driver (cuando el cambio es específico de un driver)
+
+`driver:mongodb`, `driver:postgres`, `driver:sqlite`,
+`driver:mysql/mariadb`, `driver:dynamodb`, `driver:redis`
+
+### Kind del modelo de datos (para trabajo a nivel de store/driver)
+
+`kind:sql`, `kind:document`, `kind:kv`, `kind:log`
+
+### Platform / Arch (cuando el comportamiento es específico de la plataforma)
+
+- Platform: `platform:linux`, `platform:macos`, `platform:windows`
+- Arch: `arch:amd64`, `arch:arm64`
+
+### Subtipo RPC (al tocar servicios respaldados por RPC)
+
+`rpc:auth`, `rpc:driver` (además de `rpc:bug`/`rpc:feature`)
+
+### Priority
+
+`priority:high`, `priority:medium`, `priority:low` — normalmente aplicados
+por los maintainers durante el triage.
+
+### Status (aplicado por los maintainers)
+
+`status:needs-review`, `status:approved`, `status:rejected`
+
+### Ejemplos de combinaciones
+
+- Un bug de query JSON de PostgreSQL en Linux:
+  `driver:bug`, `driver:postgres`, `query:bug`, `platform:linux`, `kind:sql`
+- Una nueva feature de pub/sub de Redis:
+  `driver:feature`, `driver:redis`, `kind:kv`
+- Una regresión del flujo de aprobación de MCP en Windows:
+  `mcp:bug`, `platform:windows`
+- Una mejora de UI del túnel SSH:
+  `ui:feature`, `ssh:feature`, `ssh`
+
+Si no estás seguro, etiqueta lo mejor que puedas — los maintainers lo
+refinarán durante el triage.
+
+## Seguridad
+
+No reportes issues de seguridad públicamente. Envía un correo al maintainer
+o usa un canal privado. Los logs y reproducciones deben tener los secretos
+redactados (tokens, contraseñas, connection strings).
+
+## Licencia
+
+Al contribuir aceptas que tus contribuciones se licencian bajo la licencia
+dual MIT / Apache-2.0 del proyecto.

--- a/docs/es/DASHBOARDS.md
+++ b/docs/es/DASHBOARDS.md
@@ -1,0 +1,289 @@
+# Dashboards y Saved Charts
+
+DBFlux persiste configuraciones de chart como **Saved Charts** y las agrupa en
+**Dashboards** — un grid de paneles de chart (y divisores markdown opcionales)
+que comparten un rango de tiempo y una política de refresco.
+
+Para los internals del motor de charts (renderizado, ejes, decimación,
+paleta), ver [`CHARTS.md`](./CHARTS.md). Para la capa de almacenamiento
+SQLite, ver [`ARCHITECTURE.md`](../ARCHITECTURE.md#storage--configuration).
+
+## Visión general
+
+- Un **SavedChart** es la forma persistida de una configuración de chart:
+  binding de fuente de datos, series, bindings del eje Y, política de
+  refresco y preset de rango de tiempo.
+- Un **Dashboard** es un grid con nombre compuesto por paneles. Cada panel es
+  o bien un slot `Chart` (referencia a un `SavedChart` por id) o bien un
+  slot `Divider` (franja de encabezado markdown inline — sin chart, sin
+  toolbar).
+- Los dashboards tienen un **rango de tiempo** y una **política de refresco**
+  compartidos que se propagan a cada panel de chart cargado mediante
+  suscripciones.
+- Los dashboards remotos (por ejemplo CloudWatch) se pueden **explorar** en
+  la sidebar e **importar** a un Dashboard local cuando el driver anuncia las
+  capacidades adecuadas.
+
+## Capa de almacenamiento
+
+Todos los datos de dashboard y saved-chart viven en
+`~/.local/share/dbflux/dbflux.db`, bajo el prefijo de tabla `viz_*`:
+
+| Tabla | Propósito |
+|-------|---------|
+| `viz_dashboards` | Registros de dashboard (`profile_id` nullable, `ON DELETE SET NULL`) |
+| `viz_dashboard_panels` | Slots de panel: discriminador `panel_kind` + `divider_markdown` opcional |
+| `viz_saved_charts` | Raíz de saved chart (`SavedChartDto`) |
+| `viz_saved_chart_series` | Configuración por serie |
+| `viz_saved_chart_binding_y` | Bindings del eje Y |
+| `viz_saved_chart_source_metric_dimensions` | Dimensiones de métrica de CloudWatch |
+| `viz_saved_chart_source_metric_series` | Spec de serie de métrica de CloudWatch |
+
+Los repositorios viven en `crates/dbflux_storage/src/repositories/viz_*.rs` e
+implementan el trait `Repository` estándar
+(`all()`, `find_by_id()`, `upsert()`, `delete()`).
+
+## Gestores en memoria
+
+Ambos gestores envuelven los repositorios SQLite con cachés en memoria para
+lecturas síncronas. Las escrituras van primero al repositorio; las cachés se
+actualizan solo si tienen éxito.
+
+- **`DashboardManager`** (`crates/dbflux_ui_base/src/dashboard_manager.rs`) —
+  tipos de dominio `Dashboard`, `DashboardPanel`, `DashboardPanelKind`
+  (`Chart { saved_chart_id }` | `Divider { markdown }` |
+  `Inspector { metric_id }`), `DashboardPanelDraft`. Los dashboards nuevos se
+  crean con `grid_columns = 12`; los paneles nuevos se añaden en
+  `grid_column = 0` en una fila nueva con `grid_width = 12, grid_height = 2`.
+- **`SavedChartManager`** (`crates/dbflux_ui_base/src/saved_chart_manager.rs`)
+  — gestiona el ciclo de vida de `SavedChart`, incluyendo
+  `SavedChartRefreshPolicy` (`Off` / `Interval { every_secs }`).
+- **`RemoteDashboardCache`** (`crates/dbflux_app/src/remote_dashboard_cache.rs`)
+  — caché en memoria con alcance de sesión para los listados de dashboards
+  remotos. No se persiste entre reinicios.
+
+## Integración con el sistema de documentos
+
+Los dashboards se abren como un `DashboardDocument`
+(`crates/dbflux_ui_document/src/dashboard/`):
+
+- **Clave de dedup**: `DocumentKey::Dashboard { dashboard_id }` (persistido) o
+  `DocumentKey::InstanceOverview { profile_id }` (auto-generado, de solo
+  lectura).
+- **Paneles de chart**: cada slot envuelve una entidad `ChartDocument`
+  (`Loaded`) o un placeholder para un chart eliminado (`Orphan`).
+- **Paneles de inspector**: cada slot envuelve una entidad `InspectorPanel`
+  que aloja un `DataGridPanel` y se refresca en el intervalo compartido del
+  dashboard. Las acciones de fila suministradas por el driver (por ejemplo,
+  terminar conexión, cancelar query) aparecen en el menú contextual de la
+  fila.
+- **Toolbar compartida**: un único `TimeRangePanel` propaga los cambios de
+  ventana a todos los paneles cargados mediante suscripciones.
+- **Concurrencia**: la re-ejecución de paneles está acotada por
+  `PANEL_REEXEC_CAP` para evitar saturar la conexión con queries
+  concurrentes.
+- **Grid**: grid canónico de 12 columnas; arrastrar para reordenar y
+  arrastrar para redimensionar mediante `DragReorderState` /
+  `DragResizeState` en `dashboard/builder.rs`.
+
+Los saved charts independientes se abren como `ChartDocument`
+(`crates/dbflux_ui_document/src/chart_document/`), con clave
+`DocumentKey::Chart { saved_chart_id }`. `ChartDocument` se renderiza tanto de
+forma independiente como embebido dentro de un panel de `DashboardDocument`.
+
+## Instance Overview e inspectores
+
+Las conexiones cuyo driver anuncia `INSTANCE_METRICS` o `INSTANCE_INSPECTOR`
+exponen un **Instance Overview** de solo lectura — un dashboard sintetizado
+con métricas de servidor en vivo e inspectores tabulares que nunca toca el
+almacenamiento hasta que el usuario decide conservarlo.
+
+### Abrir el Instance Overview
+
+La sidebar muestra una única hoja **Instance Overview** bajo un perfil
+conectado (encima de las carpetas *Instance Metrics* e *Instance
+Inspectors*). Al hacer clic en ella — o al elegir **Open** desde su menú de
+clic derecho — se abre el overview.
+
+| Paso | Detalle |
+|------|--------|
+| Fuente | El descriptor `DefaultInstanceDashboard` del driver (layout fijo de 12 columnas) devuelto por `InstanceCatalog::default_dashboard()` |
+| Dedup | `DocumentKey::InstanceOverview { profile_id }` — una pestaña por conexión; hacer clic de nuevo enfoca la pestaña existente |
+| Persistencia | Ninguna. El `DashboardDocument` se construye en memoria en el momento de la apertura; no se escribe ninguna fila `viz_*` |
+| Modo | Solo lectura. Las transiciones a modo edición, *Add Panel* y el toggle Edit/View se suprimen; el arrastrar-para-reordenar y arrastrar-para-redimensionar están deshabilitados |
+
+### Guardarlo como dashboard editable
+
+Un overview de solo lectura muestra un botón **Save as editable** (toolbar,
+grupo derecho; tooltip *"Clone this overview into a new editable
+dashboard"*). Clona el layout sintetizado — incluyendo las posiciones exactas
+de los paneles — en un nuevo `Dashboard` persistido y propiedad del usuario,
+vía `DashboardManager::append_panels` con un `DraftGridLayout` explícito por
+panel. El clon se abre como una pestaña editable normal
+`DocumentKey::Dashboard { dashboard_id }`. El overview original permanece de
+solo lectura y se re-sintetiza en cada apertura.
+
+### Paneles de inspector
+
+Los inspectores son el tercer tipo de panel de dashboard, junto a `Chart` y
+`Divider`:
+
+| Tipo de panel | Respaldo | Notas |
+|------------|---------|-------|
+| `Chart` | Referencia a `SavedChart` (`saved_chart_id`) | Chart de serie temporal |
+| `Divider` | Markdown inline | Franja de encabezado; sin toolbar |
+| `Inspector` | `DashboardPanelKind::Inspector { metric_id }` | Snapshot tabular; se refresca en el intervalo compartido |
+
+`DashboardPanelKind::Inspector { metric_id }`
+(`crates/dbflux_ui_base/src/dashboard_manager.rs`) no lleva ninguna
+referencia a chart — el inspector se identifica únicamente por `metric_id`.
+Cada panel de inspector aloja un `DataGridPanel` que muestra el snapshot
+actual devuelto por `InstanceCatalog::fetch_inspector_snapshot` (por ejemplo
+`pg_stat_activity` de PostgreSQL, `PROCESSLIST` de MySQL, `currentOp` de
+MongoDB, `CLIENT LIST` de Redis).
+
+Persistencia: el valor `Inspector` se almacena en
+`viz_dashboard_panels.panel_kind`, con la clave del inspector en
+`inspector_metric_id`. Ambos fueron añadidos por la **migración 014**
+(`014_viz_inspector_and_instance_metric`), que extiende el CHECK de
+`panel_kind` — introducido primero en la migración 013 con `chart` /
+`divider` — para aceptar también `inspector`. (Las pestañas de inspector
+independientes abiertas directamente desde la carpeta de sidebar *Instance
+Inspectors* usan `DocumentKey::InstanceInspector { profile_id, metric_id }`.)
+
+### Acciones de fila del inspector
+
+Las filas del inspector pueden exponer acciones de fila suministradas por el
+driver (menú contextual de clic derecho), por ejemplo *Kill connection* /
+*Terminate session*. El flujo:
+
+1. El driver devuelve `InspectorRowAction`s desde `InstanceCatalog::row_actions(metric_id)`. La disponibilidad está condicionada por sondas de privilegio propias de cada driver (ver los README de driver), de modo que una sesión con privilegios insuficientes nunca ve una acción que no puede ejecutar.
+2. Las acciones `is_destructive` piden confirmación en un modal antes de ejecutarse.
+3. Al confirmar, la conexión se re-resuelve en el momento de la ejecución (no en el momento del clic) y se ejecuta `InstanceCatalog::execute_row_action(metric_id, action_id, row_values)`.
+4. Cada intento registra un evento de auditoría. Los fallos se enrutan a través de `report_error_async` (`UserFacingError` de `ErrorKind::Driver`), así que el usuario recibe un toast con un id de correlación que enlaza a la fila de auditoría.
+
+La ejecución vive en
+`crates/dbflux_ui_document/src/instance_inspector/mod.rs`.
+
+### Comportamiento de refresco
+
+Los timers de refresco de dashboard, chart independiente e inspector
+comprueban `AppState::connections()` para el perfil del panel antes de cada
+tick y omiten su trabajo cuando la conexión está cerrada. El timer en sí
+permanece activo, así que el refresco se reanuda automáticamente al
+reconectar sin necesidad de rearmarlo.
+
+### Cobertura de drivers integrados
+
+| Driver | `INSTANCE_METRICS` | `INSTANCE_INSPECTOR` | Lista de métricas / inspectores |
+|--------|:---:|:---:|---|
+| PostgreSQL | ✓ | ✓ | [README](../crates/dbflux_driver_postgres/README.md) |
+| MySQL / MariaDB | ✓ | ✓ | [README](../crates/dbflux_driver_mysql/README.md) |
+| MongoDB | ✓ | ✓ | [README](../crates/dbflux_driver_mongodb/README.md) |
+| Redis | ✓ | ✓ | [README](../crates/dbflux_driver_redis/README.md) |
+| SQL Server | ✓ | ✓ | [README](../crates/dbflux_driver_mssql/README.md) |
+
+El README de cada driver lista las métricas, inspectores y acciones de fila
+concretas que expone; este documento no las duplica.
+
+## Seams de driver
+
+Los drivers se integran con los dashboards a través de seams genéricos del
+core — la UI nunca bifurca según IDs de driver.
+
+### Importar dashboards (JSON → Dashboard local)
+
+- **Trait**: `DashboardImporter`
+  (`crates/dbflux_core/src/connection/dashboard_import.rs`)
+- **Capacidad**: `DriverCapabilities::DASHBOARD_IMPORT`
+- **Tipos de valor**:
+  - `WidgetImportSpec` — spec de widget parseado
+  - `MetricView::{TimeSeries, StackedArea, SingleValue}`
+  - `ImportedMetricSeries` — serie + dimensiones
+  - `WidgetLayout` — coordenadas de layout nativas trasladadas al grid local
+
+Los drivers parsean el JSON del dashboard en un conjunto normalizado de
+widgets que la UI importa como `SavedChart`s y coloca en un nuevo
+`Dashboard`.
+
+### Explorar dashboards remotos (sidebar)
+
+- **Trait**: `DashboardSource`
+  (`crates/dbflux_core/src/connection/dashboard_source.rs`)
+- **Capacidad**: `DriverCapabilities::DASHBOARD_SYNC`
+- **Tipos de valor**: `RemoteDashboard`, `DashboardRef`
+  (`last_modified: ISO8601` opcional)
+
+La sidebar lista los dashboards remotos a través de este seam; los
+resultados se cachean en `RemoteDashboardCache`. Seleccionar un dashboard
+remoto dispara `DashboardImporter` para materializarlo localmente.
+
+### Métricas e inspectores de instancia
+
+- **Trait**: `InstanceCatalog`
+  (`crates/dbflux_core/src/connection/instance_catalog.rs`)
+- **Capacidades**: `DriverCapabilities::INSTANCE_METRICS` (series temporales),
+  `DriverCapabilities::INSTANCE_INSPECTOR` (snapshots tabulares)
+- **Tipos de valor**: `InstanceMetricDef`, `InstanceInspectorDef`,
+  `DefaultInstanceDashboard`, `InspectorRowAction`
+
+Los drivers exponen métricas de servidor en vivo (por ejemplo `pg.tps`,
+`mysql.queries_per_sec`) e inspectores tabulares (por ejemplo `pg.activity`,
+`mysql.processlist`, `mongo.currentop`, `redis.client_list`) a través de un
+único catálogo. Cada driver también publica un descriptor
+`DefaultInstanceDashboard` con un layout fijo de 12 columnas — el workspace
+abre este descriptor como un dashboard **Instance Overview de solo lectura**
+(clave de dedup `DocumentKey::InstanceOverview { profile_id }`). La acción
+"Save as editable" clona el layout en un dashboard persistido propiedad del
+usuario.
+
+Las filas de inspector pueden declarar `InspectorRowAction`s (por ejemplo
+*Terminate connection*). La disponibilidad de las acciones está condicionada
+por sondas de privilegio propias de cada driver (`pg_monitor` /
+`pg_signal_backend` para PostgreSQL, `PROCESS` / `CONNECTION_ADMIN` para
+MySQL, `killOp` para MongoDB, `CLIENT KILL` para Redis, `VIEW SERVER STATE` /
+`KILL` para SQL Server), de modo que una sesión con privilegios insuficientes
+nunca ve acciones que no podría ejecutar.
+
+Cada timer de refresco (tick de dashboard, tick de chart independiente, tick
+de inspector) comprueba `AppState::connections()` para el perfil del panel y
+omite su trabajo cuando la conexión está cerrada; el timer permanece activo
+así que el refresco se reanuda automáticamente al reconectar.
+
+Para el comportamiento de cara al usuario de este seam (cómo se abre el
+Instance Overview, *Save as editable*, paneles de inspector y acciones de
+fila), ver [Instance Overview e inspectores](#instance-overview-e-inspectores)
+más arriba.
+
+### Implementación de CloudWatch
+
+`crates/dbflux_driver_cloudwatch/src/` provee:
+
+- `CloudWatchDashboardSource` — lista los dashboards de CloudWatch a través
+  del SDK de AWS
+- `CloudWatchDashboardImporter` — parsea el JSON de dashboard de CloudWatch
+  en `WidgetImportSpec`s con series de métrica, dimensiones y agregaciones
+  estadísticas
+
+Esto es **exploración e importación de solo lectura**, no una función de
+sincronización. DBFlux nunca escribe de vuelta en los dashboards de
+CloudWatch.
+
+## Matriz de capacidades
+
+| Bit de capacidad | Significado |
+|---|---|
+| `DASHBOARD_IMPORT` (51) | El driver puede parsear JSON de dashboard en specs de widget |
+| `DASHBOARD_SYNC` (52) | El driver puede listar dashboards remotos |
+
+Ambas capacidades son independientes: un driver puede anunciar sync sin
+import, o viceversa.
+
+## Añadir un nuevo driver compatible con dashboards
+
+1. Implementa `DashboardSource` en el `Connection` del driver para listar los
+   dashboards remotos. Añade `DASHBOARD_SYNC` a `DriverMetadata.capabilities`.
+2. Implementa `DashboardImporter` en el `Connection` del driver para parsear
+   un payload de dashboard en `WidgetImportSpec`s. Añade `DASHBOARD_IMPORT`.
+3. La UI mostrará el árbol de dashboards en la sidebar y enrutará las
+   importaciones sin ninguna bifurcación específica de driver.

--- a/docs/es/DASHBOARDS_AND_AUDIT.md
+++ b/docs/es/DASHBOARDS_AND_AUDIT.md
@@ -1,0 +1,229 @@
+# Dashboards y Audit — Guía de uso
+
+Cómo graficar y guardar queries, construir dashboards, ver métricas de instancia en
+vivo y usar el visor de audit. Este es el complemento de *cómo se usa* de la
+documentación interna: [Charts](CHARTS.md), [Dashboards](DASHBOARDS.md) y
+[Audit](AUDIT.md).
+
+---
+
+## Charts guardados
+
+### Graficar el resultado de una query
+
+1. Ejecuta una query que devuelva datos tabulares.
+2. Haz clic derecho en la result grid y elige **Chart this query**.
+
+Se abre un chart document, sembrado con tu query, y se ejecuta automáticamente. La
+opción solo aparece cuando el resultado tiene una query original utilizable y
+DBFlux puede autodetectar columnas graficables. Tipos de chart soportados: Line,
+Bar, Scatter, Area, Stacked Bar, Pie. La detección de ejes usa el kind de cada
+columna (time, numeric, text); ver [Charts](CHARTS.md) para las reglas.
+
+### Guardar y reabrir
+
+- En un chart document, pulsa **Save** y dale un nombre. Volver a guardar el mismo
+  chart lo sobrescribe (sin duplicados).
+- Reabre un chart guardado con **Open Chart…** en el command palette — lista los
+  charts guardados de la conexión activa. (Si no hay ninguno: *"No saved charts
+  for the current profile"*.)
+- Los charts guardados también aparecen en el sidebar bajo **Saved Charts**, donde
+  cada chart tiene **Open / Rename… / Duplicate / Delete…**.
+
+Los charts se guardan por connection profile.
+
+---
+
+## Dashboards
+
+Un dashboard es una cuadrícula con nombre de 12 columnas de panels que comparten
+un rango de tiempo y una política de refresh.
+
+### Crear uno
+
+1. Ejecuta **New Dashboard…** desde el command palette (o **New Dashboard…** en la
+   carpeta **Dashboards** del sidebar).
+2. Ponle nombre. Se abre con una cuadrícula de 12 columnas y el refresh apagado.
+
+Los dashboards nuevos se abren en modo **View**. La carpeta Dashboards del
+sidebar lista los dashboards guardados con **Open / Rename… / Duplicate /
+Delete…**.
+
+### Edit vs. view
+
+Alterna el botón **lápiz / ojo** en la toolbar:
+
+- El modo **Edit** muestra tiradores de arrastre — arrastra panels para
+  reordenarlos, arrastra los bordes o la esquina para redimensionar dentro de la
+  cuadrícula de 12 columnas.
+- El modo **View** es de solo lectura.
+
+En modo Edit también puedes usar el teclado sobre un panel enfocado: `F2` para
+renombrar, `Delete`/`Backspace` para eliminar, `Enter` para abrir su popover
+Configure.
+
+### Añadir panels
+
+Haz clic en **+ Add Panel**. El selector tiene hasta tres pestañas:
+
+| Pestaña | Crea |
+|---------|------|
+| **Saved** | Un panel a partir de uno o más charts guardados existentes. |
+| **Query** | Un panel nuevo a partir de un nombre + una query que escribes. |
+| **Metric** | Un panel a partir de una metric del driver (solo se muestra cuando el driver de la conexión expone un catálogo de métricas). |
+
+El menú kebab de cada panel (modo Edit) ofrece **Configure / Edit title / Remove
+panel**. El popover **Configure** te permite cambiar el tipo de chart (Line, Bar,
+Scatter, Area, Stacked, Pie), ajustar los axis bindings, ver **Stats** y
+**Export PNG**.
+
+Los dashboards también pueden contener tiras **Divider** — cabeceras markdown que
+agrupan visualmente los panels y colapsan los panels debajo al hacer clic.
+
+> Un panel **Chart** referencia un chart guardado. Si borras ese chart guardado,
+> el panel se convierte en un placeholder ("Chart not found — saved chart was
+> deleted") en lugar de desaparecer.
+
+### Rango de tiempo y refresh
+
+La toolbar tiene:
+
+- Un desplegable de **rango de tiempo**: Last 15 min, Last 1 hour, Last 6 hours,
+  Last 24 hours, Last 7 days, o **Custom** (que revela selectores de fecha y
+  hora/minuto). El rango se aplica a todos los chart panels a la vez.
+- Un botón split de **refresh**: haz clic para refrescar todos los panels ahora;
+  el desplegable establece un intervalo de auto-refresh (o Off / refresh al
+  abrir).
+
+> **Las conexiones desconectadas se gestionan con elegancia.** Cuando la conexión
+> de un panel se cierra, su tick de refresh se salta — el timer sigue vivo y se
+> reanuda automáticamente al reconectar, sin necesidad de volver a abrir el
+> dashboard.
+
+---
+
+## Instance Overview, metrics e inspectors
+
+Para los drivers que lo soportan — **PostgreSQL, MySQL/MariaDB, MongoDB, Redis y
+SQL Server** — un profile conectado muestra una entrada **Instance Overview** en
+el sidebar, encima de las carpetas **Instance Metrics** e **Instance
+Inspectors**.
+
+- **Instance Overview** es un dashboard de solo lectura sintetizado a partir del
+  layout por defecto del driver (una pestaña por conexión). No se puede editar ni
+  añadirle panels, pero puedes pulsar **Save as editable** para clonar su layout
+  en un dashboard nuevo, totalmente editable.
+- **Instance Metrics** son charts de series temporales (p. ej. connections,
+  throughput).
+- **Instance Inspectors** son snapshots tabulares del estado en vivo del servidor
+  (p. ej. `pg_stat_activity` de Postgres, la process list de MySQL, las
+  operaciones actuales de MongoDB, la client list de Redis), refrescados en el
+  intervalo compartido.
+
+### Acciones por fila en los inspectors
+
+Algunos inspectors ofrecen acciones por fila (por ejemplo **Kill connection** /
+**Terminate session**). Estas son:
+
+- **Reguladas por permisos** — una acción para la que no tienes privilegio se
+  oculta, así nunca ves un botón que simplemente fallaría.
+- **Confirmadas cuando son destructivas** — las acciones destructivas piden
+  confirmación antes de ejecutarse.
+- **Auditadas** — cada intento registra un audit event, y los fallos muestran un
+  toast con un enlace a la fila de audit correspondiente.
+
+---
+
+## Dashboards remotos (CloudWatch)
+
+Cuando un driver lo soporta (CloudWatch es la implementación de referencia),
+DBFlux puede **explorar (browse)** e **importar** dashboards upstream.
+
+- **Browse**: los dashboards upstream aparecen en el sidebar. Abrir uno obtiene y
+  renderiza el dashboard como uno **en memoria, de solo lectura** — no se escribe
+  nada de vuelta en la fuente, y nada se guarda localmente. Una acción
+  **Refresh** vuelve a obtener el listado. El listado tiene el ámbito de la
+  sesión y **no** se conserva entre reinicios.
+- **Import**: el comando **Import Dashboard** (palette o sidebar) parsea la
+  definición upstream en un dashboard **local** nuevo con charts importados.
+  Solo está disponible cuando el driver de la conexión activa soporta la
+  importación — de lo contrario verás *"The active connection does not support
+  dashboard import."*
+
+Los dashboards remotos son de exploración/importación de solo lectura; DBFlux
+nunca modifica la fuente.
+
+---
+
+## Visor de audit
+
+El visor de audit es el único lugar para revisar todo lo que DBFlux registró:
+queries, conexiones, hooks, scripts, cambios de configuración y decisiones de
+governance de AI/MCP.
+
+### Abrirlo
+
+- Teclado: **Ctrl+Shift+A** (**Cmd+Shift+A** en macOS).
+- Command palette: **Open Audit Viewer**.
+
+Hay una única pestaña de audit; reabrirla enfoca la existente.
+
+### Qué se ve
+
+Cada fila muestra un timestamp, un chip de **severity** (ERROR/WARN/INFO), un
+chip de **category** y un summary. Expande una fila para ver **Category,
+Outcome, Actor, Action, Duration y Summary**.
+
+Las categorías de un vistazo:
+
+| Categoría | Cubre |
+|-----------|-------|
+| **Query** | Ejecución de queries y scans. |
+| **Connection** | Connect / disconnect / reconnect. |
+| **Hook** | Ejecuciones de connection-hooks. |
+| **Script** | Ejecuciones de scripts Lua / Python / Bash. |
+| **Mcp** | Llamadas a tools de un AI client. |
+| **Governance** | Decisiones de policy. |
+| **Config** | Cambios de profile y settings. |
+| **System** | Arranque, migraciones y eventos de log internos. |
+
+### Filtrar
+
+La toolbar ofrece **búsqueda** de texto libre, un **time range** (los mismos
+presets que los dashboards, más Custom), un **timestamp mode** (Local / UTC), y
+filtros multi-select para **Level** (Error/Warn/Info), **Category** y
+**Outcome** (Success/Failure/Cancelled). **Clear** los restablece.
+
+El menú contextual de una fila añade **Copy Row as CSV**, **Copy Summary** y —
+cuando el evento tiene un correlation id — **Filter by Correlation**.
+
+### Seguir un error hasta su fila de audit
+
+Cuando algo que hiciste falla, DBFlux muestra un toast con una acción **View in
+Audit**. Al hacer clic se abre el visor de audit filtrado a ese evento exacto
+(emparejado por un correlation id compartido entre el toast y la fila de audit).
+El **badge de error** en la status bar abre el visor pre-filtrado a los fallos
+recientes orientados al usuario.
+
+### Exportar
+
+El botón **Export** escribe los eventos actualmente visibles a **CSV** o
+**JSON** en tu carpeta `~/Downloads` (`audit_export.csv` / `audit_export.json`),
+usando el schema extendido (todos los campos, incluidos los details estructurados).
+Un toast de éxito informa de cuántos eventos se escribieron y dónde.
+
+### Retención
+
+Los eventos antiguos se pueden purgar según una programación de retención cuando
+está configurada (ver [Settings → Audit](SETTINGS.md#audit)). El audit log crece
+con el uso salvo que se purgue; vive en el mismo `dbflux.db` que todo lo demás
+([Data & Privacy](DATA_AND_PRIVACY.md#audit-and-privacy)).
+
+---
+
+## Relacionado
+
+- [Charts](CHARTS.md) — tipos de chart, column kinds, autodetección de ejes.
+- [Dashboards](DASHBOARDS.md) — modelo de almacenamiento y seams de driver.
+- [Audit](AUDIT.md) — schema completo de eventos y redacción.
+- [Settings & Hooks](SETTINGS.md) — audit y refresh settings.

--- a/docs/es/DATA_AND_PRIVACY.md
+++ b/docs/es/DATA_AND_PRIVACY.md
@@ -1,0 +1,224 @@
+# Datos y privacidad
+
+Dónde almacena DBFlux tus datos, cómo protege tus credenciales, qué guarda el
+audit log y cómo hacer un backup o un reseteo completo.
+
+## De un vistazo
+
+| Tus datos | Dónde viven |
+|-----------|----------------|
+| Perfiles de conexión, settings, historial, saved charts/queries, audit log | Un único archivo SQLite: `dbflux.db` en el directorio de datos |
+| Pestañas abiertas / sesión | El mismo `dbflux.db`, más archivos scratch en el directorio de datos |
+| Contraseñas, passphrases, secretos de API | Tu **keyring del sistema operativo** — nunca en `dbflux.db` |
+| Token de auth de IPC/MCP | Un archivo `0600` en el directorio de configuración |
+
+DBFlux mantiene casi todo en una única base de datos SQLite. Los secretos son
+la excepción deliberada: van al keyring del sistema operativo, y la base de
+datos solo almacena una *referencia* a ellos.
+
+---
+
+## Ubicaciones de datos
+
+DBFlux usa los directorios estándar de tu plataforma.
+
+| Plataforma | Directorio de datos | Directorio de configuración |
+|----------|----------------|------------------|
+| **Linux** | `~/.local/share/dbflux/` | `~/.config/dbflux/` |
+| **macOS** | `~/Library/Application Support/dbflux/` | `~/Library/Application Support/dbflux/` |
+| **Windows** | `%APPDATA%\dbflux\` | `%APPDATA%\dbflux\` |
+
+El directorio de datos contiene:
+
+- **`dbflux.db`** — la base de datos unificada (todo lo de más abajo en
+  [Qué hay en la base de datos](#qué-hay-en-la-base-de-datos)).
+- **`st_sessions/`** — archivos scratch/shadow para las pestañas de editor
+  abiertas.
+- **`ipc_auth_token`** — el token de auth de IPC/MCP (ver
+  [más abajo](#token-de-auth-de-ipcmcp)).
+- **`ssh_known_hosts`** — claves de host SSH aceptadas (TOFU).
+
+DBFlux ya no usa el directorio de configuración. Versiones antiguas
+almacenaban ahí el token de auth de IPC y los known-hosts de SSH; pueden
+quedar archivos residuales tras actualizar y se pueden eliminar.
+
+### Stable vs. Nightly
+
+Un build Nightly usa un archivo de base de datos separado,
+`dbflux-nightly.db`, así que una migración de pre-lanzamiento nunca puede
+tocar tus datos stable. Los builds Stable y release candidate usan ambos
+`dbflux.db`.
+
+Puedes hacer que un build Nightly comparta la base de datos stable mediante
+**Settings → General → Storage → Use the stable database** (aplica en el
+siguiente arranque). Internamente esto solo crea un archivo marcador vacío
+`use-stable-db` en el directorio de datos.
+
+---
+
+## Qué hay en la base de datos
+
+`dbflux.db` es un único archivo SQLite. Sus tablas se agrupan por prefijo:
+
+| Prefijo | Contiene |
+|--------|----------|
+| `cfg_*` | Configuración: perfiles de conexión, perfiles de auth/proxy/túnel SSH, servicios RPC, hooks de conexión, gobernanza MCP, y los settings de General/Audit. (Los *valores* de los secretos **no** están aquí — solo referencias al keyring.) |
+| `st_*` | Estado del workbench: sesiones/pestañas abiertas, **historial de queries** (texto completo de la query), saved queries, elementos recientes, caché de schema, estado de la UI. |
+| `aud_*` | El audit log y los filtros de auditoría guardados. |
+| `viz_*` | Saved charts y dashboards. |
+| `qry_*` | Saved queries del Visual Query Builder. |
+| `sys_*` | Interno: versión de migración del schema, metadatos de la app. |
+
+> **Nota sobre el historial de queries.** El historial de queries del
+> workbench (`st_*`) almacena el **texto completo** de las queries que
+> ejecutas, en claro. Esto es distinto del audit log, que por defecto
+> convierte el texto de la query en fingerprint (ver abajo). Si no quieres
+> que se retenga el texto de las queries, reduce **Max history entries** en
+> Settings → General, o borra el historial desde la vista de historial del
+> editor.
+
+---
+
+## Secretos y el keyring del sistema operativo
+
+Las contraseñas, passphrases SSH, credenciales de proxy y secretos de
+provider se almacenan en el keyring de tu sistema operativo, **no** en
+`dbflux.db`.
+
+| Plataforma | Backend de keyring |
+|----------|-----------------|
+| **Linux** | Secret Service (GNOME Keyring / KWallet, a través de libsecret) |
+| **macOS** | Keychain |
+| **Windows** | Windows Credential Manager |
+
+Todas las entradas se almacenan bajo el nombre de servicio **`dbflux`**. La
+base de datos solo guarda un string de referencia por secreto:
+
+| Secreto | Referencia |
+|--------|-----------|
+| Contraseña de conexión | `dbflux:conn:<profile-id>` |
+| Contraseña/passphrase SSH inline | `dbflux:ssh:<profile-id>` |
+| Túnel SSH guardado | `dbflux:ssh_tunnel:<tunnel-id>` |
+| Credencial de proxy | `dbflux:proxy:<proxy-id>` |
+| Campo de auth profile | `dbflux:auth:<profile-id>:<field>` (uno por campo) |
+
+### Cuándo se guardan los secretos (y cuándo no)
+
+- La contraseña de una conexión solo se almacena cuando marcas **Save
+  password**; los secretos de SSH y proxy solo cuando marcas su casilla
+  **Save**.
+- Si no hay ningún keyring disponible, DBFlux oculta las casillas **Save** y
+  no persiste secretos — tendrás que reintroducirlos cada sesión.
+- Un keyring *bloqueado* sigue contando como disponible: las escrituras
+  pueden fallar hasta que lo desbloquees, pero DBFlux mantiene el soporte de
+  secretos habilitado.
+
+---
+
+## Restauración de sesión y pestañas
+
+Qué pestañas tienes abiertas — su tipo, rutas de archivo, orden, pestaña
+activa y estado de pin — se registra en `dbflux.db` (`st_sessions` /
+`st_session_tabs`). El contenido real de los archivos scratch/shadow vive
+junto a ella bajo `st_sessions/` en el directorio de datos. Al arrancar,
+DBFlux restaura esta sesión cuando **Settings → General → Restore session on
+startup** está activado (el valor por defecto).
+
+---
+
+## Auditoría y privacidad
+
+DBFlux registra operaciones significativas (queries, conexiones, hooks,
+scripts, cambios de configuración, decisiones de MCP/gobernanza) en el audit
+log dentro de `dbflux.db`. Está diseñado para preservar la privacidad por
+defecto:
+
+| Comportamiento | Por defecto | Efecto |
+|----------|---------|--------|
+| **Capture query text** | Desactivado | El texto de la query se reemplaza por un **fingerprint** SHA-256 más su longitud — el texto completo nunca se almacena en la fila de auditoría. |
+| **Redact sensitive values** | Activado | Los patrones sensibles (claves de AWS, JWTs, connection strings con credenciales, etc.) se reemplazan por `[REDACTED]`. |
+| **Detail size cap** | 64 KiB | Los payloads de evento sobredimensionados se truncan a un pequeño envelope parcial. |
+
+Las **claves JSON** sensibles (`password`, `token`, `secret`, `api_key`,
+`access_key`, `session_token`, `connection_string`, `url`, …) siempre se
+redactan — incluso si desactivas la redacción basada en patrones.
+
+> Recuerda la [salvedad del historial de queries](#qué-hay-en-la-base-de-datos):
+> el audit log convierte el texto de la query en fingerprint, pero el
+> *historial del workbench* lo almacena completo. Son dos almacenes
+> distintos.
+
+Para el schema completo de eventos, las categorías y el visor, ver
+[Audit](AUDIT.md) y
+[Dashboards & Audit → Audit viewer](DASHBOARDS_AND_AUDIT.md#audit-viewer).
+
+---
+
+## Token de auth de IPC/MCP
+
+DBFlux expone una superficie IPC local (usada por el servidor MCP y los
+servicios RPC externos). Autentica a los llamantes con un token almacenado
+en:
+
+```
+<data dir>/dbflux/ipc_auth_token
+```
+
+(en Linux, `~/.local/share/dbflux/ipc_auth_token`). Es un valor aleatorio que
+se regenera en cada arranque, se escribe con permisos `0600` de solo el
+propietario, y también se exporta a las variables de entorno
+`DBFLUX_IPC_TOKEN`, `DBFLUX_DRIVER_IPC_TOKEN` y
+`DBFLUX_AUTH_PROVIDER_IPC_TOKEN` para los procesos hijos.
+
+Este token es **solo de identidad de proceso** — cualquier proceso local que
+pueda leerlo puede conectarse. No expongas la superficie IPC/MCP más allá de
+localhost sin una capa de autenticación adicional. Ver
+[AI + MCP Integration](MCP_AI_INTEGRATION.md) para el modelo de confianza.
+
+---
+
+## Backup y reseteo
+
+DBFlux no tiene un comando dedicado de backup/restore, pero como todo vive en
+un único archivo, ambas operaciones son sencillas.
+
+### Hacer un backup
+
+Copia el único archivo de base de datos mientras DBFlux está cerrado:
+
+```
+~/.local/share/dbflux/dbflux.db        # Linux (ajusta según la plataforma)
+```
+
+Ese archivo contiene tus perfiles, historial, saved charts/queries y audit
+log. Tus **secretos no están en él** — permanecen en el keyring del sistema
+operativo — así que una base de datos copiada en otra máquina hará
+referencia a entradas de keyring que no existen ahí hasta que reintroduzcas
+los secretos.
+
+### Reseteo completo
+
+Para borrar los datos de DBFlux:
+
+1. Elimina el **directorio de datos** (`~/.local/share/dbflux/` en Linux) —
+   elimina la base de datos, los archivos de sesión, el token de auth de IPC
+   y los known-hosts de SSH.
+2. **Solo versiones antiguas:** elimina el directorio de configuración legado
+   (`~/.config/dbflux/` en Linux) si todavía existe — las versiones actuales
+   ya no lo usan.
+3. **Borra las entradas del keyring manualmente.** Los secretos bajo el
+   servicio `dbflux` permanecen en tu keyring del sistema operativo después
+   de eliminar los directorios; elimínalos con la herramienta de keyring de
+   tu plataforma si quieres un borrado completo.
+
+> Eliminar el directorio de datos es irreversible. Haz un backup de
+> `dbflux.db` primero si podrías querer recuperar tus perfiles o tu
+> historial.
+
+---
+
+## Relacionado
+
+- [Settings & Hooks](SETTINGS.md) — los controles de General/Audit/Storage referenciados aquí.
+- [Connecting → Advanced Setup](CONNECTIONS.md) — dónde se introducen los secretos.
+- [Audit](AUDIT.md) — el schema completo de eventos de auditoría y los detalles de redacción.

--- a/docs/es/DRIVERS.md
+++ b/docs/es/DRIVERS.md
@@ -1,0 +1,175 @@
+# Drivers de DBFlux
+
+Este documento es una visión comparativa de los drivers de base de datos que se
+distribuyen con DBFlux. Para el detalle de cada driver, sigue el enlace al
+`README.md` del crate correspondiente. Para la arquitectura interna de los
+drivers (traits, registro, la interfaz `DbDriver`/`Connection`), consulta la
+sección **Driver System** de [`ARCHITECTURE.md`](../ARCHITECTURE.md). Los
+contribuidores que vayan a implementar un driver deben empezar por la
+[Guía de autoría de drivers](DRIVER_AUTHORING.md).
+
+## Cómo se abstraen los drivers
+
+Cada driver expone un valor `DriverMetadata` (definido en
+`crates/dbflux_core/src/driver/capabilities.rs`). La UI es agnóstica al driver
+y se adapta únicamente a partir de estos metadatos. Los campos relevantes son:
+
+- **`DatabaseCategory`** — selecciona el modelo de vista y la terminología.
+  Valores: `Relational`, `Document`, `KeyValue`, `Graph`, `TimeSeries`,
+  `WideColumn`, `LogStream`. (No todos los valores tienen un driver que los
+  implemente.)
+- **`QueryLanguage`** — determina el modo del editor, el texto de placeholder y
+  el parseo de queries. Incluye `Sql`, `MongoQuery`, `RedisCommands`, `Cypher`,
+  `InfluxQuery`, `Flux`, `Cql`, `CloudWatchLogsInsightsQl`, `OpenSearchPpl`,
+  `OpenSearchSql`, los lenguajes de script `Lua` / `Python` / `Bash`, y
+  `Custom(String)`.
+- **`DriverCapabilities`** — un conjunto de bitflags `u64` que declara las
+  funcionalidades soportadas (transactions, pagination, schemas, operaciones
+  key-value, etc.). Las bases de conveniencia `RELATIONAL_BASE`,
+  `DOCUMENT_BASE` y `KEYVALUE_BASE` agrupan los flags comunes de cada
+  categoría.
+
+Los flags de capacidad listados abajo son exactamente los que cada driver fija
+en su `DriverMetadata` en código; nada se infiere.
+
+## Comparación
+
+| Driver | Categoría | Lenguaje de query | Capacidades clave | Notas / limitaciones |
+| --- | --- | --- | --- | --- |
+| PostgreSQL | Relational | SQL | Base relacional + schemas, túnel SSH, SSL, auth, foreign keys, constraints check/unique, tipos personalizados, `RETURNING`, DDL transaccional, routines, multi-statement | Driver SQL completo; el visor de routines es de solo lectura; DDL transaccional salvo `CREATE INDEX CONCURRENTLY`. |
+| Amazon Redshift | Relational | SQL | Múltiples bases de datos, schemas, views, túnel SSH, SSL/certificados de cliente, auth, cancelación de queries, prepared statements, paginación, ordenamiento, filtrado, export CSV/JSON | Solo lectura sobre el protocolo wire de PostgreSQL; single-statement; expone hints de almacenamiento de Redshift; sin writes/DDL, IAM/SSO ni índices. |
+| MySQL | Relational | SQL | Base relacional + túnel SSH, SSL, auth, foreign keys, constraints check/unique, routines, multi-statement | El DDL no es transaccional; los scripts multi-statement se dividen por texto y se ejecutan en secuencia; el listado de routines cubre solo FUNCTION/PROCEDURE. |
+| MariaDB | Relational | SQL | Mismo crate y capacidades que MySQL | Registrado como metadatos `mariadb` separados que comparten la implementación de MySQL. |
+| SQLite | Relational | SQL | Views, índices, foreign keys, constraints check/unique, prepared statements, insert/update/delete, paginación, ordenamiento, filtrado, export CSV/JSON, cancelación de queries, DDL transaccional, multi-statement | Driver de archivo embebido: sin red, túnel SSH ni TLS; sin namespace multi-schema. |
+| SQL Server | Relational | SQL | Base relacional + schemas, túnel SSH, SSL, auth, foreign keys, constraints check/unique, DDL transaccional, routines, multi-statement | Construido sobre `tiberius`; la búsqueda por instancia nombrada no está disponible a través de túnel SSH; los batches multi-result-set devuelven el último set como primario. |
+| MongoDB | Document | MongoQuery | Base document + aggregation, túnel SSH, índices | Solo sintaxis estilo shell de MongoDB (sin SQL); sin cancelación de queries; el parser está limitado a los patrones de comando soportados. |
+| Redis | Key-Value | RedisCommands | Base key-value + múltiples bases de datos, TTL, tipos de key, tamaño de valor, rename, bulk get, stream range/add/delete, auth, túnel SSH, SSL | Solo sintaxis de comandos de Redis (sin SQL); sin cancelación de queries; el túnel SSH no está disponible en modo URI. |
+| DynamoDB | Document | Custom("DynamoDB") | Auth, paginación, filtrado, insert/update/delete, documentos anidados, arrays | Gestionado por AWS; envelope de comandos nativo (`scan`/`query`/`put`/`update`/`delete`); sin PartiQL/transactions; sin cancelación de queries; `update many+upsert` no soportado. |
+| CloudWatch Logs | Log Stream | Sql (default de metadatos) | Auth | Gestionado por AWS; ejecuta Logs Insights QL, OpenSearch PPL y OpenSearch SQL vía contexto de fuente gestionado por el editor; aún sin cancelación de queries. |
+| InfluxDB | Time Series | InfluxQuery | Auth, múltiples bases de datos, paginación, export CSV/JSON | v1 y v2 en un solo crate; InfluxQL en ambas, Flux solo en v2; solo lectura (sin INSERT/UPDATE/DELETE); sin transactions. |
+| ClickHouse | Relational | SQL | Múltiples bases de datos, views, auth, paginación, ordenamiento, filtrado, agrupación, joins, CTEs, windows, export CSV/JSON | HTTP(S), incluyendo ClickHouse Cloud; integración orientada a lectura sin mutaciones estructuradas, DDL, transactions, túnel SSH ni parámetros de query. |
+| Amazon S3 | Object Storage | Custom("S3") | Auth (profile/SSO o credenciales estáticas, endpoint personalizado), navegación de buckets, navegación paginada de objetos, preview, CRUD completo, URLs presignadas | Compatible con S3 (Cloudflare R2, MinIO); sin panel de multipart upload/transfers, sin visor de PDF embebido, sin gestión de lifecycle/ACL ni S3 Select. |
+
+## Resumen por driver
+
+### PostgreSQL
+
+Driver SQL completo con descubrimiento de schema, routines almacenadas (visor
+de solo lectura), SSL, túnel SSH, cancelación de queries vía cancel tokens,
+DDL transaccional y generación de código específica de PostgreSQL. Los scripts
+multi-statement se ejecutan como batch vía el simple query protocol. Ver
+[`crates/dbflux_driver_postgres/README.md`](../crates/dbflux_driver_postgres/README.md).
+
+### Amazon Redshift
+
+Driver SQL relacional de solo lectura que usa el protocolo wire de
+PostgreSQL. Soporta introspección de schema, table, view y column; túnel SSH;
+TLS y certificados de cliente; cancelación de queries; y hints de
+distribución/sort-key de almacenamiento de Redshift. No soporta writes ni
+DDL, autenticación IAM/SSO, queries multi-statement ni índices. Ver
+[`crates/dbflux_driver_redshift/README.md`](../crates/dbflux_driver_redshift/README.md).
+
+### MySQL / MariaDB
+
+Un solo crate implementa MySQL y MariaDB. Soporta ejecución SQL,
+descubrimiento de schema, cancelación de queries vía `KILL QUERY`, generación
+de código y descubrimiento de routines para functions y procedures. El DDL no
+es transaccional y la división multi-statement se hace por texto. Ver
+[`crates/dbflux_driver_mysql/README.md`](../crates/dbflux_driver_mysql/README.md).
+
+### SQLite
+
+Driver embebido basado en archivo con descubrimiento de schema, cancelación
+de queries vía interrupt handles, DDL transaccional y generación de código.
+Sin transporte de red, túnel SSH ni TLS, y sin namespace multi-schema. Ver
+[`crates/dbflux_driver_sqlite/README.md`](../crates/dbflux_driver_sqlite/README.md).
+
+### SQL Server
+
+Construido sobre el cliente TDS `tiberius`. Soporta SQL Server / Azure SQL,
+modos TLS, instancias nombradas (resueltas vía SQL Browser), túnel SSH,
+cambio de base de datos por pestaña y batches multi-result-set. Ver
+[`crates/dbflux_driver_mssql/README.md`](../crates/dbflux_driver_mssql/README.md).
+
+### MongoDB
+
+Driver document con navegación de collections, CRUD de documentos, parseo de
+queries estilo shell de MongoDB, aggregation y metadatos de schema orientados
+a documentos. SQL no está soportado y la cancelación de queries no está
+disponible. Ver
+[`crates/dbflux_driver_mongodb/README.md`](../crates/dbflux_driver_mongodb/README.md).
+
+### Redis
+
+Driver key-value que cubre strings, hashes, lists, sets, sorted sets y
+streams, además de key scanning, operaciones TTL, rename, bulk get y
+múltiples bases de datos lógicas. SQL no está soportado y el túnel SSH no
+está disponible en modo URI. Ver
+[`crates/dbflux_driver_redis/README.md`](../crates/dbflux_driver_redis/README.md).
+
+### DynamoDB
+
+Driver NoSQL de AWS construido sobre `aws-sdk-dynamodb` con configuración de
+region/profile/endpoint. El descubrimiento de tables mapea metadatos de
+PK/SK y GSI/LSI; la ejecución usa un envelope de comandos nativo (`scan`,
+`query`, `put`, `update`, `delete`). PartiQL y las transactions de DynamoDB no
+se exponen. Ver
+[`crates/dbflux_driver_dynamodb/README.md`](../crates/dbflux_driver_dynamodb/README.md).
+
+### CloudWatch Logs
+
+Driver de AWS CloudWatch Logs que ejecuta queries a través de `StartQuery`
+con time range y contexto de fuente de log-group gestionados por el editor.
+Los documentos de query pueden ejecutar Logs Insights QL, OpenSearch PPL y
+OpenSearch SQL; el descubrimiento de schema enumera log groups y expone los
+log streams como hijos de event-stream. Su `DriverMetadata.query_language`
+se fija en `Sql` como modo de editor por defecto, mientras que el modo real
+se elige por documento de query. Ver
+[`crates/dbflux_driver_cloudwatch/README.md`](../crates/dbflux_driver_cloudwatch/README.md).
+
+### InfluxDB
+
+Driver time-series que soporta InfluxDB v1 y v2 en un solo crate. InfluxQL se
+ejecuta en ambas versiones; Flux solo en v2. La API de queries es de solo
+lectura (sin INSERT/UPDATE/DELETE, sin transactions), con bucket/database por
+defecto opcional y routing de bucket por query. Ver
+[`crates/dbflux_driver_influxdb/README.md`](../crates/dbflux_driver_influxdb/README.md).
+
+### ClickHouse
+
+Driver SQL relacional para ClickHouse autoalojado y ClickHouse Cloud vía
+HTTP(S). Descubre databases, tables, views, columns y metadatos de engine, y
+soporta flujos SQL orientados a lectura con paginación y generación visual de
+SELECT. Las mutaciones estructuradas, el DDL, las transactions, el túnel SSH
+y los parámetros de query genéricos no están soportados en este alcance
+inicial. Ver
+[`crates/dbflux_driver_clickhouse/README.md`](../crates/dbflux_driver_clickhouse/README.md).
+
+### Amazon S3
+
+Driver de almacenamiento de objetos para AWS S3 y endpoints compatibles con
+S3 (Cloudflare R2, MinIO), autenticando vía profile/SSO de AWS o credenciales
+estáticas con override de endpoint y direccionamiento path-style. La raíz de
+la conexión abre una tabla de buckets; la navegación de buckets pagina por
+nivel (estilo consola de AWS) con un modo de árbol no paginado opcional. El
+preview de objetos cubre imágenes de forma nativa, objetos de tipo texto en
+un buffer editable inline con save-back, y metadatos más
+download/abrir-externamente para PDF y otros objetos binarios; las clases de
+almacenamiento archivadas (GLACIER, DEEP_ARCHIVE) omiten por completo el
+preview del cuerpo. Soporta upload, delete, borrado recursivo de
+prefix/bucket con confirmación por escritura, creación de folder/bucket,
+rename (copy-then-delete) y URLs presignadas. No soporta multipart upload, un
+panel de transfers, un visor de PDF embebido, gestión de lifecycle/ACL ni S3
+Select. Ver
+[`crates/dbflux_driver_s3/README.md`](../crates/dbflux_driver_s3/README.md).
+
+## Drivers RPC externos
+
+DBFlux puede cargar drivers que se ejecutan fuera de proceso y se comunican
+por IPC local, implementados a través de `dbflux_driver_ipc` y alojados vía
+`dbflux_driver_host`. Estos drivers se registran con el formato de ID
+sintético `rpc:<socket_id>` y proveen su propio `DriverMetadata` (category,
+query language, capabilities) por el wire, de modo que la UI los trata
+exactamente igual que a los drivers integrados. Para el handshake de
+descubrimiento, el ciclo de vida del servicio y los detalles del protocolo,
+ver [`docs/DRIVER_RPC_PROTOCOL.md`](DRIVER_RPC_PROTOCOL.md).

--- a/docs/es/DRIVER_AUTHORING.md
+++ b/docs/es/DRIVER_AUTHORING.md
@@ -1,0 +1,217 @@
+# Guía de autoría de drivers
+
+Usa esta guía para elegir e implementar una integración de driver de base de
+datos de DBFlux. Cubre el camino del contribuidor sin repetir las referencias
+más amplias de arquitectura o protocolo RPC.
+
+## Elegir un camino de integración
+
+| Elige | Driver Rust integrado | Driver RPC externo |
+| --- | --- | --- |
+| Mejor opción cuando | El driver debe distribuirse dentro del workspace y proceso de DBFlux | El driver debe ejecutarse fuera de proceso o desarrollarse y desplegarse de forma independiente |
+| Implementación | Un crate `crates/dbflux_driver_<name>/` que implementa los contratos Rust del core | Un servicio que implementa el protocolo RPC de drivers |
+| Registro | Wiring de features en tiempo de compilación y `AppState::build_builtin_drivers()` | Settings -> RPC Services con `kind=driver` y un `socket_id` |
+| Clave estable | `builtin:<name>` | `rpc:<socket_id>` |
+| Configuración | `DriverFormDef` propio del driver convertido a una variante `DbConfig` integrada | Datos de formulario provistos por el handshake y almacenados como `DbConfig::External` |
+
+## Driver integrado: camino feliz
+
+1. Copia la estructura del crate `crates/dbflux_driver_*/` existente más
+   cercano.
+2. Implementa `DbDriver` y `Connection`, incluyendo metadata, conversión de
+   form/config, comportamiento de conexión, errores y columnas de resultado
+   tipadas.
+3. Declara solo las capacidades respaldadas por implementaciones funcionales;
+   añade seams opcionales únicamente cuando el driver los soporte.
+4. Conecta el crate y el feature a través del workspace, la app y el binario,
+   y luego regístralo en `build_builtin_drivers()`.
+5. Añade tests focalizados, un README del crate y actualiza la matriz de
+   soporte de drivers.
+
+El [checklist detallado del driver integrado](#checklist-de-driver-integrado)
+desarrolla cada paso.
+
+## Driver RPC externo: camino feliz
+
+1. Implementa el [Protocolo RPC de drivers](DRIVER_RPC_PROTOCOL.md) canónico,
+   usando el [ejemplo de driver personalizado](../examples/custom_driver/README.md)
+   como punto de partida.
+2. Construye y ejecuta el servicio, ya sea de forma independiente o con un
+   comando gestionado.
+3. Añádelo en Settings -> RPC Services con `kind=driver`, un `socket_id`
+   estable y el comando gestionado opcional.
+4. Reinicia DBFlux y verifica que la metadata y el formulario provistos por el
+   handshake aparezcan en el connection manager.
+
+Consulta la [referencia de configuración de RPC Services](RPC_SERVICES_CONFIG.md)
+para el comportamiento de configuración vigente. No copies flags de
+lanzamiento de esta guía; el protocolo, la referencia de configuración y el
+ejemplo son las fuentes autoritativas.
+
+## Contratos principales y regla de desacoplamiento
+
+El contrato principal es [`DbDriver` más `Connection`](../crates/dbflux_core/src/core/traits.rs):
+
+- `DbDriver` provee la metadata del driver, su definición de formulario de
+  conexión, la construcción y extracción de config, la construcción de la
+  conexión y una `DriverKey` estable.
+- `Connection` provee el comportamiento en tiempo de ejecución de query,
+  schema, mutation y el comportamiento específico de capacidad opcional.
+  Existen defaults para muchas operaciones no soportadas; los métodos
+  requeridos y las capacidades anunciadas deben seguir siendo consistentes
+  entre sí.
+- Los valores `driver_key()` integrados usan `builtin:<name>`. Los drivers
+  externos usan `rpc:<socket_id>`.
+
+La metadata y la adaptación se definen mediante
+[`DriverMetadata`, `DatabaseCategory`, `QueryLanguage` y `DriverCapabilities`](../crates/dbflux_core/src/driver/capabilities.rs),
+incluyendo metadata genérica de presentación de editor. El comportamiento de
+fuente y presentación en tiempo de ejecución se expone mediante seams
+genéricos en `Connection` en [`traits.rs`](../crates/dbflux_core/src/core/traits.rs).
+
+**Regla estricta:** el código de la UI y del workflow de la app no debe
+ramificarse por driver ID concreto. Adapta a partir de metadata, category,
+query language, flags de capacidad, definiciones de formulario y seams
+genéricos de fuente/presentación. Si una nueva distinción de UI es
+necesaria, añade un contrato genérico del core que otro driver también
+pudiera implementar.
+
+Para los datos de resultado, completa
+[`ColumnMeta.kind` con `ColumnKind`](../crates/dbflux_core/src/query/types.rs).
+Los charts y otros consumidores usan este kind semántico; no lo infieren de
+un driver ID ni de `type_name`.
+
+## Checklist de driver integrado
+
+### 1. Crate y contratos
+
+- [ ] Añade `crates/dbflux_driver_<name>/Cargo.toml`, `src/lib.rs`, los
+      módulos de implementación y los tests. Sigue el driver más cercano en
+      lugar de asumir que todos los drivers tienen módulos idénticos.
+- [ ] Implementa `DbDriver` y una `Connection` thread-safe desde
+      [`crates/dbflux_core/src/core/traits.rs`](../crates/dbflux_core/src/core/traits.rs).
+- [ ] Devuelve una `DriverKey` estable con la forma `builtin:<name>`.
+- [ ] Mantén los tipos de cliente de base de datos y el comportamiento
+      específico del driver dentro del crate del driver; expón el
+      comportamiento a través de los contratos del core.
+
+### 2. Metadata y capacidades
+
+- [ ] Define un `DriverMetadata` factual: identidad, campos de display,
+      `DatabaseCategory`, `QueryLanguage`, `DriverCapabilities`, defaults de
+      conexión y las estructuras de capacidad genéricas aplicables.
+- [ ] Usa la metadata y los seams genéricos de presentación/fuente para la
+      adaptación de la UI. No añadas condicionales de driver ID a la UI ni a
+      los workflows de la app.
+- [ ] Anuncia una capacidad solo cuando la operación o el seam opcional
+      correspondiente funcione. Confirma tanto las afirmaciones negativas
+      como el comportamiento soportado.
+
+### 3. Formularios y configuración
+
+- [ ] Define y posee el `DriverFormDef` del crate; la UI de conexión lo
+      renderiza de forma genérica.
+- [ ] Implementa la validación de `build_config()` y los round trips de
+      edición de `extract_values()`.
+- [ ] Mantén los secretos en los paths de secretos establecidos en lugar de
+      embeberlos en los valores de formulario persistidos.
+- [ ] Implementa el parseo/construcción de URI o los overrides de campos de
+      export solo cuando aplique.
+
+### 4. Conexiones, errores y resultados
+
+- [ ] Construye y prueba la conexión a través de los métodos de `DbDriver`,
+      incluyendo el manejo de secretos requerido y los tests de conexión.
+- [ ] Implementa formateo estructurado de errores de query y conexión
+      mediante [`QueryErrorFormatter` y `ConnectionErrorFormatter`](../crates/dbflux_core/src/core/error_formatter.rs).
+      Preserva el contexto útil de la base de datos sin exponer secretos.
+- [ ] Devuelve datos de schema y query a través de tipos del core, incluyendo
+      `ColumnMeta.kind` para cada columna de resultado usando el
+      `ColumnKind` correcto.
+- [ ] Prueba el mapeo de tipos directamente. No dependas de que los
+      consumidores deriven la semántica a partir de cadenas `type_name` en
+      crudo.
+
+### 5. Seams opcionales
+
+Implementa estos únicamente cuando la base de datos los soporte, y mantén los
+flags de capacidad sincronizados con la implementación:
+
+- [ ] Un `LanguageService` no-default para validación específica del lenguaje
+      y clasificación de mutations.
+- [ ] Comportamiento de dialecto SQL, generador de código, generador de
+      queries o semantic planner según aplique.
+- [ ] Comportamiento de contexto de fuente, catálogo de métricas, importador
+      de dashboards o fuente de dashboards según aplique.
+- [ ] Un catálogo de instancia para métricas o inspectors según aplique.
+- [ ] Otros seams de schema, CRUD, cancelación, transfer o key-value
+      representados por los traits del core y los flags de capacidad.
+
+### 6. Wiring de features y registro
+
+- [ ] Añade membresía de workspace y una dependencia de workspace en el
+      [`Cargo.toml`](../Cargo.toml) raíz.
+- [ ] Añade una dependencia opcional y un relay de feature en
+      [`crates/dbflux_app/Cargo.toml`](../crates/dbflux_app/Cargo.toml).
+- [ ] Reenvía el feature del binario en
+      [`crates/dbflux/Cargo.toml`](../crates/dbflux/Cargo.toml).
+- [ ] Añade imports y registro con feature gate en
+      [`AppState::build_builtin_drivers()`](../crates/dbflux_app/src/app_state/bootstrap.rs).
+- [ ] Verifica tanto el build con el feature habilitado como uno
+      representativo con el feature deshabilitado para que el registro se
+      mantenga correctamente controlado por el gate.
+
+### 7. Tests y documentación
+
+- [ ] Prueba metadata, declaraciones de capacidad, round trips de
+      form/config, errores, comportamiento de conexión, mapeo de schema,
+      resultados de query y cada seam opcional anunciado.
+- [ ] Añade tests de integración donde el comportamiento cruce el límite
+      driver/core; mantén los tests de servicio en vivo ignorados o
+      controlados por gate según las convenciones existentes del crate.
+- [ ] Añade `crates/dbflux_driver_<name>/README.md` con secciones claras de
+      **Features** y **Limitations**.
+- [ ] Actualiza [`docs/DRIVERS.md`](DRIVERS.md) y mantén sus afirmaciones de
+      capacidad alineadas con el README del crate y la implementación.
+
+## Checklist de driver RPC externo
+
+- [ ] Implementa handshake, form, session, query y las operaciones opcionales
+      soportadas frente al [Protocolo RPC de drivers](DRIVER_RPC_PROTOCOL.md).
+- [ ] Provee metadata, capabilities y la definición de formulario a través
+      del handshake del protocolo; mantén cada afirmación de capacidad
+      alineada con las operaciones RPC implementadas.
+- [ ] Configura el servicio bajo Settings -> RPC Services como `kind=driver`
+      con un `socket_id` estable; añade un comando gestionado solo cuando
+      DBFlux deba controlar el ciclo de vida del proceso.
+- [ ] Espera la clave de runtime `rpc:<socket_id>` y el almacenamiento de
+      configuración genérico a través de `DbConfig::External`.
+- [ ] Sigue [RPC Services Config](RPC_SERVICES_CONFIG.md) para la
+      configuración persistida y la semántica del ciclo de vida.
+- [ ] Construye y haz smoke-test desde el
+      [ejemplo de driver personalizado](../examples/custom_driver/README.md),
+      y luego prueba reinicio, fallo de handshake, operaciones no soportadas
+      y round trips del formulario de conexión.
+
+Los drivers RPC externos no usan el wiring de features de Cargo integrado ni
+el path de registro de `build_builtin_drivers()`.
+
+## Checklist de revisión
+
+Antes de abrir un PR, confirma:
+
+- [ ] El camino integrado o RPC seleccionado se usa de forma consistente; los
+      dos paths de registro no se mezclan.
+- [ ] Ninguna ramificación de la UI ni del workflow de la app depende de un
+      driver ID concreto.
+- [ ] La metadata, los flags de capacidad, los seams opcionales, los tests,
+      el README del crate y `docs/DRIVERS.md` afirman lo mismo.
+- [ ] Los round trips de edición de form/config funcionan y los secretos no
+      se persisten ni se registran de forma inesperada.
+- [ ] Los resultados de query completan `ColumnMeta.kind` correctamente.
+- [ ] Los fallos de conexión y query producen errores estructurados, útiles
+      y seguros respecto a los secretos.
+- [ ] Los builds con el feature integrado deshabilitado y habilitado pasan, o
+      el servicio RPC completa su handshake y el smoke test de reinicio.
+- [ ] Los checks del repositorio en [CONTRIBUTING.md](../CONTRIBUTING.md)
+      pasan.

--- a/docs/es/DRIVER_RPC_PROTOCOL.md
+++ b/docs/es/DRIVER_RPC_PROTOCOL.md
@@ -1,0 +1,390 @@
+# Especificación del protocolo Driver RPC
+
+Este documento define cómo DBFlux descubre, lanza y se comunica con servicios RPC a través de IPC local.
+
+DBFlux ahora activa dos familias de servicios en runtime:
+
+- `RpcServiceKind::Driver` -> drivers de base de datos en runtime
+- `RpcServiceKind::AuthProvider` -> registros de auth-provider en runtime, en la app y en el servidor MCP
+
+## Fuente de verdad
+
+Para los servicios de driver activos, **el servicio es la fuente de verdad** para:
+
+- el tipo de driver (`DbKind`)
+- los metadatos del driver (`DriverMetadataDto`: nombre, icon, category, capabilities, query language, etc.)
+- la definición del formulario de conexión (`DriverFormDefDto`)
+
+DBFlux guarda la configuración de lanzamiento en su services config respaldada por SQLite. Los servicios RPC se crean y editan desde **Settings → RPC Services**.
+
+## Modelo de integración
+
+Al arrancar la app, DBFlux carga los servicios RPC configurados desde `~/.local/share/dbflux/dbflux.db`, y para cada servicio:
+
+1. descubre el descriptor de servicio persistido, incluyendo `RpcServiceKind`
+2. bifurca según `kind`
+3. asegura que el servicio esté corriendo (lo inicia si es necesario)
+4. realiza el handshake `Hello` específico de la familia
+5. lee los metadatos en runtime desde el servicio
+6. registra el servicio en runtime adaptado en el registro en memoria correspondiente
+
+Si algún paso falla, ese servicio se omite sin abortar el arranque. Los fallos de driver no rompen los auth providers, y los fallos de auth-provider no rompen los drivers.
+
+Comportamiento importante:
+
+- La configuración de servicios se lee al arrancar. Reinicia DBFlux después de cambiar la configuración de servicios RPC.
+- `socket_id` se usa tal cual (DBFlux no lo reescribe).
+- La clave interna del registro es `rpc:<socket_id>`.
+
+## Transporte
+
+DBFlux usa sockets locales vía `interprocess`:
+
+- **Linux**: sockets Unix de namespace abstracto (`\0name`)
+- **macOS**: sockets Unix en `/tmp/`
+- **Windows**: named pipes (`\\.\pipe\...`)
+
+Los mensajes se enmarcan como:
+
+- longitud little-endian de 4 bytes (`u32`)
+- payload en bincode
+
+Tamaño máximo de mensaje: `16 MiB`.
+
+La limpieza de sockets es automática al salir/soltar el proceso (provista por `interprocess`).
+
+## Configuración en runtime
+
+Almacenamiento primario: `~/.local/share/dbflux/dbflux.db` (`cfg_services`, `cfg_service_args`, `cfg_service_env`)
+
+UI de settings: **Settings → RPC Services**
+
+Notas:
+
+- `socket_id` es obligatorio.
+- `kind` soporta `driver` y `auth_provider`.
+- `command` es opcional.
+  - Si `command` se omite y `args` está vacío, DBFlux espera que el servicio ya esté corriendo.
+  - Para `driver`, si `command` se omite y `args` no está vacío, DBFlux lanza `dbflux-driver-host`.
+  - Para `auth_provider`, el lanzamiento gestionado requiere un `command` explícito; DBFlux no asume un binario host por defecto.
+- `args`, `env` y `startup_timeout_ms` son opcionales.
+- DBFlux deriva una clave interna de registro de drivers como `rpc:<socket_id>`.
+- Solo los servicios `driver` se registran como drivers de base de datos.
+- Los servicios `auth_provider` se registran únicamente en los registros de auth-provider y nunca reciben una identidad de driver `rpc:<socket_id>`.
+
+## Contrato de handshake
+
+DBFlux conecta y envía `Hello` primero.
+
+La familia activa de la API driver RPC es `driver_rpc`. En el transporte driver RPC dedicado actual, esa familia es implícita en el propio protocolo en lugar de transmitirse por el cable durante `Hello`. La compatibilidad se hace cumplir mediante el endpoint driver RPC más la versión mayor de protocolo seleccionada; las versiones menores son aditivas y se negocian de forma determinista dentro de esa línea mayor.
+
+Solicitud del cliente:
+
+```rust
+DriverRequestBody::Hello(DriverHelloRequest {
+    client_name: "dbflux_driver_ipc".to_string(),
+    client_version: "<version>".to_string(),
+    supported_versions: vec![
+        ProtocolVersion::new(1, 0),
+        ProtocolVersion::new(1, 1),
+        ProtocolVersion::new(1, 2),
+    ],
+    requested_capabilities: vec![
+        DriverCapability::Cancellation,
+        DriverCapability::ChunkedResults,
+        DriverCapability::SchemaIntrospection,
+        DriverCapability::MultiDatabase,
+    ],
+})
+```
+
+La respuesta del servidor debe incluir:
+
+- `selected_version`
+- `capabilities`
+- `driver_kind`
+- `driver_metadata`
+- `form_definition`
+
+Ejemplo:
+
+```rust
+DriverResponseBody::Hello(DriverHelloResponse {
+    server_name: "my-driver".to_string(),
+    server_version: "1.0.0".to_string(),
+    selected_version: DRIVER_RPC_VERSION,
+    capabilities: vec![DriverCapability::SchemaIntrospection],
+    driver_kind: DbKind::SQLite,
+    driver_metadata: DriverMetadataDto {
+        id: "my-driver".to_string(),
+        display_name: "My Driver".to_string(),
+        description: "External RPC driver".to_string(),
+        category: DatabaseCategory::Relational,
+        query_language: QueryLanguageDto::Sql,
+        capabilities: DriverCapabilities::RELATIONAL_BASE.bits(),
+        default_port: None,
+        uri_scheme: "mydriver".to_string(),
+        icon: Icon::Database,
+    },
+    form_definition: DriverFormDefDto {
+        tabs: vec![
+            // ...
+        ],
+    },
+})
+```
+
+Si se solapan varias versiones menores compatibles, el host debe seleccionar la versión menor mutua más alta.
+
+Si no existe ninguna versión compatible, se devuelve `DriverRpcErrorCode::VersionMismatch`.
+
+Después de `Hello`, cada envelope de request y response debe usar la `selected_version` negociada. Un peer que reciba un envelope post-handshake con una versión distinta debe rechazarlo como version mismatch.
+
+Límite de validación actual:
+
+- DBFlux persiste metadatos de API family/version por servicio, para discovery y futuros seams en runtime.
+- El handshake de driver en vivo actualmente valida las versiones de protocolo negociadas, pero no transmite ni revalida por separado el string de API family en el cable, porque el transporte driver RPC ya es específico de esa familia.
+
+### Emisión de audit desde drivers (v1.2+)
+
+Un driver que anuncia `DriverCapability::AuditEmit` (driver RPC ≥ 1.2) puede escribir en el audit log del host enviando frames intermedios `EmitAuditEvent` (`done=false`) durante cualquier ciclo de request/response. El host sanitiza cada evento antes de persistirlo en `aud_audit_events`.
+
+Categorías permitidas: `Connection`, `Query`, `System`. Todas las demás categorías se descartan silenciosamente.
+
+El host sobrescribe los campos de identidad (`actor_type` → `ExternalDriver`, `actor_id`, `source_id`, `driver_id`, `correlation_id`) y el contexto de conexión desde `AppState`, y trunca `details_json` al límite configurado. El rate limiting se comparte con los auth providers: 100 eventos por 60 segundos por `socket_id`; los eventos que exceden ese límite se descartan sin generar error en la sesión. Los peers que negocian por debajo de v1.2 u omiten la capability permanecen silenciosos. Ver [Audit § emisión de audit externa](AUDIT.md) para el contrato completo de sanitización.
+
+## Contrato RPC de auth-provider
+
+La familia activa de la API auth-provider RPC es `auth_provider_rpc` en `1.3`.
+
+DBFlux usa los metadatos persistidos `api_family` / `api_major` como preflight de arranque. Las filas compatibles luego negocian la versión menor mutua más alta durante `Hello`.
+
+Solicitud del cliente:
+
+```rust
+AuthProviderRequestBody::Hello(AuthProviderHelloRequest {
+    client_name: "dbflux_ipc".to_string(),
+    client_version: "<version>".to_string(),
+    supported_versions: vec![
+        ProtocolVersion::new(1, 3),
+        ProtocolVersion::new(1, 2),
+        ProtocolVersion::new(1, 1),
+        ProtocolVersion::new(1, 0),
+    ],
+    auth_token: Some("<token>".to_string()),
+})
+```
+
+La respuesta del servidor debe incluir:
+
+- `selected_version`
+- `provider_id`
+- `display_name`
+- `form_definition`
+
+La respuesta `Hello` de v1.2 lleva adicionalmente `secret_dependency_opt_in` (`bool`), que declara si el provider opta por recibir valores de campos secretos dentro de los dependency maps para las búsquedas de opciones dinámicas. Cuando es `false` (default), DBFlux elimina los valores secretos de los dependency maps antes de reenviar las solicitudes `FetchDynamicOptions`.
+
+La respuesta `Hello` de v1.3 lleva adicionalmente `audit_emit_opt_in` (`bool`). Establécelo en `true` para habilitar la emisión de audit events (ver abajo). El default es `false`.
+
+Flujo de request/response soportado:
+
+| Request | Response | Propósito |
+|---|---|---|
+| `Hello` | `Hello` | negociación de protocolo + identidad del provider |
+| `ValidateSession` | `SessionState` | validar el estado de auth cacheado |
+| `Login` | `LoginUrlProgress?` + `LoginResult` | URL de verificación opcional + resultado de login terminal |
+| `ResolveCredentials` | `Credentials` | resolver los campos de credenciales en runtime |
+| `FetchDynamicOptions` | `DynamicOptions` | resolver opciones de dropdown dinámicas para un campo de formulario `DynamicSelect` (v1.2+) |
+| (cualquier request) | `EmitAuditEvent` (intermedio) | emisión de audit event (v1.3+) |
+
+Notas:
+
+- `Login` puede emitir cero o un evento `LoginUrlProgress` antes de `LoginResult`.
+- Si no se envía ningún evento de progreso, DBFlux trata el callback de la URL de verificación como `None`.
+- `FetchDynamicOptions` solo está disponible cuando la versión negociada es al menos `1.2`. Los providers que negocian por debajo de v1.2 reciben del host un resultado permanente de "not supported" sin round-trip de IPC.
+- `detect_importable_profiles`, los hooks de write-back de perfil y el registro de value-provider específico de cada provider quedan intencionalmente fuera del alcance del contrato RPC en este cambio.
+- Los fallos en runtime de auth-provider se manejan a través del manejo existente de `DbError` y no abortan el arranque.
+
+### Emisión de audit desde auth providers (v1.3+)
+
+Los auth providers que negocian v1.3+ y establecen `audit_emit_opt_in: true` pueden enviar frames intermedios `EmitAuditEvent` (`done=false`) durante cualquier ciclo de request/response. El host los sanitiza y los escribe en `aud_audit_events`.
+
+Categoría permitida: solo `Connection`. Todas las demás categorías se descartan silenciosamente.
+
+El payload `AuditEventEmitDto` sigue la misma estructura que los frames de emit de driver. El host sobrescribe los campos de identidad (`actor_type`, `actor_id`, `source_id`, `driver_id`, `correlation_id`). El rate limiting se comparte con los drivers: 100 eventos por 60 segundos por `socket_id`.
+
+## Contrato del formulario
+
+El formulario de conexión mostrado en DBFlux se construye a partir de `form_definition`, devuelto en `Hello`.
+
+- El servicio define fields/tabs/sections.
+- DBFlux valida los campos obligatorios en la UI.
+- Al conectar/guardar, DBFlux envía los valores recolectados a través de `DbConfig::External.values` en el JSON de profile de `OpenSession`.
+
+Si `form_definition.tabs` está vacío, el formulario de conexión no mostrará ningún input específico del driver.
+
+## Ciclo de vida de la sesión
+
+1. `Hello`
+2. `OpenSession`
+3. operaciones de request/response
+4. `CloseSession`
+
+`OpenSession` siempre devuelve `SessionOpened` con metadatos. Mantén esto consistente con los metadatos de `Hello`.
+
+DBFlux envía el JSON del profile guardado a `OpenSession`. Para drivers externos, la configuración del profile es:
+
+```rust
+DbConfig::External {
+    kind: DbKind,
+    values: HashMap<String, String>,
+}
+```
+
+`values` contiene los valores de campo recolectados desde tu `form_definition`.
+
+El servicio debe parsear `profile_json`, esperar `DbConfig::External`, y validar de nuevo los campos obligatorios del lado del servidor.
+
+## Resumen de request/response
+
+| Request | Response | Propósito |
+|---|---|---|
+| `Hello` | `Hello` | negociación de protocolo + identidad del driver |
+| `OpenSession` | `SessionOpened` | abrir conexión/sesión |
+| `CloseSession` | `SessionClosed` | cerrar sesión |
+| `Ping` | `Pong` | liveness |
+| `Execute` | `ExecuteResult` | ejecución de query |
+| `Schema` | `Schema` | snapshot de schema |
+| `ListDatabases` | `Databases` | listado de bases de datos |
+
+El protocolo también soporta operaciones de browse, CRUD, key-value y generación de código. Ver `crates/dbflux_ipc/src/driver_protocol.rs` para el conjunto completo de enums.
+
+## Emisión de audit desde drivers (v1.2+)
+
+Los drivers que negocian la versión de protocolo v1.2 o superior pueden emitir audit events de vuelta al host como frames de respuesta intermedios (`done=false`). El host los sanitiza, aplica rate limiting y los escribe en `aud_audit_events`.
+
+### Habilitar la opción
+
+Incluye `DriverCapability::AuditEmit` en la lista `capabilities` de tu respuesta `Hello`. Los drivers que no anuncian esta capability tendrán cualquier frame `EmitAuditEvent` descartado silenciosamente por el host.
+
+### Enviar un frame de audit
+
+Emite un `DriverResponseEnvelope` con `done = false` y `body = DriverResponseBody::EmitAuditEvent(AuditEventEmitDto { .. })` en cualquier punto durante una request, antes de la respuesta terminal:
+
+```rust
+DriverResponseEnvelope {
+    protocol_version: negotiated_version,
+    request_id: request.request_id,
+    session_id: request.session_id,
+    done: false,
+    body: DriverResponseBody::EmitAuditEvent(AuditEventEmitDto {
+        ts_ms: chrono::Utc::now().timestamp_millis(),
+        level: EventSeverityDto::Info,
+        category: EventCategoryDto::Connection,
+        action: "session.open".to_string(),
+        outcome: EventOutcomeDto::Success,
+        summary: "Database session opened".to_string(),
+        object_type: None,
+        object_id: None,
+        duration_ms: Some(42),
+        error_code: None,
+        error_message: None,
+        details_json: None,
+    }),
+}
+```
+
+Luego envía la respuesta terminal como de costumbre.
+
+### Qué provee el host
+
+El host siempre sobrescribe estos campos; no los incluyas en el DTO (están intencionalmente ausentes de `AuditEventEmitDto`):
+
+- `actor_type`, `actor_id`, `source_id`, `driver_id` — siempre fijados a `ExternalDriver` / `rpc:<socket_id>`
+- `connection_id`, `database_name` — resueltos desde el contexto de sesión activo
+- `correlation_id` — uno por sesión, generado por el host
+
+### Categorías permitidas
+
+Los drivers pueden emitir eventos `Connection`, `Query` y `System`. Todas las demás categorías se descartan silenciosamente.
+
+### Rate limit
+
+100 eventos por 60 segundos por `socket_id`. Los frames que exceden el límite se descartan y se cuentan en `AuditService::external_audit_dropped_count()`.
+
+## Manejo de errores
+
+Devuelve errores estructurados a través de `DriverResponseBody::Error(DriverRpcError { ... })`.
+
+Códigos comunes:
+
+- `InvalidRequest`
+- `UnsupportedMethod`
+- `VersionMismatch`
+- `SessionNotFound`
+- `Timeout`
+- `Cancelled`
+- `Transport`
+- `Driver`
+- `Internal`
+
+Usa `InvalidRequest` para profiles/valores de formulario malformados y `UnsupportedMethod` para métodos intencionalmente no implementados. El auth-provider RPC usa el conjunto paralelo `AuthProviderRpcErrorCode` con el mismo significado operativo (`VersionMismatch`, `UnsupportedMethod`, `Timeout`, `Transport`, etc.).
+
+## Ciclo de vida del proceso y limpieza
+
+Cuando DBFlux inicia un proceso de servicio por sí mismo (vía `command` o el comando de host por defecto soportado), ese proceso se rastrea como un host gestionado.
+
+Al cerrar DBFlux:
+
+- todos los hosts gestionados rastreados se matan (`kill + wait`)
+- los hosts iniciados manualmente fuera de DBFlux no se rastrean y no se matan
+
+Esto garantiza que DBFlux solo limpia los procesos que posee.
+
+Si un host gestionado sale antes de tiempo o excede el timeout antes de que el socket esté listo, DBFlux reporta el id del servicio junto con una cola acotada del stdout/stderr reciente para ayudar en el diagnóstico.
+
+## Checklist mínimo de implementación
+
+Tu servicio debería:
+
+1. hacer bind del socket vía `interprocess`
+2. manejar `Hello` y devolver metadata/kind
+3. devolver una definición de formulario en `Hello`
+4. manejar `OpenSession`/`CloseSession`
+5. implementar al menos una operación útil (`Execute`)
+6. devolver `UnsupportedMethod` para operaciones no implementadas
+
+Recomendado:
+
+7. validar `DbConfig::External.values` en `OpenSession`
+8. devolver errores `InvalidRequest` claros para valores de formulario faltantes/inválidos
+9. mantener consistentes los metadatos de `Hello` y los de `SessionOpened`
+10. sellar cada envelope post-`Hello` con la versión negociada en lugar de asumir la última constante
+
+## Ejemplo funcional en este repositorio
+
+Usa:
+
+- `examples/custom_driver/src/main.rs`
+- `examples/custom_driver/README.md`
+- `examples/custom_auth_provider/src/main.rs`
+- `examples/custom_auth_provider/README.md`
+
+Esos ejemplos son compatibles con el modelo de integración de servicio de driver activo actual.
+
+Ruta de prueba rápida:
+
+1. agrega un nuevo servicio **Driver** en **Settings → RPC Services**
+2. apunta `command` a tu binario de ejemplo compilado
+3. establece `args` a `--socket <your-socket-id>`
+4. reinicia DBFlux
+5. crea ya sea una conexión (ejemplo de driver) o un perfil de auth (ejemplo de auth-provider) a través de los formularios de UI expuestos por el servicio
+
+## Referencias
+
+- `crates/dbflux_ipc/src/driver_protocol.rs`
+- `crates/dbflux_driver_ipc/src/transport.rs`
+- `crates/dbflux_driver_host/src/main.rs`
+- `crates/dbflux/src/app.rs`
+- `crates/dbflux_driver_ipc/src/driver.rs`
+- `docs/RPC_SERVICES_CONFIG.md`

--- a/docs/es/LUA.md
+++ b/docs/es/LUA.md
@@ -1,0 +1,616 @@
+# El runtime de Lua embebido
+
+El crate `dbflux_lua` es el runtime de Lua 5.4 sandboxed de DBFlux para los hooks de conexión. Este documento describe la arquitectura del crate, la API de Lua expuesta a los scripts de hooks, el modelo de sandbox y timeout, y cómo el runtime se integra en la aplicación.
+
+---
+
+## Qué hace este crate
+
+`dbflux_lua` permite a los usuarios escribir scripts de Lua que se ejecutan durante los eventos del ciclo de vida de la conexión (pre-connect, post-connect, pre-disconnect, post-disconnect). Los hooks son de propósito general: pueden impulsar flujos de login SSO, configuración de entorno, audit logging, o disparar herramientas externas antes/después de que se abra una conexión.
+
+El crate expone exactamente un tipo público: `LuaExecutor`. Todo lo demás — la fábrica de VMs, los módulos de API, el estado compartido — es interno al crate. Desde afuera, llamas a `executor.execute_hook(hook, context, cancel_token, parent_cancel_token, output, detached)` y obtienes un `HookResult`. El argumento final `detached: Option<&DetachedProcessSender>` permite que el executor entregue procesos detached de larga duración de vuelta al caller.
+
+---
+
+## Visión general de la arquitectura
+
+```mermaid
+flowchart TD
+    subgraph APP["dbflux (app crate)"]
+        COMPOSITE["CompositeExecutor"]
+        PROCESS["ProcessExecutor<br/>commands, scripts"]
+        LUAEXEC["LuaExecutor<br/>Lua hooks — feature = lua"]
+        COMPOSITE --> PROCESS
+        COMPOSITE --> LUAEXEC
+    end
+
+    subgraph LUA["dbflux_lua"]
+        EXEC["LuaExecutor (zero-sized)"]
+        VM["fresh LuaVm per call"]
+        MLUA["Lua 5.4 VM (mlua)"]
+        STATE["LuaRuntimeState (shared)"]
+        HOOKI["instruction hook (1000)"]
+        API["API modules<br/>hook.* always<br/>connection.* capability<br/>dbflux.log.* capability<br/>dbflux.env.* capability<br/>dbflux.process.* capability + gate"]
+        EXEC --> VM
+        VM --> MLUA
+        VM --> STATE
+        VM --> HOOKI
+        EXEC --> API
+    end
+
+    subgraph CORE["dbflux_core"]
+        TRAIT["HookExecutor trait"]
+        TYPES["ConnectionHook, HookKind::Lua<br/>LuaCapabilities, HookContext<br/>HookResult, CancelToken"]
+    end
+
+    LUAEXEC -->|implements HookExecutor| EXEC
+    EXEC -->|types + traits| TRAIT
+```
+
+El principio de diseño clave: **se crea una VM de Lua nueva para cada ejecución de hook**. Sin pooling de VMs, sin estado que se filtre entre ejecuciones. Esto hace que el sandbox sea trivialmente seguro — incluso si un script de alguna forma corrompe el estado de la VM, esta se descarta después de la ejecución.
+
+---
+
+## Dependencias
+
+| Dependencia   | Versión   | Propósito                                                                                                |
+| ------------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `mlua`        | 0.10      | Bindings de Lua 5.4. Features: `lua54`, `send` (hace `Lua: Send`), `vendored` (compila Lua desde source) |
+| `dbflux_core` | workspace | Traits (`HookExecutor`), tipos (`ConnectionHook`, `HookContext`, etc.)                                   |
+| `log`         | 0.4       | Logging desde el lado de Rust para callbacks de Lua                                                      |
+
+El feature `vendored` es importante — significa que no se requiere una instalación de Lua a nivel de sistema. El intérprete de Lua 5.4 se compila desde código fuente en C y se enlaza estáticamente. Esto elimina una dependencia de deployment pero agrega ~200KB al binario.
+
+---
+
+## El sandbox
+
+### Qué se carga
+
+Solo cuatro librerías estándar de Lua:
+
+```rust
+let stdlib = StdLib::TABLE | StdLib::STRING | StdLib::MATH | StdLib::UTF8;
+let lua = Lua::new_with(stdlib, LuaOptions::default())?;
+```
+
+Esto le da a los scripts acceso a:
+
+- **table**: `table.insert`, `table.remove`, `table.sort`, `table.concat`, `table.pack`, `table.unpack`
+- **string**: `string.format`, `string.find`, `string.gsub`, `string.sub`, `string.len`, `string.match`, `string.rep`, pattern matching
+- **math**: `math.floor`, `math.ceil`, `math.random`, `math.sqrt`, `math.abs`, `math.max`, `math.min`, `math.pi`
+- **utf8**: `utf8.char`, `utf8.codepoint`, `utf8.len`
+
+Más los built-ins de Lua que no requieren cargar librerías: `type()`, `tostring()`, `tonumber()`, `pairs()`, `ipairs()`, `next()`, `select()`, `pcall()`, `xpcall()`, `error()`, `setmetatable()`, `getmetatable()`, `rawget()`, `rawset()`, `rawequal()`, `rawlen()`. Los closures, variables locales, metatables, todo el control de flujo — todo lo que hace que Lua sea _Lua_ funciona sin problema.
+
+### Qué está bloqueado
+
+| Librería    | Por qué está bloqueada                                                                                                                                     |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `io`        | Lectura/escritura de archivos. No se puede permitir que los hooks lean archivos arbitrarios o escriban en disco.                                          |
+| `os`        | Llamadas al sistema: `os.execute()` sería un escape completo a shell, `os.remove()` puede borrar archivos. Incluso `os.getenv()` se reemplaza con el `dbflux.env.get()` gated. |
+| `debug`     | `debug.sethook()` podría interferir con el interrupt basado en conteo de instrucciones. `debug.getlocal()` y `debug.getinfo()` podrían inspeccionar estado interno. |
+| `package`   | `require()`, `dofile()`, `loadfile()` permitirían cargar código arbitrario desde disco.                                                                    |
+| `coroutine` | No es peligrosa en sí misma, pero agrega complejidad al modelo de timeout/cancelación (las coroutines pueden hacer yield más allá del instruction hook).   |
+
+El sandbox es "allowlist, no blocklist". Solo existen las cuatro librerías cargadas explícitamente más las funciones de API registradas. Si no está en la lista de arriba, no existe en la VM de Lua.
+
+### Límite de memoria
+
+Cada VM se crea con un cap de memoria forzado de 16 MiB (`lua.set_memory_limit(16 * 1024 * 1024)` en `engine.rs`). Un script que asigna más allá de este límite falla con un error de memoria en lugar de que se le permita agotar la memoria del host.
+
+---
+
+## La API de Lua
+
+### `hook.*` — Siempre disponible
+
+Esta es la API central de control de flujo. Cada script de hook de Lua comunica su resultado a través de estas funciones.
+
+```lua
+-- Read the current phase
+local phase = hook.phase  -- "pre_connect", "post_connect", ...
+
+-- Signal outcomes
+hook.ok()           -- success (this is the default if nothing is called)
+hook.warn("msg")    -- success, but surface a warning to the user
+hook.fail("msg")    -- failure, abort the connection flow
+```
+
+El outcome es una máquina de estados simple con tres estados: `Ok`, `Warn(msg)`, `Fail(msg)`. **Las llamadas múltiples se sobrescriben** — solo importa la última llamada antes de que el script termine. Si el script se completa sin llamar a ninguna de estas, el outcome por defecto es `Ok`.
+
+El outcome se mapea a `HookResult` así:
+
+| Outcome     | `exit_code` | `stderr` | `warnings` |
+| ----------- | ----------- | -------- | ---------- |
+| `Ok`        | `0`         | vacío    | `[]`       |
+| `Warn(msg)` | `0`         | vacío    | `[msg]`    |
+| `Fail(msg)` | `1`         | `msg`    | `[]`       |
+
+### `connection.*` — Metadata de conexión
+
+Gated por `capabilities.connection_metadata` (por defecto: **true**).
+
+```lua
+connection.profile_id     -- "550e8400-e29b-41d4-a716-446655440000"
+connection.profile_name   -- "Production DB"
+connection.db_kind        -- "Postgres", "SQLite", "MongoDB", "Redis", "MySQL"
+connection.host           -- "db.example.com" or nil (SQLite has no host)
+connection.port           -- 5432 or nil
+connection.database       -- "myapp" or nil
+```
+
+Todos los valores son **snapshots estáticos** tomados en el momento de crear la VM. El script no puede cambiarlos. Esto es intencional — los hooks observan la conexión, no la configuran.
+
+### `dbflux.log.*` — Logging
+
+Gated por `capabilities.logging` (por defecto: **true**).
+
+```lua
+dbflux.log.info("Starting SSO flow")
+dbflux.log.warn("Token expires in 5 minutes")
+dbflux.log.error("AWS CLI not found")
+```
+
+Cada llamada hace dos cosas:
+
+1. Agrega `[LEVEL] message` a un buffer de log interno (que se convierte en el `stdout` del `HookResult`)
+2. Reenvía al crate `log` de Rust en el nivel correspondiente, con el prefijo `[lua]`
+
+Cuando el caller provee un canal de salida, la misma línea de log también se transmite inmediatamente a la UI. El buffer de log sigue siendo la salida durable primaria para el `HookResult` final.
+
+### `dbflux.env.*` — Variables de entorno
+
+Gated por `capabilities.env_read` (por defecto: **true**).
+
+```lua
+local home = dbflux.env.get("HOME")          -- "/home/user" or nil
+local profile = dbflux.env.get("AWS_PROFILE") -- "production" or nil
+
+if not dbflux.env.get("DATABASE_URL") then
+    hook.fail("DATABASE_URL is not set")
+end
+```
+
+Solo lectura. Sin `set()` ni `unset()` — los hooks no pueden modificar el entorno. Esto reemplaza `os.getenv()`, que requeriría cargar la librería insegura `os`.
+
+### `dbflux.process.*` — Ejecución de procesos controlada
+
+Gated por `capabilities.process_run` (por defecto: **false**). Debe habilitarse explícitamente.
+
+Incluso cuando está habilitada, la API de procesos tiene **doble gate** mediante un sistema de allowlist. No puedes ejecutar programas arbitrarios — solo herramientas específicas de categorías predefinidas.
+
+```lua
+local result = dbflux.process.run({
+    program = "aws",
+    allowlist = "aws_cli",
+    args = { "sso", "login", "--profile", "prod" },
+    timeout_ms = 120000,
+    cwd = "/home/user",
+    stream = true,
+})
+
+if not result.ok then
+    hook.fail("AWS SSO login failed: " .. result.stderr)
+end
+
+dbflux.log.info("AWS SSO login succeeded")
+hook.ok()
+```
+
+**Opciones de entrada:**
+
+| Campo        | Tipo     | Requerido | Descripción                                                             |
+| ------------ | -------- | --------- | ------------------------------------------------------------------------ |
+| `program`    | string   | sí        | Nombre de comando plano (sin separadores de ruta)                        |
+| `allowlist`  | string   | sí        | Debe coincidir con un nombre de allowlist conocido                       |
+| `args`       | string[] | no        | Argumentos del comando                                                   |
+| `timeout_ms` | integer  | no\*      | Timeout por proceso (ms). El timeout a nivel de hook igual aplica por encima. |
+| `cwd`        | string   | no        | Directorio de trabajo                                                    |
+| `stream`     | boolean  | no        | Transmite stdout/stderr al caller mientras el proceso sigue en ejecución |
+| `detached`   | boolean  | no        | Entrega el proceso spawneado de vuelta al caller y retorna inmediatamente, en lugar de esperar a que termine |
+
+\* Para un `run` no detached, `timeout_ms` es efectivamente requerido cuando no hay timeout a nivel de hook: una llamada sin `timeout_ms` ni timeout a nivel de hook falla con el error de runtime `"dbflux.process.run requires a timeout_ms when no hook-level timeout is set"`. Un `run` detached está exento de esta restricción.
+
+**Valor de retorno:**
+
+| Campo       | Tipo        | Descripción                                        |
+| ----------- | ----------- | --------------------------------------------------- |
+| `ok`        | boolean     | `true` si el proceso fue detached, o si el exit code es 0 y no hubo timeout |
+| `detached`  | boolean     | `true` si el proceso se entregó como detached (en cuyo caso los campos de output/exit de abajo quedan vacíos/nil) |
+| `exit_code` | integer/nil | Exit code del proceso                               |
+| `stdout`    | string      | stdout capturado                                     |
+| `stderr`    | string      | stderr capturado                                     |
+| `timed_out` | boolean     | `true` si se disparó el timeout por proceso          |
+
+**Allowlists disponibles:**
+
+| Allowlist     | Programas permitidos                             |
+| ------------- | ------------------------------------------------- |
+| `aws_cli`     | `aws`, `aws.exe`                                   |
+| `python_cli`  | `python`, `python.exe`, `python3`, `python3.exe`   |
+| `ssh_cli`     | `ssh`, `ssh.exe`                                   |
+| `cloudflared` | `cloudflared`, `cloudflared.exe`                   |
+| `gcloud_cli`  | `gcloud`, `gcloud.cmd`, `gcloud.exe`               |
+| `az_cli`      | `az`, `az.cmd`, `az.exe`                           |
+
+`program` debe ser un **nombre de comando plano**. Los nombres calificados con ruta se rechazan antes de verificar la allowlist: cualquier programa que contenga un `/` o `\`, que esté compuesto de múltiples componentes de ruta, o que empiece con `~` falla con el error de runtime `"Program '...' must be a bare command name (no path separators)"`. Así que `program = "/usr/local/bin/aws"` se rechaza directamente — pasa `program = "aws"` en su lugar y deja que se resuelva vía `PATH`. La comparación del nombre plano contra la allowlist no distingue mayúsculas/minúsculas.
+
+Este diseño responde a un caso de uso específico: hooks que necesitan disparar herramientas de CLI en la nube (login SSO, configuración de túnel, obtención de secrets) sin abrir un escape completo a shell. La allowlist es una guardia de ergonomía y footgun — previene typos y ejecución accidental de programas inesperados. **No** es un límite de aislamiento de seguridad: un usuario que controla `PATH` aún puede sustituir un binario diferente bajo el mismo nombre. Las allowlists hardcodeadas se pueden extender más adelante a medida que surjan nuevos casos de uso.
+
+---
+
+## Timeout y cancelación
+
+Hay tres capas de interrupción, y entender cómo interactúan es importante.
+
+### Capa 1: instruction hook de Lua
+
+```rust
+lua.set_hook(
+    HookTriggers::new().every_nth_instruction(1_000),
+    move |_lua, _debug| { ... }
+);
+```
+
+Cada 1.000 instrucciones de Lua, el hook se dispara y verifica:
+
+1. ¿Está seteado el cancel token? → `RuntimeError("Lua hook cancelled")`
+2. ¿Se agotó el timeout? → `RuntimeError("Lua hook timed out")`
+
+Esto captura loops infinitos, cómputos descontrolados y código Lua puro de larga duración. El intervalo de 1.000 instrucciones es un balance entre responsividad (verificar seguido) y performance (verificar no es gratis).
+
+**Limitación**: este hook solo se dispara para instrucciones de bytecode de Lua. Si el script llama a una función bloqueante de Rust (como `dbflux.process.run`), el instruction hook no se dispara hasta que esa función retorna. Por eso...
+
+### Capa 2: Process Executor compartido
+
+Dentro de `dbflux.process.run`, la ejecución de procesos se delega al helper compartido `dbflux_core::execute_streaming_process()`. Ese helper:
+
+- crea threads lectores para stdout y stderr
+- empuja chunks de output a través de un canal
+- verifica cancel tokens y timeouts en un intervalo corto
+- mata al proceso hijo en caso de cancelación o timeout
+- retorna una tabla de resultado normal para el timeout por proceso, o un error de runtime de Lua para cancelación/timeout a nivel de hook
+
+Esto mantiene alineados los hooks de Lua y los hooks de script que no son Lua. Se usa el mismo camino de ejecución de procesos de bajo nivel para subprocesos disparados desde Bash, Python y Lua.
+
+### Capa 3: Parent cancel token
+
+El flujo de conexión pasa un parent cancel token que cancela todos los hooks cuando se aborta la operación general de connect/disconnect. Tanto el instruction hook como el process executor compartido verifican este token junto con el específico del hook.
+
+### Jerarquía de timeouts
+
+```
+Hook-level timeout (e.g., 30s)
+  └── Process-level timeout (e.g., 120s for SSO login)
+        └── Actually, process timeout < hook timeout to be useful
+```
+
+Si el timeout a nivel de hook se dispara mientras un proceso está corriendo, el proceso se mata y todo el hook aborta con un error de timeout de Lua, que `LuaExecutor` convierte en `HookResult { timed_out: true }`.
+
+Si el timeout a nivel de proceso se dispara, solo ese proceso se mata. El script sigue ejecutándose y puede manejar el timeout con gracia:
+
+```lua
+local result = dbflux.process.run({ ..., timeout_ms = 5000 })
+if result.timed_out then
+    dbflux.log.warn("Process timed out, falling back to cached credentials")
+end
+```
+
+---
+
+## Manejo de errores
+
+### Cómo fluyen los errores
+
+```
+Script execution
+    │
+    ├─ Completes normally → outcome (Ok/Warn/Fail) determines HookResult
+    │
+    ├─ "Lua hook cancelled" → Err(String) returned to caller
+    │                          (the ONLY case that returns Err)
+    │
+    ├─ "Lua hook timed out" → Ok(HookResult { timed_out: true })
+    │
+    └─ Any other Lua error → Ok(HookResult { exit_code: 1, stderr: error_msg })
+```
+
+La cancelación es el único caso que retorna `Err` desde `execute_hook`. Los timeouts y errores de runtime son outcomes normales de "el hook falló" y se capturan en `HookResult`.
+
+### Detección de errores basada en sentinelas
+
+mlua envuelve los errores en capas de `CallbackError` y `WithContext`. Para detectar cancelación vs. timeout, el código usa una función recursiva `error_has_message` que desenvuelve estas capas buscando las cadenas sentinela exactas `"Lua hook cancelled"` y `"Lua hook timed out"`.
+
+Esta es una solución pragmática. Un approach más limpio sería usar tipos de error personalizados, pero el modelo de errores de mlua hace eso poco práctico sin luchar contra la librería. El approach de sentinelas funciona de forma confiable porque estas cadenas exactas solo son producidas por nuestro instruction hook y el camino de ejecución de procesos compartido.
+
+---
+
+## LuaCapabilities
+
+Definido en `dbflux_core::connection::hook`:
+
+```rust
+pub struct LuaCapabilities {
+    pub logging: bool,              // default: true
+    pub env_read: bool,             // default: true
+    pub connection_metadata: bool,  // default: true
+    pub process_run: bool,          // default: false
+}
+```
+
+Estos se configuran por hook en la UI de Settings. Los defaults son deliberadamente conservadores — `process_run` es la única capability peligrosa, y está deshabilitada por defecto.
+
+Las verificaciones de capability ocurren en el momento de crear la VM, no en el momento de la llamada. Si `logging` es false, la tabla `dbflux.log` simplemente no existe en la VM. No hay verificación en runtime; el sandbox es estructural.
+
+---
+
+## Detalles internos de arquitectura
+
+### LuaRuntimeState
+
+```rust
+pub struct LuaRuntimeState {
+    pub outcome: Arc<Mutex<LuaHookOutcome>>,
+    pub log_buffer: Arc<Mutex<Vec<String>>>,
+    pub output: Option<OutputSender>,
+    pub detached: Option<DetachedProcessSender>,
+    pub cancel_token: CancelToken,
+    pub parent_cancel_token: Option<CancelToken>,
+    pub hook_started_at: Instant,
+    pub hook_timeout: Option<Duration>,
+}
+```
+
+Este es el estado mutable compartido al que acceden tanto los callbacks de Lua como el executor. El patrón `Arc<Mutex<...>>` es necesario porque los closures de Lua (registrados como funciones de API) capturan `Arc`s clonados, y el executor lee el estado final después de la ejecución del script.
+
+El sender de `output` es opcional. Cuando está presente, las llamadas de log de Lua y `dbflux.process.run({ stream = true })` reenvían output en vivo a la UI mientras siguen preservando el output buffereado final en `HookResult`.
+
+El `cancel_token` y los campos de timing también se comparten con la ejecución de procesos, creando una única vista del contexto de ejecución a través de todas las capas.
+
+### LuaVmConfig
+
+`LuaEngine::create_vm()` toma un struct `LuaVmConfig` en lugar de una lista larga de argumentos. Agrupa el contexto del hook, la fase, las capabilities, el estado de cancelación, el sender de output opcional y la metadata de timeout necesaria para construir una VM nueva.
+
+### LuaVm
+
+```rust
+pub struct LuaVm {
+    pub lua: Lua,
+    pub state: LuaRuntimeState,
+}
+```
+
+Agrupa la VM de Lua y el estado compartido para que el executor pueda acceder a ambos. Después de que `vm.lua.load(&script).exec()` se completa, el executor lee `vm.state.log_buffer` y `vm.state.outcome` para construir el `HookResult`.
+
+### El patrón de lazy init de la tabla `dbflux`
+
+```rust
+fn ensure_dbflux_table(lua: &Lua) -> LuaResult<Table> {
+    let globals = lua.globals();
+    match globals.get::<Table>("dbflux") {
+        Ok(table) => Ok(table),
+        Err(_) => {
+            let table = lua.create_table()?;
+            globals.set("dbflux", table.clone())?;
+            Ok(table)
+        }
+    }
+}
+```
+
+Cada función `register_*_api` llama a esto para obtener-o-crear el global `dbflux`. Esto permite que las capabilities se registren de forma independiente sin conocerse entre sí — cada una simplemente agrega su sub-tabla al padre compartido.
+
+---
+
+## Guía de estilo de scripts
+
+Basándose en los casos de test y el diseño de la API, así es la forma idiomática de escribir hooks de Lua:
+
+### Hook básico
+
+```lua
+dbflux.log.info("Pre-connect hook for " .. connection.profile_name)
+
+if connection.db_kind == "Postgres" and hook.phase == "pre_connect" then
+    local db_url = dbflux.env.get("DATABASE_URL")
+    if not db_url then
+        hook.fail("DATABASE_URL environment variable is not set")
+        return
+    end
+end
+
+hook.ok()
+```
+
+### Hook de login SSO
+
+```lua
+local result = dbflux.process.run({
+    program = "aws",
+    allowlist = "aws_cli",
+    args = { "sso", "login", "--profile", connection.profile_name },
+    timeout_ms = 120000,
+})
+
+if not result.ok then
+    hook.fail("AWS SSO login failed: " .. result.stderr)
+    return
+end
+
+dbflux.log.info("AWS SSO login completed successfully")
+hook.ok()
+```
+
+### Condicional por fase
+
+```lua
+if hook.phase == "pre_connect" then
+    dbflux.log.info("Establishing tunnel...")
+    -- setup logic
+elseif hook.phase == "post_disconnect" then
+    dbflux.log.info("Cleaning up...")
+    -- teardown logic
+end
+```
+
+### Patrón de manejo de errores
+
+```lua
+-- Use pcall for operations that might fail
+local ok, err = pcall(function()
+    -- risky operations here
+end)
+
+if not ok then
+    hook.fail("Unexpected error: " .. tostring(err))
+    return
+end
+```
+
+### Convenciones
+
+- **Usa `return` después de `hook.fail()`** — el script sigue ejecutándose después de `hook.fail()`, que simplemente setea un flag. Si no haces return, código posterior podría llamar a `hook.ok()` y sobrescribir el fallo. Gana la última llamada.
+- **Loguea con generosidad** — el output de `dbflux.log.info()` aparece en el result panel. Es la única forma de comunicar progreso y depurar problemas.
+- **Verifica `result.ok`, no `result.exit_code`** — el campo `ok` considera tanto el exit code como el timeout. `exit_code` puede ser `nil` en casos límite.
+- **No dependas de que `hook.phase` esté ausente en el editor** — cuando se ejecuta un script desde el botón Run del editor de código (no como parte de un flujo de conexión), la fase por defecto es `"pre_connect"`. La lógica dependiente de fase debe manejar esto con gracia.
+
+---
+
+## Limitaciones
+
+### Sin async
+
+Todo es síncrono y bloqueante. La VM de Lua corre en un thread en background, y `dbflux.process.run` bloquea ese thread hasta que el process executor compartido termina. Para la mayoría de los casos de uso de hooks (llamadas a herramientas CLI, verificaciones de entorno), esto está bien. Pero no puedes hacer requests HTTP asíncronos ni operaciones en paralelo.
+
+### Sin acceso a red
+
+No hay cliente HTTP, librería de sockets, ni API de red. La única forma de interactuar con servicios externos es a través de `dbflux.process.run` con una herramienta CLI en la allowlist. Esto es intencional — un cliente HTTP sandboxed necesitaría filtrado cuidadoso de URLs y expandiría significativamente la superficie de ataque.
+
+### Sin I/O de archivos
+
+Sin `io.open`, sin `os.rename`, sin lectura o escritura directa de archivos desde Lua mismo. Si necesitas datos del mundo exterior, tienes que pasar por un proceso permitido en la allowlist como Python o un CLI de nube.
+
+### Sin estado persistente
+
+Cada ejecución de hook crea una VM nueva. No hay forma de guardar estado entre invocaciones. Si necesitas estado persistente, escríbelo a un archivo a través de un proceso externo y léelo de vuelta en la siguiente invocación.
+
+### Sin `require()`
+
+La librería `package` no se carga, así que `require()` no existe. No puedes dividir código Lua en múltiples archivos ni usar librerías de Lua de terceros. Toda la lógica del hook debe ser autocontenida en un único script.
+
+### Sin `os.time()` ni `os.clock()`
+
+La librería `os` está bloqueada por completo. Si necesitas timing, tendrás que medirlo externamente. Esto también significa que `math.randomseed(os.time())` no funciona — `math.random()` usa el seed que sea que mlua provea (que depende de la implementación).
+
+### Allowlists limitadas
+
+Las allowlists de procesos están hardcodeadas. Agregar una herramienta nueva requiere un cambio de código, un rebuild y un release nuevo. No hay (por ahora) un mecanismo de allowlist configurable por el usuario. Las seis allowlists actuales cubren los casos de uso más comunes (CLIs de nube, SSH, scripts de Python).
+
+### Sin syntax highlighting de Lua en el editor
+
+gpui-component (v0.5.0) no incluye una grammar `tree-sitter-lua`. Al editar scripts de Lua en el editor de código, no hay syntax highlighting. `editor_mode()` retorna `"lua"`, que cae con gracia a plaintext. Los scripts de Python y Bash tienen highlighting completo.
+
+### Memoria acotada
+
+Cada VM tiene un cap de 16 MiB de memoria asignada por Lua. Los scripts que intentan construir estructuras de datos muy grandes en memoria van a golpear este techo y fallar. Esta es una guardia de sandbox, no un ajuste configurable por hook.
+
+### El output está impulsado por API
+
+La forma soportada de comunicar progreso y diagnósticos es `dbflux.log.*`. Ese output se buffea en el `HookResult` final, y también puede transmitirse en vivo cuando el caller lo solicita.
+
+---
+
+## Cómo se integra en la aplicación
+
+### Feature flag
+
+La dependencia opcional `dbflux_lua` y su feature `lua` viven en el app crate, `crates/dbflux_app/Cargo.toml`:
+
+```toml
+dbflux_lua = { workspace = true, optional = true }
+# ...
+[features]
+lua = ["dbflux_lua"]
+```
+
+El binary crate, `crates/dbflux/Cargo.toml`, no tiene dependencia directa de `dbflux_lua`. Su feature `lua` simplemente reenvía a los crates de app y UI, y forma parte del set por defecto:
+
+```toml
+[features]
+lua = ["dbflux_app/lua", "dbflux_ui/lua"]
+default = ["sqlite", "postgres", "mysql", "mongodb", "redis", "dynamodb", "cloudwatch", "influxdb", "mssql", "lua", "aws", "mcp"]
+```
+
+El feature `lua` está en el set por defecto, así que siempre está habilitado en builds normales. Se puede deshabilitar para builds que no necesitan Lua (reduce el tamaño del binario en ~200KB).
+
+### CompositeExecutor
+
+`crates/dbflux_app/src/hook_executor.rs` define el router (re-exportado desde `crates/dbflux_app/src/lib.rs`):
+
+```rust
+#[derive(Clone)]
+pub struct CompositeExecutor {
+    process: ProcessExecutor,
+    #[cfg(feature = "lua")]
+    lua: dbflux_lua::LuaExecutor,
+}
+```
+
+`HookKind::Lua` se enruta a `LuaExecutor`. `HookKind::Command` y `HookKind::Script` van a `ProcessExecutor`. Sin el feature `lua`, los hooks de Lua retornan un mensaje de error.
+
+### Integración con el botón Run
+
+El botón Run del editor de código (`execution.rs`) usa `CompositeExecutor` para ejecutar scripts. Para scripts de Lua, crea un `ConnectionHook` inline a partir del contenido del editor con `LuaCapabilities::all_enabled()` y un timeout de 30 segundos, pasa un canal de output a `execute_hook`, y renderiza output en vivo en el results panel mientras el script sigue en ejecución. El stdout final (buffer de log) y el stderr se siguen preservando en el resultado de texto completado.
+
+---
+
+## Testing
+
+Todos los tests están en el crate mismo (no en un directorio `tests/` separado). La cobertura actualmente abarca:
+
+- `executor.rs`: outcomes normales, errores de runtime, scripts respaldados por archivo, cancelación, timeouts, gating de capabilities, enforcement de allowlist, y comportamiento de output de procesos transmitidos
+- `engine.rs`: fase del hook, metadata de conexión, librerías inseguras ocultas, visibilidad opcional de API, y comportamiento de construcción de VM
+- `api/dbflux.rs`: validación de opciones de proceso, manejo de timeout de hook expirado antes de spawnear, formateo de eventos de log en vivo, y stdout/stderr parcial transmitido durante cancelación
+
+### Ejecutar los tests
+
+```bash
+cargo test -p dbflux_lua           # all tests
+cargo test -p dbflux_lua -- timeout  # specific test by name
+```
+
+Algunos tests spawnean procesos reales (`echo`, `sleep`, `python3`) y tienen timeouts, así que toman uno o dos segundos. Los tests relacionados con procesos usan `cfg!(target_os = "windows")` para seleccionar comandos apropiados por plataforma.
+
+---
+
+## Lecciones y trampas
+
+### El problema del envoltorio de errores de mlua
+
+mlua envuelve los errores en múltiples capas: `CallbackError { cause: WithContext { context: "...", cause: RuntimeError("actual message") } }`. Cuando quieres detectar un error específico (como "Lua hook cancelled"), no puedes simplemente hacer match sobre la variante externa — tienes que desenvolver recursivamente. La función `error_has_message` hace esto, pero es frágil. Si mlua cambia su comportamiento de envoltorio, la detección de sentinelas se rompe en silencio.
+
+Un approach mejor podría ser usar `Error::external()` de mlua con un tipo de error personalizado que implemente `std::error::Error`, pero el approach de sentinelas actual se ha mantenido bien a través de las versiones de mlua.
+
+### El intervalo de 1.000 instrucciones
+
+El instruction hook se dispara cada 1.000 instrucciones. Esto significa:
+
+- Un loop ajustado que no hace nada toma ~1.000 iteraciones antes de que se dispare la verificación de cancelación
+- Para precisión de timeout, 1.000 instrucciones se traducen a aproximadamente microsegundos, así que la precisión del timeout es excelente
+- Setearlo demasiado bajo (p. ej., cada instrucción) impacta medible en la performance de scripts computacionales
+- Setearlo demasiado alto (p. ej., cada 100.000) hace que la cancelación se sienta lenta
+
+1.000 balancea la responsividad de cancelación contra el overhead por verificación.
+
+### La estratificación de timeout en process_run
+
+El timeout de tres capas (instruction hook, process executor compartido, timeout por proceso) puede resultar confuso. La observación clave: **el timeout a nivel de proceso es recuperable** (el script continúa), **el timeout a nivel de hook no lo es** (el hook falla). Así que siempre debes setear `timeout_ms` en las llamadas a `dbflux.process.run` a algo menor que el timeout del hook, permitiendo que el script maneje el fallo con gracia.
+
+### ¿Por qué no simplemente permitir `os.execute()`?
+
+Podría parecer más simple cargar la librería `os` y dejar que los usuarios corran lo que quieran. El problema es que `os.execute()` no provee captura de output, sin timeout, sin cancelación, y sin filtrado de programas. La API `dbflux.process.run` nos da todo esto. La allowlist es el precio de restringir qué programas puede lanzar un hook en una app GUI que ejecuta scripts de usuario. Es una guardia de ergonomía/footgun más que un límite de aislamiento de seguridad — la sustitución vía PATH todavía puede intercambiar el binario detrás de un nombre permitido.
+
+### VM nueva por ejecución — costo vs. seguridad
+
+Crear una VM de Lua 5.4 nueva por invocación de hook cuesta ~0.5ms. Para algo que corre como máximo 4 veces por ciclo de vida de conexión, esto es despreciable. El beneficio — aislamiento perfecto entre ejecuciones — vale mucho más que el costo. Un approach de VM pooled ahorraría microsegundos pero introduciría bugs sutiles de filtrado de estado.

--- a/docs/es/MCP_AI_INTEGRATION.md
+++ b/docs/es/MCP_AI_INTEGRATION.md
@@ -1,0 +1,344 @@
+# Guía de integración de DBFlux con IA + MCP
+
+Esta guía explica cómo integrar agentes de IA con DBFlux a través del binario standalone del servidor MCP.
+
+Es intencionalmente explícita sobre qué está disponible hoy y qué sigue pendiente, para que las integraciones no dependan de un comportamiento que no está implementado.
+
+## 1. Visión general de la arquitectura
+
+DBFlux expone la funcionalidad de servidor MCP a través del subcomando `dbflux mcp`, que habla el Model Context Protocol sobre stdio. Los clientes de IA (Claude Desktop, Cursor, etc.) lanzan este binario como subproceso y se comunican vía JSON-RPC 2.0, delimitado por saltos de línea.
+
+```
+AI Client (Claude Desktop / Cursor / any MCP client)
+        |  stdio  (JSON-RPC 2.0, newline-delimited)
+        v
+  dbflux mcp                    ← integrated into main dbflux binary
+        |
+        +--  dbflux_mcp          governance, authorization, tool catalog
+        +--  dbflux_core         profiles, config, driver traits
+        +--  dbflux_driver_*     real database drivers
+        +--  dbflux_policy       policy engine
+        +--  dbflux_audit        audit trail (SQLite)
+```
+
+El servidor MCP y la app GUI de DBFlux son procesos independientes. Comparten la misma base de datos SQLite unificada en `~/.local/share/dbflux/dbflux.db` (profiles, governance, audit, history, sessions). La governance configurada en la GUI (trusted clients, roles, policies, ajustes por conexión) es leída por el servidor desde esa base de datos al arrancar. El flag `--config-dir` se acepta por compatibilidad de CLI, pero no reubica la base de datos unificada; governance y audit siempre leen desde `~/.local/share/dbflux/dbflux.db`.
+
+## 2. Ejecutar el servidor MCP
+
+### Build
+
+```bash
+# All drivers with MCP support (default)
+cargo build -p dbflux --release
+
+# SQLite only with MCP
+cargo build -p dbflux --features sqlite,mcp --release
+
+# Without MCP support (AI integration disabled)
+cargo build -p dbflux --no-default-features --features sqlite,postgres,mysql,mongodb,redis,dynamodb,lua,aws --release
+```
+
+El servidor MCP está integrado en el binario principal `dbflux`.
+
+### Uso
+
+```
+dbflux mcp --client-id <id> [--config-dir <path>]
+```
+
+| Flag | Descripción |
+|------|-------------|
+| `--client-id <id>` | Identidad de este cliente de IA. Debe coincidir con un trusted client registrado en la configuración de governance. **Obligatorio.** |
+| `--config-dir <path>` | Se acepta por compatibilidad de CLI. La base de datos de governance/audit siempre se resuelve a la unificada `~/.local/share/dbflux/dbflux.db`; este flag no la reubica. Para entornos de test aislados, sobrescribe `HOME`/`XDG_DATA_HOME` en su lugar. |
+
+### Configuración de Claude Desktop
+
+Agrega esto a `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) o el equivalente en tu plataforma:
+
+```json
+{
+  "mcpServers": {
+    "dbflux": {
+      "command": "/path/to/dbflux",
+      "args": ["mcp", "--client-id", "claude-desktop"]
+    }
+  }
+}
+```
+
+El valor de `client-id` debe coincidir con una entrada de trusted client que hayas creado en la GUI de DBFlux, en **Settings → MCP → Clients**.
+
+**Nota**: si compilaste DBFlux sin el feature `mcp` (`--no-default-features`), el servidor MCP no estará disponible.
+
+## 3. Modelo de governance (conceptos centrales)
+
+Toda solicitud de IA se hace cumplir a través de todas estas capas, en orden:
+
+1. **Trusted client**: la identidad del solicitante debe estar activa y registrada.
+2. **Connection MCP gate**: la conexión objetivo debe tener MCP habilitado.
+3. **Policy assignment**: el actor debe tener una asignación con scope en esa conexión.
+4. **Tool + classification allowlist**: tanto el tool ID como su clase de ejecución deben estar permitidos por la policy asignada.
+5. **Approval path**: los flujos de write/destructive pueden requerir aprobación humana antes de ejecutarse.
+6. **Audit trail**: cada decisión se añade a `aud_audit_events` en la base de datos SQLite unificada y es consultable/exportable. Ver `docs/AUDIT.md` para el esquema completo de eventos.
+
+Las seis capas se ejecutan dentro del proceso del servidor en cada solicitud `tools/call`. Ninguna puede saltarse desde el lado del cliente.
+
+## 4. Superficie canónica de tools (v1)
+
+| Grupo | Tool ID | Clase | Qué hace |
+|-------|---------|-------|--------------|
+| Connection | `list_connections` | metadata | Enumera todas las conexiones de base de datos configuradas |
+| Connection | `connect` | metadata | Abre una sesión contra una conexión configurada |
+| Connection | `disconnect` | metadata | Cierra una sesión abierta |
+| Connection | `get_connection_info` | metadata | Obtiene las capabilities del driver y los metadatos de la conexión |
+| Schema | `list_databases` | metadata | Lista todas las bases de datos accesibles en una conexión |
+| Schema | `list_schemas` | metadata | Lista los schemas dentro de una base de datos |
+| Schema | `list_tables` | metadata | Lista tablas y vistas dentro de un schema |
+| Schema | `list_collections` | metadata | Lista colecciones de MongoDB |
+| Schema | `describe_object` | metadata | Obtiene las definiciones de columnas/campos e índices de una tabla |
+| Read | `select_data` | read | Ejecuta un SELECT estructurado contra una tabla o colección. Los `joins` no soportados se rechazan explícitamente |
+| Read | `count_records` | read | Devuelve un conteo de filas/documentos para un target |
+| Read | `aggregate_data` | read | Ejecuta un pipeline de agregación de solo lectura |
+| Read | `explain_query` | read | Muestra el plan de ejecución de la query sin ejecutar la mutación objetivo |
+| Read | `preview_mutation` | read | Devuelve un preview/plan de solo lectura para una write query. Siempre de solo lectura; la mutación nunca se ejecuta |
+| Write | `insert_record` | write | Inserta un único registro |
+| Write | `update_records` | write | Actualiza registros que coinciden con un filtro |
+| Write | `upsert_record` | write | Inserta o actualiza un único registro por clave |
+| Write | `delete_records` | destructive | Elimina registros que coinciden con un filtro |
+| Destructive | `truncate_table` | destructive | Elimina todas las filas de una tabla |
+| DDL | `create_table` | admin | Crea una tabla |
+| DDL | `alter_table` | admin_safe / admin / admin_destructive | Altera una tabla; la clasificación se calcula según el tipo de cambio |
+| DDL | `create_index` | admin | Crea un índice |
+| DDL Destructive | `drop_index` | admin_destructive | Elimina un índice |
+| DDL | `create_type` | admin | Crea un tipo definido por el usuario |
+| DDL Destructive | `drop_table` | admin_destructive | Elimina una tabla |
+| DDL Destructive | `drop_database` | admin_destructive | Elimina una base de datos |
+| Scripts | `list_scripts` | metadata | Lista los scripts guardados en el directorio de scripts |
+| Scripts | `get_script` | read | Obtiene el source de un script guardado específico |
+| Scripts | `create_script` | write | Guarda un nuevo script en el directorio de scripts |
+| Scripts | `update_script` | write | Sobrescribe un script guardado existente |
+| Scripts | `delete_script` | admin | Elimina permanentemente un script |
+| Scripts | `execute_script` | computed | Ejecuta un script guardado contra una conexión. La clasificación se deriva del cuerpo del script |
+| Approval | `request_execution` | admin | Envía una mutación para aprobación humana antes de ejecutarla |
+| Approval | `list_pending_executions` | read | Muestra todas las ejecuciones pendientes de aprobación |
+| Approval | `get_pending_execution` | read | Obtiene los detalles de una ejecución pendiente específica |
+| Approval | `approve_execution` | admin | Aprueba una mutación pendiente (solo admin) |
+| Approval | `reject_execution` | admin | Rechaza y descarta una mutación pendiente (solo admin) |
+| Audit | `query_audit_logs` | read | Busca y filtra el audit trail |
+| Audit | `get_audit_entry` | read | Obtiene una entrada específica del audit log por ID |
+| Audit | `export_audit_logs` | read | Descarga entradas del audit log como CSV o JSON |
+
+Tools diferidas (rechazadas explícitamente en tiempo de solicitud en v1):
+
+- `estimate_query_cost`
+- `get_execution_status`
+
+## 5. Clases de ejecución
+
+Las policies controlan las tools en dos niveles: el tool ID en sí y la clasificación de ejecución. Una solicitud solo se permite cuando ambos coinciden con la allowlist de la policy.
+
+| Clase | Qué cubre |
+|-------|---------------|
+| `metadata` | Inspección de schema — listar bases de datos, tablas y describir objetos |
+| `read` | Ejecutar queries de solo lectura, obtener datos y previews de solo lectura |
+| `write` | Insertar, actualizar o ejecutar scripts que modifican datos |
+| `destructive` | DELETE, DROP, TRUNCATE y otras operaciones irreversibles |
+| `admin_safe` | Operaciones DDL seguras como cambios de schema aditivos y creación de índices |
+| `admin` | Operaciones DDL riesgosas, aprobaciones, export de audit y acciones privilegiadas |
+| `admin_destructive` | Operaciones admin irreversibles, como eliminar o truncar objetos de schema |
+
+## 6. Policies y roles integrados
+
+Se incluyen tres policies y tres roles como built-ins inmutables. Siempre están presentes sin importar qué esté persistido en disco, y no pueden eliminarse ni modificarse.
+
+### Policies integradas
+
+| ID | Clases permitidas | Scope |
+|----|----------------|-------|
+| `builtin/read-only` | metadata, read | Todas las tools de discovery + schema; tools de query y preview de solo lectura; listado/get de scripts; tools de lectura de audit |
+| `builtin/write` | metadata, read, write | Todas las tools de solo lectura más los flujos de scripts con capacidad de write y de request/approval-submission |
+| `builtin/admin` | metadata, read, write, destructive, admin_safe, admin, admin_destructive | Todas las tools canónicas expuestas en esta branch |
+
+### Roles integrados
+
+| ID | Policy asignada |
+|----|----------------|
+| `builtin/read-only` | `builtin/read-only` |
+| `builtin/write` | `builtin/write` |
+| `builtin/admin` | `builtin/admin` |
+
+Los built-ins se inyectan al arranque tanto en la app GUI (`AppState`) como en el servidor MCP (a través de los loops `builtin_policies()` / `builtin_roles()` en `dbflux_mcp_server::governance`). Nunca se escriben en disco. Cualquier intento de eliminar un built-in devuelve un error.
+
+Para la mayoría de las integraciones, asigna `builtin/read-only` para empezar y escala a `builtin/write` o a una policy personalizada solo cuando el acceso de escritura sea explícitamente necesario.
+
+## 7. Configuración del operador en la GUI de DBFlux
+
+Configura la governance en la GUI de DBFlux antes de arrancar el servidor MCP.
+
+1. **Settings → MCP → pestaña Clients**
+   - Registra cada agente de IA como trusted client (`client_id` estable, nombre legible, issuer opcional).
+   - Marca los clients como activos. Los clients inactivos se deniegan en el primer gate de autorización.
+
+2. **Settings → MCP → pestaña Roles**
+   - Los roles integrados (`Read Only`, `Write`, `Admin`) aparecen arriba y no se pueden eliminar.
+   - Crea roles personalizados combinando múltiples policies con el dropdown multi-select.
+
+3. **Settings → MCP → pestaña Policies**
+   - Las policies integradas aparecen arriba y no se pueden modificar.
+   - Crea policies personalizadas activando checkboxes de tools y clases.
+
+4. **Connection Manager → pestaña MCP**
+   - Habilita MCP para la conexión objetivo.
+   - Selecciona el actor (trusted client), el role y/o la policy para esta conexión desde los dropdowns ya poblados.
+
+5. **Workspace → Pending Approvals**
+   - Revisa y aprueba/rechaza solicitudes de write/destructive que dispararon el approval path.
+
+6. **Workspace → Audit**
+   - Filtra por actor/tool/decisión/rango de tiempo y exporta CSV/JSON.
+
+El servidor MCP lee esta configuración desde disco al arrancar. Si cambias la configuración de governance en la GUI mientras el servidor está corriendo, reinícialo para que tome la nueva configuración.
+
+## 8. Archivos y rutas persistidas
+
+DBFlux persiste todo su estado en una única base de datos SQLite unificada y unos pocos directorios de soporte. Las rutas se resuelven con `dirs` (`XDG_*` en Linux, `~/Library` en macOS).
+
+Valores por defecto típicos en Linux:
+
+| Ruta | Contenido |
+|------|-----------|
+| `~/.local/share/dbflux/dbflux.db` | Base de datos unificada: profiles, auth, SSH tunnels, governance, audit events, history, sessions, estado de UI |
+| `~/.local/share/dbflux/sessions/` | Archivos de scratch y shadow para el auto-save de restauración de sesión |
+| `~/.local/share/dbflux/scripts/` | Directorio de scripts creados por el usuario |
+
+La base de datos `dbflux.db` contiene todas las tablas de dominio bajo schemas con prefijo:
+
+- `cfg_*` — config (profiles, auth, governance, services, hooks, drivers)
+- `st_*` — state (sessions, query history, estado de UI, saved queries)
+- `aud_audit_events` — audit log unificado (eventos MCP, eventos de query, conexiones, hooks, scripts)
+- `sys_*` — system (migrations, tracking de legacy import)
+
+Las policies y roles integrados se sintetizan al arrancar y nunca se escriben en disco.
+
+Importante para tests: no uses directorios reales del usuario. Pasa `--config-dir` al binario o define `HOME`/`XDG_CONFIG_HOME`/`XDG_DATA_HOME` a rutas temporales para ejecuciones aisladas. El helper `dbflux_audit::temp_sqlite_path(name)` genera rutas aisladas para tests de audit.
+
+## 9. Patrón de integración en Rust
+
+### En proceso (app GUI, `AppState`)
+
+```rust
+// Register a trusted client
+state.upsert_mcp_trusted_client(TrustedClientDto {
+    id: "agent-a".into(),
+    name: "Agent A".into(),
+    issuer: None,
+    active: true,
+})?;
+
+// Assign a built-in role to the agent on a connection
+state.save_mcp_connection_policy_assignment(ConnectionPolicyAssignmentDto {
+    connection_id: connection_id.to_string(),
+    assignments: vec![ConnectionPolicyAssignment {
+        actor_id: "agent-a".into(),
+        role_ids: vec!["builtin/read-only".into()],
+        policy_ids: vec![],
+    }],
+})?;
+```
+
+### Comprobar IDs de built-ins antes de eliminar
+
+```rust
+if dbflux_mcp::is_builtin(id) {
+    // built-ins cannot be modified or deleted
+}
+```
+
+### Llamada de autorización (usada internamente por el servidor MCP)
+
+```rust
+use dbflux_mcp::server::authorization::{AuthorizationRequest, authorize_request};
+
+let outcome = authorize_request(
+    &trusted_clients,
+    &policy_engine,
+    &audit_service,
+    &AuthorizationRequest {
+        identity: RequestIdentity { client_id: "agent-a".into(), issuer: None },
+        connection_id: connection_id.to_string(),
+        tool_id: "select_data".to_string(),
+        classification: ExecutionClassification::Read,
+        mcp_enabled_for_connection: true,
+    },
+    now_epoch_ms(),
+)?;
+
+if !outcome.allowed {
+    // deny_code and deny_reason explain why
+}
+```
+
+## 10. Checklist de integración
+
+Antes de apuntar un cliente de IA al servidor MCP:
+
+- [ ] `dbflux` compilado con soporte MCP (habilitado por defecto, o con `--features mcp`)
+- [ ] Trusted client registrado y activo en la GUI de DBFlux
+- [ ] `--client-id` pasado al binario coincide con el client registrado
+- [ ] La conexión objetivo tiene MCP habilitado
+- [ ] El actor tiene una policy assignment en esa conexión
+- [ ] La policy cubre las tools que usará el agente
+- [ ] El flujo de aprobación está entendido para cualquier tool de write/destructive
+
+## 11. Higiene de tests
+
+Para evitar contaminar las máquinas de desarrollo durante los tests:
+
+- Pasa `--config-dir` a un directorio temporal o define `HOME`/`XDG_CONFIG_HOME`/`XDG_DATA_HOME`.
+- Usa rutas SQLite temporales para tests de audit.
+- No leas/escribas `~/.config/dbflux` ni `~/.local/share/dbflux` en código de test.
+- Las policies y roles integrados están disponibles sin ninguna configuración previa — no los insertes manualmente en fixtures de test.
+- El helper `dbflux_audit::temp_sqlite_path(name)` genera una ruta aislada para cada test.
+
+## 12. Solución de problemas
+
+### El servidor se cierra inmediatamente
+
+- Falta el argumento `--client-id`.
+- El directorio de configuración es inaccesible o no se puede crear.
+
+### La solicitud se deniega como no confiable
+
+- Verifica que el client exista y esté activo en la lista de trusted clients.
+- Verifica que `--client-id` coincida exactamente con el `id` registrado (sensible a mayúsculas/minúsculas).
+
+### La solicitud se deniega porque la conexión no tiene MCP habilitado
+
+- Habilita MCP en la configuración de governance de la conexión objetivo (Connection Manager → pestaña MCP).
+- O define `mcp_enabled_by_default: true` en la configuración si quieres que todas las conexiones estén habilitadas.
+
+### Policy denegada
+
+- Confirma que el actor tiene una assignment en el scope de esa conexión.
+- Confirma que el tool ID está en las tools permitidas de la policy asignada.
+- Confirma que la clase de ejecución está en las clases permitidas de la policy.
+- Si usas `builtin/read-only`, las tools de write (`create_script`, etc.) quedan excluidas por diseño.
+
+### Aprobación atascada en pending
+
+- Revisa la cola de pending en el workspace de DBFlux y aprueba/rechaza explícitamente.
+- `approve_execution` requiere la clase `admin` — asegúrate de que la policy del aprobador la incluya.
+
+### La exportación de audit no muestra eventos
+
+- Verifica que los filtros (`actor_id`, `tool_id`, rango de tiempo, decisión) no sean demasiado restrictivos.
+- `export_audit_logs` está clasificada con la clase de ejecución `read`.
+
+### No se puede eliminar una policy o un role
+
+- Los IDs integrados (`builtin/read-only`, `builtin/write`, `builtin/admin`) no se pueden eliminar.
+- Crea una policy personalizada con un ID distinto si necesitas una variante modificable.
+
+### La configuración cambió en la GUI pero el servidor sigue usando los valores anteriores
+
+- Reinicia el proceso del servidor MCP. La governance se carga desde disco una sola vez, al arrancar.

--- a/docs/es/RELEASE.md
+++ b/docs/es/RELEASE.md
@@ -1,0 +1,304 @@
+# Proceso de Release
+
+DBFlux usa **desarrollo trunk-based con release branches de corta duración**. Un branch de larga duración (`main`) es el objetivo de integración; un branch `release/vX.Y` se crea por cada minor durante la estabilización y se descarta después de su EOL.
+
+Este documento es la referencia orientada a humanos. El skill automatizado `dbflux-release` (`skills/dbflux-release/SKILL.md`) sigue estas mismas reglas.
+
+## Canales
+
+| Canal       | Branch de origen | Patrón de tag            | Tipo de GitHub release | Construido por    |
+|-------------|-------------------|--------------------------|-------------------------|-------------------|
+| **nightly** | `main` HEAD       | `nightly` (rolling)      | prerelease               | Cron — diario      |
+| **rc**      | `release/vX.Y`    | `vX.Y.Z-rc.N`             | prerelease               | Tag push           |
+| **stable**  | `release/vX.Y`    | `vX.Y.Z`                  | published                 | Tag push           |
+
+El canal `-dev.N` está **retirado**. Nightly lo reemplaza. Los tags `-dev.N` antiguos permanecen en GitHub pero no se crean nuevos.
+
+Los íconos de aplicación por canal se rastrean en el [issue #183](https://github.com/0xErwin1/dbflux/issues/183). No los implementes aquí.
+
+## Modelo de Changelog (git-cliff, Modelo B)
+
+El changelog se **deriva del historial de git** mediante [git-cliff](https://git-cliff.org). No edites `[Unreleased]` a mano.
+
+- `cliff.toml` en la raíz del repositorio configura el generador.
+- `[Unreleased]` significa "cada commit convencional visible para el usuario desde el último tag **stable**." Los tags rc y nightly son transparentes: no cierran la ventana `[Unreleased]` (`skip_tags` en `cliff.toml`).
+- **Los mensajes de commit son fundamentales para el proceso.** Un commit `feat`, `fix` o `perf` aparece en el changelog; un commit `chore`, `ci`, `docs`, `test`, `refactor` o `style` se descarta. Los cambios relevantes de seguridad usan `fix(security):` o un footer `Security:`.
+- El bloque `[Unreleased]` se cierra **solo en stable**. Cuando se hace push de un tag stable, git-cliff renderiza el conjunto completo de commits visibles para el usuario desde el stable anterior como las release notes de ese tag.
+- No renombres `[Unreleased]` a mano al cortar un RC o un nightly. El procedimiento de corte de RC es más simple bajo este modelo — ver abajo.
+
+`CHANGELOG.md` se mantiene en el repositorio y se actualiza en el momento del release **anteponiendo** (prepending) la sección de la nueva versión con `git-cliff --prepend`. Nunca se edita a mano ni se regenera por completo — una regeneración completa (`git-cliff -o CHANGELOG.md`) colapsaría todas las secciones históricas en un único rango desde el último tag stable, destruyendo las entradas `## [0.6.0]` y `## [0.6.0-dev.N]`.
+
+> **Transición a v0.7.0:** la generación de changelog con git-cliff aplica desde v0.7.0 en adelante. Las secciones `## [0.6.0]` y `## [0.6.0-dev.N]` son baselines escritas a mano, comiteadas en `CHANGELOG.md`. Nunca deben regenerarse — hacerlo las duplicaría o colapsaría. El flujo de prepend comienza con el primer RC de v0.7.0.
+
+## Branches
+
+| Branch          | Duración   | Acepta                                            | Tags producidos            |
+|-----------------|------------|----------------------------------------------------|------------------------------|
+| `main`          | permanente | cada commit nuevo (features, fixes, refactors)     | (ninguno — nightly rolling) |
+| `release/vX.Y`  | hasta EOL  | solo fixes cherry-picked (sin features nuevas)     | `vX.Y.Z-rc.N`, `vX.Y.Z`, `vX.Y.(Z+1)` |
+
+### Reglas inviolables
+
+- Un commit **nunca** se autoriza directamente en un release branch. Siempre aterriza primero en `main`, y luego se hace `git cherry-pick -x <sha>` hacia el release branch.
+- Un release branch **nunca** se hace merge de vuelta a `main`.
+- **Sin features nuevas** en un release branch una vez creado. Solo bugfixes y los propios bumps de version-artifact del release.
+- `main` siempre está abierto para desarrollo. No se requiere una entrada manual de CHANGELOG en `main` — los mensajes de commit llevan la información.
+
+## Tags
+
+Los tags deben ser anotados:
+
+```bash
+git tag -a vX.Y.Z[-suffix.N] -m "vX.Y.Z[-suffix.N]"
+git push origin vX.Y.Z[-suffix.N]
+```
+
+El workflow de release (`.github/workflows/release.yml`) clasifica los tags automáticamente:
+
+| Patrón de tag  | Branch de origen permitido | Tipo de GitHub release |
+|-----------------|-----------------------------|--------------------------|
+| `vX.Y.Z-rc.N`   | `release/vX.Y`               | prerelease                |
+| `vX.Y.Z`        | `release/vX.Y`               | stable (published)        |
+| cualquier otro  | (red de seguridad)           | draft                     |
+
+## Reglas de Versionado
+
+La versión del workspace (`Cargo.toml` `[workspace.package].version`) es la fuente de verdad. Todos los demás manifiestos deben mantenerse sincronizados.
+
+**En `main`:**
+
+La versión del manifiesto es `X.(Y+1).0-dev.0`, donde `X.Y` es el minor que se está estabilizando actualmente en `release/vX.Y`. Este marcador se fija cuando se crea `release/vX.Y` y permanece en `main` durante toda la ventana de estabilización y más allá, hasta el siguiente corte. Es solo un marcador de desarrollo — nunca se publican releases `-dev.N`. El workflow de nightly deriva `X.(Y+1).0-nightly+<sha>` a partir de él, quitando el sufijo de pre-release y agregando `-nightly+<short-sha>`.
+
+**En `release/vX.Y`:**
+
+- Próximo RC: si el último tag es `vX.Y.Z-rc.N` → `-rc.(N+1)`. Si no hay ninguno → `-rc.0`.
+- Promover a stable: quitar el sufijo RC → `vX.Y.0`.
+- Patch: incrementar `Z` → `vX.Y.(Z+1)`. Nunca subir el minor en un release branch.
+
+## Ejemplo de Ciclo: `0.7.0`
+
+1. Las features aterrizan en `main`. No se requieren entradas manuales de changelog.
+2. Cuando está listo para estabilizar, se crea `release/v0.7` desde `main` HEAD.
+   - En `release/v0.7`: subir cada artefacto versionado a `0.7.0-rc.0`. Commit y push.
+   - En `main`: subir cada artefacto versionado a `0.8.0-dev.0`. Commit y push. `main` ahora apunta al siguiente minor.
+   - Tag `v0.7.0-rc.0` en el release branch. git-cliff renderiza el rango unreleased como el cuerpo del RC automáticamente.
+3. Se encuentra un bug durante el RC:
+   - Commitear el fix en `main`.
+   - `git cherry-pick -x <sha>` hacia `release/v0.7`.
+   - Subir a `v0.7.0-rc.1` y taggear.
+4. Cuando está limpio, subir el release branch de `v0.7.0-rc.N` a `v0.7.0`. Tag `v0.7.0`. git-cliff renderiza el rango unreleased completo (desde `v0.6.0`) como las release notes de stable.
+5. `main` ya está en `0.8.0-dev.0` — no se necesita más bump después de stable.
+6. Los patches (`v0.7.1`, `v0.7.2`, …) vienen del mismo release branch vía cherry-picks desde `main`.
+
+## Procedimiento de Corte: `main` → `release/vX.Y`
+
+1. Verifica que estás en `main`, árbol limpio, actualizado con `origin/main`.
+2. Verifica que `.github/workflows/release.yml` en `main` contiene el job `Classify release`. Si falta, arréglalo en `main` primero — de lo contrario los tags stable se publicarán como drafts.
+3. Crea el branch (usa un worktree dedicado si usas el layout de bare-repo para que `main` siga checked out):
+
+   ```bash
+   git worktree add ../release-vX.Y -b release/vX.Y main
+   # o en un repo de checkout único:
+   git checkout -b release/vX.Y
+   ```
+
+4. En `release/vX.Y`:
+   - Sube cada artefacto versionado a `X.Y.0-rc.0` (ver [Archivos a Actualizar](#archivos-a-actualizar)).
+   - Antepón la nueva sección de RC a `CHANGELOG.md`:
+
+     ```bash
+     git-cliff --tag vX.Y.0-rc.0 --unreleased --prepend CHANGELOG.md
+     git add CHANGELOG.md
+     # incorpóralo al mismo commit chore(release) que el bump de versión
+     ```
+
+     > **Advertencia:** NO uses `git-cliff -o CHANGELOG.md`. Eso regenera el archivo por completo y colapsa todas las secciones históricas desde el último tag stable en un único bloque.
+
+   - Commit: `chore(release): cut release/vX.Y at vX.Y.0-rc.0`.
+   - Push: `git push -u origin release/vX.Y`.
+
+5. De vuelta en `main`:
+   - Sube cada artefacto versionado a `X.(Y+1).0-dev.0` (main ahora apunta al siguiente minor).
+   - Commit: `chore(version): move main to X.(Y+1).0-dev.0 marker`.
+   - Push.
+
+6. Tag `vX.Y.0-rc.0` en el release branch.
+
+No hay **paso de renombre de CHANGELOG** bajo el modelo de git-cliff. El cuerpo del release RC se genera automáticamente a partir de commits convencionales.
+
+## Promoción a Stable: `release/vX.Y` → `vX.Y.0`
+
+Ejecuta esto en `release/vX.Y` cuando el RC está limpio:
+
+1. Sube cada artefacto versionado de `X.Y.0-rc.N` a `X.Y.0`.
+2. Antepón la sección stable a `CHANGELOG.md`:
+
+   ```bash
+   git-cliff --tag vX.Y.0 --unreleased --prepend CHANGELOG.md
+   git add CHANGELOG.md
+   # incorpóralo al mismo commit chore(release) que el bump de versión
+   ```
+
+   > **Advertencia:** NO uses `git-cliff -o CHANGELOG.md`. Eso regenera el archivo por completo y colapsa todas las secciones históricas desde el último tag stable en un único bloque.
+
+3. Commit: `chore(release): promote release/vX.Y to vX.Y.0`.
+4. Tag `vX.Y.0` en el release branch y push del branch + tag.
+
+git-cliff genera las release notes curadas a partir de todos los commits visibles para el usuario desde el tag stable anterior. No hay paso manual de curación de CHANGELOG.
+
+> **Curación opcional:** si quieres agregar una introducción escrita a mano o una nota editorial al cuerpo del release stable, puedes hacerlo directamente en la UI de edición de GitHub Release después de que el workflow lo publique. Esto no toca CHANGELOG.md.
+
+## Próximo Ciclo de Desarrollo
+
+`main` se sube a `X.(Y+1).0-dev.0` **cuando se crea `release/vX.Y`** (ver Procedimiento de Corte, paso 5). No se requiere más bump a `main` después del tag stable. Los builds de nightly continúan desde `main` HEAD automáticamente, produciendo `X.(Y+1).0-nightly+<sha>` durante toda la ventana de estabilización.
+
+## Archivos a Actualizar
+
+Por cada release, actualiza todos los siguientes a exactamente la misma versión:
+
+- `Cargo.toml` — `[workspace.package].version`. Los crates del workspace heredan vía `version.workspace = true`.
+- `flake.nix`
+- `resources/windows/installer.iss`
+- Revisión manual (no hereda): `examples/custom_driver/Cargo.toml`.
+
+Después de que se publican los artefactos del GitHub Release para el tag, actualiza también:
+
+- `nix/release-info.nix` — `version` + ambos `url`s y `hash`es del tarball prebuilt (ver [Nix](#nix-el-flake-de-este-repo) abajo). Este es un puntero de canal por branch. Requiere los artefactos publicados, así que aterriza como un commit de seguimiento una vez que el workflow de release termina.
+
+El `PKGBUILD` de AUR vive en un **repositorio AUR externo**, no en este repo. Solo se sube para tags stable.
+
+## Cómo Funciona Nightly
+
+`.github/workflows/nightly.yml` corre diariamente a las 03:17 UTC:
+
+1. Lee la versión del workspace desde `Cargo.toml`, quita cualquier sufijo de pre-release existente, y agrega `-nightly+<short-sha>` (p. ej. `0.8.0-nightly+abc1234` cuando `main` lleva `0.8.0-dev.0`). No se requiere commit de `Cargo.toml`. Como `main` rastrea el **siguiente** minor desde el momento en que se crea `release/vX.Y`, la versión nightly siempre está claramente por delante de la línea en estabilización.
+2. Llama a `build.yml` con `channel: nightly`.
+3. Calcula el hash SRI SHA256 de cada tarball de Linux y regenera `nix/nightly-info.nix` con los hashes reales y las URLs de release rolling.
+4. Commitea el `nix/nightly-info.nix` actualizado encima del `main` HEAD actual. Este commit **no se hace push a `main`** — se convierte en el único destino del tag `nightly`.
+5. Fuerza el movimiento del tag `nightly` al commit de pin y hace push del tag. Hacer push del tag es suficiente para que el commit sea alcanzable en el remoto; no se requiere push de branch.
+6. Publica o actualiza el GitHub prerelease rolling `nightly` con los nuevos artefactos y un cuerpo generado por git-cliff cubriendo los commits desde el último tag stable. El tag del release apunta al commit de pin, así que `nix/nightly-info.nix` en la ref `nightly` siempre coincide con los artefactos publicados.
+
+El tag nightly se fuerza (force-push) y el release se reemplaza en cada corrida. Solo el repositorio canónico (`0xErwin1/dbflux`) ejecuta el schedule.
+
+**Se salta cuando `main` no ha avanzado.** Una corrida programada primero compara el `main` HEAD actual contra el commit desde el que se construyó el último nightly (`git rev-parse nightly^`, el primer padre del commit de pin). Si coinciden, la corrida se salta por completo: sin rebuild, sin mover el tag, sin churn de release. Esto evita republicar un build idéntico bajo un hash fresco no reproducible que rompería innecesariamente los pins de Nix. Una corrida manual `workflow_dispatch` siempre construye, incluso sin commits nuevos.
+
+### Paquete Nix de Nightly
+
+El workflow fija `nix/nightly-info.nix` en la ref `nightly` en cada corrida. Los usuarios downstream obtienen el binario nightly prebuilt sin compilar desde el código fuente:
+
+```bash
+# Ejecutar nightly directamente
+nix run github:0xErwin1/dbflux/nightly#dbflux-nightly
+
+# Instalar en un perfil
+nix profile install github:0xErwin1/dbflux/nightly#dbflux-nightly
+```
+
+Un nightly desde el código fuente (sin fijación de hash requerida) también funciona:
+
+```bash
+nix run github:0xErwin1/dbflux/nightly#dbflux-source
+```
+
+**No consumas `#dbflux-nightly` desde `main`.** En `main`, `nix/nightly-info.nix` contiene hashes de placeholder que no van a fetch. Usa siempre la ref `nightly` como se muestra arriba.
+
+## Disciplina de Cherry-Pick
+
+Un release branch nunca debería contener commits ausentes en `main`, excepto commits exclusivos del release (`chore(release): ...`, `chore(version): ...`).
+
+```bash
+# En main: aterriza el fix.
+git checkout main
+# ...commit, push...
+
+# En el release branch: cherry-pick con -x para registrar el SHA de origen.
+git checkout release/vX.Y
+git cherry-pick -x <sha>
+```
+
+Auditoría: cada commit que no sea de release en `release/vX.Y` desde el branch-off debería mencionar `(cherry picked from commit ...)` en su mensaje.
+
+```bash
+git log --grep='cherry picked from' release/vX.Y
+```
+
+## Canales Downstream
+
+| Tipo de tag      | GitHub Release | AUR         | Nix flake (este repo)                          | nixpkgs (futuro) |
+|-------------------|-----------------|-------------|--------------------------------------------------|--------------------|
+| nightly           | prerelease       | skip        | auto-fijado — `#dbflux-nightly` en la ref nightly | skip              |
+| `-rc.N`           | prerelease       | skip        | sube el `release-info` del release branch + main | skip              |
+| Stable `vX.Y.Z`   | published        | bump + push | sube el `release-info` del release branch + main | bump + PR          |
+
+### AUR
+
+`pkgver` de AUR no permite `-` (reservado para `pkgrel`). Para releases stable la traducción es un no-op (`pkgver=X.Y.Z`). Para hipotéticos prereleases de AUR:
+
+- `vX.Y.Z-rc.N` → `pkgver=X.Y.Z.rc.N`
+
+### Nix (el flake de este repo)
+
+El flake expone varios paquetes en Linux (x86_64 y aarch64):
+
+| Paquete            | Qué provee                                             |
+|---------------------|-----------------------------------------------------------|
+| `dbflux` (default)  | Binario stable/rc prebuilt cuando está disponible, source en caso contrario |
+| `dbflux-bin`        | Prebuilt explícito desde `nix/release-info.nix`            |
+| `dbflux-source`     | Build desde source vía crane (todas las plataformas)       |
+| `dbflux-nightly`    | Nightly rolling prebuilt desde `nix/nightly-info.nix` (usa la ref `nightly`) |
+
+**Stable / RC (`nix/release-info.nix`):** puntero de canal por branch. `main` rastrea el tag publicado más reciente de cualquier tipo; cada `release/vX.Y` rastrea el más reciente de su propia línea. Después de que se publican los artefactos de un tag, refresca `release-info.nix` en cada branch cuyo canal ese tag hace avanzar.
+
+```bash
+ver=X.Y.Z
+for arch in amd64 arm64; do
+  hex=$(curl -fsSL "https://github.com/0xErwin1/dbflux/releases/download/v$ver/dbflux-linux-$arch.tar.gz.sha256" | awk '{print $1}')
+  nix-hash --to-sri --type sha256 "$hex"
+done
+```
+
+Actualiza `version`, ambos `url`s, y ambos `hash`es en `nix/release-info.nix`. Verifica localmente:
+
+```bash
+nix build .#dbflux-bin --no-link --print-out-paths
+```
+
+**Nightly (`nix/nightly-info.nix`):** auto-actualizado por el workflow de nightly en la ref `nightly`. No actualices este archivo manualmente. Consúmelo vía:
+
+```bash
+nix run github:0xErwin1/dbflux/nightly#dbflux-nightly
+```
+
+### nixpkgs (futuro)
+
+Aún no está en upstream. Cuando lo esté, solo los tags stable recibirán un PR a `NixOS/nixpkgs`. Convención de título de PR: `dbflux: A -> B`.
+
+## Anti-Patrones (evita esto)
+
+- Taggear `vX.Y.Z` o `vX.Y.Z-rc.N` mientras HEAD está en `main`.
+- Taggear un RC mientras HEAD está en `main`.
+- Hacer merge de `release/vX.Y` de vuelta a `main`.
+- Crear features nuevas (commits que no sean fix) en un branch `release/*`.
+- Subir el minor o major dentro de un branch `release/*`.
+- Hacer push de un tag sin un árbol de trabajo limpio.
+- Hacer push del bump de AUR con `pkgver` conteniendo un guion.
+- Cortar `release/vX.Y` desde un `main` HEAD que no contiene el job `Classify release` en `release.yml`.
+- Crear tags `-dev.N` nuevos (el canal está retirado; usa nightly en su lugar).
+
+## Validación Local Antes de Etiquetar
+
+```bash
+cargo check --workspace
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+```
+
+## Relacionado
+
+- `.github/workflows/release.yml` — lógica de clasificación y publicación de artefactos
+- `.github/workflows/nightly.yml` — build nightly diario
+- `.github/workflows/build.yml` — jobs de build reutilizables (llamados por release y nightly)
+- `.github/release-template.md` — sección de instalación agregada a cada cuerpo de release
+- `cliff.toml` — configuración de git-cliff para la generación de changelog
+- `skills/dbflux-release/SKILL.md` — skill orientado a agentes que automatiza este proceso

--- a/docs/es/RPC_SERVICES_CONFIG.md
+++ b/docs/es/RPC_SERVICES_CONFIG.md
@@ -1,0 +1,110 @@
+# Referencia de la UI de RPC Services
+
+Este archivo documenta el almacenamiento y la gestión de los RPC services en DBFlux.
+
+DBFlux ahora persiste una base de RPC services de primera clase a través de `RpcServiceKind`:
+
+- `Driver` — se adapta a drivers de base de datos en runtime
+- `AuthProvider` — se adapta a registros de auth provider en runtime, tanto en la app como en el MCP server
+
+## Almacenamiento
+
+Los RPC services se almacenan en SQLite en `~/.local/share/dbflux/dbflux.db`, no en un archivo JSON.
+
+**Tablas:**
+
+- `cfg_services` — registro principal del service (socket_id, service_kind, command, startup_timeout_ms, enabled)
+- `cfg_services.api_family`, `cfg_services.api_major`, `cfg_services.api_minor` — metadata opcional del contrato de la API RPC
+- `cfg_service_args` — argumentos de proceso ordenados
+- `cfg_service_env` — variables de entorno
+
+## Schema
+
+```sql
+-- Base table (migration 001). `service_kind` is added by migration 005 and
+-- `api_family`/`api_major`/`api_minor` by migration 006; they are shown here
+-- inline for reference but are not part of the base DDL.
+CREATE TABLE cfg_services (
+    socket_id TEXT PRIMARY KEY,
+    enabled INTEGER DEFAULT 1,
+    command TEXT,
+    startup_timeout_ms INTEGER,        -- no SQL-level default; the 5000ms
+                                       -- fallback (DEFAULT_STARTUP_TIMEOUT_MS)
+                                       -- is applied in app code
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    service_kind TEXT NOT NULL DEFAULT 'driver',  -- added by migration 005
+    api_family TEXT,                              -- added by migration 006
+    api_major INTEGER,                            -- added by migration 006
+    api_minor INTEGER                             -- added by migration 006
+);
+
+CREATE TABLE cfg_service_args (
+    id TEXT PRIMARY KEY,
+    service_id TEXT NOT NULL REFERENCES cfg_services(socket_id),
+    position INTEGER NOT NULL,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE cfg_service_env (
+    id TEXT PRIMARY KEY,
+    service_id TEXT NOT NULL REFERENCES cfg_services(socket_id),
+    key TEXT NOT NULL,
+    value TEXT NOT NULL
+);
+```
+
+## Gestión de Services
+
+Los services se gestionan a través de la UI de Settings, en la sección **RPC Services**, no editando archivos directamente.
+
+Para agregar o editar un service:
+1. Abre Settings → RPC Services
+2. Agrega un nuevo service o selecciona uno existente
+3. Elige el service kind (`Driver` o `Auth Provider`)
+4. Configura el socket ID, la ruta del command, arguments, environment variables, y el timeout
+5. Guarda los cambios
+
+Notas:
+
+- Los services `Driver` están activos en el runtime y conservan la identidad de driver existente `rpc:<socket_id>`.
+- Los services `Auth Provider` están activos únicamente en los registros de auth provider en runtime; nunca aparecen como drivers.
+- DBFlux preserva la compatibilidad de los IDs de registro de driver como `rpc:<socket_id>`.
+- Si falta la metadata de API en una fila de driver existente, DBFlux la define por defecto según el contrato `driver_rpc` actual en la versión `1.1`.
+- Si falta la metadata de API en una fila de auth-provider, DBFlux la define por defecto según el contrato `auth_provider_rpc` actual en la versión `1.2`.
+- `api_family` / `api_major` se usan como preflight de arranque para los auth providers antes de que DBFlux sondee el socket.
+
+## Semántica
+
+- `socket_id` se usa literalmente como el nombre del archivo del socket
+- DBFlux identifica internamente cada service como `rpc:<socket_id>`
+- DBFlux clasifica cada service por `service_kind` antes de la adaptación en runtime
+- El nombre/icon/category/form del driver vienen de la respuesta `Hello` del service (`driver_metadata`, `form_definition`), no de la configuración
+- Los services con `service_kind='driver'` que fallan al completar el handshake RPC (`Hello`) durante el arranque no se registran
+- Los services con `service_kind='auth_provider'` se cargan en los registros de auth provider cuando pasan los chequeos de compatibilidad y sondean exitosamente
+- La negociación del driver-path selecciona la minor version compatible mutuamente soportada más alta durante `Hello`, y luego requiere que cada envelope posterior use exactamente esa versión negociada
+- La negociación de auth-provider sigue el mismo esquema family/major/minor bajo `auth_provider_rpc`; las family o major versions incompatibles se omiten antes del registro
+
+## Campos
+
+- `socket_id` (requerido): nombre de socket local usado por DBFlux y el service.
+  - Caracteres permitidos: letras ASCII, números, `.`, `_`, `-`
+  - Los separadores de ruta, espacios, y otra puntuación se rechazan.
+  - El valor se pasa tal cual al namespace de socket de la plataforma, así que mantenlo corto y estable.
+- `command` (opcional): ejecutable a correr cuando DBFlux necesita arrancar el service.
+  - Si se omite y `args` también está vacío, DBFlux trata el service como ya corriendo y no lanza nada.
+  - Para `driver`, si se omite y `args` no está vacío, DBFlux lanza `dbflux-driver-host`.
+  - Para `auth_provider`, si DBFlux debe lanzar el service, `command` debe fijarse explícitamente.
+- `args` (opcional): argumentos del proceso.
+- `env` (opcional): variables de entorno para el proceso lanzado.
+- `startup_timeout_ms` (opcional): tiempo máximo de espera para que el socket esté listo después del spawn.
+  - Default: `5000`
+
+## Errores Comunes
+
+- Nombres de socket desalineados entre la configuración del service y los args del service
+- Ruta relativa de `command` que no se resuelve bajo el entorno del proceso de DBFlux
+- Editar la base de datos directamente en lugar de a través de la UI de Settings
+- El service no implementa los campos requeridos de `Hello` para la versión actual del protocolo RPC
+- Omitir `command` mientras se proveen `args` parciales; si quieres que DBFlux lance el host por defecto, `args` debe incluir tanto `--driver` como `--socket`.
+- Configurar un service de auth-provider con `args` pero sin `command`; DBFlux rechazará ese launch config en lugar de asumir el driver host

--- a/docs/es/SETTINGS.md
+++ b/docs/es/SETTINGS.md
@@ -1,0 +1,279 @@
+# Settings y Hooks de Conexión
+
+Una referencia para cada sección de Settings y para los connection hooks — los
+comandos, scripts o snippets de Lua que DBFlux ejecuta alrededor del ciclo de
+vida de una conexión.
+
+Abre Settings desde la command palette (**Open Settings**) o desde la barra
+lateral. La ventana está organizada en secciones a lo largo del lado
+izquierdo.
+
+| Sección | Cubre |
+|---------|-------|
+| [General](#general) | Comportamiento a nivel de app: theme, inicio, refresh, seguridad de queries. |
+| [Audit](#auditoría) | Qué captura el audit log y cuánto tiempo se conserva. |
+| [Keybindings](#atajos-de-teclado) | Explora el keymap (solo lectura). |
+| [Auth Profiles](#auth-profiles-proxies-túneles-ssh) | Perfiles AWS SSO / shared-credentials. |
+| [Proxies](#auth-profiles-proxies-túneles-ssh) | Perfiles de proxy SOCKS5 / HTTP. |
+| [SSH Tunnels](#auth-profiles-proxies-túneles-ssh) | Perfiles reutilizables de túnel SSH. |
+| [Services](#servicios-rpc) | Drivers RPC externos y auth providers. |
+| [Hooks](#hooks-de-conexión) | Definiciones reutilizables de connection hooks. |
+| [Drivers](#drivers) | Overrides y ajustes por driver. |
+
+Las secciones relacionadas con MCP (Clients, Roles, Policies) aparecen solo
+cuando el binario se construye con el feature `mcp`; ver
+[AI + MCP Integration](MCP_AI_INTEGRATION.md).
+
+---
+
+## General
+
+### Apariencia
+
+| Setting | Opciones | Default |
+|---------|----------|---------|
+| **Theme** | Dark, Mirage, Light | Dark |
+| **Style** | Default, Compact | Default |
+| **Language** | System, English, Spanish | System |
+
+System sigue el locale de tu sistema operativo y recurre a English cuando ese
+locale no está soportado. Un cambio de idioma tiene efecto después de
+reiniciar DBFlux, por lo que el control muestra una nota permanente al
+respecto. Este release solo traduce la sección General; el resto de la UI se
+está convirtiendo crate por crate y permanece en English por ahora.
+
+### Inicio y sesión
+
+| Setting | Default | Qué hace |
+|---------|---------|----------|
+| **Restore session on startup** | On | Reabre las tabs que tenías abiertas la última vez. |
+| **Reopen last connections** | Off | Reconecta a las conexiones que estaban activas. |
+| **Default focus** | Sidebar | Dónde cae el focus al iniciar (Sidebar o la última tab). |
+| **Max history entries** | 1000 | Tope del historial de queries (mínimo 10). |
+| **Auto-save interval (ms)** | 2000 | Cada cuánto se auto-guardan los buffers del editor (mínimo 500). |
+
+### Actualización y segundo plano
+
+| Setting | Default | Qué hace |
+|---------|---------|----------|
+| **Default refresh policy** | Manual | Manual o Interval auto-refresh para las data views. |
+| **Default refresh interval (seconds)** | 5 | Intervalo usado cuando la policy es Interval (mínimo 1). |
+| **Max concurrent background tasks** | 8 | Tope de trabajo simultáneo en segundo plano (mínimo 1). |
+| **Pause auto-refresh on error** | On | Detiene el auto-refresh de una view después de que falla. |
+| **Auto-refresh only if tab is visible** | Off | Se salta el refresh de las tabs que no estás mirando. |
+
+### Seguridad de ejecución (confirmación de queries peligrosas)
+
+Estos tres settings gobiernan cómo DBFlux trata las queries riesgosas en
+**todos** los drivers y query languages. No hay un toggle por base de datos —
+las mismas reglas aplican a `DELETE`/`DROP`/`TRUNCATE` de SQL,
+`deleteMany`/`drop` de MongoDB, `FLUSHALL`/`FLUSHDB` de Redis, etc.
+
+| Setting | Default | Qué hace |
+|---------|---------|----------|
+| **Confirm dangerous queries** | On | Muestra una confirmación antes de ejecutar una query peligrosa. Desactívalo para permitirlas sin preguntar. |
+| **Require WHERE for DELETE/UPDATE** | On | Trata un `DELETE`/`UPDATE` sin `WHERE` como peligroso. |
+| **Always require preview (ignore suppressions)** | Off | Fuerza el modal de confirmación/preview incluso para queries que anteriormente elegiste dejar de confirmar. |
+
+### Almacenamiento (solo builds Nightly)
+
+| Setting | Default | Qué hace |
+|---------|---------|----------|
+| **Use the stable database** | Off | Hace que un build Nightly comparta el `dbflux.db` stable en lugar de `dbflux-nightly.db`. Aplica en el próximo inicio. |
+
+Ver [Data & Privacy](DATA_AND_PRIVACY.md#data-locations) para cómo se separan
+las bases de datos Nightly y stable.
+
+---
+
+## Audit
+
+La sección Audit controla el audit log unificado. El control principal
+orientado al usuario es **Log Capture → Minimum Level** (trace / debug / info
+/ warn / error), que determina cuánto del logging interno de DBFlux se pliega
+en el audit trail. Guardar tiene efecto sin reiniciar.
+
+La retention (cuánto tiempo se conservan los eventos) impulsa un purge
+periódico en segundo plano cuando está configurada. Para la experiencia
+diaria de audit — abrir el viewer, filtrar, exportar — ver
+[Dashboards & Audit](DASHBOARDS_AND_AUDIT.md#audit-viewer). Para el schema
+completo de eventos y el comportamiento de redaction ver
+[Audit](AUDIT.md) y [Data & Privacy](DATA_AND_PRIVACY.md#audit-and-privacy).
+
+---
+
+## Keybindings
+
+Esta sección es un **viewer de solo lectura**. Lista el keymap activo
+agrupado por contexto, con un filtro de texto y advertencias inline cuando un
+chord está vinculado a más de un comando. Actualmente **no** te permite
+rebind ni guardar shortcuts personalizados desde la UI. Úsala para descubrir
+y verificar bindings; el keymap por defecto completo está documentado en
+[Usage → Keyboard Reference](USAGE.md#7-keyboard-reference).
+
+---
+
+## Auth Profiles, Proxies, Túneles SSH
+
+Estas tres secciones gestionan los perfiles reutilizables que luego
+seleccionas por conexión en la pestaña Access. Están documentadas en
+detalle — campos, flujo AWS SSO, reglas de no-proxy, métodos de auth SSH —
+en [Connecting to a Database → Advanced Setup](CONNECTIONS.md):
+
+- [Auth Profiles](CONNECTIONS.md#auth-profiles-aws-sso-and-shared-credentials)
+- [Proxies](CONNECTIONS.md#proxies)
+- [SSH Tunnels](CONNECTIONS.md#ssh-tunnels)
+
+Las credenciales que ingresas aquí se guardan en el keyring de tu sistema
+operativo, no en la base de datos. Ver
+[Data & Privacy → Secrets](DATA_AND_PRIVACY.md#secrets-and-the-os-keyring).
+
+---
+
+## Servicios (RPC)
+
+Los drivers externos y los auth providers corren como procesos separados con
+los que DBFlux se comunica a través de un socket local. Cada service que
+agregas aquí tiene:
+
+| Campo | Notas |
+|-------|-------|
+| **Socket ID** | Identificador único, usado como nombre del archivo del socket. Solo letras ASCII, dígitos, `.`, `_`, `-`. |
+| **Command** | El ejecutable a lanzar (opcional para algunas configuraciones). |
+| **Startup Timeout (ms)** | Cuánto esperar a que el proceso arranque. Default 5000. |
+| **Service Type** | **Driver** o **Auth Provider**. |
+| **Enable this service** | Si el service arranca. Default on. |
+| **Arguments** | Argumentos ordenados del proceso. |
+| **Environment Variables** | Pares `KEY=value` pasados al proceso. |
+
+Los cambios aquí **tienen efecto en el próximo inicio**. Referencia completa:
+[RPC Services Config](RPC_SERVICES_CONFIG.md) y el
+[Driver RPC Protocol](DRIVER_RPC_PROTOCOL.md).
+
+---
+
+## Drivers
+
+Elige un driver para ver y sobrescribir su comportamiento. Dos grupos son
+editables:
+
+**Global overrides** — versiones por driver de los settings de General. Cada
+uno es un tri-state (Inherit / On / Off, o un valor explícito); dejarlo en
+*Inherit* usa el default de General mostrado junto al control:
+
+- Refresh policy e interval
+- Confirm dangerous queries
+- Require WHERE
+- Require preview
+
+**Driver settings** — opciones definidas por el propio driver (renderizadas
+de forma genérica a partir del schema del driver, así que los campos
+disponibles dependen del driver).
+
+La sección también muestra, en solo lectura, la **capability matrix**, la
+category, y el query language del driver.
+
+---
+
+## Hooks de Conexión
+
+Los hooks son comandos, scripts o snippets de Lua reutilizables que corren
+alrededor del ciclo de vida de una conexión. Los **defines** globalmente en
+**Settings → Hooks**, y luego los **vinculas** a fases en conexiones
+individuales en la pestaña **Hooks** del Connection Manager.
+
+### Camino rápido
+
+1. **Settings → Hooks → agrega un hook.** Dale un **Hook ID**, elige un
+   **Type**, y completa el command/script.
+2. Abre una conexión en **Connection Manager → Hooks tab**.
+3. Selecciona tu hook en uno de los cuatro dropdowns de fase (Pre-connect,
+   Post-connect, Pre-disconnect, Post-disconnect).
+4. Conecta. La salida del hook se transmite al panel de **Tasks**.
+
+### Tipos de Hook
+
+| Type | Qué ejecuta | Qué proporcionas |
+|------|-------------|-------------------|
+| **Command** | Un ejecutable | Un comando y argumentos separados por espacios. |
+| **Script** | Un archivo Bash o Python | Un lenguaje, una ruta de archivo, y un override opcional del interpreter (en blanco = `bash` / `python3`, ajustado según la plataforma). |
+| **Lua** | Un script Lua in-process | Una ruta de archivo y un conjunto de capabilities (ver abajo). Lua corre dentro de DBFlux — sin interpreter externo. |
+
+Los scripts se editan en el editor de DBFlux y se guardan por defecto bajo
+una carpeta `hooks/`.
+
+#### Capacidades de Lua
+
+Un hook de Lua solo obtiene las habilidades que habilitas:
+
+| Capability | Default | Otorga |
+|------------|---------|--------|
+| **Logging** | On | Escribir en la salida del hook. |
+| **Environment read** | On | Leer variables de entorno. |
+| **Connection metadata** | On | Leer la metadata del perfil que se está conectando. |
+| **Controlled process run** | Off | Llamar a `dbflux.process.run(...)` para lanzar procesos externos. |
+
+> Habilitar **Controlled process run** permite que el hook ejecute comandos
+> externos arbitrarios. DBFlux muestra una advertencia de seguridad cuando
+> está activado, tanto en la definición del hook como en el binding por
+> conexión. Habilítalo solo para hooks en los que confíes.
+
+El runtime de Lua embebido (APIs disponibles, sandboxing) está documentado en
+[Lua Scripting](LUA.md).
+
+### Opciones de Hook
+
+| Option | Notas |
+|--------|-------|
+| **Enabled** | Los hooks deshabilitados se omiten. |
+| **Working Directory** | El cwd del process/script (no usado por Lua). |
+| **Environment** | Pares extra `KEY=value`. |
+| **Inherit parent environment** | On por defecto; pasa el env de DBFlux al hook. |
+| **Env Denylist** | Nombres de variables a quitar del env heredado. |
+| **Timeout (ms)** | En blanco = sin timeout. Al hacer timeout se mata el process group. |
+| **Execution mode** | **Blocking** (default) espera al hook; **Detached** corre en segundo plano y no bloquea connect/disconnect. |
+| **Ready signal** (Detached) | Texto que DBFlux espera en la salida del hook antes de continuar. |
+| **On Failure** | La failure policy — ver abajo. |
+
+DBFlux siempre inyecta variables de entorno de contexto en los hooks de
+proceso: `DBFLUX_PROFILE_ID`, `DBFLUX_PROFILE_NAME`, `DBFLUX_DB_KIND`, y,
+cuando se conocen, `DBFLUX_HOST`, `DBFLUX_PORT`, `DBFLUX_DATABASE`.
+
+> **Los secrets nunca se filtran accidentalmente a los hooks.** Además de tu
+> Env Denylist, DBFlux siempre quita las variables heredadas cuyo nombre
+> contiene `SECRET`, `TOKEN`, `PASSWORD`, o `_KEY`, y cualquier variable
+> `AWS_*`.
+
+### Políticas de fallo
+
+Qué pasa cuando un hook falla (exit distinto de cero, timeout, o error):
+
+| Policy | Efecto |
+|--------|--------|
+| **Disconnect** (default) | Aborta la fase — el flujo de connect o disconnect se detiene. |
+| **Warn** | Continúa, pero muestra una advertencia. |
+| **Ignore** | Continúa; el fallo solo se registra en el log. |
+
+### Fases
+
+| Phase | Corre |
+|-------|-------|
+| **Pre-connect** | Antes de que la conexión se abra. |
+| **Post-connect** | Después de un connect exitoso. |
+| **Pre-disconnect** | Antes de desconectar. |
+| **Post-disconnect** | Después de desconectar. |
+
+La pestaña Hooks de una conexión tiene un dropdown por fase (más un input
+"Extra" para vincular hook IDs adicionales). Los dropdowns listan los hooks
+reutilizables que definiste en Settings → Hooks. Cada hook corre como su
+propia background task con stdout/stderr en vivo en el panel Tasks; la salida
+tiene un tope de 4 MiB por hook.
+
+---
+
+## Relacionado
+
+- [Usage Guide](USAGE.md) — flujo principal y referencia de teclado.
+- [Connecting → Advanced Setup](CONNECTIONS.md) — SSH, proxy, auth, fuentes de valores.
+- [Data & Privacy](DATA_AND_PRIVACY.md) — dónde se almacenan los settings y secrets.
+- [Lua Scripting](LUA.md) — el runtime de Lua embebido para hooks.

--- a/docs/es/drivers/clickhouse.md
+++ b/docs/es/drivers/clickhouse.md
@@ -1,0 +1,65 @@
+# ClickHouse
+
+Base de datos analítica orientada a columnas sobre HTTP.
+
+## De un vistazo
+
+- **Categoría** — Relacional
+- **Lenguaje de query** — SQL
+- **Puerto por defecto** — 8123
+- **Esquema de URI** — `http`
+
+## Conexión
+
+El driver habla la interfaz HTTP de ClickHouse en lugar del protocolo nativo, así que
+el endpoint es una URL y no un par host/port.
+
+| Campo | Por defecto | Notas |
+|---|---|---|
+| URL HTTP | `http://localhost:8123` | los endpoints `https://` se sirven a través de rustls |
+| Database | `default` | delimita el descubrimiento de schema y las queries sin calificar |
+| Timeout de request | `30` segundos | debe ser mayor que cero |
+| Usuario | `default` | |
+| Contraseña | — | se guarda en el keyring del sistema operativo y se envía como HTTP Basic auth |
+
+## Funcionalidades
+
+- Transporte HTTP(S) bloqueante construido sobre rustls, autenticando con HTTP Basic.
+- SQL arbitrario de un solo statement, con respuestas forzadas a `JSONCompact` para que
+  los nombres y tipos de columna lleguen junto con las filas.
+- El ancho de fila se verifica contra el número de columnas declaradas en cada respuesta, así
+  que una respuesta malformada falla con un error claro en lugar de desplazar valores entre columnas.
+- Descubrimiento de schema desde `system.databases`, `system.tables` y `system.columns`:
+  databases, tables, views, columns, engine, sorting y partition keys, tamaño en disco
+  y compresión.
+- La carga de schema es perezosa por database, así que un servidor con muchas databases no paga
+  el costo de todas ellas al conectar.
+- Paginación, ordenamiento y filtrado se aplican por el driver como `LIMIT`/`OFFSET`
+  alrededor del statement, que es lo que hace funcionar el browsing de resultados sin un cursor.
+- Generación de SELECT visual de solo lectura, usando las reglas de quoting de identificadores y literales de ClickHouse.
+- Creación de gráficos a partir de resultados de queries, y exportación a CSV y JSON.
+
+### Manejo de tipos
+
+Los valores se decodifican de forma recursiva, así que un `Map(String, Array(Nullable(Decimal256)))`
+llega completamente estructurado en lugar de como texto crudo:
+
+- Wrappers — `Nullable`, `LowCardinality`
+- Contenedores — `Array`, `Tuple`, `Map`, `Nested`
+- Números — enteros hasta `UInt256`, `Decimal256`, `BFloat16`, `Bool`
+- Tiempo — `Date32`, `DateTime64`
+- Otros — `Enum16`, `Nothing`
+
+## Limitaciones
+
+- Sin túneles SSH.
+- Sin transacciones, prepared statements ni cancelación de query. Un statement en ejecución
+  está acotado únicamente por el timeout de request, y el driver no reporta soporte de lock-timeout.
+- Sin soporte estructurado de `INSERT`, `UPDATE`, `DELETE`, DDL ni transferencia de datos. El SQL de
+  escritura solo se ejecuta cuando se escribe explícitamente en el editor, así que la grilla es de solo lectura y
+  el driver no es un destino de transferencia.
+- Un statement SQL por request; los scripts multi-statement no se procesan por lotes.
+- Los cuerpos de respuesta HTTP están limitados a 128 MiB.
+- Las zonas horarias con nombre de ClickHouse no se interpretan del lado del cliente. Los timestamps ISO
+  con un offset se manejan correctamente; los timestamps sin uno se tratan
+  como UTC.

--- a/docs/es/drivers/cloudwatch.md
+++ b/docs/es/drivers/cloudwatch.md
@@ -1,0 +1,42 @@
+# CloudWatch Logs
+
+Queries de AWS CloudWatch Logs Insights con source context gestionado por el editor.
+
+## De un vistazo
+
+- **Categoría** — Log stream
+- **Lenguaje de query** — Logs Insights (modo editor SQL)
+- **Esquema de URI** — `cloudwatch`
+
+Driver de AWS CloudWatch Logs para DBFlux, construido sobre el SDK [`aws-sdk-cloudwatchlogs`](https://crates.io/crates/aws-sdk-cloudwatchlogs).
+
+## Funcionalidades
+
+- Driver de log-streaming clasificado como `DatabaseCategory::LogStream`; `deployment_class` es `CloudManaged`. Las capacidades declaradas son `AUTHENTICATION` y `METRIC_SERIES`.
+- Configuración de conexión AWS vía región, perfil con nombre y override de endpoint opcional, alineado con el flujo de conexión AWS de DynamoDB.
+- Ejecución de queries a través de `StartQuery` + polling de `GetQueryResults` (intervalo de polling de 500 ms, hasta 120 intentos), con un source context gestionado por el editor que provee los log groups objetivo y el rango de tiempo.
+- Tres sintaxis de query seleccionables desde el desplegable "Syntax" del source context:
+  - CloudWatch Logs Insights QL (`cwli`, la opción por defecto) — `QueryLanguage::CloudWatchLogsInsightsQl`.
+  - OpenSearch PPL (`ppl`) — `QueryLanguage::OpenSearchPpl`.
+  - OpenSearch SQL (`sql`) — `QueryLanguage::OpenSearchSql`.
+  Estas se mapean a los valores de lenguaje de query `Cwli`, `Ppl` y `Sql` del SDK.
+- El spec de source context (`SourceContextSpec`) expone un selector de objetivo "Log groups" y controles de rango de tiempo Start/End; las queries CWLI y PPL pasan los log groups seleccionados a `StartQuery` vía `set_log_group_names`.
+- El descubrimiento de schema enumera log groups (`fetch_log_groups`) como la única database lógica (`SchemaLoadingStrategy::SingleDatabase`, database por defecto `logs`).
+- Los log streams se exponen como hijos de collection paginados (`collection_children` sobre `fetch_log_stream_page`) y se abren como event streams (`CollectionPresentation::EventStream`).
+- Browsing de event streams (`browse_event_stream` / `EventStreamTarget`) respaldado por `FilterLogEvents`, con una ventana de browse por defecto de 24 horas y soporte para patrón de filtro, prefijo de nombre de stream, nombres de stream explícitos y un toggle de "más reciente".
+- Los nombres de columna de Insights se clasifican en `ColumnKind`s semánticos (p. ej. `@timestamp`, `@ingestionTime` reconocidos como timestamps) para la auto-detección de gráficos.
+- CloudWatch Metrics vía `GetMetricData`: ejecuta un único `MetricDataQuery` por request, mapea la respuesta a un `QueryResult` de dos columnas (timestamp, value) ordenado ascendentemente por timestamp. Los timestamps de AWS (precisión de segundos) se convierten a milisegundos. Se soporta el pivot multi-métrica a formato ancho cuando se devuelven múltiples entradas `MetricDataResult`.
+- Explorar el catálogo de métricas de CloudWatch (namespaces y métricas por namespace con combinaciones de dimensiones) vía paginación de `ListMetrics`. El listado de namespaces se sintetiza barriendo `ListMetrics` sin filtro y recolectando cadenas de namespace distintas. Los resultados se cachean en la sesión mediante `MetricCatalogCache`.
+- El catálogo de métricas se puede explorar desde el árbol de la barra lateral de conexión (Metrics > Namespace > Metric). Hacer clic en una métrica hoja abre un gráfico pre-poblado con valores por defecto (Average / período de 5 min / agregado entre todas las dimensiones) y lo ejecuta de inmediato. El panel lateral (picker rail) en el documento de gráfico permite refinar dimensiones, período y estadística.
+
+## Limitaciones
+
+- El campo `profile` (perfil con nombre de AWS) es un campo de formulario `AuthProfileRef`. El seam genérico de portabilidad (`DbDriver::export_field_hint`) mapea todos los campos `AuthProfileRef` a `RequiredOnImport`, así que el valor del campo se omite de cualquier bundle exportado y los destinatarios deben suministrar o crear un auth profile coincidente al momento de importar. No se requiere ningún override específico del driver.
+- La cancelación de query no está implementada; `cancel()` devuelve `NotSupported`.
+- El modo OpenSearch SQL no recibe log groups externos: las queries SQL deben declarar sus log groups consultados en el propio texto SQL, porque la API de CloudWatch no acepta parámetros de log group externos para el modo SQL (solo CWLI y PPL reciben `set_log_group_names`).
+- El resaltado de sintaxis del editor permanece genérico (`query_language` se reporta como `Sql` a nivel de metadata); la selección de modo dirige la semántica de ejecución y las palabras clave de completado en lugar del resaltado por modo.
+- Solo lectura: no se declaran capacidades de mutación, DDL, transacción ni paginación (`query`, `mutation`, `ddl`, `transactions`, `limits` son todos `None`); `schema_features` está vacío.
+- Sin formulario SSL (TLS es manejado por el transporte del SDK de AWS).
+- La ejecución de métricas soporta un único `MetricDataQuery` por request por llamada.
+- La síntesis del listado de namespaces (barriendo `ListMetrics` sin filtro) puede ser lenta para cuentas de AWS grandes con muchas métricas; se cachea para la sesión una vez completada. El barrido está limitado a 50 páginas (~25.000 métricas) para acotar el peor caso en cuentas muy grandes. Cuando se alcanza el límite, el listado de namespaces se trunca en silencio y se registra una advertencia; un cambio futuro reemplazará el límite con infraestructura completa de timeout + cancelación.
+- Las pruebas de integración en vivo para métricas (`live_execute_cloudwatch_metric`) requieren credenciales reales de AWS y están marcadas `#[ignore]` por defecto. LocalStack Community no soporta la API de CloudWatch Metrics.

--- a/docs/es/drivers/dynamodb.md
+++ b/docs/es/drivers/dynamodb.md
@@ -1,0 +1,38 @@
+# DynamoDB
+
+Base de datos NoSQL clave-valor y de documentos gestionada por AWS.
+
+## De un vistazo
+
+- **Categoría** — Documento
+- **Lenguaje de query** — Expresiones DynamoDB
+- **Esquema de URI** — `dynamodb`
+
+Driver de AWS DynamoDB para DBFlux, construido sobre el SDK [`aws-sdk-dynamodb`](https://crates.io/crates/aws-sdk-dynamodb).
+
+## Funcionalidades
+
+- Driver NoSQL gestionado clasificado como `DatabaseCategory::Document` con un envelope de comandos `QueryLanguage::Custom("DynamoDB")`; el editor usa una sintaxis específica de DynamoDB, no SQL.
+- Configuración de conexión AWS vía región, perfil con nombre y override de endpoint opcional (para DynamoDB Local o endpoints VPC). `deployment_class` es `CloudManaged`.
+- Descubrimiento de tables con `ListTables` y `DescribeTable`, mapeando la metadata de clave de partition key (PK), sort key (SK) y Global/Local Secondary Index (GSI/LSI) a las abstracciones de schema de DBFlux.
+- Ejecución nativa de envelope de comandos para `scan`, `query`, `put`, `update` y `delete`. El generador de queries emite envelopes de vista previa con forma de scan y anota que la ejecución puede optimizarse a `Query` cuando el filtro coincide con el key schema de la table.
+- Opciones de lectura para el direccionamiento de índices, control de lectura consistente y una política de fallback de traducción de filtros (filtro del lado del servidor vs. fallback del lado del cliente; el filtrado del lado del cliente se rechaza cuando la política de fallback está configurada para rechazar).
+- Operadores WHERE en filtros semánticos: `Eq`, `Ne`, `Gt`, `Gte`, `Lt`, `Lte`, `In`, `NotIn`, y el lógico `And`/`Or` (ver Limitaciones para `Not`).
+- Mutaciones: insert (`put`), update y delete (`INSERT`/`UPDATE`/`DELETE`). Las escrituras por lotes soportan hasta 25 items (`max_insert_values: 25`, `supports_batch: true`) con reintento acotado para items de batch-write no procesados.
+- Soporte de upsert de un solo item vía un update condicional con fallback a put; el mapa de clave se resuelve desde el filtro o el payload de update (partition key requerida, sort key requerida cuando la table define una).
+- Ruta de update multi-item (`update` con `many=true`) usando una expresión de update compartida.
+- Documentos anidados y arrays mapeados a la vista de árbol de documentos (`NESTED_DOCUMENTS`, `ARRAYS`).
+- DDL: drop table (`supports_drop_table: true`).
+- Paginación vía page tokens (`PaginationStyle::PageToken`).
+
+## Limitaciones
+
+- El campo `profile` (perfil con nombre de AWS) es un campo de formulario `AuthProfileRef`. El seam genérico de portabilidad (`DbDriver::export_field_hint`) mapea todos los campos `AuthProfileRef` a `RequiredOnImport`, así que el valor del campo se omite de cualquier bundle exportado y los destinatarios deben suministrar o crear un auth profile coincidente al momento de importar. No se requiere ningún override específico del driver.
+- La cancelación de query no está soportada; el driver devuelve `NotSupported` para las solicitudes de cancelación.
+- La API de envelope de comandos no expone PartiQL ni operaciones de transacción de DynamoDB; las transacciones están deshabilitadas (`supports_transactions: false`).
+- El upsert de un solo item está soportado (`supports_upsert: true`); `update` con `many=true` y `upsert=true` juntos se rechaza (`update_many_with_upsert`).
+- El update masivo y el delete masivo no están soportados (`supports_bulk_update: false`, `supports_bulk_delete: false`), y `RETURNING` no está soportado.
+- Los filtros semánticos no soportan expresiones `NOT` ni operadores fuera del conjunto soportado; los operadores no soportados devuelven `NotSupported`.
+- Sin formulario SSL (TLS es manejado por el transporte del SDK de AWS), sin schemas, y sin DDL más allá de drop-table (sin creación/alteración de table, sin creación de índices).
+- Las requests de agregación no están soportadas por el planificador semántico.
+- El browsing de collections en la capa de request del núcleo permanece basado en offset, mientras que la API subyacente está basada en page-token.

--- a/docs/es/drivers/influxdb.md
+++ b/docs/es/drivers/influxdb.md
@@ -1,0 +1,87 @@
+# InfluxDB
+
+Base de datos de series temporales InfluxDB v1 y v2, con soporte de queries InfluxQL y Flux.
+
+## De un vistazo
+
+- **Categoría** — Series temporales
+- **Lenguaje de query** — InfluxQL / Flux
+- **Puerto por defecto** — 8086
+- **Esquema de URI** — `http`
+
+Driver de InfluxDB para DBFlux.
+
+## Funcionalidades
+
+- **Categoría de series temporales** — clasificado como `DatabaseCategory::TimeSeries` con `QueryLanguage::InfluxQuery` como lenguaje de editor por defecto. Las capacidades declaradas son `AUTHENTICATION`, `MULTIPLE_DATABASES`, `PAGINATION`, `EXPORT_CSV` y `EXPORT_JSON`. Las conexiones usan el esquema de URI `http` en el puerto por defecto 8086, con TLS provisto por el cliente HTTP basado en rustls.
+- **InfluxDB v1 y v2** — ambas versiones de la API se soportan en un único crate de driver.
+- **InfluxQL en ambas versiones** — el lenguaje de query de v1 funciona en v1 y a través del endpoint de compatibilidad de v2.
+- **Flux en v2** — las queries Flux están disponibles cuando la conexión está configurada para v2.
+- **Bucket por defecto opcional** — el campo bucket (v2) o database (v1) del perfil de conexión es opcional. Un token de API de v2 da acceso a todos los buckets de la organización; un usuario de v1 da acceso a todas las databases del servidor. Dejar el campo vacío permite al usuario seleccionar un bucket por query desde el desplegable de source-context en el editor. Configurarlo pre-selecciona ese bucket sin restringir el acceso a los demás.
+- **Enrutamiento de bucket por query** — el bucket usado en cada query InfluxQL viene de la selección del desplegable de source-context, no del perfil de conexión. Para queries Flux, el bucket va incrustado en el propio texto de la query (`from(bucket: "...")`).
+- **Ping sin bucket** — la verificación de disponibilidad de la conexión no requiere un bucket: v1 usa `SHOW DATABASES` contra la database interna; v2 obtiene `/api/v2/buckets?limit=1`.
+- **Macros de rango de tiempo** — las queries InfluxQL y Flux soportan tokens de macro compatibles con Grafana que se sustituyen por la ventana de rango de tiempo vinculada antes de enviar la query al driver:
+
+  | Token | Lenguaje | Expansión |
+  |---|---|---|
+  | `$timeFilter` | InfluxQL | `time >= 'RFC3339_start' AND time <= 'RFC3339_end'` |
+  | `$__from` | InfluxQL | `'RFC3339_start'` |
+  | `$__to` | InfluxQL | `'RFC3339_end'` |
+  | `v.timeRangeStart` | Flux | `'RFC3339_start'` |
+  | `v.timeRangeStop` | Flux | `'RFC3339_end'` |
+
+  Estos tokens coinciden con las convenciones de variables de Grafana (`$timeFilter` para InfluxQL, `v.timeRangeStart`/`v.timeRangeStop` para Flux). Los usuarios familiarizados con Grafana deberían encontrar la sintaxis intuitiva.
+
+  Formato RFC3339: `YYYY-MM-DDTHH:MM:SSZ` (UTC, precisión de segundos, sufijo Z).
+
+  **Ejemplo InfluxQL** — usando `$timeFilter`:
+
+  ```influxql
+  -- Typed:
+  SELECT mean(usage_user) FROM cpu WHERE $timeFilter GROUP BY time(1m)
+
+  -- Executed (window = 2026-05-20T00:00:00Z to 2026-05-22T23:59:00Z):
+  SELECT mean(usage_user) FROM cpu WHERE time >= '2026-05-20T00:00:00Z' AND time <= '2026-05-22T23:59:00Z' GROUP BY time(1m)
+  ```
+
+  **Ejemplo Flux** — usando `v.timeRangeStart` / `v.timeRangeStop`:
+
+  ```flux
+  -- Typed:
+  from(bucket: "telegraf")
+    |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+    |> filter(fn: (r) => r._measurement == "cpu")
+
+  -- Executed (same window):
+  from(bucket: "telegraf")
+    |> range(start: '2026-05-20T00:00:00Z', stop: '2026-05-22T23:59:00Z')
+    |> filter(fn: (r) => r._measurement == "cpu")
+  ```
+
+  **Las macros requieren una ventana vinculada** — si la query contiene tokens de macro pero no hay un rango de tiempo definido (es decir, el panel de source-context no tiene selección), las macros pasan al driver sin sustituir. InfluxDB devolverá un error de parseo, ya que `$timeFilter`, etc. no son sintaxis InfluxQL/Flux válida.
+
+  **Las macros suprimen la inyección automática** — cuando una query contiene alguno de los tokens de macro reconocidos, la inyección automática de ventana de tiempo (ver abajo) se suprime. La sustitución de macro se trata como el límite de tiempo autoritativo del usuario.
+
+  **Limitación conocida en v1 (sustitución de subcadena ingenua)** — los tokens de macro dentro de literales de cadena entrecomillados o comentarios también se sustituyen. No hay sintaxis de escape en v1. Para Flux, una variable cuyo nombre simplemente comience con `v.timeRangeStart` o `v.timeRangeStop` (p. ej. `v.timeRangeStartCustom`) también se sustituirá. Se planea una tokenización adecuada para una versión futura.
+
+- **Inyección automática de ventana de tiempo** — cuando se establece un rango de tiempo a través del panel de source context y la query aún no contiene un predicado de tiempo (`time >=`, etc. para InfluxQL, `|> range(` para Flux), el driver inyecta los límites automáticamente. Este comportamiento se suprime cuando la query contiene tokens de macro de rango de tiempo explícitos.
+- **Mensajes de error estructurados** — los errores del lado del servidor se parsean desde el campo JSON `{"error": "..."}` en lugar de mostrarse como códigos de estado HTTP crudos.
+- **Exportación a CSV y JSON** — los resultados de las queries se pueden exportar a través del pipeline de exportación estándar de DBFlux.
+- **Emisión de auditoría** — todas las queries se rastrean a través del sink de auditoría estándar de DBFlux. El campo de metadata `bucket_or_database` registra el bucket real usado en cada query, no el valor por defecto del perfil.
+- **InfluxQL multi-statement** — cuando una query contiene múltiples statements separados por `;` (p. ej. `SHOW MEASUREMENTS; SHOW SERIES`), todos los resultados se concatenan en un único result set. Se antepone una columna entera sintética `statement_index` para distinguir las filas de los distintos statements.
+- **Menú contextual "Query Measurement"** — hacer clic derecho en un measurement en la barra lateral muestra "Query Measurement". La acción abre un nuevo documento de código pre-poblado con una query de plantilla (`SELECT * FROM ...` para InfluxQL, `from(bucket: ...) |> range(...)` para Flux).
+- **Menú contextual "New Query" en buckets** — hacer clic derecho en un nodo de bucket/database muestra "New Query", abriendo un documento de código en blanco con la conexión activada.
+- **Generación de plantillas de lectura** — `InfluxQueryGenerator` produce plantillas de lectura select-all y por measurement tanto para InfluxQL como para Flux (usadas por las acciones del menú contextual y copy-as-query), sensibles a la versión según la versión configurada de la conexión y el bucket por defecto.
+
+## Limitaciones
+
+- **Sin cancelación de query** — `cancel()` devuelve `NotSupported`; las queries en curso no se pueden abortar desde la UI (`QUERY_CANCELLATION` no está declarada).
+- **Sin generación de mutaciones** — `QueryGenerator::generate_mutation` siempre devuelve `None`; solo se generan plantillas de lectura, en consonancia con la API de queries de solo lectura.
+- **Flux no soportado en v1** — intentar ejecutar una query Flux contra una conexión v1 devuelve un error de inmediato, sin realizar una llamada HTTP.
+- **Sin INSERT/UPDATE/DELETE** — la API de queries de InfluxDB es de solo lectura. La ingesta de datos usa la Line Protocol write API, que este driver no expone.
+- **Sin transacciones** — InfluxDB no soporta transacciones.
+- **InfluxQL requiere un bucket** — las queries InfluxQL incrustan el bucket en la URL (`?db=<bucket>`). Si ni el desplegable de source-context ni el valor por defecto del perfil proveen un bucket, la ejecución se rechaza con un error claro que pide al usuario seleccionar uno.
+- **Detección de predicado de tiempo basada en regex** — el driver usa expresiones regulares para determinar si una query ya contiene un predicado de tiempo. Esto puede dar falsos positivos con literales de cadena entrecomillados que contengan texto coincidente con `time <`, `time >` o `|> range(`.
+- **Las columnas multi-statement quedan fijadas por el primer statement no vacío** — cuando una query multi-statement devuelve resultados con formas distintas (p. ej. `SHOW MEASUREMENTS; SHOW SERIES`), el diseño de columnas queda determinado por el primer statement no vacío. Las filas de los statements siguientes se mapean a ese diseño. Formas no coincidentes producen columnas desalineadas en lugar de un error.
+- **Autenticación básica vía cabecera Authorization** — las credenciales de usuario/contraseña de v1 se envían como una cabecera `Authorization: Basic <base64>` en lugar de mediante parámetros de query en la URL. Esto es más limpio para la higiene de logs pero difiere de algunas bibliotecas cliente de InfluxDB.
+- **Serialización retrocompatible** — los perfiles guardados con el antiguo campo obligatorio `bucket_or_database` se siguen cargando correctamente. El campo se deserializa como `default_bucket` mediante un alias de serde. Los perfiles guardados tras este cambio usan la clave `default_bucket`.

--- a/docs/es/drivers/ipc.md
+++ b/docs/es/drivers/ipc.md
@@ -1,0 +1,62 @@
+# Drivers RPC externos
+
+Puente que permite que un driver ejecutándose en su propio proceso sirva a DBFlux a través de un
+socket local, de modo que se pueda agregar una base de datos que DBFlux no soporta de forma nativa
+sin necesidad de hacer un fork de la aplicación.
+
+## De un vistazo
+
+- **Categoría** — declarada por el driver remoto
+- **Lenguaje de query** — declarado por el driver remoto
+- **Id de registro** — `rpc:<socket_id>`
+- **Protocolo** — ver la referencia del protocolo RPC de drivers
+
+## Cómo funciona
+
+El puente no tiene conocimiento de ninguna base de datos en particular. Al conectar, realiza un
+handshake `Hello` con el proceso remoto, y todo lo que DBFlux necesita para presentar
+el driver — su tipo, su metadata, su formulario de conexión — vuelve en esa
+respuesta. A partir de ahí el puente reenvía las operaciones a través del socket y traduce
+las respuestas a los mismos contratos del núcleo que implementa un driver de Rust integrado, de modo que
+el resto de la aplicación no puede notar la diferencia.
+
+Los valores de conexión se persisten como `DbConfig::External { kind, values }`, indexados por
+el formulario que declaró el driver remoto.
+
+### Capacidades negociadas en el handshake
+
+El driver remoto anuncia lo que soporta, y el puente se adapta:
+
+- `SchemaIntrospection` — la barra lateral construye un árbol de schema a partir del driver
+- `MultiDatabase` — la conexión expone más de una database
+- `ChunkedResults` — los result sets grandes se transmiten en chunks en lugar de en una sola respuesta
+- `Cancellation` — una query en ejecución se puede cancelar desde la UI
+- `AuditEmit` — el driver puede emitir sus propios eventos de auditoría (protocolo v1.2 y posteriores)
+
+Todo lo que no se anuncia simplemente está ausente de la interfaz, de la misma forma en que
+una capability flag no establecida en un driver integrado elimina funcionalidades de la UI.
+
+### Ciclo de vida del host
+
+Un servicio RPC configurado puede ser gestionado por DBFlux: el proceso host se lanza bajo
+demanda, se espera hasta que reporte estar saludable, y se rastrea para su apagado. Un servicio
+sin configuración de lanzamiento se asume ya en ejecución.
+
+### Reenvío de auditoría
+
+Los drivers que anuncian `AuditEmit` pueden enviar frames `EmitAuditEvent` intercalados
+con sus respuestas. El puente intercepta esos frames y los despacha al
+sink de sanitización del host, de modo que los eventos de un driver externo terminan en el mismo log
+de auditoría que todo lo demás, con la misma redacción aplicada. Los frames de un driver que
+no anunció la capacidad se descartan en lugar de ser confiados.
+
+## Limitaciones
+
+- Requiere un proceso host de driver compatible y un socket alcanzable. El puente
+  no puede iniciar un host que no tenga configuración de lanzamiento, así que un servicio no disponible
+  permanece no disponible.
+- El conjunto de funcionalidades efectivo está acotado por la metadata anunciada del driver remoto
+  y por su implementación. El puente nunca agrega una capacidad que el driver no tenga.
+- La emisión de auditoría necesita protocolo v1.2 o posterior y `AuditEmit` en el handshake.
+  Los drivers más antiguos no emiten nada, y sus operaciones aparecen en el log solo a través de
+  los eventos que DBFlux registra en su nombre.

--- a/docs/es/drivers/mongodb.md
+++ b/docs/es/drivers/mongodb.md
@@ -1,0 +1,65 @@
+# MongoDB
+
+Base de datos de documentos para aplicaciones modernas.
+
+## De un vistazo
+
+- **Categoría** — Documento
+- **Lenguaje de query** — Sintaxis de query de MongoDB
+- **Puerto por defecto** — 27017
+- **Esquema de URI** — `mongodb`
+
+Driver de documentos MongoDB para DBFlux.
+
+## Funcionalidades
+
+- Driver de documentos clasificado como `DatabaseCategory::Document` con el lenguaje de query `MongoQuery`; el editor usa sintaxis de shell de MongoDB, no SQL.
+- Modos de conexión: manual (host/port/credenciales/database) y modo URI. El modo URI acepta cadenas de conexión `mongodb://` y `mongodb+srv://` (los registros SRV se parsean para el descubrimiento de replica-set).
+- Múltiples databases lógicas (`MULTIPLE_DATABASES`) con browsing de collections y conteo de documentos.
+- Autenticación (`AUTHENTICATION`) y TLS/SSL con tres modos (`off`, `on`, `verify`), soportando un certificado raíz y un certificado de cliente opcional.
+- Soporte de túnel SSH para llegar a MongoDB a través de un bastion host.
+- Parseo de queries en estilo shell para las formas `db.collection.method(...)` y `db.method(...)`, con un fallback de documento JSON para retrocompatibilidad. Métodos soportados: `find`, `findOne`, `aggregate`, `count`/`countDocuments`, `insertOne`, `insertMany`, `updateOne`, `updateMany`, `deleteOne`, `deleteMany`. Los errores de parseo llevan posiciones de byte-offset para los diagnósticos del editor.
+- Pipelines de agregación (`AGGREGATION`); las capacidades de query anuncian order-by, group-by, having, limit y offset.
+- Operadores WHERE: `Eq`, `Ne`, `Gt`, `Gte`, `Lt`, `Lte`, `In`, `NotIn`, y los lógicos `And`/`Or`/`Not`.
+- Paginación mediante los estilos cursor y page-token (`PaginationStyle::Cursor`, `PaginationStyle::PageToken`).
+- Metadata de schema centrada en documentos: campos e índices de collection (`INDEXES`), con documentos anidados y arrays mapeados a la vista de árbol de documentos (`NESTED_DOCUMENTS`, `ARRAYS`).
+- Mutaciones: insert, update (incluyendo upsert) y delete (`supports_upsert: true`). `MongoShellGenerator` emite `insertOne`/`insertMany`, `updateOne`/`updateMany` (con `{ upsert: true }`), y `deleteOne`/`deleteMany` para vistas previas y copy-as-query.
+- DDL: drop database, drop collection, create index y drop index.
+- Exportación de resultados a JSON (`EXPORT_JSON`).
+
+### Métricas de instancia
+
+Expone un conjunto seleccionado de métricas de servidor en vivo tomadas del comando `serverStatus` de MongoDB. Las métricas se extraen mediante recorrido de rutas con puntos en BSON:
+
+- `mongo.connections_current` — conexiones abiertas actualmente
+- `mongo.connections_available` — slots de conexión disponibles
+- `mongo.opcounters_insert` — operaciones insert desde el arranque
+- `mongo.opcounters_query` — operaciones query desde el arranque
+- `mongo.opcounters_update` — operaciones update desde el arranque
+- `mongo.opcounters_delete` — operaciones delete desde el arranque
+- `mongo.opcounters_getmore` — operaciones getMore desde el arranque
+- `mongo.mem_resident` — memoria residente en MB
+- `mongo.mem_virtual` — memoria virtual en MB
+- `mongo.network_bytes_in` — bytes recibidos desde el arranque
+
+Cada métrica se devuelve como una única fila `(timestamp_ms, value)` para graficado en vivo.
+
+### Inspector de instancia
+
+Expone snapshots tabulares del estado del servidor en ejecución:
+
+- `mongo.current_op` — operaciones en curso desde el pipeline de agregación `$currentOp` (opid, type, ns, op, secs_running, wait_for_lock)
+
+## Limitaciones
+
+- SQL no está soportado; las queries deben usar sintaxis estilo shell de MongoDB (o el fallback JSON).
+
+- Las métricas de instancia devuelven un único punto de datos por llamada (snapshot actual de `serverStatus`), no una serie temporal histórica. Los contadores de operaciones (p. ej. `mongo.opcounters_insert`) crecen de forma monótona — interprétalos como deltas entre muestras en lugar de tasas absolutas.
+
+- `$currentOp` requiere el privilegio `inprog` o el rol `clusterMonitor` en clusters de Atlas. Sin privilegios suficientes, `fetch_inspector_snapshot("mongo.current_op")` devuelve un result set vacío.
+- La cancelación de query no está soportada (`QUERY_CANCELLATION` no está establecida).
+- `RETURNING` no está soportado; las capacidades de mutación también reportan sin batch, sin update masivo y sin delete masivo a nivel de capacidad (`supports_batch`, `supports_bulk_update`, `supports_bulk_delete` son todos `false`), aunque el generador pueda emitir texto `updateMany`/`deleteMany`.
+- La cobertura del parser está intencionalmente acotada al conjunto de métodos soportado arriba, no al lenguaje completo del shell interactivo; `distinct` no se expone como capacidad de query (`supports_distinct: false`).
+- Sin joins, subqueries, uniones, CTEs, funciones de ventana ni `EXPLAIN` a nivel de capacidad de query.
+- Las transacciones se anuncian a nivel de capacidad (`supports_transactions: true`) pero sin niveles de aislamiento, savepoints, transacciones anidadas, read-only ni soporte deferrable.
+- El DDL no es transaccional (`transactional_ddl: false`); create-database, create-collection, alter, views y triggers no están soportados.

--- a/docs/es/drivers/mssql.md
+++ b/docs/es/drivers/mssql.md
@@ -1,0 +1,295 @@
+# SQL Server
+
+Base de datos relacional Microsoft SQL Server.
+
+## De un vistazo
+
+- **Categoría** — Relacional
+- **Query language** — T-SQL
+- **Puerto por defecto** — 1433
+- **Esquema de URI** — `sqlserver`
+
+Driver de Microsoft SQL Server para DBFlux, construido sobre el cliente TDS
+[`tiberius`](https://crates.io/crates/tiberius).
+
+## Funcionalidades
+
+- Driver relacional para SQL Server / Azure SQL con ejecución de queries SQL y
+  descubrimiento de schema.
+- Autenticación mediante logins de SQL Server (usuario + contraseña); el modo
+  URI acepta connection strings ADO, JDBC y `sqlserver://user:pass@host:port/db`.
+- Modos de encriptación TLS (`off`, `on`, `required`) vía el `EncryptionLevel`
+  de tiberius. El formulario expone un único desplegable **SSL Mode**; el flag
+  `TrustServerCertificate` se deriva automáticamente:
+  - `off` — sin encriptación (el paquete de login sigue encriptado por TDS).
+  - `on` — encriptado, acepta certificados autofirmados. Ideal para SQL Server
+    local/de desarrollo con su certificado autogenerado.
+  - `required` — encriptado, valida la cadena del certificado. Úsalo contra
+    servidores con un certificado firmado por una CA real (Azure SQL, etc.).
+  En modo URI, `?trust=true|false` sobrescribe explícitamente el valor
+  derivado si necesitas una combinación inusual (p. ej.
+  `?encrypt=required&trust=true`).
+- Soporte opcional de instancias con nombre de SQL Server (`SQLEXPRESS`,
+  `MSSQLSERVER2019`, etc.) resueltas en el momento de conectar consultando
+  SQL Browser sobre UDP 1434 (habilitado vía el feature `sql-browser-tokio`
+  de tiberius). El campo Instance del formulario, la forma `host\instance` al
+  estilo SSMS en modo URI, y el parámetro de query `?instance=` en la URI fijan
+  todos el mismo `instance_name` en la configuración de tiberius.
+- Soporte de túnel SSH para conectar a través de bastion hosts (la búsqueda de
+  instancia con nombre no está disponible a través de un túnel solo-TCP).
+- Cambio de base de datos por pestaña vía `USE [database]`; el estado de sesión
+  (opciones SET, tablas temporales, transacciones) persiste entre llamadas a
+  `execute()` sobre la misma conexión.
+- Lotes con múltiples result sets: cuando un lote produce varios result sets
+  (p. ej. `SELECT 1; SELECT 2;` o un stored procedure con múltiples `SELECT`),
+  el driver devuelve el **último** set no vacío como el `QueryResult`
+  primario (preservando la UX histórica de "gana la última sentencia") y
+  adjunta cada set anterior no vacío a `QueryResult.additional_results` en el
+  orden del lote. Los lotes de pura preparación (`SET LOCK_TIMEOUT 5000`)
+  siguen mostrándose como un único primario vacío. Los callers que quieran
+  recorrer cada set usan `QueryResult::iter_result_sets()`.
+- Motor de transferencia de datos: carga masiva nativa multi-fila con
+  `INSERT` (`BULK_INSERT`, con un tope de 1000 filas por sentencia según el
+  límite de filas de `VALUES` de T-SQL, expuesto vía
+  `DriverLimits::max_bulk_insert_rows`) y DDL `CREATE TABLE` nativo del driver
+  a partir de las columnas de una tabla origen (`TRUNCATE_TABLE` también
+  está soportado).
+
+### Instance Metrics
+
+Expone un conjunto curado de métricas de servidor en vivo obtenidas de
+`sys.dm_os_performance_counters`:
+
+- `mssql.batch_requests_per_sec` — batch requests de T-SQL por segundo
+- `mssql.compilations_per_sec` — compilaciones SQL por segundo
+- `mssql.recompilations_per_sec` — recompilaciones SQL por segundo
+- `mssql.user_connections` — conexiones de usuario abiertas actualmente
+- `mssql.lock_waits_per_sec` — esperas de lock por segundo (instancia `_Total`)
+- `mssql.page_reads_per_sec` — lecturas de página del buffer pool por segundo
+- `mssql.page_writes_per_sec` — escrituras de página del buffer pool por
+  segundo
+- `mssql.buffer_cache_hit_ratio` — ratio de aciertos del buffer cache
+  (porcentaje)
+- `mssql.server_memory_kb` — memoria total del servidor en KB
+
+Cada métrica se devuelve como una única fila `(timestamp_ms, value)` para
+graficado en vivo.
+
+Requiere el permiso de servidor `VIEW SERVER STATE`. Sin él, `list_metrics()`
+devuelve una lista vacía y se registra una advertencia. El driver sondea este
+permiso una vez al construir el catálogo.
+
+### Instance Inspector
+
+Expone snapshots tabulares del estado del servidor en ejecución:
+
+- `mssql.active_sessions` — sesiones de usuario de `sys.dm_exec_sessions`
+  unidas con `sys.dm_exec_requests` (session id, login name, host name,
+  program name, status, tiempo de CPU, uso de memoria, command, request
+  status, wait type, wait time, blocking session id)
+
+Requiere el permiso `VIEW SERVER STATE`.
+
+### Cancelación de queries
+
+- La cancelación se implementa como `KILL <spid>` emitido desde una conexión
+  side-channel nueva. tiberius actualmente no expone la primitiva TDS
+  Attention que usa SSMS, así que la siguiente mejor opción es pedirle al
+  servidor que termine la sesión que ejecuta la query.
+- Al conectar, el driver captura `@@SPID` y cachea un clon de la `Config` de
+  tiberius (con el login ya incorporado). El handle de cancelación abre una
+  segunda conexión bajo demanda, ejecuta `KILL <spid>`, y marca la conexión
+  primaria como envenenada.
+- Tras la cancelación, `cleanup_after_cancel()` reconstruye el cliente
+  tiberius primario, captura el nuevo SPID, y reemite el `USE [db]` anterior
+  para que la siguiente query se ejecute en la misma base de datos. Desde la
+  perspectiva de la UI, la conexión sigue conectada; solo cambia el id de
+  sesión subyacente.
+- Los errores lanzados en la sesión eliminada (códigos 596 / 233 / 6005) se
+  traducen a `DbError::Cancelled` para que la UI muestre "query cancelled" en
+  vez de un fallo a nivel de transporte.
+- El propietario de la sesión puede hacer `KILL` de su propio SPID en SQL
+  Server moderno sin el permiso `ALTER ANY CONNECTION`. En logins más
+  antiguos o restringidos, el propio KILL puede fallar con un error de
+  permisos; el driver lo muestra al usuario.
+
+### Descubrimiento de schema
+
+- Bases de datos (`sys.databases`, oculta las bases de datos de sistema).
+- Tablas y vistas por base de datos (`sys.tables`, `sys.views`).
+- Columnas por tabla + flag de primary key, índices, foreign keys.
+- Constraints por tabla: constraints CHECK (con su definición) y constraints
+  UNIQUE (vía `sys.indexes.is_unique_constraint`).
+- Índices y foreign keys de todo el schema para el panel lateral de
+  navegación de schema.
+- Tipos definidos por el usuario (`sys.types where is_user_defined = 1`)
+  clasificados como `Domain` (tipos alias) o `Composite` (table types).
+- `view_details()` verifica que la vista existe en la base de datos
+  solicitada.
+- **Routines:** stored procedures (`P`), scalar functions (`FN`), inline
+  table-valued functions (`IF`), multi-statement table-valued functions
+  (`TF`), y CLR aggregates (`AF`) se listan por schema vía `sys.objects`. Las
+  definiciones fuente se obtienen con `OBJECT_DEFINITION(object_id)`.
+
+### CRUD con OUTPUT
+
+- INSERT/UPDATE/DELETE sobre una fila usan la cláusula `OUTPUT INSERTED.*` /
+  `OUTPUT DELETED.*` de SQL Server para que los datos de la fila
+  post-mutación se devuelvan al caller (`CrudResult::success(row)`), de la
+  misma forma que el driver de Postgres usa `RETURNING *`.
+- `MutationCapabilities::supports_returning` es `true`.
+- La identidad de fila debe ser una primary key compuesta (la única variante
+  de `RecordIdentity` que tiene sentido para un driver relacional).
+
+### Planificación de queries
+
+- `explain()` ejecuta la query bajo `SET SHOWPLAN_XML ON` y devuelve el plan
+  de query como XML. El driver siempre ejecuta `SET SHOWPLAN_XML OFF`
+  después para que el estado de sesión no se filtre.
+- `version_query()` devuelve `SELECT @@VERSION`.
+
+### Dialecto
+
+- Comillas de identificador con `[corchetes]` con escape de `]`.
+- Literales de string Unicode `N'…'`; literales binarios `0x…` (en
+  mayúsculas); `1`/`0` para valores booleanos (`BIT`).
+- Paginación `OFFSET … ROWS FETCH NEXT … ROWS ONLY` (con un fallback
+  `ORDER BY 1` para que las queries con OFFSET sin ORDER BY no den error).
+- `SELECT TOP N` no se usa; OFFSET/FETCH es la forma canónica de paginación.
+- `UPSERT` intencionalmente no se genera; `MERGE` en SQL Server tiene bugs
+  conocidos y debería escribirse a mano.
+
+### Reporte de errores
+
+- Los errores de token `Server` de tiberius muestran su código numérico,
+  severity state, y línea de origen a través de `FormattedError`.
+- Los números de error comunes de MSSQL se mapean a variantes semánticas de
+  `DbError` en vez del `QueryFailed` genérico:
+
+  | Código(s)                                       | Variante de DbError      |
+  | --------------------------------------------- | ----------------------- |
+  | 4060, 18450, 18452, 18456, 18486, 18487, 18488 | `AuthFailed`            |
+  | 229, 230, 262, 297, 916                       | `PermissionDenied`      |
+  | 207, 208, 2812, 4902                          | `ObjectNotFound`        |
+  | 245, 334, 515, 547, 2601, 2627, 8152          | `ConstraintViolation`   |
+  | 102, 156, 8180                                | `SyntaxError`           |
+
+- Los mensajes de violación de constraint se parsean para poblar
+  `ErrorLocation` (schema, tabla, columna, nombre de constraint) para que la
+  UI pueda resaltar el objeto en cuestión.
+
+### Operaciones y límites
+
+- Todas las operaciones declaran `transactional_ddl: true` y
+  `supports_savepoints: true`.
+- Niveles de aislamiento soportados: ReadUncommitted, ReadCommitted,
+  RepeatableRead, Serializable, Snapshot. El valor por defecto es
+  ReadCommitted.
+
+## Comportamiento de DDL
+
+- **DDL transaccional.** La mayoría del DDL en SQL Server es transaccional.
+  Envolver `CREATE`, `ALTER`, o `DROP TABLE` dentro de
+  `BEGIN TRAN … COMMIT` / `ROLLBACK` funciona. Excepciones: `CREATE DATABASE`,
+  `DROP DATABASE`, `ALTER DATABASE`, `BACKUP`/`RESTORE`, y
+  `CREATE FULLTEXT INDEX` no pueden ejecutarse dentro de una transacción
+  explícita.
+- **Locking de ALTER TABLE.** `ALTER TABLE … ADD COLUMN <nullable>` es rápido
+  (solo metadata). Agregar una columna NOT NULL con un default escribe en
+  cada página y toma un lock Sch-M. `ALTER TABLE … ALTER COLUMN` puede
+  reescribir la tabla y bloquea lecturas y escrituras hasta que termina.
+- **Operaciones de índice online** (Enterprise / Azure SQL):
+  `CREATE INDEX … WITH (ONLINE = ON)` y
+  `ALTER INDEX … REBUILD WITH (ONLINE = ON)` permiten DML concurrente. Sin
+  `ONLINE = ON`, la construcción de índices toma un lock Sch-M y bloquea
+  escrituras (Standard/Express solo soportan modo offline).
+- **TRUNCATE TABLE.** Solo metadata, rápido, transaccional, requiere el
+  permiso `ALTER` sobre la tabla. No puede usarse en tablas referenciadas por
+  una foreign key (usa `DELETE` o elimina la FK primero).
+- **DROP TABLE / DROP VIEW.** Transaccional. `IF EXISTS` está soportado desde
+  2016+.
+- **Constraints.** Agregar constraints `CHECK` / `UNIQUE` / `FOREIGN KEY`
+  valida todas las filas existentes por defecto (toma un Sch-M brevemente).
+  Usa `WITH NOCHECK` para agregar el constraint sin escanear, luego
+  `WITH CHECK CHECK CONSTRAINT` más tarde para validar cuando quieras — el
+  mismo patrón que `NOT VALID` + `VALIDATE CONSTRAINT` en Postgres.
+
+## Limitaciones
+
+- Las funcionalidades de Instance Metrics e Instance Inspector requieren el
+  permiso de servidor `VIEW SERVER STATE`. Sin él, tanto `list_metrics()`
+  como `list_inspectors()` devuelven listas vacías en vez de un error.
+
+- Instance Metrics devuelve un único dato por llamada (valor actual de
+  `sys.dm_os_performance_counters`), no una serie temporal histórica. Los
+  contadores de tasa (p. ej. `mssql.batch_requests_per_sec`) representan el
+  promedio en ejecución que reporta la DMV del lado del servidor, no un
+  delta calculado por el driver.
+
+- SQL Server mínimo soportado: 2016 (13.0). El driver usa la sintaxis
+  `DROP INDEX IF EXISTS … ON …`, que los servidores más antiguos rechazan
+  con un error de sintaxis (102). Azure SQL Database y Managed Instance
+  funcionan bien.
+- CRUD sobre tablas (o vistas actualizables) con triggers `INSTEAD OF` no
+  está soportado. El driver devuelve la fila post-mutación vía
+  `OUTPUT INSERTED.*` / `OUTPUT DELETED.*` sin una cláusula `INTO`, que SQL
+  Server rechaza con el error 334 ("the target table cannot have any
+  enabled triggers if the statement contains an OUTPUT clause without
+  INTO"). El error se muestra como `ConstraintViolation`.
+- Driver solo SQL; no expone APIs de documentos ni de key-value.
+- La cancelación elimina la sesión subyacente y reconecta de forma
+  transparente; no es la cancelación quirúrgica vía TDS Attention que usa
+  SSMS (tiberius actualmente no expone esa primitiva). En la práctica, la
+  única diferencia visible para el usuario es que todo el estado local de
+  sesión (opciones `SET`, tablas temporales, transacciones abiertas) se
+  reinicia con la cancelación. La base de datos activa se restaura
+  automáticamente.
+- La latencia de cancelación depende del scheduler de SQL Server:
+  típicamente unos pocos milisegundos para queries limitadas por CPU,
+  inmediata para las que esperan un lock. Los rollbacks largos (p. ej.
+  cancelar un `DELETE` grande a mitad de transacción) pueden mantener el
+  SPID *del lado del servidor* en estado KILLED/ROLLBACK durante un rato
+  después de que el driver ya pasó a una sesión nueva.
+- No se usa parameter binding — las sentencias se despachan vía
+  `simple_query`. Los helpers CRUD componen valores dentro del texto SQL a
+  través del `SqlQueryBuilder` compartido y los formatters de literales del
+  dialecto. Los payloads binarios o Unicode grandes se insertan como
+  literales `0x…` o `N'…'`.
+- Streaming: los result sets se materializan en `Vec<Row>`. El trait
+  `Connection::execute` devuelve un `QueryResult` totalmente resuelto, así
+  que el streaming al estilo cursor requeriría un cambio de API a nivel de
+  workspace, no solo del driver.
+- Los lotes multi-sentencia muestran cada result set no vacío vía
+  `QueryResult.additional_results`, pero la UI actualmente solo renderiza el
+  set primario (el último). Hasta que el sistema de pestañas de resultados
+  lea `additional_results`, los sets anteriores son capturados por el driver
+  pero invisibles en el editor.
+- Los mensajes `PRINT` e informativos emitidos durante un lote se descartan.
+  Mostrarlos requeriría manejar el `TokenStream` de bajo nivel de tiberius
+  en vez de `QueryStream::into_results()`.
+- `UPSERT` intencionalmente no se genera. Usa `MERGE` manualmente cuando lo
+  necesites.
+- Las instancias con nombre se respetan al conectar directamente (tiberius
+  consulta el servicio SQL Browser sobre UDP 1434) pero no al pasar por un
+  túnel SSH, ya que libssh2 solo hace forward de TCP. El workaround estándar
+  es asignar un puerto TCP estático a la instancia y conectar directamente a
+  ese puerto.
+- La introspección de schema usa las vistas de catálogo `sys.*`; los
+  usuarios sin el permiso `VIEW DEFINITION` por defecto verán metadata
+  parcial. Aplican las reglas de visibilidad de metadata de SQL Server.
+- Las rutinas CLR (funciones escalares CLR, funciones table-valued CLR,
+  stored procedures CLR) y cualquier rutina creada con `ENCRYPTION` devuelven
+  `NULL` desde `OBJECT_DEFINITION`, en cuyo caso el driver muestra un mensaje
+  de fallback corto en vez de un error.
+- `parameter_types` no se pobla para rutinas; `sys.parameters` no se
+  consulta en esta implementación.
+- SQL Server no tiene un tipo `Window` en la taxonomía de
+  `sys.objects.type`; este driver nunca emite `RoutineKind::Window`.
+- Sin toggle de integridad referencial para el flujo de migración del motor
+  de transferencia de datos (`DriverCapabilities::DISABLE_FK_CHECKS` no está
+  fijado; `Connection::set_referential_integrity` devuelve `NotSupported`).
+  SQL Server deshabilita la comprobación de FK por tabla vía
+  `ALTER TABLE ... NOCHECK CONSTRAINT`, lo cual no encaja con el toggle
+  global único del motor; una variante por tabla es una posible mejora
+  futura.
+

--- a/docs/es/drivers/mysql.md
+++ b/docs/es/drivers/mysql.md
@@ -1,0 +1,225 @@
+# MySQL y MariaDB
+
+Base de datos relacional open-source popular.
+
+## De un vistazo
+
+- **Categoría** — Relacional
+- **Query language** — SQL
+- **Puerto por defecto** — 3306
+- **Esquema de URI** — `mysql`
+
+## Funcionalidades
+
+- Implementaciones de driver relacional para MySQL y MariaDB en un solo
+  crate.
+- Soporta ejecución de SQL, descubrimiento de schema, índices, foreign keys,
+  constraints CHECK, y constraints UNIQUE.
+- Soporta autenticación, túnel SSH, y modos de conexión URI/manual.
+- TLS con los cinco modos SSL nativos (`DISABLED`, `PREFERRED`, `REQUIRED`,
+  `VERIFY_CA`, `VERIFY_IDENTITY`): `VERIFY_CA` verifica la cadena del
+  servidor sin validar el hostname y `VERIFY_IDENTITY` verifica ambos. Una CA
+  raíz personalizada reemplaza el trust store del sistema en los modos que
+  verifican, y un certificado de cliente + clave habilita mutual TLS. Usa el
+  backend `rustls`/`aws-lc-rs`.
+- Soporta cancelación de queries a través de un camino de cancelación
+  dedicado (flujo `KILL QUERY`).
+- Incluye generación de SQL/código para CRUD, índices, foreign keys, y
+  operaciones de DDL de tabla.
+- Descubrimiento de routines: lista stored procedures y funciones definidas
+  por el usuario desde `information_schema.ROUTINES` incluyendo tipos de
+  parámetros y hints de tipo de retorno (solo Functions).
+- Definición de routines: obtiene el cuerpo completo de `CREATE FUNCTION` o
+  `CREATE PROCEDURE` vía `SHOW CREATE FUNCTION`/`SHOW CREATE PROCEDURE`
+  (de solo lectura; la definición no es editable ni ejecutable en el
+  visor).
+- Los scripts multi-sentencia (varias sentencias separadas por `;`) se
+  dividen y ejecutan sentencia por sentencia, cada una a través del camino
+  preparado tipado, devolviendo un result set por sentencia.
+- Motor de transferencia de datos: carga masiva nativa multi-fila con
+  `INSERT` (`BULK_INSERT`), DDL `CREATE TABLE` nativo del driver a partir de
+  las columnas de una tabla origen, soporte de `TRUNCATE TABLE`, y un toggle
+  de integridad referencial (`SET FOREIGN_KEY_CHECKS`) para migraciones
+  seguras con FK. Tanto MySQL como MariaDB comparten este soporte.
+
+### Instance Metrics
+
+Expone un conjunto curado de métricas de servidor en vivo obtenidas de
+`SHOW GLOBAL STATUS`:
+
+- `mysql.threads_connected` — conexiones abiertas actualmente
+- `mysql.threads_running` — queries en ejecución actualmente
+- `mysql.queries_per_sec` — queries por segundo (contador acumulativo)
+- `mysql.innodb_buffer_pool_hit_ratio` — eficiencia de lectura del buffer
+  pool de InnoDB
+- `mysql.innodb_rows_read` — filas leídas del storage engine InnoDB
+- `mysql.innodb_rows_inserted` — filas insertadas en InnoDB
+- `mysql.innodb_rows_updated` — filas actualizadas en InnoDB
+- `mysql.innodb_rows_deleted` — filas eliminadas en InnoDB
+- `mysql.slow_queries` — conteo acumulativo de slow queries
+- `mysql.table_locks_waited` — contador de contención de locks a nivel de
+  tabla
+- `mysql.bytes_sent` — bytes de red enviados
+
+Cada métrica se devuelve como una única fila `(timestamp_ms, value)` para
+graficado en vivo.
+
+### Instance Inspector
+
+Expone snapshots tabulares del estado del servidor en ejecución:
+
+- `mysql.processlist` — sesiones activas de
+  `information_schema.PROCESSLIST` (user, host, db, command, time, state,
+  info)
+
+## Limitaciones
+
+- Driver solo SQL; no expone APIs de documentos ni de key-value.
+
+- Instance Metrics devuelve un único dato por llamada (snapshot actual de
+  `SHOW GLOBAL STATUS`), no una serie temporal histórica. Los contadores
+  acumulativos (p. ej. `mysql.bytes_sent`) crecen de forma monótona —
+  interprétalos como deltas entre muestras en vez de tasas absolutas.
+
+- El sondeo de disponibilidad de `performance_schema` se ejecuta una vez al
+  construir el catálogo. Cuando `performance_schema` no está presente, las
+  métricas específicas de performance schema se omiten de `list_metrics()`.
+  El conjunto de métricas estáticas (basado en `SHOW GLOBAL STATUS`) siempre
+  está disponible.
+
+- Un script multi-sentencia ejecuta cada sentencia secuencialmente en vez de
+  como un único lote atómico del lado del servidor; la división de
+  sentencias es basada en texto y puede dividir incorrectamente cuerpos de
+  stored programs que contienen `;` (p. ej.
+  `CREATE PROCEDURE ... BEGIN ... END`).
+- La cancelación depende de los permisos del servidor y el estado de la
+  conexión cuando se emite `KILL QUERY`.
+- La generación de código está limitada a las construcciones MySQL/MariaDB
+  soportadas; los IDs de generador no soportados devuelven `NotSupported`.
+- El listado de routines cubre solo los tipos FUNCTION y PROCEDURE. Las
+  funciones agregadas de MySQL (registradas vía el plugin UDF
+  `CREATE AGGREGATE FUNCTION`) y las funciones window no aparecen en
+  `information_schema.ROUTINES` y por lo tanto no se listan.
+- `SHOW CREATE FUNCTION`/`SHOW CREATE PROCEDURE` requiere el privilegio
+  `SHOW_ROUTINE` (MySQL 8.0+) o ser propietario de la rutina; sin privilegios
+  suficientes la columna de definición devuelve `NULL` y el visor muestra un
+  aviso en vez del código fuente.
+
+## Capacidades de DDL
+
+### DDL no transaccional
+
+**CRÍTICO**: las operaciones de DDL en MySQL **NO son transaccionales** — no
+se pueden revertir con rollback:
+
+```sql
+BEGIN;
+ALTER TABLE users ADD COLUMN phone VARCHAR(20) NULL;
+-- El DDL se confirma inmediatamente, ¡ROLLBACK no tiene efecto!
+ROLLBACK;  -- Demasiado tarde, la columna ya fue agregada
+```
+
+**Excepción**: `RENAME TABLE` es atómico (seguro de usar dentro de
+transacciones).
+
+### Comportamiento de ALTER TABLE
+
+**Reescrituras de tabla**:
+- La mayoría de las operaciones `ALTER TABLE` reescriben toda la tabla
+  (bloquea la tabla durante la operación)
+- Usa `ALGORITHM=INPLACE` y `LOCK=NONE` para DDL online (MySQL 5.6+):
+  ```sql
+  ALTER TABLE users ADD COLUMN phone VARCHAR(20) NULL, ALGORITHM=INPLACE, LOCK=NONE;
+  ```
+
+**Agregar columnas**:
+- Agregar columna al **final de la tabla**: rápido (solo metadata)
+- Agregar columna en **medio de la tabla**: reescritura de tabla (bloquea la
+  tabla)
+- Usa `AFTER column_name` para controlar la posición
+
+**Agregar columnas con defaults**:
+- Reescritura de tabla (bloquea la tabla)
+- El valor por defecto se escribe en todas las filas existentes
+
+**Cambiar tipos de columna**:
+- Siempre requiere reescritura de tabla (bloquea la tabla)
+- La conversión de datos ocurre durante la reescritura
+
+**Eliminar columnas**:
+- Reescritura de tabla (bloquea la tabla)
+- Los datos se eliminan inmediatamente
+
+**Renombrar columnas**:
+- Reescritura de tabla (bloquea la tabla)
+- Puede romper vistas, triggers, y código de la aplicación
+
+### Operaciones de índice
+
+**CREATE INDEX**:
+- Bloquea la tabla para escrituras (lecturas permitidas)
+- Usa `ALGORITHM=INPLACE, LOCK=NONE` para creación de índices online:
+  ```sql
+  CREATE INDEX idx_users_email ON users(email) ALGORITHM=INPLACE, LOCK=NONE;
+  ```
+
+**DROP INDEX**:
+- Bloquea la tabla para escrituras (lecturas permitidas)
+- Usa `ALGORITHM=INPLACE, LOCK=NONE` para eliminación de índices online
+
+### Constraints
+
+**Foreign keys**:
+- Agregar foreign keys escanea ambas tablas (bloquea ambas)
+- Usa `ALGORITHM=INPLACE, LOCK=NONE` cuando sea posible
+
+**Constraints UNIQUE**:
+- Requiere creación de índice (bloquea la tabla)
+
+**Constraints CHECK** (MySQL 8.0.16+):
+- Solo metadata (rápido)
+- Validado solo en INSERT/UPDATE
+
+### DDL online (MySQL 5.6+)
+
+**Opciones de ALGORITHM**:
+- `INPLACE` — modifica la tabla en su lugar (sin copia)
+- `COPY` — crea una nueva tabla y copia las filas (por defecto en versiones
+  antiguas de MySQL)
+- `INSTANT` — solo metadata (MySQL 8.0+, operaciones limitadas)
+
+**Opciones de LOCK**:
+- `NONE` — permite lecturas y escrituras concurrentes
+- `SHARED` — permite lecturas, bloquea escrituras
+- `EXCLUSIVE` — bloquea lecturas y escrituras
+
+**Ejemplo**:
+```sql
+ALTER TABLE users 
+  ADD COLUMN phone VARCHAR(20) NULL,
+  ALGORITHM=INPLACE,
+  LOCK=NONE;
+```
+
+### Limitaciones conocidas
+
+- El DDL no es transaccional (no se puede revertir con rollback)
+- La mayoría de las operaciones `ALTER TABLE` reescriben toda la tabla
+  (bloquea la tabla)
+- Agregar una columna en medio de la tabla requiere reescritura
+- El soporte de DDL online varía según la versión de MySQL
+- Usa `pt-online-schema-change` (Percona Toolkit) para DDL sin downtime en
+  tablas grandes
+
+### Buenas prácticas
+
+1. **Prueba primero en una copia** — el DDL no se puede revertir con rollback
+2. **Usa DDL online** — agrega `ALGORITHM=INPLACE, LOCK=NONE` cuando esté
+   soportado
+3. **Planifica ventanas de mantenimiento** — ejecuta el DDL en periodos de
+   bajo tráfico
+4. **Monitorea el tamaño de la tabla** — las tablas grandes tardan más en
+   reescribirse
+5. **Usa pt-online-schema-change** — para DDL sin downtime en tablas de
+   producción
+

--- a/docs/es/drivers/postgres.md
+++ b/docs/es/drivers/postgres.md
@@ -1,0 +1,193 @@
+# PostgreSQL
+
+Base de datos relacional open-source avanzada.
+
+## De un vistazo
+
+- **Categoría** — Relacional
+- **Query language** — SQL
+- **Puerto por defecto** — 5432
+- **Esquema de URI** — `postgresql`
+
+## Funcionalidades
+
+- Driver relacional de PostgreSQL con ejecución de queries SQL y
+  descubrimiento de schema.
+- Soporta schemas, tablas, vistas, índices, foreign keys, constraints CHECK,
+  constraints UNIQUE, y tipos personalizados.
+- Expone routines almacenadas (funciones, procedures, agregados, funciones
+  window) en el árbol de schema con un visor de definición de solo lectura.
+- Soporta autenticación, SSL, túnel SSH, y modos de conexión URI/manual.
+- Soporta cancelación de queries a través de los cancel tokens de
+  PostgreSQL.
+- Incluye generación de SQL/código específica de PostgreSQL para CRUD,
+  índices, reindex, foreign keys, y operaciones de tipos.
+- Los scripts multi-sentencia (varias sentencias separadas por `;`) se
+  ejecutan como un lote vía el simple query protocol, devolviendo un result
+  set por sentencia.
+- Motor de transferencia de datos: carga masiva nativa multi-fila con
+  `INSERT` (`BULK_INSERT`), DDL `CREATE TABLE` nativo del driver a partir de
+  las columnas de una tabla origen, soporte de `TRUNCATE TABLE`, y un toggle
+  de integridad referencial (`SET session_replication_role`) para
+  migraciones seguras con FK.
+- Muestra valores `vector`, `halfvec`, y `sparsevec` de `pgvector`,
+  incluyendo arrays unidimensionales verificados, como resultados textuales.
+- Muestra valores `tsvector` y `tsquery` de búsqueda de texto completo,
+  incluyendo arrays unidimensionales, en la forma de texto canónica de
+  PostgreSQL.
+
+### Instance Metrics
+
+Expone un conjunto curado de métricas de servidor en vivo obtenidas de las
+vistas de sistema de PostgreSQL:
+
+- `pg.tps` — transacciones por segundo (de `pg_stat_database`)
+- `pg.cache_hit_ratio` — ratio de aciertos del buffer cache (de
+  `pg_statio_user_tables`)
+- `pg.active_connections` — conexiones en estado `'active'`
+- `pg.idle_connections` — conexiones en estado `'idle'`
+- `pg.blocks_read` — bloques leídos desde disco (de
+  `pg_statio_user_tables`)
+- `pg.stat_statements.mean_exec_ms` — tiempo de ejecución medio por query
+  (requiere la extensión `pg_stat_statements`)
+
+Cada métrica se devuelve como una única fila `(timestamp_ms, value)` para
+graficado en vivo.
+
+### Instance Inspector
+
+Expone snapshots tabulares del estado del servidor en ejecución:
+
+- `pg.activity` — sesiones actuales de `pg_stat_activity` (texto de query,
+  state, wait event, duración)
+- `pg.locks` — locks activos de `pg_locks` unidos con `pg_class`
+
+## Limitaciones
+
+- Las columnas de resultados en lote (multi-sentencia) no llevan metadata de
+  tipo; los valores se devuelven como texto y la auto-detección de gráficos
+  está deshabilitada para ellas. Ejecuta una única sentencia para obtener
+  columnas completamente tipadas.
+
+- `pg.stat_statements.mean_exec_ms` solo está disponible cuando la extensión
+  `pg_stat_statements` está instalada y cargada. El driver sondea su
+  presencia al construir el catálogo; cuando está ausente, la métrica se
+  omite de `list_metrics()`.
+
+- Instance Metrics devuelve un único dato por llamada (snapshot actual), no
+  una serie temporal histórica. La UI hace polling en el intervalo de
+  refresco configurado para construir el gráfico en vivo.
+
+- Driver solo SQL; no expone APIs de documentos ni de key-value.
+- Las definiciones de routines para funciones agregadas y window se
+  sintetizan a partir de metadata del catálogo porque `pg_get_functiondef`
+  no las soporta.
+- La edición y ejecución de routines no están soportadas; el visor de
+  routines es de solo lectura.
+- La cancelación es best effort y depende del estado del servidor/sesión en
+  el momento de la cancelación.
+- La generación de código apunta solo a construcciones de PostgreSQL
+  soportadas; los IDs de generador no soportados devuelven `NotSupported`.
+
+## Capacidades de DDL
+
+### DDL transaccional
+
+PostgreSQL soporta **DDL transaccional** — todas las operaciones de DDL
+(excepto `CREATE INDEX CONCURRENTLY`) pueden envolverse en transacciones y
+revertirse con rollback:
+
+```sql
+BEGIN;
+ALTER TABLE users ADD COLUMN phone VARCHAR(20) NULL;
+-- Prueba el cambio
+ROLLBACK;  -- Seguro de revertir si algo sale mal
+```
+
+**Excepción**: `CREATE INDEX CONCURRENTLY` y `DROP INDEX CONCURRENTLY` no
+pueden ejecutarse dentro de una transacción.
+
+### Comportamiento de ALTER TABLE
+
+**Agregar columnas con defaults (PostgreSQL 11+)**:
+- Rápido (operación solo de metadata)
+- No requiere reescritura de tabla
+- No bloquea la tabla para lecturas/escrituras
+
+**Agregar columnas sin defaults**:
+- Rápido (sin reescritura)
+- Las filas existentes reciben `NULL` para la columna nueva
+
+**Cambiar tipos de columna**:
+- Puede requerir reescritura de tabla (bloquea la tabla)
+- Usa la cláusula `USING` para conversión personalizada:
+  `ALTER COLUMN age TYPE integer USING age::integer`
+
+**Eliminar columnas**:
+- Rápido (marca la columna como eliminada, sin reescritura)
+- Los datos no se liberan inmediatamente (usa `VACUUM FULL` si es
+  necesario)
+
+**Renombrar columnas**:
+- Rápido (solo metadata)
+- Puede romper vistas, triggers, y código de la aplicación
+
+### Operaciones de índice
+
+**CREATE INDEX**:
+- Bloquea la tabla para escrituras (lecturas permitidas)
+- Usa `CONCURRENTLY` para creación de índices sin downtime:
+  ```sql
+  CREATE INDEX CONCURRENTLY idx_users_email ON users(email);
+  ```
+
+**DROP INDEX**:
+- Bloquea la tabla para escrituras (lecturas permitidas)
+- Usa `CONCURRENTLY` para eliminación de índices sin downtime:
+  ```sql
+  DROP INDEX CONCURRENTLY idx_users_email;
+  ```
+
+**REINDEX**:
+- Bloquea la tabla para lecturas y escrituras
+- Usa `CONCURRENTLY` (PostgreSQL 12+) para reindex sin downtime
+
+### Constraints
+
+**Agregar constraints**:
+- Los constraints `CHECK` y `UNIQUE` escanean la tabla (puede tomar tiempo
+  en tablas grandes)
+- Usa `NOT VALID` para diferir la validación:
+  ```sql
+  ALTER TABLE users ADD CONSTRAINT age_check CHECK (age >= 0) NOT VALID;
+  -- Más tarde, valida sin bloquear:
+  ALTER TABLE users VALIDATE CONSTRAINT age_check;
+  ```
+
+**Foreign keys**:
+- Agregar foreign keys escanea ambas tablas
+- Usa `NOT VALID` + `VALIDATE CONSTRAINT` para creación de FK sin downtime
+
+### Tipos personalizados
+
+**CREATE TYPE (enum)**:
+- Rápido (solo metadata)
+- Usa `ALTER TYPE ... ADD VALUE` para agregar valores enum:
+  ```sql
+  ALTER TYPE status_enum ADD VALUE 'archived';
+  ```
+  **Nota**: no se puede revertir con rollback dentro de una transacción (se
+  confirma inmediatamente)
+
+**DROP TYPE**:
+- Falla si el tipo está en uso por tablas
+- Debes eliminar primero las columnas dependientes
+
+### Limitaciones conocidas
+
+- `CREATE INDEX CONCURRENTLY` requiere un lock exclusivo momentáneamente
+  (puede bloquear en tablas de alto tráfico)
+- `ALTER TYPE ADD VALUE` no se puede revertir con rollback
+- Eliminar columnas no libera el espacio en disco inmediatamente (requiere
+  `VACUUM FULL`)
+

--- a/docs/es/drivers/redis.md
+++ b/docs/es/drivers/redis.md
@@ -1,0 +1,77 @@
+# Redis
+
+Base de datos clave-valor en memoria.
+
+## De un vistazo
+
+- **Categoría** — Clave-valor
+- **Lenguaje de query** — Comandos Redis
+- **Puerto por defecto** — 6379
+- **Esquema de URI** — `redis`
+
+Driver de clave-valor Redis para DBFlux, construido sobre el crate [`redis`](https://crates.io/crates/redis).
+
+## Funcionalidades
+
+- Driver clave-valor clasificado como `DatabaseCategory::KeyValue` con el lenguaje de query `RedisCommands`; el editor usa sintaxis de comandos Redis, no SQL.
+- Modos de conexión: manual (host/port/user/password/database) y modo URI. El modo URI acepta cadenas de conexión `redis://` y `rediss://`.
+- Múltiples databases lógicas mediante `SELECT <db>` (`MULTIPLE_DATABASES`). El índice de la database activa se rastrea en la conexión.
+- Autenticación con username + password opcionales (`AUTHENTICATION`).
+- TLS/SSL con tres modos (`off`, `on`, `verify`):
+  - `off` — conexión `redis://` plana.
+  - `on` — `rediss://` con el certificado confiado sin validación de cadena (marcador inseguro).
+  - `verify` — `rediss://` con un certificado raíz suministrado y certificado/clave de cliente opcionales, construido a través de `Client::build_with_tls`.
+- Soporte de túnel SSH para llegar a Redis a través de un bastion host (solo en modo manual; ver Limitaciones).
+- Exploración y descubrimiento de claves:
+  - Escaneo de claves basado en cursor (`KV_SCAN`, `PaginationStyle::Cursor`).
+  - Descubrimiento de tipo por clave (`KV_KEY_TYPES`) entre string, hash, list, set, sorted set y stream.
+  - Inspección de TTL (`KV_TTL`) y reporte de tamaño de valor (`KV_VALUE_SIZE`).
+  - Comprobaciones de existencia (`KV_GET`/`KV_EXISTS`), renombrado de claves (`KV_RENAME`) y obtención masiva de múltiples claves (`KV_BULK_GET`).
+- Cobertura de tipos de valor: strings, hashes, lists, sets, sorted sets y streams, incluyendo lecturas de rango de stream, adición de entradas de stream y eliminación de entradas de stream (`KV_STREAM_RANGE`, `KV_STREAM_ADD`, `KV_STREAM_DELETE`).
+- Límite de vista previa de stream configurable, expuesto como ajuste de conexión.
+- Mutaciones: insert, update, delete, operaciones por lotes y eliminación masiva. `RedisCommandGenerator` emite comandos Redis para set/delete, hash set/delete, list push/set/remove, set add/remove, sorted-set add/remove y stream add/delete, para su uso en vistas previas y copy-as-command.
+- Exportación de resultados a JSON (`EXPORT_JSON`).
+
+### Métricas de instancia
+
+Expone un conjunto seleccionado de métricas de servidor en vivo tomadas de la salida del comando `INFO`:
+
+- `redis.connected_clients` — clientes actualmente conectados
+- `redis.blocked_clients` — clientes esperando en un comando bloqueante
+- `redis.used_memory` — bytes asignados por el allocator de Redis
+- `redis.used_memory_rss` — bytes asignados por el sistema operativo (resident set size)
+- `redis.total_commands_processed` — comandos procesados acumulados
+- `redis.total_connections_received` — conexiones aceptadas acumuladas
+- `redis.instantaneous_ops_per_sec` — comandos procesados por segundo (tasa del lado del servidor)
+- `redis.keyspace_hits` — aciertos de caché en búsquedas de claves
+- `redis.keyspace_misses` — fallos de caché en búsquedas de claves
+- `redis.evicted_keys` — claves desalojadas por la política `maxmemory`
+- `redis.expired_keys` — claves expiradas por TTL
+- `redis.rdb_changes_since_last_save` — cambios desde el último snapshot RDB
+- `redis.connected_slaves` — cantidad de réplicas conectadas
+
+Cada métrica se devuelve como una única fila `(timestamp_ms, value)` para graficado en vivo.
+
+### Inspector de instancia
+
+Expone snapshots tabulares del estado del servidor en ejecución:
+
+- `redis.client_list` — clientes activos desde `CLIENT LIST` (id, cmd, age, idle, flags, db, sub, multi)
+
+Los campos sensibles (`addr`, `laddr`, `name`) se redactan a `[redacted]` para evitar exponer direcciones IP y hostnames de clientes.
+
+## Limitaciones
+
+- SQL no está soportado; las queries deben escribirse como comandos Redis.
+
+- Las métricas de instancia devuelven un único punto de datos por llamada (snapshot actual de `INFO`), no una serie temporal histórica. Los contadores acumulativos (p. ej. `redis.total_commands_processed`) crecen de forma monótona — interprétalos como deltas entre muestras en lugar de tasas absolutas.
+
+- El inspector `CLIENT LIST` redacta los campos `addr`, `laddr` y `name` en cada fila para evitar exponer direcciones IP y nombres suministrados por el usuario a la UI.
+
+- La cancelación de query no está soportada (`QUERY_CANCELLATION` no está establecida); los comandos de larga duración no se pueden abortar desde la UI.
+- Sin upsert (`supports_upsert: false`), sin `RETURNING` y sin update masivo (`supports_bulk_update: false`).
+- Las capacidades DDL están todas deshabilitadas (sin tables, views, indexes, schemas) — esto es un almacén clave-valor, no relacional.
+- Las transacciones se anuncian a nivel de capacidad (`supports_transactions: true`) pero sin niveles de aislamiento, savepoints, transacciones anidadas, read-only ni soporte deferrable.
+- Pub/Sub no está expuesto (la capacidad `PUBSUB` no está establecida).
+- El túnel SSH no está disponible cuando el modo URI está habilitado; la ruta del túnel solo está conectada para el modo de conexión manual.
+- Los grupos de consumidores de stream no están modelados; solo se soportan lecturas de rango, adición de entradas y eliminación de entradas.

--- a/docs/es/drivers/redshift.md
+++ b/docs/es/drivers/redshift.md
@@ -1,0 +1,37 @@
+# Amazon Redshift
+
+Data warehouse gestionado por AWS, compatible a nivel de wire protocol con PostgreSQL. Solo lectura.
+
+## De un vistazo
+
+- **Categoría** — Relacional
+- **Lenguaje de query** — SQL
+- **Puerto por defecto** — 5439
+- **Esquema de URI** — `redshift`
+
+Driver de Amazon Redshift para DBFlux (v1 de solo lectura), construido directamente sobre el cliente de wire protocol [`postgres`](https://crates.io/crates/postgres) en lugar de sobre `dbflux_driver_postgres`.
+
+## Funcionalidades
+
+- Driver relacional (`DatabaseCategory::Relational`, `QueryLanguage::Sql`) que habla el protocolo wire de PostgreSQL contra un cluster de Redshift o un endpoint de Redshift Serverless.
+- Formulario de conexión con host, port (por defecto `5439`), database, user, password, SSL/`sslmode` (`disable`/`allow`/`prefer`/`require`/`verify-ca`/`verify-full`), un modo de URI de conexión (`redshift://...`, normalizado internamente a `postgresql://...`), y túnel SSH.
+- Confianza TLS personalizada y TLS mutuo: para los modos con TLS habilitado se agrega una CA raíz privada fijada (PEM) al almacén de confianza además de las raíces del sistema, y un certificado de cliente + clave privada (PEM/PKCS#8) habilitan el TLS mutuo. El material del certificado se carga por conexión desde las rutas configuradas en el formulario; la validación nunca se debilita (`verify-ca`/`verify-full` siguen rechazando un certificado no confiable). Un archivo de certificado/clave faltante, ilegible o malformado se muestra como un error de conexión claro en lugar de recurrir silenciosamente al almacén de confianza del sistema, y el contenido de la clave privada nunca se registra en logs.
+- Introspección de schema sobre `information_schema` para databases, schemas, tables, views y columns, con clasificación de `ColumnKind` (timestamp/integer/float/text) reflejando los OIDs estándar de PostgreSQL.
+- Los tipos extendidos exclusivos de Redshift (`SUPER`, `VARBYTE`, `GEOMETRY`, `GEOGRAPHY`, `HLLSKETCH`) se clasifican como `ColumnKind::Text` y se renderizan como texto; cualquier otro OID no reconocido recurre a una decodificación defensiva a texto UTF-8 en lugar de causar un panic.
+- Los detalles de table exponen metadata de almacenamiento específica de Redshift a través del seam genérico `TableInfo.storage_hints` (leído de `SVV_TABLE_INFO` y `PG_TABLE_DEF`): distribution key (`KEY`/`EVEN`/`ALL`/`AUTO`, con la columna clave cuando aplica) y sort key (compuesta o interleaved, con sus columnas ordenadas). Las constraints declaradas de primary key, foreign key y unique se siguen exponiendo a través de las formas de metadata estándar del núcleo, cada una etiquetada como advisory/no forzada — Redshift acepta pero nunca fuerza estas constraints, y no se fabrica ninguna lista de índices a partir de ellas.
+- La ejecución de queries (`SELECT`/browse) devuelve filas con columnas tipadas a través de la ruta estándar `Connection::execute`; la cancelación de query está soportada a través del token de cancelación del cliente de wire protocol.
+- `RedshiftErrorFormatter` mapea fallos comunes de conexión y de query (timeouts, conexiones rechazadas, fallos de autenticación, clusters inalcanzables, errores de query con `SQLSTATE`) a mensajes claros formateados por el driver en lugar de output de debug crudo.
+
+## Limitaciones
+
+- Solo lectura: `DriverMetadata.capabilities` omite `INSERT`, `UPDATE`, `DELETE`, `RETURNING`, `BULK_INSERT`, `TRUNCATE_TABLE`, y todas las flags de DDL/DDL-transaccional. No hay edición inline en la grilla ni mutation/visual-query builder para este driver. `Connection::execute` además rechaza cualquier statement que no sea de lectura a nivel del wire con un error explícito, así que un intento de escritura nunca se convierte en un no-op silencioso.
+- Solo un statement por vez: `Connection::execute` ejecuta un statement de solo lectura a la vez. La entrada multi-statement (p. ej. `SELECT 1; SELECT 2`) se rechaza con un error explícito antes de llegar al wire; se permite un único `;` final opcional, y `;` dentro de literales de cadena, identificadores entrecomillados o comentarios no se trata como separador.
+- Sin capacidad `INDEXES`: Redshift no tiene estructuras de índice reales, así que `TableDetails.indexes` siempre es `None` en lugar de sintetizarse a partir de la primary key (no forzada).
+- Sin triggers: Redshift no soporta triggers, así que ninguno se descubre ni se expone.
+- Sin autenticación basada en IAM/SSO. Solo se soporta username/password (opcionalmente vía túnel SSH); el `GetClusterCredentials` basado en IAM de Redshift y los flujos de SSO por navegador no están implementados.
+- Los certificados de cliente para TLS mutuo deben suministrarse como un certificado PEM más una clave privada PEM PKCS#8 (ambos se configuran como rutas de archivo separadas); no se acepta un bundle PKCS#12 combinado. El parseo PEM y el manejo de errores de la ruta de carga de CA raíz/certificado de cliente están cubiertos por pruebas unitarias, pero el handshake TLS de extremo a extremo contra un cluster respaldado por una CA privada o que requiere un certificado de cliente solo se valida mediante una prueba de integración en vivo marcada `#[ignore]` (`redshift_live_verify_full_with_private_ca_and_client_cert`), ya que no existe ningún motor de Redshift local ni basado en Docker.
+- Sin soporte de `COPY`/`UNLOAD` ni integración de transferencia de datos/exportación masiva específica de Redshift.
+- Sin visualización de plan de query (el output de `EXPLAIN` no se parsea ni se renderiza).
+- Sin métricas de instancia ni inspector de instancia (`INSTANCE_METRICS`/`INSTANCE_INSPECTOR` no están declaradas).
+- Los valores de OID de tipo extendido usados para `SUPER`/`VARBYTE`/`GEOMETRY`/`GEOGRAPHY`/`HLLSKETCH`, y las formas exactas de query de `SVV_TABLE_INFO`/`PG_TABLE_DEF` usadas para los storage hints, solo se validan mediante pruebas de integración en vivo marcadas `#[ignore]` (`crates/dbflux_driver_redshift/tests/live_integration.rs`), ya que no existe ningún motor de Redshift local ni basado en Docker. Ejecútalas explícitamente contra un cluster real con `cargo nextest run -p dbflux_driver_redshift --run-ignored all`.
+- Los valores `NUMERIC`/`DECIMAL` SÍ se decodifican: el driver parsea el formato wire binario `NUMERIC` de PostgreSQL directamente a una cadena `Value::Decimal` exacta (reconstrucción de parte entera/fraccionaria a la escala declarada de la columna, más `NaN`/±`Infinity`). Los payloads malformados recurren a un fallback seguro en lugar de corromper datos. El decodificador binario está cubierto por pruebas unitarias sobre payloads wire sintéticos; la fidelidad de extremo a extremo solo se valida contra un cluster real vía las pruebas de integración marcadas `#[ignore]`.

--- a/docs/es/drivers/s3.md
+++ b/docs/es/drivers/s3.md
@@ -1,0 +1,35 @@
+# Amazon S3
+
+Almacenamiento de objetos AWS S3 y compatible con S3, incluyendo Cloudflare R2 y MinIO.
+
+## De un vistazo
+
+- **Categoría** — Almacenamiento de objetos
+- **Lenguaje de query** — Explorador de objetos (sin lenguaje de query)
+- **Esquema de URI** — `s3`
+
+Driver de almacenamiento de objetos AWS S3 y compatible con S3 para DBFlux, construido sobre el SDK [`aws-sdk-s3`](https://crates.io/crates/aws-sdk-s3). Está detrás del feature flag `s3`.
+
+## Funcionalidades
+
+- Driver de almacenamiento de objetos clasificado como `DatabaseCategory::ObjectStorage`, que conecta a AWS S3 y a endpoints compatibles con S3 (Cloudflare R2, MinIO) mediante un `AuthProfileRef` de perfil/SSO de AWS o credenciales estáticas de access-key, con override de endpoint y direccionamiento por path-style.
+- Browsing de buckets: una tabla dedicada de buckets (name, region, object count, size, versioning, created) con búsqueda, refresh y creación de buckets; la barra lateral lista los buckets planos, un nivel de profundidad.
+- Navegación paginada de objetos por nivel por defecto (estilo consola de AWS, usando el continuation token devuelto por el driver), con un toggle opcional de modo árbol para expansión completa no paginada.
+- Diseño dividido árbol/vista previa en el explorador de objetos: las filas de objeto muestran key, size, storage class y last-modified; las filas de directorio muestran conteos de objetos hijos.
+- Matriz de vista previa: las imágenes se renderizan de forma nativa vía `img()`; los objetos tipo texto (txt, md, json, csv, log, ...) se abren en un buffer editable inline con badge de cambios sin guardar, Ctrl+S para guardar (`put_object`), Discard, y una confirmación de ediciones sin guardar al navegar fuera; PDF y otros objetos binarios recurren a metadata más descarga/apertura externa, sin renderizado de PDF dentro de la app.
+- Metadata completa de objeto (key, size, content-type, last modified, ETag, storage class, encryption, versions donde estén disponibles), con estilizado por storage class distinguiendo STANDARD/STANDARD_IA/GLACIER y objetos archivados degradando a solo-metadata (sin intento de obtener el body).
+- Límite de tamaño de vista previa configurable, verificado mediante una request HEAD antes de obtener el body de cualquier objeto.
+- CRUD: eliminación de un solo objeto, eliminación recursiva de prefix/bucket (modal de peligro con confirmación por escritura de texto, `DeleteObjects` por lotes de hasta 1000 keys/request), creación de carpetas (marcador de prefix de cero bytes), creación de buckets (validación de nombre, región, versioning/block-public-access/object-lock, encryption por defecto con degradación elegante en endpoints no soportados), subida simple por streaming (`put_object`/`ByteStream`, sin multipart), y renombrado de objetos (copiar y luego eliminar, vinculado a `r`, nunca a `F2`).
+- URLs prefirmadas: elección de método GET/PUT, expiración de 15 minutos/1 hora/12 horas/7 días, acción de copiar URL, y texto de advertencia nombrando la expiración y la identidad de firma.
+- Cada operación CRUD/mutación (upload, delete, delete recursivo, creación de carpeta/bucket, eliminación de bucket, guardado de edición, renombrado, presign) se audita bajo la `EventCategory` de object-storage, sin que las credenciales ni las URLs prefirmadas se registren ni persistan jamás.
+- Los errores de permiso y de no-encontrado (`AccessDenied`, `NoSuchBucket`, `NoSuchKey`) se formatean con el bucket/key afectado nombrado en el mensaje, no solo con el texto de error genérico de AWS.
+
+## Limitaciones
+
+- Sin subida multipart ni panel de Transfers dedicado — las subidas siempre pasan por una única llamada `put_object` de streaming, sin importar el tamaño del archivo.
+- Sin visor de PDF embebido; PDF y otros objetos que no son imagen/texto solo ofrecen metadata, descarga y apertura externa.
+- Sin gestión de reglas de lifecycle ni de ACLs, y sin S3 Select.
+- El renombrado es copiar-y-eliminar sin rollback: si el delete tras una copia exitosa falla, tanto la key de origen como la de destino quedan en su lugar y el usuario debe reintentar el delete manualmente.
+- `delete_bucket` solo tiene éxito en un bucket vacío; eliminar un bucket no vacío se rechaza del lado del cliente con un mensaje que apunta al flujo de eliminación recursiva de prefix/bucket.
+- La vista previa y la visualización de metadata están condicionadas por HEAD: el size y la storage class de un objeto siempre se obtienen vía `head_object` antes de intentar cualquier vista previa del body.
+- Las pruebas de integración en vivo respaldadas por MinIO requieren Docker y se ejecutan con `cargo nextest run -p dbflux_driver_s3 --run-ignored all`.

--- a/docs/es/drivers/sqlite.md
+++ b/docs/es/drivers/sqlite.md
@@ -1,0 +1,152 @@
+# SQLite
+
+Base de datos embebida basada en archivos.
+
+## De un vistazo
+
+- **Categoría** — Relacional
+- **Query language** — SQL
+- **Esquema de URI** — `sqlite`
+
+## Funcionalidades
+
+- Driver relacional SQLite embebido usando rutas de base de datos basadas
+  en archivos.
+- Soporta ejecución de SQL, descubrimiento de schema, vistas, índices,
+  foreign keys, constraints CHECK, y constraints UNIQUE.
+- Soporta cancelación de queries vía los handles de interrupt de SQLite.
+- Incluye generación de SQL/código para CRUD, índices, reindex, create
+  table, y drop table.
+- Los scripts multi-sentencia (varias sentencias separadas por `;`) se
+  dividen y ejecutan sentencia por sentencia, cada una a través del camino
+  preparado tipado, devolviendo un result set por sentencia.
+  (`rusqlite::prepare` solo parsea la primera sentencia de un string, así
+  que un script debe dividirse.)
+- Motor de transferencia de datos: carga masiva nativa multi-fila con
+  `INSERT` (`BULK_INSERT`), DDL `CREATE TABLE` nativo del driver a partir de
+  las columnas de una tabla origen, y un toggle de integridad referencial
+  por conexión (`PRAGMA foreign_keys`) para migraciones seguras con FK.
+
+## Limitaciones
+
+- Driver solo de archivo local; sin transporte de red, túnel SSH, ni modo
+  TLS/SSL.
+- Driver solo SQL; no expone APIs de documentos ni de key-value.
+- El modelo de schema de SQLite no tiene un equivalente de namespace
+  multi-schema del lado del servidor.
+- No existe la sentencia `TRUNCATE TABLE`; la opción de carga Truncate del
+  motor de transferencia de datos no está disponible para destinos SQLite
+  (`DriverCapabilities::TRUNCATE_TABLE` no está fijado).
+
+## Capacidades de DDL
+
+### DDL transaccional
+
+SQLite soporta **DDL transaccional** — todas las operaciones de DDL pueden
+envolverse en transacciones y revertirse con rollback:
+
+```sql
+BEGIN;
+ALTER TABLE users ADD COLUMN phone TEXT NULL;
+-- Prueba el cambio
+ROLLBACK;  -- Seguro de revertir si algo sale mal
+```
+
+### Limitaciones de ALTER TABLE
+
+**CRÍTICO**: SQLite tiene soporte **muy limitado** de `ALTER TABLE`:
+
+**Operaciones soportadas**:
+- `ADD COLUMN` (solo al final de la tabla)
+- `RENAME COLUMN` (SQLite 3.25.0+)
+- `RENAME TABLE`
+
+**NO soportadas**:
+- `DROP COLUMN` (requiere recreación de la tabla)
+- `ALTER COLUMN` (el cambio de tipo requiere recreación de la tabla)
+- `ADD COLUMN` en medio de la tabla (requiere recreación de la tabla)
+
+### Patrón de recreación de tabla
+
+Para operaciones de `ALTER TABLE` no soportadas, usa el patrón de
+recreación de tabla:
+
+```sql
+BEGIN;
+
+-- 1. Crea una tabla nueva con el schema deseado
+CREATE TABLE users_new (
+  id INTEGER PRIMARY KEY,
+  email TEXT NOT NULL,
+  name TEXT,
+  -- columna phone eliminada, columna age agregada
+  age INTEGER
+);
+
+-- 2. Copia los datos de la tabla vieja
+INSERT INTO users_new (id, email, name, age)
+  SELECT id, email, name, NULL FROM users;
+
+-- 3. Elimina la tabla vieja
+DROP TABLE users;
+
+-- 4. Renombra la tabla nueva
+ALTER TABLE users_new RENAME TO users;
+
+COMMIT;
+```
+
+**IMPORTANTE**: este patrón pierde:
+- Las referencias de foreign key desde otras tablas
+- Los triggers en la tabla original
+- Los índices en la tabla original (deben recrearse)
+
+### Operaciones de índice
+
+**CREATE INDEX**:
+- Bloquea la base de datos durante la operación (bloquea escrituras)
+- Sin opción concurrente (a diferencia de PostgreSQL)
+
+**DROP INDEX**:
+- Rápido (solo metadata)
+
+**REINDEX**:
+- Reconstruye el índice (bloquea la base de datos)
+
+### Constraints
+
+**Agregar constraints**:
+- SQLite valida los constraints en el momento de `INSERT`/`UPDATE`
+- No se pueden agregar constraints a tablas existentes (requiere
+  recreación de la tabla)
+
+**Foreign keys**:
+- Deshabilitadas por defecto (deben habilitarse con
+  `PRAGMA foreign_keys = ON`)
+- No se pueden agregar a tablas existentes (requiere recreación de la
+  tabla)
+
+### Limitaciones conocidas
+
+- Sin `DROP COLUMN` (requiere recreación de la tabla)
+- Sin `ALTER COLUMN` (requiere recreación de la tabla)
+- No se pueden agregar constraints a tablas existentes
+- Sin creación de índices concurrente (bloquea la base de datos)
+- Tipado dinámico (los tipos de columna son solo indicativos)
+
+### Buenas prácticas
+
+1. **Usa transacciones** — el DDL es transaccional, envuelve siempre en
+   `BEGIN`/`COMMIT`
+2. **Planifica el schema con anticipación** — es difícil de modificar
+   después
+3. **Usa el patrón de recreación de tabla** — para operaciones de
+   `ALTER TABLE` no soportadas
+4. **Recrea índices y triggers** — después de recrear la tabla
+5. **Prueba primero en una copia** — especialmente para el patrón de
+   recreación de tabla
+6. **Habilita foreign keys** — `PRAGMA foreign_keys = ON` antes de alterar
+   el schema
+7. **Usa VACUUM** — para liberar espacio en disco después de `DROP TABLE`
+   o de recrear una tabla
+

--- a/web/scripts/fetch-docs.mjs
+++ b/web/scripts/fetch-docs.mjs
@@ -20,7 +20,7 @@ export const VERSIONS_DIR = join(WEB, '.versions');
 
 /** Paths every version contributes, matching the collection in content.config.ts. */
 const WANTED =
-  /^(docs\/[^/]+\.md|docs\/es\/[^/]+\.md|ARCHITECTURE\.md|CONTRIBUTING\.md|crates\/dbflux_driver_[^/]+\/README\.md)$/;
+  /^(docs\/[^/]+\.md|docs\/es\/[^/]+\.md|docs\/es\/drivers\/[^/]+\.md|ARCHITECTURE\.md|CONTRIBUTING\.md|crates\/dbflux_driver_[^/]+\/README\.md)$/;
 
 const git = (args) =>
   execFileSync('git', args, { cwd: REPO, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });

--- a/web/src/components/LanguagePicker.astro
+++ b/web/src/components/LanguagePicker.astro
@@ -1,0 +1,191 @@
+---
+import { LOCALES, LOCALE_NAMES, localeFromPathname, t, withLocale } from '../i18n';
+import type { Locale } from '../i18n';
+
+interface Props {
+  locale?: Locale;
+}
+
+const { locale = localeFromPathname(Astro.url.pathname) } = Astro.props;
+
+const pathname = Astro.url.pathname;
+
+const options = LOCALES.map((target) => ({
+  locale: target,
+  href: withLocale(pathname, target),
+  label: LOCALE_NAMES[target],
+}));
+---
+
+<div class="lang" data-lang-picker>
+  <button
+    type="button"
+    class="lang__button nav__link"
+    aria-expanded="false"
+    aria-controls="lang-menu"
+    aria-label={t(locale, 'nav.language')}
+    data-lang-toggle
+  >
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="9"></circle>
+      <path d="M3 12h18"></path>
+      <path d="M12 3a14 14 0 0 1 0 18 14 14 0 0 1 0-18z"></path>
+    </svg>
+    <span>{LOCALE_NAMES[locale]}</span>
+  </button>
+
+  <ul class="lang__menu" id="lang-menu" hidden>
+    {
+      options.map((option) => (
+        <li>
+          <a
+            href={option.href}
+            hreflang={option.locale}
+            lang={option.locale}
+            aria-current={option.locale === locale ? 'true' : undefined}
+          >
+            {option.label}
+          </a>
+        </li>
+      ))
+    }
+  </ul>
+</div>
+
+<style>
+  .lang {
+    position: relative;
+  }
+
+  /*
+   * `nav__link` on the button only matches SiteNav's scoped styles when the
+   * markup lives there; from this component the class is inert, so the same
+   * typography and colors are restated here.
+   */
+  .lang__button {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: var(--s-2);
+    background: none;
+    border: 0;
+    padding-bottom: 3px;
+    font-family: var(--font-mono);
+    font-size: var(--fs-small);
+    color: var(--text);
+    cursor: pointer;
+    transition: color var(--t-instant) linear;
+  }
+
+  .lang__button::after {
+    content: '';
+    position: absolute;
+    inset-inline: 0;
+    bottom: -1px;
+    height: 1px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform var(--t-quick) var(--ease-std);
+  }
+
+  .lang__button:hover,
+  .lang__button[aria-expanded='true'] {
+    color: var(--text-strong);
+  }
+
+  .lang__button:hover::after,
+  .lang__button[aria-expanded='true']::after {
+    transform: scaleX(1);
+  }
+
+  .lang__button svg {
+    color: var(--text-muted);
+    transition: color var(--t-instant) linear;
+  }
+
+  .lang__button:hover svg,
+  .lang__button[aria-expanded='true'] svg {
+    color: currentColor;
+  }
+
+  .lang__menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    z-index: var(--z-dropdown);
+    min-width: 140px;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    background: var(--raised);
+    border: var(--bw) solid var(--border-interactive);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .lang__menu[hidden] {
+    display: none;
+  }
+
+  .lang__menu a {
+    display: block;
+    padding: var(--s-3) var(--s-4);
+    font-family: var(--font-mono);
+    font-size: var(--fs-small);
+    color: var(--text);
+    transition:
+      background 120ms linear,
+      color 120ms linear;
+  }
+
+  .lang__menu a:hover {
+    background: var(--panel);
+    color: var(--text-strong);
+    text-decoration: none;
+  }
+
+  .lang__menu a[aria-current='true'] {
+    color: var(--text-strong);
+    box-shadow: inset 2px 0 0 0 var(--accent);
+  }
+</style>
+
+<script>
+  const pickers = document.querySelectorAll<HTMLElement>('[data-lang-picker]');
+
+  pickers.forEach((picker) => {
+    const toggle = picker.querySelector<HTMLButtonElement>('[data-lang-toggle]');
+    const menu = picker.querySelector<HTMLElement>('.lang__menu');
+
+    if (!toggle || !menu) return;
+
+    const close = () => {
+      menu.hidden = true;
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+
+    toggle.addEventListener('click', () => {
+      const open = !menu.hidden;
+
+      menu.hidden = open;
+      toggle.setAttribute('aria-expanded', String(!open));
+    });
+
+    document.addEventListener('click', (event) => {
+      if (event.target instanceof Node && !picker.contains(event.target)) close();
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') close();
+    });
+  });
+</script>

--- a/web/src/components/SiteFooter.astro
+++ b/web/src/components/SiteFooter.astro
@@ -23,16 +23,16 @@ const COLUMNS = [
   {
     title: t(locale, 'footer.docs'),
     links: [
-      { href: docsUrl('usage'), label: t(locale, 'footer.usage') },
-      { href: docsUrl('connections'), label: t(locale, 'footer.connecting') },
-      { href: docsUrl('mcp_ai_integration'), label: t(locale, 'footer.mcp') },
+      { href: docsUrl('usage', '', locale), label: t(locale, 'footer.usage') },
+      { href: docsUrl('connections', '', locale), label: t(locale, 'footer.connecting') },
+      { href: docsUrl('mcp_ai_integration', '', locale), label: t(locale, 'footer.mcp') },
     ],
   },
   {
     title: t(locale, 'footer.project'),
     links: [
       { href: '/about/', label: t(locale, 'footer.about') },
-      { href: docsUrl('contributing'), label: t(locale, 'footer.contributing') },
+      { href: docsUrl('contributing', '', locale), label: t(locale, 'footer.contributing') },
       { href: REPO, label: t(locale, 'footer.source') },
     ],
   },

--- a/web/src/components/SiteNav.astro
+++ b/web/src/components/SiteNav.astro
@@ -1,9 +1,10 @@
 ---
 import Icon from './Icon.astro';
 import BrandMark from './BrandMark.astro';
+import LanguagePicker from './LanguagePicker.astro';
 import { REPO } from '../data/nav';
 import { docsUrl, siteUrl } from '../data/site';
-import { localeFromPathname, t, withLocale } from '../i18n';
+import { LOCALES, LOCALE_NAMES, localeFromPathname, t, withLocale } from '../i18n';
 import type { Locale } from '../i18n';
 
 interface Props {
@@ -16,7 +17,7 @@ const { current, locale = localeFromPathname(Astro.url.pathname) } = Astro.props
 const LINKS = [
   { href: `${siteUrl()}#features`, label: t(locale, 'nav.features'), key: 'features' },
   { href: `${siteUrl()}#drivers`, label: t(locale, 'nav.drivers'), key: 'drivers' },
-  { href: docsUrl(''), label: t(locale, 'nav.docs'), key: 'docs' },
+  { href: docsUrl('', '', locale), label: t(locale, 'nav.docs'), key: 'docs' },
   { href: siteUrl('about/'), label: t(locale, 'nav.about'), key: 'about' },
 ] as const;
 
@@ -27,8 +28,12 @@ const LINKS = [
  */
 const pathname = Astro.url.pathname;
 const showSwitcher = current === 'home' || current === 'docs' || current === 'about';
-const switchTarget = withLocale(pathname, locale === 'es' ? 'en' : 'es');
-const switchHreflang = locale === 'es' ? 'en' : 'es';
+
+const localeLinks = LOCALES.map((target) => ({
+  locale: target,
+  href: withLocale(pathname, target),
+  label: LOCALE_NAMES[target],
+}));
 ---
 
 <header class="nav" data-nav>
@@ -53,13 +58,7 @@ const switchHreflang = locale === 'es' ? 'en' : 'es';
     </nav>
 
     <div class="nav__actions">
-      {
-        showSwitcher && (
-          <a class="nav__link nav__switch" href={switchTarget} hreflang={switchHreflang}>
-            {t(locale, 'nav.switch_locale')}
-          </a>
-        )
-      }
+      {showSwitcher && <LanguagePicker locale={locale} />}
       <a class="nav__link nav__link--icon" href={REPO} rel="noopener">
         <Icon name="github" size={16} />
         <span>{t(locale, 'nav.github')}</span>
@@ -83,11 +82,17 @@ const switchHreflang = locale === 'es' ? 'en' : 'es';
   <div class="nav__sheet" id="nav-sheet" hidden>
     {LINKS.map((link) => <a href={link.href}>{link.label}</a>)}
     {
-      showSwitcher && (
-        <a href={switchTarget} hreflang={switchHreflang}>
-          {t(locale, 'nav.switch_locale')}
-        </a>
-      )
+      showSwitcher &&
+        localeLinks.map((option) => (
+          <a
+            href={option.href}
+            hreflang={option.locale}
+            lang={option.locale}
+            aria-current={option.locale === locale ? 'true' : undefined}
+          >
+            {option.label}
+          </a>
+        ))
     }
     <a href={REPO} rel="noopener">
       {t(locale, 'nav.github')}

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -24,6 +24,7 @@ const docs = defineCollection({
     pattern: [
       '*/docs/*.md',
       '*/docs/es/*.md',
+      '*/docs/es/drivers/*.md',
       '*/ARCHITECTURE.md',
       '*/CONTRIBUTING.md',
       '*/crates/dbflux_driver_*/README.md',

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -9,7 +9,7 @@ export const en = {
     github: 'GitHub',
     download: 'Download',
     menu: 'Menu',
-    switch_locale: 'Español',
+    language: 'Language',
   },
   footer: {
     product: 'Product',

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -9,7 +9,7 @@ export const es: Dictionary = {
     github: 'GitHub',
     download: 'Descargar',
     menu: 'Menú',
-    switch_locale: 'English',
+    language: 'Idioma',
   },
   footer: {
     product: 'Producto',

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -7,6 +7,12 @@ export const LOCALES: readonly Locale[] = ['en', 'es'];
 
 export const DEFAULT_LOCALE: Locale = 'en';
 
+/** Native display name for each locale, used by the language picker. */
+export const LOCALE_NAMES: Record<Locale, string> = {
+  en: 'English',
+  es: 'Español',
+};
+
 /**
  * The complete shape of every chrome string the site renders.
  *
@@ -23,7 +29,7 @@ export interface Dictionary {
     github: string;
     download: string;
     menu: string;
-    switch_locale: string;
+    language: string;
   };
   footer: {
     product: string;


### PR DESCRIPTION
Closes #360 (follow-up)

## Summary

- Replaces the site's language switcher (a single en/es toggle link) with a dropdown driven by the locale list, so adding a language later needs no component change. It matches the nav's typography and hover underline, and marks the active language.
- Fixes cross-host language loss: the docs links in the navigation and footer now pass the reader's locale to `docsUrl`, so dbflux.dev `/es/` no longer drops to English when jumping to docs.dbflux.dev.
- Completes the Spanish documentation: every document the site serves now has a `docs/es/` sibling — the remaining 14 guides, ARCHITECTURE, CONTRIBUTING, and all 13 driver READMEs (new `docs/es/drivers/<name>.md` convention, wired into the content collection and `fetch-docs`).

## Review path

Start with `web/src/components/LanguagePicker.astro` (the only new component) and the two-line mechanism change in `web/src/content.config.ts` + `web/scripts/fetch-docs.mjs`. The `docs/es/` files are translations only: no content added or removed, code blocks and identifiers verbatim, internal anchors re-slugged to the Spanish headings.

## Out of scope

- Publishing these translations on the current-release docs (`release/v0.7`) — done as a separate docs-only cherry-pick after this merges, since the unprefixed docs are served from that branch's ref.

## Test plan

- [x] `pnpm check` — 0 errors, 0 warnings.
- [x] `pnpm build` with nightly temporarily pointed at this branch — 189 pages, `check-links` reports every internal link resolves.
- [x] Verified in `dist/` that `/es/nightly/docs/architecture/` renders the Spanish H1 and all 13 `/es/nightly/docs/drivers/<name>/` pages render translated content.
- [x] Verified the dropdown manually in the dev server on `/` and `/es/`: options list both languages with `hreflang`/`lang`, active locale marked, Escape and outside-click close it.
