### PR TITLE
ci(release): stop cold builds and unblock the platform builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,12 @@ jobs:
           shared-key: linux-${{ matrix.arch }}
           cache-targets: true
           cache-on-failure: true
+          # A release runs on a tag ref, and a cache saved there is scoped to
+          # that tag: no later run can read it, yet it still counts toward the
+          # repository's 10 GB limit and evicts the caches main relies on.
+          # Only the nightly, which runs on main, writes; releases restore from
+          # main through the shared-key fallback.
+          save-if: ${{ inputs.channel == 'nightly' }}
 
       - name: Stamp workspace version
         env:
@@ -410,6 +416,12 @@ jobs:
           shared-key: macos-${{ matrix.arch }}
           cache-targets: true
           cache-on-failure: true
+          # A release runs on a tag ref, and a cache saved there is scoped to
+          # that tag: no later run can read it, yet it still counts toward the
+          # repository's 10 GB limit and evicts the caches main relies on.
+          # Only the nightly, which runs on main, writes; releases restore from
+          # main through the shared-key fallback.
+          save-if: ${{ inputs.channel == 'nightly' }}
 
       - name: Stamp workspace version
         env:
@@ -554,6 +566,12 @@ jobs:
           shared-key: windows-amd64
           cache-targets: true
           cache-on-failure: true
+          # A release runs on a tag ref, and a cache saved there is scoped to
+          # that tag: no later run can read it, yet it still counts toward the
+          # repository's 10 GB limit and evicts the caches main relies on.
+          # Only the nightly, which runs on main, writes; releases restore from
+          # main through the shared-key fallback.
+          save-if: ${{ inputs.channel == 'nightly' }}
 
       - name: Stamp workspace version
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,10 @@ jobs:
 
   build:
     name: Build
-    needs: [tests, style, classify]
+    # Tests and style do not gate the build, only the publish step below: the
+    # platform builds are the longest jobs in this workflow and depend on
+    # nothing the checks produce. A red check still blocks the release.
+    needs: [classify]
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.classify.outputs.version }}
@@ -116,7 +119,7 @@ jobs:
 
   release:
     name: Create Release
-    needs: [classify, build]
+    needs: [tests, style, classify, build]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -102,7 +102,9 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16  # v2
         with:
-          shared-key: ci-clippy-${{ matrix.os }}
+          # Shared with the cross-platform check in tests.yml: both run the
+          # same feature set against the same target dir on the same runner.
+          shared-key: ci-check-${{ matrix.os }}
           cache-targets: true
           cache-on-failure: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,7 +74,6 @@ jobs:
     name: Driver Live Integration
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    needs: deterministic-tests
 
     steps:
       - name: Checkout repository
@@ -236,7 +235,8 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16  # v2
         with:
-          shared-key: ci-cross-check-${{ matrix.os }}
+          # Shared with clippy in style.yml (same features, same target dir).
+          shared-key: ci-check-${{ matrix.os }}
           cache-targets: true
           cache-on-failure: true
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -47,11 +47,13 @@ jobs:
         with:
           version: 11
 
+      # No pnpm cache: it is saved once per branch, so every open PR adds a
+      # near-identical ~170 MB entry that pushes the repository past its 10 GB
+      # cache limit and evicts the Rust build caches. A frozen install from the
+      # registry takes seconds.
       - uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: web/pnpm-lock.yaml
 
       - name: Install
         working-directory: web

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,9 @@ debug = false
 # `panic` is intentionally left at the default `unwind`: switching to `abort` is a
 # separate decision that loses `catch_unwind` and may break GPUI internals that
 # rely on unwinding, so it is not changed here.
+# `codegen-units` stays at cargo's release default (16): a single unit makes
+# the final binary crate a serial 4-8 minute step on every CI platform, and
+# thin LTO already recovers most of the cross-unit optimization.
 [profile.release]
 lto = "thin"
-codegen-units = 1
 strip = "symbols"


### PR DESCRIPTION
Resolves #550

Every platform build in nightly and release started from a cold Rust cache, and on release the builds also waited 18 minutes for the test jobs. This PR makes the cache survive between runs and lets the builds start immediately. Config only, no Rust source changes.

## Review first

`.github/workflows/release.yml`: `build` now depends only on `classify`, and the publish job depends on `tests`, `style`, `classify`, `build`. Confirm that a red check still blocks publication.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/build.yml` | `save-if: inputs.channel == 'nightly'` on the three Rust cache steps. Tag runs only restore. |
| `.github/workflows/style.yml`, `tests.yml` | Clippy and the cross-platform check share `ci-check-<os>` instead of storing the same target dir twice. |
| `.github/workflows/web.yml` | Drop the per-branch pnpm cache (~170 MB per open PR). |
| `.github/workflows/release.yml` | Build in parallel with tests and style; publish still requires all of them. |
| `.github/workflows/tests.yml` | Live integration no longer waits for the deterministic suite. |
| `Cargo.toml` | Release profile keeps `lto = "thin"`, drops `codegen-units = 1`. |

## Why

Measured on the 2026-09-03 nightly and release v0.7.7 (details in #550):

- All five nightly build jobs and four of five release build jobs logged `No cache found`. The repository cache totals 10.98 GB against a 10 GB limit, so the build caches are evicted before the next run.
- Dependencies are 60 to 70% of a cold build (Windows 21 of 36 minutes).
- The final binary crate with a single codegen unit is a serial 4 to 8 minute step per platform that the cache cannot save.

## Verification

- [x] `actionlint` on all workflows: same 22 pre-existing shellcheck style notes as `main`, nothing new.
- [x] `cargo metadata` accepts the edited manifest.
- [ ] Not verified: release binary size and runtime with the new codegen-units setting. The macOS amd64 job already built with 16 units, so the profile is known to link.
- [ ] Not verified: warm-cache timings. The first nightly after merge writes the caches; the second one shows the gain.

## Out of scope

- Larger paid runners for the Windows job.
- sccache.
- Releases cut from `release/v0.7` keep the old `release.yml` until this is cherry-picked there.