### PR TITLE
docs: remove duplicate table cells flagged by Weblate

### DIFF
--- a/docs/AUDIT.md
+++ b/docs/AUDIT.md
@@ -345,14 +345,8 @@ The bridge recognizes these named fields on tracing events and maps them to `Eve
 |---------------|---------------------|
 | `message` | `summary` |
 | `category` | `category` (coerced to `System`) |
-| `actor_type` | `actor_type` |
-| `actor_id` | `actor_id` |
-| `connection_id` | `connection_id` |
-| `database_name` | `database_name` |
-| `driver_id` | `driver_id` |
-| `action` | `action` |
-| `outcome` | `outcome` |
-| `details_json` | `details_json` |
+
+The fields `actor_type`, `actor_id`, `connection_id`, `database_name`, `driver_id`, `action`, `outcome`, and `details_json` are recognized as well and map to the `EventRecord` field of the same name.
 
 Unknown fields accumulate in `details_json` as a JSON object. If the message exceeds 512 characters it is truncated with `…` and the full message is stored in `details_json["message"]`.
 

--- a/docs/DRIVER_RPC_PROTOCOL.md
+++ b/docs/DRIVER_RPC_PROTOCOL.md
@@ -201,14 +201,14 @@ The v1.3 `Hello` response additionally carries `audit_emit_opt_in` (`bool`). Set
 
 Supported request / response flow:
 
-| Request | Response | Purpose |
-|---|---|---|
-| `Hello` | `Hello` | protocol negotiation + provider identity |
-| `ValidateSession` | `SessionState` | validate cached auth state |
-| `Login` | `LoginUrlProgress?` + `LoginResult` | optional verification URL + terminal login result |
-| `ResolveCredentials` | `Credentials` | resolve runtime credential fields |
-| `FetchDynamicOptions` | `DynamicOptions` | resolve dynamic dropdown options for a `DynamicSelect` form field (v1.2+) |
-| (any request) | `EmitAuditEvent` (intermediate) | audit event emission (v1.3+) |
+| Request → Response | Purpose |
+|---|---|
+| `Hello` → `Hello` | protocol negotiation + provider identity |
+| `ValidateSession` → `SessionState` | validate cached auth state |
+| `Login` → `LoginUrlProgress?` + `LoginResult` | optional verification URL + terminal login result |
+| `ResolveCredentials` → `Credentials` | resolve runtime credential fields |
+| `FetchDynamicOptions` → `DynamicOptions` | resolve dynamic dropdown options for a `DynamicSelect` form field (v1.2+) |
+| (any request) → `EmitAuditEvent` (intermediate) | audit event emission (v1.3+) |
 
 Notes:
 
@@ -260,15 +260,15 @@ The service should parse `profile_json`, expect `DbConfig::External`, and valida
 
 ## Request/response overview
 
-| Request | Response | Purpose |
-|---|---|---|
-| `Hello` | `Hello` | protocol negotiation + driver identity |
-| `OpenSession` | `SessionOpened` | open connection/session |
-| `CloseSession` | `SessionClosed` | close session |
-| `Ping` | `Pong` | liveness |
-| `Execute` | `ExecuteResult` | query execution |
-| `Schema` | `Schema` | schema snapshot |
-| `ListDatabases` | `Databases` | database list |
+| Request → Response | Purpose |
+|---|---|
+| `Hello` → `Hello` | protocol negotiation + driver identity |
+| `OpenSession` → `SessionOpened` | open connection/session |
+| `CloseSession` → `SessionClosed` | close session |
+| `Ping` → `Pong` | liveness |
+| `Execute` → `ExecuteResult` | query execution |
+| `Schema` → `Schema` | schema snapshot |
+| `ListDatabases` → `Databases` | database list |
 
 The protocol also supports browse, CRUD, key-value, and code generation operations. See `crates/dbflux_ipc/src/driver_protocol.rs` for the full enum set.
 

--- a/docs/LUA.md
+++ b/docs/LUA.md
@@ -214,14 +214,14 @@ hook.ok()
 
 **Return value:**
 
-| Field       | Type        | Description                                |
-| ----------- | ----------- | ------------------------------------------ |
-| `ok`        | boolean     | `true` if the process was detached, or if exit code is 0 and not timed out |
-| `detached`  | boolean     | `true` if the process was handed off as detached (in which case the output/exit fields below are empty/nil) |
-| `exit_code` | integer/nil | Process exit code                          |
-| `stdout`    | string      | Captured stdout                            |
-| `stderr`    | string      | Captured stderr                            |
-| `timed_out` | boolean     | `true` if per-process timeout fired        |
+| Field       | Description                                |
+| ----------- | ------------------------------------------ |
+| `ok`        | boolean. `true` if the process was detached, or if exit code is 0 and not timed out |
+| `detached`  | boolean. `true` if the process was handed off as detached (in which case the output/exit fields below are empty/nil) |
+| `exit_code` | integer/nil. Process exit code             |
+| `stdout`    | string. Captured stdout                    |
+| `stderr`    | string. Captured stderr                    |
+| `timed_out` | boolean. `true` if per-process timeout fired |
 
 **Available allowlists:**
 

--- a/docs/MCP_AI_INTEGRATION.md
+++ b/docs/MCP_AI_INTEGRATION.md
@@ -161,11 +161,7 @@ Three policies and three roles are shipped as immutable built-ins. They are alwa
 
 ### Built-in roles
 
-| ID | Assigned policy |
-|----|----------------|
-| `builtin/read-only` | `builtin/read-only` |
-| `builtin/write` | `builtin/write` |
-| `builtin/admin` | `builtin/admin` |
+There are three built-in roles, `builtin/read-only`, `builtin/write`, and `builtin/admin`. Each one is assigned the policy of the same ID.
 
 Built-ins are injected at startup in both the GUI app (`AppState`) and the MCP server (via the `builtin_policies()` / `builtin_roles()` loops in `dbflux_mcp_server::governance`). They are never written to disk. Any attempt to delete a built-in returns an error.
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -6,11 +6,11 @@ This document is the human-facing reference. The automated `dbflux-release` skil
 
 ## Channels
 
-| Channel     | Source branch   | Tag pattern             | GitHub release kind | Built by          |
-|-------------|-----------------|-------------------------|---------------------|-------------------|
-| **nightly** | `main` HEAD     | `nightly` (rolling)     | prerelease          | Cron — daily      |
-| **rc**      | `release/vX.Y`  | `vX.Y.Z-rc.N`           | prerelease          | Tag push          |
-| **stable**  | `release/vX.Y`  | `vX.Y.Z`                | published           | Tag push          |
+| Channel (source branch)     | Tag pattern         | GitHub release                    |
+|-----------------------------|---------------------|-----------------------------------|
+| **nightly** (`main` HEAD)   | `nightly` (rolling) | prerelease, built by a daily cron |
+| **rc** (`release/vX.Y`)     | `vX.Y.Z-rc.N`       | prerelease, built on tag push     |
+| **stable** (`release/vX.Y`) | `vX.Y.Z`            | published, built on tag push      |
 
 The `-dev.N` channel is **retired**. Nightly replaces it. Old `-dev.N` tags remain on GitHub but no new ones are created.
 
@@ -55,11 +55,11 @@ git push origin vX.Y.Z[-suffix.N]
 
 The release workflow (`.github/workflows/release.yml`) classifies tags automatically:
 
-| Tag pattern    | Allowed source branch | GitHub release kind |
-|----------------|-----------------------|---------------------|
-| `vX.Y.Z-rc.N`  | `release/vX.Y`        | prerelease          |
-| `vX.Y.Z`       | `release/vX.Y`        | stable (published)  |
-| anything else  | (safety net)          | draft               |
+| Tag pattern (allowed source branch) | GitHub release kind |
+|-------------------------------------|---------------------|
+| `vX.Y.Z-rc.N` from `release/vX.Y`   | prerelease          |
+| `vX.Y.Z` from `release/vX.Y`        | stable (published)  |
+| anything else (safety net)          | draft               |
 
 ## Versioning Rules
 
@@ -224,11 +224,11 @@ git log --grep='cherry picked from' release/vX.Y
 
 ## Downstream Channels
 
-| Tag kind        | GitHub Release | AUR         | Nix flake (this repo)                         | nixpkgs (future) |
-|-----------------|----------------|-------------|-----------------------------------------------|------------------|
-| nightly         | prerelease     | skip        | auto-pinned — `#dbflux-nightly` on nightly ref | skip            |
-| `-rc.N`         | prerelease     | skip        | bump release branch's + main's `release-info` | skip             |
-| Stable `vX.Y.Z` | published      | bump + push | bump release branch's + main's `release-info` | bump + PR        |
+| Tag kind (GitHub Release)   | AUR         | Nix flake (this repo)                         | nixpkgs (future) |
+|-----------------------------|-------------|-----------------------------------------------|------------------|
+| nightly (prerelease)        | skip        | auto-pinned — `#dbflux-nightly` on nightly ref | skip            |
+| `-rc.N` (prerelease)        | skip        | bump release branch's + main's `release-info` | skip             |
+| Stable `vX.Y.Z` (published) | bump + push | bump release branch's + main's `release-info` | bump + PR        |
 
 ### AUR
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -69,11 +69,11 @@ drivers and query languages. There is no per-database toggle — the same rules
 apply to SQL `DELETE`/`DROP`/`TRUNCATE`, MongoDB `deleteMany`/`drop`, Redis
 `FLUSHALL`/`FLUSHDB`, and so on.
 
