### PR TITLE
feat(driver): report a client identity on every driver connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2938,6 +2938,7 @@ dependencies = [
  "dbflux_core",
  "dbflux_ssh",
  "dbflux_test_support",
+ "log",
  "redis",
  "serde_json",
  "urlencoding",

--- a/crates/dbflux/tests/client_identity_version.rs
+++ b/crates/dbflux/tests/client_identity_version.rs
@@ -1,0 +1,12 @@
+//! Guards against the reported client identity drifting from the app version.
+//!
+//! `dbflux_core::client_identity()` bakes in `dbflux_core`'s compile-time
+//! version. Every crate inherits the single `[workspace.package]` version, so
+//! the two must always match; this test fails if a crate ever stops
+//! inheriting it.
+
+#[test]
+fn client_identity_matches_app_version() {
+    let expected = format!("dbflux/{}", env!("CARGO_PKG_VERSION"));
+    assert_eq!(dbflux_core::client_identity(), expected);
+}

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -23,7 +23,7 @@ pub use access::{AccessHandle, AccessKind, AccessManager};
 
 pub use document_id::DocumentId;
 
-pub use release_channel::ReleaseChannel;
+pub use release_channel::{ReleaseChannel, client_identity};
 
 pub use auth::{
     AuthEditCapabilities, AuthEditSnapshot, AuthEditTarget, AuthFormDef, AuthProfile,

--- a/crates/dbflux_core/src/release_channel.rs
+++ b/crates/dbflux_core/src/release_channel.rs
@@ -67,9 +67,27 @@ impl ReleaseChannel {
     }
 }
 
+/// Client identity string reported to database servers on connect
+/// (PostgreSQL `application_name`, MySQL `program_name`, SQL Server
+/// `Application Name`, MongoDB `appName`, Redis `CLIENT SETNAME`).
+///
+/// The version is the shared workspace version, which CI stamps before
+/// building, so every driver reports the app's version rather than the
+/// version of the crate that happens to compile the call.
+pub fn client_identity() -> &'static str {
+    concat!("dbflux/", env!("CARGO_PKG_VERSION"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn client_identity_carries_app_prefix_and_version() {
+        let identity = client_identity();
+        assert!(identity.starts_with("dbflux/"));
+        assert_eq!(&identity["dbflux/".len()..], env!("CARGO_PKG_VERSION"));
+    }
 
     #[test]
     fn classifies_versions() {

--- a/crates/dbflux_driver_mongodb/README.md
+++ b/crates/dbflux_driver_mongodb/README.md
@@ -26,6 +26,7 @@ MongoDB document driver for DBFlux.
 - Mutations: insert, update (including upsert), and delete (`supports_upsert: true`). The `MongoShellGenerator` emits `insertOne`/`insertMany`, `updateOne`/`updateMany` (with `{ upsert: true }`), and `deleteOne`/`deleteMany` for previews and copy-as-query.
 - DDL: drop database, drop collection, create index, and drop index.
 - JSON export of results (`EXPORT_JSON`).
+- Reports client identity as `appName=dbflux/<version>` on connect (visible in server logs and `db.currentOp()`), unless the connection URI already sets an `appName`.
 
 ### Instance Metrics
 

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -31,6 +31,7 @@ use dbflux_core::{
     field_use_uri, sanitize_uri, ssh_tab, when_checked, when_unchecked, with_default,
 };
 use dbflux_ssh::SshTunnel;
+use mongodb::options::ClientOptions;
 use mongodb::sync::{Client, Database};
 use uuid::Uuid;
 
@@ -634,8 +635,13 @@ impl MongoDriver {
 
         log::info!("Connecting to MongoDB with URI");
 
+        let mut options = ClientOptions::parse(&uri)
+            .run()
+            .map_err(|e| format_mongo_uri_error(&e, base_uri))?;
+        apply_default_app_name(&mut options);
+
         let client =
-            Client::with_uri_str(&uri).map_err(|e| format_mongo_uri_error(&e, base_uri))?;
+            Client::with_options(options).map_err(|e| format_mongo_uri_error(&e, base_uri))?;
 
         client
             .list_database_names()
@@ -673,7 +679,13 @@ impl MongoDriver {
 
         log::info!("Connecting to MongoDB at {}:{}", host, port);
 
-        let client = Client::with_uri_str(&uri).map_err(|e| format_mongo_error(&e, host, port))?;
+        let mut options = ClientOptions::parse(&uri)
+            .run()
+            .map_err(|e| format_mongo_error(&e, host, port))?;
+        apply_default_app_name(&mut options);
+
+        let client =
+            Client::with_options(options).map_err(|e| format_mongo_error(&e, host, port))?;
 
         client
             .list_database_names()
@@ -1168,6 +1180,14 @@ fn inject_credentials_into_uri(
         )
     } else {
         base_uri.to_string()
+    }
+}
+
+/// Fills in a default `appName` when the URI did not already set one via `appName=`,
+/// so a user-supplied value always wins over ours.
+fn apply_default_app_name(options: &mut ClientOptions) {
+    if options.app_name.is_none() {
+        options.app_name = Some(dbflux_core::client_identity().to_string());
     }
 }
 
@@ -4221,6 +4241,31 @@ mod tests {
             Some("pw"),
         );
         assert_eq!(untouched, "mongodb://existing:creds@localhost:27017/admin");
+    }
+
+    #[test]
+    fn apply_default_app_name_keeps_user_supplied_app_name() {
+        let mut options = ClientOptions::parse("mongodb://localhost:27017/?appName=custom")
+            .run()
+            .expect("parsing a plain URI must not require a network round trip");
+
+        apply_default_app_name(&mut options);
+
+        assert_eq!(options.app_name.as_deref(), Some("custom"));
+    }
+
+    #[test]
+    fn apply_default_app_name_fills_missing_app_name() {
+        let mut options = ClientOptions::parse("mongodb://localhost:27017")
+            .run()
+            .expect("parsing a plain URI must not require a network round trip");
+
+        apply_default_app_name(&mut options);
+
+        assert_eq!(
+            options.app_name.as_deref(),
+            Some(dbflux_core::client_identity())
+        );
     }
 
     #[test]

--- a/crates/dbflux_driver_mssql/README.md
+++ b/crates/dbflux_driver_mssql/README.md
@@ -18,6 +18,10 @@ Microsoft SQL Server driver for DBFlux, built on the
   discovery.
 - Authentication via SQL Server logins (username + password); URI mode accepts
   ADO, JDBC, and `sqlserver://user:pass@host:port/db` connection strings.
+- Reports `Application Name` as `dbflux/<version>` unless the connection
+  string or URI already sets one, in which case the user-supplied value
+  always wins; the `sqlserver://`/`mssql://` URL scheme accepts an
+  `applicationname` query parameter for this.
 - TLS encryption modes (`off`, `on`, `required`) via tiberius
   `EncryptionLevel`. The form exposes a single **SSL Mode** dropdown;
   the `TrustServerCertificate` flag is derived automatically:

--- a/crates/dbflux_driver_mssql/src/driver.rs
+++ b/crates/dbflux_driver_mssql/src/driver.rs
@@ -946,7 +946,19 @@ fn build_tiberius_config(params: &MssqlConnectParams) -> Config {
         config.trust_cert();
     }
 
+    // The manual-field connection form has no field for it, so our identity
+    // always applies here — unlike the ADO/JDBC and URL-scheme paths, there
+    // is no user-supplied value that could ever win.
+    config.application_name(manual_mode_application_name());
+
     config
+}
+
+/// The `Application Name` reported for connections built from discrete
+/// profile fields (host/port/user/...), where the caller has no way to set
+/// their own value.
+fn manual_mode_application_name() -> &'static str {
+    dbflux_core::client_identity()
 }
 
 struct MssqlConnectParams<'a> {
@@ -1038,9 +1050,19 @@ impl MssqlDriver {
         let config = if is_mssql_url {
             parse_mssql_url(&uri).map_err(|e| format_mssql_uri_error(&e, base_uri))?
         } else {
-            Config::from_ado_string(&uri)
+            let mut config = Config::from_ado_string(&uri)
                 .or_else(|_| Config::from_jdbc_string(&uri))
-                .map_err(|e| format_mssql_uri_error(&e, base_uri))?
+                .map_err(|e| format_mssql_uri_error(&e, base_uri))?;
+
+            // tiberius parses `Application Name=` / `ApplicationName=` out of
+            // the raw string but exposes no getter on `Config`, so we scan
+            // the same raw string ourselves to decide whether the caller
+            // already set one before applying our default.
+            if !ado_sets_application_name(&uri) {
+                config.application_name(dbflux_core::client_identity());
+            }
+
+            config
         };
 
         let reconnect_config = config.clone();
@@ -3374,6 +3396,7 @@ struct UriQueryParams {
     encryption: EncryptionLevel,
     trust_cert_override: Option<bool>,
     instance_from_query: Option<String>,
+    application_name: Option<String>,
 }
 
 fn split_mssql_uri(uri: &str) -> Result<ParsedMssqlUri<'_>, tiberius::error::Error> {
@@ -3429,6 +3452,22 @@ fn split_mssql_uri(uri: &str) -> Result<ParsedMssqlUri<'_>, tiberius::error::Err
     })
 }
 
