### PR TITLE
docs: add trademark and privacy policies and publish them on the site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,4 +187,4 @@ Do not file security issues publicly. Email the maintainer or use a private chan
 
 ## License
 
-By contributing you agree your contributions are licensed under the project's dual MIT / Apache-2.0 license.
+By contributing you agree your contributions are licensed under the project's dual MIT / Apache-2.0 license. The DBFlux name and logo are not part of that license; see [TRADEMARK.md](TRADEMARK.md).

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,87 @@
+# Privacy Policy
+
+DBFlux is a local-first desktop application. It does not collect, transmit, or
+store any information about you or your usage. The project website sets no
+cookies and loads no third-party scripts. This document says what that means
+in practice and names the two infrastructure providers that see traffic on the
+way to you.
+
+## Quick path
+
+1. The application sends data only to the database servers you configure, and
+   only what is needed to run the queries you ask for.
+2. There is no telemetry, no crash reporting, no usage analytics, and no
+   account. Nothing phones home.
+3. The website and documentation are static pages. They set no cookies, run no
+   analytics script, and keep no record of individual visitors.
+
+## The application
+
+| Question | Answer |
+|----------|--------|
+| Does DBFlux send usage data anywhere? | No. There is no telemetry and no crash reporter. |
+| Does it check for updates? | No. Updates are found on the GitHub releases page. |
+| What network connections does it open? | Only the ones you configure: database servers, SSH tunnels, proxies, and cloud APIs for the drivers you use. |
+| Where does my data live? | On your machine, in one SQLite file plus the operating system keyring for secrets. |
+| Does it keep a record of what I do? | Only the audit log, on your machine. It records connections, queries, and hook runs so you can review them, and it never leaves the computer it was written on. |
+| Is anything shared with the project? | No. Bug reports and logs reach the project only when you attach them to an issue yourself. |
+
+Connections to a database, an SSH host, a proxy, or a cloud provider go
+directly from your machine to the server you named. The project operates none
+of those servers and has no visibility into that traffic.
+
+[Data & Privacy](docs/DATA_AND_PRIVACY.md) documents the files DBFlux writes,
+what the audit log records, how secrets are stored, and how to back up or fully
+reset the application.
+
+## The website and documentation
+
+`dbflux.dev` and `docs.dbflux.dev` are static sites built from this
+repository. They:
+
+- set no cookies, first-party or third-party;
+- load no analytics, advertising, or tracking script;
+- serve their fonts and assets from the same host, so a page view contacts no
+  other domain;
+- keep no server-side log the project can read per visitor.
+
+The documentation search runs in your browser against an index file fetched
+from the same host. The query never leaves the page.
+
+## Infrastructure providers
+
+Two services sit between the project and you. Neither is used to identify
+individual visitors.
+
+| Provider | Role | What it sees |
+|----------|------|--------------|
+| Cloudflare | Hosts the website, the documentation, and the documentation MCP endpoint at `mcp.dbflux.dev`. | Every HTTP request to those hosts, including the IP address and user agent, as any host does. Cloudflare exposes aggregate traffic counts to the project. It does not expose per-visitor records, and the project has enabled no feature that would. |
+| Google Search Console | Reports how the site appears in Google search results. | Only what Google's crawler and search results already know. No script from Google is loaded on any page. |
+
+Cloudflare's own handling of request data is described in the
+[Cloudflare privacy policy](https://www.cloudflare.com/privacypolicy/).
+
+## The documentation MCP endpoint
+
+`mcp.dbflux.dev` lets an AI client search the documentation. A session lives
+for the duration of one connection and holds only the messages exchanged in
+it. There are no accounts, no persistent storage of queries, and no record
+linking a session to a visitor after it ends.
+
+## GitHub
+
+Issues, pull requests, discussions, and release downloads are on GitHub.
+Anything you post there is public and governed by
+[GitHub's privacy statement](https://docs.github.com/site-policy/privacy-policies/github-general-privacy-statement).
+
+## Changes to this policy
+
+This file is versioned with the source code. The commit history of
+`PRIVACY.md` is the change log. A change that makes the application or the
+website collect anything it does not collect today will be announced in the
+release notes of the version that introduces it.
+
+## Contact
+
+Questions go to an issue in this repository with the title prefix
+`[privacy]`.

--- a/README.md
+++ b/README.md
@@ -296,4 +296,4 @@ nix-shell
 
 ## License
 
-MIT & Apache-2.0
+MIT & Apache-2.0. The DBFlux name and logo are covered by the [Trademark Policy](TRADEMARK.md), not by the code license.

--- a/README.md
+++ b/README.md
@@ -297,3 +297,5 @@ nix-shell
 ## License
 
 MIT & Apache-2.0. The DBFlux name and logo are covered by the [Trademark Policy](TRADEMARK.md), not by the code license.
+
+DBFlux collects no data. See the [Privacy Policy](PRIVACY.md).

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,80 @@
+# DBFlux Trademark Policy
+
+The DBFlux source code is free software under `MIT OR Apache-2.0`. The name
+**DBFlux**, the DBFlux logo, and the `dbflux.dev` domain are not part of that
+grant. This document says what you may do with them without asking.
+
+## Quick path
+
+1. You can use the name to say where your work comes from: "based on DBFlux",
+   "a fork of DBFlux", "compatible with DBFlux".
+2. You can redistribute **unmodified** official release artifacts under the
+   DBFlux name, for example as a Homebrew, AUR, or nixpkgs package.
+3. If you publish **modified** builds, use a different name and logo. Say that
+   your project is derived from DBFlux and is not the official one.
+
+If your case is not one of these three, open an issue in this repository and
+ask.
+
+## Marks covered
+
+| Mark | What it means |
+|------|---------------|
+| DBFlux | The product name, in any capitalization, alone or in compounds such as "DBFlux Pro" or "DBFlux Nightly". |
+| The logo | Every file under `resources/branding/` and `packaging/icons/`, and any derivative of them. |
+| dbflux.dev | The domain and every page under it. |
+
+The code license does not change this. The Apache 2.0 text says so in
+section 6. MIT does not mention trademarks at all, so choosing MIT over Apache
+does not grant a right to the name that Apache withholds.
+
+## What you may do
+
+| Use | Allowed without asking |
+|-----|------------------------|
+| Describe origin, compatibility, or comparison ("built on DBFlux", "works with DBFlux") | Yes |
+| Keep the name in source files, commit history, and documentation of a fork | Yes |
+| Package or mirror **unmodified** official releases under the DBFlux name | Yes |
+| Write articles, talks, or tutorials about DBFlux, including the logo in a screenshot | Yes |
+| Use the name and logo for a build that includes patches not in an official release | No |
+| Publish releases, installers, or an update channel branded DBFlux from another repository | No |
+| Register a domain, package name, app-store listing, or account whose main element is "DBFlux" | No |
+| Use the logo, or an edited version of it, as the icon of a derived product | No |
+
+"Unmodified" means the artifact was produced by the official release workflow
+from a tag in this repository and its checksum matches the one published with
+the release. A rebuild from the same tag counts as unmodified when the source
+tree is byte-identical to that tag.
+
+## Naming a fork
+
+A derived product needs a name that a user cannot confuse with DBFlux. The
+following work:
+
+- A distinct name with an origin note: "Fluxbase, a fork of DBFlux".
+- A qualifier that clearly marks it as unofficial: "DBFlux (community edition,
+  unofficial)" is acceptable in a README, but the binary, window title, bundle
+  identifier, and installer must not present themselves as plain "DBFlux".
+
+The following do not work:
+
+- Shipping a release named "DBFlux vX.Y.Z" from a fork.
+- Pointing an in-app update check at a fork while the app still calls itself
+  DBFlux.
+- Reusing the DBFlux icon, or a recolored one, as the app icon.
+
+The rename does not have to touch the source tree. Changing the display name,
+bundle identifier, icon set, `repository` field, and release title is enough.
+
+## Why this exists
+
+A user who installs "DBFlux" expects the builds published by this project:
+reviewed changes, the documented data-and-privacy behavior, and signed
+artifacts where the platform supports them. A modified build under the same
+name breaks that expectation, and the bug reports for it land here.
+
+## Contact
+
+Questions and permission requests go to an issue in this repository with the
+title prefix `[trademark]`. There is no fee and no form. Most requests that
+explain the use case are answered with a yes.

--- a/docs/DATA_AND_PRIVACY.md
+++ b/docs/DATA_AND_PRIVACY.md
@@ -203,3 +203,4 @@ To wipe DBFlux's data:
 - [Settings & Hooks](SETTINGS.md) — the General/Audit/Storage controls referenced here.
 - [Connecting → Advanced Setup](CONNECTIONS.md) — where secrets are entered.
 - [Audit](AUDIT.md) — the full audit event schema and redaction details.
+- [Privacy Policy](../PRIVACY.md) — what the application and the website do not collect.

--- a/docs/TRANSLATIONS.md
+++ b/docs/TRANSLATIONS.md
@@ -55,7 +55,7 @@ adding one file in the right place. Each language has a directory under
 | `docs/USAGE.md` | `docs/<locale-dir>/USAGE.md` |
 | `docs/SETTINGS.md` | `docs/<locale-dir>/SETTINGS.md` |
 | Driver README (`crates/dbflux_driver_postgres/README.md`) | `docs/<locale-dir>/drivers/postgres.md` |
-| `ARCHITECTURE.md`, `CONTRIBUTING.md`, `SECURITY.md` (repository root) | `docs/<locale-dir>/ARCHITECTURE.md`, etc. |
+| `ARCHITECTURE.md`, `CONTRIBUTING.md`, `SECURITY.md`, `TRADEMARK.md`, `PRIVACY.md` (repository root) | `docs/<locale-dir>/ARCHITECTURE.md`, etc. |
 
 Rules that keep the site build happy:
 

--- a/docs/es/CONTRIBUTING.md
+++ b/docs/es/CONTRIBUTING.md
@@ -227,4 +227,5 @@ redactados (tokens, contraseñas, connection strings).
 ## Licencia
 
 Al contribuir aceptas que tus contribuciones se licencian bajo la licencia dual
-MIT / Apache-2.0 del proyecto.
+MIT / Apache-2.0 del proyecto. El nombre y el logo de DBFlux no forman parte de
+esa licencia; consulta [TRADEMARK.md](TRADEMARK.md).

--- a/docs/es/DATA_AND_PRIVACY.md
+++ b/docs/es/DATA_AND_PRIVACY.md
@@ -217,3 +217,5 @@ Para borrar los datos de DBFlux:
   secretos.
 - [Audit](AUDIT.md) — el schema completo de eventos de auditoría y los detalles
   de redacción.
+- [Política de privacidad](PRIVACY.md) — qué no recopilan la aplicación ni el
+  sitio web.

--- a/docs/es/PRIVACY.md
+++ b/docs/es/PRIVACY.md
@@ -1,0 +1,90 @@
+# Política de privacidad
+
+DBFlux es una aplicación de escritorio local-first. No recopila, transmite ni
+almacena información sobre ti ni sobre tu uso. El sitio web del proyecto no
+usa cookies ni carga scripts de terceros. Este documento explica qué significa
+eso en la práctica y nombra a los dos proveedores de infraestructura que ven
+el tráfico en su camino hacia ti.
+
+## Ruta rápida
+
+1. La aplicación envía datos únicamente a los servidores de base de datos que
+   configuras, y solo lo necesario para ejecutar las consultas que pides.
+2. No hay telemetría, ni reporte de fallos, ni analítica de uso, ni cuenta de
+   usuario. Nada llama a casa.
+3. El sitio web y la documentación son páginas estáticas. No usan cookies, no
+   ejecutan scripts de analítica y no guardan registro de visitantes
+   individuales.
+
+## La aplicación
+
+| Pregunta | Respuesta |
+|----------|-----------|
+| ¿DBFlux envía datos de uso a algún sitio? | No. No hay telemetría ni reporte de fallos. |
+| ¿Comprueba si hay actualizaciones? | No. Las actualizaciones se encuentran en la página de releases de GitHub. |
+| ¿Qué conexiones de red abre? | Solo las que configuras: servidores de base de datos, túneles SSH, proxies y APIs cloud de los drivers que uses. |
+| ¿Dónde viven mis datos? | En tu máquina, en un único archivo SQLite más el llavero del sistema operativo para los secretos. |
+| ¿Guarda un registro de lo que hago? | Solo el log de auditoría, en tu máquina. Registra conexiones, consultas y ejecuciones de hooks para que puedas revisarlas, y nunca sale del equipo en el que se escribió. |
+| ¿Se comparte algo con el proyecto? | No. Los reportes de error y los logs llegan al proyecto solo cuando tú los adjuntas a un issue. |
+
+Las conexiones a una base de datos, un host SSH, un proxy o un proveedor cloud
+van directamente desde tu máquina al servidor que indicaste. El proyecto no
+opera ninguno de esos servidores y no tiene visibilidad de ese tráfico.
+
+[Datos y privacidad](DATA_AND_PRIVACY.md) documenta los archivos que DBFlux
+escribe, qué registra el log de auditoría, cómo se guardan los secretos y cómo
+hacer copia de seguridad o reiniciar la aplicación por completo.
+
+## El sitio web y la documentación
+
+`dbflux.dev` y `docs.dbflux.dev` son sitios estáticos construidos desde este
+repositorio. Estos sitios:
+
+- no usan cookies, ni propias ni de terceros;
+- no cargan scripts de analítica, publicidad ni seguimiento;
+- sirven sus fuentes y recursos desde el mismo host, así que una visita no
+  contacta con ningún otro dominio;
+- no mantienen ningún registro por visitante en el servidor que el proyecto
+  pueda leer.
+
+La búsqueda de la documentación se ejecuta en tu navegador contra un archivo
+de índice descargado del mismo host. La consulta nunca sale de la página.
+
+## Proveedores de infraestructura
+
+Dos servicios se sitúan entre el proyecto y tú. Ninguno se usa para
+identificar visitantes individuales.
+
+| Proveedor | Función | Qué ve |
+|-----------|---------|--------|
+| Cloudflare | Aloja el sitio web, la documentación y el endpoint MCP de documentación en `mcp.dbflux.dev`. | Cada petición HTTP a esos hosts, incluyendo la dirección IP y el user agent, como cualquier host. Cloudflare expone al proyecto recuentos de tráfico agregados. No expone registros por visitante, y el proyecto no ha activado ninguna función que lo haga. |
+| Google Search Console | Informa de cómo aparece el sitio en los resultados de búsqueda de Google. | Solo lo que el rastreador y los resultados de Google ya conocen. Ninguna página carga scripts de Google. |
+
+El tratamiento que Cloudflare hace de los datos de las peticiones se describe
+en la [política de privacidad de Cloudflare](https://www.cloudflare.com/privacypolicy/).
+
+## El endpoint MCP de documentación
+
+`mcp.dbflux.dev` permite a un cliente de IA buscar en la documentación. Una
+sesión dura lo que dura una conexión y solo contiene los mensajes
+intercambiados en ella. No hay cuentas, no se almacenan consultas de forma
+persistente y no queda ningún registro que vincule una sesión con un visitante
+una vez termina.
+
+## GitHub
+
+Los issues, pull requests, discusiones y descargas de releases están en GitHub.
+Todo lo que publiques allí es público y se rige por la
+[declaración de privacidad de GitHub](https://docs.github.com/site-policy/privacy-policies/github-general-privacy-statement).
+
+## Cambios en esta política
+
+Este archivo se versiona junto con el código fuente. El historial de commits de
+`PRIVACY.md` es el registro de cambios. Cualquier cambio que haga que la
+aplicación o el sitio web recopilen algo que hoy no recopilan se anunciará en
+las notas de la versión que lo introduzca.
+
+## Contacto
+
+Las preguntas van a un issue en este repositorio con el prefijo `[privacy]` en
+el título.

--- a/docs/es/TRADEMARK.md
+++ b/docs/es/TRADEMARK.md
@@ -1,0 +1,86 @@
+# Política de marca de DBFlux
+
+El código fuente de DBFlux es software libre bajo `MIT OR Apache-2.0`. El
+nombre **DBFlux**, el logo de DBFlux y el dominio `dbflux.dev` no forman parte
+de esa concesión. Este documento indica qué puedes hacer con ellos sin pedir
+permiso.
+
+## Ruta rápida
+
+1. Puedes usar el nombre para indicar de dónde viene tu trabajo: "basado en
+   DBFlux", "un fork de DBFlux", "compatible con DBFlux".
+2. Puedes redistribuir los artefactos de release oficiales **sin modificar**
+   bajo el nombre DBFlux, por ejemplo como paquete de Homebrew, AUR o nixpkgs.
+3. Si publicas builds **modificadas**, usa otro nombre y otro logo. Indica que
+   tu proyecto deriva de DBFlux y que no es el oficial.
+
+Si tu caso no es ninguno de estos tres, abre un issue en este repositorio y
+pregunta.
+
+## Marcas cubiertas
+
+| Marca | Qué significa |
+|-------|---------------|
+| DBFlux | El nombre del producto, en cualquier capitalización, solo o en compuestos como "DBFlux Pro" o "DBFlux Nightly". |
+| El logo | Todos los archivos bajo `resources/branding/` y `packaging/icons/`, y cualquier derivado de ellos. |
+| dbflux.dev | El dominio y todas las páginas bajo él. |
+
+La licencia del código no cambia esto. El texto de Apache 2.0 lo dice en su
+sección 6. MIT no menciona las marcas, así que elegir MIT en lugar de Apache no
+otorga un derecho sobre el nombre que Apache retiene.
+
+## Qué puedes hacer
+
+| Uso | Permitido sin pedir |
+|-----|---------------------|
+| Describir origen, compatibilidad o comparación ("construido sobre DBFlux", "funciona con DBFlux") | Sí |
+| Conservar el nombre en los archivos fuente, el historial de commits y la documentación de un fork | Sí |
+| Empaquetar o replicar releases oficiales **sin modificar** bajo el nombre DBFlux | Sí |
+| Escribir artículos, charlas o tutoriales sobre DBFlux, incluyendo el logo en una captura | Sí |
+| Usar el nombre y el logo en una build que incluye parches que no están en una release oficial | No |
+| Publicar releases, instaladores o un canal de actualización con la marca DBFlux desde otro repositorio | No |
+| Registrar un dominio, nombre de paquete, ficha en una tienda de aplicaciones o cuenta cuyo elemento principal sea "DBFlux" | No |
+| Usar el logo, o una versión editada de él, como icono de un producto derivado | No |
+
+"Sin modificar" significa que el artefacto fue producido por el flujo de
+release oficial a partir de un tag de este repositorio y que su checksum
+coincide con el publicado junto a la release. Una recompilación del mismo tag
+cuenta como sin modificar cuando el árbol de fuentes es idéntico byte a byte a
+ese tag.
+
+## Cómo nombrar un fork
+
+Un producto derivado necesita un nombre que un usuario no pueda confundir con
+DBFlux. Lo siguiente funciona:
+
+- Un nombre distinto con una nota de origen: "Fluxbase, un fork de DBFlux".
+- Un calificador que lo marque claramente como no oficial: "DBFlux (edición de
+  la comunidad, no oficial)" es aceptable en un README, pero el binario, el
+  título de la ventana, el identificador del bundle y el instalador no deben
+  presentarse como "DBFlux" a secas.
+
+Lo siguiente no funciona:
+
+- Publicar una release llamada "DBFlux vX.Y.Z" desde un fork.
+- Apuntar una comprobación de actualizaciones integrada en la aplicación a un
+  fork mientras la aplicación sigue llamándose DBFlux.
+- Reutilizar el icono de DBFlux, o uno recoloreado, como icono de la
+  aplicación.
+
+El cambio de nombre no tiene que tocar el árbol de fuentes. Cambiar el nombre
+mostrado, el identificador del bundle, el conjunto de iconos, el campo
+`repository` y el título de la release es suficiente.
+
+## Por qué existe esto
+
+Un usuario que instala "DBFlux" espera las builds publicadas por este
+proyecto: cambios revisados, el comportamiento documentado de datos y
+privacidad, y artefactos firmados donde la plataforma lo permite. Una build
+modificada bajo el mismo nombre rompe esa expectativa, y los reportes de error
+que genera acaban aquí.
+
+## Contacto
+
+Las preguntas y solicitudes de permiso van a un issue en este repositorio con
+el prefijo `[trademark]` en el título. No hay tarifa ni formulario. La mayoría
+de las solicitudes que explican el caso de uso se responden con un sí.

--- a/docs/zh_Hans/TRANSLATIONS.md
+++ b/docs/zh_Hans/TRANSLATIONS.md
@@ -35,7 +35,7 @@ DBFlux 的翻译分布在三处，各自的贡献方式不同：应用程序界�
 | `docs/USAGE.md` | `docs/<locale-dir>/USAGE.md` |
 | `docs/SETTINGS.md` | `docs/<locale-dir>/SETTINGS.md` |
 | 驱动程序 README（`crates/dbflux_driver_postgres/README.md`） | `docs/<locale-dir>/drivers/postgres.md` |
-| `ARCHITECTURE.md`、`CONTRIBUTING.md`、`SECURITY.md`（仓库根目录） | `docs/<locale-dir>/ARCHITECTURE.md` 等 |
+| `ARCHITECTURE.md`、`CONTRIBUTING.md`、`SECURITY.md`、`TRADEMARK.md`、`PRIVACY.md`（仓库根目录） | `docs/<locale-dir>/ARCHITECTURE.md` 等 |
 
 保证站点构建顺利的规则：
 

--- a/web/scripts/fetch-docs.ts
+++ b/web/scripts/fetch-docs.ts
@@ -26,7 +26,7 @@ export const VERSIONS_DIR = join(WEB, '.versions');
 
 /** Non-document paths every version contributes alongside registered locale docs. */
 const WANTED_REPOSITORY_PATH =
-  /^(ARCHITECTURE\.md|CONTRIBUTING\.md|SECURITY\.md|crates\/dbflux_driver_[^/]+\/README\.md|examples\/custom_driver\/README\.md)$/;
+  /^(ARCHITECTURE\.md|CONTRIBUTING\.md|SECURITY\.md|TRADEMARK\.md|PRIVACY\.md|crates\/dbflux_driver_[^/]+\/README\.md|examples\/custom_driver\/README\.md)$/;
 
 const wantedPath = (path: string) => isDocsRepoPath(path) || WANTED_REPOSITORY_PATH.test(path);
 

--- a/web/src/components/SiteFooter.astro
+++ b/web/src/components/SiteFooter.astro
@@ -34,6 +34,8 @@ const COLUMNS = [
       { href: siteUrl('about/', locale), label: t(locale, 'footer.about') },
       { href: docsUrl('contributing', '', locale), label: t(locale, 'footer.contributing') },
       { href: REPO, label: t(locale, 'footer.source') },
+      { href: docsUrl('trademark', '', locale), label: t(locale, 'footer.trademark') },
+      { href: docsUrl('privacy', '', locale), label: t(locale, 'footer.privacy') },
     ],
   },
 ] as const;

