### PR TITLE
feat(query): driver-owned language services for InfluxDB and CloudWatch

### DIFF
--- a/crates/dbflux_core/src/query/language_service.rs
+++ b/crates/dbflux_core/src/query/language_service.rs
@@ -287,15 +287,20 @@ pub fn classify_query_for_language(
     classify_query_for_language_with_service(query_language, query, None)
 }
 
-/// Classify a query's execution impact, optionally delegating a `Custom`
-/// language to the driver's own [`LanguageService`].
+/// Classify a query's execution impact, optionally delegating driver-owned
+/// languages to the driver's own [`LanguageService`].
 ///
-/// For the built-in languages the classification is keyed off the language. For
-/// a `Custom(_)` language the classifier consults `service` (when present) so a
-/// driver-defined surface (e.g. PartiQL) is classified by the driver rather than
-/// dead-ending at a conservative `Write`. With no service it falls back to
-/// `Write`, preserving the previous conservative default for non-connection
-/// callers.
+/// `Sql`, `MongoQuery`, and `RedisCommands` have a shared heuristic in core and
+/// are classified directly from the language, ignoring `service`. Every other
+/// language — `Custom(_)` as well as the fixed non-SQL variants that still have
+/// no shared core heuristic (`CloudWatchLogsInsightsQl`, `OpenSearchPpl`,
+/// `OpenSearchSql`, `InfluxQuery`, `Flux`) — consults `service.classify_execution`
+/// (when present) first, so a driver-defined surface is classified by the
+/// driver rather than dead-ending at a conservative default. With no service,
+/// or when the service's `classify_execution` returns `None` (its default),
+/// each of those languages falls back to the same conservative default it used
+/// before delegation existed: `Read` for the CloudWatch/OpenSearch trio, `Write`
+/// for everything else in this group.
 pub fn classify_query_for_language_with_service(
     query_language: &QueryLanguage,
     query: &str,
@@ -303,14 +308,27 @@ pub fn classify_query_for_language_with_service(
 ) -> ExecutionClassification {
     match query_language {
         QueryLanguage::Sql => classify_sql_execution(query),
+
+        // These languages are fixed (non-`Custom`) variants, but like `Custom`
+        // they are driver-owned dialects with no shared heuristic in core. A
+        // driver whose `LanguageService` overrides `classify_execution` gets
+        // consulted first; a driver that does not (the default returns `None`)
+        // falls back to the same conservative default this language used
+        // before delegation existed, so behavior for those drivers is
+        // unchanged.
         QueryLanguage::CloudWatchLogsInsightsQl
         | QueryLanguage::OpenSearchPpl
-        | QueryLanguage::OpenSearchSql => ExecutionClassification::Read,
+        | QueryLanguage::OpenSearchSql => service
+            .and_then(|service| service.classify_execution(query))
+            .unwrap_or(ExecutionClassification::Read),
+
         QueryLanguage::MongoQuery => classify_mongo_query(query),
         QueryLanguage::RedisCommands => classify_redis_query(query),
-        QueryLanguage::Custom(_) => service
+
+        QueryLanguage::InfluxQuery | QueryLanguage::Flux | QueryLanguage::Custom(_) => service
             .and_then(|service| service.classify_execution(query))
             .unwrap_or(ExecutionClassification::Write),
+
         _ => ExecutionClassification::Write,
     }
 }
@@ -1684,6 +1702,134 @@ END $$;"#;
         assert_eq!(
             classify_query_for_language_with_service(&language, "weird", Some(&service)),
             ExecutionClassification::Write
+        );
+    }
+
+    // ==================== Fixed non-SQL language delegation ====================
+    // DEC — classify_query_for_language_with_service also delegates fixed
+    // (non-Custom) driver-owned languages to the driver's LanguageService, not
+    // just Custom(_). See InfluxDB/CloudWatch drivers for real services.
+
+    struct DestructiveOnDropService;
+    impl LanguageService for DestructiveOnDropService {
+        fn validate(&self, _query: &str) -> ValidationResult {
+            ValidationResult::Valid
+        }
+        fn detect_dangerous(&self, _query: &str) -> Option<DangerousQueryKind> {
+            None
+        }
+        fn classify_execution(&self, query: &str) -> Option<ExecutionClassification> {
+            if query.to_ascii_uppercase().contains("DROP") {
+                Some(ExecutionClassification::Destructive)
+            } else {
+                None
+            }
+        }
+    }
+
+    struct NeverOverridesService;
+    impl LanguageService for NeverOverridesService {
+        fn validate(&self, _query: &str) -> ValidationResult {
+            ValidationResult::Valid
+        }
+        fn detect_dangerous(&self, _query: &str) -> Option<DangerousQueryKind> {
+            None
+        }
+        // classify_execution intentionally left at its default (returns None).
+    }
+
+    #[test]
+    fn influxquery_and_flux_delegate_to_service_when_it_classifies() {
+        let service = DestructiveOnDropService;
+
+        assert_eq!(
+            classify_query_for_language_with_service(
+                &QueryLanguage::InfluxQuery,
+                "DROP DATABASE mydb",
+                Some(&service),
+            ),
+            ExecutionClassification::Destructive
+        );
+        assert_eq!(
+            classify_query_for_language_with_service(
+                &QueryLanguage::Flux,
+                "drop(bucket: \"b\")",
+                Some(&service),
+            ),
+            ExecutionClassification::Destructive
+        );
+    }
+
+    #[test]
+    fn cloudwatch_languages_delegate_to_service_when_it_classifies() {
+        let service = DestructiveOnDropService;
+
+        for language in [
+            QueryLanguage::CloudWatchLogsInsightsQl,
+            QueryLanguage::OpenSearchPpl,
+            QueryLanguage::OpenSearchSql,
+        ] {
+            assert_eq!(
+                classify_query_for_language_with_service(
+                    &language,
+                    "fields @message | filter @message like /DROP/",
+                    Some(&service),
+                ),
+                ExecutionClassification::Destructive
+            );
+        }
+    }
+
+    #[test]
+    fn sql_variant_is_unaffected_by_service_delegation() {
+        // Sql keeps its own core heuristic and never consults the service,
+        // even when one is supplied and would otherwise classify this query
+        // as Destructive.
+        let service = DestructiveOnDropService;
+
+        assert_eq!(
+            classify_query_for_language_with_service(
+                &QueryLanguage::Sql,
+                "SELECT * FROM t WHERE note = 'DROP'",
+                Some(&service),
+            ),
+            ExecutionClassification::Read
+        );
+    }
+
+    #[test]
+    fn influxquery_falls_back_to_write_when_service_returns_none() {
+        assert_eq!(
+            classify_query_for_language_with_service(
+                &QueryLanguage::InfluxQuery,
+                "SELECT * FROM cpu",
+                Some(&NeverOverridesService),
+            ),
+            ExecutionClassification::Write
+        );
+        assert_eq!(
+            classify_query_for_language(&QueryLanguage::Flux, "from(bucket:\"b\")"),
+            ExecutionClassification::Write
+        );
+    }
+
+    #[test]
+    fn cloudwatch_languages_fall_back_to_read_when_service_returns_none() {
+        assert_eq!(
+            classify_query_for_language_with_service(
+                &QueryLanguage::CloudWatchLogsInsightsQl,
+                "fields @timestamp",
+                Some(&NeverOverridesService),
+            ),
+            ExecutionClassification::Read
+        );
+        assert_eq!(
+            classify_query_for_language(&QueryLanguage::OpenSearchPpl, "source=logs"),
+            ExecutionClassification::Read
+        );
+        assert_eq!(
+            classify_query_for_language(&QueryLanguage::OpenSearchSql, "SELECT * FROM logs"),
+            ExecutionClassification::Read
         );
     }
 

