### PR TITLE
fix(connection): use the keyring password on the pipeline connect path

### DIFF
--- a/crates/dbflux_mcp_server/src/server.rs
+++ b/crates/dbflux_mcp_server/src/server.rs
@@ -176,6 +176,13 @@ impl McpConnectionFactory {
         driver: Arc<dyn dbflux_core::DbDriver>,
         profile: dbflux_core::ConnectionProfile,
     ) -> Result<Arc<CachedConnection>, String> {
+        // The keyring password is resolved before the pipeline runs: the pipeline
+        // only yields a password when the profile carries a `ValueRef` for it, so a
+        // profile that routes through the pipeline (auth profile, access kind, value
+        // refs) but stores its password in the OS keyring would otherwise connect
+        // with no password at all. The GUI applies the same fallback.
+        let keyring_password =
+            DbFluxServer::resolve_profile_secrets(&self.state, &profile)?.password;
         let pipeline_input = self.build_pipeline_input(profile).await?;
         let (state_tx, _state_rx) = dbflux_core::pipeline_state_channel();
         let pipeline_output = dbflux_core::run_pipeline(pipeline_input, &state_tx)
@@ -191,7 +198,8 @@ impl McpConnectionFactory {
                 .redirect_to_tunnel(access_handle.local_port());
         }
 
-        let overrides = ConnectionOverrides::new(pipeline_output.resolved_password);
+        let overrides =
+            ConnectionOverrides::new(pipeline_output.resolved_password.or(keyring_password));
         let driver_id_for_error = driver_id.clone();
         let connection_key_for_error = connection_key.clone();
 
@@ -759,10 +767,57 @@ mod tests {
         }
     }
 
