### PR TITLE
docs(i18n): remove a leaked tool artifact from the Spanish charts guide

### DIFF
--- a/docs/es/CHARTS.md
+++ b/docs/es/CHARTS.md
@@ -251,5 +251,3 @@ Estas limitaciones están fundamentadas en el código actual, no son suposicione
   demás tipos de chart se seleccionan después de la construcción.
 - La decimación de series usa un umbral LTTB cuyo valor por defecto es 10.000
   puntos (`default_decimation_threshold`).
-  </content>
-  </invoke>


### PR DESCRIPTION
Two stray lines (`</content>`, `</invoke>`) leaked by a translation tool sat at the end of `docs/es/CHARTS.md`, outside any markdown block, and rendered as literal text on the Spanish charts page. This deletes them; no other content changes.