### PR TITLE
feat(web): round-2 agent audit fixes

### DIFF
--- a/web/public/.well-known/ai-catalog.json
+++ b/web/public/.well-known/ai-catalog.json
@@ -1,9 +1,13 @@
 {
-  "specVersion": "0.1",
-  "host": { "name": "DBFlux", "url": "https://dbflux.dev" },
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "DBFlux",
+    "identifier": "did:web:dbflux.dev",
+    "url": "https://dbflux.dev"
+  },
   "entries": [
     {
-      "id": "urn:air:dbflux.dev:docs:documentation",
+      "identifier": "urn:air:dbflux.dev:docs:documentation",
       "displayName": "DBFlux documentation",
       "type": "text/html",
       "url": "https://docs.dbflux.dev/",
@@ -14,7 +18,7 @@
       ]
     },
     {
-      "id": "urn:air:dbflux.dev:docs:llms-txt",
+      "identifier": "urn:air:dbflux.dev:docs:llms-txt",
       "displayName": "DBFlux llms.txt index",
       "type": "text/plain",
       "url": "https://dbflux.dev/llms.txt",
@@ -24,7 +28,7 @@
       ]
     },
     {
-      "id": "urn:air:dbflux.dev:skills:dbflux",
+      "identifier": "urn:air:dbflux.dev:skills:dbflux",
       "displayName": "DBFlux agent skill",
       "type": "text/markdown",
       "url": "https://dbflux.dev/.well-known/agent-skills/dbflux/SKILL.md",
@@ -34,10 +38,10 @@
       ]
     },
     {
-      "id": "urn:air:dbflux.dev:mcp:docs",
+      "identifier": "urn:air:dbflux.dev:mcp:docs",
       "displayName": "DBFlux docs MCP server",
-      "type": "application/json",
-      "url": "https://mcp.dbflux.dev/mcp",
+      "type": "application/mcp-server-card+json",
+      "url": "https://dbflux.dev/.well-known/mcp/server-card.json",
       "representativeQueries": [
         "Search the DBFlux documentation",
         "Read the DBFlux usage guide as markdown"

--- a/web/public/webmcp.js
+++ b/web/public/webmcp.js
@@ -1,0 +1,111 @@
+// Registers DBFlux docs tools with any browser-side WebMCP host (navigator.modelContext).
+// No-op when the API is absent, so this file is safe to load unconditionally.
+(function () {
+  const modelContext = navigator.modelContext;
+  if (!modelContext) return;
+
+  const textResult = (text) => ({ content: [{ type: 'text', text }] });
+
+  const searchDocs = {
+    name: 'search_docs',
+    description: 'Search the DBFlux documentation and return the top matching sections.',
+    inputSchema: {
+      type: 'object',
+      properties: { query: { type: 'string' } },
+      required: ['query'],
+    },
+    execute: async ({ query }) => {
+      try {
+        const response = await fetch('https://docs.dbflux.dev/search-index.json');
+        if (!response.ok) return textResult(`Search index unavailable (${response.status}).`);
+        const sections = await response.json();
+        const tokens = query.toLowerCase().split(/\W+/).filter(Boolean);
+
+        const scored = sections
+          .map((section) => {
+            const title = (section.t ?? '').toLowerCase();
+            const heading = (section.h ?? '').toLowerCase();
+            const snippet = (section.s ?? '').toLowerCase();
+            let score = 0;
+            for (const token of tokens) {
+              score += count(title, token) * 5;
+              score += count(heading, token) * 3;
+              score += count(snippet, token);
+            }
+            return { section, score };
+          })
+          .filter(({ score }) => score > 0)
+          .sort((a, b) => b.score - a.score)
+          .slice(0, 5)
+          .map(({ section }) => ({
+            path: section.p,
+            title: section.t,
+            heading: section.h,
+            url: `https://docs.dbflux.dev${section.p}${section.a ? `#${section.a}` : ''}`,
+            snippet: section.s,
+          }));
+
+        return textResult(JSON.stringify(scored));
+      } catch (error) {
+        return textResult(`Search failed: ${error}`);
+      }
+    },
+  };
+
+  const readDocsPage = {
+    name: 'read_docs_page',
+    description: 'Fetch a DBFlux documentation page as markdown.',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string', description: 'Docs page path such as /usage/' } },
+      required: ['path'],
+    },
+    execute: async ({ path }) => {
+      try {
+        const normalized = normalizePath(path);
+        const response = await fetch(`https://docs.dbflux.dev${normalized}index.md`);
+        if (!response.ok) return textResult(`Docs page unavailable (${response.status}).`);
+        return textResult(await response.text());
+      } catch (error) {
+        return textResult(`Fetch failed: ${error}`);
+      }
+    },
+  };
+
+  const openDocsPage = {
+    name: 'open_docs_page',
+    description: 'Navigate the browser to a DBFlux documentation page.',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string', description: 'Docs page path such as /usage/' } },
+      required: ['path'],
+    },
+    execute: async ({ path }) => {
+      try {
+        const normalized = normalizePath(path);
+        window.location.assign(`https://docs.dbflux.dev${normalized}`);
+        return textResult(`Navigating to https://docs.dbflux.dev${normalized}`);
+      } catch (error) {
+        return textResult(`Navigation failed: ${error}`);
+      }
+    },
+  };
+
+  function normalizePath(path) {
+    const withLeading = path.startsWith('/') ? path : `/${path}`;
+    return withLeading.endsWith('/') ? withLeading : `${withLeading}/`;
+  }
+
+  function count(haystack, token) {
+    if (!token) return 0;
+    return haystack.split(token).length - 1;
+  }
+
+  const tools = [searchDocs, readDocsPage, openDocsPage];
+
+  if (typeof modelContext.registerTool === 'function') {
+    for (const tool of tools) modelContext.registerTool(tool);
+  } else if (typeof modelContext.provideContext === 'function') {
+    modelContext.provideContext({ tools });
+  }
+})();

