### PR TITLE
fix(settings): keyboard navigation for MCP and Hooks with a reusable master-detail list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@ All notable changes to DBFlux will be documented in this file.
   `crates/dbflux_i18n/locales/{en,es}.yml`, one file per locale, and are
   managed through Weblate.
 
+### Fixed
+
+* **Keyboard navigation in Settings lists and forms (#543)** — MCP Clients,
+  Roles and Policies can now be browsed, created and edited from the keyboard:
+  `l`/`enter` opens the form, `n` starts a new item, `j`/`k` and `tab` move
+  between fields with a visible focus ring, `enter` activates a field and
+  `h`/`escape` return to the list. Built-in roles and policies stay read-only
+  under the keyboard cursor. Hooks shows the focus ring on every form field,
+  so the cursor moved by `j`/`k` is no longer invisible. `n` creates a new
+  item in Proxies, SSH Tunnels and Services as well, and the Audit status
+  indicator is no longer a keyboard stop. The MCP sections render their list
+  through a new reusable master-detail composite.
+
 ## [0.7.0] - 2026-07-31
 
 ### Added

--- a/crates/dbflux_components/src/composites/master_detail_list.rs
+++ b/crates/dbflux_components/src/composites/master_detail_list.rs
@@ -1,0 +1,325 @@
+//! Domain-free master-detail list panel: a scrollable column of rows (each
+//! with an id, label, optional detail/badge) plus an optional "New" and
+//! "Secondary" action, shaped like the hand-rendered list panels in the
+//! settings sections (Proxies, SSH Tunnels, MCP). Callers own selection,
+//! focus, and scroll state; this module only renders.
+
+use gpui::prelude::FluentBuilder;
+use gpui::*;
+use gpui_component::ActiveTheme;
+use gpui_component::scroll::ScrollableElement;
+
+use crate::primitives::{Icon, Text, focus_frame};
+use crate::tokens::{Radii, Spacing, Widths};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BadgeTone {
+    Neutral,
+    Accent,
+    Success,
+    Danger,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MasterDetailItem {
+    pub id: SharedString,
+    pub label: SharedString,
+    pub detail: Option<SharedString>,
+    pub badge: Option<(SharedString, BadgeTone)>,
+    pub selected: bool,
+    pub focused: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct MasterDetailAction {
+    pub label: SharedString,
+    pub enabled: bool,
+    pub focused: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct MasterDetailListConfig {
+    pub id: SharedString,
+    pub width: Pixels,
+    pub new_action: Option<MasterDetailAction>,
+    pub secondary_action: Option<MasterDetailAction>,
+    pub empty_message: Option<SharedString>,
+}
+
+impl Default for MasterDetailListConfig {
+    fn default() -> Self {
+        Self {
+            id: SharedString::from("master-detail-list"),
+            width: Widths::SETTINGS_LIST_PANEL,
+            new_action: None,
+            secondary_action: None,
+            empty_message: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MasterDetailActionKind {
+    New,
+    Secondary,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RowKind {
+    Selected,
+    Focused,
+    Plain,
+}
+
+/// Derives a row's visual kind from its selection and list-cursor state.
+///
+/// `Selected` takes precedence over `Focused` when both are true: selection
+/// marks the item currently open in the detail form, which stays the more
+/// prominent signal even while the keyboard cursor also sits on that row.
+pub fn master_detail_row_kind(selected: bool, focused: bool) -> RowKind {
+    if selected {
+        RowKind::Selected
+    } else if focused {
+        RowKind::Focused
+    } else {
+        RowKind::Plain
+    }
+}
+
+struct RowColors {
+    primary: Hsla,
+    secondary: Hsla,
+    list_even: Hsla,
+    muted_foreground: Hsla,
+    accent: Hsla,
+    success: Hsla,
+    danger: Hsla,
+    border: Hsla,
+}
+
+fn badge_color(tone: BadgeTone, colors: &RowColors) -> Hsla {
+    match tone {
+        BadgeTone::Neutral => colors.muted_foreground,
+        BadgeTone::Accent => colors.accent,
+        BadgeTone::Success => colors.success,
+        BadgeTone::Danger => colors.danger,
+    }
+}
+
+fn render_action_button(
+    kind: MasterDetailActionKind,
+    action: MasterDetailAction,
+    colors: &RowColors,
+    cx: &App,
+    on_action: impl Fn(MasterDetailActionKind, &mut Window, &mut App) + 'static,
+) -> impl IntoElement {
+    let element_id = match kind {
+        MasterDetailActionKind::New => "master-detail-list-new-action",
+        MasterDetailActionKind::Secondary => "master-detail-list-secondary-action",
+    };
+
+    div()
+        .id(element_id)
+        .rounded(Radii::SM)
+        .child(focus_frame(
+            action.focused,
+            None,
+            div()
+                .flex()
+                .items_center()
+                .justify_center()
+                .gap(Spacing::XS)
+                .px(Spacing::SM)
+                .py(Spacing::XS)
+                .rounded(Radii::SM)
+                .when(action.enabled, |el| {
+                    el.cursor_pointer().hover({
+                        let secondary = colors.secondary;
+                        move |style| style.bg(secondary)
+                    })
+                })
+                .when(!action.enabled, |el| el.opacity(0.5))
+                .child(Icon::new(crate::icons::AppIcon::Plus).size(px(14.0)))
+                .child(Text::body(action.label)),
+            cx,
+        ))
+        .when(action.enabled, |el| {
+            el.on_click(move |_event, window, cx| on_action(kind, window, cx))
+        })
+}
+
+fn render_row<S>(
+    item: MasterDetailItem,
+    index: usize,
+    colors: &RowColors,
+    cx: &App,
+    on_select: S,
+) -> Div
+where
+    S: Fn(usize, &mut Window, &mut App) + 'static,
+{
+    let kind = master_detail_row_kind(item.selected, item.focused);
+
+    let ring_color = match kind {
+        RowKind::Selected | RowKind::Focused => Some(colors.primary),
+        RowKind::Plain => None,
+    };
+
+    let row = div()
+        .id(SharedString::from(format!("master-detail-row-{}", item.id)))
+        .rounded(Radii::SM)
+        .bg(colors.list_even)
+        .cursor_pointer()
+        .when(kind == RowKind::Selected, |el| el.bg(colors.secondary))
+        .hover({
+            let secondary = colors.secondary;
+            move |style| style.bg(secondary)
+        })
+        .on_click(move |_event, window, cx| on_select(index, window, cx))
+        .child(
+            div()
+                .flex()
+                .items_start()
+                .justify_between()
+                .gap(Spacing::SM)
+                .px(Spacing::SM)
+                .py(Spacing::XS)
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .min_w_0()
+                        .gap(Spacing::XXS)
+                        .child(Text::body(item.label))
+                        .when_some(item.detail, |el, detail| el.child(Text::caption(detail))),
+                )
+                .when_some(item.badge, |el, (label, tone)| {
+                    el.child(Text::caption(label).color(badge_color(tone, colors)))
+                }),
+        );
+
+    focus_frame(ring_color.is_some(), ring_color, row, cx).rounded(Radii::SM)
+}
+
+pub fn render_master_detail_list<S, A>(
+    config: &MasterDetailListConfig,
+    items: &[MasterDetailItem],
+    scroll_handle: &ScrollHandle,
+    on_select: S,
+    on_action: A,
+    cx: &App,
+) -> impl IntoElement
+where
+    S: Fn(usize, &mut Window, &mut App) + Clone + 'static,
+    A: Fn(MasterDetailActionKind, &mut Window, &mut App) + Clone + 'static,
+{
+    let theme = cx.theme();
+    let colors = RowColors {
+        primary: theme.primary,
+        secondary: theme.secondary,
+        list_even: theme.list_even,
+        muted_foreground: theme.muted_foreground,
+        accent: theme.accent,
+        success: theme.success,
+        danger: theme.danger,
+        border: theme.border,
+    };
+
+    let header = if config.new_action.is_some() || config.secondary_action.is_some() {
+        Some(
+            div()
+                .p(Spacing::SM)
+                .border_b_1()
+                .border_color(colors.border)
+                .flex()
+                .flex_col()
+                .gap(Spacing::SM)
+                .when_some(config.new_action.clone(), |el, action| {
+                    let on_action = on_action.clone();
+                    el.child(render_action_button(
+                        MasterDetailActionKind::New,
+                        action,
+                        &colors,
+                        cx,
+                        move |kind, window, cx| on_action(kind, window, cx),
+                    ))
+                })
+                .when_some(config.secondary_action.clone(), |el, action| {
+                    let on_action = on_action.clone();
+                    el.child(render_action_button(
+                        MasterDetailActionKind::Secondary,
+                        action,
+                        &colors,
+                        cx,
+                        move |kind, window, cx| on_action(kind, window, cx),
+                    ))
+                }),
+        )
+    } else {
+        None
+    };
+
+    let body = div()
+        .id(SharedString::from(format!("{}-body", config.id)))
+        .track_scroll(scroll_handle)
+        .flex_1()
+        .min_h_0()
+        .overflow_y_scrollbar()
+        .p(Spacing::SM)
+        .flex()
+        .flex_col()
+        .gap(Spacing::XS)
+        .when(items.is_empty(), |el| {
+            if let Some(message) = config.empty_message.clone() {
+                el.child(
+                    div()
+                        .p(Spacing::LG)
+                        .child(Text::body(message).color(colors.muted_foreground)),
+                )
+            } else {
+                el
+            }
+        })
+        .children(items.iter().cloned().enumerate().map(|(index, item)| {
+            let on_select = on_select.clone();
+            render_row(item, index, &colors, cx, move |idx, window, cx| {
+                on_select(idx, window, cx)
+            })
+        }));
+
+    div()
+        .id(config.id.clone())
+        .w(config.width)
+        .h_full()
+        .border_r_1()
+        .border_color(colors.border)
+        .flex()
+        .flex_col()
+        .when_some(header, |el, header| el.child(header))
+        .child(body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RowKind, master_detail_row_kind};
+
+    #[test]
+    fn plain_row_when_neither_selected_nor_focused() {
+        assert_eq!(master_detail_row_kind(false, false), RowKind::Plain);
+    }
+
+    #[test]
+    fn selected_row_when_selected_only() {
+        assert_eq!(master_detail_row_kind(true, false), RowKind::Selected);
+    }
+
+    #[test]
+    fn focused_row_when_focused_only() {
+        assert_eq!(master_detail_row_kind(false, true), RowKind::Focused);
+    }
+
+    #[test]
+    fn selected_wins_when_both_selected_and_focused() {
+        assert_eq!(master_detail_row_kind(true, true), RowKind::Selected);
+    }
+}

--- a/crates/dbflux_components/src/composites/mod.rs
+++ b/crates/dbflux_components/src/composites/mod.rs
@@ -1,6 +1,7 @@
 mod collapsible_section;
 mod control_shell;
 mod field_row;
+mod master_detail_list;
 mod menu_item;
 mod menu_popup;
 mod modal_frame;
@@ -18,6 +19,10 @@ pub use control_shell::control_shell;
 pub use field_row::{
     field_row, field_row_vertical, field_row_vertical_with_desc, field_row_with_desc,
     field_row_with_label_width,
+};
+pub use master_detail_list::{
+    BadgeTone, MasterDetailAction, MasterDetailActionKind, MasterDetailItem,
+    MasterDetailListConfig, RowKind, master_detail_row_kind, render_master_detail_list,
 };
 pub use menu_item::{MenuItem, render_menu_container, render_menu_item, render_separator};
 pub use menu_popup::{render_menu_items, render_menu_overlay};

--- a/crates/dbflux_ui_windows/src/settings/audit_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/audit_section.rs
@@ -23,7 +23,6 @@ use gpui_component::{ActiveTheme, Sizable};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(super) enum AuditFormRow {
-    StatusIndicator,
     EnableAudit,
     RetentionDays,
     CaptureUserActions,
@@ -36,6 +35,23 @@ pub(super) enum AuditFormRow {
     BackgroundPurgeInterval,
     LogCaptureMinLevel,
     SaveButton,
+}
+
+fn audit_form_rows() -> Vec<AuditFormRow> {
+    vec![
+        AuditFormRow::EnableAudit,
+        AuditFormRow::RetentionDays,
+        AuditFormRow::CaptureUserActions,
+        AuditFormRow::CaptureSystemEvents,
+        AuditFormRow::CaptureQueryText,
+        AuditFormRow::CaptureHookOutputMetadata,
+        AuditFormRow::RedactSensitiveValues,
+        AuditFormRow::MaxDetailBytes,
+        AuditFormRow::PurgeOnStartup,
+        AuditFormRow::BackgroundPurgeInterval,
+        AuditFormRow::LogCaptureMinLevel,
+        AuditFormRow::SaveButton,
+    ]
 }
 
 #[allow(dead_code)]
@@ -183,30 +199,12 @@ impl AuditSection {
         repo.get().ok().flatten().unwrap_or_default()
     }
 
-    fn audit_form_rows(&self) -> Vec<AuditFormRow> {
-        vec![
-            AuditFormRow::StatusIndicator,
-            AuditFormRow::EnableAudit,
-            AuditFormRow::RetentionDays,
-            AuditFormRow::CaptureUserActions,
-            AuditFormRow::CaptureSystemEvents,
-            AuditFormRow::CaptureQueryText,
-            AuditFormRow::CaptureHookOutputMetadata,
-            AuditFormRow::RedactSensitiveValues,
-            AuditFormRow::MaxDetailBytes,
-            AuditFormRow::PurgeOnStartup,
-            AuditFormRow::BackgroundPurgeInterval,
-            AuditFormRow::LogCaptureMinLevel,
-            AuditFormRow::SaveButton,
-        ]
-    }
-
     fn audit_current_row(&self) -> Option<AuditFormRow> {
-        self.audit_form_rows().get(self.audit_form_cursor).copied()
+        audit_form_rows().get(self.audit_form_cursor).copied()
     }
 
     pub(super) fn audit_move_down(&mut self) {
-        let count = self.audit_form_rows().len();
+        let count = audit_form_rows().len();
         if self.audit_form_cursor + 1 < count {
             self.audit_form_cursor += 1;
         }
@@ -223,7 +221,7 @@ impl AuditSection {
     }
 
     fn audit_move_last(&mut self) {
-        self.audit_form_cursor = self.audit_form_rows().len().saturating_sub(1);
+        self.audit_form_cursor = audit_form_rows().len().saturating_sub(1);
     }
 
     pub(super) fn audit_activate_current_field(
@@ -272,7 +270,7 @@ impl AuditSection {
             Some(AuditFormRow::SaveButton) => {
                 self.save_audit_settings(window, cx);
             }
-            Some(AuditFormRow::StatusIndicator) | None => {}
+            None => {}
         }
     }
 
@@ -540,7 +538,7 @@ impl AuditSection {
         let muted_fg = theme.muted_foreground;
         let is_focused = self.content_focused;
         let cursor = self.audit_form_cursor;
-        let rows = self.audit_form_rows();
+        let rows = audit_form_rows();
 
         let is_at =
             |row: AuditFormRow| -> bool { is_focused && rows.get(cursor).copied() == Some(row) };
@@ -695,7 +693,7 @@ impl AuditSection {
 
     fn render_audit_footer_actions(&self, cx: &mut Context<Self>) -> AnyElement {
         let is_save_focused = self.content_focused
-            && self.audit_form_rows().get(self.audit_form_cursor).copied()
+            && audit_form_rows().get(self.audit_form_cursor).copied()
                 == Some(AuditFormRow::SaveButton);
 
         div()
@@ -714,8 +712,7 @@ impl AuditSection {
                 .w_full()
                 .on_click(cx.listener(|this, _, window, cx| {
                     this.content_focused = true;
-                    this.audit_form_cursor = this
-                        .audit_form_rows()
+                    this.audit_form_cursor = audit_form_rows()
                         .iter()
                         .position(|row| *row == AuditFormRow::SaveButton)
                         .unwrap_or_default();
@@ -783,8 +780,7 @@ impl AuditSection {
                 MouseButton::Left,
                 cx.listener(move |this, _, _, cx| {
                     this.content_focused = true;
-                    if let Some(position) = this
-                        .audit_form_rows()
+                    if let Some(position) = audit_form_rows()
                         .iter()
                         .position(|candidate| *candidate == row)
                     {
@@ -871,8 +867,7 @@ impl AuditSection {
                 MouseButton::Left,
                 cx.listener(move |this, _, _, cx| {
                     this.content_focused = true;
-                    if let Some(position) = this
-                        .audit_form_rows()
+                    if let Some(position) = audit_form_rows()
                         .iter()
                         .position(|candidate| *candidate == row)
                     {
@@ -990,8 +985,7 @@ impl AuditSection {
                             cx.listener(move |this, _, window, cx| {
                                 this.switching_input = true;
                                 this.content_focused = true;
-                                if let Some(position) = this
-                                    .audit_form_rows()
+                                if let Some(position) = audit_form_rows()
                                     .iter()
                                     .position(|candidate| *candidate == row)
                                 {
@@ -1009,6 +1003,22 @@ impl AuditSection {
 
 #[cfg(test)]
 mod tests {
+    use super::{AuditFormRow, audit_form_rows};
+
+    #[test]
+    fn audit_form_rows_excludes_status_indicator_row() {
+        let rows = audit_form_rows();
+
+        assert_eq!(rows.len(), 12);
+    }
+
+    #[test]
+    fn audit_form_rows_starts_with_enable_audit() {
+        let rows = audit_form_rows();
+
+        assert_eq!(rows.first().copied(), Some(AuditFormRow::EnableAudit));
+    }
+
     const AUDIT_SECTION_KEYS: &[&str] = &[
         "settings.audit.placeholder_level",
         "settings.audit.section_title",

--- a/crates/dbflux_ui_windows/src/settings/drivers_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/drivers_section.rs
@@ -401,7 +401,7 @@ impl SettingsSection for DriversSection {
                     self.exit_form(window, cx);
                     cx.notify();
                 }
-                ("h", modifiers) | ("left", modifiers) if modifiers == Modifiers::none() => {
+                ("left", modifiers) if modifiers == Modifiers::none() => {
                     self.move_left();
                     cx.notify();
                 }

--- a/crates/dbflux_ui_windows/src/settings/hooks.rs
+++ b/crates/dbflux_ui_windows/src/settings/hooks.rs
@@ -3,7 +3,7 @@ use dbflux_app::keymap::Modifiers;
 use dbflux_components::controls::{Button, Checkbox, Input};
 use dbflux_components::controls::{InputEvent, InputState};
 use dbflux_components::icons::AppIcon;
-use dbflux_components::primitives::{Icon, Label};
+use dbflux_components::primitives::{Icon, Label, focus_frame};
 use dbflux_components::tokens::{Heights, Radii, Spacing, Widths};
 use dbflux_components::typography::{Body, MonoCaption, MonoLabel, PanelTitle};
 use dbflux_core::{
@@ -479,56 +479,6 @@ impl HooksSection {
         }
 
         self.form_has_hook_content(cx)
-    }
-
-    pub(super) fn hook_count(&self, cx: &App) -> usize {
-        self.app_state.read(cx).hook_definitions().len()
-    }
-
-    pub(super) fn hook_selected_id(&self) -> Option<String> {
-        self.hook_selected_id.clone()
-    }
-
-    pub(super) fn hook_move_next(&mut self, _cx: &App) {
-        let ids = self.hook_sorted_ids();
-        if ids.is_empty() {
-            self.hook_list_idx = None;
-            self.hook_selected_id = None;
-            return;
-        }
-
-        match self.hook_list_idx {
-            None => {
-                self.hook_list_idx = Some(0);
-                self.hook_selected_id = Some(ids[0].clone());
-            }
-            Some(idx) if idx + 1 < ids.len() => {
-                self.hook_list_idx = Some(idx + 1);
-                self.hook_selected_id = Some(ids[idx + 1].clone());
-            }
-            _ => {}
-        }
-    }
-
-    pub(super) fn hook_move_prev(&mut self, _cx: &App) {
-        let ids = self.hook_sorted_ids();
-        if ids.is_empty() {
-            self.hook_list_idx = None;
-            self.hook_selected_id = None;
-            return;
-        }
-
-        match self.hook_list_idx {
-            Some(idx) if idx > 0 => {
-                self.hook_list_idx = Some(idx - 1);
-                self.hook_selected_id = Some(ids[idx - 1].clone());
-            }
-            Some(0) => {
-                self.hook_list_idx = None;
-                self.hook_selected_id = None;
-            }
-            _ => {}
-        }
     }
 
     fn form_has_hook_content(&self, cx: &App) -> bool {
@@ -1559,8 +1509,201 @@ impl HooksSection {
             })
     }
 
+    fn hook_field_frame(
+        &self,
+        field: HookFormField,
+        primary: Hsla,
+        child: impl IntoElement,
+        cx: &mut Context<Self>,
+    ) -> Div {
+        let is_focused = self.hook_focus == HookFocus::Form && self.hook_form_field == field;
+
+        focus_frame(is_focused, Some(primary), child, cx).on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, window, cx| {
+                this.switching_input = true;
+                this.hook_focus = HookFocus::Form;
+                this.hook_form_field = field;
+                this.hook_focus_current_field(window, cx);
+                cx.notify();
+            }),
+        )
+    }
+
+    #[cfg(feature = "lua")]
+    fn render_hook_lua_capability_rows(&self, primary: Hsla, cx: &mut Context<Self>) -> Div {
+        div()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .child(
+                self.hook_field_frame(
+                    HookFormField::LuaLogging,
+                    primary,
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            Checkbox::new("hook-lua-logging")
+                                .checked(self.hook_lua_logging)
+                                .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                    this.hook_lua_logging = *checked;
+                                    cx.notify();
+                                })),
+                        )
+                        .child(Body::new(dbflux_i18n::t!(
+                            "settings.hooks.form.capability.logging"
+                        ))),
+                    cx,
+                ),
+            )
+            .child(
+                self.hook_field_frame(
+                    HookFormField::LuaEnvRead,
+                    primary,
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            Checkbox::new("hook-lua-env-read")
+                                .checked(self.hook_lua_env_read)
+                                .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                    this.hook_lua_env_read = *checked;
+                                    cx.notify();
+                                })),
+                        )
+                        .child(Body::new(dbflux_i18n::t!(
+                            "settings.hooks.form.capability.env_read"
+                        ))),
+                    cx,
+                ),
+            )
+            .child(
+                self.hook_field_frame(
+                    HookFormField::LuaConnectionMetadata,
+                    primary,
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            Checkbox::new("hook-lua-connection-metadata")
+                                .checked(self.hook_lua_connection_metadata)
+                                .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                    this.hook_lua_connection_metadata = *checked;
+                                    cx.notify();
+                                })),
+                        )
+                        .child(Body::new(dbflux_i18n::t!(
+                            "settings.hooks.form.capability.connection_metadata"
+                        ))),
+                    cx,
+                ),
+            )
+            .child(
+                self.hook_field_frame(
+                    HookFormField::LuaProcessRun,
+                    primary,
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            Checkbox::new("hook-lua-process-run")
+                                .checked(self.hook_lua_process_run)
+                                .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                    this.hook_lua_process_run = *checked;
+                                    cx.notify();
+                                })),
+                        )
+                        .child(Body::new(dbflux_i18n::t!(
+                            "settings.hooks.form.capability.process_run"
+                        ))),
+                    cx,
+                ),
+            )
+    }
+
+    #[cfg(not(feature = "lua"))]
+    fn render_hook_lua_capability_rows(&self, _primary: Hsla, cx: &mut Context<Self>) -> Div {
+        div()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(
+                        Checkbox::new("hook-lua-logging")
+                            .checked(self.hook_lua_logging)
+                            .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                this.hook_lua_logging = *checked;
+                                cx.notify();
+                            })),
+                    )
+                    .child(Body::new(dbflux_i18n::t!(
+                        "settings.hooks.form.capability.logging"
+                    ))),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(
+                        Checkbox::new("hook-lua-env-read")
+                            .checked(self.hook_lua_env_read)
+                            .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                this.hook_lua_env_read = *checked;
+                                cx.notify();
+                            })),
+                    )
+                    .child(Body::new(dbflux_i18n::t!(
+                        "settings.hooks.form.capability.env_read"
+                    ))),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(
+                        Checkbox::new("hook-lua-connection-metadata")
+                            .checked(self.hook_lua_connection_metadata)
+                            .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                this.hook_lua_connection_metadata = *checked;
+                                cx.notify();
+                            })),
+                    )
+                    .child(Body::new(dbflux_i18n::t!(
+                        "settings.hooks.form.capability.connection_metadata"
+                    ))),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(
+                        Checkbox::new("hook-lua-process-run")
+                            .checked(self.hook_lua_process_run)
+                            .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                                this.hook_lua_process_run = *checked;
+                                cx.notify();
+                            })),
+                    )
+                    .child(Body::new(dbflux_i18n::t!(
+                        "settings.hooks.form.capability.process_run"
+                    ))),
+            )
+    }
+
     fn render_hook_form(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let theme = cx.theme();
+        let theme = cx.theme().clone();
 
         let editing = self.editing_hook_id.is_some();
         let title = if editing {
@@ -1575,6 +1718,9 @@ impl HooksSection {
         let warnings = self.hook_form_warnings(cx);
         let preview = self.hook_form_preview(cx);
         let default_interpreter = self.default_script_interpreter_label(cx);
+        let primary = theme.primary;
+        let kind_focused =
+            self.hook_focus == HookFocus::Form && is_kind_form_field(self.hook_form_field);
 
         layout::sticky_form_shell(
             PanelTitle::new(title),
@@ -1596,7 +1742,12 @@ impl HooksSection {
                             .flex_col()
                             .gap_1()
                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.id")))
-                            .child(Input::new(&self.input_hook_id).small()),
+                            .child(self.hook_field_frame(
+                                HookFormField::HookId,
+                                primary,
+                                Input::new(&self.input_hook_id).small(),
+                                cx,
+                            )),
                     )
                     .child(
                         div()
@@ -1604,7 +1755,12 @@ impl HooksSection {
                             .flex_col()
                             .gap_1()
                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.kind")))
-                            .child(div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_kind_dropdown.clone())),
+                            .child(focus_frame(
+                                kind_focused,
+                                Some(primary),
+                                div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_kind_dropdown.clone()),
+                                cx,
+                            )),
                     )
                     .when(hook_kind == HookKindSelection::Command, |container| {
                         container.child(
@@ -1618,7 +1774,12 @@ impl HooksSection {
                                         .flex_col()
                                         .gap_1()
                                         .child(Label::new(dbflux_i18n::t!("settings.hooks.form.command")))
-                                        .child(Input::new(&self.input_hook_command).small()),
+                                        .child(self.hook_field_frame(
+                                            HookFormField::Command,
+                                            primary,
+                                            Input::new(&self.input_hook_command).small(),
+                                            cx,
+                                        )),
                                 )
                                 .child(
                                     div()
@@ -1629,7 +1790,12 @@ impl HooksSection {
                                         .child(Body::new(dbflux_i18n::t!("settings.hooks.form.args_hint")).color(
                                             theme.muted_foreground,
                                         ))
-                                        .child(Input::new(&self.input_hook_args).small()),
+                                        .child(self.hook_field_frame(
+                                            HookFormField::Arguments,
+                                            primary,
+                                            Input::new(&self.input_hook_args).small(),
+                                            cx,
+                                        )),
                                 ),
                         )
                     })
@@ -1646,11 +1812,14 @@ impl HooksSection {
                                             .flex_col()
                                             .gap_1()
                                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.language")))
-                                            .child(
+                                            .child(self.hook_field_frame(
+                                                HookFormField::ScriptLanguage,
+                                                primary,
                                                 div()
                                                     .w(Widths::SETTINGS_FORM_LABEL)
                                                     .child(self.script_language_dropdown.clone()),
-                                            ),
+                                                cx,
+                                            )),
                                     )
                                 })
                                 .child(
@@ -1666,27 +1835,36 @@ impl HooksSection {
                                         .flex_col()
                                         .gap_1()
                                         .child(Body::new(dbflux_i18n::t!("settings.hooks.form.file_path_hint")).color(theme.muted_foreground))
-                                        .child(
+                                        .child(self.hook_field_frame(
+                                            HookFormField::FilePath,
+                                            primary,
                                             Input::new(&self.input_hook_script_file_path).small(),
-                                        )
+                                            cx,
+                                        ))
                                         .child(
                                             div()
                                                 .flex()
                                                 .gap_2()
-                                                .child(
+                                                .child(self.hook_field_frame(
+                                                    HookFormField::OpenInApp,
+                                                    primary,
                                                     Button::new("open-script-app", dbflux_i18n::t!("settings.hooks.form.open_in_app"))
                                                         .small()
                                                         .on_click(cx.listener(|this, _, window, cx| {
                                                             this.open_script_in_app(window, cx);
                                                         })),
-                                                )
-                                                .child(
+                                                    cx,
+                                                ))
+                                                .child(self.hook_field_frame(
+                                                    HookFormField::OpenInEditor,
+                                                    primary,
                                                     Button::new("open-script-editor", dbflux_i18n::t!("settings.hooks.form.open_in_editor"))
                                                         .small()
                                                         .on_click(cx.listener(|this, _, window, cx| {
                                                             this.open_script_in_default_editor(window, cx);
                                                         })),
-                                                ),
+                                                    cx,
+                                                )),
                                         ),
                                 )
                                 .when(is_script, |container| {
@@ -1697,7 +1875,12 @@ impl HooksSection {
                                             .gap_1()
                                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.interpreter")))
                                             .child(Body::new(hooks_form_interpreter_hint(&default_interpreter)).color(theme.muted_foreground))
-                                            .child(Input::new(&self.input_hook_interpreter).small()),
+                                            .child(self.hook_field_frame(
+                                                HookFormField::Interpreter,
+                                                primary,
+                                                Input::new(&self.input_hook_interpreter).small(),
+                                                cx,
+                                            )),
                                     )
                                 })
                                 .when(is_lua, |container| {
@@ -1707,66 +1890,7 @@ impl HooksSection {
                                             .flex_col()
                                             .gap_2()
                                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.capabilities")))
-                                            .child(
-                                                div()
-                                                    .flex()
-                                                    .items_center()
-                                                    .gap_2()
-                                                    .child(
-                                                        Checkbox::new("hook-lua-logging")
-                                                            .checked(self.hook_lua_logging)
-                                                            .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                                                this.hook_lua_logging = *checked;
-                                                                cx.notify();
-                                                            })),
-                                                    )
-                                                    .child(Body::new(dbflux_i18n::t!("settings.hooks.form.capability.logging"))),
-                                            )
-                                            .child(
-                                                div()
-                                                    .flex()
-                                                    .items_center()
-                                                    .gap_2()
-                                                    .child(
-                                                        Checkbox::new("hook-lua-env-read")
-                                                            .checked(self.hook_lua_env_read)
-                                                            .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                                                this.hook_lua_env_read = *checked;
-                                                                cx.notify();
-                                                            })),
-                                                    )
-                                                    .child(Body::new(dbflux_i18n::t!("settings.hooks.form.capability.env_read"))),
-                                            )
-                                            .child(
-                                                div()
-                                                    .flex()
-                                                    .items_center()
-                                                    .gap_2()
-                                                    .child(
-                                                        Checkbox::new("hook-lua-connection-metadata")
-                                                            .checked(self.hook_lua_connection_metadata)
-                                                            .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                                                this.hook_lua_connection_metadata = *checked;
-                                                                cx.notify();
-                                                            })),
-                                                    )
-                                                    .child(Body::new(dbflux_i18n::t!("settings.hooks.form.capability.connection_metadata"))),
-                                            )
-                                            .child(
-                                                div()
-                                                    .flex()
-                                                    .items_center()
-                                                    .gap_2()
-                                                    .child(
-                                                        Checkbox::new("hook-lua-process-run")
-                                                            .checked(self.hook_lua_process_run)
-                                                            .on_click(cx.listener(|this, checked: &bool, _, cx| {
-                                                                this.hook_lua_process_run = *checked;
-                                                                cx.notify();
-                                                            })),
-                                                    )
-                                                    .child(Body::new(dbflux_i18n::t!("settings.hooks.form.capability.process_run"))),
-                                            )
+                                            .child(self.render_hook_lua_capability_rows(primary, cx))
                                             .child(Body::new(
                                                 dbflux_i18n::t!("settings.hooks.form.capability.process_run_hint"),
                                             )
@@ -1783,7 +1907,12 @@ impl HooksSection {
                             .gap_1()
                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.execution_mode")))
                             .child(Body::new(dbflux_i18n::t!("settings.hooks.form.execution_mode_hint")).color(theme.muted_foreground))
-                            .child(div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_execution_mode_dropdown.clone())),
+                            .child(self.hook_field_frame(
+                                HookFormField::ExecutionMode,
+                                primary,
+                                div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_execution_mode_dropdown.clone()),
+                                cx,
+                            )),
                     )
                     })
                     .when(!is_lua && self.selected_hook_execution_mode(cx) == HookExecutionMode::Detached, |container| {
@@ -1794,7 +1923,12 @@ impl HooksSection {
                             .gap_1()
                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.ready_signal")))
                             .child(Body::new(dbflux_i18n::t!("settings.hooks.form.ready_signal_hint")).color(theme.muted_foreground))
-                            .child(Input::new(&self.input_hook_ready_signal).small()),
+                            .child(self.hook_field_frame(
+                                HookFormField::ReadySignal,
+                                primary,
+                                Input::new(&self.input_hook_ready_signal).small(),
+                                cx,
+                            )),
                     )
                     })
                     .when(!is_lua, |container| {
@@ -1804,7 +1938,12 @@ impl HooksSection {
                             .flex_col()
                             .gap_1()
                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.cwd")))
-                            .child(Input::new(&self.input_hook_cwd).small()),
+                            .child(self.hook_field_frame(
+                                HookFormField::WorkingDirectory,
+                                primary,
+                                Input::new(&self.input_hook_cwd).small(),
+                                cx,
+                            )),
                     )
                     })
                     .when(!is_lua, |container| {
@@ -1815,7 +1954,12 @@ impl HooksSection {
                             .gap_1()
                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.env")))
                             .child(Body::new(dbflux_i18n::t!("settings.hooks.form.env_hint")).color(theme.muted_foreground))
-                            .child(Input::new(&self.input_hook_env).small()),
+                            .child(self.hook_field_frame(
+                                HookFormField::Environment,
+                                primary,
+                                Input::new(&self.input_hook_env).small(),
+                                cx,
+                            )),
                     )
                     })
                     .when(!is_lua, |container| {
@@ -1826,7 +1970,12 @@ impl HooksSection {
                             .gap_1()
                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.env_denylist")))
                             .child(Body::new(dbflux_i18n::t!("settings.hooks.form.env_denylist_hint")).color(theme.muted_foreground))
-                            .child(Input::new(&self.input_hook_env_denylist).small()),
+                            .child(self.hook_field_frame(
+                                HookFormField::EnvDenylist,
+                                primary,
+                                Input::new(&self.input_hook_env_denylist).small(),
+                                cx,
+                            )),
                     )
                     })
                     .child(
@@ -1835,7 +1984,12 @@ impl HooksSection {
                             .flex_col()
                             .gap_1()
                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.timeout")))
-                            .child(Input::new(&self.input_hook_timeout).small()),
+                            .child(self.hook_field_frame(
+                                HookFormField::Timeout,
+                                primary,
+                                Input::new(&self.input_hook_timeout).small(),
+                                cx,
+                            )),
                     )
                     .child(
                         div()
@@ -1871,7 +2025,9 @@ impl HooksSection {
                             })),
                         )
                     })
