### PR TITLE
fix(mongodb): use separate password in username-only URIs

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -90,6 +90,12 @@ jobs:
       - name: Install system dependencies
         if: runner.os == 'Linux'
         run: |
+          # The external Chrome APT source is irrelevant to Rust CI and can fail independently.
+          for chrome_source in /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources; do
+            if [ -f "$chrome_source" ]; then
+              sudo mv -- "$chrome_source" "$chrome_source.disabled"
+            fi
+          done
           sudo apt-get update
           sudo apt-get install -y \
             mold \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,12 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          # The external Chrome APT source is irrelevant to Rust CI and can fail independently.
+          for chrome_source in /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources; do
+            if [ -f "$chrome_source" ]; then
+              sudo mv -- "$chrome_source" "$chrome_source.disabled"
+            fi
+          done
           sudo apt-get update
           sudo apt-get install -y \
             mold \
@@ -84,6 +90,12 @@ jobs:
 
       - name: Install system dependencies
         run: |
+          # The external Chrome APT source is irrelevant to Rust CI and can fail independently.
+          for chrome_source in /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources; do
+            if [ -f "$chrome_source" ]; then
+              sudo mv -- "$chrome_source" "$chrome_source.disabled"
+            fi
+          done
           sudo apt-get update
           sudo apt-get install -y \
             mold \

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -1176,17 +1176,17 @@ fn inject_credentials_into_uri(
             ":"
         };
 
