### PR TITLE
fix(web): point the nightly docs back at main

### DIFF
--- a/web/versions.json
+++ b/web/versions.json
@@ -1,5 +1,5 @@
 [
-  { "id": "nightly", "ref": "docs/trademark-policy", "noindex": true },
+  { "id": "nightly", "ref": "main", "noindex": true },
   { "id": "v0.7", "ref": "release/v0.7", "current": true },
   { "id": "v0.6", "ref": "release/v0.6" }
 ]


### PR DESCRIPTION
## Summary

Restores the `nightly` entry of `web/versions.json` to `ref: main`.

## What does this resolve?

The docs build on `main` fails since #553 merged: `fatal: couldn't find remote ref docs/trademark-policy`, then `No materialised documentation for version "nightly"`. The entry had been pointed at the PR branch for a local build check and slipped into the merge. The branch no longer exists.

## How was this solved?

One-line revert of the ref. No other change.

## Validation

`git diff` shows only the ref line. The docs build materialises nightly from `main` again once merged.

## Where was this tested?

- [x] Local development environment

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I applied the appropriate labels

## Labels to apply

`pipeline:bug`