### PR TITLE
fix(web): localize the docs section titles and keep the locale toward the site

### DIFF
--- a/web/src/components/DocsIndex.astro
+++ b/web/src/components/DocsIndex.astro
@@ -1,7 +1,7 @@
 ---
 import { localizedDocTitle, sectionsFor } from '../data/docs';
 import { docsHref } from '../data/versions';
-import { localeFromPathname, t } from '../i18n';
+import { localeFromPathname, sectionTitle, t } from '../i18n';
 import type { Locale } from '../i18n';
 
 interface Props {
@@ -27,7 +27,7 @@ const { sections, unfiled } = sectionsFor(available);
 {
   sections.map((section) => (
     <section>
-      <h2 id={section.id}>{section.title}</h2>
+      <h2 id={section.id}>{sectionTitle(locale, section.id)}</h2>
       <ul>
         {section.entries.map((path) => (
           <li>

--- a/web/src/components/DocsTree.astro
+++ b/web/src/components/DocsTree.astro
@@ -3,7 +3,7 @@ import Icon from '../components/Icon.astro';
 import { localizedDocTitle, sectionsFor } from '../data/docs';
 import type { DocsVersion } from '../data/versions';
 import { docsHref } from '../data/versions';
-import { localeFromPathname, t } from '../i18n';
+import { localeFromPathname, sectionTitle, t } from '../i18n';
 import type { Locale } from '../i18n';
 
 interface Props {
@@ -32,7 +32,10 @@ const sections = sectionsFor(available).sections.map((section) => ({
 
 <nav class="tree" aria-label="Documentation">
   <button class="tree__search" type="button" data-search-open>
-    <span><Icon name="search" size={13} /> {t(locale, 'docs_tree.search_cta')}</span>
+    <span>
+      <Icon name="search" size={13} />
+      <span class="tree__search-label">{t(locale, 'docs_tree.search_cta')}</span>
+    </span>
     <kbd>Ctrl K</kbd>
   </button>
 
@@ -46,7 +49,7 @@ const sections = sectionsFor(available).sections.map((section) => ({
                 <Icon name="chevron" size={11} />
               </span>
               <span class="tree__num">{String(index + 1).padStart(2, '0')}</span>
-              <span class="tree__title">{section.title}</span>
+              <span class="tree__title">{sectionTitle(locale, section.id)}</span>
               <span class="tree__count">{section.entries.length}</span>
             </summary>
             <ul class="tree__leaves">
@@ -100,12 +103,22 @@ const sections = sectionsFor(available).sections.map((section) => ({
     display: flex;
     align-items: center;
     gap: var(--s-3);
+    min-width: 0;
+  }
+
+  .tree__search-label {
+    min-width: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   .tree__search kbd {
     font-size: var(--fs-label);
     border: var(--bw) solid var(--border);
     padding: 1px 5px;
+    flex-shrink: 0;
+    white-space: nowrap;
   }
 
   .tree__groups,

--- a/web/src/components/SiteFooter.astro
+++ b/web/src/components/SiteFooter.astro
@@ -1,7 +1,7 @@
 ---
 import BrandMark from './BrandMark.astro';
 import { REPO } from '../data/nav';
-import { docsUrl } from '../data/site';
+import { docsUrl, siteUrl } from '../data/site';
 import { localeFromPathname, t } from '../i18n';
 import type { Locale } from '../i18n';
 
@@ -15,8 +15,8 @@ const COLUMNS = [
   {
     title: t(locale, 'footer.product'),
     links: [
-      { href: '/#features', label: t(locale, 'footer.features') },
-      { href: '/#drivers', label: t(locale, 'footer.drivers') },
+      { href: `${siteUrl('', locale)}#features`, label: t(locale, 'footer.features') },
+      { href: `${siteUrl('', locale)}#drivers`, label: t(locale, 'footer.drivers') },
       { href: `${REPO}/releases`, label: t(locale, 'footer.releases') },
     ],
   },
@@ -31,7 +31,7 @@ const COLUMNS = [
   {
     title: t(locale, 'footer.project'),
     links: [
-      { href: '/about/', label: t(locale, 'footer.about') },
+      { href: siteUrl('about/', locale), label: t(locale, 'footer.about') },
       { href: docsUrl('contributing', '', locale), label: t(locale, 'footer.contributing') },
       { href: REPO, label: t(locale, 'footer.source') },
     ],

--- a/web/src/components/SiteNav.astro
+++ b/web/src/components/SiteNav.astro
@@ -15,10 +15,10 @@ interface Props {
 const { current, locale = localeFromPathname(Astro.url.pathname) } = Astro.props;
 
 const LINKS = [
-  { href: `${siteUrl()}#features`, label: t(locale, 'nav.features'), key: 'features' },
-  { href: `${siteUrl()}#drivers`, label: t(locale, 'nav.drivers'), key: 'drivers' },
+  { href: `${siteUrl('', locale)}#features`, label: t(locale, 'nav.features'), key: 'features' },
+  { href: `${siteUrl('', locale)}#drivers`, label: t(locale, 'nav.drivers'), key: 'drivers' },
   { href: docsUrl('', '', locale), label: t(locale, 'nav.docs'), key: 'docs' },
-  { href: siteUrl('about/'), label: t(locale, 'nav.about'), key: 'about' },
+  { href: siteUrl('about/', locale), label: t(locale, 'nav.about'), key: 'about' },
 ] as const;
 
 /**
@@ -38,7 +38,7 @@ const localeLinks = LOCALES.map((target) => ({
 
 <header class="nav" data-nav>
   <div class="nav__inner">
-    <a class="nav__brand" href={siteUrl()}>
+    <a class="nav__brand" href={siteUrl('', locale)}>
       <BrandMark size={28} />
       <span>DBFlux</span>
     </a>
@@ -63,7 +63,7 @@ const localeLinks = LOCALES.map((target) => ({
         <Icon name="github" size={16} />
         <span>{t(locale, 'nav.github')}</span>
       </a>
-      <a class="btn btn--primary nav__cta" href={`${siteUrl()}#install`}>
+      <a class="btn btn--primary nav__cta" href={`${siteUrl('', locale)}#install`}>
         {t(locale, 'nav.download')}
       </a>
       <button
@@ -98,7 +98,7 @@ const localeLinks = LOCALES.map((target) => ({
       {t(locale, 'nav.github')}
     </a>
     <div class="nav__sheet-cta">
-      <a class="btn btn--primary" href={`${siteUrl()}#install`}>
+      <a class="btn btn--primary" href={`${siteUrl('', locale)}#install`}>
         {t(locale, 'nav.download')}
       </a>
     </div>

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -43,6 +43,15 @@ export const en = {
     index_tag: 'index',
     default_tag: 'default',
   },
+  docs_sections: {
+    start: 'Start here',
+    using: 'Using DBFlux',
+    configure: 'Configuring',
+    integrate: 'Integrations',
+    reference: 'Reference',
+    drivers: 'Driver reference',
+    contribute: 'Contributing',
+  },
   docs_tree: {
     search_cta: 'Search the docs',
     rail_toggle: 'Documentation menu',

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -44,6 +44,15 @@ export const es: Dictionary = {
     index_tag: 'índice',
     default_tag: 'predeterminada',
   },
+  docs_sections: {
+    start: 'Empieza aquí',
+    using: 'Usando DBFlux',
+    configure: 'Configuración',
+    integrate: 'Integraciones',
+    reference: 'Referencia',
+    drivers: 'Referencia de drivers',
+    contribute: 'Cómo contribuir',
+  },
   docs_tree: {
     search_cta: 'Busca en la documentación',
     rail_toggle: 'Menú de documentación',

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -63,6 +63,15 @@ export interface Dictionary {
     index_tag: string;
     default_tag: string;
   };
+  docs_sections: {
+    start: string;
+    using: string;
+    configure: string;
+    integrate: string;
+    reference: string;
+    drivers: string;
+    contribute: string;
+  };
   docs_tree: {
     search_cta: string;
     rail_toggle: string;
@@ -217,6 +226,25 @@ export function t(locale: Locale, key: DictionaryKey): string {
 
   if (typeof value !== 'string') {
     throw new Error(`i18n key "${key}" does not resolve to a string for locale "${locale}"`);
+  }
+
+  return value;
+}
+
+/**
+ * The translated title for a docs rail section, keyed by `DocsSection.id`.
+ *
+ * `DocsSection.id` is typed as a plain `string` in `data/nav.ts` (it doubles
+ * as an anchor id and a `<details>` key), so this resolves it against
+ * `docs_sections` with a runtime check rather than widening `t()`'s key type
+ * for one caller.
+ */
+export function sectionTitle(locale: Locale, id: string): string {
+  const key = id as keyof Dictionary['docs_sections'];
+  const value = DICTIONARIES[locale].docs_sections[key];
+
+  if (typeof value !== 'string') {
+    throw new Error(`Missing docs section title for id "${id}"`);
   }
 
   return value;


### PR DESCRIPTION
Closes #360 (follow-up)

## Summary

- The docs sidebar and index section titles (Start here, Using DBFlux, …) now come from the dictionaries and render in Spanish on `/es/` pages.
- The search trigger no longer breaks with the longer Spanish placeholder: the label ellipsizes on one line and the Ctrl+K chip never wraps.
- Docs → site links (brand, Features, Drivers, About, Download) now pass the reader's locale to `siteUrl`, so leaving docs.dbflux.dev/es lands on dbflux.dev/es instead of English — the inverse of the fix shipped in #458.

## Test plan

- [x] `pnpm check` — 0 errors; `pnpm build` — 189 pages; `check-links` — every internal link resolves.
- [x] Verified in the dev server: /es/docs/ renders all seven section titles in Spanish, the search chip stays on one line, and the nav links point at `/es…` while English pages keep `/…`.