### PR TITLE
fix(ui): raise secondary text and icon contrast to WCAG AA on all palettes

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -15,6 +15,7 @@ colors:
   tiles: "#111823"
   foreground: "#B3B1AD"
   muted: "#5C6773"
+  muted-foreground: "#828D9D"
   border: "#1F2430"
   ghost-border: "rgba(82, 68, 54, 0.15)"
   selection: "#273747"
@@ -181,7 +182,7 @@ components:
     size: "{spacing.border-thin}"
   tab-strip:
     backgroundColor: "{colors.panel}"
-    textColor: "{colors.muted}"
+    textColor: "{colors.muted-foreground}"
     typography: "{typography.label-sm}"
     height: "{spacing.tab}"
     padding: "{spacing.md}"
@@ -211,7 +212,7 @@ components:
     backgroundColor: "{colors.table-active}"
   table-header:
     backgroundColor: "{colors.panel}"
-    textColor: "{colors.muted}"
+    textColor: "{colors.muted-foreground}"
     typography: "{typography.label-sm}"
   panel:
     backgroundColor: "{colors.background}"
@@ -257,19 +258,19 @@ components:
     padding: "{spacing.xs}"
   badge-neutral:
     backgroundColor: "{colors.raised}"
-    textColor: "{colors.muted}"
+    textColor: "{colors.muted-foreground}"
     typography: "{typography.caption-xs}"
     rounded: "{rounded.sm}"
     padding: "{spacing.xs}"
   status-bar:
     backgroundColor: "{colors.background}"
-    textColor: "{colors.muted}"
+    textColor: "{colors.muted-foreground}"
     typography: "{typography.caption-xs}"
     height: "{spacing.toolbar}"
   status-bar-item-hover:
     backgroundColor: "{colors.raised}"
   key-hint:
-    textColor: "{colors.muted}"
+    textColor: "{colors.muted-foreground}"
     typography: "{typography.key-hint}"
 ---
 
@@ -303,7 +304,8 @@ Three palettes share one structure. Each defines the same twelve base slots and 
 | raised (secondary, popover) | `#151E2B` | `#242936` | `#F7F8FA` |
 | tiles | `#111823` | `#202734` | `#E8E8E8` |
 | foreground | `#B3B1AD` | `#CBCCC6` | `#5C6166` |
-| muted | `#5C6773` | `#707A8C` | `#ABB0B6` |
+| muted (decoration, switch, slider) | `#5C6773` | `#707A8C` | `#ABB0B6` |
+| muted foreground (secondary text, icons) | `#828D9D` | `#8F98AA` | `#676E75` |
 | border | `#1F2430` | `#3A4052` | `#D9DEE8` |
 | selection | `#273747` | `#33415E` | `#D3E8F8` |
 | primary (accent, caret, drag border) | `#FFB454` | `#FFCC66` | `#FF9940` |
@@ -354,7 +356,7 @@ The size scale has six steps and shifts down one notch under the Compact style:
 
 Weights are Medium for everything that reads and Bold for everything that labels a region: titles, headings, sidebar group labels, key hints. Semi-bold appears only on the third headline level. Line height is left to GPUI's default.
 
-Muted text has three levels: the muted color at full alpha for captions, at 70% for secondary dims, at 50% for tertiary dims. Never invent a fourth.
+Secondary text uses the muted foreground slot, a hand-picked readable value per palette. It has three levels: full alpha for captions, at 70% for secondary dims, at 50% for tertiary dims. Never invent a fourth.
 
 ## Layout
 

