### PR TITLE
feat(clickhouse): add instance metrics and a running-queries inspector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -493,7 +493,7 @@ MCP authentication is process-identity only: presenting `--client-id` is the sol
   - `DashboardSource` (`dbflux_core/src/connection/dashboard_source.rs`) — lists upstream dashboards; gated by `DriverCapabilities::DASHBOARD_SYNC`.
   - `DashboardImporter` (`dbflux_core/src/connection/dashboard_import.rs`) — parses upstream JSON into `WidgetImportSpec`s; gated by `DriverCapabilities::DASHBOARD_IMPORT`.
   - `InstanceCatalog` (`dbflux_core/src/connection/instance_catalog.rs`) — exposes per-driver metrics, inspectors, default-dashboard descriptor, and row actions; gated by `DriverCapabilities::INSTANCE_METRICS` / `INSTANCE_INSPECTOR`.
-  - CloudWatch is the reference implementation for `DashboardSource` / `DashboardImporter`. PostgreSQL, MySQL/MariaDB, MongoDB, Redis, and SQL Server are the reference implementations for `InstanceCatalog`.
+  - CloudWatch is the reference implementation for `DashboardSource` / `DashboardImporter`. PostgreSQL, MySQL/MariaDB, MongoDB, Redis, SQL Server, and ClickHouse are the reference implementations for `InstanceCatalog`.
 - Remote dashboard listings are session-scoped via `RemoteDashboardCache` (`crates/dbflux_app/src/remote_dashboard_cache.rs`); they do not persist across restart.
 
 Full reference: `docs/DASHBOARDS.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2788,6 +2788,7 @@ dependencies = [
 name = "dbflux_driver_clickhouse"
 version = "0.8.0-dev.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "dbflux_core",
  "dbflux_test_support",

--- a/crates/dbflux_driver_clickhouse/Cargo.toml
+++ b/crates/dbflux_driver_clickhouse/Cargo.toml
@@ -13,6 +13,7 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+async-trait.workspace = true
 chrono.workspace = true
 dbflux_core = { path = "../dbflux_core" }
 hex.workspace = true

--- a/crates/dbflux_driver_clickhouse/README.md
+++ b/crates/dbflux_driver_clickhouse/README.md
@@ -42,6 +42,7 @@ the endpoint is a URL and not a host/port pair.
 - Every HTTP request reports `dbflux/<version>` as the `User-Agent` header, visible in server-side request logs.
 - Dangerous-query detection uses the shared `SqlLanguageService` (no ClickHouse-specific override): `ALTER TABLE ... DELETE WHERE ...` and `ALTER TABLE ... UPDATE ... WHERE ...` are already caught as `Alter` (any `ALTER`-prefixed statement is flagged regardless of sub-command), and `TRUNCATE`/`DROP` are caught as usual. `KILL QUERY`/`KILL MUTATION` and `OPTIMIZE TABLE ... FINAL` are not flagged — neither deletes rows or changes table structure — matching how other relational drivers treat comparable non-destructive administrative statements.
 - Write-privilege probe: after connecting, checks the `readonly` server setting and `system.grants` for the current user and their active session roles to detect a read-only session or a user without `INSERT`/`ALTER UPDATE`/`ALTER DELETE` grants, tightening the resolved mutation policy to read-only when the server would reject writes anyway (side-effect free; grants reachable only through a role-of-a-role are not resolved and leave the policy unchanged).
+- Instance metrics and inspector (`INSTANCE_METRICS`/`INSTANCE_INSPECTOR`): a curated set of gauges and counters from `system.metrics`, `system.events`, and `system.asynchronous_metrics` (active queries, tracked memory, TCP/HTTP connections, selected/inserted rows, OS memory available), plus a `system.processes` running-queries inspector with a "Kill query" row action. The kill action is gated by a `KILL QUERY` privilege probe run once when the catalog is built; the action stays hidden unless that probe succeeds, so a probe that fails for any reason leaves a destructive control out of the UI rather than offering one the session cannot execute.
 
 ### Type handling
 
@@ -68,8 +69,3 @@ arrives fully structured rather than as raw text:
 - Named ClickHouse time zones are not interpreted client-side. ISO timestamps
   carrying an offset are handled accurately; timestamps without one are treated
   as UTC.
-- No instance metrics or instance inspector yet (`INSTANCE_METRICS`/
-  `INSTANCE_INSPECTOR` are not declared). Unlike DynamoDB and CloudWatch,
-  ClickHouse has no external metrics service to point at instead: `system.metrics`,
-  `system.events`, and `system.processes` are natural candidates for a future
-  `InstanceCatalog`, so this is planned rather than permanently excluded.

--- a/crates/dbflux_driver_clickhouse/src/connection.rs
+++ b/crates/dbflux_driver_clickhouse/src/connection.rs
@@ -4,9 +4,10 @@ use std::time::{Duration, Instant};
 
 use dbflux_core::{
     ColumnMeta, Connection, ConnectionExt, DatabaseInfo, DbError, DbKind, DbSchemaInfo,
-    DocumentConnection, DriverMetadata, KeyValueConnection, QueryCancelHandle, QueryGenerator,
-    QueryHandle, QueryRequest, QueryResult, RelationalConnection, RelationalSchema, Row,
-    SchemaLoadingStrategy, SchemaSnapshot, SqlDialect, TableInfo, Value, WritePrivilege,
+    DocumentConnection, DriverMetadata, ExecutionSourceContext, InstanceCatalog,
+    KeyValueConnection, QueryCancelHandle, QueryGenerator, QueryHandle, QueryRequest, QueryResult,
+    RelationalConnection, RelationalSchema, Row, SchemaLoadingStrategy, SchemaSnapshot, SqlDialect,
+    TableInfo, Value, WritePrivilege,
 };
 use serde::Deserialize;
 
@@ -21,14 +22,14 @@ use crate::types::{
 };
 
 pub struct ClickHouseConnection {
-    client: ClickHouseHttpClient,
+    client: Arc<ClickHouseHttpClient>,
     active_database: RwLock<String>,
 }
 
 impl ClickHouseConnection {
     pub(crate) fn new(client: ClickHouseHttpClient, database: String) -> Self {
         Self {
-            client,
+            client: Arc::new(client),
             active_database: RwLock::new(database),
         }
     }
@@ -235,6 +236,28 @@ impl Connection for ClickHouseConnection {
     }
 
     fn execute(&self, request: &QueryRequest) -> Result<QueryResult, DbError> {
+        if let Some(source) = request
+            .execution_context
+            .as_ref()
+            .and_then(|context| context.source.as_ref())
+        {
+            match source {
+                ExecutionSourceContext::InstanceMetricQuery { metric_id, .. } => {
+                    return crate::instance_catalog::dispatch_metric_series(
+                        &self.client,
+                        metric_id,
+                    );
+                }
+                ExecutionSourceContext::InstanceInspectorQuery { metric_id } => {
+                    return crate::instance_catalog::dispatch_inspector_snapshot(
+                        &self.client,
+                        metric_id,
+                    );
+                }
+                _ => {}
+            }
+        }
+
         if !request.params.is_empty() {
             return Err(DbError::NotSupported(
                 "ClickHouse HTTP queries do not support QueryRequest parameters".to_string(),
@@ -328,6 +351,14 @@ impl Connection for ClickHouseConnection {
         let grants = self.probe_grants();
         resolve_clickhouse_write_privilege(readonly_setting, &grants)
     }
+
+    fn instance_catalog(&self) -> Option<Box<dyn InstanceCatalog>> {
+        Some(Box::new(
+            crate::instance_catalog::ClickHouseInstanceCatalog::new_probed(Arc::clone(
+                &self.client,
+            )),
+        ))
+    }
 }
 
 impl RelationalConnection for ClickHouseConnection {}
@@ -361,7 +392,7 @@ struct CompactColumn {
     type_name: String,
 }
 
-fn parse_response(
+pub(crate) fn parse_response(
     response: HttpResponse,
     execution_time: Duration,
 ) -> Result<QueryResult, DbError> {

--- a/crates/dbflux_driver_clickhouse/src/driver.rs
+++ b/crates/dbflux_driver_clickhouse/src/driver.rs
@@ -37,7 +37,9 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
             | DriverCapabilities::FILTERING.bits()
             | DriverCapabilities::CHART_AUTHORING.bits()
             | DriverCapabilities::EXPORT_CSV.bits()
-            | DriverCapabilities::EXPORT_JSON.bits(),
+            | DriverCapabilities::EXPORT_JSON.bits()
+            | DriverCapabilities::INSTANCE_METRICS.bits()
+            | DriverCapabilities::INSTANCE_INSPECTOR.bits(),
     ),
     default_port: Some(8123),
     uri_scheme: "http".to_string(),

--- a/crates/dbflux_driver_clickhouse/src/instance_catalog.rs
+++ b/crates/dbflux_driver_clickhouse/src/instance_catalog.rs
@@ -1,0 +1,621 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use dbflux_core::{
+    ColumnKind, ColumnMeta, DbError, DefaultDashboardPanel, DefaultInstanceDashboard,
+    DriverCapabilities, InspectorRowAction, InstanceCatalog, InstanceInspectorDef,
+    InstanceMetricDef, InstanceMetricUnit, QueryResult, QueryResultShape, Row, Value,
+};
+
+use crate::connection::parse_response;
+use crate::error_formatter::ClickHouseErrorFormatter;
+use crate::http::ClickHouseHttpClient;
+
+/// System table backing a curated ClickHouse instance metric.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MetricSource {
+    /// `system.metrics` — a current gauge value, keyed by the `metric` column.
+    Metrics,
+    /// `system.events` — a cumulative counter, keyed by the `event` column.
+    Events,
+    /// `system.asynchronous_metrics` — a periodically sampled gauge, keyed by
+    /// the `metric` column.
+    AsynchronousMetrics,
+}
+
+impl MetricSource {
+    /// Builds the read-only `SELECT` that fetches this metric's current value.
+    ///
+    /// `raw_name` is always sourced from [`METRIC_DEFS`], never from caller
+    /// input, so string interpolation here carries no injection surface.
+    fn select_sql(self, raw_name: &str) -> String {
+        match self {
+            MetricSource::Metrics => {
+                format!("SELECT toFloat64(value) FROM system.metrics WHERE metric = '{raw_name}'")
+            }
+            MetricSource::Events => {
+                format!("SELECT toFloat64(value) FROM system.events WHERE event = '{raw_name}'")
+            }
+            MetricSource::AsynchronousMetrics => format!(
+                "SELECT toFloat64(value) FROM system.asynchronous_metrics WHERE metric = '{raw_name}'"
+            ),
+        }
+    }
+}
+
+/// Curated list of ClickHouse system-table metrics mapped to chartable instance metrics.
+///
+/// Each entry: `(raw_name, metric_id, display_name, group, unit, source)`.
+/// `raw_name` matches the `metric`/`event` column value in the source system table.
+pub const METRIC_DEFS: &[(&str, &str, &str, &str, InstanceMetricUnit, MetricSource)] = &[
+    (
+        "Query",
+        "clickhouse.query",
+        "Active queries",
+        "Activity",
+        InstanceMetricUnit::Count,
+        MetricSource::Metrics,
+    ),
+    (
+        "MemoryTracking",
+        "clickhouse.memory_tracking",
+        "Tracked memory",
+        "Memory",
+        InstanceMetricUnit::Bytes,
+        MetricSource::Metrics,
+    ),
+    (
+        "TCPConnection",
+        "clickhouse.tcp_connection",
+        "TCP connections",
+        "Connections",
+        InstanceMetricUnit::Count,
+        MetricSource::Metrics,
+    ),
+    (
+        "HTTPConnection",
+        "clickhouse.http_connection",
+        "HTTP connections",
+        "Connections",
+        InstanceMetricUnit::Count,
+        MetricSource::Metrics,
+    ),
+    (
+        "SelectedRows",
+        "clickhouse.selected_rows",
+        "Selected rows",
+        "Throughput",
+        InstanceMetricUnit::Count,
+        MetricSource::Events,
+    ),
+    (
+        "InsertedRows",
+        "clickhouse.inserted_rows",
+        "Inserted rows",
+        "Throughput",
+        InstanceMetricUnit::Count,
+        MetricSource::Events,
+    ),
+    (
+        "OSMemoryAvailable",
+        "clickhouse.os_memory_available",
+        "OS memory available",
+        "Memory",
+        InstanceMetricUnit::Bytes,
+        MetricSource::AsynchronousMetrics,
+    ),
+];
+
+/// Read-only projection of `system.processes` used by the `clickhouse.processes` inspector.
+///
+/// Numeric columns are cast to `Float64` so every non-text column resolves to
+/// `ColumnKind::Float` uniformly, following the same cast-in-SQL pattern used
+/// by the PostgreSQL activity inspector.
+const PROCESSES_SQL: &str = "\
+    SELECT query_id, user, toString(address) AS address, elapsed AS elapsed_secs, \
+           toFloat64(read_rows) AS read_rows, toFloat64(memory_usage) AS memory_usage_bytes, \
+           substring(query, 1, 200) AS query_preview \
+    FROM system.processes \
+    ORDER BY elapsed DESC";
+
+/// Placeholder query id used to probe `KILL QUERY` privilege without side effects.
+///
+/// ClickHouse `query_id` values are user-supplied strings, not necessarily
+/// UUIDs, so this only needs to be a value unlikely to match a real running
+/// query; ClickHouse allows `KILL QUERY` against zero matching processes.
+const KILL_QUERY_PROBE_ID: &str = "dbflux-instance-catalog-kill-probe";
+
+/// Maximum recognized `system.grants` `ACCESS_DENIED` error code, used to
+/// detect a missing `KILL QUERY` privilege during the probe.
+const ACCESS_DENIED_CODE: &str = "497";
+
+/// ClickHouse instance metrics and inspector catalog.
+///
+/// Holds a shared reference to the connection's HTTP client so it can issue
+/// queries on demand. ClickHouse's HTTP interface is stateless, so no lock is
+/// required to share the client across the connection and the catalog.
+pub struct ClickHouseInstanceCatalog {
+    client: Arc<ClickHouseHttpClient>,
+    kill_query_allowed: bool,
+}
+
+impl ClickHouseInstanceCatalog {
+    /// Constructs a catalog with a probed `kill_query_allowed` flag.
+    ///
+    /// Issues a harmless `KILL QUERY WHERE query_id = '<placeholder>'` probe:
+    /// success (including zero matching rows) means the privilege is granted;
+    /// an `ACCESS_DENIED` error (code `497` or a "not enough privileges"
+    /// message) means it is not. Any other failure defaults to `false`.
+    pub(crate) fn new_probed(client: Arc<ClickHouseHttpClient>) -> Self {
+        let kill_query_allowed = probe_kill_query_allowed(&client);
+        Self {
+            client,
+            kill_query_allowed,
+        }
+    }
+
+    pub fn static_metrics() -> Vec<InstanceMetricDef> {
+        METRIC_DEFS
+            .iter()
+            .map(|(_, id, display_name, group, unit, _)| InstanceMetricDef {
+                id: id.to_string(),
+                display_name: display_name.to_string(),
+                group: group.to_string(),
+                unit: *unit,
+                description: None,
+                default_refresh_secs: 15,
+            })
+            .collect()
+    }
+
+    pub fn static_inspectors() -> Vec<InstanceInspectorDef> {
+        vec![InstanceInspectorDef {
+            id: "clickhouse.processes".to_string(),
+            display_name: "Running queries".to_string(),
+            description: Some(
+                "Live snapshot of system.processes — one row per running query.".to_string(),
+            ),
+            default_refresh_secs: 10,
+        }]
+    }
+
+    /// Curated "Instance Overview" dashboard layout for ClickHouse.
+    ///
+    /// Row 0: active queries (cols 0-5) | tracked memory (cols 6-11)
+    /// Row 3: TCP connections (cols 0-5) | selected rows (cols 6-11)
+    /// Row 6: running queries inspector (full width)
+    pub fn static_default_dashboard() -> Option<DefaultInstanceDashboard> {
+        Some(DefaultInstanceDashboard {
+            title: "ClickHouse Instance Overview".to_string(),
+            description: Some(
+                "Curated ClickHouse system-table metrics and running-queries inspector."
+                    .to_string(),
+            ),
+            panels: vec![
+                DefaultDashboardPanel {
+                    metric_id: "clickhouse.query".to_string(),
+                    is_inspector: false,
+                    grid_column: 0,
+                    grid_row: 0,
+                    grid_width: 6,
+                    grid_height: 3,
+                },
+                DefaultDashboardPanel {
+                    metric_id: "clickhouse.memory_tracking".to_string(),
+                    is_inspector: false,
+                    grid_column: 6,
+                    grid_row: 0,
+                    grid_width: 6,
+                    grid_height: 3,
+                },
+                DefaultDashboardPanel {
+                    metric_id: "clickhouse.tcp_connection".to_string(),
+                    is_inspector: false,
+                    grid_column: 0,
+                    grid_row: 3,
+                    grid_width: 6,
+                    grid_height: 3,
+                },
+                DefaultDashboardPanel {
+                    metric_id: "clickhouse.selected_rows".to_string(),
+                    is_inspector: false,
+                    grid_column: 6,
+                    grid_row: 3,
+                    grid_width: 6,
+                    grid_height: 3,
+                },
+                DefaultDashboardPanel {
+                    metric_id: "clickhouse.processes".to_string(),
+                    is_inspector: true,
+                    grid_column: 0,
+                    grid_row: 6,
+                    grid_width: 12,
+                    grid_height: 4,
+                },
+            ],
+        })
+    }
+
+    /// Static list of row-level actions for the given inspector metric.
+    pub fn static_row_actions(metric_id: &str) -> Vec<InspectorRowAction> {
+        match metric_id {
+            "clickhouse.processes" => vec![InspectorRowAction {
+                id: "kill".to_string(),
+                label: "Kill query".to_string(),
+                description: Some(
+                    "Sends KILL QUERY WHERE query_id = '<id>' to stop the selected query."
+                        .to_string(),
+                ),
+                is_destructive: true,
+            }],
+            _ => Vec::new(),
+        }
+    }
+}
+
+fn now_epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+fn timestamp_col(name: &str) -> ColumnMeta {
+    ColumnMeta {
+        name: name.to_string(),
+        kind: ColumnKind::Timestamp,
+        type_name: "DateTime64".to_string(),
+        nullable: false,
+        is_primary_key: false,
+    }
+}
+
+fn float_col(name: &str) -> ColumnMeta {
+    ColumnMeta {
+        name: name.to_string(),
+        kind: ColumnKind::Float,
+        type_name: "Float64".to_string(),
+        nullable: false,
+        is_primary_key: false,
+    }
+}
+
+fn extract_float(value: &Value) -> f64 {
+    match value {
+        Value::Float(value) => *value,
+        Value::Int(value) => *value as f64,
+        Value::Decimal(value) => value.parse().unwrap_or(0.0),
+        _ => 0.0,
+    }
+}
+
+/// Runs a read-only instance-catalog query against the current database.
+///
+/// Shared by metric fetches, the inspector snapshot, the row-action kill
+/// command, and the privilege probe; every caller reuses the same HTTP
+/// error-formatting and response-parsing path as `ClickHouseConnection::execute_sql`.
+fn run_instance_query(client: &ClickHouseHttpClient, sql: &str) -> Result<QueryResult, DbError> {
+    let started = Instant::now();
+    let response = client
+        .execute(sql, None, None, None, None)
+        .map_err(|error| ClickHouseErrorFormatter::format_http_error(&error).into_query_error())?;
+    parse_response(response, started.elapsed())
+}
+
+/// Probes whether the current user can run `KILL QUERY`.
+///
+/// `KILL QUERY` against zero matching processes succeeds, so only a
+/// successful probe grants the privilege. Every failure — `ACCESS_DENIED`
+/// (error code `497` or a "not enough privileges" message), a transport
+/// error, or anything else — leaves the action hidden, matching the
+/// conservative default used by the Redis and PostgreSQL catalogs. Hiding an
+/// action the user could have run is recoverable; offering one they cannot is
+/// a dead button on a destructive control.
+fn probe_kill_query_allowed(client: &ClickHouseHttpClient) -> bool {
+    let probe_sql = format!("KILL QUERY WHERE query_id = '{KILL_QUERY_PROBE_ID}'");
+
+    match run_instance_query(client, &probe_sql) {
+        Ok(_) => true,
+        Err(DbError::QueryFailed(formatted)) => {
+            let denied_by_code = formatted.code.as_deref() == Some(ACCESS_DENIED_CODE);
+            let denied_by_message = formatted
+                .message
+                .to_ascii_lowercase()
+                .contains("not enough privileges");
+
+            log::debug!(
+                "ClickHouse KILL QUERY privilege probe failed (access denied: {}): {}",
+                denied_by_code || denied_by_message,
+                formatted.message
+            );
+
+            false
+        }
+        Err(_) => false,
+    }
+}
+
+/// Rejects a `query_id` that is not a plain identifier before it is
+/// interpolated into a `KILL QUERY` statement.
+///
+/// ClickHouse `query_id` values are client-supplied strings, so this allows
+/// only ASCII letters, digits, `-`, and `_` — covering both the server's
+/// default UUID-shaped ids and any custom id a client may have set.
+fn validate_query_id(raw: &str) -> Result<&str, DbError> {
+    let trimmed = raw.trim();
+    let valid = !trimmed.is_empty()
+        && trimmed.len() <= 128
+        && trimmed
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+
+    if valid {
+        Ok(trimmed)
+    } else {
+        Err(DbError::QueryFailed(
+            format!("clickhouse.processes kill: invalid query_id format: '{trimmed}'").into(),
+        ))
+    }
+}
+
+#[async_trait]
+impl InstanceCatalog for ClickHouseInstanceCatalog {
+    async fn list_metrics(&self) -> Result<Vec<InstanceMetricDef>, DbError> {
+        Ok(Self::static_metrics())
+    }
+
+    async fn list_inspectors(&self) -> Result<Vec<InstanceInspectorDef>, DbError> {
+        Ok(Self::static_inspectors())
+    }
+
+    fn default_dashboard(&self) -> Option<DefaultInstanceDashboard> {
+        Self::static_default_dashboard()
+    }
+
+    async fn fetch_metric_series(
+        &self,
+        metric_id: &str,
+        _start_ms: i64,
+        _end_ms: i64,
+    ) -> Result<QueryResult, DbError> {
+        dispatch_metric_series(&self.client, metric_id)
+    }
+
+    async fn fetch_inspector_snapshot(&self, metric_id: &str) -> Result<QueryResult, DbError> {
+        dispatch_inspector_snapshot(&self.client, metric_id)
+    }
+
+    fn row_actions(&self, metric_id: &str) -> Vec<InspectorRowAction> {
+        if !self.kill_query_allowed {
+            return Vec::new();
+        }
+        Self::static_row_actions(metric_id)
+    }
+
+    async fn execute_row_action(
+        &self,
+        metric_id: &str,
+        action_id: &str,
+        row_values: &[Value],
+    ) -> Result<(), DbError> {
+        if metric_id == "clickhouse.processes" && action_id == "kill" {
+            let raw_id = match row_values.first() {
+                Some(Value::Text(text)) => text.clone(),
+                _ => {
+                    return Err(DbError::QueryFailed(
+                        "clickhouse.processes kill: could not read query_id from row"
+                            .to_string()
+                            .into(),
+                    ));
+                }
+            };
+
+            let query_id = validate_query_id(&raw_id)?;
+            run_instance_query(
+                &self.client,
+                &format!("KILL QUERY WHERE query_id = '{query_id}'"),
+            )
+            .map(|_| ())
+        } else {
+            Err(DbError::NotSupported(format!(
+                "row action '{action_id}' not supported for inspector '{metric_id}'"
+            )))
+        }
+    }
+}
+
+pub(crate) fn dispatch_metric_series(
+    client: &ClickHouseHttpClient,
+    metric_id: &str,
+) -> Result<QueryResult, DbError> {
+    let entry = METRIC_DEFS.iter().find(|(_, id, ..)| *id == metric_id);
+
+    match entry {
+        Some((raw_name, _, display_name, _, _, source)) => {
+            let result = run_instance_query(client, &source.select_sql(raw_name))?;
+            let value = result
+                .rows
+                .first()
+                .and_then(|row| row.first())
+                .map(extract_float)
+                .unwrap_or(0.0);
+
+            let row: Row = vec![Value::Int(now_epoch_ms()), Value::Float(value)];
+
+            Ok(QueryResult {
+                shape: QueryResultShape::Table,
+                columns: vec![timestamp_col("timestamp_ms"), float_col(display_name)],
+                rows: vec![row],
+                affected_rows: None,
+                execution_time: Duration::ZERO,
+                text_body: None,
+                raw_bytes: None,
+                next_page_token: None,
+                resolved_window: None,
+                metadata_extra: None,
+                additional_results: Vec::new(),
+            })
+        }
+        None => Err(DbError::NotSupported(format!(
+            "unknown instance metric: {metric_id}"
+        ))),
+    }
+}
+
+pub(crate) fn dispatch_inspector_snapshot(
+    client: &ClickHouseHttpClient,
+    metric_id: &str,
+) -> Result<QueryResult, DbError> {
+    match metric_id {
+        "clickhouse.processes" => run_instance_query(client, PROCESSES_SQL),
+        other => Err(DbError::NotSupported(format!("unknown inspector: {other}"))),
+    }
+}
+
+/// Returns `true` if the ClickHouse driver metadata advertises both
+/// instance-metrics capability bits.
+pub fn clickhouse_advertises_instance_capabilities() -> bool {
+    let caps = crate::driver::METADATA.capabilities;
+    caps.contains(DriverCapabilities::INSTANCE_METRICS)
+        && caps.contains(DriverCapabilities::INSTANCE_INSPECTOR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metric_defs_list_is_non_empty_with_distinct_ids() {
+        assert!(!METRIC_DEFS.is_empty(), "METRIC_DEFS must have entries");
+
+        let mut ids: Vec<&str> = METRIC_DEFS.iter().map(|(_, id, ..)| *id).collect();
+        let inspector_ids: Vec<String> = ClickHouseInstanceCatalog::static_inspectors()
+            .into_iter()
+            .map(|inspector| inspector.id)
+            .collect();
+        ids.extend(inspector_ids.iter().map(String::as_str));
+
+        let mut deduped = ids.clone();
+        deduped.sort_unstable();
+        deduped.dedup();
+        assert_eq!(
+            ids.len(),
+            deduped.len(),
+            "metric and inspector ids must be distinct across the shared namespace"
+        );
+    }
+
+    #[test]
+    fn static_metric_default_refresh_secs_at_or_above_floor() {
+        for metric in ClickHouseInstanceCatalog::static_metrics() {
+            assert!(
+                metric.default_refresh_secs >= 10,
+                "metric {:?} default_refresh_secs {} is below the 10s floor",
+                metric.id,
+                metric.default_refresh_secs
+            );
+        }
+    }
+
+    #[test]
+    fn static_inspector_default_refresh_secs_at_or_above_floor() {
+        for inspector in ClickHouseInstanceCatalog::static_inspectors() {
+            assert!(
+                inspector.default_refresh_secs >= 10,
+                "inspector {:?} default_refresh_secs {} is below the 10s floor",
+                inspector.id,
+                inspector.default_refresh_secs
+            );
+        }
+    }
+
+    #[test]
+    fn clickhouse_advertises_both_instance_capability_bits() {
+        assert!(
+            clickhouse_advertises_instance_capabilities(),
+            "ClickHouse METADATA must include INSTANCE_METRICS and INSTANCE_INSPECTOR bits"
+        );
+    }
+
+    #[test]
+    fn clickhouse_default_dashboard_is_non_none_and_valid() {
+        let dashboard = ClickHouseInstanceCatalog::static_default_dashboard()
+            .expect("ClickHouseInstanceCatalog must return Some(default_dashboard)");
+
+        assert!(
+            !dashboard.panels.is_empty(),
+            "default dashboard must have at least one panel"
+        );
+        assert!(
+            !dashboard.title.is_empty(),
+            "default dashboard must have a non-empty title"
+        );
+
+        let metric_ids: Vec<String> = ClickHouseInstanceCatalog::static_metrics()
+            .into_iter()
+            .map(|metric| metric.id)
+            .collect();
+        let inspector_ids: Vec<String> = ClickHouseInstanceCatalog::static_inspectors()
+            .into_iter()
+            .map(|inspector| inspector.id)
+            .collect();
+
+        for panel in &dashboard.panels {
+            let valid =
+                metric_ids.contains(&panel.metric_id) || inspector_ids.contains(&panel.metric_id);
+            assert!(
+                valid,
+                "panel metric_id {:?} is not in static metrics or inspectors",
+                panel.metric_id
+            );
+            assert!(panel.grid_column <= 11, "grid_column must be within 0..=11");
+            assert!(
+                panel.grid_width >= 1 && panel.grid_width <= 12,
+                "grid_width must be within 1..=12"
+            );
+        }
+    }
+
+    #[test]
+    fn row_actions_processes_returns_kill() {
+        let actions = ClickHouseInstanceCatalog::static_row_actions("clickhouse.processes");
+        assert_eq!(
+            actions.len(),
+            1,
+            "clickhouse.processes must have exactly one row action"
+        );
+        assert_eq!(actions[0].id, "kill");
+        assert!(actions[0].is_destructive);
+    }
+
+    #[test]
+    fn row_actions_unknown_inspector_returns_empty() {
+        let actions = ClickHouseInstanceCatalog::static_row_actions("clickhouse.does_not_exist");
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn validate_query_id_accepts_uuid_shaped_id() {
+        let result = validate_query_id("a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+        assert_eq!(result.ok(), Some("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+    }
+
+    #[test]
+    fn validate_query_id_rejects_quote_injection() {
+        assert!(validate_query_id("abc'; DROP TABLE x; --").is_err());
+    }
+
+    #[test]
+    fn validate_query_id_rejects_empty() {
+        assert!(validate_query_id("").is_err());
+    }
+
+    #[test]
+    fn extract_float_reads_float_int_and_decimal() {
+        assert_eq!(extract_float(&Value::Float(1.5)), 1.5);
+        assert_eq!(extract_float(&Value::Int(3)), 3.0);
+        assert_eq!(extract_float(&Value::Decimal("2.25".to_string())), 2.25);
+        assert_eq!(extract_float(&Value::Null), 0.0);
+    }
+}

--- a/crates/dbflux_driver_clickhouse/src/instance_catalog.rs
+++ b/crates/dbflux_driver_clickhouse/src/instance_catalog.rs
@@ -18,6 +18,10 @@ pub enum MetricSource {
     /// `system.metrics` — a current gauge value, keyed by the `metric` column.
     Metrics,
     /// `system.events` — a cumulative counter, keyed by the `event` column.
+    ///
+    /// The table lists only events that have fired at least once since the
+    /// server started, so a counter with no row yet reports zero, which is
+    /// its true value rather than a missing reading.
     Events,
     /// `system.asynchronous_metrics` — a periodically sampled gauge, keyed by
     /// the `metric` column.

--- a/crates/dbflux_driver_clickhouse/src/lib.rs
+++ b/crates/dbflux_driver_clickhouse/src/lib.rs
@@ -14,6 +14,7 @@ pub mod dialect;
 pub mod driver;
 pub mod error_formatter;
 mod http;
+pub mod instance_catalog;
 mod introspection;
 #[cfg(test)]
 mod language_service;

--- a/crates/dbflux_driver_clickhouse/tests/live_integration.rs
+++ b/crates/dbflux_driver_clickhouse/tests/live_integration.rs
@@ -336,11 +336,30 @@ fn clickhouse_instance_metric_query_rejects_unknown_metric_id() -> Result<(), Db
 /// A metric whose row is missing reports `0.0` rather than failing, so a
 /// misspelled name would chart a flat zero forever and every shape assertion
 /// above would still pass. This asserts the name itself.
+///
+/// `system.events` only lists events that have already fired at least once on
+/// this server, so the counters are exercised first: a fresh container has
+/// never inserted a row, and `InsertedRows` would be genuinely absent through
+/// no fault of the metric name.
 #[test]
 #[ignore = "requires Docker daemon"]
 fn clickhouse_metric_raw_names_exist_in_their_system_tables() -> Result<(), DbError> {
     containers::with_clickhouse(|config| {
         let connection = connect(&config)?;
+
+        connection.execute(&QueryRequest::new(
+            "CREATE TABLE dbflux_live_events_probe (id UInt64) ENGINE = MergeTree ORDER BY id",
+        ))?;
+        let _cleanup = TableCleanup {
+            connection: connection.as_ref(),
+            table: "dbflux_live_events_probe",
+        };
+        connection.execute(&QueryRequest::new(
+            "INSERT INTO dbflux_live_events_probe VALUES (1)",
+        ))?;
+        connection.execute(&QueryRequest::new(
+            "SELECT count() FROM dbflux_live_events_probe",
+        ))?;
 
         for (raw_name, metric_id, .., source) in METRIC_DEFS {
             let (table, key_column) = match source {

--- a/crates/dbflux_driver_clickhouse/tests/live_integration.rs
+++ b/crates/dbflux_driver_clickhouse/tests/live_integration.rs
@@ -14,9 +14,13 @@
 //! ```
 
 use dbflux_core::secrecy::SecretString;