+    /// In-memory secret store so tests can exercise the keyring-backed
+    /// resolution paths without touching the OS keyring.
+    #[derive(Default)]
+    struct InMemorySecretStore {
+        secrets: Mutex<HashMap<String, String>>,
+    }
+
+    impl dbflux_core::SecretStore for InMemorySecretStore {
+        fn is_available(&self) -> bool {
+            true
+        }
+
+        fn get(&self, secret_ref: &str) -> Result<Option<SecretString>, dbflux_core::DbError> {
+            Ok(self
+                .secrets
+                .lock()
+                .expect("secret store mutex poisoned")
+                .get(secret_ref)
+                .map(|value| SecretString::from(value.clone())))
+        }
+
+        fn set(&self, secret_ref: &str, value: &SecretString) -> Result<(), dbflux_core::DbError> {
+            self.secrets
+                .lock()
+                .expect("secret store mutex poisoned")
+                .insert(secret_ref.to_string(), value.expose_secret().to_string());
+            Ok(())
+        }
+
+        fn delete(&self, secret_ref: &str) -> Result<(), dbflux_core::DbError> {
+            self.secrets
+                .lock()
+                .expect("secret store mutex poisoned")
+                .remove(secret_ref);
+            Ok(())
+        }
+    }
+
     fn test_state_with_driver(
         driver_id: &str,
         driver: Arc<dyn DbDriver>,
         profile: ConnectionProfile,
+    ) -> ServerState {
+        test_state_with_driver_and_store(driver_id, driver, profile, Box::new(NoopSecretStore))
+    }
+
+    fn test_state_with_driver_and_store(
+        driver_id: &str,
+        driver: Arc<dyn DbDriver>,
+        profile: ConnectionProfile,
+        secret_store: Box<dyn dbflux_core::SecretStore>,
     ) -> ServerState {
         let audit_path = dbflux_audit::temp_sqlite_path(&format!(
             "server_test_{}.sqlite",
@@ -792,7 +847,7 @@ mod tests {
                 RwLock::new(crate::connection_cache::ConnectionCache::new()),
             ),
             connection_setup_lock: Arc::new(tokio::sync::Mutex::new(())),
-            secret_manager: Arc::new(dbflux_core::SecretManager::new(Box::new(NoopSecretStore))),
+            secret_manager: Arc::new(dbflux_core::SecretManager::new(secret_store)),
             mcp_enabled_by_default: true,
         }
     }
@@ -859,6 +914,48 @@ mod tests {
         assert_eq!(
             connection.connection().active_database().as_deref(),
             Some("analytics")
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_connection_factory_falls_back_to_keyring_password_on_pipeline_path() {
+        let driver = RecordingDriver::new(FakeDriver::new(DbKind::Postgres));
+        let driver_handle = Arc::new(driver.clone()) as Arc<dyn DbDriver>;
+
+        // A pipeline profile whose only ValueRef is the host: the pipeline resolves
+        // no password, so the keyring value is the only credential available.
+        let mut profile = ConnectionProfile::new("test-pg", DbConfig::default_postgres());
+        profile.save_password = true;
+        profile.value_refs.insert(
+            "host".to_string(),
+            ValueRef::literal("pipeline.example.internal"),
+        );
+        assert!(profile.uses_pipeline());
+
+        let store = InMemorySecretStore::default();
+        dbflux_core::SecretStore::set(
+            &store,
+            &profile.secret_ref(),
+            &SecretString::from("keyring-password".to_string()),
+        )
+        .expect("in-memory secret store write should succeed");
+
+        let connection_id = profile.id.to_string();
+        let state =
+            test_state_with_driver_and_store("postgres", driver_handle, profile, Box::new(store));
+
+        McpConnectionFactory::new(state)
+            .connect(&connection_id, None)
+            .await
+            .expect("pipeline-backed connection should succeed");
+
+        let invocations = driver.invocations();
+        assert_eq!(invocations.len(), 1, "expected a single driver connection");
+        assert_eq!(
+            invocations[0].password.as_deref(),
+            Some("keyring-password"),
+            "pipeline path must fall back to the keyring password when the \
+             pipeline resolves none"
         );
     }
 }

--- a/crates/dbflux_ui_windows/src/connection_manager/form.rs
+++ b/crates/dbflux_ui_windows/src/connection_manager/form.rs
@@ -771,8 +771,14 @@ impl ConnectionManagerWindow {
                                         );
                                     }
 
-                                    let overrides =
-                                        ConnectionOverrides::new(pipeline_output.resolved_password);
+                                    // The pipeline only yields a password when the
+                                    // profile carries a `ValueRef` for it. Fall back to
+                                    // the form password (prefilled from the keyring when
+                                    // editing) so a pipeline profile is not probed
+                                    // without credentials.
+                                    let overrides = ConnectionOverrides::new(
+                                        pipeline_output.resolved_password.or(password),
+                                    );
                                     let access_handle_drop = TestConnectionProbeResource {
                                         name: "pipeline access handle",
                                         drop_guard: drop_guards.access_handle,


### PR DESCRIPTION
## Summary

Connecting through the MCP server to a profile that routes through the connect pipeline authenticated with **no password at all**, while the same profile connected fine from the GUI sidebar. With MongoDB this surfaced as `SCRAM failure: no password supplied`.

The defect is driver-agnostic — MongoDB is only where it was first observed. Any engine that authenticates with a password is affected.

## What does this resolve?

- Resolves #588

This is **not** the same defect as #573. That one was inside the MongoDB driver's URI credential injection (`inject_credentials_into_uri`) and is already fixed. Here the driver never receives a password in the first place, so the driver-level fix could not help.

## How was this solved?

`ConnectionProfile::uses_pipeline()` is true when the profile has an `auth_profile_id`, any `value_refs`, or any `access_kind` — so most non-trivial profiles take the pipeline path. On that path, `PipelineOutput::resolved_password` is only populated from a password `ValueRef`; a profile that keeps its password in the OS keyring resolves to `None`.

The GUI sidebar already compensated for this at `crates/dbflux_ui_sidebar/src/operations/pipeline.rs:406`:

```rust
let effective_password = resolved_password.or(keyring_password);
```

Of the three call sites that build `ConnectionOverrides` from a pipeline output, only that one had the fallback. This PR adds it to the other two, so all three agree.

| File | Change |
|------|--------|
| `crates/dbflux_mcp_server/src/server.rs` | `connect_with_pipeline` resolves the keyring password before running the pipeline and applies `resolved_password.or(keyring_password)`. Adds a regression test plus a test-only `InMemorySecretStore` and a `test_state_with_driver_and_store` helper; the existing helper keeps `NoopSecretStore`. |
| `crates/dbflux_ui_windows/src/connection_manager/form.rs` | The pipeline branch of "Test connection" now uses `resolved_password.or(password)`. That form field is prefilled from the keyring when editing an existing profile (`connection_manager/mod.rs:1064`), so the probe previously ran without credentials for any pipeline profile. |

Precedence is deliberate and matches the GUI: a password resolved by the pipeline (an explicit `ValueRef`) wins over the keyring value, which is only a fallback.

## Validation

```
cargo test -p dbflux_mcp_server --lib     # 82 passed, 0 failed
cargo fmt --all -- --check                # clean
cargo clippy -p dbflux_mcp_server -p dbflux_ui_windows --all-targets
```

Clippy is clean for the touched code. The one warning it reports (`unused_mut` in `settings/sidebar_nav.rs`) is pre-existing and unrelated to this change.

The new test `mcp_connection_factory_falls_back_to_keyring_password_on_pipeline_path` builds a pipeline profile whose only `ValueRef` is the host, puts a password in an in-memory secret store, and asserts the driver receives it. It was verified to fail without the fix:

```
assertion `left == right` failed: pipeline path must fall back to the keyring
password when the pipeline resolves none
  left: None
 right: Some("keyring-password")
```

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [x] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` — not applicable: `CHANGELOG.md` is generated by git-cliff from git history and must not be hand-edited (see CONTRIBUTING.md § "Commit messages are load-bearing"). The `fix` commit type surfaces this under **Fixed**.
- [x] I applied the appropriate labels

## Known limitations / follow-ups

Deliberately out of scope, flagged rather than folded in:

- **`save_password` gate divergence.** `resolve_profile_secrets` in the MCP server gates the keyring lookup on `profile.save_password`; the GUI's `AppState::get_password` does not gate at all. A profile with `save_password = false` that still has a secret in the keyring works in the GUI and fails in MCP. Worth a maintainer decision on which behavior is correct before aligning them.
- **New failure path.** `resolve_profile_secrets` returns `Result`, so the added `?` is a new error path on connect. It cannot fire today — the function has no `Err` branch — but it becomes reachable if one is ever added.
- **Precedence is not asserted by a test.** The pipeline-over-keyring ordering is intentional but only the fallback direction is covered; the existing pipeline test uses `NoopSecretStore`.
- **The GUI form fallback has no test.** `form.rs` has no coverage for the pipeline branch of "Test connection".

## Labels to apply

`mcp:bug`, `pipeline:bug`, `ui:bug`, `platform:linux`
