### PR TITLE
feat(ui): import connection profiles from other database clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,13 +3113,17 @@ dependencies = [
 name = "dbflux_portability"
 version = "0.8.0-dev.0"
 dependencies = [
+ "aes",
  "age",
  "base64 0.22.1",
+ "cbc",
  "chrono",
  "dbflux_core",
+ "rusqlite",
  "secrecy",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.19",
  "toml 1.1.3+spec-1.1.0",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,10 @@ secrecy = "0.10"
 age = { version = "0.11", features = ["armor"] }
 dirs = "6"
 rusqlite = { version = "0.40", features = ["bundled"] }
+# Pinned to match the aes/cbc versions already vendored transitively via
+# gpui -> oo7, avoiding a second copy of the RustCrypto block-cipher stack.
+aes = "0.8"
+cbc = "0.1"
 tokio-postgres = "0.7"
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 log = "0.4"

--- a/crates/dbflux_app/src/portability.rs
+++ b/crates/dbflux_app/src/portability.rs
@@ -550,6 +550,96 @@ pub fn confirm_summary(
 }
 
 // ---------------------------------------------------------------------------
+// External client import — pure candidate mapping and per-candidate
+// persistence, reusing the same `ImportPersistence` seam as bundle import.
+// ---------------------------------------------------------------------------
+
+/// Result of persisting a batch of confirmed external-import candidates.
+#[derive(Debug, Clone, Default)]
+pub struct ExternalPersistOutcome {
+    /// Names of candidates that were fully persisted.
+    pub succeeded: Vec<String>,
+    /// Names of persisted candidates whose secret failed to write to the keyring.
+    pub secret_failures: Vec<String>,
+    /// `(candidate_name, driver_id)` pairs whose driver is not registered.
+    pub needs_driver: Vec<(String, String)>,
+    /// `(candidate_name, error_message)` pairs where `build_config` returned an error.
+    pub config_failures: Vec<(String, String)>,
+}
+
+/// Maps one parsed external candidate into a `ConnectionProfile`.
+///
+/// Pure mapping: `save_password` is derived from whether a secret was
+/// recovered from the source format. The profile id is freshly generated —
+/// external client formats have no id dbflux can reuse across imports.
+pub fn external_candidate_to_profile(
+    candidate: &dbflux_portability::external::ExternalImportCandidate,
+) -> ConnectionProfile {
+    let mut profile = ConnectionProfile::new_with_kind(
+        candidate.name.clone(),
+        candidate.kind,
+        candidate.config.clone(),
+    );
+    profile.save_password = candidate.secret.is_some();
+    profile
+}
+
+/// Persists one confirmed external candidate through `deps`, writing its
+/// recovered secret (when present) under the new connection's own
+/// `connection_secret_ref`.
+///
+/// Takes the candidate by value because its `secret` field is not `Clone`
+/// (`secrecy::SecretString` deliberately does not implement `Clone` for
+/// string payloads); this mirrors the `Option::take()` ownership pattern
+/// used elsewhere in the import pipeline.
+pub fn persist_external_candidate(
+    candidate: dbflux_portability::external::ExternalImportCandidate,
+    deps: &mut dyn ImportPersistence,
+    outcome: &mut ExternalPersistOutcome,
+) {
+    let profile = external_candidate_to_profile(&candidate);
+    let name = candidate.name;
+    let secret = candidate.secret;
+    let profile_id = profile.id;
+    let driver_id = profile.driver_id().to_string();
+
+    match deps.add_connection(profile) {
+        ConnectionInsertResult::Ok => {
+            outcome.succeeded.push(name.clone());
+
+            if let Some(secret) = secret {
+                let secret_ref = dbflux_core::connection_secret_ref(&profile_id);
+                if !deps.write_secret(&secret_ref, &secret) {
+                    outcome.secret_failures.push(name);
+                }
+            }
+        }
+        ConnectionInsertResult::NeedsDriver => {
+            outcome.needs_driver.push((name, driver_id));
+        }
+        ConnectionInsertResult::ConfigFailed(reason) => {
+            outcome.config_failures.push((name, reason));
+        }
+    }
+}
+
+/// Selection-state reducer for the external-import review checklist: one
+/// include flag per parsed candidate, defaulting to included.
+pub fn default_candidate_includes(count: usize) -> Vec<bool> {
+    vec![true; count]
+}
+
+/// Toggles the include flag for one candidate index.
+///
+/// A no-op on an out-of-range index rather than a panic, since the index
+/// always comes from a rendered row that matches the current candidate list.
+pub fn toggle_candidate_include(includes: &mut [bool], index: usize) {
+    if let Some(flag) = includes.get_mut(index) {
+        *flag = !*flag;
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Unit tests
 // ---------------------------------------------------------------------------
 
@@ -1002,6 +1092,10 @@ mod tests {
         conn_names: Vec<String>,
         /// `None` keys succeed; `Some(false)` simulates keyring-locked failure.
         secret_outcomes: HashMap<String, bool>,
+        /// When set, every `write_secret` call fails regardless of the ref,
+        /// for tests where the exact ref cannot be known ahead of time (e.g.
+        /// a freshly generated connection id).
+        fail_all_secrets: bool,
     }
 
     impl FakePersistence {
@@ -1013,6 +1107,7 @@ mod tests {
                 proxy_count: 0,
                 conn_names: Vec::new(),
                 secret_outcomes: HashMap::new(),
+                fail_all_secrets: false,
             }
         }
 
@@ -1024,6 +1119,11 @@ mod tests {
 
         fn with_keyring_failure(mut self, secret_ref: &str) -> Self {
             self.secret_outcomes.insert(secret_ref.to_string(), false);
+            self
+        }
+
+        fn with_all_secrets_failing(mut self) -> Self {
+            self.fail_all_secrets = true;
             self
         }
     }
@@ -1051,6 +1151,9 @@ mod tests {
         }
 
         fn write_secret(&self, secret_ref: &str, _secret: &SecretString) -> bool {
+            if self.fail_all_secrets {
+                return false;
+            }
             self.secret_outcomes
                 .get(secret_ref)
                 .copied()
@@ -1799,5 +1902,112 @@ mod tests {
             "the token field must be hydrated; got: {:?}",
             fields.keys().collect::<Vec<_>>()
         );
+    }
+
+    // -----------------------------------------------------------------
+    // External client import
+    // -----------------------------------------------------------------
+
+    fn make_external_candidate(
+        name: &str,
+        secret: Option<&str>,
+    ) -> dbflux_portability::external::ExternalImportCandidate {
+        dbflux_portability::external::ExternalImportCandidate {
+            name: name.to_string(),
+            config: dbflux_core::DbConfig::SQLite {
+                path: std::path::PathBuf::from("/tmp/example.db"),
+                connection_id: None,
+            },
+            kind: dbflux_core::DbKind::SQLite,
+            secret: secret.map(|s| SecretString::from(s.to_string())),
+            secret_skip_reason: None,
+        }
+    }
+
+    #[test]
+    fn external_candidate_to_profile_sets_save_password_from_secret_presence() {
+        let with_secret = make_external_candidate("Has Secret", Some("s3cret"));
+        let profile = external_candidate_to_profile(&with_secret);
+        assert_eq!(profile.name, "Has Secret");
+        assert_eq!(profile.kind, Some(dbflux_core::DbKind::SQLite));
+        assert!(profile.save_password);
+
+        let without_secret = make_external_candidate("No Secret", None);
+        let profile = external_candidate_to_profile(&without_secret);
+        assert!(!profile.save_password);
+    }
+
+    #[test]
+    fn external_candidate_to_profile_generates_a_fresh_id_each_time() {
+        let candidate = make_external_candidate("Demo", None);
+        let first = external_candidate_to_profile(&candidate);
+        let second = external_candidate_to_profile(&candidate);
+        assert_ne!(first.id, second.id);
+    }
+
+    #[test]
+    fn persist_external_candidate_writes_secret_under_the_new_connection_ref() {
+        let mut deps = FakePersistence::all_drivers();
+        let mut outcome = ExternalPersistOutcome::default();
+        let candidate = make_external_candidate("Demo", Some("s3cret"));
+
+        persist_external_candidate(candidate, &mut deps, &mut outcome);
+
+        assert_eq!(outcome.succeeded, vec!["Demo".to_string()]);
+        assert!(outcome.secret_failures.is_empty());
+        assert_eq!(deps.conn_names, vec!["Demo".to_string()]);
+    }
+
+    #[test]
+    fn persist_external_candidate_records_secret_failure_without_dropping_the_connection() {
+        let candidate = make_external_candidate("Demo", Some("s3cret"));
+        let mut deps = FakePersistence::all_drivers().with_all_secrets_failing();
+        let mut outcome = ExternalPersistOutcome::default();
+
+        persist_external_candidate(candidate, &mut deps, &mut outcome);
+
+        assert_eq!(
+            deps.conn_names,
+            vec!["Demo".to_string()],
+            "a keyring failure must not undo the already-persisted connection"
+        );
+        assert_eq!(outcome.succeeded, vec!["Demo".to_string()]);
+        assert_eq!(outcome.secret_failures, vec!["Demo".to_string()]);
+    }
+
+    #[test]
+    fn persist_external_candidate_reports_needs_driver_for_unregistered_driver() {
+        let mut deps = FakePersistence::with_drivers(&[]);
+        let mut outcome = ExternalPersistOutcome::default();
+        let candidate = make_external_candidate("Demo", None);
+
+        persist_external_candidate(candidate, &mut deps, &mut outcome);
+
+        assert!(outcome.succeeded.is_empty());
+        assert_eq!(outcome.needs_driver.len(), 1);
+        assert_eq!(outcome.needs_driver[0].0, "Demo");
+    }
+
+    #[test]
+    fn default_candidate_includes_defaults_every_slot_to_true() {
+        assert_eq!(default_candidate_includes(3), vec![true, true, true]);
+        assert_eq!(default_candidate_includes(0), Vec::<bool>::new());
+    }
+
+    #[test]
+    fn toggle_candidate_include_flips_only_the_targeted_index() {
+        let mut includes = default_candidate_includes(3);
+        toggle_candidate_include(&mut includes, 1);
+        assert_eq!(includes, vec![true, false, true]);
+
+        toggle_candidate_include(&mut includes, 1);
+        assert_eq!(includes, vec![true, true, true]);
+    }
+
+    #[test]
+    fn toggle_candidate_include_is_a_no_op_on_out_of_range_index() {
+        let mut includes = default_candidate_includes(2);
+        toggle_candidate_include(&mut includes, 5);
+        assert_eq!(includes, vec![true, true]);
     }
 }

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -270,6 +270,7 @@ connection_manager:
     subtitle: choose a database type
     empty_state: No drivers match your filter
     import_from_file: "Import from file…"
+    import_from_client: "Import from another client…"
     cancel: Cancel
     configure: Configure
     configure_named: "Configure %{name}"
@@ -438,6 +439,34 @@ connection_manager:
       load: Load
       continue_: Continue
       import: Import
+    source:
+      label: "Import from"
+      bundle: DBflux bundle
+    external:
+      dialog:
+        open_title: Open File
+      filter:
+        primary: Connection file
+        secondary: Credentials file
+      field:
+        primary_file: Connection file
+        secondary_file: "Credentials file (optional)"
+      hint:
+        secondary_optional: Skip this to import connections without their saved passwords.
+      error:
+        choose_primary_file: Choose a file to import.
+      review:
+        intro: "Review the connections found in this file. Uncheck any you do not want to import."
+        skips_intro:
+          one: "%{count} entry could not be imported:"
+          many: "%{count} entries could not be imported:"
+      secret:
+        will_store: Password will be stored in the system keyring.
+        none: No password found in the source file.
+      action:
+        import_selected:
+          one: "Import %{count} connection"
+          many: "Import %{count} connections"
 connections:
   window:
     manager_title: Connection Manager

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -270,6 +270,7 @@ connection_manager:
     subtitle: elige un tipo de base de datos
     empty_state: Ningún driver coincide con tu filtro
     import_from_file: "Importar desde archivo…"
+    import_from_client: "Importar desde otro cliente…"
     cancel: Cancelar
     configure: Configurar
     configure_named: "Configurar %{name}"
@@ -438,6 +439,34 @@ connection_manager:
       load: Cargar
       continue_: Continuar
       import: Importar
+    source:
+      label: "Importar desde"
+      bundle: Paquete de DBflux
+    external:
+      dialog:
+        open_title: Abrir archivo
+      filter:
+        primary: Archivo de conexión
+        secondary: Archivo de credenciales
+      field:
+        primary_file: Archivo de conexión
+        secondary_file: "Archivo de credenciales (opcional)"
+      hint:
+        secondary_optional: Omite esto para importar conexiones sin sus contraseñas guardadas.
+      error:
+        choose_primary_file: Elige un archivo para importar.
+      review:
+        intro: "Revisa las conexiones encontradas en este archivo. Desmarca las que no quieras importar."
+        skips_intro:
+          one: "%{count} entrada no se pudo importar:"
+          many: "%{count} entradas no se pudieron importar:"
+      secret:
+        will_store: La contraseña se guardará en el llavero del sistema.
+        none: No se encontró ninguna contraseña en el archivo de origen.
+      action:
+        import_selected:
+          one: "Importar %{count} conexión"
+          many: "Importar %{count} conexiones"
 connections:
   window:
     manager_title: Administrador de conexiones

--- a/crates/dbflux_portability/Cargo.toml
+++ b/crates/dbflux_portability/Cargo.toml
@@ -26,6 +26,12 @@ base64 = { workspace = true }
 secrecy = { workspace = true }
 chrono = { workspace = true }
 age = { workspace = true, optional = true }
+rusqlite = { workspace = true }
+aes = { workspace = true }
+cbc = { workspace = true, features = ["alloc"] }
+
+[dev-dependencies]
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/crates/dbflux_portability/src/external/beekeeper.rs
+++ b/crates/dbflux_portability/src/external/beekeeper.rs
@@ -1,0 +1,529 @@
+/// Beekeeper Studio `app.db` importer.
+///
+/// Beekeeper Studio persists saved connections as a TypeORM entity in its own
+/// SQLite database. The table is expected to be named `saved_connection`, but
+/// column and table naming has drifted across Beekeeper releases, so the
+/// table is located by its column signature rather than assumed by name.
+///
+/// Passwords are encrypted with a key generated per Beekeeper install and
+/// never leave that install's keychain/config, so this importer cannot
+/// recover them. A connection with a saved password still imports; only the
+/// secret is skipped, with a reason telling the user to re-enter it.
+use dbflux_core::{DbConfig, DbKind};
+use rusqlite::Connection;
+
+use super::{
+    ConnectionImporter, ExternalImportCandidate, ExternalImportError, ExternalImportOutcome,
+    ExternalImportSkip, ImportInput,
+};
+
+/// Column names this importer looks for, tried in order per logical field to
+/// tolerate naming drift between Beekeeper Studio versions.
+struct ColumnSet {
+    name: String,
+    connection_type: String,
+    host: Option<String>,
+    port: Option<String>,
+    username: Option<String>,
+    default_database: Option<String>,
+    socket_path: Option<String>,
+    password: Option<String>,
+}
+
+pub struct BeekeeperImporter;
+
+impl ConnectionImporter for BeekeeperImporter {
+    fn id(&self) -> &'static str {
+        "beekeeper"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "Beekeeper Studio"
+    }
+
+    fn parse(&self, input: &ImportInput<'_>) -> Result<ExternalImportOutcome, ExternalImportError> {
+        let path = input.primary.as_path()?;
+
+        let conn =
+            Connection::open(path).map_err(|e| ExternalImportError::Sqlite(e.to_string()))?;
+
+        let table = find_connection_table(&conn)?;
+        let columns = resolve_columns(&conn, &table)?;
+
+        let query = format!("SELECT * FROM \"{table}\"");
+        let mut stmt = conn
+            .prepare(&query)
+            .map_err(|e| ExternalImportError::Sqlite(e.to_string()))?;
+
+        let mut outcome = ExternalImportOutcome::default();
+
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| ExternalImportError::Sqlite(e.to_string()))?;
+
+        while let Some(row) = rows
+            .next()
+            .map_err(|e| ExternalImportError::Sqlite(e.to_string()))?
+        {
+            let name: String = get_text(row, &columns.name).unwrap_or_default();
+            let connection_type = get_text(row, &columns.connection_type).unwrap_or_default();
+
+            match map_row(row, &columns, &connection_type) {
+                Ok((config, kind, has_secret)) => {
+                    let secret_skip_reason = has_secret.then(|| {
+                        "password is encrypted with a Beekeeper-local key; re-enter it after import"
+                            .to_string()
+                    });
+
+                    outcome.candidates.push(ExternalImportCandidate {
+                        name,
+                        config,
+                        kind,
+                        secret: None,
+                        secret_skip_reason,
+                    });
+                }
+                Err(reason) => outcome.skips.push(ExternalImportSkip { name, reason }),
+            }
+        }
+
+        Ok(outcome)
+    }
+}
+
+/// Locates the saved-connections table by column signature: a table with at
+/// least `name`, a connection-type-like column, and `host` is treated as the
+/// saved-connections table regardless of its exact name.
+fn find_connection_table(conn: &Connection) -> Result<String, ExternalImportError> {
+    let mut stmt = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .map_err(|e| ExternalImportError::Sqlite(e.to_string()))?;
+
+    let table_names: Vec<String> = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|e| ExternalImportError::Sqlite(e.to_string()))?
+        .filter_map(Result::ok)
+        .collect();
+
+    for table_name in &table_names {
+        let columns = table_columns(conn, table_name)?;
+        let has_name = find_column(&columns, &["name"]).is_some();
+        let has_type = find_column(&columns, &["connectionType", "connection_type"]).is_some();
+        let has_host = find_column(&columns, &["host"]).is_some();
+
+        if has_name && has_type && has_host {
+            return Ok(table_name.clone());
+        }
+    }
+
+    Err(ExternalImportError::NotBeekeeperDatabase(
+        "no table with name/connectionType/host columns was found".to_string(),
+    ))
+}
+
+fn table_columns(conn: &Connection, table: &str) -> Result<Vec<String>, ExternalImportError> {
+    let query = format!("PRAGMA table_info(\"{table}\")");
+    let mut stmt = conn
+        .prepare(&query)
+        .map_err(|e| ExternalImportError::Sqlite(e.to_string()))?;
+
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| ExternalImportError::Sqlite(e.to_string()))?
+        .filter_map(Result::ok)
+        .collect();
+
+    Ok(columns)
+}
+
+/// Returns the first candidate name present in `columns`, case-insensitively.
+fn find_column(columns: &[String], candidates: &[&str]) -> Option<String> {
+    candidates.iter().find_map(|candidate| {
+        columns
+            .iter()
+            .find(|c| c.eq_ignore_ascii_case(candidate))
+            .cloned()
+    })
+}
+
+fn resolve_columns(conn: &Connection, table: &str) -> Result<ColumnSet, ExternalImportError> {
+    let columns = table_columns(conn, table)?;
+
+    let name = find_column(&columns, &["name"])
+        .ok_or_else(|| ExternalImportError::NotBeekeeperDatabase("missing 'name' column".into()))?;
+    let connection_type = find_column(&columns, &["connectionType", "connection_type"])
+        .ok_or_else(|| {
+            ExternalImportError::NotBeekeeperDatabase("missing 'connectionType' column".into())
+        })?;
+
+    Ok(ColumnSet {
+        name,
+        connection_type,
+        host: find_column(&columns, &["host"]),
+        port: find_column(&columns, &["port"]),
+        username: find_column(&columns, &["username"]),
+        default_database: find_column(&columns, &["defaultDatabase", "default_database"]),
+        socket_path: find_column(&columns, &["socketPath", "socket_path"]),
+        password: find_column(&columns, &["password"]),
+    })
+}
+
+fn get_text(row: &rusqlite::Row<'_>, column: &str) -> Option<String> {
+    row.get::<_, Option<String>>(column).ok().flatten()
+}
+
+fn get_port(row: &rusqlite::Row<'_>, column: &Option<String>) -> Option<u16> {
+    let column = column.as_ref()?;
+
+    if let Ok(Some(text)) = row.get::<_, Option<String>>(column.as_str())
+        && let Ok(port) = text.trim().parse::<u16>()
+    {
+        return Some(port);
+    }
+
+    row.get::<_, Option<i64>>(column.as_str())
+        .ok()
+        .flatten()
+        .and_then(|v| u16::try_from(v).ok())
+}
+
+fn get_opt_text(row: &rusqlite::Row<'_>, column: &Option<String>) -> Option<String> {
+    let column = column.as_ref()?;
+    get_text(row, column).filter(|v| !v.is_empty())
+}
+
+/// Maps one saved-connection row into a `(DbConfig, DbKind, has_secret)` triple.
+fn map_row(
+    row: &rusqlite::Row<'_>,
+    columns: &ColumnSet,
+    connection_type: &str,
+) -> Result<(DbConfig, DbKind, bool), String> {
+    let has_secret = columns
+        .password
+        .as_ref()
+        .and_then(|c| get_text(row, c))
+        .is_some_and(|v| !v.is_empty());
+
+    let host = get_opt_text(row, &columns.host);
+    let port = get_port(row, &columns.port);
+    let username = get_opt_text(row, &columns.username);
+    let database = get_opt_text(row, &columns.default_database);
+    let socket_path = get_opt_text(row, &columns.socket_path);
+
+    let (config, kind) = match connection_type {
+        "postgresql" => (
+            DbConfig::Postgres {
+                use_uri: false,
+                uri: None,
+                host: host.ok_or_else(|| "missing required field 'host'".to_string())?,
+                port: port.unwrap_or(5432),
+                user: username.unwrap_or_default(),
+                database: database.unwrap_or_default(),
+                ssl_mode: None,
+                ssl_root_cert_path: None,
+                ssl_client_cert_path: None,
+                ssl_client_key_path: None,
+                ssh_tunnel: None,
+                ssh_tunnel_profile_id: None,
+            },
+            DbKind::Postgres,
+        ),
+
+        "mysql" | "mariadb" => {
+            let kind = if connection_type == "mariadb" {
+                DbKind::MariaDB
+            } else {
+                DbKind::MySQL
+            };
+            (
+                DbConfig::MySQL {
+                    use_uri: false,
+                    uri: None,
+                    host: host.ok_or_else(|| "missing required field 'host'".to_string())?,
+                    port: port.unwrap_or(3306),
+                    user: username.unwrap_or_default(),
+                    database,
+                    ssl_mode: None,
+                    ssl_root_cert_path: None,
+                    ssl_client_cert_path: None,
+                    ssl_client_key_path: None,
+                    ssh_tunnel: None,
+                    ssh_tunnel_profile_id: None,
+                },
+                kind,
+            )
+        }
+
+        "sqlite" => {
+            let path = database
+                .or(socket_path)
+                .ok_or_else(|| "sqlite connection has no database file path".to_string())?;
+            (
+                DbConfig::SQLite {
+                    path: path.into(),
+                    connection_id: None,
+                },
+                DbKind::SQLite,
+            )
+        }
+
+        "sqlserver" => (
+            DbConfig::SqlServer {
+                use_uri: false,
+                uri: None,
+                host: host.ok_or_else(|| "missing required field 'host'".to_string())?,
+                port: port.unwrap_or(1433),
+                user: username.unwrap_or_default(),
+                database,
+                instance: None,
+                ssl_mode: None,
+                trust_server_certificate: false,
+                ssl_root_cert_path: None,
+                ssh_tunnel: None,
+                ssh_tunnel_profile_id: None,
+            },
+            DbKind::SqlServer,
+        ),
+
+        "mongodb" => (
+            DbConfig::MongoDB {
+                use_uri: false,
+                uri: None,
+                host: host.ok_or_else(|| "missing required field 'host'".to_string())?,
+                port: port.unwrap_or(27017),
+                user: username,
+                database,
+                auth_database: None,
+                ssl_mode: None,
+                ssl_root_cert_path: None,
+                ssl_client_cert_path: None,
+                ssl_client_key_path: None,
+                ssh_tunnel: None,
+                ssh_tunnel_profile_id: None,
+            },
+            DbKind::MongoDB,
+        ),
+
+        "redis" => (
+            DbConfig::Redis {
+                use_uri: false,
+                uri: None,
+                host: host.ok_or_else(|| "missing required field 'host'".to_string())?,
+                port: port.unwrap_or(6379),
+                user: username,
+                database: None,
+                tls: false,
+                ssl_mode: None,
+                ssl_root_cert_path: None,
+                ssl_client_cert_path: None,
+                ssl_client_key_path: None,
+                ssh_tunnel: None,
+                ssh_tunnel_profile_id: None,
+                topology: None,
+                sentinel_master_name: None,
+                additional_nodes: None,
+            },
+            DbKind::Redis,
+        ),
+
+        other => return Err(format!("unsupported connectionType '{other}'")),
+    };
+
+    Ok((config, kind, has_secret))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::external::{ImportSource, importers};
+    use tempfile::NamedTempFile;
+
+    fn seed_db(rows: &[(&str, &str, &str, i64, &str, &str, &str)]) -> NamedTempFile {
+        let file = NamedTempFile::new().expect("temp file");
+        let conn = Connection::open(file.path()).expect("open");
+
+        conn.execute(
+            "CREATE TABLE saved_connection (
+                id INTEGER PRIMARY KEY,
+                name TEXT,
+                connectionType TEXT,
+                host TEXT,
+                port INTEGER,
+                username TEXT,
+                defaultDatabase TEXT,
+                socketPath TEXT,
+                password TEXT,
+                ssl INTEGER,
+                readOnlyMode INTEGER
+            )",
+            [],
+        )
+        .expect("create table");
+
+        for (name, connection_type, host, port, username, default_database, password) in rows {
+            conn.execute(
+                "INSERT INTO saved_connection
+                    (name, connectionType, host, port, username, defaultDatabase, password)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params![
+                    name,
+                    connection_type,
+                    host,
+                    port,
+                    username,
+                    default_database,
+                    password
+                ],
+            )
+            .expect("insert row");
+        }
+
+        file
+    }
+
+    #[test]
+    fn registry_includes_beekeeper() {
+        assert!(importers().iter().any(|i| i.id() == "beekeeper"));
+    }
+
+    #[test]
+    fn happy_path_postgres_connection() {
+        let file = seed_db(&[(
+            "Demo Postgres",
+            "postgresql",
+            "db.example.invalid",
+            5432,
+            "demo",
+            "app",
+            "",
+        )]);
+
+        let source = ImportSource::Path(file.path().to_path_buf());
+        let outcome = BeekeeperImporter
+            .parse(&ImportInput::new(&source))
+            .expect("parse");
+
+        assert!(outcome.skips.is_empty());
+        assert_eq!(outcome.candidates.len(), 1);
+        let candidate = outcome.candidates.first().expect("candidate");
+        assert_eq!(candidate.name, "Demo Postgres");
+        assert_eq!(candidate.kind, DbKind::Postgres);
+        assert!(candidate.secret_skip_reason.is_none());
+        match &candidate.config {
+            DbConfig::Postgres {
+                host,
+                port,
+                user,
+                database,
+                ..
+            } => {
+                assert_eq!(host, "db.example.invalid");
+                assert_eq!(*port, 5432);
+                assert_eq!(user, "demo");
+                assert_eq!(database, "app");
+            }
+            other => panic!("expected Postgres config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encrypted_password_still_imports_connection_with_secret_skip() {
+        let file = seed_db(&[(
+            "Demo MySQL",
+            "mysql",
+            "db.example.invalid",
+            3306,
+            "demo",
+            "app",
+            "{\"iv\":\"...\",\"ciphertext\":\"...\"}",
+        )]);
+
+        let source = ImportSource::Path(file.path().to_path_buf());
+        let outcome = BeekeeperImporter
+            .parse(&ImportInput::new(&source))
+            .expect("parse");
+
+        assert_eq!(outcome.candidates.len(), 1);
+        let candidate = outcome.candidates.first().expect("candidate");
+        assert!(candidate.secret.is_none());
+        assert!(candidate.secret_skip_reason.is_some());
+    }
+
+    #[test]
+    fn unsupported_connection_type_is_skipped_with_reason() {
+        let file = seed_db(&[(
+            "Legacy Cassandra",
+            "cassandra",
+            "db.example.invalid",
+            9042,
+            "demo",
+            "",
+            "",
+        )]);
+
+        let source = ImportSource::Path(file.path().to_path_buf());
+        let outcome = BeekeeperImporter
+            .parse(&ImportInput::new(&source))
+            .expect("parse");
+
+        assert!(outcome.candidates.is_empty());
+        assert_eq!(outcome.skips.len(), 1);
+        assert!(
+            outcome
+                .skips
+                .first()
+                .expect("skip")
+                .reason
+                .contains("cassandra")
+        );
+    }
+
+    #[test]
+    fn non_beekeeper_sqlite_returns_typed_error() {
+        let file = NamedTempFile::new().expect("temp file");
+        let conn = Connection::open(file.path()).expect("open");
+        conn.execute("CREATE TABLE unrelated_table (id INTEGER PRIMARY KEY)", [])
+            .expect("create table");
+
+        let source = ImportSource::Path(file.path().to_path_buf());
+        let result = BeekeeperImporter.parse(&ImportInput::new(&source));
+
+        assert!(matches!(
+            result,
+            Err(ExternalImportError::NotBeekeeperDatabase(_))
+        ));
+    }
+
+    #[test]
+    fn one_bad_entry_does_not_abort_the_batch() {
+        let file = seed_db(&[
+            (
+                "Good Postgres",
+                "postgresql",
+                "db.example.invalid",
+                5432,
+                "demo",
+                "app",
+                "",
+            ),
+            (
+                "Bad Cassandra",
+                "cassandra",
+                "db.example.invalid",
+                9042,
+                "demo",
+                "",
+                "",
+            ),
+        ]);
+
+        let source = ImportSource::Path(file.path().to_path_buf());
+        let outcome = BeekeeperImporter
+            .parse(&ImportInput::new(&source))
+            .expect("parse");
+
+        assert_eq!(outcome.candidates.len(), 1);
+        assert_eq!(outcome.skips.len(), 1);
+    }
+}

--- a/crates/dbflux_portability/src/external/dbeaver.rs
+++ b/crates/dbflux_portability/src/external/dbeaver.rs
@@ -1,0 +1,657 @@
+/// DBeaver `data-sources.json` / `credentials-config.json` importer.
+///
+/// `data-sources.json` lists connections under a top-level `connections` map,
+/// keyed by DBeaver's internal connection id. `credentials-config.json` is an
+/// optional companion file holding the saved username/password for each
+/// connection, encrypted so it cannot be read by simply copying the file.
+///
+/// The credentials cipher is AES-128-CBC with a fixed key and a zero IV. The
+/// key is not a secret DBeaver tries to protect: it ships in the DBeaver
+/// source tree and is documented on the project's own wiki (see
+/// https://github.com/dbeaver/dbeaver/wiki/Project-security, "Credentials
+/// encryption"). Decrypting this file recovers exactly what a local DBeaver
+/// install already recovers on every startup; the barrier is obscurity within
+/// the file format, not confidentiality. A failure to decrypt (corrupted
+/// file, unexpected key) is therefore a graceful per-batch skip on the
+/// secrets only, never a hard error — the connections themselves still
+/// import from `data-sources.json` alone.
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use dbflux_core::{DbConfig, DbKind};
+use secrecy::SecretString;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::{
+    ConnectionImporter, ExternalImportCandidate, ExternalImportError, ExternalImportOutcome,
+    ExternalImportSkip, ImportInput, port_from_json,
+};
+
+/// Fixed AES-128-CBC key DBeaver uses for `credentials-config.json`, documented
+/// publicly on the DBeaver wiki. Not a per-user secret.
+const CREDENTIALS_KEY: [u8; 16] = [
+    0xba, 0xbb, 0x4a, 0x9f, 0x77, 0x4a, 0xb8, 0x53, 0xc9, 0x6c, 0x2d, 0x65, 0x3d, 0xfe, 0x54, 0x4a,
+];
+
+const CREDENTIALS_IV: [u8; 16] = [0u8; 16];
+
+/// The exporter discards this many leading bytes of the decrypted plaintext;
+/// DBeaver prefixes the JSON payload with a fixed-size random salt block that
+/// carries no data of its own.
+const CREDENTIALS_PREFIX_LEN: usize = 16;
+
+pub struct DBeaverImporter;
+
+impl ConnectionImporter for DBeaverImporter {
+    fn id(&self) -> &'static str {
+        "dbeaver"
+    }
+
+    fn display_name(&self) -> &'static str {
+        "DBeaver"
+    }
+
+    fn parse(&self, input: &ImportInput<'_>) -> Result<ExternalImportOutcome, ExternalImportError> {
+        let text = std::str::from_utf8(input.primary.as_bytes()?)
+            .map_err(|e| ExternalImportError::InvalidUtf8(e.to_string()))?;
+
+        let file: DataSourcesFile = serde_json::from_str(text)?;
+
+        let credentials = match input.secondary {
+            Some(source) => decrypt_credentials(source.as_bytes()?),
+            None => None,
+        };
+
+        let mut outcome = ExternalImportOutcome::default();
+
+        for (connection_id, entry) in file.connections {
+            let name = entry.name.clone().unwrap_or_default();
+
+            match map_connection(&entry, connection_id.as_str(), credentials.as_ref()) {
+                Ok(candidate) => outcome.candidates.push(candidate),
+                Err(reason) => outcome.skips.push(ExternalImportSkip { name, reason }),
+            }
+        }
+
+        Ok(outcome)
+    }
+}
+
+#[derive(Deserialize)]
+struct DataSourcesFile {
+    #[serde(default)]
+    connections: HashMap<String, DBeaverConnection>,
+}
+
+#[derive(Deserialize)]
+struct DBeaverConnection {
+    provider: Option<String>,
+    name: Option<String>,
+    configuration: Option<DBeaverConfiguration>,
+}
+
+#[derive(Deserialize)]
+struct DBeaverConfiguration {
+    host: Option<String>,
+    port: Option<Value>,
+    database: Option<String>,
+    url: Option<String>,
+    #[serde(rename = "configurationType")]
+    configuration_type: Option<String>,
+    #[serde(rename = "auth-properties", default)]
+    auth_properties: HashMap<String, String>,
+}
+
+/// Maps one DBeaver connection entry to a candidate, or a skip reason.
+fn map_connection(
+    entry: &DBeaverConnection,
+    connection_id: &str,
+    credentials: Option<&HashMap<String, Value>>,
+) -> Result<ExternalImportCandidate, String> {
+    let name = entry
+        .name
+        .clone()
+        .unwrap_or_else(|| connection_id.to_string());
+
+    let provider = entry
+        .provider
+        .as_deref()
+        .ok_or_else(|| "connection has no provider".to_string())?;
+
+    let configuration = entry
+        .configuration
+        .as_ref()
+        .ok_or_else(|| "connection has no configuration".to_string())?;
+
+    let is_url_mode = configuration.configuration_type.as_deref() == Some("URL");
+    let user = configuration.auth_properties.get("user").cloned();
+
+    let (config, kind) = match provider {
+        "postgresql" => {
+            let (use_uri, uri, host, port, database) =
+                connection_shape(configuration, is_url_mode, 5432)?;
+            (
+                DbConfig::Postgres {
+                    use_uri,
+                    uri,
+                    host,
+                    port,
+                    user: user.unwrap_or_default(),
+                    database,
+                    ssl_mode: None,
+                    ssl_root_cert_path: None,
+                    ssl_client_cert_path: None,
+                    ssl_client_key_path: None,
+                    ssh_tunnel: None,
+                    ssh_tunnel_profile_id: None,
+                },
+                DbKind::Postgres,
+            )
+        }
+
+        "mysql" | "mariadb" => {
+            let (use_uri, uri, host, port, database) =
+                connection_shape(configuration, is_url_mode, 3306)?;
+            let kind = if provider == "mariadb" {
+                DbKind::MariaDB
+            } else {
+                DbKind::MySQL
+            };
+            (
+                DbConfig::MySQL {
+                    use_uri,
+                    uri,
+                    host,
+                    port,
+                    user: user.unwrap_or_default(),
+                    database: Some(database).filter(|d| !d.is_empty()),
+                    ssl_mode: None,
+                    ssl_root_cert_path: None,
+                    ssl_client_cert_path: None,
+                    ssl_client_key_path: None,
+                    ssh_tunnel: None,
+                    ssh_tunnel_profile_id: None,
+                },
+                kind,
+            )
+        }
+
+        "sqlite" => {
+            // DbConfig::SQLite has no URI mode, unlike the other drivers here;
+            // a URL-configured sqlite connection cannot be represented and is
+            // skipped rather than guessed at by string-stripping the JDBC url.
+            if is_url_mode {
+                return Err("URL-mode configuration is not supported for sqlite".to_string());
+            }
+
+            let path = configuration
+                .database
+                .clone()
+                .filter(|p| !p.is_empty())
+                .ok_or_else(|| "sqlite connection has no database file path".to_string())?;
+
+            (
+                DbConfig::SQLite {
+                    path: PathBuf::from(path),
+                    connection_id: None,
+                },
+                DbKind::SQLite,
+            )
+        }
+
+        "mongodb" => {
+            let (use_uri, uri, host, port, database) =
+                connection_shape(configuration, is_url_mode, 27017)?;
+            (
+                DbConfig::MongoDB {
+                    use_uri,
+                    uri,
+                    host,
+                    port,
+                    user: user.clone().filter(|u| !u.is_empty()),
+                    database: Some(database).filter(|d| !d.is_empty()),
+                    auth_database: None,
+                    ssl_mode: None,
+                    ssl_root_cert_path: None,
+                    ssl_client_cert_path: None,
+                    ssl_client_key_path: None,
+                    ssh_tunnel: None,
+                    ssh_tunnel_profile_id: None,
+                },
+                DbKind::MongoDB,
+            )
+        }
+
+        "redis" => {
+            let (use_uri, uri, host, port, _database) =
+                connection_shape(configuration, is_url_mode, 6379)?;
+            (
+                DbConfig::Redis {
+                    use_uri,
+                    uri,
+                    host,
+                    port,
+                    user: user.clone().filter(|u| !u.is_empty()),
+                    database: None,
+                    tls: false,
+                    ssl_mode: None,
+                    ssl_root_cert_path: None,
+                    ssl_client_cert_path: None,
+                    ssl_client_key_path: None,
+                    ssh_tunnel: None,
+                    ssh_tunnel_profile_id: None,
+                    topology: None,
+                    sentinel_master_name: None,
+                    additional_nodes: None,
+                },
+                DbKind::Redis,
+            )
+        }
+
+        "mssqlserver" | "sqlserver" => {
+            let (use_uri, uri, host, port, database) =
+                connection_shape(configuration, is_url_mode, 1433)?;
+            (
+                DbConfig::SqlServer {
+                    use_uri,
+                    uri,
+                    host,
+                    port,
+                    user: user.unwrap_or_default(),
+                    database: Some(database).filter(|d| !d.is_empty()),
+                    instance: None,
+                    ssl_mode: None,
+                    trust_server_certificate: false,
+                    ssl_root_cert_path: None,
+                    ssh_tunnel: None,
+                    ssh_tunnel_profile_id: None,
+                },
+                DbKind::SqlServer,
+            )
+        }
+
+        other => return Err(format!("unsupported provider '{other}'")),
+    };
+
+    let secret = credentials.and_then(|map| {
+        let entry = map.get(connection_id)?;
+        find_credential_field(entry, "password")
+    });
+
+    Ok(ExternalImportCandidate {
+        name,
+        config,
+        kind,
+        secret: secret.map(SecretString::from),
+        secret_skip_reason: None,
+    })
+}
+
+/// Resolves the `(use_uri, uri, host, port, database)` tuple shared by every
+/// URI-capable driver's `connection_shape`.
+///
+/// In URL mode the connection's raw `url` field is carried as-is into the
+/// driver's `uri` field; the driver's own URI parser is responsible for
+/// making sense of it. In manual mode, `host` is required — its absence is a
+/// missing-fields skip rather than a silent empty-string default.
+fn connection_shape(
+    configuration: &DBeaverConfiguration,
+    is_url_mode: bool,
+    default_port: u16,
+) -> Result<(bool, Option<String>, String, u16, String), String> {
+    if is_url_mode {
+        let url = configuration
+            .url
+            .clone()
+            .ok_or_else(|| "URL-mode connection has no url".to_string())?;
+        return Ok((true, Some(url), String::new(), default_port, String::new()));
+    }
+
+    let host = configuration
+        .host
+        .clone()
+        .filter(|h| !h.is_empty())
+        .ok_or_else(|| "missing required field 'host'".to_string())?;
+
+    let port = port_from_json(configuration.port.as_ref()).unwrap_or(default_port);
+    let database = configuration.database.clone().unwrap_or_default();
+
+    Ok((false, None, host, port, database))
+}
+
+/// Decrypts `credentials-config.json` bytes into a map keyed by DBeaver
+/// connection id. Returns `None` (rather than an error) on any failure —
+/// wrong/rotated key material, truncated file, bad padding — so a corrupted
+/// credentials file degrades to "no secrets available" instead of aborting
+/// the whole batch.
+fn decrypt_credentials(ciphertext: &[u8]) -> Option<HashMap<String, Value>> {
+    use aes::Aes128;
+    use cbc::Decryptor;
+    use cbc::cipher::{BlockDecryptMut, KeyIvInit, block_padding::Pkcs7};
+
+    if ciphertext.is_empty() || !ciphertext.len().is_multiple_of(16) {
+        return None;
+    }
+
+    let mut buffer = ciphertext.to_vec();
+    let decryptor = Decryptor::<Aes128>::new(&CREDENTIALS_KEY.into(), &CREDENTIALS_IV.into());
+    let plaintext = decryptor.decrypt_padded_mut::<Pkcs7>(&mut buffer).ok()?;
+
+    let payload = plaintext.get(CREDENTIALS_PREFIX_LEN..)?;
+    serde_json::from_slice(payload).ok()
+}
+
+/// Searches a decrypted credentials entry for a named field, tolerating both
+/// a flat `{ "user": ..., "password": ... }` shape and DBeaver's nested
+/// `{ "#connection": { "user": ..., "password": ... } }` shape.
+fn find_credential_field(entry: &Value, field: &str) -> Option<String> {
+    if let Some(value) = entry.get(field).and_then(Value::as_str) {
+        return Some(value.to_string());
+    }
+
+    entry
+        .get("#connection")
+        .and_then(|nested| nested.get(field))
+        .and_then(Value::as_str)
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::*;
+    use crate::external::{ImportSource, importers};
+    use secrecy::ExposeSecret;
+    use serde_json::json;
+
+    fn parse_bytes(json: &str) -> ExternalImportOutcome {
+        let source = ImportSource::Bytes(json.as_bytes().to_vec());
+        DBeaverImporter
+            .parse(&ImportInput::new(&source))
+            .expect("parse")
+    }
+
+    #[test]
+    fn registry_includes_dbeaver() {
+        assert!(importers().iter().any(|i| i.id() == "dbeaver"));
+    }
+
+    #[test]
+    fn happy_path_postgres_manual_connection() {
+        let json = r#"{
+            "connections": {
+                "conn-1": {
+                    "provider": "postgresql",
+                    "driver": "postgres-jdbc",
+                    "name": "Demo Postgres",
+                    "save-password": true,
+                    "configuration": {
+                        "host": "db.example.invalid",
+                        "port": 5432,
+                        "database": "app",
+                        "configurationType": "MANUAL",
+                        "auth-properties": { "user": "demo" }
+                    }
+                }
+            }
+        }"#;
+
+        let outcome = parse_bytes(json);
+
+        assert!(
+            outcome.skips.is_empty(),
+            "unexpected skips: {:?}",
+            outcome.skips.iter().map(|s| &s.reason).collect::<Vec<_>>()
+        );
+        assert_eq!(outcome.candidates.len(), 1);
+        let candidate = outcome.candidates.first().expect("candidate");
+        assert_eq!(candidate.name, "Demo Postgres");
+        assert_eq!(candidate.kind, DbKind::Postgres);
+        match &candidate.config {
+            DbConfig::Postgres {
+                host,
+                port,
+                user,
+                database,
+                use_uri,
+                ..
+            } => {
+                assert_eq!(host, "db.example.invalid");
+                assert_eq!(*port, 5432);
+                assert_eq!(user, "demo");
+                assert_eq!(database, "app");
+                assert!(!use_uri);
+            }
+            other => panic!("expected Postgres config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tolerant_string_port() {
+        let json = r#"{
+            "connections": {
+                "conn-1": {
+                    "provider": "mysql",
+                    "name": "Demo MySQL",
+                    "configuration": {
+                        "host": "db.example.invalid",
+                        "port": "3307",
+                        "database": "app",
+                        "configurationType": "MANUAL",
+                        "auth-properties": { "user": "demo" }
+                    }
+                }
+            }
+        }"#;
+
+        let outcome = parse_bytes(json);
+        assert_eq!(outcome.candidates.len(), 1);
+        match &outcome.candidates.first().expect("candidate").config {
+            DbConfig::MySQL { port, .. } => assert_eq!(*port, 3307),
+            other => panic!("expected MySQL config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_provider_is_skipped_with_reason() {
+        let json = r#"{
+            "connections": {
+                "conn-1": {
+                    "provider": "oracle",
+                    "name": "Legacy Oracle",
+                    "configuration": {
+                        "host": "db.example.invalid",
+                        "configurationType": "MANUAL"
+                    }
+                }
+            }
+        }"#;
+
+        let outcome = parse_bytes(json);
+        assert!(outcome.candidates.is_empty());
+        assert_eq!(outcome.skips.len(), 1);
+        assert!(
+            outcome
+                .skips
+                .first()
+                .expect("skip")
+                .reason
+                .contains("oracle")
+        );
+    }
+
+    #[test]
+    fn url_mode_maps_to_driver_uri_field() {
+        let json = r#"{
+            "connections": {
+                "conn-1": {
+                    "provider": "postgresql",
+                    "name": "URL Postgres",
+                    "configuration": {
+                        "url": "jdbc:postgresql://db.example.invalid:5432/app",
+                        "configurationType": "URL"
+                    }
+                }
+            }
+        }"#;
+
+        let outcome = parse_bytes(json);
+        assert_eq!(outcome.candidates.len(), 1);
+        match &outcome.candidates.first().expect("candidate").config {
+            DbConfig::Postgres { use_uri, uri, .. } => {
+                assert!(use_uri);
+                assert_eq!(
+                    uri.as_deref(),
+                    Some("jdbc:postgresql://db.example.invalid:5432/app")
+                );
+            }
+            other => panic!("expected Postgres config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sqlite_url_mode_is_skipped() {
+        let json = r#"{
+            "connections": {
+                "conn-1": {
+                    "provider": "sqlite",
+                    "name": "URL Sqlite",
+                    "configuration": {
+                        "url": "jdbc:sqlite::memory:",
+                        "configurationType": "URL"
+                    }
+                }
+            }
+        }"#;
+
+        let outcome = parse_bytes(json);
+        assert_eq!(outcome.candidates.len(), 0);
+        assert_eq!(outcome.skips.len(), 1);
+    }
+
+    #[test]
+    fn one_bad_entry_does_not_abort_the_batch() {
+        let json = r#"{
+            "connections": {
+                "conn-1": {
+                    "provider": "postgresql",
+                    "name": "Good Postgres",
+                    "configuration": {
+                        "host": "db.example.invalid",
+                        "port": 5432,
+                        "database": "app",
+                        "configurationType": "MANUAL"
+                    }
+                },
+                "conn-2": {
+                    "provider": "oracle",
+                    "name": "Bad Oracle",
+                    "configuration": { "configurationType": "MANUAL" }
+                }
+            }
+        }"#;
+
+        let outcome = parse_bytes(json);
+        assert_eq!(outcome.candidates.len(), 1);
+        assert_eq!(outcome.skips.len(), 1);
+    }
+
+    /// Encrypts a fixture credentials payload the same way DBeaver does, so
+    /// the round trip is verified against our own decryptor rather than a
+    /// hand-crafted byte string.
+    fn encrypt_fixture_credentials(payload: &[u8]) -> Vec<u8> {
+        use aes::Aes128;
+        use cbc::Encryptor;
+        use cbc::cipher::{BlockEncryptMut, KeyIvInit, block_padding::Pkcs7};
+
+        let mut prefixed = vec![0u8; CREDENTIALS_PREFIX_LEN];
+        prefixed.extend_from_slice(payload);
+
+        let encryptor = Encryptor::<Aes128>::new(&CREDENTIALS_KEY.into(), &CREDENTIALS_IV.into());
+        encryptor.encrypt_padded_vec_mut::<Pkcs7>(&prefixed)
+    }
+
+    #[test]
+    fn dbeaver_credentials_round_trip_recovers_user_and_password() {
+        let inner = json!({
+            "conn-1": {
+                "#connection": {
+                    "user": "demo",
+                    "password": "s3cret-fixture"
+                }
+            }
+        });
+        let ciphertext = encrypt_fixture_credentials(inner.to_string().as_bytes());
+
+        let data_sources = r#"{
+            "connections": {
+                "conn-1": {
+                    "provider": "postgresql",
+                    "name": "Demo Postgres",
+                    "configuration": {
+                        "host": "db.example.invalid",
+                        "port": 5432,
+                        "database": "app",
+                        "configurationType": "MANUAL",
+                        "auth-properties": { "user": "demo" }
+                    }
+                }
+            }
+        }"#;
+
+        let primary = ImportSource::Bytes(data_sources.as_bytes().to_vec());
+        let secondary = ImportSource::Path(std::path::PathBuf::new());
+        // Ensure the path variant is rejected up front for the secondary slot
+        // when bytes are expected, then exercise the real bytes path below.
+        assert!(secondary.as_bytes().is_err());
+
+        let secondary = ImportSource::Bytes(ciphertext);
+        let input = ImportInput::with_secondary(&primary, &secondary);
+
+        let outcome = DBeaverImporter.parse(&input).expect("parse");
+        assert_eq!(outcome.candidates.len(), 1);
+        let secret = outcome
+            .candidates
+            .first()
+            .expect("candidate")
+            .secret
+            .as_ref()
+            .expect("password recovered");
+        assert_eq!(secret.expose_secret(), "s3cret-fixture");
+    }
+
+    #[test]
+    fn corrupted_credentials_file_is_a_graceful_skip_on_secret_only() {
+        let data_sources = r#"{
+            "connections": {
+                "conn-1": {
+                    "provider": "postgresql",
+                    "name": "Demo Postgres",
+                    "configuration": {
+                        "host": "db.example.invalid",
+                        "port": 5432,
+                        "database": "app",
+                        "configurationType": "MANUAL"
+                    }
+                }
+            }
+        }"#;
+
+        let primary = ImportSource::Bytes(data_sources.as_bytes().to_vec());
+        // Not a multiple of the AES block size: must not panic or abort parsing.
+        let secondary = ImportSource::Bytes(vec![1, 2, 3]);
+        let input = ImportInput::with_secondary(&primary, &secondary);
+
+        let outcome = DBeaverImporter.parse(&input).expect("parse");
+        assert_eq!(outcome.candidates.len(), 1);
+        assert!(
+            outcome
+                .candidates
+                .first()
+                .expect("candidate")
+                .secret
+                .is_none()
+        );
+    }
+}

