### PR TITLE
feat(i18n): derive the language list from the translation catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to DBFlux will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+* **Language list derived from the translation catalogs (#360)** — the
+  Settings language dropdown now lists every language that ships a catalog in
+  `crates/dbflux_i18n/locales/`, with each language named in its own tongue
+  via the `language.native_name` key. Contributing a new language on Weblate
+  is enough for it to appear in the next build, with no code changes.
+
 ### Added
 
 * **Complete Spanish documentation and a language menu (#360)** — the

--- a/crates/dbflux_app/src/config_loader.rs
+++ b/crates/dbflux_app/src/config_loader.rs
@@ -1086,16 +1086,14 @@ fn theme_setting_from_storage(theme: &str) -> dbflux_core::ThemeSetting {
 
 /// Maps a storage `language` string to a `GeneralSettings::language` value.
 ///
-/// Mirrors the supported set of `dbflux_i18n::Language` storage identifiers
-/// without depending on `dbflux_i18n` from this app/core layer. Any value
-/// other than the empty string or a currently supported language falls back
-/// to the empty string, which `dbflux_i18n::resolve` treats as "follow the
-/// system locale" (`LanguagePreference::System`).
+/// The value passes through unvalidated on purpose: the supported set of
+/// languages is derived from the translation catalogs in `dbflux_i18n`, and
+/// this app/core layer must not duplicate it. `dbflux_i18n::resolve` treats
+/// any unrecognized value as "follow the system locale", so a stale or
+/// not-yet-shipped language code degrades safely instead of being erased
+/// here and losing the user's choice across an upgrade cycle.
 fn language_setting_from_storage(language: &str) -> String {
-    match language {
-        "en" | "es" => language.to_string(),
-        _ => String::new(),
-    }
+    language.to_string()
 }
 
 /// Maps a storage `style` string to `AppStyle`.
@@ -2441,7 +2439,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_language_storage_value_falls_back_to_empty_string() {
+    fn unrecognized_language_storage_value_loads_through_unchanged() {
         let runtime = StorageRuntime::in_memory().expect("in-memory storage runtime");
 
         let mut dto = GeneralSettingsDto {
@@ -2473,8 +2471,9 @@ mod tests {
 
         let loaded = load_config(&runtime).expect("load configuration");
         assert_eq!(
-            loaded.general_settings.language, "",
-            "unsupported language storage value must fall back to empty string (System)"
+            loaded.general_settings.language, "de",
+            "an unrecognized language code must survive the load; dbflux_i18n::resolve \
+             degrades it to System without erasing the stored choice"
         );
 
         dto.language = "es".to_string();

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -2124,6 +2124,8 @@ hooks:
   tab:
     intro: Select reusable hooks configured in Settings -> Hooks
     lua_process_run_note: Selected hook enables Lua process.run and can execute external programs with your user permissions
+language:
+  native_name: English
 login:
   window_title: Connection Flow
   field:
@@ -2449,8 +2451,6 @@ settings:
       label: Language
       option:
         system: System
-        english: English
-        spanish: Spanish
       notice: Language changes apply after restarting DBFlux.
     restore_session:
       label: Restore session on startup

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -2124,6 +2124,8 @@ hooks:
   tab:
     intro: Selecciona hooks reutilizables configurados en Ajustes -> Hooks
     lua_process_run_note: El hook seleccionado habilita Lua process.run y puede ejecutar programas externos con tus permisos de usuario
+language:
+  native_name: Español
 login:
   window_title: Flujo de conexión
   field:
@@ -2449,8 +2451,6 @@ settings:
       label: Idioma
       option:
         system: Sistema
-        english: Inglés
-        spanish: Español
       notice: Los cambios de idioma se aplican al reiniciar DBFlux.
     restore_session:
       label: Restaurar la sesión al iniciar

--- a/crates/dbflux_i18n/src/lib.rs
+++ b/crates/dbflux_i18n/src/lib.rs
@@ -1,36 +1,73 @@
 rust_i18n::i18n!("locales", fallback = "en");
 
 /// A language DBFlux ships a translation catalog for.
+///
+/// The set of available languages is derived at runtime from the catalog
+/// files under `locales/` via [`Language::available`], so adding a new
+/// catalog (for example `zh.yml`) makes the language available with no code
+/// changes here.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Language {
-    English,
-    Spanish,
-}
+pub struct Language(&'static str);
 
 impl Language {
+    /// The fallback language. Always available, regardless of which other
+    /// catalogs are present.
+    pub const ENGLISH: Language = Language("en");
+
+    /// Every language DBFlux ships a translation catalog for, sorted with
+    /// English first and the rest alphabetically by storage identifier.
+    pub fn available() -> &'static [Language] {
+        static AVAILABLE: std::sync::OnceLock<Vec<Language>> = std::sync::OnceLock::new();
+
+        AVAILABLE.get_or_init(|| {
+            let mut codes = rust_i18n::available_locales!();
+            codes.sort_by(|a, b| match (*a, *b) {
+                ("en", "en") => std::cmp::Ordering::Equal,
+                ("en", _) => std::cmp::Ordering::Less,
+                (_, "en") => std::cmp::Ordering::Greater,
+                _ => a.cmp(b),
+            });
+
+            codes.into_iter().map(Language).collect()
+        })
+    }
+
     /// The stable identifier persisted to settings storage.
     pub fn as_storage_str(self) -> &'static str {
-        match self {
-            Language::English => "en",
-            Language::Spanish => "es",
-        }
+        self.0
     }
 
     /// Parses a persisted storage identifier back into a `Language`.
     ///
-    /// Returns `None` for anything other than the exact stored identifiers,
-    /// including unsupported languages and locale strings with region tags.
+    /// Returns `None` for anything other than an identifier of a currently
+    /// available language, including unsupported languages and locale
+    /// strings with region tags.
     pub fn from_storage_str(value: &str) -> Option<Language> {
-        match value {
-            "en" => Some(Language::English),
-            "es" => Some(Language::Spanish),
-            _ => None,
-        }
+        Language::available()
+            .iter()
+            .copied()
+            .find(|language| language.0 == value)
     }
 
     /// The `rust-i18n` locale code, currently identical to the storage string.
     pub fn locale_code(self) -> &'static str {
-        self.as_storage_str()
+        self.0
+    }
+
+    /// The language's own name in that language, for example `"English"` or
+    /// `"Español"`.
+    ///
+    /// Falls back to the raw storage identifier when the catalog has no
+    /// `language.native_name` entry for this language.
+    pub fn native_name(self) -> String {
+        let name = translate_in(self.0, "language.native_name");
+        let missing_marker = format!("{}.language.native_name", self.0);
+
+        if name == missing_marker {
+            self.0.to_string()
+        } else {
+            name
+        }
     }
 }
 
@@ -90,7 +127,7 @@ pub fn resolve(persisted: Option<&str>, system: Option<&str>) -> Language {
         }
     }
 
-    Language::English
+    Language::ENGLISH
 }
 
 /// Detects the OS-reported locale (for example `"en-US"` or `"es-ES"`).
@@ -152,31 +189,35 @@ macro_rules! t {
 mod tests {
     use super::*;
 
+    fn spanish() -> Language {
+        Language::from_storage_str("es").expect("es.yml ships a catalog for Spanish")
+    }
+
     #[test]
     fn resolve_prefers_valid_persisted_language() {
-        assert_eq!(resolve(Some("es"), Some("en-US")), Language::Spanish);
+        assert_eq!(resolve(Some("es"), Some("en-US")), spanish());
     }
 
     #[test]
     fn resolve_empty_persisted_falls_back_to_system() {
-        assert_eq!(resolve(Some(""), Some("es-ES")), Language::Spanish);
+        assert_eq!(resolve(Some(""), Some("es-ES")), spanish());
     }
 
     #[test]
     fn resolve_invalid_persisted_falls_back_to_system() {
-        assert_eq!(resolve(Some("de"), Some("es-419")), Language::Spanish);
-        assert_eq!(resolve(Some("de"), Some("fr-FR")), Language::English);
+        assert_eq!(resolve(Some("de"), Some("es-419")), spanish());
+        assert_eq!(resolve(Some("de"), Some("fr-FR")), Language::ENGLISH);
     }
 
     #[test]
     fn resolve_unsupported_system_subtag_falls_back_to_english() {
-        assert_eq!(resolve(None, Some("fr-FR")), Language::English);
-        assert_eq!(resolve(None, None), Language::English);
+        assert_eq!(resolve(None, Some("fr-FR")), Language::ENGLISH);
+        assert_eq!(resolve(None, None), Language::ENGLISH);
     }
 
     #[test]
     fn resolve_es419_maps_to_spanish() {
-        assert_eq!(resolve(None, Some("es-419")), Language::Spanish);
+        assert_eq!(resolve(None, Some("es-419")), spanish());
     }
 
     #[test]
@@ -207,22 +248,56 @@ mod tests {
         );
 
         assert_eq!(
-            LanguagePreference::Explicit(Language::English).as_storage_str(),
+            LanguagePreference::Explicit(Language::ENGLISH).as_storage_str(),
             "en"
         );
         assert_eq!(
             LanguagePreference::from_storage_str("en"),
-            LanguagePreference::Explicit(Language::English)
+            LanguagePreference::Explicit(Language::ENGLISH)
         );
 
         assert_eq!(
-            LanguagePreference::Explicit(Language::Spanish).as_storage_str(),
+            LanguagePreference::Explicit(spanish()).as_storage_str(),
             "es"
         );
         assert_eq!(
             LanguagePreference::from_storage_str("es"),
-            LanguagePreference::Explicit(Language::Spanish)
+            LanguagePreference::Explicit(spanish())
         );
+    }
+
+    #[test]
+    fn available_contains_en_and_es_with_en_first() {
+        let available = Language::available();
+
+        assert_eq!(available[0].as_storage_str(), "en");
+        assert!(
+            available
+                .iter()
+                .any(|language| language.as_storage_str() == "es")
+        );
+    }
+
+    #[test]
+    fn from_storage_str_round_trips_available_languages() {
+        assert_eq!(Language::from_storage_str("en"), Some(Language::ENGLISH));
+        assert_eq!(Language::from_storage_str("es"), Some(spanish()));
+        assert_eq!(Language::from_storage_str("zz"), None);
+    }
+
+    #[test]
+    fn from_storage_str_empty_resolves_to_system_preference() {
+        assert_eq!(Language::from_storage_str(""), None);
+        assert_eq!(
+            LanguagePreference::from_storage_str(""),
+            LanguagePreference::System
+        );
+    }
+
+    #[test]
+    fn native_name_returns_the_language_own_name() {
+        assert_eq!(Language::ENGLISH.native_name(), "English");
+        assert_eq!(spanish().native_name(), "Español");
     }
 
     fn flatten_catalog_keys(value: &serde_yaml::Value, prefix: String, out: &mut Vec<String>) {

--- a/crates/dbflux_ui_windows/src/settings/general_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/general_section.rs
@@ -283,11 +283,15 @@ impl GeneralSection {
     }
 
     fn language_items() -> Vec<DropdownItem> {
-        vec![
-            DropdownItem::new(dbflux_i18n::t!("settings.general.language.option.system")),
-            DropdownItem::new(dbflux_i18n::t!("settings.general.language.option.english")),
-            DropdownItem::new(dbflux_i18n::t!("settings.general.language.option.spanish")),
-        ]
+        std::iter::once(DropdownItem::new(dbflux_i18n::t!(
+            "settings.general.language.option.system"
+        )))
+        .chain(
+            dbflux_i18n::Language::available()
+                .iter()
+                .map(|language| DropdownItem::new(language.native_name())),
+        )
+        .collect()
     }
 
     fn startup_focus_items() -> Vec<DropdownItem> {
@@ -345,16 +349,23 @@ impl GeneralSection {
     fn language_index(persisted: &str) -> usize {
         match dbflux_i18n::LanguagePreference::from_storage_str(persisted) {
             dbflux_i18n::LanguagePreference::System => 0,
-            dbflux_i18n::LanguagePreference::Explicit(dbflux_i18n::Language::English) => 1,
-            dbflux_i18n::LanguagePreference::Explicit(dbflux_i18n::Language::Spanish) => 2,
+            dbflux_i18n::LanguagePreference::Explicit(language) => {
+                dbflux_i18n::Language::available()
+                    .iter()
+                    .position(|available| *available == language)
+                    .map(|position| position + 1)
+                    .unwrap_or(0)
+            }
         }
     }
 
     fn language_for_index(index: usize) -> &'static str {
-        let preference = match index {
-            1 => dbflux_i18n::LanguagePreference::Explicit(dbflux_i18n::Language::English),
-            2 => dbflux_i18n::LanguagePreference::Explicit(dbflux_i18n::Language::Spanish),
-            _ => dbflux_i18n::LanguagePreference::System,
+        let preference = match index
+            .checked_sub(1)
+            .and_then(|position| dbflux_i18n::Language::available().get(position).copied())
+        {
+            Some(language) => dbflux_i18n::LanguagePreference::Explicit(language),
+            None => dbflux_i18n::LanguagePreference::System,
         };
         preference.as_storage_str()
     }
@@ -482,35 +493,42 @@ mod tests {
     }
 
     #[test]
-    fn language_dropdown_exposes_exactly_three_labels() {
+    fn language_dropdown_exposes_system_plus_every_available_language() {
         let labels: Vec<_> = GeneralSection::language_items()
             .into_iter()
             .map(|item| item.label)
             .collect();
 
-        assert_eq!(
-            labels,
-            vec![
-                dbflux_i18n::t!("settings.general.language.option.system"),
-                dbflux_i18n::t!("settings.general.language.option.english"),
-                dbflux_i18n::t!("settings.general.language.option.spanish"),
-            ]
-        );
+        let expected: Vec<_> =
+            std::iter::once(dbflux_i18n::t!("settings.general.language.option.system"))
+                .chain(
+                    dbflux_i18n::Language::available()
+                        .iter()
+                        .map(|language| language.native_name()),
+                )
+                .collect();
+
+        assert_eq!(labels, expected);
     }
 
     #[test]
     fn language_index_and_reverse_mapping_cover_system_and_explicit_languages() {
         assert_eq!(GeneralSection::language_index(""), 0);
         assert_eq!(GeneralSection::language_index("en"), 1);
-        assert_eq!(GeneralSection::language_index("es"), 2);
+        let available = dbflux_i18n::Language::available();
+        let es_position = available
+            .iter()
+            .position(|language| language.as_storage_str() == "es")
+            .expect("es.yml ships a catalog for Spanish");
+        assert_eq!(GeneralSection::language_index("es"), es_position + 1);
         // An unrecognized persisted value falls back to System.
         assert_eq!(GeneralSection::language_index("de"), 0);
 
         assert_eq!(GeneralSection::language_for_index(0), "");
         assert_eq!(GeneralSection::language_for_index(1), "en");
-        assert_eq!(GeneralSection::language_for_index(2), "es");
+        assert_eq!(GeneralSection::language_for_index(es_position + 1), "es");
         // Out-of-range falls back to System.
-        assert_eq!(GeneralSection::language_for_index(99), "");
+        assert_eq!(GeneralSection::language_for_index(available.len() + 1), "");
     }
 
     #[test]


### PR DESCRIPTION
Part of #360.

## Summary

- `dbflux_i18n::Language` is now a string-backed type whose domain comes from `rust_i18n::available_locales!()` at build time, instead of a closed `English | Spanish` enum. Each language names itself through the new `language.native_name` catalog key.
- The Settings language dropdown builds its items as System + `Language::available()` and maps selection by position, so a new catalog file (e.g. `zh.yml` contributed on Weblate) appears in the picker in the next build with zero code changes.
- `config_loader` no longer whitelists `en|es` when loading the persisted language: the value passes through and `dbflux_i18n::resolve` (the single validation point, called at startup) degrades unknown codes to System — so a stored selection for a language that ships later is preserved instead of being erased on reload.
- Removed the now-orphaned `settings.general.language.option.english/.spanish` catalog keys; the System option keeps its translated key.

## Review path

Start with `crates/dbflux_i18n/src/lib.rs` (the type change and `available()`/`native_name()`), then `general_section.rs` (position-based dropdown), then the one-function change in `config_loader.rs`.

## Test plan

- [x] `cargo nextest run` over dbflux_i18n, dbflux_ui_windows, dbflux_storage, dbflux_core, dbflux_app — 1854 passed.
- [x] `cargo clippy --workspace -- -D warnings` and `cargo fmt --check` — clean.
- [x] New tests: `available()` contains en/es with en first; storage round-trip; unknown code → System preference while the stored value survives the config load; `native_name` resolves English/Español.