+/// Detects whether a raw ADO/JDBC connection string already declares an
+/// `Application Name` (tiberius also accepts the no-space `ApplicationName`
+/// alias), so we know not to override the caller's own value.
+///
+/// `Config` parses this out internally but exposes no getter, so we scan the
+/// same raw string tiberius parsed rather than re-deriving it from a `Config`.
+fn ado_sets_application_name(s: &str) -> bool {
+    s.split(';').any(|pair| {
+        let Some((key, _)) = pair.split_once('=') else {
+            return false;
+        };
+        let normalized = key.trim().to_ascii_lowercase();
+        normalized == "application name" || normalized == "applicationname"
+    })
+}
+
 fn parse_uri_query_params(params: &str) -> UriQueryParams {
     // SSL Mode is the single user-facing knob; trust_cert is derived from
     // it unless the caller explicitly overrides via `?trust=` in the URI.
@@ -3440,6 +3479,7 @@ fn parse_uri_query_params(params: &str) -> UriQueryParams {
         encryption: EncryptionLevel::On,
         trust_cert_override: None,
         instance_from_query: None,
+        application_name: None,
     };
 
     for pair in params.split('&').filter(|p| !p.is_empty()) {
@@ -3466,6 +3506,12 @@ fn parse_uri_query_params(params: &str) -> UriQueryParams {
                     .map(|cow| cow.into_owned())
                     .unwrap_or_else(|_| value.to_string());
                 out.instance_from_query = Some(decoded);
+            }
+            "applicationname" if !value.is_empty() => {
+                let decoded = urlencoding::decode(value)
+                    .map(|cow| cow.into_owned())
+                    .unwrap_or_else(|_| value.to_string());
+                out.application_name = Some(decoded);
             }
             _ => {}
         }
@@ -3536,6 +3582,13 @@ fn parse_mssql_url(uri: &str) -> Result<Config, tiberius::error::Error> {
     if trust_cert {
         config.trust_cert();
     }
+
+    // A user-supplied `?applicationname=` always wins over our default.
+    config.application_name(
+        query
+            .application_name
+            .unwrap_or_else(|| dbflux_core::client_identity().to_string()),
+    );
 
     Ok(config)
 }
@@ -4251,6 +4304,60 @@ mod tests {
     #[test]
     fn parse_mssql_url_accepts_instance_query_param() {
         let result = parse_mssql_url("sqlserver://sa:pw@localhost:1433/?instance=SQLEXPRESS");
+        assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
+    }
+
+    #[test]
+    fn manual_mode_application_name_is_our_client_identity() {
+        // The manual connection form has no field for it, so our identity
+        // always applies — there is nothing for a user value to win over.
+        assert_eq!(
+            manual_mode_application_name(),
+            dbflux_core::client_identity()
+        );
+    }
+
+    #[test]
+    fn ado_sets_application_name_detects_space_and_no_space_keys() {
+        assert!(ado_sets_application_name(
+            "Server=host;Application Name=Foo;User Id=sa"
+        ));
+        assert!(ado_sets_application_name("Server=host;ApplicationName=Foo"));
+        // Case-insensitive and tolerant of surrounding whitespace.
+        assert!(ado_sets_application_name(
+            "Server=host; APPLICATION NAME = Foo "
+        ));
+    }
+
+    #[test]
+    fn ado_sets_application_name_ignores_absent_key() {
+        assert!(!ado_sets_application_name("Server=host;User Id=sa"));
+    }
+
+    #[test]
+    fn ado_sets_application_name_does_not_match_value_substring() {
+        // A value that merely contains the text must not be mistaken for the
+        // key itself.
+        assert!(!ado_sets_application_name(
+            "Server=host;Description=Application Name lookalike"
+        ));
+    }
+
+    #[test]
+    fn parse_uri_query_params_captures_application_name() {
+        let query = parse_uri_query_params("applicationname=MyTool");
+        assert_eq!(query.application_name.as_deref(), Some("MyTool"));
+    }
+
+    #[test]
+    fn parse_uri_query_params_leaves_application_name_absent_without_param() {
+        let query = parse_uri_query_params("instance=SQLEXPRESS");
+        assert!(query.application_name.is_none());
+    }
+
+    #[test]
+    fn parse_mssql_url_accepts_applicationname_query_param() {
+        let result = parse_mssql_url("sqlserver://sa:pw@localhost:1433/?applicationname=MyTool");
         assert!(result.is_ok(), "expected Ok, got {:?}", result.err());
     }
 

--- a/crates/dbflux_driver_mysql/README.md
+++ b/crates/dbflux_driver_mysql/README.md
@@ -21,6 +21,7 @@ Popular open-source relational database.
 - Routine definition: retrieves the full `CREATE FUNCTION` or `CREATE PROCEDURE` body via `SHOW CREATE FUNCTION`/`SHOW CREATE PROCEDURE` (read-only; definition is not editable or executable in the viewer).
 - Multi-statement scripts (several `;`-separated statements) are split and executed statement by statement, each through the typed prepared path, returning one result set per statement.
 - Data-transfer engine: native multi-row `INSERT` bulk-load (`BULK_INSERT`), driver-native `CREATE TABLE` DDL from a source table's columns, `TRUNCATE TABLE` support, and a referential-integrity toggle (`SET FOREIGN_KEY_CHECKS`) for FK-safe migrations. Both MySQL and MariaDB share this support.
+- Sends the `program_name` connection attribute as `dbflux/<version>`, visible in `performance_schema.session_connect_attrs`.
 
 ### Instance Metrics
 

--- a/crates/dbflux_driver_mysql/src/driver.rs
+++ b/crates/dbflux_driver_mysql/src/driver.rs
@@ -1200,7 +1200,11 @@ fn build_mysql_opts(
         .tcp_port(port)
         .prefer_socket(false)
         .user(Some(user))
-        .pass(password);
+        .pass(password)
+        .connect_attrs(Some(HashMap::from([(
+            "program_name".to_string(),
+            dbflux_core::client_identity().to_string(),
+        )])));
 
     if let Some(db) = database {
         builder = builder.db_name(Some(db));
@@ -1279,6 +1283,14 @@ impl MysqlDriver {
         let uri = inject_password_into_mysql_uri(base_uri, password);
 
         let opts = Opts::from_url(&uri).map_err(|e| format_mysql_uri_error(&e, base_uri))?;
+        // MySQL connection URIs have no program_name/application_name query key,
+        // so the identity attr must be applied unconditionally after parsing.
+        let opts: Opts = OptsBuilder::from_opts(opts)
+            .connect_attrs(Some(HashMap::from([(
+                "program_name".to_string(),
+                dbflux_core::client_identity().to_string(),
+            )])))
+            .into();
 
         let catalog_conn =
             Conn::new(opts.clone()).map_err(|e| format_mysql_uri_error(&e, base_uri))?;
@@ -3917,9 +3929,9 @@ pub fn fetch_dependents(
 #[cfg(test)]
 mod tests {
     use super::{
-        MysqlCodeGenerator, MysqlDialect, MysqlDriver, inject_password_into_mysql_uri,
-        mysql_routine_type_to_kind, mysql_text_literal, normalize_mysql_tcp_host,
-        plan_mysql_semantic_request,
+        MysqlCodeGenerator, MysqlDialect, MysqlDriver, MysqlSslPaths, build_mysql_opts,
+        inject_password_into_mysql_uri, mysql_routine_type_to_kind, mysql_text_literal,
+        normalize_mysql_tcp_host, plan_mysql_semantic_request,
     };
     use dbflux_core::{
         AddColumnRequest, AlterColumnRequest, CodeGenerator, DatabaseCategory, DbConfig, DbDriver,
@@ -3927,6 +3939,7 @@ mod tests {
         OrderByColumn, QueryLanguage, RoutineKind, RowInsert, SemanticRequest, SqlDialect,
         SqlMutationGenerator, TableBrowseRequest, TableRef, TransferFamily, Value,
     };
+    use mysql::{Opts, OptsBuilder};
 
     #[test]
     fn build_and_parse_uri_roundtrip_basics() {
@@ -4051,6 +4064,47 @@ mod tests {
                 .parse_uri("postgres://postgres@localhost:5432/app")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn build_mysql_opts_sends_client_identity_program_name() {
+        let opts = build_mysql_opts(
+            "localhost",
+            3306,
+            "root",
+            None,
+            None,
+            "DISABLED",
+            &MysqlSslPaths {
+                root_cert: None,
+                client_cert: None,
+                client_key: None,
+            },
+        );
+
+        let program_name = opts
+            .get_connect_attrs()
+            .and_then(|attrs| attrs.get("program_name"))
+            .map(String::as_str);
+        assert_eq!(program_name, Some(dbflux_core::client_identity()));
+    }
+
+    #[test]
+    fn uri_opts_send_client_identity_program_name() {
+        let opts = Opts::from_url("mysql://root@localhost:3306/app")
+            .expect("uri should parse into mysql Opts");
+        let opts: Opts = OptsBuilder::from_opts(opts)
+            .connect_attrs(Some(std::collections::HashMap::from([(
+                "program_name".to_string(),
+                dbflux_core::client_identity().to_string(),
+            )])))
+            .into();
+
+        let program_name = opts
+            .get_connect_attrs()
+            .and_then(|attrs| attrs.get("program_name"))
+            .map(String::as_str);
+        assert_eq!(program_name, Some(dbflux_core::client_identity()));
     }
 
     #[test]

--- a/crates/dbflux_driver_postgres/README.md
+++ b/crates/dbflux_driver_postgres/README.md
@@ -21,6 +21,7 @@ Advanced open-source relational database.
 - Data-transfer engine: native multi-row `INSERT` bulk-load (`BULK_INSERT`), driver-native `CREATE TABLE` DDL from a source table's columns, `TRUNCATE TABLE` support, and a referential-integrity toggle (`SET session_replication_role`) for FK-safe migrations.
 - Displays `pgvector` `vector`, `halfvec`, and `sparsevec` values, including verified one-dimensional arrays, as textual results.
 - Displays full-text search `tsvector` and `tsquery` values, including one-dimensional arrays, in PostgreSQL's canonical text form.
+- Reports its client identity to the server as `application_name=dbflux/<version>` unless the connection string already sets `application_name`, in which case the user-supplied value is kept.
 
 ### Instance Metrics
 

--- a/crates/dbflux_driver_postgres/src/driver.rs
+++ b/crates/dbflux_driver_postgres/src/driver.rs
@@ -1016,10 +1016,10 @@ struct PostgresConnectParams<'a> {
 /// - `"require"` — TLS required, self-signed certs accepted
 /// - `"verify-ca"` / `"verify-full"` — TLS required with certificate validation
 fn connect_postgres(params: &PostgresConnectParams) -> Result<Client, DbError> {
-    let conn_string = format!(
+    let conn_string = with_client_identity(&format!(
         "host={} port={} user={} password={} dbname={} connect_timeout=30",
         params.host, params.port, params.user, params.password, params.database
-    );
+    ));
 
     match params.ssl_mode {
         "disable" => Client::connect(&conn_string, NoTls)
@@ -1098,6 +1098,7 @@ impl PostgresDriver {
         password: Option<&str>,
     ) -> Result<Box<dyn Connection>, DbError> {
         let uri = inject_password_into_pg_uri(base_uri, password);
+        let uri = with_client_identity(&uri);
 
         let ssl_mode = parse_pg_uri_sslmode(&uri);
 
@@ -4725,6 +4726,32 @@ fn inject_password_into_pg_uri(base_uri: &str, password: Option<&str>) -> String
     base_uri.to_string()
 }
 
+/// Appends dbflux's client identity as `application_name` unless the connection string
+/// already declares one, so a user-supplied `application_name` always wins.
+fn with_client_identity(conn_str: &str) -> String {
+    if has_application_name(conn_str) {
+        return conn_str.to_string();
+    }
+
+    let identity = dbflux_core::client_identity();
+    let is_uri = conn_str.starts_with("postgres://") || conn_str.starts_with("postgresql://");
+
+    if is_uri {
+        let separator = if conn_str.contains('?') { '&' } else { '?' };
+        format!("{}{}application_name={}", conn_str, separator, identity)
+    } else {
+        format!("{} application_name={}", conn_str, identity)
+    }
+}
+
+/// Detects an `application_name` key in both the libpq keyword syntax (space-separated
+/// `key=value` pairs) and the URI query syntax (`?application_name=` / `&application_name=`).
+fn has_application_name(conn_str: &str) -> bool {
+    conn_str.match_indices("application_name=").any(|(idx, _)| {
+        idx == 0 || matches!(conn_str.as_bytes().get(idx - 1), Some(b' ' | b'?' | b'&'))
+    })
+}
+
 fn pg_quote_ident(ident: &str) -> String {
     debug_assert!(!ident.is_empty(), "identifier cannot be empty");
     format!("\"{}\"", ident.replace('"', "\"\""))
@@ -5168,7 +5195,7 @@ mod tests {
         format_pgvector_float4, format_pgvector_sparse, inject_password_into_pg_uri,
         parse_pg_uri_sslmode, pgvector_array_decode_to_value, pgvector_array_values_to_value,
         plan_postgres_semantic_request, prokind_to_routine_kind, text_search_array_values_to_value,
-        unsupported_type_names,
+        unsupported_type_names, with_client_identity,
     };
     use dbflux_core::{
         AddColumnRequest, AlterColumnRequest, CodeGenerator, ColumnAssignment, CreateTableSpec,
@@ -5639,6 +5666,74 @@ mod tests {
         let uri =
             inject_password_into_pg_uri("postgresql://user@localhost:5432/app", Some("new pass"));
         assert_eq!(uri, "postgresql://user:new%20pass@localhost:5432/app");
+    }
+
+    #[test]
+    fn with_client_identity_appends_to_keyword_string_when_absent() {
+        let identity = dbflux_core::client_identity();
+        let conn_str = "host=localhost port=5432 user=app password=secret dbname=app";
+
+        let result = with_client_identity(conn_str);
+
+        assert_eq!(
+            result,
+            format!("{} application_name={}", conn_str, identity)
+        );
+    }
+
+    #[test]
+    fn with_client_identity_keeps_user_supplied_value_in_keyword_string() {
+        let conn_str =
+            "host=localhost port=5432 user=app password=secret dbname=app application_name=myapp";
+
+        let result = with_client_identity(conn_str);
+
+        assert_eq!(result, conn_str);
+    }
+
+    #[test]
+    fn with_client_identity_appends_query_param_to_uri_without_existing_query() {
+        let identity = dbflux_core::client_identity();
+        let conn_str = "postgresql://user:pass@localhost:5432/app";
+
+        let result = with_client_identity(conn_str);
+
+        assert_eq!(
+            result,
+            format!("{}?application_name={}", conn_str, identity)
+        );
+    }
+
+    #[test]
+    fn with_client_identity_appends_query_param_to_uri_with_existing_query() {
+        let identity = dbflux_core::client_identity();
+        let conn_str = "postgresql://user:pass@localhost:5432/app?sslmode=require";
+
+        let result = with_client_identity(conn_str);
+
+        assert_eq!(
+            result,
+            format!("{}&application_name={}", conn_str, identity)
+        );
+    }
+
+    #[test]
+    fn with_client_identity_keeps_user_supplied_value_in_uri_query() {
+        let conn_str = "postgresql://user:pass@localhost:5432/app?application_name=myapp";
+
+        let result = with_client_identity(conn_str);
+
+        assert_eq!(result, conn_str);
+    }
+
+    #[test]
+    fn with_client_identity_keeps_user_supplied_value_as_first_query_param() {
+        let conn_str =
+            "postgres://user:pass@localhost:5432/app?application_name=myapp&sslmode=require";
+
+        let result = with_client_identity(conn_str);
+
+        assert_eq!(result, conn_str);
     }
 
     #[test]

--- a/crates/dbflux_driver_redis/Cargo.toml
+++ b/crates/dbflux_driver_redis/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 async-trait = { workspace = true }
 dbflux_core.workspace = true
 dbflux_ssh.workspace = true
+log.workspace = true
 redis = { version = "0.27", features = ["tls-rustls"] }
 serde_json.workspace = true
 urlencoding = "2"

--- a/crates/dbflux_driver_redis/README.md
+++ b/crates/dbflux_driver_redis/README.md
@@ -17,6 +17,7 @@ Redis key-value driver for DBFlux, built on the [`redis`](https://crates.io/crat
 - Connection modes: manual (host/port/user/password/database) and URI mode. URI mode accepts `redis://` and `rediss://` connection strings.
 - Multiple logical databases via `SELECT <db>` (`MULTIPLE_DATABASES`). The active database index is tracked on the connection.
 - Authentication with optional username + password (`AUTHENTICATION`).
+- Reports its client identity to the server via `CLIENT SETNAME` on connect (`dbflux/<version>`, visible in `CLIENT LIST`); best-effort, since some managed providers restrict `CLIENT` commands.
 - TLS/SSL with three modes (`off`, `on`, `verify`):
   - `off` — plain `redis://` connection.
   - `on` — `rediss://` with the certificate trusted without chain validation (insecure marker).

--- a/crates/dbflux_driver_redis/src/driver.rs
+++ b/crates/dbflux_driver_redis/src/driver.rs
@@ -304,6 +304,8 @@ impl RedisDriver {
                 .map_err(|e| format_redis_error(&e, params.host, params.port))?;
         }
 
+        set_client_name(&mut connection);
+
         redis::cmd("PING")
             .query::<String>(&mut connection)
             .map_err(|e| format_redis_error(&e, params.host, params.port))?;
@@ -336,6 +338,8 @@ impl RedisDriver {
         if let Some(db) = database {
             select_db(&mut connection, db).map_err(|e| format_redis_uri_error(&e, uri))?;
         }
+
+        set_client_name(&mut connection);
 
         redis::cmd("PING")
             .query::<String>(&mut connection)
@@ -1995,6 +1999,20 @@ fn authenticate(
 fn select_db(conn: &mut redis::Connection, db_index: u32) -> redis::RedisResult<()> {
     redis::cmd("SELECT").arg(db_index).query::<String>(conn)?;
     Ok(())
+}
+
+/// Reports the client identity to the server via `CLIENT SETNAME` so it is
+/// visible in `CLIENT LIST`/`CLIENT INFO`. Some managed Redis providers
+/// restrict the `CLIENT` command family, so a failure here must not fail the
+/// connection.
+fn set_client_name(conn: &mut redis::Connection) {
+    if let Err(error) = redis::cmd("CLIENT")
+        .arg("SETNAME")
+        .arg(dbflux_core::client_identity())
+        .query::<String>(conn)
+    {
+        log::warn!("Redis CLIENT SETNAME failed (server may restrict CLIENT commands): {error}");
+    }
 }
 
 fn uri_authority_has_credentials(uri: &str) -> bool {

--- a/crates/dbflux_driver_redshift/README.md
+++ b/crates/dbflux_driver_redshift/README.md
@@ -21,6 +21,7 @@ Amazon Redshift driver for DBFlux (read-only v1), built directly on the [`postgr
 - Table details surface Redshift-specific storage metadata through the generic `TableInfo.storage_hints` seam (read from `SVV_TABLE_INFO` and `PG_TABLE_DEF`): distribution key (`KEY`/`EVEN`/`ALL`/`AUTO`, with the key column when applicable) and sort key (compound or interleaved, with its ordered columns). Declared primary key, foreign key, and unique constraints are still surfaced through the standard core metadata shapes, each labeled advisory/non-enforced — Redshift accepts but never enforces these constraints, and no index list is fabricated from them.
 - Query execution (`SELECT`/browse) returns rows with typed columns via the standard `Connection::execute` path; query cancellation is supported through the wire client's cancel token.
 - `RedshiftErrorFormatter` maps common connection and query failures (timeouts, refused connections, authentication failures, unreachable clusters, `SQLSTATE`-bearing query errors) to clear, driver-formatted messages instead of raw debug output.
+- Reports `application_name` as `dbflux/<version>` on every connection, unless the connection URI already sets its own `application_name` query parameter.
 
 ## Limitations
 

--- a/crates/dbflux_driver_redshift/src/connection.rs
+++ b/crates/dbflux_driver_redshift/src/connection.rs
@@ -113,7 +113,8 @@ fn build_base_config(params: &RedshiftConnectParams, ssl_mode: RedshiftSslMode) 
         .password(params.password)
         .dbname(params.database)
         .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
-        .ssl_mode(ssl_mode.config_ssl_mode());
+        .ssl_mode(ssl_mode.config_ssl_mode())
+        .application_name(dbflux_core::client_identity());
 
     config
 }
@@ -1027,6 +1028,26 @@ mod tests {
         assert_eq!(config.get_ssl_mode(), SslMode::Require);
         assert_eq!(config.get_dbname(), Some("dev"));
         assert_eq!(config.get_user(), Some("awsuser"));
+    }
+
+    #[test]
+    fn build_base_config_reports_dbflux_as_the_application_name() {
+        let tls_certs = RedshiftTlsCerts::default();
+        let params = RedshiftConnectParams {
+            host: "cluster.example.com",
+            port: 5439,
+            user: "awsuser",
+            password: "secret",
+            database: "dev",
+            ssl_mode: "require",
+            tls_certs: &tls_certs,
+        };
+        let config = build_base_config(&params, RedshiftSslMode::parse(params.ssl_mode));
+
+        assert_eq!(
+            config.get_application_name(),
+            Some(dbflux_core::client_identity())
+        );
     }
 
     #[test]

--- a/crates/dbflux_driver_redshift/src/driver.rs
+++ b/crates/dbflux_driver_redshift/src/driver.rs
@@ -552,6 +552,10 @@ fn build_uri_config(
         config.connect_timeout(DEFAULT_URI_CONNECT_TIMEOUT);
     }
 
+    if config.get_application_name().is_none() {
+        config.application_name(dbflux_core::client_identity());
+    }
+
     Ok((config, ssl_mode))
 }
 
@@ -1043,6 +1047,29 @@ mod tests {
             .expect("URI should parse after sslmode is stripped");
 
             assert_eq!(ssl_mode, RedshiftSslMode::Verify);
+        }
+
+        #[test]
+        fn build_uri_config_defaults_application_name_when_uri_omits_one() {
+            let (config, _) =
+                build_uri_config("postgresql://awsuser:pw@cluster.example.com:5439/dev", None)
+                    .expect("URI should parse");
+
+            assert_eq!(
+                config.get_application_name(),
+                Some(dbflux_core::client_identity())
+            );
+        }
+
+        #[test]
+        fn build_uri_config_preserves_a_user_supplied_application_name() {
+            let (config, _) = build_uri_config(
+                "postgresql://awsuser:pw@cluster.example.com:5439/dev?application_name=custom",
+                None,
+            )
+            .expect("URI should parse");
+
+            assert_eq!(config.get_application_name(), Some("custom"));
         }
 
         #[test]

--- a/docs/es/drivers/mongodb.md
+++ b/docs/es/drivers/mongodb.md
@@ -46,6 +46,9 @@ Driver de documentos MongoDB para DBFlux.
   para vistas previas y copy-as-query.
 - DDL: drop database, drop collection, create index y drop index.
 - Exportación de resultados a JSON (`EXPORT_JSON`).
+- Reporta la identidad de cliente como `appName=dbflux/<version>` al conectar
+  (visible en los logs del servidor y en `db.currentOp()`), salvo que la URI de
+  conexión ya defina un `appName`.
 
 ### Instance Metrics
 

--- a/docs/es/drivers/mssql.md
+++ b/docs/es/drivers/mssql.md
@@ -19,6 +19,10 @@ Driver de Microsoft SQL Server para DBFlux, construido sobre el cliente TDS
 - Autenticación mediante logins de SQL Server (usuario + contraseña); el modo
   URI acepta connection strings ADO, JDBC y
   `sqlserver://user:pass@host:port/db`.
+- Reporta `Application Name` como `dbflux/<version>` salvo que la connection
+  string o URI ya definan uno, en cuyo caso el valor del usuario siempre gana;
+  el esquema de URL `sqlserver://`/`mssql://` acepta un parámetro de query
+  `applicationname` para esto.
 - Modos de encriptación TLS (`off`, `on`, `required`) vía el `EncryptionLevel`
   de tiberius. El formulario expone un único desplegable **SSL Mode**; el flag
   `TrustServerCertificate` se deriva automáticamente:

--- a/docs/es/drivers/mysql.md
+++ b/docs/es/drivers/mysql.md
@@ -39,6 +39,8 @@ Base de datos relacional open-source popular.
   de una tabla origen, soporte de `TRUNCATE TABLE`, y un toggle de integridad
   referencial (`SET FOREIGN_KEY_CHECKS`) para migraciones seguras con FK. Tanto
   MySQL como MariaDB comparten este soporte.
+- Envía el atributo de conexión `program_name` como `dbflux/<version>`, visible
+  en `performance_schema.session_connect_attrs`.
 
 ### Instance Metrics
 

--- a/docs/es/drivers/postgres.md
+++ b/docs/es/drivers/postgres.md
@@ -33,6 +33,9 @@ Base de datos relacional open-source avanzada.
 - Muestra valores `tsvector` y `tsquery` de búsqueda de texto completo,
   incluyendo arrays unidimensionales, en la forma de texto canónica de
   PostgreSQL.
+- Reporta su identidad de cliente al servidor como
+  `application_name=dbflux/<version>`, salvo que la connection string ya defina
+  `application_name`, en cuyo caso se conserva el valor del usuario.
 
 ### Instance Metrics
 

--- a/docs/es/drivers/redis.md
+++ b/docs/es/drivers/redis.md
@@ -22,6 +22,9 @@ Driver de clave-valor Redis para DBFlux, construido sobre el crate
 - Múltiples databases lógicas mediante `SELECT <db>` (`MULTIPLE_DATABASES`). El
   índice de la database activa se rastrea en la conexión.
 - Autenticación con username + password opcionales (`AUTHENTICATION`).
+- Reporta su identidad de cliente al servidor vía `CLIENT SETNAME` al conectar
+  (`dbflux/<version>`, visible en `CLIENT LIST`); best-effort, ya que algunos
+  proveedores managed restringen los comandos `CLIENT`.
 - TLS/SSL con tres modos (`off`, `on`, `verify`):
   - `off` — conexión `redis://` plana.
   - `on` — `rediss://` con el certificado confiado sin validación de cadena

--- a/docs/es/drivers/redshift.md
+++ b/docs/es/drivers/redshift.md
@@ -58,6 +58,9 @@ directamente sobre el cliente de wire protocol
   (timeouts, conexiones rechazadas, fallos de autenticación, clusters
   inalcanzables, errores de query con `SQLSTATE`) a mensajes claros formateados
   por el driver en lugar de output de debug crudo.
+- Reporta `application_name` como `dbflux/<version>` en cada conexión, salvo
+  que la URI de conexión ya defina su propio parámetro de query
+  `application_name`.
 
 ## Limitaciones
 


### PR DESCRIPTION
Closes #352

## Summary

- Adds a single `dbflux_core::client_identity()` helper (next to `ReleaseChannel`) that returns `dbflux/<version>` from the workspace version, with a drift test in the `dbflux` binary crate that fails if the reported version ever diverges from the app's.
- Every driver reports that identity on connect: PostgreSQL and Redshift via `application_name`, MySQL/MariaDB via the `program_name` connect attribute, SQL Server via `Application Name`, MongoDB via `appName`, and Redis via a best-effort `CLIENT SETNAME` (some managed providers restrict `CLIENT`, so a failure there logs a warning instead of failing the connection).
- A client name the user already supplied always wins: detected in the PostgreSQL keyword and URI syntaxes, through `Config::get_application_name()` for Redshift URIs, by raw-string scan for SQL Server ADO/JDBC strings (tiberius exposes no getter), and through `ClientOptions::parse` for MongoDB. The custom `sqlserver://` URL scheme gains a recognized `applicationname` query parameter. MySQL and Redis URIs have no client-name concept, so the default applies unconditionally there.

## Changes

| Area | Change |
|------|--------|
| `crates/dbflux_core/src/release_channel.rs` | New `client_identity()` helper plus unit test |
| `crates/dbflux/tests/client_identity_version.rs` | Version-drift guard test |
| `crates/dbflux_driver_postgres` | `with_client_identity()` appended to keyword and URI connect strings, 6 precedence tests |
| `crates/dbflux_driver_redshift` | `application_name` in `build_base_config`; URI path only when unset, 3 tests |
| `crates/dbflux_driver_mysql` | `program_name` connect attribute in both connect paths, 2 tests |
| `crates/dbflux_driver_mssql` | `Application Name` in manual mode; ADO/JDBC raw-string detection; `applicationname` URL query param, 7 tests |
| `crates/dbflux_driver_mongodb` | Refactor to `ClientOptions::parse` + `apply_default_app_name`, 2 tests |
| `crates/dbflux_driver_redis` | Best-effort `CLIENT SETNAME` after auth/select in both connect paths |
| Driver READMEs | One Features line each documenting the reported identity |

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo nextest run --workspace`: 5607/5608 passed; the single failure is `palette_filtering_large_dataset_completes_within_budget` (`dbflux_ui`, untouched), a pre-existing time-budget test that passes in isolation and fails only under full-suite parallel load
- [x] `cargo test --doc --workspace` clean
- [ ] Live verification against real servers (`pg_stat_activity`, `CLIENT LIST`, `session_connect_attrs`, `db.currentOp()`) not run