### PR TITLE
docs(turso): document editor transaction-control limits

### DIFF
--- a/crates/dbflux_driver_turso/README.md
+++ b/crates/dbflux_driver_turso/README.md
@@ -33,8 +33,13 @@ Remote Turso / libSQL database over HTTP.
   join it.
 - Column kinds from declared types with SQLite affinity rules, falling back to a
   scan of the returned values for expression columns.
+- Pagination, sorting, and filtering as SQL `LIMIT`/`OFFSET`, `ORDER BY`, and
+  `WHERE`, plus CSV and JSON export.
 - SQLite-style code generation (`CREATE TABLE` with rowid semantics,
   `ADD COLUMN`, `DROP COLUMN`, indexes, `REINDEX`) and the visual query builder.
+- Dangerous-query detection uses the shared `SqlLanguageService`: `DELETE` and
+  `UPDATE` without `WHERE`, `DROP`, `TRUNCATE`, and `ALTER` are flagged as for
+  any other SQL driver.
 - Error classification for auth failures, constraint violations, syntax errors,
   missing objects, and busy servers, without leaking response bodies.
 
@@ -44,7 +49,16 @@ Remote Turso / libSQL database over HTTP.
   transport gives up.
 - No SSH tunnels, embedded replicas, local files, or sync; local `sqld`
   instances are reached over plain HTTP only.
+- In the editor, transaction control is one statement per run: `BEGIN`,
+  `COMMIT`, and `ROLLBACK` each run on their own, and a script that mixes
+  them with other statements is rejected before reaching the server.
+  `SAVEPOINT`, `RELEASE`, and `ROLLBACK TO` are rejected the same way.
 - One database per connection; `ATTACH` and database switching are not exposed.
+- No write-privilege probe: the mutation policy is not tightened for
+  read-only tokens, so a write with a read-only token fails at execution time.
+- No instance metrics, inspectors, or dashboard sources.
+- Data transfer into Turso is untested; the driver advertises bulk insert but
+  the transfer engine has not been exercised against a Turso endpoint.
 - Results are fully buffered by the SDK before rows are returned.
 - `PRAGMA foreign_keys` toggling is not exposed because it is per-stream and
   would not apply to isolated sessions.

--- a/crates/dbflux_driver_turso/src/driver.rs
+++ b/crates/dbflux_driver_turso/src/driver.rs
@@ -148,7 +148,9 @@ pub static METADATA: LazyLock<DriverMetadata> = LazyLock::new(|| DriverMetadata 
         supports_transactions: true,
         supported_isolation_levels: vec![IsolationLevel::ReadCommitted],
         default_isolation_level: Some(IsolationLevel::ReadCommitted),
-        supports_savepoints: true,
+        // SAVEPOINT / RELEASE / ROLLBACK TO are rejected by the editor's
+        // transaction-control classifier before they reach the server.
+        supports_savepoints: false,
         supports_nested_transactions: false,
         supports_read_only: true,
         supports_deferrable: true,

--- a/docs/DRIVERS.md
+++ b/docs/DRIVERS.md
@@ -144,8 +144,9 @@ Relational SQL driver for Turso Cloud and self-hosted `sqld` over HTTP, built on
 the `turso_serverless` SDK. It speaks the SQLite dialect, discovers tables,
 views, columns, indexes, foreign keys, and constraints through `sqlite_master`
 and PRAGMAs, and supports typed CRUD, bound parameters, batched scripts, and
-interactive transactions on per-document server streams. Query cancellation,
-SSH tunneling, embedded replicas, and database switching are not supported. See
+interactive transactions on per-document server streams, one control
+statement per editor run. Query cancellation, savepoints, SSH tunneling,
+embedded replicas, and database switching are not supported. See
 [`crates/dbflux_driver_turso/README.md`](../crates/dbflux_driver_turso/README.md).
 
 ### Amazon S3

--- a/docs/es/DRIVERS.md
+++ b/docs/es/DRIVERS.md
@@ -151,9 +151,10 @@ Driver SQL relacional para Turso Cloud y `sqld` autoalojado vía HTTP, construid
 sobre el SDK `turso_serverless`. Habla el dialecto SQLite, descubre tables,
 views, columns, índices, foreign keys y constraints mediante `sqlite_master` y
 PRAGMAs, y soporta CRUD tipado, parámetros vinculados, scripts en batch y
-transactions interactivas en streams del servidor por documento. No soporta
-cancelación de queries, túnel SSH, réplicas embebidas ni cambio de base de
-datos. Ver
+transactions interactivas en streams del servidor por documento, con un
+statement de control por ejecución del editor. No soporta cancelación de
+queries, savepoints, túnel SSH, réplicas embebidas ni cambio de base de datos.
+Ver
 [`crates/dbflux_driver_turso/README.md`](../crates/dbflux_driver_turso/README.md).
 
 ### Amazon S3

--- a/docs/zh_Hans/DRIVERS.md
+++ b/docs/zh_Hans/DRIVERS.md
@@ -79,7 +79,7 @@ AWS CloudWatch Logs 驱动程序，通过 `StartQuery` 执行查询，时间范�
 
 ### TursoDB
 
-面向 Turso Cloud 与自托管 `sqld` 的关系型 SQL 驱动程序，走 HTTP，基于 `turso_serverless` SDK。它使用 SQLite 方言，通过 `sqlite_master` 与 PRAGMA 发现表、视图、列、索引、外键与约束，并支持类型化 CRUD、绑定参数、批量脚本，以及在每个文档独立的服务端流上运行的交互式事务。不支持查询取消、SSH 隧道、嵌入式副本与切换数据库。参见 [`crates/dbflux_driver_turso/README.md`](../crates/dbflux_driver_turso/README.md)。
+面向 Turso Cloud 与自托管 `sqld` 的关系型 SQL 驱动程序，走 HTTP，基于 `turso_serverless` SDK。它使用 SQLite 方言，通过 `sqlite_master` 与 PRAGMA 发现表、视图、列、索引、外键与约束，并支持类型化 CRUD、绑定参数、批量脚本，以及在每个文档独立的服务端流上运行的交互式事务（编辑器每次运行只能执行一条事务控制语句）。不支持查询取消、保存点、SSH 隧道、嵌入式副本与切换数据库。参见 [`crates/dbflux_driver_turso/README.md`](../crates/dbflux_driver_turso/README.md)。
 
 ### Amazon S3
 


### PR DESCRIPTION
## Summary

Follow-up to #596. Aligns the TursoDB driver metadata and documentation with what the editor actually allows.

## What does this resolve?

- Metadata declared `supports_savepoints: true`, but the editor's transaction-control classifier rejects `SAVEPOINT`, `RELEASE`, and `ROLLBACK TO` before they reach the server. The flag is now `false` with a comment saying why.
- The README did not say that transaction control in the editor is one statement per run (a `BEGIN; …; COMMIT;` script is rejected), nor that pagination/sorting/filtering/export, dangerous-query detection, the missing write-privilege probe, missing instance metrics, and the untested transfer path exist. All added under Features / Limitations.
- `docs/DRIVERS.md` and its `es` / `zh_Hans` mirrors carry the same limitation sentence.

## Validation

- `cargo nextest run -p dbflux_driver_turso` — 17 passed.
- Docs-only otherwise.

## Where was this tested?

- [x] Local development environment
- [x] Automated tests
- [x] Linux