-| Setting | Default | What it does |
-|---------|---------|--------------|
-| **Confirm dangerous queries** | On | Show a confirmation before running a dangerous query. Turn off to allow them without prompting. |
-| **Require WHERE for DELETE/UPDATE** | On | Treat a `DELETE`/`UPDATE` with no `WHERE` as dangerous. |
-| **Always require preview (ignore suppressions)** | Off | Force the confirm/preview modal even for queries you previously chose to stop confirming. |
+| Setting | What it does |
+|---------|--------------|
+| **Confirm dangerous queries** | On by default; show a confirmation before running a dangerous query. Turn off to allow them without prompting. |
+| **Require WHERE for DELETE/UPDATE** | On by default; treat a `DELETE`/`UPDATE` with no `WHERE` as dangerous. |
+| **Always require preview (ignore suppressions)** | Off by default; force the confirm/preview modal even for queries you previously chose to stop confirming. |
 
 ### Storage (Nightly builds only)
 
@@ -200,12 +200,12 @@ default.
 
 A Lua hook only gets the abilities you enable:
 
-| Capability | Default | Grants |
-|------------|---------|--------|
-| **Logging** | On | Write to the hook's output. |
-| **Environment read** | On | Read environment variables. |
-| **Connection metadata** | On | Read the connecting profile's metadata. |
-| **Controlled process run** | Off | Call `dbflux.process.run(...)` to launch external processes. |
+| Capability | Grants |
+|------------|--------|
+| **Logging** | On by default; write to the hook's output. |
+| **Environment read** | On by default; read environment variables. |
+| **Connection metadata** | On by default; read the connecting profile's metadata. |
+| **Controlled process run** | Off by default; call `dbflux.process.run(...)` to launch external processes. |
 
 > Enabling **Controlled process run** lets the hook execute arbitrary external
 > commands. DBFlux shows a security warning when it's on, both in the hook