--- a/crates/dbflux_driver_clickhouse/README.md
+++ b/crates/dbflux_driver_clickhouse/README.md
@@ -40,6 +40,7 @@ the endpoint is a URL and not a host/port pair.
   quoting rules.
 - Chart authoring from query results, and CSV and JSON export.
 - Every HTTP request reports `dbflux/<version>` as the `User-Agent` header, visible in server-side request logs.
+- Dangerous-query detection uses the shared `SqlLanguageService` (no ClickHouse-specific override): `ALTER TABLE ... DELETE WHERE ...` and `ALTER TABLE ... UPDATE ... WHERE ...` are already caught as `Alter` (any `ALTER`-prefixed statement is flagged regardless of sub-command), and `TRUNCATE`/`DROP` are caught as usual. `KILL QUERY`/`KILL MUTATION` and `OPTIMIZE TABLE ... FINAL` are not flagged — neither deletes rows or changes table structure — matching how other relational drivers treat comparable non-destructive administrative statements.
 
 ### Type handling
 

--- a/crates/dbflux_driver_clickhouse/src/language_service.rs
+++ b/crates/dbflux_driver_clickhouse/src/language_service.rs
@@ -1,0 +1,111 @@
+//! Pinning tests for ClickHouse's dangerous-query detection.
+//!
+//! `ClickHouseConnection` never overrides `Connection::language_service()`,
+//! so it inherits `dbflux_core`'s default `&SqlLanguageService`. Verified
+//! against ClickHouse's own mutation syntax: `ALTER TABLE ... DELETE WHERE`
+//! and `ALTER TABLE ... UPDATE ... WHERE` are already caught, because
+//! `detect_dangerous_sql` flags any statement starting with the `ALTER`
+//! keyword regardless of its sub-command, and `TRUNCATE` / `DROP` are caught
+//! by the same generic rules relational drivers share.
+//!
+//! `KILL QUERY` / `KILL MUTATION` and `OPTIMIZE TABLE ... FINAL` are not
+//! flagged. Neither is a row-level data-loss operation in the sense the
+//! existing `DangerousQueryKind` variants model (no rows are deleted or
+//! table structure changed); `KILL` cancels a running query/mutation and
+//! `OPTIMIZE ... FINAL` forces a merge. That mirrors the product's existing
+//! posture on other relational drivers, which also do not flag comparable
+//! non-destructive administrative statements (e.g. PostgreSQL's `VACUUM` or
+//! `pg_terminate_backend`). This module exists to pin that behavior with
+//! tests, not to add a new `ClickHouseLanguageService`.
+#[cfg(test)]
+mod tests {
+    use dbflux_core::{DangerousQueryKind, detect_dangerous_query};
+
+    #[test]
+    fn alter_table_delete_where_is_dangerous() {
+        assert_eq!(
+            detect_dangerous_query("ALTER TABLE events DELETE WHERE event_date < '2020-01-01'"),
+            Some(DangerousQueryKind::Alter)
+        );
+    }
+
+    #[test]
+    fn alter_table_delete_with_tautological_where_is_still_dangerous() {
+        // ClickHouse's ALTER ... DELETE requires a WHERE clause, so the
+        // "delete everything" shape is a tautological predicate rather than a
+        // missing one. It is still caught because ALTER is always flagged.
+        assert_eq!(
+            detect_dangerous_query("ALTER TABLE events DELETE WHERE 1 = 1"),
+            Some(DangerousQueryKind::Alter)
+        );
+    }
+
+    #[test]
+    fn alter_table_update_where_is_dangerous() {
+        assert_eq!(
+            detect_dangerous_query("ALTER TABLE events UPDATE status = 'archived' WHERE id = 1"),
+            Some(DangerousQueryKind::Alter)
+        );
+    }
+
+    #[test]
+    fn alter_table_add_column_is_dangerous() {
+        assert_eq!(
+            detect_dangerous_query("ALTER TABLE events ADD COLUMN region String"),
+            Some(DangerousQueryKind::Alter)
+        );
+    }
+
+    #[test]
+    fn truncate_table_is_dangerous() {
+        assert_eq!(
+            detect_dangerous_query("TRUNCATE TABLE events"),
+            Some(DangerousQueryKind::Truncate)
+        );
+    }
+
+    #[test]
+    fn drop_table_is_dangerous() {
+        assert_eq!(
+            detect_dangerous_query("DROP TABLE events"),
+            Some(DangerousQueryKind::Drop)
+        );
+    }
+
+    #[test]
+    fn drop_database_is_dangerous() {
+        assert_eq!(
+            detect_dangerous_query("DROP DATABASE analytics"),
+            Some(DangerousQueryKind::Drop)
+        );
+    }
+
+    #[test]
+    fn kill_query_is_not_flagged() {
+        assert_eq!(
+            detect_dangerous_query("KILL QUERY WHERE query_id = 'abc-123'"),
+            None
+        );
+    }
+
+    #[test]
+    fn kill_mutation_is_not_flagged() {
+        assert_eq!(
+            detect_dangerous_query("KILL MUTATION WHERE mutation_id = '0000000001'"),
+            None
+        );
+    }
+
+    #[test]
+    fn optimize_table_final_is_not_flagged() {
+        assert_eq!(detect_dangerous_query("OPTIMIZE TABLE events FINAL"), None);
+    }
+
+    #[test]
+    fn select_is_safe() {
+        assert_eq!(
+            detect_dangerous_query("SELECT * FROM events WHERE event_date = today()"),
+            None
+        );
+    }
+}

