### PR TITLE
feat(ui): narrow the bundled tree-sitter grammars to the ones the editor uses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2735,6 +2735,14 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.19",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-cypher",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-lua",
+ "tree-sitter-python",
+ "tree-sitter-sequel",
  "uuid",
 ]
 
@@ -4713,35 +4721,7 @@ dependencies = [
  "smol",
  "tracing",
  "tree-sitter",
- "tree-sitter-bash",
- "tree-sitter-c",
- "tree-sitter-c-sharp",
- "tree-sitter-cmake",
- "tree-sitter-cpp",
- "tree-sitter-css",
- "tree-sitter-diff",
- "tree-sitter-elixir",
- "tree-sitter-embedded-template",
- "tree-sitter-go",
- "tree-sitter-graphql",
- "tree-sitter-html",
- "tree-sitter-java",
- "tree-sitter-javascript",
- "tree-sitter-jsdoc",
  "tree-sitter-json",
- "tree-sitter-make",
- "tree-sitter-md",
- "tree-sitter-proto",
- "tree-sitter-python",
- "tree-sitter-ruby",
- "tree-sitter-rust",
- "tree-sitter-scala",
- "tree-sitter-sequel",
- "tree-sitter-swift",
- "tree-sitter-toml-ng",
- "tree-sitter-typescript",
- "tree-sitter-yaml",
- "tree-sitter-zig",
  "unicode-segmentation",
  "uuid",
  "zed-sum-tree",
@@ -10805,120 +10785,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-c"
-version = "0.24.2"
+name = "tree-sitter-cypher"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-c-sharp"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-cmake"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1b35d1dd7396d24b3e826bb0f975b915ec7e9125b989d5e9d24ebb6a08509a"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-cpp"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-css"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad6489794d41350d12a7fbe520e5199f688618f43aace5443980d1ddcf1b29e"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-diff"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe1e5ca280a65dfe5ba4205c1bcc84edf486464fed315db53dee6da9a335889"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-elixir"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-embedded-template"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790063ef14e5b67556abc0b3be0ed863fb41d65ee791cf8c0b20eb42a1fa46af"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-go"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13d476345220dbe600147dd444165c5791bf85ef53e28acbedd46112ee18431"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-graphql"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efedc4cac157161cc23a0adc4553a2cedc908e1cd754b6cd033a919bb81ce5d6"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-html"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-java"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+checksum = "c22e06abe4ed210fabe796dd72bf5ca56f788f633b993ed303525178ca7b4608"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -10929,16 +10799,6 @@ name = "tree-sitter-javascript"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf40bf599e0416c16c125c3cec10ee5ddc7d1bb8b0c60fa5c4de249ad34dc1b1"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-jsdoc"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3862dfcb1038fc5e7812d7df14190afdeb7e1415288fd5f51f58395f8cb0faf"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -10961,30 +10821,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
-name = "tree-sitter-make"
-version = "1.1.1"
+name = "tree-sitter-lua"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5998dc7cbcbdab19fae8aefef982bf2d6544513d8d2e69cc44aec4c63810104"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-md"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-proto"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4360b434b5980fc397137ef29e1988619fef4159ac86fa7ac5777d459d3924"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -11001,90 +10841,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-ruby"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-rust"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-scala"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efde5e68b4736e9eac17bfa296c6f104a26bffab363b365eb898c40a63c15d2f"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
 name = "tree-sitter-sequel"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d198ad3c319c02e43c21efa1ec796b837afcb96ffaef1a40c1978fbdcec7d17"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-swift"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b98fb6bc8e6a6a10023f401aa6a1858115e849dfaf7de57dd8b8ea0f257bd9"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-toml-ng"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-typescript"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-yaml"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-zig"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab11fc124851b0db4dd5e55983bbd9631192e93238389dcd44521715e5d53e28"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,20 @@ dbflux_i18n = { path = "crates/dbflux_i18n" }
 mysql = "28"
 
 gpui = "0.2.2"
-gpui-component = { version = "0.5.0", features = ["tree-sitter-languages"] }
+gpui-component = { version = "0.5.0" }
+# Grammars for the code-editor highlighter (gpui-component's highlighter::LanguageRegistry).
+# gpui-component's own `tree-sitter-languages` feature pulls in ~30 grammars; DBFlux only
+# ever asks the editor for the modes `QueryLanguage::editor_mode()` can return (sql,
+# javascript, cypher, lua, python, bash, plaintext) plus json, so those are registered
+# individually at startup instead (see dbflux_components::highlighting).
+tree-sitter = "0.25.4"
+tree-sitter-sequel = "0.3.8"
+tree-sitter-javascript = "0.23.1"
+tree-sitter-cypher = "0.2.6"
+tree-sitter-lua = "0.5.0"
+tree-sitter-python = "0.23.6"
+tree-sitter-bash = "0.23.3"
+tree-sitter-json = "0.24.8"
 core-text = ">=21.0.0, <21.1.0"
 smallvec = "1.13.2"
 rfd = "0.17"

--- a/crates/dbflux_components/Cargo.toml
+++ b/crates/dbflux_components/Cargo.toml
@@ -15,6 +15,14 @@ gpui.workspace = true
 gpui-component.workspace = true
 dbflux_core.workspace = true
 dbflux_i18n.workspace = true
+tree-sitter.workspace = true
+tree-sitter-sequel.workspace = true
+tree-sitter-javascript.workspace = true
+tree-sitter-cypher.workspace = true
+tree-sitter-lua.workspace = true
+tree-sitter-python.workspace = true
+tree-sitter-bash.workspace = true
+tree-sitter-json.workspace = true
 thiserror.workspace = true
 log.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/dbflux_components/src/highlighting.rs
+++ b/crates/dbflux_components/src/highlighting.rs
@@ -1,0 +1,172 @@
+//! Registers the tree-sitter grammars the code-editor highlighter needs.
+//!
+//! `gpui-component`'s `tree-sitter-languages` feature bundles roughly thirty
+//! grammars, but DBFlux only ever opens the editor with the modes
+//! `QueryLanguage::editor_mode()` can return, plus `json` for the document
+//! tree, cell editor, document preview, and dashboard import modals.
+//! Registering those individually with `LanguageRegistry::register` keeps
+//! the release binary from linking grammars nothing in the app requests.
+
+use gpui_component::highlighter::{LanguageConfig, LanguageRegistry};
+
+/// Every language name the code editor is asked to highlight: the modes
+/// `QueryLanguage::editor_mode()` can return, plus `json`.
+#[cfg(test)]
+const REGISTERED_LANGUAGES: &[&str] = &[
+    "sql",
+    "javascript",
+    "cypher",
+    "lua",
+    "python",
+    "bash",
+    "plaintext",
+    "json",
+];
+
+/// Registers the grammars DBFlux's editors actually request. Must run once,
+/// before any `InputState::code_editor(...)` call — call alongside
+/// `gpui_component::init`.
+pub fn register_languages() {
+    let registry = LanguageRegistry::singleton();
+
+    registry.register(
+        "sql",
+        &LanguageConfig::new(
+            "sql",
+            tree_sitter::Language::new(tree_sitter_sequel::LANGUAGE),
+            vec![],
+            tree_sitter_sequel::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+    );
+
+    registry.register(
+        "javascript",
+        &LanguageConfig::new(
+            "javascript",
+            tree_sitter::Language::new(tree_sitter_javascript::LANGUAGE),
+            vec![],
+            tree_sitter_javascript::HIGHLIGHT_QUERY,
+            "",
+            "",
+        ),
+    );
+
+    registry.register(
+        "cypher",
+        &LanguageConfig::new(
+            "cypher",
+            tree_sitter::Language::new(tree_sitter_cypher::LANGUAGE),
+            vec![],
+            tree_sitter_cypher::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+    );
+
+    registry.register(
+        "lua",
+        &LanguageConfig::new(
+            "lua",
+            tree_sitter::Language::new(tree_sitter_lua::LANGUAGE),
+            vec![],
+            tree_sitter_lua::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+    );
+
+    registry.register(
+        "python",
+        &LanguageConfig::new(
+            "python",
+            tree_sitter::Language::new(tree_sitter_python::LANGUAGE),
+            vec![],
+            tree_sitter_python::HIGHLIGHTS_QUERY,
+            "",
+            "",
+        ),
+    );
+
+    registry.register(
+        "bash",
+        &LanguageConfig::new(
+            "bash",
+            tree_sitter::Language::new(tree_sitter_bash::LANGUAGE),
+            vec![],
+            tree_sitter_bash::HIGHLIGHT_QUERY,
+            "",
+            "",
+        ),
+    );
+
+    // Empty highlight query: parses with the JSON grammar but emits no
+    // highlight spans, matching gpui-component's own `Language::Plain`,
+    // which only exists behind the `tree-sitter-languages` feature we no
+    // longer enable. Registered under both names because the object-store
+    // text editor's unknown-extension fallback (`object_text::editor_language`)
+    // resolves to "text", while `QueryLanguage::editor_mode()` uses "plaintext".
+    let plaintext = LanguageConfig::new(
+        "plaintext",
+        tree_sitter::Language::new(tree_sitter_json::LANGUAGE),
+        vec![],
+        "",
+        "",
+        "",
+    );
+    registry.register("plaintext", &plaintext);
+    registry.register("text", &plaintext);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dbflux_core::QueryLanguage;
+
+    /// The guard: every `QueryLanguage::editor_mode()` value except
+    /// "plaintext" must have a grammar registered, so a future driver with a
+    /// new query language fails this test instead of silently shipping
+    /// unhighlighted.
+    #[test]
+    fn every_editor_mode_except_plaintext_is_registered() {
+        register_languages();
+        let registry = LanguageRegistry::singleton();
+
+        for language in all_query_languages() {
+            let mode = language.editor_mode();
+            if mode == "plaintext" {
+                continue;
+            }
+
+            assert!(
+                REGISTERED_LANGUAGES.contains(&mode),
+                "QueryLanguage {language:?} returns editor_mode {mode:?}, \
+                 which has no registered grammar"
+            );
+            assert!(
+                registry.language(mode).is_some(),
+                "editor_mode {mode:?} is not registered in LanguageRegistry"
+            );
+        }
+    }
+
+    fn all_query_languages() -> Vec<QueryLanguage> {
+        vec![
+            QueryLanguage::Sql,
+            QueryLanguage::CloudWatchLogsInsightsQl,
+            QueryLanguage::OpenSearchPpl,
+            QueryLanguage::OpenSearchSql,
+            QueryLanguage::MongoQuery,
+            QueryLanguage::RedisCommands,
+            QueryLanguage::Cypher,
+            QueryLanguage::InfluxQuery,
+            QueryLanguage::Flux,
+            QueryLanguage::Cql,
+            QueryLanguage::Lua,
+            QueryLanguage::Python,
+            QueryLanguage::Bash,
+            QueryLanguage::Custom("custom".to_string()),
+        ]
+    }
+}

--- a/crates/dbflux_components/src/lib.rs
+++ b/crates/dbflux_components/src/lib.rs
@@ -20,6 +20,7 @@ pub mod common;
 pub mod components;
 pub mod composites;
 pub mod controls;
+pub mod highlighting;
 pub mod icons;
 pub mod modals;
 pub mod primitives;

--- a/crates/dbflux_components/src/theme.rs
+++ b/crates/dbflux_components/src/theme.rs
@@ -16,6 +16,7 @@ pub fn ghost_border_color() -> Hsla {
 
 pub fn init(cx: &mut App) {
     gpui_component::init(cx);
+    crate::highlighting::register_languages();
     crate::controls::register_input_overrides(cx);
     load_bundled_fonts(cx);
     apply_theme(ThemeSetting::Dark, AppStyle::Default, None, cx);

--- a/crates/dbflux_ui_document/src/object_text.rs
+++ b/crates/dbflux_ui_document/src/object_text.rs
@@ -73,8 +73,10 @@ pub struct TextBody {
     pub byte_len: u64,
 }
 
-/// Highlighter language for the buffer, from the key's extension. Unknown
-/// extensions resolve to the plain highlighter inside the editor component.
+/// Highlighter language for the buffer, from the key's extension. Only
+/// extensions with a grammar registered in `dbflux_components::highlighting`
+/// map to their own language; every other extension resolves to the plain
+/// highlighter inside the editor component.
 ///
 /// Dotenv files (`.env`, `.env.local`, `production.env`, ...) have no
 /// registered grammar of their own, but their `KEY=value` + `#` comment shape
@@ -90,9 +92,20 @@ pub fn editor_language(key: &str) -> String {
         return "bash".to_string();
     }
 
-    name.rsplit_once('.')
-        .map(|(_, extension)| extension.to_lowercase())
-        .unwrap_or_else(|| "text".to_string())
+    let extension = name
+        .rsplit_once('.')
+        .map(|(_, extension)| extension.to_lowercase());
+
+    match extension.as_deref() {
+        Some("json" | "jsonc") => "json".to_string(),
+        Some("sql") => "sql".to_string(),
+        Some("js" | "mjs" | "cjs") => "javascript".to_string(),
+        Some("py") => "python".to_string(),
+        Some("sh" | "bash") => "bash".to_string(),
+        Some("lua") => "lua".to_string(),
+        Some("cypher" | "cql") => "cypher".to_string(),
+        _ => "text".to_string(),
+    }
 }
 
 const MAX_HIGHLIGHT_BYTES: usize = 1024 * 1024;
@@ -256,8 +269,17 @@ mod tests {
     #[test]
     fn editor_language_follows_the_extension() {
         assert_eq!(editor_language("logs/app.JSON"), "json");
-        assert_eq!(editor_language("notes.md"), "md");
         assert_eq!(editor_language("data/dump"), "text");
+    }
+
+    /// Extensions without a registered grammar (issue #357 narrowed the set
+    /// to what `QueryLanguage::editor_mode()` can return) fall back to the
+    /// plain highlighter rather than being mis-rendered with the JSON grammar.
+    #[test]
+    fn unregistered_extensions_fall_back_to_plain() {
+        assert_eq!(editor_language("notes.md"), "text");
+        assert_eq!(editor_language("site/index.html"), "text");
+        assert_eq!(editor_language("config.yaml"), "text");
     }
 
     /// Dotenv files open with the bash highlighter in every naming shape:
@@ -283,10 +305,10 @@ mod tests {
 
     #[test]
     fn small_multi_line_files_keep_their_language() {
-        let body = "<html>\n<body>hello</body>\n</html>\n";
+        let body = "select * from users;\n";
         assert_eq!(
-            highlight_language("site/index.html", body),
-            Some("html".to_string())
+            highlight_language("query.sql", body),
+            Some("sql".to_string())
         );
     }
 

--- a/docs/LUA.md
+++ b/docs/LUA.md
@@ -507,10 +507,6 @@ The `os` library is blocked entirely. If you need timing, you'll have to measure
 
 The process allowlists are hardcoded. Adding a new tool requires a code change, rebuild, and new release. There's no user-configurable allowlist mechanism (yet). The current six allowlists cover the most common use cases (cloud CLIs, SSH, Python scripts).
 
-### No Lua Syntax Highlighting in Editor
-
-gpui-component (v0.5.0) does not include a `tree-sitter-lua` grammar. When editing Lua scripts in the code editor, there's no syntax highlighting. The `editor_mode()` returns `"lua"` which gracefully falls back to plaintext. Python and Bash scripts get full highlighting.
-
 ### Bounded Memory
 
 Each VM is capped at 16 MiB of Lua-allocated memory. Scripts that try to build very large data structures in memory will hit this ceiling and fail. This is a sandbox guard, not a tunable per-hook setting.

--- a/docs/es/LUA.md
+++ b/docs/es/LUA.md
@@ -644,13 +644,6 @@ un mecanismo de allowlist configurable por el usuario. Las seis allowlists
 actuales cubren los casos de uso más comunes (CLIs de nube, SSH, scripts de
 Python).
 
-### Sin syntax highlighting de Lua en el editor
-
-gpui-component (v0.5.0) no incluye una grammar `tree-sitter-lua`. Al editar
-scripts de Lua en el editor de código, no hay syntax highlighting.
-`editor_mode()` retorna `"lua"`, que cae con gracia a plaintext. Los scripts de
-Python y Bash tienen highlighting completo.
-
 ### Memoria acotada
 
 Cada VM tiene un cap de 16 MiB de memoria asignada por Lua. Los scripts que


### PR DESCRIPTION
Closes #357

## Summary

- Drops the `tree-sitter-languages` feature on gpui-component (30+ grammars compiled into every binary) and registers exactly the eight DBFlux reaches: `sql`, `javascript`, `cypher`, `lua`, `python`, `bash`, `json`, `plaintext`. The list is derived, not remembered: every `QueryLanguage::editor_mode` value (all 14 variants enumerated, including the dynamodb driver override) plus every `code_editor(...)` literal across the workspace.
- gpui-component has no per-grammar feature and ships no Cypher or Lua grammar at all, so DBFlux now depends on `tree-sitter-cypher` and `tree-sitter-lua` directly and registers them through `LanguageRegistry` — both languages gain real syntax highlighting for the first time (`docs/LUA.md` documented the Lua gap as permanent; that section is now gone).
- Trap found while implementing: with the feature off, the registry's fallback resolves any unregistered name to JSON, so unknown languages (e.g. arbitrary file extensions in the object-store text editor) would silently highlight as JSON. An explicit empty-query `plaintext` registration plus a narrowed `editor_language()` mapping close that hole.
- The issue's trap has its guard: `every_editor_mode_except_plaintext_is_registered` fails CI if a future driver introduces a query language without a registered grammar — the silent-degradation case the issue called out.

## Binary size (release, full driver feature set, before measured on an isolated checkout of the pre-change commit)

| | bytes |
|---|---|
| Before | 134,801,288 |
| After | 108,139,240 |
| Delta | **−26,662,048 (−19.8%)** |

## Test plan

- [x] Guard test passes; `cargo clippy --workspace -- -D warnings` clean; `cargo check --workspace` with the full driver feature set clean
- [x] `cargo nextest run` over the touched crates: 1875/1876 (the one failure is the known flaky palette time-budget test, unrelated and passing in isolation)
- [ ] Manual smoke pending: open a Lua script and a Cypher query tab to see the new highlighting render