### PR TITLE
fix(mongodb): report unsupported scripts instead of a JSON parse error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,17 @@ All notable changes to DBFlux will be documented in this file.
 
 ### Fixed
 
+* **Honest errors for MongoDB input that is not a single query (#587)** — the
+  Mongo editor accepts one `db.collection.method(...)` call or a JSON query,
+  and it now says so. Pasting a `mongosh` script used to fail with
+  `Invalid JSON: expected value at line 1 column 1`, blaming JSON for input
+  that was never JSON; it now reports that scripts are not supported yet.
+  Two silent failures are gone with it: a script whose first statement was a
+  `db.` call ran that one statement and discarded the rest, and a chained
+  call such as `db.users.find({}).limit(5)` ran the `find` and dropped the
+  `.limit(5)`, returning more rows than asked for. Both are now refused, the
+  chained case naming the method it cannot honour.
+
 * **Several MCP clients per connection (#542)** — the Connection Manager MCP
   tab is now a master-detail view: a filterable list of every trusted client
   on the left, and on the right whether the selected client may use this

--- a/crates/dbflux_driver_mongodb/src/query_parser.rs
+++ b/crates/dbflux_driver_mongodb/src/query_parser.rs
@@ -62,7 +62,56 @@ fn parse_query_positional(input: &str) -> Result<MongoQuery, MongoParseError> {
         return parse_shell_syntax_positional(trimmed, trim_offset);
     }
 
+    if looks_like_javascript(trimmed) {
+        let first_line_len = trimmed.lines().next().unwrap_or(trimmed).len();
+        return Err(MongoParseError::new(
+            SCRIPT_UNSUPPORTED_MESSAGE,
+            trim_offset,
+            first_line_len,
+        ));
+    }
+
     parse_json_format(trimmed).map_err(|e| MongoParseError::from_db_error(e, trim_offset))
+}
+
+const SCRIPT_UNSUPPORTED_MESSAGE: &str = "JavaScript scripts are not supported yet. Run a single db.collection.method(...) call, \
+     a db.method(...) call, or a JSON query.";
+
+/// Statement forms that open a script rather than a single query.
+///
+/// Each keyword carries its delimiter so a longer identifier that merely
+/// starts with the same letters — `constant`, `iffy`, `forEach` — is not
+/// mistaken for the keyword.
+const JAVASCRIPT_STATEMENT_STARTERS: &[&str] = &[
+    "const ",
+    "let ",
+    "var ",
+    "function ",
+    "for ",
+    "for(",
+    "while ",
+    "while(",
+    "if ",
+    "if(",
+    "class ",
+    "async ",
+    "return ",
+    "//",
+    "/*",
+];
+
+/// True when the input opens with a JavaScript statement rather than a query.
+///
+/// Only used once shell syntax has been ruled out, to choose between a
+/// "scripts are unsupported" error and the JSON fallback. A JSON query needs
+/// no guard here: every starter above begins with a letter or a slash, so an
+/// object or an array can never match one.
+fn looks_like_javascript(input: &str) -> bool {
+    let trimmed = input.trim_start();
+
+    JAVASCRIPT_STATEMENT_STARTERS
+        .iter()
+        .any(|starter| trimmed.starts_with(starter))
 }
 
 /// Parse a query string into a MongoQuery.
@@ -77,6 +126,12 @@ pub fn parse_query(input: &str) -> Result<MongoQuery, DbError> {
     // Try shell syntax first
     if trimmed.starts_with("db.") {
         return parse_shell_syntax(trimmed);
+    }
+
+    if looks_like_javascript(trimmed) {
+        return Err(DbError::query_failed(
+            SCRIPT_UNSUPPORTED_MESSAGE.to_string(),
+        ));
     }
 
     // Fall back to JSON format
@@ -343,6 +398,27 @@ fn parse_method_call(input: &str) -> Result<(&str, &str), DbError> {
     let args_start = paren_pos + 1;
     let args_end = find_matching_paren(input, paren_pos)?;
     let args_str = &input[args_start..args_end];
+
+    // Anything beyond the matched `)` was previously parsed and then dropped,
+    // so a chained call ran without its modifier and a second statement never
+    // ran at all — both silently. Refuse instead, and name which one it is.
+    let trailing = input[args_end + 1..].trim().trim_start_matches(';').trim();
+    if let Some(chained) = trailing.strip_prefix('.') {
+        let chained_name: String = chained
+            .chars()
+            .take_while(|character| character.is_alphanumeric() || *character == '_')
+            .collect();
+
+        return Err(DbError::query_failed(format!(
+            "Chained method '.{chained_name}()' is not supported. Express it in the \
+             method's own arguments, or use db.collection.aggregate([...])."
+        )));
+    }
+    if !trailing.is_empty() {
+        return Err(DbError::query_failed(
+            SCRIPT_UNSUPPORTED_MESSAGE.to_string(),
+        ));
+    }
 
     Ok((method_name, args_str))
 }
@@ -1210,5 +1286,123 @@ mod tests {
     fn test_db_level_validation_run_command() {
         let errors = validate_query_positional(r#"db.runCommand({"ping": 1})"#);
         assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_javascript_script_reports_unsupported_not_invalid_json() {
+        let script = concat!(
+            "const OLD_ID = \"abc\";\n",
+            "for (const name of db.getCollectionNames()) {\n",
+            "  print(name);\n",
+            "}\n"
+        );
+
+        let message = match parse_query(script) {
+            Ok(_) => panic!("a JS script must not parse as a single query"),
+            Err(error) => error.to_string(),
+        };
+
+        assert_eq!(message, SCRIPT_UNSUPPORTED_MESSAGE);
+    }
+
+    #[test]
+    fn test_javascript_script_diagnostic_points_at_first_statement() {
+        let script = "let total = 0;\ndb.users.countDocuments({});\n";
+
+        let errors = validate_query_positional(script);
+
+        assert_eq!(errors.len(), 1, "expected exactly one diagnostic");
+        assert_eq!(
+            errors[0].offset, 0,
+            "diagnostic should anchor at the script start"
+        );
+        assert_eq!(
+            errors[0].len,
+            "let total = 0;".len(),
+            "diagnostic should underline the first statement only"
+        );
+        assert_eq!(errors[0].message, SCRIPT_UNSUPPORTED_MESSAGE);
+    }
+
+    #[test]
+    fn test_malformed_json_still_reports_invalid_json() {
+        let message = match parse_query(r#"{"collection": "users",}"#) {
+            Ok(_) => panic!("a trailing comma is not valid JSON"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(
+            message.contains("Invalid JSON"),
+            "genuine JSON breakage must keep its JSON message, got: {message}"
+        );
+    }
+
+    #[test]
+    fn test_identifiers_prefixed_with_a_keyword_are_not_scripts() {
+        // The starter list carries its delimiters precisely so these do not
+        // match; without that, each would be misreported as a script.
+        for input in ["constant", "iffy", "forEach()", "classic", "variable"] {
+            assert!(
+                !looks_like_javascript(input),
+                "{input} is not a script and must not be detected as one"
+            );
+        }
+
+        // ...while the keywords themselves still are.
+        for input in ["const x = 1;", "if (a) {}", "for (const a of b) {}"] {
+            assert!(looks_like_javascript(input), "{input} is a script");
+        }
+    }
+
+    #[test]
+    fn test_script_starting_with_a_db_call_is_rejected_not_silently_truncated() {
+        // Regression: the shell parser used to stop at the first matched `)`
+        // and discard the rest, so this ran ONLY the users query, silently.
+        let script = "db.users.find({});\ndb.orders.find({});\n";
+
+        let message = match parse_query(script) {
+            Ok(_) => panic!("two statements must not parse as one query"),
+            Err(error) => error.to_string(),
+        };
+
+        assert_eq!(message, SCRIPT_UNSUPPORTED_MESSAGE);
+    }
+
+    #[test]
+    fn test_trailing_semicolon_is_accepted() {
+        // mongosh users paste trailing semicolons; rejecting trailing content
+        // must not reject these.
+        let query = parse_query("db.users.find({});").unwrap();
+        assert_eq!(query.collection.as_deref(), Some("users"));
+
+        let db_level = parse_query("db.getName();").unwrap();
+        assert!(db_level.collection.is_none());
+
+        let spaced = parse_query("db.users.find({}) ;  ").unwrap();
+        assert_eq!(spaced.collection.as_deref(), Some("users"));
+    }
+
+    #[test]
+    fn test_chained_method_is_named_not_reported_as_a_script() {
+        // Before the trailing check this ran find({}) and dropped `.limit(5)`,
+        // returning unlimited rows with no warning.
+        let message = match parse_query("db.users.find({}).limit(5)") {
+            Ok(_) => panic!("a chained call must not parse"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(
+            message.contains("'.limit()'"),
+            "the message must name the chained method, got: {message}"
+        );
+        assert_ne!(message, SCRIPT_UNSUPPORTED_MESSAGE);
+    }
+
+    #[test]
+    fn test_trailing_statement_diagnostic_is_positional() {
+        let errors = validate_query_positional("db.users.find({});\ndb.orders.find({});");
+
+        assert_eq!(errors.len(), 1, "expected exactly one diagnostic");
+        assert_eq!(errors[0].message, SCRIPT_UNSUPPORTED_MESSAGE);
     }
 }


### PR DESCRIPTION
## Summary

- The Mongo editor no longer blames JSON for input that was never JSON: a pasted `mongosh` script now reports that scripts are not supported yet.
- Two silent failures are fixed along the way — a multi-statement script whose first statement was a `db.` call ran only that statement, and a chained call such as `db.users.find({}).limit(5)` ran the `find` and dropped the `.limit(5)`.
- Stage 1 of #587. This does not add a JavaScript runtime; it makes the current limit honest.

## What does this resolve?

- Part of #587

Not a `Resolves`: #587 asks for real JavaScript execution, which is a separate change still in planning. This PR only fixes how the existing limit is reported.

## How was this solved?

`parse_query` accepts a `db.` shell call or a JSON query. Anything else fell through to `serde_json`, so `const OLD_ID = "…"` produced `Invalid JSON: expected value at line 1 column 1`.

A `looks_like_javascript` check now runs between those two branches. It matches a leading JavaScript statement keyword, each carried with its delimiter (`const `, `if(`, `//`, …) so an identifier that merely shares a prefix — `constant`, `iffy`, `forEach` — is not mistaken for one. JSON needs no guard of its own: every starter begins with a letter or a slash, so an object or an array can never match.

The two silent failures surfaced while writing the tests, and both are worse than the misleading message because neither produced an error at all:

- `parse_method_call` found the first `(`, matched its `)`, and ignored everything after it. `db.users.find({});\ndb.orders.find({});` parsed as a single valid query and ran only the first statement.
- The same path dropped chained modifiers, so `db.users.find({}).limit(5)` ran an unlimited `find` and returned more rows than the user asked for.

Trailing content after the matched `)` is now refused. A trailing `.method(` is named specifically — `Chained method '.limit()' is not supported` — so it is not misreported as a script, since the two need different fixes from the user. Trailing semicolons stay accepted, because mongosh users paste them.

Tradeoff worth flagging for review: the detection is a keyword-prefix list, not a JavaScript parser. It is deliberately narrow — it only has to beat "fall through to the JSON parser", and a false positive would reject a valid query, so the list errs toward under-matching. A script opening with an unlisted form (say a bare function call on line 1) still reaches the JSON error.

## Validation

- `cargo nextest run --workspace --locked --features "sqlite,postgres,mysql,mssql,mongodb,redis,dynamodb,cloudwatch,influxdb,clickhouse,aws"` — 6091 passed, 234 skipped
- `cargo clippy -p dbflux_driver_mongodb --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- Nine tests added to `query_parser.rs`, covering: the reported script, the positional diagnostic and its span, keyword-prefixed identifiers that must NOT match, the two silent-failure regressions, trailing semicolons, and a guard that genuinely malformed JSON still reports as `Invalid JSON`.

Note on one earlier run: `dbflux_ui … palette_filtering_large_dataset_completes_within_budget` failed once during a full-suite run on a loaded machine and passed 3/3 in isolation, then passed in the clean full run above. It is a timing-budget test and `dbflux_ui` has no driver dependencies, so this change cannot reach it.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [x] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

## Labels to apply

`query:bug`, `driver:mongodb`, `kind:document`

## Follow-up work

Known limitations, deliberately not addressed here:

- No JavaScript runtime — #587 stage 2, in SDD planning.
- Dangerous-query classification for Mongo is a text regex in `dbflux_core` (`language_service.rs:325` hardcodes `MongoQuery => classify_mongo_query`) and never delegates to the driver's `LanguageService`. That is the real governance gap and it belongs with stage 2, since a regex over source text cannot survive a script.
- The starter list does not cover tab- or newline-delimited keywords (`const\tx`).