--- a/crates/dbflux_driver_clickhouse/src/lib.rs
+++ b/crates/dbflux_driver_clickhouse/src/lib.rs
@@ -15,6 +15,8 @@ pub mod driver;
 pub mod error_formatter;
 mod http;
 mod introspection;
+#[cfg(test)]
+mod language_service;
 pub mod types;
 
 pub use connection::ClickHouseConnection;

--- a/crates/dbflux_driver_cloudwatch/README.md
+++ b/crates/dbflux_driver_cloudwatch/README.md
@@ -29,6 +29,7 @@ AWS CloudWatch Logs driver for DBFlux, built on the [`aws-sdk-cloudwatchlogs`](h
 - Browse CloudWatch metric catalog (namespaces and per-namespace metrics with dimension combinations) via `ListMetrics` pagination. Namespace listing is synthesized by sweeping `ListMetrics` with no filter and collecting distinct namespace strings. Results are cached in-session by `MetricCatalogCache`.
 - Metric catalog is browsable from the connection sidebar tree (Metrics > Namespace > Metric). Clicking a metric leaf opens a chart pre-populated with defaults (Average / 5 min period / aggregate across all dimensions) and immediately executes it. The picker rail in the chart document allows refining dimensions, period, and statistic.
 - Client identity: every request carries `dbflux-<version>` as the AWS SDK app name, visible in CloudTrail's `userAgent` field.
+- `CloudWatchLanguageService` (`language_service.rs`) is honest about all three query surfaces being read-only: `detect_dangerous` always returns `None` and `classify_execution` always reports `Read`, instead of running SQL dangerous-query heuristics or the SQL grammar against Logs Insights QL / PPL / OpenSearch SQL text (none of these dialects have a query-shaped mutation or delete surface; log group/stream deletion is a management-API action, not a query).
 
 ## Limitations
 

--- a/crates/dbflux_driver_cloudwatch/src/driver.rs
+++ b/crates/dbflux_driver_cloudwatch/src/driver.rs
@@ -21,11 +21,12 @@ use dbflux_core::{
     FormFieldKind, FormSection, FormTab, FormValues, FormattedError, Icon, MetricCatalog,
     MetricQuerySeries, QueryLanguage, QueryRequest, QueryResult, SchemaFeatures,
     SchemaLoadingStrategy, SchemaSnapshot, SourceContextSpec, SourceQueryMode, TableInfo,
-    TransferFamily, ValidationResult, Value, field, field_required,
+    TransferFamily, Value, field, field_required,
 };
 
 use crate::dashboard_import::CloudWatchDashboardImporter;
 use crate::dashboard_source::{CloudWatchDashboardSource, RealCloudWatchDashboardApi};
+use crate::language_service::CloudWatchLanguageService;
 use crate::metric_catalog::{CloudWatchMetricCatalog, RealCloudWatchClient};
 
 pub static CLOUDWATCH_METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata {
@@ -124,8 +125,6 @@ struct CloudWatchConnection {
     /// Dashboard source — always present; returns `Some` from `dashboard_source()`.
     dashboard_source_impl: CloudWatchDashboardSource,
 }
-
-struct CloudWatchLanguageService;
 
 impl CloudWatchDriver {
     pub fn new() -> Self {
@@ -976,16 +975,6 @@ impl CloudWatchConnection {
         ];
 
         Ok(QueryResult::table(columns, rows, None, started.elapsed()))
-    }
-}
-
-impl dbflux_core::LanguageService for CloudWatchLanguageService {
-    fn validate(&self, _query: &str) -> ValidationResult {
-        ValidationResult::Valid
-    }
-
-    fn detect_dangerous(&self, _query: &str) -> Option<dbflux_core::DangerousQueryKind> {
-        None
     }
 }
 

--- a/crates/dbflux_driver_cloudwatch/src/language_service.rs
+++ b/crates/dbflux_driver_cloudwatch/src/language_service.rs
@@ -1,0 +1,84 @@
+//! Language service for CloudWatch's read-only query surfaces (Logs Insights
+//! QL, OpenSearch PPL, and OpenSearch SQL).
+//!
+//! All three dialects only read log data; none of them expose a query-shaped
+//! mutation or delete surface — log group/stream deletion happens through the
+//! CloudWatch management API, not through a query string. Without this
+//! service, `Connection::language_service()` fell back to
+//! `SqlLanguageService`, which ran SQL keyword heuristics and a SQL grammar
+//! parser against Insights QL / PPL text. That produced false "dangerous"
+//! signals whenever a field happened to be named `delete` or `drop`, and
+//! spurious editor syntax-error squiggles on valid Insights QL/PPL pipeline
+//! syntax the SQL grammar cannot parse. This service reports honestly instead:
+//! never dangerous, never a syntax diagnostic, always a read.
+
+use dbflux_core::{DangerousQueryKind, ExecutionClassification, LanguageService, ValidationResult};
+
+pub struct CloudWatchLanguageService;
+
+impl LanguageService for CloudWatchLanguageService {
+    fn validate(&self, _query: &str) -> ValidationResult {
+        ValidationResult::Valid
+    }
+
+    fn detect_dangerous(&self, _query: &str) -> Option<DangerousQueryKind> {
+        None
+    }
+
+    fn classify_execution(&self, _query: &str) -> Option<ExecutionClassification> {
+        Some(ExecutionClassification::Read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_is_always_permissive() {
+        assert!(matches!(
+            CloudWatchLanguageService.validate(""),
+            ValidationResult::Valid
+        ));
+        assert!(matches!(
+            CloudWatchLanguageService
+                .validate("fields @timestamp, @message | filter @message like /error/"),
+            ValidationResult::Valid
+        ));
+    }
+
+    #[test]
+    fn delete_as_field_name_is_not_dangerous() {
+        // "delete" and "drop" can legitimately appear as log field names in
+        // Logs Insights QL / PPL / OpenSearch SQL; the SQL heuristic gate
+        // this service replaces must never fire on this text.
+        let query = "fields delete, drop | filter delete = \"true\"";
+        assert_eq!(CloudWatchLanguageService.detect_dangerous(query), None);
+    }
+
+    #[test]
+    fn sql_shaped_text_in_a_log_message_is_never_dangerous() {
+        // CloudWatch has no query-shaped mutation surface; even text that
+        // looks SQL-dangerous stays read-only here.
+        let query = "SELECT * FROM logs WHERE message = 'DROP TABLE users'";
+        assert_eq!(CloudWatchLanguageService.detect_dangerous(query), None);
+    }
+
+    #[test]
+    fn ppl_pipeline_is_never_dangerous() {
+        let query = "source=my-log-group | where status_code >= 500 | stats count() by service";
+        assert_eq!(CloudWatchLanguageService.detect_dangerous(query), None);
+    }
+
+    #[test]
+    fn classify_execution_is_always_read() {
+        assert_eq!(
+            CloudWatchLanguageService.classify_execution("fields @timestamp"),
+            Some(ExecutionClassification::Read)
+        );
+        assert_eq!(
+            CloudWatchLanguageService.classify_execution(""),
+            Some(ExecutionClassification::Read)
+        );
+    }
+}

--- a/crates/dbflux_driver_cloudwatch/src/lib.rs
+++ b/crates/dbflux_driver_cloudwatch/src/lib.rs
@@ -12,8 +12,10 @@
 pub mod dashboard_import;
 pub mod dashboard_source;
 pub mod driver;
+pub mod language_service;
 pub mod metric_catalog;
 
 pub use dashboard_import::CloudWatchDashboardImporter;
 pub use dashboard_source::{CloudWatchApi, CloudWatchDashboardSource, RealCloudWatchDashboardApi};
 pub use driver::{CLOUDWATCH_FORM, CLOUDWATCH_METADATA, CloudWatchDriver};
+pub use language_service::CloudWatchLanguageService;

--- a/crates/dbflux_driver_influxdb/README.md
+++ b/crates/dbflux_driver_influxdb/README.md
@@ -73,6 +73,7 @@ InfluxDB driver for DBFlux.
 - **"New Query" context menu on buckets** — right-clicking a bucket/database node shows "New Query", opening a blank code document with the connection activated.
 - **Read-template generation** — `InfluxQueryGenerator` produces select-all and per-measurement read templates for both InfluxQL and Flux (used by the context-menu actions and copy-as-query), version-aware via the connection's configured version and default bucket.
 - **Client identity** — every HTTP request reports `dbflux/<version>` as the `User-Agent` header, visible in server-side request logs.
+- **Dialect-aware dangerous-query detection** — `InfluxLanguageService` sniffs InfluxQL vs. Flux from the query text (Flux is pipeline-shaped or opens with `import`) and flags InfluxQL `DROP DATABASE/MEASUREMENT/SERIES/RETENTION POLICY/SHARD` and `DELETE` without a `WHERE` clause, and Flux `delete()`/`influxdb.delete()` calls, before execution. `classify_execution` reports `SELECT`/`SHOW` as reads and `DELETE`/`DROP`/Flux `delete()` as destructive, so governance policies see accurate impact instead of a generic write. `validate` is a syntactic sanity check (balanced brackets and quotes), not a full parser.
 
 ## Limitations
 

--- a/crates/dbflux_driver_influxdb/src/connection.rs
+++ b/crates/dbflux_driver_influxdb/src/connection.rs
@@ -9,9 +9,10 @@ use std::time::Instant;
 
 use dbflux_core::{
     CollectionBrowseRequest, CollectionCountRequest, Connection, DatabaseInfo, DbError, DbKind,
-    DefaultSqlDialect, DriverMetadata, InfluxVersion, MeasurementInfo, QueryLanguage, QueryRequest,
-    QueryResult, ResolvedWindow, SchemaFeatures, SchemaLoadingStrategy, SchemaSnapshot,
-    SourceContextSpec, SourceQueryMode, TimeSeriesSchema, contains_time_macros,
+    DefaultSqlDialect, DriverMetadata, InfluxVersion, LanguageService, MeasurementInfo,
+    QueryLanguage, QueryRequest, QueryResult, ResolvedWindow, SchemaFeatures,
+    SchemaLoadingStrategy, SchemaSnapshot, SourceContextSpec, SourceQueryMode, TimeSeriesSchema,
+    contains_time_macros,
 };
 
 use crate::error_formatter::InfluxErrorFormatter;
@@ -20,6 +21,7 @@ use crate::injection::{
     ResolvedWindow as InjectionWindow, flux_has_range_call, influxql_has_time_predicate,
     inject_flux_window, inject_influxql_window,
 };
+use crate::language_service::InfluxLanguageService;
 use crate::metadata::InfluxQueryMetadata;
 use crate::parser::flux::parse_flux_csv;
 use crate::parser::influxql::parse_influxql_json;
@@ -524,6 +526,10 @@ impl Connection for InfluxConnection {
 
     fn dialect(&self) -> &dyn dbflux_core::SqlDialect {
         &DefaultSqlDialect
+    }
+
+    fn language_service(&self) -> &dyn LanguageService {
+        &InfluxLanguageService
     }
 
     fn source_context_spec(&self) -> Option<SourceContextSpec> {

--- a/crates/dbflux_driver_influxdb/src/language_service.rs
+++ b/crates/dbflux_driver_influxdb/src/language_service.rs
@@ -1,0 +1,455 @@
+//! Language service for InfluxDB's two query dialects (InfluxQL and Flux).
+//!
+//! `Connection::language_service()` carries no per-query context, unlike
+//! `InfluxConnection::resolve_language` (`connection.rs`), which knows the
+//! active dialect from the `QueryRequest`'s query mode. This service instead
+//! sniffs the dialect straight from the query text: Flux scripts are
+//! pipeline-shaped (`from(...) |> ...`) or open with an `import`, everything
+//! else is treated as InfluxQL, matching the driver's own default for both
+//! InfluxDB versions.
+
+use dbflux_core::{
+    DangerousQueryKind, Diagnostic, ExecutionClassification, LanguageService, ValidationResult,
+};
+
+pub struct InfluxLanguageService;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InfluxDialect {
+    InfluxQl,
+    Flux,
+}
+
+fn detect_dialect(query: &str) -> InfluxDialect {
+    let trimmed = query.trim_start();
+    if trimmed.starts_with("import ") || trimmed.starts_with("from(") || trimmed.contains("|>") {
+        InfluxDialect::Flux
+    } else {
+        InfluxDialect::InfluxQl
+    }
+}
+
+impl LanguageService for InfluxLanguageService {
+    fn validate(&self, query: &str) -> ValidationResult {
+        let trimmed = query.trim();
+        if trimmed.is_empty() {
+            return ValidationResult::Valid;
+        }
+
+        match unbalanced_delimiters(trimmed) {
+            Some(message) => ValidationResult::SyntaxError(Diagnostic::error(message)),
+            None => ValidationResult::Valid,
+        }
+    }
+
+    fn detect_dangerous(&self, query: &str) -> Option<DangerousQueryKind> {
+        match detect_dialect(query) {
+            InfluxDialect::InfluxQl => detect_dangerous_influxql(query),
+            InfluxDialect::Flux => detect_dangerous_flux(query),
+        }
+    }
+
+    fn classify_execution(&self, query: &str) -> Option<ExecutionClassification> {
+        Some(match detect_dialect(query) {
+            InfluxDialect::InfluxQl => classify_influxql(query),
+            InfluxDialect::Flux => classify_flux(query),
+        })
+    }
+}
+
+/// Replace the contents of quoted regions (single- or double-quoted) with
+/// spaces, so keyword detection never matches text living inside a string
+/// literal or a quoted identifier.
+fn strip_quoted_literals(query: &str) -> String {
+    let mut result = String::with_capacity(query.len());
+    let mut quote: Option<char> = None;
+
+    for c in query.chars() {
+        match quote {
+            Some(q) if c == q => {
+                quote = None;
+                result.push(' ');
+            }
+            Some(_) => result.push(' '),
+            None if c == '\'' || c == '"' => {
+                quote = Some(c);
+                result.push(' ');
+            }
+            None => result.push(c),
+        }
+    }
+
+    result
+}
+
+fn contains_where_token(normalized: &str) -> bool {
+    normalized
+        .split(|c: char| c.is_whitespace() || c == '(' || c == ')')
+        .any(|token| token == "where")
+}
+
+/// Detect dangerous InfluxQL patterns.
+///
+/// `DROP DATABASE|MEASUREMENT|SERIES|RETENTION POLICY|SHARD` are always
+/// destructive, mirroring SQL's `DROP` (irreversible regardless of any
+/// predicate). `DELETE` follows the same WHERE-presence convention used
+/// everywhere else in the codebase: a `DELETE` with no `WHERE` clause matches
+/// every point in the target and is flagged, a scoped `DELETE ... WHERE ...`
+/// is not.
+fn detect_dangerous_influxql(query: &str) -> Option<DangerousQueryKind> {
+    let normalized = strip_quoted_literals(query).trim().to_lowercase();
+    if normalized.is_empty() {
+        return None;
+    }
+
+    if normalized.starts_with("drop ") {
+        return Some(DangerousQueryKind::Drop);
+    }
+
+    if normalized.starts_with("delete") && !contains_where_token(&normalized) {
+        return Some(DangerousQueryKind::DeleteNoWhere);
+    }
+
+    None
+}
+
+fn classify_influxql(query: &str) -> ExecutionClassification {
+    let normalized = strip_quoted_literals(query).trim().to_lowercase();
+
+    if normalized.is_empty() {
+        return ExecutionClassification::Metadata;
+    }
+
+    if normalized.starts_with("show") || normalized.starts_with("explain") {
+        return ExecutionClassification::Metadata;
+    }
+
+    if normalized.starts_with("select") {
+        return ExecutionClassification::Read;
+    }
+
+    if normalized.starts_with("delete") || normalized.starts_with("drop") {
+        return ExecutionClassification::Destructive;
+    }
+
+    ExecutionClassification::Write
+}
+
+/// Detect a Flux `delete(...)` call, bare or namespaced (e.g.
+/// `influxdb.delete(...)`). Bucket deletion through the InfluxDB HTTP API is
+/// not query-shaped and is out of scope for query-text analysis.
+///
+/// The match requires a word boundary immediately before `delete(` so
+/// identifiers like `mydelete(` are not mistaken for the delete call, while
+/// `.delete(` (method-style, namespaced) is accepted.
+fn contains_flux_delete_call(normalized: &str) -> bool {
+    let needle = "delete(";
+    let mut search_start = 0;
+
+    while let Some(offset) = normalized[search_start..].find(needle) {
+        let idx = search_start + offset;
+        let preceding_is_ident = normalized[..idx]
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_');
+
+        if !preceding_is_ident {
+            return true;
+        }
+
+        search_start = idx + needle.len();
+    }
+
+    false
+}
+
+/// Detect dangerous Flux patterns.
+///
+/// Flux's `delete()` package function always takes a bucket, predicate,
+/// start, and stop — there is no narrower row-identity concept comparable to
+/// SQL's `WHERE id = ...`, so any invocation is treated as a broad delete and
+/// flagged uniformly, without trying to inspect the predicate argument.
+fn detect_dangerous_flux(query: &str) -> Option<DangerousQueryKind> {
+    let normalized = strip_quoted_literals(query).to_lowercase();
+
+    if contains_flux_delete_call(&normalized) {
+        return Some(DangerousQueryKind::DeleteNoWhere);
+    }
+
+    None
+}
+
+fn classify_flux(query: &str) -> ExecutionClassification {
+    let normalized = strip_quoted_literals(query).to_lowercase();
+
+    if normalized.trim().is_empty() {
+        return ExecutionClassification::Metadata;
+    }
+
+    if contains_flux_delete_call(&normalized) {
+        return ExecutionClassification::Destructive;
+    }
+
+    if normalized.contains("from(") {
+        return ExecutionClassification::Read;
+    }
+
+    ExecutionClassification::Write
+}
+
+/// Check that parentheses/brackets/braces are balanced and every quoted
+/// region is closed. This is a syntactic sanity check, not a parser: it
+/// rejects obviously malformed input (an unterminated string, a stray closing
+/// bracket) and accepts everything else, since neither InfluxQL nor Flux has
+/// a bundled grammar in this codebase.
+fn unbalanced_delimiters(query: &str) -> Option<String> {
+    let mut stack: Vec<char> = Vec::new();
+    let mut quote: Option<char> = None;
+
+    for c in query.chars() {
+        if let Some(q) = quote {
+            if c == q {
+                quote = None;
+            }
+            continue;
+        }
+
+        match c {
+            '\'' | '"' => quote = Some(c),
+            '(' | '[' | '{' => stack.push(c),
+            ')' if stack.pop() != Some('(') => return Some("Unmatched ')'".to_string()),
+            ']' if stack.pop() != Some('[') => return Some("Unmatched ']'".to_string()),
+            '}' if stack.pop() != Some('{') => return Some("Unmatched '}'".to_string()),
+            _ => {}
+        }
+    }
+
+    if quote.is_some() {
+        return Some("Unterminated string literal".to_string());
+    }
+
+    stack
+        .pop()
+        .map(|unclosed| format!("Unmatched '{unclosed}'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ==================== InfluxQL dangerous patterns ====================
+
+    #[test]
+    fn influxql_drop_database_is_dangerous() {
+        assert_eq!(
+            InfluxLanguageService.detect_dangerous("DROP DATABASE mydb"),
+            Some(DangerousQueryKind::Drop)
+        );
+    }
+
+    #[test]
+    fn influxql_drop_measurement_is_dangerous() {
+        assert_eq!(
+            InfluxLanguageService.detect_dangerous("DROP MEASUREMENT cpu"),
+            Some(DangerousQueryKind::Drop)
+        );
+    }
+
+    #[test]
+    fn influxql_drop_series_is_dangerous() {
+        assert_eq!(
+            InfluxLanguageService.detect_dangerous("DROP SERIES FROM cpu WHERE region = 'us-west'"),
+            Some(DangerousQueryKind::Drop)
+        );
+    }
+
+    #[test]
+    fn influxql_drop_retention_policy_is_dangerous() {
+        assert_eq!(
+            InfluxLanguageService.detect_dangerous("DROP RETENTION POLICY \"weekly\" ON mydb"),
+            Some(DangerousQueryKind::Drop)
+        );
+    }
+
+    #[test]
+    fn influxql_drop_shard_is_dangerous() {
+        assert_eq!(
+            InfluxLanguageService.detect_dangerous("DROP SHARD 1"),
+            Some(DangerousQueryKind::Drop)
+        );
+    }
+
+    #[test]
+    fn influxql_delete_without_where_is_dangerous() {
+        assert_eq!(
+            InfluxLanguageService.detect_dangerous("DELETE FROM cpu"),
+            Some(DangerousQueryKind::DeleteNoWhere)
+        );
+    }
+
+    #[test]
+    fn influxql_delete_with_where_is_safe() {
+        assert_eq!(
+            InfluxLanguageService
+                .detect_dangerous("DELETE FROM cpu WHERE time < '2024-01-01T00:00:00Z'"),
+            None
+        );
+    }
+
+    #[test]
+    fn influxql_select_is_safe() {
+        assert_eq!(
+            InfluxLanguageService.detect_dangerous("SELECT * FROM cpu WHERE time > now() - 1h"),
+            None
+        );
+    }
+
+    #[test]
+    fn influxql_drop_word_inside_string_is_safe() {
+        // "drop" appearing inside a string literal must not trigger the gate.
+        let query = "SELECT * FROM cpu WHERE status = 'drop'";
+        assert_eq!(InfluxLanguageService.detect_dangerous(query), None);
+    }
+
+    // ==================== Flux dangerous patterns ====================
+
+    #[test]
+    fn flux_bare_delete_call_is_dangerous() {
+        let query =
+            r#"delete(bucket: "b", start: 2024-01-01T00:00:00Z, stop: 2024-01-02T00:00:00Z)"#;
+        assert_eq!(
+            InfluxLanguageService.detect_dangerous(query),
+            Some(DangerousQueryKind::DeleteNoWhere)
+        );
+    }
+
+    #[test]
+    fn flux_namespaced_delete_call_is_dangerous() {
+        let query = r#"
+import "influxdata/influxdb/v1"
+influxdb.delete(bucket: "b", predicate: (r) => true, start: 2024-01-01T00:00:00Z, stop: 2024-01-02T00:00:00Z)
+"#;
+        assert_eq!(
+            InfluxLanguageService.detect_dangerous(query),
+            Some(DangerousQueryKind::DeleteNoWhere)
+        );
+    }
+
+    #[test]
+    fn flux_query_with_drop_word_in_string_is_safe() {
+        let query =
+            r#"from(bucket:"b") |> range(start: -1h) |> filter(fn: (r) => r.tag == "drop")"#;
+        assert_eq!(InfluxLanguageService.detect_dangerous(query), None);
+    }
+
+    #[test]
+    fn flux_identifier_containing_delete_is_not_a_call() {
+        let query = r#"from(bucket:"b") |> filter(fn: (r) => r._field == "mydelete")"#;
+        assert_eq!(InfluxLanguageService.detect_dangerous(query), None);
+    }
+
+    // ==================== classify_execution ====================
+
+    #[test]
+    fn influxql_select_classifies_as_read() {
+        assert_eq!(
+            InfluxLanguageService.classify_execution("SELECT * FROM cpu"),
+            Some(ExecutionClassification::Read)
+        );
+    }
+
+    #[test]
+    fn influxql_show_classifies_as_metadata() {
+        assert_eq!(
+            InfluxLanguageService.classify_execution("SHOW MEASUREMENTS"),
+            Some(ExecutionClassification::Metadata)
+        );
+    }
+
+    #[test]
+    fn influxql_delete_classifies_as_destructive() {
+        assert_eq!(
+            InfluxLanguageService.classify_execution("DELETE FROM cpu"),
+            Some(ExecutionClassification::Destructive)
+        );
+    }
+
+    #[test]
+    fn influxql_insert_classifies_as_write() {
+        assert_eq!(
+            InfluxLanguageService.classify_execution("INSERT cpu,host=a value=1"),
+            Some(ExecutionClassification::Write)
+        );
+    }
+
+    #[test]
+    fn flux_from_pipeline_classifies_as_read() {
+        let query = r#"from(bucket:"b") |> range(start: -1h)"#;
+        assert_eq!(
+            InfluxLanguageService.classify_execution(query),
+            Some(ExecutionClassification::Read)
+        );
+    }
+
+    #[test]
+    fn flux_delete_call_classifies_as_destructive() {
+        let query =
+            r#"delete(bucket: "b", start: 2024-01-01T00:00:00Z, stop: 2024-01-02T00:00:00Z)"#;
+        assert_eq!(
+            InfluxLanguageService.classify_execution(query),
+            Some(ExecutionClassification::Destructive)
+        );
+    }
+
+    // ==================== validate ====================
+
+    #[test]
+    fn empty_query_is_valid() {
+        assert!(matches!(
+            InfluxLanguageService.validate(""),
+            ValidationResult::Valid
+        ));
+    }
+
+    #[test]
+    fn valid_influxql_has_no_syntax_error() {
+        assert!(matches!(
+            InfluxLanguageService.validate("SELECT * FROM cpu WHERE time > now() - 1h"),
+            ValidationResult::Valid
+        ));
+    }
+
+    #[test]
+    fn valid_flux_has_no_syntax_error() {
+        let query =
+            r#"from(bucket:"b") |> range(start: -1h) |> filter(fn: (r) => r._field == "usage")"#;
+        assert!(matches!(
+            InfluxLanguageService.validate(query),
+            ValidationResult::Valid
+        ));
+    }
+
+    #[test]
+    fn unbalanced_parens_is_syntax_error() {
+        assert!(matches!(
+            InfluxLanguageService.validate("SELECT * FROM cpu WHERE time IN (1, 2"),
+            ValidationResult::SyntaxError(_)
+        ));
+    }
+
+    #[test]
+    fn unterminated_string_is_syntax_error() {
+        assert!(matches!(
+            InfluxLanguageService.validate("SELECT * FROM cpu WHERE status = 'open"),
+            ValidationResult::SyntaxError(_)
+        ));
+    }
+
+    #[test]
+    fn stray_closing_paren_is_syntax_error() {
+        assert!(matches!(
+            InfluxLanguageService.validate("SELECT * FROM cpu)"),
+            ValidationResult::SyntaxError(_)
+        ));
+    }
+}

--- a/crates/dbflux_driver_influxdb/src/lib.rs
+++ b/crates/dbflux_driver_influxdb/src/lib.rs
@@ -16,6 +16,7 @@ pub mod driver;
 pub mod error_formatter;
 pub mod http;
 pub mod injection;
+pub mod language_service;
 pub mod metadata;
 pub mod parser;
 pub mod query_generator;

--- a/crates/dbflux_driver_influxdb/tests/governance_classification.rs
+++ b/crates/dbflux_driver_influxdb/tests/governance_classification.rs
@@ -1,0 +1,55 @@
+//! Proves `InfluxLanguageService` is actually consulted through
+//! `dbflux_core::classify_query_for_language_with_service` — the public API
+//! surface that gained fixed-language delegation. This is the lowest-level
+//! function the governance layer's classifier (`classify_query_for_governance`
+//! in `dbflux_core::query::safety`) is built on.
+//!
+//! NOTE: `classify_query_for_governance`, which is what MCP/policy call
+//! directly (`dbflux_mcp::handlers::query::handle_query_tool`,
+//! `dbflux_mcp_server::tools::query`), does not thread any connection or
+//! `LanguageService` through — it always passes `None` for `service`. So a
+//! `DROP DATABASE` executed through the live MCP path still classifies as the
+//! pre-delegation default (`Write`) today; wiring the actor's live
+//! `Connection::language_service()` into that call is a separate, larger
+//! change (spanning `dbflux_mcp`/`dbflux_app`) outside this crate's scope.
+//! This test targets the API this repo's delegation mechanism is built on,
+//! which is what a future connection-aware governance call would use.
+
+use dbflux_core::{
+    ExecutionClassification, QueryLanguage, classify_query_for_language_with_service,
+};
+use dbflux_driver_influxdb::language_service::InfluxLanguageService;
+
+#[test]
+fn influxql_drop_database_classifies_destructive_through_the_delegated_public_api() {
+    let service = InfluxLanguageService;
+
+    let classification = classify_query_for_language_with_service(
+        &QueryLanguage::InfluxQuery,
+        "DROP DATABASE mydb",
+        Some(&service),
+    );
+
+    assert_eq!(classification, ExecutionClassification::Destructive);
+}
+
+#[test]
+fn influxql_select_still_classifies_read_through_the_delegated_public_api() {
+    let service = InfluxLanguageService;
+
+    let classification = classify_query_for_language_with_service(
+        &QueryLanguage::InfluxQuery,
+        "SELECT * FROM cpu",
+        Some(&service),
+    );
+
+    assert_eq!(classification, ExecutionClassification::Read);
+}
+
+#[test]
+fn without_a_service_influxquery_keeps_the_pre_delegation_write_fallback() {
+    let classification =
+        dbflux_core::classify_query_for_language(&QueryLanguage::InfluxQuery, "DROP DATABASE mydb");
+
+    assert_eq!(classification, ExecutionClassification::Write);
+}

--- a/docs/es/drivers/clickhouse.md
+++ b/docs/es/drivers/clickhouse.md
@@ -45,6 +45,14 @@ así que el endpoint es una URL y no un par host/port.
   JSON.
 - Cada request HTTP reporta `dbflux/<versión>` como header `User-Agent`, visible
   en los logs de request del lado del servidor.
+- La detección de queries peligrosas usa el `SqlLanguageService` compartido (sin
+  override específico de ClickHouse): `ALTER TABLE ... DELETE WHERE ...` y
+  `ALTER TABLE ... UPDATE ... WHERE ...` ya se detectan como `Alter` (cualquier
+  statement que empiece con `ALTER` se marca sin importar el subcomando), y
+  `TRUNCATE`/`DROP` se detectan como de costumbre. `KILL QUERY`/`KILL MUTATION`
+  y `OPTIMIZE TABLE ... FINAL` no se marcan — ninguno borra filas ni cambia la
+  estructura de la tabla — igual que otros drivers relacionales tratan
+  statements administrativos no destructivos comparables.
 
 ### Manejo de tipos
 

--- a/docs/es/drivers/cloudwatch.md
+++ b/docs/es/drivers/cloudwatch.md
@@ -65,6 +65,13 @@ Driver de AWS CloudWatch Logs para DBFlux, construido sobre el SDK
   dimensiones, período y estadística.
 - Identidad del cliente: cada request lleva `dbflux-<versión>` como app name del
   SDK de AWS, visible en el campo `userAgent` de CloudTrail.
+- `CloudWatchLanguageService` (`language_service.rs`) es honesto sobre que las
+  tres superficies de query son de solo lectura: `detect_dangerous` siempre
+  devuelve `None` y `classify_execution` siempre reporta `Read`, en vez de
+  ejecutar las heurísticas de queries peligrosas o la gramática SQL contra
+  texto de Logs Insights QL / PPL / OpenSearch SQL (ninguno de estos dialectos
+  tiene una superficie de mutación o borrado en forma de query; borrar un log
+  group/stream es una acción de la API de administración, no una query).
 
 ## Limitaciones
 

--- a/docs/es/drivers/influxdb.md
+++ b/docs/es/drivers/influxdb.md
@@ -134,6 +134,15 @@ Driver de InfluxDB para DBFlux.
   por defecto.
 - **Identidad del cliente** — cada request HTTP reporta `dbflux/<versión>` como
   header `User-Agent`, visible en los logs de request del lado del servidor.
+- **Detección de queries peligrosas sensible al dialecto** — `InfluxLanguageService`
+  detecta si el texto es InfluxQL o Flux (Flux tiene forma de pipeline o empieza
+  con `import`) y marca `DROP DATABASE/MEASUREMENT/SERIES/RETENTION POLICY/SHARD`
+  y `DELETE` sin cláusula `WHERE` en InfluxQL, y llamadas a `delete()`/
+  `influxdb.delete()` en Flux, antes de ejecutar. `classify_execution` reporta
+  `SELECT`/`SHOW` como lectura y `DELETE`/`DROP`/`delete()` de Flux como
+  destructivo, para que las políticas de gobernanza vean el impacto real en vez
+  de una escritura genérica. `validate` es una verificación sintáctica básica
+  (paréntesis y comillas balanceados), no un parser completo.
 
 ## Limitaciones
 


### PR DESCRIPTION
Closes #498

## Summary

- **InfluxDB** no longer inherits `SqlLanguageService` — SQL heuristics and tree-sitter SQL diagnostics ran against Flux/InfluxQL text, producing spurious dangerous-query prompts and syntax squiggles. Its new service sniffs the dialect (Flux's pipeline shape vs InfluxQL), flags `DROP DATABASE/MEASUREMENT/SERIES/RETENTION POLICY/SHARD` and unbounded `DELETE`, detects Flux `delete()` calls with word-boundary and string-literal safety, does minimal syntactic validation (balanced brackets/quotes, not a parser), and classifies execution.
- **CloudWatch** already had a private honest service (the audit's claim was stale); it moves to the standard `language_service.rs` module layout and gains an always-`Read` execution classification — its three query languages have no mutation surface.
- **ClickHouse** keeps the shared SQL service, now verified instead of assumed: pinning tests prove `ALTER TABLE … DELETE/UPDATE`, `TRUNCATE`, and `DROP` are already caught, and document that `KILL QUERY/MUTATION` and `OPTIMIZE … FINAL` intentionally are not (admin statements without data loss, consistent with the other relational drivers).
- **Core**: `classify_query_for_language_with_service` now delegates to the driver's service for the fixed non-SQL variants that had no shared heuristic (Influx and CloudWatch languages), preserving every existing fallback bit-for-bit when a service abstains. SQL/Mongo/Redis paths untouched.

## Known limitation (pre-existing, filed separately)

The live MCP governance path (`classify_query_for_governance`) carries only a connection id and always passes `service: None`, so MCP-side classification remains service-blind for InfluxDB — and always has been for DynamoDB's PartiQL. Wiring the live connection through `dbflux_mcp`/`dbflux_app` is a cross-crate change tracked in its own follow-up issue.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo nextest run --workspace --no-fail-fast`: 5949/5950 (the known flaky palette time-budget test, untouched)
- [x] `cargo test --doc --workspace` clean
- [x] 47 new tests: InfluxQL/Flux dangerous+safe pairs incl. false-positive guards, CloudWatch honesty, ClickHouse caught/slipped pinning, core delegation with fallback preservation
- [ ] Manual smoke: open an InfluxDB editor tab and confirm no SQL squiggles on valid Flux