### PR TITLE
feat(driver): report a client identity on the remaining drivers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,6 +2820,7 @@ dependencies = [
  "aws-sdk-dynamodb",
  "dbflux_core",
  "dbflux_test_support",
+ "log",
  "serde_json",
  "tokio",
 ]
@@ -2995,6 +2996,7 @@ dependencies = [
  "chrono",
  "dbflux_core",
  "dbflux_test_support",
+ "log",
  "tokio",
  "urlencoding",
 ]

--- a/crates/dbflux/tests/client_identity_version.rs
+++ b/crates/dbflux/tests/client_identity_version.rs
@@ -10,3 +10,9 @@ fn client_identity_matches_app_version() {
     let expected = format!("dbflux/{}", env!("CARGO_PKG_VERSION"));
     assert_eq!(dbflux_core::client_identity(), expected);
 }
+
+#[test]
+fn client_identity_token_matches_app_version() {
+    let expected = format!("dbflux-{}", env!("CARGO_PKG_VERSION"));
+    assert_eq!(dbflux_core::client_identity_token(), expected);
+}

--- a/crates/dbflux_core/src/lib.rs
+++ b/crates/dbflux_core/src/lib.rs
@@ -23,7 +23,7 @@ pub use access::{AccessHandle, AccessKind, AccessManager};
 
 pub use document_id::DocumentId;
 
-pub use release_channel::{ReleaseChannel, client_identity};
+pub use release_channel::{ReleaseChannel, client_identity, client_identity_token};
 
 pub use auth::{
     AuthEditCapabilities, AuthEditSnapshot, AuthEditTarget, AuthFormDef, AuthProfile,

--- a/crates/dbflux_core/src/release_channel.rs
+++ b/crates/dbflux_core/src/release_channel.rs
@@ -78,6 +78,18 @@ pub fn client_identity() -> &'static str {
     concat!("dbflux/", env!("CARGO_PKG_VERSION"))
 }
 