--- a/crates/dbflux_portability/src/external/dbeaver.rs
+++ b/crates/dbflux_portability/src/external/dbeaver.rs
@@ -305,6 +305,10 @@ fn connection_shape(
             .url
             .clone()
             .ok_or_else(|| "URL-mode connection has no url".to_string())?;
+        // DBeaver stores URL-mode connections with a `jdbc:` prefix
+        // (e.g. `jdbc:postgresql://host/db`); DBflux's own URI fields expect
+        // the driver's native scheme without it.
+        let url = url.strip_prefix("jdbc:").map(str::to_string).unwrap_or(url);
         return Ok((true, Some(url), String::new(), default_port, String::new()));
     }
 
@@ -503,7 +507,37 @@ mod tests {
                 assert!(use_uri);
                 assert_eq!(
                     uri.as_deref(),
-                    Some("jdbc:postgresql://db.example.invalid:5432/app")
+                    Some("postgresql://db.example.invalid:5432/app"),
+                    "the leading `jdbc:` prefix must be stripped before storing the URI"
+                );
+            }
+            other => panic!("expected Postgres config, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn url_mode_without_jdbc_prefix_is_stored_unchanged() {
+        let json = r#"{
+            "connections": {
+                "conn-1": {
+                    "provider": "postgresql",
+                    "name": "URL Postgres",
+                    "configuration": {
+                        "url": "postgresql://db.example.invalid:5432/app",
+                        "configurationType": "URL"
+                    }
+                }
+            }
+        }"#;
+
+        let outcome = parse_bytes(json);
+        assert_eq!(outcome.candidates.len(), 1);
+        match &outcome.candidates.first().expect("candidate").config {
+            DbConfig::Postgres { use_uri, uri, .. } => {
+                assert!(use_uri);
+                assert_eq!(
+                    uri.as_deref(),
+                    Some("postgresql://db.example.invalid:5432/app")
                 );
             }
             other => panic!("expected Postgres config, got {other:?}"),

--- a/crates/dbflux_portability/src/external/mod.rs
+++ b/crates/dbflux_portability/src/external/mod.rs
@@ -1,0 +1,182 @@
+/// External connection-profile importers.
+///
+/// Each importer turns a foreign client's connection-storage format (DBeaver's
+/// `data-sources.json`, Beekeeper Studio's SQLite database, ...) into DBflux
+/// `DbConfig` candidates. This module is pure logic: parsing and mapping only.
+/// I/O is the caller's job, with one deliberate exception — Beekeeper Studio
+/// stores connections in a SQLite file, so its importer opens that file
+/// directly through `rusqlite` from a filesystem path, mirroring how the
+/// SQLite driver itself must read a file to do anything useful.
+///
+/// A single bad entry never fails the whole batch: unsupported drivers,
+/// missing fields, or undecryptable secrets are reported as per-entry skips
+/// in `ExternalImportOutcome`, while every other entry still imports.
+pub mod beekeeper;
+pub mod dbeaver;
+
+use std::path::PathBuf;
+
+use dbflux_core::{DbConfig, DbKind};
+use secrecy::SecretString;
+use thiserror::Error;
+
+/// Input handed to a `ConnectionImporter`.
+///
+/// `Bytes` covers JSON-based formats the caller already read into memory.
+/// `Path` covers formats that require their own file handle, such as
+/// Beekeeper Studio's SQLite database, which cannot be parsed from an
+/// in-memory byte buffer without vendoring a SQLite implementation twice.
+pub enum ImportSource {
+    Bytes(Vec<u8>),
+    Path(PathBuf),
+}
+
+impl ImportSource {
+    /// Returns the source bytes, or an error when this source is a `Path`.
+    pub fn as_bytes(&self) -> Result<&[u8], ExternalImportError> {
+        match self {
+            ImportSource::Bytes(bytes) => Ok(bytes),
+            ImportSource::Path(_) => Err(ExternalImportError::ExpectedBytes),
+        }
+    }
+
+    /// Returns the source path, or an error when this source is `Bytes`.
+    pub fn as_path(&self) -> Result<&std::path::Path, ExternalImportError> {
+        match self {
+            ImportSource::Path(path) => Ok(path.as_path()),
+            ImportSource::Bytes(_) => Err(ExternalImportError::ExpectedPath),
+        }
+    }
+}
+
+/// Input bundle passed to `ConnectionImporter::parse`.
+///
+/// `primary` is the format's main file (DBeaver's `data-sources.json`,
+/// Beekeeper's `app.db`). `secondary` is an optional companion file used only
+/// by formats that split credentials from connection metadata, such as
+/// DBeaver's `credentials-config.json`.
+pub struct ImportInput<'a> {
+    pub primary: &'a ImportSource,
+    pub secondary: Option<&'a ImportSource>,
+}
+
+impl<'a> ImportInput<'a> {
+    pub fn new(primary: &'a ImportSource) -> Self {
+        Self {
+            primary,
+            secondary: None,
+        }
+    }
+
+    pub fn with_secondary(primary: &'a ImportSource, secondary: &'a ImportSource) -> Self {
+        Self {
+            primary,
+            secondary: Some(secondary),
+        }
+    }
+}
+
+/// A single connection successfully parsed from an external format.
+pub struct ExternalImportCandidate {
+    pub name: String,
+
+    /// Target connection configuration.
+    pub config: DbConfig,
+
+    /// Authoritative database kind, distinct from `config.kind()` for drivers
+    /// that share a `DbConfig` shape (e.g. MariaDB reuses `DbConfig::MySQL`
+    /// but must report `DbKind::MariaDB`). Pass this to
+    /// `ConnectionProfile::new_with_kind` rather than deriving it from `config`.
+    pub kind: DbKind,
+
+    /// Plaintext secret recovered from the source format, when one was found
+    /// and could be decrypted. Never a plain `String` so the value cannot be
+    /// accidentally logged or serialized by a careless caller.
+    pub secret: Option<SecretString>,
+
+    /// Set when a secret exists in the source but could not be carried over
+    /// (e.g. Beekeeper's per-install encryption key, or a DBeaver credentials
+    /// file that failed to decrypt). The connection itself is still a valid
+    /// candidate; only the secret is missing.
+    pub secret_skip_reason: Option<String>,
+}
+
+/// An entry that could not be turned into a candidate at all.
+pub struct ExternalImportSkip {
+    /// Best-effort display name for the skipped entry. Empty when the source
+    /// entry carried no usable name.
+    pub name: String,
+
+    /// Human-readable reason, e.g. "unsupported driver 'oracle'".
+    pub reason: String,
+}
+
+/// Result of parsing one external source file (or file pair).
+#[derive(Default)]
+pub struct ExternalImportOutcome {
+    pub candidates: Vec<ExternalImportCandidate>,
+    pub skips: Vec<ExternalImportSkip>,
+}
+
+/// Errors that abort parsing the whole batch.
+///
+/// Per-entry problems (unsupported driver, missing field, undecryptable
+/// secret) are never represented here — they become an `ExternalImportSkip`
+/// so one bad entry cannot fail the batch. This type is reserved for cases
+/// where the input as a whole is not the format the importer expects.
+#[derive(Debug, Error)]
+pub enum ExternalImportError {
+    #[error("expected in-memory bytes for this input, got a filesystem path")]
+    ExpectedBytes,
+
+    #[error("expected a filesystem path for this input, got in-memory bytes")]
+    ExpectedPath,
+
+    #[error("input is not valid UTF-8: {0}")]
+    InvalidUtf8(String),
+
+    #[error("input is not valid JSON: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+
+    #[error("unexpected structure: {0}")]
+    Structure(String),
+
+    #[error("could not open SQLite database: {0}")]
+    Sqlite(String),
+
+    #[error("not a recognized Beekeeper Studio database: {0}")]
+    NotBeekeeperDatabase(String),
+}
+
+/// Parses one external connection-storage format into DBflux candidates.
+pub trait ConnectionImporter: Send + Sync {
+    /// Stable machine identifier, e.g. `"dbeaver"`, `"beekeeper"`.
+    fn id(&self) -> &'static str;
+
+    /// Human-readable name for the import-source picker.
+    fn display_name(&self) -> &'static str;
+
+    fn parse(&self, input: &ImportInput<'_>) -> Result<ExternalImportOutcome, ExternalImportError>;
+}
+
+/// Every known external importer, so the UI can list formats generically.
+///
+/// Adding a new client's importer is one file plus one entry here.
+pub fn importers() -> Vec<Box<dyn ConnectionImporter>> {
+    vec![
+        Box::new(dbeaver::DBeaverImporter),
+        Box::new(beekeeper::BeekeeperImporter),
+    ]
+}
+
+/// Tolerantly reads a port from a JSON value that may be a string or a number.
+///
+/// Both DBeaver and Beekeeper have been observed to serialize ports as either
+/// type depending on version and connection kind.
+pub(crate) fn port_from_json(value: Option<&serde_json::Value>) -> Option<u16> {
+    match value? {
+        serde_json::Value::String(s) => s.trim().parse::<u16>().ok(),
+        serde_json::Value::Number(n) => n.as_u64().and_then(|v| u16::try_from(v).ok()),
+        _ => None,
+    }
+}

--- a/crates/dbflux_portability/src/lib.rs
+++ b/crates/dbflux_portability/src/lib.rs
@@ -2,6 +2,7 @@ pub mod bundle;
 pub mod conflict;
 pub mod error;
 pub mod export;
+pub mod external;
 pub mod import;
 
 #[cfg(feature = "encryption")]

--- a/crates/dbflux_ui_windows/src/connection_manager/import_panel.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/import_panel.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use dbflux_app::portability::{
-    ConfirmSummary, ImportOutcome, ImportPersistence, OwnedDestSnapshot, confirm_summary,
-    mapto_candidates,
+    ConfirmSummary, ExternalPersistOutcome, ImportOutcome, ImportPersistence, OwnedDestSnapshot,
+    confirm_summary, default_candidate_includes, mapto_candidates, persist_external_candidate,
+    toggle_candidate_include,
 };
 use dbflux_components::controls::{Button, Checkbox, Input, InputEvent, InputState};
 use dbflux_components::icons::AppIcon;
@@ -13,6 +14,10 @@ use dbflux_components::primitives::{
 use dbflux_components::tokens::{FontSizes, Heights, Spacing};
 use dbflux_core::secrecy::SecretString;
 use dbflux_core::{AuthProfile, ConnectionProfile, ProxyProfile, SshTunnelProfile};
+use dbflux_portability::external::{
+    ExternalImportCandidate, ExternalImportOutcome, ExternalImportSkip, ImportInput, ImportSource,
+    importers,
+};
 use dbflux_portability::{
     ConflictChoice, ImportPlan, ParsedBundle, RequiredResolutionKind, ResolutionChoices,
 };
@@ -44,6 +49,19 @@ const AUTH_SKIP: &str = "skip";
 /// Prefix for "use destination auth profile <id>" segment ids.
 const AUTH_USE_PREFIX: &str = "use:";
 
+/// Segment id for the native DBflux bundle option in the source picker.
+/// External-client options use the importer's own `id()` as their segment id.
+const SOURCE_BUNDLE: &str = "bundle";
+
+/// Which source the SelectFile step is currently configured for: the native
+/// DBflux bundle format, or one of `dbflux_portability::external::importers()`
+/// (identified by that importer's `id()`).
+#[derive(Clone, PartialEq, Debug)]
+enum ImportSourceSelection {
+    Bundle,
+    External(String),
+}
+
 /// Steps of the import flow. Mirrors the previous wizard's state machine, minus
 /// the window chrome.
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -52,6 +70,10 @@ enum Step {
     Preview,
     Conflicts,
     RequiredReferences,
+    /// Review checklist for a parsed external-client import (DBeaver, Beekeeper
+    /// Studio, ...), shown instead of Preview/Conflicts/RequiredReferences since
+    /// those candidates carry no conflict-resolution or required-reference state.
+    ExternalReview,
     Outcome,
 }
 
@@ -145,6 +167,8 @@ impl ImportPersistence for AppStatePersistence<'_> {
 enum ImportRunResult {
     Outcome(ImportOutcome),
     Failed(String),
+    /// Outcome of persisting a confirmed selection from an external-client import.
+    External(ExternalPersistOutcome),
 }
 
 /// In-window connection import panel.
@@ -157,6 +181,26 @@ pub struct ImportConnectionsPanel {
     app_state: Entity<AppStateEntity>,
 
     step: Step,
+
+    // Step 1: source picker, shared by both the bundle and external flows.
+    source_selection: ImportSourceSelection,
+
+    // Step 1: external-client file(s). Plain path strings rather than
+    // `InputState` entities, since these fields are Browse-only (no manual
+    // path typing) and the round-trip only ever needs to store the last pick.
+    external_primary_path: Option<String>,
+    external_secondary_path: Option<String>,
+    pending_external_primary_path: Option<String>,
+    pending_external_secondary_path: Option<String>,
+    external_parse_error: Option<String>,
+    is_parsing_external: bool,
+
+    // External-review products: the parsed candidates/skips and one include
+    // flag per candidate, defaulting to included.
+    external_candidates: Vec<ExternalImportCandidate>,
+    external_skips: Vec<ExternalImportSkip>,
+    external_includes: Vec<bool>,
+    is_applying_external: bool,
 
     // Step 1: file + passphrase.
     file_input: Entity<InputState>,
@@ -238,6 +282,17 @@ impl ImportConnectionsPanel {
         Self {
             app_state,
             step: Step::SelectFile,
+            source_selection: ImportSourceSelection::Bundle,
+            external_primary_path: None,
+            external_secondary_path: None,
+            pending_external_primary_path: None,
+            pending_external_secondary_path: None,
+            external_parse_error: None,
+            is_parsing_external: false,
+            external_candidates: Vec::new(),
+            external_skips: Vec::new(),
+            external_includes: Vec::new(),
+            is_applying_external: false,
             file_input,
             pending_file_path: None,
             native_picker_unavailable: false,
@@ -266,6 +321,17 @@ impl ImportConnectionsPanel {
     /// manager when switching into the import view.
     pub fn reset(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.step = Step::SelectFile;
+        self.source_selection = ImportSourceSelection::Bundle;
+        self.external_primary_path = None;
+        self.external_secondary_path = None;
+        self.pending_external_primary_path = None;
+        self.pending_external_secondary_path = None;
+        self.external_parse_error = None;
+        self.is_parsing_external = false;
+        self.external_candidates.clear();
+        self.external_skips.clear();
+        self.external_includes.clear();
+        self.is_applying_external = false;
         self.pending_file_path = None;
         self.native_picker_unavailable = false;
         self.bundle_encrypted = false;
@@ -291,6 +357,253 @@ impl ImportConnectionsPanel {
 
         window.focus(&self.focus_handle);
         cx.notify();
+    }
+
+    /// Switches the source picker to the first registered external-client
+    /// importer. Called by the connection manager's "Import from another
+    /// client" footer button, right after `reset`.
+    pub fn preselect_external_source(&mut self, cx: &mut Context<Self>) {
+        if let Some(importer) = importers().into_iter().next() {
+            self.source_selection = ImportSourceSelection::External(importer.id().to_string());
+            cx.notify();
+        }
+    }
+
+    /// Whether `importer_id`'s primary input must be read from a filesystem
+    /// path rather than in-memory bytes. Beekeeper Studio's format is a SQLite
+    /// database, so `rusqlite` needs to open it directly from disk (see
+    /// `dbflux_portability::external::beekeeper`).
+    ///
+    /// `ConnectionImporter` does not expose this as trait metadata: it is a
+    /// property of the format, not something a caller can discover generically,
+    /// so the UI's file-picking behavior branches on the (small, fixed) set of
+    /// known importer ids rather than on driver identity.
+    fn external_format_uses_path_primary(importer_id: &str) -> bool {
+        importer_id == "beekeeper"
+    }
+
+    /// Whether `importer_id` accepts an optional secondary file. DBeaver splits
+    /// saved credentials into a companion `credentials-config.json`.
+    fn external_format_has_secondary(importer_id: &str) -> bool {
+        importer_id == "dbeaver"
+    }
+
+    fn selected_external_importer_id(&self) -> Option<String> {
+        match &self.source_selection {
+            ImportSourceSelection::External(id) => Some(id.clone()),
+            ImportSourceSelection::Bundle => None,
+        }
+    }
+
+    fn browse_external_file(&mut self, is_secondary: bool, cx: &mut Context<Self>) {
+        if !dbflux_ui_base::file_dialog::is_native_file_dialog_available() {
+            self.native_picker_unavailable = true;
+            cx.notify();
+            return;
+        }
+
+        let this = cx.entity().clone();
+        let task = cx.background_executor().spawn(async move {
+            let filter_label = if is_secondary {
+                dbflux_i18n::t!("connection_manager.import.external.filter.secondary")
+            } else {
+                dbflux_i18n::t!("connection_manager.import.external.filter.primary")
+            };
+
+            rfd::FileDialog::new()
+                .set_title(dbflux_i18n::t!(
+                    "connection_manager.import.external.dialog.open_title"
+                ))
+                .add_filter(filter_label, &["*"])
+                .pick_file()
+        });
+
+        cx.spawn(async move |_this, cx| {
+            if let Some(path) = task.await
+                && let Err(error) = cx.update(|cx| {
+                    this.update(cx, |this, cx| {
+                        let path = path.to_string_lossy().to_string();
+                        if is_secondary {
+                            this.pending_external_secondary_path = Some(path);
+                        } else {
+                            this.pending_external_primary_path = Some(path);
+                        }
+                        this.external_parse_error = None;
+                        cx.notify();
+                    });
+                })
+            {
+                log::warn!(
+                    "Failed to apply external import file path to panel state: {:?}",
+                    error
+                );
+            }
+        })
+        .detach();
+    }
+
+    /// Parse the selected external-client file(s) on the background executor,
+    /// then advance to the review checklist.
+    fn do_parse_external(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(importer_id) = self.selected_external_importer_id() else {
+            return;
+        };
+        let Some(primary_path) = self.external_primary_path.clone() else {
+            self.external_parse_error = Some(dbflux_i18n::t!(
+                "connection_manager.import.external.error.choose_primary_file"
+            ));
+            cx.notify();
+            return;
+        };
+        let secondary_path = self.external_secondary_path.clone();
+
+        self.is_parsing_external = true;
+        self.external_parse_error = None;
+        self.run_result = None;
+        window.focus(&self.focus_handle);
+        cx.notify();
+
+        let this = cx.entity().clone();
+
+        cx.spawn(async move |_this, cx| {
+            let result: Result<ExternalImportOutcome, String> = cx
+                .background_executor()
+                .spawn(async move {
+                    let primary_source = if Self::external_format_uses_path_primary(&importer_id) {
+                        ImportSource::Path(std::path::PathBuf::from(&primary_path))
+                    } else {
+                        match std::fs::read(&primary_path) {
+                            Ok(bytes) => ImportSource::Bytes(bytes),
+                            Err(e) => {
+                                return Err(crate::labels::import_error_cannot_read_file(
+                                    &e.to_string(),
+                                ));
+                            }
+                        }
+                    };
+
+                    let secondary_source = if Self::external_format_has_secondary(&importer_id) {
+                        match secondary_path.as_ref().map(std::fs::read).transpose() {
+                            Ok(bytes) => bytes.map(ImportSource::Bytes),
+                            Err(e) => {
+                                return Err(crate::labels::import_error_cannot_read_file(
+                                    &e.to_string(),
+                                ));
+                            }
+                        }
+                    } else {
+                        None
+                    };
+
+                    let input = match &secondary_source {
+                        Some(secondary) => ImportInput::with_secondary(&primary_source, secondary),
+                        None => ImportInput::new(&primary_source),
+                    };
+
+                    let Some(importer) = importers().into_iter().find(|i| i.id() == importer_id)
+                    else {
+                        return Err(crate::labels::import_error_parse_error(
+                            "unknown import source",
+                        ));
+                    };
+
+                    importer
+                        .parse(&input)
+                        .map_err(|e| crate::labels::import_error_parse_error(&e.to_string()))
+                })
+                .await;
+
+            if let Err(e) = cx.update(|cx| {
+                this.update(cx, |this, cx| {
+                    this.is_parsing_external = false;
+
+                    match result {
+                        Ok(outcome) => {
+                            this.external_includes =
+                                default_candidate_includes(outcome.candidates.len());
+                            this.external_candidates = outcome.candidates;
+                            this.external_skips = outcome.skips;
+                            this.step = Step::ExternalReview;
+                        }
+                        Err(e) => {
+                            this.external_parse_error = Some(e);
+                        }
+                    }
+                    cx.notify();
+                });
+            }) {
+                log::warn!(
+                    "Failed to update import panel after external parse: {:?}",
+                    e
+                );
+            }
+        })
+        .detach();
+    }
+
+    /// Persist the user-confirmed selection of external-import candidates
+    /// through the same `AppStatePersistence` seam bundle import uses, then
+    /// move to the outcome step.
+    fn do_apply_external(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let includes = std::mem::take(&mut self.external_includes);
+        let selected: Vec<ExternalImportCandidate> = std::mem::take(&mut self.external_candidates)
+            .into_iter()
+            .zip(includes)
+            .filter_map(|(candidate, include)| include.then_some(candidate))
+            .collect();
+
+        let app_state_entity = self.app_state.clone();
+        let this = cx.entity().clone();
+
+        self.is_applying_external = true;
+        window.focus(&self.focus_handle);
+        cx.notify();
+
+        cx.spawn(async move |_this, cx| {
+            if let Err(e) = cx.update(|cx| {
+                let outcome = app_state_entity.update(cx, |state, cx| {
+                    let mut deps = AppStatePersistence::new(state);
+                    let mut outcome = ExternalPersistOutcome::default();
+                    for candidate in selected {
+                        persist_external_candidate(candidate, &mut deps, &mut outcome);
+                    }
+                    cx.emit(dbflux_ui_base::AppStateChanged);
+                    cx.notify();
+                    outcome
+                });
+
+                if !outcome.secret_failures.is_empty() {
+                    let count = outcome.secret_failures.len();
+                    let msg = crate::labels::import_error_secret_failures_toast(count);
+                    report_error(UserFacingError::new(ErrorKind::Storage, msg), cx);
+                }
+
+                this.update(cx, |this, cx| {
+                    this.is_applying_external = false;
+                    let succeeded = outcome.succeeded.len();
+                    let has_failures = !outcome.secret_failures.is_empty()
+                        || !outcome.needs_driver.is_empty()
+                        || !outcome.config_failures.is_empty();
+
+                    if !has_failures && succeeded > 0 {
+                        dbflux_ui_base::toast::Toast::success(
+                            crate::labels::import_status_imported_toast(succeeded),
+                        )
+                        .push(cx);
+                    }
+
+                    this.run_result = Some(ImportRunResult::External(outcome));
+                    this.step = Step::Outcome;
+                    cx.notify();
+                });
+            }) {
+                log::warn!(
+                    "Failed to update import panel after external apply: {:?}",
+                    e
+                );
+            }
+        })
+        .detach();
     }
 
     fn browse_input_path(&mut self, cx: &mut Context<Self>) {
@@ -665,6 +978,13 @@ impl Render for ImportConnectionsPanel {
                 .update(cx, |state, cx| state.set_value(path, window, cx));
         }
 
+        if let Some(path) = self.pending_external_primary_path.take() {
+            self.external_primary_path = Some(path);
+        }
+        if let Some(path) = self.pending_external_secondary_path.take() {
+            self.external_secondary_path = Some(path);
+        }
+
         if self.pending_provision_secrets {
             self.pending_provision_secrets = false;
             self.provision_secret_inputs(window, cx);
@@ -681,6 +1001,7 @@ impl Render for ImportConnectionsPanel {
             Step::Preview => self.render_preview(cx),
             Step::Conflicts => self.render_conflicts(cx),
             Step::RequiredReferences => self.render_required_references(cx),
+            Step::ExternalReview => self.render_external_review(cx),
             Step::Outcome => self.render_outcome(cx),
         };
 
@@ -710,7 +1031,65 @@ impl Render for ImportConnectionsPanel {
 }
 
 impl ImportConnectionsPanel {
+    /// Renders the source picker shared by the bundle and external-client
+    /// flows, followed by that source's own fields.
     fn render_select_file(&self, cx: &Context<Self>) -> AnyElement {
+        let theme = cx.theme().clone();
+
+        let mut source_items = vec![SegmentedItem::new(
+            SOURCE_BUNDLE,
+            dbflux_i18n::t!("connection_manager.import.source.bundle"),
+        )];
+        for importer in importers() {
+            source_items.push(SegmentedItem::new(
+                importer.id().to_string(),
+                importer.display_name().to_string(),
+            ));
+        }
+
+        let active_source = match &self.source_selection {
+            ImportSourceSelection::Bundle => SOURCE_BUNDLE.to_string(),
+            ImportSourceSelection::External(id) => id.clone(),
+        };
+
+        let entity = cx.entity().clone();
+        let source_control =
+            SegmentedControl::new(source_items, active_source, move |selected, _window, cx| {
+                let selection = if selected.as_ref() == SOURCE_BUNDLE {
+                    ImportSourceSelection::Bundle
+                } else {
+                    ImportSourceSelection::External(selected.to_string())
+                };
+                entity.update(cx, |this, cx| {
+                    this.source_selection = selection;
+                    this.parse_error = None;
+                    this.external_parse_error = None;
+                    this.native_picker_unavailable = false;
+                    cx.notify();
+                });
+            });
+
+        let col = div().flex().flex_col().gap(Spacing::MD).child(
+            div()
+                .flex()
+                .flex_col()
+                .gap(Spacing::XS)
+                .child(
+                    Text::body(dbflux_i18n::t!("connection_manager.import.source.label"))
+                        .color(theme.muted_foreground),
+                )
+                .child(source_control),
+        );
+
+        let col = match &self.source_selection {
+            ImportSourceSelection::Bundle => col.child(self.render_bundle_fields(cx)),
+            ImportSourceSelection::External(id) => col.child(self.render_external_fields(id, cx)),
+        };
+
+        col.into_any_element()
+    }
+
+    fn render_bundle_fields(&self, cx: &Context<Self>) -> AnyElement {
         let theme = cx.theme().clone();
         let entity = cx.entity().clone();
 
@@ -809,6 +1188,209 @@ impl ImportConnectionsPanel {
         }
 
         col.into_any_element()
+    }
+
+    fn render_external_fields(&self, importer_id: &str, cx: &Context<Self>) -> AnyElement {
+        let theme = cx.theme().clone();
+        let has_secondary = Self::external_format_has_secondary(importer_id);
+
+        let primary_label = self.external_primary_path.clone().unwrap_or_else(|| {
+            dbflux_i18n::t!("connection_manager.import.external.field.primary_file")
+        });
+
+        let entity = cx.entity().clone();
+        let primary_browse =
+            IconButton::new("import-external-primary-browse", AppIcon::Folder.into())
+                .icon_size(Heights::ICON_SM)
+                .on_click(move |_event, _window, cx| {
+                    entity.update(cx, |this, cx| this.browse_external_file(false, cx));
+                });
+
+        let mut col = div()
+            .flex()
+            .flex_col()
+            .gap(Spacing::XS)
+            .child(
+                Text::body(dbflux_i18n::t!(
+                    "connection_manager.import.external.field.primary_file"
+                ))
+                .color(theme.muted_foreground),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(Spacing::XS)
+                    .child(
+                        div()
+                            .flex_1()
+                            .text_size(FontSizes::SM)
+                            .text_color(theme.foreground)
+                            .child(primary_label),
+                    )
+                    .child(primary_browse),
+            );
+
+        if has_secondary {
+            let secondary_label = self.external_secondary_path.clone().unwrap_or_else(|| {
+                dbflux_i18n::t!("connection_manager.import.external.field.secondary_file")
+            });
+
+            let entity = cx.entity().clone();
+            let secondary_browse =
+                IconButton::new("import-external-secondary-browse", AppIcon::Folder.into())
+                    .icon_size(Heights::ICON_SM)
+                    .on_click(move |_event, _window, cx| {
+                        entity.update(cx, |this, cx| this.browse_external_file(true, cx));
+                    });
+
+            col = col
+                .child(
+                    Text::body(dbflux_i18n::t!(
+                        "connection_manager.import.external.field.secondary_file"
+                    ))
+                    .color(theme.muted_foreground),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(Spacing::XS)
+                        .child(
+                            div()
+                                .flex_1()
+                                .text_size(FontSizes::SM)
+                                .text_color(theme.foreground)
+                                .child(secondary_label),
+                        )
+                        .child(secondary_browse),
+                )
+                .child(
+                    Text::muted(dbflux_i18n::t!(
+                        "connection_manager.import.external.hint.secondary_optional"
+                    ))
+                    .font_size(FontSizes::XS),
+                );
+        }
+
+        if self.native_picker_unavailable {
+            col = col.child(
+                Text::muted(dbflux_i18n::t!(
+                    "connection_manager.import.hint.no_native_picker"
+                ))
+                .font_size(FontSizes::XS),
+            );
+        }
+
+        if let Some(err) = self.external_parse_error.clone() {
+            col = col.child(BannerBlock::new(BannerVariant::Danger, err));
+        }
+
+        col.into_any_element()
+    }
+
+    fn render_external_review(&self, cx: &Context<Self>) -> AnyElement {
+        let theme = cx.theme().clone();
+
+        let mut col = div().flex().flex_col().gap(Spacing::SM).child(
+            Text::body(dbflux_i18n::t!(
+                "connection_manager.import.external.review.intro"
+            ))
+            .color(theme.muted_foreground),
+        );
+
+        if !self.external_skips.is_empty() {
+            let body = self
+                .external_skips
+                .iter()
+                .map(|skip| {
+                    if skip.name.is_empty() {
+                        skip.reason.clone()
+                    } else {
+                        format!("\"{}\": {}", skip.name, skip.reason)
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            col = col.child(
+                BannerBlock::new(
+                    BannerVariant::Warning,
+                    crate::labels::import_external_review_skips_intro(self.external_skips.len()),
+                )
+                .with_body(body),
+            );
+        }
+
+        for (index, candidate) in self.external_candidates.iter().enumerate() {
+            col = col.child(self.render_external_candidate_row(index, candidate, cx));
+        }
+
+        col.into_any_element()
+    }
+
+    fn render_external_candidate_row(
+        &self,
+        index: usize,
+        candidate: &ExternalImportCandidate,
+        cx: &Context<Self>,
+    ) -> AnyElement {
+        let theme = cx.theme().clone();
+        let included = self.external_includes.get(index).copied().unwrap_or(false);
+
+        let host_summary = crate::labels::import_external_host_summary(&candidate.config);
+        let kind_label = candidate.kind.display_name();
+
+        let secret_status = if let Some(reason) = &candidate.secret_skip_reason {
+            reason.clone()
+        } else if candidate.secret.is_some() {
+            dbflux_i18n::t!("connection_manager.import.external.secret.will_store")
+        } else {
+            dbflux_i18n::t!("connection_manager.import.external.secret.none")
+        };
+
+        surface_raised(cx)
+            .w_full()
+            .px(Spacing::SM)
+            .py(Spacing::XS)
+            .flex()
+            .flex_col()
+            .gap(Spacing::XS)
+            .id(SharedString::from(format!(
+                "import-external-candidate-{index}"
+            )))
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(Spacing::XS)
+                    .child(
+                        Checkbox::new(SharedString::from(format!(
+                            "import-external-candidate-toggle-{index}"
+                        )))
+                        .checked(included)
+                        .on_click(cx.listener(
+                            move |this, _checked: &bool, _, cx| {
+                                toggle_candidate_include(&mut this.external_includes, index);
+                                cx.notify();
+                            },
+                        )),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .child(
+                                div()
+                                    .text_size(FontSizes::SM)
+                                    .text_color(theme.foreground)
+                                    .child(format!("{} — {kind_label}", candidate.name)),
+                            )
+                            .child(Text::muted(host_summary).font_size(FontSizes::XS)),
+                    ),
+            )
+            .child(Text::muted(secret_status).font_size(FontSizes::XS))
+            .into_any_element()
     }
 
     fn render_preview(&self, cx: &Context<Self>) -> AnyElement {
@@ -1244,6 +1826,57 @@ impl ImportConnectionsPanel {
                     ));
                 }
             }
+            Some(ImportRunResult::External(outcome)) => {
+                if !outcome.succeeded.is_empty() {
+                    col = col.child(BannerBlock::new(
+                        BannerVariant::Success,
+                        crate::labels::import_outcome_succeeded(outcome.succeeded.len()),
+                    ));
+                }
+
+                if !outcome.needs_driver.is_empty() {
+                    let body = outcome
+                        .needs_driver
+                        .iter()
+                        .map(|(name, driver)| format!("\"{name}\" (driver: {driver})"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    col = col.child(
+                        BannerBlock::new(
+                            BannerVariant::Warning,
+                            crate::labels::import_outcome_needs_driver(outcome.needs_driver.len()),
+                        )
+                        .with_body(body),
+                    );
+                }
+
+                if !outcome.config_failures.is_empty() {
+                    let body = outcome
+                        .config_failures
+                        .iter()
+                        .map(|(name, reason)| format!("\"{name}\": {reason}"))
+                        .collect::<Vec<_>>()
+                        .join("\n");
+                    col = col.child(
+                        BannerBlock::new(
+                            BannerVariant::Warning,
+                            crate::labels::import_outcome_config_failures(
+                                outcome.config_failures.len(),
+                            ),
+                        )
+                        .with_body(body),
+                    );
+                }
+
+                if !outcome.secret_failures.is_empty() {
+                    col = col.child(BannerBlock::new(
+                        BannerVariant::Warning,
+                        crate::labels::import_outcome_secret_failures(
+                            outcome.secret_failures.len(),
+                        ),
+                    ));
+                }
+            }
         }
 
         col.into_any_element()
@@ -1290,6 +1923,15 @@ impl ImportConnectionsPanel {
                 };
                 cx.notify();
             })),
+            Step::ExternalReview => Button::new(
+                "import-back",
+                dbflux_i18n::t!("connection_manager.import.action.back"),
+            )
+            .ghost()
+            .on_click(cx.listener(|this, _: &gpui::ClickEvent, _, cx| {
+                this.step = Step::SelectFile;
+                cx.notify();
+            })),
             Step::Outcome => Button::new(
                 "import-done",
                 dbflux_i18n::t!("connection_manager.import.action.done"),
@@ -1315,9 +1957,17 @@ impl ImportConnectionsPanel {
     fn render_primary_button(&self, cx: &Context<Self>) -> Option<AnyElement> {
         match self.step {
             Step::SelectFile => {
-                let can_load =
-                    !self.file_input.read(cx).value().trim().is_empty() && !self.is_parsing;
-                let label = if self.is_parsing {
+                let (can_load, is_busy) = match &self.source_selection {
+                    ImportSourceSelection::Bundle => (
+                        !self.file_input.read(cx).value().trim().is_empty() && !self.is_parsing,
+                        self.is_parsing,
+                    ),
+                    ImportSourceSelection::External(_) => (
+                        self.external_primary_path.is_some() && !self.is_parsing_external,
+                        self.is_parsing_external,
+                    ),
+                };
+                let label = if is_busy {
                     dbflux_i18n::t!("connection_manager.import.status.loading")
                 } else {
                     dbflux_i18n::t!("connection_manager.import.action.load")
@@ -1327,7 +1977,12 @@ impl ImportConnectionsPanel {
                         .primary()
                         .disabled(!can_load)
                         .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
-                            this.do_parse_and_plan(window, cx);
+                            match this.source_selection.clone() {
+                                ImportSourceSelection::Bundle => this.do_parse_and_plan(window, cx),
+                                ImportSourceSelection::External(_) => {
+                                    this.do_parse_external(window, cx)
+                                }
+                            }
                         }))
                         .into_any_element(),
                 )
@@ -1372,6 +2027,23 @@ impl ImportConnectionsPanel {
                         .disabled(self.is_applying)
                         .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
                             this.do_apply(window, cx);
+                        }))
+                        .into_any_element(),
+                )
+            }
+            Step::ExternalReview => {
+                let included_count = self.external_includes.iter().filter(|&&v| v).count();
+                let label = if self.is_applying_external {
+                    dbflux_i18n::t!("connection_manager.import.status.importing")
+                } else {
+                    crate::labels::import_external_action_import_selected(included_count)
+                };
+                Some(
+                    Button::new("import-external-apply", label)
+                        .primary()
+                        .disabled(self.is_applying_external || included_count == 0)
+                        .on_click(cx.listener(|this, _: &gpui::ClickEvent, window, cx| {
+                            this.do_apply_external(window, cx);
                         }))
                         .into_any_element(),
                 )
@@ -1488,6 +2160,22 @@ mod tests {
         "connection_manager.import.action.load",
         "connection_manager.import.action.continue_",
         "connection_manager.import.action.import",
+        "connection_manager.import.source.label",
+        "connection_manager.import.source.bundle",
+        "connection_manager.import.external.dialog.open_title",
+        "connection_manager.import.external.filter.primary",
+        "connection_manager.import.external.filter.secondary",
+        "connection_manager.import.external.field.primary_file",
+        "connection_manager.import.external.field.secondary_file",
+        "connection_manager.import.external.hint.secondary_optional",
+        "connection_manager.import.external.error.choose_primary_file",
+        "connection_manager.import.external.review.intro",
+        "connection_manager.import.external.review.skips_intro.one",
+        "connection_manager.import.external.review.skips_intro.many",
+        "connection_manager.import.external.secret.will_store",
+        "connection_manager.import.external.secret.none",
+        "connection_manager.import.external.action.import_selected.one",
+        "connection_manager.import.external.action.import_selected.many",
     ];
 
     #[test]

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -889,6 +889,17 @@ impl ConnectionManagerWindow {
         cx.notify();
     }
 
+    /// Switch to the in-window import panel, pre-selecting an external-client
+    /// source (DBeaver, Beekeeper Studio, ...) instead of the native bundle.
+    pub(super) fn open_import_external(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.import_panel.update(cx, |panel, cx| {
+            panel.reset(window, cx);
+            panel.preselect_external_source(cx);
+        });
+        self.view = View::Import;
+        cx.notify();
+    }
+
     pub fn new_for_edit(
         app_state: Entity<AppStateEntity>,
         profile: &dbflux_core::ConnectionProfile,
@@ -4186,6 +4197,7 @@ mod tests {
         "connection_manager.driver_select.subtitle",
         "connection_manager.driver_select.empty_state",
         "connection_manager.driver_select.import_from_file",
+        "connection_manager.driver_select.import_from_client",
         "connection_manager.driver_select.cancel",
         "connection_manager.driver_select.configure",
         "connection_manager.driver_select.configure_named",

--- a/crates/dbflux_ui_windows/src/connection_manager/render_driver_select.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_driver_select.rs
@@ -273,6 +273,16 @@ impl ConnectionManagerWindow {
                     )
                     .child(
                         Button::new(
+                            "cm-driver-import-external",
+                            dbflux_i18n::t!("connection_manager.driver_select.import_from_client"),
+                        )
+                        .small()
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.open_import_external(window, cx);
+                        })),
+                    )
+                    .child(
+                        Button::new(
                             "cm-driver-cancel",
                             dbflux_i18n::t!("connection_manager.driver_select.cancel"),
                         )

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -596,6 +596,109 @@ pub(crate) fn import_action_use_profile(name: &str) -> String {
     dbflux_i18n::t!("connection_manager.import.action.use_profile", name = name)
 }
 
+/// Formats the pluralized "N entry/entries could not be imported" review-step
+/// intro for the external-client import flow's skip list.
+pub(crate) fn import_external_review_skips_intro(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.external.review.skips_intro.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.external.review.skips_intro.many",
+            count = count
+        )
+    }
+}
+
+/// Formats the pluralized "Import N connection(s)" primary button label for the
+/// external-client import review step.
+pub(crate) fn import_external_action_import_selected(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!(
+            "connection_manager.import.external.action.import_selected.one",
+            count = count
+        )
+    } else {
+        dbflux_i18n::t!(
+            "connection_manager.import.external.action.import_selected.many",
+            count = count
+        )
+    }
+}
+
+/// Short "host:port/db" (or file path) summary of an external-import candidate's
+/// config, shown in the review checklist.
+///
+/// Only the six `DbConfig` shapes an external importer can currently produce
+/// (Postgres, MySQL, SQLite, MongoDB, Redis, SQL Server) are handled; any other
+/// variant falls back to an empty string rather than a driver-specific branch,
+/// since no current importer emits one.
+pub(crate) fn import_external_host_summary(config: &dbflux_core::DbConfig) -> String {
+    use dbflux_core::DbConfig;
+
+    match config {
+        DbConfig::Postgres {
+            use_uri: true, uri, ..
+        } => uri.clone().unwrap_or_default(),
+        DbConfig::Postgres {
+            host,
+            port,
+            database,
+            ..
+        } => format!("{host}:{port}/{database}"),
+
+        DbConfig::MySQL {
+            use_uri: true, uri, ..
+        } => uri.clone().unwrap_or_default(),
+        DbConfig::MySQL {
+            host,
+            port,
+            database,
+            ..
+        } => match database {
+            Some(db) => format!("{host}:{port}/{db}"),
+            None => format!("{host}:{port}"),
+        },
+
+        DbConfig::SQLite { path, .. } => path.display().to_string(),
+
+        DbConfig::MongoDB {
+            use_uri: true, uri, ..
+        } => uri.clone().unwrap_or_default(),
+        DbConfig::MongoDB {
+            host,
+            port,
+            database,
+            ..
+        } => match database {
+            Some(db) => format!("{host}:{port}/{db}"),
+            None => format!("{host}:{port}"),
+        },
+
+        DbConfig::Redis {
+            use_uri: true, uri, ..
+        } => uri.clone().unwrap_or_default(),
+        DbConfig::Redis { host, port, .. } => format!("{host}:{port}"),
+
+        DbConfig::SqlServer {
+            use_uri: true, uri, ..
+        } => uri.clone().unwrap_or_default(),
+        DbConfig::SqlServer {
+            host,
+            port,
+            database,
+            ..
+        } => match database {
+            Some(db) => format!("{host}:{port}/{db}"),
+            None => format!("{host}:{port}"),
+        },
+
+        _ => String::new(),
+    }
+}
+
 /// Formats the "Export <kind>" window/dialog title for a resolved export target.
 pub(crate) fn export_title_with_kind(kind: &str) -> String {
     dbflux_i18n::t!("connection_manager.export.title_with_kind", kind = kind)
@@ -772,15 +875,17 @@ mod tests {
         hooks_write_script_failed, import_action_map_to, import_action_use_profile,
         import_conflict_kind_label, import_conflicts_row_label, import_error_cannot_read_file,
         import_error_decryption_error, import_error_import_failed, import_error_parse_error,
-        import_error_secret_failures_toast, import_outcome_config_failures,
-        import_outcome_needs_driver, import_outcome_secret_failures, import_outcome_succeeded,
-        import_outcome_unresolved_refs, import_preview_conflicts_banner,
-        import_preview_count_auth_profiles, import_preview_count_connections,
-        import_preview_count_proxies, import_preview_count_ssh_tunnels,
-        import_preview_required_banner, import_required_auth_profile_ref_label,
-        import_required_aws_reference_label, import_required_secret_label,
-        import_status_imported_toast, mcp_preview_summary, proxies_delete_body,
-        rpc_services_delete_body, ssh_private_key_with_path, ssh_tunnels_delete_body,
+        import_error_secret_failures_toast, import_external_action_import_selected,
+        import_external_host_summary, import_external_review_skips_intro,
+        import_outcome_config_failures, import_outcome_needs_driver,
+        import_outcome_secret_failures, import_outcome_succeeded, import_outcome_unresolved_refs,
+        import_preview_conflicts_banner, import_preview_count_auth_profiles,
+        import_preview_count_connections, import_preview_count_proxies,
+        import_preview_count_ssh_tunnels, import_preview_required_banner,
+        import_required_auth_profile_ref_label, import_required_aws_reference_label,
+        import_required_secret_label, import_status_imported_toast, mcp_preview_summary,
+        proxies_delete_body, rpc_services_delete_body, ssh_private_key_with_path,
+        ssh_tunnels_delete_body,
     };
     use super::{
         connection_manager_window_title_edit, connection_manager_window_title_new,
@@ -1307,6 +1412,118 @@ mod tests {
     fn import_action_segment_labels_embed_their_names() {
         assert!(import_action_map_to("staging-db").contains("staging-db"));
         assert!(import_action_use_profile("prod-sso").contains("prod-sso"));
+    }
+
+    #[test]
+    fn import_external_review_skips_intro_uses_singular_form_for_one() {
+        assert!(import_external_review_skips_intro(1).contains('1'));
+        assert!(import_external_review_skips_intro(3).contains('3'));
+        assert_ne!(
+            import_external_review_skips_intro(1),
+            import_external_review_skips_intro(2)
+        );
+    }
+
+    #[test]
+    fn import_external_action_import_selected_pluralizes_by_count() {
+        assert!(import_external_action_import_selected(1).contains('1'));
+        assert!(import_external_action_import_selected(4).contains('4'));
+        assert_ne!(
+            import_external_action_import_selected(1),
+            import_external_action_import_selected(2)
+        );
+    }
+
+    #[test]
+    fn import_external_host_summary_covers_every_importer_producible_kind() {
+        use dbflux_core::DbConfig;
+        use std::path::PathBuf;
+
+        let postgres_manual = DbConfig::Postgres {
+            use_uri: false,
+            uri: None,
+            host: "db.example.invalid".to_string(),
+            port: 5432,
+            user: "demo".to_string(),
+            database: "app".to_string(),
+            ssl_mode: None,
+            ssl_root_cert_path: None,
+            ssl_client_cert_path: None,
+            ssl_client_key_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+        };
+        assert_eq!(
+            import_external_host_summary(&postgres_manual),
+            "db.example.invalid:5432/app"
+        );
+
+        let postgres_uri = DbConfig::Postgres {
+            use_uri: true,
+            uri: Some("postgresql://db.example.invalid:5432/app".to_string()),
+            host: String::new(),
+            port: 5432,
+            user: String::new(),
+            database: String::new(),
+            ssl_mode: None,
+            ssl_root_cert_path: None,
+            ssl_client_cert_path: None,
+            ssl_client_key_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+        };
+        assert_eq!(
+            import_external_host_summary(&postgres_uri),
+            "postgresql://db.example.invalid:5432/app"
+        );
+
+        let sqlite = DbConfig::SQLite {
+            path: PathBuf::from("/tmp/example.db"),
+            connection_id: None,
+        };
+        assert_eq!(import_external_host_summary(&sqlite), "/tmp/example.db");
+
+        let mysql_no_database = DbConfig::MySQL {
+            use_uri: false,
+            uri: None,
+            host: "db.example.invalid".to_string(),
+            port: 3306,
+            user: "demo".to_string(),
+            database: None,
+            ssl_mode: None,
+            ssl_root_cert_path: None,
+            ssl_client_cert_path: None,
+            ssl_client_key_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+        };
+        assert_eq!(
+            import_external_host_summary(&mysql_no_database),
+            "db.example.invalid:3306"
+        );
+
+        let redis = DbConfig::Redis {
+            use_uri: false,
+            uri: None,
+            host: "db.example.invalid".to_string(),
+            port: 6379,
+            user: None,
+            database: None,
+            tls: false,
+            ssl_mode: None,
+            ssl_root_cert_path: None,
+            ssl_client_cert_path: None,
+            ssl_client_key_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+            topology: None,
+            sentinel_master_name: None,
+            additional_nodes: None,
+        };
+        assert_eq!(
+            import_external_host_summary(&redis),
+            "db.example.invalid:6379"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #356

## Summary

- `dbflux_portability` gains an `external` module: a `ConnectionImporter` trait with a format registry, so the third client is one new file. Two formats ship:
  - **DBeaver** — parses `data-sources.json` (manual and URL configurations, tolerant field types); the optional `credentials-config.json` decrypts with the publicly documented static AES-128-CBC key (DBeaver's own wiki labels the scheme insecure by design; verified against an independent open-source decryptor). A missing or corrupted credentials file degrades to importing without secrets, never failing the batch. `jdbc:` URL prefixes are stripped so driver URI parsers accept the values.
  - **Beekeeper Studio** — reads the `app.db` SQLite store via the existing rusqlite dependency; every connection imports, and its locally-encrypted passwords are marked "re-enter after import" per entry (their key is per-install, not portable).
- Partial imports are the normal case: unknown providers, malformed entries, and undecryptable secrets become per-entry skip reasons; one bad entry never aborts the batch.
- The connection manager's import panel gains a source picker (bundle + registry entries listed generically), a review checklist with include toggles and per-entry secret status, and an outcome summary. Nothing persists until the user confirms; secrets go through `SecretManager` to the keyring and are never written to the profile store.
- TablePlus and DataGrip were researched and excluded deliberately: both delegate passwords to the OS keychain/KeePass and TablePlus's export format is undocumented, so a portable importer cannot read them.
- New deps: `aes` 0.8 + `cbc` 0.1 (RustCrypto, pure Rust, pinned to versions already vendored transitively).

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo nextest run --workspace --no-fail-fast`: 5757/5758; the single failure is the known flaky palette time-budget test (untouched, passes in isolation)
- [x] `cargo test --doc --workspace` clean
- [x] Parser fixtures are fully synthetic (example.invalid hosts, fixture credentials); DBeaver credential decryption round-trips in-test with the same cipher
- [x] The connection-manager style guardrail (no driver-id branching) passes over the new UI code
- [ ] Unverified against real DBeaver/Beekeeper installations — fixtures follow their documented formats; Beekeeper's table detection is defensive against column drift
- [ ] Manual GPUI smoke pending: source picker, review checklist, and toggle interaction