### PR TITLE
fix(windows): link the MSVC C runtime statically so dbflux.exe starts without VCRedist

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,10 +6,25 @@
 #
 # IMPORTANT: this applies to ALL builds for this triple, including
 # `cargo build --release`. Linux x86_64 release artifacts are therefore linked
-# with mold (functionally equivalent binary). Other triples — Windows (msvc),
-# macOS, and Linux aarch64 — are unaffected and keep their default linker.
+# with mold (functionally equivalent binary). macOS and Linux aarch64 are
+# unaffected and keep their default linker.
 
 [target.x86_64-unknown-linux-gnu]
 # Use the mold linker through the default cc driver. Drastically reduces link
 # time and peak memory when linking the 60+ workspace crates.
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+# Link the MSVC C runtime statically into dbflux.exe.
+#
+# The msvc target links the CRT dynamically by default, so the executable
+# imports VCRUNTIME140.dll and only starts on machines that have the Visual
+# C++ Redistributable installed. A clean Windows (the winget validation
+# sandbox, a fresh VM, the portable zip on a new machine) fails with
+# STATUS_DLL_NOT_FOUND (0xC0000135) before main runs. A static CRT removes
+# that runtime dependency; every other import is shipped with Windows 10+.
+#
+# The vendored C libraries stay compatible: the `cc` and `cmake` crates pick
+# `/MT` from this target feature, and the vendored OpenSSL static libraries
+# are built with `/MT /Zl` (no CRT reference), so no mixed-runtime link.
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
## Summary

Link the MSVC C runtime statically into `dbflux.exe`, so the Windows binary starts on a clean machine without the Visual C++ Redistributable.

## What does this resolve?

- Refs #513
- The winget automatic validation of [microsoft/winget-pkgs#426628](https://github.com/microsoft/winget-pkgs/pull/426628) rejected the package: both the installer and the portable executable exit with `-1073741515` (`0xC0000135`, `STATUS_DLL_NOT_FOUND`).

Inspecting the v0.7.7 `dbflux-windows-amd64.zip` with `objdump -p` shows the only non-OS import:

```
DLL Name: VCRUNTIME140.dll
DLL Name: api-ms-win-crt-*-l1-1-0.dll   (UCRT forwarders)
```

Every other import (`d3d11`, `dxgi`, `dcomp`, `dwrite`, `icuuc`, `bcrypt`, ...) ships with Windows 10+. OpenSSL is already vendored on Windows, SQLite is `bundled`, and Lua is `vendored`, so the CRT was the last external dependency.

## How was this solved?

Add a `[target.x86_64-pc-windows-msvc]` section to `.cargo/config.toml` with `-C target-feature=+crt-static`. This is the standard Rust mechanism and applies to every build for that triple, including the release job in `build.yml`.

Mixed-runtime linking is not a concern for the vendored C libraries:

- `cc`-based crates (`libssh2-sys`, `libsqlite3-sys`, `lua-src`) and the `cmake` crate (`aws-lc-sys`) read `crt-static` from the target features and compile with `/MT`.
- OpenSSL built by `openssl-src` with `no-shared` compiles its static libraries with `/MT /Zl`, which leaves no CRT reference in the objects.

Alternatives considered: declaring `Microsoft.VCRedist.2015+.x64` as a winget dependency, or bundling the redistributable in the Inno Setup installer. Both fix only one distribution channel and leave the portable zip broken on a clean machine.

## Validation

- `objdump -p` on the v0.7.7 release executable confirms the `VCRUNTIME140.dll` import (evidence above).
- The PR CI runs `cargo check` on `windows-latest`, which does not link. The real proof is the release artifact: this change is cherry-picked into `release/v0.7` and the `v0.7.8-rc.0` Windows zip is inspected with `objdump -p` to confirm `VCRUNTIME140.dll` and the `api-ms-win-crt-*` forwarders are gone before `v0.7.8` is promoted.

## Where was this tested?

- [x] Local development environment
- [ ] Automated tests
- [ ] Linux
- [ ] macOS
- [x] Windows (release artifact inspection, see Validation)
- [ ] X11
- [ ] Wayland
- [ ] Other:

## Checklist

- [x] I verified the change against the affected user flow(s)
- [ ] I added or updated tests when needed
- [x] I documented follow-up work or known limitations when applicable
- [ ] I updated `CHANGELOG.md` under `## [Unreleased]` if this is user-visible (git-cliff derives it from the commit)
- [x] I applied the appropriate labels

## Labels to apply

`platform:windows`, `arch:amd64`, `bug`
