### PR TITLE
docs(web): describe the product on its own terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An extensible, keyboard-first data platform delivered as a Rust + GPUI desktop c
 
 DBFlux is an open-source desktop client with built-in drivers for relational and non-relational databases. Its core contracts are driver-neutral, and external drivers can integrate over RPC.
 
-The client focuses on performance, a clean UX, and keyboard-first workflows. The long-term goal is to provide a fully open-source alternative to DBeaver.
+The client focuses on performance, a clean UX, and keyboard-first workflows. The long-term goal is one fully open-source client for every database you work with.
 
 ![DBFlux](resources/dbflux.png)
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Choose the path that matches what you want to do.
 
 ### Start here
 
-| Goal | Guide |
-|------|-------|
-| Create a connection | Start with the [Usage Guide](docs/USAGE.md#1-first-launch-and-creating-a-connection). For SSH tunnels, proxies, AWS SSO, and value sources, use [Connecting — Advanced Setup](docs/CONNECTIONS.md). |
-| Run queries and follow common workflows | Follow the [Usage Guide](docs/USAGE.md) for querying, browsing results, charting, exporting, and keyboard navigation. |
-| View audit events | Open the audit viewer with the [Dashboards & Audit User Guide](docs/DASHBOARDS_AND_AUDIT.md#audit-viewer). |
-| Use MCP | Follow the [AI + MCP Integration Guide](docs/MCP_AI_INTEGRATION.md). |
-| Check driver support and limitations | Use [Drivers Overview](docs/DRIVERS.md), the canonical capability and limitations overview. |
+| Goal                                    | Guide                                                                                                                                                                                               |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Create a connection                     | Start with the [Usage Guide](docs/USAGE.md#1-first-launch-and-creating-a-connection). For SSH tunnels, proxies, AWS SSO, and value sources, use [Connecting — Advanced Setup](docs/CONNECTIONS.md). |
+| Run queries and follow common workflows | Follow the [Usage Guide](docs/USAGE.md) for querying, browsing results, charting, exporting, and keyboard navigation.                                                                               |
+| View audit events                       | Open the audit viewer with the [Dashboards & Audit User Guide](docs/DASHBOARDS_AND_AUDIT.md#audit-viewer).                                                                                          |
+| Use MCP                                 | Follow the [AI + MCP Integration Guide](docs/MCP_AI_INTEGRATION.md).                                                                                                                                |
+| Check driver support and limitations    | Use [Drivers Overview](docs/DRIVERS.md), the canonical capability and limitations overview.                                                                                                         |
 
 ### More user guides
 
@@ -186,27 +186,32 @@ your package manager (included below). Windows and macOS use their default
 linker and are unaffected.
 
 **Ubuntu/Debian:**
+
 ```bash
 sudo apt install pkg-config libssl-dev libdbus-1-dev libxkbcommon-dev mold
 ```
 
 **Fedora:**
+
 ```bash
 sudo dnf install pkg-config openssl-devel dbus-devel libxkbcommon-devel mold
 ```
 
 **Arch:**
+
 ```bash
 sudo pacman -S pkg-config openssl dbus libxkbcommon mold
 ```
 
 **macOS:**
+
 ```bash
 # Xcode Command Line Tools (required)
 xcode-select --install
 ```
 
 **Windows:**
+
 ```powershell
 # Visual Studio Build Tools with C++ workload (required)
 # Download from: https://visualstudio.microsoft.com/visual-cpp-build-tools/

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -24,7 +24,7 @@ export const en = {
     about: 'About',
     contributing: 'Contributing',
     source: 'Source',
-    tagline: 'A fully open-source alternative to DBeaver, built in the open.',
+    tagline: 'A fully open-source, keyboard-first database client, built in the open.',
     license: 'MIT or Apache-2.0, at your option.',
   },
   search: {
@@ -181,7 +181,7 @@ export const en = {
     intro_p2:
       'That constraint is enforced in the code, not in a style guide. The interface adapts through capability flags and metadata, so a document store gets a document view and a time-series store gets a range picker without a single branch on a driver name. Adding a database is writing a driver, not patching the app.',
     intro_p3:
-      'The long-term goal is stated plainly on the README: a fully open-source alternative to DBeaver. Rust and GPUI are how it stays fast enough to be worth switching to.',
+      'The long-term goal is stated plainly on the README: one fully open-source client for every database you work with. Rust and GPUI are how it stays fast enough to be worth switching to.',
     principles_eyebrow: 'Principles',
     principle: {
       p01: {

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -24,7 +24,7 @@ export const es: Dictionary = {
     about: 'Acerca de',
     contributing: 'Cómo contribuir',
     source: 'Código fuente',
-    tagline: 'Una alternativa totalmente de código abierto a DBeaver, desarrollada en abierto.',
+    tagline: 'Un cliente de bases de datos keyboard-first y totalmente de código abierto, desarrollado en abierto.',
     license: 'MIT o Apache-2.0, a tu elección.',
   },
   search: {
@@ -185,7 +185,7 @@ export const es: Dictionary = {
     intro_p2:
       'Esa restricción se aplica en el código, no en una guía de estilo. La interfaz se adapta mediante flags de capacidades y metadatos, de modo que un almacén de documentos obtiene una vista de documentos y una fuente de series temporales obtiene un selector de rango sin una sola condición sobre el nombre del driver. Añadir una base de datos es escribir un driver, no parchear la aplicación.',
     intro_p3:
-      'El objetivo a largo plazo se declara sin rodeos en el README: una alternativa totalmente de código abierto a DBeaver. Rust y GPUI son lo que lo mantienen lo bastante rápido como para valer la pena cambiarse.',
+      'El objetivo a largo plazo se declara sin rodeos en el README: un único cliente totalmente de código abierto para todas las bases de datos con las que trabajas. Rust y GPUI son lo que lo mantienen lo bastante rápido como para valer la pena cambiarse.',
     principles_eyebrow: 'Principios',
     principle: {
       p01: {

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -24,7 +24,8 @@ export const es: Dictionary = {
     about: 'Acerca de',
     contributing: 'Cómo contribuir',
     source: 'Código fuente',
-    tagline: 'Un cliente de bases de datos keyboard-first y totalmente de código abierto, desarrollado en abierto.',
+    tagline:
+      'Un cliente de bases de datos keyboard-first y totalmente de código abierto, desarrollado en abierto.',
     license: 'MIT o Apache-2.0, a tu elección.',
   },
   search: {


### PR DESCRIPTION
Closes #360 (copy follow-up)

## Summary

- Rewrites the footer tagline, the about page's long-term-goal paragraph (en/es), and the README goal line so the product is defined by what it is — a fully open-source, keyboard-first client for every database you work with — rather than as an alternative to DBeaver.

## Test plan

- [x] `pnpm check` — 0 errors (dictionary key parity holds).