### PR TITLE
fix(web): resolve relative links to source files and publish the driver example

### DIFF
--- a/web/astro.config.ts
+++ b/web/astro.config.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import manifest from './.versions/manifest.json';
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
-import { routeForRepoPath, titleForRepoPath } from './src/data/nav';
+import { repoBlobUrl, routeForRepoPath, titleForRepoPath } from './src/data/nav';
 import { sitemapPathsFor } from './src/data/docs';
 import { CURRENT } from './src/data/versions';
 import { DOCS_MODE, ORIGIN } from './src/data/site';
@@ -86,20 +86,30 @@ function rehypeRepoLinks() {
 
         if (typeof href === 'string' && !/^[a-z]+:|^\/|^#/i.test(href)) {
           const [target, hash] = href.split('#');
+          const suffix = hash ? `#${hash}` : '';
+          const resolved = relative(root, resolve(fromDir, target)).split('\\').join('/');
 
-          if (target.endsWith('.md')) {
-            const repoPath = relative(root, resolve(fromDir, target)).split('\\').join('/');
+          // A link climbing out of the version mirror names nothing in the
+          // repository, so the author's href is left exactly as written.
+          if (!resolved.startsWith('..')) {
+            const repoPath = target.endsWith('/') ? `${resolved}/` : resolved;
 
-            node.properties.href =
-              routeForRepoPath(repoPath, locale, version) + (hash ? `#${hash}` : '');
+            if (target.endsWith('.md')) {
+              node.properties.href = routeForRepoPath(repoPath, locale, version) + suffix;
 
-            // Only relabel when the text is the path itself. A link already
-            // written as a sentence is the author's wording and stays.
-            const label = textOf(node).trim();
-            const title = titleForRepoPath(repoPath);
+              // Only relabel when the text is the path itself. A link already
+              // written as a sentence is the author's wording and stays.
+              const label = textOf(node).trim();
+              const title = titleForRepoPath(repoPath);
 
-            if (title && /\.md$/.test(label)) {
-              node.children = [{ type: 'text', value: title }];
+              if (title && /\.md$/.test(label)) {
+                node.children = [{ type: 'text', value: title }];
+              }
+            } else {
+              // Everything else linked relatively is source the site does not
+              // publish: a module, a manifest, a directory. Left alone the href
+              // resolves against the page's own URL and 404s.
+              node.properties.href = repoBlobUrl(repoPath, version) + suffix;
             }
           }
         }

--- a/web/scripts/check-links.ts
+++ b/web/scripts/check-links.ts
@@ -1,10 +1,13 @@
 /**
  * Fail the build on an internal link that points at a page the site does not
- * render.
+ * render, and on a relative link the rewriting never resolved.
  *
- * The docs are authored to be read on GitHub and link to each other by
- * filename; those hrefs are rewritten at build time. This is the check that the
- * rewriting kept up when a document is added, renamed or removed.
+ * The docs are authored to be read on GitHub and link to each other and to
+ * source files by repository path; those hrefs are rewritten at build time.
+ * This is the check that the rewriting kept up when a document is added,
+ * renamed or removed. A surviving relative href is its own failure: it resolves
+ * against whichever page happens to render it, so the same link is broken on
+ * one page and not another, and checking absolute hrefs alone never sees it.
  *
  * Only same-origin links are checked. In a split deployment the landing page
  * links to the documentation host on purpose, and those targets are not in this
@@ -31,6 +34,20 @@ async function htmlFiles(dir: string): Promise<string[]> {
 
 const files = await htmlFiles(DIST);
 
+/**
+ * The document without its scripts.
+ *
+ * Client bundles contain `href="..."` inside template literals and string
+ * assignments. Those are code that computes a link at runtime, not a link in
+ * the page, and reading them as markup reports every rendered template as a
+ * broken relative href.
+ */
+const markup = (html: string) => html.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '');
+
+/** An href resolved against the current page rather than the site root. */
+const relativeHref = (href: string) =>
+  href !== '' && !/^[a-z][a-z0-9+.-]*:|^\/\/|^\/|^#/i.test(href);
+
 /** `relative()` is platform-separator aware; URLs are always forward slashes. */
 const toPosix = (path: string) => relative(DIST, path).split('\\').join('/');
 
@@ -39,26 +56,45 @@ const pages = new Set(
 );
 
 const broken: string[] = [];
+const unrewritten: string[] = [];
 
 for (const file of files) {
   const html = await readFile(file, 'utf8');
   const from = `/${toPosix(file)}`;
 
-  for (const match of html.matchAll(/href="(\/[^"#?]*)/g)) {
+  for (const match of markup(html).matchAll(/href="([^"]*)"/g)) {
     const href = match[1];
 
-    if (href.startsWith('/_astro/') || /\.[a-z0-9]+$/i.test(href)) continue;
+    // A relative href is a repository path the rewriting failed to resolve. It
+    // resolves against the page's own URL, so it points at a page that was
+    // never built and no absolute-href check would ever see it.
+    if (relativeHref(href)) {
+      unrewritten.push(`${from} -> ${href}`);
+      continue;
+    }
 
-    const target = href.endsWith('/') ? href : `${href}/`;
+    if (!href.startsWith('/')) continue;
 
-    if (!pages.has(target)) broken.push(`${from} -> ${href}`);
+    const path = href.split(/[#?]/)[0];
+
+    if (path.startsWith('/_astro/') || /\.[a-z0-9]+$/i.test(path)) continue;
+
+    const target = path.endsWith('/') ? path : `${path}/`;
+
+    if (!pages.has(target)) broken.push(`${from} -> ${path}`);
   }
+}
+
+if (unrewritten.length > 0) {
+  console.error(`${unrewritten.length} relative link(s) were never rewritten to a site route:\n`);
+  for (const entry of [...new Set(unrewritten)].sort()) console.error(`  ${entry}`);
 }
 
 if (broken.length > 0) {
   console.error(`${broken.length} internal link(s) point at a page that is not built:\n`);
   for (const entry of [...new Set(broken)].sort()) console.error(`  ${entry}`);
-  process.exit(1);
 }
+
+if (broken.length + unrewritten.length > 0) process.exit(1);
 
 console.log(`ok: ${files.length} pages, every internal link resolves`);

--- a/web/scripts/fetch-docs.ts
+++ b/web/scripts/fetch-docs.ts
@@ -26,7 +26,7 @@ export const VERSIONS_DIR = join(WEB, '.versions');
 
 /** Non-document paths every version contributes alongside registered locale docs. */
 const WANTED_REPOSITORY_PATH =
-  /^(ARCHITECTURE\.md|CONTRIBUTING\.md|SECURITY\.md|crates\/dbflux_driver_[^/]+\/README\.md)$/;
+  /^(ARCHITECTURE\.md|CONTRIBUTING\.md|SECURITY\.md|crates\/dbflux_driver_[^/]+\/README\.md|examples\/custom_driver\/README\.md)$/;
 
 const wantedPath = (path: string) => isDocsRepoPath(path) || WANTED_REPOSITORY_PATH.test(path);
 

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -27,6 +27,7 @@ const docs = defineCollection({
       '*/CONTRIBUTING.md',
       '*/SECURITY.md',
       '*/crates/dbflux_driver_*/README.md',
+      '*/examples/custom_driver/README.md',
     ],
     generateId: ({ entry }) => contentEntryId(entry),
   }),

--- a/web/src/data/nav.ts
+++ b/web/src/data/nav.ts
@@ -1,8 +1,12 @@
 import { docsUrl } from './site';
-import { CURRENT } from './versions';
+import { CURRENT, buildInfo } from './versions';
 import { DEFAULT_LOCALE } from '../i18n';
 import type { Locale } from '../i18n';
-import { localizedDocPath } from '../i18n/locale-registry.ts';
+import {
+  EXAMPLE_DRIVER_PAGE,
+  EXAMPLE_DRIVER_README,
+  localizedDocPath,
+} from '../i18n/locale-registry.ts';
 
 export const REPO = 'https://github.com/0xErwin1/dbflux';
 
@@ -54,6 +58,7 @@ export const DOCS_SECTIONS: readonly DocsSection[] = [
       'security',
       'architecture',
       'driver_authoring',
+      'custom_driver_example',
       'driver_rpc_protocol',
       'rpc_services_config',
       'release',
@@ -77,6 +82,7 @@ export const DOC_TITLES: Readonly<Record<string, string>> = {
   drivers: 'Drivers',
   concepts: 'Key concepts',
   driver_authoring: 'Driver authoring',
+  custom_driver_example: 'Custom driver example',
   driver_rpc_protocol: 'Driver RPC protocol',
   rpc_services_config: 'RPC services config',
   release: 'Release process',
@@ -138,11 +144,26 @@ export function routeForRepoPath(
     return docsUrl(doc.path, versionPrefix, routeLocale);
   }
 
+  if (path === EXAMPLE_DRIVER_README) return docsUrl(EXAMPLE_DRIVER_PAGE, versionPrefix, locale);
   if (path === 'ARCHITECTURE.md') return docsUrl('architecture', versionPrefix, locale);
   if (path === 'CONTRIBUTING.md') return docsUrl('contributing', versionPrefix, locale);
   if (path === 'SECURITY.md') return docsUrl('security', versionPrefix, locale);
 
-  return `${REPO}/blob/main/${path}`;
+  return repoBlobUrl(path, versionId);
+}
+
+/**
+ * A repository file at the revision the reader is reading about.
+ *
+ * The documentation cites source files the site does not publish, and those
+ * citations are only useful if they resolve to the code that version describes.
+ * A `main` link read from `/v0.6/` shows a file that may have moved or changed
+ * since, so the commit each version was built from is what the URL pins.
+ */
+export function repoBlobUrl(path: string, versionId: string = CURRENT.id): string {
+  const view = path.endsWith('/') ? 'tree' : 'blob';
+
+  return `${REPO}/${view}/${buildInfo(versionId).commit}/${path.replace(/\/$/, '')}`;
 }
 
 /**
@@ -159,6 +180,7 @@ export function titleForRepoPath(path: string): string | null {
   const doc = localizedDocPath(path);
   if (doc) return DOC_TITLES[doc.path] ?? null;
 
+  if (path === EXAMPLE_DRIVER_README) return DOC_TITLES[EXAMPLE_DRIVER_PAGE] ?? null;
   if (path === 'ARCHITECTURE.md') return DOC_TITLES.architecture ?? null;
   if (path === 'CONTRIBUTING.md') return DOC_TITLES.contributing ?? null;
   if (path === 'SECURITY.md') return DOC_TITLES.security ?? null;

--- a/web/src/i18n/locale-registry.test.ts
+++ b/web/src/i18n/locale-registry.test.ts
@@ -117,6 +117,13 @@ test('preserves canonical locale identity while lowercasing only document paths'
   );
 });
 
+test('routes the custom driver example to its own page id', () => {
+  assert.equal(
+    contentEntryId('nightly/examples/custom_driver/README.md', extendedRegistry, 'en'),
+    'nightly/custom_driver_example',
+  );
+});
+
 test('detects a localized repository path from its registered docs directory', () => {
   assert.equal(localeForRepoPath('docs/zh-hans/SETTINGS.md', extendedRegistry, 'en'), 'zh-Hans');
   assert.equal(localeForRepoPath('docs/SETTINGS.md', extendedRegistry, 'en'), 'en');

--- a/web/src/i18n/locale-registry.ts
+++ b/web/src/i18n/locale-registry.ts
@@ -11,6 +11,16 @@ export interface LocaleDefinition {
 
 export const DEFAULT_LOCALE = 'en';
 
+/**
+ * The runnable driver example, which the site publishes as a page.
+ *
+ * It lives outside `docs/` because it is a working crate a reader compiles, not
+ * prose. Publishing it anyway keeps the driver authoring guide linking within
+ * the site instead of handing the reader off to the repository mid-guide.
+ */
+export const EXAMPLE_DRIVER_README = 'examples/custom_driver/README.md';
+export const EXAMPLE_DRIVER_PAGE = 'custom_driver_example';
+
 export const LOCALE_REGISTRY = validateLocaleRegistry(
   [
     { id: 'en', name: 'English', docsDirectory: null },
@@ -254,6 +264,8 @@ export function contentEntryId(
 
   const driver = repoPath.match(/^crates\/dbflux_driver_([^/]+)\/README\.md$/);
   if (driver) return `${version}/drivers/${driver[1]}`;
+
+  if (repoPath === EXAMPLE_DRIVER_README) return `${version}/${EXAMPLE_DRIVER_PAGE}`;
 
   const locale = localeForRepoPath(repoPath, registry, defaultLocale);
   const localeDefinition = registry.find(({ id }) => id === locale);


### PR DESCRIPTION
## Summary

- Relative links to source files reached the HTML unrewritten and 404'd. They now resolve for every target, not only `.md` ones.
- Links into the repository are pinned to the commit each documentation version was built from, instead of a fixed `main`.
- `examples/custom_driver/README.md` is published as a page, so the driver authoring guide stops handing the reader off to GitHub mid-walkthrough.

## What does this resolve?

- Resolves #527

## How was this solved?

**Start the review at `web/astro.config.ts`.** `rehypeRepoLinks` gated the entire rewrite on `target.endsWith('.md')`, which is the single cause behind all three symptoms. The rewrite now runs for any relative href: a document still resolves to the page rendering it, and everything else resolves to the repository. A link that climbs out of the version mirror names nothing in the repository, so it is left exactly as the author wrote it.

`repoBlobUrl` in `web/src/data/nav.ts` replaces the old `${REPO}/blob/main/` fallback. It reads the commit from `buildInfo(versionId)`, so a citation read from `/v0.6/` opens the code that release describes rather than whatever `main` holds today. A path ending in `/` becomes a `tree` URL instead of a `blob` one.

`check-links.ts` could not have caught this: it matched only `href="/…"`, and a relative href never starts with a slash. It now inspects every href and fails on any relative one surviving in the built HTML. It reads the markup with `<script>` blocks stripped, because client bundles contain `href="…"` inside template literals and reading those as markup reports every rendered template as broken.

Publishing the example needed four coordinated edits: the path in `fetch-docs.ts`, the glob in `content.config.ts`, a `contentEntryId` case mapping it to `custom_driver_example`, and the section, title and route in `nav.ts`.

**Out of scope:** the "Edit this page" link still points at `blob/main` from every version. Same shape of problem, different code path, and no reader lands on a 404 because of it.

## Validation

```
pnpm build          298 pages
pnpm check          0 errors, 0 warnings, 0 hints
pnpm test           12 pass, 0 fail
pnpm format:check   clean
node scripts/check-links.ts
                    ok: 298 pages, every internal link resolves
```

The `contentEntryId` case was written test-first: the assertion failed with `nightly/examples/custom_driver/readme` before the mapping existed.

The new gate was verified negatively. Injecting `<a href="../crates/x.rs">` into a built page makes `check-links.ts` exit 1 and name the page:

```
1 relative link(s) were never rewritten to a site route:

  /docs/concepts/index.html -> ../crates/dbflux_core/src/core/traits.rs
```

Rendered output on `/docs/driver_authoring/`, before and after:

| Before | After |
|---|---|
| `../crates/dbflux_core/src/core/traits.rs` (404) | `github.com/0xErwin1/dbflux/blob/9849b87c/crates/dbflux_core/src/core/traits.rs` |
| `github.com/…/blob/main/examples/custom_driver/README.md` | `/docs/custom_driver_example/` |

Per-version pinning confirmed in `dist/`: nightly renders `blob/3de9974d`, v0.7 renders `blob/9849b87c`.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

`bug`, `documentation`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyxC4tqzDuUKnip8yt1BM8
