### PR TITLE
fix(mcp): make the trusted-client filter input focusable in the Connection Manager

### DIFF
--- a/crates/dbflux_ui_windows/src/connection_manager/mod.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/mod.rs
@@ -687,10 +687,10 @@ impl ConnectionManagerWindow {
         let mcp_client_filter_sub = cx.subscribe_in(
             &conn_mcp_client_filter_input,
             window,
-            |_this, _, event: &InputEvent, _window, cx| {
-                if matches!(event, InputEvent::Change) {
-                    cx.notify();
-                }
+            |this, _, event: &InputEvent, window, cx| match event {
+                InputEvent::Change => cx.notify(),
+                InputEvent::Blur => this.exit_edit_mode_on_blur(window, cx),
+                _ => {}
             },
         );
 

--- a/crates/dbflux_ui_windows/src/connection_manager/navigation.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/navigation.rs
@@ -1430,9 +1430,15 @@ impl ConnectionManagerWindow {
             &self.access.input_ssm_remote_port,
         ];
 
+        #[cfg(feature = "mcp")]
+        let mcp_filter_input = Some(&self.mcp_tab.conn_mcp_client_filter_input);
+        #[cfg(not(feature = "mcp"))]
+        let mcp_filter_input: Option<&Entity<dbflux_components::controls::InputState>> = None;
+
         static_inputs
             .into_iter()
             .chain(self.form.driver_inputs.values())
+            .chain(mcp_filter_input)
             .any(|input| input.read(cx).focus_handle(cx).is_focused(window))
     }
 

--- a/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs
@@ -898,6 +898,15 @@ impl ConnectionManagerWindow {
             .child(
                 div()
                     .p(Spacing::SM)
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _, window, cx| {
+                            this.begin_inline_editor_interaction(cx);
+                            this.mcp_tab
+                                .conn_mcp_client_filter_input
+                                .update(cx, |state, cx| state.focus(window, cx));
+                        }),
+                    )
                     .child(Input::new(&self.mcp_tab.conn_mcp_client_filter_input)),
             )
             .child(div().flex_1().min_h_0().child(list));


### PR DESCRIPTION
## Summary

- The trusted-client filter in the Connection Manager MCP tab could not be clicked or typed into. It now takes focus on click and accepts input.

## What does this resolve?

Follow-up to #544 (issue #542). Reported by the maintainer after merge: the filter input behaved as if disabled.

## How was this solved?

**Review this first:** `crates/dbflux_ui_windows/src/connection_manager/render_tabs.rs`, the new `on_mouse_down` on the filter container.

| Area | Decision |
|------|----------|
| Cause | The Connection Manager root reclaims window focus on every left mouse-down while `edit_state == Navigating` (`render.rs`, `on_mouse_down` on `#connection-manager`). Form inputs avoid this by switching to `Editing` and focusing themselves in their own mouse-down handler before the root handler runs. The filter input had no such handler, so the root took focus back immediately after the click. |
| Fix | The filter container calls `begin_inline_editor_interaction` and focuses the input on mouse-down, the same pattern as the fallback field inputs in `render.rs`. |
| Blur | The existing filter subscription now also handles `InputEvent::Blur` through `exit_edit_mode_on_blur`, so keyboard navigation resumes after leaving the filter. |
| Blur check | `any_form_input_is_focused` includes the filter input (gated on `mcp`), so a blur from another input does not drop edit mode while the filter is focused. |

## Validation

- `cargo fmt --all`
- `cargo clippy -p dbflux_ui_windows -- -D warnings` (with and without `--features mcp`)
- `cargo nextest run -p dbflux_ui_windows --features mcp` → 372 passed
- Manual smoke pending: open a connection, MCP tab, click the filter, type, confirm the list narrows, press `esc`/click elsewhere and confirm `j`/`k` navigation resumes.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [x] Wayland
- [ ] Other:

## Checklist

- [ ] I verified the change against the affected user flow(s) (manual smoke pending)
- [x] I added or updated tests when needed (no new test: GPUI focus flow has no automated harness)
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (covered by the #542 entry, feature is unreleased)