--- a/docs/es/AUDIT.md
+++ b/docs/es/AUDIT.md
@@ -413,14 +413,10 @@ a campos de `EventRecord`:
 | ---------------- | ----------------------------------- |
 | `message`        | `summary`                           |
 | `category`       | `category` (coaccionado a `System`) |
-| `actor_type`     | `actor_type`                        |
-| `actor_id`       | `actor_id`                          |
-| `connection_id`  | `connection_id`                     |
-| `database_name`  | `database_name`                     |
-| `driver_id`      | `driver_id`                         |
-| `action`         | `action`                            |
-| `outcome`        | `outcome`                           |
-| `details_json`   | `details_json`                      |
+
+Los campos `actor_type`, `actor_id`, `connection_id`, `database_name`,
+`driver_id`, `action`, `outcome` y `details_json` también se reconocen y se
+mapean al campo de `EventRecord` con el mismo nombre.
 
 Los campos desconocidos se acumulan en `details_json` como un objeto JSON. Si el
 mensaje excede los 512 caracteres, se trunca con `…` y el mensaje completo se

--- a/docs/es/DRIVER_RPC_PROTOCOL.md
+++ b/docs/es/DRIVER_RPC_PROTOCOL.md
@@ -236,14 +236,14 @@ default es `false`.
 
 Flujo de request/response soportado:
 
