### PR TITLE
fix(web): use the BCP-47 form zh-Hans as the locale id

### DIFF
--- a/web/src/components/SiteNav.astro
+++ b/web/src/components/SiteNav.astro
@@ -22,7 +22,7 @@ const LINKS = [
 ] as const;
 
 /**
- * Home, docs and about all have a `/es/` and `/zh_Hans/` counterpart now — a
+ * Home, docs and about all have a `/es/` and `/zh-Hans/` counterpart now — a
  * real translation where one exists, the English body with a fallback notice
  * otherwise for docs (never a 404).
  */

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -3,7 +3,7 @@ import { es } from './es';
 import { zh_Hans } from './zh_Hans';
 import { DEFAULT_LOCALE as REGISTRY_DEFAULT_LOCALE, LOCALE_REGISTRY } from './locale-registry.mjs';
 
-const DICTIONARY_MODULES = { en, es, zh_Hans };
+const DICTIONARY_MODULES = { en, es, 'zh-Hans': zh_Hans };
 
 export type Locale = keyof typeof DICTIONARY_MODULES;
 
@@ -280,7 +280,7 @@ export function dictionary(locale: Locale): Dictionary {
  *
  * Routing is manual (`i18n.routing: 'manual'`), so the locale is never in
  * `Astro.currentLocale` — it is read back from the leading locale segment (e.g.
- * `/es/`, `/zh_Hans/`) the same way `[...path].astro` will compute it when
+ * `/es/`, `/zh-Hans/`) the same way `[...path].astro` will compute it when
  * emitting that segment.
  */
 export function localeFromPathname(pathname: string): Locale {

--- a/web/src/i18n/locale-registry.mjs
+++ b/web/src/i18n/locale-registry.mjs
@@ -9,7 +9,7 @@ export const LOCALE_REGISTRY = validateLocaleRegistry(
   [
     { id: 'en', name: 'English', docsDirectory: null },
     { id: 'es', name: 'Español', docsDirectory: 'es' },
-    { id: 'zh_Hans', name: '简体中文', docsDirectory: 'zh_Hans' },
+    { id: 'zh-Hans', name: '简体中文', docsDirectory: 'zh_Hans' },
   ],
   DEFAULT_LOCALE,
 );

--- a/web/src/i18n/locale-registry.test.mjs
+++ b/web/src/i18n/locale-registry.test.mjs
@@ -28,7 +28,7 @@ test('ships only the current English, Spanish and Simplified Chinese locale meta
     [
       { id: 'en', name: 'English', docsDirectory: null },
       { id: 'es', name: 'Español', docsDirectory: 'es' },
-      { id: 'zh_Hans', name: '简体中文', docsDirectory: 'zh_Hans' },
+      { id: 'zh-Hans', name: '简体中文', docsDirectory: 'zh_Hans' },
     ],
   );
 });

--- a/web/src/pages/404.astro
+++ b/web/src/pages/404.astro
@@ -13,7 +13,7 @@ const versions = VERSIONS;
 
 /**
  * Astro serves one static `404.html`, so there is no `/es/404` or
- * `/zh_Hans/404` route — this always renders in English. `locale` is still
+ * `/zh-Hans/404` route — this always renders in English. `locale` is still
  * derived from the build-time URL rather than hardcoded, matching every other
  * page's pattern.
  */


### PR DESCRIPTION
## What

Renames the Simplified Chinese locale id from `zh_Hans` to `zh-Hans` in the web locale registry. The docs directory stays `docs/zh_Hans/` — only the canonical id (and therefore the URL prefix) changes.

## Why

The registry id from #478 is emitted verbatim into `<html lang>` and the `hreflang` alternate links, and an underscore is not valid in a BCP-47 language tag. Search engines ignore invalid `hreflang` values, which undermines the discovery work from #472. `zh-Hans` is the valid form.

The registry separates the canonical id from `docsDirectory` exactly for this case, so no documentation file moves and translation PRs keep targeting `docs/zh_Hans/`.

The `/zh-Hans/` URLs replace `/zh_Hans/` before either was ever published, so nothing breaks.

## Verification

- `node --test src/i18n/locale-registry.test.mjs` — 11 pass
- `pnpm check` — 0 errors
- `pnpm build` — 286 pages, then `check-links.mjs` reports every internal link resolves
- Built output emits `lang="zh-Hans"` and `hreflang="zh-Hans"`