+/// Client identity in the charset the AWS SDK's `AppName` accepts.
+///
+/// `AppName` allows only ASCII alphanumerics and `!#$%&'*+-.^_`|~`
+/// (`aws-types::app_name::AppName::new`); every character `client_identity()`
+/// produces already falls in that set except the `/` separator, so replacing
+/// it with `-` is the only transform needed. Returned as an owned `String`
+/// because `AppName::new` takes `Cow<'static, str>` and this is computed at
+/// call time rather than baked in via `concat!`.
+pub fn client_identity_token() -> String {
+    client_identity().replace('/', "-")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,6 +99,25 @@ mod tests {
         let identity = client_identity();
         assert!(identity.starts_with("dbflux/"));
         assert_eq!(&identity["dbflux/".len()..], env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn client_identity_token_matches_app_name_charset() {
+        fn is_app_name_char(c: char) -> bool {
+            c.is_ascii_alphanumeric() || "!#$%&'*+-.^_`|~".contains(c)
+        }
+
+        let token = client_identity_token();
+        assert!(!token.is_empty());
+        assert!(token.chars().all(is_app_name_char));
+    }
+
+    #[test]
+    fn client_identity_token_replaces_slash_with_dash() {
+        assert_eq!(
+            client_identity_token(),
+            format!("dbflux-{}", env!("CARGO_PKG_VERSION"))
+        );
     }
 
     #[test]

--- a/crates/dbflux_driver_clickhouse/README.md
+++ b/crates/dbflux_driver_clickhouse/README.md
@@ -39,6 +39,7 @@ the endpoint is a URL and not a host/port pair.
 - Read-only visual SELECT generation, using ClickHouse identifier and literal
   quoting rules.
 - Chart authoring from query results, and CSV and JSON export.
+- Every HTTP request reports `dbflux/<version>` as the `User-Agent` header, visible in server-side request logs.
 
 ### Type handling
 

--- a/crates/dbflux_driver_clickhouse/src/http.rs
+++ b/crates/dbflux_driver_clickhouse/src/http.rs
@@ -71,6 +71,7 @@ impl ClickHouseHttpClient {
             .tcp_nodelay(true)
             .use_rustls_tls()
             .redirect(Policy::none())
+            .user_agent(dbflux_core::client_identity())
             .build()
             .map_err(|error| ClickHouseHttpError::Transport(error.to_string()))?;
 

--- a/crates/dbflux_driver_cloudwatch/README.md
+++ b/crates/dbflux_driver_cloudwatch/README.md
@@ -28,6 +28,7 @@ AWS CloudWatch Logs driver for DBFlux, built on the [`aws-sdk-cloudwatchlogs`](h
 - CloudWatch Metrics via `GetMetricData`: executes a single `MetricDataQuery` per request, maps the response to a two-column (timestamp, value) `QueryResult` ordered ascending by timestamp. Timestamps from AWS (second-precision) are converted to milliseconds. Multi-metric pivot to wide format is supported when multiple `MetricDataResult` entries are returned.
 - Browse CloudWatch metric catalog (namespaces and per-namespace metrics with dimension combinations) via `ListMetrics` pagination. Namespace listing is synthesized by sweeping `ListMetrics` with no filter and collecting distinct namespace strings. Results are cached in-session by `MetricCatalogCache`.
 - Metric catalog is browsable from the connection sidebar tree (Metrics > Namespace > Metric). Clicking a metric leaf opens a chart pre-populated with defaults (Average / 5 min period / aggregate across all dimensions) and immediately executes it. The picker rail in the chart document allows refining dimensions, period, and statistic.
+- Client identity: every request carries `dbflux-<version>` as the AWS SDK app name, visible in CloudTrail's `userAgent` field.
 
 ## Limitations
 

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use aws_config::{BehaviorVersion, Region};
+use aws_config::{AppName, BehaviorVersion, Region};
 use aws_sdk_cloudwatch::config::Builder as CloudWatchMetricsConfigBuilder;
 use aws_sdk_cloudwatch::error::ProvideErrorMetadata as CloudWatchProvideErrorMetadata;
 use aws_sdk_cloudwatch::primitives::DateTime as MetricsDateTime;
@@ -1166,6 +1166,11 @@ fn build_clients(
 ) -> Result<(Client, aws_sdk_cloudwatch::Client), DbError> {
     let mut loader =
         aws_config::defaults(BehaviorVersion::latest()).region(Region::new(config.region.clone()));
+
+    match AppName::new(dbflux_core::client_identity_token()) {
+        Ok(app_name) => loader = loader.app_name(app_name),
+        Err(error) => log::warn!("failed to set AWS SDK app name: {error}"),
+    }
 
     if let Some(profile) = &config.profile {
         loader = loader.profile_name(profile);

--- a/crates/dbflux_driver_dynamodb/Cargo.toml
+++ b/crates/dbflux_driver_dynamodb/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/lib.rs"
 dbflux_core.workspace = true
 aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-dynamodb = "1"
+log.workspace = true
 tokio = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/dbflux_driver_dynamodb/README.md
+++ b/crates/dbflux_driver_dynamodb/README.md
@@ -24,6 +24,7 @@ AWS DynamoDB driver for DBFlux, built on the [`aws-sdk-dynamodb`](https://crates
 - Nested documents and arrays mapped into the document-tree view (`NESTED_DOCUMENTS`, `ARRAYS`).
 - DDL: drop table (`supports_drop_table: true`).
 - Pagination via page tokens (`PaginationStyle::PageToken`).
+- Client identity: every request carries `dbflux-<version>` as the AWS SDK app name, visible in CloudTrail's `userAgent` field.
 
 ## Limitations
 

--- a/crates/dbflux_driver_dynamodb/src/driver.rs
+++ b/crates/dbflux_driver_dynamodb/src/driver.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use aws_config::{BehaviorVersion, Region};
+use aws_config::{AppName, BehaviorVersion, Region};
 use aws_sdk_dynamodb::config::{Builder as DynamoConfigBuilder, Credentials};
 use aws_sdk_dynamodb::error::ProvideErrorMetadata;
 use aws_sdk_dynamodb::operation::batch_write_item::BatchWriteItemError;
@@ -3716,6 +3716,11 @@ fn unsupported_operation(operation: &str, message: &str) -> DbError {
 fn build_client(config: &DynamoProfileConfig) -> Result<Client, DbError> {
     let mut loader =
         aws_config::defaults(BehaviorVersion::latest()).region(Region::new(config.region.clone()));
+
+    match AppName::new(dbflux_core::client_identity_token()) {
+        Ok(app_name) => loader = loader.app_name(app_name),
+        Err(error) => log::warn!("failed to set AWS SDK app name: {error}"),
+    }
 
     if let Some(profile) = &config.profile {
         loader = loader.profile_name(profile);

--- a/crates/dbflux_driver_influxdb/README.md
+++ b/crates/dbflux_driver_influxdb/README.md
@@ -72,6 +72,7 @@ InfluxDB driver for DBFlux.
 - **"Query Measurement" context menu** — right-clicking a measurement in the sidebar shows "Query Measurement". The action opens a new code document pre-populated with a template query (`SELECT * FROM ...` for InfluxQL, `from(bucket: ...) |> range(...)` for Flux).
 - **"New Query" context menu on buckets** — right-clicking a bucket/database node shows "New Query", opening a blank code document with the connection activated.
 - **Read-template generation** — `InfluxQueryGenerator` produces select-all and per-measurement read templates for both InfluxQL and Flux (used by the context-menu actions and copy-as-query), version-aware via the connection's configured version and default bucket.
+- **Client identity** — every HTTP request reports `dbflux/<version>` as the `User-Agent` header, visible in server-side request logs.
 
 ## Limitations
 

--- a/crates/dbflux_driver_influxdb/src/http.rs
+++ b/crates/dbflux_driver_influxdb/src/http.rs
@@ -150,6 +150,7 @@ impl HttpClient {
             .gzip(true)
             .tcp_nodelay(true)
             .use_rustls_tls()
+            .user_agent(dbflux_core::client_identity())
             .build()
             .map_err(|error| HttpError::Transport(error.to_string()))?;
 

--- a/crates/dbflux_driver_s3/Cargo.toml
+++ b/crates/dbflux_driver_s3/Cargo.toml
@@ -18,6 +18,7 @@ aws-config = { version = "1", features = ["behavior-version-latest"] }
 aws-sdk-s3 = "1"
 aws-smithy-types = "1"
 chrono = { workspace = true }
+log.workspace = true
 tokio = { workspace = true }
 urlencoding = { workspace = true }
 

--- a/crates/dbflux_driver_s3/README.md
+++ b/crates/dbflux_driver_s3/README.md
@@ -23,6 +23,7 @@ AWS S3 and S3-compatible object-storage driver for DBFlux, built on the [`aws-sd
 - Presigned URLs: GET/PUT method choice, 15-minute/1-hour/12-hour/7-day expiry, copy-URL action, and warning text naming the expiry and signing identity.
 - Every CRUD/mutation operation (upload, delete, recursive delete, folder/bucket create, bucket delete, save-back edit, rename, presign) is audited under the object-storage `EventCategory`, with credentials and presigned URLs never logged or persisted.
 - Permission and not-found errors (`AccessDenied`, `NoSuchBucket`, `NoSuchKey`) are formatted with the affected bucket/key named in the message, not just AWS's generic error text.
+- Client identity: every request carries `dbflux-<version>` as the AWS SDK app name, visible in CloudTrail's `userAgent` field.
 
 ## Limitations
 

--- a/crates/dbflux_driver_s3/src/driver.rs
+++ b/crates/dbflux_driver_s3/src/driver.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use aws_config::{BehaviorVersion, Region};
+use aws_config::{AppName, BehaviorVersion, Region};
 use aws_sdk_s3::Client;
 use aws_sdk_s3::config::{Builder as S3ConfigBuilder, Credentials};
 use aws_sdk_s3::presigning::PresigningConfig;
@@ -326,6 +326,11 @@ fn build_client(
 ) -> Result<Client, DbError> {
     let mut loader =
         aws_config::defaults(BehaviorVersion::latest()).region(Region::new(config.region.clone()));
+
+    match AppName::new(dbflux_core::client_identity_token()) {
+        Ok(app_name) => loader = loader.app_name(app_name),
+        Err(error) => log::warn!("failed to set AWS SDK app name: {error}"),
+    }
 
     if let Some(profile) = &config.profile {
         loader = loader.profile_name(profile);

--- a/docs/es/drivers/clickhouse.md
+++ b/docs/es/drivers/clickhouse.md
@@ -43,6 +43,8 @@ así que el endpoint es una URL y no un par host/port.
   identificadores y literales de ClickHouse.
 - Creación de gráficos a partir de resultados de queries, y exportación a CSV y
   JSON.
+- Cada request HTTP reporta `dbflux/<versión>` como header `User-Agent`, visible
+  en los logs de request del lado del servidor.
 
 ### Manejo de tipos
 

--- a/docs/es/drivers/cloudwatch.md
+++ b/docs/es/drivers/cloudwatch.md
@@ -63,6 +63,8 @@ Driver de AWS CloudWatch Logs para DBFlux, construido sobre el SDK
   min / agregado entre todas las dimensiones) y lo ejecuta de inmediato. El
   panel lateral (picker rail) en el documento de gráfico permite refinar
   dimensiones, período y estadística.
+- Identidad del cliente: cada request lleva `dbflux-<versión>` como app name del
+  SDK de AWS, visible en el campo `userAgent` de CloudTrail.
 
 ## Limitaciones
 

--- a/docs/es/drivers/dynamodb.md
+++ b/docs/es/drivers/dynamodb.md
@@ -46,6 +46,8 @@ Driver de AWS DynamoDB para DBFlux, construido sobre el SDK
   (`NESTED_DOCUMENTS`, `ARRAYS`).
 - DDL: drop table (`supports_drop_table: true`).
 - Paginación vía page tokens (`PaginationStyle::PageToken`).
+- Identidad del cliente: cada request lleva `dbflux-<versión>` como app name del
+  SDK de AWS, visible en el campo `userAgent` de CloudTrail.
 
 ## Limitaciones
 

--- a/docs/es/drivers/influxdb.md
+++ b/docs/es/drivers/influxdb.md
@@ -132,6 +132,8 @@ Driver de InfluxDB para DBFlux.
   para Flux (usadas por las acciones del menú contextual y copy-as-query),
   sensibles a la versión según la versión configurada de la conexión y el bucket
   por defecto.
+- **Identidad del cliente** — cada request HTTP reporta `dbflux/<versión>` como
+  header `User-Agent`, visible en los logs de request del lado del servidor.
 
 ## Limitaciones
 

--- a/docs/es/drivers/s3.md
+++ b/docs/es/drivers/s3.md
@@ -59,6 +59,8 @@ Está detrás del feature flag `s3`.
 - Los errores de permiso y de no-encontrado (`AccessDenied`, `NoSuchBucket`,
   `NoSuchKey`) se formatean con el bucket/key afectado nombrado en el mensaje,
   no solo con el texto de error genérico de AWS.
+- Identidad del cliente: cada request lleva `dbflux-<versión>` como app name del
+  SDK de AWS, visible en el campo `userAgent` de CloudTrail.
 
 ## Limitaciones
 


### PR DESCRIPTION
Closes #500

## Summary

- **InfluxDB / ClickHouse**: both drivers build all requests through a single `reqwest` client constructor (`http.rs`); each now sets `.user_agent(dbflux_core::client_identity())`. Neither driver has a user-configurable header mechanism, so there is no override to respect.
- **DynamoDB / CloudWatch / S3**: each crate's one `aws_config::defaults(...)` site now sets the SDK `AppName`, making DBFlux sessions attributable in CloudTrail's `userAgent`. `AppName` rejects `/` (charset verified against `aws-types` source: ASCII alphanumerics plus `!#$%&'*+-.^_`|~`), so a new core helper `client_identity_token()` produces `dbflux-<version>`; construction is best-effort — a rejected name logs a warning and the connection proceeds.
- The existing version-drift guard in `crates/dbflux/tests/client_identity_version.rs` now covers the token helper too.
- Five driver READMEs and their Spanish mirrors document the reported identity.

With this, every driver that has a server to identify to reports `dbflux/<version>` (or the AWS-safe token); SQLite remains the only N/A.

## Test plan

- [x] `cargo clippy` `-D warnings` clean on all seven touched crates; `cargo check --workspace` clean
- [x] Scoped `cargo nextest run`: 1495 tests, the single failure being a pre-existing timing-flaky hook-streaming test in an untouched file
- [x] Core helper charset and drift tests
- [ ] HTTP header emission not unit-testable without a live server (builders all terminate in `.send()`); verifiable live via server logs / CloudTrail