-                    .child(
+                    .child(self.hook_field_frame(
+                        HookFormField::Enabled,
+                        primary,
                         div()
                             .flex()
                             .items_center()
@@ -1885,9 +2041,12 @@ impl HooksSection {
                                     })),
                             )
                             .child(Body::new(dbflux_i18n::t!("settings.hooks.form.enabled"))),
-                    )
+                        cx,
+                    ))
                     .when(!is_lua, |container| {
-                        container.child(
+                        container.child(self.hook_field_frame(
+                            HookFormField::InheritEnv,
+                            primary,
                             div()
                                 .flex()
                                 .items_center()
@@ -1901,7 +2060,8 @@ impl HooksSection {
                                         })),
                                 )
                                 .child(Body::new(dbflux_i18n::t!("settings.hooks.form.inherit_env"))),
-                        )
+                            cx,
+                        ))
                     })
                     .child(
                         div()
@@ -1909,10 +2069,15 @@ impl HooksSection {
                             .flex_col()
                             .gap_1()
                             .child(Label::new(dbflux_i18n::t!("settings.hooks.form.on_failure")))
-                            .child(div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_failure_dropdown.clone())),
+                            .child(self.hook_field_frame(
+                                HookFormField::OnFailure,
+                                primary,
+                                div().w(Widths::SETTINGS_FORM_LABEL).child(self.hook_failure_dropdown.clone()),
+                                cx,
+                            )),
                     )),
             None,