--- a/web/src/content.config.ts
+++ b/web/src/content.config.ts
@@ -26,6 +26,8 @@ const docs = defineCollection({
       '*/ARCHITECTURE.md',
       '*/CONTRIBUTING.md',
       '*/SECURITY.md',
+      '*/TRADEMARK.md',
+      '*/PRIVACY.md',
       '*/crates/dbflux_driver_*/README.md',
       '*/examples/custom_driver/README.md',
     ],

--- a/web/src/data/nav.ts
+++ b/web/src/data/nav.ts
@@ -27,7 +27,11 @@ export interface DocsSection {
 export const DOCS_SECTIONS: readonly DocsSection[] = [
   { id: 'start', title: 'Start here', entries: ['install', 'usage', 'connections'] },
   { id: 'using', title: 'Using DBFlux', entries: ['charts', 'dashboards', 'dashboards_and_audit'] },
-  { id: 'configure', title: 'Configuring', entries: ['settings', 'lua', 'data_and_privacy'] },
+  {
+    id: 'configure',
+    title: 'Configuring',
+    entries: ['settings', 'lua', 'data_and_privacy', 'privacy'],
+  },
   { id: 'integrate', title: 'Integrations', entries: ['mcp_ai_integration', 'audit'] },
   { id: 'reference', title: 'Reference', entries: ['drivers', 'concepts'] },
   {
@@ -56,6 +60,7 @@ export const DOCS_SECTIONS: readonly DocsSection[] = [
       'contributing',
       'translations',
       'security',
+      'trademark',
       'architecture',
       'driver_authoring',
       'custom_driver_example',
@@ -90,6 +95,8 @@ export const DOC_TITLES: Readonly<Record<string, string>> = {
   contributing: 'Contributing',
   translations: 'Translations',
   security: 'Security',
+  trademark: 'Trademark policy',
+  privacy: 'Privacy policy',
   'drivers/postgres': 'PostgreSQL',
   'drivers/mysql': 'MySQL / MariaDB',
   'drivers/mssql': 'SQL Server',
@@ -148,6 +155,8 @@ export function routeForRepoPath(
   if (path === 'ARCHITECTURE.md') return docsUrl('architecture', versionPrefix, locale);
   if (path === 'CONTRIBUTING.md') return docsUrl('contributing', versionPrefix, locale);
   if (path === 'SECURITY.md') return docsUrl('security', versionPrefix, locale);
+  if (path === 'TRADEMARK.md') return docsUrl('trademark', versionPrefix, locale);
+  if (path === 'PRIVACY.md') return docsUrl('privacy', versionPrefix, locale);
 
   return repoBlobUrl(path, versionId);
 }
@@ -184,6 +193,8 @@ export function titleForRepoPath(path: string): string | null {
   if (path === 'ARCHITECTURE.md') return DOC_TITLES.architecture ?? null;
   if (path === 'CONTRIBUTING.md') return DOC_TITLES.contributing ?? null;
   if (path === 'SECURITY.md') return DOC_TITLES.security ?? null;
+  if (path === 'TRADEMARK.md') return DOC_TITLES.trademark ?? null;
+  if (path === 'PRIVACY.md') return DOC_TITLES.privacy ?? null;
 
   return null;
 }

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -24,6 +24,8 @@ export const en = {
     about: 'About',
     contributing: 'Contributing',
     source: 'Source',
+    trademark: 'Trademark policy',
+    privacy: 'Privacy policy',
     tagline: 'A fully open-source, keyboard-first database client, built in the open.',
     license: 'MIT or Apache-2.0, at your option.',
   },

--- a/web/src/i18n/es.ts
+++ b/web/src/i18n/es.ts
@@ -24,6 +24,8 @@ export const es: Dictionary = {
     about: 'Acerca de',
     contributing: 'Cómo contribuir',
     source: 'Código fuente',
+    trademark: 'Política de marca',
+    privacy: 'Política de privacidad',
     tagline:
       'Un cliente de bases de datos keyboard-first y totalmente de código abierto, desarrollado en abierto.',
     license: 'MIT o Apache-2.0, a tu elección.',

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -58,6 +58,8 @@ export interface Dictionary {
     about: string;
     contributing: string;
     source: string;
+    trademark: string;
+    privacy: string;
     tagline: string;
     license: string;
   };

--- a/web/src/i18n/zh_Hans.ts
+++ b/web/src/i18n/zh_Hans.ts
@@ -24,6 +24,8 @@ export const zh_Hans: Dictionary = {
     about: '关于',
     contributing: '如何贡献',
     source: '源代码',
+    trademark: '商标政策',
+    privacy: '隐私政策',
     tagline: '完全开源、以键盘为核心的数据库客户端，在开放中构建。',
     license: 'MIT 或 Apache-2.0，任你选择。',
   },

--- a/web/versions.json
+++ b/web/versions.json
@@ -1,5 +1,5 @@
 [
-  { "id": "nightly", "ref": "main", "noindex": true },
+  { "id": "nightly", "ref": "docs/trademark-policy", "noindex": true },
   { "id": "v0.7", "ref": "release/v0.7", "current": true },
   { "id": "v0.6", "ref": "release/v0.6" }
 ]


### PR DESCRIPTION
## Summary

Adds two policy documents and publishes them on the site:

- `TRADEMARK.md`: what the DBFlux name, logo, and `dbflux.dev` domain may be used for. The code is `MIT OR Apache-2.0`; Apache section 6 withholds the name, MIT says nothing, and a downstream user may pick MIT, so nothing written covered a modified build published as "DBFlux" from another repository.
- `PRIVACY.md`: DBFlux is local-first and collects nothing. The website sets no cookies and loads no third-party script. The document names the two providers that see traffic (Cloudflare at the edge with aggregate counts, Google Search Console with nothing on the page) and the docs MCP endpoint's session-only state.

Both have Spanish translations under `docs/es/`, and `README.md`, `CONTRIBUTING.md`, and `DATA_AND_PRIVACY.md` link them.

## What does this resolve?

No tracked issue. Policy documents plus the site wiring to serve them.

## How was this solved?

Root documents are enumerated by hand in the site, so publishing a new one touches five places: the content loader pattern, the fetch regex, the reading order in `nav.ts`, the two hardcoded root-path maps (`routeForRepoPath`, `titleForRepoPath`) so markdown links to `TRADEMARK.md` and `PRIVACY.md` resolve to site pages instead of GitHub, and the footer's Project column. `Dictionary` is an explicit interface, so the two footer keys are declared there and translated in `en`, `es`, and `zh_Hans`.

The footer links target the current release. That release is `release/v0.7`, which does not carry these documents, so **#554 must merge first**. Without it the link checker reports every page's footer as pointing at a page that is not built.

## Validation

Ran with `versions.json` pointed at this branch for `nightly` and at the #554 branch for `v0.7`, then restored:

```
pnpm test        ok
pnpm check       0 errors
pnpm build       ok
node scripts/check-links.ts   ok: 310 pages, every internal link resolves
pnpm build:site && pnpm audit:dist --mode site   ok
pnpm build:docs && pnpm audit:dist --mode docs   ok, 307 pages
```

Rendered `/nightly/docs/contributing/` links to `/nightly/docs/trademark/` and `/nightly/docs/privacy/`; the footer links to `/docs/trademark/` and `/docs/privacy/`.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [ ] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

Not included: `zh_Hans` translations of the two documents. The site serves the English body under `/zh-Hans/` with the "not translated yet" notice, as it does for the other root documents.

## Labels to apply

`documentation`
