### PR TITLE
fix(web): cap the hero pulse and gate the skip link on focus-visible

### DIFF
--- a/web/src/components/Landing.astro
+++ b/web/src/components/Landing.astro
@@ -319,7 +319,9 @@ const APPLICATION = {
     height: 7px;
     border-radius: var(--radius-full);
     background: var(--success);
-    animation: pulse 2.4s ease-out infinite;
+    /* Finite so the viewport settles: an infinite pulse keeps repainting and
+       tanks the mobile Speed Index while adding nothing after a few beats. */
+    animation: pulse 2.4s ease-out 3;
   }
 
   .sec-head {

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -119,16 +119,18 @@ kbd {
   left: var(--s-5);
   top: -100px;
   z-index: calc(var(--z-nav) + 1);
-  background: var(--accent);
-  color: var(--accent-on);
+  background: var(--bg);
+  color: var(--text);
+  border: var(--bw) solid var(--border-interactive);
   font-family: var(--font-mono);
   font-size: var(--fs-small);
-  font-weight: 700;
   padding: var(--s-4) var(--s-5);
   transition: top var(--t-instant) var(--ease-std);
 }
 
-.skip-link:focus {
+/* focus-visible, not focus: programmatic focus (closing devtools, dialog
+   returns) must not slide the link in — only real keyboard navigation. */
+.skip-link:focus-visible {
   top: var(--s-5);
   text-decoration: none;
 }


### PR DESCRIPTION
## Summary

- The hero status dot pulsed infinitely, so the initial mobile viewport never settled visually: Lighthouse mobile Speed Index sat at 12.3s (everything else was fine: LCP 3.1s, TBT 160ms, 311KiB total). The animation now runs three iterations and stops.
- The skip link appeared on any programmatic focus — closing the devtools panel was enough — because it keyed on `:focus`. It now keys on `:focus-visible`, so only real keyboard navigation reveals it, and it is restyled with the page tokens (background/border/text) instead of the loud accent block.

## What does this resolve?

The two findings from the fresh Lighthouse runs: mobile performance 81 driven by Speed Index, and the skip link surfacing uninvited over the landing. Keyboard and screen-reader users keep the skip navigation.

## Validation

- `astro check` 0 errors, site build + audit green, Prettier clean.