-| Request               | Response                            | Propósito                                                                                   |
-| --------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------- |
-| `Hello`               | `Hello`                             | negociación de protocolo + identidad del provider                                           |
-| `ValidateSession`     | `SessionState`                      | validar el estado de auth cacheado                                                          |
-| `Login`               | `LoginUrlProgress?` + `LoginResult` | URL de verificación opcional + resultado de login terminal                                  |
-| `ResolveCredentials`  | `Credentials`                       | resolver los campos de credenciales en runtime                                              |
-| `FetchDynamicOptions` | `DynamicOptions`                    | resolver opciones de dropdown dinámicas para un campo de formulario `DynamicSelect` (v1.2+) |
-| (cualquier request)   | `EmitAuditEvent` (intermedio)       | emisión de audit event (v1.3+)                                                              |
+| Request → Response                            | Propósito                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `Hello` → `Hello`                             | negociación de protocolo + identidad del provider                                           |
+| `ValidateSession` → `SessionState`            | validar el estado de auth cacheado                                                          |
+| `Login` → `LoginUrlProgress?` + `LoginResult` | URL de verificación opcional + resultado de login terminal                                  |
+| `ResolveCredentials` → `Credentials`          | resolver los campos de credenciales en runtime                                              |
+| `FetchDynamicOptions` → `DynamicOptions`      | resolver opciones de dropdown dinámicas para un campo de formulario `DynamicSelect` (v1.2+) |
+| (cualquier request) → `EmitAuditEvent` (intermedio) | emisión de audit event (v1.3+)                                                        |
 
 Notas:
 
@@ -315,15 +315,15 @@ de nuevo los campos obligatorios del lado del servidor.
 
 ## Resumen de request/response
 
-| Request         | Response        | Propósito                                       |
-| --------------- | --------------- | ----------------------------------------------- |
-| `Hello`         | `Hello`         | negociación de protocolo + identidad del driver |
-| `OpenSession`   | `SessionOpened` | abrir conexión/sesión                           |
-| `CloseSession`  | `SessionClosed` | cerrar sesión                                   |
-| `Ping`          | `Pong`          | liveness                                        |
-| `Execute`       | `ExecuteResult` | ejecución de query                              |
-| `Schema`        | `Schema`        | snapshot de schema                              |
-| `ListDatabases` | `Databases`     | listado de bases de datos                       |
+| Request → Response               | Propósito                                       |
+| -------------------------------- | ----------------------------------------------- |
+| `Hello` → `Hello`                | negociación de protocolo + identidad del driver |
+| `OpenSession` → `SessionOpened`  | abrir conexión/sesión                           |
+| `CloseSession` → `SessionClosed` | cerrar sesión                                   |
+| `Ping` → `Pong`                  | liveness                                        |
+| `Execute` → `ExecuteResult`      | ejecución de query                              |
+| `Schema` → `Schema`              | snapshot de schema                              |
+| `ListDatabases` → `Databases`    | listado de bases de datos                       |
 
 El protocolo también soporta operaciones de browse, CRUD, key-value y generación
 de código. Ver `crates/dbflux_ipc/src/driver_protocol.rs` para el conjunto