--- a/web/scripts/audit-dist.ts
+++ b/web/scripts/audit-dist.ts
@@ -147,21 +147,26 @@ else if (!apiCatalog.linkset[0]?.anchor)
   fail('.well-known/api-catalog linkset entry is missing an anchor');
 
 interface AiCatalogEntry {
-  id?: string;
+  identifier?: string;
   url?: string;
   representativeQueries?: string[];
 }
-const aiCatalog: { specVersion?: string; host?: { url?: string }; entries?: AiCatalogEntry[] } =
-  JSON.parse(text(resolve(wellKnownRoot, 'ai-catalog.json')));
+const aiCatalog: {
+  specVersion?: string;
+  host?: { displayName?: string; identifier?: string; url?: string };
+  entries?: AiCatalogEntry[];
+} = JSON.parse(text(resolve(wellKnownRoot, 'ai-catalog.json')));
 if (!aiCatalog.specVersion) fail('.well-known/ai-catalog.json is missing specVersion');
 if (!aiCatalog.host?.url) fail('.well-known/ai-catalog.json is missing host.url');
+if (!aiCatalog.host?.displayName) fail('.well-known/ai-catalog.json is missing host.displayName');
+if (!aiCatalog.host?.identifier) fail('.well-known/ai-catalog.json is missing host.identifier');
 for (const entry of aiCatalog.entries ?? []) {
-  if (!entry.id?.startsWith('urn:air:'))
-    fail(`.well-known/ai-catalog.json entry has an invalid id: ${entry.id}`);
-  if (!entry.url) fail(`.well-known/ai-catalog.json entry "${entry.id}" is missing a url`);
+  if (!entry.identifier?.startsWith('urn:air:'))
+    fail(`.well-known/ai-catalog.json entry has an invalid identifier: ${entry.identifier}`);
+  if (!entry.url) fail(`.well-known/ai-catalog.json entry "${entry.identifier}" is missing a url`);
   const queryCount = entry.representativeQueries?.length ?? 0;
   if (queryCount < 2 || queryCount > 5)
-    fail(`.well-known/ai-catalog.json entry "${entry.id}" needs 2-5 representativeQueries`);
+    fail(`.well-known/ai-catalog.json entry "${entry.identifier}" needs 2-5 representativeQueries`);
 }
 
 interface AgentSkillEntry {
@@ -199,6 +204,10 @@ if (mode === 'site' && !existsSync(homeMarkdownPath)) fail('site build is missin
 if (mode === 'docs' && existsSync(homeMarkdownPath))
   fail('docs build must not publish a homepage dist/index.md');
 
+const homeHtml = text(fileFor('/'));
+if (!homeHtml.includes('rel="ai-catalog"')) fail('homepage is missing rel="ai-catalog" link');
+if (!homeHtml.includes('/webmcp.js')) fail('homepage is missing the webmcp.js script');
+
 const headersPath = existsSync(resolve(root, '_headers'))
   ? resolve(root, '_headers')
   : resolve('public/_headers');
@@ -214,6 +223,8 @@ const assets = {
     const path = new URL(request.url).pathname;
     if (path === '/.well-known/api-catalog')
       return new Response('{}', { headers: { 'content-type': 'application/json' } });
+    if (path === '/search-index.json')
+      return new Response('[]', { headers: { 'content-type': 'application/json' } });
     if (path.endsWith('index.md'))
       return path.includes('missing-sibling')
         ? new Response('', { status: 404 })
@@ -246,6 +257,7 @@ for (const [accept, body] of [
   ['text/html;q=0.4,text/markdown;q=0.9', 'markdown'],
   ['text/html,text/markdown', 'markdown'],
   ['text/markdown;q=0', 'html'],
+  ['text/html,application/xhtml+xml;q=0.9,text/markdown;q=0.5', 'markdown'],
 ]) {
   const response = await request(accept);
   if (
@@ -254,6 +266,8 @@ for (const [accept, body] of [
     !response.headers.get('link')?.includes('old')
   )
     fail(`Worker negotiation failed for ${accept || 'absent'}`);
+  if (body === 'markdown' && !response.headers.get('x-markdown-tokens'))
+    fail(`Worker did not set x-markdown-tokens for ${accept}`);
 }
 for (const [method, path, status, body] of [
   ['HEAD', '/usage/', 200, ''],
@@ -270,5 +284,9 @@ for (const [method, path, status, body] of [
 const apiCatalogResponse = await request('*/*', 'GET', '/.well-known/api-catalog');
 if (apiCatalogResponse.headers.get('content-type') !== 'application/linkset+json')
   fail('Worker did not set application/linkset+json for /.well-known/api-catalog');
+
+const searchIndexResponse = await request('*/*', 'GET', '/search-index.json');
+if (searchIndexResponse.headers.get('access-control-allow-origin') !== '*')
+  fail('Worker did not set Access-Control-Allow-Origin for /search-index.json');
 
 console.log(`ok: SEO foundation audit (${mode})`);

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -95,6 +95,7 @@ const xDefaultHref =
     <link rel="icon" href="/brand/favicon.svg" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/brand/mark-256.png" />
     <link rel="sitemap" href="/sitemap-index.xml" />
+    <link rel="ai-catalog" href="/.well-known/ai-catalog.json" />
     <link
       rel="preload"
       href="/fonts/jetbrains-mono-latin-wght-normal.woff2"
@@ -118,5 +119,6 @@ const xDefaultHref =
     <BackToTop />
     <Mermaid />
     <SearchDialog indexUrl={searchIndex} locale={locale} />
+    <script is:inline src="/webmcp.js" defer></script>
   </body>
 </html>

--- a/web/worker.ts
+++ b/web/worker.ts
@@ -39,8 +39,19 @@ export default {
       !html.ok ||
       !request.url.endsWith('/') ||
       !html.headers.get('content-type')?.includes('text/html')
-    )
+    ) {
+      const pathname = new URL(request.url).pathname;
+      if (pathname.endsWith('.md') || pathname === '/search-index.json') {
+        const headers = new Headers(html.headers);
+        headers.set('Access-Control-Allow-Origin', '*');
+        return new Response(request.method === 'HEAD' ? null : html.body, {
+          status: html.status,
+          statusText: html.statusText,
+          headers,
+        });
+      }
       return html;
+    }
     const markdownUrl = new URL('index.md', request.url).href;
     const markdown = await env.ASSETS.fetch(new Request(markdownUrl));
     if (!markdown.ok) return html;
@@ -48,11 +59,7 @@ export default {
     merge(headers, 'Vary', 'Accept');
     merge(headers, 'Link', `<${markdownUrl}>; rel="alternate"; type="text/markdown"`);
     const markdownQuality = quality(request.headers.get('Accept'), 'text/markdown');
-    const htmlQuality = quality(request.headers.get('Accept'), 'text/html');
-    const selected =
-      markdownQuality !== undefined &&
-      markdownQuality > 0 &&
-      (htmlQuality === undefined || markdownQuality >= htmlQuality);
+    const selected = markdownQuality !== undefined && markdownQuality > 0;
     if (selected) {
       headers.set('content-type', 'text/markdown; charset=utf-8');
       headers.delete('content-length');
@@ -60,8 +67,15 @@ export default {
         'Link',
         `${html.headers.get('Link') ? `${html.headers.get('Link')}, ` : ''}<${request.url}>; rel="alternate"; type="text/html"`,
       );
+      const markdownText = await markdown.text();
+      headers.set('x-markdown-tokens', String(Math.ceil(markdownText.length / 4)));
+      return new Response(request.method === 'HEAD' ? null : markdownText, {
+        status: html.status,
+        statusText: html.statusText,
+        headers,
+      });
     }
-    return new Response(request.method === 'HEAD' ? null : (selected ? markdown : html).body, {
+    return new Response(request.method === 'HEAD' ? null : html.body, {
       status: html.status,
       statusText: html.statusText,
       headers,


### PR DESCRIPTION
## Summary

- Conform `ai-catalog.json` to the ai-catalog data model scanners validate: `identifier` fields (urn:air), `host.displayName`/`host.identifier` (did:web), `specVersion` 1.0, and the MCP entry now pointing at the server card with type `application/mcp-server-card+json`; advertised via `<link rel="ai-catalog">`.
- Expose WebMCP tools on page load (`/webmcp.js`, feature-detected `navigator.modelContext`): `search_docs`, `read_docs_page`, `open_docs_page` against the published docs artifacts.
- Loosen markdown negotiation to Cloudflare's Markdown-for-Agents semantics: serve markdown whenever `Accept` lists `text/markdown` with q>0 (browsers never send it, so HTML behavior is unchanged), add `x-markdown-tokens`, and add `Access-Control-Allow-Origin: *` on markdown siblings and the search index so browser agents can fetch them cross-origin.

## What does this resolve?

Second round against the agent-readiness audit, following #481 and #484. The scanner rejected our ARD entries (`id` vs `identifier`), detected no WebMCP tools, and received HTML through its own fetch path even though curl, a Miami vantage probe, and a Worker subrequest all negotiate markdown — the leniency change mirrors how Cloudflare's native feature behaves so composite Accept headers still get markdown. DNS-AID records were published directly in the zone (`_mcp._agents` HTTPS + `_catalog._agents` TXT), no repo change involved.

## How was this solved?

Worker-side changes stay in `worker.ts` (selection rule, tokens header, CORS on the passthrough path). WebMCP is a dependency-free script in `public/` loaded from the base layout. The distribution audit now asserts the new manifest shape, the lenient negotiation case, the tokens header, the CORS header, and the homepage advertising both discovery hooks.

## Validation

- `pnpm check`, both builds, `audit-dist.ts` in site and docs modes, `check-links.ts`, and Prettier all green (re-verified independently, not only by the implementing agent).
- Post-merge: re-run the isitagentready scan against the live site.