-            theme,
+            &theme,
         )
     }
 
@@ -2200,6 +2365,22 @@ impl HooksSection {
             _ => {}
         }
     }
+}
+
+#[cfg(feature = "lua")]
+fn is_kind_form_field(field: HookFormField) -> bool {
+    matches!(
+        field,
+        HookFormField::KindCommand | HookFormField::KindScript | HookFormField::KindLua
+    )
+}
+
+#[cfg(not(feature = "lua"))]
+fn is_kind_form_field(field: HookFormField) -> bool {
+    matches!(
+        field,
+        HookFormField::KindCommand | HookFormField::KindScript
+    )
 }
 
 fn interpreter_exists(program: &str) -> bool {

--- a/crates/dbflux_ui_windows/src/settings/hooks_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/hooks_section.rs
@@ -5,11 +5,9 @@ use super::form_section::FormSection;
 use super::section_trait::SectionFocusEvent;
 use crate::labels::{hooks_delete_message, hooks_delete_unreadable_message};
 use dbflux_app::config_loader::EditableGlobalHook;
-use dbflux_app::keymap::Modifiers;
 use dbflux_components::controls::{Dropdown, DropdownItem, DropdownSelectionChanged};
 use dbflux_components::controls::{InputEvent, InputState};
 use dbflux_core::{HookExecutionMode, ScriptLanguage};
-use dbflux_ui_base::keymap::key_chord_from_gpui;
 use dbflux_ui_base::{AppStateChanged, AppStateEntity};
 use gpui::prelude::*;
 use gpui::*;
@@ -647,106 +645,7 @@ impl SettingsSection for HooksSection {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.content_focused {
-            return;
-        }
-
-        if self.handle_editing_keys(event, window, cx) {
-            return;
-        }
-
-        let chord = key_chord_from_gpui(&event.keystroke);
-
-        match self.hook_focus {
-            HookFocus::List => match (chord.key.as_str(), chord.modifiers) {
-                ("j", modifiers) | ("down", modifiers) if modifiers == Modifiers::none() => {
-                    self.hook_move_next(cx);
-                    cx.notify();
-                }
-                ("k", modifiers) | ("up", modifiers) if modifiers == Modifiers::none() => {
-                    self.hook_move_prev(cx);
-                    cx.notify();
-                }
-                ("l", modifiers) | ("right", modifiers) | ("enter", modifiers)
-                    if modifiers == Modifiers::none() =>
-                {
-                    if let Some(hook_id) = self.hook_selected_id.clone() {
-                        self.load_hook_values_without_focus(&hook_id, window, cx);
-                    }
-                    self.enter_form(window, cx);
-                    cx.notify();
-                }
-                ("d", modifiers) if modifiers == Modifiers::none() => {
-                    if let Some(hook_id) = self.hook_selected_id() {
-                        self.request_delete_hook(hook_id, cx);
-                    }
-                }
-                ("g", modifiers) if modifiers == Modifiers::none() => {
-                    self.hook_list_idx = None;
-                    self.hook_selected_id = None;
-                    cx.notify();
-                }
-                ("G", modifiers) if modifiers == Modifiers::none() => {
-                    let count = self.hook_count(cx);
-                    if count > 0 {
-                        self.hook_list_idx = Some(count - 1);
-                        let ids = self.hook_sorted_ids();
-                        if let Some(last_id) = ids.last() {
-                            self.hook_selected_id = Some(last_id.clone());
-                        }
-                    }
-                    cx.notify();
-                }
-                _ => {}
-            },
-            HookFocus::Form => match (chord.key.as_str(), chord.modifiers) {
-                ("escape", modifiers) if modifiers == Modifiers::none() => {
-                    self.exit_form(window, cx);
-                    cx.notify();
-                }
-                ("j", modifiers) | ("down", modifiers) if modifiers == Modifiers::none() => {
-                    self.move_down();
-                    cx.notify();
-                }
-                ("k", modifiers) | ("up", modifiers) if modifiers == Modifiers::none() => {
-                    self.move_up();
-                    cx.notify();
-                }
-                ("h", modifiers) if modifiers == Modifiers::none() && !self.hook_editing_field => {
-                    self.exit_form(window, cx);
-                    cx.notify();
-                }
-                ("h", modifiers) | ("left", modifiers) if modifiers == Modifiers::none() => {
-                    self.move_left();
-                    cx.notify();
-                }
-                ("l", modifiers) | ("right", modifiers) if modifiers == Modifiers::none() => {
-                    self.move_right();
-                    cx.notify();
-                }
-                ("enter", modifiers) if modifiers == Modifiers::none() => {
-                    self.activate_current_field(window, cx);
-                    cx.notify();
-                }
-                ("tab", modifiers) if modifiers == Modifiers::none() => {
-                    self.tab_next();
-                    cx.notify();
-                }
-                ("tab", modifiers) if modifiers == Modifiers::shift() => {
-                    self.tab_prev();
-                    cx.notify();
-                }
-                ("g", modifiers) if modifiers == Modifiers::none() => {
-                    self.move_first();
-                    cx.notify();
-                }
-                ("G", modifiers) if modifiers == Modifiers::none() => {
-                    self.move_last();
-                    cx.notify();
-                }
-                _ => {}
-            },
-        }
+        HooksSection::handle_key_event(self, event, window, cx);
     }
 
     fn focus_in(&mut self, _window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/dbflux_ui_windows/src/settings/mcp_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/mcp_section.rs
@@ -581,6 +581,8 @@ impl McpSection {
             ms.set_items(policy_items, cx);
             ms.set_selected_values(&role.policy_ids, cx);
         });
+
+        self.validate_form_field();
     }
 
     fn clear_role_form(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -708,6 +710,8 @@ impl McpSection {
             .update(cx, |i, cx| i.set_value(policy.id.clone(), window, cx));
         self.draft_policy_classes = policy.allowed_classes.into_iter().collect();
         self.draft_policy_tools = policy.allowed_tools.into_iter().collect();
+
+        self.validate_form_field();
     }
 
     fn clear_policy_form(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -1945,6 +1949,18 @@ impl FormSection for McpSection {
         self.mcp_focus = McpFocus::Form;
         self.mcp_form_field = Self::first_field_for(self.variant);
         self.editing_field = false;
+    }
+
+    /// Selecting a builtin role or policy drops the button row, so a cursor
+    /// left on Save or Delete must fall back to the variant's first field.
+    fn validate_form_field(&mut self) {
+        let current = self.mcp_form_field;
+
+        if self.form_rows().iter().any(|row| row.contains(&current)) {
+            return;
+        }
+
+        self.mcp_form_field = Self::first_field_for(self.variant);
     }
 }
 

--- a/crates/dbflux_ui_windows/src/settings/mcp_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/mcp_section.rs
@@ -1,14 +1,19 @@
+use super::form_section::{FormSection, create_blur_subscription};
 use super::section_trait::SectionFocusEvent;
 use super::{SettingsSection, SettingsSectionId, layout};
 use crate::labels::{mcp_policy_tools_classes_summary, mcp_role_policy_count};
-use dbflux_app::keymap::{KeyChord, Modifiers};
+use dbflux_app::keymap::Modifiers;
 use dbflux_components::components::multi_select::MultiSelect;
+use dbflux_components::composites::{
+    BadgeTone, MasterDetailAction, MasterDetailActionKind, MasterDetailItem,
+    MasterDetailListConfig, render_master_detail_list,
+};
 use dbflux_components::controls::DropdownItem;
+use dbflux_components::controls::InputState;
 use dbflux_components::controls::{Button, Checkbox, Input};
-use dbflux_components::controls::{InputEvent, InputState};
-use dbflux_components::primitives::Label;
-use dbflux_components::tokens::{Radii, Widths};
-use dbflux_components::typography::{Body, FieldLabel, MonoCaption, MonoMeta, SubSectionLabel};
+use dbflux_components::primitives::{Label, focus_frame};
+use dbflux_components::tokens::Widths;
+use dbflux_components::typography::{Body, FieldLabel, SubSectionLabel};
 use dbflux_mcp::{PolicyRoleDto, ToolPolicyDto, TrustedClientDto};
 use dbflux_ui_base::keymap::key_chord_from_gpui;
 use dbflux_ui_base::toast::{Toast, copy_action, now_hms};
@@ -163,6 +168,99 @@ pub(super) enum McpSectionVariant {
     Policies,
 }
 
+/// One focusable form field across the three MCP variants. `PolicyClass`/
+/// `PolicyTool` carry the row index into `mcp_policy_class_ids()` /
+/// `mcp_policy_tool_ids()`, keeping the field enum `Copy`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum McpFormField {
+    ClientId,
+    ClientName,
+    ClientIssuer,
+    ClientActive,
+    ClientToggleActive,
+    RoleId,
+    RolePolicies,
+    PolicyId,
+    PolicyClass(usize),
+    PolicyTool(usize),
+    DeleteButton,
+    SaveButton,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(super) enum McpFocus {
+    List,
+    Form,
+}
+
+/// The ordered ids `PolicyClass(index)` refers to; the render layout and this
+/// row table must stay in the same order.
+pub(super) fn mcp_policy_class_ids() -> Vec<&'static str> {
+    CLASS_IDS.to_vec()
+}
+
+/// The ordered ids `PolicyTool(index)` refers to: `TOOL_GROUPS` flattened in
+/// display order, which is the same order as `TOOL_IDS`.
+pub(super) fn mcp_policy_tool_ids() -> Vec<&'static str> {
+    TOOL_GROUPS
+        .iter()
+        .flat_map(|(_, tools)| tools.iter().copied())
+        .collect()
+}
+
+/// The row table a `McpSection` form walks with `j`/`k`/`tab`. Builtin roles
+/// and policies drop the save/delete button row so a stale field cursor can
+/// never land on a mutating control for a read-only item.
+pub(super) fn mcp_form_rows(
+    variant: McpSectionVariant,
+    is_builtin: bool,
+    class_count: usize,
+    tool_count: usize,
+) -> Vec<Vec<McpFormField>> {
+    match variant {
+        McpSectionVariant::Clients => vec![
+            vec![McpFormField::ClientId],
+            vec![McpFormField::ClientName],
+            vec![McpFormField::ClientIssuer],
+            vec![McpFormField::ClientActive],
+            vec![
+                McpFormField::ClientToggleActive,
+                McpFormField::DeleteButton,
+                McpFormField::SaveButton,
+            ],
+        ],
+        McpSectionVariant::Roles => {
+            let mut rows = vec![vec![McpFormField::RoleId], vec![McpFormField::RolePolicies]];
+            if !is_builtin {
+                rows.push(vec![McpFormField::DeleteButton, McpFormField::SaveButton]);
+            }
+            rows
+        }
+        McpSectionVariant::Policies => {
+            let mut rows = vec![vec![McpFormField::PolicyId]];
+            rows.push((0..class_count).map(McpFormField::PolicyClass).collect());
+            rows.extend((0..tool_count).map(|i| vec![McpFormField::PolicyTool(i)]));
+            if !is_builtin {
+                rows.push(vec![McpFormField::DeleteButton, McpFormField::SaveButton]);
+            }
+            rows
+        }
+    }
+}
+
+/// Whether `field` is a text input that `focus_current_field` should move
+/// keyboard focus into (as opposed to a checkbox, button, or multiselect).
+pub(super) fn mcp_is_input_field(field: McpFormField) -> bool {
+    matches!(
+        field,
+        McpFormField::ClientId
+            | McpFormField::ClientName
+            | McpFormField::ClientIssuer
+            | McpFormField::RoleId
+            | McpFormField::PolicyId
+    )
+}
+
 pub(super) struct McpSection {
     app_state: Entity<AppStateEntity>,
     variant: McpSectionVariant,
@@ -186,6 +284,10 @@ pub(super) struct McpSection {
     selected_policy_id: Option<String>,
 
     // Common
+    mcp_focus: McpFocus,
+    mcp_form_field: McpFormField,
+    editing_field: bool,
+    list_scroll_handle: ScrollHandle,
     content_focused: bool,
     switching_input: bool,
     pending_sync_from_state: bool,
@@ -246,25 +348,13 @@ impl McpSection {
             cx.notify();
         });
 
-        fn make_blur_sub(cx: &mut Context<McpSection>, input: &Entity<InputState>) -> Subscription {
-            cx.subscribe(input, |this, _, event: &InputEvent, cx| {
-                if matches!(event, InputEvent::Blur) {
-                    if this.switching_input {
-                        this.switching_input = false;
-                        return;
-                    }
-                    cx.emit(SectionFocusEvent::RequestFocusReturn);
-                }
-            })
-        }
-
         let subs = vec![
             state_sub,
-            make_blur_sub(cx, &input_client_id),
-            make_blur_sub(cx, &input_client_name),
-            make_blur_sub(cx, &input_client_issuer),
-            make_blur_sub(cx, &input_role_id),
-            make_blur_sub(cx, &input_policy_id),
+            create_blur_subscription(cx, &input_client_id),
+            create_blur_subscription(cx, &input_client_name),
+            create_blur_subscription(cx, &input_client_issuer),
+            create_blur_subscription(cx, &input_role_id),
+            create_blur_subscription(cx, &input_policy_id),
         ];
 
         Self {
@@ -286,11 +376,37 @@ impl McpSection {
             draft_policy_tools: HashSet::new(),
             selected_policy_id: None,
 
+            mcp_focus: McpFocus::List,
+            mcp_form_field: Self::first_field_for(variant),
+            editing_field: false,
+            list_scroll_handle: ScrollHandle::new(),
             content_focused: false,
             switching_input: false,
             pending_sync_from_state: true,
             _subscriptions: subs,
         }
+    }
+
+    fn first_field_for(variant: McpSectionVariant) -> McpFormField {
+        match variant {
+            McpSectionVariant::Clients => McpFormField::ClientId,
+            McpSectionVariant::Roles => McpFormField::RoleId,
+            McpSectionVariant::Policies => McpFormField::PolicyId,
+        }
+    }
+
+    fn role_is_builtin(&self) -> bool {
+        self.selected_role_id
+            .as_deref()
+            .map(dbflux_mcp::is_builtin)
+            .unwrap_or(false)
+    }
+
+    fn policy_is_builtin(&self) -> bool {
+        self.selected_policy_id
+            .as_deref()
+            .map(dbflux_mcp::is_builtin)
+            .unwrap_or(false)
     }
 
     // ─── Client helpers ──────────────────────────────────────────────────────
@@ -680,80 +796,44 @@ impl McpSection {
         let theme = cx.theme().clone();
         let clients = self.trusted_clients(cx);
         let selected = self.selected_client_id.clone();
+        let is_list_focused = self.mcp_focus == McpFocus::List;
 
-        let list = div()
-            .w(Widths::SETTINGS_LIST_PANEL)
-            .h_full()
-            .border_r_1()
-            .border_color(theme.border)
-            .p_3()
-            .flex()
-            .flex_col()
-            .gap_2()
-            .child(
-                Button::new("mcp-client-new", dbflux_i18n::t!("settings.mcp.new_client"))
-                    .small()
-                    .ghost()
-                    .on_click(
-                        cx.listener(|this, _, window, cx| this.clear_client_form(window, cx)),
-                    ),
-            )
-            .child(
-                div()
-                    .flex_1()
-                    .min_h_0()
-                    .overflow_y_scrollbar()
-                    .flex()
-                    .flex_col()
-                    .gap_1()
-                    .when(clients.is_empty(), |r| {
-                        r.child(
-                            Body::new(dbflux_i18n::t!("settings.mcp.empty.clients"))
-                                .color(theme.muted_foreground),
-                        )
-                    })
-                    .children(clients.iter().map(|client| {
-                        let id = client.id.clone();
-                        let is_selected = selected.as_deref() == Some(client.id.as_str());
+        let ids: Vec<String> = clients.iter().map(|c| c.id.clone()).collect();
+        let items: Vec<MasterDetailItem> = clients
+            .iter()
+            .map(|client| {
+                let is_selected = selected.as_deref() == Some(client.id.as_str());
+                MasterDetailItem {
+                    id: SharedString::from(client.id.clone()),
+                    label: SharedString::from(client.name.clone()),
+                    detail: Some(SharedString::from(client.id.clone())),
+                    badge: Some(if client.active {
+                        (SharedString::from("active"), BadgeTone::Success)
+                    } else {
+                        (SharedString::from("inactive"), BadgeTone::Neutral)
+                    }),
+                    selected: is_selected,
+                    focused: is_list_focused && is_selected,
+                }
+            })
+            .collect();
 
-                        div()
-                            .id(SharedString::from(format!("client-{}", client.id)))
-                            .p_2()
-                            .rounded(Radii::SM)
-                            .border_1()
-                            .border_color(if is_selected {
-                                theme.primary
-                            } else {
-                                transparent_black()
-                            })
-                            .bg(if is_selected {
-                                theme.secondary
-                            } else {
-                                transparent_black()
-                            })
-                            .cursor_pointer()
-                            .hover({
-                                let s = theme.secondary;
-                                move |d| d.bg(s)
-                            })
-                            .on_click(cx.listener(move |this, _, window, cx| {
-                                this.select_client(&id, window, cx);
-                            }))
-                            .child(
-                                div()
-                                    .flex()
-                                    .justify_between()
-                                    .items_center()
-                                    .child(FieldLabel::new(client.name.clone()))
-                                    .child(if client.active {
-                                        MonoCaption::new("active").color(theme.success)
-                                    } else {
-                                        MonoCaption::new("inactive")
-                                    }),
-                            )
-                            .child(MonoMeta::new(client.id.clone()))
-                    })),
-            );
+        let config = MasterDetailListConfig {
+            id: SharedString::from("mcp-clients-list"),
+            width: Widths::SETTINGS_LIST_PANEL,
+            new_action: Some(MasterDetailAction {
+                label: SharedString::from(dbflux_i18n::t!("settings.mcp.new_client")),
+                enabled: true,
+                focused: is_list_focused && selected.is_none(),
+            }),
+            secondary_action: None,
+            empty_message: Some(SharedString::from(dbflux_i18n::t!(
+                "settings.mcp.empty.clients"
+            ))),
+        };
+
+        let entity = cx.entity();
+        let entity_for_action = entity.clone();
 
         let form = div()
             .flex_1()
@@ -775,14 +855,32 @@ impl McpSection {
                     .flex_col()
                     .gap_3()
                     .child(Label::new(dbflux_i18n::t!("settings.mcp.field.client_id")))
-                    .child(Input::new(&self.input_client_id).small())
+                    .child(self.render_mcp_input_field(
+                        &self.input_client_id,
+                        McpFormField::ClientId,
+                        theme.primary,
+                        cx,
+                    ))
                     .child(Label::new(dbflux_i18n::t!("settings.mcp.field.name")))
-                    .child(Input::new(&self.input_client_name).small())
+                    .child(self.render_mcp_input_field(
+                        &self.input_client_name,
+                        McpFormField::ClientName,
+                        theme.primary,
+                        cx,
+                    ))
                     .child(Label::new(dbflux_i18n::t!(
                         "settings.mcp.field.issuer_optional"
                     )))
-                    .child(Input::new(&self.input_client_issuer).small())
-                    .child(
+                    .child(self.render_mcp_input_field(
+                        &self.input_client_issuer,
+                        McpFormField::ClientIssuer,
+                        theme.primary,
+                        cx,
+                    ))
+                    .child(focus_frame(
+                        self.mcp_focus == McpFocus::Form
+                            && self.mcp_form_field == McpFormField::ClientActive,
+                        Some(theme.primary),
                         div()
                             .flex()
                             .items_center()
@@ -796,8 +894,28 @@ impl McpSection {
                                     })),
                             )
                             .child(Body::new(dbflux_i18n::t!("settings.mcp.field.active"))),
-                    ),
+                        cx,
+                    )),
             );