--- a/docs/es/LUA.md
+++ b/docs/es/LUA.md
@@ -264,14 +264,14 @@ restricción.
 
 **Valor de retorno:**
 
-| Campo       | Tipo        | Descripción                                                                                                       |
-| ----------- | ----------- | ----------------------------------------------------------------------------------------------------------------- |
-| `ok`        | boolean     | `true` si el proceso fue detached, o si el exit code es 0 y no hubo timeout                                       |
-| `detached`  | boolean     | `true` si el proceso se entregó como detached (en cuyo caso los campos de output/exit de abajo quedan vacíos/nil) |
-| `exit_code` | integer/nil | Exit code del proceso                                                                                             |
-| `stdout`    | string      | stdout capturado                                                                                                  |
-| `stderr`    | string      | stderr capturado                                                                                                  |
-| `timed_out` | boolean     | `true` si se disparó el timeout por proceso                                                                       |
+| Campo       | Descripción                                                                                                                |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `ok`        | boolean. `true` si el proceso fue detached, o si el exit code es 0 y no hubo timeout                                       |
+| `detached`  | boolean. `true` si el proceso se entregó como detached (en cuyo caso los campos de output/exit de abajo quedan vacíos/nil) |
+| `exit_code` | integer/nil. Exit code del proceso                                                                                         |
+| `stdout`    | string. stdout capturado                                                                                                   |
+| `stderr`    | string. stderr capturado                                                                                                   |
+| `timed_out` | boolean. `true` si se disparó el timeout por proceso                                                                       |
 
 **Allowlists disponibles:**
 

--- a/docs/es/MCP_AI_INTEGRATION.md
+++ b/docs/es/MCP_AI_INTEGRATION.md
@@ -187,11 +187,8 @@ modificarse.
 
 ### Roles integrados
 
