### PR TITLE
fix(web): format llms.txt per the llmstxt.org spec

### DIFF
--- a/web/scripts/audit-dist.ts
+++ b/web/scripts/audit-dist.ts
@@ -83,14 +83,18 @@ for (const url of locations) {
   if (html.includes('name="robots" content="noindex, follow"'))
     fail(`indexed noindex page ${url.pathname}`);
 }
+if (!/^# DBFlux\n\n> /.test(llms)) fail('llms lacks the llmstxt.org H1 + blockquote preamble');
 for (const path of ['/', '/install/', '/usage/']) {
-  if (!llms.includes(`- ${mode === 'docs' ? path : `https://docs.dbflux.dev${path}`}`))
+  if (!llms.includes(`](${mode === 'docs' ? path : `https://docs.dbflux.dev${path}`})`))
     fail(`llms lacks ${path}`);
 }
-for (const link of llms.matchAll(/^- (https?:\/\/[^\s]+)$/gm)) {
-  const url = new URL(link[1]);
-  if (url.hostname !== 'docs.dbflux.dev' || /nightly|v0\.6/.test(url.pathname))
-    fail(`unsafe llms link ${url}`);
+const llmsLinks = [...llms.matchAll(/^- \[[^\]]+\]\((\/[^)\s]*|https?:\/\/[^)\s]+)\): \S/gm)];
+if (llmsLinks.length < 3) fail('llms has fewer than 3 markdown links with descriptions');
+for (const link of llmsLinks) {
+  const url = new URL(link[1], 'https://docs.dbflux.dev');
+  const docsLink = url.hostname === 'docs.dbflux.dev' && !/nightly|v0\.6/.test(url.pathname);
+  const wellKnownLink = url.hostname === 'dbflux.dev' && url.pathname.startsWith('/.well-known/');
+  if (!docsLink && !wellKnownLink) fail(`unsafe llms link ${url}`);
 }
 if (
   mode === 'docs' &&

--- a/web/src/pages/llms.txt.ts
+++ b/web/src/pages/llms.txt.ts
@@ -1,9 +1,32 @@
 import type { APIRoute } from 'astro';
 import { docsUrl } from '../data/site';
 
+/**
+ * llms.txt per https://llmstxt.org/: an H1, a one-line blockquote summary, and
+ * sections whose entries are markdown links with a short description. Agents
+ * and audits parse the link syntax, so bare URLs are not equivalent.
+ */
 export const GET: APIRoute = () =>
   new Response(
-    `# DBFlux\n\nCurrent documentation:\n${[docsUrl(''), docsUrl('install'), docsUrl('usage')].map((link) => `- ${link}`).join('\n')}\n`,
+    [
+      '# DBFlux',
+      '',
+      '> DBFlux is a keyboard-first, open-source database client for PostgreSQL, MySQL/MariaDB, SQL Server, SQLite, MongoDB, Redis, DynamoDB, CloudWatch, InfluxDB, Redshift, and S3, built in Rust on GPUI.',
+      '',
+      'Every documentation page also serves a Markdown version: request it with `Accept: text/markdown` or append `index.md` to the page URL.',
+      '',
+      '## Documentation',
+      '',
+      `- [Documentation home](${docsUrl('')}): entry point to the current documentation`,
+      `- [Install](${docsUrl('install')}): platform installers and package managers`,
+      `- [Usage guide](${docsUrl('usage')}): connecting, browsing schemas, running queries, and charting`,
+      '',
+      '## Agent resources',
+      '',
+      '- [MCP server card](https://dbflux.dev/.well-known/mcp/server-card.json): remote MCP endpoint exposing this documentation as searchable tools',
+      '- [AI catalog](https://dbflux.dev/.well-known/ai-catalog.json): ARD capability manifest for this site',
+      '',
+    ].join('\n'),
     {
       headers: { 'content-type': 'text/plain; charset=utf-8' },
     },


### PR DESCRIPTION
## Summary

- `llms.txt` listed bare URLs, which llms.txt consumers (Lighthouse's agentic-browsing audit included) parse as a file with no links.
- Emit the llmstxt.org shape instead: H1, one-line blockquote summary, a note that every docs page negotiates `Accept: text/markdown`, a Documentation section, and an Agent resources section (MCP server card, AI catalog) — all as markdown links with descriptions.
- The distribution audit now asserts the preamble and the link syntax in both build modes (docs mode emits relative links).

## What does this resolve?

The one actionable finding in the user's Lighthouse run against dbflux.dev: `llms-txt — File does not appear to contain any links` (agentic-browsing category).

## Validation

- `pnpm check`, both builds, both audits, and Prettier green.