### PR TITLE
ci: pull container images from the Docker Hub mirror, and guard the list

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,6 +117,12 @@ jobs:
       # aborts mid-stream ("bytes remaining on stream"). Pulling everything
       # up front, serially and with retries, removes that failure mode.
       #
+      # Most images come from mirror.gcr.io, Google's pull-through mirror of
+      # Docker Hub: it has no per-IP rate limit and needs no credentials, so
+      # it removes the throttling this step was built to survive and keeps
+      # working on pull requests from forks. grokzen/redis-cluster is not
+      # carried there and stays on Docker Hub.
+      #
       # This step is an optimisation, not a gate, so it never fails the job.
       # It used to `exit 1` on the first image it could not fetch, which meant
       # one withdrawn image took down every driver suite — a dead MinIO tag
@@ -128,19 +134,19 @@ jobs:
       - name: Pre-pull container images
         run: |
           images=(
-            postgres:16
-            pgvector/pgvector:0.8.0-pg16
-            mysql:8.4
-            mongo:7
-            redis:7
+            mirror.gcr.io/library/postgres:16
+            mirror.gcr.io/pgvector/pgvector:0.8.0-pg16
+            mirror.gcr.io/library/mysql:8.4
+            mirror.gcr.io/library/mongo:7
+            mirror.gcr.io/library/redis:7
             grokzen/redis-cluster:7.0.10
-            clickhouse/clickhouse-server:25.8.30.16
+            mirror.gcr.io/clickhouse/clickhouse-server:25.8.30.16
             mcr.microsoft.com/mssql/server:2022-latest
-            amazon/dynamodb-local:latest
-            influxdb:2.7
-            influxdb:1.8
+            mirror.gcr.io/amazon/dynamodb-local:latest
+            mirror.gcr.io/library/influxdb:2.7
+            mirror.gcr.io/library/influxdb:1.8
             quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
-            localstack/localstack:3
+            mirror.gcr.io/localstack/localstack:3
           )
           unpulled=()
           for image in "${images[@]}"; do

--- a/crates/dbflux_test_support/src/containers.rs
+++ b/crates/dbflux_test_support/src/containers.rs
@@ -3,11 +3,39 @@ use testcontainers::core::{ContainerPort, WaitFor};
 use testcontainers::runners::SyncRunner;
 use testcontainers::{Container, GenericImage, ImageExt};
 
+/// Google's pull-through mirror of Docker Hub.
+///
+/// CI runners share NAT'd addresses, so anonymous Docker Hub pulls hit the
+/// per-IP rate limit and abort mid-stream — the failure the workflow's
+/// serialised pre-pull step exists to work around. The mirror has no such
+/// limit and needs no credentials, which also keeps it working for pull
+/// requests from forks, where secrets are unavailable.
+const MIRROR: &str = "mirror.gcr.io";
+
+/// A Docker Hub image, pulled from [`MIRROR`] instead.
+///
+/// Official images live under `library/` on the mirror, which is implicit on
+/// Docker Hub: `postgres` is `library/postgres` here. A name that already
+/// carries an organisation keeps it.
+///
+/// The image names passed here must stay in step with the pre-pull list in
+/// `.github/workflows/tests.yml`; `pre_pull_list_covers_every_mirrored_image`
+/// below fails the build when they drift apart.
+fn hub_image(image: &str, tag: &str) -> GenericImage {
+    let name = if image.contains('/') {
+        format!("{MIRROR}/{image}")
+    } else {
+        format!("{MIRROR}/library/{image}")
+    };
+
+    GenericImage::new(name, tag.to_string())
+}
+
 pub fn with_postgres_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let image = GenericImage::new("postgres", "16")