+
+        let list = render_master_detail_list(
+            &config,
+            &items,
+            &self.list_scroll_handle,
+            move |index: usize, window: &mut Window, cx: &mut App| {
+                let Some(id) = ids.get(index).cloned() else {
+                    return;
+                };
+                entity.update(cx, |this, cx| {
+                    this.select_client(&id, window, cx);
+                    this.enter_form(window, cx);
+                });
+            },
+            move |_kind: MasterDetailActionKind, window: &mut Window, cx: &mut App| {
+                entity_for_action.update(cx, |this, cx| this.new_current_item(window, cx));
+            },
+            cx,
+        );
 
         div()
             .size_full()
@@ -807,100 +925,81 @@ impl McpSection {
             .child(form)
     }
 
+    fn render_mcp_input_field(
+        &self,
+        input: &Entity<InputState>,
+        field: McpFormField,
+        primary: Hsla,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let is_focused = self.mcp_focus == McpFocus::Form && self.mcp_form_field == field;
+
+        focus_frame(is_focused, Some(primary), Input::new(input).small(), cx).on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, window, cx| {
+                this.switching_input = true;
+                this.mcp_focus = McpFocus::Form;
+                this.mcp_form_field = field;
+                this.mcp_focus_current_field(window, cx);
+                cx.notify();
+            }),
+        )
+    }
+
     fn render_roles_content(&self, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme().clone();
         let roles = self.roles(cx);
         let selected = self.selected_role_id.clone();
+        let is_list_focused = self.mcp_focus == McpFocus::List;
 
-        let list = div()
-            .w(Widths::SETTINGS_LIST_PANEL)
-            .h_full()
-            .border_r_1()
-            .border_color(theme.border)
-            .p_3()
-            .flex()
-            .flex_col()
-            .gap_2()
-            .child(
-                Button::new("mcp-role-new", dbflux_i18n::t!("settings.mcp.new_role"))
-                    .small()
-                    .ghost()
-                    .on_click(cx.listener(|this, _, window, cx| this.clear_role_form(window, cx))),
-            )
-            .child(
-                div()
-                    .flex_1()
-                    .min_h_0()
-                    .overflow_y_scrollbar()
-                    .flex()
-                    .flex_col()
-                    .gap_1()
-                    .when(roles.is_empty(), |r| {
-                        r.child(
-                            Body::new(dbflux_i18n::t!("settings.mcp.empty.roles"))
-                                .color(theme.muted_foreground),
-                        )
-                    })
-                    .children(roles.iter().map(|role| {
-                        let id = role.id.clone();
-                        let is_selected = selected.as_deref() == Some(role.id.as_str());
+        let ids: Vec<String> = roles.iter().map(|r| r.id.clone()).collect();
+        let items: Vec<MasterDetailItem> = roles
+            .iter()
+            .map(|role| {
+                let is_selected = selected.as_deref() == Some(role.id.as_str());
+                let label = builtin_display_name(&role.id)
+                    .unwrap_or(role.id.as_str())
+                    .to_string();
+                let badge = if dbflux_mcp::is_builtin(&role.id) {
+                    Some((
+                        SharedString::from(dbflux_i18n::t!("settings.mcp.field.builtin_badge")),
+                        BadgeTone::Accent,
+                    ))
+                } else {
+                    None
+                };
+                MasterDetailItem {
+                    id: SharedString::from(role.id.clone()),
+                    label: SharedString::from(label),
+                    detail: Some(SharedString::from(mcp_role_policy_count(
+                        role.policy_ids.len(),
+                    ))),
+                    badge,
+                    selected: is_selected,
+                    focused: is_list_focused && is_selected,
+                }
+            })
+            .collect();
 
-                        div()
-                            .id(SharedString::from(format!("role-{}", role.id)))
-                            .p_2()
-                            .rounded(Radii::SM)
-                            .border_1()
-                            .border_color(if is_selected {
-                                theme.primary
-                            } else {
-                                transparent_black()
-                            })
-                            .bg(if is_selected {
-                                theme.secondary
-                            } else {
-                                transparent_black()
-                            })
-                            .cursor_pointer()
-                            .hover({
-                                let s = theme.secondary;
-                                move |d| d.bg(s)
-                            })
-                            .on_click(cx.listener(move |this, _, window, cx| {
-                                this.select_role(&id, window, cx);
-                            }))
-                            .child(
-                                div()
-                                    .flex()
-                                    .items_center()
-                                    .justify_between()
-                                    .gap_2()
-                                    .child(FieldLabel::new(
-                                        builtin_display_name(&role.id)
-                                            .unwrap_or(role.id.as_str())
-                                            .to_string(),
-                                    ))
-                                    .when(dbflux_mcp::is_builtin(&role.id), |d| {
-                                        d.child(
-                                            div()
-                                                .px_1p5()
-                                                .py_0p5()
-                                                .rounded_sm()
-                                                .text_xs()
-                                                .bg(theme.accent.opacity(0.2))
-                                                .child(
-                                                    MonoCaption::new(dbflux_i18n::t!(
-                                                        "settings.mcp.field.builtin_badge"
-                                                    ))
-                                                    .color(theme.accent_foreground),
-                                                ),
-                                        )
-                                    }),
-                            )
-                            .child(MonoCaption::new(mcp_role_policy_count(
-                                role.policy_ids.len(),
-                            )))
-                    })),
-            );
+        let config = MasterDetailListConfig {
+            id: SharedString::from("mcp-roles-list"),
+            width: Widths::SETTINGS_LIST_PANEL,
+            new_action: Some(MasterDetailAction {
+                label: SharedString::from(dbflux_i18n::t!("settings.mcp.new_role")),
+                enabled: true,
+                focused: is_list_focused && selected.is_none(),
+            }),
+            secondary_action: None,
+            empty_message: Some(SharedString::from(dbflux_i18n::t!(
+                "settings.mcp.empty.roles"
+            ))),
+        };
+
+        let entity = cx.entity();
+        let entity_for_action = entity.clone();
+
+        let role_policies_focused =
+            self.mcp_focus == McpFocus::Form && self.mcp_form_field == McpFormField::RolePolicies;
 
         let form = div()
             .flex_1()
@@ -922,14 +1021,43 @@ impl McpSection {
                     .flex_col()
                     .gap_3()
                     .child(Label::new(dbflux_i18n::t!("settings.mcp.field.role_id")))
-                    .child(Input::new(&self.input_role_id).small())
+                    .child(self.render_mcp_input_field(
+                        &self.input_role_id,
+                        McpFormField::RoleId,
+                        theme.primary,
+                        cx,
+                    ))
                     .child(Label::new(dbflux_i18n::t!("settings.mcp.field.policies")))
                     .child(
                         Body::new(dbflux_i18n::t!("settings.mcp.hint.select_policies"))
                             .color(theme.muted_foreground),
                     )
-                    .child(self.role_policies_multiselect.clone()),
+                    .child(focus_frame(
+                        role_policies_focused,
+                        Some(theme.primary),
+                        self.role_policies_multiselect.clone(),
+                        cx,
+                    )),
             );
+
+        let list = render_master_detail_list(
+            &config,
+            &items,
+            &self.list_scroll_handle,
+            move |index: usize, window: &mut Window, cx: &mut App| {
+                let Some(id) = ids.get(index).cloned() else {
+                    return;
+                };
+                entity.update(cx, |this, cx| {
+                    this.select_role(&id, window, cx);
+                    this.enter_form(window, cx);
+                });
+            },
+            move |_kind: MasterDetailActionKind, window: &mut Window, cx: &mut App| {
+                entity_for_action.update(cx, |this, cx| this.new_current_item(window, cx));
+            },
+            cx,
+        );
 
         div()
             .size_full()
@@ -949,99 +1077,58 @@ impl McpSection {
             .list_mcp_policies()
             .unwrap_or_default();
         let selected = self.selected_policy_id.clone();
+        let is_list_focused = self.mcp_focus == McpFocus::List;
+        let is_form_focused = self.mcp_focus == McpFocus::Form;
+        let field = self.mcp_form_field;
 
-        let list = div()
-            .w(Widths::SETTINGS_LIST_PANEL)
-            .h_full()
-            .border_r_1()
-            .border_color(theme.border)
-            .p_3()
-            .flex()
-            .flex_col()
-            .gap_2()
-            .child(
-                Button::new("mcp-policy-new", dbflux_i18n::t!("settings.mcp.new_policy"))
-                    .small()
-                    .ghost()
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        this.clear_policy_form(window, cx);
-                    })),
-            )
-            .child(
-                div()
-                    .flex_1()
-                    .min_h_0()
-                    .overflow_y_scrollbar()
-                    .flex()
-                    .flex_col()
-                    .gap_1()
-                    .when(policies.is_empty(), |r| {
-                        r.child(
-                            Body::new(dbflux_i18n::t!("settings.mcp.empty.policies"))
-                                .color(theme.muted_foreground),
-                        )
-                    })
-                    .children(policies.iter().map(|policy| {
-                        let id = policy.id.clone();
-                        let is_selected = selected.as_deref() == Some(policy.id.as_str());
+        let ids: Vec<String> = policies.iter().map(|p| p.id.clone()).collect();
+        let items: Vec<MasterDetailItem> = policies
+            .iter()
+            .map(|policy| {
+                let is_selected = selected.as_deref() == Some(policy.id.as_str());
+                let label = builtin_display_name(&policy.id)
+                    .unwrap_or(policy.id.as_str())
+                    .to_string();
+                let badge = if dbflux_mcp::is_builtin(&policy.id) {
+                    Some((
+                        SharedString::from(dbflux_i18n::t!("settings.mcp.field.builtin_badge")),
+                        BadgeTone::Accent,
+                    ))
+                } else {
+                    None
+                };
+                MasterDetailItem {
+                    id: SharedString::from(policy.id.clone()),
+                    label: SharedString::from(label),
+                    detail: Some(SharedString::from(mcp_policy_tools_classes_summary(
+                        policy.allowed_tools.len(),
+                        policy.allowed_classes.len(),
+                    ))),
+                    badge,
+                    selected: is_selected,
+                    focused: is_list_focused && is_selected,
+                }
+            })
+            .collect();
 
-                        div()
-                            .id(SharedString::from(format!("policy-{}", policy.id)))
-                            .p_2()
-                            .rounded(Radii::SM)
-                            .border_1()
-                            .border_color(if is_selected {
-                                theme.primary
-                            } else {
-                                transparent_black()
-                            })
-                            .bg(if is_selected {
-                                theme.secondary
-                            } else {
-                                transparent_black()
-                            })
-                            .cursor_pointer()
-                            .hover({
-                                let s = theme.secondary;
-                                move |d| d.bg(s)
-                            })
-                            .on_click(cx.listener(move |this, _, window, cx| {
-                                this.select_policy(&id, window, cx);
-                            }))
-                            .child(
-                                div()
-                                    .flex()
-                                    .items_center()
-                                    .justify_between()
-                                    .gap_2()
-                                    .child(FieldLabel::new(
-                                        builtin_display_name(&policy.id)
-                                            .unwrap_or(policy.id.as_str())
-                                            .to_string(),
-                                    ))
-                                    .when(dbflux_mcp::is_builtin(&policy.id), |d| {
-                                        d.child(
-                                            div()
-                                                .px_1p5()
-                                                .py_0p5()
-                                                .rounded_sm()
-                                                .text_xs()
-                                                .bg(theme.accent.opacity(0.2))
-                                                .child(
-                                                    MonoCaption::new(dbflux_i18n::t!(
-                                                        "settings.mcp.field.builtin_badge"
-                                                    ))
-                                                    .color(theme.accent_foreground),
-                                                ),
-                                        )
-                                    }),
-                            )
-                            .child(MonoCaption::new(mcp_policy_tools_classes_summary(
-                                policy.allowed_tools.len(),
-                                policy.allowed_classes.len(),
-                            )))
-                    })),
-            );
+        let config = MasterDetailListConfig {
+            id: SharedString::from("mcp-policies-list"),
+            width: Widths::SETTINGS_LIST_PANEL,
+            new_action: Some(MasterDetailAction {
+                label: SharedString::from(dbflux_i18n::t!("settings.mcp.new_policy")),
+                enabled: true,
+                focused: is_list_focused && selected.is_none(),
+            }),
+            secondary_action: None,
+            empty_message: Some(SharedString::from(dbflux_i18n::t!(
+                "settings.mcp.empty.policies"
+            ))),
+        };
+
+        let entity = cx.entity();
+        let entity_for_action = entity.clone();
+
+        let mut tool_index = 0usize;
 
         let form = div()
             .flex_1()
