### PR TITLE
fix(editor): re-derive the editor language from the bound connection

### DIFF
--- a/crates/dbflux_ui_document/src/code/context_bar.rs
+++ b/crates/dbflux_ui_document/src/code/context_bar.rs
@@ -56,6 +56,32 @@ fn resolve_query_mode_selection(
         .or_else(|| spec_default.map(|mode| mode.to_string()))
 }
 
+/// Resolve the language an editor presents and classifies with.
+///
+/// Precedence: a driver-declared query mode is the user's own explicit choice
+/// inside one connection (InfluxDB's InfluxQL/Flux toggle), so it outranks
+/// everything. A pinned document then keeps its own language. Otherwise the
+/// bound connection decides, because that connection already decides which
+/// driver executes the text — `document` is only the fallback for a tab with
+/// nothing bound yet.
+fn resolve_effective_language(
+    binding: LanguageBinding,
+    document: &QueryLanguage,
+    connection: Option<&QueryLanguage>,
+    source_mode: Option<&QueryLanguage>,
+) -> QueryLanguage {
+    if let Some(mode) = source_mode {
+        return mode.clone();
+    }
+
+    match binding {
+        LanguageBinding::Pinned => document.clone(),
+        LanguageBinding::FollowsConnection => {
+            connection.cloned().unwrap_or_else(|| document.clone())
+        }
+    }
+}
+
 impl CodeDocument {
     // === Context dropdown creation ===
 
@@ -139,6 +165,7 @@ impl CodeDocument {
 
         self.editor.cached_supports_connection_context = editor_profile.supports_connection_context;
         self.editor.cached_comment_prefix = editor_profile.comment_prefix;
+        self.editor.cached_effective_language = query_language.clone();
 
         let completion_provider: Rc<dyn CompletionProvider> =
             Rc::new(QueryCompletionProvider::new(
@@ -197,17 +224,29 @@ impl CodeDocument {
     }
 
     pub(super) fn effective_query_language(&self, cx: &App) -> QueryLanguage {
-        let Some(spec) = self.current_source_context_spec(cx) else {
-            return self.editor.query_language.clone();
-        };
+        let source_mode = self.current_source_context_spec(cx).and_then(|spec| {
+            let selected_mode = self.current_source_query_mode_value(cx);
 
-        let selected_mode = self.current_source_query_mode_value(cx);
+            spec.query_modes
+                .into_iter()
+                .find(|mode| Some(mode.value.as_str()) == selected_mode.as_deref())
+                .map(|mode| mode.query_language)
+        });
 
-        spec.query_modes
-            .into_iter()
-            .find(|mode| Some(mode.value.as_str()) == selected_mode.as_deref())
-            .map(|mode| mode.query_language)
-            .unwrap_or_else(|| self.editor.query_language.clone())
+        let connection_language = self
+            .source
+            .exec_ctx
+            .connection_id
+            .or(self.connection_id)
+            .and_then(|id| self.app_state.read(cx).connections().get(&id))
+            .map(|connected| connected.connection.metadata().query_language.clone());
+
+        resolve_effective_language(
+            self.editor.language_binding,
+            &self.editor.query_language,
+            connection_language.as_ref(),
+            source_mode.as_ref(),
+        )
     }
 
     pub(super) fn should_show_source_controls(&self, cx: &App) -> bool {
@@ -1585,12 +1624,108 @@ impl CodeDocument {
 #[cfg(test)]
 mod tests {
     use super::{
-        ContextBarSlot, SqlQueryFocus, build_source_window_context, context_dropdown_min_width,
-        context_slot_is_keyboard_focused, parse_source_datetime_input,
-        resolve_query_mode_selection,
+        ContextBarSlot, LanguageBinding, SqlQueryFocus, build_source_window_context,
+        context_dropdown_min_width, context_slot_is_keyboard_focused, parse_source_datetime_input,
+        resolve_effective_language, resolve_query_mode_selection,
     };
-    use dbflux_core::ExecutionSourceContext;
+    use dbflux_core::{ExecutionSourceContext, QueryLanguage};
     use gpui::px;
+
+    /// Retargeting a scratch tab's connection dropdown from a relational
+    /// profile to a document one must re-derive the language. Before this,
+    /// `editor.query_language` was written once at construction and never
+    /// reassigned, so the tab kept SQL highlighting, SQL time-macro
+    /// substitution, and — the part that actually matters — SQL dangerous-query
+    /// classification while executing against MongoDB, where `deleteMany` then
+    /// went undetected.
+    #[test]
+    fn unpinned_document_follows_the_bound_connection() {
+        assert_eq!(
+            resolve_effective_language(
+                LanguageBinding::FollowsConnection,
+                &QueryLanguage::Sql,
+                Some(&QueryLanguage::MongoQuery),
+                None,
+            ),
+            QueryLanguage::MongoQuery
+        );
+    }
+
+    /// A file's extension chose its language, so no connection may override it:
+    /// a `.sql` file opened against a MongoDB connection is still SQL.
+    #[test]
+    fn pinned_document_ignores_the_bound_connection() {
+        assert_eq!(
+            resolve_effective_language(
+                LanguageBinding::Pinned,
+                &QueryLanguage::Sql,
+                Some(&QueryLanguage::MongoQuery),
+                None,
+            ),
+            QueryLanguage::Sql
+        );
+    }
+
+    /// An in-process script language is pinned for the same reason: no
+    /// connection can turn a Lua buffer into a query buffer.
+    #[test]
+    fn pinned_script_language_survives_a_connection() {
+        assert_eq!(
+            resolve_effective_language(
+                LanguageBinding::Pinned,
+                &QueryLanguage::Lua,
+                Some(&QueryLanguage::Sql),
+                None,
+            ),
+            QueryLanguage::Lua
+        );
+    }
+
+    /// A driver-declared query mode is the user's own explicit choice within
+    /// one connection (InfluxDB's InfluxQL/Flux toggle), so it outranks the
+    /// connection's default language.
+    #[test]
+    fn source_query_mode_outranks_the_connection() {
+        assert_eq!(
+            resolve_effective_language(
+                LanguageBinding::FollowsConnection,
+                &QueryLanguage::InfluxQuery,
+                Some(&QueryLanguage::InfluxQuery),
+                Some(&QueryLanguage::Flux),
+            ),
+            QueryLanguage::Flux
+        );
+    }
+
+    /// A query mode is an explicit choice even on a pinned document, so it
+    /// still wins there.
+    #[test]
+    fn source_query_mode_outranks_a_pin() {
+        assert_eq!(
+            resolve_effective_language(
+                LanguageBinding::Pinned,
+                &QueryLanguage::InfluxQuery,
+                Some(&QueryLanguage::InfluxQuery),
+                Some(&QueryLanguage::Flux),
+            ),
+            QueryLanguage::Flux
+        );
+    }
+
+    /// A scratch tab with no connection bound keeps the language it was
+    /// created with rather than silently collapsing to SQL.
+    #[test]
+    fn unpinned_document_without_a_connection_keeps_its_own_language() {
+        assert_eq!(
+            resolve_effective_language(
+                LanguageBinding::FollowsConnection,
+                &QueryLanguage::MongoQuery,
+                None,
+                None,
+            ),
+            QueryLanguage::MongoQuery
+        );
+    }
 
     #[test]
     fn query_mode_selection_prefers_committed_then_dropdown() {

--- a/crates/dbflux_ui_document/src/code/execution.rs
+++ b/crates/dbflux_ui_document/src/code/execution.rs
@@ -209,7 +209,7 @@ impl CodeDocument {
     /// Returns `None` for a single statement or a driver that cannot execute
     /// batches, in which case no confirmation is shown.
     fn script_statement_count(&self, query: &str, cx: &Context<Self>) -> Option<usize> {
-        let count = self.editor.query_language.statement_count(query);
+        let count = self.effective_language().statement_count(query);
         if count <= 1 {
             return None;
         }
@@ -621,7 +621,7 @@ impl CodeDocument {
             query.clone(),
             active_database,
             &self.source.exec_ctx,
-            self.editor.query_language.clone(),
+            self.effective_language().clone(),
         );
 
         // Capture audit_service, task_target, and started_at before spawning so we can emit
@@ -1548,7 +1548,7 @@ impl CodeDocument {
             return;
         }
 
-        let kind = match &self.editor.query_language {
+        let kind = match self.effective_language() {
             QueryLanguage::Lua => HookKind::Lua {
                 source: ScriptSource::Inline {
                     content: content.clone(),
@@ -1596,7 +1596,7 @@ impl CodeDocument {
         };
 
         let description =
-            crate::labels::run_script_task_label(self.editor.query_language.display_name());
+            crate::labels::run_script_task_label(self.effective_language().display_name());
         let (output_sender, output_receiver) = dbflux_core::output_channel();
         let (task_id, cancel_token) =
             self.runner

--- a/crates/dbflux_ui_document/src/code/file_ops.rs
+++ b/crates/dbflux_ui_document/src/code/file_ops.rs
@@ -70,8 +70,8 @@ impl CodeDocument {
     /// Open a "Save As" dialog and save to the chosen path.
     pub fn save_file_as(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         let content = self.build_file_content(cx);
-        let default_ext = self.editor.query_language.default_extension().to_string();
-        let language_name = self.editor.query_language.display_name().to_string();
+        let default_ext = self.effective_language().default_extension().to_string();
+        let language_name = self.effective_language().display_name().to_string();
 
         let suggested_name = if let Some(path) = &self.editor.path {
             path.file_name()

--- a/crates/dbflux_ui_document/src/code/mod.rs
+++ b/crates/dbflux_ui_document/src/code/mod.rs
@@ -233,6 +233,23 @@ pub(super) struct SourceContext {
     pub(super) _context_subscriptions: Vec<Subscription>,
 }
 
+/// How a document's editor language is bound over its lifetime.
+///
+/// A scratch query tab follows its connection: retargeting the connection
+/// dropdown from a relational profile to a document one has to re-derive
+/// highlighting, time-macro substitution, and dangerous-query classification,
+/// because `connection_id` alone already decides which driver executes the text.
+/// A document whose language came from somewhere the connection cannot speak
+/// for — a file extension, an in-process script language, a read-only routine
+/// body — keeps it instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LanguageBinding {
+    /// Re-derive the language from whichever connection the tab is bound to.
+    FollowsConnection,
+    /// Keep the document's own language regardless of the bound connection.
+    Pinned,
+}
+
 /// Text editor entity, file-backing metadata, language mode, and diagnostic debounce.
 ///
 /// Groups the `InputState` entity and its subscription together with the fields
@@ -266,7 +283,17 @@ pub(super) struct EditorState {
     pub(super) completion_query_generation: Rc<Cell<u64>>,
     /// Value of `completion_query_generation` at the previous `Change` event.
     pub(super) last_completion_generation: u64,
+    /// The language this document declares for itself: derived from the active
+    /// connection at construction, from a file extension, or passed explicitly.
+    /// Read it through `CodeDocument::effective_language()` rather than
+    /// directly — an unpinned document resolves to its bound connection's
+    /// language instead.
     pub(super) query_language: QueryLanguage,
+    pub(super) language_binding: LanguageBinding,
+    /// Cached `resolve_effective_language` result, refreshed alongside
+    /// `cached_supports_connection_context` whenever the effective language can
+    /// change (construction, connection change, query-mode switch).
+    pub(super) cached_effective_language: QueryLanguage,
 }
 
 /// Auto-save-to-disk machinery and saved-label UI feedback.
@@ -538,6 +565,17 @@ impl CodeDocument {
             Self::resolve_editor_profile(&app_state, connection_id, &query_language, cx);
         let editor_mode = editor_profile.editor_mode.clone();
         let placeholder = editor_profile.placeholder.clone();
+
+        // An in-process script language (Lua/Python/Bash) is pinned on sight: no
+        // connection can turn a script buffer into a query buffer. Every other
+        // language starts out following the bound connection; `with_path` and
+        // `with_read_only` pin it afterwards for the documents whose language
+        // came from a file extension or a routine body.
+        let language_binding = if query_language.supports_connection_context() {
+            LanguageBinding::FollowsConnection
+        } else {
+            LanguageBinding::Pinned
+        };
 
         let input_state = cx.new(|cx| {
             InputState::new(window, cx)
@@ -905,6 +943,8 @@ impl CodeDocument {
                 last_change_length: 0,
                 completion_query_generation,
                 last_completion_generation: 0,
+                cached_effective_language: query_language.clone(),
+                language_binding,
                 query_language,
             },
             source: SourceContext {
@@ -1089,8 +1129,13 @@ impl CodeDocument {
     }
 
     /// Attach a file path (used after opening or "Save As").
+    ///
+    /// This pins the language: the file's extension chose it, so retargeting the
+    /// document at another connection must not override it.
     pub fn with_path(mut self, path: PathBuf) -> Self {
         self.editor.path = Some(path);
+        self.editor.language_binding = LanguageBinding::Pinned;
+        self.editor.cached_effective_language = self.editor.query_language.clone();
         self
     }
 
@@ -1099,6 +1144,11 @@ impl CodeDocument {
     /// popup appears on focus or key events.
     pub fn with_read_only(mut self, cx: &mut Context<Self>) -> Self {
         self.read_only = true;
+
+        // A read-only document shows a fixed body (a routine definition), not a
+        // buffer the user retargets at another connection.
+        self.editor.language_binding = LanguageBinding::Pinned;
+        self.editor.cached_effective_language = self.editor.query_language.clone();
 
         // Disable the LSP completion provider so no autocomplete popup fires
         // when the user focuses or types (which would otherwise happen because
@@ -1226,7 +1276,18 @@ impl CodeDocument {
 
     #[allow(dead_code)]
     pub fn query_language(&self) -> QueryLanguage {
-        self.editor.query_language.clone()
+        self.effective_language().clone()
+    }
+
+    /// The language this editor currently presents and classifies with.
+    ///
+    /// This is the cached `resolve_effective_language` result, so for an
+    /// unpinned document it tracks the bound connection. Every consumer that
+    /// drives user-visible or governance behaviour — highlighting, time-macro
+    /// substitution, statement counting, dangerous-query classification — must
+    /// read this rather than `editor.query_language`.
+    pub(super) fn effective_language(&self) -> &QueryLanguage {
+        &self.editor.cached_effective_language
     }
 
     /// Returns true if the editor content is empty or whitespace-only.
@@ -1729,8 +1790,120 @@ impl CodeDocument {
 impl EventEmitter<DocumentEvent> for CodeDocument {}
 
 #[cfg(test)]
+mod language_binding_tests {
+    use super::{CodeDocument, LanguageBinding};
+    use dbflux_components::theme;
+    use dbflux_core::QueryLanguage;
+    use dbflux_storage::bootstrap::StorageRuntime;
+    use dbflux_ui_base::AppStateEntity;
+    use dbflux_ui_base::toast::{ToastGlobal, ToastHost};
+    use gpui::{AppContext, TestAppContext};
+    use gpui_component::Root;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn isolated_test_app_state(cx: &mut TestAppContext) -> gpui::Entity<AppStateEntity> {
+        cx.update(|cx| {
+            cx.new(|_| {
+                let storage_runtime =
+                    StorageRuntime::in_memory().expect("isolated storage runtime");
+                AppStateEntity::new_with_storage_runtime(storage_runtime)
+                    .expect("test storage setup")
+            })
+        })
+    }
+
+    fn init_test_runtime(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        cx.update(theme::init);
+        cx.update(|cx| {
+            let host = cx.new(|_| ToastHost::new());
+            cx.set_global(ToastGlobal { host });
+        });
+    }
+
+    /// Build a document and report the language binding it ended up with.
+    ///
+    /// `customize` runs the builder steps under test (`with_path`,
+    /// `with_read_only`, or nothing at all).
+    fn binding_for(
+        cx: &mut TestAppContext,
+        language: QueryLanguage,
+        customize: impl Fn(CodeDocument, &mut gpui::Context<CodeDocument>) -> CodeDocument + 'static,
+    ) -> LanguageBinding {
+        init_test_runtime(cx);
+
+        let app_state = isolated_test_app_state(cx);
+        let doc_holder: Rc<RefCell<Option<gpui::Entity<CodeDocument>>>> =
+            Rc::new(RefCell::new(None));
+        let doc_ref = doc_holder.clone();
+
+        let (_, window) = cx.add_window_view(|window, cx| {
+            let doc = cx.new(|cx| {
+                let document = CodeDocument::new_with_language(
+                    app_state.clone(),
+                    None,
+                    language.clone(),
+                    window,
+                    cx,
+                );
+                customize(document, cx)
+            });
+            doc_ref.replace(Some(doc.clone()));
+            Root::new(doc, window, cx)
+        });
+
+        let doc = doc_holder.borrow().clone().expect("doc should be created");
+
+        window.update(|_, app| doc.read(app).editor.language_binding)
+    }
+
+    /// A plain scratch query tab must follow its connection, so retargeting the
+    /// connection dropdown re-derives the language.
+    #[gpui::test]
+    fn a_scratch_query_tab_follows_its_connection(cx: &mut TestAppContext) {
+        assert_eq!(
+            binding_for(cx, QueryLanguage::Sql, |doc, _cx| doc),
+            LanguageBinding::FollowsConnection
+        );
+    }
+
+    /// An in-process script language is pinned at construction: no connection
+    /// can turn a Lua buffer into a query buffer.
+    #[gpui::test]
+    fn a_script_language_is_pinned_on_sight(cx: &mut TestAppContext) {
+        assert_eq!(
+            binding_for(cx, QueryLanguage::Lua, |doc, _cx| doc),
+            LanguageBinding::Pinned
+        );
+    }
+
+    /// A file's extension chose its language, so attaching a path pins it.
+    #[gpui::test]
+    fn attaching_a_file_path_pins_the_language(cx: &mut TestAppContext) {
+        assert_eq!(
+            binding_for(cx, QueryLanguage::Sql, |doc, _cx| doc
+                .with_path(std::path::PathBuf::from("/tmp/report.sql"))),
+            LanguageBinding::Pinned
+        );
+    }
+
+    /// A read-only document shows a fixed routine body, not a buffer the user
+    /// retargets at another connection.
+    #[gpui::test]
+    fn a_read_only_document_pins_its_language(cx: &mut TestAppContext) {
+        assert_eq!(
+            binding_for(cx, QueryLanguage::Sql, |doc, cx| doc.with_read_only(cx)),
+            LanguageBinding::Pinned
+        );
+    }
+}
+
+#[cfg(test)]
 mod tests {
-    use super::{CodeDocument, diff_stats_from_pair, source_input_values_from_context};
+    use super::{
+        CodeDocument, LanguageBinding, diff_stats_from_pair, source_input_values_from_context,
+    };
     use dbflux_components::theme;
     use dbflux_core::{ExecutionSourceContext, QueryLanguage};
     use dbflux_storage::bootstrap::StorageRuntime;


### PR DESCRIPTION
Resolves #591

## Summary

- A query tab's language was written once at construction and never reassigned, so switching the tab's connection from PostgreSQL to MongoDB kept the original language.
- The language is now a derived value: `LanguageBinding` records whether a document follows its connection or keeps its own language, and the pure `resolve_effective_language` resolves query-mode override > pin > connection > document fallback.
- The pin is derived, not passed, so no `dbflux_ui` call site changed.

## What was actually wrong

Execution across a connection switch already worked, because `connection_id` alone selects the driver. That is what hid the bug: the query ran fine while everything keyed off the stale language was wrong for the bound connection.

| Consumer | Effect of the stale language |
|---|---|
| Editor mode / highlighting | the visible symptom — SQL colors on a Mongo buffer |
| Placeholder, comment prefix | wrong dialect |
| `substitute_time_macros` | macros expanded with the wrong dialect's rules |
| `statement_count` | SQL `;`-splitting applied to a non-SQL query, gating the multi-statement confirmation |
| "Save As" default extension | a Mongo buffer offers `.sql` |

## Scope note

This does **not** touch dangerous-query classification, diagnostics, completion or code actions. Those resolve their `LanguageService` from `connected.connection.language_service()` — the bound connection, never the tab's stored language (`execution.rs:257-267`, `diagnostics.rs:53`, `code_actions.rs:192`) — so they were already correct across a connection switch, and `classify_query_for_language` has no call site in the UI at all.

An earlier revision of this description claimed this PR closed a governance hole where `deleteMany` went unflagged on a SQL-flagged tab. **That claim was wrong** and has been removed. This is a correctness fix in the editor and execution-shaping paths, not a security fix. The commit message has been amended to match.

## Design

Precedence is `source query mode > pin > connection > document fallback`. The query-mode override stays on top because a driver-declared dropdown (InfluxDB's InfluxQL/Flux) is an explicit user choice inside one connection.

A document pins its language when the connection cannot speak for it, and that is derived from existing state rather than threaded through the constructor:

| Situation | Binding | Why |
|---|---|---|
| Scratch query tab | `FollowsConnection` | the bound connection decides |
| `QueryLanguage` fails `supports_connection_context` | `Pinned` at construction | no connection turns a Lua buffer into a query buffer |
| `with_path` | `Pinned` | the file extension chose the language |
| `with_read_only` | `Pinned` | a routine body is not a buffer the user retargets |

Keeping the buffer and silently re-deriving was chosen over opening a second tab: execution already worked across the switch, so a new tab would have broken a working flow, and a half-written script is the thing users are iterating on.

## Changes

| File | Change |
|------|--------|
| `crates/dbflux_ui_document/src/code/mod.rs` | `LanguageBinding` enum; `language_binding` + `cached_effective_language` on `EditorState`; pins in `with_path` / `with_read_only`; `effective_language()`; binding wiring tests |
| `crates/dbflux_ui_document/src/code/context_bar.rs` | pure `resolve_effective_language`; `effective_query_language` rewired to consult the bound connection; cache refresh in `sync_editor_language`; policy tests |
| `crates/dbflux_ui_document/src/code/execution.rs` | statement counting, query request building, script-kind match and task label read `effective_language()` |
| `crates/dbflux_ui_document/src/code/file_ops.rs` | "Save As" default extension and language name read `effective_language()` |

## Test plan

- [x] 6 unit tests for the resolution policy, including the reported case (`unpinned_document_follows_the_bound_connection`)
- [x] 4 GPUI tests for the pin derivation (scratch / script language / `with_path` / `with_read_only`)
- [x] `cargo test -p dbflux_ui_document --lib` — 1229 passed, 0 failed
- [x] `cargo clippy -p dbflux_ui_document -p dbflux_ui --lib -- -D warnings` — clean
- [x] `cargo check --workspace` — clean
- [x] `cargo fmt --all`

Written test-first: the initial build failed with `unresolved import super::resolve_effective_language` before the implementation existed.

## Notes for reviewers

Two pre-existing conditions in code this PR does not touch, so they are not regressions from it: `cargo clippy --all-targets` fails on lint in `dbflux_ui_base` and `dbflux_storage` test modules, and `dbflux_core`'s `execute_streaming_process_emits_partial_line_output_before_newline` is flaky under parallel load (passes in isolation and on rerun).

Relation to #587: this is a prerequisite for the editor surface there (a Mongo tab that still reports SQL cannot present a Mongo script surface), but **not** for its governance wiring, which already resolves its service from the connection.