--- a/crates/dbflux_components/src/semantic.rs
+++ b/crates/dbflux_components/src/semantic.rs
@@ -366,7 +366,7 @@ impl ChartColors {
             panel_border: from_hex(0xD9DEE8, 1.0),
             label_fg: from_hex(0x787E85, 1.0),
             value_fg: from_hex(0x5C6166, 1.0),
-            muted_fg: from_hex(0xABB0B6, 1.0),
+            muted_fg: from_hex(0x676E75, 1.0),
             hover_bg: from_hex(0x5C6166, 0.06),
             pill_bg: from_hex(0x5C6166, 0.06),
             pill_border: from_hex(0xD9DEE8, 1.0),

--- a/crates/dbflux_components/src/theme.rs
+++ b/crates/dbflux_components/src/theme.rs
@@ -159,6 +159,7 @@ fn apply_ayu_dark(style: AppStyle, cx: &mut App) {
     let background = rgb_to_hsla(0x0A0E14);
     let panel = rgb_to_hsla(0x0F1419);
     let foreground = rgb_to_hsla(0xB3B1AD);
+    let muted_foreground = rgb_to_hsla(0x828D9D);
     let muted = rgb_to_hsla(0x5C6773);
     let accent = rgb_to_hsla(0xFFB454);
     let border = rgb_to_hsla(0x1F2430);
@@ -182,7 +183,7 @@ fn apply_ayu_dark(style: AppStyle, cx: &mut App) {
 
     // Muted
     theme.muted = muted;
-    theme.muted_foreground = muted;
+    theme.muted_foreground = muted_foreground;
 
     // Primary (accent color)
     theme.primary = accent;
@@ -255,7 +256,7 @@ fn apply_ayu_dark(style: AppStyle, cx: &mut App) {
     // Tab bar
     theme.tab = panel;
     theme.tab_bar = panel;
-    theme.tab_foreground = muted;
+    theme.tab_foreground = muted_foreground;
     theme.tab_active = background;
     theme.tab_active_foreground = foreground;
     theme.tab_bar_segmented = raised;
@@ -263,7 +264,7 @@ fn apply_ayu_dark(style: AppStyle, cx: &mut App) {
     // Table
     theme.table = background;
     theme.table_head = panel;
-    theme.table_head_foreground = muted;
+    theme.table_head_foreground = muted_foreground;
     theme.table_even = rgb_to_hsla_alpha(0xB3B1AD, 0.02);
     theme.table_hover = rgb_to_hsla_alpha(0xB3B1AD, 0.05);
     theme.table_active = rgb_to_hsla_alpha(0x59C2FF, 0.15);
@@ -317,7 +318,7 @@ fn apply_ayu_dark(style: AppStyle, cx: &mut App) {
 
     // Description list
     theme.description_list_label = panel;
-    theme.description_list_label_foreground = muted;
+    theme.description_list_label_foreground = muted_foreground;
 
     // Drag and drop
     theme.drag_border = accent;
@@ -359,6 +360,7 @@ fn apply_ayu_mirage(style: AppStyle, cx: &mut App) {
     let background = rgb_to_hsla(0x1F2430);
     let panel = rgb_to_hsla(0x232834);
     let foreground = rgb_to_hsla(0xCBCCC6);
+    let muted_foreground = rgb_to_hsla(0x8F98AA);
     let muted = rgb_to_hsla(0x707A8C);
     let accent = rgb_to_hsla(0xFFCC66);
     let border = rgb_to_hsla(0x3A4052);
@@ -381,7 +383,7 @@ fn apply_ayu_mirage(style: AppStyle, cx: &mut App) {
     theme.caret = accent;
 
     theme.muted = muted;
-    theme.muted_foreground = muted;
+    theme.muted_foreground = muted_foreground;
 
     theme.primary = accent;
     theme.primary_hover = rgb_to_hsla(0xE6B85C);
@@ -438,14 +440,14 @@ fn apply_ayu_mirage(style: AppStyle, cx: &mut App) {
 
     theme.tab = panel;
     theme.tab_bar = panel;
-    theme.tab_foreground = muted;
+    theme.tab_foreground = muted_foreground;
     theme.tab_active = background;
     theme.tab_active_foreground = foreground;
     theme.tab_bar_segmented = raised;
 
     theme.table = background;
     theme.table_head = panel;
-    theme.table_head_foreground = muted;
+    theme.table_head_foreground = muted_foreground;
     theme.table_even = rgb_to_hsla_alpha(0xCBCCC6, 0.02);
     theme.table_hover = rgb_to_hsla_alpha(0xCBCCC6, 0.05);
     theme.table_active = rgb_to_hsla_alpha(0x73D0FF, 0.12);
@@ -483,7 +485,7 @@ fn apply_ayu_mirage(style: AppStyle, cx: &mut App) {
     theme.skeleton = raised;
 
     theme.description_list_label = panel;
-    theme.description_list_label_foreground = muted;
+    theme.description_list_label_foreground = muted_foreground;
 
     theme.drag_border = accent;
     theme.drop_target = rgb_to_hsla_alpha(0xFFCC66, 0.1);
@@ -520,6 +522,7 @@ fn apply_ayu_light(style: AppStyle, cx: &mut App) {
     let background = rgb_to_hsla(0xFAFAFA);
     let panel = rgb_to_hsla(0xF3F3F3);
     let foreground = rgb_to_hsla(0x5C6166);
+    let muted_foreground = rgb_to_hsla(0x676E75);
     let muted = rgb_to_hsla(0xABB0B6);
     let accent = rgb_to_hsla(0xFF9940);
     let border = rgb_to_hsla(0xD9DEE8);
@@ -541,7 +544,7 @@ fn apply_ayu_light(style: AppStyle, cx: &mut App) {
     theme.caret = accent;
 
     theme.muted = muted;
-    theme.muted_foreground = muted;
+    theme.muted_foreground = muted_foreground;
 
     theme.primary = accent;
     theme.primary_hover = rgb_to_hsla(0xE68A3A);
@@ -600,14 +603,14 @@ fn apply_ayu_light(style: AppStyle, cx: &mut App) {
 
     theme.tab = panel;
     theme.tab_bar = panel;
-    theme.tab_foreground = muted;
+    theme.tab_foreground = muted_foreground;
     theme.tab_active = background;
     theme.tab_active_foreground = foreground;
     theme.tab_bar_segmented = raised;
 
     theme.table = background;
     theme.table_head = panel;
-    theme.table_head_foreground = muted;
+    theme.table_head_foreground = muted_foreground;
     theme.table_even = rgb_to_hsla_alpha(0x5C6166, 0.03);
     theme.table_hover = rgb_to_hsla_alpha(0x5C6166, 0.06);
     theme.table_active = rgb_to_hsla_alpha(0x399EE6, 0.12);
@@ -649,7 +652,7 @@ fn apply_ayu_light(style: AppStyle, cx: &mut App) {
     theme.skeleton = raised;
 
     theme.description_list_label = panel;
-    theme.description_list_label_foreground = muted;
+    theme.description_list_label_foreground = muted_foreground;
 
     theme.drag_border = accent;
     theme.drop_target = rgb_to_hsla_alpha(0xFF9940, 0.1);

--- a/crates/dbflux_ui/tests/theme_contrast_regression.rs
+++ b/crates/dbflux_ui/tests/theme_contrast_regression.rs
@@ -1,0 +1,78 @@
+use dbflux_core::{AppStyle, ThemeSetting};
+use dbflux_ui::theme;
+use gpui::{Hsla, TestAppContext, Window};
+use gpui_component::theme::Theme;
+
+/// WCAG 2.x minimum contrast for normal text.
+const AA_TEXT: f32 = 4.5;
+
+fn relative_luminance(color: Hsla) -> f32 {
+    let rgba = color.to_rgb();
+
+    fn linearize(channel: f32) -> f32 {
+        if channel <= 0.03928 {
+            channel / 12.92
+        } else {
+            ((channel + 0.055) / 1.055).powf(2.4)
+        }
+    }
+
+    0.2126 * linearize(rgba.r) + 0.7152 * linearize(rgba.g) + 0.0722 * linearize(rgba.b)
+}
+
+fn contrast_ratio(foreground: Hsla, background: Hsla) -> f32 {
+    let fg = relative_luminance(foreground);
+    let bg = relative_luminance(background);
+
+    (fg.max(bg) + 0.05) / (fg.min(bg) + 0.05)
+}
+
+fn assert_readable_secondary_text(theme: &Theme, setting: ThemeSetting) {
+    let surfaces = [
+        ("background", theme.background),
+        ("panel", theme.tab),
+        ("raised", theme.popover),
+    ];
+
+    let foregrounds = [
+        ("muted_foreground", theme.muted_foreground),
+        ("tab_foreground", theme.tab_foreground),
+        ("table_head_foreground", theme.table_head_foreground),
+        (
+            "description_list_label_foreground",
+            theme.description_list_label_foreground,
+        ),
+    ];
+
+    for (surface_name, surface) in surfaces {
+        for (foreground_name, foreground) in foregrounds {
+            let ratio = contrast_ratio(foreground, surface);
+
+            assert!(
+                ratio >= AA_TEXT,
+                "{setting:?}: {foreground_name} on {surface_name} measures {ratio:.2}:1, below {AA_TEXT}:1"
+            );
+        }
+    }
+}
+
+#[gpui::test]
+fn secondary_text_meets_aa_contrast_on_every_palette(cx: &mut TestAppContext) {
+    cx.update(theme::init);
+
+    for setting in [
+        ThemeSetting::Dark,
+        ThemeSetting::Mirage,
+        ThemeSetting::Light,
+    ] {
+        cx.update(|cx| {
+            theme::apply_theme(setting, AppStyle::Default, Option::<&mut Window>::None, cx)
+        });
+
+        cx.update(|cx| {
+            let theme = Theme::global_mut(cx);
+
+            assert_readable_secondary_text(theme, setting);
+        });
+    }
+}

--- a/web/src/styles/tokens.css
+++ b/web/src/styles/tokens.css
@@ -21,8 +21,8 @@
 
   --text: #b3b1ad;
   --text-strong: #e6e1cf;
-  /* The app's muted #5c6773 measures 3.35:1 on --bg, below the 4.5:1 floor for
-     text. Secondary copy uses this lighter value (5.51:1 on --panel) instead. */
+  /* Mirrors the app's muted_foreground. 5.51:1 on --panel, above the 4.5:1 floor
+     for text. The darker --text-faint below is not readable enough for copy. */
   --text-muted: #828d9d;
   /* Decoration only: icon strokes, tree guides. Never the sole carrier of meaning. */
   --text-faint: #5c6773;


### PR DESCRIPTION
## Summary

Secondary text and icons now meet WCAG AA contrast on all three palettes. Each palette gets a hand-picked `muted_foreground` separate from the decorative `muted` slot, and the four theme fields that carry secondary text move to it.

- Ayu Light: sidebar icons and secondary labels went from 2.09:1 to 4.95:1 on the background.
- Ayu Dark: 3.35:1 to 5.75:1. The new value is the same `#828d9d` the website already uses.
- Ayu Mirage: 3.58:1 to 5.35:1.

## What does this resolve?

- Resolves #531

## How was this solved?

The `muted` slot was doing two jobs: decoration (switch track, slider bar, editor line numbers) and secondary text or icon color. The second job needs at least 4.5:1 and the values were chosen for the first.

`theme.rs` now defines `muted_foreground` per palette and assigns it to `muted_foreground`, `tab_foreground`, `table_head_foreground`, and `description_list_label_foreground`. `muted` keeps its value and its remaining uses. No call site changes: the 400 or so `theme.muted_foreground` reads across the UI crates pick up the new value.

| Palette | `muted` (unchanged) | `muted_foreground` (new) | On background | On panel | On raised |
|---|---|---|---|---|---|
| Dark | `#5C6773` | `#828D9D` | 5.75:1 | 5.51:1 | 4.99:1 |
| Mirage | `#707A8C` | `#8F98AA` | 5.35:1 | 5.08:1 | 5.01:1 |
| Light | `#ABB0B6` | `#676E75` | 4.95:1 | 4.66:1 | 4.86:1 |

The Light chart palette in `semantic.rs` used the same `#ABB0B6` for muted labels and moves to `#676E75`. Dark and Mirage chart grays were already above the floor and are untouched.

`DESIGN.md` gains a `muted-foreground` token, and the five components that referenced `{colors.muted}` as text color now reference it. The website token comment that described the app's old value is updated.

## Validation

New regression test `crates/dbflux_ui/tests/theme_contrast_regression.rs` computes WCAG contrast for the four secondary-text fields against background, panel, and raised on every palette and fails below 4.5:1. It failed on `main` with `Dark: muted_foreground on background measures 3.35:1` and passes with this change.

```
cargo nextest run -p dbflux_ui --test theme_contrast_regression --test theme_font_regression
cargo nextest run -p dbflux_components semantic
cargo clippy -p dbflux_components -p dbflux_ui -- -D warnings
cd web && pnpm exec prettier --check src/styles/tokens.css
npx -y -p @google/design.md designmd lint DESIGN.md
```

| Check | Result |
|---|---|
| theme tests | 7 passed |
| semantic tests | 15 passed |
| clippy | clean |
| prettier | clean |
| design.md lint | 0 errors, `contrast-ratio` no longer flags any muted component |

Not verified: a visual pass in the running app. The dim text variants at 70% and 50% alpha and the idle status dot derive from `muted_foreground`, so they get brighter too.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

`ui:bug`