@@ -1063,69 +1150,26 @@ impl McpSection {
                     .flex_col()
                     .gap_3()
                     .child(Label::new(dbflux_i18n::t!("settings.mcp.field.policy_id")))
-                    .child(Input::new(&self.input_policy_id).small())
+                    .child(self.render_mcp_input_field(
+                        &self.input_policy_id,
+                        McpFormField::PolicyId,
+                        theme.primary,
+                        cx,
+                    ))
                     .child(Label::new(dbflux_i18n::t!(
                         "settings.mcp.field.allowed_execution_classes"
                     )))
-                    .child(
-                        div()
-                            .flex()
-                            .flex_wrap()
-                            .gap_3()
-                            .children(class_meta.iter().map(|(class, label, description)| {
+                    .child(div().flex().flex_wrap().gap_3().children(
+                        class_meta.iter().enumerate().map(
+                            |(index, (class, label, description))| {
                                 let class = *class;
                                 let checked = self.draft_policy_classes.contains(class);
-                                div()
-                                    .flex()
-                                    .items_start()
-                                    .gap_2()
-                                    .child(
-                                        div().pt(px(2.0)).child(
-                                            Checkbox::new(SharedString::from(format!(
-                                                "policy-class-{}",
-                                                class
-                                            )))
-                                            .checked(checked)
-                                            .on_click(cx.listener(
-                                                move |this, checked: &bool, _, cx| {
-                                                    if *checked {
-                                                        this.draft_policy_classes
-                                                            .insert(class.to_string());
-                                                    } else {
-                                                        this.draft_policy_classes.remove(class);
-                                                    }
-                                                    cx.notify();
-                                                },
-                                            )),
-                                        ),
-                                    )
-                                    .child(
-                                        div()
-                                            .flex()
-                                            .flex_col()
-                                            .gap_0p5()
-                                            .child(FieldLabel::new(label.clone()))
-                                            .child(
-                                                Body::new(description.clone())
-                                                    .color(theme.muted_foreground),
-                                            ),
-                                    )
-                            })),
-                    )
-                    .child(Label::new(dbflux_i18n::t!(
-                        "settings.mcp.field.allowed_tools"
-                    )))
-                    .children(TOOL_GROUPS.iter().map(|(group_id, tools)| {
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap_2()
-                            .child(SubSectionLabel::new(tool_group_label(group_id)))
-                            .child(div().flex().flex_col().gap_2().pl_2().children(
-                                tools.iter().map(|&tool| {
-                                    let checked = self.draft_policy_tools.contains(tool);
-                                    let label = tool_label(&tool_meta, tool);
-                                    let description = tool_description(&tool_meta, tool);
+                                let is_focused =
+                                    is_form_focused && field == McpFormField::PolicyClass(index);
+
+                                focus_frame(
+                                    is_focused,
+                                    Some(theme.primary),
                                     div()
                                         .flex()
                                         .items_start()
@@ -1133,17 +1177,17 @@ impl McpSection {
                                         .child(
                                             div().pt(px(2.0)).child(
                                                 Checkbox::new(SharedString::from(format!(
-                                                    "policy-tool-{}",
-                                                    tool
+                                                    "policy-class-{}",
+                                                    class
                                                 )))
                                                 .checked(checked)
                                                 .on_click(cx.listener(
                                                     move |this, checked: &bool, _, cx| {
                                                         if *checked {
-                                                            this.draft_policy_tools
-                                                                .insert(tool.to_string());
+                                                            this.draft_policy_classes
+                                                                .insert(class.to_string());
                                                         } else {
-                                                            this.draft_policy_tools.remove(tool);
+                                                            this.draft_policy_classes.remove(class);
                                                         }
                                                         cx.notify();
                                                     },
@@ -1155,16 +1199,100 @@ impl McpSection {
                                                 .flex()
                                                 .flex_col()
                                                 .gap_0p5()
-                                                .child(FieldLabel::new(label))
+                                                .child(FieldLabel::new(label.clone()))
                                                 .child(
-                                                    Body::new(description)
+                                                    Body::new(description.clone())
                                                         .color(theme.muted_foreground),
                                                 ),
-                                        )
+                                        ),
+                                    cx,
+                                )
+                            },
+                        ),
+                    ))
+                    .child(Label::new(dbflux_i18n::t!(
+                        "settings.mcp.field.allowed_tools"
+                    )))
+                    .children(TOOL_GROUPS.iter().map(|(group_id, tools)| {
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap_2()
+                            .child(SubSectionLabel::new(tool_group_label(group_id)))
+                            .child(div().flex().flex_col().gap_2().pl_2().children(
+                                tools.iter().map(|&tool| {
+                                    let index = tool_index;
+                                    tool_index += 1;
+                                    let checked = self.draft_policy_tools.contains(tool);
+                                    let label = tool_label(&tool_meta, tool);
+                                    let description = tool_description(&tool_meta, tool);
+                                    let is_focused =
+                                        is_form_focused && field == McpFormField::PolicyTool(index);
+
+                                    focus_frame(
+                                        is_focused,
+                                        Some(theme.primary),
+                                        div()
+                                            .flex()
+                                            .items_start()
+                                            .gap_2()
+                                            .child(
+                                                div().pt(px(2.0)).child(
+                                                    Checkbox::new(SharedString::from(format!(
+                                                        "policy-tool-{}",
+                                                        tool
+                                                    )))
+                                                    .checked(checked)
+                                                    .on_click(cx.listener(
+                                                        move |this, checked: &bool, _, cx| {
+                                                            if *checked {
+                                                                this.draft_policy_tools
+                                                                    .insert(tool.to_string());
+                                                            } else {
+                                                                this.draft_policy_tools
+                                                                    .remove(tool);
+                                                            }
+                                                            cx.notify();
+                                                        },
+                                                    )),
+                                                ),
+                                            )
+                                            .child(
+                                                div()
+                                                    .flex()
+                                                    .flex_col()
+                                                    .gap_0p5()
+                                                    .child(FieldLabel::new(label))
+                                                    .child(
+                                                        Body::new(description)
+                                                            .color(theme.muted_foreground),
+                                                    ),
+                                            ),
+                                        cx,
+                                    )
                                 }),
                             ))
                     })),
             );
+
+        let list = render_master_detail_list(
+            &config,
+            &items,
+            &self.list_scroll_handle,
+            move |index: usize, window: &mut Window, cx: &mut App| {
+                let Some(id) = ids.get(index).cloned() else {
+                    return;
+                };
+                entity.update(cx, |this, cx| {
+                    this.select_policy(&id, window, cx);
+                    this.enter_form(window, cx);
+                });
+            },
+            move |_kind: MasterDetailActionKind, window: &mut Window, cx: &mut App| {
+                entity_for_action.update(cx, |this, cx| this.new_current_item(window, cx));
+            },
+            cx,
+        );
 
         div()
             .size_full()
@@ -1180,6 +1308,8 @@ impl McpSection {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let primary = cx.theme().primary;
+        let is_form_focused = self.mcp_focus == McpFocus::Form;
+        let field = self.mcp_form_field;
         let save_label = if self.selected_client(cx).is_some() {
             dbflux_i18n::t!("settings.mcp.action.update_client")
         } else {
@@ -1205,7 +1335,7 @@ impl McpSection {
                 .color(cx.theme().muted_foreground),
             )
             .child(layout::footer_action_frame(
-                false,
+                is_form_focused && field == McpFormField::ClientToggleActive,
                 primary,
                 Button::new("mcp-client-toggle-active", active_label)
                     .small()
@@ -1217,7 +1347,7 @@ impl McpSection {
                     })),
             ))
             .child(layout::footer_action_frame(
-                false,
+                is_form_focused && field == McpFormField::DeleteButton,
                 primary,
                 Button::new(
                     "mcp-client-delete",
@@ -1232,7 +1362,7 @@ impl McpSection {
                 })),
             ))
             .child(layout::footer_action_frame(
-                false,
+                is_form_focused && field == McpFormField::SaveButton,
                 primary,
                 Button::new("mcp-client-save", save_label)
                     .small()
@@ -1251,6 +1381,8 @@ impl McpSection {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let primary = cx.theme().primary;
+        let is_form_focused = self.mcp_focus == McpFocus::Form;
+        let field = self.mcp_form_field;
         let role_is_builtin = self
             .selected_role_id
             .as_deref()
@@ -1274,7 +1406,7 @@ impl McpSection {
                 )
             })
             .child(layout::footer_action_frame(
-                false,
+                is_form_focused && field == McpFormField::DeleteButton,
                 primary,
                 Button::new(
                     "mcp-role-delete",
@@ -1289,7 +1421,7 @@ impl McpSection {
                 })),
             ))
             .child(layout::footer_action_frame(
-                false,
+                is_form_focused && field == McpFormField::SaveButton,
                 primary,
                 Button::new("mcp-role-save", save_label)
                     .small()
@@ -1309,6 +1441,8 @@ impl McpSection {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let primary = cx.theme().primary;
+        let is_form_focused = self.mcp_focus == McpFocus::Form;
+        let field = self.mcp_form_field;
         let policy_is_builtin = self
             .selected_policy_id
             .as_deref()
@@ -1334,7 +1468,7 @@ impl McpSection {
                 )
             })
             .child(layout::footer_action_frame(
-                false,
+                is_form_focused && field == McpFormField::DeleteButton,
                 primary,
                 Button::new(
                     "mcp-policy-delete",
@@ -1349,7 +1483,7 @@ impl McpSection {
                 })),
             ))
             .child(layout::footer_action_frame(
-                false,
+                is_form_focused && field == McpFormField::SaveButton,
                 primary,
                 Button::new("mcp-policy-save", save_label)
                     .small()
@@ -1365,30 +1499,10 @@ impl McpSection {
 
     // ─── Keyboard navigation ──────────────────────────────────────────────────
 
-    pub(super) fn handle_key_event(
-        &mut self,
-        event: &KeyDownEvent,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        if !self.content_focused {
-            return;
-        }
-
-        let chord = key_chord_from_gpui(&event.keystroke);
-
+    fn select_next(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         match self.variant {
-            McpSectionVariant::Clients => self.handle_clients_nav(chord, window, cx),
-            McpSectionVariant::Roles => self.handle_roles_nav(chord, window, cx),
-            McpSectionVariant::Policies => self.handle_policies_nav(chord, window, cx),
-        }
-    }
-
-    fn handle_clients_nav(&mut self, chord: KeyChord, window: &mut Window, cx: &mut Context<Self>) {
-        let clients = self.trusted_clients(cx);
-
-        match (chord.key.as_str(), chord.modifiers) {
-            ("j", m) | ("down", m) if m == Modifiers::none() => {
+            McpSectionVariant::Clients => {
+                let clients = self.trusted_clients(cx);
                 let next_id = match &self.selected_client_id {
                     None => clients.first().map(|c| c.id.clone()),
                     Some(current) => {
@@ -1398,49 +1512,12 @@ impl McpSection {
                             .map(|c| c.id.clone())
                     }
                 };
-
                 if let Some(id) = next_id {
                     self.select_client(&id, window, cx);
                 }
-
-                cx.notify();
             }
-
-            ("k", m) | ("up", m) if m == Modifiers::none() => {
-                let prev_id = match &self.selected_client_id {
-                    None => clients.last().map(|c| c.id.clone()),
-                    Some(current) => {
-                        let idx = clients.iter().position(|c| &c.id == current);
-                        idx.and_then(|i| i.checked_sub(1).and_then(|i| clients.get(i)))
-                            .or_else(|| clients.last())
-                            .map(|c| c.id.clone())
-                    }
-                };
-
-                if let Some(id) = prev_id {
-                    self.select_client(&id, window, cx);
-                }
-
-                cx.notify();
-            }
-
-            ("escape", m) if m == Modifiers::none() => {
-                if self.selected_client_id.is_some() {
-                    self.clear_client_form(window, cx);
-                } else {
-                    cx.emit(SectionFocusEvent::RequestFocusReturn);
-                }
-            }
-
-            _ => {}
-        }
-    }
-
-    fn handle_roles_nav(&mut self, chord: KeyChord, window: &mut Window, cx: &mut Context<Self>) {
-        let roles = self.roles(cx);
-
-        match (chord.key.as_str(), chord.modifiers) {
-            ("j", m) | ("down", m) if m == Modifiers::none() => {
+            McpSectionVariant::Roles => {
+                let roles = self.roles(cx);
                 let next_id = match &self.selected_role_id {
                     None => roles.first().map(|r| r.id.clone()),
                     Some(current) => {
@@ -1450,54 +1527,12 @@ impl McpSection {
                             .map(|r| r.id.clone())
                     }
                 };
-
                 if let Some(id) = next_id {
                     self.select_role(&id, window, cx);
                 }
-
-                cx.notify();
             }
-
-            ("k", m) | ("up", m) if m == Modifiers::none() => {
-                let prev_id = match &self.selected_role_id {
-                    None => roles.last().map(|r| r.id.clone()),
-                    Some(current) => {
-                        let idx = roles.iter().position(|r| &r.id == current);
-                        idx.and_then(|i| i.checked_sub(1).and_then(|i| roles.get(i)))
-                            .or_else(|| roles.last())
-                            .map(|r| r.id.clone())
-                    }
-                };
-
-                if let Some(id) = prev_id {
-                    self.select_role(&id, window, cx);
-                }
-
-                cx.notify();
-            }
-
-            ("escape", m) if m == Modifiers::none() => {
-                if self.selected_role_id.is_some() {
-                    self.clear_role_form(window, cx);
-                } else {
-                    cx.emit(SectionFocusEvent::RequestFocusReturn);
-                }
-            }
-
-            _ => {}
-        }
-    }
-
-    fn handle_policies_nav(
-        &mut self,
-        chord: KeyChord,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        let policies = self.policies(cx);
-
-        match (chord.key.as_str(), chord.modifiers) {
-            ("j", m) | ("down", m) if m == Modifiers::none() => {
+            McpSectionVariant::Policies => {
+                let policies = self.policies(cx);
                 let next_id = match &self.selected_policy_id {
                     None => policies.first().map(|p| p.id.clone()),
                     Some(current) => {
@@ -1507,15 +1542,47 @@ impl McpSection {
                             .map(|p| p.id.clone())
                     }
                 };
-
                 if let Some(id) = next_id {
                     self.select_policy(&id, window, cx);
                 }
-
-                cx.notify();
             }
+        }
+    }
 
-            ("k", m) | ("up", m) if m == Modifiers::none() => {
+    fn select_prev(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.variant {
+            McpSectionVariant::Clients => {
+                let clients = self.trusted_clients(cx);
+                let prev_id = match &self.selected_client_id {
+                    None => clients.last().map(|c| c.id.clone()),
+                    Some(current) => {
+                        let idx = clients.iter().position(|c| &c.id == current);
+                        idx.and_then(|i| i.checked_sub(1).and_then(|i| clients.get(i)))
+                            .or_else(|| clients.last())
+                            .map(|c| c.id.clone())
+                    }
+                };
+                if let Some(id) = prev_id {
+                    self.select_client(&id, window, cx);
+                }
+            }
+            McpSectionVariant::Roles => {
+                let roles = self.roles(cx);
+                let prev_id = match &self.selected_role_id {
+                    None => roles.last().map(|r| r.id.clone()),
+                    Some(current) => {
+                        let idx = roles.iter().position(|r| &r.id == current);
+                        idx.and_then(|i| i.checked_sub(1).and_then(|i| roles.get(i)))
+                            .or_else(|| roles.last())
+                            .map(|r| r.id.clone())
+                    }
+                };
+                if let Some(id) = prev_id {
+                    self.select_role(&id, window, cx);
+                }
+            }
+            McpSectionVariant::Policies => {
+                let policies = self.policies(cx);
                 let prev_id = match &self.selected_policy_id {
                     None => policies.last().map(|p| p.id.clone()),
                     Some(current) => {
@@ -1525,24 +1592,359 @@ impl McpSection {
                             .map(|p| p.id.clone())
                     }
                 };
-
                 if let Some(id) = prev_id {
                     self.select_policy(&id, window, cx);
                 }
-
-                cx.notify();
             }
+        }
+    }
 
-            ("escape", m) if m == Modifiers::none() => {
-                if self.selected_policy_id.is_some() {
-                    self.clear_policy_form(window, cx);
-                } else {
-                    cx.emit(SectionFocusEvent::RequestFocusReturn);
+    fn select_first(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.variant {
+            McpSectionVariant::Clients => {
+                if let Some(id) = self.trusted_clients(cx).first().map(|c| c.id.clone()) {
+                    self.select_client(&id, window, cx);
                 }
             }
+            McpSectionVariant::Roles => {
+                if let Some(id) = self.roles(cx).first().map(|r| r.id.clone()) {
+                    self.select_role(&id, window, cx);
+                }
+            }
+            McpSectionVariant::Policies => {
+                if let Some(id) = self.policies(cx).first().map(|p| p.id.clone()) {
+                    self.select_policy(&id, window, cx);
+                }
+            }
+        }
+    }
 
+    fn select_last(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.variant {
+            McpSectionVariant::Clients => {
+                if let Some(id) = self.trusted_clients(cx).last().map(|c| c.id.clone()) {
+                    self.select_client(&id, window, cx);
+                }
+            }
+            McpSectionVariant::Roles => {
+                if let Some(id) = self.roles(cx).last().map(|r| r.id.clone()) {
+                    self.select_role(&id, window, cx);
+                }
+            }
+            McpSectionVariant::Policies => {
+                if let Some(id) = self.policies(cx).last().map(|p| p.id.clone()) {
+                    self.select_policy(&id, window, cx);
+                }
+            }
+        }
+    }
+
+    fn delete_current_selection(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.variant {
+            McpSectionVariant::Clients => self.delete_selected_client(window, cx),
+            McpSectionVariant::Roles if !self.role_is_builtin() => {
+                self.delete_selected_role(window, cx);
+            }
+            McpSectionVariant::Policies if !self.policy_is_builtin() => {
+                self.delete_selected_policy(window, cx);
+            }
+            McpSectionVariant::Roles | McpSectionVariant::Policies => {}
+        }
+    }
+
+    fn clear_current_form(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        match self.variant {
+            McpSectionVariant::Clients => self.clear_client_form(window, cx),
+            McpSectionVariant::Roles => self.clear_role_form(window, cx),
+            McpSectionVariant::Policies => self.clear_policy_form(window, cx),
+        }
+    }
+
+    fn new_current_item(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.clear_current_form(window, cx);
+        self.enter_form(window, cx);
+    }
+
+    fn mcp_focus_current_field(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.editing_field = true;
+
+        match self.mcp_form_field {
+            McpFormField::ClientId => {
+                self.input_client_id
+                    .update(cx, |state, cx| state.focus(window, cx));
+            }
+            McpFormField::ClientName => {
+                self.input_client_name
+                    .update(cx, |state, cx| state.focus(window, cx));
+            }
+            McpFormField::ClientIssuer => {
+                self.input_client_issuer
+                    .update(cx, |state, cx| state.focus(window, cx));
+            }
+            McpFormField::RoleId => {
+                self.input_role_id
+                    .update(cx, |state, cx| state.focus(window, cx));
+            }
+            McpFormField::PolicyId => {
+                self.input_policy_id
+                    .update(cx, |state, cx| state.focus(window, cx));
+            }
+            _ => {
+                self.editing_field = false;
+            }
+        }
+    }
+
+    fn mcp_activate_current_field(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let blocked = match self.variant {
+            McpSectionVariant::Roles => self.role_is_builtin(),
+            McpSectionVariant::Policies => self.policy_is_builtin(),
+            McpSectionVariant::Clients => false,
+        };
+
+        // A built-in role/policy stays inspectable (the field cursor and its
+        // value ring still move over it) but never enters edit mode: a stale
+        // cursor can outlive a selection change, so this guard is checked
+        // again here even though `mcp_form_rows` already drops the button
+        // row for builtin items.
+        if blocked {
+            return;
+        }
+
+        match self.mcp_form_field {
+            McpFormField::ClientActive => {
+                self.draft_active = !self.draft_active;
+                cx.notify();
+            }
+            McpFormField::ClientToggleActive => {
+                self.toggle_selected_client_active(window, cx);
+            }
+            McpFormField::RolePolicies => {
+                self.role_policies_multiselect
+                    .update(cx, |ms, cx| ms.toggle_open(cx));
+            }
+            McpFormField::PolicyClass(index) => {
+                if let Some(&id) = mcp_policy_class_ids().get(index) {
+                    if self.draft_policy_classes.contains(id) {
+                        self.draft_policy_classes.remove(id);
+                    } else {
+                        self.draft_policy_classes.insert(id.to_string());
+                    }
+                    cx.notify();
+                }
+            }
+            McpFormField::PolicyTool(index) => {
+                if let Some(&id) = mcp_policy_tool_ids().get(index) {
+                    if self.draft_policy_tools.contains(id) {
+                        self.draft_policy_tools.remove(id);
+                    } else {
+                        self.draft_policy_tools.insert(id.to_string());
+                    }
+                    cx.notify();
+                }
+            }
+            McpFormField::SaveButton => match self.variant {
+                McpSectionVariant::Clients => self.save_client(window, cx),
+                McpSectionVariant::Roles => self.save_role(window, cx),
+                McpSectionVariant::Policies => self.save_policy(window, cx),
+            },
+            McpFormField::DeleteButton => self.delete_current_selection(window, cx),
+            field if mcp_is_input_field(field) => {
+                self.mcp_focus_current_field(window, cx);
+            }
             _ => {}
         }
+    }
+
+    pub(super) fn handle_key_event(
+        &mut self,
+        event: &KeyDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.content_focused() && !self.editing_field() {
+            return;
+        }
+
+        if self.handle_editing_keys(event, window, cx) {
+            return;
+        }
+
+        let chord = key_chord_from_gpui(&event.keystroke);
+
+        match self.mcp_focus {
+            McpFocus::List => match (chord.key.as_str(), chord.modifiers) {
+                ("j", m) | ("down", m) if m == Modifiers::none() => {
+                    self.select_next(window, cx);
+                    cx.notify();
+                }
+                ("k", m) | ("up", m) if m == Modifiers::none() => {
+                    self.select_prev(window, cx);
+                    cx.notify();
+                }
+                ("l", m) | ("right", m) | ("enter", m) if m == Modifiers::none() => {
+                    self.enter_form(window, cx);
+                    cx.notify();
+                }
+                ("n", m) if m == Modifiers::none() => {
+                    self.new_current_item(window, cx);
+                    cx.notify();
+                }
+                ("d", m) if m == Modifiers::none() => {
+                    self.delete_current_selection(window, cx);
+                    cx.notify();
+                }
+                ("g", m) if m == Modifiers::none() => {
+                    self.select_first(window, cx);
+                    cx.notify();
+                }
+                ("G", m) if m == Modifiers::none() => {
+                    self.select_last(window, cx);
+                    cx.notify();
+                }
+                ("escape", m) if m == Modifiers::none() => {
+                    let has_selection = match self.variant {
+                        McpSectionVariant::Clients => self.selected_client_id.is_some(),
+                        McpSectionVariant::Roles => self.selected_role_id.is_some(),
+                        McpSectionVariant::Policies => self.selected_policy_id.is_some(),
+                    };
+                    if has_selection {
+                        self.clear_current_form(window, cx);
+                    } else {
+                        cx.emit(SectionFocusEvent::RequestFocusReturn);
+                    }
+                }
+                _ => {}
+            },
+            McpFocus::Form => match (chord.key.as_str(), chord.modifiers) {
+                ("escape", m) | ("h", m) if m == Modifiers::none() => {
+                    self.exit_form(window, cx);
+                    cx.notify();
+                }
+                ("j", m) | ("down", m) if m == Modifiers::none() => {
+                    self.move_down();
+                    cx.notify();
+                }
+                ("k", m) | ("up", m) if m == Modifiers::none() => {
+                    self.move_up();
+                    cx.notify();
+                }
+                ("left", m) if m == Modifiers::none() => {
+                    self.move_left();
+                    cx.notify();
+                }
+                ("l", m) | ("right", m) if m == Modifiers::none() => {
+                    self.move_right();
+                    cx.notify();
+                }
+                ("enter", m) if m == Modifiers::none() => {
+                    self.activate_current_field(window, cx);
+                    cx.notify();
+                }
+                ("tab", m) if m == Modifiers::none() => {
+                    self.tab_next();
+                    cx.notify();
+                }
+                ("tab", m) if m == Modifiers::shift() => {
+                    self.tab_prev();
+                    cx.notify();
+                }
+                ("g", m) if m == Modifiers::none() => {
+                    self.move_first();
+                    cx.notify();
+                }
+                ("G", m) if m == Modifiers::none() => {
+                    self.move_last();
+                    cx.notify();
+                }
+                _ => {}
+            },
+        }
+    }
+}
+
+impl FormSection for McpSection {
+    type Focus = McpFocus;
+    type FormField = McpFormField;
+
+    fn focus_area(&self) -> Self::Focus {
+        self.mcp_focus
+    }
+
+    fn set_focus_area(&mut self, focus: Self::Focus) {
+        self.mcp_focus = focus;
+    }
+
+    fn form_field(&self) -> Self::FormField {
+        self.mcp_form_field
+    }
+
+    fn set_form_field(&mut self, field: Self::FormField) {
+        self.mcp_form_field = field;
+    }
+
+    fn editing_field(&self) -> bool {
+        self.editing_field
+    }
+
+    fn set_editing_field(&mut self, editing: bool) {
+        self.editing_field = editing;
+    }
+
+    fn switching_input(&self) -> bool {
+        self.switching_input
+    }
+
+    fn set_switching_input(&mut self, switching: bool) {
+        self.switching_input = switching;
+    }
+
+    fn content_focused(&self) -> bool {
+        self.content_focused
+    }
+
+    fn list_focus() -> Self::Focus {
+        McpFocus::List
+    }
+
+    fn form_focus() -> Self::Focus {
+        McpFocus::Form
+    }
+
+    fn first_form_field() -> Self::FormField {
+        McpFormField::ClientId
+    }
+
+    fn form_rows(&self) -> Vec<Vec<Self::FormField>> {
+        let is_builtin = match self.variant {
+            McpSectionVariant::Roles => self.role_is_builtin(),
+            McpSectionVariant::Policies => self.policy_is_builtin(),
+            McpSectionVariant::Clients => false,
+        };
+        mcp_form_rows(
+            self.variant,
+            is_builtin,
+            mcp_policy_class_ids().len(),
+            mcp_policy_tool_ids().len(),
+        )
+    }
+
+    fn is_input_field(field: Self::FormField) -> bool {
+        mcp_is_input_field(field)
+    }
+
+    fn focus_current_field(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        McpSection::mcp_focus_current_field(self, window, cx);
+    }
+
+    fn activate_current_field(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        McpSection::mcp_activate_current_field(self, window, cx);
+    }
+
+    fn enter_form(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
+        self.mcp_focus = McpFocus::Form;
+        self.mcp_form_field = Self::first_field_for(self.variant);
+        self.editing_field = false;
     }
 }
 
@@ -1571,6 +1973,7 @@ impl SettingsSection for McpSection {
 
     fn focus_out(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         self.content_focused = false;
+        self.editing_field = false;
         cx.notify();
     }
 
@@ -1636,6 +2039,145 @@ impl Render for McpSection {
                 cx,
             ))
             .child(div().flex_1().min_h_0().overflow_hidden().child(content))
+    }
+}
+
+#[cfg(test)]
+mod form_row_tests {
+    use super::{
+        McpFormField, McpSectionVariant, mcp_form_rows, mcp_is_input_field, mcp_policy_class_ids,
+        mcp_policy_tool_ids,
+    };
+
+    fn all_fields(rows: &[Vec<McpFormField>]) -> Vec<McpFormField> {
+        rows.iter().flatten().copied().collect()
+    }
+
+    #[test]
+    fn clients_rows_always_include_the_button_row() {
+        let rows = mcp_form_rows(McpSectionVariant::Clients, false, 0, 0);
+        let fields = all_fields(&rows);
+
+        assert!(fields.contains(&McpFormField::ClientId));
+        assert!(fields.contains(&McpFormField::ClientName));
+        assert!(fields.contains(&McpFormField::ClientIssuer));
+        assert!(fields.contains(&McpFormField::ClientActive));
+        assert!(fields.contains(&McpFormField::ClientToggleActive));
+        assert!(fields.contains(&McpFormField::DeleteButton));
+        assert!(fields.contains(&McpFormField::SaveButton));
+        assert_eq!(rows[0], vec![McpFormField::ClientId]);
+    }
+
+    #[test]
+    fn roles_drop_button_row_when_builtin() {
+        let editable = mcp_form_rows(McpSectionVariant::Roles, false, 0, 0);
+        let builtin = mcp_form_rows(McpSectionVariant::Roles, true, 0, 0);
+
+        assert!(all_fields(&editable).contains(&McpFormField::SaveButton));
+        assert!(all_fields(&editable).contains(&McpFormField::DeleteButton));
+        assert!(!all_fields(&builtin).contains(&McpFormField::SaveButton));
+        assert!(!all_fields(&builtin).contains(&McpFormField::DeleteButton));
+        assert_eq!(editable[0], vec![McpFormField::RoleId]);
+    }
+
+    #[test]
+    fn policies_class_row_length_matches_class_count() {
+        let rows = mcp_form_rows(McpSectionVariant::Policies, false, 5, 0);
+        let class_row = &rows[1];
+
+        assert_eq!(class_row.len(), 5);
+        assert_eq!(
+            class_row,
+            &(0..5).map(McpFormField::PolicyClass).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn policies_have_one_row_per_tool() {
+        let rows = mcp_form_rows(McpSectionVariant::Policies, false, 5, 3);
+        let tool_rows: Vec<_> = rows
+            .iter()
+            .filter(|row| matches!(row.as_slice(), [McpFormField::PolicyTool(_)]))
+            .collect();
+
+        assert_eq!(tool_rows.len(), 3);
+    }
+
+    #[test]
+    fn policies_drop_button_row_when_builtin() {
+        let editable = mcp_form_rows(McpSectionVariant::Policies, false, 5, 25);
+        let builtin = mcp_form_rows(McpSectionVariant::Policies, true, 5, 25);
+
+        assert!(all_fields(&editable).contains(&McpFormField::SaveButton));
+        assert!(!all_fields(&builtin).contains(&McpFormField::SaveButton));
+    }
+
+    #[test]
+    fn no_row_is_empty_and_no_field_repeats_within_a_variant() {
+        for (variant, is_builtin) in [
+            (McpSectionVariant::Clients, false),
+            (McpSectionVariant::Roles, false),
+            (McpSectionVariant::Roles, true),
+            (McpSectionVariant::Policies, false),
+            (McpSectionVariant::Policies, true),
+        ] {
+            let rows = mcp_form_rows(variant, is_builtin, 5, 25);
+
+            assert!(rows.iter().all(|row| !row.is_empty()));
+
+            let fields = all_fields(&rows);
+            let mut seen = fields.clone();
+            seen.sort_by_key(|f| format!("{f:?}"));
+            seen.dedup();
+            assert_eq!(seen.len(), fields.len());
+        }
+    }
+
+    #[test]
+    fn first_form_field_lands_in_row_zero() {
+        assert_eq!(
+            mcp_form_rows(McpSectionVariant::Clients, false, 0, 0)[0][0],
+            McpFormField::ClientId
+        );
+        assert_eq!(
+            mcp_form_rows(McpSectionVariant::Roles, false, 0, 0)[0][0],
+            McpFormField::RoleId
+        );
+        assert_eq!(
+            mcp_form_rows(McpSectionVariant::Policies, false, 5, 25)[0][0],
+            McpFormField::PolicyId
+        );
+    }
+
+    #[test]
+    fn policy_class_and_tool_id_lists_are_stable() {
+        let classes = mcp_policy_class_ids();
+        assert_eq!(
+            classes,
+            vec!["metadata", "read", "write", "destructive", "admin"]
+        );
+
+        let tools = mcp_policy_tool_ids();
+        assert_eq!(tools.len(), 25);
+        assert_eq!(tools[0], "list_connections");
+        assert_eq!(tools[tools.len() - 1], "export_audit_logs");
+    }
+
+    #[test]
+    fn is_input_field_covers_exactly_the_five_inputs() {
+        assert!(mcp_is_input_field(McpFormField::ClientId));
+        assert!(mcp_is_input_field(McpFormField::ClientName));
+        assert!(mcp_is_input_field(McpFormField::ClientIssuer));
+        assert!(mcp_is_input_field(McpFormField::RoleId));
+        assert!(mcp_is_input_field(McpFormField::PolicyId));
+
+        assert!(!mcp_is_input_field(McpFormField::ClientActive));
+        assert!(!mcp_is_input_field(McpFormField::ClientToggleActive));
+        assert!(!mcp_is_input_field(McpFormField::RolePolicies));
+        assert!(!mcp_is_input_field(McpFormField::PolicyClass(0)));
+        assert!(!mcp_is_input_field(McpFormField::PolicyTool(0)));
+        assert!(!mcp_is_input_field(McpFormField::DeleteButton));
+        assert!(!mcp_is_input_field(McpFormField::SaveButton));
     }
 }
 

--- a/crates/dbflux_ui_windows/src/settings/proxies.rs
+++ b/crates/dbflux_ui_windows/src/settings/proxies.rs
@@ -483,6 +483,12 @@ impl ProxiesSection {
                 ("i", modifiers) if modifiers == Modifiers::none() => {
                     self.request_import(cx);
                 }
+                ("n", modifiers) if modifiers == Modifiers::none() => {
+                    self.proxy_selected_idx = None;
+                    self.proxy_load_selected_profile(window, cx);
+                    self.proxy_enter_form(window, cx);
+                    cx.notify();
+                }
                 ("g", modifiers) if modifiers == Modifiers::none() => {
                     self.proxy_selected_idx = None;
                     self.proxy_load_selected_profile(window, cx);

--- a/crates/dbflux_ui_windows/src/settings/services_section.rs
+++ b/crates/dbflux_ui_windows/src/settings/services_section.rs
@@ -156,6 +156,12 @@ impl SettingsSection for ServicesSection {
                         self.request_delete_service(idx, cx);
                     }
                 }
+                ("n", modifiers) if modifiers == Modifiers::none() => {
+                    self.svc_selected_idx = None;
+                    self.svc_load_selected_profile(window, cx);
+                    self.svc_enter_form(window, cx);
+                    cx.notify();
+                }
                 ("g", modifiers) if modifiers == Modifiers::none() => {
                     self.svc_selected_idx = None;
                     self.svc_load_selected_profile(window, cx);

--- a/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
+++ b/crates/dbflux_ui_windows/src/settings/ssh_tunnels.rs
@@ -558,6 +558,12 @@ impl SshTunnelsSection {
                 ("i", modifiers) if modifiers == Modifiers::none() => {
                     self.request_import(cx);
                 }
+                ("n", modifiers) if modifiers == Modifiers::none() => {
+                    self.ssh_selected_idx = None;
+                    self.ssh_load_selected_profile(window, cx);
+                    self.ssh_enter_form(window, cx);
+                    cx.notify();
+                }
                 ("g", modifiers) if modifiers == Modifiers::none() => {
                     self.ssh_selected_idx = None;
                     self.ssh_load_selected_profile(window, cx);


### PR DESCRIPTION
## Summary

- Settings → MCP Clients, Roles and Policies can now be navigated, created and edited entirely from the keyboard. They were the only list-plus-form sections without a form focus area.
- Settings → Hooks now shows the focus ring on every form field, so `l`, `j` and `k` visibly move the cursor instead of walking an invisible one.
- New reusable `master_detail_list` composite in `dbflux_components`, consumed by the MCP sections. The other five list sections keep their hand-rolled panels for now (follow-up below).
- `n` creates a new item in every list section that supports create. Two dead code paths removed (a shadowed key handler in Hooks, an unreachable `h` arm in Drivers). The Audit status row is no longer a keyboard stop.

## What does this resolve?

- Resolves the keyboard flow reported for Settings: MCP Clients could not be created or edited by keyboard, and in Hooks `l` appeared to do nothing while `j`/`k` did not move anything until `h` was pressed.
- No linked issue; reported directly by the maintainer.

## How was this solved?

**Review this first:** `crates/dbflux_ui_windows/src/settings/mcp_section.rs`. It is the largest diff and the only behavioral rewrite.

| Area | Decision |
|------|----------|
| Composite | `crates/dbflux_components/src/composites/master_detail_list.rs`: items, optional New and secondary actions, parameterized width, per-item focus ring via `focus_frame`, caller-owned scroll handle. Domain-free, no `dbflux_app` or `dbflux_ui_*` dependency. |
| MCP | `McpSection` implements `FormSection` with one `McpFormField` enum and a pure `mcp_form_rows()` table per variant. Built-in roles and policies drop the Save/Delete row from the table and `activate_current_field` refuses to enter edit mode, so a stale cursor can never mutate a read-only item. The three ad hoc `handle_*_nav` functions are replaced by the shared list/form dispatch used by Proxies and SSH. |
| MCP cursor | Selecting a built-in item revalidates the cursor against the row table, so a cursor left on Save falls back to the first field instead of going off-table. |
| Hooks | Every field in `render_hook_form` is wrapped with the focus ring. The `SettingsSection::handle_key_event` body in `hooks_section.rs` was dead (shadowed by the inherent method) and is now a thin delegate, matching Proxies. |
| Create key | `n` added to Proxies, SSH Tunnels and Services lists, routing to the existing new-item path. Hooks and Auth Profiles already had it. Drivers has no create. |
| Drivers | Unreachable second `"h"` match arm removed. `left` still moves left, `h` still exits to the list. |
| Audit | `AuditFormRow::StatusIndicator` removed from the navigable rows. It is display-only. |

**Out of scope (follow-up):** migrating Drivers, Hooks, Services, Auth Profiles, Proxies and SSH Tunnels list panels to the composite. The composite API already covers their widths, badges and secondary actions so that migration needs no API change.

**Size:** this PR carries `size:exception`. The MCP `FormSection` implementation for three variants is inherently larger than a single-section fix, and splitting it from the composite would have shipped an unused component.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo nextest run --workspace` → 6036 passed, 234 skipped
- `cargo nextest run -p dbflux_components -p dbflux_ui_windows --features dbflux_ui_windows/mcp,dbflux_ui_windows/lua` → 764 passed
- `cargo test --doc --workspace`
- New unit tests: `mcp_form_rows` per variant and built-in state, field id order, `is_input_field`, composite row kinds, Audit rows without the status indicator.
- Manual keyboard smoke in the app is pending before merge. Checklist: MCP Clients/Roles/Policies list → form → field → input round trip, built-in role does not enter edit mode, Hooks ring on every field, `n` in Proxies/SSH/Services, Drivers `h`, Audit `j`/`k`.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s) (manual smoke pending)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))
