### PR TITLE
feat(web): establish SEO and AEO discovery foundation

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -28,9 +28,13 @@ concurrency:
 
 jobs:
   build:
-    name: Build the site
+    name: Production ${{ matrix.mode }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [site, docs]
 
     steps:
       - uses: actions/checkout@v4
@@ -59,11 +63,15 @@ jobs:
 
       - name: Types
         working-directory: web
-        run: pnpm check
+        run: DOCS_MODE=${{ matrix.mode }} pnpm check
 
       - name: Build
         working-directory: web
-        run: pnpm build
+        run: pnpm build:${{ matrix.mode }}
+
+      - name: Audit distribution
+        working-directory: web
+        run: pnpm audit:dist --mode ${{ matrix.mode }}
 
       - name: Check for links to pages that do not exist
         working-directory: web

--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -1,8 +1,11 @@
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import manifest from './.versions/manifest.json';
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
 import { routeForRepoPath, titleForRepoPath } from './src/data/nav';
+import { sitemapPathsFor } from './src/data/docs';
+import { CURRENT } from './src/data/versions';
 import { DOCS_MODE, ORIGIN } from './src/data/site';
 import { hostRedirects } from './src/integrations/host-redirects';
 import { DEFAULT_LOCALE } from './src/i18n';
@@ -10,6 +13,9 @@ import type { Locale } from './src/i18n';
 import { LOCALE_REGISTRY, localeForRepoPath } from './src/i18n/locale-registry.mjs';
 
 const REPO_ROOT = fileURLToPath(new URL('../', import.meta.url));
+const sitemapPaths = sitemapPathsFor(
+  manifest.find((entry) => entry.id === CURRENT.id)?.sourceFacts ?? [],
+);
 
 /** Collect the text of a node back into a plain string. */
 function textOf(node: any): string {
@@ -170,17 +176,7 @@ export default defineConfig({
   },
   integrations: [
     sitemap({
-      // `/about/` belongs to the site host and says so in its canonical tag.
-      // The documentation build emits it only because one source tree builds
-      // both hosts, so keep it out of this host's sitemap.
-      filter: (page) => !(DOCS_MODE === 'docs' && new URL(page).pathname.startsWith('/about')),
-      // Mirrors `i18n.locales` above so the generator can pair each page with
-      // its counterpart in the other locale and emit hreflang alternates,
-      // matching `routing: 'manual'`'s unprefixed default locale.
-      i18n: {
-        defaultLocale: DEFAULT_LOCALE,
-        locales: Object.fromEntries(LOCALE_REGISTRY.map(({ id }) => [id, id])),
-      },
+      filter: (page) => DOCS_MODE !== 'docs' || sitemapPaths.has(new URL(page).pathname),
     }),
     hostRedirects(),
   ],

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,8 @@
     "build:docs": "DOCS_MODE=docs pnpm run build",
     "dev:docs": "DOCS_MODE=docs pnpm run dev",
     "deploy:site": "pnpm run build:site && wrangler deploy",
-    "deploy:docs": "pnpm run build:docs && wrangler deploy --config wrangler.docs.jsonc"
+    "deploy:docs": "pnpm run build:docs && wrangler deploy --config wrangler.docs.jsonc",
+    "audit:dist": "node scripts/audit-dist.mjs"
   },
   "dependencies": {
     "@astrojs/markdown-remark": "^7.2.3",

--- a/web/scripts/audit-dist.mjs
+++ b/web/scripts/audit-dist.mjs
@@ -1,0 +1,99 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+import { DEFAULT_LOCALE, LOCALE_REGISTRY } from '../src/i18n/locale-registry.mjs';
+const mode =
+  process.argv.at(-1) === 'docs' ? 'docs' : process.argv.at(-1) === 'site' ? 'site' : null;
+if (!mode) throw new Error('usage: node scripts/audit-dist.mjs --mode site|docs');
+const origin = mode === 'docs' ? 'https://docs.dbflux.dev' : 'https://dbflux.dev';
+const fail = (message) => {
+  throw Error(`SEO audit: ${message}`);
+};
+const text = (path) => (existsSync(path) ? readFileSync(path, 'utf8') : fail(`missing ${path}`));
+const root = resolve('dist');
+const fileFor = (pathname) => resolve(root, pathname.replace(/^\//, ''), 'index.html');
+const pathnameFor = (path) => {
+  const output = relative(root, path).replaceAll('\\', '/');
+  return output === 'index.html' ? '/' : `/${output.replace(/index\.html$/, '')}`;
+};
+const locales = LOCALE_REGISTRY.map(({ id }) => id);
+const routeKey = (pathname) => {
+  const [, first, ...rest] = pathname.split('/');
+  return locales.includes(first)
+    ? { locale: first, key: `/${rest.join('/')}` }
+    : { locale: DEFAULT_LOCALE, key: pathname };
+};
+const [sitemap, robots, llms] = ['sitemap-0.xml', 'robots.txt', 'llms.txt'].map((path) =>
+  text(`dist/${path}`),
+);
+const contentSignal = 'Content-Signal: search=yes,ai-train=no,use=reference';
+for (const userAgent of ['Google-Extended', '*']) {
+  const block = `User-agent: ${userAgent}\n${contentSignal}\nAllow: /\n\n`;
+  if (!robots.includes(block)) fail(`robots has invalid ${userAgent} directive block`);
+}
+if (!robots.includes(`Sitemap: ${origin}/sitemap-index.xml`)) fail('robots has invalid sitemap');
+const locations = [...sitemap.matchAll(/<loc>([^<]+)<\/loc>/g)].map(([, url]) => new URL(url));
+const expected = new Set();
+for (const file of readdirSync(root, { recursive: true })) {
+  const path = resolve(root, file);
+  if (!path.endsWith('/index.html')) continue;
+  const pathname = pathnameFor(path);
+  const html = text(path);
+  if (
+    html.includes(`<link rel="canonical" href="${origin}${pathname}"`) &&
+    !html.includes('name="robots" content="noindex, follow"')
+  )
+    expected.add(pathname);
+}
+const actual = new Set(locations.map(({ pathname }) => pathname));
+if (
+  actual.size !== locations.length ||
+  actual.size !== expected.size ||
+  [...expected].some((pathname) => !actual.has(pathname))
+)
+  fail(`sitemap route set differs: expected ${expected.size}, found ${locations.length}`);
+const groups = new Map();
+for (const pathname of expected) {
+  const { locale, key } = routeKey(pathname);
+  groups.set(key, [...(groups.get(key) ?? []), { locale, pathname }]);
+}
+for (const pathname of expected) {
+  const siblings = groups.get(routeKey(pathname).key) ?? [];
+  const wanted = new Map(siblings.map(({ locale, pathname }) => [locale, `${origin}${pathname}`]));
+  const fallback = siblings.find(({ locale }) => locale === DEFAULT_LOCALE);
+  if (fallback) wanted.set('x-default', `${origin}${fallback.pathname}`);
+  const matches = [
+    ...text(fileFor(pathname)).matchAll(/<link rel="alternate" hreflang="([^"]+)" href="([^"]+)"/g),
+  ];
+  const found = new Map(matches.map(([, label, href]) => [label, href]));
+  if (
+    found.size !== matches.length ||
+    found.size !== wanted.size ||
+    [...wanted].some(([label, href]) => found.get(label) !== href)
+  )
+    fail(`${pathname} hreflang set differs from real canonical siblings`);
+}
+for (const url of locations) {
+  if (url.origin !== origin) fail(`sitemap host differs for ${url}`);
+  const html = text(fileFor(url.pathname));
+  if (!html.includes(`<link rel="canonical" href="${url.href}"`))
+    fail(`non-self canonical ${url.pathname}`);
+  if (html.includes('name="robots" content="noindex, follow"'))
+    fail(`indexed noindex page ${url.pathname}`);
+}
+for (const path of ['/', '/install/', '/usage/']) {
+  if (!llms.includes(`- ${mode === 'docs' ? path : `https://docs.dbflux.dev${path}`}`))
+    fail(`llms lacks ${path}`);
+}
+for (const link of llms.matchAll(/^- (https?:\/\/[^\s]+)$/gm)) {
+  const url = new URL(link[1]);
+  if (url.hostname !== 'docs.dbflux.dev' || /nightly|v0\.6/.test(url.pathname))
+    fail(`unsafe llms link ${url}`);
+}
+if (
+  mode === 'docs' &&
+  /<meta (?:name="description"|property="og:description")[^>]*(?:```|bash|curl|\$ )/i.test(
+    text('dist/install/index.html'),
+  )
+)
+  fail('/install metadata leaks code or shell content');
+console.log(`ok: SEO foundation audit (${mode})`);

--- a/web/scripts/fetch-docs.mjs
+++ b/web/scripts/fetch-docs.mjs
@@ -12,7 +12,11 @@
 import { execFileSync } from 'node:child_process';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { isDocsRepoPath } from '../src/i18n/locale-registry.mjs';
+import {
+  contentEntryId,
+  isDocsRepoPath,
+  splitContentEntryId,
+} from '../src/i18n/locale-registry.mjs';
 
 const WEB = new URL('..', import.meta.url).pathname;
 const REPO = new URL('../..', import.meta.url).pathname;
@@ -105,8 +109,16 @@ export function fetchDocs(versions) {
     const version = workspaceVersion(ref);
     const { commit, date } = buildOf(ref);
 
+    const localesByPath = new Map();
+    for (const file of files) {
+      const source = splitContentEntryId(contentEntryId(`${id}/${file}`));
+      const locales = localesByPath.get(source.path) ?? [];
+      if (!locales.includes(source.locale)) locales.push(source.locale);
+      localesByPath.set(source.path, locales);
+    }
+    const sourceFacts = [...localesByPath].map(([path, locales]) => ({ path, locales }));
     console.log(`  docs: ${id} <- ${ref} @ ${version} (${commit}, ${files.length} files)`);
-    done.push({ id, ref, version, commit, date });
+    done.push({ id, ref, version, commit, date, sourceFacts });
   }
 
   writeFileSync(join(VERSIONS_DIR, 'manifest.json'), JSON.stringify(done, null, 2));

--- a/web/src/data/docs.ts
+++ b/web/src/data/docs.ts
@@ -2,6 +2,7 @@ import type { CollectionEntry } from 'astro:content';
 import { DEFAULT_LOCALE, LOCALES } from '../i18n';
 import type { Locale } from '../i18n';
 import { splitContentEntryId } from '../i18n/locale-registry.mjs';
+import { CURRENT, docsRoute } from './versions';
 import { DOCS_SECTIONS, docTitle } from './nav';
 
 export type DocTitlesByLocale = Readonly<Partial<Record<Locale, Readonly<Record<string, string>>>>>;
@@ -123,6 +124,86 @@ export function repoPathFor(filePath: string, versionId: string): string {
   const prefix = `.versions/${versionId}/`;
 
   return filePath.startsWith(prefix) ? filePath.slice(prefix.length) : filePath;
+}
+
+export interface DocRoutePolicy {
+  readonly canonicalPath?: string;
+  readonly indexable: boolean;
+  readonly alternateLocales: readonly Locale[];
+}
+
+const routePath = (versionId: string, path: string, locale: Locale): string =>
+  `/${docsRoute(versionId, path, locale)}/`.replace(/\/+/g, '/');
+
+export const sitemapPathsFor = (
+  facts: readonly { readonly path: string; readonly locales: readonly string[] }[],
+): Set<string> =>
+  new Set([
+    ...LOCALES.map((locale) => routePath(CURRENT.id, '', locale)),
+    ...facts.flatMap(({ path, locales }) =>
+      locales
+        .filter((locale): locale is Locale => (LOCALES as readonly string[]).includes(locale))
+        .map((locale) => routePath(CURRENT.id, path, locale)),
+    ),
+  ]);
+
+export function docRoutePolicy(
+  entries: readonly CollectionEntry<'docs'>[],
+  versionId: string,
+  path: string | undefined,
+  locale: Locale,
+  translated: boolean,
+): DocRoutePolicy {
+  const page = path ?? '';
+  const currentLocales =
+    path === undefined
+      ? LOCALES
+      : LOCALES.filter((target) =>
+          entries.some((entry) => {
+            const id = splitId(entry.id);
+            return id.version === CURRENT.id && id.locale === target && id.path === page;
+          }),
+        );
+  const indexable = versionId === CURRENT.id && translated;
+  const canonicalLocale = currentLocales.includes(locale)
+    ? locale
+    : currentLocales.includes(DEFAULT_LOCALE)
+      ? DEFAULT_LOCALE
+      : undefined;
+  const canonicalPath = indexable
+    ? routePath(versionId, page, locale)
+    : canonicalLocale
+      ? routePath(CURRENT.id, page, canonicalLocale)
+      : undefined;
+  const alternateLocales = indexable ? currentLocales : [];
+  return { canonicalPath, indexable, alternateLocales };
+}
+
+/** Extract only human prose from markdown; code, headings, commands, and navigation cannot become metadata. */
+export function safeDescription(body: string | undefined): string | undefined {
+  if (!body) return undefined;
+  let fenced = false;
+  for (const raw of body.split('\n')) {
+    const line = raw.trim();
+    if (/^(?:`{3,}|~{3,})/.test(line)) {
+      fenced = !fenced;
+      continue;
+    }
+    if (
+      fenced ||
+      !line ||
+      /^(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>|---+$|<[^>]+>$)/.test(line) ||
+      /^\$\s|^(?:curl|wget|sudo|npm|pnpm|cargo|git)\b/.test(line) ||
+      line.includes('|')
+    )
+      continue;
+    const prose = line
+      .replace(/[`*_\[\]]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim();
+    if (prose.length >= 24) return prose.slice(0, 180).replace(/\s+\S*$/, '');
+  }
+  return undefined;
 }
 
 export { docTitle };

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -11,13 +11,13 @@ import '../styles/global.css';
 
 interface Props {
   title: string;
-  description: string;
+  description?: string;
   current?: 'home' | 'docs' | 'about';
   wide?: boolean;
   /** Keep this page out of search results — used for unreleased documentation. */
   noindex?: boolean;
   /** Point search engines at another path, for older and unreleased versions. */
-  canonicalPath?: string;
+  canonicalPath?: string | null;
   /** Which search index this page's dialog should load. */
   searchIndex?: string;
   /** Active locale. Derived from the URL when the caller does not know it yet. */
@@ -42,29 +42,29 @@ const {
 } = Astro.props;
 // Astro.site is unset when the config fails to load, and a crashed canonical tag
 // should not take the whole page down with it.
-const canonical = canonicalPath?.startsWith('http')
-  ? canonicalPath
-  : Astro.site
-    ? new URL(canonicalPath ?? Astro.url.pathname, Astro.site).href
-    : undefined;
+const canonical =
+  canonicalPath === null
+    ? undefined
+    : canonicalPath?.startsWith('http')
+      ? canonicalPath
+      : Astro.site
+        ? new URL(canonicalPath ?? Astro.url.pathname, Astro.site).href
+        : undefined;
 
 // Open Graph rejects a relative image: the crawler resolves it against nothing
 // and the preview falls back to a blank card.
 const socialImage = new URL('/brand/og-card.jpg', ORIGIN).href;
 
-/**
- * hreflang pairs only for locales with real content. hreflang requires absolute
- * URLs, so this stays empty without `Astro.site` — same guard as `canonical`.
- */
-const alternateHref = (target: Locale) =>
-  Astro.site ? new URL(withLocale(Astro.url.pathname, target), Astro.site).href : undefined;
-
-const alternates = Astro.site
-  ? alternateLocales.map((target) => ({ hreflang: target, href: alternateHref(target)! }))
+const alternateLinks = Astro.site
+  ? alternateLocales.map((target) => ({
+      hreflang: target,
+      href: new URL(withLocale(Astro.url.pathname, target), Astro.site).href,
+    }))
   : [];
-const xDefaultHref = alternateLocales.includes(DEFAULT_LOCALE)
-  ? alternateHref(DEFAULT_LOCALE)
-  : undefined;
+const xDefaultHref =
+  Astro.site && alternateLocales.includes(DEFAULT_LOCALE)
+    ? new URL(withLocale(Astro.url.pathname, DEFAULT_LOCALE), Astro.site).href
+    : undefined;
 ---
 
 <!doctype html>
@@ -73,13 +73,13 @@ const xDefaultHref = alternateLocales.includes(DEFAULT_LOCALE)
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{title}</title>
-    <meta name="description" content={description} />
+    {description && <meta name="description" content={description} />}
     {canonical && <link rel="canonical" href={canonical} />}
-    {alternates.map((alt) => <link rel="alternate" hreflang={alt.hreflang} href={alt.href} />)}
+    {alternateLinks.map((alt) => <link rel="alternate" hreflang={alt.hreflang} href={alt.href} />)}
     {xDefaultHref && <link rel="alternate" hreflang="x-default" href={xDefaultHref} />}
     {noindex && <meta name="robots" content="noindex, follow" />}
     <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
+    {description && <meta property="og:description" content={description} />}
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="DBFlux" />
     {canonical && <meta property="og:url" content={canonical} />}

--- a/web/src/layouts/DocsLayout.astro
+++ b/web/src/layouts/DocsLayout.astro
@@ -2,10 +2,9 @@
 import Base from '../layouts/Base.astro';
 import DocsTree from '../components/DocsTree.astro';
 import VersionPicker from '../components/VersionPicker.astro';
-import type { DocTitlesByLocale } from '../data/docs';
+import type { DocRoutePolicy, DocTitlesByLocale } from '../data/docs';
 import type { DocsVersion } from '../data/versions';
 import { CURRENT, docsHref, versionHome, versionLabel } from '../data/versions';
-import { docsUrl } from '../data/site';
 import { DEFAULT_LOCALE, localeFromPathname, t } from '../i18n';
 import type { Locale } from '../i18n';
 import { searchIndexPath } from '../i18n/locale-registry.mjs';
@@ -23,7 +22,7 @@ interface Props {
   available: readonly string[];
   headings?: readonly Heading[];
   title: string;
-  description: string;
+  description?: string;
   editPath?: string;
   locale?: Locale;
   /**
@@ -32,10 +31,8 @@ interface Props {
    * untranslated notice below and forces `noindex` regardless of `version`.
    */
   translated?: boolean;
-  /** Existing translated document H1s, indexed by canonical locale id. */
   titlesByLocale?: DocTitlesByLocale;
-  /** Locales with real content for this exact document. */
-  alternateLocales?: readonly Locale[];
+  policy: DocRoutePolicy;
 }
 
 const {
@@ -49,28 +46,12 @@ const {
   locale = localeFromPathname(Astro.url.pathname),
   translated = false,
   titlesByLocale = {},
-  alternateLocales,
+  policy,
 } = Astro.props;
 const onThisPage = headings.filter((heading) => heading.depth === 2);
-
-const isCurrent = version.id === CURRENT.id;
-const suffix = isCurrent ? '' : ` (${versionLabel(version)})`;
-const searchIndex = searchIndexPath(version.id, CURRENT.id, locale, DEFAULT_LOCALE);
-
-/**
- * Older and unreleased versions point at the current release, so a search engine
- * ranks the version most readers are running rather than whichever it crawled.
- * The version canonical and the locale prefix are independent axes, so the
- * active locale is passed through rather than always resolving to English.
- */
-const canonicalPath = isCurrent ? undefined : docsUrl(currentPath ?? '', undefined, locale);
-
-/**
- * A non-English page that fell back to the English body (no Spanish sibling
- * yet) must stay out of search results: it would otherwise index as a
- * near-duplicate of the canonical English page under a different URL.
- */
 const showsFallback = locale !== DEFAULT_LOCALE && !translated;
+const suffix = version.id === CURRENT.id ? '' : ` (${versionLabel(version)})`;
+const searchIndex = searchIndexPath(version.id, CURRENT.id, locale, DEFAULT_LOCALE);
 ---
 
 <Base
@@ -78,12 +59,11 @@ const showsFallback = locale !== DEFAULT_LOCALE && !translated;
   description={description}
   current="docs"
   wide
-  noindex={version.noindex || showsFallback}
-  canonicalPath={canonicalPath}
+  noindex={!policy.indexable}
+  canonicalPath={policy.canonicalPath ?? null}
   searchIndex={searchIndex}
   locale={locale}
-  translated={translated}
-  alternateLocales={alternateLocales}
+  alternateLocales={policy.alternateLocales}
 >
   <div class="docs">
     <button

--- a/web/src/pages/[...path].astro
+++ b/web/src/pages/[...path].astro
@@ -2,8 +2,15 @@
 import { getCollection, render } from 'astro:content';
 import DocsLayout from '../layouts/DocsLayout.astro';
 import DocsIndex from '../components/DocsIndex.astro';
-import { docTitle, localizedTitlesFor, pathsForVersion, repoPathFor } from '../data/docs';
-import { CURRENT, VERSIONS, docsRoute, versionById, versionLabel } from '../data/versions';
+import {
+  docRoutePolicy,
+  docTitle,
+  localizedTitlesFor,
+  pathsForVersion,
+  repoPathFor,
+  safeDescription,
+} from '../data/docs';
+import { VERSIONS, docsRoute, versionById, versionLabel } from '../data/versions';
 import { DOCS_MODE } from '../data/site';
 import { DEFAULT_LOCALE, LOCALES } from '../i18n';
 import type { Locale } from '../i18n';
@@ -31,8 +38,9 @@ export async function getStaticPaths() {
 
   const docs = await getCollection('docs');
   const pages = buildLocalizedDocumentMatrix(docs).map(
-    ({ version, path, locale, entry, translated, alternateLocales }) => {
+    ({ version, path, locale, entry, translated }) => {
       const canonicalLocale = locale as Locale;
+      const policy = docRoutePolicy(docs, version, path, canonicalLocale, translated);
 
       return {
         params: { path: docsRoute(version, path, canonicalLocale) },
@@ -42,7 +50,7 @@ export async function getStaticPaths() {
           doc: entry,
           locale: canonicalLocale,
           translated,
-          alternateLocales: alternateLocales as Locale[],
+          policy,
         },
       };
     },
@@ -52,10 +60,20 @@ export async function getStaticPaths() {
   // rendered entirely from the chrome dictionary, so it exists in every locale
   // the same way `/` and `/es/` already do.
   const indexes = LOCALES.flatMap((locale) =>
-    VERSIONS.map((version) => ({
-      params: { path: docsRoute(version.id, '', locale) },
-      props: { versionId: version.id, path: undefined, doc: undefined, locale, translated: true },
-    })).filter(
+    VERSIONS.map((version) => {
+      const policy = docRoutePolicy(docs, version.id, undefined, locale, true);
+      return {
+        params: { path: docsRoute(version.id, '', locale) },
+        props: {
+          versionId: version.id,
+          path: undefined,
+          doc: undefined,
+          locale,
+          translated: true,
+          policy,
+        },
+      };
+    }).filter(
       // With the documentation at the root of its own host, the current
       // release's index is `/` (or `/es/`), which `index.astro` (or
       // `es/index.astro`) already owns.
@@ -66,14 +84,12 @@ export async function getStaticPaths() {
   return [...pages, ...indexes];
 }
 
-const { versionId, path, doc, locale, translated, alternateLocales } = Astro.props;
+const { versionId, path, doc, locale, translated, policy } = Astro.props;
 
 const version = versionById(versionId)!;
 const allDocs = await getCollection('docs');
 const available = pathsForVersion(allDocs, versionId);
 const titlesByLocale = localizedTitlesFor(allDocs, versionId);
-const isCurrent = versionId === CURRENT.id;
-
 const rendered = doc ? await render(doc) : undefined;
 
 // A translated page uses its own H1; a fallback keeps the English rail title.
@@ -81,16 +97,9 @@ const localizedTitle =
   locale !== DEFAULT_LOCALE && translated && path ? titlesByLocale[locale]?.[path] : undefined;
 const title = path ? (localizedTitle ?? docTitle(path)) : 'Documentation';
 
-const firstParagraph = doc?.body
-  ?.split('\n\n')
-  .map((block) => block.trim())
-  .find((block) => block.length > 0 && !block.startsWith('#'));
-
 const description = doc
-  ? firstParagraph
-    ? firstParagraph.replace(/\s+/g, ' ').slice(0, 180)
-    : `${title} — DBFlux documentation.`
-  : isCurrent
+  ? safeDescription(doc.body)
+  : policy.indexable
     ? 'Guides for installing, connecting, querying, charting and governing DBFlux.'
     : `DBFlux ${versionLabel(version)} documentation.`;
 ---
@@ -105,7 +114,7 @@ const description = doc
   editPath={doc?.filePath ? repoPathFor(doc.filePath, versionId) : undefined}
   locale={locale}
   translated={translated}
-  alternateLocales={alternateLocales}
+  policy={policy}
   titlesByLocale={titlesByLocale}
 >
   {

--- a/web/src/pages/[locale]/index.astro
+++ b/web/src/pages/[locale]/index.astro
@@ -4,7 +4,7 @@ import Base from '../../layouts/Base.astro';
 import DocsLayout from '../../layouts/DocsLayout.astro';
 import DocsIndex from '../../components/DocsIndex.astro';
 import Landing from '../../components/Landing.astro';
-import { pathsForVersion } from '../../data/docs';
+import { docRoutePolicy, pathsForVersion } from '../../data/docs';
 import { CURRENT } from '../../data/versions';
 import { DOCS_AT_ROOT } from '../../data/site';
 import { DEFAULT_LOCALE, LOCALES } from '../../i18n';
@@ -18,7 +18,9 @@ export function getStaticPaths() {
 }
 
 const { locale } = Astro.props as { locale: Locale };
-const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CURRENT.id) : [];
+const docs = await getCollection('docs');
+const available = DOCS_AT_ROOT ? pathsForVersion(docs, CURRENT.id) : [];
+const policy = docRoutePolicy(docs, CURRENT.id, undefined, locale, true);
 ---
 
 {
@@ -30,6 +32,7 @@ const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CU
       description="Guides for installing, connecting, querying, charting and governing DBFlux."
       locale={locale}
       translated
+      policy={policy}
     >
       <DocsIndex versionId={CURRENT.id} available={available} locale={locale} />
     </DocsLayout>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -4,7 +4,7 @@ import Base from '../layouts/Base.astro';
 import DocsLayout from '../layouts/DocsLayout.astro';
 import DocsIndex from '../components/DocsIndex.astro';
 import Landing from '../components/Landing.astro';
-import { pathsForVersion } from '../data/docs';
+import { docRoutePolicy, pathsForVersion } from '../data/docs';
 import { CURRENT } from '../data/versions';
 import { DOCS_AT_ROOT } from '../data/site';
 
@@ -12,7 +12,9 @@ import { DOCS_AT_ROOT } from '../data/site';
  * The root is whatever this build is for: the landing page normally, and the
  * documentation index when the documentation has an origin of its own.
  */
-const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CURRENT.id) : [];
+const docs = await getCollection('docs');
+const available = DOCS_AT_ROOT ? pathsForVersion(docs, CURRENT.id) : [];
+const policy = docRoutePolicy(docs, CURRENT.id, undefined, 'en', true);
 ---
 
 {
@@ -23,6 +25,7 @@ const available = DOCS_AT_ROOT ? pathsForVersion(await getCollection('docs'), CU
       title="Documentation"
       description="Guides for installing, connecting, querying, charting and governing DBFlux."
       translated
+      policy={policy}
     >
       <DocsIndex versionId={CURRENT.id} available={available} />
     </DocsLayout>

--- a/web/src/pages/llms.txt.ts
+++ b/web/src/pages/llms.txt.ts
@@ -1,0 +1,10 @@
+import type { APIRoute } from 'astro';
+import { docsUrl } from '../data/site';
+
+export const GET: APIRoute = () =>
+  new Response(
+    `# DBFlux\n\nCurrent documentation:\n${[docsUrl(''), docsUrl('install'), docsUrl('usage')].map((link) => `- ${link}`).join('\n')}\n`,
+    {
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    },
+  );

--- a/web/src/pages/robots.txt.ts
+++ b/web/src/pages/robots.txt.ts
@@ -18,6 +18,10 @@ import { ORIGIN } from '../data/site';
  * what the live URL returns before concluding a rule is in effect.
  */
 const BODY = [
+  'User-agent: Google-Extended',
+  'Content-Signal: search=yes,ai-train=no,use=reference',
+  'Allow: /',
+  '',
   'User-agent: *',
   'Content-Signal: search=yes,ai-train=no,use=reference',
   'Allow: /',


### PR DESCRIPTION
## Summary

Establishes a shared SEO/AEO foundation for `dbflux.dev` and `docs.dbflux.dev` without changing deployment behavior or source documentation content.

The change makes crawler output host-aware, keeps historical and untranslated fallback routes out of inappropriate indexes, derives safer page descriptions, publishes curated discovery files, and validates generated output in CI.

## What does this resolve?

- Resolves #471

## How was this solved?

- Centralized documentation indexability, canonical, `noindex`, and verified `hreflang` decisions in `web/src/data/docs.ts`.
- Restricted generated sitemaps to eligible, current, self-canonical routes and real translation pairs.
- Added host-aware `robots.txt` output while preserving `Content-Signal: search=yes,ai-train=no,use=reference` and allowing `Google-Extended`.
- Added a curated `llms.txt` containing stable, current documentation links.
- Reworked description extraction to select human prose rather than headings, commands, code fences, lists, or tables.
- Added a dependency-free distribution audit and CI coverage for both `site` and `docs` production modes.

## Validation

Passed locally from `web/`:

```bash
pnpm format:check
DOCS_MODE=site pnpm check
DOCS_MODE=docs pnpm check
pnpm build:site
pnpm audit:dist
node scripts/check-links.mjs
pnpm build:docs
pnpm audit:dist
node scripts/check-links.mjs
```

Additional evidence:

- Docs sitemap: 64 expected, 64 actual, 64 unique, no missing or extra routes.
- Local HTTP smoke checks returned 200 for `/`, `/docs/`, `/docs/install/`, `/docs/usage/`, `/robots.txt`, and `/llms.txt`.
- High-risk bounded review completed with four lenses and no required corrections.
- Final diff: 13 files, 314 additions, 86 deletions (400 changed lines).

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Chain Context

- **Position:** 1 of 2
- **Base:** `main`
- **Depends on:** none
- **Merge order:** this PR must land first
- **Follow-up:** acquisition routes, structured data and CTA work, Markdown siblings, and Worker/Wrangler content negotiation will be proposed as PR 2 only after this foundation is accepted
- **Excluded here:** deployment and all external Cloudflare mutations
