### PR TITLE
fix(results): keep the context menu in the window and open submenus on hover

### DIFF
--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/mod.rs
@@ -32,6 +32,67 @@ enum FilterBackend {
     Mongo,
 }
 
+/// Gap kept between the context menu and the panel edge.
+const CONTEXT_MENU_EDGE_GAP: Pixels = Spacing::XS;
+
+/// Width of the widest submenu (the filter list). A menu whose right edge
+/// leaves less than this to the panel edge opens its submenus to the left,
+/// provided the left side has the room.
+const SUBMENU_MAX_WIDTH: Pixels = px(280.0);
+
+/// How far a submenu overlaps the menu it hangs off (menu width 180 less the
+/// 172 offset in `sections.rs`), so the room it needs is its width less this.
+const SUBMENU_OVERLAP: Pixels = px(8.0);
+
+/// Where a context menu goes, in panel coordinates.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct ContextMenuPlacement {
+    pub(super) origin: Point<Pixels>,
+    pub(super) submenus_open_left: bool,
+}
+
+/// Keep the menu inside the panel.
+///
+/// The click stays the anchor: the menu is shifted left when it would run
+/// past the right edge and up when it would run past the bottom, and never
+/// past the top-left gap. Submenus open to the right unless the widest one
+/// would not fit there but would fit on the left; in a panel too narrow for
+/// either they stay on the right, where at least their start is visible. A
+/// panel that has not been measured yet reports a zero size;
+/// clamping against it would pin every menu into the corner, so an unmeasured
+/// panel leaves the click alone.
+pub(super) fn place_context_menu(
+    click: Point<Pixels>,
+    menu_width: Pixels,
+    menu_height: Pixels,
+    panel: Size<Pixels>,
+) -> ContextMenuPlacement {
+    if panel.width <= menu_width || panel.height <= menu_height {
+        return ContextMenuPlacement {
+            origin: click,
+            submenus_open_left: false,
+        };
+    }
+
+    let x = click
+        .x
+        .min(panel.width - menu_width - CONTEXT_MENU_EDGE_GAP)
+        .max(CONTEXT_MENU_EDGE_GAP);
+    let y = if click.y + menu_height + CONTEXT_MENU_EDGE_GAP > panel.height {
+        (panel.height - menu_height - CONTEXT_MENU_EDGE_GAP).max(CONTEXT_MENU_EDGE_GAP)
+    } else {
+        click.y
+    };
+
+    let fits_right = x + menu_width - SUBMENU_OVERLAP + SUBMENU_MAX_WIDTH <= panel.width;
+    let fits_left = x + SUBMENU_OVERLAP >= SUBMENU_MAX_WIDTH;
+
+    ContextMenuPlacement {
+        origin: Point { x, y },
+        submenus_open_left: !fits_right && fits_left,
+    }
+}
+
 impl DataGridPanel {
     fn restore_focus_after_context_menu(
         &mut self,
@@ -1289,8 +1350,15 @@ impl DataGridPanel {
         let menu_width = px(180.0);
 
         // Convert window coordinates to panel-relative coordinates
-        let menu_x = menu.position.x - self.panel_origin.x;
-        let menu_y = menu.position.y - self.panel_origin.y;
+        let click = Point {
+            x: menu.position.x - self.panel_origin.x,
+            y: menu.position.y - self.panel_origin.y,
+        };
+        // The horizontal position decides which side the submenus open on,
+        // and the items need to know that before they are built; the
+        // vertical position needs the item count, so it is settled after.
+        let submenus_open_left =
+            place_context_menu(click, menu_width, px(0.0), self.panel_size).submenus_open_left;
 
         // Build visible menu items list for keyboard navigation
         let has_row_target = self.has_context_menu_row_target(menu.row, menu.is_document_view, cx);
@@ -1324,6 +1392,7 @@ impl DataGridPanel {
 
         self.render_filter_submenu_section(
             menu,
+            submenus_open_left,
             backend,
             has_filter,
             selected_index,
@@ -1335,6 +1404,7 @@ impl DataGridPanel {
 
         self.render_order_submenu_section(
             menu,
+            submenus_open_left,
             has_order,
             selected_index,
             theme,
@@ -1346,6 +1416,7 @@ impl DataGridPanel {
         Self::render_generate_sql_submenu_section(
             is_document_view,
             menu,
+            submenus_open_left,
             selected_index,
             theme,
             &mut menu_items,
@@ -1355,6 +1426,7 @@ impl DataGridPanel {
 
         self.render_copy_query_submenu_section(
             menu,
+            submenus_open_left,
             selected_index,
             theme,
             &mut menu_items,
@@ -1371,7 +1443,18 @@ impl DataGridPanel {
             cx,
         );
 
-        self.render_context_menu_overlay(menu_x, menu_y, menu_width, menu_items, cx)
+        // Separators are shorter than rows, so this over-estimates a little;
+        // a menu placed a few pixels higher than necessary is harmless.
+        let menu_height = Heights::ROW_COMPACT * menu_items.len() as f32 + Spacing::XS * 2.0;
+        let placement = place_context_menu(click, menu_width, menu_height, self.panel_size);
+
+        self.render_context_menu_overlay(
+            placement.origin.x,
+            placement.origin.y,
+            menu_width,
+            menu_items,
+            cx,
+        )
     }
 
     pub(super) fn handle_context_menu_action(
@@ -3640,6 +3723,95 @@ fn record_clipboard_audit(
 #[cfg(test)]
 mod tests {
     use super::DataGridPanel;
+    use super::{CONTEXT_MENU_EDGE_GAP, SUBMENU_MAX_WIDTH, SUBMENU_OVERLAP, place_context_menu};
+    use gpui::{Pixels, Point, Size, px};
+
+    fn panel() -> Size<Pixels> {
+        Size {
+            width: px(1000.0),
+            height: px(600.0),
+        }
+    }
+
+    #[test]
+    fn a_menu_that_fits_stays_at_the_click_and_opens_submenus_to_the_right() {
+        let click = Point {
+            x: px(100.0),
+            y: px(100.0),
+        };
+        let placed = place_context_menu(click, px(180.0), px(300.0), panel());
+        assert_eq!(placed.origin, click);
+        assert!(!placed.submenus_open_left);
+    }
+
+    #[test]
+    fn a_menu_near_the_right_edge_is_shifted_in_and_opens_submenus_to_the_left() {
+        let click = Point {
+            x: px(950.0),
+            y: px(100.0),
+        };
+        let placed = place_context_menu(click, px(180.0), px(300.0), panel());
+        assert_eq!(
+            placed.origin.x,
+            px(1000.0) - px(180.0) - CONTEXT_MENU_EDGE_GAP
+        );
+        assert_eq!(placed.origin.y, click.y);
+        assert!(placed.submenus_open_left);
+    }
+
+    #[test]
+    fn submenus_open_left_as_soon_as_the_widest_one_would_not_fit() {
+        let click = Point {
+            x: px(1000.0) - px(180.0) + SUBMENU_OVERLAP - SUBMENU_MAX_WIDTH + px(1.0),
+            y: px(100.0),
+        };
+        let placed = place_context_menu(click, px(180.0), px(300.0), panel());
+        assert_eq!(placed.origin.x, click.x, "the menu itself still fits");
+        assert!(placed.submenus_open_left);
+    }
+
+    /// A panel too narrow for a submenu on either side keeps them on the
+    /// right: a submenu pushed off the left edge would be invisible, one
+    /// hanging past the right edge is at least partly usable.
+    #[test]
+    fn a_narrow_panel_keeps_submenus_on_the_right() {
+        let narrow = Size {
+            width: px(400.0),
+            height: px(600.0),
+        };
+        let click = Point {
+            x: px(20.0),
+            y: px(100.0),
+        };
+        let placed = place_context_menu(click, px(180.0), px(300.0), narrow);
+        assert_eq!(placed.origin, click);
+        assert!(!placed.submenus_open_left);
+    }
+
+    #[test]
+    fn a_menu_near_the_bottom_is_moved_up_to_fit() {
+        let click = Point {
+            x: px(100.0),
+            y: px(500.0),
+        };
+        let placed = place_context_menu(click, px(180.0), px(300.0), panel());
+        assert_eq!(placed.origin.x, click.x);
+        assert_eq!(
+            placed.origin.y,
+            px(600.0) - px(300.0) - CONTEXT_MENU_EDGE_GAP
+        );
+    }
+
+    #[test]
+    fn an_unmeasured_panel_leaves_the_click_alone() {
+        let click = Point {
+            x: px(950.0),
+            y: px(500.0),
+        };
+        let placed = place_context_menu(click, px(180.0), px(300.0), Size::default());
+        assert_eq!(placed.origin, click);
+        assert!(!placed.submenus_open_left);
+    }
 
     fn labels(items: &[super::ContextMenuItem]) -> Vec<String> {
         items

--- a/crates/dbflux_ui_document/src/data_grid_panel/context_menu/sections.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/context_menu/sections.rs
@@ -7,9 +7,31 @@ use dbflux_components::tokens::{FontSizes, Heights, Radii, Spacing};
 use gpui::prelude::FluentBuilder;
 use gpui::{deferred, *};
 
+/// Distance from the menu's edge at which a submenu hangs off its item: the
+/// menu width less a small overlap, so the two read as one surface.
+const SUBMENU_OFFSET: Pixels = px(172.0);
+
+/// The frame a submenu hangs in.
+///
+/// It sits beside its row, on the right unless the menu is against the
+/// panel's right edge, and `anchored` slides it back into the window when
+/// it would run past the bottom or a side: a long filter list opened from a
+/// row near the bottom of the window is shifted up rather than cut off.
+fn submenu_frame(open_left: bool, flyout: Div) -> Div {
+    let (frame, corner) = if open_left {
+        (div().absolute().right(SUBMENU_OFFSET), Corner::TopRight)
+    } else {
+        (div().absolute().left(SUBMENU_OFFSET), Corner::TopLeft)
+    };
+    frame.top(px(-4.0)).child(
+        anchored()
+            .anchor(corner)
+            .snap_to_window_with_margin(Spacing::XS)
+            .child(flyout),
+    )
+}
+
 impl DataGridPanel {
-    /// Renders the flat list of visible menu items (Copy, Paste, Edit, Add Row, ...)
-    /// built from `build_context_menu_items`, including separators.
     pub(super) fn render_menu_item_rows(
         theme: &gpui_component::theme::Theme,
         selected_index: usize,
@@ -79,9 +101,10 @@ impl DataGridPanel {
                     })
                     .on_mouse_move(cx.listener(move |this, _, _, cx| {
                         if let Some(ref mut menu) = this.context_menu
-                            && menu.selected_index != current_index
+                            && (menu.selected_index != current_index || menu.any_submenu_open())
                         {
                             menu.selected_index = current_index;
+                            menu.close_submenus();
                             cx.notify();
                         }
                     }))
@@ -120,6 +143,7 @@ impl DataGridPanel {
     pub(super) fn render_filter_submenu_section(
         &self,
         menu: &TableContextMenu,
+        submenus_open_left: bool,
         backend: Option<FilterBackend>,
         has_filter: bool,
         selected_index: usize,
@@ -182,11 +206,16 @@ impl DataGridPanel {
                     d.hover(|d| d.bg(submenu_hover))
                 })
                 .on_mouse_move(cx.listener(move |this, _, _, cx| {
+                    // Hovering opens the submenu, as native menus do; the
+                    // flyout is a child of this row, so moving into it keeps
+                    // bubbling here and the guard leaves it open.
                     if let Some(ref mut menu) = this.context_menu
-                        && menu.selected_index != filter_index
-                        && !menu.filter_submenu_open
+                        && !(menu.selected_index == filter_index && menu.filter_submenu_open)
                     {
                         menu.selected_index = filter_index;
+                        menu.close_submenus();
+                        menu.filter_submenu_open = true;
+                        menu.submenu_selected_index = 0;
                         cx.notify();
                     }
                 }))
@@ -220,14 +249,17 @@ impl DataGridPanel {
                     },
                 ))
                 .when(filter_submenu_open, |d: Stateful<Div>| {
-                    d.child(Self::build_filter_submenu_flyout(
-                        filter_items,
-                        value_ops_count,
-                        filter_submenu_count,
-                        submenu_selected_index,
-                        cell_value_label,
-                        theme,
-                        cx,
+                    d.child(submenu_frame(
+                        submenus_open_left,
+                        Self::build_filter_submenu_flyout(
+                            filter_items,
+                            value_ops_count,
+                            filter_submenu_count,
+                            submenu_selected_index,
+                            cell_value_label,
+                            theme,
+                            cx,
+                        ),
                     ))
                 })
                 .into_any_element(),
@@ -255,9 +287,6 @@ impl DataGridPanel {
         let remove_separator_idx = filter_submenu_count.saturating_sub(1);
 
         div()
-            .absolute()
-            .left(px(172.0))
-            .top(px(-4.0))
             .w(px(280.0))
             .bg(submenu_bg)
             .border_1()
@@ -364,6 +393,7 @@ impl DataGridPanel {
     pub(super) fn render_order_submenu_section(
         &self,
         menu: &TableContextMenu,
+        submenus_open_left: bool,
         has_order: bool,
         selected_index: usize,
         theme: &gpui_component::theme::Theme,
@@ -419,11 +449,16 @@ impl DataGridPanel {
                     d.hover(|d| d.bg(submenu_hover))
                 })
                 .on_mouse_move(cx.listener(move |this, _, _, cx| {
+                    // Hovering opens the submenu, as native menus do; the
+                    // flyout is a child of this row, so moving into it keeps
+                    // bubbling here and the guard leaves it open.
                     if let Some(ref mut menu) = this.context_menu
-                        && menu.selected_index != order_index
-                        && !menu.order_submenu_open
+                        && !(menu.selected_index == order_index && menu.order_submenu_open)
                     {
                         menu.selected_index = order_index;
+                        menu.close_submenus();
+                        menu.order_submenu_open = true;
+                        menu.submenu_selected_index = 0;
                         cx.notify();
                     }
                 }))
@@ -457,12 +492,15 @@ impl DataGridPanel {
                     },
                 ))
                 .when(order_submenu_open, |d: Stateful<Div>| {
-                    d.child(Self::build_order_submenu_flyout(
-                        &col_name_for_order,
-                        submenu_selected_index,
-                        remove_ordering_label,
-                        theme,
-                        cx,
+                    d.child(submenu_frame(
+                        submenus_open_left,
+                        Self::build_order_submenu_flyout(
+                            &col_name_for_order,
+                            submenu_selected_index,
+                            remove_ordering_label,
+                            theme,
+                            cx,
+                        ),
                     ))
                 })
                 .into_any_element(),
@@ -503,9 +541,6 @@ impl DataGridPanel {
         ];
 
         div()
-            .absolute()
-            .left(px(172.0))
-            .top(px(-4.0))
             .w(px(200.0))
             .bg(submenu_bg)
             .border_1()
@@ -594,9 +629,11 @@ impl DataGridPanel {
 
     /// Renders the "Generate SQL" submenu trigger (SELECT WHERE / INSERT / UPDATE / DELETE
     /// templates). Only present for table views, never for the document view.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn render_generate_sql_submenu_section(
         is_document_view: bool,
         menu: &TableContextMenu,
+        submenus_open_left: bool,
         selected_index: usize,
         theme: &gpui_component::theme::Theme,
         menu_items: &mut Vec<AnyElement>,
@@ -655,11 +692,16 @@ impl DataGridPanel {
                     d.hover(|d| d.bg(submenu_hover))
                 })
                 .on_mouse_move(cx.listener(move |this, _, _, cx| {
+                    // Hovering opens the submenu, as native menus do; the
+                    // flyout is a child of this row, so moving into it keeps
+                    // bubbling here and the guard leaves it open.
                     if let Some(ref mut menu) = this.context_menu
-                        && menu.selected_index != gen_sql_index
-                        && !menu.sql_submenu_open
+                        && !(menu.selected_index == gen_sql_index && menu.sql_submenu_open)
                     {
                         menu.selected_index = gen_sql_index;
+                        menu.close_submenus();
+                        menu.sql_submenu_open = true;
+                        menu.submenu_selected_index = 0;
                         cx.notify();
                     }
                 }))
@@ -688,10 +730,9 @@ impl DataGridPanel {
                 ))
                 // Submenu appears to the right
                 .when(sql_submenu_open, |d: Stateful<Div>| {
-                    d.child(Self::build_generate_sql_submenu_flyout(
-                        submenu_selected_index,
-                        theme,
-                        cx,
+                    d.child(submenu_frame(
+                        submenus_open_left,
+                        Self::build_generate_sql_submenu_flyout(submenu_selected_index, theme, cx),
                     ))
                 })
                 .into_any_element(),
@@ -711,9 +752,6 @@ impl DataGridPanel {
         let submenu_hover = theme.secondary;
 
         div()
-            .absolute()
-            .left(px(172.0)) // menu_width - some padding
-            .top(px(-4.0))
             .w(px(160.0))
             .bg(submenu_bg)
             .border_1()
@@ -785,9 +823,11 @@ impl DataGridPanel {
 
     /// Renders the "Copy as Query" submenu trigger (INSERT / UPDATE / DELETE templates
     /// for the current row), gated on driver support for query generation.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn render_copy_query_submenu_section(
         &self,
         menu: &TableContextMenu,
+        submenus_open_left: bool,
         selected_index: usize,
         theme: &gpui_component::theme::Theme,
         menu_items: &mut Vec<AnyElement>,
@@ -837,11 +877,17 @@ impl DataGridPanel {
                     d.hover(|d| d.bg(submenu_hover))
                 })
                 .on_mouse_move(cx.listener(move |this, _, _, cx| {
+                    // Hovering opens the submenu, as native menus do; the
+                    // flyout is a child of this row, so moving into it keeps
+                    // bubbling here and the guard leaves it open.
                     if let Some(ref mut menu) = this.context_menu
-                        && menu.selected_index != copy_query_index
-                        && !menu.copy_query_submenu_open
+                        && !(menu.selected_index == copy_query_index
+                            && menu.copy_query_submenu_open)
                     {
                         menu.selected_index = copy_query_index;
+                        menu.close_submenus();
+                        menu.copy_query_submenu_open = true;
+                        menu.submenu_selected_index = 0;
                         cx.notify();
                     }
                 }))
@@ -875,10 +921,9 @@ impl DataGridPanel {
                     },
                 ))
                 .when(copy_submenu_open, |d: Stateful<Div>| {
-                    d.child(Self::build_copy_query_submenu_flyout(
-                        submenu_selected_index,
-                        theme,
-                        cx,
+                    d.child(submenu_frame(
+                        submenus_open_left,
+                        Self::build_copy_query_submenu_flyout(submenu_selected_index, theme, cx),
                     ))
                 })
                 .into_any_element(),
@@ -898,9 +943,6 @@ impl DataGridPanel {
         let submenu_hover = theme.secondary;
 
         div()
-            .absolute()
-            .left(px(172.0))
-            .top(px(-4.0))
             .w(px(140.0))
             .bg(submenu_bg)
             .border_1()
@@ -1039,9 +1081,10 @@ impl DataGridPanel {
                     })
                     .on_mouse_move(cx.listener(move |this, _, _, cx| {
                         if let Some(ref mut menu) = this.context_menu
-                            && menu.selected_index != current_index
+                            && (menu.selected_index != current_index || menu.any_submenu_open())
                         {
                             menu.selected_index = current_index;
+                            menu.close_submenus();
                             cx.notify();
                         }
                     }))
@@ -1093,6 +1136,19 @@ impl DataGridPanel {
 
     /// Wraps the assembled `menu_items` in the deferred, window-level overlay: a
     /// full-size click-catcher (closes the menu) plus the positioned menu surface.
+    /// Close the menu without running anything and hand focus back.
+    fn dismiss_context_menu(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let is_document_view = self
+            .context_menu
+            .as_ref()
+            .map(|menu| menu.is_document_view)
+            .unwrap_or(false);
+
+        self.context_menu = None;
+        self.restore_focus_after_context_menu(is_document_view, window, cx);
+        cx.notify();
+    }
+
     pub(super) fn render_context_menu_overlay(
         &self,
         menu_x: Pixels,
@@ -1125,31 +1181,17 @@ impl DataGridPanel {
                 }))
                 .on_mouse_down(
                     MouseButton::Left,
-                    cx.listener(|this, _, window, cx| {
-                        let is_document_view = this
-                            .context_menu
-                            .as_ref()
-                            .map(|menu| menu.is_document_view)
-                            .unwrap_or(false);
-
-                        this.context_menu = None;
-                        this.restore_focus_after_context_menu(is_document_view, window, cx);
-                        cx.notify();
-                    }),
+                    cx.listener(|this, _, window, cx| this.dismiss_context_menu(window, cx)),
                 )
                 .on_mouse_down(
                     MouseButton::Right,
-                    cx.listener(|this, _, window, cx| {
-                        let is_document_view = this
-                            .context_menu
-                            .as_ref()
-                            .map(|menu| menu.is_document_view)
-                            .unwrap_or(false);
-
-                        this.context_menu = None;
-                        this.restore_focus_after_context_menu(is_document_view, window, cx);
-                        cx.notify();
-                    }),
+                    cx.listener(|this, _, window, cx| this.dismiss_context_menu(window, cx)),
+                )
+                // The overlay covers the grid, so a wheel here would scroll
+                // nothing; closing instead keeps the menu from hanging over a
+                // grid that has scrolled away from under it.
+                .on_scroll_wheel(
+                    cx.listener(|this, _, window, cx| this.dismiss_context_menu(window, cx)),
                 )
                 .child(
                     surface_raised(cx)
@@ -1160,6 +1202,9 @@ impl DataGridPanel {
                         .w(menu_width)
                         .shadow_lg()
                         .py(Spacing::XS)
+                        // No overflow clip here: the submenus are children
+                        // of their rows and hang outside this panel. Long
+                        // labels are truncated by their own rows instead.
                         .occlude()
                         .on_mouse_down(MouseButton::Left, |_, _, cx| {
                             cx.stop_propagation();
@@ -1173,6 +1218,25 @@ impl DataGridPanel {
 
 #[cfg(test)]
 mod tests {
+    /// The menu panel must not clip its contents: submenus are absolutely
+    /// positioned children of their rows and hang past the panel's right
+    /// edge, so a clip on the panel hides every one of them.
+    #[test]
+    fn menu_panel_does_not_clip_its_submenus() {
+        let source = include_str!("sections.rs");
+        let panel_start = source
+            .find(".id(\"context-menu\")")
+            .expect("the menu panel is built in this file");
+        let panel = &source[panel_start..];
+        let panel_end = panel
+            .find(".children(menu_items)")
+            .expect("the panel takes the menu items");
+        assert!(
+            !panel[..panel_end].contains(".overflow_hidden()"),
+            "the menu panel clips its submenus"
+        );
+    }
+
     #[test]
     fn context_menu_sections_keys_resolve_in_both_locales() {
         let keys = [

--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -362,6 +362,24 @@ struct TableContextMenu {
     row_actions: Vec<dbflux_core::InspectorRowAction>,
 }
 
+impl TableContextMenu {
+    fn any_submenu_open(&self) -> bool {
+        self.sql_submenu_open
+            || self.copy_query_submenu_open
+            || self.filter_submenu_open
+            || self.order_submenu_open
+    }
+
+    /// Hovering a plain item closes whatever submenu was open, as native
+    /// menus do.
+    fn close_submenus(&mut self) {
+        self.sql_submenu_open = false;
+        self.copy_query_submenu_open = false;
+        self.filter_submenu_open = false;
+        self.order_submenu_open = false;
+    }
+}
+
 /// A single item in the context menu.
 struct ContextMenuItem {
     label: SharedString,
@@ -589,6 +607,8 @@ pub struct DataGridPanel {
     runner: DocumentTaskRunner,
     focus_handle: FocusHandle,
     panel_origin: Point<Pixels>,
+    /// Panel size from the same canvas; the context menu is kept inside it.
+    panel_size: Size<Pixels>,
     view_config: super::data_view::DataViewConfig,
     context_menu: Option<TableContextMenu>,
     is_active_tab: bool,
@@ -1163,6 +1183,7 @@ impl DataGridPanel {
             runner,
             focus_handle,
             panel_origin: Point::default(),
+            panel_size: Size::default(),
             view_config,
             context_menu: None,
             is_active_tab: true,

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -413,6 +413,7 @@ impl DataGridPanel {
             move |bounds, _, cx| {
                 this_entity.update(cx, |this, _cx| {
                     this.panel_origin = bounds.origin;
+                    this.panel_size = bounds.size;
                 });
             },
             |_, _, _, _| {},


### PR DESCRIPTION
## Summary

Three problems with the cell context menu, fixed together because they share one placement rule:

- **Cut off at the edges.** The menu was drawn exactly at the click, so near the right or bottom edge of the panel it ran off screen. It is now shifted left or up to fit, and submenus open to the left when there is no room on the right.
- **Left hanging while scrolling.** The menu stayed where it was while the grid scrolled away underneath. A wheel over the open menu now closes it, as native menus do.
- **Submenus needed a click.** Filter, Order, Generate SQL and Copy as SQL open on hover now, and hovering a plain item closes them. Each submenu hangs in an `anchored` frame that snaps back into the window, so a long filter list opened from a row near the bottom is shifted up instead of being cut off.

## What does this resolve?

No issue filed; found while using the grid.

## How was this solved?

- `DataGridPanel` measures its size alongside its origin (same canvas). `place_context_menu` in `context_menu/mod.rs` is a pure function: click → origin inside the panel plus which side submenus open on. It runs once before the items are built (the horizontal side decides how the submenu rows are rendered) and once after (the vertical shift needs the item count).
- `sections.rs`: `submenu_frame` positions each flyout beside its row on the chosen side and wraps it in `anchored().snap_to_window_with_margin(…)`. The four trigger rows open their submenu from `on_mouse_move`; plain rows close it (`TableContextMenu::close_submenus`). The overlay closes on `on_scroll_wheel` through one `dismiss_context_menu` helper shared with the existing mouse-down paths.
- Six unit tests on `place_context_menu` (fits, right edge, bottom edge, side threshold, narrow panel, unmeasured panel) and one that pins that the menu panel never clips its contents, since the submenus hang outside it.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy -p dbflux_ui_document -- -D warnings` clean.
- `cargo test -p dbflux_ui_document -- context_menu`: 42 tests pass.
- Manual, macOS: right-click near the right edge — menu fits, Filter/Order open to the left; near the bottom — menu moves up, and the Filter submenu opened from the last row is shifted up whole; wheel with the menu open closes it; hover across Filter → Order → Copy switches and closes submenus.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [ ] Linux
- [x] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (generated from commits at release time, as requested)
- [ ] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

`ui:bug`