-        if !userinfo.is_empty() {
-            if let Some(password) = password {
-                return format!(
-                    "{}{}{}{}{}",
-                    prefix,
-                    &rest[..at_pos],
-                    password_separator,
-                    urlencoding::encode(password),
-                    &rest[at_pos..]
-                );
-            }
+        if !userinfo.is_empty()
+            && let Some(password) = password
+        {
+            return format!(
+                "{}{}{}{}{}",
+                prefix,
+                &rest[..at_pos],
+                password_separator,
+                urlencoding::encode(password),
+                &rest[at_pos..]
+            );
         }
 
         return base_uri.to_string();

--- a/crates/dbflux_driver_mongodb/src/driver.rs
+++ b/crates/dbflux_driver_mongodb/src/driver.rs
@@ -1155,34 +1155,58 @@ fn inject_credentials_into_uri(
     user: Option<&str>,
     password: Option<&str>,
 ) -> String {
-    let user_val = user.unwrap_or("");
+    let (prefix, rest) = if let Some(rest) = base_uri.strip_prefix("mongodb://") {
+        ("mongodb://", rest)
+    } else if let Some(rest) = base_uri.strip_prefix("mongodb+srv://") {
+        ("mongodb+srv://", rest)
+    } else {
+        return base_uri.to_string();
+    };
 
-    // Do not inject when there is no username — injecting ":password@" produces
-    // a malformed authority and would silently use the stored password against
-    // a URI that was never intended to carry credentials.
-    if user_val.is_empty() {
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+    if let Some(at_pos) = authority.rfind('@') {
+        let userinfo = &authority[..at_pos];
+        let password_separator = if let Some((_, password)) = userinfo.split_once(':') {
+            if !password.is_empty() {
+                return base_uri.to_string();
+            }
+            ""
+        } else {
+            ":"
+        };
+
+        if !userinfo.is_empty() {
+            if let Some(password) = password {
+                return format!(
+                    "{}{}{}{}{}",
+                    prefix,
+                    &rest[..at_pos],
+                    password_separator,
+                    urlencoding::encode(password),
+                    &rest[at_pos..]
+                );
+            }
+        }
+
         return base_uri.to_string();
     }
 
-    if base_uri.contains('@') {
-        base_uri.to_string()
-    } else if let Some(rest) = base_uri.strip_prefix("mongodb://") {
-        format!(
-            "mongodb://{}:{}@{}",
-            urlencoding::encode(user_val),
-            urlencoding::encode(password.unwrap_or("")),
-            rest
-        )
-    } else if let Some(rest) = base_uri.strip_prefix("mongodb+srv://") {
-        format!(
-            "mongodb+srv://{}:{}@{}",
-            urlencoding::encode(user_val),
-            urlencoding::encode(password.unwrap_or("")),
-            rest
-        )
-    } else {
-        base_uri.to_string()
+    let user = user.unwrap_or("");
+    // Do not inject when there is no username — injecting ":password@" produces
+    // a malformed authority and would silently use the stored password against
+    // a URI that was never intended to carry credentials.
+    if user.is_empty() {
+        return base_uri.to_string();
     }
+
+    format!(
+        "{}{}:{}@{}",
+        prefix,
+        urlencoding::encode(user),
+        urlencoding::encode(password.unwrap_or("")),
+        rest
+    )
 }
 
 /// Fills in a default `appName` when the URI did not already set one via `appName=`,
@@ -4233,6 +4257,53 @@ mod tests {
         assert_eq!(
             without_user.get("auth_database").map(String::as_str),
             Some("")
+        );
+    }
+
+    #[test]
+    fn inject_credentials_fills_password_for_username_only_uri_authority() {
+        let srv = inject_credentials_into_uri(
+            "mongodb+srv://user@cluster.mongodb.net/mydb",
+            Some("separate-user"),
+            Some("secret"),
+        );
+        assert_eq!(srv, "mongodb+srv://user:secret@cluster.mongodb.net/mydb");
+
+        let standard = inject_credentials_into_uri(
+            "mongodb://encoded%40user:@localhost:27017/admin",
+            Some("separate-user"),
+            Some("p@ss word"),
+        );
+        assert_eq!(
+            standard,
+            "mongodb://encoded%40user:p%40ss%20word@localhost:27017/admin"
+        );
+
+        let complete = inject_credentials_into_uri(
+            "mongodb://existing:creds@localhost:27017/admin",
+            Some("separate-user"),
+            Some("secret"),
+        );
+        assert_eq!(complete, "mongodb://existing:creds@localhost:27017/admin");
+
+        let without_password = inject_credentials_into_uri(
+            "mongodb+srv://user@cluster.mongodb.net/mydb",
+            Some("separate-user"),
+            None,
+        );
+        assert_eq!(
+            without_password,
+            "mongodb+srv://user@cluster.mongodb.net/mydb"
+        );
+
+        let query_at = inject_credentials_into_uri(
+            "mongodb://localhost:27017/admin?tag=user@example.com",
+            Some("alice"),
+            Some("secret"),
+        );
+        assert_eq!(
+            query_at,
+            "mongodb://alice:secret@localhost:27017/admin?tag=user@example.com"
         );
     }
 


### PR DESCRIPTION
## Summary

Fix MongoDB connections that use a username-only URI and a separately supplied password. The driver previously treated any `@` as proof of complete credentials, causing SCRAM to report that no password was supplied.

## What does this resolve?

Resolves #573.

Both Test Connection and normal connections use the affected helper. Saving a profile extracts embedded passwords, so embedding the password in the URI is not a durable workaround.

## How was this solved?

- Fill missing or empty URI passwords from the separate password field while preserving the URI username and its existing percent encoding.
- Preserve complete embedded credentials and encode injected passwords exactly once.
- Limit userinfo detection to the URI authority, so `@` in a query does not suppress credential injection.

| File | Change |
|------|--------|
| `crates/dbflux_driver_mongodb/src/driver.rs` | Scoped credential injection fix and regression tests. |

Review `inject_credentials_into_uri` first, then the regression tests. No UI, persistence, or authentication-option changes are included. A separately scoped CI follow-up is documented below.

## Validation

- [x] RED: the new username-only URI regression failed before the fix.
- [x] GREEN: `cargo test -p dbflux_driver_mongodb inject_credentials` passed all 4 matching tests, including an independent rerun.
- [x] `cargo test -p dbflux_driver_mongodb --lib`: 146 tests passed.
- [x] `cargo check -p dbflux_driver_mongodb` passed.
- [x] `cargo fmt --all -- --check` passed.
- [x] `git diff --check` passed before commit.
- [x] Native review approved and acknowledged, with one non-blocking informational advisory.
- [x] `cargo clippy --workspace -- -D warnings` passed after correcting the introduced `collapsible_if` lint in commit `90813202`.
- [x] `cargo test --workspace` passed on the corrected source. The earlier compilation timeout was resolved by allowing the run to finish.
- [x] The lint correction received a fresh approved native review and acknowledgement; the parent also reran the 4 focused credential-injection tests successfully.
- [ ] Live MongoDB / UI connection verification was not performed.

Regression coverage includes SRV and standard URIs, username-only and empty-password userinfo, encoded usernames and passwords, complete credentials, absent passwords, and query `@` characters.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

Tests were headless; no display-server-specific behavior was exercised.

## Checklist

- [ ] I verified the change against the affected user flow(s) in a running application
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I used a user-visible Conventional Commit; the changelog is generated from history per CONTRIBUTING.md, not edited manually
- [x] I applied the appropriate repository labels


## CI follow-up: Chrome APT repository

Commit `067024a2` disables only the runner's `google-chrome.list` / `google-chrome.sources` entries before APT update in the three affected Linux dependency-installation steps (`tests.yml` and `style.yml`). The maintainer approved including this follow-up in this PR.

Both attempts on the prior head failed before Rust ran: APT reported `Hash Sum mismatch` from Google's Chrome package index and exited 100. The unrelated Chrome source is now renamed to a disabled extension; APT integrity checks, package lists, workflow permissions, action pins, and test commands remain unchanged.

Validation: shell syntax and a temporary fixture passed for both source formats, preservation of an unrelated Ubuntu source, and repeated execution. Structural assertions confirmed all three insertion points; `git diff --check` passed. Native review approved the CI change. Local `actionlint`, `shellcheck`, and YAML parsers were unavailable; hosted Actions results for this commit remain pending.
