### PR TITLE
fix(mcp): bind several trusted clients per connection from the Connection Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ All notable changes to DBFlux will be documented in this file.
 
 ### Fixed
 
+* **Several MCP clients per connection (#542)** — the Connection Manager MCP
+  tab is now a master-detail view: a filterable list of every trusted client
+  on the left, and on the right whether the selected client may use this
+  connection, its roles and policies, and a preview of the tools and
+  classifications those grant. Previously the tab could bind a single client,
+  and saving a connection silently dropped every other binding it held.
+
 * **Keyboard navigation in Settings lists and forms (#543)** — MCP Clients,
   Roles and Policies can now be browsed, created and edited from the keyboard:
   `l`/`enter` opens the form, `n` starts a new item, `j`/`k` and `tab` move

--- a/crates/dbflux/tests/mcp_ui_governance_acceptance_tests.rs
+++ b/crates/dbflux/tests/mcp_ui_governance_acceptance_tests.rs
@@ -42,11 +42,11 @@ fn ui_contains_trusted_client_and_connection_policy_controls() {
 
     assert!(connection_form.contains("save_mcp_connection_policy_assignment"));
     assert!(connection_form.contains("ConnectionPolicyUpdated"));
-    assert!(connection_tabs.contains("connection_manager.scope_policy_preview"));
+    assert!(connection_tabs.contains("connection_manager.mcp_effective_tools"));
     assert!(connection_tabs.contains("connection_manager.enable_mcp"));
 
     let english_catalog = read_workspace_file("../dbflux_i18n/locales/en.yml");
-    assert!(english_catalog.contains("scope_policy_preview: Scope/policy assignment preview"));
+    assert!(english_catalog.contains("mcp_effective_tools:"));
     assert!(english_catalog.contains("enable_mcp: Enable MCP for this connection"));
 }
 

--- a/crates/dbflux_components/src/tokens.rs
+++ b/crates/dbflux_components/src/tokens.rs
@@ -416,6 +416,14 @@ impl Widths {
     /// Applied to the left panel (`border_r_1`) listing selectable items in
     /// MCP (clients, roles, policies) and driver settings sections. (300 px)
     pub const SETTINGS_LIST_PANEL: Pixels = px(300.0);
+
+    /// Left list-panel width for the Connection Manager MCP tab's trusted
+    /// client list.
+    ///
+    /// The Connection Manager window (720x620) is narrower than the Settings
+    /// window (950x700), so this panel uses a smaller width than
+    /// `SETTINGS_LIST_PANEL`. (220 px)
+    pub const CONNECTION_MCP_LIST_PANEL: Pixels = px(220.0);
 }
 
 #[cfg(test)]

--- a/crates/dbflux_i18n/locales/en.yml
+++ b/crates/dbflux_i18n/locales/en.yml
@@ -168,6 +168,7 @@ connection_manager:
     use_driver_default: Use Driver Default
     no_hook: No hook
     select_trusted_client: Select trusted client
+    filter_trusted_clients: "Filter by name or id…"
     no_role: No role
     no_policy: No policy
     extra_hook_ids: extra hook IDs (comma-separated)
@@ -222,20 +223,27 @@ connection_manager:
   driver_settings_title: Driver Settings
   driver_no_custom_settings: This driver has no custom settings.
   mcp_disabled: MCP disabled for this connection
-  mcp_enabled_select_actor: MCP enabled — select a trusted client to bind
-  mcp_preview_summary: "Actor '%{actor}' | role: %{role} | policy: %{policy}"
-  mcp_preview_none: none
+  mcp_not_compiled: This build was compiled without MCP support.
   mcp_governance_title: MCP Governance
   enable_mcp: Enable MCP for this connection
-  trusted_client_actor: Trusted Client (Actor)
-  mcp_actor_hint: AI agent identity — configure in Settings → MCP
+  mcp_badge_granted: granted
+  mcp_badge_no_access: no access
+  mcp_empty_clients: No trusted clients configured. Add one in Settings → MCP.
+  mcp_allow_client: Allow this client on this connection
+  mcp_client_denied: This client is denied on this connection.
+  mcp_select_client: Select a trusted client to configure its access.
   role_label: Role
   mcp_role_hint: Configure roles in Settings → MCP → Roles
   additional_roles_optional: Additional roles (optional)
   policy_label: Policy
   mcp_policy_hint: Configure policies in Settings → MCP → Policies
   additional_policies_optional: Additional policies (optional)
-  scope_policy_preview: Scope/policy assignment preview
+  mcp_effective_tools: "Tools: %{tools}"
+  mcp_effective_classes: "Classes: %{classes}"
+  mcp_effective_none: none
+  mcp_orphan_bindings:
+    one: 1 binding references a client that no longer exists.
+    many: "%{count} bindings reference clients that no longer exist."
   mcp_governance_error:
     save_policy: "Failed to save MCP connection policy assignment: %{error}"
     clear_policy: "Failed to clear MCP connection policy assignment: %{error}"

--- a/crates/dbflux_i18n/locales/es.yml
+++ b/crates/dbflux_i18n/locales/es.yml
@@ -168,6 +168,7 @@ connection_manager:
     use_driver_default: Usar valor predeterminado del driver
     no_hook: Sin hook
     select_trusted_client: Seleccionar cliente de confianza
+    filter_trusted_clients: "Filtrar por nombre o id…"
     no_role: Sin rol
     no_policy: Sin política
     extra_hook_ids: IDs de hooks extra (separados por coma)
@@ -222,20 +223,27 @@ connection_manager:
   driver_settings_title: Ajustes del driver
   driver_no_custom_settings: Este driver no tiene ajustes personalizados.
   mcp_disabled: MCP deshabilitado para esta conexión
-  mcp_enabled_select_actor: MCP habilitado — selecciona un cliente de confianza para vincular
-  mcp_preview_summary: "Actor '%{actor}' | rol: %{role} | política: %{policy}"
-  mcp_preview_none: ninguno
+  mcp_not_compiled: Esta compilación no incluye soporte para MCP.
   mcp_governance_title: Gobernanza de MCP
   enable_mcp: Habilitar MCP para esta conexión
-  trusted_client_actor: Cliente de confianza (actor)
-  mcp_actor_hint: Identidad del agente de IA — configúrala en Ajustes → MCP
+  mcp_badge_granted: concedido
+  mcp_badge_no_access: sin acceso
+  mcp_empty_clients: No hay clientes de confianza configurados. Agrega uno en Ajustes → MCP.
+  mcp_allow_client: Permitir este cliente en esta conexión
+  mcp_client_denied: Este cliente no tiene acceso en esta conexión.
+  mcp_select_client: Selecciona un cliente de confianza para configurar su acceso.
   role_label: Rol
   mcp_role_hint: Configura roles en Ajustes → MCP → Roles
   additional_roles_optional: Roles adicionales (opcional)
   policy_label: Política
   mcp_policy_hint: Configura políticas en Ajustes → MCP → Políticas
   additional_policies_optional: Políticas adicionales (opcional)
-  scope_policy_preview: Vista previa de alcance y políticas
+  mcp_effective_tools: "Herramientas: %{tools}"
+  mcp_effective_classes: "Clases: %{classes}"
+  mcp_effective_none: ninguna
+  mcp_orphan_bindings:
+    one: 1 asignación hace referencia a un cliente que ya no existe.
+    many: "%{count} asignaciones hacen referencia a clientes que ya no existen."
   mcp_governance_error:
     save_policy: "No se pudo guardar la asignación de política MCP de la conexión: %{error}"
     clear_policy: "No se pudo borrar la asignación de política MCP de la conexión: %{error}"

--- a/crates/dbflux_i18n/locales/zh_Hans.yml
+++ b/crates/dbflux_i18n/locales/zh_Hans.yml
@@ -222,20 +222,14 @@ connection_manager:
   driver_settings_title: 驱动设置
   driver_no_custom_settings: 此驱动没有自定义设置。
   mcp_disabled: 此连接已禁用 MCP
-  mcp_enabled_select_actor: MCP 已启用 — 请选择要绑定的受信客户端
-  mcp_preview_summary: "执行者 %{actor} | 角色：%{role} | 策略：%{policy}"
-  mcp_preview_none: 无
   mcp_governance_title: MCP 治理
   enable_mcp: 为此连接启用 MCP
-  trusted_client_actor: 受信客户端（执行者）
-  mcp_actor_hint: AI 智能体身份 — 在 设置 → MCP 中配置
   role_label: 角色
   mcp_role_hint: 在 设置 → MCP → 角色 中配置角色
   additional_roles_optional: 附加角色（可选）
   policy_label: 策略
   mcp_policy_hint: 在 设置 → MCP → 策略 中配置策略
   additional_policies_optional: 附加策略（可选）
-  scope_policy_preview: 作用域 / 策略分配预览
   mcp_governance_error:
     save_policy: "保存 MCP 连接策略分配失败：%{error}"
     clear_policy: "清除 MCP 连接策略分配失败：%{error}"

--- a/crates/dbflux_i18n/locales/zh_Hans.yml
+++ b/crates/dbflux_i18n/locales/zh_Hans.yml
@@ -174,6 +174,7 @@ connection_manager:
     use_connection_auth_profile: 使用连接认证配置文件
     select_additional_roles: 选择附加角色…
     select_additional_policies: 选择附加策略…
+    filter_trusted_clients: "按名称或 ID 筛选…"
   access_method:
     direct: 直连
     ssh_tunnel: SSH 隧道
@@ -222,14 +223,27 @@ connection_manager:
   driver_settings_title: 驱动设置
   driver_no_custom_settings: 此驱动没有自定义设置。
   mcp_disabled: 此连接已禁用 MCP
+  mcp_not_compiled: 此版本在编译时未包含 MCP 支持。
   mcp_governance_title: MCP 治理
   enable_mcp: 为此连接启用 MCP
+  mcp_badge_granted: 已授权
+  mcp_badge_no_access: 无访问权限
+  mcp_empty_clients: 尚未配置受信客户端。请在 设置 → MCP 中添加。
+  mcp_allow_client: 允许此客户端访问此连接
+  mcp_client_denied: 此客户端在此连接上被拒绝访问。
+  mcp_select_client: 选择一个受信客户端以配置其访问权限。
   role_label: 角色
   mcp_role_hint: 在 设置 → MCP → 角色 中配置角色
   additional_roles_optional: 附加角色（可选）
   policy_label: 策略
   mcp_policy_hint: 在 设置 → MCP → 策略 中配置策略
   additional_policies_optional: 附加策略（可选）
+  mcp_effective_tools: "工具：%{tools}"
+  mcp_effective_classes: "分类：%{classes}"
+  mcp_effective_none: 无
+  mcp_orphan_bindings:
+    one: 有 1 个绑定引用了已不存在的客户端。
+    many: "有 %{count} 个绑定引用了已不存在的客户端。"
   mcp_governance_error:
     save_policy: "保存 MCP 连接策略分配失败：%{error}"
     clear_policy: "清除 MCP 连接策略分配失败：%{error}"

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -3,8 +3,8 @@ use dbflux_components::components::form_renderer;
 use dbflux_core::secrecy::SecretString;
 use dbflux_core::values::ValueRef;
 use dbflux_core::{
-    AccessKind, CancelToken, ConnectionMcpGovernance, ConnectionMcpPolicyBinding,
-    ConnectionOverrides, ConnectionProfile, DbConfig, FormFieldKind, HookPhase, SshTunnelConfig,
+    AccessKind, CancelToken, ConnectionMcpGovernance, ConnectionOverrides, ConnectionProfile,
+    DbConfig, FormFieldKind, HookPhase, SshTunnelConfig,
 };
 use dbflux_ui_base::hook_phase_runner::{DetachedHookScope, HookPhaseState, run_hook_phase};
 use dbflux_ui_base::toast::{Toast, now_hms};
@@ -14,6 +14,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
+use super::mcp_bindings;
 use super::{ConnectionManagerWindow, DismissEvent, TestStatus};
 
 impl ConnectionManagerWindow {
@@ -22,65 +23,16 @@ impl ConnectionManagerWindow {
             return None;
         }
 
-        let actor_id = self
-            .mcp_tab
-            .conn_mcp_actor_dropdown
-            .read(cx)
-            .selected_value()
-            .map(|v| v.to_string())
-            .unwrap_or_default();
+        let mut policy_bindings = self.mcp_tab.bindings.clone();
 
-        let mut role_ids = Vec::new();
-        if let Some(primary_role) = self
-            .mcp_tab
-            .conn_mcp_role_dropdown
-            .read(cx)
-            .selected_value()
-        {
-            let primary_str = primary_role.to_string();
-            if !primary_str.is_empty() {
-                role_ids.push(primary_str);
-            }
+        // Defensive: the currently selected client's widgets should already be in
+        // sync via `handle_mcp_binding_field_change`, but flush once more before
+        // returning `policy_bindings` so a save can never race a still-pending
+        // widget event.
+        if let Some(actor_id) = self.mcp_tab.selected_actor_id.clone() {
+            let (role_ids, policy_ids) = self.read_selected_mcp_role_and_policy_ids(cx);
+            mcp_bindings::apply_selection(&mut policy_bindings, &actor_id, role_ids, policy_ids);
         }
-        role_ids.extend(
-            self.mcp_tab
-                .conn_mcp_role_multi_select
-                .read(cx)
-                .selected_values()
-                .into_iter()
-                .map(|s| s.to_string()),
-        );
-
-        let mut policy_ids = Vec::new();
-        if let Some(primary_policy) = self
-            .mcp_tab
-            .conn_mcp_policy_dropdown
-            .read(cx)
-            .selected_value()
-        {
-            let primary_str = primary_policy.to_string();
-            if !primary_str.is_empty() {
-                policy_ids.push(primary_str);
-            }
-        }
-        policy_ids.extend(
-            self.mcp_tab
-                .conn_mcp_policy_multi_select
-                .read(cx)
-                .selected_values()
-                .into_iter()
-                .map(|s| s.to_string()),
-        );
-
-        let policy_bindings = if actor_id.is_empty() {
-            Vec::new()
-        } else {
-            vec![ConnectionMcpPolicyBinding {
-                actor_id,
-                role_ids,
-                policy_ids,
-            }]
-        };
 
         Some(ConnectionMcpGovernance {
             enabled: true,

--- a/crates/dbflux_ui_windows/src/connection_manager/mcp_bindings.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mcp_bindings.rs
@@ -1,0 +1,429 @@
+//! Pure, entity-free helpers backing the Connection Manager MCP tab's
+//! master-detail client list. Kept free of GPUI types so the binding-update
+//! and filtering rules can be unit tested without a window/context.
+
+use dbflux_core::ConnectionMcpPolicyBinding;
+
+/// Ensures a `ConnectionMcpPolicyBinding` for `actor_id` exists in `bindings`
+/// when `present` is true, and removes it otherwise. Idempotent either way.
+///
+/// Only reachable through the MCP tab's "allow this client" checkbox, which
+/// only exists when the `mcp` feature is enabled.
+#[cfg(feature = "mcp")]
+pub fn set_binding_presence(
+    bindings: &mut Vec<ConnectionMcpPolicyBinding>,
+    actor_id: &str,
+    present: bool,
+) {
+    let exists = bindings.iter().any(|binding| binding.actor_id == actor_id);
+
+    if present && !exists {
+        bindings.push(ConnectionMcpPolicyBinding {
+            actor_id: actor_id.to_string(),
+            role_ids: Vec::new(),
+            policy_ids: Vec::new(),
+        });
+    } else if !present && exists {
+        bindings.retain(|binding| binding.actor_id != actor_id);
+    }
+}
+
+/// Writes deduped role/policy ids into the binding for `actor_id`. No-op
+/// when that actor has no binding in `bindings`.
+pub fn apply_selection(
+    bindings: &mut [ConnectionMcpPolicyBinding],
+    actor_id: &str,
+    role_ids: Vec<String>,
+    policy_ids: Vec<String>,
+) {
+    if let Some(binding) = bindings
+        .iter_mut()
+        .find(|binding| binding.actor_id == actor_id)
+    {
+        binding.role_ids = dedup_preserve_order(role_ids);
+        binding.policy_ids = dedup_preserve_order(policy_ids);
+    }
+}
+
+/// Merges a primary dropdown selection with a multi-select's extra values
+/// into one deduped list, primary first. An empty primary is skipped.
+pub fn merge_primary_and_extras(primary: Option<String>, extras: Vec<String>) -> Vec<String> {
+    let mut merged = Vec::new();
+
+    if let Some(primary) = primary
+        && !primary.is_empty()
+    {
+        merged.push(primary);
+    }
+
+    merged.extend(extras);
+    dedup_preserve_order(merged)
+}
+
+fn dedup_preserve_order(values: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    values
+        .into_iter()
+        .filter(|value| seen.insert(value.clone()))
+        .collect()
+}
+
+/// Counts bindings whose `actor_id` is not present in `known_actor_ids`,
+/// i.e. bindings that reference a trusted client that no longer exists.
+///
+/// Only reachable from the MCP tab's trusted-client list, which only exists
+/// when the `mcp` feature is enabled.
+#[cfg(feature = "mcp")]
+pub fn orphan_binding_count(
+    bindings: &[ConnectionMcpPolicyBinding],
+    known_actor_ids: &[String],
+) -> usize {
+    bindings
+        .iter()
+        .filter(|binding| !known_actor_ids.contains(&binding.actor_id))
+        .count()
+}
+
+#[cfg(feature = "mcp")]
+mod mcp_feature {
+    use super::ConnectionMcpPolicyBinding;
+    use dbflux_mcp::{PolicyRoleDto, ToolPolicyDto, TrustedClientDto};
+
+    /// The union of tools and policy classes a binding effectively grants,
+    /// mirroring the union `PolicyEngine::evaluate` computes from direct
+    /// policies plus each assigned role's policies.
+    #[derive(Debug, Clone, PartialEq, Eq, Default)]
+    pub struct EffectivePermissions {
+        pub tools: Vec<String>,
+        pub classes: Vec<String>,
+    }
+
+    /// Filters `clients` by a case-insensitive substring match on name or id.
+    /// An empty query returns every client.
+    pub fn filter_clients<'a>(
+        clients: &'a [TrustedClientDto],
+        query: &str,
+    ) -> Vec<&'a TrustedClientDto> {
+        let query = query.trim().to_lowercase();
+
+        if query.is_empty() {
+            return clients.iter().collect();
+        }
+
+        clients
+            .iter()
+            .filter(|client| {
+                client.name.to_lowercase().contains(&query)
+                    || client.id.to_lowercase().contains(&query)
+            })
+            .collect()
+    }
+
+    /// Computes the sorted, deduped union of tools and classes that
+    /// `binding` grants, resolving its direct policies plus the policies of
+    /// every assigned role. Unknown role/policy ids are skipped.
+    pub fn effective_permissions(
+        binding: &ConnectionMcpPolicyBinding,
+        roles: &[PolicyRoleDto],
+        policies: &[ToolPolicyDto],
+    ) -> EffectivePermissions {
+        let mut policy_ids: Vec<&str> = binding.policy_ids.iter().map(String::as_str).collect();
+
+        for role_id in &binding.role_ids {
+            if let Some(role) = roles.iter().find(|role| &role.id == role_id) {
+                policy_ids.extend(role.policy_ids.iter().map(String::as_str));
+            }
+        }
+
+        let mut tools = std::collections::BTreeSet::new();
+        let mut classes = std::collections::BTreeSet::new();
+
+        for policy_id in policy_ids {
+            let Some(policy) = policies.iter().find(|policy| policy.id == policy_id) else {
+                continue;
+            };
+
+            tools.extend(policy.allowed_tools.iter().cloned());
+            classes.extend(policy.allowed_classes.iter().cloned());
+        }
+
+        EffectivePermissions {
+            tools: tools.into_iter().collect(),
+            classes: classes.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg(feature = "mcp")]
+pub use mcp_feature::{effective_permissions, filter_clients};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binding(actor_id: &str) -> ConnectionMcpPolicyBinding {
+        ConnectionMcpPolicyBinding {
+            actor_id: actor_id.to_string(),
+            role_ids: Vec::new(),
+            policy_ids: Vec::new(),
+        }
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn set_binding_presence_adds_missing_binding() {
+        let mut bindings = Vec::new();
+
+        set_binding_presence(&mut bindings, "agent-1", true);
+
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].actor_id, "agent-1");
+        assert!(bindings[0].role_ids.is_empty());
+        assert!(bindings[0].policy_ids.is_empty());
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn set_binding_presence_is_idempotent_when_adding_twice() {
+        let mut bindings = Vec::new();
+
+        set_binding_presence(&mut bindings, "agent-1", true);
+        set_binding_presence(&mut bindings, "agent-1", true);
+
+        assert_eq!(bindings.len(), 1);
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn set_binding_presence_removes_existing_binding() {
+        let mut bindings = vec![binding("agent-1"), binding("agent-2")];
+
+        set_binding_presence(&mut bindings, "agent-1", false);
+
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].actor_id, "agent-2");
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn set_binding_presence_removal_is_idempotent() {
+        let mut bindings = vec![binding("agent-1")];
+
+        set_binding_presence(&mut bindings, "agent-1", false);
+        set_binding_presence(&mut bindings, "agent-1", false);
+
+        assert!(bindings.is_empty());
+    }
+
+    #[test]
+    fn apply_selection_writes_deduped_ids_into_matching_binding() {
+        let mut bindings = vec![binding("agent-1")];
+
+        apply_selection(
+            &mut bindings,
+            "agent-1",
+            vec!["reader".to_string(), "reader".to_string()],
+            vec!["strict".to_string()],
+        );
+
+        assert_eq!(bindings[0].role_ids, vec!["reader".to_string()]);
+        assert_eq!(bindings[0].policy_ids, vec!["strict".to_string()]);
+    }
+
+    #[test]
+    fn apply_selection_is_a_no_op_when_actor_has_no_binding() {
+        let mut bindings = vec![binding("agent-1")];
+
+        apply_selection(
+            &mut bindings,
+            "agent-2",
+            vec!["reader".to_string()],
+            vec!["strict".to_string()],
+        );
+
+        assert!(bindings[0].role_ids.is_empty());
+    }
+
+    #[test]
+    fn merge_primary_and_extras_puts_primary_first() {
+        let merged = merge_primary_and_extras(
+            Some("reader".to_string()),
+            vec!["writer".to_string(), "admin".to_string()],
+        );
+
+        assert_eq!(merged, vec!["reader", "writer", "admin"]);
+    }
+
+    #[test]
+    fn merge_primary_and_extras_skips_empty_primary() {
+        let merged = merge_primary_and_extras(Some(String::new()), vec!["writer".to_string()]);
+
+        assert_eq!(merged, vec!["writer"]);
+    }
+
+    #[test]
+    fn merge_primary_and_extras_skips_none_primary() {
+        let merged = merge_primary_and_extras(None, vec!["writer".to_string()]);
+
+        assert_eq!(merged, vec!["writer"]);
+    }
+
+    #[test]
+    fn merge_primary_and_extras_dedups_extras_against_primary() {
+        let merged = merge_primary_and_extras(
+            Some("reader".to_string()),
+            vec!["reader".to_string(), "writer".to_string()],
+        );
+
+        assert_eq!(merged, vec!["reader", "writer"]);
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn orphan_binding_count_counts_bindings_with_unknown_actor_ids() {
+        let bindings = vec![binding("agent-1"), binding("agent-2"), binding("agent-3")];
+        let known = vec!["agent-1".to_string(), "agent-3".to_string()];
+
+        assert_eq!(orphan_binding_count(&bindings, &known), 1);
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn orphan_binding_count_is_zero_when_every_binding_is_known() {
+        let bindings = vec![binding("agent-1")];
+        let known = vec!["agent-1".to_string()];
+
+        assert_eq!(orphan_binding_count(&bindings, &known), 0);
+    }
+
+    #[cfg(feature = "mcp")]
+    mod mcp_feature_tests {
+        use super::super::{effective_permissions, filter_clients};
+        use dbflux_mcp::{PolicyRoleDto, ToolPolicyDto, TrustedClientDto};
+
+        fn client(id: &str, name: &str) -> TrustedClientDto {
+            TrustedClientDto {
+                id: id.to_string(),
+                name: name.to_string(),
+                issuer: None,
+                active: true,
+            }
+        }
+
+        #[test]
+        fn filter_clients_matches_by_id() {
+            let clients = vec![
+                client("prod-agent", "Prod Agent"),
+                client("dev-agent", "Dev Agent"),
+            ];
+
+            let filtered = filter_clients(&clients, "prod-a");
+
+            assert_eq!(filtered.len(), 1);
+            assert_eq!(filtered[0].id, "prod-agent");
+        }
+
+        #[test]
+        fn filter_clients_matches_by_name_case_insensitively() {
+            let clients = vec![
+                client("prod-agent", "Prod Agent"),
+                client("dev-agent", "Dev Agent"),
+            ];
+
+            let filtered = filter_clients(&clients, "DEV");
+
+            assert_eq!(filtered.len(), 1);
+            assert_eq!(filtered[0].id, "dev-agent");
+        }
+
+        #[test]
+        fn filter_clients_returns_all_for_empty_query() {
+            let clients = vec![
+                client("prod-agent", "Prod Agent"),
+                client("dev-agent", "Dev Agent"),
+            ];
+
+            let filtered = filter_clients(&clients, "");
+
+            assert_eq!(filtered.len(), 2);
+        }
+
+        #[test]
+        fn effective_permissions_unions_direct_and_role_policies() {
+            let binding = super::super::ConnectionMcpPolicyBinding {
+                actor_id: "agent-1".to_string(),
+                role_ids: vec!["read-only".to_string()],
+                policy_ids: vec!["direct-policy".to_string()],
+            };
+            let roles = vec![PolicyRoleDto {
+                id: "read-only".to_string(),
+                policy_ids: vec!["read-policy".to_string()],
+            }];
+            let policies = vec![
+                ToolPolicyDto {
+                    id: "direct-policy".to_string(),
+                    allowed_tools: vec!["list_tables".to_string()],
+                    allowed_classes: vec!["Metadata".to_string()],
+                },
+                ToolPolicyDto {
+                    id: "read-policy".to_string(),
+                    allowed_tools: vec!["read_query".to_string()],
+                    allowed_classes: vec!["Read".to_string()],
+                },
+            ];
+
+            let effective = effective_permissions(&binding, &roles, &policies);
+
+            assert_eq!(
+                effective.tools,
+                vec!["list_tables".to_string(), "read_query".to_string()]
+            );
+            assert_eq!(
+                effective.classes,
+                vec!["Metadata".to_string(), "Read".to_string()]
+            );
+        }
+
+        #[test]
+        fn effective_permissions_skips_unknown_role_id() {
+            let binding = super::super::ConnectionMcpPolicyBinding {
+                actor_id: "agent-1".to_string(),
+                role_ids: vec!["missing-role".to_string()],
+                policy_ids: Vec::new(),
+            };
+
+            let effective = effective_permissions(&binding, &[], &[]);
+
+            assert!(effective.tools.is_empty());
+            assert!(effective.classes.is_empty());
+        }
+
+        #[test]
+        fn effective_permissions_dedups_tools_shared_across_policies() {
+            let binding = super::super::ConnectionMcpPolicyBinding {
+                actor_id: "agent-1".to_string(),
+                role_ids: vec!["role-a".to_string(), "role-b".to_string()],
+                policy_ids: Vec::new(),
+            };
+            let roles = vec![
+                PolicyRoleDto {
+                    id: "role-a".to_string(),
+                    policy_ids: vec!["shared-policy".to_string()],
+                },
+                PolicyRoleDto {
+                    id: "role-b".to_string(),
+                    policy_ids: vec!["shared-policy".to_string()],
+                },
+            ];
+            let policies = vec![ToolPolicyDto {
+                id: "shared-policy".to_string(),
+                allowed_tools: vec!["read_query".to_string()],
+                allowed_classes: vec!["Read".to_string()],
+            }];
+
+            let effective = effective_permissions(&binding, &roles, &policies);
+
+            assert_eq!(effective.tools, vec!["read_query".to_string()]);
+        }
+    }
+}

--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -3,6 +3,7 @@ pub mod export_modal;
 mod form;
 mod hooks_tab;
 pub mod import_panel;
+mod mcp_bindings;
 mod navigation;
 mod render;
 mod render_driver_select;
@@ -14,16 +15,16 @@ pub use import_panel::{ImportConnectionsPanel, ImportConnectionsPanelEvent};
 use crate::ssh_shared::SshAuthSelection;
 use dbflux_app::keymap::KeymapStack;
 use dbflux_components::components::form_renderer::{self, FormRendererState};
-use dbflux_components::components::multi_select::MultiSelect;
+use dbflux_components::components::multi_select::{MultiSelect, MultiSelectChanged};
 use dbflux_components::components::value_source_selector::ValueSourceSelector;
 use dbflux_components::controls::{Dropdown, DropdownSelectionChanged};
 use dbflux_components::controls::{InputEvent, InputState};
 use dbflux_core::access::AccessKind;
 use dbflux_core::secrecy::{ExposeSecret, SecretString};
 use dbflux_core::{
-    AuthProfile, AuthSessionState, ConnectionHookBindings, DbConfig, DbDriver, DbKind,
-    DriverFormDef, FormFieldDef, FormFieldKind, GlobalOverrides, SshAuthMethod, SshTunnelProfile,
-    ValueRef,
+    AuthProfile, AuthSessionState, ConnectionHookBindings, ConnectionMcpPolicyBinding, DbConfig,
+    DbDriver, DbKind, DriverFormDef, FormFieldDef, FormFieldKind, GlobalOverrides, SshAuthMethod,
+    SshTunnelProfile, ValueRef,
 };
 use dbflux_ui_base::platform;
 use dbflux_ui_base::sso_wizard::SsoWizard;
@@ -324,13 +325,26 @@ struct SettingsTabState {
 }
 
 /// MCP governance tab widgets.
+///
+/// `bindings` holds every `ConnectionMcpPolicyBinding` for the connection
+/// being edited, independent of which trusted client is currently selected
+/// in the master-detail list. Widget changes write into the binding for
+/// `selected_actor_id` immediately (see `handle_mcp_binding_field_change`),
+/// so switching the selected client never loses edits.
 struct McpTabState {
     conn_mcp_enabled: bool,
-    conn_mcp_actor_dropdown: Entity<Dropdown>,
     conn_mcp_role_dropdown: Entity<Dropdown>,
     conn_mcp_role_multi_select: Entity<MultiSelect>,
     conn_mcp_policy_dropdown: Entity<Dropdown>,
     conn_mcp_policy_multi_select: Entity<MultiSelect>,
+    #[cfg(feature = "mcp")]
+    conn_mcp_client_filter_input: Entity<InputState>,
+    #[cfg(feature = "mcp")]
+    conn_mcp_client_list_scroll_handle: ScrollHandle,
+    #[cfg(feature = "mcp")]
+    conn_mcp_detail_scroll_handle: ScrollHandle,
+    bindings: Vec<ConnectionMcpPolicyBinding>,
+    selected_actor_id: Option<String>,
 }
 
 /// Deferred actions written by background tasks or event handlers and drained on the next render.
@@ -581,9 +595,10 @@ impl ConnectionManagerWindow {
                 "connection_manager.placeholder.extra_hook_ids"
             ))
         });
-        let conn_mcp_actor_dropdown = cx.new(|_cx| {
-            Dropdown::new("conn-mcp-actor").placeholder(dbflux_i18n::t!(
-                "connection_manager.placeholder.select_trusted_client"
+        #[cfg(feature = "mcp")]
+        let conn_mcp_client_filter_input = cx.new(|cx| {
+            InputState::new(window, cx).placeholder(dbflux_i18n::t!(
+                "connection_manager.placeholder.filter_trusted_clients"
             ))
         });
         let conn_mcp_role_dropdown = cx.new(|_cx| {
@@ -637,6 +652,45 @@ impl ConnectionManagerWindow {
             &ssm_auth_profile_dropdown,
             |this, _dropdown, event: &DropdownSelectionChanged, cx| {
                 this.handle_ssm_auth_profile_dropdown_selection(event, cx);
+            },
+        );
+
+        let mcp_role_dropdown_sub = cx.subscribe(
+            &conn_mcp_role_dropdown,
+            |this, _dropdown, _event: &DropdownSelectionChanged, cx| {
+                this.handle_mcp_binding_field_change(cx);
+            },
+        );
+
+        let mcp_policy_dropdown_sub = cx.subscribe(
+            &conn_mcp_policy_dropdown,
+            |this, _dropdown, _event: &DropdownSelectionChanged, cx| {
+                this.handle_mcp_binding_field_change(cx);
+            },
+        );
+
+        let mcp_role_multi_select_sub = cx.subscribe(
+            &conn_mcp_role_multi_select,
+            |this, _multi_select, _event: &MultiSelectChanged, cx| {
+                this.handle_mcp_binding_field_change(cx);
+            },
+        );
+
+        let mcp_policy_multi_select_sub = cx.subscribe(
+            &conn_mcp_policy_multi_select,
+            |this, _multi_select, _event: &MultiSelectChanged, cx| {
+                this.handle_mcp_binding_field_change(cx);
+            },
+        );
+
+        #[cfg(feature = "mcp")]
+        let mcp_client_filter_sub = cx.subscribe_in(
+            &conn_mcp_client_filter_input,
+            window,
+            |_this, _, event: &InputEvent, _window, cx| {
+                if matches!(event, InputEvent::Change) {
+                    cx.notify();
+                }
             },
         );
 
@@ -722,7 +776,8 @@ impl ConnectionManagerWindow {
             },
         );
 
-        let subscriptions = vec![
+        #[cfg_attr(not(feature = "mcp"), allow(unused_mut))]
+        let mut subscriptions = vec![
             import_panel_sub,
             driver_filter_focus_sub,
             dropdown_subscription,
@@ -730,6 +785,10 @@ impl ConnectionManagerWindow {
             auth_profile_dropdown_sub,
             access_method_dropdown_sub,
             ssm_auth_profile_dropdown_sub,
+            mcp_role_dropdown_sub,
+            mcp_policy_dropdown_sub,
+            mcp_role_multi_select_sub,
+            mcp_policy_multi_select_sub,
             app_state_changed_sub,
             auth_profile_created_sub,
             subscribe_input(cx, window, &input_name),
@@ -744,6 +803,8 @@ impl ConnectionManagerWindow {
             subscribe_input(cx, window, &input_ssm_region),
             subscribe_input(cx, window, &input_ssm_remote_port),
         ];
+        #[cfg(feature = "mcp")]
+        subscriptions.push(mcp_client_filter_sub);
 
         let focus_handle = cx.focus_handle();
         window.focus(&focus_handle);
@@ -859,11 +920,18 @@ impl ConnectionManagerWindow {
             },
             mcp_tab: McpTabState {
                 conn_mcp_enabled: false,
-                conn_mcp_actor_dropdown,
                 conn_mcp_role_dropdown,
                 conn_mcp_role_multi_select,
                 conn_mcp_policy_dropdown,
                 conn_mcp_policy_multi_select,
+                #[cfg(feature = "mcp")]
+                conn_mcp_client_filter_input,
+                #[cfg(feature = "mcp")]
+                conn_mcp_client_list_scroll_handle: ScrollHandle::new(),
+                #[cfg(feature = "mcp")]
+                conn_mcp_detail_scroll_handle: ScrollHandle::new(),
+                bindings: Vec::new(),
+                selected_actor_id: None,
             },
             pending: PendingActions::default(),
         }
@@ -1010,15 +1078,29 @@ impl ConnectionManagerWindow {
 
         instance.mcp_tab.conn_mcp_enabled =
             profile.mcp_governance.as_ref().is_some_and(|g| g.enabled);
+        instance.mcp_tab.bindings = profile
+            .mcp_governance
+            .as_ref()
+            .map(|governance| governance.policy_bindings.clone())
+            .unwrap_or_default();
+        instance.mcp_tab.selected_actor_id = instance
+            .mcp_tab
+            .bindings
+            .first()
+            .map(|binding| binding.actor_id.clone());
 
         #[cfg(feature = "mcp")]
         {
-            let first_binding = profile
-                .mcp_governance
-                .as_ref()
-                .and_then(|governance| governance.policy_bindings.first().cloned());
+            let selected_binding = instance.mcp_tab.selected_actor_id.clone().and_then(|id| {
+                instance
+                    .mcp_tab
+                    .bindings
+                    .iter()
+                    .find(|binding| binding.actor_id == id)
+                    .cloned()
+            });
 
-            instance.load_mcp_dropdowns(first_binding.as_ref(), window, cx);
+            instance.load_mcp_dropdowns(selected_binding.as_ref(), window, cx);
         }
 
         instance.access.selected_proxy_id = profile.proxy_profile_id;
@@ -1178,6 +1260,8 @@ impl ConnectionManagerWindow {
         self.reset_value_source_selectors(window, cx);
 
         self.load_settings_tab(None, None, None, window, cx);
+        self.mcp_tab.bindings = Vec::new();
+        self.mcp_tab.selected_actor_id = None;
         #[cfg(feature = "mcp")]
         self.load_mcp_dropdowns(None, window, cx);
         self.populate_auth_profile_dropdown(cx);
@@ -1740,8 +1824,9 @@ impl ConnectionManagerWindow {
         }
     }
 
-    /// Populate the MCP actor/role/policy dropdowns from the global governance state and
-    /// optionally pre-select the actor/role/policy from an existing policy binding.
+    /// Populate the MCP role/policy dropdowns from the global governance state and
+    /// optionally pre-select the role/policy from an existing policy binding for the
+    /// currently selected trusted client.
     #[cfg(feature = "mcp")]
     fn load_mcp_dropdowns(
         &mut self,
@@ -1749,27 +1834,12 @@ impl ConnectionManagerWindow {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let clients = self
-            .app_state
-            .read(cx)
-            .list_mcp_trusted_clients()
-            .unwrap_or_default();
         let roles = self.app_state.read(cx).list_mcp_roles().unwrap_or_default();
         let policies = self
             .app_state
             .read(cx)
             .list_mcp_policies()
             .unwrap_or_default();
-
-        let actor_items: Vec<dbflux_components::controls::DropdownItem> = clients
-            .iter()
-            .map(|c| {
-                dbflux_components::controls::DropdownItem::with_value(
-                    format!("{} ({})", c.name, c.id),
-                    c.id.clone(),
-                )
-            })
-            .collect();
 
         let mut role_items = vec![dbflux_components::controls::DropdownItem::with_value(
             dbflux_i18n::t!("connection_manager.placeholder.no_role"),
@@ -1793,11 +1863,6 @@ impl ConnectionManagerWindow {
             dbflux_components::controls::DropdownItem::with_value(label, p.id.clone())
         }));
 
-        let actor_index = binding.and_then(|b| {
-            actor_items
-                .iter()
-                .position(|item| item.value.as_ref() == b.actor_id.as_str())
-        });
         let role_index = binding.and_then(|b| {
             b.role_ids.first().and_then(|role_id| {
                 role_items
@@ -1813,10 +1878,6 @@ impl ConnectionManagerWindow {
             })
         });
 
-        self.mcp_tab.conn_mcp_actor_dropdown.update(cx, |d, cx| {
-            d.set_items(actor_items, cx);
-            d.set_selected_index(actor_index, cx);
-        });
         self.mcp_tab.conn_mcp_role_dropdown.update(cx, |d, cx| {
             d.set_items(role_items, cx);
             d.set_selected_index(role_index.or(Some(0)), cx);
@@ -1859,23 +1920,126 @@ impl ConnectionManagerWindow {
                 ms.set_items(all_policy_items, cx);
             });
 
-        // Set selected values from binding
-        if let Some(binding) = binding {
-            let extra_roles: Vec<String> = binding.role_ids.iter().skip(1).cloned().collect();
-            let extra_policies: Vec<String> = binding.policy_ids.iter().skip(1).cloned().collect();
+        // Set selected values from the binding, clearing them when there is none
+        // (e.g. the selected client has no binding yet).
+        let extra_roles: Vec<String> = binding
+            .map(|b| b.role_ids.iter().skip(1).cloned().collect())
+            .unwrap_or_default();
+        let extra_policies: Vec<String> = binding
+            .map(|b| b.policy_ids.iter().skip(1).cloned().collect())
+            .unwrap_or_default();
 
-            self.mcp_tab
-                .conn_mcp_role_multi_select
-                .update(cx, |ms, cx| {
-                    ms.set_selected_values(&extra_roles, cx);
-                });
+        self.mcp_tab
+            .conn_mcp_role_multi_select
+            .update(cx, |ms, cx| {
+                ms.set_selected_values(&extra_roles, cx);
+            });
 
-            self.mcp_tab
-                .conn_mcp_policy_multi_select
-                .update(cx, |ms, cx| {
-                    ms.set_selected_values(&extra_policies, cx);
-                });
+        self.mcp_tab
+            .conn_mcp_policy_multi_select
+            .update(cx, |ms, cx| {
+                ms.set_selected_values(&extra_policies, cx);
+            });
+    }
+
+    /// Reads the role/policy dropdown and multi-select widgets and merges each
+    /// pair (primary dropdown + multi-select extras) into a deduped id list,
+    /// primary first.
+    pub(super) fn read_selected_mcp_role_and_policy_ids(
+        &self,
+        cx: &Context<Self>,
+    ) -> (Vec<String>, Vec<String>) {
+        let primary_role = self
+            .mcp_tab
+            .conn_mcp_role_dropdown
+            .read(cx)
+            .selected_value()
+            .map(|v| v.to_string());
+        let extra_roles: Vec<String> = self
+            .mcp_tab
+            .conn_mcp_role_multi_select
+            .read(cx)
+            .selected_values()
+            .into_iter()
+            .map(|v| v.to_string())
+            .collect();
+        let role_ids = mcp_bindings::merge_primary_and_extras(primary_role, extra_roles);
+
+        let primary_policy = self
+            .mcp_tab
+            .conn_mcp_policy_dropdown
+            .read(cx)
+            .selected_value()
+            .map(|v| v.to_string());
+        let extra_policies: Vec<String> = self
+            .mcp_tab
+            .conn_mcp_policy_multi_select
+            .read(cx)
+            .selected_values()
+            .into_iter()
+            .map(|v| v.to_string())
+            .collect();
+        let policy_ids = mcp_bindings::merge_primary_and_extras(primary_policy, extra_policies);
+
+        (role_ids, policy_ids)
+    }
+
+    /// Rewrites the binding for the currently selected trusted client from the
+    /// role/policy dropdown and multi-select widgets. No-op when no client is
+    /// selected. Called on every dropdown/multi-select change so switching the
+    /// selected client (which repopulates these widgets) never loses edits.
+    fn handle_mcp_binding_field_change(&mut self, cx: &mut Context<Self>) {
+        let Some(actor_id) = self.mcp_tab.selected_actor_id.clone() else {
+            return;
+        };
+
+        let (role_ids, policy_ids) = self.read_selected_mcp_role_and_policy_ids(cx);
+
+        mcp_bindings::apply_selection(&mut self.mcp_tab.bindings, &actor_id, role_ids, policy_ids);
+        cx.notify();
+    }
+
+    /// Selects a trusted client in the MCP tab's master-detail list and
+    /// repopulates the role/policy widgets from its existing binding, if any.
+    #[cfg(feature = "mcp")]
+    fn select_mcp_client(&mut self, actor_id: String, window: &mut Window, cx: &mut Context<Self>) {
+        self.mcp_tab.selected_actor_id = Some(actor_id.clone());
+
+        let binding = self
+            .mcp_tab
+            .bindings
+            .iter()
+            .find(|binding| binding.actor_id == actor_id)
+            .cloned();
+
+        self.load_mcp_dropdowns(binding.as_ref(), window, cx);
+        cx.notify();
+    }
+
+    /// Adds or removes the binding for `actor_id`, then repopulates the
+    /// role/policy widgets when that client is the one currently selected.
+    #[cfg(feature = "mcp")]
+    fn set_mcp_client_allowed(
+        &mut self,
+        actor_id: String,
+        allowed: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        mcp_bindings::set_binding_presence(&mut self.mcp_tab.bindings, &actor_id, allowed);
+
+        if self.mcp_tab.selected_actor_id.as_deref() == Some(actor_id.as_str()) {
+            let binding = self
+                .mcp_tab
+                .bindings
+                .iter()
+                .find(|binding| binding.actor_id == actor_id)
+                .cloned();
+
+            self.load_mcp_dropdowns(binding.as_ref(), window, cx);
         }
+
+        cx.notify();
     }
 
     /// Initialize the Settings tab controls from the selected driver's defaults
@@ -4039,6 +4203,7 @@ mod tests {
         "connection_manager.placeholder.use_driver_default",
         "connection_manager.placeholder.no_hook",
         "connection_manager.placeholder.select_trusted_client",
+        "connection_manager.placeholder.filter_trusted_clients",
         "connection_manager.placeholder.no_role",
         "connection_manager.placeholder.no_policy",
         "connection_manager.access_method.direct",

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -1,15 +1,21 @@
 use dbflux_components::components::form_renderer;
 use dbflux_components::controls::Input;
 use dbflux_components::icons::AppIcon;
+#[cfg(feature = "mcp")]
+use dbflux_components::primitives::Label;
 use dbflux_components::primitives::{
-    FilePicker, Icon as AppIconElement, Label, SegmentedControl, SegmentedItem, Text,
+    FilePicker, Icon as AppIconElement, SegmentedControl, SegmentedItem, Text,
 };
+#[cfg(feature = "mcp")]
+use dbflux_components::tokens::Spacing;
 use dbflux_components::tokens::{Radii, Widths};
 use dbflux_core::FormFieldKind;
 use gpui::prelude::*;
 use gpui::*;
 use gpui_component::ActiveTheme;
 use gpui_component::checkbox::Checkbox;
+#[cfg(feature = "mcp")]
+use gpui_component::scroll::ScrollableElement;
 
 use dbflux_components::typography::SubSectionLabel;
 
@@ -775,117 +781,300 @@ impl ConnectionManagerWindow {
         sections
     }
 
+    fn render_mcp_enabled_checkbox(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .items_center()
+            .gap_2()
+            .child(
+                Checkbox::new("conn-mcp-enabled")
+                    .checked(self.mcp_tab.conn_mcp_enabled)
+                    .on_click(cx.listener(|this, checked: &bool, _, cx| {
+                        this.mcp_tab.conn_mcp_enabled = *checked;
+                        cx.notify();
+                    })),
+            )
+            .child(
+                div()
+                    .text_sm()
+                    .child(dbflux_i18n::t!("connection_manager.enable_mcp")),
+            )
+    }
+
+    #[cfg(feature = "mcp")]
     pub(super) fn render_mcp_tab(&self, cx: &mut Context<Self>) -> Vec<AnyElement> {
         let theme = cx.theme().clone();
         let enabled = self.mcp_tab.conn_mcp_enabled;
         let opacity = if enabled { 1.0 } else { 0.5 };
 
-        let actor_label = self
-            .mcp_tab
-            .conn_mcp_actor_dropdown
+        let clients = self
+            .app_state
             .read(cx)
-            .selected_label()
-            .map(|l| l.to_string())
+            .list_mcp_trusted_clients()
             .unwrap_or_default();
-        let role_label = self
-            .mcp_tab
-            .conn_mcp_role_dropdown
+        let roles = self.app_state.read(cx).list_mcp_roles().unwrap_or_default();
+        let policies = self
+            .app_state
             .read(cx)
-            .selected_value()
-            .filter(|v| !v.is_empty())
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| dbflux_i18n::t!("connection_manager.mcp_preview_none"));
-        let policy_label = self
-            .mcp_tab
-            .conn_mcp_policy_dropdown
-            .read(cx)
-            .selected_value()
-            .filter(|v| !v.is_empty())
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| dbflux_i18n::t!("connection_manager.mcp_preview_none"));
+            .list_mcp_policies()
+            .unwrap_or_default();
 
-        let preview_text = if !enabled {
-            dbflux_i18n::t!("connection_manager.mcp_disabled")
-        } else if actor_label.is_empty() {
-            dbflux_i18n::t!("connection_manager.mcp_enabled_select_actor")
-        } else {
-            crate::labels::mcp_preview_summary(&actor_label, &role_label, &policy_label)
+        let filter_query = self
+            .mcp_tab
+            .conn_mcp_client_filter_input
+            .read(cx)
+            .value()
+            .to_string();
+        let filtered_clients = super::mcp_bindings::filter_clients(&clients, &filter_query);
+
+        let bindings = self.mcp_tab.bindings.clone();
+        let selected_actor_id = self.mcp_tab.selected_actor_id.clone();
+
+        let known_actor_ids: Vec<String> = clients.iter().map(|c| c.id.clone()).collect();
+        let orphan_count = super::mcp_bindings::orphan_binding_count(&bindings, &known_actor_ids);
+
+        let ids: Vec<String> = filtered_clients.iter().map(|c| c.id.clone()).collect();
+        let items: Vec<dbflux_components::composites::MasterDetailItem> = filtered_clients
+            .iter()
+            .map(|client| {
+                let has_binding = bindings.iter().any(|b| b.actor_id == client.id);
+                let is_selected = selected_actor_id.as_deref() == Some(client.id.as_str());
+
+                dbflux_components::composites::MasterDetailItem {
+                    id: SharedString::from(client.id.clone()),
+                    label: SharedString::from(client.name.clone()),
+                    detail: Some(SharedString::from(client.id.clone())),
+                    badge: Some(if has_binding {
+                        (
+                            SharedString::from(dbflux_i18n::t!(
+                                "connection_manager.mcp_badge_granted"
+                            )),
+                            dbflux_components::composites::BadgeTone::Success,
+                        )
+                    } else {
+                        (
+                            SharedString::from(dbflux_i18n::t!(
+                                "connection_manager.mcp_badge_no_access"
+                            )),
+                            dbflux_components::composites::BadgeTone::Neutral,
+                        )
+                    }),
+                    selected: is_selected,
+                    focused: false,
+                }
+            })
+            .collect();
+
+        let list_config = dbflux_components::composites::MasterDetailListConfig {
+            id: SharedString::from("connection-mcp-clients-list"),
+            width: Widths::CONNECTION_MCP_LIST_PANEL,
+            new_action: None,
+            secondary_action: None,
+            empty_message: Some(SharedString::from(dbflux_i18n::t!(
+                "connection_manager.mcp_empty_clients"
+            ))),
         };
 
-        let content = div()
+        let entity = cx.entity();
+        let list = dbflux_components::composites::render_master_detail_list(
+            &list_config,
+            &items,
+            &self.mcp_tab.conn_mcp_client_list_scroll_handle,
+            move |index: usize, window: &mut Window, cx: &mut App| {
+                let Some(id) = ids.get(index).cloned() else {
+                    return;
+                };
+                entity.update(cx, |this, cx| this.select_mcp_client(id, window, cx));
+            },
+            |_kind, _window, _cx| {},
+            cx,
+        );
+
+        let list_column = div()
+            .flex()
+            .flex_col()
+            .h_full()
+            .opacity(opacity)
+            .child(
+                div()
+                    .p(Spacing::SM)
+                    .child(Input::new(&self.mcp_tab.conn_mcp_client_filter_input)),
+            )
+            .child(div().flex_1().min_h_0().child(list));
+
+        let detail = self.render_mcp_client_detail(
+            selected_actor_id.as_deref(),
+            &bindings,
+            &roles,
+            &policies,
+            opacity,
+            cx,
+        );
+
+        let split = div()
+            .flex()
+            .h(px(340.0))
+            .overflow_hidden()
+            .child(list_column)
+            .child(detail);
+
+        let mut content = div()
             .flex()
             .flex_col()
             .gap_3()
+            .child(self.render_mcp_enabled_checkbox(cx))
+            .child(split);
+
+        if orphan_count > 0 {
+            content = content.child(Text::caption(crate::labels::mcp_orphan_bindings_caption(
+                orphan_count,
+            )));
+        }
+
+        vec![
+            self.render_section(
+                &dbflux_i18n::t!("connection_manager.mcp_governance_title"),
+                content,
+                &theme,
+            )
+            .into_any_element(),
+        ]
+    }
+
+    #[cfg(feature = "mcp")]
+    fn render_mcp_client_detail(
+        &self,
+        selected_actor_id: Option<&str>,
+        bindings: &[dbflux_core::ConnectionMcpPolicyBinding],
+        roles: &[dbflux_mcp::PolicyRoleDto],
+        policies: &[dbflux_mcp::ToolPolicyDto],
+        opacity: f32,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let Some(actor_id) = selected_actor_id else {
+            return div()
+                .flex_1()
+                .h_full()
+                .p(Spacing::SM)
+                .opacity(opacity)
+                .child(Text::caption(dbflux_i18n::t!(
+                    "connection_manager.mcp_select_client"
+                )))
+                .into_any_element();
+        };
+
+        let binding = bindings.iter().find(|b| b.actor_id == actor_id).cloned();
+        let has_binding = binding.is_some();
+        let actor_id_for_checkbox = actor_id.to_string();
+
+        let mut column = div()
+            .id("connection-mcp-client-detail")
+            .flex_1()
+            .h_full()
+            .track_scroll(&self.mcp_tab.conn_mcp_detail_scroll_handle)
+            .overflow_y_scrollbar()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .p(Spacing::SM)
+            .opacity(opacity)
             .child(
                 div()
                     .flex()
                     .items_center()
                     .gap_2()
-                    .child(Checkbox::new("conn-mcp-enabled").checked(enabled).on_click(
-                        cx.listener(|this, checked: &bool, _, cx| {
-                            this.mcp_tab.conn_mcp_enabled = *checked;
-                            cx.notify();
-                        }),
-                    ))
+                    .child(
+                        Checkbox::new("conn-mcp-client-allowed")
+                            .checked(has_binding)
+                            .on_click(cx.listener(move |this, checked: &bool, window, cx| {
+                                this.set_mcp_client_allowed(
+                                    actor_id_for_checkbox.clone(),
+                                    *checked,
+                                    window,
+                                    cx,
+                                );
+                            })),
+                    )
                     .child(
                         div()
                             .text_sm()
-                            .child(dbflux_i18n::t!("connection_manager.enable_mcp")),
+                            .child(dbflux_i18n::t!("connection_manager.mcp_allow_client")),
                     ),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap_1()
-                    .opacity(opacity)
-                    .child(Label::new(dbflux_i18n::t!(
-                        "connection_manager.trusted_client_actor"
-                    )))
-                    .child(Text::caption(dbflux_i18n::t!(
-                        "connection_manager.mcp_actor_hint"
-                    )))
-                    .child(self.mcp_tab.conn_mcp_actor_dropdown.clone()),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap_1()
-                    .opacity(opacity)
-                    .child(Label::new(dbflux_i18n::t!("connection_manager.role_label")))
-                    .child(Text::caption(dbflux_i18n::t!(
-                        "connection_manager.mcp_role_hint"
-                    )))
-                    .child(self.mcp_tab.conn_mcp_role_dropdown.clone())
-                    .child(Text::caption(dbflux_i18n::t!(
-                        "connection_manager.additional_roles_optional"
-                    )))
-                    .child(self.mcp_tab.conn_mcp_role_multi_select.clone()),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_col()
-                    .gap_1()
-                    .opacity(opacity)
-                    .child(Text::label(dbflux_i18n::t!(
-                        "connection_manager.policy_label"
-                    )))
-                    .child(Text::caption(dbflux_i18n::t!(
-                        "connection_manager.mcp_policy_hint"
-                    )))
-                    .child(self.mcp_tab.conn_mcp_policy_dropdown.clone())
-                    .child(Text::caption(dbflux_i18n::t!(
-                        "connection_manager.additional_policies_optional"
-                    )))
-                    .child(self.mcp_tab.conn_mcp_policy_multi_select.clone()),
-            )
-            .child(
-                Text::caption(dbflux_i18n::t!("connection_manager.scope_policy_preview"))
-                    .into_any_element(),
-            )
-            .child(Text::body(preview_text));
+            );
+
+        column = if let Some(binding) = &binding {
+            let effective = super::mcp_bindings::effective_permissions(binding, roles, policies);
+            let tools_text = if effective.tools.is_empty() {
+                dbflux_i18n::t!("connection_manager.mcp_effective_none")
+            } else {
+                effective.tools.join(", ")
+            };
+            let classes_text = if effective.classes.is_empty() {
+                dbflux_i18n::t!("connection_manager.mcp_effective_none")
+            } else {
+                effective.classes.join(", ")
+            };
+
+            column
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap_1()
+                        .child(Label::new(dbflux_i18n::t!("connection_manager.role_label")))
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "connection_manager.mcp_role_hint"
+                        )))
+                        .child(self.mcp_tab.conn_mcp_role_dropdown.clone())
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "connection_manager.additional_roles_optional"
+                        )))
+                        .child(self.mcp_tab.conn_mcp_role_multi_select.clone()),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap_1()
+                        .child(Text::label(dbflux_i18n::t!(
+                            "connection_manager.policy_label"
+                        )))
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "connection_manager.mcp_policy_hint"
+                        )))
+                        .child(self.mcp_tab.conn_mcp_policy_dropdown.clone())
+                        .child(Text::caption(dbflux_i18n::t!(
+                            "connection_manager.additional_policies_optional"
+                        )))
+                        .child(self.mcp_tab.conn_mcp_policy_multi_select.clone()),
+                )
+                .child(Text::caption(crate::labels::mcp_effective_tools_line(
+                    &tools_text,
+                )))
+                .child(Text::caption(crate::labels::mcp_effective_classes_line(
+                    &classes_text,
+                )))
+        } else {
+            column.child(Text::caption(dbflux_i18n::t!(
+                "connection_manager.mcp_client_denied"
+            )))
+        };
+
+        column.into_any_element()
+    }
+
+    #[cfg(not(feature = "mcp"))]
+    pub(super) fn render_mcp_tab(&self, cx: &mut Context<Self>) -> Vec<AnyElement> {
+        let theme = cx.theme().clone();
+
+        let content = div()
+            .flex()
+            .flex_col()
+            .gap_3()
+            .child(self.render_mcp_enabled_checkbox(cx))
+            .child(Text::caption(dbflux_i18n::t!(
+                "connection_manager.mcp_not_compiled"
+            )));
 
         vec![
             self.render_section(
@@ -1007,18 +1196,26 @@ mod driver_settings_and_mcp_governance_i18n_tests {
         "connection_manager.driver_no_custom_settings",
         "connection_manager.mcp_disabled",
         "connection_manager.enable_mcp",
-        "connection_manager.trusted_client_actor",
         "connection_manager.role_label",
         "connection_manager.additional_roles_optional",
         "connection_manager.policy_label",
         "connection_manager.additional_policies_optional",
-        "connection_manager.scope_policy_preview",
         "connection_manager.mcp_governance_title",
-        "connection_manager.mcp_enabled_select_actor",
-        "connection_manager.mcp_actor_hint",
         "connection_manager.mcp_role_hint",
         "connection_manager.mcp_policy_hint",
-        "connection_manager.mcp_preview_none",
+        "connection_manager.mcp_not_compiled",
+        "connection_manager.placeholder.filter_trusted_clients",
+        "connection_manager.mcp_badge_granted",
+        "connection_manager.mcp_badge_no_access",
+        "connection_manager.mcp_empty_clients",
+        "connection_manager.mcp_allow_client",
+        "connection_manager.mcp_client_denied",
+        "connection_manager.mcp_select_client",
+        "connection_manager.mcp_effective_tools",
+        "connection_manager.mcp_effective_classes",
+        "connection_manager.mcp_effective_none",
+        "connection_manager.mcp_orphan_bindings.one",
+        "connection_manager.mcp_orphan_bindings.many",
     ];
 
     #[test]

--- a/crates/dbflux_ui_windows/src/labels.rs
+++ b/crates/dbflux_ui_windows/src/labels.rs
@@ -145,13 +145,31 @@ pub(crate) fn auth_session_status_valid_expires(expires_at: &str) -> String {
     )
 }
 
-/// Formats the MCP tab's "Actor 'x' | role: y | policy: z" scope/policy preview line.
-pub(crate) fn mcp_preview_summary(actor: &str, role: &str, policy: &str) -> String {
+/// Formats the "N bindings reference clients that no longer exist" caption
+/// shown under the MCP tab's trusted-client list when it holds orphan bindings.
+#[cfg(feature = "mcp")]
+pub(crate) fn mcp_orphan_bindings_caption(count: usize) -> String {
+    if count == 1 {
+        dbflux_i18n::t!("connection_manager.mcp_orphan_bindings.one")
+    } else {
+        dbflux_i18n::t!("connection_manager.mcp_orphan_bindings.many", count = count)
+    }
+}
+
+/// Formats the "Tools: a, b, c" effective-permissions caption in the MCP tab's
+/// client detail pane.
+#[cfg(feature = "mcp")]
+pub(crate) fn mcp_effective_tools_line(tools: &str) -> String {
+    dbflux_i18n::t!("connection_manager.mcp_effective_tools", tools = tools)
+}
+
+/// Formats the "Classes: Read, Write" effective-permissions caption in the
+/// MCP tab's client detail pane.
+#[cfg(feature = "mcp")]
+pub(crate) fn mcp_effective_classes_line(classes: &str) -> String {
     dbflux_i18n::t!(
-        "connection_manager.mcp_preview_summary",
-        actor = actor,
-        role = role,
-        policy = policy
+        "connection_manager.mcp_effective_classes",
+        classes = classes
     )
 }
 
@@ -883,9 +901,8 @@ mod tests {
         import_preview_count_connections, import_preview_count_proxies,
         import_preview_count_ssh_tunnels, import_preview_required_banner,
         import_required_auth_profile_ref_label, import_required_aws_reference_label,
-        import_required_secret_label, import_status_imported_toast, mcp_preview_summary,
-        proxies_delete_body, rpc_services_delete_body, ssh_private_key_with_path,
-        ssh_tunnels_delete_body,
+        import_required_secret_label, import_status_imported_toast, proxies_delete_body,
+        rpc_services_delete_body, ssh_private_key_with_path, ssh_tunnels_delete_body,
     };
     use super::{
         connection_manager_window_title_edit, connection_manager_window_title_new,
@@ -1148,14 +1165,44 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "mcp")]
     #[test]
-    fn mcp_preview_summary_embeds_actor_role_policy() {
-        let message = mcp_preview_summary("prod-agent", "read-only", "strict");
+    fn mcp_orphan_bindings_caption_uses_singular_form_for_one() {
+        use super::mcp_orphan_bindings_caption;
 
-        assert_eq!(
-            message,
-            "Actor 'prod-agent' | role: read-only | policy: strict"
-        );
+        let message = mcp_orphan_bindings_caption(1);
+
+        assert!(message.contains('1'));
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn mcp_orphan_bindings_caption_embeds_count_for_many() {
+        use super::mcp_orphan_bindings_caption;
+
+        let message = mcp_orphan_bindings_caption(3);
+
+        assert!(message.contains('3'));
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn mcp_effective_tools_line_embeds_tools() {
+        use super::mcp_effective_tools_line;
+
+        let message = mcp_effective_tools_line("read_query, list_tables");
+
+        assert!(message.contains("read_query, list_tables"));
+    }
+
+    #[cfg(feature = "mcp")]
+    #[test]
+    fn mcp_effective_classes_line_embeds_classes() {
+        use super::mcp_effective_classes_line;
+
+        let message = mcp_effective_classes_line("Read, Metadata");
+
+        assert!(message.contains("Read, Metadata"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The Connection Manager MCP tab can now grant several trusted clients on one connection, each with its own roles and policies. It was limited to one client, and saving a connection discarded every binding except the first.
- The tab is a master-detail view over the existing `master_detail_list` composite: a filterable list of every trusted client on the left, and the selected client's access, roles, policies and effective permissions on the right.
- The pure state logic (binding presence, role/policy merge, effective permissions, filtering, orphan count) lives in a new `mcp_bindings.rs` module with unit tests written before the UI.

## What does this resolve?

Closes #542.

The model and the policy engine already supported N bindings per connection (`ConnectionMcpGovernance.policy_bindings`, `PolicyEngine::evaluate`). Only the Connection Manager collapsed them: the load path read `policy_bindings.first()` and `collect_mcp_governance` rebuilt a single-element list from one actor dropdown. The MCP server writes one assignment per client, so opening such a connection in the Connection Manager and saving was a silent data loss.

## How was this solved?

**Review this first:** `crates/dbflux_ui_windows/src/connection_manager/mod.rs`, the `handle_mcp_binding_field_change` / `select_mcp_client` / `set_mcp_client_allowed` trio and the four `cx.subscribe` calls on the role/policy widgets. That is the path that decides whether an edit survives switching clients.

| Area | Decision |
|------|----------|
| State ownership | `mcp_tab.bindings: Vec<ConnectionMcpPolicyBinding>` plus `selected_actor_id`. Every dropdown or multi-select change writes into the selected client's binding immediately. `collect_mcp_governance` returns the whole `Vec` after one defensive flush of the selected client. |
| Client switch | `select_mcp_client` repopulates the widgets from the new client's binding through `load_mcp_dropdowns`. `Dropdown::set_selected_index` and `MultiSelect::set_selected_values` do not emit change events, so the repopulation cannot write the previous client's values into the new binding. If those setters ever start emitting, the load path needs a guard flag. |
| Access toggle | The "Allow this client on this connection" checkbox adds or removes the binding. The engine treats a missing binding and a disabled one identically (`NoAssignment`), so no `enabled` flag was added to the core model. |
| Effective permissions | `mcp_bindings::effective_permissions` unions the binding's direct policies with each role's policies, then the tools and classes of those policies, matching what `PolicyEngine::evaluate` sees. Unknown ids are skipped. Rendered as two caption lines under the widgets. |
| List | `render_master_detail_list` from #543 with a caller-owned filter `Input` above it (case-insensitive substring on name or id) and a granted / no access badge per row. New `Widths::CONNECTION_MCP_LIST_PANEL` (220px) because the Connection Manager window is 720px wide, not 950px like Settings. The split has a fixed height so the composite's `h_full` resolves inside the scrolling tab column. |
| Orphan bindings | Bindings whose `actor_id` is not a trusted client are counted in a caption and preserved on save. They cannot be selected. |
| i18n | New `connection_manager.mcp_*` keys in `en`, `es` and `zh_Hans`. The six keys of the single-actor UI were removed from all three catalogs. |
| No MCP feature | `render_mcp_tab` has a `#[cfg(not(feature = "mcp"))]` variant that renders the enable checkbox and a "compiled without MCP" caption. |

**Out of scope:** keyboard navigation for the list and detail inside the Connection Manager tab (Settings got it in #543, this tab never had it), and migrating the remaining Settings list panels to the composite.

**Size:** this PR carries `size:exception`. Half of the added lines are the tested `mcp_bindings.rs` module and the i18n catalogs. Splitting the state module from the tab that consumes it would ship dead code.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo clippy -p dbflux_ui_windows --features mcp -- -D warnings`
- `cargo nextest run -p dbflux_ui_windows -p dbflux_i18n -p dbflux_components -p dbflux_policy` → 808 passed
- `cargo nextest run -p dbflux_ui_windows --features mcp` → 372 passed
- `cargo test -p dbflux --test mcp_ui_governance_acceptance_tests` → 4 passed
- New unit tests in `mcp_bindings.rs` (18): binding presence add/remove/idempotency, primary + extras merge and dedup, unknown role skipped, direct + role policy union, tool dedup across policies, filter by id and by name, empty query, orphan counting.
- Manual smoke in the app is pending before merge. Checklist: open a connection, enable MCP, filter the list, grant two clients with different roles, switch between them and confirm neither loses its selection, save, reopen and confirm both bindings are present.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s) (manual smoke pending)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
