### PR TITLE
ci(build): relax link-time optimization for the macOS amd64 cross build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -433,7 +433,21 @@ jobs:
         # present), and keeps both macOS binaries self-contained at runtime.
         # No --locked: the version stamp above mutates Cargo.toml; see the Linux build
         # step for the full rationale.
-        run: cargo build --release --features "$FEATURES,vendored-openssl" --target ${{ matrix.target }}
+        #
+        # The amd64 entry relaxes the release profile's link-time optimization. It is
+        # the only job that holds two build trees on one runner — the cross target and
+        # the host artifacts that produce it — and `lto = "thin"` with a single codegen
+        # unit makes the final binary the peak of both memory and temporary disk. That
+        # peak is what kills rustc there with SIGBUS. Splitting the work across codegen
+        # units trades some speed and size in the Intel binary for a build that fits.
+        # Every other target keeps the profile from Cargo.toml untouched.
+        run: |
+          if [ "${{ matrix.arch }}" = "amd64" ]; then
+            export CARGO_PROFILE_RELEASE_LTO=false
+            export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16
+          fi
+
+          cargo build --release --features "$FEATURES,vendored-openssl" --target ${{ matrix.target }}
 
       - name: Create app bundle
         run: |


### PR DESCRIPTION
## Summary

Gives the `Build / Build macOS amd64` job enough headroom to finish. It is the only job failing in the nightly, and since the publish step waits on the whole matrix, no nightly has shipped since 2026-08-26.

## What does this resolve?

- Resolves #490

## How was this solved?

rustc was dying with `signal: 10, SIGBUS` while producing the final `dbflux` binary for `x86_64-apple-darwin`, with no diagnostic and exit code 101. That is resource exhaustion, not a code error.

The amd64 entry cross-compiles x86_64 on the Apple Silicon runner, so it is the only job holding two build trees on one machine (the cross target plus the host artifacts that produce it), on top of vendored OpenSSL and the restored Rust cache. The release profile asks for `lto = "thin"` with `codegen-units = 1`, which makes that last binary the peak of both memory and temporary disk in the job that has the least of each.

The build step now exports `CARGO_PROFILE_RELEASE_LTO=false` and `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16` for that matrix entry only. `Cargo.toml` is untouched, so macOS arm64, Linux amd64/arm64 and Windows keep thin LTO in a single codegen unit. The Intel binary loses some speed and gains some size, which is the price of it existing at all.

Worth knowing before merging: this is also the experiment. If the job goes green, the peak was the cause and the matter is closed. If it still gets SIGBUS, the pressure comes from something other than that peak (most likely the duplicated build tree filling the disk) and the next step is to reclaim space in the job rather than to tune the profile further.

## Validation

- `yq '.jobs.build-macos.steps[] | select(.name=="Build DBFlux") | .run'` parses the workflow and renders the intended script, so the YAML is well formed and the conditional reaches the build.
- Real proof only exists on the runner. This needs a nightly run, or a manual dispatch of the release workflow, to confirm the macOS amd64 job completes and produces its DMG.

## Where was this tested?

- [x] Automated tests
- [ ] Local development environment
- [ ] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Follow-up

We cross-compile the Intel build because the native Intel runner is roughly five times slower, and Apple has closed that architecture. At some point the question stops being how to make the build fit and becomes whether we keep publishing an Intel DMG. That is a product decision and belongs in its own issue.