-use dbflux_core::{ColumnKind, Connection, ConnectionProfile, DbConfig, DbDriver, DbError};
+use dbflux_core::{
+    ColumnKind, Connection, ConnectionProfile, DbConfig, DbDriver, DbError, ExecutionContext,
+    ExecutionSourceContext,
+};
 use dbflux_core::{QueryRequest, Value};
 use dbflux_driver_clickhouse::ClickHouseDriver;
+use dbflux_driver_clickhouse::instance_catalog::{METRIC_DEFS, MetricSource};
 use dbflux_test_support::containers::{self, ClickHouseConfig};
 use std::time::Duration;
 
@@ -207,6 +211,159 @@ fn clickhouse_probe_write_privilege_default_user_is_writable() -> Result<(), DbE
             connection.probe_write_privilege(),
             dbflux_core::WritePrivilege::Writable
         );
+
+        Ok(())
+    })
+}
+
+fn metric_request(metric_id: &str) -> QueryRequest {
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before UNIX epoch")
+        .as_millis() as i64;
+
+    QueryRequest {
+        execution_context: Some(ExecutionContext {
+            source: Some(ExecutionSourceContext::InstanceMetricQuery {
+                metric_id: metric_id.to_string(),
+                start_ms: now_ms - 60_000,
+                end_ms: now_ms,
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn inspector_request(metric_id: &str) -> QueryRequest {
+    QueryRequest {
+        execution_context: Some(ExecutionContext {
+            source: Some(ExecutionSourceContext::InstanceInspectorQuery {
+                metric_id: metric_id.to_string(),
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn clickhouse_instance_metrics_have_timestamp_and_float_columns() -> Result<(), DbError> {
+    containers::with_clickhouse(|config| {
+        let connection = connect(&config)?;
+
+        for metric in
+            dbflux_driver_clickhouse::instance_catalog::ClickHouseInstanceCatalog::static_metrics()
+        {
+            let result = connection.execute(&metric_request(&metric.id))?;
+
+            assert_eq!(
+                result.columns.len(),
+                2,
+                "metric {} must return exactly one timestamp and one value column",
+                metric.id
+            );
+            assert_eq!(
+                result.columns[0].kind,
+                ColumnKind::Timestamp,
+                "metric {} column 0 must be Timestamp",
+                metric.id
+            );
+            assert_eq!(
+                result.columns[1].kind,
+                ColumnKind::Float,
+                "metric {} column 1 must be Float",
+                metric.id
+            );
+            assert_eq!(
+                result.rows.len(),
+                1,
+                "metric {} must return exactly one sample row",
+                metric.id
+            );
+        }
+
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn clickhouse_processes_inspector_returns_typed_columns() -> Result<(), DbError> {
+    containers::with_clickhouse(|config| {
+        let connection = connect(&config)?;
+        let result = connection.execute(&inspector_request("clickhouse.processes"))?;
+
+        assert_eq!(result.columns.len(), 7);
+        assert_eq!(result.columns[0].name, "query_id");
+        assert_eq!(result.columns[0].kind, ColumnKind::Text);
+        assert_eq!(result.columns[1].name, "user");
+        assert_eq!(result.columns[1].kind, ColumnKind::Text);
+        assert_eq!(result.columns[2].name, "address");
+        assert_eq!(result.columns[2].kind, ColumnKind::Text);
+        assert_eq!(result.columns[3].name, "elapsed_secs");
+        assert_eq!(result.columns[3].kind, ColumnKind::Float);
+        assert_eq!(result.columns[4].name, "read_rows");
+        assert_eq!(result.columns[4].kind, ColumnKind::Float);
+        assert_eq!(result.columns[5].name, "memory_usage_bytes");
+        assert_eq!(result.columns[5].kind, ColumnKind::Float);
+        assert_eq!(result.columns[6].name, "query_preview");
+        assert_eq!(result.columns[6].kind, ColumnKind::Text);
+
+        Ok(())
+    })
+}
+
+#[test]
+#[ignore = "requires Docker daemon"]
+fn clickhouse_instance_metric_query_rejects_unknown_metric_id() -> Result<(), DbError> {
+    containers::with_clickhouse(|config| {
+        let connection = connect(&config)?;
+        let error = connection
+            .execute(&metric_request("clickhouse.does_not_exist"))
+            .expect_err("unknown metric id must be rejected");
+
+        assert!(matches!(error, DbError::NotSupported(_)));
+
+        Ok(())
+    })
+}
+
+/// Guards the assumption every declared metric rests on: that its raw name
+/// exists in the system table it is read from.
+///
+/// A metric whose row is missing reports `0.0` rather than failing, so a
+/// misspelled name would chart a flat zero forever and every shape assertion
+/// above would still pass. This asserts the name itself.
+#[test]
+#[ignore = "requires Docker daemon"]
+fn clickhouse_metric_raw_names_exist_in_their_system_tables() -> Result<(), DbError> {
+    containers::with_clickhouse(|config| {
+        let connection = connect(&config)?;
+
+        for (raw_name, metric_id, .., source) in METRIC_DEFS {
+            let (table, key_column) = match source {
+                MetricSource::Metrics => ("system.metrics", "metric"),
+                MetricSource::Events => ("system.events", "event"),
+                MetricSource::AsynchronousMetrics => ("system.asynchronous_metrics", "metric"),
+            };
+
+            let result = connection.execute(&QueryRequest::new(format!(
+                "SELECT count() FROM {table} WHERE {key_column} = '{raw_name}'"
+            )))?;
+
+            let count = match result.rows.first().and_then(|row| row.first()) {
+                Some(Value::Int(count)) => *count,
+                Some(Value::Decimal(text)) => text.parse().unwrap_or(0),
+                other => panic!("unexpected count value for {metric_id}: {other:?}"),
+            };
+
+            assert_eq!(
+                count, 1,
+                "metric {metric_id} declares raw name '{raw_name}', absent from {table}"
+            );
+        }
 
         Ok(())
     })

--- a/docs/DASHBOARDS.md
+++ b/docs/DASHBOARDS.md
@@ -214,12 +214,12 @@ to materialize it locally.
   `DefaultInstanceDashboard`, `InspectorRowAction`
 
 Drivers expose live server metrics (e.g. `pg.tps`,
-`mysql.queries_per_sec`) and tabular inspectors (e.g. `pg.activity`,
-`mysql.processlist`, `mongo.currentop`, `redis.client_list`) through a
-single catalog. Each driver also publishes a
-`DefaultInstanceDashboard` descriptor with a fixed 12-column layout —
-the workspace opens this descriptor as a **read-only Instance
-Overview** dashboard (dedup key
+`mysql.queries_per_sec`, `clickhouse.query`) and tabular inspectors
+(e.g. `pg.activity`, `mysql.processlist`, `mongo.currentop`,
+`redis.client_list`, `clickhouse.processes`) through a single catalog.
+Each driver also publishes a `DefaultInstanceDashboard` descriptor with
+a fixed 12-column layout — the workspace opens this descriptor as a
+**read-only Instance Overview** dashboard (dedup key
 `DocumentKey::InstanceOverview { profile_id }`). The "Save as
 editable" action clones the layout into a persisted dashboard owned
 by the user.
@@ -228,8 +228,9 @@ Inspector rows can declare `InspectorRowAction`s (e.g. *Terminate
 connection*). Action availability is gated by per-driver privilege
 probes (`pg_monitor` / `pg_signal_backend` for PostgreSQL, `PROCESS` /
 `CONNECTION_ADMIN` for MySQL, `killOp` for MongoDB, `CLIENT KILL` for
-Redis, `VIEW SERVER STATE` / `KILL` for SQL Server) so an
-under-privileged session never sees actions it could not execute.
+Redis, `VIEW SERVER STATE` / `KILL` for SQL Server, `KILL QUERY` for
+ClickHouse) so an under-privileged session never sees actions it could
+not execute.
 
 Every refresh timer (dashboard tick, chart standalone tick, inspector
 tick) checks `AppState::connections()` for the panel's profile and


### PR DESCRIPTION
Closes #510

## Summary

- **`ClickHouseInstanceCatalog`** exposes seven curated metrics — active queries and tracked memory from `system.metrics`, TCP/HTTP connections from `system.metrics`, selected/inserted rows from `system.events`, OS memory available from `system.asynchronous_metrics` — plus a `clickhouse.processes` inspector over `system.processes` and a curated `DefaultInstanceDashboard`.
- **Counters stay raw.** The issue asked for `system.events` to be delta-interpreted "like the Redis precedent", but Redis does not do that: it reports the raw cumulative `INFO` value per sample and leaves the rate to the chart layer. This follows the precedent as it actually exists, not as described.
- **The kill action fails closed.** `KILL QUERY WHERE query_id = '<id>'` is offered on the inspector only when a probe at catalog construction succeeds. Any probe failure — access denied, transport error, anything — leaves the action hidden. `query_id` is validated as a plain identifier before interpolation.
- **Nothing driver-specific reaches the UI.** The catalog is discovered through `Connection::instance_catalog()` and the two `ExecutionSourceContext` variants, exactly as Redis and PostgreSQL are.

## Changes

| File | Change |
|------|--------|
| `crates/dbflux_driver_clickhouse/src/instance_catalog.rs` | New: metric table, inspector, dashboard, privilege probe, row action, unit tests |
| `crates/dbflux_driver_clickhouse/src/connection.rs` | `client` becomes `Arc<ClickHouseHttpClient>` (the HTTP client is stateless, so sharing needs no mutex); `instance_catalog()` override; `InstanceMetricQuery`/`InstanceInspectorQuery` routing in `execute()` |
| `crates/dbflux_driver_clickhouse/src/driver.rs` | Declares `INSTANCE_METRICS` and `INSTANCE_INSPECTOR` |
| `crates/dbflux_driver_clickhouse/Cargo.toml` | Adds `async-trait` for the trait impl |
| `crates/dbflux_driver_clickhouse/tests/live_integration.rs` | Four Docker-backed tests appended to the existing suite, so the CI step already at `tests.yml:184` covers them |
| `crates/dbflux_driver_clickhouse/README.md`, `docs/DASHBOARDS.md`, `CLAUDE.md` | Planned-limitation bullet replaced by what now exists; ClickHouse added to the reference-driver and privilege-probe enumerations |

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,clickhouse,aws" -- -D warnings` clean (the CI invocation), and `cargo clippy -p dbflux_driver_clickhouse --all-targets -- -D warnings` clean
- [x] `cargo nextest run -p dbflux_driver_clickhouse -p dbflux_core` — all green, including the twelve new unit tests
- [ ] **The Docker-backed suite has not run.** This machine has podman with an active socket but no `containers/policy.json`, which is host configuration outside this repo, so `testcontainers` cannot pull an image. Every pre-existing ClickHouse live test fails the same way here, so this is not a regression. CI's Driver Live Integration job is the first real execution.

## Note for the reviewer

The system-table column names (`metric`, `event`, `value`, `query_id`, `elapsed`, `read_rows`, `memory_usage`, `query`, `address`) come from ClickHouse's documented, long-stable system tables but were **not** verified against a live server here.

A missing metric row reports `0.0` rather than failing, so a misspelled metric name would chart a flat zero forever and every shape assertion would still pass. `clickhouse_metric_raw_names_exist_in_their_system_tables` exists to catch exactly that: it asserts each declared raw name resolves to one row in its source table. If the ClickHouse live step fails after this lands, read that test's message first.