-| ID                  | Policy asignada     |
-| ------------------- | ------------------- |
-| `builtin/read-only` | `builtin/read-only` |
-| `builtin/write`     | `builtin/write`     |
-| `builtin/admin`     | `builtin/admin`     |
+Hay tres roles integrados: `builtin/read-only`, `builtin/write` y
+`builtin/admin`. A cada uno se le asigna la policy con el mismo ID.
 
 Los built-ins se inyectan al arranque tanto en la app GUI (`AppState`) como en
 el servidor MCP (a través de los loops `builtin_policies()` / `builtin_roles()`

--- a/docs/es/RELEASE.md
+++ b/docs/es/RELEASE.md
@@ -10,11 +10,11 @@ Este documento es la referencia orientada a humanos. El skill automatizado
 
 ## Canales
 
-| Canal       | Branch de origen | Patrón de tag       | Tipo de GitHub release | Construido por |
-| ----------- | ---------------- | ------------------- | ---------------------- | -------------- |
-| **nightly** | `main` HEAD      | `nightly` (rolling) | prerelease             | Cron — diario  |
-| **rc**      | `release/vX.Y`   | `vX.Y.Z-rc.N`       | prerelease             | Push del tag   |
-| **stable**  | `release/vX.Y`   | `vX.Y.Z`            | published              | Push del tag   |
+| Canal (branch de origen)    | Patrón de tag       | GitHub release                       |
+| --------------------------- | ------------------- | ------------------------------------ |
+| **nightly** (`main` HEAD)   | `nightly` (rolling) | prerelease, construido por cron diario |
+| **rc** (`release/vX.Y`)     | `vX.Y.Z-rc.N`       | prerelease, construido con push del tag |
+| **stable** (`release/vX.Y`) | `vX.Y.Z`            | published, construido con push del tag |
 
 El canal `-dev.N` está **retirado**. Nightly lo reemplaza. Los tags `-dev.N`
 antiguos permanecen en GitHub pero no se crean nuevos.
@@ -84,11 +84,11 @@ git push origin vX.Y.Z[-suffix.N]
 El workflow de release (`.github/workflows/release.yml`) clasifica los tags
 automáticamente:
 
-| Patrón de tag  | Branch de origen permitido | Tipo de GitHub release |
-| -------------- | -------------------------- | ---------------------- |
-| `vX.Y.Z-rc.N`  | `release/vX.Y`             | prerelease             |
-| `vX.Y.Z`       | `release/vX.Y`             | stable (published)     |
-| cualquier otro | (red de seguridad)         | draft                  |
+| Patrón de tag (branch de origen permitido) | Tipo de GitHub release |
+| ------------------------------------------ | ---------------------- |
+| `vX.Y.Z-rc.N` desde `release/vX.Y`          | prerelease             |
+| `vX.Y.Z` desde `release/vX.Y`               | stable (published)     |
+| cualquier otro (red de seguridad)           | draft                  |
 
 ## Reglas de Versionado
 
@@ -321,11 +321,11 @@ git log --grep='cherry picked from' release/vX.Y
 
 ## Canales Downstream
 
-| Tipo de tag     | GitHub Release | AUR         | Nix flake (este repo)                                      | nixpkgs (futuro) |
-| --------------- | -------------- | ----------- | ---------------------------------------------------------- | ---------------- |
-| nightly         | prerelease     | se omite    | auto-fijado — `#dbflux-nightly` en la ref nightly          | se omite         |
-| `-rc.N`         | prerelease     | se omite    | actualiza el `release-info` de la release branch y de main | se omite         |
-| Stable `vX.Y.Z` | published      | bump + push | actualiza el `release-info` de la release branch y de main | bump + PR        |
+| Tipo de tag (GitHub Release) | AUR         | Nix flake (este repo)                                      | nixpkgs (futuro) |
+| ---------------------------- | ----------- | ---------------------------------------------------------- | ---------------- |
+| nightly (prerelease)         | se omite    | auto-fijado — `#dbflux-nightly` en la ref nightly          | se omite         |
+| `-rc.N` (prerelease)         | se omite    | actualiza el `release-info` de la release branch y de main | se omite         |
+| Stable `vX.Y.Z` (published)  | bump + push | actualiza el `release-info` de la release branch y de main | bump + PR        |
 
 ### AUR
 


### PR DESCRIPTION
Weblate reports a "duplicate string" error on six documentation components, which is holding up the libre-hosting approval. Its Markdown parser assigns one unit key per table (the table's starting line), so every cell of that table shares the key and two identical cells inside one table collide. Cells in different tables never collide.

Verified against `/browse/dbflux/docs-settings/en/?q=source:="On"`, which returns four units keyed `:47`, `:57`, `:72`, `:203`, one per table rather than one per occurrence.

Each fix removes the repeat without dropping information:

| Document | Duplicate | Fix |
|---|---|---|
| `SETTINGS.md` | `On` x3 | fold the `Default` column into the description |
| `AUDIT.md` | eight `EventRecord` field names | collapse the identity rows into a sentence |
| `LUA.md` | `boolean`, `string` | fold the `Type` column into `Description` |
| `RELEASE.md` | `release/vX.Y`, `prerelease` | merge the source-branch and built-by columns into their neighbours |
| `MCP_AI_INTEGRATION.md` | the three `builtin/*` ids | replace the identity-only table with a sentence |
| `DRIVER_RPC_PROTOCOL.md` | `Hello` | merge `Request` and `Response` into one column |

The Spanish translations under `docs/es/` carry the same structural change, so Weblate sees matching unit counts on both sides.

One table is deliberately left alone: the input-options table in `LUA.md` still repeats `boolean` and `string`, but Weblate flagged counts that match only the return-value table. If it errors after the rescan, the same column merge clears it.