### PR TITLE
fix(deps): bump fast-uri and qs to patch Dependabot alerts

### DIFF
--- a/web/mcp/pnpm-lock.yaml
+++ b/web/mcp/pnpm-lock.yaml
@@ -1301,8 +1301,8 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   range-parser@1.3.0:
@@ -2103,7 +2103,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -2296,7 +2296,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0(supports-color@10.2.2)
       send: 1.2.1(supports-color@10.2.2)
@@ -2489,7 +2489,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -1359,8 +1359,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -3215,7 +3215,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3731,7 +3731,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:


### PR DESCRIPTION
## What

Bumps two transitive npm dependencies in the website workspaces, closing all six open Dependabot alerts. Only the lockfiles change — both parent packages already accept the patched ranges, so no `pnpm.overrides` entry and no `package.json` edits were needed.

| Alerts | Package | Version | Lockfile | Pulled in by |
| --- | --- | --- | --- | --- |
| 12, 13, 15, 16 (high) | `fast-uri` | 3.1.5 → 3.1.7 | `web/pnpm-lock.yaml` | `ajv@8.20.0` |
| 14, 17 (medium) | `qs` | 6.15.3 → 6.16.0 | `web/mcp/pnpm-lock.yaml` | `express`, `body-parser` |

The `fast-uri` advisories cover host confusion via percent-encoded scheme normalization, SSRF via malformed IPv6 normalization, SSRF via repeated hostname percent-decoding, and host confusion via skipped IDN canonicalization. The `qs` advisories cover a denial of service through attacker-controlled `isBuffer` and an array-limit bypass through bracket-key comma parsing.

## Why

Both alerts sit in the website, not in the Rust binary, so the practical exposure differs between them. `fast-uri` arrives through `ajv`, which validates schemas at build time and never resolves untrusted URLs, so the four high-severity advisories have no reachable surface here. `qs` runs inside a real Express handler in `web/mcp`, which makes the denial-of-service advisory the one with a plausible path. Patching all six is cheap either way, and it clears the alert list so a genuinely reachable advisory stands out next time.

## Verification

- `pnpm install --frozen-lockfile` succeeds in `web/` and `web/mcp/`
- `pnpm check` in `web/` → 50 files, 0 errors, 0 warnings, 0 hints
- `pnpm check` (`tsc --noEmit`) in `web/mcp/` → clean
- `pnpm build` in `web/` → 298 pages built, complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LEbVuzsckMa4CBnrH9JZyE
