### PR TITLE
fix(ci): pull MinIO from quay and stop one image from blocking every suite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,6 +116,15 @@ jobs:
       # binaries race to pull the same tag and anonymous Docker Hub throttling
       # aborts mid-stream ("bytes remaining on stream"). Pulling everything
       # up front, serially and with retries, removes that failure mode.
+      #
+      # This step is an optimisation, not a gate, so it never fails the job.
+      # It used to `exit 1` on the first image it could not fetch, which meant
+      # one withdrawn image took down every driver suite — a dead MinIO tag
+      # blocked PostgreSQL, MySQL, MongoDB, Redis and DynamoDB, none of which
+      # use it, and blocked every pull request in the repository with it.
+      # An image that cannot be pre-pulled is reported here and left to
+      # testcontainers, so only the suite that actually needs it fails, and it
+      # fails with a test error rather than a red job that ran no tests.
       - name: Pre-pull container images
         run: |
           images=(
@@ -130,21 +139,28 @@ jobs:
             amazon/dynamodb-local:latest
             influxdb:2.7
             influxdb:1.8
-            minio/minio:RELEASE.2025-09-07T16-13-09Z
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
             localstack/localstack:3
           )
+          unpulled=()
           for image in "${images[@]}"; do
             for attempt in 1 2 3; do
               if docker pull --quiet "$image"; then
                 break
               fi
               if [ "$attempt" = 3 ]; then
-                echo "failed to pull $image after 3 attempts" >&2
-                exit 1
+                echo "::warning::could not pre-pull $image after 3 attempts; \
+          the suite that needs it will pull it at test time and fail there if it is genuinely gone"
+                unpulled+=("$image")
+                break
               fi
               sleep $((attempt * 15))
             done
           done
+
+          if [ ${#unpulled[@]} -gt 0 ]; then
+            echo "images left for testcontainers to pull: ${unpulled[*]}"
+          fi
 
       - name: Run PostgreSQL live integration tests
         run: cargo test -p dbflux_driver_postgres --locked --test live_integration -- --ignored

--- a/crates/dbflux_test_support/src/containers.rs
+++ b/crates/dbflux_test_support/src/containers.rs
@@ -448,7 +448,9 @@ where
     let access_key_id = "minioadmin";
     let secret_access_key = "minioadmin";
 
-    let image = GenericImage::new("minio/minio", "RELEASE.2025-09-07T16-13-09Z")
+    // quay.io, not Docker Hub: the minio/minio repository was withdrawn from
+    // Docker Hub, so the Hub reference 404s on every pull. Same release tag.
+    let image = GenericImage::new("quay.io/minio/minio", "RELEASE.2025-09-07T16-13-09Z")
         .with_exposed_port(ContainerPort::Tcp(9000))
         .with_wait_for(WaitFor::seconds(1))
         .with_env_var("MINIO_ROOT_USER", access_key_id)


### PR DESCRIPTION
## Summary

- `minio/minio` was withdrawn from Docker Hub, so the Driver Live Integration job fails on every branch, on every run, before a single test starts. The reference moves to quay.io, same release tag.
- The pre-pull step no longer aborts the job on an image it cannot fetch. One withdrawn image was taking down every driver suite and, because the job is a required check, blocking every pull request in the repository.

## What does this resolve?

The Driver Live Integration job has been red on every PR since the image was withdrawn. Evidence from this repository's own runs:

- run `34647256853` and run `34649646462` (branch `feat/mongo-js-script-runtime`) — both died in `Pre-pull container images`, three attempts, identical error, zero tests executed.
- The same job succeeded on `main` at 19:28 and on `fix/editor-language-follows-connection` at 19:03, which is what initially made this look transient. It is not — the later runs simply crossed the withdrawal.

## How was this solved?

**The registry.** Checked at the registry protocol level rather than inferred from the error text:

| Reference | Tag manifest |
|---|---|
| `minio/minio` (Docker Hub) | **401** — and `GET /v2/repositories/minio/minio/` returns **404** |
| `quay.io/minio/minio` | **200**, anonymously, no token |

The `minio` namespace on Docker Hub still publishes 20 other repositories (`mint`, `warp`, `sidekick`, …), so this is a withdrawal of the server image specifically, not an account removal. The tag `RELEASE.2025-09-07T16-13-09Z` exists on quay.io unchanged, so this is a registry move with no version bump and no behaviour change.

Both references are updated — `.github/workflows/tests.yml` and `crates/dbflux_test_support/src/containers.rs`. They have to move together: the pre-pull warms an image by name, and testcontainers pulls by name at test time, so leaving one behind would silently pre-pull one image and start another.

**The structural half, which is the part worth reviewing.** The pre-pull step exists to serialise pulls so concurrent test binaries do not race for the same tag and get throttled mid-stream — its own comment says so. It is an optimisation. But it ended with `exit 1` on the first failure, which made it a gate: a dead MinIO tag, used only by the S3 suite, stopped PostgreSQL, MySQL, MongoDB, Redis, Redis Cluster, DynamoDB and the rest from running at all.

It now emits a `::warning::`, records the image, and continues. A genuinely missing image still fails the build — but in the suite that actually needs it, as a test failure naming the container, instead of a red job that ran nothing and reports the same way whether the code is broken or a registry had a bad day. That distinction is the real fix here; the registry change alone would just reset the clock until the next withdrawal.

## Validation

- Registry checks above (`curl` against both registries' `/v2/` manifest endpoints and the Docker Hub API).
- `bash -n` on the extracted pre-pull script — syntax clean.
- Simulated the loop with a stubbed `docker pull`: with MinIO failing it emits the warning, lists the image, and exits **0**, so the driver suites that follow still run. With every image succeeding it exits 0 and emits nothing.
- `cargo check -p dbflux_test_support --locked` — clean.

Not validated locally: the actual `docker pull` from quay, since there is no Docker daemon in this environment. CI is the first real execution — which is the honest place for it, and the manifest returning 200 anonymously is the strongest signal available short of the pull itself.

## Where was this tested?

- [x] Local development environment
- [ ] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

No CHANGELOG entry: this changes CI only, nothing a user of DBFlux can observe.

## Follow-up worth considering, not done here

Every other image in the list is an unpinned-registry Docker Hub reference, so the same withdrawal or the same anonymous rate limit can happen to any of them. Two options, both bigger than this fix: authenticate the pulls so the job is not anonymous, or mirror the images the suites need. Worth deciding deliberately rather than after the next outage.
