### PR TITLE
fix(results): hold the no-primary-key banner until the key is fetched

### DIFF
--- a/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/mod.rs
@@ -589,6 +589,10 @@ pub struct DataGridPanel {
     runner: DocumentTaskRunner,
     focus_handle: FocusHandle,
     panel_origin: Point<Pixels>,
+    /// A table-details fetch for the primary key is in flight. Until it
+    /// answers, the grid is read-only for want of a key it may well have, so
+    /// the "no primary key" banner waits rather than flashing on every open.
+    pk_details_pending: bool,
     view_config: super::data_view::DataViewConfig,
     context_menu: Option<TableContextMenu>,
     is_active_tab: bool,
@@ -718,6 +722,9 @@ impl DataGridPanel {
             }
         };
 
+        self.pk_details_pending = true;
+        cx.notify();
+
         let entity = cx.entity().clone();
         let app_state = self.app_state.clone();
 
@@ -738,6 +745,10 @@ impl DataGridPanel {
                             ),
                             cx,
                         );
+                        entity.update(cx, |panel, cx| {
+                            panel.pk_details_pending = false;
+                            cx.notify();
+                        });
                         return;
                     }
                 };
@@ -771,6 +782,8 @@ impl DataGridPanel {
 
                 // Update panel with PK info and recompute editable binding.
                 entity.update(cx, |panel, cx| {
+                    panel.pk_details_pending = false;
+                    cx.notify();
                     if !pk_names.is_empty() {
                         panel.pk_columns = pk_names;
                     }
@@ -1163,6 +1176,7 @@ impl DataGridPanel {
             runner,
             focus_handle,
             panel_origin: Point::default(),
+            pk_details_pending: false,
             view_config,
             context_menu: None,
             is_active_tab: true,

--- a/crates/dbflux_ui_document/src/data_grid_panel/render.rs
+++ b/crates/dbflux_ui_document/src/data_grid_panel/render.rs
@@ -355,6 +355,7 @@ impl DataGridPanel {
             && shows_table_content
             && !is_editable
             && !is_grouped_result
+            && !self.pk_details_pending
             && self.builder.current_visual_spec.is_none();
         let show_builder_readonly_hint = is_table_view
             && shows_table_content


### PR DESCRIPTION
## Summary

Opening a table from the sidebar flashed the "This table has no primary key – editing is disabled" banner for a moment, then hid it. The rows load before the table details that carry the primary key, so the grid was briefly read-only for want of a key it usually has. The panel now records that the details fetch is in flight and shows the banner only once it has answered; a table that really has no key still gets it.

## What does this resolve?

No issue filed; found while using the grid.

## How was this solved?

- `DataGridPanel::pk_details_pending` is set when `fetch_table_details_for_pk` starts and cleared on both its success and error paths.
- `show_pk_warning` in `render.rs` adds `&& !self.pk_details_pending`.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy -p dbflux_ui_document -- -D warnings` clean.
- Manual, macOS: opening several tables from the sidebar no longer flashes the banner; a table without a primary key still shows it once loaded.

## Where was this tested?

- [x] Local development environment
- [ ] Automated tests
- [ ] Linux
- [x] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed (a timing-only change in an async path)
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (generated from commits at release time, as requested)
- [ ] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

`ui:bug`