### PR TITLE
fix(mcp): classify MCP queries through the driver language service

### DIFF
--- a/crates/dbflux_core/src/query/safety.rs
+++ b/crates/dbflux_core/src/query/safety.rs
@@ -2,7 +2,7 @@ use dbflux_policy::ExecutionClassification;
 
 use crate::QueryLanguage;
 
-use super::language_service::classify_query_for_language;
+use super::language_service::{LanguageService, classify_query_for_language_with_service};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ScanState {
@@ -43,11 +43,21 @@ pub fn classify_sql_execution(sql: &str) -> ExecutionClassification {
     }
 }
 
+/// Classify a query's execution impact for MCP/policy governance.
+///
+/// Pass the live connection's `Connection::language_service()` as `service`
+/// whenever one is available, so driver-owned dialects (`InfluxQuery`, `Flux`,
+/// `Custom(_)`, and the CloudWatch/OpenSearch trio) are classified by the
+/// driver instead of a conservative default. `None` preserves the
+/// language-keyed fallback classification for those dialects; `Sql`,
+/// `MongoQuery`, and `RedisCommands` always use the shared core heuristic
+/// regardless of `service`.
 pub fn classify_query_for_governance(
     query_language: &QueryLanguage,
     query: &str,
+    service: Option<&dyn LanguageService>,
 ) -> ExecutionClassification {
-    classify_query_for_language(query_language, query)
+    classify_query_for_language_with_service(query_language, query, service)
 }
 
 pub fn is_safe_read_query(sql: &str) -> bool {
@@ -291,7 +301,46 @@ mod tests {
     #[test]
     fn ambiguous_query_escalates_conservatively() {
         assert_eq!(
-            classify_query_for_governance(&QueryLanguage::Sql, "VACUUM users"),
+            classify_query_for_governance(&QueryLanguage::Sql, "VACUUM users", None),
+            ExecutionClassification::Write
+        );
+    }
+
+    #[test]
+    fn language_service_delegation_overrides_the_conservative_default() {
+        use super::super::language_service::{
+            DangerousQueryKind, LanguageService, ValidationResult,
+        };
+
+        struct FakeService;
+
+        impl LanguageService for FakeService {
+            fn validate(&self, _query: &str) -> ValidationResult {
+                ValidationResult::Valid
+            }
+
+            fn detect_dangerous(&self, _query: &str) -> Option<DangerousQueryKind> {
+                None
+            }
+
+            fn classify_execution(&self, _query: &str) -> Option<ExecutionClassification> {
+                Some(ExecutionClassification::Destructive)
+            }
+        }
+
+        let service = FakeService;
+
+        assert_eq!(
+            classify_query_for_governance(
+                &QueryLanguage::InfluxQuery,
+                "DROP DATABASE x",
+                Some(&service)
+            ),
+            ExecutionClassification::Destructive
+        );
+
+        assert_eq!(
+            classify_query_for_governance(&QueryLanguage::InfluxQuery, "DROP DATABASE x", None),
             ExecutionClassification::Write
         );
     }

--- a/crates/dbflux_driver_influxdb/tests/governance_classification.rs
+++ b/crates/dbflux_driver_influxdb/tests/governance_classification.rs
@@ -4,16 +4,13 @@
 //! function the governance layer's classifier (`classify_query_for_governance`
 //! in `dbflux_core::query::safety`) is built on.
 //!
-//! NOTE: `classify_query_for_governance`, which is what MCP/policy call
-//! directly (`dbflux_mcp::handlers::query::handle_query_tool`,
-//! `dbflux_mcp_server::tools::query`), does not thread any connection or
-//! `LanguageService` through — it always passes `None` for `service`. So a
-//! `DROP DATABASE` executed through the live MCP path still classifies as the
-//! pre-delegation default (`Write`) today; wiring the actor's live
-//! `Connection::language_service()` into that call is a separate, larger
-//! change (spanning `dbflux_mcp`/`dbflux_app`) outside this crate's scope.
-//! This test targets the API this repo's delegation mechanism is built on,
-//! which is what a future connection-aware governance call would use.
+//! `classify_query_for_governance` takes an `Option<&dyn LanguageService>`
+//! parameter that MCP call sites (`dbflux_mcp::handlers::query::handle_query_tool`,
+//! `dbflux_mcp_server::tools::query::run_explain_request`,
+//! `dbflux_mcp_server::tools::scripts::detect_execution_classification`) fill
+//! with the live connection's `Connection::language_service()` when one is
+//! available. This crate has no access to a live MCP connection, so it stays
+//! focused on the driver-level delegation mechanism those call sites rely on.
 
 use dbflux_core::{
     ExecutionClassification, QueryLanguage, classify_query_for_language_with_service,

--- a/crates/dbflux_mcp/src/handlers/query.rs
+++ b/crates/dbflux_mcp/src/handlers/query.rs
@@ -1,4 +1,4 @@
-use dbflux_core::{QueryLanguage, classify_query_for_governance};
+use dbflux_core::{LanguageService, QueryLanguage, classify_query_for_governance};
 use dbflux_policy::{
     ExecutionClassification, PolicyDecision, PolicyEngine, PolicyEvaluationRequest,
 };
@@ -30,9 +30,11 @@ pub enum QueryHandlerError {
 
 pub fn handle_query_tool(
     request: &QueryExecutionRequest,
+    language_service: Option<&dyn LanguageService>,
     policy_engine: &PolicyEngine,
 ) -> Result<QueryExecutionResponse, QueryHandlerError> {
-    let classification = classify_query_for_governance(&request.query_language, &request.query);
+    let classification =
+        classify_query_for_governance(&request.query_language, &request.query, language_service);
 
     let decision = policy_engine.evaluate(&PolicyEvaluationRequest {
         actor_id: request.actor_id.clone(),

--- a/crates/dbflux_mcp/tests/capability_routing_tests.rs
+++ b/crates/dbflux_mcp/tests/capability_routing_tests.rs
@@ -365,12 +365,18 @@ fn query_handler_classifies_queries_by_language() {
     // This test verifies that query classification works for different languages
     // We test the classification function directly to avoid policy engine complexity
 
-    let sql_classification =
-        dbflux_core::classify_query_for_governance(&QueryLanguage::Sql, "SELECT * FROM users");
+    let sql_classification = dbflux_core::classify_query_for_governance(
+        &QueryLanguage::Sql,
+        "SELECT * FROM users",
+        None,
+    );
     assert!(matches!(sql_classification, ExecutionClassification::Read));
 
-    let mongo_classification =
-        dbflux_core::classify_query_for_governance(&QueryLanguage::MongoQuery, "db.users.find({})");
+    let mongo_classification = dbflux_core::classify_query_for_governance(
+        &QueryLanguage::MongoQuery,
+        "db.users.find({})",
+        None,
+    );
     assert!(matches!(
         mongo_classification,
         ExecutionClassification::Read | ExecutionClassification::Metadata

--- a/crates/dbflux_mcp/tests/discovery_query_runtime_tests.rs
+++ b/crates/dbflux_mcp/tests/discovery_query_runtime_tests.rs
@@ -148,6 +148,7 @@ fn read_and_explain_query_paths_return_expected_semantics() {
             query_language: QueryLanguage::Sql,
             query: "SELECT id, email FROM users".to_string(),
         },
+        None,
         &read_engine,
     )
     .expect("read query should pass policy and execute");
@@ -165,6 +166,7 @@ fn read_and_explain_query_paths_return_expected_semantics() {
             query_language: QueryLanguage::Sql,
             query: "EXPLAIN SELECT id FROM users".to_string(),
         },
+        None,
         &explain_engine,
     )
     .expect("explain query should pass policy and execute");

--- a/crates/dbflux_mcp/tests/runtime_batch2_tests.rs
+++ b/crates/dbflux_mcp/tests/runtime_batch2_tests.rs
@@ -1,7 +1,7 @@
 use dbflux_audit::AuditService;
-use dbflux_core::QueryLanguage;
 use dbflux_core::observability::EventCategory;
 use dbflux_core::observability::actions::MCP_AUTHORIZE;
+use dbflux_core::{DangerousQueryKind, LanguageService, QueryLanguage, ValidationResult};
 use dbflux_mcp::handlers::query::{QueryExecutionRequest, QueryHandlerError, handle_query_tool};
 use dbflux_mcp::handlers::scripts::{ScriptHandler, ScriptHandlerError, ScriptLifecycleState};
 use dbflux_mcp::server::authorization::{AuthorizationRequest, authorize_request};
@@ -119,6 +119,7 @@ fn preview_mutation_never_executes() {
             query_language: QueryLanguage::Sql,
             query: "UPDATE users SET active = true".to_string(),
         },
+        None,
         &engine,
     )
     .expect("preview should be allowed");
@@ -139,10 +140,54 @@ fn denied_query_fails_policy_gate() {
             query_language: QueryLanguage::Sql,
             query: "DROP TABLE users".to_string(),
         },
+        None,
         &engine,
     );
 
     assert!(matches!(result, Err(QueryHandlerError::PolicyDenied)));
+}
+
+struct DestructiveOverrideLanguageService;
+
+impl LanguageService for DestructiveOverrideLanguageService {
+    fn validate(&self, _query: &str) -> ValidationResult {
+        ValidationResult::Valid
+    }
+
+    fn detect_dangerous(&self, _query: &str) -> Option<DangerousQueryKind> {
+        None
+    }
+
+    fn classify_execution(&self, _query: &str) -> Option<ExecutionClassification> {
+        Some(ExecutionClassification::Destructive)
+    }
+}
+
+#[test]
+fn driver_language_service_overrides_conservative_default_when_supplied() {
+    let engine = allow_engine("read_query", ExecutionClassification::Destructive);
+    let service = DestructiveOverrideLanguageService;
+
+    let request = QueryExecutionRequest {
+        actor_id: "agent-a".to_string(),
+        connection_id: "conn-a".to_string(),
+        tool_id: "read_query".to_string(),
+        query_language: QueryLanguage::InfluxQuery,
+        query: "DROP DATABASE mydb".to_string(),
+    };
+
+    let with_service = handle_query_tool(&request, Some(&service), &engine)
+        .expect("policy allows the driver-classified destructive query");
+    assert_eq!(
+        with_service.classification,
+        ExecutionClassification::Destructive
+    );
+
+    let without_service = handle_query_tool(&request, None, &engine);
+    assert!(matches!(
+        without_service,
+        Err(QueryHandlerError::PolicyDenied)
+    ));
 }
 
 #[test]

--- a/crates/dbflux_mcp/tests/transport_integration_tests.rs
+++ b/crates/dbflux_mcp/tests/transport_integration_tests.rs
@@ -127,7 +127,7 @@ impl IntegrationHarness {
                         .to_string(),
                 };
 
-                let response = handle_query_tool(&request, &self.read_engine)?;
+                let response = handle_query_tool(&request, None, &self.read_engine)?;
                 Ok(ToolCallResponse::Query(response))
             }
             _ => Err("unsupported tool in integration harness".into()),

--- a/crates/dbflux_mcp_server/src/tools/query.rs
+++ b/crates/dbflux_mcp_server/src/tools/query.rs
@@ -211,8 +211,11 @@ impl DbFluxServer {
                         )
                     })?;
 
-                    let classification =
-                        classify_query_for_governance(&planned_query.language, &planned_query.text);
+                    let classification = classify_query_for_governance(
+                        &planned_query.language,
+                        &planned_query.text,
+                        Some(connection.language_service()),
+                    );
                     if !matches!(
                         classification,
                         dbflux_policy::ExecutionClassification::Metadata
@@ -259,10 +262,11 @@ mod tests {
     use super::*;
 
     use dbflux_core::{
-        DbError, DbKind, DefaultSqlDialect, DriverCapabilities, DriverMetadata, ExplainRequest,
-        MutationCapabilities, PlaceholderStyle, QueryCapabilities, QueryHandle, QueryLanguage,
-        QueryResult, SchemaLoadingStrategy, SchemaSnapshot, SemanticPlan, SemanticPlanKind,
-        SyntaxInfo, TransactionCapabilities,
+        DangerousQueryKind, DbError, DbKind, DefaultSqlDialect, DriverCapabilities, DriverMetadata,
+        ExplainRequest, LanguageService, MutationCapabilities, PlaceholderStyle, QueryCapabilities,
+        QueryHandle, QueryLanguage, QueryResult, SchemaLoadingStrategy, SchemaSnapshot,
+        SemanticPlan, SemanticPlanKind, SqlLanguageService, SyntaxInfo, TransactionCapabilities,
+        ValidationResult,
     };
     use std::sync::LazyLock;
 
@@ -299,6 +303,25 @@ mod tests {
         editor_profile: None,
     });
 
+    struct DestructiveOverrideLanguageService;
+
+    impl LanguageService for DestructiveOverrideLanguageService {
+        fn validate(&self, _query: &str) -> ValidationResult {
+            ValidationResult::Valid
+        }
+
+        fn detect_dangerous(&self, _query: &str) -> Option<DangerousQueryKind> {
+            None
+        }
+
+        fn classify_execution(
+            &self,
+            _query: &str,
+        ) -> Option<dbflux_policy::ExecutionClassification> {
+            Some(dbflux_policy::ExecutionClassification::Destructive)
+        }
+    }
+
     struct TestConnection {
         plan: Option<SemanticPlan>,
         planner_supported: bool,
@@ -306,6 +329,7 @@ mod tests {
         execute_result: QueryResult,
         executed_queries: std::sync::Mutex<Vec<String>>,
         explain_queries: std::sync::Mutex<Vec<Option<String>>>,
+        language_service_override: bool,
     }
 
     impl TestConnection {
@@ -317,7 +341,13 @@ mod tests {
                 execute_result: QueryResult::empty(),
                 executed_queries: std::sync::Mutex::new(Vec::new()),
                 explain_queries: std::sync::Mutex::new(Vec::new()),
+                language_service_override: false,
             }
+        }
+
+        fn with_destructive_language_service(mut self) -> Self {
+            self.language_service_override = true;
+            self
         }
     }
 
@@ -360,6 +390,14 @@ mod tests {
 
         fn dialect(&self) -> &dyn dbflux_core::SqlDialect {
             &DefaultSqlDialect
+        }
+
+        fn language_service(&self) -> &dyn LanguageService {
+            if self.language_service_override {
+                &DestructiveOverrideLanguageService
+            } else {
+                &SqlLanguageService
+            }
         }
 
         fn explain(&self, request: &ExplainRequest) -> Result<QueryResult, DbError> {
@@ -487,5 +525,37 @@ mod tests {
                 .expect("executed queries mutex poisoned")
                 .is_empty()
         );
+    }
+
+    #[tokio::test]
+    async fn run_explain_request_consults_the_connections_language_service() {
+        // `OpenSearchPpl` falls back to `Read` (and executes) with no driver
+        // service; a driver service overriding `classify_execution` to
+        // `Destructive` must be consulted and reject the preview instead.
+        let plan = Some(SemanticPlan::single_query(
+            SemanticPlanKind::Query,
+            dbflux_core::PlannedQuery::new(QueryLanguage::OpenSearchPpl, "source=logs | head 1"),
+        ));
+
+        let connection_without_override = Arc::new(TestConnection::new(plan.clone(), true));
+        DbFluxServer::run_explain_request(
+            connection_without_override.clone(),
+            ExplainRequest::new(TableRef::new("logs")).with_query("source=logs | head 1"),
+            "Preview",
+        )
+        .await
+        .expect("fallback classification allows a read-only preview");
+
+        let connection_with_override =
+            Arc::new(TestConnection::new(plan, true).with_destructive_language_service());
+        let error = DbFluxServer::run_explain_request(
+            connection_with_override,
+            ExplainRequest::new(TableRef::new("logs")).with_query("source=logs | head 1"),
+            "Preview",
+        )
+        .await
+        .expect_err("driver language service must be consulted and reject the preview");
+
+        assert!(error.contains("non-read-only preview query"));
     }
 }

--- a/crates/dbflux_mcp_server/src/tools/scripts.rs
+++ b/crates/dbflux_mcp_server/src/tools/scripts.rs
@@ -10,7 +10,7 @@ use crate::{
     helper::{IntoErrorData, to_json_content},
     state::ServerState,
 };
-use dbflux_core::{QueryLanguage, QueryRequest};
+use dbflux_core::{LanguageService, QueryLanguage, QueryRequest};
 use rmcp::{
     ErrorData,
     handler::server::wrapper::Parameters,
@@ -285,8 +285,38 @@ impl DbFluxServer {
             .await
             .map_err(|e| e.into_error_data())?;
 
-        // Detect classification based on content
-        let classification = Self::detect_execution_classification(&content, &language);
+        // Non-query script languages (Lua/Python/Bash) are always classified
+        // as Admin without needing a connection; only resolve one for
+        // languages that actually run a query.
+        let connection_for_classification = if matches!(
+            language,
+            QueryLanguage::Lua | QueryLanguage::Python | QueryLanguage::Bash
+        ) {
+            None
+        } else {
+            match Self::get_or_connect(state.clone(), &params.connection_id).await {
+                Ok(connection) => Some(connection),
+                Err(error) => {
+                    log::debug!(
+                        "Failed to resolve connection '{}' for script classification, \
+                         falling back to language-only classification: {}",
+                        params.connection_id,
+                        error
+                    );
+                    None
+                }
+            }
+        };
+
+        // Detect classification based on content, consulting the connection's
+        // driver-owned language service when one was resolved.
+        let classification = Self::detect_execution_classification(
+            &content,
+            &language,
+            connection_for_classification
+                .as_deref()
+                .map(|connection| connection.language_service()),
+        );
 
         let connection_id = params.connection_id.clone();
         let state_clone = state.clone();
@@ -557,10 +587,10 @@ impl DbFluxServer {
         Ok((content, language))
     }
 
-    #[allow(dead_code)]
     fn detect_execution_classification(
         content: &str,
         language: &QueryLanguage,
+        service: Option<&dyn LanguageService>,
     ) -> dbflux_policy::ExecutionClassification {
         use dbflux_core::classify_query_for_governance;
         use dbflux_policy::ExecutionClassification;
@@ -573,8 +603,9 @@ impl DbFluxServer {
             _ => {}
         }
 
-        // For query languages, use the safety module to classify
-        classify_query_for_governance(language, content)
+        // For query languages, use the safety module to classify, consulting
+        // the driver's language service when one is available.
+        classify_query_for_governance(language, content, service)
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
Closes #506

## Summary

- **`classify_query_for_governance` now takes the service.** It always passed `None`, so every driver-owned `classify_execution` was invisible to MCP governance: an InfluxDB `DROP DATABASE` classified as `Write` through the fixed-variant fallback, and DynamoDB PartiQL had the same blindness. The function gained an `Option<&dyn LanguageService>` parameter and forwards to `classify_query_for_language_with_service`, which #498 already wired and tested at the core level.
- **The MCP call sites fill it from the live connection.** `run_explain_request` already held the resolved `Arc<dyn Connection>`. `execute_script` now resolves the connection before classifying, but only for query languages: Lua, Python and Bash still short-circuit to `Admin` without forcing a connection. `handle_query_tool` takes the service as a parameter, because `dbflux_mcp` has no connection registry of its own.
- **Classification can only get stricter.** With no service, or when the driver abstains, the previous language-keyed fallback applies byte for byte. A failure to resolve the connection in `execute_script` logs at debug and falls back to the language-only classification rather than erroring early, so the existing failure path inside the governance closure still reports it exactly as before.
- **The stale note is gone.** `crates/dbflux_driver_influxdb/tests/governance_classification.rs` carried a header saying this threading was out of scope and that a live `DROP DATABASE` still classified as `Write`. It now describes what those tests actually cover.

## Changes

| File | Change |
|------|--------|
| `crates/dbflux_core/src/query/safety.rs` | `classify_query_for_governance` takes `Option<&dyn LanguageService>`; new test proving a service overrides the `InfluxQuery` default |
| `crates/dbflux_mcp/src/handlers/query.rs` | `handle_query_tool` takes the service as a parameter, kept out of `QueryExecutionRequest` so it stays `Clone + PartialEq + Eq` |
| `crates/dbflux_mcp_server/src/tools/query.rs` | `run_explain_request` passes `Some(connection.language_service())`; `TestConnection` gained an override and a test that a `Destructive` driver verdict rejects a preview the fallback would allow |
| `crates/dbflux_mcp_server/src/tools/scripts.rs` | `detect_execution_classification` takes the service; `execute_script` resolves the connection first for query languages only |
| `crates/dbflux_mcp/tests/*` | Existing call sites pass `None`; new test proving `Some(service)` yields `Destructive` where `None` yields `Write` |
| `crates/dbflux_driver_influxdb/tests/governance_classification.rs` | Replaced the obsolete header comment |

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,clickhouse,aws" -- -D warnings` clean (the CI invocation)
- [x] `cargo nextest run -p dbflux_core -p dbflux_mcp -p dbflux_mcp_server -p dbflux_driver_influxdb` — 1483 passed, 35 skipped
- [x] `cargo test --doc -p dbflux_core` clean
- [x] Workspace grep confirms no remaining `classify_query_for_governance` call site on the old signature

## Note for the reviewer

`dbflux_mcp_server` declares no `influxdb` feature, so the end-to-end assertion uses a local fake `LanguageService` rather than the real driver. The driver-level proof that InfluxDB `DROP DATABASE` classifies as `Destructive` already lives in `crates/dbflux_driver_influxdb/tests/governance_classification.rs`; this PR connects that path to the handlers.