### PR TITLE
feat(redis): offline RDB dump analysis for key-space profiling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,6 +152,9 @@ jobs:
       - name: Run Redis Cluster live integration tests
         run: cargo test -p dbflux_driver_redis --locked --test live_cluster -- --ignored --test-threads=1
 
+      - name: Run Redis RDB analyzer live integration tests
+        run: cargo test -p dbflux_driver_redis --locked --test live_rdb -- --ignored
+
       - name: DynamoDB live integration
         run: cargo test -p dbflux_driver_dynamodb --locked --test live_integration -- --ignored
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2961,6 +2961,8 @@ dependencies = [
  "log",
  "redis",
  "serde_json",
+ "tempfile",
+ "testcontainers",
  "urlencoding",
  "uuid",
 ]
@@ -3296,6 +3298,7 @@ name = "dbflux_ui_document"
 version = "0.8.0-dev.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "dbflux_app",
  "dbflux_audit",
  "dbflux_components",

--- a/crates/dbflux_core/src/connection/dump_analysis.rs
+++ b/crates/dbflux_core/src/connection/dump_analysis.rs
@@ -1,0 +1,110 @@
+//! Dump-analyzer seam for DBFlux.
+//!
+//! Defines the `DumpAnalyzer` trait and the value types it produces. Drivers
+//! whose native export format can be scanned offline (e.g. a Redis RDB file)
+//! implement `DumpAnalyzer` and return `Some(analyzer)` from
+//! `DbDriver::dump_analyzer()`; all other drivers inherit the default `None`.
+//!
+//! The UI never inspects `driver_id` — it calls `driver.dump_analyzer()` to
+//! decide whether to show the "Analyze dump" affordance, and reads
+//! `size_caveat()` to explain that serialized size on disk is not the same
+//! as the space a key occupies in live memory.
+//!
+//! Implementations MUST keep memory bounded regardless of dump size: the
+//! largest-keys and prefix-rollup results are computed as a streaming
+//! aggregation over the file, never by materializing a full key list.
+
+use std::path::Path;
+
+/// One entry in the bounded top-N largest-keys list.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DumpKeyEntry {
+    /// Key name, decoded lossily to UTF-8 for display.
+    pub key: String,
+    /// Driver-reported value type (e.g. `"string"`, `"hash"`, `"stream"`).
+    pub type_name: String,
+    /// Bytes consumed by this entry in the source dump's serialization format.
+    ///
+    /// This is the on-disk/on-wire size, not the key's footprint in live
+    /// memory — allocator overhead, pointers, and in-memory encoding
+    /// differences mean the two numbers diverge, sometimes by a lot.
+    pub serialized_bytes: u64,
+    /// Absolute expiry time in epoch milliseconds, if the key carries one.
+    pub expires_at_ms: Option<i64>,
+    /// Logical database index the key belongs to.
+    pub database: u32,
+}
+
+/// One bucket in the bounded prefix-rollup aggregation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DumpPrefixEntry {
+    /// Prefix bucket label (see the driver's prefix-splitting rule for how
+    /// this is derived from key names).
+    pub prefix: String,
+    /// Number of keys aggregated into this bucket.
+    pub key_count: u64,
+    /// Sum of `serialized_bytes` for every key aggregated into this bucket.
+    pub serialized_bytes: u64,
+}
+
+/// Result of analyzing one dump file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DumpAnalysisReport {
+    /// Total number of keys observed across every logical database.
+    pub total_keys: u64,
+    /// Total serialized bytes consumed by every key entry observed.
+    pub total_serialized_bytes: u64,
+    /// Per-type breakdown: `(type_name, key_count, serialized_bytes)`.
+    pub keys_by_type: Vec<(String, u64, u64)>,
+    /// Bounded top-N largest keys by serialized size, descending.
+    pub largest_keys: Vec<DumpKeyEntry>,
+    /// Bounded by-prefix aggregation.
+    pub prefix_rollup: Vec<DumpPrefixEntry>,
+}
+
+/// Error produced while analyzing a dump file.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DumpAnalysisError {
+    /// Filesystem I/O failure while reading the dump.
+    #[error("I/O error reading dump: {0}")]
+    Io(String),
+
+    /// The dump's binary format could not be parsed at the given byte offset.
+    #[error("malformed dump at offset {offset}: {message}")]
+    Format { offset: u64, message: String },
+
+    /// Analysis was cancelled by the caller before completion.
+    #[error("dump analysis cancelled")]
+    Cancelled,
+}
+
+/// Analyzes a driver's native dump/export format offline, without a live connection.
+///
+/// Implementations MUST stream the file rather than loading it into memory,
+/// and MUST keep the aggregated result bounded (top-N largest keys, capped
+/// prefix rollup) regardless of how many keys the dump contains.
+pub trait DumpAnalyzer: Send + Sync {
+    /// Human-readable name for the dump format (e.g. `"Redis RDB"`).
+    fn display_name(&self) -> &'static str;
+
+    /// File extensions this analyzer accepts, without the leading dot (e.g. `["rdb"]`).
+    fn file_extensions(&self) -> &'static [&'static str];
+
+    /// Explains why serialized dump size and live memory usage differ.
+    ///
+    /// The UI surfaces this text verbatim next to the analysis results.
+    fn size_caveat(&self) -> &'static str;
+
+    /// Analyzes the dump file at `path`.
+    ///
+    /// `progress` is called periodically with `(bytes_read, total_bytes)`;
+    /// `total_bytes` is `None` when the total size could not be determined.
+    /// `cancelled` is polled periodically and analysis stops as soon as it
+    /// returns `true`, returning `Err(DumpAnalysisError::Cancelled)`.
+    fn analyze(
+        &self,
+        path: &Path,
+        progress: &(dyn Fn(u64, Option<u64>) + Sync),
+        cancelled: &(dyn Fn() -> bool + Sync),
+    ) -> Result<DumpAnalysisReport, DumpAnalysisError>;
+}

--- a/crates/dbflux_core/src/connection/mod.rs
+++ b/crates/dbflux_core/src/connection/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod context;
 pub mod dashboard_import;
 pub mod dashboard_source;
+pub mod dump_analysis;
 pub(crate) mod hook;
 pub mod instance_catalog;
 pub(crate) mod item_manager;

--- a/crates/dbflux_core/src/core/task.rs
+++ b/crates/dbflux_core/src/core/task.rs
@@ -37,6 +37,9 @@ pub enum TaskKind {
     KeyScan,
     KeyGet,
     KeyMutation,
+    /// Offline analysis of a driver's native dump/export format (e.g. a Redis
+    /// RDB file), run without a live connection.
+    DumpAnalysis,
 }
 
 impl TaskKind {
@@ -56,6 +59,7 @@ impl TaskKind {
             TaskKind::KeyScan => "Key Scan",
             TaskKind::KeyGet => "Key Get",
             TaskKind::KeyMutation => "Key Mutation",
+            TaskKind::DumpAnalysis => "Dump Analysis",
         }
     }
 }
