### PR TITLE
fix(results): let the Export button close its menu

### DIFF
--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -160,6 +160,9 @@ impl Render for DataGridPanel {
             .when_some(self.context_menu.as_ref(), |d, menu| {
                 d.child(self.render_context_menu(menu, st.is_editable, &st.theme, cx))
             })
+            .when(self.chrome.export_menu_open, |d| {
+                d.child(self.render_export_backdrop(cx))
+            })
             .when(self.pending_delete_confirm.is_some(), |d| {
                 d.child(self.render_delete_confirm_modal(&st.theme, cx))
             })
@@ -3828,11 +3831,43 @@ impl DataGridPanel {
                 .on_mouse_down(MouseButton::Left, |_, _, cx| {
                     cx.stop_propagation();
                 })
-                .on_mouse_down_out(cx.listener(|this, _, _, cx| {
-                    this.chrome.export_menu_open = false;
-                    cx.notify();
-                }))
                 .children(items),
+        )
+        // Above the backdrop, which shares the deferred layer.
+        .with_priority(2)
+    }
+
+    /// Full-panel layer under the export menu.
+    ///
+    /// Any press on it closes the menu. Because it also covers the Export
+    /// button, a second click on the button lands here and closes the menu
+    /// rather than reaching the button and reopening it — which is what made
+    /// the button open-only before. Scrolling closes the menu as well.
+    fn render_export_backdrop(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        // The press must end here: the Export button below toggles the menu
+        // on click, so a press that reached it would reopen what this closed.
+        let close = |this: &mut Self, cx: &mut Context<Self>| {
+            this.chrome.export_menu_open = false;
+            cx.stop_propagation();
+            cx.notify();
+        };
+
+        deferred(
+            div()
+                .id("export-menu-backdrop")
+                .absolute()
+                .top_0()
+                .left_0()
+                .size_full()
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _, _, cx| close(this, cx)),
+                )
+                .on_mouse_down(
+                    MouseButton::Right,
+                    cx.listener(move |this, _, _, cx| close(this, cx)),
+                )
+                .on_scroll_wheel(cx.listener(move |this, _, _, cx| close(this, cx))),
         )
         .with_priority(1)
     }


### PR DESCRIPTION
## Summary

A second click on **Export** did not close its menu. The menu closed on a press outside it (`on_mouse_down_out`, capture phase), and then the same click reached the button, whose handler toggles the menu — so it closed and reopened in one click. A full-panel layer under the menu now takes any press or wheel, closes the menu and stops the event; the button reads as a toggle, and a click anywhere else still dismisses.

## What does this resolve?

No issue filed; found while using the grid.

## How was this solved?

- `render_export_backdrop` in `data_grid_panel/render.rs`: a deferred, full-size, transparent layer rendered while `export_menu_open`, closing on left/right mouse-down and on wheel, with `stop_propagation` so the press does not reach the Export button beneath it.
- The menu itself moves to deferred priority 2 so it stays above the backdrop; its `on_mouse_down_out` is gone.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy -p dbflux_ui_document -- -D warnings` clean.
- Manual, macOS: Export opens; Export again closes; open then click into the grid — closes; open then choose CSV — export runs as before.

## Where was this tested?

- [x] Local development environment
- [ ] Automated tests
- [ ] Linux
- [x] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed (interaction-only change; no unit seam)
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (generated from commits at release time, as requested)
- [ ] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

`ui:bug`