+    let image = hub_image("postgres", "16")
         .with_exposed_port(ContainerPort::Tcp(5432))
         .with_wait_for(WaitFor::message_on_stdout(
             "database system is ready to accept connections",
@@ -29,7 +57,7 @@ pub fn with_pgvector_postgres_16_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let image = GenericImage::new("pgvector/pgvector", "0.8.0-pg16")
+    let image = hub_image("pgvector/pgvector", "0.8.0-pg16")
         .with_exposed_port(ContainerPort::Tcp(5432))
         .with_wait_for(WaitFor::message_on_stdout(
             "database system is ready to accept connections",
@@ -53,7 +81,7 @@ pub fn with_mysql_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let image = GenericImage::new("mysql", "8.4")
+    let image = hub_image("mysql", "8.4")
         .with_exposed_port(ContainerPort::Tcp(3306))
         .with_wait_for(WaitFor::message_on_stderr("ready for connections"))
         .with_env_var("MYSQL_ROOT_PASSWORD", "root")
@@ -72,7 +100,7 @@ pub fn with_mongodb_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let image = GenericImage::new("mongo", "7")
+    let image = hub_image("mongo", "7")
         .with_exposed_port(ContainerPort::Tcp(27017))
         .with_wait_for(WaitFor::message_on_stdout("Waiting for connections"));
 
@@ -89,7 +117,7 @@ pub fn with_redis_url<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let image = GenericImage::new("redis", "7")
+    let image = hub_image("redis", "7")
         .with_exposed_port(ContainerPort::Tcp(6379))
         .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"));
 
@@ -118,7 +146,7 @@ pub fn with_redis_container<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String, &Container<GenericImage>) -> Result<T, E>,
 {
-    let image = GenericImage::new("redis", "7")
+    let image = hub_image("redis", "7")
         .with_exposed_port(ContainerPort::Tcp(6379))
         .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"));
 
@@ -160,6 +188,12 @@ pub fn with_redis_cluster_urls<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(Vec<String>) -> Result<T, E>,
 {
+    // Docker Hub directly, not the mirror: mirror.gcr.io does not carry this
+    // repository (every tag 404s there, while Docker Hub serves them). It is
+    // therefore the one anonymous Hub pull left, and the least maintained
+    // image in the suite — a personal account, last pushed in 2024. Replacing
+    // it is its own change: the all-in-one layout, the fixed 7000-7005 ports
+    // and the IP=0.0.0.0 contract below are specific to this image.
     let mut image = GenericImage::new("grokzen/redis-cluster", "7.0.10")
         .with_wait_for(WaitFor::seconds(5))
         .with_env_var("IP", "0.0.0.0");
@@ -197,7 +231,7 @@ where
     let user = "dbflux";
     let password = "dbflux";
     let database = "dbflux_test";
-    let image = GenericImage::new("clickhouse/clickhouse-server", "25.8.30.16")
+    let image = hub_image("clickhouse/clickhouse-server", "25.8.30.16")
         .with_exposed_port(ContainerPort::Tcp(8123))
         .with_wait_for(WaitFor::seconds(1))
         .with_env_var("CLICKHOUSE_USER", user)
@@ -285,7 +319,7 @@ pub fn with_dynamodb_endpoint<T, E, F>(run: F) -> Result<T, E>
 where
     F: FnOnce(String) -> Result<T, E>,
 {
-    let image = GenericImage::new("amazon/dynamodb-local", "latest")
+    let image = hub_image("amazon/dynamodb-local", "latest")
         .with_exposed_port(ContainerPort::Tcp(8000))
         .with_wait_for(WaitFor::message_on_stdout("Initializing DynamoDB Local"));
 
@@ -324,7 +358,7 @@ where
     let bucket = "dbflux-test-bucket";
 
     // InfluxDB v2 logs to stdout; the "Listening" message signals HTTP readiness.
-    let image = GenericImage::new("influxdb", "2.7")
+    let image = hub_image("influxdb", "2.7")
         .with_exposed_port(ContainerPort::Tcp(8086))
         .with_wait_for(WaitFor::message_on_stdout("Listening"))
         .with_env_var("DOCKER_INFLUXDB_INIT_MODE", "setup")
@@ -383,7 +417,7 @@ where
     F: FnOnce(InfluxV1Config) -> Result<T, E>,
 {
     // InfluxDB v1 logs to stderr; the "Listening on HTTP" message signals readiness.
-    let image = GenericImage::new("influxdb", "1.8")
+    let image = hub_image("influxdb", "1.8")
         .with_exposed_port(ContainerPort::Tcp(8086))
         .with_wait_for(WaitFor::message_on_stderr("Listening on HTTP"));
 
@@ -508,7 +542,7 @@ where
     E: From<dbflux_core::DbError>,
     F: FnOnce(String) -> Result<T, E>,
 {
-    let image = GenericImage::new("localstack/localstack", "3")
+    let image = hub_image("localstack/localstack", "3")
         .with_exposed_port(ContainerPort::Tcp(4566))
         .with_wait_for(WaitFor::message_on_stdout("Ready."))
         .with_env_var("SERVICES", "logs,cloudwatch");
@@ -563,5 +597,70 @@ where
         }
 
         std::thread::sleep(Duration::from_millis(250));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// Every container image this module starts must also appear in the
+    /// workflow's pre-pull list.
+    ///
+    /// The two drifted once already: the MinIO image is named in both places
+    /// and a registry move that touched only one would have pre-pulled one
+    /// image while the tests started another. This test reads both and fails
+    /// on the difference, in either direction — an image started but never
+    /// pre-pulled loses the throttling protection the list exists to give,
+    /// and an image pre-pulled but no longer started is dead weight that
+    /// slows every run.
+    #[test]
+    fn pre_pull_list_covers_every_mirrored_image() {
+        let source = include_str!("containers.rs");
+        let workflow = include_str!("../../../.github/workflows/tests.yml");
+
+        let mut started: Vec<String> = Vec::new();
+        for line in source.lines() {
+            // Skip this test's own text so its examples are not read as usage.
+            if line.contains("include_str!") {
+                continue;
+            }
+            if let Some(rest) = line.split_once("hub_image(\"") {
+                let (image, rest) = rest.1.split_once("\", \"").expect("hub_image arity");
+                let tag = rest.split('"').next().expect("hub_image tag");
+                let prefix = if image.contains('/') { "" } else { "library/" };
+                started.push(format!("mirror.gcr.io/{prefix}{image}:{tag}"));
+            } else if let Some(rest) = line.split_once("GenericImage::new(\"") {
+                let (image, rest) = rest.1.split_once("\", \"").expect("GenericImage arity");
+                let tag = rest.split('"').next().expect("GenericImage tag");
+                started.push(format!("{image}:{tag}"));
+            }
+        }
+        started.sort();
+        started.dedup();
+        assert!(!started.is_empty(), "found no images in containers.rs");
+
+        let pre_pulled: Vec<String> = workflow
+            .lines()
+            .skip_while(|line| !line.contains("images=("))
+            .skip(1)
+            .take_while(|line| !line.trim_start().starts_with(')'))
+            .map(|line| line.trim().to_string())
+            .filter(|line| !line.is_empty())
+            .collect();
+
+        let missing: Vec<&String> = started
+            .iter()
+            .filter(|image| !pre_pulled.contains(image))
+            .collect();
+        let stale: Vec<&String> = pre_pulled
+            .iter()
+            .filter(|image| !started.contains(image))
+            .collect();
+
+        assert!(
+            missing.is_empty() && stale.is_empty(),
+            "pre-pull list and containers.rs disagree.\n  \
+             started but not pre-pulled: {missing:?}\n  \
+             pre-pulled but not started: {stale:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Eleven of the thirteen CI container images were anonymous Docker Hub pulls. They now come from `mirror.gcr.io`, which has no per-IP rate limit and needs no credentials — removing the failure the pre-pull step was built to survive, rather than continuing to work around it.
- A guard test fails the build when the workflow's pre-pull list and the code that starts the containers disagree. They had already drifted.
- Follows #594, which fixed the withdrawn MinIO image and stopped one bad image from taking down every driver suite.

## What does this resolve?

The follow-up recorded in #594: every remaining image was an unauthenticated Docker Hub reference, so the same withdrawal or the same anonymous rate limit could happen to any of them.

## How was this solved?

**Why the mirror and not credentials.** Authenticating to Docker Hub was the other option. It raises the limit but does nothing about withdrawal — MinIO would still have 404'd — and secrets are unavailable to pull requests from forks, so the job would stay fragile exactly where contributors touch it. The mirror needs no account, no token and no repository secret.

**Checked, not assumed.** The worry with a pull-through cache is that a tag the repo does not use yet returns 404 and every future version bump breaks CI. Probing says otherwise — the mirror serves tags on demand:

| Probe | Result |
|---|---|
| The ten repositories at the tags in use | all **200** |
| `postgres:17`, `postgres:18`, `redis:8`, `mongo:latest` (unused here) | all **200** |
| ClickHouse's newest tag at time of writing | **200** |
| `mongo:9.4` (does not exist anywhere) | 404 |
| `grokzen/redis-cluster`, every tag | **404**, while Docker Hub serves them |

So the mirror carries a subset of repositories, but within one it is transparent. A version bump does not walk into a cold cache.

**The exception.** `grokzen/redis-cluster` is not mirrored and stays on Docker Hub. That leaves it as the one anonymous Hub pull, and it is also the least maintained image in the suite — a personal account, last pushed 2024-06-25. Replacing it is its own change and deliberately not attempted here: the all-in-one six-node layout, the fixed 7000–7005 host ports and the `IP=0.0.0.0` advertisement contract in `with_redis_cluster_urls` are specific to this image. A comment now records all of that at the call site. Thanks to #594 it can no longer take the other suites down with it.

**The drift, which is the part worth reviewing.** Container images are named in two places — the workflow's pre-pull list and `containers.rs` — and nothing kept them together. MinIO's registry move in #594 had to touch both files; changing one would have pre-pulled one image while the tests started another, silently losing the protection and quietly pulling from the wrong registry.

`pre_pull_list_covers_every_mirrored_image` now reads both files and fails on a difference in either direction: an image started but never pre-pulled loses the throttling protection, and one pre-pulled but no longer started is dead weight on every run. This follows the existing `style_guardrails` pattern in `dbflux_ui_windows`.

I proved it fails rather than trusting that it passes:

- removing `mirror.gcr.io/library/mongo:7` from the list → `started but not pre-pulled: ["mirror.gcr.io/library/mongo:7"]`
- rewriting MinIO's registry in the workflow only → `started but not pre-pulled: ["quay.io/..."]` **and** `pre-pulled but not started: ["docker.io/..."]`, which is the MinIO shape exactly

## Validation

- `cargo nextest run --workspace --locked --features "…"` — 6167 of 6168 (see below)
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p dbflux_test_support --all-targets -- -D warnings` — clean
- Registry probes above, run against each registry's `/v2/` manifest endpoint
- The guard test deliberately broken twice and confirmed to fail, then restored

Not validated locally: the actual pulls from `mirror.gcr.io`, since there is no Docker daemon here. CI is the first real execution — a 200 on every manifest is the strongest signal available short of the pull.

**On the one failing test.** `dbflux_ui … palette_filtering_large_dataset_completes_within_budget` fails locally. It is not this change — this branch touches only `containers.rs` and the workflow, and `dbflux_ui` has no dependency on either. Measured six runs on this branch and six on clean `main`: **4 passed / 2 failed on both**, identically. It is a wall-clock budget test that a busy development machine trips about a third of the time while CI, on a dedicated runner, has stayed green. Worth its own issue; deliberately not bundled here.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux
- [ ] macOS
- [ ] Windows
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [x] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible
- [x] I applied the appropriate labels (see [CONTRIBUTING.md](../CONTRIBUTING.md#label-guide))

No CHANGELOG entry: CI and test infrastructure only, nothing a user of DBFlux can observe.

## Known limitations and follow-ups

- **`grokzen/redis-cluster` is unmirrored, unmaintained and on a personal account.** It is the most likely next MinIO. Replacing it means finding an image with an equivalent all-in-one cluster contract, or standing six nodes up explicitly.
- **`crates/dbflux_proxy/tests/live_integration.rs` starts `serjs/go-socks5-proxy:latest` and `monokal/tinyproxy:latest`** — two more personal accounts, both on unpinned `latest`. That suite does not run in CI, so those images are absent from the pre-pull list and out of the guard's scope; they only affect whoever runs the suite locally. Pinning them is worth doing regardless: `latest` can change under you as easily as it can vanish.
- The mirror is another third party. It removes Docker Hub's rate limit but is not a promise; the difference is that after #594 a registry having a bad day no longer stops every suite.