@@ -573,6 +577,7 @@ mod tests {
             TaskKind::KeyScan,
             TaskKind::KeyGet,
             TaskKind::KeyMutation,
+            TaskKind::DumpAnalysis,
         ];
 
         for kind in kinds {

--- a/crates/dbflux_core/src/core/traits.rs
+++ b/crates/dbflux_core/src/core/traits.rs
@@ -484,6 +484,16 @@ pub trait DbDriver: Send + Sync {
         let _conn = self.connect_with_secrets(profile, password, ssh_secret)?;
         Ok(crate::TestConnectionResult::default())
     }
+
+    /// Return this driver's offline dump analyzer, if it supports one.
+    ///
+    /// Analyzing a dump file does not require a live connection, so this
+    /// lives on `DbDriver` rather than `Connection`. Drivers that implement
+    /// `DumpAnalyzer` override this and return `Some(analyzer)`. Drivers
+    /// without offline dump analysis inherit this default and return `None`.
+    fn dump_analyzer(&self) -> Option<Arc<dyn crate::connection::dump_analysis::DumpAnalyzer>> {
+        None
+    }
 }
 
 /// Key-value operations exposed by drivers in `DatabaseCategory::KeyValue`.

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -79,6 +79,10 @@ pub use connection::dashboard_import::{
 
 pub use connection::dashboard_source::{DashboardRef, DashboardSource, RemoteDashboard};
 
+pub use connection::dump_analysis::{
+    DumpAnalysisError, DumpAnalysisReport, DumpAnalyzer, DumpKeyEntry, DumpPrefixEntry,
+};
+
 pub use connection::{
     DefaultDashboardPanel, DefaultInstanceDashboard, InspectorRowAction, InstanceCatalog,
     InstanceInspectorDef, InstanceMetricDef, InstanceMetricId, InstanceMetricUnit,

--- a/crates/dbflux_driver_redis/Cargo.toml
+++ b/crates/dbflux_driver_redis/Cargo.toml
@@ -24,6 +24,8 @@ uuid.workspace = true
 
 [dev-dependencies]
 dbflux_test_support.workspace = true
+tempfile = "3"
+testcontainers = { version = "0.27", features = ["blocking"] }
 
 [lints]
 workspace = true

--- a/crates/dbflux_driver_redis/README.md
+++ b/crates/dbflux_driver_redis/README.md
@@ -39,6 +39,7 @@ Redis key-value driver for DBFlux, built on the [`redis`](https://crates.io/crat
 - Mutations: insert, update, delete, batch operations, and bulk delete. The `RedisCommandGenerator` emits Redis commands for set/delete, hash set/delete, list push/set/remove, set add/remove, sorted-set add/remove, and stream add/delete, for use in previews and copy-as-command.
 - JSON export of results (`EXPORT_JSON`).
 - Size gate on whole-payload reads: when the request carries a byte budget, string/JSON values are probed with `STRLEN` before `GET` and oversized values return a placeholder with the real size instead of transferring the payload; collection types are unaffected, and stream reads that hit the fetch cap report themselves as truncated.
+- Offline RDB dump analysis (`DumpAnalyzer`): a `.rdb` file is scanned key-by-key without connecting to a server, streaming the file at I/O speed with flat memory (key values are never decoded, only key names and value types). Reports total key count, a per-type breakdown, the 500 largest keys, and a by-prefix size rollup. Reported sizes are each key's **serialized size on disk**, not its footprint in live Redis memory — allocator overhead and in-memory encodings mean the two numbers diverge.
 
 Schema introspection reports a single aggregated `db0` keyspace on a Cluster connection: the key count and average TTL are summed/averaged across every master's `DBSIZE`/keyspace stats rather than reported per-node.
 

--- a/crates/dbflux_driver_redis/src/driver.rs
+++ b/crates/dbflux_driver_redis/src/driver.rs
@@ -955,6 +955,10 @@ impl DbDriver for RedisDriver {
         let conn = self.connect_with_secrets(profile, None, None)?;
         conn.ping()
     }
+
+    fn dump_analyzer(&self) -> Option<Arc<dyn dbflux_core::DumpAnalyzer>> {
+        Some(Arc::new(crate::rdb::RdbAnalyzer))
+    }
 }
 
 #[derive(Debug)]

--- a/crates/dbflux_driver_redis/src/lib.rs
+++ b/crates/dbflux_driver_redis/src/lib.rs
@@ -13,8 +13,10 @@ pub mod command_generator;
 pub mod driver;
 pub mod instance_catalog;
 pub mod language_service;
+pub mod rdb;
 pub(crate) mod transport;
 
 pub use command_generator::RedisCommandGenerator;
 pub use driver::{REDIS_FORM, REDIS_METADATA, RedisDriver};
 pub use language_service::RedisLanguageService;
+pub use rdb::RdbAnalyzer;

--- a/crates/dbflux_driver_redis/src/rdb.rs
+++ b/crates/dbflux_driver_redis/src/rdb.rs
@@ -1,0 +1,1385 @@
+//! Streaming RDB (Redis dump file) parser and `DumpAnalyzer` implementation.
+//!
+//! The parser deliberately never decodes value payloads: it only reads
+//! opcodes and key names, and skips every value byte-for-byte using the
+//! length encoding embedded in the format. This keeps memory flat and lets a
+//! multi-gigabyte dump be analyzed at I/O speed through a `BufReader`.
+//!
+//! Key names are the one thing materialized, including decompressing an
+//! LZF-compressed key name — everything else (aggregate counts, ziplists,
+//! listpacks, scores, stream payloads) is skipped without allocation beyond
+//! a bounded scratch buffer.
+
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
+use std::fs::File;
+use std::io::{self, BufReader, Read};
+use std::path::Path;
+
+use dbflux_core::{
+    DumpAnalysisError, DumpAnalysisReport, DumpAnalyzer, DumpKeyEntry, DumpPrefixEntry,
+};
+
+const TOP_N_LARGEST_KEYS: usize = 500;
+const MAX_PREFIX_BUCKETS: usize = 10_000;
+const MAX_SHORT_KEY_AS_OWN_PREFIX: usize = 32;
+const MAX_KEY_NAME_BYTES: usize = 16 * 1024 * 1024;
+const PROGRESS_EVERY_ENTRIES: u64 = 4096;
+const PROGRESS_EVERY_BYTES: u64 = 4 * 1024 * 1024;
+
+const OPCODE_SLOT_INFO: u8 = 0xF4;
+const OPCODE_FUNCTION2: u8 = 0xF5;
+const OPCODE_FUNCTION_PRE_GA: u8 = 0xF6;
+const OPCODE_MODULE_AUX: u8 = 0xF7;
+const OPCODE_IDLE: u8 = 0xF8;
+const OPCODE_FREQ: u8 = 0xF9;
+const OPCODE_AUX: u8 = 0xFA;
+const OPCODE_RESIZEDB: u8 = 0xFB;
+const OPCODE_EXPIRETIME_MS: u8 = 0xFC;
+const OPCODE_EXPIRETIME: u8 = 0xFD;
+const OPCODE_SELECTDB: u8 = 0xFE;
+const OPCODE_EOF: u8 = 0xFF;
+
+/// Analyzes Redis RDB dump files without connecting to a live server.
+pub struct RdbAnalyzer;
+
+impl DumpAnalyzer for RdbAnalyzer {
+    fn display_name(&self) -> &'static str {
+        "Redis RDB"
+    }
+
+    fn file_extensions(&self) -> &'static [&'static str] {
+        &["rdb"]
+    }
+
+    fn size_caveat(&self) -> &'static str {
+        "Sizes reflect each key's serialized footprint in the RDB file, not its footprint in \
+         live Redis memory. Allocator overhead and Redis's in-memory encodings (ziplists, \
+         listpacks, hash tables) mean the two numbers diverge, sometimes significantly."
+    }
+
+    fn analyze(
+        &self,
+        path: &Path,
+        progress: &(dyn Fn(u64, Option<u64>) + Sync),
+        cancelled: &(dyn Fn() -> bool + Sync),
+    ) -> Result<DumpAnalysisReport, DumpAnalysisError> {
+        let file = File::open(path).map_err(|error| DumpAnalysisError::Io(error.to_string()))?;
+        let total_bytes = file.metadata().ok().map(|metadata| metadata.len());
+        let reader = BufReader::new(file);
+
+        analyze_reader(reader, total_bytes, progress, cancelled)
+    }
+}
+
+/// Parses an RDB byte stream, aggregating results with bounded memory.
+///
+/// Split out from `RdbAnalyzer::analyze` so tests can feed hand-built
+/// in-memory fixtures (`std::io::Cursor<Vec<u8>>`) without touching the
+/// filesystem.
+fn analyze_reader<R: Read>(
+    reader: R,
+    total_bytes: Option<u64>,
+    progress: &(dyn Fn(u64, Option<u64>) + Sync),
+    cancelled: &(dyn Fn() -> bool + Sync),
+) -> Result<DumpAnalysisReport, DumpAnalysisError> {
+    let mut reader = RdbReader::new(reader);
+    parse_header(&mut reader)?;
+
+    let mut aggregator = Aggregator::new();
+    let mut current_db: u32 = 0;
+    let mut pending_expire_ms: Option<i64> = None;
+    let mut entry_count: u64 = 0;
+    let mut last_progress_offset: u64 = 0;
+
+    loop {
+        if cancelled() {
+            return Err(DumpAnalysisError::Cancelled);
+        }
+
+        let entry_start = reader.offset();
+        let opcode = reader.read_u8()?;
+
+        match opcode {
+            OPCODE_EOF => {
+                reader.try_skip_checksum()?;
+                progress(reader.offset(), total_bytes);
+                return Ok(aggregator.into_report());
+            }
+            OPCODE_SELECTDB => {
+                current_db = reader.read_length()? as u32;
+            }
+            OPCODE_RESIZEDB => {
+                reader.read_length()?;
+                reader.read_length()?;
+            }
+            OPCODE_AUX => {
+                reader.skip_string()?;
+                reader.skip_string()?;
+            }
+            OPCODE_EXPIRETIME => {
+                let seconds = u32::from_le_bytes(reader.read_array::<4>()?);
+                pending_expire_ms = Some(i64::from(seconds) * 1000);
+            }
+            OPCODE_EXPIRETIME_MS => {
+                let millis = u64::from_le_bytes(reader.read_array::<8>()?);
+                pending_expire_ms = Some(millis as i64);
+            }
+            OPCODE_IDLE => {
+                reader.read_length()?;
+            }
+            OPCODE_FREQ => {
+                reader.read_u8()?;
+            }
+            OPCODE_MODULE_AUX | OPCODE_FUNCTION_PRE_GA | OPCODE_FUNCTION2 | OPCODE_SLOT_INFO => {
+                return Err(DumpAnalysisError::Format {
+                    offset: entry_start,
+                    message: format!("unsupported opcode 0x{opcode:02X} is not implemented"),
+                });
+            }
+            type_byte => {
+                let key_bytes = reader.read_string(MAX_KEY_NAME_BYTES)?;
+                skip_value(&mut reader, type_byte, entry_start)?;
+
+                let serialized_bytes = reader.offset() - entry_start;
+                aggregator.record(DumpKeyEntry {
+                    key: String::from_utf8_lossy(&key_bytes).into_owned(),
+                    type_name: type_name_for(type_byte),
+                    serialized_bytes,
+                    expires_at_ms: pending_expire_ms.take(),
+                    database: current_db,
+                });
+            }
+        }
+
+        entry_count += 1;
+        let should_report_by_count = entry_count.is_multiple_of(PROGRESS_EVERY_ENTRIES);
+        let should_report_by_bytes = reader.offset() - last_progress_offset >= PROGRESS_EVERY_BYTES;
+        if should_report_by_count || should_report_by_bytes {
+            progress(reader.offset(), total_bytes);
+            last_progress_offset = reader.offset();
+        }
+    }
+}
+
+fn parse_header<R: Read>(reader: &mut RdbReader<R>) -> Result<(), DumpAnalysisError> {
+    let header = reader.read_array::<9>()?;
+
+    if &header[..5] != b"REDIS" {
+        return Err(DumpAnalysisError::Format {
+            offset: 0,
+            message: "missing REDIS magic header".to_string(),
+        });
+    }
+
+    if !header[5..].iter().all(u8::is_ascii_digit) {
+        return Err(DumpAnalysisError::Format {
+            offset: 5,
+            message: "RDB version field is not ASCII digits".to_string(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Maps an RDB value-type byte to the coarse type name shown in the report.
+fn type_name_for(type_byte: u8) -> String {
+    match type_byte {
+        0 => "string",
+        1 | 10 | 14 | 18 => "list",
+        2 | 11 | 20 => "set",
+        3 | 5 | 12 | 17 => "zset",
+        4 | 9 | 13 | 16 => "hash",
+        15 | 19 | 21 => "stream",
+        other => return format!("unknown-0x{other:02X}"),
+    }
+    .to_string()
+}
+
+/// Skips the value payload for `type_byte`, advancing the reader without
+/// materializing any of it. `entry_start` is only used to point a `Format`
+/// error at the type byte that introduced the entry.
+fn skip_value<R: Read>(
+    reader: &mut RdbReader<R>,
+    type_byte: u8,
+    entry_start: u64,
+) -> Result<(), DumpAnalysisError> {
+    match type_byte {
+        0 => reader.skip_string()?,
+
+        1 | 2 => skip_string_list(reader, 1)?,
+        4 => skip_string_list(reader, 2)?,
+
+        3 => {
+            let count = reader.read_length()?;
+            for _ in 0..count {
+                reader.skip_string()?;
+                reader.skip_ascii_double()?;
+            }
+        }
+        5 => {
+            let count = reader.read_length()?;
+            for _ in 0..count {
+                reader.skip_string()?;
+                reader.skip(8)?;
+            }
+        }
+
+        9 | 10 | 11 | 12 | 13 | 16 | 17 | 20 => reader.skip_string()?,
+
+        14 => {
+            let node_count = reader.read_length()?;
+            for _ in 0..node_count {
+                reader.skip_string()?;
+            }
+        }
+        18 => {
+            let node_count = reader.read_length()?;
+            for _ in 0..node_count {
+                reader.read_length()?;
+                reader.skip_string()?;
+            }
+        }
+
+        15 | 19 | 21 => skip_stream(reader, type_byte)?,
+
+        other => {
+            return Err(DumpAnalysisError::Format {
+                offset: entry_start,
+                message: format!("unknown value type 0x{other:02X}"),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn skip_string_list<R: Read>(
+    reader: &mut RdbReader<R>,
+    strings_per_element: u64,
+) -> Result<(), DumpAnalysisError> {
+    let count = reader.read_length()?;
+    for _ in 0..(count * strings_per_element) {
+        reader.skip_string()?;
+    }
+    Ok(())
+}
+
+/// Skips an RDB stream value (types 15/19/21), which is otherwise-unrelated
+/// structural data rather than a single blob: listpack entries, stream
+/// metadata, consumer groups, and two flavors of PEL (pending entries list).
+///
+/// Types 19 and 21 (STREAM_LISTPACKS_2/_3) add extra length-encoded metadata
+/// fields over type 15, and type 21 additionally stores a per-consumer
+/// "active time" timestamp. None of this data is decoded — only its shape is
+/// walked so the reader ends up exactly at the start of the next opcode.
+fn skip_stream<R: Read>(reader: &mut RdbReader<R>, type_byte: u8) -> Result<(), DumpAnalysisError> {
+    let is_v2_or_v3 = type_byte != 15;
+
+    let listpack_count = reader.read_length()?;
+    for _ in 0..listpack_count {
+        reader.skip_string()?; // master stream ID, packed as a 16-byte string
+        reader.skip_string()?; // listpack blob
+    }
+
+    reader.read_length()?; // items count
+    reader.read_length()?; // last_id.ms
+    reader.read_length()?; // last_id.seq
+
+    if is_v2_or_v3 {
+        reader.read_length()?; // first_id.ms
+        reader.read_length()?; // first_id.seq
+        reader.read_length()?; // max_deleted_entry_id.ms
+        reader.read_length()?; // max_deleted_entry_id.seq
+        reader.read_length()?; // entries_added
+    }
+
+    let group_count = reader.read_length()?;
+    for _ in 0..group_count {
+        skip_stream_group(reader, type_byte, is_v2_or_v3)?;
+    }
+
+    Ok(())
+}
+
+fn skip_stream_group<R: Read>(
+    reader: &mut RdbReader<R>,
+    type_byte: u8,
+    is_v2_or_v3: bool,
+) -> Result<(), DumpAnalysisError> {
+    reader.skip_string()?; // group name
+    reader.read_length()?; // g_ms
+    reader.read_length()?; // g_seq
+    if is_v2_or_v3 {
+        reader.read_length()?; // entries_read
+    }
+
+    let global_pel_count = reader.read_length()?;
+    for _ in 0..global_pel_count {
+        reader.skip(16)?; // stream ID, raw (not length-encoded)
+        reader.skip(8)?; // delivery time ms, raw little-endian
+        reader.read_length()?; // delivery count
+    }
+
+    let consumer_count = reader.read_length()?;
+    for _ in 0..consumer_count {
+        reader.skip_string()?; // consumer name
+        reader.skip(8)?; // seen time ms, raw little-endian
+        if type_byte == 21 {
+            reader.skip(8)?; // active time ms, raw little-endian (v3 only)
+        }
+
+        let consumer_pel_count = reader.read_length()?;
+        for _ in 0..consumer_pel_count {
+            reader.skip(16)?; // stream ID only, raw (delivery info lives in the global PEL)
+        }
+    }
+
+    Ok(())
+}
+
+/// A length-or-encoding value read from the RDB length prefix.
+enum StringEncoding {
+    /// A plain byte length: the string that follows is exactly this many bytes.
+    Len(u64),
+    /// An 8-bit signed integer stored as a string.
+    Int8,
+    /// A 16-bit little-endian signed integer stored as a string.
+    Int16,
+    /// A 32-bit little-endian signed integer stored as a string.
+    Int32,
+    /// An LZF-compressed string.
+    Lzf,
+}
+
+/// Wraps a `Read` implementation with absolute byte-offset tracking.
+///
+/// Offset tracking uses only forward reads (never `Seek`), so it works
+/// uniformly over files, pipes, and in-memory cursors alike.
+struct RdbReader<R> {
+    inner: R,
+    offset: u64,
+}
+
+impl<R: Read> RdbReader<R> {
+    fn new(inner: R) -> Self {
+        Self { inner, offset: 0 }
+    }
+
+    fn offset(&self) -> u64 {
+        self.offset
+    }
+
+    fn map_io_error(&self, error: io::Error) -> DumpAnalysisError {
+        if error.kind() == io::ErrorKind::UnexpectedEof {
+            DumpAnalysisError::Format {
+                offset: self.offset,
+                message: "unexpected end of file".to_string(),
+            }
+        } else {
+            DumpAnalysisError::Io(error.to_string())
+        }
+    }
+
+    fn read_u8(&mut self) -> Result<u8, DumpAnalysisError> {
+        Ok(self.read_array::<1>()?[0])
+    }
+
+    fn read_array<const N: usize>(&mut self) -> Result<[u8; N], DumpAnalysisError> {
+        let mut buf = [0u8; N];
+        self.inner
+            .read_exact(&mut buf)
+            .map_err(|error| self.map_io_error(error))?;
+        self.offset += N as u64;
+        Ok(buf)
+    }
+
+    /// Discards `n` bytes from the stream without allocating a buffer of
+    /// that size, tracking the offset as it goes.
+    fn skip(&mut self, n: u64) -> Result<(), DumpAnalysisError> {
+        let copied = io::copy(&mut (&mut self.inner).take(n), &mut io::sink())
+            .map_err(|error| self.map_io_error(error))?;
+        self.offset += copied;
+
+        if copied != n {
+            return Err(DumpAnalysisError::Format {
+                offset: self.offset,
+                message: "unexpected end of file while skipping a value".to_string(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn try_skip_checksum(&mut self) -> Result<(), DumpAnalysisError> {
+        let mut buf = [0u8; 8];
+        match self.inner.read_exact(&mut buf) {
+            Ok(()) => {
+                self.offset += 8;
+                Ok(())
+            }
+            Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => Ok(()),
+            Err(error) => Err(DumpAnalysisError::Io(error.to_string())),
+        }
+    }
+
+    fn read_length_or_encoding(&mut self) -> Result<StringEncoding, DumpAnalysisError> {
+        let byte = self.read_u8()?;
+
+        match byte >> 6 {
+            0b00 => Ok(StringEncoding::Len(u64::from(byte & 0x3F))),
+            0b01 => {
+                let low = self.read_u8()?;
+                Ok(StringEncoding::Len(
+                    (u64::from(byte & 0x3F) << 8) | u64::from(low),
+                ))
+            }
+            0b10 if byte == 0x80 => {
+                let bytes = self.read_array::<4>()?;
+                Ok(StringEncoding::Len(u64::from(u32::from_be_bytes(bytes))))
+            }
+            0b10 if byte == 0x81 => {
+                let bytes = self.read_array::<8>()?;
+                Ok(StringEncoding::Len(u64::from_be_bytes(bytes)))
+            }
+            0b10 => Err(DumpAnalysisError::Format {
+                offset: self.offset - 1,
+                message: format!("unsupported length prefix 0x{byte:02X}"),
+            }),
+            _ => match byte & 0x3F {
+                0 => Ok(StringEncoding::Int8),
+                1 => Ok(StringEncoding::Int16),
+                2 => Ok(StringEncoding::Int32),
+                3 => Ok(StringEncoding::Lzf),
+                other => Err(DumpAnalysisError::Format {
+                    offset: self.offset - 1,
+                    message: format!("unsupported special string encoding {other}"),
+                }),
+            },
+        }
+    }
+
+    /// Reads a plain length prefix, used for counts, database numbers, and
+    /// other non-string integers. Returns an error if the prefix turns out
+    /// to be a special string encoding, which is never valid in these contexts.
+    fn read_length(&mut self) -> Result<u64, DumpAnalysisError> {
+        match self.read_length_or_encoding()? {
+            StringEncoding::Len(len) => Ok(len),
+            _ => Err(DumpAnalysisError::Format {
+                offset: self.offset,
+                message: "expected a plain length, found a special string encoding".to_string(),
+            }),
+        }
+    }
+
+    /// Advances past a string without materializing it. Never allocates a
+    /// buffer proportional to the string's length, so no length cap applies.
+    fn skip_string(&mut self) -> Result<(), DumpAnalysisError> {
+        match self.read_length_or_encoding()? {
+            StringEncoding::Len(len) => self.skip(len),
+            StringEncoding::Int8 => {
+                self.read_u8()?;
+                Ok(())
+            }
+            StringEncoding::Int16 => {
+                self.read_array::<2>()?;
+                Ok(())
+            }
+            StringEncoding::Int32 => {
+                self.read_array::<4>()?;
+                Ok(())
+            }
+            StringEncoding::Lzf => {
+                let compressed_len = self.read_length()?;
+                self.read_length()?;
+                self.skip(compressed_len)
+            }
+        }
+    }
+
+    fn read_string(&mut self, cap: usize) -> Result<Vec<u8>, DumpAnalysisError> {
+        match self.read_length_or_encoding()? {
+            StringEncoding::Len(len) => self.read_raw_bytes(len, cap),
+            StringEncoding::Int8 => {
+                let byte = self.read_u8()?;
+                Ok((byte as i8).to_string().into_bytes())
+            }
+            StringEncoding::Int16 => {
+                let bytes = self.read_array::<2>()?;
+                Ok(i16::from_le_bytes(bytes).to_string().into_bytes())
+            }
+            StringEncoding::Int32 => {
+                let bytes = self.read_array::<4>()?;
+                Ok(i32::from_le_bytes(bytes).to_string().into_bytes())
+            }
+            StringEncoding::Lzf => self.read_lzf_string(cap),
+        }
+    }
+
+    fn read_raw_bytes(&mut self, len: u64, cap: usize) -> Result<Vec<u8>, DumpAnalysisError> {
+        if len as usize > cap {
+            return Err(DumpAnalysisError::Format {
+                offset: self.offset,
+                message: format!("string length {len} exceeds the {cap}-byte cap"),
+            });
+        }
+
+        let mut buf = vec![0u8; len as usize];
+        self.inner
+            .read_exact(&mut buf)
+            .map_err(|error| self.map_io_error(error))?;
+        self.offset += len;
+        Ok(buf)
+    }
+
+    fn read_lzf_string(&mut self, cap: usize) -> Result<Vec<u8>, DumpAnalysisError> {
+        let compressed_len = self.read_length()?;
+        let uncompressed_len = self.read_length()?;
+
+        if uncompressed_len as usize > cap {
+            return Err(DumpAnalysisError::Format {
+                offset: self.offset,
+                message: format!(
+                    "LZF uncompressed length {uncompressed_len} exceeds the {cap}-byte cap"
+                ),
+            });
+        }
+
+        let compressed = self.read_raw_bytes(compressed_len, cap)?;
+
+        lzf_decompress(&compressed, uncompressed_len as usize, cap).map_err(|message| {
+            DumpAnalysisError::Format {
+                offset: self.offset,
+                message,
+            }
+        })
+    }
+
+    /// Skips one RDB-encoded double, used by the old (type 3) zset format.
+    ///
+    /// A leading length byte of 253/254/255 means NaN/+Infinity/-Infinity
+    /// with no further bytes; otherwise that many ASCII bytes follow.
+    fn skip_ascii_double(&mut self) -> Result<(), DumpAnalysisError> {
+        let len = self.read_u8()?;
+        match len {
+            253..=255 => Ok(()),
+            len => self.skip(u64::from(len)),
+        }
+    }
+}
+
+/// Decompresses an LZF-compressed byte stream.
+///
+/// Implements the liblzf algorithm: a control byte either starts a literal
+/// run (`ctrl < 32`, copy `ctrl + 1` raw bytes) or a back-reference
+/// (`ctrl >= 32`, copy `len + 2` bytes from `offset` bytes behind the
+/// current output position, where `len` and `offset` are packed across the
+/// control byte and the one or two bytes that follow it).
+fn lzf_decompress(input: &[u8], expected_len: usize, cap: usize) -> Result<Vec<u8>, String> {
+    if expected_len > cap {
+        return Err(format!(
+            "declared LZF length {expected_len} exceeds the {cap}-byte cap"
+        ));
+    }
+
+    let mut out: Vec<u8> = Vec::with_capacity(expected_len);
+    let mut pos = 0usize;
+
+    while pos < input.len() {
+        let ctrl = usize::from(*input.get(pos).ok_or("LZF control byte missing")?);
+        pos += 1;
+
+        if ctrl < 32 {
+            let len = ctrl + 1;
+            let end = pos
+                .checked_add(len)
+                .ok_or("LZF literal run length overflow")?;
+            let literal = input
+                .get(pos..end)
+                .ok_or("LZF literal run reads past end of compressed input")?;
+            if out.len() + literal.len() > cap {
+                return Err(format!("LZF output exceeds the {cap}-byte cap"));
+            }
+            out.extend_from_slice(literal);
+            pos = end;
+            continue;
+        }
+
+        let mut len = ctrl >> 5;
+        if len == 7 {
+            let extra = *input
+                .get(pos)
+                .ok_or("LZF back-reference length byte missing")?;
+            len += usize::from(extra);
+            pos += 1;
+        }
+
+        let offset_low = *input
+            .get(pos)
+            .ok_or("LZF back-reference offset byte missing")?;
+        pos += 1;
+
+        let offset = ((ctrl & 0x1F) << 8) + usize::from(offset_low) + 1;
+        if offset > out.len() {
+            return Err("LZF back-reference points before the start of the output".to_string());
+        }
+
+        let total_len = len + 2;
+        if out.len() + total_len > cap {
+            return Err(format!("LZF output exceeds the {cap}-byte cap"));
+        }
+
+        // Copies byte-by-byte (never a slice-range copy) because a back-reference
+        // may overlap the bytes it is still writing, which is how LZF encodes runs.
+        let start = out.len() - offset;
+        for ref_pos in start..start + total_len {
+            let byte = *out
+                .get(ref_pos)
+                .ok_or("LZF back-reference read out of bounds")?;
+            out.push(byte);
+        }
+    }
+
+    if out.len() != expected_len {
+        return Err(format!(
+            "LZF decompressed length {} does not match the declared length {expected_len}",
+            out.len()
+        ));
+    }
+
+    Ok(out)
+}
+
+/// Streaming aggregation state, bounded regardless of dump size.
+struct Aggregator {
+    total_keys: u64,
+    total_serialized_bytes: u64,
+    by_type: HashMap<String, (u64, u64)>,
+    largest_keys: BinaryHeap<Reverse<HeapEntry>>,
+    largest_keys_seq: u64,
+    prefixes: HashMap<String, (u64, u64)>,
+}
+
+/// Wraps a `DumpKeyEntry` with a monotonic sequence number so the bounded
+/// top-N heap has a total order even when two entries tie on size.
+struct HeapEntry {
+    serialized_bytes: u64,
+    sequence: u64,
+    entry: DumpKeyEntry,
+}
+
+impl PartialEq for HeapEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.serialized_bytes == other.serialized_bytes && self.sequence == other.sequence
+    }
+}
+
+impl Eq for HeapEntry {}
+
+impl PartialOrd for HeapEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for HeapEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.serialized_bytes
+            .cmp(&other.serialized_bytes)
+            .then(self.sequence.cmp(&other.sequence))
+    }
+}
+
+impl Aggregator {
+    fn new() -> Self {
+        Self {
+            total_keys: 0,
+            total_serialized_bytes: 0,
+            by_type: HashMap::new(),
+            largest_keys: BinaryHeap::new(),
+            largest_keys_seq: 0,
+            prefixes: HashMap::new(),
+        }
+    }
+
+    fn record(&mut self, entry: DumpKeyEntry) {
+        self.total_keys += 1;
+        self.total_serialized_bytes += entry.serialized_bytes;
+
+        let type_totals = self
+            .by_type
+            .entry(entry.type_name.clone())
+            .or_insert((0, 0));
+        type_totals.0 += 1;
+        type_totals.1 += entry.serialized_bytes;
+
+        self.record_prefix(&entry.key, entry.serialized_bytes);
+        self.record_top_n(entry);
+    }
+
+    fn record_prefix(&mut self, key: &str, serialized_bytes: u64) {
+        let prefix = prefix_bucket_for(key);
+        let overflowed =
+            self.prefixes.len() >= MAX_PREFIX_BUCKETS && !self.prefixes.contains_key(&prefix);
+        let bucket = if overflowed {
+            "(other)".to_string()
+        } else {
+            prefix
+        };
+
+        let totals = self.prefixes.entry(bucket).or_insert((0, 0));
+        totals.0 += 1;
+        totals.1 += serialized_bytes;
+    }
+
+    fn record_top_n(&mut self, entry: DumpKeyEntry) {
+        self.largest_keys_seq += 1;
+        let candidate = HeapEntry {
+            serialized_bytes: entry.serialized_bytes,
+            sequence: self.largest_keys_seq,
+            entry,
+        };
+
+        if self.largest_keys.len() < TOP_N_LARGEST_KEYS {
+            self.largest_keys.push(Reverse(candidate));
+            return;
+        }
+
+        let should_replace = self.largest_keys.peek().is_some_and(|Reverse(smallest)| {
+            candidate.serialized_bytes > smallest.serialized_bytes
+        });
+
+        if should_replace {
+            self.largest_keys.pop();
+            self.largest_keys.push(Reverse(candidate));
+        }
+    }
+
+    /// Consumes the aggregator into the final bounded report.
+    ///
+    /// `BinaryHeap::into_sorted_vec` sorts `Reverse<HeapEntry>` ascending,
+    /// which is descending order for the wrapped `HeapEntry` — exactly the
+    /// "largest first" order the report requires.
+    fn into_report(self) -> DumpAnalysisReport {
+        let mut keys_by_type: Vec<(String, u64, u64)> = self
+            .by_type
+            .into_iter()
+            .map(|(type_name, (count, bytes))| (type_name, count, bytes))
+            .collect();
+        keys_by_type.sort_by_key(|(_, _, bytes)| Reverse(*bytes));
+
+        let largest_keys: Vec<DumpKeyEntry> = self
+            .largest_keys
+            .into_sorted_vec()
+            .into_iter()
+            .map(|Reverse(heap_entry)| heap_entry.entry)
+            .collect();
+
+        let mut prefix_rollup: Vec<DumpPrefixEntry> = self
+            .prefixes
+            .into_iter()
+            .map(|(prefix, (key_count, serialized_bytes))| DumpPrefixEntry {
+                prefix,
+                key_count,
+                serialized_bytes,
+            })
+            .collect();
+        prefix_rollup.sort_by_key(|entry| Reverse(entry.serialized_bytes));
+
+        DumpAnalysisReport {
+            total_keys: self.total_keys,
+            total_serialized_bytes: self.total_serialized_bytes,
+            keys_by_type,
+            largest_keys,
+            prefix_rollup,
+        }
+    }
+}
+
+/// Computes the prefix bucket for a key name.
+///
+/// Splits on the first occurrence of any of `: / . |`, keeping the
+/// separator as part of the bucket. Keys with no separator bucket under
+/// their own full name when short (`<= 32` bytes), otherwise under
+/// `"(no prefix)"`.
+fn prefix_bucket_for(key: &str) -> String {
+    match key.find([':', '/', '.', '|']) {
+        Some(index) => key[..=index].to_string(),
+        None if key.len() <= MAX_SHORT_KEY_AS_OWN_PREFIX => key.to_string(),
+        None => "(no prefix)".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn no_progress(_bytes_read: u64, _total: Option<u64>) {}
+    fn never_cancelled() -> bool {
+        false
+    }
+
+    fn analyze_bytes(bytes: Vec<u8>) -> Result<DumpAnalysisReport, DumpAnalysisError> {
+        analyze_reader(Cursor::new(bytes), None, &no_progress, &never_cancelled)
+    }
+
+    fn header() -> Vec<u8> {
+        b"REDIS0011".to_vec()
+    }
+
+    /// Plain (non-special) length encoding for values `0..=0x3FFF`.
+    fn encode_length(len: u64) -> Vec<u8> {
+        if len < 64 {
+            vec![len as u8]
+        } else if len < 16384 {
+            vec![0x40 | ((len >> 8) as u8), (len & 0xFF) as u8]
+        } else {
+            let mut out = vec![0x80];
+            out.extend_from_slice(&(len as u32).to_be_bytes());
+            out
+        }
+    }
+
+    fn encode_raw_string(bytes: &[u8]) -> Vec<u8> {
+        let mut out = encode_length(bytes.len() as u64);
+        out.extend_from_slice(bytes);
+        out
+    }
+
+    #[test]
+    fn parses_a_minimal_dump_with_one_string_key() {
+        let mut bytes = header();
+        bytes.push(0); // string type
+        bytes.extend(encode_raw_string(b"greeting"));
+        bytes.extend(encode_raw_string(b"hello"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("valid dump must parse");
+
+        assert_eq!(report.total_keys, 1);
+        assert_eq!(
+            report.keys_by_type,
+            vec![("string".to_string(), 1, report.total_serialized_bytes)]
+        );
+        assert_eq!(report.largest_keys.len(), 1);
+        assert_eq!(report.largest_keys[0].key, "greeting");
+        assert_eq!(report.largest_keys[0].type_name, "string");
+        assert_eq!(report.largest_keys[0].database, 0);
+        assert_eq!(report.largest_keys[0].expires_at_ms, None);
+    }
+
+    #[test]
+    fn parses_old_list_type() {
+        let mut bytes = header();
+        bytes.push(1); // list
+        bytes.extend(encode_raw_string(b"mylist"));
+        bytes.extend(encode_length(2)); // 2 elements
+        bytes.extend(encode_raw_string(b"a"));
+        bytes.extend(encode_raw_string(b"b"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("list dump must parse");
+        assert_eq!(report.total_keys, 1);
+        assert_eq!(report.largest_keys[0].type_name, "list");
+    }
+
+    #[test]
+    fn parses_old_set_type() {
+        let mut bytes = header();
+        bytes.push(2); // set
+        bytes.extend(encode_raw_string(b"myset"));
+        bytes.extend(encode_length(2));
+        bytes.extend(encode_raw_string(b"a"));
+        bytes.extend(encode_raw_string(b"b"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("set dump must parse");
+        assert_eq!(report.largest_keys[0].type_name, "set");
+    }
+
+    #[test]
+    fn parses_old_hash_type() {
+        let mut bytes = header();
+        bytes.push(4); // hash
+        bytes.extend(encode_raw_string(b"myhash"));
+        bytes.extend(encode_length(1)); // 1 field/value pair -> 2 strings
+        bytes.extend(encode_raw_string(b"field"));
+        bytes.extend(encode_raw_string(b"value"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("hash dump must parse");
+        assert_eq!(report.largest_keys[0].type_name, "hash");
+    }
+
+    #[test]
+    fn parses_old_zset_type_with_ascii_scores() {
+        let mut bytes = header();
+        bytes.push(3); // zset (old)
+        bytes.extend(encode_raw_string(b"myzset"));
+        bytes.extend(encode_length(1));
+        bytes.extend(encode_raw_string(b"member"));
+        let score = b"1.5";
+        bytes.push(score.len() as u8);
+        bytes.extend_from_slice(score);
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("zset dump must parse");
+        assert_eq!(report.largest_keys[0].type_name, "zset");
+    }
+
+    #[test]
+    fn parses_zset2_type_with_binary_double() {
+        let mut bytes = header();
+        bytes.push(5); // zset_2
+        bytes.extend(encode_raw_string(b"myzset2"));
+        bytes.extend(encode_length(1));
+        bytes.extend(encode_raw_string(b"member"));
+        bytes.extend_from_slice(&1.5f64.to_le_bytes());
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("zset_2 dump must parse");
+        assert_eq!(report.largest_keys[0].type_name, "zset");
+    }
+
+    #[test]
+    fn parses_a_ziplist_blob_variant_as_a_single_string() {
+        let mut bytes = header();
+        bytes.push(10); // list encoded as ziplist blob
+        bytes.extend(encode_raw_string(b"mylist_zl"));
+        bytes.extend(encode_raw_string(b"fake-ziplist-bytes"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("ziplist-blob dump must parse");
+        assert_eq!(report.largest_keys[0].type_name, "list");
+    }
+
+    #[test]
+    fn parses_quicklist_as_n_string_nodes() {
+        let mut bytes = header();
+        bytes.push(14); // quicklist
+        bytes.extend(encode_raw_string(b"myquicklist"));
+        bytes.extend(encode_length(2)); // 2 nodes
+        bytes.extend(encode_raw_string(b"node-ziplist-1"));
+        bytes.extend(encode_raw_string(b"node-ziplist-2"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("quicklist dump must parse");
+        assert_eq!(report.largest_keys[0].type_name, "list");
+    }
+
+    #[test]
+    fn parses_quicklist2_with_per_node_container_flag() {
+        let mut bytes = header();
+        bytes.push(18); // quicklist2
+        bytes.extend(encode_raw_string(b"myquicklist2"));
+        bytes.extend(encode_length(1)); // 1 node
+        bytes.extend(encode_length(2)); // container flag (PACKED)
+        bytes.extend(encode_raw_string(b"node-listpack"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("quicklist2 dump must parse");
+        assert_eq!(report.largest_keys[0].type_name, "list");
+    }
+
+    #[test]
+    fn records_expiretime_ms_on_the_following_key() {
+        let mut bytes = header();
+        bytes.push(OPCODE_EXPIRETIME_MS);
+        bytes.extend_from_slice(&1_700_000_000_000u64.to_le_bytes());
+        bytes.push(0); // string
+        bytes.extend(encode_raw_string(b"expiring"));
+        bytes.extend(encode_raw_string(b"value"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("dump with expiry must parse");
+        assert_eq!(
+            report.largest_keys[0].expires_at_ms,
+            Some(1_700_000_000_000)
+        );
+    }
+
+    #[test]
+    fn records_expiretime_seconds_on_the_following_key() {
+        let mut bytes = header();
+        bytes.push(OPCODE_EXPIRETIME);
+        bytes.extend_from_slice(&1_700_000_000u32.to_le_bytes());
+        bytes.push(0);
+        bytes.extend(encode_raw_string(b"expiring"));
+        bytes.extend(encode_raw_string(b"value"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("dump with expiry must parse");
+        assert_eq!(
+            report.largest_keys[0].expires_at_ms,
+            Some(1_700_000_000_000)
+        );
+    }
+
+    #[test]
+    fn decodes_an_lzf_compressed_key_name() {
+        // "aaaaaaaaaa" (10 bytes) encoded as: literal 'a' + back-reference of 9 more.
+        let compressed: Vec<u8> = vec![0x00, b'a', 0xE0, 0x00, 0x00];
+        let uncompressed = b"aaaaaaaaaa";
+        assert_eq!(
+            lzf_decompress(&compressed, uncompressed.len(), 1024).expect("must decompress"),
+            uncompressed
+        );
+
+        let mut bytes = header();
+        bytes.push(0); // string
+        // Special-encoding LZF string: ctrl byte 0xC3 (0b11 000011 -> encoding 3 = LZF).
+        bytes.push(0xC3);
+        bytes.extend(encode_length(compressed.len() as u64)); // compressed length
+        bytes.extend(encode_length(uncompressed.len() as u64)); // uncompressed length
+        bytes.extend_from_slice(&compressed);
+        bytes.extend(encode_raw_string(b"value"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("dump with LZF key name must parse");
+        assert_eq!(report.largest_keys[0].key, "aaaaaaaaaa");
+    }
+
+    #[test]
+    fn switches_database_on_selectdb() {
+        let mut bytes = header();
+        bytes.push(OPCODE_SELECTDB);
+        bytes.extend(encode_length(3));
+        bytes.push(0);
+        bytes.extend(encode_raw_string(b"key-in-db-3"));
+        bytes.extend(encode_raw_string(b"value"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("dump with SELECTDB must parse");
+        assert_eq!(report.largest_keys[0].database, 3);
+    }
+
+    #[test]
+    fn skips_aux_fields() {
+        let mut bytes = header();
+        bytes.push(OPCODE_AUX);
+        bytes.extend(encode_raw_string(b"redis-ver"));
+        bytes.extend(encode_raw_string(b"7.2.0"));
+        bytes.push(0);
+        bytes.extend(encode_raw_string(b"key"));
+        bytes.extend(encode_raw_string(b"value"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("dump with AUX must parse");
+        assert_eq!(report.total_keys, 1);
+    }
+
+    #[test]
+    fn unknown_value_type_returns_format_error_with_offset() {
+        let mut bytes = header();
+        let type_byte_offset = bytes.len() as u64;
+        bytes.push(200); // not a recognized value type
+        bytes.extend(encode_raw_string(b"key"));
+        bytes.push(OPCODE_EOF);
+
+        match analyze_bytes(bytes) {
+            Err(DumpAnalysisError::Format { offset, message }) => {
+                assert_eq!(offset, type_byte_offset);
+                assert!(message.contains("0xC8"), "message was: {message}");
+            }
+            other => panic!("expected a Format error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_a_stream_v1_with_one_listpack_and_no_groups() {
+        let mut bytes = header();
+        bytes.push(15); // STREAM_LISTPACKS
+        bytes.extend(encode_raw_string(b"mystream-v1"));
+        bytes.extend(encode_length(1)); // one listpack
+        bytes.extend(encode_raw_string(&[0xAA; 16])); // master stream ID
+        bytes.extend(encode_raw_string(b"fake-listpack-blob"));
+        bytes.extend(encode_length(1)); // items count
+        bytes.extend(encode_length(1000)); // last_id.ms
+        bytes.extend(encode_length(0)); // last_id.seq
+        bytes.extend(encode_length(0)); // no consumer groups
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("stream v1 dump must parse");
+        assert_eq!(report.total_keys, 1);
+        assert_eq!(report.largest_keys[0].type_name, "stream");
+        assert_eq!(report.largest_keys[0].key, "mystream-v1");
+    }
+
+    #[test]
+    fn parses_a_stream_v2_with_a_group_and_pending_entries() {
+        let mut bytes = header();
+        bytes.push(19); // STREAM_LISTPACKS_2
+        bytes.extend(encode_raw_string(b"mystream-v2"));
+        bytes.extend(encode_length(1)); // one listpack
+        bytes.extend(encode_raw_string(&[0xAA; 16]));
+        bytes.extend(encode_raw_string(b"fake-listpack-blob"));
+        bytes.extend(encode_length(1)); // items count
+        bytes.extend(encode_length(1000)); // last_id.ms
+        bytes.extend(encode_length(0)); // last_id.seq
+        bytes.extend(encode_length(500)); // first_id.ms
+        bytes.extend(encode_length(0)); // first_id.seq
+        bytes.extend(encode_length(0)); // max_deleted_entry_id.ms
+        bytes.extend(encode_length(0)); // max_deleted_entry_id.seq
+        bytes.extend(encode_length(1)); // entries_added
+        bytes.extend(encode_length(1)); // one consumer group
+        bytes.extend(encode_raw_string(b"mygroup"));
+        bytes.extend(encode_length(1000)); // g_ms
+        bytes.extend(encode_length(0)); // g_seq
+        bytes.extend(encode_length(1)); // entries_read (v2+)
+        bytes.extend(encode_length(1)); // one global PEL entry
+        bytes.extend_from_slice(&[0xBB; 16]); // stream ID, raw
+        bytes.extend_from_slice(&1_700_000_000_000u64.to_le_bytes()); // delivery time, raw
+        bytes.extend(encode_length(1)); // delivery count
+        bytes.extend(encode_length(1)); // one consumer
+        bytes.extend(encode_raw_string(b"consumer-1"));
+        bytes.extend_from_slice(&1_700_000_000_000u64.to_le_bytes()); // seen time, raw
+        bytes.extend(encode_length(1)); // one consumer PEL entry
+        bytes.extend_from_slice(&[0xCC; 16]); // stream ID only, raw
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("stream v2 dump must parse");
+        assert_eq!(report.total_keys, 1);
+        assert_eq!(report.largest_keys[0].type_name, "stream");
+        assert_eq!(report.largest_keys[0].key, "mystream-v2");
+    }
+
+    #[test]
+    fn parses_a_stream_v3_with_consumer_active_time() {
+        let mut bytes = header();
+        bytes.push(21); // STREAM_LISTPACKS_3
+        bytes.extend(encode_raw_string(b"mystream-v3"));
+        bytes.extend(encode_length(1));
+        bytes.extend(encode_raw_string(&[0xAA; 16]));
+        bytes.extend(encode_raw_string(b"fake-listpack-blob"));
+        bytes.extend(encode_length(1)); // items count
+        bytes.extend(encode_length(1000)); // last_id.ms
+        bytes.extend(encode_length(0)); // last_id.seq
+        bytes.extend(encode_length(500)); // first_id.ms
+        bytes.extend(encode_length(0)); // first_id.seq
+        bytes.extend(encode_length(0)); // max_deleted_entry_id.ms
+        bytes.extend(encode_length(0)); // max_deleted_entry_id.seq
+        bytes.extend(encode_length(1)); // entries_added
+        bytes.extend(encode_length(1)); // one consumer group
+        bytes.extend(encode_raw_string(b"mygroup"));
+        bytes.extend(encode_length(1000)); // g_ms
+        bytes.extend(encode_length(0)); // g_seq
+        bytes.extend(encode_length(1)); // entries_read
+        bytes.extend(encode_length(1)); // one global PEL entry
+        bytes.extend_from_slice(&[0xBB; 16]);
+        bytes.extend_from_slice(&1_700_000_000_000u64.to_le_bytes());
+        bytes.extend(encode_length(1)); // delivery count
+        bytes.extend(encode_length(1)); // one consumer
+        bytes.extend(encode_raw_string(b"consumer-1"));
+        bytes.extend_from_slice(&1_700_000_000_000u64.to_le_bytes()); // seen time, raw
+        bytes.extend_from_slice(&1_700_000_001_000u64.to_le_bytes()); // active time, raw (v3 only)
+        bytes.extend(encode_length(1)); // one consumer PEL entry
+        bytes.extend_from_slice(&[0xCC; 16]);
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("stream v3 dump must parse");
+        assert_eq!(report.total_keys, 1);
+        assert_eq!(report.largest_keys[0].type_name, "stream");
+        assert_eq!(report.largest_keys[0].key, "mystream-v3");
+    }
+
+    #[test]
+    fn truncated_stream_mid_pel_returns_an_error_not_a_panic() {
+        let mut bytes = header();
+        bytes.push(15); // STREAM_LISTPACKS
+        bytes.extend(encode_raw_string(b"mystream-truncated"));
+        bytes.extend(encode_length(0)); // no listpacks
+        bytes.extend(encode_length(0)); // items count
+        bytes.extend(encode_length(0)); // last_id.ms
+        bytes.extend(encode_length(0)); // last_id.seq
+        bytes.extend(encode_length(1)); // one consumer group
+        bytes.extend(encode_raw_string(b"mygroup"));
+        bytes.extend(encode_length(0)); // g_ms
+        bytes.extend(encode_length(0)); // g_seq
+        bytes.extend(encode_length(1)); // one global PEL entry
+        bytes.extend_from_slice(&[0xBB; 10]); // truncated: only 10 of the 16 raw ID bytes
+
+        let result = analyze_bytes(bytes);
+        assert!(
+            result.is_err(),
+            "truncated stream PEL must error, not panic"
+        );
+    }
+
+    #[test]
+    fn mixed_dump_aggregates_stream_and_string_keys() {
+        let mut bytes = header();
+        bytes.push(15); // STREAM_LISTPACKS
+        bytes.extend(encode_raw_string(b"mystream"));
+        bytes.extend(encode_length(0)); // no listpacks
+        bytes.extend(encode_length(0)); // items count
+        bytes.extend(encode_length(0)); // last_id.ms
+        bytes.extend(encode_length(0)); // last_id.seq
+        bytes.extend(encode_length(0)); // no consumer groups
+
+        bytes.push(0); // string
+        bytes.extend(encode_raw_string(b"mystring"));
+        bytes.extend(encode_raw_string(b"value"));
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("mixed dump must parse");
+        assert_eq!(report.total_keys, 2);
+
+        let type_names: Vec<&str> = report
+            .keys_by_type
+            .iter()
+            .map(|(type_name, _, _)| type_name.as_str())
+            .collect();
+        assert!(type_names.contains(&"stream"));
+        assert!(type_names.contains(&"string"));
+    }
+
+    #[test]
+    fn truncated_file_mid_value_returns_an_error_not_a_panic() {
+        let mut bytes = header();
+        bytes.push(0); // string
+        bytes.extend(encode_raw_string(b"key"));
+        bytes.extend(encode_length(100)); // claims 100 bytes but the file ends here
+
+        let result = analyze_bytes(bytes);
+        assert!(result.is_err(), "truncated file must error, not panic");
+    }
+
+    #[test]
+    fn invalid_magic_header_returns_format_error_at_offset_zero() {
+        let bytes = b"NOTREDIS1".to_vec();
+        match analyze_bytes(bytes) {
+            Err(DumpAnalysisError::Format { offset, .. }) => assert_eq!(offset, 0),
+            other => panic!("expected a Format error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prefix_rollup_groups_by_first_separator() {
+        let mut bytes = header();
+        for key in ["user:1", "user:2", "session/abc", "no-separator-but-short"] {
+            bytes.push(0);
+            bytes.extend(encode_raw_string(key.as_bytes()));
+            bytes.extend(encode_raw_string(b"v"));
+        }
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("dump must parse");
+        let user_bucket = report
+            .prefix_rollup
+            .iter()
+            .find(|entry| entry.prefix == "user:")
+            .expect("user: bucket must exist");
+        assert_eq!(user_bucket.key_count, 2);
+
+        assert!(
+            report
+                .prefix_rollup
+                .iter()
+                .any(|entry| entry.prefix == "session/")
+        );
+        assert!(
+            report
+                .prefix_rollup
+                .iter()
+                .any(|entry| entry.prefix == "no-separator-but-short")
+        );
+    }
+
+    #[test]
+    fn long_key_without_separator_buckets_under_no_prefix() {
+        let long_key = "x".repeat(64);
+        assert_eq!(prefix_bucket_for(&long_key), "(no prefix)");
+    }
+
+    #[test]
+    fn top_n_largest_keys_is_bounded_and_sorted_descending() {
+        let mut bytes = header();
+        // One more key than the cap, with strictly increasing value sizes so
+        // the smallest one must be evicted from the bounded heap.
+        for i in 0..(TOP_N_LARGEST_KEYS + 1) {
+            bytes.push(0);
+            bytes.extend(encode_raw_string(format!("key-{i}").as_bytes()));
+            bytes.extend(encode_raw_string(&vec![b'v'; i + 1]));
+        }
+        bytes.push(OPCODE_EOF);
+
+        let report = analyze_bytes(bytes).expect("dump must parse");
+        assert_eq!(report.largest_keys.len(), TOP_N_LARGEST_KEYS);
+        assert_eq!(report.total_keys, (TOP_N_LARGEST_KEYS + 1) as u64);
+
+        let sizes: Vec<u64> = report
+            .largest_keys
+            .iter()
+            .map(|entry| entry.serialized_bytes)
+            .collect();
+        let mut sorted = sizes.clone();
+        sorted.sort_unstable_by(|a, b| b.cmp(a));
+        assert_eq!(sizes, sorted, "largest_keys must be sorted descending");
+
+        // The very first key (smallest value) must have been evicted.
+        assert!(!report.largest_keys.iter().any(|entry| entry.key == "key-0"));
+    }
+
+    #[test]
+    fn cancellation_mid_parse_returns_cancelled() {
+        let mut bytes = header();
+        for i in 0..10 {
+            bytes.push(0);
+            bytes.extend(encode_raw_string(format!("key-{i}").as_bytes()));
+            bytes.extend(encode_raw_string(b"v"));
+        }
+        bytes.push(OPCODE_EOF);
+
+        let calls = AtomicU32::new(0);
+        let cancelled = || calls.fetch_add(1, Ordering::SeqCst) > 2;
+
+        let result = analyze_reader(Cursor::new(bytes), None, &no_progress, &cancelled);
+        assert!(matches!(result, Err(DumpAnalysisError::Cancelled)));
+    }
+
+    mod lzf {
+        use super::lzf_decompress;
+
+        #[test]
+        fn decompresses_pure_literal_runs() {
+            // Two literal runs: "hello" (5 bytes) and "world" (5 bytes).
+            let compressed = vec![
+                4, b'h', b'e', b'l', b'l', b'o', 4, b'w', b'o', b'r', b'l', b'd',
+            ];
+            let out = lzf_decompress(&compressed, 10, 1024).expect("must decompress");
+            assert_eq!(out, b"helloworld");
+        }
+
+        #[test]
+        fn decompresses_a_back_reference() {
+            // literal 'a', then a back-reference copying 9 more 'a's.
+            let compressed = vec![0x00, b'a', 0xE0, 0x00, 0x00];
+            let out = lzf_decompress(&compressed, 10, 1024).expect("must decompress");
+            assert_eq!(out, b"aaaaaaaaaa");
+        }
+
+        #[test]
+        fn rejects_declared_length_larger_than_cap() {
+            let compressed = vec![0x00, b'a'];
+            let result = lzf_decompress(&compressed, 1, 0);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn rejects_back_reference_before_start_of_output() {
+            // A back-reference control byte with no prior literal output.
+            let compressed = vec![0xE0, 0x00, 0x00];
+            let result = lzf_decompress(&compressed, 9, 1024);
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn rejects_mismatched_declared_length() {
+            let compressed = vec![4, b'h', b'e', b'l', b'l'];
+            let result = lzf_decompress(&compressed, 100, 1024);
+            assert!(result.is_err());
+        }
+    }
+}

--- a/crates/dbflux_driver_redis/tests/live_rdb.rs
+++ b/crates/dbflux_driver_redis/tests/live_rdb.rs
@@ -1,0 +1,246 @@
+//! Live Docker-backed test proving `RdbAnalyzer` handles a dump.rdb file
+//! actually produced by a real Redis server, closing the gap left by the
+//! hand-built fixtures in `rdb.rs`'s unit tests.
+//!
+//! The dump is retrieved via `docker exec cat` rather than a host bind
+//! mount: the official `redis` image declares `/data` as an anonymous
+//! `VOLUME`, and under a rootless container runtime that volume's ownership
+//! is mapped through a subordinate UID/GID range the host user may not have
+//! configured, which makes bind-mounting or reading it directly from the
+//! host fail. Executing `cat` inside the container's own user namespace
+//! sidesteps that entirely.
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing,
+    clippy::result_large_err
+)]
+
+use dbflux_core::{
+    ConnectionProfile, DbConfig, DbDriver, DbError, DumpAnalyzer, HashSetRequest, KeyExpireRequest,
+    KeySetRequest, ListEnd, ListPushRequest, QueryRequest, SetAddRequest, StreamAddRequest,
+    StreamEntryId, ValueRepr, ZSetAddRequest,
+};
+use dbflux_driver_redis::{RdbAnalyzer, RedisDriver};
+use dbflux_test_support::containers;
+use std::io::Write;
+use std::time::Duration;
+use testcontainers::core::ExecCommand;
+use testcontainers::{Container, GenericImage};
+
+fn connect_redis(uri: String) -> Result<Box<dyn dbflux_core::Connection>, DbError> {
+    let driver = RedisDriver::new();
+    let profile = ConnectionProfile::new(
+        "live-redis-rdb",
+        DbConfig::Redis {
+            use_uri: true,
+            uri: Some(uri),
+            host: String::new(),
+            port: 6379,
+            user: None,
+            database: Some(0),
+            tls: false,
+            ssl_mode: None,
+            ssl_root_cert_path: None,
+            ssl_client_cert_path: None,
+            ssl_client_key_path: None,
+            ssh_tunnel: None,
+            ssh_tunnel_profile_id: None,
+            topology: None,
+            sentinel_master_name: None,
+            additional_nodes: None,
+        },
+    );
+
+    let connection =
+        containers::retry_db_operation(Duration::from_secs(30), || -> Result<_, DbError> {
+            let connection = driver.connect(&profile)?;
+            connection.ping()?;
+            Ok(connection)
+        })?;
+
+    Ok(connection)
+}
+
+/// Copies `/data/dump.rdb` out of the container's own filesystem via
+/// `docker exec cat` and writes it to a fresh temp file on the host.
+fn fetch_dump_rdb(container: &Container<GenericImage>) -> tempfile::NamedTempFile {
+    let mut exec_result = container
+        .exec(ExecCommand::new(["cat", "/data/dump.rdb"]))
+        .expect("exec cat dump.rdb should succeed");
+    let bytes = exec_result
+        .stdout_to_vec()
+        .expect("reading dump.rdb bytes from exec stdout should succeed");
+    assert!(!bytes.is_empty(), "dump.rdb must not be empty after SAVE");
+
+    let mut file = tempfile::NamedTempFile::new().expect("creating host temp file should succeed");
+    file.write_all(&bytes)
+        .expect("writing dump.rdb bytes to temp file should succeed");
+    file.flush()
+        .expect("flushing temp dump file should succeed");
+
+    file
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn rdb_analyzer_matches_real_redis_produced_dump() -> Result<(), DbError> {
+    containers::with_redis_container(|uri, container| -> Result<(), DbError> {
+        let connection = connect_redis(uri)?;
+        let kv = connection
+            .key_value_api()
+            .expect("Redis should have KV API");
+
+        // One key of every type, including a prefix that repeats so the
+        // prefix-rollup aggregation has something to group.
+        kv.set_key(
+            &KeySetRequest::new("fixture:a", b"plain-string".to_vec()).with_repr(ValueRepr::Text),
+        )?;
+
+        kv.set_key(
+            &KeySetRequest::new("fixture:b", b"expiring-string".to_vec())
+                .with_repr(ValueRepr::Text),
+        )?;
+        kv.expire_key(&KeyExpireRequest::new("fixture:b", 3600))?;
+
+        kv.hash_set(&HashSetRequest {
+            key: "fixture:hash".to_string(),
+            fields: vec![
+                ("field1".to_string(), "value1".to_string()),
+                ("field2".to_string(), "value2".to_string()),
+            ],
+            keyspace: None,
+        })?;
+
+        kv.list_push(&ListPushRequest {
+            key: "fixture:list".to_string(),
+            values: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            end: ListEnd::Tail,
+            keyspace: None,
+        })?;
+
+        kv.set_add(&SetAddRequest {
+            key: "fixture:set".to_string(),
+            members: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            keyspace: None,
+        })?;
+
+        kv.zset_add(&ZSetAddRequest {
+            key: "fixture:zset".to_string(),
+            members: vec![
+                ("alice".to_string(), 100.0),
+                ("bob".to_string(), 200.0),
+                ("charlie".to_string(), 150.0),
+            ],
+            keyspace: None,
+        })?;
+
+        kv.stream_add(&StreamAddRequest {
+            key: "fixture:stream".to_string(),
+            id: StreamEntryId::Auto,
+            fields: vec![("field1".to_string(), "value1".to_string())],
+            maxlen: None,
+            keyspace: None,
+        })?;
+
+        // Create a consumer group and read through it so the stream carries
+        // a pending-entries list (PEL) in the dump, exercising the v2/v3
+        // stream-with-consumer-groups skipping path against real output.
+        connection.execute(&QueryRequest::new(
+            "XGROUP CREATE fixture:stream fixture-group 0",
+        ))?;
+        connection.execute(&QueryRequest::new(
+            "XREADGROUP GROUP fixture-group fixture-consumer COUNT 1 STREAMS fixture:stream >",
+        ))?;
+
+        // SAVE (not BGSAVE) so dump.rdb is guaranteed complete and current
+        // by the time this call returns.
+        connection.execute(&QueryRequest::new("SAVE"))?;
+
+        let dump_file = fetch_dump_rdb(container);
+
+        let report = RdbAnalyzer
+            .analyze(dump_file.path(), &|_bytes_read, _total| {}, &|| false)
+            .expect("analyzing a real Redis-produced dump.rdb must succeed");
+
+        let seeded_keys = [
+            "fixture:a",
+            "fixture:b",
+            "fixture:hash",
+            "fixture:list",
+            "fixture:set",
+            "fixture:zset",
+            "fixture:stream",
+        ];
+
+        assert_eq!(report.total_keys, seeded_keys.len() as u64);
+
+        let largest_key_names: Vec<&str> = report
+            .largest_keys
+            .iter()
+            .map(|entry| entry.key.as_str())
+            .collect();
+        for key in seeded_keys {
+            assert!(
+                largest_key_names.contains(&key),
+                "expected {key} in largest_keys, got {largest_key_names:?}"
+            );
+        }
+
+        let types_by_key: std::collections::HashMap<&str, &str> = report
+            .largest_keys
+            .iter()
+            .map(|entry| (entry.key.as_str(), entry.type_name.as_str()))
+            .collect();
+        assert_eq!(types_by_key.get("fixture:a"), Some(&"string"));
+        assert_eq!(types_by_key.get("fixture:b"), Some(&"string"));
+        assert_eq!(types_by_key.get("fixture:hash"), Some(&"hash"));
+        assert_eq!(types_by_key.get("fixture:list"), Some(&"list"));
+        assert_eq!(types_by_key.get("fixture:set"), Some(&"set"));
+        assert_eq!(types_by_key.get("fixture:zset"), Some(&"zset"));
+        assert_eq!(types_by_key.get("fixture:stream"), Some(&"stream"));
+
+        let type_names_in_rollup: Vec<&str> = report
+            .keys_by_type
+            .iter()
+            .map(|(type_name, _, _)| type_name.as_str())
+            .collect();
+        for expected_type in ["string", "hash", "list", "set", "zset", "stream"] {
+            assert!(
+                type_names_in_rollup.contains(&expected_type),
+                "expected {expected_type} in keys_by_type, got {type_names_in_rollup:?}"
+            );
+        }
+
+        let expiring_entry = report
+            .largest_keys
+            .iter()
+            .find(|entry| entry.key == "fixture:b")
+            .expect("fixture:b must be present");
+        assert!(
+            expiring_entry.expires_at_ms.is_some(),
+            "fixture:b was given an EXPIRE and must report an expiry"
+        );
+
+        let non_expiring_entry = report
+            .largest_keys
+            .iter()
+            .find(|entry| entry.key == "fixture:a")
+            .expect("fixture:a must be present");
+        assert!(
+            non_expiring_entry.expires_at_ms.is_none(),
+            "fixture:a was never given an EXPIRE and must not report one"
+        );
+
+        let fixture_bucket = report
+            .prefix_rollup
+            .iter()
+            .find(|entry| entry.prefix == "fixture:")
+            .expect("fixture: prefix bucket must exist");
+        assert_eq!(fixture_bucket.key_count, seeded_keys.len() as u64);
+
+        Ok(())
+    })
+}

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -1246,6 +1246,39 @@ document:
         references: REFERENCES
         row: ROW
       title: "Row %{row}"
+  dump_analysis:
+    title: "%{analyzer} — %{file}"
+    task: "Analyzing %{file} (%{analyzer})"
+    multiple_analyzers_note: "Multiple registered drivers can read this extension; analyzed with %{analyzer}."
+    parsing:
+      title: "Parsing dump…"
+      cancel: Cancel
+      progress:
+        of_total: "%{read} of %{total} read"
+        only: "%{read} read"
+    cancelled:
+      title: Analysis cancelled
+    error:
+      io: "I/O error reading dump: %{message}"
+      format: "Malformed dump at offset %{offset}: %{message}"
+      cancelled: Dump analysis was cancelled.
+    done:
+      summary: "%{keys} keys · %{bytes} serialized"
+      size_caveat_heading: "Why this differs from live memory usage"
+      largest_keys:
+        title: Largest keys
+        column:
+          key: Key
+          type: Type
+          size: Serialized size
+          expiry: Expiry
+        no_expiry: No expiry
+      by_prefix:
+        title: By prefix
+        column:
+          prefix: Prefix
+          count: Count
+          size: Serialized size
   export_wizard:
     title: Export Data
     task:
@@ -2103,6 +2136,15 @@ documents:
   error:
     write_initial_script_failed: "Failed to write initial script content: %{error}"
     save_session_failed: Failed to save session manifest
+dump_analysis:
+  dialog:
+    title: "Analyze database dump…"
+    filter:
+      dumps: Dump files
+      all_files: All Files
+  error:
+    no_dialog: File picker is unavailable in this environment.
+    unsupported_extension: "No registered driver can analyze a “.%{extension}” file."
 errors:
   action:
     view_in_audit: View in Audit
@@ -2451,6 +2493,8 @@ palette:
       name: "Open Chart..."
     new_dashboard:
       name: "New Dashboard..."
+    analyze_dump_file:
+      name: "Analyze database dump…"
   category:
     editor: Editor
     tabs: Tabs
@@ -2460,6 +2504,7 @@ palette:
     view: View
     charts: Charts
     dashboards: Dashboards
+    tools: Tools
 scripts:
   dialog:
     title: Open Script

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -1246,6 +1246,39 @@ document:
         references: REFERENCIAS
         row: FILA
       title: "Fila %{row}"
+  dump_analysis:
+    title: "%{analyzer} — %{file}"
+    task: "Analizando %{file} (%{analyzer})"
+    multiple_analyzers_note: "Varios controladores registrados pueden leer esta extensión; se analizó con %{analyzer}."
+    parsing:
+      title: "Analizando volcado…"
+      cancel: Cancelar
+      progress:
+        of_total: "%{read} de %{total} leídos"
+        only: "%{read} leídos"
+    cancelled:
+      title: Análisis cancelado
+    error:
+      io: "Error de E/S al leer el volcado: %{message}"
+      format: "Volcado con formato incorrecto en el desplazamiento %{offset}: %{message}"
+      cancelled: Se canceló el análisis del volcado.
+    done:
+      summary: "%{keys} claves · %{bytes} serializados"
+      size_caveat_heading: "Por qué esto difiere del uso de memoria en vivo"
+      largest_keys:
+        title: Claves más grandes
+        column:
+          key: Clave
+          type: Tipo
+          size: Tamaño serializado
+          expiry: Expiración
+        no_expiry: Sin expiración
+      by_prefix:
+        title: Por prefijo
+        column:
+          prefix: Prefijo
+          count: Cantidad
+          size: Tamaño serializado
   export_wizard:
     title: Exportar datos
     task:
@@ -2103,6 +2136,15 @@ documents:
   error:
     write_initial_script_failed: "No se pudo escribir el contenido inicial del script: %{error}"
     save_session_failed: No se pudo guardar el manifiesto de la sesión
+dump_analysis:
+  dialog:
+    title: "Analizar volcado de base de datos…"
+    filter:
+      dumps: Archivos de volcado
+      all_files: Todos los archivos
+  error:
+    no_dialog: El selector de archivos no está disponible en este entorno.
+    unsupported_extension: "Ningún controlador registrado puede analizar un archivo “.%{extension}”."
 errors:
   action:
     view_in_audit: Ver en auditoría
@@ -2451,6 +2493,8 @@ palette:
       name: "Abrir gráfico..."
     new_dashboard:
       name: "Nuevo dashboard..."
+    analyze_dump_file:
+      name: "Analizar volcado de base de datos…"
   category:
     editor: Editor
     tabs: Pestañas
@@ -2460,6 +2504,7 @@ palette:
     view: Vista
     charts: Gráficos
     dashboards: Dashboards
+    tools: Herramientas
 scripts:
   dialog:
     title: Abrir script

--- a/crates/dbflux_test_support/src/containers.rs
+++ b/crates/dbflux_test_support/src/containers.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, Instant};
 use testcontainers::core::{ContainerPort, WaitFor};
 use testcontainers::runners::SyncRunner;
-use testcontainers::{GenericImage, ImageExt};
+use testcontainers::{Container, GenericImage, ImageExt};
 
 pub fn with_postgres_url<T, E, F>(run: F) -> Result<T, E>
 where
@@ -100,6 +100,35 @@ where
     let url = format!("redis://127.0.0.1:{port}/0");
 
     run(url)
+}
+
+/// Like [`with_redis_url`], but also hands `run` a reference to the running
+/// container so it can `exec` into it (e.g. to `cat` a file written inside
+/// the container's filesystem).
+///
+/// Prefer this over a host bind mount for reading files Redis writes (such
+/// as `dump.rdb`): the official `redis` image declares `/data` as an
+/// anonymous `VOLUME`, and a rootless container runtime maps that volume's
+/// ownership to a subordinate UID/GID range that the host user does not
+/// necessarily have configured, causing bind-mount and direct-volume access
+/// to fail with a "potentially insufficient UIDs or GIDs" error. `docker
+/// exec`/`podman exec` runs as a process inside the container's own user
+/// namespace and has no such requirement.
+pub fn with_redis_container<T, E, F>(run: F) -> Result<T, E>
+where
+    F: FnOnce(String, &Container<GenericImage>) -> Result<T, E>,
+{
+    let image = GenericImage::new("redis", "7")
+        .with_exposed_port(ContainerPort::Tcp(6379))
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"));
+
+    let container = image.start().expect("failed to start redis container");
+    let port = container
+        .get_host_port_ipv4(6379)
+        .expect("failed to get redis host port");
+    let url = format!("redis://127.0.0.1:{port}/0");
+
+    run(url, &container)
 }
 
 /// Host TCP ports of the six nodes (3 masters + 3 replicas) started by the

--- a/crates/dbflux_ui/src/ui/labels.rs
+++ b/crates/dbflux_ui/src/ui/labels.rs
@@ -299,6 +299,59 @@ pub(crate) fn scripts_read_file_failed_message(
     )
 }
 
+/// Formats the "Analyze database dump…" file dialog title.
+pub(crate) fn dump_analysis_dialog_title() -> String {
+    dbflux_i18n::t!("dump_analysis.dialog.title")
+}
+
+/// Formats the dump-files file-dialog filter label.
+pub(crate) fn dump_analysis_filter_dumps_label() -> String {
+    dbflux_i18n::t!("dump_analysis.dialog.filter.dumps")
+}
+
+/// Formats the "All Files" file-dialog filter label for the dump-analysis dialog.
+pub(crate) fn dump_analysis_filter_all_files_label() -> String {
+    dbflux_i18n::t!("dump_analysis.dialog.filter.all_files")
+}
+
+/// Formats the error shown when the native file picker is unavailable.
+pub(crate) fn dump_analysis_no_dialog_message() -> String {
+    dbflux_i18n::t!("dump_analysis.error.no_dialog")
+}
+
+/// Formats the error shown when no registered driver can analyze a file
+/// with the given extension.
+pub(crate) fn dump_analysis_unsupported_extension_message(extension: &str) -> String {
+    dbflux_i18n::t!(
+        "dump_analysis.error.unsupported_extension",
+        extension = extension
+    )
+}
+
+/// Selects which registered dump analyzer to use for a picked file, given
+/// the analyzers' `(display_name, file_extensions)` pairs already sorted by
+/// display name, and the file's extension (without the leading dot).
+///
+/// Returns the index of the first analyzer whose extensions contain a
+/// case-insensitive match, plus whether more than one analyzer matched
+/// (in which case the caller should note which one was chosen). Returns
+/// `None` when no analyzer supports the extension.
+pub(crate) fn select_dump_analyzer(
+    analyzers: &[(&str, &[&str])],
+    extension: &str,
+) -> Option<(usize, bool)> {
+    let mut matches = analyzers.iter().enumerate().filter(|(_, (_, extensions))| {
+        extensions
+            .iter()
+            .any(|candidate| candidate.eq_ignore_ascii_case(extension))
+    });
+
+    let first = matches.next()?;
+    let multiple_matched = matches.next().is_some();
+
+    Some((first.0, multiple_matched))
+}
+
 /// Formats the "Focusing existing audit viewer" toast.
 pub(crate) fn audit_focus_existing_viewer_message() -> String {
     dbflux_i18n::t!("audit.toast.focus_existing_viewer")
@@ -419,9 +472,12 @@ mod tests {
         connections_refreshing_schema_message, documents_default_title, documents_new_query_name,
         documents_no_active_connection_message, documents_save_session_failed_message,
         documents_schema_diff_opened_message, documents_write_initial_script_failed_message,
-        scripts_filter_all_files_label, scripts_filter_javascript_mongodb_label,
-        scripts_filter_redis_label, scripts_filter_sql_label, scripts_open_dialog_title,
-        scripts_read_file_failed_message, settings_default_connection_name, shutdown_phase_label,
+        dump_analysis_dialog_title, dump_analysis_filter_all_files_label,
+        dump_analysis_filter_dumps_label, dump_analysis_no_dialog_message,
+        dump_analysis_unsupported_extension_message, scripts_filter_all_files_label,
+        scripts_filter_javascript_mongodb_label, scripts_filter_redis_label,
+        scripts_filter_sql_label, scripts_open_dialog_title, scripts_read_file_failed_message,
+        select_dump_analyzer, settings_default_connection_name, shutdown_phase_label,
         tasks_running_label, workspace_delete_connection_message, workspace_delete_folder_message,
         workspace_delete_selected_message, workspace_drop_object_message,
     };
@@ -757,5 +813,43 @@ mod tests {
     fn charts_instance_overview_editable_name_embeds_source_title() {
         let name = charts_instance_overview_editable_name("Instance Overview");
         assert!(name.contains("Instance Overview"));
+    }
+
+    #[test]
+    fn dump_analysis_dialog_labels_resolve() {
+        assert!(!dump_analysis_dialog_title().is_empty());
+        assert!(!dump_analysis_filter_dumps_label().is_empty());
+        assert!(!dump_analysis_filter_all_files_label().is_empty());
+        assert!(!dump_analysis_no_dialog_message().is_empty());
+    }
+
+    #[test]
+    fn dump_analysis_unsupported_extension_message_embeds_extension() {
+        let message = dump_analysis_unsupported_extension_message("bak");
+        assert!(message.contains("bak"));
+    }
+
+    #[test]
+    fn select_dump_analyzer_returns_none_when_no_extension_matches() {
+        let analyzers: &[(&str, &[&str])] = &[("Redis RDB", &["rdb"])];
+        assert_eq!(select_dump_analyzer(analyzers, "sql"), None);
+    }
+
+    #[test]
+    fn select_dump_analyzer_matches_case_insensitively() {
+        let analyzers: &[(&str, &[&str])] = &[("Redis RDB", &["rdb"])];
+        assert_eq!(select_dump_analyzer(analyzers, "RDB"), Some((0, false)));
+    }
+
+    #[test]
+    fn select_dump_analyzer_picks_first_match_and_flags_multiple() {
+        let analyzers: &[(&str, &[&str])] = &[("Analyzer A", &["dump"]), ("Analyzer B", &["dump"])];
+        assert_eq!(select_dump_analyzer(analyzers, "dump"), Some((0, true)));
+    }
+
+    #[test]
+    fn select_dump_analyzer_single_match_reports_not_multiple() {
+        let analyzers: &[(&str, &[&str])] = &[("Analyzer A", &["rdb"]), ("Analyzer B", &["dump"])];
+        assert_eq!(select_dump_analyzer(analyzers, "dump"), Some((1, false)));
     }
 }

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/dump_analysis.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/dump_analysis.rs
@@ -1,0 +1,166 @@
+use super::*;
+use crate::ui::labels::{
+    dump_analysis_dialog_title, dump_analysis_filter_all_files_label,
+    dump_analysis_filter_dumps_label, dump_analysis_no_dialog_message,
+    dump_analysis_unsupported_extension_message, select_dump_analyzer,
+};
+use dbflux_core::DumpAnalyzer;
+use std::sync::Arc;
+
+impl Workspace {
+    /// Opens a file dialog to pick a driver's native dump/export file and
+    /// opens it in a `DumpAnalysisDocument` tab.
+    ///
+    /// Every registered driver is asked for `dump_analyzer()`; whichever
+    /// analyzer's extensions match the picked file drives the analysis. The
+    /// workspace never branches on driver id or name.
+    pub(in crate::ui::views::workspace) fn analyze_dump_file(
+        &mut self,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let analyzers: Vec<Arc<dyn DumpAnalyzer>> = {
+            let mut analyzers: Vec<Arc<dyn DumpAnalyzer>> = self
+                .app_state
+                .read(cx)
+                .drivers()
+                .values()
+                .filter_map(|driver| driver.dump_analyzer())
+                .collect();
+            analyzers.sort_by_key(|analyzer| analyzer.display_name());
+            analyzers
+        };
+
+        if analyzers.is_empty() {
+            return;
+        }
+
+        let dialog_available = dbflux_ui_base::file_dialog::is_native_file_dialog_available();
+
+        if !dialog_available {
+            report_error(
+                UserFacingError::new(ErrorKind::Config, dump_analysis_no_dialog_message()),
+                cx,
+            );
+            return;
+        }
+
+        let all_extensions: Vec<&'static str> = {
+            let mut extensions: Vec<&'static str> = analyzers
+                .iter()
+                .flat_map(|analyzer| analyzer.file_extensions().iter().copied())
+                .collect();
+            extensions.sort_unstable();
+            extensions.dedup();
+            extensions
+        };
+
+        let tab_manager = self.tab_manager.clone();
+        let app_state = self.app_state.clone();
+
+        cx.spawn(async move |this, cx| {
+            let dialog_title = dump_analysis_dialog_title();
+            let dumps_filter_label = dump_analysis_filter_dumps_label();
+            let all_files_filter_label = dump_analysis_filter_all_files_label();
+
+            let file_handle = rfd::AsyncFileDialog::new()
+                .set_title(&dialog_title)
+                .add_filter(&dumps_filter_label, &all_extensions)
+                .add_filter(&all_files_filter_label, &["*"])
+                .pick_file()
+                .await;
+
+            let Some(handle) = file_handle else {
+                return;
+            };
+
+            let path = handle.path().to_path_buf();
+
+            let extension = path
+                .extension()
+                .map(|ext| ext.to_string_lossy().into_owned())
+                .unwrap_or_default();
+
+            let analyzer_candidates: Vec<(&str, &[&str])> = analyzers
+                .iter()
+                .map(|analyzer| (analyzer.display_name(), analyzer.file_extensions()))
+                .collect();
+
+            let Some((selected_index, multiple_matched)) =
+                select_dump_analyzer(&analyzer_candidates, &extension)
+            else {
+                report_error_async(
+                    UserFacingError::new(
+                        ErrorKind::User,
+                        dump_analysis_unsupported_extension_message(&extension),
+                    ),
+                    cx,
+                );
+                return;
+            };
+
+            let analyzer = analyzers[selected_index].clone();
+
+            let already_open = match cx.update(|cx| {
+                tab_manager.read(cx).find_by_key(
+                    &crate::ui::document::DocumentKey::DumpAnalysis { path: path.clone() },
+                    cx,
+                )
+            }) {
+                Ok(value) => value,
+                Err(error) => {
+                    log::warn!(
+                        "Failed to inspect open tabs while opening dump analysis: {:?}",
+                        error
+                    );
+                    None
+                }
+            };
+
+            if let Some(id) = already_open {
+                if let Err(error) = cx.update(|cx| {
+                    tab_manager.update(cx, |mgr, cx| {
+                        mgr.activate(id, cx);
+                    });
+                }) {
+                    log::warn!(
+                        "Failed to activate already-open dump analysis tab: {:?}",
+                        error
+                    );
+                }
+                return;
+            }
+
+            if let Err(error) = cx.update(|cx| {
+                this.update(cx, |ws, cx| {
+                    let doc = cx.new(|cx| {
+                        crate::ui::document::DumpAnalysisDocument::new(
+                            analyzer,
+                            path,
+                            multiple_matched,
+                            app_state.clone(),
+                            cx,
+                        )
+                    });
+                    let pane = crate::ui::document::DumpAnalysisDocument::into_pane(doc, cx);
+
+                    ws.tab_manager.update(cx, |mgr, cx| {
+                        mgr.open(Tab::Pane(Box::new(pane)), cx);
+                    });
+
+                    ws.pending_focus = Some(FocusTarget::Document);
+                    cx.notify();
+                })
+                .unwrap_or_else(|inner_error| {
+                    log::warn!(
+                        "Failed to open dump analysis document in workspace: {:?}",
+                        inner_error
+                    );
+                });
+            }) {
+                log::warn!("Failed to apply picked dump file to workspace: {:?}", error);
+            }
+        })
+        .detach();
+    }
+}

--- a/crates/dbflux_ui/src/ui/views/workspace/actions/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/actions/mod.rs
@@ -89,6 +89,7 @@ mod audit;
 mod charts_dashboards;
 mod connections;
 mod documents;
+mod dump_analysis;
 mod metrics;
 mod query;
 mod schema_diff;
@@ -102,6 +103,14 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // Dynamically gated actions that are not part of the closed
+        // `Command` enum (their palette entry only appears when at least
+        // one registered driver supports it) are intercepted here.
+        if command_id == "analyze_dump_file" {
+            self.analyze_dump_file(window, cx);
+            return;
+        }
+
         let Some(command) = Command::from_palette_id(command_id) else {
             log::warn!("Unknown command: {}", command_id);
             return;

--- a/crates/dbflux_ui/src/ui/views/workspace/mod.rs
+++ b/crates/dbflux_ui/src/ui/views/workspace/mod.rs
@@ -1904,6 +1904,22 @@ impl Workspace {
             items.push(PaletteItem::ImportDashboard);
         }
 
+        // "Analyze database dump…" only appears when at least one registered
+        // driver's `dump_analyzer()` supports offline dump analysis — the
+        // workspace never branches on driver id to decide this.
+        if app_state
+            .drivers()
+            .values()
+            .any(|driver| driver.dump_analyzer().is_some())
+        {
+            items.push(PaletteItem::Action {
+                id: "analyze_dump_file",
+                name: dbflux_i18n::t!("palette.command.analyze_dump_file.name").into(),
+                category: dbflux_i18n::t!("palette.category.tools").into(),
+                shortcut: None,
+            });
+        }
+
         items
     }
 

--- a/crates/dbflux_ui_document/Cargo.toml
+++ b/crates/dbflux_ui_document/Cargo.toml
@@ -23,6 +23,7 @@ dbflux_export.workspace = true
 dbflux_i18n.workspace = true
 dbflux_transfer.workspace = true
 uuid.workspace = true
+chrono.workspace = true
 log.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/dbflux_ui_document/src/dedup.rs
+++ b/crates/dbflux_ui_document/src/dedup.rs
@@ -104,6 +104,12 @@ pub enum DocumentKey {
         bucket: String,
         key: String,
     },
+
+    /// An offline dump-analysis report opened for a driver's native
+    /// export/dump file. Distinct from `File` (which implies a file-backed
+    /// code document). Deduplicated by `path` — analyzing the same file a
+    /// second time focuses the existing tab.
+    DumpAnalysis { path: PathBuf },
 }
 
 #[cfg(test)]
@@ -276,6 +282,20 @@ mod tests {
             key,
             DocumentKey::ObjectEditor { profile_id: pid, bucket, key }
                 if pid == profile_id && bucket == "my-bucket" && key == "logs/app.log"
+        ));
+    }
+
+    /// `DocumentKey::DumpAnalysis` must construct and round-trip through
+    /// clone and debug without panic, and is distinct by `path`.
+    #[test]
+    fn dump_analysis_key_constructs_and_clones() {
+        let path = PathBuf::from("/tmp/dump.rdb");
+        let key = DocumentKey::DumpAnalysis { path: path.clone() };
+        let cloned = key.clone();
+        let _ = format!("{:?}", cloned);
+        assert!(matches!(
+            key,
+            DocumentKey::DumpAnalysis { path: p } if p == path
         ));
     }
 

--- a/crates/dbflux_ui_document/src/dump_analysis/mod.rs
+++ b/crates/dbflux_ui_document/src/dump_analysis/mod.rs
@@ -1,0 +1,415 @@
+//! Offline analysis report for a driver's native dump/export file (e.g. a
+//! Redis RDB file), opened from the "Analyze database dump…" command.
+//!
+//! The document never inspects `driver_id`: it is constructed with an
+//! already-resolved `Arc<dyn DumpAnalyzer>` (see
+//! `dbflux_core::connection::dump_analysis`) and only reads that trait's
+//! generic surface (`display_name`, `size_caveat`, `analyze`).
+
+mod pane;
+mod render;
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use dbflux_components::components::data_table::{DataTable, DataTableEvent, DataTableState};
+use dbflux_core::{
+    DumpAnalysisError, DumpAnalysisReport, DumpAnalyzer, SortDirection, TaskKind, TaskStatus,
+};
+use dbflux_ui_base::AppStateEntity;
+use gpui::*;
+
+use super::handle::DocumentEvent;
+use super::task_runner::DocumentTaskRunner;
+use super::types::{DocumentId, DocumentState};
+
+/// The document's current state, driven by the background analysis task.
+enum DumpAnalysisPhase {
+    /// The dump file is being streamed and aggregated on a background
+    /// executor. `bytes_read`/`total_bytes` mirror the analyzer's own
+    /// progress callback.
+    Parsing {
+        bytes_read: u64,
+        total_bytes: Option<u64>,
+    },
+    /// Analysis was cancelled before completion (via the inline Cancel
+    /// button or the Tasks panel).
+    Cancelled,
+    /// Analysis failed; the error is kept so its display message can be
+    /// rendered and re-derived without losing detail (e.g. the byte offset
+    /// of a malformed dump).
+    Failed(DumpAnalysisError),
+    /// Analysis completed. The report's `largest_keys`/`prefix_rollup`
+    /// vectors are re-sorted in place when the user clicks a table header.
+    Done(DumpAnalysisReport),
+}
+
+/// Searchable, read-only analysis report opened for a driver's native
+/// dump/export file, without a live connection to any profile.
+pub struct DumpAnalysisDocument {
+    id: DocumentId,
+    app_state: Entity<AppStateEntity>,
+    focus_handle: FocusHandle,
+    is_active_tab: bool,
+    path: PathBuf,
+    analyzer_display_name: &'static str,
+    size_caveat: &'static str,
+    /// `true` when more than one registered driver's analyzer matched the
+    /// dump file's extension and the first (by display name) was used —
+    /// surfaced in the header so the choice isn't silent.
+    multiple_analyzers_matched: bool,
+    phase: DumpAnalysisPhase,
+    runner: DocumentTaskRunner,
+    largest_keys_state: Option<Entity<DataTableState>>,
+    largest_keys_table: Option<Entity<DataTable>>,
+    prefix_rollup_state: Option<Entity<DataTableState>>,
+    prefix_rollup_table: Option<Entity<DataTable>>,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl EventEmitter<DocumentEvent> for DumpAnalysisDocument {}
+
+/// Computes the fraction (0.0–1.0) of a dump file read so far, for the
+/// task-manager progress bar. Returns `None` when the analyzer could not
+/// determine the dump's total size upfront, in which case progress stays
+/// indeterminate rather than showing a misleading bar.
+pub(crate) fn progress_fraction(bytes_read: u64, total_bytes: Option<u64>) -> Option<f32> {
+    let total = total_bytes.filter(|&total| total > 0)?;
+    Some((bytes_read as f32 / total as f32).clamp(0.0, 1.0))
+}
+
+impl DumpAnalysisDocument {
+    pub fn new(
+        analyzer: Arc<dyn DumpAnalyzer>,
+        path: PathBuf,
+        multiple_analyzers_matched: bool,
+        app_state: Entity<AppStateEntity>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let mut doc = Self {
+            id: DocumentId::new(),
+            app_state: app_state.clone(),
+            focus_handle: cx.focus_handle(),
+            is_active_tab: true,
+            path: path.clone(),
+            analyzer_display_name: analyzer.display_name(),
+            size_caveat: analyzer.size_caveat(),
+            multiple_analyzers_matched,
+            phase: DumpAnalysisPhase::Parsing {
+                bytes_read: 0,
+                total_bytes: None,
+            },
+            runner: DocumentTaskRunner::new(app_state),
+            largest_keys_state: None,
+            largest_keys_table: None,
+            prefix_rollup_state: None,
+            prefix_rollup_table: None,
+            _subscriptions: Vec::new(),
+        };
+
+        doc.start_analysis(analyzer, cx);
+        doc
+    }
+
+    pub fn id(&self) -> DocumentId {
+        self.id
+    }
+
+    pub fn title(&self) -> String {
+        let file_name = self
+            .path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| self.path.display().to_string());
+
+        crate::labels::dump_analysis_title(self.analyzer_display_name, &file_name)
+    }
+
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    pub fn can_close(&self) -> bool {
+        true
+    }
+
+    pub fn state(&self) -> DocumentState {
+        match &self.phase {
+            DumpAnalysisPhase::Parsing { .. } => DocumentState::Loading,
+            DumpAnalysisPhase::Cancelled => DocumentState::Clean,
+            DumpAnalysisPhase::Failed(_) => DocumentState::Error,
+            DumpAnalysisPhase::Done(_) => DocumentState::Clean,
+        }
+    }
+
+    /// Always `None` — this document never carries a live connection.
+    pub fn connection_id(&self) -> Option<uuid::Uuid> {
+        None
+    }
+
+    pub fn refresh_policy(&self) -> dbflux_core::RefreshPolicy {
+        dbflux_core::RefreshPolicy::Manual
+    }
+
+    pub fn set_refresh_policy(
+        &mut self,
+        _policy: dbflux_core::RefreshPolicy,
+        _cx: &mut Context<Self>,
+    ) {
+        // A one-shot offline report has nothing to periodically refresh.
+    }
+
+    pub fn set_active_tab(&mut self, active: bool) {
+        self.is_active_tab = active;
+    }
+
+    pub fn active_context(&self) -> dbflux_app::keymap::ContextId {
+        dbflux_app::keymap::ContextId::Results
+    }
+
+    pub fn dispatch_command(
+        &mut self,
+        _cmd: dbflux_app::keymap::Command,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> bool {
+        // Table navigation is handled internally by the embedded `DataTable`
+        // entities via their own focus handles; this document has no
+        // additional commands to intercept.
+        false
+    }
+
+    pub fn focus(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(state) = &self.largest_keys_state {
+            let handle = state.read(cx).focus_handle().clone();
+            handle.focus(window);
+        } else {
+            self.focus_handle.focus(window);
+        }
+    }
+
+    fn start_analysis(&mut self, analyzer: Arc<dyn DumpAnalyzer>, cx: &mut Context<Self>) {
+        let file_name = self
+            .path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| self.path.display().to_string());
+        let description =
+            crate::labels::dump_analysis_task_label(self.analyzer_display_name, &file_name);
+
+        let (task_id, cancel_token) =
+            self.runner
+                .start_primary(TaskKind::DumpAnalysis, description, cx);
+
+        let progress = Arc::new(Mutex::new((0u64, None::<u64>)));
+
+        let ticker_progress = Arc::clone(&progress);
+        cx.spawn(async move |this, cx| {
+            loop {
+                cx.background_executor()
+                    .timer(Duration::from_millis(150))
+                    .await;
+
+                let still_running = cx
+                    .update(|cx| {
+                        this.update(cx, |doc, cx| {
+                            let is_running = doc
+                                .app_state
+                                .read(cx)
+                                .tasks()
+                                .get(task_id)
+                                .map(|snapshot| snapshot.status == TaskStatus::Running)
+                                .unwrap_or(false);
+
+                            if !is_running {
+                                return false;
+                            }
+
+                            let (bytes_read, total_bytes) = *ticker_progress
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+                            doc.phase = DumpAnalysisPhase::Parsing {
+                                bytes_read,
+                                total_bytes,
+                            };
+
+                            if let Some(fraction) = progress_fraction(bytes_read, total_bytes) {
+                                doc.app_state.update(cx, |state, _cx| {
+                                    state.tasks_mut().update_progress(task_id, fraction);
+                                });
+                            }
+
+                            cx.notify();
+                            true
+                        })
+                        .unwrap_or(false)
+                    })
+                    .unwrap_or(false);
+
+                if !still_running {
+                    break;
+                }
+            }
+        })
+        .detach();
+
+        let worker_progress = Arc::clone(&progress);
+        let worker_path = self.path.clone();
+
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    analyzer.analyze(
+                        &worker_path,
+                        &|bytes_read, total_bytes| {
+                            if let Ok(mut guard) = worker_progress.lock() {
+                                *guard = (bytes_read, total_bytes);
+                            }
+                        },
+                        &|| cancel_token.is_cancelled(),
+                    )
+                })
+                .await;
+
+            cx.update(|cx| {
+                this.update(cx, |doc, cx| {
+                    // A prior cancellation (button or Tasks panel) already
+                    // moved the document to its terminal state; a late
+                    // result from the background executor must not
+                    // overwrite it.
+                    if matches!(doc.phase, DumpAnalysisPhase::Cancelled) {
+                        return;
+                    }
+
+                    match result {
+                        Ok(report) => {
+                            doc.runner.complete_primary(task_id, cx);
+                            doc.build_tables(report, cx);
+                        }
+                        Err(DumpAnalysisError::Cancelled) => {
+                            doc.phase = DumpAnalysisPhase::Cancelled;
+                        }
+                        Err(other) => {
+                            let message = crate::labels::dump_analysis_error_message(&other);
+                            doc.runner.fail_primary(task_id, message, cx);
+                            doc.phase = DumpAnalysisPhase::Failed(other);
+                        }
+                    }
+
+                    cx.notify();
+                })
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn cancel_analysis(&mut self, cx: &mut Context<Self>) {
+        self.runner.cancel_primary(cx);
+    }
+
+    fn build_tables(&mut self, report: DumpAnalysisReport, cx: &mut Context<Self>) {
+        let largest_model = Arc::new(render::largest_keys_table_model(&report.largest_keys));
+        let largest_keys_state = cx.new(|cx| DataTableState::new(largest_model, cx));
+        let largest_keys_subscription = cx.subscribe(
+            &largest_keys_state,
+            |this, _, event: &DataTableEvent, cx| {
+                if let DataTableEvent::SortChanged(Some(sort)) = event {
+                    this.sort_largest_keys(sort.column_ix, sort.direction, cx);
+                }
+            },
+        );
+        let largest_keys_table = cx
+            .new(|cx| DataTable::new("dump-analysis-largest-keys", largest_keys_state.clone(), cx));
+
+        let prefix_model = Arc::new(render::prefix_rollup_table_model(&report.prefix_rollup));
+        let prefix_rollup_state = cx.new(|cx| DataTableState::new(prefix_model, cx));
+        let prefix_rollup_subscription = cx.subscribe(
+            &prefix_rollup_state,
+            |this, _, event: &DataTableEvent, cx| {
+                if let DataTableEvent::SortChanged(Some(sort)) = event {
+                    this.sort_prefix_rollup(sort.column_ix, sort.direction, cx);
+                }
+            },
+        );
+        let prefix_rollup_table =
+            cx.new(|cx| DataTable::new("dump-analysis-by-prefix", prefix_rollup_state.clone(), cx));
+
+        self.largest_keys_state = Some(largest_keys_state);
+        self.largest_keys_table = Some(largest_keys_table);
+        self.prefix_rollup_state = Some(prefix_rollup_state);
+        self.prefix_rollup_table = Some(prefix_rollup_table);
+        self._subscriptions
+            .extend([largest_keys_subscription, prefix_rollup_subscription]);
+        self.phase = DumpAnalysisPhase::Done(report);
+    }
+
+    fn sort_largest_keys(
+        &mut self,
+        column_ix: usize,
+        direction: SortDirection,
+        cx: &mut Context<Self>,
+    ) {
+        let DumpAnalysisPhase::Done(report) = &mut self.phase else {
+            return;
+        };
+
+        render::sort_largest_keys(&mut report.largest_keys, column_ix, direction);
+        let model = Arc::new(render::largest_keys_table_model(&report.largest_keys));
+
+        if let Some(state) = &self.largest_keys_state {
+            state.update(cx, |state, cx| state.set_model(model, cx));
+        }
+    }
+
+    fn sort_prefix_rollup(
+        &mut self,
+        column_ix: usize,
+        direction: SortDirection,
+        cx: &mut Context<Self>,
+    ) {
+        let DumpAnalysisPhase::Done(report) = &mut self.phase else {
+            return;
+        };
+
+        render::sort_prefix_rollup(&mut report.prefix_rollup, column_ix, direction);
+        let model = Arc::new(render::prefix_rollup_table_model(&report.prefix_rollup));
+
+        if let Some(state) = &self.prefix_rollup_state {
+            state.update(cx, |state, cx| state.set_model(model, cx));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Import only what we need — avoid `use super::*` which pulls in
+    // `gpui::*` and triggers macro recursion (see `task_runner.rs`).
+    use super::progress_fraction;
+
+    #[test]
+    fn progress_fraction_is_none_when_total_unknown() {
+        assert_eq!(progress_fraction(1024, None), None);
+    }
+
+    #[test]
+    fn progress_fraction_is_none_when_total_is_zero() {
+        assert_eq!(progress_fraction(0, Some(0)), None);
+    }
+
+    #[test]
+    fn progress_fraction_computes_ratio_when_total_known() {
+        assert_eq!(progress_fraction(50, Some(200)), Some(0.25));
+    }
+
+    #[test]
+    fn progress_fraction_clamps_above_one() {
+        // The analyzer's progress callback may briefly overshoot the
+        // reported total (e.g. trailing checksum bytes); the fraction must
+        // never exceed 1.0.
+        assert_eq!(progress_fraction(300, Some(200)), Some(1.0));
+    }
+}

--- a/crates/dbflux_ui_document/src/dump_analysis/pane.rs
+++ b/crates/dbflux_ui_document/src/dump_analysis/pane.rs
@@ -1,0 +1,108 @@
+//! `PaneHandle` constructor for `DumpAnalysisDocument`.
+
+use super::DumpAnalysisDocument;
+use crate::dedup::DocumentKey;
+use crate::handle::DocumentEvent;
+use crate::pane::{BoxedDocEventCallback, PaneHandle};
+use crate::types::{DocumentIcon, DocumentKind, DocumentMetaSnapshot};
+use gpui::{App, Entity, IntoElement};
+
+impl DumpAnalysisDocument {
+    /// Wrap a typed `Entity<DumpAnalysisDocument>` in a `PaneHandle`.
+    pub fn into_pane(entity: Entity<Self>, cx: &App) -> PaneHandle {
+        let id = entity.read(cx).id();
+
+        PaneHandle::new_chart(
+            id,
+            DocumentKind::DumpAnalysis,
+            // render
+            {
+                let e = entity.clone();
+                Box::new(move |_w, _cx| e.clone().into_any_element())
+            },
+            // focus
+            {
+                let e = entity.clone();
+                Box::new(move |w, cx| e.update(cx, |d, cx| d.focus(w, cx)))
+            },
+            // dispatch_command
+            {
+                let e = entity.clone();
+                Box::new(move |cmd, w, cx| e.update(cx, |d, cx| d.dispatch_command(cmd, w, cx)))
+            },
+            // meta_snapshot
+            {
+                let e = entity.clone();
+                Box::new(move |cx| {
+                    let d = e.read(cx);
+                    DocumentMetaSnapshot {
+                        id,
+                        kind: DocumentKind::DumpAnalysis,
+                        title: d.title(),
+                        icon: DocumentIcon::DumpAnalysis,
+                        state: d.state(),
+                        closable: true,
+                        connection_id: d.connection_id(),
+                    }
+                })
+            },
+            // tab_title
+            {
+                let e = entity.clone();
+                Box::new(move |cx| e.read(cx).title())
+            },
+            // can_close
+            {
+                let e = entity.clone();
+                Box::new(move |cx| e.read(cx).can_close())
+            },
+            // connection_id — always None, this document never carries a connection
+            {
+                let e = entity.clone();
+                Box::new(move |cx| e.read(cx).connection_id())
+            },
+            // active_context
+            {
+                let e = entity.clone();
+                Box::new(move |cx| e.read(cx).active_context())
+            },
+            // change_summary — a read-only report has no unsaved changes
+            Box::new(|_cx| None),
+            // refresh_policy
+            {
+                let e = entity.clone();
+                Box::new(move |cx| e.read(cx).refresh_policy())
+            },
+            // flush_auto_save — no auto-save
+            Box::new(|_cx| {}),
+            // set_active_tab
+            {
+                let e = entity.clone();
+                Box::new(move |active, cx| e.update(cx, |d, _cx| d.set_active_tab(active)))
+            },
+            // set_refresh_policy
+            {
+                let e = entity.clone();
+                Box::new(move |policy, cx| e.update(cx, |d, cx| d.set_refresh_policy(policy, cx)))
+            },
+            // matches_dedup_key
+            {
+                let e = entity.clone();
+                Box::new(move |key, cx| {
+                    let d = e.read(cx);
+                    match key {
+                        DocumentKey::DumpAnalysis { path } => d.path() == path.as_path(),
+                        _ => false,
+                    }
+                })
+            },
+            // subscribe — DumpAnalysisDocument emits DocumentEvent directly
+            {
+                let e = entity.clone();
+                Box::new(move |cx, cb: BoxedDocEventCallback| {
+                    cx.subscribe(&e, move |_, ev: &DocumentEvent, cx| cb(ev, cx))
+                })
+            },
+        )
+    }
+}

--- a/crates/dbflux_ui_document/src/dump_analysis/render.rs
+++ b/crates/dbflux_ui_document/src/dump_analysis/render.rs
@@ -1,0 +1,284 @@
+//! Rendering and table-model construction for `DumpAnalysisDocument`.
+//!
+//! Layout, top to bottom: a summary header (total keys, total serialized
+//! bytes, and the analyzer's `size_caveat()` shown verbatim), then two
+//! stacked read-only data tables — "Largest keys" and "By prefix".
+
+use std::sync::Arc;
+
+use dbflux_components::components::data_table::TableModel;
+use dbflux_components::components::data_table::model::{
+    CellValue, ColumnKind, ColumnSpec, RowData,
+};
+use dbflux_components::primitives::Text;
+use dbflux_components::tokens::Spacing;
+use dbflux_core::{DumpKeyEntry, DumpPrefixEntry, SortDirection};
+use gpui::prelude::*;
+use gpui::*;
+use gpui_component::ActiveTheme;
+
+use super::{DumpAnalysisDocument, DumpAnalysisPhase};
+
+/// Builds the "Largest keys" table model, in the order the entries are given
+/// (the analyzer already returns them sorted descending by serialized size).
+pub(super) fn largest_keys_table_model(entries: &[DumpKeyEntry]) -> TableModel {
+    let columns = vec![
+        ColumnSpec {
+            id: Arc::from("key"),
+            title: Arc::from(dbflux_i18n::t!(
+                "document.dump_analysis.done.largest_keys.column.key"
+            )),
+            kind: ColumnKind::Text,
+            align: TextAlign::Left,
+            type_name: Arc::from(""),
+        },
+        ColumnSpec {
+            id: Arc::from("type"),
+            title: Arc::from(dbflux_i18n::t!(
+                "document.dump_analysis.done.largest_keys.column.type"
+            )),
+            kind: ColumnKind::Text,
+            align: TextAlign::Left,
+            type_name: Arc::from(""),
+        },
+        ColumnSpec {
+            id: Arc::from("size"),
+            title: Arc::from(dbflux_i18n::t!(
+                "document.dump_analysis.done.largest_keys.column.size"
+            )),
+            kind: ColumnKind::Integer,
+            align: TextAlign::Right,
+            type_name: Arc::from(""),
+        },
+        ColumnSpec {
+            id: Arc::from("expiry"),
+            title: Arc::from(dbflux_i18n::t!(
+                "document.dump_analysis.done.largest_keys.column.expiry"
+            )),
+            kind: ColumnKind::Text,
+            align: TextAlign::Left,
+            type_name: Arc::from(""),
+        },
+    ];
+
+    let rows = entries
+        .iter()
+        .map(|entry| RowData {
+            cells: vec![
+                CellValue::text(&entry.key),
+                CellValue::text(&entry.type_name),
+                CellValue::text(&crate::buckets_table::format_bytes(entry.serialized_bytes)),
+                CellValue::text(&format_expiry(entry.expires_at_ms)),
+            ],
+        })
+        .collect();
+
+    TableModel::new(columns, rows)
+}
+
+/// Builds the "By prefix" table model, in the order the entries are given
+/// (the analyzer already returns them sorted descending by serialized size).
+pub(super) fn prefix_rollup_table_model(entries: &[DumpPrefixEntry]) -> TableModel {
+    let columns = vec![
+        ColumnSpec {
+            id: Arc::from("prefix"),
+            title: Arc::from(dbflux_i18n::t!(
+                "document.dump_analysis.done.by_prefix.column.prefix"
+            )),
+            kind: ColumnKind::Text,
+            align: TextAlign::Left,
+            type_name: Arc::from(""),
+        },
+        ColumnSpec {
+            id: Arc::from("count"),
+            title: Arc::from(dbflux_i18n::t!(
+                "document.dump_analysis.done.by_prefix.column.count"
+            )),
+            kind: ColumnKind::Integer,
+            align: TextAlign::Right,
+            type_name: Arc::from(""),
+        },
+        ColumnSpec {
+            id: Arc::from("size"),
+            title: Arc::from(dbflux_i18n::t!(
+                "document.dump_analysis.done.by_prefix.column.size"
+            )),
+            kind: ColumnKind::Integer,
+            align: TextAlign::Right,
+            type_name: Arc::from(""),
+        },
+    ];
+
+    let rows = entries
+        .iter()
+        .map(|entry| RowData {
+            cells: vec![
+                CellValue::text(&entry.prefix),
+                CellValue::text(&entry.key_count.to_string()),
+                CellValue::text(&crate::buckets_table::format_bytes(entry.serialized_bytes)),
+            ],
+        })
+        .collect();
+
+    TableModel::new(columns, rows)
+}
+
+/// Formats an optional absolute expiry (epoch milliseconds) as a readable
+/// UTC timestamp, or the "no expiry" label when the key carries none.
+pub(super) fn format_expiry(expires_at_ms: Option<i64>) -> String {
+    match expires_at_ms {
+        Some(ms) => match chrono::DateTime::from_timestamp_millis(ms) {
+            Some(dt) => dt.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+            None => dbflux_i18n::t!("document.dump_analysis.done.largest_keys.no_expiry"),
+        },
+        None => dbflux_i18n::t!("document.dump_analysis.done.largest_keys.no_expiry"),
+    }
+}
+
+/// Sorts the largest-keys entries in place by the given column index and
+/// direction. Unknown column indices leave the order unchanged.
+pub(super) fn sort_largest_keys(
+    entries: &mut [DumpKeyEntry],
+    column_ix: usize,
+    direction: SortDirection,
+) {
+    match column_ix {
+        0 => entries.sort_by(|a, b| a.key.cmp(&b.key)),
+        1 => entries.sort_by(|a, b| a.type_name.cmp(&b.type_name)),
+        2 => entries.sort_by_key(|entry| entry.serialized_bytes),
+        3 => entries.sort_by_key(|entry| entry.expires_at_ms),
+        _ => return,
+    }
+
+    if direction == SortDirection::Descending {
+        entries.reverse();
+    }
+}
+
+/// Sorts the prefix-rollup entries in place by the given column index and
+/// direction. Unknown column indices leave the order unchanged.
+pub(super) fn sort_prefix_rollup(
+    entries: &mut [DumpPrefixEntry],
+    column_ix: usize,
+    direction: SortDirection,
+) {
+    match column_ix {
+        0 => entries.sort_by(|a, b| a.prefix.cmp(&b.prefix)),
+        1 => entries.sort_by_key(|entry| entry.key_count),
+        2 => entries.sort_by_key(|entry| entry.serialized_bytes),
+        _ => return,
+    }
+
+    if direction == SortDirection::Descending {
+        entries.reverse();
+    }
+}
+
+impl Render for DumpAnalysisDocument {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+
+        let body: AnyElement = match &self.phase {
+            DumpAnalysisPhase::Parsing {
+                bytes_read,
+                total_bytes,
+            } => div()
+                .flex()
+                .flex_col()
+                .gap(Spacing::MD)
+                .p(Spacing::MD)
+                .child(Text::body(dbflux_i18n::t!(
+                    "document.dump_analysis.parsing.title"
+                )))
+                .child(Text::caption(
+                    crate::labels::dump_analysis_parsing_progress(*bytes_read, *total_bytes),
+                ))
+                .child(
+                    dbflux_components::controls::Button::new(
+                        "dump-analysis-cancel",
+                        dbflux_i18n::t!("document.dump_analysis.parsing.cancel"),
+                    )
+                    .on_click(cx.listener(|this, _, _, cx| this.cancel_analysis(cx))),
+                )
+                .into_any_element(),
+
+            DumpAnalysisPhase::Cancelled => div()
+                .flex()
+                .flex_col()
+                .gap(Spacing::MD)
+                .p(Spacing::MD)
+                .child(Text::body(dbflux_i18n::t!(
+                    "document.dump_analysis.cancelled.title"
+                )))
+                .into_any_element(),
+
+            DumpAnalysisPhase::Failed(error) => div()
+                .flex()
+                .flex_col()
+                .gap(Spacing::MD)
+                .p(Spacing::MD)
+                .child(Text::body(crate::labels::dump_analysis_error_message(error)).danger())
+                .into_any_element(),
+
+            DumpAnalysisPhase::Done(report) => {
+                let mut column = div().flex().flex_col().size_full().child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap(Spacing::XS)
+                        .p(Spacing::MD)
+                        .border_b_1()
+                        .border_color(theme.border)
+                        .child(Text::body(crate::labels::dump_analysis_summary_line(
+                            report.total_keys,
+                            report.total_serialized_bytes,
+                        )))
+                        .when(self.multiple_analyzers_matched, |el| {
+                            el.child(Text::caption(dbflux_i18n::t!(
+                                "document.dump_analysis.multiple_analyzers_note",
+                                analyzer = self.analyzer_display_name
+                            )))
+                        })
+                        .child(Text::caption(self.size_caveat).warning()),
+                );
+
+                if let Some(largest_keys_table) = self.largest_keys_table.clone() {
+                    column = column.child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .flex_1()
+                            .min_h(px(0.0))
+                            .child(div().px(Spacing::MD).pt(Spacing::MD).child(Text::body(
+                                dbflux_i18n::t!("document.dump_analysis.done.largest_keys.title"),
+                            )))
+                            .child(div().flex_1().min_h(px(0.0)).child(largest_keys_table)),
+                    );
+                }
+
+                if let Some(prefix_rollup_table) = self.prefix_rollup_table.clone() {
+                    column = column.child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .flex_1()
+                            .min_h(px(0.0))
+                            .child(div().px(Spacing::MD).pt(Spacing::MD).child(Text::body(
+                                dbflux_i18n::t!("document.dump_analysis.done.by_prefix.title"),
+                            )))
+                            .child(div().flex_1().min_h(px(0.0)).child(prefix_rollup_table)),
+                    );
+                }
+
+                column.into_any_element()
+            }
+        };
+
+        div()
+            .id("dump-analysis-document")
+            .track_focus(&self.focus_handle)
+            .size_full()
+            .bg(theme.background)
+            .child(body)
+    }
+}

--- a/crates/dbflux_ui_document/src/labels.rs
+++ b/crates/dbflux_ui_document/src/labels.rs
@@ -2233,6 +2233,76 @@ pub(crate) fn migrate_wizard_target_schema_read_failed_error(error: &str) -> Str
     )
 }
 
+/// Tab title for a dump-analysis document: the analyzer's display name plus
+/// the dump file's own file name (not the full path, which is often long).
+pub(crate) fn dump_analysis_title(analyzer_display_name: &str, file_name: &str) -> String {
+    dbflux_i18n::t!(
+        "document.dump_analysis.title",
+        analyzer = analyzer_display_name,
+        file = file_name
+    )
+}
+
+/// Progress label shown while a dump file is being parsed.
+///
+/// Uses the "of total" bucket only when the analyzer reported a total byte
+/// count; some formats cannot determine this upfront.
+pub(crate) fn dump_analysis_parsing_progress(bytes_read: u64, total_bytes: Option<u64>) -> String {
+    match total_bytes {
+        Some(total) if total > 0 => dbflux_i18n::t!(
+            "document.dump_analysis.parsing.progress.of_total",
+            read = crate::buckets_table::format_bytes(bytes_read),
+            total = crate::buckets_table::format_bytes(total)
+        ),
+        _ => dbflux_i18n::t!(
+            "document.dump_analysis.parsing.progress.only",
+            read = crate::buckets_table::format_bytes(bytes_read)
+        ),
+    }
+}
+
+/// Maps a `DumpAnalysisError` to its user-facing display message.
+pub(crate) fn dump_analysis_error_message(error: &dbflux_core::DumpAnalysisError) -> String {
+    use dbflux_core::DumpAnalysisError;
+
+    match error {
+        DumpAnalysisError::Io(message) => {
+            dbflux_i18n::t!(
+                "document.dump_analysis.error.io",
+                message = message.as_str()
+            )
+        }
+        DumpAnalysisError::Format { offset, message } => dbflux_i18n::t!(
+            "document.dump_analysis.error.format",
+            offset = offset,
+            message = message.as_str()
+        ),
+        DumpAnalysisError::Cancelled => {
+            dbflux_i18n::t!("document.dump_analysis.error.cancelled")
+        }
+    }
+}
+
+/// Task-panel description for a running dump analysis, with the analyzer's
+/// display name and file name interpolated.
+pub(crate) fn dump_analysis_task_label(analyzer_display_name: &str, file_name: &str) -> String {
+    dbflux_i18n::t!(
+        "document.dump_analysis.task",
+        analyzer = analyzer_display_name,
+        file = file_name
+    )
+}
+
+/// Summary header line for a finished dump analysis: total keys and total
+/// serialized bytes across every logical database in the dump.
+pub(crate) fn dump_analysis_summary_line(total_keys: u64, total_serialized_bytes: u64) -> String {
+    dbflux_i18n::t!(
+        "document.dump_analysis.done.summary",
+        keys = total_keys,
+        bytes = crate::buckets_table::format_bytes(total_serialized_bytes)
+    )
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "mcp")]
@@ -2257,7 +2327,8 @@ mod tests {
         context_menu_export_native_picker_fallback_toast, copy_query_language_label,
         dangerous_query_body, dangerous_query_title, delete_confirm_copy,
         delete_prefix_delete_button_label, delete_prefix_deleted_toast, delete_prefix_probe_totals,
-        delete_rows_label, error_with_detail_clipboard, execution_count_state_label,
+        delete_rows_label, dump_analysis_error_message, dump_analysis_parsing_progress,
+        dump_analysis_summary_line, dump_analysis_task_label, dump_analysis_title, error_with_detail_clipboard, execution_count_state_label,
         execution_mode_label, export_running_position_label, export_running_rows_label,
         export_summary_label, export_table_status_line, export_wizard_task_label,
         history_items_count_label, history_tab_label, image_decode_error, image_header_error,
@@ -6322,5 +6393,69 @@ mod tests {
             value,
             "document.data.grid.error.chart_save_no_profile_binding"
         );
+    }
+
+    #[test]
+    fn dump_analysis_title_interpolates_analyzer_and_file() {
+        let value = dump_analysis_title("Redis RDB", "dump.rdb");
+
+        assert!(value.contains("Redis RDB"));
+        assert!(value.contains("dump.rdb"));
+    }
+
+    #[test]
+    fn dump_analysis_parsing_progress_uses_of_total_bucket_when_total_known() {
+        let value = dump_analysis_parsing_progress(1024, Some(2048));
+
+        assert!(value.contains("1.0 KiB"));
+        assert!(value.contains("2.0 KiB"));
+    }
+
+    #[test]
+    fn dump_analysis_parsing_progress_falls_back_when_total_unknown() {
+        let value = dump_analysis_parsing_progress(1024, None);
+
+        assert!(value.contains("1.0 KiB"));
+        assert!(!value.contains("KiB of") && !value.contains("of 1.0 KiB"));
+    }
+
+    #[test]
+    fn dump_analysis_error_message_includes_offset_for_format_errors() {
+        let error = dbflux_core::DumpAnalysisError::Format {
+            offset: 4096,
+            message: "unexpected type byte".to_string(),
+        };
+
+        let value = dump_analysis_error_message(&error);
+
+        assert!(value.contains("4096"));
+        assert!(value.contains("unexpected type byte"));
+    }
+
+    #[test]
+    fn dump_analysis_error_message_maps_io_and_cancelled_variants() {
+        let io = dump_analysis_error_message(&dbflux_core::DumpAnalysisError::Io(
+            "permission denied".to_string(),
+        ));
+        let cancelled = dump_analysis_error_message(&dbflux_core::DumpAnalysisError::Cancelled);
+
+        assert!(io.contains("permission denied"));
+        assert_ne!(cancelled, "document.dump_analysis.error.cancelled");
+    }
+
+    #[test]
+    fn dump_analysis_task_label_interpolates_analyzer_and_file() {
+        let value = dump_analysis_task_label("Redis RDB", "dump.rdb");
+
+        assert!(value.contains("Redis RDB"));
+        assert!(value.contains("dump.rdb"));
+    }
+
+    #[test]
+    fn dump_analysis_summary_line_interpolates_keys_and_bytes() {
+        let value = dump_analysis_summary_line(42, 1024 * 1024);
+
+        assert!(value.contains('4') && value.contains('2'));
+        assert!(value.contains("1.0 MiB"));
     }
 }

--- a/crates/dbflux_ui_document/src/lib.rs
+++ b/crates/dbflux_ui_document/src/lib.rs
@@ -15,6 +15,7 @@ mod data_grid_panel;
 mod data_view;
 pub mod data_view_trait;
 pub mod dedup;
+pub mod dump_analysis;
 pub mod query_builder;
 pub mod schema_diff;
 mod style_guardrails;
@@ -54,6 +55,7 @@ pub use data_document::DataDocument;
 pub use data_grid_panel::{DataGridEvent, DataGridPanel, DataSource};
 pub use data_view::{DataViewConfig, DataViewMode};
 pub use data_view_trait::DataView;
+pub use dump_analysis::DumpAnalysisDocument;
 
 #[cfg(feature = "mcp")]
 pub use governance::McpApprovalsView;

--- a/crates/dbflux_ui_document/src/tab_bar.rs
+++ b/crates/dbflux_ui_document/src/tab_bar.rs
@@ -287,6 +287,7 @@ impl TabBar {
             super::types::DocumentIcon::Dashboard => AppIcon::ChartSpline,
             super::types::DocumentIcon::Buckets => AppIcon::Box,
             super::types::DocumentIcon::ObjectBrowser => AppIcon::Folder,
+            super::types::DocumentIcon::DumpAnalysis => AppIcon::HardDrive,
         };
 
         let center_x = self.active_tab_center_x.clone();

--- a/crates/dbflux_ui_document/src/types.rs
+++ b/crates/dbflux_ui_document/src/types.rs
@@ -34,6 +34,8 @@ pub enum DocumentKind {
     ObjectBrowser,
     // A single object-storage text object opened in its own editor tab
     ObjectEditor,
+    // Offline analysis report for a driver's native dump/export file
+    DumpAnalysis,
 }
 
 /// Source kind for DataDocument (affects icon and behavior).
@@ -63,6 +65,7 @@ pub enum DocumentIcon {
     Dashboard,
     Buckets,
     ObjectBrowser,
+    DumpAnalysis,
 }
 
 impl DocumentIcon {
@@ -81,6 +84,7 @@ impl DocumentIcon {
             Self::Dashboard => "layout-dashboard",
             Self::Buckets => "box",
             Self::ObjectBrowser => "folder-open",
+            Self::DumpAnalysis => "hard-drive",
         }
     }
 }

--- a/docs/es/drivers/redis.md
+++ b/docs/es/drivers/redis.md
@@ -89,6 +89,15 @@ Driver de clave-valor Redis para DBFlux, construido sobre el crate
   real en lugar de transferir el payload; los tipos de colección no se ven
   afectados, y las lecturas de stream que alcanzan el tope de fetch se reportan
   como truncadas.
+- Análisis offline de dumps RDB (`DumpAnalyzer`): un archivo `.rdb` se escanea
+  clave por clave sin conectarse a un servidor, procesando el archivo a
+  velocidad de E/S con memoria plana (los valores de las claves nunca se
+  decodifican, solo los nombres de clave y el tipo de valor). Reporta el total
+  de claves, un desglose por tipo, las 500 claves más grandes y una
+  agregación por prefijo. Los tamaños reportados son el **tamaño serializado
+  en disco** de cada clave, no su huella en la memoria viva de Redis — el
+  overhead del allocator y las codificaciones en memoria hacen que ambos
+  números diverjan.
 
 La introspección de schema reporta un único keyspace `db0` agregado en una
 conexión Cluster: el conteo de claves y el TTL promedio se suman/promedian a


### PR DESCRIPTION
Closes #358

## Summary

- A streaming RDB parser (`crates/dbflux_driver_redis/src/rdb.rs`) walks a user-picked dump at I/O speed with flat memory: values are skipped by their encodings and never decoded, only key names materialize (with a hand-rolled, bounded LZF decompressor for compressed names — no new dependency), expiries and database switches are tracked, and any unrecognized structure returns a typed error naming the file offset instead of desyncing. Streams are fully skippable across all three format versions, including consumer groups and PELs.
- The parser sits behind a driver-agnostic seam: a `DumpAnalyzer` trait in `dbflux_core` with a defaulted `DbDriver::dump_analyzer()` hook. Reports carry bounded aggregates only — top-500 largest keys via a min-heap, a by-prefix rollup capped at 10k buckets plus overflow, and per-type totals — so a multi-gigabyte dump with millions of keys never builds a full key list.
- A new file-scoped document renders the report: summary header showing the analyzer's serialized-size caveat verbatim, sortable largest-keys and by-prefix tables, with every size column labeled **Serialized size** — the number is dump bytes, not live memory, and the UI says so per the issue. Parsing runs on the background executor with live progress and cancellation through the Tasks panel.
- The command palette's "Analyze database dump…" action enumerates analyzers from the driver registry generically — no driver id appears anywhere in UI code (the existing style guardrail passes).
- 31 unit tests cover the parser with hand-built byte fixtures (every value type, LZF names, expiries, SELECTDB, truncation, unknown opcodes with exact offsets, cancellation), and a new Docker-backed `live_rdb` CI suite seeds every type including a stream with a consumer group, runs `SAVE`, and asserts the analyzer against a genuinely Redis-produced dump.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo nextest run --workspace --no-fail-fast`: 5779/5780; the single failure is the known flaky palette time-budget test (untouched, passes in isolation)
- [x] `cargo test --doc --workspace` clean
- [ ] The `live_rdb` suite could not run locally (rootless podman without subuid mappings cannot start the redis image at all) — this PR's CI run is its first real execution, same situation the `live_cluster` suite passed on first run
- [ ] Manual GPUI smoke pending: run the palette action on a real dump, watch progress, cancel from the Tasks panel, sort both tables